### PR TITLE
fix(app): link local Cloud development to staging by default

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -51,7 +51,7 @@ jobs:
       config: dev-smoke
 
   dev-smoke:
-    name: bun run dev onboarding chat
+    name: default staging + local onboarding
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
@@ -105,8 +105,11 @@ jobs:
       - name: Build @elizaos/core browser bundle
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
-      - name: Run bun dev onboarding chat smoke
+      - name: Run default staging dev smoke
         run: bun run --cwd packages/app test:dev-smoke
+
+      - name: Run explicit local onboarding smoke
+        run: bun run --cwd packages/app test:dev-smoke:local
 
       # The smoke has historically failed inside gotoChatComposer (the /chat
       # composer never paints) with no captured renderer state, making the

--- a/bun.lock
+++ b/bun.lock
@@ -1551,6 +1551,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/cloud-sdk": "workspace:*",
+        "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
         "@elizaos/core": "workspace:*",
@@ -3133,6 +3134,7 @@
         "@electric-sql/experimental": "1.0.14",
         "@electric-sql/pglite": "^0.4.0",
         "@electric-sql/pglite-sync": "0.5.6",
+        "@elizaos/shared": "workspace:*",
         "@neondatabase/serverless": "^1.1.0",
         "@noble/hashes": "2.2.0",
         "drizzle-orm": "0.45.2",
@@ -3473,6 +3475,7 @@
       },
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
       },
     },
     "plugins/plugin-zai": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "start:eliza": "node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/src/entry.ts start",
     "dev:prepare": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app... --filter=!@elizaos/app",
     "dev": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun --no-install --conditions=eliza-source packages/app-core/scripts/dev-ui.mjs",
+    "dev:local": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun --no-install --conditions=eliza-source packages/app-core/scripts/dev-ui.mjs --cloud-target=offline",
     "dev:ui": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun --no-install --conditions=eliza-source packages/app-core/scripts/dev-ui.mjs --ui-only",
     "dev:cloud-only": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun run --cwd packages/app dev:cloud-only",
     "dev:desktop": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",

--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -36,6 +36,7 @@ import {
 import {
   getFirstRunProviderOption,
   normalizeFirstRunProviderId,
+  resolveDevCloudEnvAuthority,
 } from "@elizaos/shared";
 import {
   applyFirstRunConnectionConfig,
@@ -186,6 +187,15 @@ async function handleUpdateAiProvider(
       "UNKNOWN_PROVIDER",
       `Unknown AI provider: ${rawProvider}. Use one from the first-run catalog (anthropic, openai, openrouter, gemini, grok, groq, deepseek, mistral, together, ollama, zai, elizacloud).`,
       { provider: rawProvider },
+    );
+  }
+
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
+  if (normalizedProvider === "elizacloud" && devCloudAuthority) {
+    return fail(
+      "DEV_CLOUD_AUTHORITY_ACTIVE",
+      "Cloud provider activation is owned by the immutable local dev launch target; restart with the intended target and credential.",
+      { provider: normalizedProvider, authority: devCloudAuthority },
     );
   }
 

--- a/packages/agent/src/actions/settings-chat-config-ops.test.ts
+++ b/packages/agent/src/actions/settings-chat-config-ops.test.ts
@@ -37,6 +37,10 @@ import {
   type World,
   type WorldSettings,
 } from "@elizaos/core";
+import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { settingsAction } from "./settings-actions.ts";
 
@@ -56,6 +60,16 @@ let tempDir: string;
 let configPath: string;
 let priorConfigPath: string | undefined;
 let priorPersistPath: string | undefined;
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_ENABLED",
+] as const;
+const originalAuthorityEnv = Object.fromEntries(
+  AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
 
 function readConfig(): Record<string, unknown> {
   return JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<
@@ -65,6 +79,8 @@ function readConfig(): Record<string, unknown> {
 }
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "settings-chat-ops-"));
   configPath = path.join(tempDir, "eliza.json");
   // Seed a minimal-but-real config so load/merge/save exercise the real path.
@@ -86,6 +102,12 @@ afterEach(() => {
   if (priorPersistPath === undefined)
     delete process.env.ELIZA_PERSIST_CONFIG_PATH;
   else process.env.ELIZA_PERSIST_CONFIG_PATH = priorPersistPath;
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = originalAuthorityEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
@@ -123,6 +145,50 @@ describe("SETTINGS action — always available at the chat boundary", () => {
 });
 
 describe("SETTINGS update_ai_provider — persists to the real config store", () => {
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "rejects elizacloud under frozen %s authority before loading or mutating config",
+    async (authority) => {
+      const invalidConfig = "{ deliberately invalid config";
+      fs.writeFileSync(configPath, invalidConfig);
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        authority === "self-hosted"
+          ? "https://private.example:8787/api/v1"
+          : "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+      process.env.ELIZAOS_CLOUD_ENABLED = "true";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-hostile-key";
+      const environmentBefore = {
+        apiKey: process.env.ELIZAOS_CLOUD_API_KEY,
+        enabled: process.env.ELIZAOS_CLOUD_ENABLED,
+      };
+      const result = await invoke({
+        action: "update_ai_provider",
+        provider: "elizacloud",
+        apiKey: "request-key",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data).toMatchObject({
+        error: "DEV_CLOUD_AUTHORITY_ACTIVE",
+        provider: "elizacloud",
+        authority,
+      });
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(invalidConfig);
+      expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe(environmentBefore.apiKey);
+      expect(process.env.ELIZAOS_CLOUD_ENABLED).toBe(environmentBefore.enabled);
+    },
+  );
+
   it('"switch my model provider to openai" writes provider routing to eliza.json', async () => {
     const result = await invoke({
       action: "update_ai_provider",

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -5,6 +5,10 @@ import { Socket } from "node:net";
 import { runInNewContext } from "node:vm";
 import { logger } from "@elizaos/core";
 import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import {
   CLOUD_PAIR_LEGACY_STORAGE_KEY,
   CLOUD_PAIR_LOCAL_OWNER_HINT_KEY,
   cloudPairTokenKeyForAgent,
@@ -35,7 +39,10 @@ interface FakeRes {
 }
 
 const AGENT_ID = "55555555-5555-4555-8555-555555555555";
+const HOSTILE_AGENT_ID = "99999999-9999-4999-8999-999999999999";
 const MANAGED_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
   "ELIZA_CLOUD_PROVISIONED",
   "ELIZA_CLOUD_PAIR_DIRECT_RELAY",
   "ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS",
@@ -140,6 +147,7 @@ function fakeReq(opts: {
 const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   __resetCloudPairRateLimitForTests();
   clearManagedEnv();
   process.env.ELIZA_CLOUD_PROVISIONED = "1";
@@ -151,9 +159,113 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   vi.unstubAllGlobals();
   restoreManagedEnv();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("handleStandaloneCloudPairRoute", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "keeps the relay disabled under frozen %s authority despite late env pollution",
+    async (authority) => {
+      delete process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY;
+      delete process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS;
+      delete process.env.ELIZA_CLOUD_AGENT_ID;
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api-staging.eliza.app/api/v1";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY = "1";
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "203.0.113.0/24";
+      process.env.ELIZA_CLOUD_AGENT_ID = HOSTILE_AGENT_ID;
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=late-token" }),
+        harness.res,
+      );
+
+      expect(harness.status()).toBe(421);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      authority: "staging-explicit" as const,
+      launchBase: "https://api-staging.eliza.app/api/v1",
+      exchangeUrl: "https://api-staging.eliza.app/api/auth/pair",
+    },
+    {
+      authority: "self-hosted" as const,
+      launchBase: "https://private.example:8787/api/v1",
+      exchangeUrl: "https://private.example:8787/api/auth/pair",
+    },
+  ])(
+    "uses only the frozen $authority relay identity, base, and CIDRs",
+    async ({ authority, launchBase, exchangeUrl }) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBase;
+      process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY = "1";
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "172.17.0.0/16";
+      process.env.ELIZA_CLOUD_AGENT_ID = AGENT_ID;
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY = "0";
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "192.168.0.0/16";
+      process.env.ELIZA_CLOUD_AGENT_ID = HOSTILE_AGENT_ID;
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            apiKey: "agent_secret_value",
+            agentId: AGENT_ID,
+            agentName: "Frozen",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const admitted = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=frozen-token",
+          ip: "172.17.0.2",
+        }),
+        admitted.res,
+      );
+      expect(admitted.status()).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        exchangeUrl,
+        expect.objectContaining({
+          body: JSON.stringify({
+            token: "frozen-token",
+            agentId: AGENT_ID,
+          }),
+        }),
+      );
+
+      fetchMock.mockClear();
+      const lateOnlyPeer = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=late-token",
+          ip: "192.168.1.2",
+        }),
+        lateOnlyPeer.res,
+      );
+      expect(lateOnlyPeer.status()).toBe(421);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("falls through for non-pair paths", async () => {
     const harness = fakeRes();
     await expect(

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -19,6 +19,9 @@ import { logger } from "@elizaos/core";
 import {
   isLoopbackRemoteAddress,
   isRemoteAddressInCidrList,
+  resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
 } from "@elizaos/shared";
 import {
   type CloudPairRelaySession,
@@ -60,19 +63,44 @@ function rateLimitConsume(key: string | null): boolean {
 }
 
 function resolveCloudApiBaseUrl(): string {
-  const raw =
-    process.env.ELIZAOS_CLOUD_BASE_URL ||
-    process.env.NEXT_PUBLIC_API_URL ||
-    "https://api.eliza.app/api/v1";
-  return raw.replace(/\/+$/, "");
+  return resolveCanonicalCloudApiBaseUrl(
+    process.env.NEXT_PUBLIC_API_URL,
+  ).replace(/\/+$/, "");
 }
 
 function resolveCloudAuthRoot(): string {
   return resolveCloudApiBaseUrl().replace(/\/api\/v1\/?$/, "");
 }
 
-function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
-  if (process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY !== "1") return false;
+interface CloudPairRelayPolicy {
+  readonly directRelayEnabled: boolean;
+  readonly allowedPeerCidrs: string | undefined;
+  readonly agentEnv: Readonly<Record<string, string | undefined>>;
+}
+
+function resolveCloudPairRelayPolicy(): CloudPairRelayPolicy {
+  const authority = resolveDevCloudEnvAuthority();
+  const read = (key: string): string | undefined =>
+    authority ? resolveDevCloudAuthorityEnvValue(key) : process.env[key];
+  const activationBlocked =
+    authority === "staging-default" || authority === "offline";
+
+  return Object.freeze({
+    directRelayEnabled:
+      !activationBlocked && read("ELIZA_CLOUD_PAIR_DIRECT_RELAY") === "1",
+    allowedPeerCidrs: read("ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS"),
+    agentEnv: Object.freeze({
+      ELIZA_CLOUD_AGENT_ID: read("ELIZA_CLOUD_AGENT_ID"),
+      WAIFU_ELIZA_CLOUD_AGENT_ID: read("WAIFU_ELIZA_CLOUD_AGENT_ID"),
+    }),
+  });
+}
+
+function canUseManagedDirectRelay(
+  req: http.IncomingMessage,
+  policy: CloudPairRelayPolicy,
+): boolean {
+  if (!policy.directRelayEnabled) return false;
   // The local-only gate must key on the TCP peer, never on request headers:
   // Host and X-Forwarded-Host are client-controlled, so a remote caller
   // could previously spoof a loopback origin and redeem a held pairing token
@@ -84,10 +112,7 @@ function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
   const peer = req.socket?.remoteAddress;
   return (
     isLoopbackRemoteAddress(peer) ||
-    isRemoteAddressInCidrList(
-      peer,
-      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS,
-    )
+    isRemoteAddressInCidrList(peer, policy.allowedPeerCidrs)
   );
 }
 
@@ -203,7 +228,10 @@ export async function handleStandaloneCloudPairRoute(
   const url = new URL(req.url ?? "/", "http://localhost");
   if (method !== "GET" || url.pathname !== "/pair") return false;
 
-  if (!canUseManagedDirectRelay(req)) {
+  // Capture every authority-owned relay input once per request. Later env
+  // writes cannot enable a blocked relay or redirect an admitted exchange.
+  const relayPolicy = resolveCloudPairRelayPolicy();
+  if (!canUseManagedDirectRelay(req, relayPolicy)) {
     sendHtml(
       res,
       421,
@@ -257,7 +285,7 @@ export async function handleStandaloneCloudPairRoute(
     return true;
   }
 
-  const agentId = resolveCloudPairAgentIdFromEnv(process.env);
+  const agentId = resolveCloudPairAgentIdFromEnv(relayPolicy.agentEnv);
   if (!agentId) {
     sendHtml(
       res,

--- a/packages/agent/src/api/config-routes.test.ts
+++ b/packages/agent/src/api/config-routes.test.ts
@@ -10,6 +10,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority";
+import {
   type ConfigRouteContext,
   configPatchExceedsBound,
   handleConfigRoutes,
@@ -30,6 +34,7 @@ function makeCtx(
   strip: ConfigRouteContext["stripRedactedPlaceholderValuesDeep"],
   options: {
     config?: ConfigRouteContext["config"];
+    allowedTopKeys?: string[];
   } = {},
 ): {
   ctx: ConfigRouteContext;
@@ -54,7 +59,9 @@ function makeCtx(
     stripRedactedPlaceholderValuesDeep: strip,
     patchTouchesProviderSelection: () => false,
     isBlockedEnvKey: () => false,
-    CONFIG_WRITE_ALLOWED_TOP_KEYS: new Set(["ui", "env"]),
+    CONFIG_WRITE_ALLOWED_TOP_KEYS: new Set(
+      options.allowedTopKeys ?? ["ui", "env"],
+    ),
     resolveMcpServersRejection: async () => null,
     resolveMcpTerminalAuthorizationRejection: () => null,
   };
@@ -98,10 +105,24 @@ describe("config patch nest bound", () => {
 describe("config patch persistence", () => {
   const envKey = "ELIZA_CONFIG_ROUTE_ATOMICITY_TEST";
   const previousEnvValue = process.env[envKey];
+  const previousOpenAIKey = process.env.OPENAI_API_KEY;
   const previousConfigPath = process.env.ELIZA_CONFIG_PATH;
+  const authorityEnvKeys = [
+    "ELIZA_DEV_SOURCE",
+    "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+    "ELIZA_DEV_CLOUD_TARGET",
+    "ELIZAOS_CLOUD_API_KEY",
+    "ELIZAOS_CLOUD_BASE_URL",
+  ] as const;
+  const previousAuthorityEnv = Object.fromEntries(
+    authorityEnvKeys.map((key) => [key, process.env[key]]),
+  );
   let tempDir = "";
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    for (const key of authorityEnvKeys) delete process.env[key];
+    delete process.env.OPENAI_API_KEY;
     tempDir = mkdtempSync(path.join(tmpdir(), "eliza-config-route-"));
     process.env.ELIZA_CONFIG_PATH = path.join(tempDir, "eliza.json");
   });
@@ -117,6 +138,17 @@ describe("config patch persistence", () => {
     } else {
       process.env.ELIZA_CONFIG_PATH = previousConfigPath;
     }
+    if (previousOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = previousOpenAIKey;
+    }
+    for (const key of authorityEnvKeys) {
+      const value = previousAuthorityEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -211,5 +243,382 @@ describe("config patch persistence", () => {
       expect(error).not.toHaveBeenCalled();
       expect(json).toHaveBeenCalledWith(ctx.res, entry.expected);
     }
+  });
+
+  it("strips forged launcher authority from direct and nested env patches", async () => {
+    for (const key of [
+      "ELIZA_DEV_SOURCE",
+      "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+      "ELIZA_DEV_CLOUD_TARGET",
+    ]) {
+      delete process.env[key];
+    }
+    resetDevCloudEnvAuthorityForTests();
+    const config: ConfigRouteContext["config"] = {};
+    const { ctx, error } = makeCtx(
+      {
+        env: {
+          ELIZA_DEV_SOURCE: "1",
+          vars: {
+            ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-default",
+            ELIZA_DEV_CLOUD_TARGET: "production",
+            [envKey]: "safe-value",
+          },
+        },
+      },
+      vi.fn(),
+      { config },
+    );
+
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(config.env?.ELIZA_DEV_SOURCE).toBeUndefined();
+    expect(config.env?.vars?.ELIZA_DEV_CLOUD_ENV_AUTHORITY).toBeUndefined();
+    expect(config.env?.vars?.ELIZA_DEV_CLOUD_TARGET).toBeUndefined();
+    expect(process.env.ELIZA_DEV_SOURCE).toBeUndefined();
+    expect(process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY).toBeUndefined();
+    expect(process.env.ELIZA_DEV_CLOUD_TARGET).toBeUndefined();
+    expect(process.env[envKey]).toBe("safe-value");
+    expect(resolveDevCloudEnvAuthority()).toBeNull();
+  });
+
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "does not persist Cloud-owned env edits under %s authority",
+    async (authority) => {
+      resetDevCloudEnvAuthorityForTests();
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        authority === "production"
+          ? "https://api.eliza.app/api/v1"
+          : authority === "self-hosted"
+            ? "http://127.0.0.1:8787/api/v1"
+            : "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY =
+        authority === "staging-default" || authority === "offline"
+          ? ""
+          : "launcher-key";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      const config: ConfigRouteContext["config"] = {
+        env: {
+          ELIZAOS_CLOUD_API_KEY: "durable-production-key",
+          vars: {
+            ELIZAOS_CLOUD_BASE_URL: "https://durable.example/api/v1",
+            ELIZAOS_CLOUD_SMALL_MODEL: "durable-cloud-model",
+            [envKey]: "before",
+          },
+        },
+      };
+      const durableCloudBefore = structuredClone(config.env);
+      const launchBase = process.env.ELIZAOS_CLOUD_BASE_URL;
+      const launchKey = process.env.ELIZAOS_CLOUD_API_KEY;
+      const { ctx, error } = makeCtx(
+        {
+          env: {
+            ELIZAOS_CLOUD_API_KEY: "late-production-key",
+            vars: {
+              ELIZAOS_CLOUD_BASE_URL: "https://api.attacker.example/v1",
+              ELIZAOS_CLOUD_SMALL_MODEL: "late-cloud-model",
+              [envKey]: "safe-after",
+            },
+          },
+        },
+        vi.fn(),
+        { config },
+      );
+
+      expect(await handleConfigRoutes(ctx)).toBe(true);
+      expect(error).not.toHaveBeenCalled();
+      expect(config.env?.ELIZAOS_CLOUD_API_KEY).toBe(
+        durableCloudBefore?.ELIZAOS_CLOUD_API_KEY,
+      );
+      expect(config.env?.vars?.ELIZAOS_CLOUD_BASE_URL).toBe(
+        durableCloudBefore?.vars?.ELIZAOS_CLOUD_BASE_URL,
+      );
+      expect(config.env?.vars?.ELIZAOS_CLOUD_SMALL_MODEL).toBe(
+        durableCloudBefore?.vars?.ELIZAOS_CLOUD_SMALL_MODEL,
+      );
+      expect(config.env?.vars?.[envKey]).toBe("safe-after");
+      expect(process.env[envKey]).toBe("safe-after");
+      expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBe(launchBase);
+      expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe(launchKey);
+      const persisted = JSON.parse(
+        readFileSync(process.env.ELIZA_CONFIG_PATH as string, "utf8"),
+      ) as ConfigRouteContext["config"];
+      expect(persisted.env?.ELIZAOS_CLOUD_API_KEY).toBe(
+        durableCloudBefore?.ELIZAOS_CLOUD_API_KEY,
+      );
+      expect(persisted.env?.vars?.ELIZAOS_CLOUD_BASE_URL).toBe(
+        durableCloudBefore?.vars?.ELIZAOS_CLOUD_BASE_URL,
+      );
+      expect(persisted.env?.vars?.ELIZAOS_CLOUD_SMALL_MODEL).toBe(
+        durableCloudBefore?.vars?.ELIZAOS_CLOUD_SMALL_MODEL,
+      );
+    },
+  );
+
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "preserves durable Cloud topology under %s authority while applying unrelated topology",
+    async (authority) => {
+      resetDevCloudEnvAuthorityForTests();
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        authority === "production"
+          ? "https://api.eliza.app/api/v1"
+          : authority === "self-hosted"
+            ? "http://127.0.0.1:8787/api/v1"
+            : "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY =
+        authority === "staging-default" || authority === "offline"
+          ? ""
+          : "launcher-key";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      const config: ConfigRouteContext["config"] = {
+        cloud: {
+          apiKey: "durable-production-key",
+          baseUrl: "https://durable.example/api/v1",
+          enabled: true,
+        },
+        deploymentTarget: { runtime: "remote", provider: "elizacloud" },
+        linkedAccounts: {
+          elizacloud: { status: "linked", source: "api-key" },
+          "openai-codex": { status: "linked", source: "oauth" },
+        },
+        serviceRouting: {
+          llmText: {
+            backend: "elizacloud",
+            transport: "cloud-proxy",
+            accountId: "elizacloud",
+            largeModel: "durable-cloud-model",
+          },
+          media: { backend: "local-media", transport: "direct" },
+        },
+      } as ConfigRouteContext["config"];
+      const durableCloudBefore = structuredClone({
+        cloud: config.cloud,
+        deploymentTarget: config.deploymentTarget,
+        linkedAccount: config.linkedAccounts?.elizacloud,
+        cloudRoute: config.serviceRouting?.llmText,
+      });
+      const { ctx, error } = makeCtx(
+        {
+          cloud: {
+            apiKey: "replacement-key",
+            baseUrl: "https://attacker.example/api/v1",
+            enabled: true,
+          },
+          deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+          linkedAccounts: {
+            elizacloud: { status: "unlinked", source: "credentials" },
+            "anthropic-subscription": {
+              status: "linked",
+              source: "subscription",
+            },
+          },
+          serviceRouting: {
+            llmText: {
+              backend: "elizacloud",
+              transport: "cloud-proxy",
+              accountId: "elizacloud",
+              largeModel: "replacement-cloud-model",
+            },
+            tts: { backend: "eliza-cloud", transport: "cloud-proxy" },
+            media: { backend: "direct-media-v2", transport: "direct" },
+          },
+        },
+        vi.fn(),
+        {
+          config,
+          allowedTopKeys: [
+            "cloud",
+            "deploymentTarget",
+            "linkedAccounts",
+            "serviceRouting",
+          ],
+        },
+      );
+
+      expect(await handleConfigRoutes(ctx)).toBe(true);
+      expect(error).not.toHaveBeenCalled();
+      expect(config.cloud).toEqual(durableCloudBefore.cloud);
+      expect(config.deploymentTarget).toEqual(
+        durableCloudBefore.deploymentTarget,
+      );
+      expect(config.linkedAccounts?.elizacloud).toEqual(
+        durableCloudBefore.linkedAccount,
+      );
+      expect(config.serviceRouting?.llmText).toEqual(
+        durableCloudBefore.cloudRoute,
+      );
+      expect(config.linkedAccounts?.["anthropic-subscription"]).toEqual({
+        status: "linked",
+        source: "subscription",
+      });
+      expect(config.serviceRouting?.media).toEqual({
+        backend: "direct-media-v2",
+        transport: "direct",
+      });
+      expect(config.serviceRouting?.tts).toBeUndefined();
+    },
+  );
+
+  it("preserves legacy top-level Cloud topology writes without launcher authority", async () => {
+    const config: ConfigRouteContext["config"] = {};
+    const { ctx, error } = makeCtx(
+      {
+        cloud: {
+          apiKey: "legacy-key",
+          baseUrl: "https://legacy.example/api/v1",
+          enabled: true,
+        },
+        deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+        linkedAccounts: {
+          elizacloud: { status: "linked", source: "api-key" },
+        },
+        serviceRouting: {
+          llmText: {
+            backend: "elizacloud",
+            transport: "cloud-proxy",
+            accountId: "elizacloud",
+          },
+        },
+      },
+      vi.fn(),
+      {
+        config,
+        allowedTopKeys: [
+          "cloud",
+          "deploymentTarget",
+          "linkedAccounts",
+          "serviceRouting",
+        ],
+      },
+    );
+
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(config.cloud).toMatchObject({
+      apiKey: "legacy-key",
+      baseUrl: "https://legacy.example/api/v1",
+      enabled: true,
+    });
+    expect(config.deploymentTarget).toEqual({
+      runtime: "cloud",
+      provider: "elizacloud",
+    });
+    expect(config.linkedAccounts?.elizacloud).toEqual({
+      status: "linked",
+      source: "api-key",
+    });
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+      accountId: "elizacloud",
+    });
+  });
+
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "rejects config reload under %s authority before any side effect",
+    async (authority) => {
+      resetDevCloudEnvAuthorityForTests();
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        authority === "production"
+          ? "https://api.eliza.app/api/v1"
+          : authority === "self-hosted"
+            ? "http://127.0.0.1:8787/api/v1"
+            : "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY =
+        authority === "staging-default" || authority === "offline"
+          ? ""
+          : "launcher-key";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      const config: ConfigRouteContext["config"] = {
+        ui: { theme: "eliza" },
+        cloud: { apiKey: "durable-production-key" },
+      };
+      const configBefore = structuredClone(config);
+      const runtime = {
+        character: {
+          name: "Current Agent",
+          settings: { ELIZAOS_CLOUD_API_KEY: "current-runtime-key" },
+        },
+      };
+      const runtimeBefore = structuredClone(runtime.character);
+      process.env.OPENAI_API_KEY = "current-openai-key";
+      writeFileSync(
+        process.env.ELIZA_CONFIG_PATH as string,
+        JSON.stringify({
+          ui: { theme: "haxor" },
+          cloud: { apiKey: "loaded-production-key" },
+          env: { vars: { OPENAI_API_KEY: "loaded-openai-key" } },
+          agents: {
+            defaults: {
+              name: "Loaded Agent",
+              settings: { ELIZAOS_CLOUD_API_KEY: "loaded-runtime-key" },
+            },
+          },
+        }),
+      );
+      const { ctx, error, json } = makeCtx({}, vi.fn(), { config });
+      ctx.method = "POST";
+      ctx.pathname = "/api/config/reload";
+      ctx.runtime = runtime as never;
+
+      expect(await handleConfigRoutes(ctx)).toBe(true);
+      expect(error).toHaveBeenCalledWith(
+        ctx.res,
+        expect.stringContaining("immutable local dev Cloud target"),
+        409,
+      );
+      expect(json).not.toHaveBeenCalled();
+      expect(config).toEqual(configBefore);
+      expect(runtime.character).toEqual(runtimeBefore);
+      expect(process.env.OPENAI_API_KEY).toBe("current-openai-key");
+    },
+  );
+
+  it("preserves config reload behavior without launcher authority", async () => {
+    const config: ConfigRouteContext["config"] = {
+      ui: { theme: "eliza" },
+    };
+    writeFileSync(
+      process.env.ELIZA_CONFIG_PATH as string,
+      JSON.stringify({ ui: { theme: "haxor" } }),
+    );
+    const { ctx, error, json } = makeCtx({}, vi.fn(), { config });
+    ctx.method = "POST";
+    ctx.pathname = "/api/config/reload";
+
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(config.ui?.theme).toBe("haxor");
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ reloaded: true }),
+    );
   });
 });

--- a/packages/agent/src/api/config-routes.ts
+++ b/packages/agent/src/api/config-routes.ts
@@ -24,6 +24,11 @@ import {
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import { loadElizaConfig, saveElizaConfig } from "../config/config.ts";
+import {
+  isDevCloudEnvOwnedKey,
+  isDevCloudInternalEnvKey,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
 import { buildCharacterFromConfig } from "../runtime/build-character-config.ts";
 import {
   hasBlockedObjectKeyDeep,
@@ -74,6 +79,62 @@ export interface ConfigRouteContext {
     servers: Record<string, unknown>,
     body: { terminalToken?: string },
   ) => { reason: string; status: number } | null;
+}
+
+const DEV_CLOUD_PROVIDER_IDS = new Set([
+  "elizacloud",
+  "eliza-cloud",
+  "@elizaos/plugin-elizacloud",
+]);
+
+function isDevCloudProxyRoute(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const route = value as Record<string, unknown>;
+  const backend =
+    typeof route.backend === "string" ? route.backend.trim().toLowerCase() : "";
+  return (
+    route.transport === "cloud-proxy" && DEV_CLOUD_PROVIDER_IDS.has(backend)
+  );
+}
+
+/**
+ * Remove only launcher-owned Cloud topology from a generic config patch.
+ * Unrelated linked accounts and direct-provider routes remain editable in the
+ * same request; the durable Cloud tuple is changed only outside dev authority.
+ */
+function stripDevCloudAuthorityOwnedTopology(
+  filtered: Record<string, unknown>,
+): void {
+  delete filtered.cloud;
+  delete filtered.deploymentTarget;
+
+  const linkedAccounts = filtered.linkedAccounts;
+  if (
+    linkedAccounts &&
+    typeof linkedAccounts === "object" &&
+    !Array.isArray(linkedAccounts)
+  ) {
+    const accounts = linkedAccounts as Record<string, unknown>;
+    for (const accountId of Object.keys(accounts)) {
+      if (DEV_CLOUD_PROVIDER_IDS.has(accountId.trim().toLowerCase())) {
+        delete accounts[accountId];
+      }
+    }
+    if (Object.keys(accounts).length === 0) delete filtered.linkedAccounts;
+  }
+
+  const serviceRouting = filtered.serviceRouting;
+  if (
+    serviceRouting &&
+    typeof serviceRouting === "object" &&
+    !Array.isArray(serviceRouting)
+  ) {
+    const routes = serviceRouting as Record<string, unknown>;
+    for (const capability of Object.keys(routes)) {
+      if (isDevCloudProxyRoute(routes[capability])) delete routes[capability];
+    }
+    if (Object.keys(routes).length === 0) delete filtered.serviceRouting;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -309,6 +370,14 @@ export async function handleConfigRoutes(
   // still require a full restart (plugin list, provider/model registry,
   // database adapter).
   if (method === "POST" && pathname === "/api/config/reload") {
+    if (resolveDevCloudEnvAuthority()) {
+      error(
+        res,
+        "Config reload is disabled while the immutable local dev Cloud target owns runtime configuration; restart the development process to reload safely.",
+        409,
+      );
+      return true;
+    }
     let next: ElizaConfig;
     try {
       next = loadElizaConfig();
@@ -419,6 +488,10 @@ export async function handleConfigRoutes(
       error(res, "config patch exceeds the nesting-depth limit", 400);
       return true;
     }
+    // Capture authority before inspecting the untrusted patch. Persisted/API
+    // config must never be able to manufacture the launcher-only marker.
+    const devCloudAuthority = resolveDevCloudEnvAuthority();
+    if (devCloudAuthority) stripDevCloudAuthorityOwnedTopology(filtered);
 
     // Security: keep auth/step-up secrets out of API-driven config writes so
     // secret rotation remains an out-of-band operation.
@@ -460,7 +533,7 @@ export async function handleConfigRoutes(
       // chain is closed.
       for (const key of Object.keys(envPatch)) {
         if (key === "vars" || key === "shellEnv") continue;
-        if (isBlockedEnvKey(key)) {
+        if (isBlockedEnvKey(key) || isDevCloudInternalEnvKey(key)) {
           delete envPatch[key];
         }
       }
@@ -471,10 +544,36 @@ export async function handleConfigRoutes(
       ) {
         const innerVars = envPatch.vars as Record<string, unknown>;
         for (const key of Object.keys(innerVars)) {
-          if (isBlockedEnvKey(key)) {
+          if (isBlockedEnvKey(key) || isDevCloudInternalEnvKey(key)) {
             delete innerVars[key];
           }
         }
+      }
+
+      // A launcher authority owns Cloud-prefixed environment fields for the
+      // lifetime of this development process. Do not merely suppress their
+      // live process.env projection below: persisting a request value would
+      // silently replace the operator's durable production/self-hosted config
+      // for the next non-authoritative launch. Preserve unrelated env edits in
+      // the same request.
+      if (devCloudAuthority) {
+        for (const key of Object.keys(envPatch)) {
+          if (key !== "vars" && isDevCloudEnvOwnedKey(key)) {
+            delete envPatch[key];
+          }
+        }
+        if (
+          envPatch.vars &&
+          typeof envPatch.vars === "object" &&
+          !Array.isArray(envPatch.vars)
+        ) {
+          const vars = envPatch.vars as Record<string, unknown>;
+          for (const key of Object.keys(vars)) {
+            if (isDevCloudEnvOwnedKey(key)) delete vars[key];
+          }
+          if (Object.keys(vars).length === 0) delete envPatch.vars;
+        }
+        if (Object.keys(envPatch).length === 0) delete filtered.env;
       }
     }
 
@@ -642,7 +741,13 @@ export async function handleConfigRoutes(
       const vars = envPatch.vars;
       if (vars && typeof vars === "object" && !Array.isArray(vars)) {
         for (const [k, v] of Object.entries(vars as Record<string, unknown>)) {
-          if (isBlockedEnvKey(k)) continue;
+          if (
+            isBlockedEnvKey(k) ||
+            isDevCloudInternalEnvKey(k) ||
+            (devCloudAuthority && isDevCloudEnvOwnedKey(k))
+          ) {
+            continue;
+          }
           const str = typeof v === "string" ? v : "";
           if (str.trim()) {
             process.env[k] = str;
@@ -655,7 +760,13 @@ export async function handleConfigRoutes(
       // 2) Direct env.* string keys (legacy)
       for (const [k, v] of Object.entries(envPatch)) {
         if (k === "vars" || k === "shellEnv") continue;
-        if (isBlockedEnvKey(k)) continue;
+        if (
+          isBlockedEnvKey(k) ||
+          isDevCloudInternalEnvKey(k) ||
+          (devCloudAuthority && isDevCloudEnvOwnedKey(k))
+        ) {
+          continue;
+        }
         if (typeof v !== "string") continue;
         if (v.trim()) process.env[k] = v;
         else delete process.env[k];

--- a/packages/agent/src/api/first-run-routes.ts
+++ b/packages/agent/src/api/first-run-routes.ts
@@ -37,6 +37,10 @@ import {
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import { configFileExists, loadElizaConfig } from "../config/config.ts";
+import {
+  captureDevCloudEnvAuthority,
+  restoreDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
 import { resolveDefaultAgentWorkspaceDir } from "../shared/workspace-resolution.ts";
 import {
   applyCanonicalFirstRunConfig,
@@ -363,6 +367,7 @@ export async function handleFirstRunRoutes(
 
   // ── POST /api/first-run ────────────────────────────────────────────
   if (method === "POST" && pathname === "/api/first-run") {
+    const devCloudSnapshot = captureDevCloudEnvAuthority();
     const rawFirstRun = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawFirstRun === null) return true;
     const parsedFirstRun = PostFirstRunRequestSchema.safeParse(rawFirstRun);
@@ -514,13 +519,17 @@ export async function handleFirstRunRoutes(
       body,
       "credentialInputs",
     );
-    const explicitCredentialInputs = explicitCredentialInputsRequested
+    const parsedCredentialInputs = explicitCredentialInputsRequested
       ? normalizeFirstRunCredentialInputs(body.credentialInputs)
       : null;
-    if (explicitCredentialInputsRequested && !explicitCredentialInputs) {
+    if (explicitCredentialInputsRequested && !parsedCredentialInputs) {
       error(res, "Invalid credentialInputs", 400);
       return true;
     }
+    const explicitCredentialInputs =
+      devCloudSnapshot && parsedCredentialInputs
+        ? { ...parsedCredentialInputs, cloudApiKey: undefined }
+        : parsedCredentialInputs;
     const hasCanonicalRuntimeConfig =
       explicitDeploymentTargetRequested ||
       explicitLinkedAccountsRequested ||
@@ -565,26 +574,38 @@ export async function handleFirstRunRoutes(
             : [],
       });
 
-      await applyFirstRunCredentialPersistence(config, {
-        credentialInputs: explicitCredentialInputs,
-        deploymentTarget:
-          normalizedDeploymentTarget ??
-          normalizeDeploymentTargetConfig(config.deploymentTarget),
-        serviceRouting:
-          normalizedServiceRouting ??
-          normalizeServiceRoutingConfig(config.serviceRouting),
-      });
+      try {
+        await applyFirstRunCredentialPersistence(config, {
+          credentialInputs: explicitCredentialInputs,
+          deploymentTarget:
+            normalizedDeploymentTarget ??
+            normalizeDeploymentTargetConfig(config.deploymentTarget),
+          serviceRouting:
+            normalizedServiceRouting ??
+            normalizeServiceRoutingConfig(config.serviceRouting),
+        });
 
-      delete process.env.ELIZAOS_CLOUD_ENABLED;
-      delete process.env.ELIZAOS_CLOUD_NANO_MODEL;
-      delete process.env.ELIZAOS_CLOUD_MEDIUM_MODEL;
-      delete process.env.ELIZAOS_CLOUD_SMALL_MODEL;
-      delete process.env.ELIZAOS_CLOUD_LARGE_MODEL;
-      delete process.env.ELIZAOS_CLOUD_MEGA_MODEL;
-      delete process.env.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL;
-      delete process.env.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL;
-      delete process.env.ELIZAOS_CLOUD_ACTION_PLANNER_MODEL;
-      delete process.env.ELIZAOS_CLOUD_PLANNER_MODEL;
+        delete process.env.ELIZAOS_CLOUD_ENABLED;
+        delete process.env.ELIZAOS_CLOUD_NANO_MODEL;
+        delete process.env.ELIZAOS_CLOUD_MEDIUM_MODEL;
+        delete process.env.ELIZAOS_CLOUD_SMALL_MODEL;
+        delete process.env.ELIZAOS_CLOUD_LARGE_MODEL;
+        delete process.env.ELIZAOS_CLOUD_MEGA_MODEL;
+        delete process.env.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL;
+        delete process.env.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL;
+        delete process.env.ELIZAOS_CLOUD_ACTION_PLANNER_MODEL;
+        delete process.env.ELIZAOS_CLOUD_PLANNER_MODEL;
+
+        if (
+          !isCloudInferenceSelectedInConfig(config as Record<string, unknown>)
+        ) {
+          delete process.env.ELIZAOS_CLOUD_API_KEY;
+        }
+      } finally {
+        if (devCloudSnapshot) {
+          restoreDevCloudEnvAuthority(devCloudSnapshot);
+        }
+      }
 
       if (config.models && typeof config.models === "object") {
         const legacyModels = config.models as Record<string, unknown>;
@@ -593,12 +614,6 @@ export async function handleFirstRunRoutes(
         delete legacyModels.medium;
         delete config.models.large;
         delete legacyModels.mega;
-      }
-
-      if (
-        !isCloudInferenceSelectedInConfig(config as Record<string, unknown>)
-      ) {
-        delete process.env.ELIZAOS_CLOUD_API_KEY;
       }
     }
     if (hasCanonicalRuntimeConfig && config.agents.defaults.model) {

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -29,6 +29,7 @@ import {
   parseCanonicalInteger,
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
+import { createDevCloudConfigAuthorityView } from "../config/dev-cloud-env-authority.ts";
 import { getDeferredBootStatus } from "../runtime/deferred-boot-status.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
 import type { ConnectorHealthMonitor } from "./connector-health.ts";
@@ -507,6 +508,7 @@ export async function handleHealthRoutes(
 
   // ── GET /api/status ─────────────────────────────────────────────────────
   if (method === "GET" && pathname === "/api/status") {
+    const effectiveConfig = createDevCloudConfigAuthorityView(state.config);
     const uptime = state.startedAt ? Date.now() - state.startedAt : undefined;
     // The active-model snapshot is optional status info; never let an
     // unavailable local-inference API turn /api/status into a 500. The deep
@@ -535,7 +537,7 @@ export async function handleHealthRoutes(
     // the one serving now. Resolve live first and keep the cache only as the
     // fallback for a runtime we can no longer inspect (#20045 review).
     const model =
-      detectRuntimeModel(state.runtime ?? null, state.config) ??
+      detectRuntimeModel(state.runtime ?? null, effectiveConfig) ??
       activeLocalModel ??
       state.model;
     // Managed hosting detection is a pure env check from @elizaos/shared and
@@ -546,7 +548,9 @@ export async function handleHealthRoutes(
     let hasCloudApiKey = false;
     try {
       const { resolveCloudApiKey } = await getCloudApiKeyResolver();
-      hasCloudApiKey = Boolean(resolveCloudApiKey(state.config, state.runtime));
+      hasCloudApiKey = Boolean(
+        resolveCloudApiKey(effectiveConfig, state.runtime),
+      );
     } catch {
       // error-policy:J4 optional cloud API-key probe must not fail /api/status
     }

--- a/packages/agent/src/api/mobile-optional-routes.ts
+++ b/packages/agent/src/api/mobile-optional-routes.ts
@@ -16,7 +16,7 @@ import {
   isMobilePlatform,
   normalizeDeploymentTargetConfig,
 } from "@elizaos/shared";
-import { loadElizaConfig } from "../config/config.ts";
+import { loadEffectiveElizaConfig } from "../config/config.ts";
 import { resolveAbsentPluginRouteStub } from "./absent-plugin-route-stubs.ts";
 
 /**
@@ -135,7 +135,7 @@ function getRuntimeModeFallbackSnapshot(): {
     };
   }
   const deploymentTarget = normalizeDeploymentTargetConfig(
-    loadElizaConfig().deploymentTarget,
+    loadEffectiveElizaConfig().deploymentTarget,
   );
   const deploymentRuntime = deploymentTarget?.runtime ?? "local";
   return {

--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -9,8 +9,9 @@
  */
 import type http from "node:http";
 import { ModelType } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ElizaConfig } from "../config/config";
+import { resetDevCloudEnvAuthorityForTests } from "../config/dev-cloud-env-authority";
 import { buildModelCatalog } from "./model-catalog";
 import { handleModelConfigRoutes } from "./model-config-routes";
 
@@ -19,6 +20,11 @@ const catalog = buildModelCatalog({
     throw new Error("ENOENT");
   },
   env: {} as NodeJS.ProcessEnv,
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 interface HarnessOptions {
@@ -189,6 +195,87 @@ describe("POST /api/models/config validation", () => {
 });
 
 describe("POST /api/models/config chat writes", () => {
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "rejects Cloud model writes under %s authority without side effects",
+    async (authority) => {
+      vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+      vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", authority);
+      vi.stubEnv(
+        "ELIZAOS_CLOUD_BASE_URL",
+        authority === "production"
+          ? "https://api.eliza.app/api/v1"
+          : authority === "self-hosted"
+            ? "http://127.0.0.1:8787/api/v1"
+            : "https://api-staging.eliza.app/api/v1",
+      );
+      vi.stubEnv(
+        "ELIZAOS_CLOUD_API_KEY",
+        authority === "staging-default" || authority === "offline"
+          ? ""
+          : "launcher-key",
+      );
+      const config = {
+        env: {
+          ELIZAOS_CLOUD_LARGE_MODEL: "durable-cloud-model",
+          vars: { ELIZAOS_CLOUD_LARGE_MODEL: "durable-cloud-model" },
+        },
+      } as ElizaConfig;
+      const before = structuredClone(config);
+      const processEnv = {
+        ELIZAOS_CLOUD_LARGE_MODEL: "durable-process-model",
+      } as NodeJS.ProcessEnv;
+      const managerStart = vi.fn();
+      const { ctx, json, saveElizaConfig } = makeHarness(
+        "POST",
+        {
+          target: "large",
+          provider: "elizacloud",
+          model: "zai-glm-4.7",
+          effort: "high",
+        },
+        { config, processEnv, managerStart },
+      );
+
+      await handleModelConfigRoutes(ctx as never);
+
+      expect(responseOf(json).status).toBe(409);
+      expect(managerStart).not.toHaveBeenCalled();
+      expect(saveElizaConfig).not.toHaveBeenCalled();
+      expect(config).toEqual(before);
+      expect(processEnv).toEqual({
+        ELIZAOS_CLOUD_LARGE_MODEL: "durable-process-model",
+      });
+    },
+  );
+
+  it("still applies a direct-provider model write under Cloud authority", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-default");
+    vi.stubEnv(
+      "ELIZAOS_CLOUD_BASE_URL",
+      "https://api-staging.eliza.app/api/v1",
+    );
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "");
+    const { ctx, config, processEnv, saveElizaConfig, managerStart } =
+      makeHarness("POST", {
+        target: "large",
+        provider: "cerebras",
+        model: "gpt-oss-120b",
+      });
+
+    await handleModelConfigRoutes(ctx as never);
+
+    expect(managerStart).toHaveBeenCalledOnce();
+    expect(saveElizaConfig).toHaveBeenCalledWith(config);
+    expect(processEnv.OPENAI_LARGE_MODEL).toBe("gpt-oss-120b");
+  });
+
   it("writes both config seams + process.env and requests a restart", async () => {
     const { ctx, json, saveElizaConfig, managerStart, config, processEnv } =
       makeHarness("POST", {

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -44,6 +44,10 @@ import {
   resolveServiceRoutingInConfig,
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
+import {
+  isDevCloudEnvOwnedKey,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
 import type { RuntimeOperationManager } from "../runtime/operations/index.ts";
 import { hasCloudTextHandlerRegistered } from "./agent-model.ts";
 import {
@@ -728,6 +732,10 @@ export async function handleModelConfigRoutes(
   const { req, res, method, pathname, state, json, readJsonBody } = ctx;
   if (pathname !== "/api/models/config") return false;
   const processEnv = ctx.processEnv ?? process.env;
+  // Capture launcher ownership before reading the request. The model route may
+  // edit non-Cloud providers during local development, but Cloud-prefixed
+  // model selections belong to the immutable launch tuple.
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
 
   if (method === "GET") {
     const activeChat = resolveActiveChat(
@@ -783,6 +791,20 @@ export async function handleModelConfigRoutes(
       body,
       resolveActiveChat(state.config, processEnv, state.runtime)?.provider,
     );
+    if (
+      devCloudAuthority &&
+      writes.some((write) => isDevCloudEnvOwnedKey(write.key))
+    ) {
+      json(
+        res,
+        {
+          error:
+            "Cloud model selection is owned by the immutable local dev launch target; restart with the intended Cloud model configuration.",
+        },
+        409,
+      );
+      return true;
+    }
     const conflicts: string[] = [];
     const outcome = await ctx.runtimeOperationManager.start({
       intent: {

--- a/packages/agent/src/api/provider-switch-routes.test.ts
+++ b/packages/agent/src/api/provider-switch-routes.test.ts
@@ -7,8 +7,9 @@
 import type http from "node:http";
 import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import type { SecretsManager } from "@elizaos/vault";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
+import { resetDevCloudEnvAuthorityForTests } from "../config/dev-cloud-env-authority.ts";
 import type {
   OperationIntent,
   RuntimeOperation,
@@ -26,11 +27,22 @@ const CLOUD_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
   "OPENAI_BASE_URL",
   "OPENAI_API_KEY",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_ENABLED",
 ] as const;
 
 const originalCloudEnv = Object.fromEntries(
   CLOUD_ENV_KEYS.map((key) => [key, process.env[key]]),
 );
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of CLOUD_ENV_KEYS) delete process.env[key];
+});
 
 afterEach(() => {
   for (const key of CLOUD_ENV_KEYS) {
@@ -38,6 +50,7 @@ afterEach(() => {
     if (original === undefined) delete process.env[key];
     else process.env[key] = original;
   }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 function operation(
@@ -104,8 +117,9 @@ function makeContext(args: {
   headers?: http.IncomingHttpHeaders;
   manager?: RuntimeOperationManager;
   secretsManager?: SecretsManager;
+  config?: ElizaConfig;
 }) {
-  const config = {} as ElizaConfig;
+  const config = args.config ?? ({} as ElizaConfig);
   const json = vi.fn();
   const error = vi.fn();
   const readJsonBody = vi.fn();
@@ -281,6 +295,57 @@ describe("handleProviderSwitchRoutes", () => {
     expect(process.env.ANTHROPIC_API_KEY).toBe("cloud-key");
     expect(config.cloud?.apiKey).toBe("cloud-key");
   });
+
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "rejects elizacloud switching under %s authority without side effects",
+    async (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "";
+      const manager = managerReturning({
+        kind: "accepted",
+        operation: operation("op-blocked-cloud"),
+      });
+      const durableConfig = {
+        cloud: {
+          apiKey: "durable-unrelated-key",
+          serviceKey: "durable-unrelated-service-key",
+          baseUrl: "https://durable.example/api/v1",
+        },
+      } as ElizaConfig;
+      const durableBefore = structuredClone(durableConfig);
+      const { ctx, config, error, saveElizaConfig } = makeContext({
+        body: { provider: "elizacloud", apiKey: "request-production-key" },
+        manager,
+        config: durableConfig,
+      });
+
+      await expect(handleProviderSwitchRoutes(ctx)).resolves.toBe(true);
+
+      expect(error).toHaveBeenCalledWith(
+        ctx.res,
+        expect.stringContaining(
+          "owned by the immutable local dev launch target",
+        ),
+        409,
+      );
+      expect(manager.start).not.toHaveBeenCalled();
+      expect(saveElizaConfig).not.toHaveBeenCalled();
+      expect(config).toEqual(durableBefore);
+      expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+      expect(process.env.OPENAI_API_KEY).toBeUndefined();
+      expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+    },
+  );
 
   it.each([
     ["pending", true],

--- a/packages/agent/src/api/provider-switch-routes.ts
+++ b/packages/agent/src/api/provider-switch-routes.ts
@@ -13,6 +13,7 @@ import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import {
   normalizeFirstRunProviderId,
   PostProviderSwitchRequestSchema,
+  resolveDevCloudEnvAuthority,
 } from "@elizaos/shared";
 import type { SecretsManager } from "@elizaos/vault";
 import type { ElizaConfig } from "../config/config.ts";
@@ -96,6 +97,15 @@ export async function handleProviderSwitchRoutes(
     }
 
     const trimmedApiKey = body.apiKey;
+    const devCloudAuthority = resolveDevCloudEnvAuthority();
+    if (normalizedProvider === "elizacloud" && devCloudAuthority) {
+      error(
+        res,
+        "Cloud provider activation is owned by the immutable local dev launch target; restart with the intended target and credential.",
+        409,
+      );
+      return true;
+    }
 
     try {
       let connection:
@@ -155,15 +165,14 @@ export async function handleProviderSwitchRoutes(
             }
           }
 
+          await applyFirstRunConnectionConfig(config, connection);
           if (normalizedProvider === "elizacloud" && trimmedApiKey) {
-            const cloudBaseUrl = "https://cloud.eliza.app";
-            process.env.ANTHROPIC_BASE_URL = `${cloudBaseUrl}/api/v1`;
+            const cloudProxyBaseUrl = "https://cloud.eliza.app/api/v1";
+            process.env.ANTHROPIC_BASE_URL = cloudProxyBaseUrl;
             process.env.ANTHROPIC_API_KEY = trimmedApiKey;
-            process.env.OPENAI_BASE_URL = `${cloudBaseUrl}/api/v1`;
+            process.env.OPENAI_BASE_URL = cloudProxyBaseUrl;
             process.env.OPENAI_API_KEY = trimmedApiKey;
           }
-
-          await applyFirstRunConnectionConfig(config, connection);
           ctx.saveElizaConfig(config);
 
           return {

--- a/packages/agent/src/api/runtime-mode/runtime-mode.ts
+++ b/packages/agent/src/api/runtime-mode/runtime-mode.ts
@@ -21,7 +21,7 @@ import {
   normalizeDeploymentTargetConfig,
 } from "@elizaos/shared";
 import * as zod from "zod";
-import { loadElizaConfig } from "../../config/config.ts";
+import { loadEffectiveElizaConfig } from "../../config/config.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
 
@@ -135,12 +135,13 @@ export function resolveRuntimeMode(
  * next request without a restart.
  */
 export function getRuntimeMode(): RuntimeMode {
-  return resolveRuntimeMode(parseRuntimeModeConfig(loadElizaConfig())).mode;
+  return resolveRuntimeMode(parseRuntimeModeConfig(loadEffectiveElizaConfig()))
+    .mode;
 }
 
 /** Disk-backed snapshot. */
 export function getRuntimeModeSnapshot(): RuntimeModeSnapshot {
-  return resolveRuntimeMode(parseRuntimeModeConfig(loadElizaConfig()));
+  return resolveRuntimeMode(parseRuntimeModeConfig(loadEffectiveElizaConfig()));
 }
 
 /** True for both `local` and `local-only`. */

--- a/packages/agent/src/api/server-route-dispatch.test.ts
+++ b/packages/agent/src/api/server-route-dispatch.test.ts
@@ -12,7 +12,11 @@
  */
 import type http from "node:http";
 import type { AgentRuntime, Route } from "@elizaos/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  captureDevCloudEnvAuthority,
+  resetDevCloudEnvAuthorityForTests,
+} from "../config/dev-cloud-env-authority.ts";
 import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability.ts";
 import {
   handleCloudAndCoreRouteGroup,
@@ -46,6 +50,9 @@ type SandboxCtx = Parameters<typeof handleSandboxRouteGroup>[0];
 type DatabaseCtx = Parameters<typeof handleDatabaseRouteGroup>[0];
 type ConversationCtx = Parameters<typeof handleConversationRouteGroup>[0];
 type LifeOpsCtx = Parameters<typeof handleLifeOpsRuntimePluginRoute>[0];
+type CloudPluginState = Parameters<
+  typeof import("@elizaos/plugin-elizacloud/host-routes")["handleCloudRoute"]
+>[4];
 
 function makeRes(): http.ServerResponse {
   const headers: Record<string, string> = {};
@@ -112,6 +119,7 @@ function helpers() {
 }
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   cloudHost.handleCloudRelayRoute.mockClear();
   cloudHost.handleCloudBillingRoute.mockClear();
   cloudHost.handleCloudCompatRoute.mockClear();
@@ -122,6 +130,11 @@ beforeEach(() => {
   cloudHost.handleCloudRoute.mockResolvedValue(true);
   computeUse.handleSandboxRoute.mockClear();
   computeUse.handleSandboxRoute.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("handleInboxAndCloudRelayRouteGroup", () => {
@@ -318,21 +331,226 @@ describe("handleCloudAndCoreRouteGroup", () => {
     expect(cloudHost.handleCloudCompatRoute).toHaveBeenCalledTimes(1);
     expect(cloudHost.handleCloudRoute).toHaveBeenCalledTimes(1);
     const pluginState = cloudHost.handleCloudRoute.mock.calls[0]?.[4] as
-      | {
-          config: unknown;
-          cloudManager: unknown;
-          saveConfig: CloudCtx["saveConfig"];
-          restartRuntime: CloudCtx["restartRuntime"];
-          createTelemetrySpan: typeof createIntegrationTelemetrySpan;
-        }
+      | CloudPluginState
       | undefined;
     expect(pluginState?.config).toEqual({ cloud: true });
     expect(pluginState?.cloudManager).toEqual({ id: "cm" });
-    expect(pluginState?.saveConfig).toBe(args.saveConfig);
     expect(pluginState?.restartRuntime).toBe(args.restartRuntime);
-    expect(pluginState?.createTelemetrySpan).toBe(
+    expect(pluginState?.services?.saveElizaConfig).toBe(args.saveConfig);
+    expect(pluginState?.services?.createIntegrationTelemetrySpan).toBe(
       createIntegrationTelemetrySpan,
     );
+    expect(pluginState).not.toHaveProperty("saveConfig");
+    expect(pluginState).not.toHaveProperty("createTelemetrySpan");
+  });
+
+  it("lets the real disconnect handler persist only its staging-authority working state", async () => {
+    for (const [key, value] of Object.entries(process.env)) {
+      if (key.startsWith("ELIZAOS_CLOUD_") && value !== undefined) {
+        vi.stubEnv(key, value);
+      }
+    }
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-default");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "ambient-prod-key");
+    vi.stubEnv("ELIZAOS_CLOUD_BASE_URL", "https://api.eliza.app/api/v1");
+    resetDevCloudEnvAuthorityForTests();
+
+    const actualCloudHost = await vi.importActual<
+      typeof import("@elizaos/plugin-elizacloud/host-routes")
+    >("@elizaos/plugin-elizacloud/host-routes");
+    cloudHost.handleCloudRoute.mockImplementationOnce(
+      actualCloudHost.handleCloudRoute as unknown as PluginHandler,
+    );
+
+    const durableConfig = {
+      keep: "durable",
+      cloud: {
+        enabled: true,
+        baseUrl: "https://api.eliza.app/api/v1",
+        apiKey: "persisted-prod-key",
+        serviceKey: "persisted-prod-service-key",
+      },
+    };
+    const saveConfig = vi.fn<CloudCtx["saveConfig"]>();
+    const args = ctx("/api/cloud/disconnect");
+    args.req = makeReq("POST", args.pathname);
+    args.method = "POST";
+    args.state = dispatchState({ config: durableConfig });
+    args.saveConfig = saveConfig;
+
+    await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    const savedConfig = saveConfig.mock.calls[0]?.[0];
+    expect(savedConfig).toMatchObject({
+      keep: "durable",
+      deploymentTarget: { runtime: "local" },
+      cloud: {
+        enabled: false,
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+      },
+    });
+    expect(savedConfig?.cloud).not.toHaveProperty("apiKey");
+    expect(savedConfig?.cloud).not.toHaveProperty("serviceKey");
+    expect(JSON.stringify(savedConfig)).not.toContain("persisted-prod");
+    expect(args.state.config).toBe(savedConfig);
+    expect(durableConfig.cloud).toMatchObject({
+      apiKey: "persisted-prod-key",
+      serviceKey: "persisted-prod-service-key",
+    });
+  });
+
+  it("blocks hostile login persistence from mutating runtime state under staging-default authority", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-default");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "");
+    vi.stubEnv("ELIZAOS_CLOUD_ENABLED", "");
+    vi.stubEnv(
+      "ELIZAOS_CLOUD_BASE_URL",
+      "https://api-staging.eliza.app/api/v1",
+    );
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthority();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-process-prod-key";
+    process.env.ELIZAOS_CLOUD_ENABLED = "late-process-sentinel";
+    const cloudAuth = {
+      authenticateWithApiKey: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const relay = { startRelayLoopIfReady: vi.fn() };
+    const runtimeSecrets = {
+      ELIZAOS_CLOUD_API_KEY: "runtime-prod-key",
+      ELIZAOS_CLOUD_ENABLED: "true",
+    };
+    const runtime = {
+      agentId: "runtime-agent",
+      character: { secrets: runtimeSecrets },
+      getService: vi.fn((name: string) => {
+        if (name === "CLOUD_AUTH") return cloudAuth;
+        if (name.includes("GATEWAY_RELAY") || name.includes("gateway-relay")) {
+          return relay;
+        }
+        return null;
+      }),
+      getSetting: vi.fn((key: string) =>
+        key === "ELIZAOS_CLOUD_API_KEY" ? "runtime-prod-key" : undefined,
+      ),
+      setSetting: vi.fn(),
+      updateAgent: vi.fn(async () => undefined),
+    } as unknown as AgentRuntime;
+    const cloudManager = {
+      replaceApiKey: vi.fn(async () => undefined),
+      getClient: vi.fn(() => null),
+      init: vi.fn(async () => undefined),
+    };
+    const durableConfig = {
+      keep: "durable",
+      cloud: {
+        enabled: true,
+        baseUrl: "https://api.eliza.app/api/v1",
+        apiKey: "persisted-prod-key",
+      },
+    };
+    const saveConfig = vi.fn<CloudCtx["saveConfig"]>();
+    const actualCloudHost = await vi.importActual<
+      typeof import("@elizaos/plugin-elizacloud/host-routes")
+    >("@elizaos/plugin-elizacloud/host-routes");
+    cloudHost.handleCloudRoute.mockImplementationOnce(
+      actualCloudHost.handleCloudRoute as unknown as PluginHandler,
+    );
+    const args = ctx("/api/cloud/login/persist");
+    args.method = "POST";
+    args.req = makeReq("POST", args.pathname);
+    (args.req as http.IncomingMessage & { body?: unknown }).body = {
+      apiKey: "hostile-body-prod-key",
+      organizationId: "prod-org",
+      userId: "prod-user",
+      forceInferenceEnabled: true,
+    };
+    args.res = makeRes();
+    args.state = dispatchState({
+      config: durableConfig,
+      runtime,
+      cloudManager,
+    });
+    args.saveConfig = saveConfig;
+
+    await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
+
+    expect(args.res.statusCode).toBe(409);
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(args.state.config).toBe(durableConfig);
+    expect(durableConfig.cloud.apiKey).toBe("persisted-prod-key");
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("late-process-prod-key");
+    expect(process.env.ELIZAOS_CLOUD_ENABLED).toBe("late-process-sentinel");
+    expect(runtime.character.secrets).toEqual(runtimeSecrets);
+    expect(runtime.setSetting).not.toHaveBeenCalled();
+    expect(runtime.updateAgent).not.toHaveBeenCalled();
+    expect(cloudAuth.authenticateWithApiKey).not.toHaveBeenCalled();
+    expect(relay.startRelayLoopIfReady).not.toHaveBeenCalled();
+    expect(cloudManager.replaceApiKey).not.toHaveBeenCalled();
+    expect(cloudManager.init).not.toHaveBeenCalled();
+  });
+
+  it("rejects a replacement credential under staging-explicit authority", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-explicit");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "launch-staging-key");
+    vi.stubEnv(
+      "ELIZAOS_CLOUD_BASE_URL",
+      "https://api-staging.eliza.app/api/v1",
+    );
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthority();
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+
+    const cloudAuth = { authenticateWithApiKey: vi.fn() };
+    const runtimeSecrets = { ELIZAOS_CLOUD_API_KEY: "runtime-prod-key" };
+    const runtime = {
+      agentId: "runtime-agent",
+      character: { secrets: runtimeSecrets },
+      getService: vi.fn((name: string) =>
+        name === "CLOUD_AUTH" ? cloudAuth : null,
+      ),
+      getSetting: vi.fn(() => "runtime-prod-key"),
+      setSetting: vi.fn(),
+      updateAgent: vi.fn(async () => undefined),
+    } as unknown as AgentRuntime;
+    const saveConfig = vi.fn<CloudCtx["saveConfig"]>();
+    const actualCloudHost = await vi.importActual<
+      typeof import("@elizaos/plugin-elizacloud/host-routes")
+    >("@elizaos/plugin-elizacloud/host-routes");
+    cloudHost.handleCloudRoute.mockImplementationOnce(
+      actualCloudHost.handleCloudRoute as unknown as PluginHandler,
+    );
+    const args = ctx("/api/cloud/login/persist");
+    args.method = "POST";
+    args.req = makeReq("POST", args.pathname);
+    (args.req as http.IncomingMessage & { body?: unknown }).body = {
+      apiKey: "replacement-production-key",
+    };
+    args.state = dispatchState({
+      config: {
+        cloud: {
+          apiKey: "persisted-production-key",
+          baseUrl: "https://api.eliza.app/api/v1",
+        },
+      },
+      runtime,
+    });
+    args.saveConfig = saveConfig;
+
+    await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
+
+    expect(args.res.statusCode).toBe(409);
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("late-production-key");
+    expect(runtime.character.secrets).toEqual(runtimeSecrets);
+    expect(runtime.setSetting).not.toHaveBeenCalled();
+    expect(runtime.updateAgent).not.toHaveBeenCalled();
+    expect(cloudAuth.authenticateWithApiKey).not.toHaveBeenCalled();
   });
 
   it("returns handleCloudRoute's false when nothing in the cascade claims the path", async () => {

--- a/packages/agent/src/api/server-route-dispatch.ts
+++ b/packages/agent/src/api/server-route-dispatch.ts
@@ -9,6 +9,10 @@
  * memoized lazy imports so they stay out of the static boot graph.
  */
 import type http from "node:http";
+import {
+  createDevCloudConfigAuthorityView,
+  materializeDevCloudConfigAuthorityView,
+} from "../config/dev-cloud-env-authority.ts";
 import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability.ts";
 import type { AgentHttpRequestAuthorization } from "../runtime/host-bridge.ts";
 import { handleApprovalRoute } from "./approval-routes.ts";
@@ -204,12 +208,13 @@ export async function handleCloudAndCoreRouteGroup({
   // through to `tryHandleRuntimePluginRoute`.
 
   const cloudRoutes = await getCloudRoutesPlugin();
+  const effectiveConfig = createDevCloudConfigAuthorityView(state.config);
   const billingHandled = await cloudRoutes.handleCloudBillingRoute(
     req,
     res,
     pathname,
     method,
-    { config: state.config, runtime: state.runtime },
+    { config: effectiveConfig, runtime: state.runtime },
   );
   if (billingHandled) return true;
 
@@ -218,17 +223,32 @@ export async function handleCloudAndCoreRouteGroup({
     res,
     pathname,
     method,
-    { config: state.config, runtime: state.runtime },
+    { config: effectiveConfig, runtime: state.runtime },
   );
   if (compatHandled) return true;
 
-  const cloudState = {
-    config: state.config,
+  // Core Cloud routes include explicit login/disconnect mutations. Give those
+  // handlers a sanitized, unmarked working copy and persist it only through
+  // this deliberate adapter; the durable state object remains separate from
+  // the read-only authority view until a successful save.
+  const cloudRouteConfig =
+    materializeDevCloudConfigAuthorityView(effectiveConfig);
+  const persistCloudRouteConfig =
+    cloudRouteConfig === state.config
+      ? saveConfig
+      : (nextConfig: ServerState["config"]): void => {
+          saveConfig(nextConfig);
+          state.config = nextConfig;
+        };
+  const cloudState: Parameters<CloudHostRoutesModule["handleCloudRoute"]>[4] = {
+    config: cloudRouteConfig,
     cloudManager: state.cloudManager,
     runtime: state.runtime,
-    saveConfig,
-    createTelemetrySpan: createIntegrationTelemetrySpan,
     restartRuntime,
+    services: {
+      saveElizaConfig: persistCloudRouteConfig,
+      createIntegrationTelemetrySpan,
+    },
   };
   return cloudRoutes.handleCloudRoute(req, res, pathname, method, cloudState);
 }
@@ -347,5 +367,11 @@ export async function handleLifeOpsRuntimePluginRoute({
     url,
     runtime: state.runtime,
     isAuthorized: () => isAuthorizedRequest(req),
+    hostContext: {
+      config: createDevCloudConfigAuthorityView(state.config) as Record<
+        string,
+        unknown
+      >,
+    },
   });
 }

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -341,6 +341,11 @@ import {
   loadElizaConfig,
   saveElizaConfig,
 } from "../config/config.ts";
+import {
+  createDevCloudConfigAuthorityView,
+  materializeDevCloudConfigAuthorityView,
+  mergeDevCloudConfigAuthorityMutation,
+} from "../config/dev-cloud-env-authority.ts";
 import { isCloudWalletEnabled } from "../config/feature-flags.ts";
 import { resolveModelsCacheDir, resolveStateDir } from "../config/paths.ts";
 import { CharacterSchema } from "../config/zod-schema.ts";
@@ -2805,14 +2810,30 @@ async function handleRequest(
       setSolanaWalletEnv,
       validatePrivateKey,
     } = await getCoreWalletApi();
+    const durableWalletConfig = loadElizaConfig();
+    const walletUsesCloudNetwork =
+      method === "GET" || pathname === "/api/wallet/refresh-cloud";
+    const walletAuthorityView = walletUsesCloudNetwork
+      ? createDevCloudConfigAuthorityView(durableWalletConfig)
+      : durableWalletConfig;
+    const walletConfig =
+      materializeDevCloudConfigAuthorityView(walletAuthorityView);
+    const saveWalletConfig = (nextConfig: ElizaConfig): void => {
+      const persistable = mergeDevCloudConfigAuthorityMutation(
+        durableWalletConfig,
+        walletAuthorityView,
+        nextConfig,
+      );
+      saveElizaConfig(persistable);
+    };
     if (
       await handleWalletRoutes({
         req,
         res,
         method,
         pathname,
-        config: loadElizaConfig(),
-        saveConfig: saveElizaConfig,
+        config: walletConfig,
+        saveConfig: saveWalletConfig,
         ensureWalletKeysInEnvAndConfig,
         resolveWalletExportRejection,
         restartRuntime,
@@ -2876,7 +2897,13 @@ async function handleRequest(
         method,
         pathname,
         url,
-        state,
+        state:
+          pathname === "/api/agent/self-status"
+            ? {
+                ...state,
+                config: createDevCloudConfigAuthorityView(state.config),
+              }
+            : state,
         json,
         error,
         readJsonBody,
@@ -3178,7 +3205,7 @@ async function handleRequest(
       res,
       method,
       pathname,
-      config: state.config,
+      config: createDevCloudConfigAuthorityView(state.config),
       runtime: state.runtime,
       json,
     })
@@ -3539,6 +3566,11 @@ async function handleRequest(
   // Extracted to @elizaos/plugin-whatsapp setup-routes.ts (Plugin.routes).
 
   // ── elizaOS plugin HTTP routes (runtime.routes, e.g. /music-player/*) ───
+  const runtimeRouteConfig = pathname.startsWith("/api/cloud/")
+    ? materializeDevCloudConfigAuthorityView(
+        createDevCloudConfigAuthorityView(state.config),
+      )
+    : state.config;
   if (
     await tryHandleRuntimePluginRoute({
       req,
@@ -3549,10 +3581,11 @@ async function handleRequest(
       runtime: state.runtime,
       isAuthorized: () => hostSessionAuthorization.ok || isAuthorized(req),
       hostContext: {
-        config: state.config as Record<string, unknown>,
+        config: runtimeRouteConfig as Record<string, unknown>,
         saveConfig: (nextConfig) => {
-          state.config = nextConfig as ElizaConfig;
-          saveElizaConfig(state.config);
+          const persistable = nextConfig as ElizaConfig;
+          saveElizaConfig(persistable);
+          state.config = persistable;
         },
         restartRuntime,
       },

--- a/packages/agent/src/api/wallet-rpc.test.ts
+++ b/packages/agent/src/api/wallet-rpc.test.ts
@@ -6,7 +6,9 @@
  */
 import {
   DEFAULT_WALLET_RPC_SELECTIONS,
+  resetDevCloudEnvAuthorityForTests,
   resolveCloudApiBaseUrl,
+  resolveDevCloudEnvAuthority,
   type WalletConfigUpdateRequest,
   type WalletRpcSelections,
 } from "@elizaos/shared";
@@ -39,6 +41,7 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
   "ELIZA_WALLET_NETWORK",
   "ALCHEMY_API_KEY",
   "INFURA_API_KEY",
@@ -185,6 +188,7 @@ describe("resolveWalletNetworkMode", () => {
 
   afterEach(() => {
     restoreEnv(snap);
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("prefers an explicit fallback over config and env", () => {
@@ -277,12 +281,14 @@ describe("cloud RPC access and proxy URLs", () => {
   let snap: EnvSnapshot;
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     snap = snapshotEnv();
     clearWalletEnv();
   });
 
   afterEach(() => {
     restoreEnv(snap);
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("denies cloud RPC access without a usable API key", () => {
@@ -353,6 +359,54 @@ describe("cloud RPC access and proxy URLs", () => {
     );
     expect(built?.startsWith("http://127.0.0.1:8787/")).toBe(true);
   });
+
+  it.each(["staging-default", "offline"])(
+    "blocks managed RPC credentials and hostile options under %s authority",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+      expect(
+        hasElizaCloudRpcAccess({
+          cloud: { apiKey: "persisted-production-key" },
+        }),
+      ).toBe(false);
+      expect(
+        buildCloudEvmRpcUrl("mainnet", {
+          cloudManagedAccess: true,
+          cloudApiKey: "option-production-key",
+          cloudBaseUrl: "https://api.eliza.app/api/v1",
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it.each([
+    ["staging-explicit", "https://api-staging.eliza.app/api/v1"],
+    ["self-hosted", "http://192.168.1.20:8787/api/v1"],
+  ])(
+    "pins managed RPC to the %s launch tuple after late pollution",
+    (authority, launchBaseUrl) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "launcher-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBaseUrl;
+      resolveDevCloudEnvAuthority();
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+      expect(
+        buildCloudEvmRpcUrl("mainnet", {
+          cloudManagedAccess: true,
+          cloudApiKey: "option-production-key",
+          cloudBaseUrl: "https://api.eliza.app/api/v1",
+        }),
+      ).toBe(expectedCloudEvmUrl("mainnet", "launcher-key", launchBaseUrl));
+    },
+  );
 });
 
 describe("resolveBscRpcUrls", () => {

--- a/packages/agent/src/api/wallet-rpc.ts
+++ b/packages/agent/src/api/wallet-rpc.ts
@@ -12,6 +12,8 @@ import {
   migrateLegacyRuntimeConfig,
   normalizeWalletRpcSelections,
   resolveCloudApiBaseUrl,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
   type WalletConfigUpdateRequest,
   type WalletRpcChain,
   type WalletRpcCredentialKey,
@@ -28,6 +30,11 @@ function normalizeSecret(value: string | null | undefined): string | null {
 function resolveCloudApiKey(
   config?: Pick<WalletCapableConfig, "cloud"> | null,
 ): string | null {
+  if (resolveDevCloudEnvAuthority()) {
+    return normalizeSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+  }
   return normalizeSecret(
     config?.cloud?.apiKey ?? process.env.ELIZAOS_CLOUD_API_KEY,
   );
@@ -282,8 +289,11 @@ function buildCloudRpcProxyUrl(
   pathname: string,
   options: WalletRpcResolutionOptions = {},
 ): string | null {
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
   const cloudApiKey = normalizeSecret(
-    options.cloudApiKey ?? process.env.ELIZAOS_CLOUD_API_KEY,
+    devCloudAuthority
+      ? resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")
+      : (options.cloudApiKey ?? process.env.ELIZAOS_CLOUD_API_KEY),
   );
   const cloudManagedAccess = options.cloudManagedAccess ?? Boolean(cloudApiKey);
   if (!cloudManagedAccess || !cloudApiKey) {

--- a/packages/agent/src/api/wallet-steward-authority.test.ts
+++ b/packages/agent/src/api/wallet-steward-authority.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getWalletAddresses,
+  getWalletAddressesWithSteward,
+  initStewardWalletCache,
+} from "./wallet.ts";
+
+const ENV_KEYS = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "STEWARD_EVM_ADDRESS",
+  "STEWARD_SOLANA_ADDRESS",
+  "EVM_PRIVATE_KEY",
+  "SOLANA_PRIVATE_KEY",
+  "WALLET_SOURCE_EVM",
+  "WALLET_SOURCE_SOLANA",
+] as const;
+
+describe("agent Steward wallet authority", () => {
+  let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+  let stateDir: string;
+
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    saved = Object.fromEntries(
+      ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+    for (const key of ENV_KEYS) delete process.env[key];
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "eliza-steward-authority-"));
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+    rmSync(stateDir, { force: true, recursive: true });
+  });
+
+  it("ignores persisted production credentials and stale addresses under default staging", async () => {
+    writeFileSync(
+      path.join(stateDir, "steward-credentials.json"),
+      JSON.stringify({
+        apiUrl: "https://eliza.app/steward",
+        tenantId: "elizacloud",
+        agentId: "production-agent",
+        apiKey: "production-key",
+        agentToken: "production-token",
+      }),
+    );
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    captureDevCloudEnvAuthoritySnapshot();
+    process.env.STEWARD_EVM_ADDRESS =
+      "0x1111111111111111111111111111111111111111";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await initStewardWalletCache();
+    await getWalletAddressesWithSteward();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getWalletAddresses()).toEqual({
+      evmAddress: null,
+      solanaAddress: null,
+    });
+  });
+
+  it("does not let late URL and token pollution complete an insufficient explicit tuple", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+    process.env.STEWARD_API_KEY = "late-production-key";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await initStewardWalletCache();
+    await getWalletAddressesWithSteward();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a complete explicit tuple on its frozen URL and credentials", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    process.env.STEWARD_AGENT_TOKEN = "staging-token";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud";
+    process.env.STEWARD_AGENT_ID = "production-agent";
+    process.env.STEWARD_AGENT_TOKEN = "production-token";
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ walletAddresses: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await initStewardWalletCache();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://staging.eliza.app/steward/agents/staging-agent",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer staging-token",
+      "X-Steward-Tenant": "elizacloud-staging",
+    });
+  });
+});

--- a/packages/agent/src/api/wallet.ts
+++ b/packages/agent/src/api/wallet.ts
@@ -19,6 +19,7 @@ import type {
   WalletImportResult,
   WalletKeys,
 } from "@elizaos/shared";
+import { resolveDevCloudStewardOperationalTuple } from "@elizaos/shared";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { resolveStewardCredentialsPath } from "../config/paths.ts";
@@ -366,6 +367,8 @@ function deriveLocalSolanaAddress(): string | null {
 }
 
 function readStewardEvmAddress(): string | null {
+  const authoritative = resolveDevCloudStewardOperationalTuple();
+  if (authoritative && !authoritative.enabled) return null;
   const stewardEvm =
     stewardAddressCache?.evm?.trim() ??
     process.env[STEWARD_EVM_ADDRESS_ENV_KEY]?.trim();
@@ -373,6 +376,8 @@ function readStewardEvmAddress(): string | null {
 }
 
 function readStewardSolanaAddress(): string | null {
+  const authoritative = resolveDevCloudStewardOperationalTuple();
+  if (authoritative && !authoritative.enabled) return null;
   const stewardSolana =
     stewardAddressCache?.solana?.trim() ??
     process.env[STEWARD_SOLANA_ADDRESS_ENV_KEY]?.trim();
@@ -747,6 +752,14 @@ type PersistedStewardCredentials = {
   agentToken?: string;
 };
 
+type OperationalStewardConnection = {
+  apiUrl: string;
+  tenantId?: string;
+  agentId: string;
+  apiKey?: string;
+  agentToken?: string;
+};
+
 function normalizeOptionalString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
@@ -782,6 +795,58 @@ function readPersistedStewardCredentials(): {
   }
 }
 
+function resolveOperationalStewardConnection(
+  includePersisted: boolean,
+  fallbackAgentId?: string | null,
+): OperationalStewardConnection | null {
+  const authoritative = resolveDevCloudStewardOperationalTuple();
+  if (authoritative) {
+    return authoritative.enabled
+      ? {
+          apiUrl: authoritative.apiUrl,
+          ...(authoritative.tenantId
+            ? { tenantId: authoritative.tenantId }
+            : {}),
+          agentId: authoritative.agentId,
+          ...(authoritative.apiKey ? { apiKey: authoritative.apiKey } : {}),
+          ...(authoritative.agentToken
+            ? { agentToken: authoritative.agentToken }
+            : {}),
+        }
+      : null;
+  }
+
+  const persisted = includePersisted ? readPersistedStewardCredentials() : null;
+  const apiUrl =
+    normalizeOptionalString(process.env.STEWARD_API_URL) ?? persisted?.apiUrl;
+  const agentId =
+    normalizeOptionalString(process.env.STEWARD_AGENT_ID) ??
+    normalizeOptionalString(process.env.ELIZA_STEWARD_AGENT_ID) ??
+    persisted?.agentId ??
+    normalizeOptionalString(fallbackAgentId);
+  if (!apiUrl || !agentId) return null;
+
+  const tenantId =
+    normalizeOptionalString(process.env.STEWARD_TENANT_ID) ??
+    persisted?.tenantId ??
+    undefined;
+  const apiKey =
+    normalizeOptionalString(process.env.STEWARD_API_KEY) ??
+    persisted?.apiKey ??
+    undefined;
+  const agentToken =
+    normalizeOptionalString(process.env.STEWARD_AGENT_TOKEN) ??
+    persisted?.agentToken ??
+    undefined;
+  return {
+    apiUrl,
+    ...(tenantId ? { tenantId } : {}),
+    agentId,
+    ...(apiKey ? { apiKey } : {}),
+    ...(agentToken ? { agentToken } : {}),
+  };
+}
+
 /**
  * Initialise the steward wallet address cache.
  *
@@ -791,41 +856,29 @@ function readPersistedStewardCredentials(): {
  * `getWalletAddresses()` can use them without hitting the network.
  */
 export async function initStewardWalletCache(): Promise<void> {
-  const persisted = readPersistedStewardCredentials();
-  const stewardApiUrl =
-    normalizeOptionalString(process.env.STEWARD_API_URL) ?? persisted?.apiUrl;
-  if (!stewardApiUrl) return;
-
-  const agentId =
-    normalizeOptionalString(process.env.STEWARD_AGENT_ID) ||
-    normalizeOptionalString(process.env.ELIZA_STEWARD_AGENT_ID) ||
-    persisted?.agentId ||
-    null;
-
-  if (!agentId) return;
+  const connection = resolveOperationalStewardConnection(true);
+  if (!connection) {
+    if (resolveDevCloudStewardOperationalTuple()) {
+      stewardAddressCache = null;
+      delete process.env[STEWARD_EVM_ADDRESS_ENV_KEY];
+      delete process.env[STEWARD_SOLANA_ADDRESS_ENV_KEY];
+    }
+    return;
+  }
 
   try {
     const headers: Record<string, string> = { Accept: "application/json" };
-    const bearerToken =
-      normalizeOptionalString(process.env.STEWARD_AGENT_TOKEN) ??
-      persisted?.agentToken;
-    const apiKey =
-      normalizeOptionalString(process.env.STEWARD_API_KEY) ?? persisted?.apiKey;
-    const tenantId =
-      normalizeOptionalString(process.env.STEWARD_TENANT_ID) ??
-      persisted?.tenantId;
-
-    if (bearerToken) {
-      headers.Authorization = `Bearer ${bearerToken}`;
-    } else if (apiKey) {
-      headers["X-Steward-Key"] = apiKey;
+    if (connection.agentToken) {
+      headers.Authorization = `Bearer ${connection.agentToken}`;
+    } else if (connection.apiKey) {
+      headers["X-Steward-Key"] = connection.apiKey;
     }
-    if (tenantId) {
-      headers["X-Steward-Tenant"] = tenantId;
+    if (connection.tenantId) {
+      headers["X-Steward-Tenant"] = connection.tenantId;
     }
 
     const res = await fetch(
-      `${stewardApiUrl}/agents/${encodeURIComponent(agentId)}`,
+      `${connection.apiUrl}/agents/${encodeURIComponent(connection.agentId)}`,
       { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
     );
 
@@ -936,41 +989,27 @@ export async function getWalletAddressesWithSteward(
 > {
   const base = getWalletAddresses(runtimeAgentId);
 
-  // Only augment when steward is configured
-  const stewardApiUrl = process.env.STEWARD_API_URL?.trim();
-  if (!stewardApiUrl) {
-    return base;
-  }
-
-  const agentId =
-    process.env.STEWARD_AGENT_ID?.trim() ||
-    process.env.ELIZA_STEWARD_AGENT_ID?.trim() ||
-    base.evmAddress?.trim() ||
-    null;
-
-  if (!agentId) {
-    return base;
-  }
+  const connection = resolveOperationalStewardConnection(
+    false,
+    base.evmAddress,
+  );
+  if (!connection) return base;
 
   try {
     const headers: Record<string, string> = {
       Accept: "application/json",
     };
-    const bearerToken = process.env.STEWARD_AGENT_TOKEN?.trim();
-    const apiKey = process.env.STEWARD_API_KEY?.trim();
-    const tenantId = process.env.STEWARD_TENANT_ID?.trim();
-
-    if (bearerToken) {
-      headers.Authorization = `Bearer ${bearerToken}`;
-    } else if (apiKey) {
-      headers["X-Steward-Key"] = apiKey;
+    if (connection.agentToken) {
+      headers.Authorization = `Bearer ${connection.agentToken}`;
+    } else if (connection.apiKey) {
+      headers["X-Steward-Key"] = connection.apiKey;
     }
-    if (tenantId) {
-      headers["X-Steward-Tenant"] = tenantId;
+    if (connection.tenantId) {
+      headers["X-Steward-Tenant"] = connection.tenantId;
     }
 
     const res = await fetch(
-      `${stewardApiUrl}/agents/${encodeURIComponent(agentId)}`,
+      `${connection.apiUrl}/agents/${encodeURIComponent(connection.agentId)}`,
       { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
     );
 

--- a/packages/agent/src/config/config-bind-mount-persistence.test.ts
+++ b/packages/agent/src/config/config-bind-mount-persistence.test.ts
@@ -9,6 +9,10 @@ import {
   loadElizaConfig,
   saveElizaConfig,
 } from "./config.ts";
+import {
+  createDevCloudConfigAuthorityView,
+  resetDevCloudEnvAuthorityForTests,
+} from "./dev-cloud-env-authority.ts";
 
 const originalEnv = { ...process.env };
 let root = "";
@@ -36,10 +40,73 @@ afterEach(() => {
   vi.restoreAllMocks();
   __setConfigRenameSyncForTests(null);
   process.env = { ...originalEnv };
+  resetDevCloudEnvAuthorityForTests();
   fs.rmSync(root, { recursive: true, force: true });
 });
 
 describe("saveElizaConfig bind-mount fallback", () => {
+  it("keeps launcher-owned staging env ahead of persisted Cloud env", () => {
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          env: {
+            ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+            ELIZAOS_CLOUD_API_KEY: "persisted-production-key",
+            ELIZAOS_CLOUD_EMBEDDING_URL:
+              "https://api.eliza.app/api/v1/embeddings",
+            ELIZA_CLOUD_WRITE_BASE_URL: "https://api.eliza.app/api/v1",
+            SMALL_MODEL: "persisted-direct-model",
+            ELIZA_DEV_SOURCE: "persisted-marker-must-not-win",
+            vars: {
+              ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+              ELIZAOS_CLOUD_API_KEY: "persisted-production-key",
+              ELIZA_DEV_CLOUD_ENV_AUTHORITY: "production",
+              UNRELATED_DEV_SETTING: "preserved",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "";
+    process.env.ELIZAOS_CLOUD_EMBEDDING_URL = "";
+    process.env.ELIZA_CLOUD_WRITE_BASE_URL = "";
+    delete process.env.SMALL_MODEL;
+
+    const config = loadElizaConfig();
+
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("");
+    expect(process.env.ELIZAOS_CLOUD_EMBEDDING_URL).toBe("");
+    expect(process.env.ELIZA_CLOUD_WRITE_BASE_URL).toBe("");
+    expect(process.env.SMALL_MODEL).toBe("persisted-direct-model");
+    expect(process.env.ELIZA_DEV_SOURCE).toBe("1");
+    expect(process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY).toBe("staging-default");
+    expect(process.env.UNRELATED_DEV_SETTING).toBe("preserved");
+    // Loading remains lossless; only the ephemeral runtime view is sanitized.
+    expect(config.env?.vars?.ELIZAOS_CLOUD_API_KEY).toBe(
+      "persisted-production-key",
+    );
+  });
+
+  it("refuses to persist the ephemeral dev Cloud runtime view", () => {
+    const persistedBefore = fs.readFileSync(configPath, "utf8");
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    const view = createDevCloudConfigAuthorityView(loadElizaConfig());
+
+    expect(() => saveElizaConfig(view)).toThrow(/ephemeral.*authority view/i);
+    expect(fs.readFileSync(configPath, "utf8")).toBe(persistedBefore);
+  });
+
   it("retires the former aggregate view plugin without removing canonical views", () => {
     fs.writeFileSync(
       configPath,

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -24,6 +24,13 @@ import JSON5 from "json5";
 import { readConfigEnvSync } from "../api/config-env.ts";
 import { syncSolanaPublicKeyEnv } from "../api/wallet-env-sync.ts";
 import { isVaultRef } from "../runtime/operations/vault-bridge.ts";
+import {
+  createDevCloudConfigAuthorityView,
+  isDevCloudConfigAuthorityView,
+  isDevCloudEnvOwnedKey,
+  isDevCloudInternalEnvKey,
+  resolveDevCloudEnvAuthority,
+} from "./dev-cloud-env-authority.ts";
 import { collectConfigEnvVars, collectConnectorEnvVars } from "./env-vars.ts";
 import { resolveConfigIncludes } from "./includes.ts";
 import { normalizeModelMetadataInConfig } from "./model-metadata.ts";
@@ -88,7 +95,10 @@ function resolveBindMountOverlayPath(
 }
 
 function applyConfigEnvToProcessEnv(entries: Record<string, string>): void {
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
   for (const [key, value] of Object.entries(entries)) {
+    if (isDevCloudInternalEnvKey(key)) continue;
+    if (devCloudAuthority && isDevCloudEnvOwnedKey(key)) continue;
     // Skip unresolved vault sentinels. The boot-time vault hydration
     // (resolveConfigEnvForProcess + applyCloudConfigToEnv) writes the resolved
     // plaintext to process.env once at startup. Many services call
@@ -286,6 +296,16 @@ export function loadElizaConfig(): ElizaConfig {
   return resolved;
 }
 
+/**
+ * Load the operational/runtime view of config. The durable loader remains the
+ * source for settings mutations; network and execution paths use this helper
+ * so a launcher-selected dev Cloud target cannot be displaced by persisted
+ * production topology or credentials.
+ */
+export function loadEffectiveElizaConfig(): ElizaConfig {
+  return createDevCloudConfigAuthorityView(loadElizaConfig());
+}
+
 function syncDirectory(dir: string): void {
   let fd: number | undefined;
   try {
@@ -405,6 +425,11 @@ function stripWalletPrivateKeysFromConfig(config: ElizaConfig): void {
 }
 
 export function saveElizaConfig(config: ElizaConfig): void {
+  if (isDevCloudConfigAuthorityView(config)) {
+    throw new Error(
+      "[eliza-config] Refusing to persist an ephemeral dev Cloud authority view",
+    );
+  }
   const configPath = resolveConfigWritePath();
   const canonicalConfigPath = resolveConfigPath();
   const dir = path.dirname(configPath);

--- a/packages/agent/src/config/dev-cloud-env-authority.ts
+++ b/packages/agent/src/config/dev-cloud-env-authority.ts
@@ -1,0 +1,575 @@
+/**
+ * Internal contract stamped by the app development launchers. Persisted
+ * account/config state must not replace the Cloud environment selected for a
+ * local development process.
+ */
+
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS,
+  type DevCloudEnvAuthority,
+  resetDevCloudEnvAuthorityForTests as resetSharedDevCloudEnvAuthorityForTests,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority as resolveSharedDevCloudEnvAuthority,
+} from "@elizaos/shared";
+
+export const DEV_CLOUD_ENV_AUTHORITY_KEY =
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY" as const;
+
+export type { DevCloudEnvAuthority };
+
+/**
+ * Persisted environment fields whose launch-time values outrank config/vault
+ * state. Keep this Cloud-specific: generic model aliases such as SMALL_MODEL
+ * still belong to direct/local providers when the dev target is offline.
+ */
+export const DEV_CLOUD_ENV_OWNED_KEYS = [
+  ...DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS,
+  "ELIZA_DEV_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_SERVICE_KEY",
+  "ELIZA_CLOUD_API_KEY",
+  "ELIZA_CLOUD_SERVICE_KEY",
+  "ELIZA_CLOUD_SERVICE_TOKEN",
+  "ELIZA_CLOUD_SESSION_TOKEN",
+  "ELIZA_CLOUD_TOKEN",
+  "ELIZACLOUD_API_KEY",
+  "ELIZACLOUD_TOKEN",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_API_BASE_URL",
+  "ELIZAOS_CLOUD_REQUEST_BASE_URL",
+  "ELIZAOS_CLOUD_URL",
+  "ELIZAOS_CLOUD_BROWSER_BASE_URL",
+  "ELIZAOS_CLOUD_BROWSER_EMBEDDING_URL",
+  "ELIZAOS_CLOUD_EMBEDDING_API_KEY",
+  "ELIZAOS_CLOUD_EMBEDDING_URL",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZAOS_CLOUD_AGENT_ID",
+  "ELIZA_CLOUD_AGENT_ID",
+  "WAIFU_ELIZA_CLOUD_AGENT_ID",
+  "ELIZA_CLOUD_API_BASE_URL",
+  "ELIZA_CLOUD_API_BASE",
+  "ELIZA_CLOUD_API_URL",
+  "ELIZA_CLOUD_BASE",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_LOCAL_API_URL",
+  "ELIZA_CLOUD_LOCAL_APP_URL",
+  "ELIZA_CLOUD_OPENAI_BASE_URL",
+  "ELIZA_CLOUD_PUBLIC_URL",
+  "ELIZA_CLOUD_ROUTE_BASE",
+  "ELIZA_CLOUD_URL",
+  "ELIZA_CLOUD_WEB_URL",
+  "ELIZA_CLOUD_WRITE_BASE_URL",
+  "ELIZACLOUD_API_BASE_URL",
+  "ELIZACLOUD_API_URL",
+  "ELIZACLOUD_DEFAULT_URL",
+  "ELIZA_CLOUD_SANDBOX_API_BASE_URL",
+  "ELIZA_CLOUD_SANDBOX_BASE_URL",
+  "ELIZA_CLOUD_SANDBOX_ACCESS_URL",
+  "ELIZA_CLOUD_REMOTE_RUNNER_URL",
+  "ELIZA_CLOUD_RUNNER_URL",
+  "ELIZA_CLOUD_AUTH_TOKEN",
+  "ELIZA_CLOUD_SANDBOX_TOKEN",
+  "ELIZAOS_CLOUD_USE_INFERENCE",
+  "ELIZAOS_CLOUD_USE_TTS",
+  "ELIZAOS_CLOUD_USE_STT",
+  "ELIZAOS_CLOUD_USE_MEDIA",
+  "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+  "ELIZAOS_CLOUD_USE_RPC",
+  "ELIZAOS_CLOUD_NANO_MODEL",
+  "ELIZAOS_CLOUD_SMALL_MODEL",
+  "ELIZAOS_CLOUD_MEDIUM_MODEL",
+  "ELIZAOS_CLOUD_LARGE_MODEL",
+  "ELIZAOS_CLOUD_MEGA_MODEL",
+  "ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL",
+  "ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL",
+  "ELIZAOS_CLOUD_ACTION_PLANNER_MODEL",
+  "ELIZAOS_CLOUD_PLANNER_MODEL",
+  "ELIZAOS_CLOUD_RESPONSE_MODEL",
+  "ELIZAOS_CLOUD_MEDIA_DESCRIPTION_MODEL",
+] as const;
+
+/**
+ * applyCloudConfigToEnv also writes compatibility model aliases and derived
+ * disabled flags. Snapshot them so the authority wrapper can restore the exact
+ * launcher process environment without treating them as Cloud-owned config.
+ */
+export const DEV_CLOUD_ENV_RESTORE_KEYS = [
+  ...DEV_CLOUD_ENV_OWNED_KEYS,
+  "ELIZA_DEV_SOURCE",
+  DEV_CLOUD_ENV_AUTHORITY_KEY,
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_CLOUD_TTS_DISABLED",
+  "ELIZA_CLOUD_MEDIA_DISABLED",
+  "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
+  "ELIZA_CLOUD_RPC_DISABLED",
+  "NANO_MODEL",
+  "SMALL_MODEL",
+  "MEDIUM_MODEL",
+  "LARGE_MODEL",
+  "MEGA_MODEL",
+] as const;
+
+const DEV_CLOUD_ENV_OWNED_KEY_SET = new Set<string>(DEV_CLOUD_ENV_OWNED_KEYS);
+
+const DEV_CLOUD_INTERNAL_KEYS = new Set<string>([
+  "ELIZA_DEV_SOURCE",
+  DEV_CLOUD_ENV_AUTHORITY_KEY,
+  "ELIZA_DEV_CLOUD_TARGET",
+]);
+
+const DEV_CLOUD_CONFIG_AUTHORITY_VIEW = Symbol.for(
+  "@elizaos/agent/dev-cloud-config-authority-view",
+);
+
+export type DevCloudEnvSnapshot = Readonly<{
+  authority: DevCloudEnvAuthority;
+  values: Readonly<Record<string, string | undefined>>;
+}>;
+
+let frozenProcessEnvSnapshot: DevCloudEnvSnapshot | undefined;
+
+/** Ignore the marker outside a launcher-owned development process. */
+export function resolveDevCloudEnvAuthority(
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvAuthority | null {
+  return resolveSharedDevCloudEnvAuthority(env);
+}
+
+export function isDevCloudEnvOwnedKey(key: string): boolean {
+  const normalizedKey = key.toUpperCase();
+  if (DEV_CLOUD_INTERNAL_KEYS.has(normalizedKey)) return false;
+  return (
+    DEV_CLOUD_ENV_OWNED_KEY_SET.has(normalizedKey) ||
+    normalizedKey.startsWith("ELIZAOS_CLOUD_") ||
+    normalizedKey.startsWith("ELIZA_CLOUD_") ||
+    normalizedKey.startsWith("ELIZA_DEV_CLOUD_") ||
+    normalizedKey.startsWith("ELIZACLOUD_") ||
+    normalizedKey.startsWith("WAIFU_ELIZA_CLOUD_")
+  );
+}
+
+/** Internal launcher markers must never be fabricated by persisted config. */
+export function isDevCloudInternalEnvKey(key: string): boolean {
+  return DEV_CLOUD_INTERNAL_KEYS.has(key.toUpperCase());
+}
+
+export function captureDevCloudEnvAuthority(
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvSnapshot | null {
+  const authority = resolveDevCloudEnvAuthority(env);
+  if (!authority) return null;
+  if (env === process.env && frozenProcessEnvSnapshot) {
+    return frozenProcessEnvSnapshot;
+  }
+
+  const sharedSnapshot = captureDevCloudEnvAuthoritySnapshot(env);
+  if (!sharedSnapshot) return null;
+
+  const keys = new Set<string>([
+    ...DEV_CLOUD_ENV_RESTORE_KEYS,
+    ...Object.keys(sharedSnapshot.values),
+    ...Object.keys(env).filter(isDevCloudEnvOwnedKey),
+  ]);
+  const values = Object.fromEntries(
+    [...keys].map((key) => [
+      key,
+      isDevCloudEnvOwnedKey(key) || isDevCloudInternalEnvKey(key)
+        ? resolveDevCloudAuthorityEnvValue(key, env)
+        : env[key],
+    ]),
+  );
+  const snapshot = Object.freeze({
+    authority,
+    values: Object.freeze(values),
+  });
+  if (env === process.env) frozenProcessEnvSnapshot = snapshot;
+  return snapshot;
+}
+
+/** @internal Test isolation for the process-lifetime launch snapshot. */
+export function resetDevCloudEnvAuthorityForTests(): void {
+  frozenProcessEnvSnapshot = undefined;
+  resetSharedDevCloudEnvAuthorityForTests();
+}
+
+/** Restore the exact launcher-owned tuple after config/vault projection. */
+export function restoreDevCloudEnvAuthority(
+  snapshot: DevCloudEnvSnapshot,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const keys = new Set<string>([
+    ...DEV_CLOUD_ENV_RESTORE_KEYS,
+    ...Object.keys(snapshot.values),
+    ...Object.keys(env).filter(isDevCloudEnvOwnedKey),
+  ]);
+  for (const key of keys) {
+    const value = snapshot.values[key];
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const next = value?.trim();
+  return next || undefined;
+}
+
+function usableCredential(value: string | undefined): string | undefined {
+  const next = trimmed(value);
+  if (
+    !next ||
+    next.toUpperCase() === "[REDACTED]" ||
+    next.toLowerCase().startsWith("vault://")
+  ) {
+    return undefined;
+  }
+  return next;
+}
+
+function truthy(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? "");
+}
+
+function isElizaCloudRoute(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const route = value as Record<string, unknown>;
+  const backend =
+    typeof route.backend === "string" ? route.backend.trim().toLowerCase() : "";
+  return (
+    route.transport === "cloud-proxy" &&
+    ["elizacloud", "eliza-cloud", "@elizaos/plugin-elizacloud"].includes(
+      backend,
+    )
+  );
+}
+
+function hasDirectTextRoute(config: unknown): boolean {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return false;
+  }
+  const routing = (config as Record<string, unknown>).serviceRouting;
+  if (!routing || typeof routing !== "object" || Array.isArray(routing)) {
+    return false;
+  }
+  const route = (routing as Record<string, unknown>).llmText;
+  if (!route || typeof route !== "object" || Array.isArray(route)) {
+    return false;
+  }
+  const record = route as Record<string, unknown>;
+  return (
+    record.transport === "direct" &&
+    typeof record.backend === "string" &&
+    Boolean(trimmed(record.backend))
+  );
+}
+
+function removeOwnedConfigEnv(config: Record<string, unknown>): void {
+  const configEnv = config.env;
+  if (!configEnv || typeof configEnv !== "object" || Array.isArray(configEnv)) {
+    return;
+  }
+  const mutableEnv = configEnv as Record<string, unknown>;
+  const vars = mutableEnv.vars;
+  if (vars && typeof vars === "object" && !Array.isArray(vars)) {
+    const mutableVars = vars as Record<string, unknown>;
+    for (const key of Object.keys(mutableVars)) {
+      if (isDevCloudEnvOwnedKey(key)) delete mutableVars[key];
+    }
+    for (const key of DEV_CLOUD_INTERNAL_KEYS) delete mutableVars[key];
+    if (Object.keys(mutableVars).length === 0) delete mutableEnv.vars;
+  }
+  for (const key of Object.keys(mutableEnv)) {
+    if (isDevCloudEnvOwnedKey(key)) delete mutableEnv[key];
+  }
+  for (const key of DEV_CLOUD_INTERNAL_KEYS) delete mutableEnv[key];
+}
+
+function removeOwnedRuntimeSettingKeys(value: unknown): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (isDevCloudEnvOwnedKey(key) || isDevCloudInternalEnvKey(key)) {
+      delete record[key];
+      continue;
+    }
+    if (["secrets", "extra", "vars", "env"].includes(key)) {
+      removeOwnedRuntimeSettingKeys(record[key]);
+    }
+  }
+}
+
+function removeOwnedAgentRuntimeSettings(
+  config: Record<string, unknown>,
+): void {
+  const agents = config.agents;
+  if (!agents || typeof agents !== "object" || Array.isArray(agents)) return;
+  const agentsRecord = agents as Record<string, unknown>;
+  const sanitizeAgent = (agent: unknown): void => {
+    if (!agent || typeof agent !== "object" || Array.isArray(agent)) return;
+    const record = agent as Record<string, unknown>;
+    removeOwnedRuntimeSettingKeys(record.settings);
+    removeOwnedRuntimeSettingKeys(record.secrets);
+    removeOwnedRuntimeSettingKeys(record.env);
+  };
+  sanitizeAgent(agentsRecord.defaults);
+  if (Array.isArray(agentsRecord.list)) {
+    for (const agent of agentsRecord.list) sanitizeAgent(agent);
+  }
+}
+
+/**
+ * Remove persisted Cloud ownership from the in-memory config and project only
+ * the launcher-selected connection. This never writes the sanitized view back
+ * to disk; it protects the current local-development process only.
+ */
+export function applyDevCloudConfigAuthority(
+  config: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvSnapshot | null {
+  const snapshot = captureDevCloudEnvAuthority(env);
+  if (!snapshot) return null;
+  const activationBlocked =
+    snapshot.authority === "staging-default" ||
+    snapshot.authority === "offline";
+  const forceCloudInference =
+    !activationBlocked && truthy(snapshot.values.ELIZAOS_CLOUD_USE_INFERENCE);
+
+  removeOwnedConfigEnv(config);
+  removeOwnedAgentRuntimeSettings(config);
+
+  config.deploymentTarget = { runtime: "local" };
+
+  const routing = config.serviceRouting;
+  if (routing && typeof routing === "object" && !Array.isArray(routing)) {
+    const filteredRouting = Object.fromEntries(
+      Object.entries(routing as Record<string, unknown>).filter(
+        ([capability, route]) =>
+          !isElizaCloudRoute(route) &&
+          !(capability === "llmText" && forceCloudInference),
+      ),
+    );
+    if (Object.keys(filteredRouting).length === 0) {
+      delete config.serviceRouting;
+    } else {
+      config.serviceRouting = filteredRouting;
+    }
+  }
+
+  const linkedAccounts = config.linkedAccounts;
+  if (
+    linkedAccounts &&
+    typeof linkedAccounts === "object" &&
+    !Array.isArray(linkedAccounts)
+  ) {
+    const nextLinkedAccounts = {
+      ...(linkedAccounts as Record<string, unknown>),
+    };
+    delete nextLinkedAccounts.elizacloud;
+    if (Object.keys(nextLinkedAccounts).length > 0) {
+      config.linkedAccounts = nextLinkedAccounts;
+    } else {
+      delete config.linkedAccounts;
+    }
+  }
+
+  const existingCloud =
+    config.cloud &&
+    typeof config.cloud === "object" &&
+    !Array.isArray(config.cloud)
+      ? { ...(config.cloud as Record<string, unknown>) }
+      : {};
+  for (const key of [
+    "provider",
+    "remoteApiBase",
+    "remoteAccessToken",
+    "baseUrl",
+    "apiKey",
+    "serviceKey",
+    "agentId",
+    "enabled",
+    "inferenceMode",
+    "services",
+    "runtime",
+  ]) {
+    delete existingCloud[key];
+  }
+
+  const apiKey = activationBlocked
+    ? undefined
+    : (usableCredential(snapshot.values.ELIZAOS_CLOUD_API_KEY) ??
+      usableCredential(snapshot.values.ELIZA_DEV_CLOUD_API_KEY) ??
+      usableCredential(snapshot.values.ELIZA_CLOUD_API_KEY) ??
+      usableCredential(snapshot.values.ELIZACLOUD_API_KEY));
+  const baseUrl = trimmed(snapshot.values.ELIZAOS_CLOUD_BASE_URL);
+  const agentId =
+    trimmed(snapshot.values.ELIZAOS_CLOUD_AGENT_ID) ??
+    trimmed(snapshot.values.ELIZA_CLOUD_AGENT_ID) ??
+    trimmed(snapshot.values.WAIFU_ELIZA_CLOUD_AGENT_ID);
+  const enabled =
+    !activationBlocked &&
+    (Boolean(apiKey) ||
+      snapshot.values.ELIZA_CLOUD_PROVISIONED?.trim() === "1");
+
+  config.cloud = {
+    ...existingCloud,
+    enabled,
+    ...(baseUrl ? { baseUrl } : {}),
+    // An explicit blank is a deny-fallback sentinel for helpers that otherwise
+    // consult runtime secrets or process.env when config.cloud.apiKey is absent.
+    // That closes stale-runtime escapes in status, billing, wallet RPC, and
+    // compatibility routes under staging-default/offline authority.
+    apiKey: apiKey ?? "",
+    ...(agentId ? { agentId } : {}),
+  };
+
+  return snapshot;
+}
+
+/**
+ * Exact per-runtime settings that outrank DB-persisted AgentRuntime values.
+ * AgentRuntime's initialization merge deliberately lets constructor settings
+ * override DB values without writing those overrides back to the database.
+ */
+export function createDevCloudRuntimeSettingsAuthorityOverlay(
+  env: NodeJS.ProcessEnv = process.env,
+  config?: unknown,
+): Record<string, string> {
+  const snapshot = captureDevCloudEnvAuthority(env);
+  if (!snapshot) return {};
+  const keys = new Set<string>([
+    ...DEV_CLOUD_ENV_OWNED_KEYS,
+    ...Object.keys(snapshot.values).filter(isDevCloudEnvOwnedKey),
+  ]);
+  const overlay = Object.fromEntries(
+    [...keys].map((key) => [key, snapshot.values[key] ?? ""]),
+  );
+  // A launcher credential may keep Cloud loaded for non-text capabilities while
+  // a canonical direct route owns the chat brain. An omitted/blank launch flag
+  // means "no Cloud inference override", not the plugin's standalone default of
+  // registering every priority-50 text handler. Project the route decision into
+  // runtime settings; an explicit truthy launcher flag remains authoritative.
+  if (
+    hasDirectTextRoute(config) &&
+    !truthy(snapshot.values.ELIZAOS_CLOUD_USE_INFERENCE)
+  ) {
+    overlay.ELIZAOS_CLOUD_USE_INFERENCE = "false";
+  }
+  return overlay;
+}
+
+/** Build an ephemeral runtime view without altering the persistable config. */
+export function createDevCloudConfigAuthorityView<T extends object>(
+  config: T,
+  env: NodeJS.ProcessEnv = process.env,
+): T {
+  if (!resolveDevCloudEnvAuthority(env)) return config;
+  const view = structuredClone(config);
+  applyDevCloudConfigAuthority(view as Record<string, unknown>, env);
+  Object.defineProperty(view, DEV_CLOUD_CONFIG_AUTHORITY_VIEW, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
+  return view;
+}
+
+export function isDevCloudConfigAuthorityView(value: object): boolean {
+  return (
+    (value as Record<PropertyKey, unknown>)[DEV_CLOUD_CONFIG_AUTHORITY_VIEW] ===
+    true
+  );
+}
+
+/**
+ * Deliberately turn a mutated authority view into a persistable snapshot.
+ * Only explicit Cloud mutation routes should call this; ordinary persistence
+ * continues to reject marked ephemeral views.
+ */
+export function materializeDevCloudConfigAuthorityView<T extends object>(
+  config: T,
+): T {
+  return isDevCloudConfigAuthorityView(config)
+    ? structuredClone(config)
+    : config;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function configValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => configValuesEqual(value, right[index]))
+    );
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) return false;
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.hasOwn(right, key) && configValuesEqual(left[key], right[key]),
+    )
+  );
+}
+
+function applyConfigMutationDelta(
+  durable: unknown,
+  before: unknown,
+  after: unknown,
+): unknown {
+  if (configValuesEqual(before, after)) return durable;
+  if (!isPlainRecord(before) || !isPlainRecord(after)) {
+    return structuredClone(after);
+  }
+
+  const merged: Record<string, unknown> = isPlainRecord(durable)
+    ? structuredClone(durable)
+    : {};
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    if (!Object.hasOwn(after, key)) {
+      delete merged[key];
+      continue;
+    }
+    if (!Object.hasOwn(before, key)) {
+      merged[key] = structuredClone(after[key]);
+      continue;
+    }
+    merged[key] = applyConfigMutationDelta(
+      merged[key],
+      before[key],
+      after[key],
+    );
+  }
+  return merged;
+}
+
+/**
+ * Apply only mutations made after an authority view was created onto the
+ * durable source config. This is for mixed read/write routes (wallet refresh):
+ * the network read sees staging, while an unrelated persisted production or
+ * self-hosted Cloud topology is neither contacted nor overwritten.
+ */
+export function mergeDevCloudConfigAuthorityMutation<T extends object>(
+  durable: T,
+  authorityViewBeforeMutation: T,
+  authorityViewAfterMutation: T,
+): T {
+  if (!isDevCloudConfigAuthorityView(authorityViewBeforeMutation)) {
+    return authorityViewAfterMutation;
+  }
+  return applyConfigMutationDelta(
+    durable,
+    authorityViewBeforeMutation,
+    authorityViewAfterMutation,
+  ) as T;
+}

--- a/packages/agent/src/runtime/cloud-github-token.test.ts
+++ b/packages/agent/src/runtime/cloud-github-token.test.ts
@@ -9,6 +9,7 @@
  * can neither observe nor be overwritten by another agent's token.
  */
 
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   autoFetchCloudGithubToken,
@@ -22,6 +23,8 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
   "ELIZAOS_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -45,6 +48,7 @@ function fakeRuntime(initialSecrets: Record<string, string> = {}) {
 }
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   for (const key of ENV_KEYS) {
     savedEnv[key] = process.env[key];
     delete process.env[key];
@@ -58,6 +62,7 @@ afterEach(() => {
   }
   globalThis.fetch = realFetch;
   vi.restoreAllMocks();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 function armCloudEnv() {
@@ -128,6 +133,22 @@ describe("autoFetchCloudGithubToken", () => {
     expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
     armCloudEnv();
     expect(await autoFetchCloudGithubToken(undefined)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores production Cloud env injected after a staging-default launch", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    // Freeze the launch tuple before simulating a late config/vault mutation.
+    expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
+
+    armCloudEnv();
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await autoFetchCloudGithubToken("agent-a")).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -11,9 +11,21 @@ import { resolveElizaCloudTopology } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import {
+  captureDevCloudEnvAuthority,
+  createDevCloudConfigAuthorityView,
+  createDevCloudRuntimeSettingsAuthorityOverlay,
+  DEV_CLOUD_ENV_AUTHORITY_KEY,
+  type DEV_CLOUD_ENV_OWNED_KEYS,
+  DEV_CLOUD_ENV_RESTORE_KEYS,
+  mergeDevCloudConfigAuthorityMutation,
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
+import {
   applyCloudConfigToEnv,
   cloudApiKeyFingerprint,
   ensureProvisionedCloudContainerConfig,
+  hydrateConfigEnvForBoot,
   resolveConfigEnvVaultRefsForBoot,
   resolveEmbeddingProviderPluginName,
   resolveRuntimeProviderName,
@@ -29,7 +41,10 @@ import { collectPluginNames } from "./plugin-collector.ts";
 // applyCloudConfigToEnv keeps inference cloud-routed for provisioned containers,
 // while embeddings stay on the explicitly selected provider so the runtime does
 // not silently steal the recall hot path.
-const ENV_KEYS = [
+const ENV_KEYS: readonly string[] = [
+  ...DEV_CLOUD_ENV_RESTORE_KEYS,
+  "ELIZA_DEV_SOURCE",
+  DEV_CLOUD_ENV_AUTHORITY_KEY,
   "ELIZA_CLOUD_PROVISIONED",
   "ELIZAOS_CLOUD_USE_INFERENCE",
   "ELIZAOS_CLOUD_USE_EMBEDDINGS",
@@ -63,11 +78,12 @@ const ENV_KEYS = [
   "MEDIUM_MODEL",
   "LARGE_MODEL",
   "MEGA_MODEL",
-] as const;
+];
 
 let savedEnv: Record<string, string | undefined>;
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
   for (const k of ENV_KEYS) delete process.env[k];
 });
@@ -80,6 +96,589 @@ afterEach(() => {
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
   }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+function hostilePersistedCloudConfig(): ElizaConfig {
+  const cloudRoute = {
+    backend: "elizacloud",
+    transport: "cloud-proxy",
+    accountId: "elizacloud",
+  } as const;
+  return {
+    cloud: {
+      enabled: true,
+      provider: "elizacloud",
+      runtime: "cloud",
+      inferenceMode: "cloud",
+      services: {
+        inference: true,
+        tts: true,
+        media: true,
+        embeddings: true,
+        rpc: true,
+      },
+      apiKey: "persisted-production-key",
+      serviceKey: "persisted-production-service-key",
+      baseUrl: "https://api.eliza.app/api/v1",
+      agentId: "persisted-production-agent",
+    },
+    deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+    linkedAccounts: {
+      elizacloud: { status: "linked", source: "api-key" },
+    },
+    serviceRouting: {
+      llmText: { ...cloudRoute },
+      tts: { ...cloudRoute },
+      media: { ...cloudRoute },
+      embeddings: { ...cloudRoute },
+      rpc: { ...cloudRoute },
+    },
+    env: {
+      ELIZAOS_CLOUD_API_KEY: "persisted-top-level-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+      ELIZAOS_CLOUD_EMBEDDING_API_KEY: "persisted-embedding-key",
+      ELIZAOS_CLOUD_EMBEDDING_URL: "https://api.eliza.app/api/v1/embeddings",
+      ELIZA_CLOUD_API_BASE_URL: "https://api.eliza.app/api/v1",
+      ELIZA_CLOUD_AUTH_TOKEN: "persisted-cloud-auth-token",
+      SMALL_MODEL: "persisted-direct-small-model",
+      vars: {
+        ELIZAOS_CLOUD_API_KEY: "persisted-nested-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+        ELIZAOS_CLOUD_ENABLED: "true",
+        ELIZAOS_CLOUD_USE_INFERENCE: "true",
+      },
+    },
+    plugins: {
+      allow: ["elizacloud"],
+      entries: { elizacloud: { enabled: true } },
+    },
+    agents: {
+      list: [
+        {
+          name: "Persisted Agent",
+          settings: {
+            ELIZAOS_CLOUD_API_KEY: "persisted-agent-production-key",
+            ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+            KEEP_AGENT_SETTING: "preserved",
+            secrets: {
+              ELIZAOS_CLOUD_SERVICE_KEY:
+                "persisted-agent-production-service-key",
+              KEEP_AGENT_SECRET: "preserved",
+            },
+          },
+        },
+      ],
+    },
+  } as unknown as ElizaConfig;
+}
+
+function setDevCloudAuthority(
+  authority:
+    | "staging-default"
+    | "staging-explicit"
+    | "production"
+    | "offline"
+    | "self-hosted",
+  values: Partial<Record<(typeof DEV_CLOUD_ENV_OWNED_KEYS)[number], string>>,
+): void {
+  for (const key of DEV_CLOUD_ENV_RESTORE_KEYS) delete process.env[key];
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env[DEV_CLOUD_ENV_AUTHORITY_KEY] = authority;
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+}
+
+function snapshotOwnedDevCloudEnv(): Record<string, string | undefined> {
+  return Object.fromEntries(
+    DEV_CLOUD_ENV_RESTORE_KEYS.map((key) => [key, process.env[key]]),
+  );
+}
+
+describe("launcher-owned local development Cloud policy", () => {
+  it("builds a non-persisted default-staging runtime view", () => {
+    setDevCloudAuthority("staging-default", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+      ELIZAOS_CLOUD_ENABLED: "",
+      ELIZA_CLOUD_PROVISIONED: "",
+      ELIZA_CLOUD_AGENT_ID: "",
+      ELIZAOS_CLOUD_USE_INFERENCE: "",
+    });
+    const persisted = hostilePersistedCloudConfig();
+    const original = structuredClone(persisted);
+
+    const view = createDevCloudConfigAuthorityView(persisted);
+
+    expect(view).not.toBe(persisted);
+    expect(persisted).toEqual(original);
+    expect(view.deploymentTarget).toEqual({ runtime: "local" });
+    expect(view.linkedAccounts?.elizacloud).toBeUndefined();
+    expect(view.serviceRouting).toBeUndefined();
+    expect(view.cloud).toMatchObject({
+      enabled: false,
+      baseUrl: "https://api-staging.eliza.app/api/v1",
+    });
+    expect(view.cloud?.apiKey).toBe("");
+    expect((view.cloud as Record<string, unknown>)?.serviceKey).toBeUndefined();
+    expect(view.cloud?.agentId).toBeUndefined();
+    expect(view.env?.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(view.env?.vars?.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(view.env?.ELIZAOS_CLOUD_EMBEDDING_API_KEY).toBeUndefined();
+    expect(view.env?.ELIZAOS_CLOUD_EMBEDDING_URL).toBeUndefined();
+    expect(view.env?.ELIZA_CLOUD_API_BASE_URL).toBeUndefined();
+    expect(view.env?.ELIZA_CLOUD_AUTH_TOKEN).toBeUndefined();
+    expect(view.env?.SMALL_MODEL).toBe("persisted-direct-small-model");
+    const agentSettings = view.agents?.list?.[0]?.settings as
+      | Record<string, unknown>
+      | undefined;
+    expect(agentSettings?.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(agentSettings?.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
+    expect(agentSettings?.KEEP_AGENT_SETTING).toBe("preserved");
+    expect(
+      (agentSettings?.secrets as Record<string, unknown> | undefined)
+        ?.ELIZAOS_CLOUD_SERVICE_KEY,
+    ).toBeUndefined();
+    expect(
+      (agentSettings?.secrets as Record<string, unknown> | undefined)
+        ?.KEEP_AGENT_SECRET,
+    ).toBe("preserved");
+    expect(shouldStartElizaCloudThinClient(view)).toBe(false);
+    expect(shouldStartElizaCloudThinClient(persisted)).toBe(true);
+  });
+
+  it("keeps the frozen launch tuple after later process-env pollution", () => {
+    setDevCloudAuthority("staging-default", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+      ELIZAOS_CLOUD_SERVICE_KEY: "",
+    });
+    createDevCloudConfigAuthorityView(hostilePersistedCloudConfig());
+
+    process.env.ELIZA_DEV_SOURCE = "0";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "production";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_SERVICE_KEY = "late-production-service-key";
+    const config = hostilePersistedCloudConfig();
+    applyCloudConfigToEnv(config);
+
+    expect(config.cloud).toMatchObject({
+      enabled: false,
+      baseUrl: "https://api-staging.eliza.app/api/v1",
+      apiKey: "",
+    });
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("");
+    expect(process.env.ELIZAOS_CLOUD_SERVICE_KEY).toBe("");
+    expect(process.env.ELIZA_DEV_SOURCE).toBe("1");
+    expect(process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY).toBe("staging-default");
+    expect(process.env.ELIZA_DEV_CLOUD_TARGET).toBeUndefined();
+  });
+
+  it("projects exact launch values over DB-backed runtime settings", () => {
+    setDevCloudAuthority("staging-default", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+    });
+
+    const overlay = createDevCloudRuntimeSettingsAuthorityOverlay();
+
+    expect(overlay).toMatchObject({
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+      ELIZAOS_CLOUD_SERVICE_KEY: "",
+      ELIZA_CLOUD_SERVICE_KEY: "",
+      ELIZA_CLOUD_WRITE_BASE_URL: "",
+      ELIZA_CLOUD_URL: "",
+    });
+  });
+
+  it("preserves direct non-text capability routes while removing stale Cloud routes", () => {
+    setDevCloudAuthority("staging-default", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+    });
+    const persisted = hostilePersistedCloudConfig();
+    persisted.serviceRouting = {
+      ...persisted.serviceRouting,
+      embeddings: { backend: "openai", transport: "direct" },
+      tts: { backend: "elevenlabs", transport: "direct" },
+    };
+
+    const view = createDevCloudConfigAuthorityView(persisted);
+
+    expect(view.serviceRouting?.llmText).toBeUndefined();
+    expect(view.serviceRouting?.embeddings).toMatchObject({
+      backend: "openai",
+      transport: "direct",
+    });
+    expect(view.serviceRouting?.tts).toMatchObject({
+      backend: "elevenlabs",
+      transport: "direct",
+    });
+    expect(view.env?.SMALL_MODEL).toBe("persisted-direct-small-model");
+  });
+
+  it("applies only route mutations back onto the untouched durable config", () => {
+    setDevCloudAuthority("staging-default", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+    });
+    const durable = hostilePersistedCloudConfig();
+    const before = createDevCloudConfigAuthorityView(durable);
+    const after = structuredClone(before);
+    after.wallet = {
+      ...(after.wallet ?? {}),
+      cloud: {
+        ...(after.wallet?.cloud ?? {}),
+        evm: { address: "0x1234567890123456789012345678901234567890" },
+      },
+    };
+
+    const merged = mergeDevCloudConfigAuthorityMutation(durable, before, after);
+
+    expect(merged.cloud).toEqual(durable.cloud);
+    expect(merged.deploymentTarget).toEqual(durable.deploymentTarget);
+    expect(merged.wallet?.cloud?.evm?.address).toBe(
+      "0x1234567890123456789012345678901234567890",
+    );
+  });
+
+  it.each(["staging-default", "offline"] as const)(
+    "%s cannot be reactivated by persisted config or plugin entries",
+    (authority) => {
+      setDevCloudAuthority(authority, {
+        ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+        ELIZAOS_CLOUD_API_KEY: "",
+        ELIZAOS_CLOUD_ENABLED: "",
+        ELIZA_CLOUD_PROVISIONED: "",
+        ELIZA_CLOUD_AGENT_ID: "",
+        ELIZAOS_CLOUD_USE_INFERENCE: "",
+        ELIZAOS_CLOUD_USE_TTS: "",
+        ELIZAOS_CLOUD_USE_STT: "",
+        ELIZAOS_CLOUD_USE_MEDIA: "",
+        ELIZAOS_CLOUD_USE_EMBEDDINGS: "",
+        ELIZAOS_CLOUD_USE_RPC: "",
+      });
+      const frozen = captureDevCloudEnvAuthority();
+      expect(frozen).not.toBeNull();
+      const expectedEnv = Object.fromEntries(
+        DEV_CLOUD_ENV_RESTORE_KEYS.map((key) => [key, frozen?.values[key]]),
+      );
+      const config = hostilePersistedCloudConfig();
+
+      applyCloudConfigToEnv(config);
+
+      expect(snapshotOwnedDevCloudEnv()).toEqual(expectedEnv);
+      expect(config.cloud).toMatchObject({
+        enabled: false,
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+      });
+      expect(config.cloud?.apiKey).toBe("");
+      expect(config.serviceRouting).toBeUndefined();
+      expect(
+        collectPluginNames(config, undefined, [
+          "@elizaos/plugin-elizacloud",
+        ]).has("@elizaos/plugin-elizacloud"),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["staging-default", "offline"] as const)(
+    "%s ignores late container and Cloud activation pollution across all surfaces",
+    (authority) => {
+      setDevCloudAuthority(authority, {
+        ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+        ELIZAOS_CLOUD_API_KEY: "",
+        ELIZAOS_CLOUD_ENABLED: "",
+        ELIZA_CLOUD_PROVISIONED: "",
+        ELIZAOS_CLOUD_USE_INFERENCE: "",
+        ELIZAOS_CLOUD_USE_EMBEDDINGS: "",
+      });
+      captureDevCloudEnvAuthority();
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_ENABLED = "true";
+      process.env.ELIZA_CLOUD_PROVISIONED = "1";
+      process.env.ELIZAOS_CLOUD_USE_INFERENCE = "true";
+      process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "true";
+
+      const names = collectPluginNames(
+        hostilePersistedCloudConfig(),
+        undefined,
+        ["@elizaos/plugin-elizacloud"],
+      );
+
+      expect(names.has("@elizaos/plugin-elizacloud")).toBe(false);
+      expect(names.has("agent-orchestrator")).toBe(false);
+      expect(names.has("@elizaos/plugin-pty")).toBe(false);
+      expect(names.has("@elizaos/plugin-cli-inference")).toBe(false);
+      expect(names.has("@elizaos/plugin-local-inference")).toBe(true);
+    },
+  );
+
+  it.each([
+    ["staging-explicit", "https://api-staging.eliza.app/api/v1"],
+    ["self-hosted", "https://api.private.example/api/v1"],
+  ] as const)(
+    "%s keeps the frozen capability-only plugin set after late activation pollution",
+    (authority, baseUrl) => {
+      setDevCloudAuthority(authority, {
+        ELIZAOS_CLOUD_BASE_URL: baseUrl,
+        ELIZAOS_CLOUD_API_KEY: "launcher-key",
+        ELIZAOS_CLOUD_ENABLED: "true",
+        ELIZA_CLOUD_PROVISIONED: "",
+        ELIZAOS_CLOUD_USE_INFERENCE: "false",
+      });
+      process.env.OPENAI_API_KEY = "direct-provider-key";
+      captureDevCloudEnvAuthority();
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZA_CLOUD_PROVISIONED = "1";
+      process.env.ELIZAOS_CLOUD_USE_INFERENCE = "true";
+
+      const names = collectPluginNames(
+        hostilePersistedCloudConfig(),
+        undefined,
+        ["@elizaos/plugin-openai"],
+      );
+
+      expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+      expect(names.has("@elizaos/plugin-openai")).toBe(true);
+      expect(names.has("agent-orchestrator")).toBe(false);
+      expect(names.has("@elizaos/plugin-pty")).toBe(false);
+      expect(names.has("@elizaos/plugin-cli-inference")).toBe(false);
+    },
+  );
+
+  it.each([
+    [
+      "staging-explicit",
+      "https://api-staging.eliza.app/api/v1",
+      "staging-launch-key",
+      "staging-agent",
+    ],
+    [
+      "production",
+      "https://api.eliza.app/api/v1",
+      "production-launch-key",
+      "production-agent",
+    ],
+    [
+      "self-hosted",
+      "https://api.private.example/api/v1",
+      "private-launch-key",
+      "private-agent",
+    ],
+  ] as const)(
+    "%s keeps only launch-time Cloud identity and matches inference ownership",
+    (authority, baseUrl, apiKey, agentId) => {
+      setDevCloudAuthority(authority, {
+        ELIZAOS_CLOUD_BASE_URL: baseUrl,
+        ELIZAOS_CLOUD_API_KEY: apiKey,
+        ELIZAOS_CLOUD_ENABLED: "true",
+        ELIZA_CLOUD_AGENT_ID: agentId,
+      });
+      process.env.OPENAI_API_KEY = "direct-provider-key";
+      const frozen = captureDevCloudEnvAuthority();
+      expect(frozen).not.toBeNull();
+      const expectedEnv = Object.fromEntries(
+        DEV_CLOUD_ENV_RESTORE_KEYS.map((key) => [key, frozen?.values[key]]),
+      );
+      const config = hostilePersistedCloudConfig();
+
+      applyCloudConfigToEnv(config);
+
+      expect(snapshotOwnedDevCloudEnv()).toEqual(expectedEnv);
+      expect(config.cloud).toMatchObject({
+        enabled: true,
+        baseUrl,
+        apiKey,
+        agentId,
+      });
+      expect(config.serviceRouting).toBeUndefined();
+      const names = collectPluginNames(config, undefined, [
+        "@elizaos/plugin-openai",
+      ]);
+      expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+      // plugin-elizacloud owns text when USE_INFERENCE is unset; direct model
+      // providers must not be left loaded under a higher-priority Cloud brain.
+      expect(names.has("@elizaos/plugin-openai")).toBe(false);
+    },
+  );
+
+  it("keeps direct providers when explicit Cloud is capability-only", () => {
+    setDevCloudAuthority("staging-explicit", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "staging-launch-key",
+      ELIZAOS_CLOUD_USE_INFERENCE: "false",
+    });
+    process.env.OPENAI_API_KEY = "direct-provider-key";
+
+    const names = collectPluginNames(hostilePersistedCloudConfig(), undefined, [
+      "@elizaos/plugin-openai",
+    ]);
+
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+    expect(names.has("@elizaos/plugin-openai")).toBe(true);
+  });
+
+  it("keeps an explicit direct text route unless launch policy selects Cloud inference", () => {
+    setDevCloudAuthority("staging-explicit", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "staging-launch-key",
+      ELIZAOS_CLOUD_USE_INFERENCE: "",
+    });
+    process.env.OPENAI_API_KEY = "direct-provider-key";
+    const config = hostilePersistedCloudConfig();
+    config.serviceRouting = {
+      llmText: { backend: "openai", transport: "direct" },
+      embeddings: { backend: "openai", transport: "direct" },
+    };
+
+    const view = createDevCloudConfigAuthorityView(config);
+    const names = collectPluginNames(view, undefined, [
+      "@elizaos/plugin-openai",
+    ]);
+    const settings = createDevCloudRuntimeSettingsAuthorityOverlay(
+      process.env,
+      view,
+    );
+    const registered: string[] = [];
+    registerTextInferenceModels({
+      getSetting: (key: string) => settings[key],
+      registerModel: (modelType: string) => registered.push(modelType),
+    } as unknown as IAgentRuntime);
+
+    expect(view.serviceRouting?.llmText?.backend).toBe("openai");
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+    expect(names.has("@elizaos/plugin-openai")).toBe(true);
+    expect(settings.ELIZAOS_CLOUD_USE_INFERENCE).toBe("false");
+    expect(registered).toEqual([]);
+  });
+
+  it("lets explicit Cloud inference replace direct text but retains direct embeddings", () => {
+    setDevCloudAuthority("staging-explicit", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "staging-launch-key",
+      ELIZAOS_CLOUD_USE_INFERENCE: "on",
+    });
+    process.env.OPENAI_API_KEY = "direct-provider-key";
+    const config = hostilePersistedCloudConfig();
+    config.serviceRouting = {
+      llmText: { backend: "openai", transport: "direct" },
+      embeddings: { backend: "openai", transport: "direct" },
+    };
+
+    const view = createDevCloudConfigAuthorityView(config);
+    const names = collectPluginNames(view, undefined, [
+      "@elizaos/plugin-openai",
+    ]);
+    const settings = createDevCloudRuntimeSettingsAuthorityOverlay(
+      process.env,
+      view,
+    );
+    const registered: string[] = [];
+    registerTextInferenceModels({
+      getSetting: (key: string) => settings[key],
+      registerModel: (modelType: string) => registered.push(modelType),
+    } as unknown as IAgentRuntime);
+
+    expect(view.serviceRouting?.llmText).toBeUndefined();
+    expect(view.serviceRouting?.embeddings?.backend).toBe("openai");
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+    expect(names.has("@elizaos/plugin-openai")).toBe(true);
+    expect(settings.ELIZAOS_CLOUD_USE_INFERENCE).toBe("on");
+    expect(registered.length).toBeGreaterThan(0);
+  });
+
+  it("does not load Cloud from an enabled flag without a usable launch credential", () => {
+    setDevCloudAuthority("staging-explicit", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "",
+      ELIZAOS_CLOUD_ENABLED: "true",
+    });
+    process.env.OPENAI_API_KEY = "direct-provider-key";
+
+    const view = createDevCloudConfigAuthorityView(
+      hostilePersistedCloudConfig(),
+    );
+    const names = collectPluginNames(view, undefined, [
+      "@elizaos/plugin-openai",
+    ]);
+
+    expect(view.cloud?.enabled).toBe(false);
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(false);
+    expect(names.has("@elizaos/plugin-openai")).toBe(true);
+  });
+
+  it.each([
+    "[REDACTED]",
+    "vault://ELIZAOS_CLOUD_API_KEY",
+    "VAULT://ELIZAOS_CLOUD_API_KEY",
+  ])(
+    "does not activate explicit Cloud from an unusable %s credential",
+    (apiKey) => {
+      setDevCloudAuthority("production", {
+        ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+        ELIZAOS_CLOUD_API_KEY: apiKey,
+      });
+
+      const view = createDevCloudConfigAuthorityView(
+        hostilePersistedCloudConfig(),
+      );
+
+      expect(view.cloud?.enabled).toBe(false);
+      expect(view.cloud?.apiKey).toBe("");
+      expect(collectPluginNames(view).has("@elizaos/plugin-elizacloud")).toBe(
+        false,
+      );
+    },
+  );
+
+  it("ignores an authority marker that was not stamped by a dev launcher", () => {
+    process.env[DEV_CLOUD_ENV_AUTHORITY_KEY] = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    const config = hostilePersistedCloudConfig();
+
+    applyCloudConfigToEnv(config);
+
+    expect(config.cloud?.apiKey).toBe("persisted-production-key");
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("persisted-production-key");
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBe(
+      "https://api.eliza.app/api/v1",
+    );
+  });
+
+  it("cannot hydrate forged launcher authority from persisted config env", () => {
+    const targetEnv: NodeJS.ProcessEnv = {};
+    hydrateConfigEnvForBoot(
+      {
+        env: {
+          ELIZA_DEV_SOURCE: "1",
+          ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-default",
+          vars: {
+            ELIZA_DEV_CLOUD_TARGET: "production",
+            ELIZAOS_CLOUD_API_KEY: "persisted-production-key",
+            OPENAI_API_KEY: "preserved-direct-provider-key",
+          },
+        },
+      },
+      targetEnv,
+    );
+
+    expect(targetEnv.ELIZA_DEV_SOURCE).toBeUndefined();
+    expect(targetEnv.ELIZA_DEV_CLOUD_ENV_AUTHORITY).toBeUndefined();
+    expect(targetEnv.ELIZA_DEV_CLOUD_TARGET).toBeUndefined();
+    expect(targetEnv.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(targetEnv.OPENAI_API_KEY).toBe("preserved-direct-provider-key");
+    expect(resolveDevCloudEnvAuthority(targetEnv)).toBeNull();
+  });
 });
 
 describe("applyCloudConfigToEnv cloud-container embeddings (#8769)", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -168,6 +168,7 @@ import {
   readAliasedEnv,
   resolveDeploymentTargetInConfig,
   resolveDesktopApiPort,
+  resolveDevCloudAuthorityEnvValue,
   resolveElizaCloudTopology,
   resolveServerOnlyPort,
   resolveServiceRoutingInConfig,
@@ -285,8 +286,17 @@ import {
 import {
   configFileExists,
   type ElizaConfig,
+  loadEffectiveElizaConfig,
   loadElizaConfig,
 } from "../config/config.ts";
+import {
+  applyDevCloudConfigAuthority,
+  createDevCloudConfigAuthorityView,
+  createDevCloudRuntimeSettingsAuthorityOverlay,
+  isDevCloudEnvOwnedKey,
+  isDevCloudInternalEnvKey,
+  restoreDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
 import {
   CONNECTOR_ENV_MAP,
   collectConnectorEnvVars,
@@ -1941,20 +1951,36 @@ function assertPersistentDatabaseRequired(
 
 function isElizaCloudManagedProcessEnvKey(key: string): boolean {
   const upper = key.toUpperCase();
-  return (
-    upper === "ELIZAOS_CLOUD_API_KEY" ||
-    upper === "ELIZAOS_CLOUD_ENABLED" ||
-    upper === "ELIZAOS_CLOUD_BASE_URL" ||
-    upper === "ELIZAOS_CLOUD_NANO_MODEL" ||
-    upper === "ELIZAOS_CLOUD_MEDIUM_MODEL" ||
-    upper === "ELIZAOS_CLOUD_SMALL_MODEL" ||
-    upper === "ELIZAOS_CLOUD_LARGE_MODEL" ||
-    upper === "ELIZAOS_CLOUD_MEGA_MODEL" ||
-    upper === "ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL" ||
-    upper === "ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL" ||
-    upper === "ELIZAOS_CLOUD_ACTION_PLANNER_MODEL" ||
-    upper === "ELIZAOS_CLOUD_PLANNER_MODEL"
-  );
+  return isDevCloudEnvOwnedKey(upper) || isDevCloudInternalEnvKey(upper);
+}
+
+/**
+ * Hydrate user-owned config environment values without allowing persisted
+ * state to forge launcher authority or repopulate launcher-owned Cloud keys.
+ * @internal Exported for regression tests.
+ */
+export function hydrateConfigEnvForBoot(
+  config: Pick<ElizaConfig, "env">,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (
+    !config.env ||
+    typeof config.env !== "object" ||
+    Array.isArray(config.env)
+  ) {
+    return;
+  }
+  const hydrateEntries = (values: Record<string, unknown>): void => {
+    for (const [key, value] of Object.entries(values)) {
+      if (isElizaCloudManagedProcessEnvKey(key)) continue;
+      if (typeof value === "string" && !env[key]) env[key] = value;
+    }
+  };
+  hydrateEntries(config.env as Record<string, unknown>);
+  const vars = (config.env as Record<string, unknown>).vars;
+  if (vars && typeof vars === "object" && !Array.isArray(vars)) {
+    hydrateEntries(vars as Record<string, unknown>);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2274,12 +2300,21 @@ export async function autoFetchCloudGithubToken(
   if (process.env.GITHUB_TOKEN || process.env.GITHUB_PAT) return null;
 
   // Need cloud credentials and an agent ID
-  const cloudApiKey = process.env.ELIZAOS_CLOUD_API_KEY?.trim();
+  const cloudApiKey = resolveDevCloudAuthorityEnvValue(
+    "ELIZAOS_CLOUD_API_KEY",
+  )?.trim();
   const cloudBaseUrl =
-    process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || "https://api.eliza.app";
+    resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL")?.trim() ||
+    "https://api.eliza.app";
   if (!cloudApiKey || !agentId) return null;
 
-  const managedNs = readAliasedEnv("ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT");
+  const managedNs =
+    resolveDevCloudAuthorityEnvValue(
+      "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+    )?.trim() ||
+    resolveDevCloudAuthorityEnvValue(
+      "ELIZAOS_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+    )?.trim();
   if (!managedNs) return null;
 
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
@@ -2366,6 +2401,19 @@ export function cloudApiKeyFingerprint(value: string | undefined): string {
  */
 export function applyCloudConfigToEnv(config: ElizaConfig): void {
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
+  const devCloudSnapshot = applyDevCloudConfigAuthority(
+    config as Record<string, unknown>,
+  );
+  try {
+    applyCloudConfigToEnvResolved(config);
+  } finally {
+    if (devCloudSnapshot) {
+      restoreDevCloudEnvAuthority(devCloudSnapshot);
+    }
+  }
+}
+
+function applyCloudConfigToEnvResolved(config: ElizaConfig): void {
   ensureProvisionedCloudContainerConfig(config);
   const cloud = config.cloud;
 
@@ -3353,7 +3401,10 @@ function summarizeComponentWrite(input: unknown): Record<string, unknown> {
   };
 }
 
-export function installRuntimeMethodBindings(runtime: AgentRuntime): void {
+export function installRuntimeMethodBindings(
+  runtime: AgentRuntime,
+  devCloudAuthorityOverlay: Readonly<Record<string, string>> = {},
+): void {
   const runtimeWithBindings = runtime as RuntimeWithMethodBindings;
   if (runtimeWithBindings.__elizaMethodBindingsInstalled) {
     return;
@@ -3419,8 +3470,24 @@ export function installRuntimeMethodBindings(runtime: AgentRuntime): void {
     // to forward to coding agents via this comma-separated key list (e.g. MCP server tokens).
     "CUSTOM_CREDENTIAL_KEYS",
   ]);
+  const frozenDevCloudAuthorityOverlay = Object.freeze({
+    ...devCloudAuthorityOverlay,
+  });
+  const hasDevCloudAuthorityOverlay =
+    Object.keys(frozenDevCloudAuthorityOverlay).length > 0;
   const originalGetSetting = runtime.getSetting.bind(runtime);
   runtime.getSetting = (key: string) => {
+    // Constructor settings normally lose to character/DB values in core's
+    // getSetting precedence. A launcher-owned development tuple is different:
+    // every Cloud consumer must observe the same immutable launch value even
+    // after a character/config merge mutates the higher-precedence stores.
+    if (hasDevCloudAuthorityOverlay && isDevCloudEnvOwnedKey(key)) {
+      const authorityValue =
+        frozenDevCloudAuthorityOverlay[key.toUpperCase()] ?? "";
+      if (authorityValue === "true") return true;
+      if (authorityValue === "false") return false;
+      return authorityValue;
+    }
     const result = originalGetSetting(key);
     if (result !== null && result !== undefined) return result;
     if (GETSETTING_ENV_ALLOWLIST.has(key)) {
@@ -4120,6 +4187,10 @@ export async function startEliza(
   if (!opts?.headless) {
     config = await runFirstTimeSetup(config);
   }
+  // The launcher-selected dev Cloud target is an ephemeral runtime view. Build
+  // it only after interactive setup has had a chance to persist the user's
+  // real config, then keep stale production state out of every boot consumer.
+  config = createDevCloudConfigAuthorityView(config);
   bootContext.enterPhase("resolve-settings");
 
   // 1c. Apply logging level from config to process.env so the global
@@ -4240,33 +4311,8 @@ export async function startEliza(
   // in config.env; elizaOS plugins read them via process.env / getSetting.
   // Skip ELIZAOS_CLOUD_* — applyCloudConfigToEnv() owns those; otherwise a
   // stale key in config.env refills process.env after disconnect cleared it.
-  if (
-    config.env &&
-    typeof config.env === "object" &&
-    !Array.isArray(config.env)
-  ) {
-    for (const [key, value] of Object.entries(config.env)) {
-      if (isElizaCloudManagedProcessEnvKey(key)) continue;
-      if (typeof value === "string" && !process.env[key]) {
-        process.env[key] = value;
-      }
-    }
-    // Also hydrate from config.env.vars — setEnvValue writes API keys to
-    // both config.env["KEY"] and config.env.vars["KEY"]. If the top-level
-    // key was lost (e.g. pruneEnv, config migration), the nested form is
-    // the authoritative source.
-    const vars = (config.env as Record<string, unknown>).vars;
-    if (vars && typeof vars === "object" && !Array.isArray(vars)) {
-      for (const [key, value] of Object.entries(
-        vars as Record<string, unknown>,
-      )) {
-        if (isElizaCloudManagedProcessEnvKey(key)) continue;
-        if (typeof value === "string" && !process.env[key]) {
-          process.env[key] = value;
-        }
-      }
-    }
-  }
+  // Also hydrates config.env.vars (the nested form written by setEnvValue).
+  hydrateConfigEnvForBoot(config);
 
   // Persisted plugin settings are hydrated into process.env above. Resolve the
   // watchdog only after that merge so first boot validates and uses the same
@@ -4886,6 +4932,9 @@ export async function startEliza(
   await configureLocalEmbeddingEnvEarlyIfNeeded(config);
   opts?.abortSignal?.throwIfAborted();
   bootContext.enterPhase("construct-runtime");
+  const devCloudRuntimeSettingsAuthorityOverlay = Object.freeze(
+    createDevCloudRuntimeSettingsAuthorityOverlay(process.env, config),
+  );
   let runtime = await constructWithRuntimeInstallationIdentity({
     stateDirectory: resolveStateDir(),
     abortSignal: opts?.abortSignal,
@@ -4918,24 +4967,34 @@ export async function startEliza(
                 : undefined,
             }
           : {}),
-        settings: buildRuntimeSettings(config, {
-          preferredProviderId,
-          brainProviderName: preferredTextRuntimeProviderName,
-          embeddingProviderName: preferredEmbeddingRuntimeProviderName,
-          visionModeSetting,
-          managedSkillsDir,
-          bundledSkillsDir,
-          workspaceSkillsDir,
-          connectorSecretsOverlay,
-          providerCredentialsOverlay,
-        }),
+        settings: {
+          ...buildRuntimeSettings(config, {
+            preferredProviderId,
+            brainProviderName: preferredTextRuntimeProviderName,
+            embeddingProviderName: preferredEmbeddingRuntimeProviderName,
+            visionModeSetting,
+            managedSkillsDir,
+            bundledSkillsDir,
+            workspaceSkillsDir,
+            connectorSecretsOverlay,
+            providerCredentialsOverlay,
+          }),
+          // Core's initialization merge gives constructor settings precedence
+          // over DB-persisted values without writing them back. Supplying the
+          // frozen launch tuple here prevents stale DB Cloud secrets/topology
+          // from resurfacing through runtime.getSetting after initialization.
+          ...devCloudRuntimeSettingsAuthorityOverlay,
+        },
       }),
   });
   const walletAddressCacheSession = opts?.deferWalletAddressCacheActivation
     ? beginDeferredAgentWalletAddressCacheSession(runtime.agentId)
     : beginAgentWalletAddressCacheSession(runtime.agentId);
   walletAddressCacheSessionsByRuntime.set(runtime, walletAddressCacheSession);
-  installRuntimeMethodBindings(runtime);
+  installRuntimeMethodBindings(
+    runtime,
+    devCloudRuntimeSettingsAuthorityOverlay,
+  );
   opts?.onRuntimeCreated?.(runtime);
   opts?.abortSignal?.throwIfAborted();
 
@@ -6287,7 +6346,7 @@ export async function startEliza(
             disposedRuntimeBeforeReplacement = true;
           }
           const replacement = await buildInitializedRuntime({
-            config: loadElizaConfig(),
+            config: loadEffectiveElizaConfig(),
             localAgentMode: opts?.localAgentMode,
           });
           logger.info("[eliza] Hot-reload: replacement runtime is ready");

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -41,6 +41,11 @@ import {
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import {
+  applyDevCloudConfigAuthority,
+  createDevCloudConfigAuthorityView,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
+import {
   CORE_PLUGINS,
   ELIZAOS_ANDROID_CORE_PLUGINS,
   ELIZAOS_ANDROID_TERMINAL_PLUGINS,
@@ -75,7 +80,10 @@ function gitpathologistPackageAvailable(): boolean {
  * Agent orchestrator ships as the standalone @elizaos/plugin-agent-orchestrator package;
  * Eliza loads it via STATIC_ELIZA_PLUGINS["agent-orchestrator"].
  */
-function orchestratorCompatPluginRequested(config: ElizaConfig): boolean {
+function orchestratorCompatPluginRequested(
+  config: ElizaConfig,
+  isCloudContainer: boolean,
+): boolean {
   const agentEntry = config.agents?.list?.[0];
   const fromEntry = agentEntry?.agentOrchestrator;
   const fromDefaults = config.agents?.defaults?.agentOrchestrator;
@@ -97,7 +105,7 @@ function orchestratorCompatPluginRequested(config: ElizaConfig): boolean {
   // match a local desktop agent instead of requiring a per-container env
   // opt-in. Explicit config/env opt-outs above still win, and lean-chat
   // containers force-drop it via LEAN_CHAT_EXCLUDED_PLUGINS regardless.
-  if (readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1") {
+  if (isCloudContainer) {
     return true;
   }
   return [
@@ -132,7 +140,7 @@ function isUsableCloudApiKey(value: unknown): value is string {
   return (
     trimmed.length > 0 &&
     trimmed.toUpperCase() !== "[REDACTED]" &&
-    !trimmed.startsWith("vault://")
+    !trimmed.toLowerCase().startsWith("vault://")
   );
 }
 
@@ -255,7 +263,7 @@ function isDirectlyRoutableProviderPlugin(
 function isTruthyCloudEnvValue(raw: string | undefined): boolean {
   if (!raw) return false;
   const value = raw.trim().toLowerCase();
-  return value === "1" || value === "true" || value === "yes";
+  return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
 function isStoreBuildVariant(): boolean {
@@ -436,10 +444,18 @@ export function collectPluginNames(
   reasons?: PluginLoadReasons,
   forceIncludePluginNames: readonly string[] = [],
 ): Set<string> {
+  config = createDevCloudConfigAuthorityView(config);
   const legacyLocalOnlyInference =
     config.cloud?.inferenceMode === "local" ||
     config.cloud?.services?.inference === false;
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
+  const devCloudSnapshot = applyDevCloudConfigAuthority(
+    config as Record<string, unknown>,
+  );
+  const devCloudAuthority =
+    devCloudSnapshot?.authority ?? resolveDevCloudEnvAuthority();
+  const effectiveCloudEnvValue = (key: string): string | undefined =>
+    devCloudSnapshot ? devCloudSnapshot.values[key] : process.env[key];
   const deploymentTarget = resolveDeploymentTargetInConfig(
     config as Record<string, unknown>,
   );
@@ -453,7 +469,9 @@ export function collectPluginNames(
   const hasCanonicalRuntimeConfig = hasExplicitCanonicalRuntimeConfig(
     config as Record<string, unknown>,
   );
-  const isCloudContainer = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
+  const isCloudContainer = devCloudSnapshot
+    ? devCloudSnapshot.values.ELIZA_CLOUD_PROVISIONED?.trim() === "1"
+    : readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
   const storeBuild = isStoreBuildVariant();
   const cloudExplicitlyDisabled = config.cloud?.enabled === false;
   // `ELIZA_LOCAL_LLAMA=1` is the AOSP / on-device signal that the in-process
@@ -472,8 +490,8 @@ export function collectPluginNames(
   const cloudPluginRequestedByEnv =
     !hasCanonicalRuntimeConfig &&
     !cloudExplicitlyDisabled &&
-    (Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim()) ||
-      isTruthyCloudEnvValue(process.env.ELIZAOS_CLOUD_ENABLED));
+    (Boolean(effectiveCloudEnvValue("ELIZAOS_CLOUD_API_KEY")?.trim()) ||
+      isTruthyCloudEnvValue(effectiveCloudEnvValue("ELIZAOS_CLOUD_ENABLED")));
   const cloudEffectivelyEnabled =
     resolveCloudPluginRequirement(cloudTopology, cloudPluginRequestedByEnv) ||
     isCloudContainer;
@@ -481,7 +499,7 @@ export function collectPluginNames(
     | (Record<string, unknown> & { vars?: Record<string, unknown> })
     | undefined;
   const hasUsableCloudApiKey = [
-    process.env.ELIZAOS_CLOUD_API_KEY,
+    effectiveCloudEnvValue("ELIZAOS_CLOUD_API_KEY"),
     config.cloud?.apiKey,
     _configEnv?.ELIZAOS_CLOUD_API_KEY,
     _configEnv?.vars?.ELIZAOS_CLOUD_API_KEY,
@@ -497,6 +515,27 @@ export function collectPluginNames(
   const cloudHandlesInference =
     cloudTopology.services.inference &&
     (hasUsableCloudApiKey || isCloudContainer);
+  const devCloudCredentialAvailable = hasUsableCloudApiKey;
+  const devCloudActivationBlocked =
+    devCloudAuthority === "staging-default" || devCloudAuthority === "offline";
+  const devCloudPluginEnabled = Boolean(
+    devCloudAuthority &&
+      !devCloudActivationBlocked &&
+      (devCloudCredentialAvailable || isCloudContainer),
+  );
+  const devInferencePolicy = effectiveCloudEnvValue(
+    "ELIZAOS_CLOUD_USE_INFERENCE",
+  )
+    ?.trim()
+    .toLowerCase();
+  const hasDirectTextRoute =
+    serviceRouting?.llmText?.transport === "direct" &&
+    Boolean(serviceRouting.llmText.backend);
+  const devCloudOwnsInference = Boolean(
+    devCloudPluginEnabled &&
+      (isTruthyCloudEnvValue(devInferencePolicy) ||
+        (devInferencePolicy !== "false" && !hasDirectTextRoute)),
+  );
   const pluginEntries = (config.plugins as Record<string, unknown> | undefined)
     ?.entries as Record<string, { enabled?: boolean }> | undefined;
 
@@ -590,7 +629,10 @@ export function collectPluginNames(
   // never gets it; privileged AOSP adds it through
   // ELIZAOS_ANDROID_TERMINAL_PLUGINS above so it can use the bundled Bun service
   // and Android shell process model.
-  if (!onMobile && orchestratorCompatPluginRequested(config)) {
+  if (
+    !onMobile &&
+    orchestratorCompatPluginRequested(config, isCloudContainer)
+  ) {
     // Only the BACKEND is gated to non-mobile + an explicit request. The
     // operator-console view (@elizaos/plugin-task-coordinator) is seeded for
     // all platforms via MOBILE_VIEW_PLUGINS above (views-only, degrades
@@ -608,11 +650,7 @@ export function collectPluginNames(
   // PTY_SERVICE and waits for a terminal to connect; plugin-cli-inference's
   // model map is inert unless ELIZA_CHAT_VIA_CLI selects a backend. lean-chat
   // containers stay lean: these are in LEAN_CHAT_EXCLUDED_PLUGINS.
-  if (
-    !onMobile &&
-    !leanChat &&
-    readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1"
-  ) {
+  if (!onMobile && !leanChat && isCloudContainer) {
     pluginsToLoad.add("@elizaos/plugin-pty");
     track(
       "@elizaos/plugin-pty",
@@ -721,6 +759,32 @@ export function collectPluginNames(
   }
 
   const applyProviderPrecedence = (): void => {
+    const directlyRoutedProviderPlugins = new Set(
+      Object.values(serviceRouting ?? {}).flatMap((route) => {
+        if (route?.transport !== "direct" || !route.backend) return [];
+        const pluginName = providerPluginNameFromBackend(route.backend);
+        return isDirectlyRoutableProviderPlugin(route.backend, pluginName)
+          ? [pluginName]
+          : [];
+      }),
+    );
+    if (devCloudAuthority) {
+      if (devCloudPluginEnabled) {
+        pluginsToLoad.add("@elizaos/plugin-elizacloud");
+        if (devCloudOwnsInference) {
+          removeDirectModelProviderSurfaces(pluginsToLoad);
+          // Cloud may own text while direct plugins still own embeddings,
+          // media, TTS, or another explicitly routed capability.
+          for (const pluginName of directlyRoutedProviderPlugins) {
+            pluginsToLoad.add(pluginName);
+          }
+        }
+      } else {
+        pluginsToLoad.delete("@elizaos/plugin-elizacloud");
+      }
+      return;
+    }
+
     if (deploymentTarget.runtime === "remote") {
       removeAllModelProviderSurfaces(pluginsToLoad);
       return;
@@ -731,15 +795,6 @@ export function collectPluginNames(
       // owner supplies the text brain directly. The canonical llmText route is
       // the arbitration signal; stripping direct providers here would make the
       // persisted route impossible to execute and let Cloud inference win.
-      const directlyRoutedProviderPlugins = new Set(
-        Object.values(serviceRouting ?? {}).flatMap((route) => {
-          if (route?.transport !== "direct" || !route.backend) return [];
-          const pluginName = providerPluginNameFromBackend(route.backend);
-          return isDirectlyRoutableProviderPlugin(route.backend, pluginName)
-            ? [pluginName]
-            : [];
-        }),
-      );
       // Ambient credentials may belong to other tools or stale configuration;
       // the canonical route matrix is the sole ownership signal in Cloud mode.
       removeDirectModelProviderSurfaces(pluginsToLoad);
@@ -973,7 +1028,9 @@ export function collectPluginNames(
     // explicitly pinned it true) so the two providers don't both register.
     const localEmbeddingsOptIn =
       readAliasedEnv("ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS") === "1" &&
-      process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS?.trim().toLowerCase() !== "true";
+      effectiveCloudEnvValue("ELIZAOS_CLOUD_USE_EMBEDDINGS")
+        ?.trim()
+        .toLowerCase() !== "true";
     for (const name of LEAN_CHAT_EXCLUDED_PLUGINS) {
       if (localEmbeddingsOptIn && name === "@elizaos/plugin-local-inference") {
         // Keep the local embedder; ensure it wins TEXT_EMBEDDING over cloud.
@@ -984,7 +1041,7 @@ export function collectPluginNames(
         );
         // Yield the cloud embedding slot so plugin-elizacloud does not also
         // register TEXT_EMBEDDING (registerCloudEmbeddingModels checks this).
-        if (!process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS) {
+        if (!devCloudAuthority && !process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS) {
           process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
         }
         continue;
@@ -1005,6 +1062,10 @@ export function collectPluginNames(
       "telegram standalone bot (gate ELIZA_TELEGRAM_STANDALONE_BOT)",
     );
   }
+
+  // Persisted plugin entries and platform gates are not allowed to override
+  // the launcher-owned development Cloud policy.
+  if (devCloudAuthority) applyProviderPrecedence();
 
   return pluginsToLoad;
 }

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -34,6 +34,10 @@ import {
 } from "@elizaos/shared/config/plugin-manifest";
 
 import { type ElizaConfig, saveElizaConfig } from "../config/config.ts";
+import {
+  isDevCloudConfigAuthorityView,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
 import { isLegacyAppsWorkspaceDiscoveryEnabled } from "../config/feature-flags.ts";
 import { resolveStateDir, resolveUserPath } from "../config/paths.ts";
 import type { PluginInstallRecord } from "../config/types.eliza.ts";
@@ -3027,6 +3031,13 @@ export async function resolvePlugins(
   // Persist repaired install records so subsequent startups stop importing
   // from stale install directories.
   if (repairedInstallRecords.size > 0) {
+    const devCloudAuthority = resolveDevCloudEnvAuthority();
+    if (devCloudAuthority && isDevCloudConfigAuthorityView(config)) {
+      logger.info(
+        `[eliza] Repaired ${repairedInstallRecords.size} plugin install record(s) in the ephemeral ${devCloudAuthority} development config view`,
+      );
+      return plugins;
+    }
     try {
       saveElizaConfig(config);
       logger.info(

--- a/packages/agent/src/runtime/sensitive-request-cloud-authority.test.ts
+++ b/packages/agent/src/runtime/sensitive-request-cloud-authority.test.ts
@@ -1,0 +1,157 @@
+/** Launcher authority must outrank every late character Cloud setting. */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDevCloudRuntimeSettingsAuthorityOverlay,
+  resetDevCloudEnvAuthorityForTests,
+} from "../config/dev-cloud-env-authority.ts";
+import { installRuntimeMethodBindings } from "./eliza.ts";
+
+const AUTHORITY_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_REQUEST_BASE_URL",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  AUTHORITY_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function captureAuthority(
+  authority:
+    | "staging-default"
+    | "staging-explicit"
+    | "production"
+    | "offline"
+    | "self-hosted",
+): Readonly<Record<string, string>> {
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_API_KEY = "launch-cloud-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  delete process.env.ELIZAOS_CLOUD_REQUEST_BASE_URL;
+  resetDevCloudEnvAuthorityForTests();
+  return createDevCloudRuntimeSettingsAuthorityOverlay();
+}
+
+function createRuntime(
+  poisonedCharacterSettings: Record<string, string>,
+  authorityOverlay: Readonly<Record<string, string>>,
+) {
+  const character = {
+    settings: { ...poisonedCharacterSettings },
+    secrets: { ...poisonedCharacterSettings },
+  };
+  const settings = { ...poisonedCharacterSettings };
+  const runtime = {
+    agentId: "agent-1",
+    character,
+    settings,
+    getCharacterEnvSetting: () => undefined,
+    getConversationLength: () => 0,
+    getSetting(key: string) {
+      return (
+        character.secrets[key] ??
+        character.settings[key] ??
+        settings[key] ??
+        null
+      );
+    },
+    getService(name: string) {
+      return name === "SECRETS" ? { exists: async () => false } : null;
+    },
+    composeState: async () => ({}),
+    dynamicPromptExecFromState: async () => ({}),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    registerPlugin: async () => undefined,
+  };
+  installRuntimeMethodBindings(runtime as never, authorityOverlay);
+  return runtime as typeof runtime & {
+    getSetting(key: string): string | boolean | number | null;
+  };
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of AUTHORITY_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("sensitive-request Cloud authority", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "keeps Cloud settings disabled under %s after late character activation",
+    (authority) => {
+      const overlay = captureAuthority(authority);
+      const runtime = createRuntime(
+        {
+          ELIZAOS_CLOUD_API_KEY: "late-character-key",
+          ELIZAOS_CLOUD_ENABLED: "true",
+          ELIZAOS_CLOUD_REQUEST_BASE_URL: "https://collector.example",
+          ELIZAOS_CLOUD_BASE_URL: "https://collector.example/api/v1",
+          ELIZA_CLOUD_URL: "https://collector.example",
+          ELIZA_APP_URL: "https://owner-app.example",
+        },
+        overlay,
+      );
+
+      expect(runtime.getSetting("ELIZAOS_CLOUD_API_KEY")).toBe("");
+      expect(runtime.getSetting("ELIZAOS_CLOUD_REQUEST_BASE_URL")).toBe("");
+      expect(runtime.getSetting("ELIZA_CLOUD_URL")).toBe("");
+      expect(runtime.getSetting("ELIZAOS_CLOUD_BASE_URL")).toBe(
+        "https://api-staging.eliza.app/api/v1",
+      );
+      expect(runtime.getSetting("ELIZA_APP_URL")).toBe(
+        "https://owner-app.example",
+      );
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "uses only the frozen %s base after late character pollution",
+    (authority) => {
+      const overlay = captureAuthority(authority);
+      const expectedBase = overlay.ELIZAOS_CLOUD_BASE_URL;
+      const runtime = createRuntime(
+        {
+          ELIZAOS_CLOUD_API_KEY: "late-character-key",
+          ELIZAOS_CLOUD_ENABLED: "true",
+          ELIZAOS_CLOUD_REQUEST_BASE_URL: "https://collector.example",
+          ELIZAOS_CLOUD_BASE_URL: "https://collector.example/api/v1",
+          ELIZA_CLOUD_URL: "https://collector.example",
+          ELIZA_APP_URL: "https://owner-app.example",
+        },
+        overlay,
+      );
+
+      expect(runtime.getSetting("ELIZAOS_CLOUD_API_KEY")).toBe(
+        "launch-cloud-key",
+      );
+      expect(runtime.getSetting("ELIZAOS_CLOUD_BASE_URL")).toBe(expectedBase);
+      expect(runtime.getSetting("ELIZAOS_CLOUD_REQUEST_BASE_URL")).toBe("");
+      expect(runtime.getSetting("ELIZA_CLOUD_URL")).toBe("");
+      expect(runtime.getSetting("ELIZA_APP_URL")).toBe(
+        "https://owner-app.example",
+      );
+    },
+  );
+});

--- a/packages/agent/src/runtime/shared-cutover-reminder-dispatch.test.ts
+++ b/packages/agent/src/runtime/shared-cutover-reminder-dispatch.test.ts
@@ -5,14 +5,40 @@ import {
   getScheduledTaskChannelDispatcher,
   SHARED_CUTOVER_GATEWAY_CHANNEL,
 } from "@elizaos/plugin-scheduling";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSharedCutoverReminderDispatcher } from "./shared-cutover-reminder-dispatch.ts";
 
 const originalFetch = globalThis.fetch;
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_AGENT_ID",
+] as const;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  savedEnv = Object.fromEntries(
+    AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+  for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
+});
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   vi.restoreAllMocks();
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 function record() {
@@ -28,6 +54,56 @@ function record() {
 }
 
 describe("Shared cutover reminder dispatcher", () => {
+  it("stays disabled when late production values pollute a staging-default process", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "";
+    process.env.ELIZA_CLOUD_AGENT_ID = "";
+    expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZA_CLOUD_AGENT_ID = "late-production-agent";
+
+    expect(
+      registerSharedCutoverReminderDispatcher({
+        agentId: "local-agent",
+      } as IAgentRuntime),
+    ).toBe(false);
+  });
+
+  it("keeps an explicit staging dispatcher on the frozen launcher tuple", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    process.env.ELIZA_CLOUD_AGENT_ID = "staging-launch-agent";
+    expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZA_CLOUD_AGENT_ID = "late-production-agent";
+    globalThis.fetch = vi.fn(async (input, init) => {
+      expect(String(input)).toBe(
+        "https://api-staging.eliza.app/api/v1/eliza/agents/staging-launch-agent/shared-reminders/shared-reminder-1/deliver",
+      );
+      expect(new Headers(init?.headers).get("x-api-key")).toBe(
+        "staging-launch-key",
+      );
+      return Response.json({ success: true });
+    }) as unknown as typeof fetch;
+    const runtime = { agentId: "local-agent" } as IAgentRuntime;
+
+    expect(registerSharedCutoverReminderDispatcher(runtime)).toBe(true);
+    await expect(
+      getScheduledTaskChannelDispatcher(
+        runtime,
+        SHARED_CUTOVER_GATEWAY_CHANNEL,
+      )?.dispatch(record()),
+    ).resolves.toMatchObject({ ok: true });
+  });
+
   it("sends only task identity and occurrence through the authenticated Cloud boundary", async () => {
     const runtime = { agentId: "dedicated-agent" } as IAgentRuntime;
     globalThis.fetch = vi.fn(async (input, init) => {

--- a/packages/agent/src/runtime/shared-cutover-reminder-dispatch.ts
+++ b/packages/agent/src/runtime/shared-cutover-reminder-dispatch.ts
@@ -10,7 +10,10 @@ import {
   registerScheduledTaskChannelDispatcher,
   SHARED_CUTOVER_GATEWAY_CHANNEL,
 } from "@elizaos/plugin-scheduling";
-import { resolveCloudApiBaseUrl } from "@elizaos/shared";
+import {
+  resolveCloudApiBaseUrl,
+  resolveDevCloudAuthorityEnvValue,
+} from "@elizaos/shared";
 
 const DISPATCH_FAILURE_REASONS = new Set<DispatchFailureReason>([
   "disconnected",
@@ -33,8 +36,14 @@ export function registerSharedCutoverReminderDispatcher(
   runtime: IAgentRuntime,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  const apiKey = env.ELIZAOS_CLOUD_API_KEY?.trim();
-  const targetAgentId = env.ELIZA_CLOUD_AGENT_ID?.trim();
+  const apiKey = resolveDevCloudAuthorityEnvValue(
+    "ELIZAOS_CLOUD_API_KEY",
+    env,
+  )?.trim();
+  const targetAgentId = resolveDevCloudAuthorityEnvValue(
+    "ELIZA_CLOUD_AGENT_ID",
+    env,
+  )?.trim();
   if (!apiKey || !targetAgentId) return false;
   const baseUrl = resolveCloudApiBaseUrl(env.ELIZAOS_CLOUD_BASE_URL);
 

--- a/packages/agent/src/runtime/vault-profile-resolver.test.ts
+++ b/packages/agent/src/runtime/vault-profile-resolver.test.ts
@@ -15,6 +15,7 @@ import {
   writeRoutingConfig,
 } from "@elizaos/vault";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetDevCloudEnvAuthorityForTests } from "../config/dev-cloud-env-authority.ts";
 import { applyVaultProfilesForAgent } from "./vault-profile-resolver.ts";
 
 const AGENT_ID = "vault-profile-resolver-agent";
@@ -28,6 +29,10 @@ const KEY_LEGACY = "VPR_TEST_LEGACY_API_KEY";
 const KEY_REF = "VPR_TEST_REF_API_KEY";
 const KEY_WS = "VPR_TEST_WS_API_KEY";
 const KEY_MALFORMED = "VPR_TEST_MALFORMED_API_KEY";
+const CLOUD_KEY = "ELIZAOS_CLOUD_API_KEY";
+const CLOUD_BASE = "ELIZAOS_CLOUD_BASE_URL";
+const DEV_SOURCE = "ELIZA_DEV_SOURCE";
+const DEV_AUTHORITY = "ELIZA_DEV_CLOUD_ENV_AUTHORITY";
 
 const DISABLE = "ELIZA_DISABLE_VAULT_PROFILE_RESOLVER";
 
@@ -41,6 +46,10 @@ const ENV_KEYS = [
   KEY_REF,
   KEY_WS,
   KEY_MALFORMED,
+  CLOUD_KEY,
+  CLOUD_BASE,
+  DEV_SOURCE,
+  DEV_AUTHORITY,
 ] as const;
 
 function restoreEnv(
@@ -82,6 +91,7 @@ describe("applyVaultProfilesForAgent", () => {
 
   afterEach(async () => {
     restoreEnv(envSnapshot);
+    resetDevCloudEnvAuthorityForTests();
     await test.dispose();
   });
 
@@ -120,6 +130,31 @@ describe("applyVaultProfilesForAgent", () => {
     expect(result.failed).toEqual([]);
     expect(process.env[KEY_WORK]).toBe("sk-work");
   });
+
+  it.each(["staging-default", "offline"])(
+    "does not let a profiled production Cloud key replace %s authority",
+    async (authority) => {
+      process.env[DEV_SOURCE] = "1";
+      process.env[DEV_AUTHORITY] = authority;
+      process.env[CLOUD_KEY] = "";
+      process.env[CLOUD_BASE] = "https://api-staging.eliza.app/api/v1";
+      await seedProfiledKey(
+        test.vault,
+        CLOUD_KEY,
+        { production: "profiled-production-key" },
+        "production",
+      );
+
+      const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+      expect(result.overridden).toBe(0);
+      expect(result.skipped).toContain(CLOUD_KEY);
+      expect(process.env[CLOUD_KEY]).toBe("");
+      expect(process.env[CLOUD_BASE]).toBe(
+        "https://api-staging.eliza.app/api/v1",
+      );
+    },
+  );
 
   it("is idempotent: a second apply writes the same env value and recounts the override", async () => {
     await seedProfiledKey(test.vault, KEY_WORK, { work: "sk-work" }, "work");

--- a/packages/agent/src/runtime/vault-profile-resolver.ts
+++ b/packages/agent/src/runtime/vault-profile-resolver.ts
@@ -24,6 +24,11 @@ import {
   type Vault,
   type VaultEntryMeta,
 } from "@elizaos/vault";
+import {
+  isDevCloudEnvOwnedKey,
+  isDevCloudInternalEnvKey,
+  resolveDevCloudEnvAuthority,
+} from "../config/dev-cloud-env-authority.ts";
 
 export interface ResolveProfilesResult {
   /** Number of keys whose env value was overridden. */
@@ -63,9 +68,20 @@ export async function applyVaultProfilesForAgent(
   let overridden = 0;
   const skipped: string[] = [];
   const failed: string[] = [];
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
 
   for (const entry of entries) {
     if (!entry.hasProfiles) continue;
+    // The local-dev launcher tuple is frozen before vault resolution. Profiled
+    // production credentials/endpoints must not redefine that authority later
+    // in boot; non-Cloud provider profiles remain unaffected.
+    if (
+      devCloudAuthority &&
+      (isDevCloudEnvOwnedKey(entry.key) || isDevCloudInternalEnvKey(entry.key))
+    ) {
+      skipped.push(entry.key);
+      continue;
+    }
     if (entry.kind === "reference") {
       // Reference entries resolve through their backing password
       // manager, not through profiles. Skip — but only after auditing

--- a/packages/agent/src/runtime/wallet-balance-delta.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.ts
@@ -799,7 +799,7 @@ export function createAgentWalletBalanceSource(
     ]);
     const addresses = walletApi.getWalletAddresses(agentId);
     const readiness = walletRpc.resolveWalletRpcReadiness(
-      configModule.loadElizaConfig(),
+      configModule.loadEffectiveElizaConfig(),
     );
     const evmReady = Boolean(addresses.evmAddress && readiness.evmBalanceReady);
     const solReady = Boolean(

--- a/packages/agent/src/services/media-generation.ts
+++ b/packages/agent/src/services/media-generation.ts
@@ -17,7 +17,7 @@ import {
   ServiceType,
 } from "@elizaos/core";
 import { isElizaCloudServiceSelectedInConfig } from "@elizaos/shared";
-import { loadElizaConfig } from "../config/config.ts";
+import { loadEffectiveElizaConfig } from "../config/config.ts";
 import type {
   AudioGenConfig,
   ImageConfig,
@@ -31,7 +31,7 @@ import {
 } from "../providers/media-provider.ts";
 
 function getMediaProviderOptions(): MediaProviderFactoryOptions {
-  const config = loadElizaConfig();
+  const config = loadEffectiveElizaConfig();
   const cloudMediaSelected = isElizaCloudServiceSelectedInConfig(
     config as Record<string, unknown>,
     "media",
@@ -273,7 +273,7 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
   canGenerateMedia(
     request: Pick<MediaGenerationRequest, "mediaType" | "audioKind">,
   ): boolean {
-    const config = loadElizaConfig();
+    const config = loadEffectiveElizaConfig();
     const providerOptions = getMediaProviderOptions();
     try {
       if (request.mediaType === "image") {
@@ -309,7 +309,7 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
   async generateMedia(
     request: MediaGenerationRequest,
   ): Promise<MediaGenerationResponse> {
-    const config = loadElizaConfig();
+    const config = loadEffectiveElizaConfig();
     const providerOptions = getMediaProviderOptions();
 
     if (request.mediaType === "image") {

--- a/packages/agent/src/services/remote-coding-runner.test.ts
+++ b/packages/agent/src/services/remote-coding-runner.test.ts
@@ -21,7 +21,11 @@ import {
   type UUID,
   type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import codingToolsPlugin, {
   SANDBOX_SERVICE,
   SandboxService,
@@ -696,6 +700,116 @@ describe("RemoteCodingCapabilityRouterService", () => {
     );
     expect(config.remoteHttpToken).toBe("token");
     expect(config.agentRunners).toEqual(["codex", "claude-code"]);
+  });
+
+  describe("launcher-owned dev Cloud authority", () => {
+    const authorityEnvKeys = [
+      "ELIZA_DEV_SOURCE",
+      "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+      "ELIZA_DEV_CLOUD_TARGET",
+      "ELIZAOS_CLOUD_API_KEY",
+      "ELIZAOS_CLOUD_BASE_URL",
+      "ELIZA_CLOUD_REMOTE_RUNNER_URL",
+      "ELIZA_CLOUD_SANDBOX_TOKEN",
+    ] as const;
+    const originalAuthorityEnv = Object.fromEntries(
+      authorityEnvKeys.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof authorityEnvKeys)[number], string | undefined>;
+
+    beforeEach(() => {
+      resetDevCloudEnvAuthorityForTests();
+      for (const key of authorityEnvKeys) delete process.env[key];
+    });
+
+    afterEach(() => {
+      for (const key of authorityEnvKeys) {
+        const value = originalAuthorityEnv[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      resetDevCloudEnvAuthorityForTests();
+    });
+
+    it.each(["staging-default", "offline"] as const)(
+      "does not revive the Cloud runner from late production env in %s mode",
+      (authority) => {
+        process.env.ELIZA_DEV_SOURCE = "1";
+        process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+        process.env.ELIZA_DEV_CLOUD_TARGET =
+          authority === "offline" ? "offline" : "staging";
+        process.env.ELIZAOS_CLOUD_BASE_URL =
+          "https://api-staging.eliza.app/api/v1";
+        captureDevCloudEnvAuthoritySnapshot();
+
+        process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+        process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+        process.env.ELIZA_CLOUD_REMOTE_RUNNER_URL =
+          "https://production-runner.example";
+        process.env.ELIZA_CLOUD_SANDBOX_TOKEN = "late-production-token";
+
+        const config = resolveRemoteCodingRunnerConfig(
+          makeRuntime({
+            ELIZA_CODING_REMOTE_RUNNER: "eliza-cloud",
+            ELIZAOS_CLOUD_API_KEY: "",
+            ELIZAOS_CLOUD_BASE_URL: "",
+            ELIZA_CLOUD_REMOTE_RUNNER_URL: "",
+            ELIZA_CLOUD_SANDBOX_TOKEN: "",
+          }),
+        );
+
+        expect(config.cloudApiBaseUrl).toBe(
+          "https://api-staging.eliza.app/api/v1",
+        );
+        expect(config.cloudApiToken).toBeUndefined();
+        expect(config.remoteHttpBaseUrl).toBeUndefined();
+        expect(config.remoteHttpToken).toBeUndefined();
+      },
+    );
+
+    it("uses the frozen explicit staging credential after late env pollution", () => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+      process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+      process.env.ELIZAOS_CLOUD_API_KEY = "launcher-staging-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api-staging.eliza.app/api/v1";
+      captureDevCloudEnvAuthoritySnapshot();
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+      const config = resolveRemoteCodingRunnerConfig(
+        makeRuntime({
+          ELIZA_CODING_REMOTE_RUNNER: "eliza-cloud",
+          ELIZAOS_CLOUD_API_KEY: "persisted-production-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+        }),
+      );
+
+      expect(config.cloudApiBaseUrl).toBe(
+        "https://api-staging.eliza.app/api/v1",
+      );
+      expect(config.cloudApiToken).toBe("launcher-staging-key");
+    });
+
+    it("leaves Home runner resolution unchanged under Cloud authority", () => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "offline";
+      process.env.ELIZA_DEV_CLOUD_TARGET = "offline";
+      captureDevCloudEnvAuthoritySnapshot();
+
+      const config = resolveRemoteCodingRunnerConfig(
+        makeRuntime({
+          ELIZA_CODING_REMOTE_RUNNER: "home",
+          ELIZA_HOME_REMOTE_RUNNER_URL: "http://home.local:2468",
+          ELIZA_HOME_REMOTE_RUNNER_TOKEN: "home-token",
+        }),
+      );
+
+      expect(config.provider).toBe("home");
+      expect(config.remoteHttpBaseUrl).toBe("http://home.local:2468");
+      expect(config.remoteHttpToken).toBe("home-token");
+    });
   });
 
   it("rejects runner timeout settings that overflow the JavaScript timer range", () => {

--- a/packages/agent/src/services/remote-coding-runner.ts
+++ b/packages/agent/src/services/remote-coding-runner.ts
@@ -55,6 +55,10 @@ import {
   type LocalWorkspaceDeltaObservation,
   type WorkspaceDeltaFs,
 } from "@elizaos/plugin-coding-tools/lib/workspace-delta";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 export type {
   RemoteRunnerClient,
@@ -1597,7 +1601,21 @@ function requestTimeoutWithinDeadline(
   return Math.max(1, Math.min(requestTimeoutMs, remainingMs));
 }
 
+function isCloudOwnedRunnerSetting(key: string): boolean {
+  return (
+    key.startsWith("ELIZAOS_CLOUD_") ||
+    key.startsWith("ELIZA_CLOUD_") ||
+    key.startsWith("ELIZACLOUD_") ||
+    key.startsWith("ELIZA_DEV_CLOUD_") ||
+    key.startsWith("WAIFU_ELIZA_CLOUD_")
+  );
+}
+
 function readSetting(runtime: IAgentRuntime, key: string): string | undefined {
+  if (resolveDevCloudEnvAuthority() && isCloudOwnedRunnerSetting(key)) {
+    const authoritative = resolveDevCloudAuthorityEnvValue(key)?.trim();
+    return authoritative || undefined;
+  }
   const fromRuntime = runtime.getSetting(key);
   if (typeof fromRuntime === "string" && fromRuntime.trim().length > 0) {
     return fromRuntime.trim();

--- a/packages/app-core/platforms/electrobun/src/native/agent.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.test.ts
@@ -5,11 +5,14 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { applyDevCloudAuthoritySnapshotToEnv } from "@elizaos/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   applyDesktopDeferAppRoutesPolicy,
   applyPackagedStartupEmbeddingWarmupPolicy,
+  bindDesktopApiTokenToDevCloudSnapshot,
   buildChildNodePaths,
+  captureDesktopDevCloudLaunchAuthority,
   configureDesktopLocalApiAuth,
   ensureDesktopApiToken,
   getHealthPollTimeoutMs,
@@ -392,6 +395,45 @@ describe("ensureDesktopApiToken and configureDesktopLocalApiAuth", () => {
     const env: NodeJS.ProcessEnv = { ELIZA_API_TOKEN: "paired" };
     expect(configureDesktopLocalApiAuth(env)).toBe("paired");
     expect(env.ELIZA_PAIRING_DISABLED).toBe("1");
+  });
+
+  it("preserves the pre-sidecar explicit Steward tuple and first-start local API token", () => {
+    const parentEnv: NodeJS.ProcessEnv = {
+      ELIZA_DEV_SOURCE: "1",
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-explicit",
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      ELIZAOS_CLOUD_API_KEY: "staging-launch-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      STEWARD_API_URL: "https://staging.eliza.app/steward",
+      STEWARD_TENANT_ID: "elizacloud-staging",
+      STEWARD_AGENT_ID: "staging-agent",
+      STEWARD_AGENT_TOKEN: "staging-token",
+    };
+    const launchSnapshot = captureDesktopDevCloudLaunchAuthority(parentEnv);
+
+    parentEnv.STEWARD_API_URL = "http://127.0.0.1:50123";
+    parentEnv.STEWARD_TENANT_ID = "late-sidecar";
+    parentEnv.STEWARD_AGENT_ID = "late-sidecar-agent";
+    parentEnv.STEWARD_AGENT_TOKEN = "late-sidecar-token";
+    const localApiToken = configureDesktopLocalApiAuth(parentEnv);
+    const childSnapshot = bindDesktopApiTokenToDevCloudSnapshot(
+      launchSnapshot,
+      parentEnv,
+    );
+    const childEnv = { ...parentEnv };
+
+    applyDevCloudAuthoritySnapshotToEnv(childEnv, childSnapshot);
+
+    expect(localApiToken).toMatch(/^[a-f0-9]{32}$/);
+    expect(childEnv).toMatchObject({
+      ELIZA_API_TOKEN: localApiToken,
+      ELIZAOS_CLOUD_API_KEY: "staging-launch-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      STEWARD_API_URL: "https://staging.eliza.app/steward",
+      STEWARD_TENANT_ID: "elizacloud-staging",
+      STEWARD_AGENT_ID: "staging-agent",
+      STEWARD_AGENT_TOKEN: "staging-token",
+    });
   });
 });
 

--- a/packages/app-core/platforms/electrobun/src/native/agent.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.ts
@@ -28,6 +28,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  applyDevCloudAuthoritySnapshotToEnv,
+  captureDevCloudEnvAuthoritySnapshot,
+  type DevCloudEnvAuthoritySnapshot,
   resolveApiToken,
   resolveDesktopApiPort,
   resolveDisableAutoApiToken,
@@ -602,6 +605,28 @@ export function configureDesktopLocalApiAuth(
   const token = ensureDesktopApiToken(env);
   env.ELIZA_PAIRING_DISABLED = "1";
   return token;
+}
+
+/** Capture launcher-owned Cloud/Steward values before startup services mutate env. */
+export function captureDesktopDevCloudLaunchAuthority(
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvAuthoritySnapshot | null {
+  return captureDevCloudEnvAuthoritySnapshot(env);
+}
+
+/** Add the local API bearer minted at start without recapturing Cloud values. */
+export function bindDesktopApiTokenToDevCloudSnapshot(
+  snapshot: DevCloudEnvAuthoritySnapshot | null,
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvAuthoritySnapshot | null {
+  if (!snapshot) return null;
+  return Object.freeze({
+    authority: snapshot.authority,
+    values: Object.freeze({
+      ...snapshot.values,
+      ELIZA_API_TOKEN: env.ELIZA_API_TOKEN,
+    }),
+  });
 }
 
 function getDesktopApiToken(
@@ -1390,6 +1415,14 @@ export class AgentManager {
   private startupPhase = "not_started";
   private databaseSnapshot: DatabaseSnapshot = createUnknownDatabaseSnapshot();
   private databaseStartupLock: DatabaseStartupLock | null = null;
+  /** Captured before Steward sidecars or startup restore can mutate env. */
+  private readonly devCloudLaunchAuthoritySnapshot =
+    captureDesktopDevCloudLaunchAuthority();
+  /** Launch tuple plus first-start local API bearer, reused across restarts. */
+  private devCloudChildAuthoritySnapshot:
+    | DevCloudEnvAuthoritySnapshot
+    | null
+    | undefined;
   /** Timestamps (ms) of recent crash-triggered restarts, for loop detection. */
   private readonly crashRestartTimestamps: number[] = [];
   /** Pending crash auto-restart timer, if one is scheduled. */
@@ -1455,6 +1488,12 @@ export class AgentManager {
     let preferredPort: number;
     try {
       configureDesktopLocalApiAuth();
+      if (this.devCloudChildAuthoritySnapshot === undefined) {
+        this.devCloudChildAuthoritySnapshot =
+          bindDesktopApiTokenToDevCloudSnapshot(
+            this.devCloudLaunchAuthoritySnapshot,
+          );
+      }
       packagedRuntime = isPackagedDesktopRuntime();
 
       // Reset per-startup flags
@@ -1589,6 +1628,10 @@ export class AgentManager {
         ELIZA_API_PORT: String(apiPort),
         ELIZA_PORT: String(apiPort),
       };
+      applyDevCloudAuthoritySnapshotToEnv(
+        childEnv,
+        this.devCloudChildAuthoritySnapshot,
+      );
       if (packagedRuntime) childEnv.ELIZA_DESKTOP_PACKAGED_RUNTIME = "1";
       else delete childEnv.ELIZA_DESKTOP_PACKAGED_RUNTIME;
       childEnv.ELIZA_NAMESPACE = resolveDesktopChildNamespace(childEnv);

--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -77,6 +77,7 @@ import { allocateFirstFreeLoopbackPort } from "./lib/allocate-loopback-port.mjs"
 import { createApiSupervisor } from "./lib/api-supervisor.mjs";
 import { resolveMainAppDir } from "./lib/app-dir.mjs";
 import { resolveDesktopStartupEmbeddingWarmupPolicy } from "./lib/desktop-startup-embedding-warmup-policy.mjs";
+import { configureDevCloudEnvironment } from "./lib/dev-cloud-target.mjs";
 import { resolveViteCommand } from "./lib/dev-ui-vite.mjs";
 import {
   isSpawnedProcessGroupAlive,
@@ -264,6 +265,17 @@ if (existsSync(_worktreeEnvPath)) {
   dotenvConfig({ path: _worktreeEnvPath, override: false });
 }
 
+// Stamp the same exact staging-by-default Cloud tuple used by web/package dev
+// before any renderer build or long-lived desktop child inherits the env.
+// Remove the dev-only selector from argv so Electrobun/Vite never see an
+// unknown --cloud-target option.
+const devCloud = configureDevCloudEnvironment(
+  process.argv.slice(2),
+  process.env,
+);
+Object.assign(process.env, devCloud.env);
+process.argv.splice(2, process.argv.length - 2, ...devCloud.passthroughArgs);
+
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
   console.log(`Usage: bun run dev:desktop [options]
        ELIZA_DESKTOP_VITE_WATCH=1 bun eliza/packages/app-core/scripts/dev-platform.mjs   # same as bun run dev
@@ -271,6 +283,8 @@ if (process.argv.includes("--help") || process.argv.includes("-h")) {
 Starts Vite (optional), API (optional), and Electrobun with aligned ports and env.
 
 Options:
+  --cloud-target <staging|production|offline>
+                     Select the exact local Cloud environment (default: staging)
   --no-api           Skip the API server (Electrobun + renderer only)
   --force-renderer   Force vite build before starting (even if dist is fresh)
   --rollup-watch     Use vite build --watch instead of vite dev (requires ELIZA_DESKTOP_VITE_WATCH=1)

--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -35,6 +35,10 @@ import { relativeAppDir, resolveMainAppDir } from "./lib/app-dir.mjs";
 import { getBunVersionAdvisory } from "./lib/bun-version-guard.mjs";
 import { capacitorPluginsBuildNeeded } from "./lib/capacitor-plugin-build-needed.mjs";
 import {
+  applyDevCloudTarget,
+  configureDevCloudEnvironment,
+} from "./lib/dev-cloud-target.mjs";
+import {
   createApiHealthWatchdog,
   createParentExitGuard,
 } from "./lib/dev-process-lifecycle.mjs";
@@ -169,6 +173,10 @@ const { CAPACITOR_PLUGIN_NAMES, NATIVE_PLUGINS_ROOT } = await import(
 );
 
 syncElizaEnvAliases();
+const devCloud = configureDevCloudEnvironment(
+  process.argv.slice(2),
+  process.env,
+);
 
 const API_PORT = resolveDesktopApiPort(process.env);
 const cwd = process.cwd();
@@ -279,7 +287,7 @@ const VITE_RENDERER_ONLY_MOBILE_ENV_KEYS = [
 let warnedAboutStrippedDevMocks = false;
 
 function createDevChildEnv(baseEnv) {
-  const nextEnv = { ...baseEnv };
+  const nextEnv = applyDevCloudTarget(baseEnv, devCloud);
   if (nextEnv.ELIZA_DEV_ALLOW_TEST_MOCKS === "1") {
     return nextEnv;
   }
@@ -1170,6 +1178,9 @@ function scheduleViteHealthCheck(delayMs = 15_000) {
 }
 
 if (uiOnly) {
+  console.log(
+    `  ${green(logPrefix)} ${dim(`Cloud target=${devCloud.effectiveTarget} (${devCloud.source})`)}`,
+  );
   startVite();
 } else {
   console.log(`${orange(`\n${cliName} dev mode`)}\n`);
@@ -1186,6 +1197,9 @@ if (uiOnly) {
             : " (startup + warnings/errors)"
       }`,
     )}`,
+  );
+  console.log(
+    `  ${green(logPrefix)} ${dim(`Cloud target=${devCloud.effectiveTarget} (${devCloud.source})`)}`,
   );
 
   prepareMacNativeEffectsForDev();

--- a/packages/app-core/scripts/lib/dev-cloud-target.mjs
+++ b/packages/app-core/scripts/lib/dev-cloud-target.mjs
@@ -1,0 +1,345 @@
+/**
+ * Resolves one Cloud environment for local API and renderer development.
+ * Staging is the safe default; production, offline, and self-hosted tuples
+ * require an explicit selector or complete low-level endpoint configuration.
+ */
+
+const TARGET_FLAG = "--cloud-target";
+const TARGET_ENV = "ELIZA_DEV_CLOUD_TARGET";
+const DEFAULT_TARGET = "staging";
+const VALID_TARGETS = new Set(["staging", "production", "offline"]);
+
+const TARGET_CONFIG = Object.freeze({
+  staging: Object.freeze({
+    cloudApiBase: "https://api-staging.eliza.app/api/v1",
+    cloudAppBase: "https://cloud-staging.eliza.app",
+    stewardApiUrl: "https://staging.eliza.app/steward",
+    stewardTenantId: "elizacloud-staging",
+  }),
+  production: Object.freeze({
+    cloudApiBase: "https://api.eliza.app/api/v1",
+    cloudAppBase: "https://cloud.eliza.app",
+    stewardApiUrl: "https://eliza.app/steward",
+    stewardTenantId: "elizacloud",
+  }),
+});
+
+const CLOUD_ACTIVATION_KEYS = Object.freeze([
+  "ELIZA_DEV_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZA_CLOUD_API_KEY",
+  "ELIZACLOUD_API_KEY",
+  "ELIZA_CLOUD_PROVISIONED",
+]);
+
+const CANONICAL_PRODUCTION_HOSTS = new Set([
+  "eliza.app",
+  "cloud.eliza.app",
+  "api.eliza.app",
+  "elizacloud.ai",
+  "www.elizacloud.ai",
+  "dev.elizacloud.ai",
+  "app.elizacloud.ai",
+  "api.elizacloud.ai",
+]);
+const CANONICAL_STAGING_HOSTS = new Set([
+  "staging.eliza.app",
+  "cloud-staging.eliza.app",
+  "api-staging.eliza.app",
+  "staging.elizacloud.ai",
+  "app-staging.elizacloud.ai",
+  "api-staging.elizacloud.ai",
+]);
+
+function configuredValue(env, key) {
+  const value = env[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function parseEndpointUrl(value, key) {
+  if (!URL.canParse(value)) {
+    throw new Error(`${key} must be an absolute HTTP(S) URL, not "${value}".`);
+  }
+  const parsed = new URL(value);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${key} must use HTTP(S), not "${parsed.protocol}".`);
+  }
+  return parsed;
+}
+
+function canonicalEnvironmentForUrl(value, key) {
+  const hostname = parseEndpointUrl(value, key).hostname.toLowerCase();
+  if (
+    CANONICAL_STAGING_HOSTS.has(hostname) ||
+    hostname.endsWith(".cloud-staging.eliza.app") ||
+    hostname.endsWith(".staging.elizacloud.ai")
+  ) {
+    return "staging";
+  }
+  if (
+    CANONICAL_PRODUCTION_HOSTS.has(hostname) ||
+    hostname.endsWith(".cloud.eliza.app") ||
+    hostname.endsWith(".elizacloud.ai")
+  ) {
+    return "production";
+  }
+  return null;
+}
+
+function normalizedCustomCloudBase(value, key) {
+  const parsed = parseEndpointUrl(value, key);
+  const pathname = parsed.pathname
+    .replace(/\/+$/, "")
+    .replace(/\/api\/v1$/i, "");
+  return `${parsed.origin}${pathname}`;
+}
+
+function canonicalEnvironmentForTenant(value) {
+  const tenant = value.trim().toLowerCase();
+  if (tenant === "elizacloud-staging") return "staging";
+  if (tenant === "elizacloud") return "production";
+  return null;
+}
+
+function canonicalEnvironmentEntries(env) {
+  const entries = [];
+  for (const key of [
+    "ELIZAOS_CLOUD_BASE_URL",
+    "VITE_ELIZA_CLOUD_BASE",
+    "VITE_STEWARD_API_URL",
+  ]) {
+    const value = configuredValue(env, key);
+    const environment = value ? canonicalEnvironmentForUrl(value, key) : null;
+    if (environment) entries.push({ key, environment });
+  }
+
+  const tenant = configuredValue(env, "VITE_STEWARD_TENANT_ID");
+  const tenantEnvironment = tenant
+    ? canonicalEnvironmentForTenant(tenant)
+    : null;
+  if (tenantEnvironment) {
+    entries.push({
+      key: "VITE_STEWARD_TENANT_ID",
+      environment: tenantEnvironment,
+    });
+  }
+  return entries;
+}
+
+function inspectCustomCloudBases(env) {
+  const apiBase = configuredValue(env, "ELIZAOS_CLOUD_BASE_URL");
+  const rendererBase = configuredValue(env, "VITE_ELIZA_CLOUD_BASE");
+  const apiEnvironment = apiBase
+    ? canonicalEnvironmentForUrl(apiBase, "ELIZAOS_CLOUD_BASE_URL")
+    : null;
+  const rendererEnvironment = rendererBase
+    ? canonicalEnvironmentForUrl(rendererBase, "VITE_ELIZA_CLOUD_BASE")
+    : null;
+  const apiCustom = Boolean(apiBase && !apiEnvironment);
+  const rendererCustom = Boolean(rendererBase && !rendererEnvironment);
+
+  if (apiCustom !== rendererCustom) {
+    throw new Error(
+      "Self-hosted dev Cloud configuration must set both ELIZAOS_CLOUD_BASE_URL and VITE_ELIZA_CLOUD_BASE to non-canonical endpoints so the API and renderer cannot diverge.",
+    );
+  }
+  if (!apiCustom) return false;
+
+  if (
+    normalizedCustomCloudBase(apiBase, "ELIZAOS_CLOUD_BASE_URL") !==
+    normalizedCustomCloudBase(rendererBase, "VITE_ELIZA_CLOUD_BASE")
+  ) {
+    throw new Error(
+      "Self-hosted ELIZAOS_CLOUD_BASE_URL and VITE_ELIZA_CLOUD_BASE must identify the same Cloud endpoint (an optional /api/v1 suffix is ignored).",
+    );
+  }
+
+  const stewardApiUrl = configuredValue(env, "VITE_STEWARD_API_URL");
+  if (stewardApiUrl) {
+    parseEndpointUrl(stewardApiUrl, "VITE_STEWARD_API_URL");
+  }
+  return true;
+}
+
+function validateTargetValue(raw, source) {
+  const target = raw.trim().toLowerCase();
+  if (!VALID_TARGETS.has(target)) {
+    throw new Error(
+      `Unknown dev Cloud target "${raw}" from ${source}. Expected "staging", "production", or "offline".`,
+    );
+  }
+  return target;
+}
+
+/** Resolve the high-level target and remove its dev-only flag from child args. */
+export function resolveDevCloudTarget(args = [], env = process.env) {
+  const passthroughArgs = [];
+  let cliValue;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === TARGET_FLAG) {
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(
+          'Dev Cloud target is missing. Expected "staging", "production", or "offline".',
+        );
+      }
+      if (cliValue !== undefined) {
+        throw new Error("Dev Cloud target may be supplied only once.");
+      }
+      cliValue = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith(`${TARGET_FLAG}=`)) {
+      const value = arg.slice(`${TARGET_FLAG}=`.length);
+      if (!value) {
+        throw new Error(
+          'Dev Cloud target is missing. Expected "staging", "production", or "offline".',
+        );
+      }
+      if (cliValue !== undefined) {
+        throw new Error("Dev Cloud target may be supplied only once.");
+      }
+      cliValue = value;
+      continue;
+    }
+    passthroughArgs.push(arg);
+  }
+
+  if (cliValue !== undefined) {
+    return {
+      target: validateTargetValue(cliValue, TARGET_FLAG),
+      source: "cli",
+      passthroughArgs,
+    };
+  }
+
+  const envValue = configuredValue(env, TARGET_ENV);
+  if (envValue) {
+    return {
+      target: validateTargetValue(envValue, TARGET_ENV),
+      source: "env",
+      passthroughArgs,
+    };
+  }
+
+  return {
+    target: DEFAULT_TARGET,
+    source: "default",
+    passthroughArgs,
+  };
+}
+
+function buildDevCloudPlan(env, resolution) {
+  // The explicit offline selector is an escape hatch from every inherited
+  // hosted or self-hosted value, including values loaded by a shell profile.
+  if (resolution.target === "offline") {
+    return { effectiveTarget: "offline", selfHosted: false };
+  }
+
+  const selfHosted = inspectCustomCloudBases(env);
+  if (selfHosted && resolution.source !== "default") {
+    throw new Error(
+      `Explicit dev Cloud target "${resolution.target}" conflicts with the self-hosted ELIZAOS_CLOUD_BASE_URL and VITE_ELIZA_CLOUD_BASE tuple. Remove ${TARGET_FLAG}/${TARGET_ENV} to use self-hosted development.`,
+    );
+  }
+
+  if (selfHosted) {
+    const runtimeMode = configuredValue(env, "VITE_ELIZA_DESKTOP_RUNTIME_MODE");
+    if (runtimeMode && runtimeMode !== "cloud") {
+      throw new Error(
+        `Self-hosted dev Cloud configuration requires VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud, not "${runtimeMode}".`,
+      );
+    }
+    return { effectiveTarget: "self-hosted", selfHosted: true };
+  }
+
+  const conflicts = canonicalEnvironmentEntries(env).filter(
+    ({ environment }) => environment !== resolution.target,
+  );
+  if (conflicts.length > 0) {
+    const details = conflicts
+      .map(({ key, environment }) => `${key}=${environment}`)
+      .join(", ");
+    throw new Error(
+      `Dev Cloud target "${resolution.target}" conflicts with canonical configuration: ${details}. Select one environment for the API, renderer, Steward URL, and tenant.`,
+    );
+  }
+
+  const runtimeMode = configuredValue(env, "VITE_ELIZA_DESKTOP_RUNTIME_MODE");
+  if (runtimeMode && runtimeMode !== "cloud") {
+    throw new Error(
+      `Dev Cloud target "${resolution.target}" requires VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud, not "${runtimeMode}". Use --cloud-target=offline for the runtime chooser.`,
+    );
+  }
+  return { effectiveTarget: resolution.target, selfHosted: false };
+}
+
+/** Return a fresh environment with one coherent API/renderer Cloud policy. */
+export function applyDevCloudTarget(env, resolution) {
+  const plan = buildDevCloudPlan(env, resolution);
+  const nextEnv = { ...env, ELIZA_DEV_SOURCE: "1" };
+  // A CLI selector outranks an inherited process selector. Reflect that choice
+  // in children as well so nested tooling cannot observe a stale target.
+  if (resolution.source === "cli") {
+    nextEnv[TARGET_ENV] = resolution.target;
+  }
+
+  if (plan.effectiveTarget === "offline") {
+    // Local-first development must not auto-load the Cloud plugin, but the
+    // chooser still contains an explicit Cloud option. Keep that manual path
+    // on staging instead of letting blank renderer values fall back to prod.
+    const staging = TARGET_CONFIG.staging;
+    nextEnv.ELIZAOS_CLOUD_BASE_URL = staging.cloudApiBase;
+    for (const key of CLOUD_ACTIVATION_KEYS) nextEnv[key] = "";
+    nextEnv.VITE_ELIZA_CLOUD_BASE = staging.cloudAppBase;
+    nextEnv.VITE_STEWARD_API_URL = staging.stewardApiUrl;
+    nextEnv.VITE_STEWARD_TENANT_ID = staging.stewardTenantId;
+    nextEnv.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "";
+    nextEnv.VITE_ELIZA_ENABLE_RUNTIME_CHOOSER = "1";
+    return nextEnv;
+  }
+
+  if (plan.selfHosted) {
+    nextEnv.VITE_ELIZA_DESKTOP_RUNTIME_MODE =
+      configuredValue(env, "VITE_ELIZA_DESKTOP_RUNTIME_MODE") ?? "cloud";
+    return nextEnv;
+  }
+
+  const config = TARGET_CONFIG[resolution.target];
+  nextEnv.ELIZAOS_CLOUD_BASE_URL =
+    configuredValue(env, "ELIZAOS_CLOUD_BASE_URL") ?? config.cloudApiBase;
+  nextEnv.VITE_ELIZA_CLOUD_BASE =
+    configuredValue(env, "VITE_ELIZA_CLOUD_BASE") ?? config.cloudAppBase;
+  nextEnv.VITE_STEWARD_API_URL =
+    configuredValue(env, "VITE_STEWARD_API_URL") ?? config.stewardApiUrl;
+  nextEnv.VITE_STEWARD_TENANT_ID =
+    configuredValue(env, "VITE_STEWARD_TENANT_ID") ?? config.stewardTenantId;
+  nextEnv.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "cloud";
+
+  // Ordinary `bun run dev` must never reinterpret a generic production key
+  // injected by a shell or CI environment as a staging credential. Operators
+  // who deliberately need a staging runtime key opt in with the explicit
+  // `staging` selector; production and self-hosted targets are already
+  // explicit and retain their supplied credentials.
+  if (resolution.target === "staging" && resolution.source === "default") {
+    for (const key of CLOUD_ACTIVATION_KEYS) nextEnv[key] = "";
+  }
+  return nextEnv;
+}
+
+/** Resolve arguments and environment together for a development entrypoint. */
+export function configureDevCloudEnvironment(args = [], env = process.env) {
+  const resolution = resolveDevCloudTarget(args, env);
+  const plan = buildDevCloudPlan(env, resolution);
+  return {
+    ...resolution,
+    effectiveTarget: plan.effectiveTarget,
+    env: applyDevCloudTarget(env, resolution),
+  };
+}

--- a/packages/app-core/scripts/lib/dev-cloud-target.mjs
+++ b/packages/app-core/scripts/lib/dev-cloud-target.mjs
@@ -6,6 +6,7 @@
 
 const TARGET_FLAG = "--cloud-target";
 const TARGET_ENV = "ELIZA_DEV_CLOUD_TARGET";
+const ENV_AUTHORITY_KEY = "ELIZA_DEV_CLOUD_ENV_AUTHORITY";
 const DEFAULT_TARGET = "staging";
 const VALID_TARGETS = new Set(["staging", "production", "offline"]);
 
@@ -27,10 +28,77 @@ const TARGET_CONFIG = Object.freeze({
 const CLOUD_ACTIVATION_KEYS = Object.freeze([
   "ELIZA_DEV_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_SERVICE_KEY",
+  "ELIZAOS_CLOUD_EMBEDDING_API_KEY",
   "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_USE_INFERENCE",
+  "ELIZAOS_CLOUD_USE_TTS",
+  "ELIZAOS_CLOUD_USE_STT",
+  "ELIZAOS_CLOUD_USE_MEDIA",
+  "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+  "ELIZAOS_CLOUD_USE_RPC",
   "ELIZA_CLOUD_API_KEY",
+  "ELIZA_CLOUD_SERVICE_KEY",
+  "ELIZA_CLOUD_SERVICE_TOKEN",
+  "ELIZA_CLOUD_SESSION_TOKEN",
+  "ELIZA_CLOUD_TOKEN",
   "ELIZACLOUD_API_KEY",
+  "ELIZACLOUD_TOKEN",
+  "ELIZA_CLOUD_AUTH_TOKEN",
+  "ELIZA_CLOUD_SANDBOX_TOKEN",
   "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_CLOUD_AGENT_ID",
+  "WAIFU_ELIZA_CLOUD_AGENT_ID",
+  "ELIZAOS_CLOUD_AGENT_ID",
+]);
+
+// Operational Steward credentials can query, create, sign with, or trade from
+// wallets. The safe default and offline targets clear every such value;
+// explicit targets retain only launch-supplied identity/auth while stamping
+// the selected target's exact URL and tenant.
+const STEWARD_OPERATIONAL_KEYS = Object.freeze([
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "STEWARD_TRADE_SESSION_ID",
+  "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+  "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+]);
+
+// Alternative endpoint families are read ahead of the canonical base by
+// embedding and remote-runner clients. Hosted targets clear them and stamp the
+// exact canonical tuple; only a complete self-hosted tuple may retain them.
+const CLOUD_ENDPOINT_OVERRIDE_KEYS = Object.freeze([
+  "ELIZAOS_CLOUD_BROWSER_BASE_URL",
+  "ELIZAOS_CLOUD_BROWSER_EMBEDDING_URL",
+  "ELIZAOS_CLOUD_EMBEDDING_URL",
+  "ELIZAOS_CLOUD_API_BASE_URL",
+  "ELIZAOS_CLOUD_REQUEST_BASE_URL",
+  "ELIZAOS_CLOUD_URL",
+  "ELIZA_CLOUD_API_BASE_URL",
+  "ELIZA_CLOUD_API_BASE",
+  "ELIZA_CLOUD_API_URL",
+  "ELIZA_CLOUD_BASE",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_LOCAL_API_URL",
+  "ELIZA_CLOUD_LOCAL_APP_URL",
+  "ELIZA_CLOUD_OPENAI_BASE_URL",
+  "ELIZA_CLOUD_PUBLIC_URL",
+  "ELIZA_CLOUD_ROUTE_BASE",
+  "ELIZA_CLOUD_URL",
+  "ELIZA_CLOUD_WEB_URL",
+  "ELIZA_CLOUD_WRITE_BASE_URL",
+  "ELIZACLOUD_API_BASE_URL",
+  "ELIZACLOUD_API_URL",
+  "ELIZACLOUD_DEFAULT_URL",
+  "ELIZA_CLOUD_SANDBOX_API_BASE_URL",
+  "ELIZA_CLOUD_SANDBOX_BASE_URL",
+  "ELIZA_CLOUD_SANDBOX_ACCESS_URL",
+  "ELIZA_CLOUD_REMOTE_RUNNER_URL",
+  "ELIZA_CLOUD_RUNNER_URL",
 ]);
 
 const CANONICAL_PRODUCTION_HOSTS = new Set([
@@ -57,6 +125,69 @@ function configuredValue(env, key) {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed || undefined;
+}
+
+function usableCloudCredential(env, key) {
+  const value = configuredValue(env, key);
+  if (
+    !value ||
+    value.toUpperCase() === "[REDACTED]" ||
+    value.toLowerCase().startsWith("vault://")
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function selectedCanonicalCloudApiKey(env) {
+  return (
+    usableCloudCredential(env, "ELIZAOS_CLOUD_API_KEY") ??
+    usableCloudCredential(env, "ELIZA_DEV_CLOUD_API_KEY") ??
+    usableCloudCredential(env, "ELIZA_CLOUD_API_KEY") ??
+    usableCloudCredential(env, "ELIZACLOUD_API_KEY")
+  );
+}
+
+function promoteCanonicalCloudApiKey(env) {
+  const selected = selectedCanonicalCloudApiKey(env);
+  if (selected) env.ELIZAOS_CLOUD_API_KEY = selected;
+  // Downstream legacy consumers use different precedence orders. Leave one
+  // canonical credential so they cannot select a conflicting inherited alias.
+  env.ELIZA_DEV_CLOUD_API_KEY = "";
+  env.ELIZA_CLOUD_API_KEY = "";
+  env.ELIZACLOUD_API_KEY = "";
+}
+
+function hasSecureStewardApiUrl(value) {
+  if (!value || !URL.canParse(value)) return false;
+  const parsed = new URL(value);
+  if (parsed.protocol === "https:") return true;
+  return (
+    parsed.protocol === "http:" &&
+    ["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname)
+  );
+}
+
+function enforceCoherentOperationalStewardTuple(env) {
+  const apiUrl = configuredValue(env, "STEWARD_API_URL");
+  const primaryAgentId = configuredValue(env, "STEWARD_AGENT_ID");
+  const aliasAgentId = configuredValue(env, "ELIZA_STEWARD_AGENT_ID");
+  const tenantId = configuredValue(env, "STEWARD_TENANT_ID");
+  const apiKey = usableCloudCredential(env, "STEWARD_API_KEY");
+  const agentToken = usableCloudCredential(env, "STEWARD_AGENT_TOKEN");
+  const agentIdsConflict = Boolean(
+    primaryAgentId && aliasAgentId && primaryAgentId !== aliasAgentId,
+  );
+  const complete = Boolean(
+    hasSecureStewardApiUrl(apiUrl) &&
+      (primaryAgentId || aliasAgentId) &&
+      !agentIdsConflict &&
+      (agentToken || (apiKey && tenantId)) &&
+      (!apiKey || tenantId),
+  );
+  if (!complete) {
+    for (const key of STEWARD_OPERATIONAL_KEYS) env[key] = "";
+  }
 }
 
 function parseEndpointUrl(value, key) {
@@ -87,14 +218,6 @@ function canonicalEnvironmentForUrl(value, key) {
     return "production";
   }
   return null;
-}
-
-function normalizedCustomCloudBase(value, key) {
-  const parsed = parseEndpointUrl(value, key);
-  const pathname = parsed.pathname
-    .replace(/\/+$/, "")
-    .replace(/\/api\/v1$/i, "");
-  return `${parsed.origin}${pathname}`;
 }
 
 function canonicalEnvironmentForTenant(value) {
@@ -147,15 +270,6 @@ function inspectCustomCloudBases(env) {
     );
   }
   if (!apiCustom) return false;
-
-  if (
-    normalizedCustomCloudBase(apiBase, "ELIZAOS_CLOUD_BASE_URL") !==
-    normalizedCustomCloudBase(rendererBase, "VITE_ELIZA_CLOUD_BASE")
-  ) {
-    throw new Error(
-      "Self-hosted ELIZAOS_CLOUD_BASE_URL and VITE_ELIZA_CLOUD_BASE must identify the same Cloud endpoint (an optional /api/v1 suffix is ignored).",
-    );
-  }
 
   const stewardApiUrl = configuredValue(env, "VITE_STEWARD_API_URL");
   if (stewardApiUrl) {
@@ -250,6 +364,11 @@ function buildDevCloudPlan(env, resolution) {
   }
 
   if (selfHosted) {
+    if (!selectedCanonicalCloudApiKey(env)) {
+      throw new Error(
+        "Self-hosted local development requires ELIZAOS_CLOUD_API_KEY (or a supported legacy alias). The immutable launcher target cannot acquire or replace its server credential through the local agent proxy.",
+      );
+    }
     const runtimeMode = configuredValue(env, "VITE_ELIZA_DESKTOP_RUNTIME_MODE");
     if (runtimeMode && runtimeMode !== "cloud") {
       throw new Error(
@@ -277,13 +396,35 @@ function buildDevCloudPlan(env, resolution) {
       `Dev Cloud target "${resolution.target}" requires VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud, not "${runtimeMode}". Use --cloud-target=offline for the runtime chooser.`,
     );
   }
+  if (
+    resolution.target === "production" &&
+    !selectedCanonicalCloudApiKey(env)
+  ) {
+    throw new Error(
+      "Production local development requires ELIZAOS_CLOUD_API_KEY (or a supported legacy alias). Production intentionally rejects loopback browser authentication, so the credential must be supplied at launch.",
+    );
+  }
   return { effectiveTarget: resolution.target, selfHosted: false };
 }
 
 /** Return a fresh environment with one coherent API/renderer Cloud policy. */
 export function applyDevCloudTarget(env, resolution) {
   const plan = buildDevCloudPlan(env, resolution);
-  const nextEnv = { ...env, ELIZA_DEV_SOURCE: "1" };
+  const explicitStagingApiKey =
+    plan.effectiveTarget === "staging" && resolution.source !== "default"
+      ? usableCloudCredential(env, "ELIZA_DEV_CLOUD_API_KEY")
+      : undefined;
+  const authority =
+    plan.effectiveTarget === "staging"
+      ? resolution.source === "default"
+        ? "staging-default"
+        : "staging-explicit"
+      : plan.effectiveTarget;
+  const nextEnv = {
+    ...env,
+    ELIZA_DEV_SOURCE: "1",
+    [ENV_AUTHORITY_KEY]: authority,
+  };
   // A CLI selector outranks an inherited process selector. Reflect that choice
   // in children as well so nested tooling cannot observe a stale target.
   if (resolution.source === "cli") {
@@ -297,6 +438,8 @@ export function applyDevCloudTarget(env, resolution) {
     const staging = TARGET_CONFIG.staging;
     nextEnv.ELIZAOS_CLOUD_BASE_URL = staging.cloudApiBase;
     for (const key of CLOUD_ACTIVATION_KEYS) nextEnv[key] = "";
+    for (const key of STEWARD_OPERATIONAL_KEYS) nextEnv[key] = "";
+    for (const key of CLOUD_ENDPOINT_OVERRIDE_KEYS) nextEnv[key] = "";
     nextEnv.VITE_ELIZA_CLOUD_BASE = staging.cloudAppBase;
     nextEnv.VITE_STEWARD_API_URL = staging.stewardApiUrl;
     nextEnv.VITE_STEWARD_TENANT_ID = staging.stewardTenantId;
@@ -306,29 +449,40 @@ export function applyDevCloudTarget(env, resolution) {
   }
 
   if (plan.selfHosted) {
+    promoteCanonicalCloudApiKey(nextEnv);
+    enforceCoherentOperationalStewardTuple(nextEnv);
     nextEnv.VITE_ELIZA_DESKTOP_RUNTIME_MODE =
       configuredValue(env, "VITE_ELIZA_DESKTOP_RUNTIME_MODE") ?? "cloud";
     return nextEnv;
   }
 
   const config = TARGET_CONFIG[resolution.target];
-  nextEnv.ELIZAOS_CLOUD_BASE_URL =
-    configuredValue(env, "ELIZAOS_CLOUD_BASE_URL") ?? config.cloudApiBase;
-  nextEnv.VITE_ELIZA_CLOUD_BASE =
-    configuredValue(env, "VITE_ELIZA_CLOUD_BASE") ?? config.cloudAppBase;
-  nextEnv.VITE_STEWARD_API_URL =
-    configuredValue(env, "VITE_STEWARD_API_URL") ?? config.stewardApiUrl;
-  nextEnv.VITE_STEWARD_TENANT_ID =
-    configuredValue(env, "VITE_STEWARD_TENANT_ID") ?? config.stewardTenantId;
+  // A named hosted target is an exact environment tuple, not a loose hostname
+  // classification. Overwrite inherited paths and standalone Steward values so
+  // local auth, API, wallet, and renderer surfaces cannot silently diverge.
+  for (const key of CLOUD_ENDPOINT_OVERRIDE_KEYS) nextEnv[key] = "";
+  nextEnv.ELIZAOS_CLOUD_BASE_URL = config.cloudApiBase;
+  nextEnv.VITE_ELIZA_CLOUD_BASE = config.cloudAppBase;
+  nextEnv.VITE_STEWARD_API_URL = config.stewardApiUrl;
+  nextEnv.VITE_STEWARD_TENANT_ID = config.stewardTenantId;
   nextEnv.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "cloud";
 
-  // Ordinary `bun run dev` must never reinterpret a generic production key
-  // injected by a shell or CI environment as a staging credential. Operators
-  // who deliberately need a staging runtime key opt in with the explicit
-  // `staging` selector; production and self-hosted targets are already
-  // explicit and retain their supplied credentials.
-  if (resolution.target === "staging" && resolution.source === "default") {
+  // A staging selector chooses an endpoint, not an ambient credential trust
+  // boundary. Generic Cloud and Steward values may belong to production, so
+  // every staging launch scrubs them. An operator who deliberately needs a
+  // staging server credential must use the target-specific
+  // ELIZA_DEV_CLOUD_API_KEY; keyless hosted-session login remains supported.
+  if (resolution.target === "staging") {
     for (const key of CLOUD_ACTIVATION_KEYS) nextEnv[key] = "";
+    for (const key of STEWARD_OPERATIONAL_KEYS) nextEnv[key] = "";
+    if (explicitStagingApiKey) {
+      nextEnv.ELIZAOS_CLOUD_API_KEY = explicitStagingApiKey;
+    }
+  } else {
+    nextEnv.STEWARD_API_URL = config.stewardApiUrl;
+    nextEnv.STEWARD_TENANT_ID = config.stewardTenantId;
+    promoteCanonicalCloudApiKey(nextEnv);
+    enforceCoherentOperationalStewardTuple(nextEnv);
   }
   return nextEnv;
 }
@@ -342,4 +496,29 @@ export function configureDevCloudEnvironment(args = [], env = process.env) {
     effectiveTarget: plan.effectiveTarget,
     env: applyDevCloudTarget(env, resolution),
   };
+}
+
+/**
+ * Refuse targets that require a server-held credential when an entrypoint only
+ * starts the renderer. Production does not grant localhost browser auth, and a
+ * self-hosted deployment is not guaranteed to expose a browser-safe auth
+ * exchange. Passing the launch key through Vite would turn the workaround into
+ * a credential disclosure, so these targets must use the repo-root orchestrator
+ * that owns a local agent backend.
+ */
+export function assertRendererOnlyDevCloudTargetSupported(
+  configured,
+  entrypoint = "renderer-only development",
+) {
+  if (
+    configured?.effectiveTarget === "staging" ||
+    configured?.effectiveTarget === "offline"
+  ) {
+    return;
+  }
+
+  const target = configured?.effectiveTarget ?? "unknown";
+  throw new Error(
+    `${entrypoint} cannot use Cloud target "${target}" without a local agent backend. The launch credential stays server-side and is never exposed to Vite. Run the repo-root \`bun run dev\` command for production or self-hosted development.`,
+  );
 }

--- a/packages/app-core/scripts/lib/dev-cloud-target.test.mjs
+++ b/packages/app-core/scripts/lib/dev-cloud-target.test.mjs
@@ -9,12 +9,14 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   applyDevCloudTarget,
+  assertRendererOnlyDevCloudTargetSupported,
   configureDevCloudEnvironment,
   resolveDevCloudTarget,
 } from "./dev-cloud-target.mjs";
 
 const STAGING_ENV = {
   ELIZA_DEV_SOURCE: "1",
+  ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-default",
   ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
   VITE_ELIZA_CLOUD_BASE: "https://cloud-staging.eliza.app",
   VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
@@ -24,6 +26,7 @@ const STAGING_ENV = {
 
 const PRODUCTION_ENV = {
   ELIZA_DEV_SOURCE: "1",
+  ELIZA_DEV_CLOUD_ENV_AUTHORITY: "production",
   ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
   VITE_ELIZA_CLOUD_BASE: "https://cloud.eliza.app",
   VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
@@ -43,9 +46,26 @@ describe("local development Cloud target", () => {
       "ELIZA_DEV_CLOUD_API_KEY",
       "ELIZAOS_CLOUD_API_KEY",
       "ELIZAOS_CLOUD_ENABLED",
+      "ELIZAOS_CLOUD_USE_INFERENCE",
+      "ELIZAOS_CLOUD_USE_TTS",
+      "ELIZAOS_CLOUD_USE_STT",
+      "ELIZAOS_CLOUD_USE_MEDIA",
+      "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+      "ELIZAOS_CLOUD_USE_RPC",
       "ELIZA_CLOUD_API_KEY",
       "ELIZACLOUD_API_KEY",
       "ELIZA_CLOUD_PROVISIONED",
+      "ELIZA_CLOUD_AGENT_ID",
+      "WAIFU_ELIZA_CLOUD_AGENT_ID",
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "ELIZA_STEWARD_AGENT_ID",
+      "STEWARD_API_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TRADE_SESSION_ID",
+      "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+      "STEWARD_POLYMARKET_TRADE_SESSION_ID",
     ]) {
       expect(configured.env[key]).toBe("");
     }
@@ -54,6 +74,7 @@ describe("local development Cloud target", () => {
   it("selects the complete production tuple explicitly", () => {
     const configured = configureDevCloudEnvironment([], {
       ELIZA_DEV_CLOUD_TARGET: "production",
+      ELIZAOS_CLOUD_API_KEY: "production-dev-key",
     });
 
     expect(configured.target).toBe("production");
@@ -61,18 +82,73 @@ describe("local development Cloud target", () => {
     expect(configured.env).toMatchObject({
       ...PRODUCTION_ENV,
       ELIZA_DEV_CLOUD_TARGET: "production",
+      ELIZAOS_CLOUD_API_KEY: "production-dev-key",
     });
     expect(configured.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
+    expect(configured.env.STEWARD_API_URL).toBe("");
+    expect(configured.env.STEWARD_TENANT_ID).toBe("");
   });
 
-  it("masks inherited Cloud activation only for implicit staging", () => {
+  it("clears inherited production Steward authority from default staging", () => {
+    const configured = configureDevCloudEnvironment([], {
+      STEWARD_API_URL: "https://eliza.app/steward",
+      STEWARD_TENANT_ID: "elizacloud",
+      STEWARD_AGENT_ID: "production-agent",
+      ELIZA_STEWARD_AGENT_ID: "legacy-production-agent",
+      STEWARD_API_KEY: "production-key",
+      STEWARD_AGENT_TOKEN: "production-token",
+      STEWARD_TRADE_SESSION_ID: "production-session",
+    });
+
+    expect(configured.env).toMatchObject(STAGING_ENV);
+    for (const key of [
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "ELIZA_STEWARD_AGENT_ID",
+      "STEWARD_API_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TRADE_SESSION_ID",
+    ]) {
+      expect(configured.env[key]).toBe("");
+    }
+  });
+
+  it("scrubs ambient Steward authority from explicit staging", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      STEWARD_API_URL: "https://attacker.example/steward",
+      STEWARD_TENANT_ID: "attacker-tenant",
+      STEWARD_AGENT_ID: "staging-agent",
+      STEWARD_AGENT_TOKEN: "staging-token",
+    });
+
+    for (const key of [
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "STEWARD_AGENT_TOKEN",
+    ]) {
+      expect(configured.env[key]).toBe("");
+    }
+  });
+
+  it("masks implicit activation and canonicalizes explicit credentials", () => {
     const inherited = {
       ELIZA_DEV_CLOUD_API_KEY: "promoted-dev-key",
       ELIZAOS_CLOUD_API_KEY: "generic-key",
       ELIZAOS_CLOUD_ENABLED: "true",
+      ELIZAOS_CLOUD_USE_INFERENCE: "true",
+      ELIZAOS_CLOUD_USE_TTS: "true",
+      ELIZAOS_CLOUD_USE_STT: "true",
+      ELIZAOS_CLOUD_USE_MEDIA: "true",
+      ELIZAOS_CLOUD_USE_EMBEDDINGS: "true",
+      ELIZAOS_CLOUD_USE_RPC: "true",
       ELIZA_CLOUD_API_KEY: "legacy-key",
       ELIZACLOUD_API_KEY: "older-key",
       ELIZA_CLOUD_PROVISIONED: "1",
+      ELIZA_CLOUD_AGENT_ID: "prod-agent-id",
+      WAIFU_ELIZA_CLOUD_AGENT_ID: "prod-agent-id-legacy",
     };
 
     const implicit = configureDevCloudEnvironment([], inherited);
@@ -84,18 +160,131 @@ describe("local development Cloud target", () => {
       ...inherited,
       ELIZA_DEV_CLOUD_TARGET: "staging",
     });
-    expect(explicitStaging.env).toMatchObject(inherited);
+    expect(explicitStaging.env).toMatchObject({
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-explicit",
+      ELIZAOS_CLOUD_API_KEY: "promoted-dev-key",
+    });
+    for (const key of [
+      "ELIZA_DEV_CLOUD_API_KEY",
+      "ELIZAOS_CLOUD_ENABLED",
+      "ELIZAOS_CLOUD_USE_INFERENCE",
+      "ELIZAOS_CLOUD_USE_TTS",
+      "ELIZAOS_CLOUD_USE_STT",
+      "ELIZAOS_CLOUD_USE_MEDIA",
+      "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+      "ELIZAOS_CLOUD_USE_RPC",
+      "ELIZA_CLOUD_API_KEY",
+      "ELIZACLOUD_API_KEY",
+      "ELIZA_CLOUD_PROVISIONED",
+      "ELIZA_CLOUD_AGENT_ID",
+      "WAIFU_ELIZA_CLOUD_AGENT_ID",
+    ]) {
+      expect(explicitStaging.env[key]).toBe("");
+    }
 
     const explicitProduction = configureDevCloudEnvironment([], {
       ...inherited,
       ELIZA_DEV_CLOUD_TARGET: "production",
     });
-    expect(explicitProduction.env).toMatchObject(inherited);
+    expect(explicitProduction.env).toMatchObject({
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "production",
+      ELIZAOS_CLOUD_API_KEY: "generic-key",
+      ELIZAOS_CLOUD_ENABLED: "true",
+      ELIZA_CLOUD_PROVISIONED: "1",
+    });
+    for (const key of [
+      "ELIZA_DEV_CLOUD_API_KEY",
+      "ELIZA_CLOUD_API_KEY",
+      "ELIZACLOUD_API_KEY",
+    ]) {
+      expect(explicitProduction.env[key]).toBe("");
+    }
+  });
+
+  it("promotes only the staging-specific explicit credential", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      ELIZA_DEV_CLOUD_API_KEY: "staging-dev-key",
+    });
+
+    expect(configured.env.ELIZAOS_CLOUD_API_KEY).toBe("staging-dev-key");
+    expect(configured.env.ELIZA_DEV_CLOUD_API_KEY).toBe("");
+  });
+
+  it.each([
+    ["ELIZAOS_CLOUD_API_KEY", "generic-key"],
+    ["ELIZA_CLOUD_API_KEY", "legacy-alias-key"],
+    ["ELIZACLOUD_API_KEY", "oldest-alias-key"],
+  ])("scrubs ambient %s from explicit staging", (key, value) => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      [key]: value,
+    });
+
+    expect(configured.env.ELIZAOS_CLOUD_API_KEY).toBe("");
+    expect(configured.env[key]).toBe("");
+  });
+
+  it.each(["[REDACTED]", "vault://dev/cloud-key"])(
+    "rejects a production target whose only credential is %s",
+    (placeholder) => {
+      expect(() =>
+        configureDevCloudEnvironment([], {
+          ELIZA_DEV_CLOUD_TARGET: "production",
+          ELIZAOS_CLOUD_API_KEY: placeholder,
+        }),
+      ).toThrow(/production.*requires ELIZAOS_CLOUD_API_KEY/i);
+    },
+  );
+
+  it("skips a canonical placeholder and promotes the next usable legacy alias", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "production",
+      ELIZAOS_CLOUD_API_KEY: "[REDACTED]",
+      ELIZA_CLOUD_API_KEY: "usable-legacy-key",
+    });
+
+    expect(configured.env.ELIZAOS_CLOUD_API_KEY).toBe("usable-legacy-key");
+    expect(configured.env.ELIZA_CLOUD_API_KEY).toBe("");
+  });
+
+  it("replaces same-environment wrong paths and standalone hosted overrides", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/wrong-path",
+      ELIZAOS_CLOUD_BROWSER_BASE_URL:
+        "https://api.eliza.app/production-browser-escape",
+      ELIZAOS_CLOUD_EMBEDDING_URL:
+        "https://api.eliza.app/production-embedding-escape",
+      ELIZA_CLOUD_REMOTE_RUNNER_URL:
+        "https://api.eliza.app/production-runner-escape",
+      ELIZA_CLOUD_URL: "https://api.eliza.app/legacy-production-escape",
+      VITE_ELIZA_CLOUD_BASE: "https://cloud-staging.eliza.app/wrong-path",
+      VITE_STEWARD_API_URL: "https://attacker.example/steward",
+      VITE_STEWARD_TENANT_ID: "attacker-tenant",
+    });
+
+    expect(configured.env).toMatchObject({
+      ...STAGING_ENV,
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-explicit",
+    });
+    for (const key of [
+      "ELIZAOS_CLOUD_BROWSER_BASE_URL",
+      "ELIZAOS_CLOUD_EMBEDDING_URL",
+      "ELIZA_CLOUD_REMOTE_RUNNER_URL",
+      "ELIZA_CLOUD_URL",
+    ]) {
+      expect(configured.env[key]).toBe("");
+    }
   });
 
   it("lets the CLI target override the environment and strips helper flags", () => {
     const args = ["--cloud-target", "production", "--ui-only", "--port=2200"];
-    const env = { ELIZA_DEV_CLOUD_TARGET: "staging" };
+    const env = {
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      ELIZAOS_CLOUD_API_KEY: "production-dev-key",
+    };
 
     expect(resolveDevCloudTarget(args, env)).toEqual({
       target: "production",
@@ -105,7 +294,16 @@ describe("local development Cloud target", () => {
     expect(configureDevCloudEnvironment(args, env).env).toMatchObject({
       ...PRODUCTION_ENV,
       ELIZA_DEV_CLOUD_TARGET: "production",
+      ELIZAOS_CLOUD_API_KEY: "production-dev-key",
     });
+  });
+
+  it("fails production startup before serving a keyless loopback login flow", () => {
+    expect(() =>
+      configureDevCloudEnvironment([], {
+        ELIZA_DEV_CLOUD_TARGET: "production",
+      }),
+    ).toThrow(/production.*requires ELIZAOS_CLOUD_API_KEY/i);
   });
 
   it("keeps local-first development off the Cloud plugin and pins manual Cloud to staging", () => {
@@ -118,6 +316,9 @@ describe("local development Cloud target", () => {
       ELIZA_CLOUD_API_KEY: "legacy-key-must-not-reach-local-agent",
       ELIZACLOUD_API_KEY: "older-key-must-not-reach-local-agent",
       ELIZA_CLOUD_PROVISIONED: "1",
+      ELIZA_CLOUD_AGENT_ID: "prod-agent-id-must-not-reach-local-agent",
+      WAIFU_ELIZA_CLOUD_AGENT_ID:
+        "prod-agent-id-legacy-must-not-reach-local-agent",
       PRESERVED_LOCAL_SETTING: "yes",
     };
     const configured = configureDevCloudEnvironment([], input);
@@ -127,6 +328,7 @@ describe("local development Cloud target", () => {
     expect(configured.env).toMatchObject({
       ELIZA_DEV_SOURCE: "1",
       ELIZA_DEV_CLOUD_TARGET: "offline",
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "offline",
       ELIZAOS_CLOUD_BASE_URL: STAGING_ENV.ELIZAOS_CLOUD_BASE_URL,
       VITE_ELIZA_CLOUD_BASE: STAGING_ENV.VITE_ELIZA_CLOUD_BASE,
       VITE_STEWARD_API_URL: STAGING_ENV.VITE_STEWARD_API_URL,
@@ -138,10 +340,27 @@ describe("local development Cloud target", () => {
       "ELIZA_DEV_CLOUD_API_KEY",
       "ELIZAOS_CLOUD_API_KEY",
       "ELIZAOS_CLOUD_ENABLED",
+      "ELIZAOS_CLOUD_USE_INFERENCE",
+      "ELIZAOS_CLOUD_USE_TTS",
+      "ELIZAOS_CLOUD_USE_STT",
+      "ELIZAOS_CLOUD_USE_MEDIA",
+      "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+      "ELIZAOS_CLOUD_USE_RPC",
       "ELIZA_CLOUD_API_KEY",
       "ELIZACLOUD_API_KEY",
       "ELIZA_CLOUD_PROVISIONED",
+      "ELIZA_CLOUD_AGENT_ID",
+      "WAIFU_ELIZA_CLOUD_AGENT_ID",
       "VITE_ELIZA_DESKTOP_RUNTIME_MODE",
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "ELIZA_STEWARD_AGENT_ID",
+      "STEWARD_API_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TRADE_SESSION_ID",
+      "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+      "STEWARD_POLYMARKET_TRADE_SESSION_ID",
     ]) {
       expect(configured.env[key]).toBe("");
     }
@@ -163,8 +382,16 @@ describe("local development Cloud target", () => {
     expect(configured.target).toBe("staging");
     expect(configured.effectiveTarget).toBe("self-hosted");
     expect(configured.env).toMatchObject({
-      ...input,
+      ELIZAOS_CLOUD_BASE_URL: input.ELIZAOS_CLOUD_BASE_URL,
+      VITE_ELIZA_CLOUD_BASE: input.VITE_ELIZA_CLOUD_BASE,
+      VITE_ELIZA_DESKTOP_RUNTIME_MODE: input.VITE_ELIZA_DESKTOP_RUNTIME_MODE,
+      VITE_STEWARD_API_URL: input.VITE_STEWARD_API_URL,
+      VITE_STEWARD_TENANT_ID: input.VITE_STEWARD_TENANT_ID,
+      CUSTOM_SENTINEL: input.CUSTOM_SENTINEL,
       ELIZA_DEV_SOURCE: "1",
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "self-hosted",
+      ELIZAOS_CLOUD_API_KEY: "private-dev-key",
+      ELIZA_DEV_CLOUD_API_KEY: "",
     });
     expect(input).toEqual(snapshot);
     expect(configured.env).not.toBe(input);
@@ -174,6 +401,7 @@ describe("local development Cloud target", () => {
     const configured = configureDevCloudEnvironment([], {
       ELIZAOS_CLOUD_BASE_URL: "https://private.example/api/v1/",
       VITE_ELIZA_CLOUD_BASE: "https://private.example/",
+      ELIZAOS_CLOUD_API_KEY: "private-key",
     });
 
     expect(configured.effectiveTarget).toBe("self-hosted");
@@ -191,11 +419,13 @@ describe("local development Cloud target", () => {
       ELIZAOS_CLOUD_BASE_URL: "https://private.example",
       VITE_ELIZA_CLOUD_BASE: "https://private.example",
       VITE_STEWARD_API_URL: "https://identity.private.example/steward",
+      ELIZAOS_CLOUD_API_KEY: "private-key",
     });
     const withTenant = configureDevCloudEnvironment([], {
       ELIZAOS_CLOUD_BASE_URL: "https://private.example",
       VITE_ELIZA_CLOUD_BASE: "https://private.example",
       VITE_STEWARD_TENANT_ID: "private-tenant",
+      ELIZAOS_CLOUD_API_KEY: "private-key",
     });
 
     expect(withApiUrl.env.VITE_STEWARD_API_URL).toBe(
@@ -226,13 +456,29 @@ describe("local development Cloud target", () => {
     ).toThrow(/must set both/i);
   });
 
-  it("rejects mismatched self-hosted API and renderer endpoints", () => {
+  it("allows the API and renderer to use separate self-hosted surfaces", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZAOS_CLOUD_BASE_URL: "https://api.private.example/api/v1",
+      VITE_ELIZA_CLOUD_BASE: "https://app.private.example",
+      ELIZAOS_CLOUD_API_KEY: "private-key",
+    });
+
+    expect(configured.effectiveTarget).toBe("self-hosted");
+    expect(configured.env).toMatchObject({
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "self-hosted",
+      ELIZAOS_CLOUD_BASE_URL: "https://api.private.example/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "private-key",
+      VITE_ELIZA_CLOUD_BASE: "https://app.private.example",
+    });
+  });
+
+  it("fails self-hosted startup before serving a keyless proxy login flow", () => {
     expect(() =>
       configureDevCloudEnvironment([], {
         ELIZAOS_CLOUD_BASE_URL: "https://api.private.example/api/v1",
         VITE_ELIZA_CLOUD_BASE: "https://app.private.example",
       }),
-    ).toThrow(/same Cloud endpoint/i);
+    ).toThrow(/self-hosted.*requires ELIZAOS_CLOUD_API_KEY/i);
   });
 
   it("lets local-first override inherited self-hosted values with safe staging endpoints", () => {
@@ -249,6 +495,7 @@ describe("local development Cloud target", () => {
 
     expect(configured.effectiveTarget).toBe("offline");
     expect(configured.env).toMatchObject({
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "offline",
       ELIZAOS_CLOUD_BASE_URL: STAGING_ENV.ELIZAOS_CLOUD_BASE_URL,
       VITE_ELIZA_CLOUD_BASE: STAGING_ENV.VITE_ELIZA_CLOUD_BASE,
       VITE_STEWARD_API_URL: STAGING_ENV.VITE_STEWARD_API_URL,
@@ -288,12 +535,43 @@ describe("local development Cloud target", () => {
     const input = { CUSTOM_SENTINEL: "keep-me" };
     const configured = applyDevCloudTarget(input, {
       target: "staging",
+      source: "default",
       passthroughArgs: [],
     });
 
     expect(configured).toMatchObject({ ...input, ...STAGING_ENV });
     expect(configured).not.toBe(input);
     expect(input).toEqual({ CUSTOM_SENTINEL: "keep-me" });
+  });
+
+  it("keeps renderer-only development on targets that can authenticate without a server credential", () => {
+    for (const configured of [
+      configureDevCloudEnvironment([], {}),
+      configureDevCloudEnvironment(["--cloud-target=staging"], {}),
+      configureDevCloudEnvironment(["--cloud-target=offline"], {}),
+    ]) {
+      expect(() =>
+        assertRendererOnlyDevCloudTargetSupported(configured, "test renderer"),
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects production and self-hosted targets before a renderer-only entrypoint starts Vite", () => {
+    const production = configureDevCloudEnvironment(
+      ["--cloud-target=production"],
+      { ELIZAOS_CLOUD_API_KEY: "production-launch-key" },
+    );
+    const selfHosted = configureDevCloudEnvironment([], {
+      ELIZAOS_CLOUD_BASE_URL: "https://api.private.example/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "self-hosted-launch-key",
+      VITE_ELIZA_CLOUD_BASE: "https://app.private.example",
+    });
+
+    for (const configured of [production, selfHosted]) {
+      expect(() =>
+        assertRendererOnlyDevCloudTargetSupported(configured, "test renderer"),
+      ).toThrow(/cannot use Cloud target.*without a local agent backend/i);
+    }
   });
 });
 
@@ -318,6 +596,10 @@ describe("local development entrypoint contract", () => {
     path.join(repoRoot, "packages/app/scripts/dev-shared.mjs"),
     "utf8",
   );
+  const desktopDevSource = readFileSync(
+    path.join(repoRoot, "packages/app-core/scripts/dev-platform.mjs"),
+    "utf8",
+  );
 
   it("routes ordinary root development through the Cloud-configured orchestrator", () => {
     expect(rootPackage.scripts.dev).toContain("dev-ui.mjs");
@@ -327,6 +609,14 @@ describe("local development entrypoint contract", () => {
   it("routes direct app-package development through the same target helper", () => {
     expect(appPackage.scripts.dev).toContain("scripts/dev.mjs");
     expect(packageDevSource).toContain("configureDevCloudEnvironment");
+    expect(packageDevSource).toContain(
+      "assertRendererOnlyDevCloudTargetSupported(devCloud",
+    );
+    expect(
+      packageDevSource.indexOf(
+        "assertRendererOnlyDevCloudTargetSupported(devCloud",
+      ),
+    ).toBeLessThan(packageDevSource.indexOf("spawnMirroredChild("));
   });
 
   it("routes the registered shared Vite server through the same target helper", () => {
@@ -334,5 +624,22 @@ describe("local development entrypoint contract", () => {
       "scripts/dev-shared.mjs",
     );
     expect(sharedDevSource).toContain("configureDevCloudEnvironment");
+    expect(sharedDevSource).toContain(
+      "assertRendererOnlyDevCloudTargetSupported(devCloud",
+    );
+    expect(
+      sharedDevSource.indexOf(
+        "assertRendererOnlyDevCloudTargetSupported(devCloud",
+      ),
+    ).toBeLessThan(sharedDevSource.indexOf("reservePortsForWorktree("));
+  });
+
+  it("routes native desktop development through the same target helper", () => {
+    expect(rootPackage.scripts["dev:desktop"]).toContain("dev-platform.mjs");
+    expect(rootPackage.scripts["dev:desktop:watch"]).toContain(
+      "dev-platform.mjs",
+    );
+    expect(desktopDevSource).toContain("configureDevCloudEnvironment");
+    expect(desktopDevSource).toContain("devCloud.passthroughArgs");
   });
 });

--- a/packages/app-core/scripts/lib/dev-cloud-target.test.mjs
+++ b/packages/app-core/scripts/lib/dev-cloud-target.test.mjs
@@ -1,0 +1,338 @@
+/**
+ * Locks local development to a coherent Cloud environment so the API and
+ * renderer cannot silently split between staging and production.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  applyDevCloudTarget,
+  configureDevCloudEnvironment,
+  resolveDevCloudTarget,
+} from "./dev-cloud-target.mjs";
+
+const STAGING_ENV = {
+  ELIZA_DEV_SOURCE: "1",
+  ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+  VITE_ELIZA_CLOUD_BASE: "https://cloud-staging.eliza.app",
+  VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
+  VITE_STEWARD_API_URL: "https://staging.eliza.app/steward",
+  VITE_STEWARD_TENANT_ID: "elizacloud-staging",
+};
+
+const PRODUCTION_ENV = {
+  ELIZA_DEV_SOURCE: "1",
+  ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+  VITE_ELIZA_CLOUD_BASE: "https://cloud.eliza.app",
+  VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
+  VITE_STEWARD_API_URL: "https://eliza.app/steward",
+  VITE_STEWARD_TENANT_ID: "elizacloud",
+};
+
+describe("local development Cloud target", () => {
+  it("defaults ordinary local development to the complete staging tuple", () => {
+    const configured = configureDevCloudEnvironment([], {});
+
+    expect(configured.target).toBe("staging");
+    expect(configured.effectiveTarget).toBe("staging");
+    expect(configured.passthroughArgs).toEqual([]);
+    expect(configured.env).toMatchObject(STAGING_ENV);
+    for (const key of [
+      "ELIZA_DEV_CLOUD_API_KEY",
+      "ELIZAOS_CLOUD_API_KEY",
+      "ELIZAOS_CLOUD_ENABLED",
+      "ELIZA_CLOUD_API_KEY",
+      "ELIZACLOUD_API_KEY",
+      "ELIZA_CLOUD_PROVISIONED",
+    ]) {
+      expect(configured.env[key]).toBe("");
+    }
+  });
+
+  it("selects the complete production tuple explicitly", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "production",
+    });
+
+    expect(configured.target).toBe("production");
+    expect(configured.effectiveTarget).toBe("production");
+    expect(configured.env).toMatchObject({
+      ...PRODUCTION_ENV,
+      ELIZA_DEV_CLOUD_TARGET: "production",
+    });
+    expect(configured.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
+  });
+
+  it("masks inherited Cloud activation only for implicit staging", () => {
+    const inherited = {
+      ELIZA_DEV_CLOUD_API_KEY: "promoted-dev-key",
+      ELIZAOS_CLOUD_API_KEY: "generic-key",
+      ELIZAOS_CLOUD_ENABLED: "true",
+      ELIZA_CLOUD_API_KEY: "legacy-key",
+      ELIZACLOUD_API_KEY: "older-key",
+      ELIZA_CLOUD_PROVISIONED: "1",
+    };
+
+    const implicit = configureDevCloudEnvironment([], inherited);
+    for (const key of Object.keys(inherited)) {
+      expect(implicit.env[key]).toBe("");
+    }
+
+    const explicitStaging = configureDevCloudEnvironment([], {
+      ...inherited,
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+    });
+    expect(explicitStaging.env).toMatchObject(inherited);
+
+    const explicitProduction = configureDevCloudEnvironment([], {
+      ...inherited,
+      ELIZA_DEV_CLOUD_TARGET: "production",
+    });
+    expect(explicitProduction.env).toMatchObject(inherited);
+  });
+
+  it("lets the CLI target override the environment and strips helper flags", () => {
+    const args = ["--cloud-target", "production", "--ui-only", "--port=2200"];
+    const env = { ELIZA_DEV_CLOUD_TARGET: "staging" };
+
+    expect(resolveDevCloudTarget(args, env)).toEqual({
+      target: "production",
+      source: "cli",
+      passthroughArgs: ["--ui-only", "--port=2200"],
+    });
+    expect(configureDevCloudEnvironment(args, env).env).toMatchObject({
+      ...PRODUCTION_ENV,
+      ELIZA_DEV_CLOUD_TARGET: "production",
+    });
+  });
+
+  it("keeps local-first development off the Cloud plugin and pins manual Cloud to staging", () => {
+    const input = {
+      ...STAGING_ENV,
+      ELIZA_DEV_CLOUD_TARGET: "offline",
+      ELIZA_DEV_CLOUD_API_KEY: "promoted-key-must-not-reach-local-agent",
+      ELIZAOS_CLOUD_API_KEY: "production-key-must-not-reach-local-agent",
+      ELIZAOS_CLOUD_ENABLED: "true",
+      ELIZA_CLOUD_API_KEY: "legacy-key-must-not-reach-local-agent",
+      ELIZACLOUD_API_KEY: "older-key-must-not-reach-local-agent",
+      ELIZA_CLOUD_PROVISIONED: "1",
+      PRESERVED_LOCAL_SETTING: "yes",
+    };
+    const configured = configureDevCloudEnvironment([], input);
+
+    expect(configured.target).toBe("offline");
+    expect(configured.effectiveTarget).toBe("offline");
+    expect(configured.env).toMatchObject({
+      ELIZA_DEV_SOURCE: "1",
+      ELIZA_DEV_CLOUD_TARGET: "offline",
+      ELIZAOS_CLOUD_BASE_URL: STAGING_ENV.ELIZAOS_CLOUD_BASE_URL,
+      VITE_ELIZA_CLOUD_BASE: STAGING_ENV.VITE_ELIZA_CLOUD_BASE,
+      VITE_STEWARD_API_URL: STAGING_ENV.VITE_STEWARD_API_URL,
+      VITE_STEWARD_TENANT_ID: STAGING_ENV.VITE_STEWARD_TENANT_ID,
+      VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1",
+      PRESERVED_LOCAL_SETTING: "yes",
+    });
+    for (const key of [
+      "ELIZA_DEV_CLOUD_API_KEY",
+      "ELIZAOS_CLOUD_API_KEY",
+      "ELIZAOS_CLOUD_ENABLED",
+      "ELIZA_CLOUD_API_KEY",
+      "ELIZACLOUD_API_KEY",
+      "ELIZA_CLOUD_PROVISIONED",
+      "VITE_ELIZA_DESKTOP_RUNTIME_MODE",
+    ]) {
+      expect(configured.env[key]).toBe("");
+    }
+  });
+
+  it("preserves a coherent custom/self-hosted tuple without mutating input", () => {
+    const input = {
+      ELIZAOS_CLOUD_BASE_URL: "https://api.private.example",
+      VITE_ELIZA_CLOUD_BASE: "https://api.private.example",
+      VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
+      VITE_STEWARD_API_URL: "https://auth.private.example/steward",
+      VITE_STEWARD_TENANT_ID: "private-tenant",
+      ELIZA_DEV_CLOUD_API_KEY: "private-dev-key",
+      CUSTOM_SENTINEL: "keep-me",
+    };
+    const snapshot = { ...input };
+    const configured = configureDevCloudEnvironment([], input);
+
+    expect(configured.target).toBe("staging");
+    expect(configured.effectiveTarget).toBe("self-hosted");
+    expect(configured.env).toMatchObject({
+      ...input,
+      ELIZA_DEV_SOURCE: "1",
+    });
+    expect(input).toEqual(snapshot);
+    expect(configured.env).not.toBe(input);
+  });
+
+  it("allows an optional /api/v1 suffix for one self-hosted surface", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZAOS_CLOUD_BASE_URL: "https://private.example/api/v1/",
+      VITE_ELIZA_CLOUD_BASE: "https://private.example/",
+    });
+
+    expect(configured.effectiveTarget).toBe("self-hosted");
+    expect(configured.env).toMatchObject({
+      ELIZAOS_CLOUD_BASE_URL: "https://private.example/api/v1/",
+      VITE_ELIZA_CLOUD_BASE: "https://private.example/",
+      VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
+    });
+    expect(configured.env.VITE_STEWARD_API_URL).toBeUndefined();
+    expect(configured.env.VITE_STEWARD_TENANT_ID).toBeUndefined();
+  });
+
+  it("preserves independently optional self-hosted Steward overrides", () => {
+    const withApiUrl = configureDevCloudEnvironment([], {
+      ELIZAOS_CLOUD_BASE_URL: "https://private.example",
+      VITE_ELIZA_CLOUD_BASE: "https://private.example",
+      VITE_STEWARD_API_URL: "https://identity.private.example/steward",
+    });
+    const withTenant = configureDevCloudEnvironment([], {
+      ELIZAOS_CLOUD_BASE_URL: "https://private.example",
+      VITE_ELIZA_CLOUD_BASE: "https://private.example",
+      VITE_STEWARD_TENANT_ID: "private-tenant",
+    });
+
+    expect(withApiUrl.env.VITE_STEWARD_API_URL).toBe(
+      "https://identity.private.example/steward",
+    );
+    expect(withApiUrl.env.VITE_STEWARD_TENANT_ID).toBeUndefined();
+    expect(withTenant.env.VITE_STEWARD_API_URL).toBeUndefined();
+    expect(withTenant.env.VITE_STEWARD_TENANT_ID).toBe("private-tenant");
+  });
+
+  it.each([
+    ["not-a-url", "not-a-url"],
+    ["ftp://private.example", "ftp://private.example"],
+  ])("rejects malformed or non-HTTP self-hosted bases: %s", (api, renderer) => {
+    expect(() =>
+      configureDevCloudEnvironment([], {
+        ELIZAOS_CLOUD_BASE_URL: api,
+        VITE_ELIZA_CLOUD_BASE: renderer,
+      }),
+    ).toThrow(/absolute HTTP\(S\)|use HTTP\(S\)/i);
+  });
+
+  it("rejects a one-sided self-hosted base", () => {
+    expect(() =>
+      configureDevCloudEnvironment([], {
+        VITE_ELIZA_CLOUD_BASE: "https://private.example",
+      }),
+    ).toThrow(/must set both/i);
+  });
+
+  it("rejects mismatched self-hosted API and renderer endpoints", () => {
+    expect(() =>
+      configureDevCloudEnvironment([], {
+        ELIZAOS_CLOUD_BASE_URL: "https://api.private.example/api/v1",
+        VITE_ELIZA_CLOUD_BASE: "https://app.private.example",
+      }),
+    ).toThrow(/same Cloud endpoint/i);
+  });
+
+  it("lets local-first override inherited self-hosted values with safe staging endpoints", () => {
+    const configured = configureDevCloudEnvironment(
+      ["--cloud-target=offline"],
+      {
+        ELIZAOS_CLOUD_BASE_URL: "https://private.example/api/v1",
+        VITE_ELIZA_CLOUD_BASE: "https://private.example",
+        VITE_STEWARD_API_URL: "https://identity.private.example/steward",
+        VITE_STEWARD_TENANT_ID: "private-tenant",
+        VITE_ELIZA_DESKTOP_RUNTIME_MODE: "cloud",
+      },
+    );
+
+    expect(configured.effectiveTarget).toBe("offline");
+    expect(configured.env).toMatchObject({
+      ELIZAOS_CLOUD_BASE_URL: STAGING_ENV.ELIZAOS_CLOUD_BASE_URL,
+      VITE_ELIZA_CLOUD_BASE: STAGING_ENV.VITE_ELIZA_CLOUD_BASE,
+      VITE_STEWARD_API_URL: STAGING_ENV.VITE_STEWARD_API_URL,
+      VITE_STEWARD_TENANT_ID: STAGING_ENV.VITE_STEWARD_TENANT_ID,
+      VITE_ELIZA_DESKTOP_RUNTIME_MODE: "",
+      VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1",
+    });
+  });
+
+  it("rejects a canonical override that conflicts with the selected target", () => {
+    expect(() =>
+      configureDevCloudEnvironment(["--cloud-target=staging"], {
+        VITE_ELIZA_CLOUD_BASE: "https://cloud.eliza.app",
+      }),
+    ).toThrow(/conflict|staging|production/i);
+  });
+
+  it("rejects split canonical API and renderer environments", () => {
+    expect(() =>
+      configureDevCloudEnvironment([], {
+        ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+        VITE_ELIZA_CLOUD_BASE: "https://cloud.eliza.app",
+      }),
+    ).toThrow(/conflict|staging|production/i);
+  });
+
+  it("rejects unknown and missing target values", () => {
+    expect(() => resolveDevCloudTarget(["--cloud-target=preview"], {})).toThrow(
+      /unknown|preview/i,
+    );
+    expect(() => resolveDevCloudTarget(["--cloud-target"], {})).toThrow(
+      /missing|expected/i,
+    );
+  });
+
+  it("returns a fresh environment even when applying a resolved target directly", () => {
+    const input = { CUSTOM_SENTINEL: "keep-me" };
+    const configured = applyDevCloudTarget(input, {
+      target: "staging",
+      passthroughArgs: [],
+    });
+
+    expect(configured).toMatchObject({ ...input, ...STAGING_ENV });
+    expect(configured).not.toBe(input);
+    expect(input).toEqual({ CUSTOM_SENTINEL: "keep-me" });
+  });
+});
+
+describe("local development entrypoint contract", () => {
+  const libDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(libDir, "../../../..");
+  const rootPackage = JSON.parse(
+    readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  );
+  const appPackage = JSON.parse(
+    readFileSync(path.join(repoRoot, "packages/app/package.json"), "utf8"),
+  );
+  const orchestratorSource = readFileSync(
+    path.join(repoRoot, "packages/app-core/scripts/dev-ui.mjs"),
+    "utf8",
+  );
+  const packageDevSource = readFileSync(
+    path.join(repoRoot, "packages/app/scripts/dev.mjs"),
+    "utf8",
+  );
+  const sharedDevSource = readFileSync(
+    path.join(repoRoot, "packages/app/scripts/dev-shared.mjs"),
+    "utf8",
+  );
+
+  it("routes ordinary root development through the Cloud-configured orchestrator", () => {
+    expect(rootPackage.scripts.dev).toContain("dev-ui.mjs");
+    expect(orchestratorSource).toContain("configureDevCloudEnvironment");
+  });
+
+  it("routes direct app-package development through the same target helper", () => {
+    expect(appPackage.scripts.dev).toContain("scripts/dev.mjs");
+    expect(packageDevSource).toContain("configureDevCloudEnvironment");
+  });
+
+  it("routes the registered shared Vite server through the same target helper", () => {
+    expect(appPackage.scripts["dev:shared"]).toContain(
+      "scripts/dev-shared.mjs",
+    );
+    expect(sharedDevSource).toContain("configureDevCloudEnvironment");
+  });
+});

--- a/packages/app-core/src/api/cloud-pair-route.test.ts
+++ b/packages/app-core/src/api/cloud-pair-route.test.ts
@@ -6,6 +6,10 @@ import * as http from "node:http";
 import { Socket } from "node:net";
 import { runInNewContext } from "node:vm";
 import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import {
   CLOUD_PAIR_LEGACY_STORAGE_KEY,
   CLOUD_PAIR_LOCAL_OWNER_HINT_KEY,
   cloudPairTokenKeyForAgent,
@@ -37,7 +41,10 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 let handleCloudPairRoute: typeof import("./cloud-pair-route").handleCloudPairRoute;
 
 const AGENT_ID = "55555555-5555-4555-8555-555555555555";
+const HOSTILE_AGENT_ID = "99999999-9999-4999-8999-999999999999";
 const MANAGED_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
   "ELIZA_CLOUD_PROVISIONED",
   "ELIZA_CLOUD_PAIR_DIRECT_RELAY",
   "ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS",
@@ -164,6 +171,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   _resetSensitiveLimiters();
   clearManagedEnv();
   process.env.ELIZA_CLOUD_PROVISIONED = "1";
@@ -174,9 +182,113 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
   restoreManagedEnv();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("handleCloudPairRoute", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "keeps the relay disabled under frozen %s authority despite late env pollution",
+    async (authority) => {
+      delete process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY;
+      delete process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS;
+      delete process.env.ELIZA_CLOUD_AGENT_ID;
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api-staging.eliza.app/api/v1";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY = "1";
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "203.0.113.0/24";
+      process.env.ELIZA_CLOUD_AGENT_ID = HOSTILE_AGENT_ID;
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      const harness = fakeRes();
+      await handleCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=late-token" }),
+        harness.res,
+      );
+
+      expect(harness.status()).toBe(421);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      authority: "staging-explicit" as const,
+      launchBase: "https://api-staging.eliza.app/api/v1",
+      exchangeUrl: "https://api-staging.eliza.app/api/auth/pair",
+    },
+    {
+      authority: "self-hosted" as const,
+      launchBase: "https://private.example:8787/api/v1",
+      exchangeUrl: "https://private.example:8787/api/auth/pair",
+    },
+  ])(
+    "uses only the frozen $authority relay identity, base, and CIDRs",
+    async ({ authority, launchBase, exchangeUrl }) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBase;
+      process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY = "1";
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "172.17.0.0/16";
+      process.env.ELIZA_CLOUD_AGENT_ID = AGENT_ID;
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY = "0";
+      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS = "192.168.0.0/16";
+      process.env.ELIZA_CLOUD_AGENT_ID = HOSTILE_AGENT_ID;
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            apiKey: "agent_secret_value",
+            agentId: AGENT_ID,
+            agentName: "Frozen",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      const admitted = fakeRes();
+      await handleCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=frozen-token",
+          ip: "172.17.0.2",
+        }),
+        admitted.res,
+      );
+      expect(admitted.status()).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        exchangeUrl,
+        expect.objectContaining({
+          body: JSON.stringify({
+            token: "frozen-token",
+            agentId: AGENT_ID,
+          }),
+        }),
+      );
+
+      fetchMock.mockClear();
+      const lateOnlyPeer = fakeRes();
+      await handleCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=late-token",
+          ip: "192.168.1.2",
+        }),
+        lateOnlyPeer.res,
+      );
+      expect(lateOnlyPeer.status()).toBe(421);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("returns false for non-/pair paths so the dispatch chain keeps walking", async () => {
     const { res } = fakeRes();
     const req = fakeReq({ pathname: "/something-else" });

--- a/packages/app-core/src/api/cloud-pair-route.ts
+++ b/packages/app-core/src/api/cloud-pair-route.ts
@@ -22,6 +22,9 @@ import { logger } from "@elizaos/core";
 import {
   isLoopbackRemoteAddress,
   isRemoteAddressInCidrList,
+  resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
 } from "@elizaos/shared";
 import {
   type CloudPairRelaySession,
@@ -39,11 +42,9 @@ const RELAY_TIMEOUT_MS = 15_000;
 const pairingRelayLimiter = getSensitiveLimiter("cloud.pair.relay");
 
 function resolveCloudApiBaseUrl(): string {
-  const raw =
-    process.env.ELIZAOS_CLOUD_BASE_URL ||
-    process.env.NEXT_PUBLIC_API_URL ||
-    "https://api.eliza.app/api/v1";
-  return raw.replace(/\/+$/, "");
+  return resolveCanonicalCloudApiBaseUrl(
+    process.env.NEXT_PUBLIC_API_URL,
+  ).replace(/\/+$/, "");
 }
 
 function resolveCloudAuthRoot(): string {
@@ -66,8 +67,35 @@ function resolveDirectRequestOrigin(req: http.IncomingMessage): string {
   return host ? `${proto}://${host}` : "";
 }
 
-function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
-  if (process.env.ELIZA_CLOUD_PAIR_DIRECT_RELAY !== "1") return false;
+interface CloudPairRelayPolicy {
+  readonly directRelayEnabled: boolean;
+  readonly allowedPeerCidrs: string | undefined;
+  readonly agentEnv: Readonly<Record<string, string | undefined>>;
+}
+
+function resolveCloudPairRelayPolicy(): CloudPairRelayPolicy {
+  const authority = resolveDevCloudEnvAuthority();
+  const read = (key: string): string | undefined =>
+    authority ? resolveDevCloudAuthorityEnvValue(key) : process.env[key];
+  const activationBlocked =
+    authority === "staging-default" || authority === "offline";
+
+  return Object.freeze({
+    directRelayEnabled:
+      !activationBlocked && read("ELIZA_CLOUD_PAIR_DIRECT_RELAY") === "1",
+    allowedPeerCidrs: read("ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS"),
+    agentEnv: Object.freeze({
+      ELIZA_CLOUD_AGENT_ID: read("ELIZA_CLOUD_AGENT_ID"),
+      WAIFU_ELIZA_CLOUD_AGENT_ID: read("WAIFU_ELIZA_CLOUD_AGENT_ID"),
+    }),
+  });
+}
+
+function canUseManagedDirectRelay(
+  req: http.IncomingMessage,
+  policy: CloudPairRelayPolicy,
+): boolean {
+  if (!policy.directRelayEnabled) return false;
   // The local-only gate must key on the TCP peer, never on request headers:
   // Host and X-Forwarded-Host are client-controlled, so a remote caller
   // could previously spoof a loopback origin and redeem a held pairing token
@@ -77,10 +105,7 @@ function canUseManagedDirectRelay(req: http.IncomingMessage): boolean {
   const peer = req.socket?.remoteAddress;
   return (
     isLoopbackRemoteAddress(peer) ||
-    isRemoteAddressInCidrList(
-      peer,
-      process.env.ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS,
-    )
+    isRemoteAddressInCidrList(peer, policy.allowedPeerCidrs)
   );
 }
 
@@ -189,7 +214,10 @@ export async function handleCloudPairRoute(
     return false;
   }
 
-  if (!canUseManagedDirectRelay(req)) {
+  // Capture every authority-owned relay input once per request. Later env
+  // writes cannot enable a blocked relay or redirect an admitted exchange.
+  const relayPolicy = resolveCloudPairRelayPolicy();
+  if (!canUseManagedDirectRelay(req, relayPolicy)) {
     sendHtml(
       res,
       421,
@@ -240,7 +268,7 @@ export async function handleCloudPairRoute(
     return true;
   }
 
-  const agentId = resolveCloudPairAgentIdFromEnv(process.env);
+  const agentId = resolveCloudPairAgentIdFromEnv(relayPolicy.agentEnv);
   if (!agentId) {
     sendHtml(
       res,

--- a/packages/app-core/src/api/deferred-runtime-boot.test.ts
+++ b/packages/app-core/src/api/deferred-runtime-boot.test.ts
@@ -9,6 +9,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { saveElizaConfig } from "@elizaos/agent/config/config";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isRuntimeBootDeferred,
@@ -26,6 +27,9 @@ const ENV_KEYS = [
   "ELIZA_STATE_DIR",
   "ELIZA_PERSIST_CONFIG_PATH",
   "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_DEV_SOURCE",
   "ELIZA_CHAT_VIA_CLI",
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_ENABLED",
@@ -46,6 +50,7 @@ const ENV_KEYS = [
 ] as const;
 
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   for (const key of ENV_KEYS) {
     savedEnv[key] = process.env[key];
     delete process.env[key];
@@ -65,6 +70,7 @@ afterEach(() => {
   }
   fs.rmSync(stateDir, { recursive: true, force: true });
   resetDeferredRuntimeBootForTests();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 function pinDeferredBootConfigEnv(): void {
@@ -105,6 +111,34 @@ describe("shouldDeferRuntimeBootUntilOnboarding (fresh-install gate)", () => {
     pinDeferredBootConfigEnv();
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
+  });
+
+  it("keeps staging-default onboarding deferred after late managed-env pollution", () => {
+    pinDeferredBootConfigEnv();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(true);
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(true);
+  });
+
+  it("keeps explicit production boot active after late provisioning env clearing", () => {
+    pinDeferredBootConfigEnv();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_API_TOKEN = "launch-api-token";
+
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
+
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.ELIZA_API_TOKEN;
+
     expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
   });
 

--- a/packages/app-core/src/api/first-run-routes.json-body.test.ts
+++ b/packages/app-core/src/api/first-run-routes.json-body.test.ts
@@ -12,7 +12,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompatRuntimeState } from "./compat-route-shared";
 
 const saveElizaConfig = vi.fn();
+const loadElizaConfig = vi.fn(() => ({}) as Record<string, unknown>);
+const loadEffectiveElizaConfig = vi.fn(() => ({}) as Record<string, unknown>);
 const extractAndPersistFirstRunApiKey = vi.fn();
+const getCloudSecret = vi.fn(() => undefined as string | undefined);
+const normalizeLinkedAccountFlagsConfig = vi.fn(() => undefined as unknown);
+const resolveDevCloudEnvAuthority = vi.fn(() => null as string | null);
+const resolveDevCloudAuthorityEnvValue = vi.fn(
+  (key: string) => process.env[key],
+);
 const readRequestBody = vi.fn(
   async (
     req: http.IncomingMessage,
@@ -45,17 +53,20 @@ vi.mock("@elizaos/core", () => ({
 
 vi.mock("@elizaos/agent", () => ({
   applyCanonicalFirstRunConfig: vi.fn(),
-  loadElizaConfig: vi.fn(() => ({})),
+  loadEffectiveElizaConfig,
+  loadElizaConfig,
   saveElizaConfig,
 }));
 
 vi.mock("@elizaos/shared", () => ({
-  getCloudSecret: () => undefined,
+  getCloudSecret,
   migrateLegacyRuntimeConfig: vi.fn(),
   normalizeDeploymentTargetConfig: () => undefined,
   normalizeFirstRunProviderId: () => null,
-  normalizeLinkedAccountFlagsConfig: () => undefined,
+  normalizeLinkedAccountFlagsConfig,
   normalizeServiceRoutingConfig: () => undefined,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
 }));
 
 vi.mock("./auth.ts", () => ({
@@ -87,6 +98,7 @@ vi.mock("./server-first-run-helpers", () => ({
 function requestWithRawBody(
   raw: string,
   pathname = "/api/first-run",
+  localPort?: number,
 ): http.IncomingMessage {
   const stream = Readable.from(
     raw.length === 0 ? [] : [Buffer.from(raw, "utf8")],
@@ -94,7 +106,7 @@ function requestWithRawBody(
   return Object.assign(stream, {
     headers: { "content-type": "application/json" },
     method: "POST",
-    socket: { localPort: undefined },
+    socket: { localPort },
     url: pathname,
   }) as unknown as http.IncomingMessage;
 }
@@ -139,7 +151,21 @@ async function postFirstRun(raw: string) {
 describe("POST /api/first-run JSON body", () => {
   beforeEach(() => {
     saveElizaConfig.mockReset();
+    loadElizaConfig.mockReset();
+    loadElizaConfig.mockReturnValue({});
+    loadEffectiveElizaConfig.mockReset();
+    loadEffectiveElizaConfig.mockReturnValue({});
     extractAndPersistFirstRunApiKey.mockReset();
+    getCloudSecret.mockReset();
+    getCloudSecret.mockReturnValue(undefined);
+    normalizeLinkedAccountFlagsConfig.mockReset();
+    normalizeLinkedAccountFlagsConfig.mockReturnValue(undefined);
+    resolveDevCloudEnvAuthority.mockReset();
+    resolveDevCloudEnvAuthority.mockReturnValue(null);
+    resolveDevCloudAuthorityEnvValue.mockReset();
+    resolveDevCloudAuthorityEnvValue.mockImplementation(
+      (key: string) => process.env[key],
+    );
   });
 
   it.each(["", "   ", "{", "not-json", "[]", "null", '"foo"', "42", "true"])(
@@ -204,6 +230,145 @@ describe("POST /api/first-run JSON body", () => {
       error: "Failed to complete first-run setup",
     });
     expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["staging-default", "durable"],
+    ["staging-default", "sealed"],
+    ["offline", "durable"],
+    ["offline", "sealed"],
+  ] as const)(
+    "%s authority never selects or resaves a %s production Cloud key",
+    async (authority, source) => {
+      vi.useFakeTimers();
+      try {
+        const durableConfig: Record<string, unknown> = {
+          cloud: {
+            enabled: true,
+            baseUrl: "https://api.eliza.app/api/v1",
+            ...(source === "durable"
+              ? { apiKey: "persisted-production-key" }
+              : {}),
+          },
+        };
+        loadElizaConfig.mockReturnValue(durableConfig);
+        loadEffectiveElizaConfig.mockReturnValue({
+          cloud: {
+            enabled: false,
+            baseUrl: "https://api-staging.eliza.app/api/v1",
+            apiKey: "",
+          },
+        });
+        getCloudSecret.mockReturnValue("sealed-production-key");
+        normalizeLinkedAccountFlagsConfig.mockReturnValue({
+          elizacloud: { status: "linked" },
+        });
+        resolveDevCloudEnvAuthority.mockReturnValue(authority);
+        resolveDevCloudAuthorityEnvValue.mockReturnValue("");
+
+        const { handled, res } = await postFirstRun(
+          JSON.stringify({
+            linkedAccounts: { elizacloud: { status: "linked" } },
+            credentialInputs: {
+              cloudApiKey: "request-production-key",
+              llmApiKey: "direct-provider-key",
+            },
+          }),
+        );
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(getCloudSecret).not.toHaveBeenCalled();
+        expect(resolveDevCloudAuthorityEnvValue).toHaveBeenCalledWith(
+          "ELIZAOS_CLOUD_API_KEY",
+        );
+        expect(extractAndPersistFirstRunApiKey).toHaveBeenCalledWith({
+          linkedAccounts: { elizacloud: { status: "linked" } },
+          credentialInputs: { llmApiKey: "direct-provider-key" },
+        });
+        expect(saveElizaConfig).toHaveBeenCalledTimes(1);
+        const persisted = saveElizaConfig.mock.calls[0]?.[0] as {
+          cloud?: { apiKey?: string };
+        };
+        expect(persisted.cloud?.apiKey).toBe(
+          source === "durable" ? "persisted-production-key" : undefined,
+        );
+        expect(loadEffectiveElizaConfig).toHaveBeenCalledTimes(1);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("syncs only non-Cloud first-run state under launcher authority", async () => {
+    const durableCloud = {
+      enabled: true,
+      apiKey: "persisted-production-key",
+      serviceKey: "persisted-production-service-key",
+      baseUrl: "https://api.eliza.app/api/v1",
+    };
+    const durableAgents = {
+      list: [
+        {
+          id: "main",
+          settings: { ELIZAOS_CLOUD_API_KEY: "persisted-production-key" },
+        },
+      ],
+    };
+    loadElizaConfig.mockReturnValue({
+      agents: durableAgents,
+      cloud: durableCloud,
+    });
+    loadEffectiveElizaConfig.mockReturnValue({
+      meta: { firstRunComplete: true },
+      agents: { list: [{ id: "main" }] },
+      ui: { assistant: { name: "Eliza" } },
+      cloud: {
+        enabled: false,
+        apiKey: "",
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+      },
+      deploymentTarget: { runtime: "local" },
+      linkedAccounts: {},
+      serviceRouting: { llmText: { transport: "direct", backend: "openai" } },
+    });
+    resolveDevCloudEnvAuthority.mockReturnValue("staging-default");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", { status: 200 }),
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const { handleFirstRunRoute } = await import("./first-run-routes");
+      const res = responseSink();
+      const handled = await handleFirstRunRoute(
+        requestWithRawBody('{"name":"Eliza"}', "/api/first-run", 2138),
+        res,
+        emptyState(),
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      const patch = JSON.parse(String(request.body)) as Record<string, unknown>;
+      expect(patch).toEqual({
+        meta: { firstRunComplete: true },
+        agents: durableAgents,
+        ui: { assistant: { name: "Eliza" } },
+      });
+      expect(patch).not.toHaveProperty("cloud");
+      expect(patch).not.toHaveProperty("deploymentTarget");
+      expect(patch).not.toHaveProperty("linkedAccounts");
+      expect(patch).not.toHaveProperty("serviceRouting");
+      const persisted = saveElizaConfig.mock.calls[0]?.[0] as {
+        cloud?: Record<string, unknown>;
+      };
+      expect(persisted.cloud).toEqual(durableCloud);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("ignores non-first-run paths", async () => {

--- a/packages/app-core/src/api/first-run-routes.ts
+++ b/packages/app-core/src/api/first-run-routes.ts
@@ -5,7 +5,11 @@
  * (flipping `meta.firstRunComplete`). When the run is cloud-linked it resolves
  * the Eliza Cloud API key from config, sealed secrets, or env and writes it
  * back so the upstream config save keeps it, then mirrors the merged config to
- * the live runtime through a loopback `PUT /api/config`.
+ * the live runtime through a loopback `PUT /api/config`. A launcher-owned dev
+ * Cloud authority is the exception: only its frozen launch key is visible,
+ * durable credentials stay untouched, and loopback state sync omits every
+ * Cloud-owned topology field so the generic config route cannot materialize
+ * the ephemeral authority view back onto disk.
  *
  * A committed local-target run is also the boot trigger for a fresh install
  * that deferred its runtime at startup (deferred-runtime-boot.ts): once the
@@ -24,6 +28,7 @@
 import type http from "node:http";
 import {
   applyCanonicalFirstRunConfig,
+  loadEffectiveElizaConfig,
   loadElizaConfig,
   saveElizaConfig,
 } from "@elizaos/agent";
@@ -36,6 +41,8 @@ import {
   normalizeFirstRunProviderId,
   normalizeLinkedAccountFlagsConfig,
   normalizeServiceRoutingConfig,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
 } from "@elizaos/shared";
 import { ensureRouteAuthorized } from "./auth.ts";
 import {
@@ -59,6 +66,7 @@ export const MAX_FIRST_RUN_BODY_BYTES = 1_048_576;
 async function syncFirstRunConfigState(
   req: http.IncomingMessage,
   config: Record<string, unknown>,
+  includeCloudTopology = true,
 ): Promise<void> {
   const loopbackPort = req.socket.localPort;
   if (!loopbackPort) {
@@ -66,18 +74,18 @@ async function syncFirstRunConfigState(
   }
 
   const syncPatch: Record<string, unknown> = {};
-  for (const key of [
+  const syncKeys = [
     "meta",
     "agents",
     "ui",
     "messages",
-    "deploymentTarget",
-    "linkedAccounts",
-    "serviceRouting",
     "features",
     "connectors",
-    "cloud",
-  ]) {
+    ...(includeCloudTopology
+      ? ["deploymentTarget", "linkedAccounts", "serviceRouting", "cloud"]
+      : []),
+  ];
+  for (const key of syncKeys) {
     if (Object.hasOwn(config, key)) {
       syncPatch[key] = config[key];
     }
@@ -135,6 +143,11 @@ const CLOUD_API_KEY_RESAVE_DELAY_MS = 3000;
  * silent `catch {}` previously here masked real bugs.
  */
 function scheduleCloudApiKeyResave(apiKey: string): void {
+  // Dev launchers own an immutable process-lifetime Cloud tuple. Persisting a
+  // key from any first-run fallback would turn temporary staging credentials
+  // (or a later-mutated ambient env value) into durable account state.
+  if (resolveDevCloudEnvAuthority()) return;
+
   setTimeout(() => {
     try {
       const freshConfig = loadElizaConfig();
@@ -159,14 +172,22 @@ function scheduleCloudApiKeyResave(apiKey: string): void {
 }
 
 /**
- * Resolve the cloud apiKey from the three sources we accept, in priority order.
- * Returns the first hit (or `undefined` if none) and writes it back into the
- * `config.cloud` slot when found via the secrets/env fallbacks so the
- * subsequent `saveElizaConfig` persists it.
+ * Resolve the cloud apiKey from the accepted sources. Under a launcher-owned
+ * development authority, only the frozen launch value is visible and the
+ * durable config is never mutated. Outside authority mode, retain the legacy
+ * config → sealed secret → environment priority and persist fallback hits.
  */
 function resolveCloudApiKeyForFirstRun(
   config: Record<string, unknown>,
+  devCloudAuthority = resolveDevCloudEnvAuthority(),
 ): string | undefined {
+  if (devCloudAuthority) {
+    const launchValue = resolveDevCloudAuthorityEnvValue(
+      "ELIZAOS_CLOUD_API_KEY",
+    )?.trim();
+    return launchValue || undefined;
+  }
+
   if (!config.cloud || typeof config.cloud !== "object") {
     config.cloud = {};
   }
@@ -188,6 +209,31 @@ function resolveCloudApiKeyForFirstRun(
   }
 
   return undefined;
+}
+
+/** Keep direct-provider setup writable while launcher authority owns Cloud. */
+function withoutAuthorityOwnedCloudCredential(
+  body: Record<string, unknown>,
+  devCloudAuthority: ReturnType<typeof resolveDevCloudEnvAuthority>,
+): Record<string, unknown> {
+  if (!devCloudAuthority) return body;
+  const credentialInputs = body.credentialInputs;
+  if (
+    !credentialInputs ||
+    typeof credentialInputs !== "object" ||
+    Array.isArray(credentialInputs) ||
+    !Object.hasOwn(credentialInputs, "cloudApiKey")
+  ) {
+    return body;
+  }
+  const sanitizedCredentialInputs = {
+    ...(credentialInputs as Record<string, unknown>),
+  };
+  delete sanitizedCredentialInputs.cloudApiKey;
+  return {
+    ...body,
+    credentialInputs: sanitizedCredentialInputs,
+  };
 }
 
 export async function handleFirstRunRoute(
@@ -238,6 +284,9 @@ export async function handleFirstRunRoute(
     return true;
   }
   const body = parsed as Record<string, unknown>;
+  // Freeze and retain the launcher tuple before any credential helper can
+  // mutate process.env from the request body.
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
 
   let capturedCloudApiKey: string | undefined;
   let committedRuntimeTarget: DeploymentTargetRuntime | undefined;
@@ -250,7 +299,9 @@ export async function handleFirstRunRoute(
       });
       return true;
     }
-    await extractAndPersistFirstRunApiKey(body);
+    await extractAndPersistFirstRunApiKey(
+      withoutAuthorityOwnedCloudCredential(body, devCloudAuthority),
+    );
     persistFirstRunDefaults(body);
     if (typeof body.name === "string" && body.name.trim()) {
       state.pendingAgentName = body.name.trim();
@@ -298,12 +349,15 @@ export async function handleFirstRunRoute(
       if (shouldResolveCloudApiKey) {
         resolvedCloudApiKey = resolveCloudApiKeyForFirstRun(
           config as Record<string, unknown>,
+          devCloudAuthority,
         );
 
         if (!resolvedCloudApiKey) {
           logger.warn(
-            "[api] Cloud-linked first-run but no API key found on disk, in sealed secrets, or in env. " +
-              "The upstream handler will save config WITHOUT cloud.apiKey.",
+            devCloudAuthority
+              ? "[api] Cloud-linked first-run has no launcher-authoritative API key; durable, sealed, request, and ambient credentials were ignored."
+              : "[api] Cloud-linked first-run but no API key found on disk, in sealed secrets, or in env. " +
+                  "The upstream handler will save config WITHOUT cloud.apiKey.",
           );
         } else {
           logger.info(
@@ -314,7 +368,25 @@ export async function handleFirstRunRoute(
         capturedCloudApiKey = resolvedCloudApiKey;
       }
       saveElizaConfig(config);
-      await syncFirstRunConfigState(req, config as Record<string, unknown>);
+      // Durable first-run mutations preserve unrelated account state, while
+      // the live process receives only the launcher-authoritative Cloud view.
+      const operationalConfig = devCloudAuthority
+        ? loadEffectiveElizaConfig()
+        : config;
+      // The authority view removes Cloud-owned keys from per-agent settings.
+      // `agents.list` is an array, so the generic config route replaces it
+      // wholesale rather than deep-merging its entries. Use the just-saved
+      // durable agent graph for this loopback-only state refresh; otherwise a
+      // harmless first-run sync would delete unrelated durable credentials.
+      const syncConfig = devCloudAuthority
+        ? {
+            ...(operationalConfig as Record<string, unknown>),
+            ...(Object.hasOwn(config, "agents")
+              ? { agents: (config as Record<string, unknown>).agents }
+              : {}),
+          }
+        : (operationalConfig as Record<string, unknown>);
+      await syncFirstRunConfigState(req, syncConfig, !devCloudAuthority);
     } catch (err) {
       // error-policy:J1 a failed config commit is a server failure, never a
       // successful onboarding acknowledgement.
@@ -338,7 +410,7 @@ export async function handleFirstRunRoute(
 
   sendJsonResponse(res, 200, { ok: true });
 
-  if (capturedCloudApiKey) {
+  if (capturedCloudApiKey && !devCloudAuthority) {
     scheduleCloudApiKeyResave(capturedCloudApiKey);
   }
 

--- a/packages/app-core/src/api/server-cloud-authority.test.ts
+++ b/packages/app-core/src/api/server-cloud-authority.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Wrapper-level regression coverage for the app-core Cloud compat dispatcher.
+ * A launcher-owned development target must reach both billing and compat
+ * handlers through the effective config view, never through durable production
+ * topology or a key repaired from ambient/runtime state.
+ */
+import fs from "node:fs";
+import type http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { AgentCloudBillingRouteHandler } from "@elizaos/agent/api/cloud-route-contracts";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/agent/config/dev-cloud-env-authority";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentMocks = vi.hoisted(() => ({
+  billing: vi.fn<AgentCloudBillingRouteHandler>(async () => true),
+  compat: vi.fn<AgentCloudBillingRouteHandler>(async () => true),
+  save: vi.fn(),
+}));
+const cloudSecretMocks = vi.hoisted(() => ({
+  get: vi.fn<() => string | null>(() => null),
+}));
+
+vi.mock("@elizaos/agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/agent")>();
+  return {
+    ...actual,
+    handleCloudBillingRoute: agentMocks.billing,
+    handleCloudCompatRoute: agentMocks.compat,
+    handleRuntimeModePreDispatch: vi.fn(async () => false),
+    handleRuntimeModeRemoteForward: vi.fn(async () => false),
+    saveElizaConfig: (
+      config: Parameters<typeof actual.saveElizaConfig>[0],
+    ): void => {
+      agentMocks.save(config);
+      actual.saveElizaConfig(config);
+    },
+  };
+});
+
+vi.mock("@elizaos/shared/elizacloud/cloud-secrets", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@elizaos/shared/elizacloud/cloud-secrets")
+    >();
+  return {
+    ...actual,
+    getCloudSecret: cloudSecretMocks.get,
+  };
+});
+
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleElizaCompatRoute } from "./server";
+
+const STAGING_API = "https://api-staging.eliza.app/api/v1";
+const PRODUCTION_API = "https://api.eliza.app/api/v1";
+
+let originalEnv: NodeJS.ProcessEnv;
+let root = "";
+let configPath = "";
+
+function trustedLoopbackRequest(pathname: string): http.IncomingMessage {
+  return {
+    method: "GET",
+    url: pathname,
+    headers: { host: "127.0.0.1:2138" },
+    socket: { remoteAddress: "127.0.0.1" },
+  } as unknown as http.IncomingMessage;
+}
+
+function responseStub(): http.ServerResponse {
+  return {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  } as unknown as http.ServerResponse;
+}
+
+function routeState(runtimeSecret?: string): CompatRuntimeState {
+  return {
+    current: runtimeSecret
+      ? ({
+          character: {
+            secrets: { ELIZAOS_CLOUD_API_KEY: runtimeSecret },
+          },
+        } as unknown as CompatRuntimeState["current"])
+      : null,
+    pendingAgentName: null,
+    pendingRestartReasons: [],
+  };
+}
+
+function writeConfig(config: Record<string, unknown>): string {
+  const serialized = `${JSON.stringify(config, null, 2)}\n`;
+  fs.writeFileSync(configPath, serialized);
+  return serialized;
+}
+
+function capturedConfig(mock: typeof agentMocks.billing, callIndex = 0) {
+  return mock.mock.calls[callIndex]?.[4]?.config;
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  originalEnv = { ...process.env };
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-cloud-authority-"));
+  configPath = path.join(root, "eliza.json");
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_STATE_DIR = root;
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_CLOUD_PROVISIONED;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  delete process.env.ELIZA_RUNTIME_MODE;
+  agentMocks.billing.mockClear();
+  agentMocks.compat.mockClear();
+  agentMocks.save.mockClear();
+  cloudSecretMocks.get.mockClear();
+  cloudSecretMocks.get.mockReturnValue(null);
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  fs.rmSync(root, { recursive: true, force: true });
+  vi.clearAllMocks();
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("app-core Cloud config authority", () => {
+  it("keeps persisted production topology and credentials out of billing and compat routes", async () => {
+    const persisted = writeConfig({
+      deploymentTarget: {
+        runtime: "remote",
+        remoteApiBase: PRODUCTION_API,
+        remoteAccessToken: "persisted-production-access-token",
+      },
+      linkedAccounts: {
+        elizacloud: { status: "linked" },
+      },
+      cloud: {
+        enabled: true,
+        baseUrl: PRODUCTION_API,
+        apiKey: "persisted-production-key",
+        serviceKey: "persisted-production-service-key",
+      },
+      env: {
+        ELIZAOS_CLOUD_BASE_URL: PRODUCTION_API,
+        ELIZAOS_CLOUD_API_KEY: "persisted-production-env-key",
+      },
+    });
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = STAGING_API;
+    process.env.ELIZAOS_CLOUD_API_KEY = "";
+
+    const state = routeState("stale-runtime-production-key");
+    expect(
+      await handleElizaCompatRoute(
+        trustedLoopbackRequest("/api/cloud/billing/summary"),
+        responseStub(),
+        state,
+      ),
+    ).toBe(true);
+    expect(
+      await handleElizaCompatRoute(
+        trustedLoopbackRequest("/api/cloud/compat/agents"),
+        responseStub(),
+        state,
+      ),
+    ).toBe(true);
+
+    const billingConfig = capturedConfig(agentMocks.billing);
+    const compatConfig = capturedConfig(agentMocks.compat);
+    for (const config of [billingConfig, compatConfig]) {
+      expect(config?.deploymentTarget).toEqual({ runtime: "local" });
+      expect(config?.cloud).toMatchObject({
+        enabled: false,
+        baseUrl: STAGING_API,
+        apiKey: "",
+      });
+      expect(config?.cloud).not.toHaveProperty("serviceKey");
+      expect(config?.linkedAccounts ?? {}).not.toHaveProperty("elizacloud");
+      expect(config?.env ?? {}).not.toHaveProperty("ELIZAOS_CLOUD_BASE_URL");
+      expect(config?.env ?? {}).not.toHaveProperty("ELIZAOS_CLOUD_API_KEY");
+    }
+    expect(agentMocks.billing).toHaveBeenCalledTimes(1);
+    expect(agentMocks.compat).toHaveBeenCalledTimes(1);
+    expect(agentMocks.save).not.toHaveBeenCalled();
+    expect(fs.readFileSync(configPath, "utf8")).toBe(persisted);
+  });
+
+  it("retains linked-account key repair and persistence without dev authority", async () => {
+    writeConfig({
+      linkedAccounts: {
+        elizacloud: { status: "linked" },
+      },
+      cloud: {
+        enabled: true,
+        baseUrl: PRODUCTION_API,
+      },
+    });
+    delete process.env.ELIZA_DEV_SOURCE;
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+    process.env.ELIZAOS_CLOUD_API_KEY = "ambient-production-key";
+
+    expect(
+      await handleElizaCompatRoute(
+        trustedLoopbackRequest("/api/cloud/billing/summary"),
+        responseStub(),
+        routeState(),
+      ),
+    ).toBe(true);
+
+    expect(capturedConfig(agentMocks.billing)?.cloud).toMatchObject({
+      baseUrl: PRODUCTION_API,
+      apiKey: "ambient-production-key",
+    });
+    expect(agentMocks.save).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8")).cloud.apiKey).toBe(
+      "ambient-production-key",
+    );
+  });
+
+  it("does not backfill or save sealed and runtime credentials under authority", async () => {
+    const persisted = writeConfig({
+      linkedAccounts: {
+        elizacloud: { status: "linked" },
+      },
+      cloud: {
+        enabled: true,
+        baseUrl: PRODUCTION_API,
+      },
+    });
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_BASE_URL = STAGING_API;
+    process.env.ELIZAOS_CLOUD_API_KEY = "";
+    cloudSecretMocks.get.mockReturnValue("sealed-production-key");
+
+    expect(
+      await handleElizaCompatRoute(
+        trustedLoopbackRequest("/api/cloud/compat/agents"),
+        responseStub(),
+        routeState("runtime-production-key"),
+      ),
+    ).toBe(true);
+
+    expect(capturedConfig(agentMocks.compat)?.cloud).toMatchObject({
+      enabled: false,
+      baseUrl: STAGING_API,
+      apiKey: "",
+    });
+    expect(cloudSecretMocks.get).not.toHaveBeenCalled();
+    expect(agentMocks.save).not.toHaveBeenCalled();
+    expect(fs.readFileSync(configPath, "utf8")).toBe(persisted);
+  });
+});

--- a/packages/app-core/src/api/server-first-run-helpers.test.ts
+++ b/packages/app-core/src/api/server-first-run-helpers.test.ts
@@ -10,7 +10,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { loadElizaConfig, saveElizaConfig } from "@elizaos/agent";
 import { stringToUuid } from "@elizaos/core";
-import { getDefaultStylePreset, getStylePresets } from "@elizaos/shared";
+import {
+  getDefaultStylePreset,
+  getStylePresets,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   deriveFirstRunReplayBody,
@@ -40,6 +44,9 @@ const CONFIG_ENV_KEYS = [
 
 const CLOUD_ENV_KEYS = [
   "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_DEV_SOURCE",
   "STEWARD_AGENT_TOKEN",
   "ELIZA_API_TOKEN",
   "ELIZAOS_CLOUD_ENABLED",
@@ -247,11 +254,13 @@ describe("isCloudProvisioned", () => {
   const previous = snapshotEnv(CLOUD_ENV_KEYS);
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     clearEnv(CLOUD_ENV_KEYS);
   });
 
   afterEach(() => {
     restoreEnv(previous);
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("is false when the cloud flag and every token source are missing", () => {
@@ -322,6 +331,32 @@ describe("isCloudProvisioned", () => {
     process.env.ELIZAOS_CLOUD_ENABLED = "false";
     process.env.ELIZAOS_CLOUD_API_KEY = "ck-live";
     expect(isCloudProvisioned()).toBe(false);
+  });
+
+  it("staging-default cannot become provisioned through late env pollution", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+
+    expect(isCloudProvisioned()).toBe(false);
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+
+    expect(isCloudProvisioned()).toBe(false);
+  });
+
+  it("explicit production remains provisioned after late env clearing", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_API_TOKEN = "launch-api-token";
+
+    expect(isCloudProvisioned()).toBe(true);
+
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.ELIZA_API_TOKEN;
+
+    expect(isCloudProvisioned()).toBe(true);
   });
 });
 

--- a/packages/app-core/src/api/server-first-run-helpers.ts
+++ b/packages/app-core/src/api/server-first-run-helpers.ts
@@ -14,6 +14,7 @@ import {
   deriveFirstRunCredentialPersistencePlan,
   getDefaultStylePreset,
   getStylePresets,
+  isCloudProvisionedContainer,
   type LinkedAccountFlagsConfig,
   migrateLegacyRuntimeConfig,
   normalizeCharacterLanguage,
@@ -22,10 +23,8 @@ import {
   normalizeLinkedAccountFlagsConfig,
   normalizeServiceRoutingConfig,
   PREMADE_VOICES,
-  readAliasedEnv,
   type ServiceRoutingConfig,
 } from "@elizaos/shared";
-import { getCompatApiToken } from "./auth.ts";
 import { resolveProviderCredential } from "./credential-resolver";
 
 // ---------------------------------------------------------------------------
@@ -355,17 +354,5 @@ export function deriveFirstRunReplayBody(body: Record<string, unknown>): {
  * `ensureAuthSessionOrBootstrap`.
  */
 export function isCloudProvisioned(): boolean {
-  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
-
-  const hasCloudApiKeyProvisioning =
-    process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
-    Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim());
-
-  const hasPlatformToken = Boolean(
-    process.env.STEWARD_AGENT_TOKEN?.trim() ||
-      getCompatApiToken() ||
-      hasCloudApiKeyProvisioning,
-  );
-
-  return hasCloudFlag && hasPlatformToken;
+  return isCloudProvisionedContainer();
 }

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -32,6 +32,7 @@ import {
   handleRuntimeModeRemoteForward,
   isAllowedHost,
   isAuthorized,
+  loadEffectiveElizaConfig,
   loadElizaConfig,
   normalizeWsClientId,
   persistConversationRoomTitle,
@@ -44,6 +45,7 @@ import {
   streamResponseBodyWithByteLimit,
   startApiServer as upstreamStartApiServer,
 } from "@elizaos/agent";
+import { isDevCloudConfigAuthorityView } from "@elizaos/agent/config/dev-cloud-env-authority";
 import { getDeferredBootStatus } from "@elizaos/agent/runtime/deferred-boot-status";
 import { createRuntimeAccountStoragePolicy } from "@elizaos/auth/account-storage";
 // Override the wallet export rejection function with the hardened version
@@ -457,11 +459,15 @@ function patchCompatStatusResponse(
 }
 
 /**
- * Load config from disk and backfill `cloud.apiKey` from sealed secrets when the
- * user is still linked to Eliza Cloud but a stale write dropped the key.
+ * Resolve the Cloud config used by app-core's compatibility routes. A valid
+ * development Cloud authority owns the complete operational connection and is
+ * returned as an ephemeral, sanitized view; that view must never be repaired
+ * from sealed/env/runtime state or persisted. Outside authority mode, retain
+ * the legacy repair behavior for linked Cloud accounts whose persisted key was
+ * dropped by a stale write.
  */
 function resolveCloudConfig(runtime?: unknown): ElizaConfig {
-  const config = loadElizaConfig();
+  const config = loadEffectiveElizaConfig();
   const cloudRec =
     config.cloud && typeof config.cloud === "object"
       ? (config.cloud as Record<string, unknown>)
@@ -474,6 +480,14 @@ function resolveCloudConfig(runtime?: unknown): ElizaConfig {
         .sort()
         .join(",")}`,
     );
+  }
+  if (isDevCloudConfigAuthorityView(config)) {
+    if (isElizaSettingsDebugEnabled()) {
+      logger.debug(
+        "[eliza][settings][compat] resolveCloudConfig using launcher-owned ephemeral Cloud view",
+      );
+    }
+    return config;
   }
   const linkedAccounts = resolveLinkedAccountsInConfig(
     config as Record<string, unknown>,

--- a/packages/app-core/src/runtime/startup/local-model-warmup.ts
+++ b/packages/app-core/src/runtime/startup/local-model-warmup.ts
@@ -3,7 +3,10 @@
  * readiness. Expensive model work is serialized per process and remains an
  * optimization; the model handlers retain ownership of first-use failures.
  */
-import { configureLocalEmbeddingPlugin, loadElizaConfig } from "@elizaos/agent";
+import {
+  configureLocalEmbeddingPlugin,
+  loadEffectiveElizaConfig,
+} from "@elizaos/agent";
 import {
   type AgentRuntime,
   isTruthyEnvValue,
@@ -101,7 +104,7 @@ async function warmupEmbeddingModelImpl(
     return;
   }
 
-  const config = loadElizaConfig();
+  const config = loadEffectiveElizaConfig();
   await configureLocalEmbeddingPlugin({} as Plugin, config);
 
   const preset = localInference.detectEmbeddingPreset();

--- a/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.authority.test.ts
+++ b/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.authority.test.ts
@@ -1,0 +1,102 @@
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const secureStoreMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  get: vi.fn(),
+  isAvailable: vi.fn(),
+}));
+
+vi.mock("../services/vault-mirror", () => ({
+  sharedVault: () => ({
+    has: async () => false,
+    reveal: async () => {
+      throw new Error("unexpected wallet vault reveal");
+    },
+    set: async () => undefined,
+  }),
+}));
+
+vi.mock("./platform-secure-store-node", () => ({
+  createNodePlatformSecureStore: secureStoreMocks.create,
+  isWalletOsStoreReadEnabled: () => true,
+}));
+
+import { hydrateWalletKeysFromNodePlatformSecureStore } from "./hydrate-wallet-keys-from-platform-store.ts";
+
+const ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+
+describe("wallet platform-store hydration under dev Cloud authority", () => {
+  let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    saved = Object.fromEntries(
+      ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+    for (const key of ENV_KEYS) delete process.env[key];
+    secureStoreMocks.get.mockReset();
+    secureStoreMocks.isAvailable.mockReset().mockResolvedValue(true);
+    secureStoreMocks.create.mockReset().mockReturnValue({
+      get: secureStoreMocks.get,
+      isAvailable: secureStoreMocks.isAvailable,
+    });
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it("does not read or project a pre-existing production keychain into default staging", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    // Models values projected by a late persistence layer before the deferred
+    // boot hydrate. The mocked platform store itself also contains production
+    // credentials and must never be opened.
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud";
+    process.env.STEWARD_AGENT_ID = "production-agent";
+    process.env.STEWARD_API_KEY = "production-key";
+    process.env.STEWARD_AGENT_TOKEN = "production-token";
+    secureStoreMocks.get.mockImplementation(
+      async (_vaultId: string, kind: string) =>
+        kind.startsWith("steward.")
+          ? { ok: true, value: "production-keychain-secret" }
+          : { ok: false, reason: "not-found" },
+    );
+
+    await hydrateWalletKeysFromNodePlatformSecureStore();
+
+    // The shared store may still be opened for the two local-wallet migration
+    // slots. The Steward secret kinds are the forbidden reads.
+    expect(secureStoreMocks.create).toHaveBeenCalledTimes(1);
+    expect(secureStoreMocks.get.mock.calls.map((call) => call[1])).toEqual([
+      "wallet.evm_private_key",
+      "wallet.solana_private_key",
+    ]);
+    expect(process.env.STEWARD_API_URL).toBeUndefined();
+    expect(process.env.STEWARD_TENANT_ID).toBeUndefined();
+    expect(process.env.STEWARD_AGENT_ID).toBeUndefined();
+    expect(process.env.STEWARD_API_KEY).toBeUndefined();
+    expect(process.env.STEWARD_AGENT_TOKEN).toBeUndefined();
+  });
+});

--- a/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
+++ b/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
@@ -12,6 +12,10 @@
  * env while the deferred hydrate runs.
  */
 import { logger } from "@elizaos/core";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudStewardOperationalTuple,
+} from "@elizaos/shared";
 
 import { sharedVault } from "../services/vault-mirror";
 import { deriveAgentVaultId } from "./agent-vault-id";
@@ -175,7 +179,20 @@ export async function hydrateWalletKeysFromNodePlatformSecureStore(): Promise<vo
     }
   }
 
-  // ── 3. Steward OS-keystore reads (unchanged) ─────────────────────
+  // ── 3. Steward OS-keystore reads ─────────────────────────────────
+  // A development launcher owns this entire operational tuple. Project its
+  // frozen values back after persisted-config merging and never consult the OS
+  // store: default-staging/offline stay disabled, while explicit targets
+  // cannot be redirected or completed by a late keychain value.
+  if (resolveDevCloudStewardOperationalTuple()) {
+    for (const [envKey] of stewardOsPairs()) {
+      const launchValue = resolveDevCloudAuthorityEnvValue(String(envKey));
+      if (launchValue?.trim()) process.env[envKey] = launchValue;
+      else delete process.env[envKey];
+    }
+    return;
+  }
+
   if (!isWalletOsStoreReadEnabled()) return;
   try {
     const store = createNodePlatformSecureStore();

--- a/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts
@@ -12,18 +12,46 @@ import type {
   SensitiveRequestKind,
   SensitiveRequestTarget,
 } from "@elizaos/core";
-import { getBootConfig, setBootConfig } from "@elizaos/shared";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  getBootConfig,
+  resetDevCloudEnvAuthorityForTests,
+  setBootConfig,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createCloudLinkSensitiveRequestAdapter } from "./cloud-link-adapter";
 
 const EXPIRES_AT = "2099-01-01T00:00:00.000Z";
 const CREATED_AT = "2024-01-01T00:00:00.000Z";
 const SAVED_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZA_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_CLOUD_BASE_URL",
 ] as const;
+
+function setAuthority(
+  authority:
+    | "staging-default"
+    | "offline"
+    | "staging-explicit"
+    | "production"
+    | "self-hosted",
+): void {
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  resetDevCloudEnvAuthorityForTests();
+  captureDevCloudEnvAuthoritySnapshot();
+}
 function makeRequest(
   kind: SensitiveRequestKind,
   overrides: {
@@ -91,6 +119,7 @@ describe("cloudLinkSensitiveRequestAdapter", () => {
   let savedEnv: Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     savedEnv = Object.fromEntries(
       SAVED_ENV_KEYS.map((key) => [key, process.env[key]]),
     ) as Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
@@ -103,6 +132,7 @@ describe("cloudLinkSensitiveRequestAdapter", () => {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("returns the cloud sensitive-request URL for secret kind", async () => {
@@ -249,4 +279,67 @@ describe("cloudLinkSensitiveRequestAdapter", () => {
     expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
     expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
   });
+
+  it.each([
+    ["staging-explicit", "https://cloud-staging.eliza.app"],
+    ["production", "https://cloud.eliza.app"],
+    ["self-hosted", "http://127.0.0.1:8787"],
+  ] as const)(
+    "uses only the frozen %s base and credential after late runtime pollution",
+    async (authority, expectedSiteBase) => {
+      setAuthority(authority);
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://process-collector.example/api/v1";
+      const runtime = {
+        getSetting(key: string) {
+          if (key === "ELIZAOS_CLOUD_API_KEY") return "late-runtime-key";
+          if (key === "ELIZAOS_CLOUD_BASE_URL") {
+            return "https://runtime-collector.example/api/v1";
+          }
+          return undefined;
+        },
+      };
+
+      const result = await createCloudLinkSensitiveRequestAdapter().deliver({
+        request: makeRequest("secret", { id: "req-authority" }),
+        runtime,
+      });
+
+      expect(result.delivered).toBe(true);
+      if (!result.delivered) throw new Error("expected success");
+      expect(result.url).toBe(
+        `${expectedSiteBase}/sensitive-requests/req-authority`,
+      );
+    },
+  );
+
+  it.each(["staging-default", "offline"] as const)(
+    "does not activate authenticated links under %s after late credential pollution",
+    async (authority) => {
+      setAuthority(authority);
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://process-collector.example/api/v1";
+
+      const result = await createCloudLinkSensitiveRequestAdapter().deliver({
+        request: makeRequest("secret"),
+        runtime: {
+          getSetting(key: string) {
+            if (key === "ELIZAOS_CLOUD_API_KEY") return "late-runtime-key";
+            if (key === "ELIZAOS_CLOUD_BASE_URL") {
+              return "https://runtime-collector.example/api/v1";
+            }
+            return undefined;
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        delivered: false,
+        target: "cloud_authenticated_link",
+        error: "cloud not paired",
+      });
+    },
+  );
 });

--- a/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts
@@ -14,7 +14,11 @@ import type {
   DispatchSensitiveRequest as SensitiveRequest,
   SensitiveRequestDeliveryAdapter,
 } from "@elizaos/core";
-import { normalizeCloudSiteUrl, readAliasedEnv } from "@elizaos/shared";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  normalizeCloudSiteUrl,
+  readAliasedEnv,
+} from "@elizaos/shared";
 
 export interface CloudLinkAdapterDeps {
   /**
@@ -42,6 +46,21 @@ function readSetting(runtime: unknown, key: string): string | undefined {
 }
 
 function defaultResolveCloudBase(runtime: unknown): string | null {
+  const authoritySnapshot = captureDevCloudEnvAuthoritySnapshot();
+  if (authoritySnapshot) {
+    if (
+      authoritySnapshot.authority === "staging-default" ||
+      authoritySnapshot.authority === "offline"
+    ) {
+      return null;
+    }
+    const apiKey = authoritySnapshot.values.ELIZAOS_CLOUD_API_KEY?.trim();
+    const rawBase = authoritySnapshot.values.ELIZAOS_CLOUD_BASE_URL?.trim();
+    if (!apiKey || !rawBase) return null;
+    const normalized = normalizeCloudSiteUrl(rawBase);
+    return normalized || null;
+  }
+
   const apiKey =
     readSetting(runtime, "ELIZAOS_CLOUD_API_KEY") ??
     readAliasedEnv("ELIZAOS_CLOUD_API_KEY");

--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
@@ -8,7 +8,12 @@ import type {
   SensitiveRequest,
   SensitiveRequestWithPaymentContext,
 } from "@elizaos/core";
-import { getBootConfig, setBootConfig } from "@elizaos/shared";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  getBootConfig,
+  resetDevCloudEnvAuthorityForTests,
+  setBootConfig,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   CLOUD_BASE_FALLBACK,
@@ -16,9 +21,35 @@ import {
 } from "./public-link-adapter";
 
 const SAVED_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_CLOUD_BASE_URL",
 ] as const;
+
+function setAuthority(
+  authority:
+    | "staging-default"
+    | "offline"
+    | "staging-explicit"
+    | "production"
+    | "self-hosted",
+): string {
+  const baseUrl =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL = baseUrl;
+  resetDevCloudEnvAuthorityForTests();
+  captureDevCloudEnvAuthoritySnapshot();
+  return baseUrl;
+}
 
 function buildRequest(
   overrides: Partial<SensitiveRequestWithPaymentContext> = {},
@@ -89,6 +120,7 @@ describe("publicLinkSensitiveRequestAdapter", () => {
   let savedEnv: Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     savedEnv = Object.fromEntries(
       SAVED_ENV_KEYS.map((key) => [key, process.env[key]]),
     ) as Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
@@ -101,6 +133,7 @@ describe("publicLinkSensitiveRequestAdapter", () => {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("returns a public URL for any_payer payment with appId", async () => {
@@ -230,4 +263,30 @@ describe("publicLinkSensitiveRequestAdapter", () => {
     );
     expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
   });
+
+  it.each([
+    "staging-default",
+    "offline",
+    "staging-explicit",
+    "production",
+    "self-hosted",
+  ] as const)(
+    "uses only the frozen %s base after late runtime pollution",
+    async (authority) => {
+      const launchBase = setAuthority(authority);
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://process-collector.example/api/v1";
+
+      const result = await publicLinkSensitiveRequestAdapter.deliver({
+        request: buildRequest({ id: "req-authority" }),
+        runtime: runtimeWithSetting("https://runtime-collector.example/api/v1"),
+      });
+
+      expect(result.delivered).toBe(true);
+      if (!result.delivered) throw new Error("expected success");
+      expect(result.url).toBe(
+        `${launchBase}/payment/app-charge/app_demo/req-authority/public`,
+      );
+    },
+  );
 });

--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.ts
@@ -16,7 +16,10 @@ import {
   type SensitiveRequestWithPaymentContext,
   toRuntimeSettings,
 } from "@elizaos/core";
-import { readAliasedEnv } from "@elizaos/shared";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  readAliasedEnv,
+} from "@elizaos/shared";
 
 /**
  * Cloud API base used when neither a runtime setting nor an env override
@@ -54,6 +57,14 @@ function nonEmpty(value: unknown): string | undefined {
 }
 
 function resolveCloudBaseUrl(runtime: unknown): string {
+  const authoritySnapshot = captureDevCloudEnvAuthoritySnapshot();
+  if (authoritySnapshot) {
+    const fromAuthority = nonEmpty(
+      authoritySnapshot.values.ELIZAOS_CLOUD_BASE_URL,
+    );
+    return stripTrailingSlashes(fromAuthority ?? CLOUD_BASE_FALLBACK);
+  }
+
   if (isCloudBaseRuntime(runtime)) {
     const settings = toRuntimeSettings(runtime);
     const fromSetting = settings.getSetting("ELIZAOS_CLOUD_BASE_URL");

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -3,6 +3,28 @@
 # Set to https://blob.eliza.app for production or a custom CDN domain.
 VITE_ASSET_BASE_URL=https://blob.eliza.app
 
+# Development target selection and Cloud credentials are launcher inputs, not
+# package .env values: the launcher resolves them before Vite reads this file.
+# Run these commands from the repository root:
+#
+#   bun run dev
+#     Keyless staging (the default). Inherited generic Cloud keys are cleared.
+#
+#   ELIZA_DEV_CLOUD_TARGET=staging ELIZA_DEV_CLOUD_API_KEY=... bun run dev
+#     Explicit staging with a deliberately minted staging-only server key.
+#     ELIZAOS_CLOUD_API_KEY is intentionally not accepted for staging.
+#
+#   ELIZAOS_CLOUD_API_KEY=... bun run dev --cloud-target=production
+#     Explicit production. Loopback browser login is unavailable there.
+#
+#   ELIZAOS_CLOUD_BASE_URL=https://api.example.test/api/v1 \
+#   VITE_ELIZA_CLOUD_BASE=https://app.example.test \
+#   ELIZAOS_CLOUD_API_KEY=... bun run dev
+#     Self-hosted. Both non-canonical bases and the server-held key are required.
+#
+# The renderer-only packages/app dev command supports staging and offline only;
+# production and self-hosted development require the repo-root local backend.
+
 # Hosted Cloud renderer configuration. Ordinary local dev injects the complete
 # staging tuple automatically. Release environments must set their intended
 # public endpoints explicitly. Never put credentials or session tokens in

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -3,17 +3,19 @@
 # Set to https://blob.eliza.app for production or a custom CDN domain.
 VITE_ASSET_BASE_URL=https://blob.eliza.app
 
-# Hosted Cloud renderer configuration. These values select public endpoints and
-# tenant metadata only; never put credentials or session tokens in VITE_* vars.
-VITE_ELIZA_CLOUD_BASE=https://cloud.eliza.app
+# Hosted Cloud renderer configuration. Ordinary local dev injects the complete
+# staging tuple automatically. Release environments must set their intended
+# public endpoints explicitly. Never put credentials or session tokens in
+# VITE_* vars.
+VITE_ELIZA_CLOUD_BASE=
 VITE_STEWARD_API_URL=
 VITE_STEWARD_TENANT_ID=
 
-# Desktop renderer policy. `bun run dev:cloud-only` sets the runtime mode to
-# `cloud` automatically. Ordinary `bun run dev` retains the runtime chooser.
+# Desktop renderer policy. Ordinary `bun run dev` sets `cloud` and links to
+# staging. Use `bun run dev:local` for the local/cloud/remote runtime chooser.
 VITE_ELIZA_DESKTOP_RUNTIME_MODE=
-# Production/test builds may opt into the local/cloud/remote chooser with `1`.
-# The ordinary Vite development server already enables it by default.
+# Non-cloud production/test builds may opt into the local/cloud/remote chooser
+# with `1`; `dev:local` supplies it for local development.
 VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=
 
 # iOS runtime modes:

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -275,7 +275,7 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 | `ELIZA_DEV_POLLING` | Enable filesystem polling for watch (useful in VMs) |
 | `ELIZA_DEV_CLOUD_TARGET` | Local dev Cloud target: `staging` (default), `production`, or `offline` |
 | `ELIZAOS_CLOUD_BASE_URL` | Server-side Cloud API base; ordinary local dev pins `https://api-staging.eliza.app/api/v1` |
-| `ELIZAOS_CLOUD_API_KEY` | Optional server-only Cloud credential; implicit staging masks inherited values, so select `ELIZA_DEV_CLOUD_TARGET=staging` explicitly when using a staging key |
+| `ELIZAOS_CLOUD_API_KEY` | Generic Cloud credential; local staging launchers scrub it to prevent cross-environment reuse. Use target-specific `ELIZA_DEV_CLOUD_API_KEY` with explicit staging instead |
 | `ELIZA_TTS_DEBUG` | Enable TTS trace logs |
 | `ELIZA_SETTINGS_DEBUG` | Enable settings debug panel |
 | `VITE_ASSET_BASE_URL` | Override asset base URL for CDN hosting |

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -93,8 +93,9 @@ packages/app/
 Common scripts from this package's `package.json`:
 
 ```bash
-bun run --cwd packages/app dev                        # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
-bun run --cwd packages/app dev:cloud-only             # Vite renderer with hosted Cloud onboarding policy
+bun run --cwd packages/app dev                        # Vite renderer linked to staging Cloud (UI port from ELIZA_UI_PORT, default 2138)
+bun run --cwd packages/app dev:local                  # Vite renderer with the local/cloud/remote runtime chooser
+bun run --cwd packages/app dev:cloud-only             # Compatibility alias for hosted Cloud onboarding policy
 bun run --cwd packages/app dev:shared                 # Shared long-lived Vite server on deterministic worktree port
 bun run --cwd packages/app dev:status                 # List running shared dev servers (port, worktree, pid)
 bun run --cwd packages/app dev:rebuild                # Trigger explicit Vite full reload for this worktree
@@ -272,12 +273,15 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 | `ELIZA_APP_SOURCEMAP` | Enable source maps in production build |
 | `ELIZA_DESKTOP_VITE_FAST_DIST` | Set by Electrobun dev orchestrator for Rollup watch mode |
 | `ELIZA_DEV_POLLING` | Enable filesystem polling for watch (useful in VMs) |
+| `ELIZA_DEV_CLOUD_TARGET` | Local dev Cloud target: `staging` (default), `production`, or `offline` |
+| `ELIZAOS_CLOUD_BASE_URL` | Server-side Cloud API base; ordinary local dev pins `https://api-staging.eliza.app/api/v1` |
+| `ELIZAOS_CLOUD_API_KEY` | Optional server-only Cloud credential; implicit staging masks inherited values, so select `ELIZA_DEV_CLOUD_TARGET=staging` explicitly when using a staging key |
 | `ELIZA_TTS_DEBUG` | Enable TTS trace logs |
 | `ELIZA_SETTINGS_DEBUG` | Enable settings debug panel |
 | `VITE_ASSET_BASE_URL` | Override asset base URL for CDN hosting |
-| `VITE_ELIZA_CLOUD_BASE` | Hosted Cloud origin used by public-web boot and Cloud runtime configuration |
-| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces hosted Cloud sign-in policy; `dev:cloud-only` sets it automatically |
-| `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER` | `"1"` opts production/test builds into the local/cloud/remote chooser; ordinary Vite dev enables it by default |
+| `VITE_ELIZA_CLOUD_BASE` | Hosted Cloud app origin used by public-web boot and Cloud runtime configuration |
+| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces hosted Cloud sign-in policy; ordinary local dev sets it for staging |
+| `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER` | `"1"` opts builds into the local/cloud/remote chooser; `dev:local` sets it automatically |
 | `VITE_STEWARD_API_URL` | Optional public Steward API base URL override |
 | `VITE_STEWARD_TENANT_ID` | Steward tenant identifier for the selected Cloud environment |
 | `ELIZA_CAPACITOR_BUILD_TARGET` | `"ios"` or `"android"` — set during mobile builds |

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -275,7 +275,7 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 | `ELIZA_DEV_POLLING` | Enable filesystem polling for watch (useful in VMs) |
 | `ELIZA_DEV_CLOUD_TARGET` | Local dev Cloud target: `staging` (default), `production`, or `offline` |
 | `ELIZAOS_CLOUD_BASE_URL` | Server-side Cloud API base; ordinary local dev pins `https://api-staging.eliza.app/api/v1` |
-| `ELIZAOS_CLOUD_API_KEY` | Optional server-only Cloud credential; implicit staging masks inherited values, so select `ELIZA_DEV_CLOUD_TARGET=staging` explicitly when using a staging key |
+| `ELIZAOS_CLOUD_API_KEY` | Generic Cloud credential; local staging launchers scrub it to prevent cross-environment reuse. Use target-specific `ELIZA_DEV_CLOUD_API_KEY` with explicit staging instead |
 | `ELIZA_TTS_DEBUG` | Enable TTS trace logs |
 | `ELIZA_SETTINGS_DEBUG` | Enable settings debug panel |
 | `VITE_ASSET_BASE_URL` | Override asset base URL for CDN hosting |

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -93,8 +93,9 @@ packages/app/
 Common scripts from this package's `package.json`:
 
 ```bash
-bun run --cwd packages/app dev                        # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
-bun run --cwd packages/app dev:cloud-only             # Vite renderer with hosted Cloud onboarding policy
+bun run --cwd packages/app dev                        # Vite renderer linked to staging Cloud (UI port from ELIZA_UI_PORT, default 2138)
+bun run --cwd packages/app dev:local                  # Vite renderer with the local/cloud/remote runtime chooser
+bun run --cwd packages/app dev:cloud-only             # Compatibility alias for hosted Cloud onboarding policy
 bun run --cwd packages/app dev:shared                 # Shared long-lived Vite server on deterministic worktree port
 bun run --cwd packages/app dev:status                 # List running shared dev servers (port, worktree, pid)
 bun run --cwd packages/app dev:rebuild                # Trigger explicit Vite full reload for this worktree
@@ -272,12 +273,15 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 | `ELIZA_APP_SOURCEMAP` | Enable source maps in production build |
 | `ELIZA_DESKTOP_VITE_FAST_DIST` | Set by Electrobun dev orchestrator for Rollup watch mode |
 | `ELIZA_DEV_POLLING` | Enable filesystem polling for watch (useful in VMs) |
+| `ELIZA_DEV_CLOUD_TARGET` | Local dev Cloud target: `staging` (default), `production`, or `offline` |
+| `ELIZAOS_CLOUD_BASE_URL` | Server-side Cloud API base; ordinary local dev pins `https://api-staging.eliza.app/api/v1` |
+| `ELIZAOS_CLOUD_API_KEY` | Optional server-only Cloud credential; implicit staging masks inherited values, so select `ELIZA_DEV_CLOUD_TARGET=staging` explicitly when using a staging key |
 | `ELIZA_TTS_DEBUG` | Enable TTS trace logs |
 | `ELIZA_SETTINGS_DEBUG` | Enable settings debug panel |
 | `VITE_ASSET_BASE_URL` | Override asset base URL for CDN hosting |
-| `VITE_ELIZA_CLOUD_BASE` | Hosted Cloud origin used by public-web boot and Cloud runtime configuration |
-| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces hosted Cloud sign-in policy; `dev:cloud-only` sets it automatically |
-| `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER` | `"1"` opts production/test builds into the local/cloud/remote chooser; ordinary Vite dev enables it by default |
+| `VITE_ELIZA_CLOUD_BASE` | Hosted Cloud app origin used by public-web boot and Cloud runtime configuration |
+| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces hosted Cloud sign-in policy; ordinary local dev sets it for staging |
+| `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER` | `"1"` opts builds into the local/cloud/remote chooser; `dev:local` sets it automatically |
 | `VITE_STEWARD_API_URL` | Optional public Steward API base URL override |
 | `VITE_STEWARD_TENANT_ID` | Steward tenant identifier for the selected Cloud environment |
 | `ELIZA_CAPACITOR_BUILD_TARGET` | `"ios"` or `"android"` — set during mobile builds |

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -42,8 +42,9 @@ build, preview, and deployment lifecycle.
 Run from the repo root with `--cwd packages/app`, or from inside the package directly.
 
 ```bash
-bun run dev            # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
-bun run dev:cloud-only # Vite renderer with hosted Cloud onboarding policy
+bun run dev            # Vite renderer linked to staging Cloud (UI port from ELIZA_UI_PORT, default 2138)
+bun run dev:local      # Vite renderer with the local/cloud/remote runtime chooser
+bun run dev:cloud-only # Compatibility alias for the hosted Cloud onboarding policy
 bun run build          # Full app build (scripts/build.mjs)
 bun run build:web      # Vite build only (no Capacitor sync)
 bun run plugin:build   # Plugin-only build
@@ -79,24 +80,46 @@ grants still cover the target instead of minting another profile.
 The desktop shell is built by Electrobun from the repo root (`bun run dev:desktop`),
 not from inside this package â `packages/app` only produces the renderer.
 
-### Cloud-only renderer development
+### Local Cloud development
 
-The ordinary `bun run dev` command intentionally retains the local/cloud/remote
-runtime chooser for local-agent development. Use `bun run dev:cloud-only` when
-you need the same hosted Cloud sign-in policy as a production Cloud surface.
-This explicit lane starts the canonical Vite development server with the
-existing `VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud` policy; it does not introduce a
-separate renderer or change the default development experience.
-
-To compose the lane against staging, provide the public Cloud and Steward
-configuration without embedding credentials:
+Ordinary local development is Cloud-first and targets **staging**. Both the
+root `bun run dev` stack and the package-level `bun run --cwd packages/app dev`
+renderer receive the same public, non-secret configuration:
 
 ```bash
-VITE_ELIZA_CLOUD_BASE=https://cloud-staging.eliza.app \
-VITE_STEWARD_API_URL=https://staging.eliza.app/steward \
-VITE_STEWARD_TENANT_ID=elizacloud-staging \
-bun run --cwd packages/app dev:cloud-only
+ELIZAOS_CLOUD_BASE_URL=https://api-staging.eliza.app/api/v1
+VITE_ELIZA_CLOUD_BASE=https://cloud-staging.eliza.app
+VITE_STEWARD_API_URL=https://staging.eliza.app/steward
+VITE_STEWARD_TENANT_ID=elizacloud-staging
+VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud
 ```
+
+The launcher also sets `ELIZA_DEV_SOURCE=1`, but it does not enable the legacy
+Cloud runtime plugin or supply credentials. Implicit staging clears inherited
+Cloud activation keys as well, so a generic production key from a shell or CI
+cannot be replayed against staging. This keeps local sign-in, agent selection,
+and Cloud API traffic on staging without weakening production CORS. To run the
+legacy plugin with a deliberately minted staging key, opt in explicitly:
+
+```bash
+ELIZA_DEV_CLOUD_TARGET=staging ELIZAOS_CLOUD_API_KEY=... bun run dev
+```
+
+Use `bun run dev:local` (or `bun run --cwd packages/app dev:local`) for the
+local/cloud/remote chooser. This lane suppresses automatic Cloud-plugin startup,
+while an explicit Cloud choice still uses staging. Select production only when
+deliberately testing that environment with
+`bun run dev --cloud-target=production`; localhost auth continues to follow
+production's stricter CORS policy. The equivalent process environment selector
+is `ELIZA_DEV_CLOUD_TARGET=staging|production|offline`.
+
+Custom/self-hosted development remains available by setting both the server API
+`ELIZAOS_CLOUD_BASE_URL` and renderer app `VITE_ELIZA_CLOUD_BASE` in the
+launching process; they must identify the same deployment (an `/api/v1` suffix
+on the server URL is ignored for this comparison). `VITE_STEWARD_API_URL` and
+`VITE_STEWARD_TENANT_ID` remain optional independent overrides. Contradictory
+canonical staging/production values fail at startup instead of producing a
+split environment.
 
 ## Config
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -97,35 +97,70 @@ VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud
 The launcher also sets `ELIZA_DEV_SOURCE=1`, but it does not enable the legacy
 Cloud runtime plugin or supply credentials. Implicit staging clears inherited
 Cloud activation keys as well, so a generic production key from a shell or CI
-cannot be replayed against staging. This keeps local sign-in, agent selection,
-and Cloud API traffic on staging without weakening production CORS. To run the
-legacy plugin with a deliberately minted staging key, opt in explicitly:
+cannot be replayed against staging. The launch selection also outranks stale
+Cloud credentials, endpoints, and routing in persisted local config for that
+process without rewriting the stored config. This keeps local sign-in, agent
+selection, and Cloud API traffic on staging without weakening production CORS.
+To run the legacy plugin with a deliberately minted staging key, opt in with
+the staging-specific credential from the repository root. The credential is
+accepted only alongside an explicit staging selector and remains in the local
+backend; even explicit staging clears generic Cloud and Steward credentials
+because they may belong to production:
 
 ```bash
-ELIZA_DEV_CLOUD_TARGET=staging ELIZAOS_CLOUD_API_KEY=... bun run dev
+# From the repository root
+ELIZA_DEV_CLOUD_TARGET=staging ELIZA_DEV_CLOUD_API_KEY=... bun run dev
 ```
 
 Use `bun run dev:local` (or `bun run --cwd packages/app dev:local`) for the
 local/cloud/remote chooser. This lane suppresses automatic Cloud-plugin startup,
 while an explicit Cloud choice still uses staging. Select production only when
-deliberately testing that environment with
-`bun run dev --cloud-target=production`; localhost auth continues to follow
-production's stricter CORS policy. The equivalent process environment selector
-is `ELIZA_DEV_CLOUD_TARGET=staging|production|offline`.
+deliberately testing that environment, and provide the credential at launch
+because production intentionally rejects loopback browser authentication:
 
-Custom/self-hosted development remains available by setting both the server API
-`ELIZAOS_CLOUD_BASE_URL` and renderer app `VITE_ELIZA_CLOUD_BASE` in the
-launching process; they must identify the same deployment (an `/api/v1` suffix
-on the server URL is ignored for this comparison). `VITE_STEWARD_API_URL` and
-`VITE_STEWARD_TENANT_ID` remain optional independent overrides. Contradictory
-canonical staging/production values fail at startup instead of producing a
-split environment.
+```bash
+# From the repository root
+ELIZAOS_CLOUD_API_KEY=... bun run dev --cloud-target=production
+```
+
+The equivalent process environment selector is
+`ELIZA_DEV_CLOUD_TARGET=staging|production|offline`. The direct
+`packages/app` renderer supports only staging and offline. Production and
+self-hosted launch credentials stay server-side, so those targets require the
+repo-root stack.
+
+Custom/self-hosted development remains available by setting the server API
+`ELIZAOS_CLOUD_BASE_URL`, renderer app `VITE_ELIZA_CLOUD_BASE`, and
+`ELIZAOS_CLOUD_API_KEY` in the launching process. Both bases must be explicit
+non-canonical HTTP(S) endpoints, but they may use separate API and app hosts.
+`VITE_STEWARD_API_URL` and `VITE_STEWARD_TENANT_ID` remain optional independent
+overrides. Missing credentials or contradictory canonical staging/production
+values fail at startup instead of producing a split or partially authenticated
+environment.
+
+```bash
+# From the repository root
+ELIZAOS_CLOUD_BASE_URL=https://api.example.test/api/v1 \
+VITE_ELIZA_CLOUD_BASE=https://app.example.test \
+ELIZAOS_CLOUD_API_KEY=... \
+bun run dev
+```
+
+The deterministic dev smoke keeps its staging services mocked. To opt into the
+anonymous live boundary check, which creates one short-lived staging CLI
+session and stops at the Google authorization redirect without signing in or
+following an OAuth callback, run:
+
+```bash
+bun run --cwd packages/app test:dev-smoke:staging-live-auth
+```
 
 ## Config
 
 App identity lives in `app.config.ts` (`envPrefix: "ELIZA"`); copy that file to
 white-label a new app. Runtime/build env vars use the `ELIZA_` prefix. See `AGENTS.md`
-for the full env var table; `.env.example` documents the build-time `VITE_*` flags.
+for the full env var table; `.env.example` documents launcher examples and the
+build-time `VITE_*` flags.
 
 ### Desktop voice hardware evidence
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "dev:cloud-only": "node scripts/dev-cloud-only.mjs",
+    "dev:local": "node scripts/dev.mjs --cloud-target=offline",
     "dev:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node scripts/dev.mjs",
     "preview": "bun --bun vite preview",
     "design-review": "node --import tsx test/design-review/run-design-review.ts",
@@ -22,6 +23,7 @@
     "analyze:login-eager-chunks": "node scripts/list-eager-login-chunks.mjs",
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",
     "test:dev-smoke:cloud-only": "ELIZA_DEV_SMOKE_CLOUD_ONLY=1 node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts test/dev-smoke/cloud-only-mode.spec.ts",
+    "test:dev-smoke:local": "ELIZA_DEV_SMOKE_OFFLINE=1 node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts test/dev-smoke/runtime-chooser-default.spec.ts test/dev-smoke/bun-dev-onboarding-chat.spec.ts",
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "test:e2e:chat-stream-real": "ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 ELIZA_UI_SMOKE_DISABLE_VIDEO=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/chat-stream-real-runtime-perf.spec.ts",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,6 +23,7 @@
     "analyze:login-eager-chunks": "node scripts/list-eager-login-chunks.mjs",
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",
     "test:dev-smoke:cloud-only": "ELIZA_DEV_SMOKE_CLOUD_ONLY=1 node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts test/dev-smoke/cloud-only-mode.spec.ts",
+    "test:dev-smoke:staging-live-auth": "ELIZA_DEV_CLOUD_TARGET=staging ELIZA_DEV_CLOUD_API_KEY= ELIZA_DEV_SMOKE_STAGING_LIVE_AUTH=1 node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts test/dev-smoke/staging-live-auth-boundary.spec.ts",
     "test:dev-smoke:local": "ELIZA_DEV_SMOKE_OFFLINE=1 node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts test/dev-smoke/runtime-chooser-default.spec.ts test/dev-smoke/bun-dev-onboarding-chat.spec.ts",
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",

--- a/packages/app/playwright.dev-smoke.config.ts
+++ b/packages/app/playwright.dev-smoke.config.ts
@@ -26,10 +26,15 @@ const stateDir =
   path.join(os.tmpdir(), `eliza-dev-smoke-${process.pid}`);
 const cloudOnlyLane = process.env.ELIZA_DEV_SMOKE_CLOUD_ONLY === "1";
 const offlineLane = process.env.ELIZA_DEV_SMOKE_OFFLINE === "1";
+const stagingLiveAuthLane =
+  process.env.ELIZA_DEV_SMOKE_STAGING_LIVE_AUTH === "1";
 
-if (cloudOnlyLane && offlineLane) {
+if (
+  Number(cloudOnlyLane) + Number(offlineLane) + Number(stagingLiveAuthLane) >
+  1
+) {
   throw new Error(
-    "ELIZA_DEV_SMOKE_CLOUD_ONLY and ELIZA_DEV_SMOKE_OFFLINE are mutually exclusive",
+    "ELIZA_DEV_SMOKE_CLOUD_ONLY, ELIZA_DEV_SMOKE_OFFLINE, and ELIZA_DEV_SMOKE_STAGING_LIVE_AUTH are mutually exclusive",
   );
 }
 
@@ -37,7 +42,9 @@ const laneName = cloudOnlyLane
   ? "cloud-only"
   : offlineLane
     ? "local"
-    : "staging";
+    : stagingLiveAuthLane
+      ? "staging-live-auth"
+      : "staging";
 
 process.env.ELIZA_API_PORT = String(apiPort);
 process.env.ELIZA_UI_PORT = String(uiPort);

--- a/packages/app/playwright.dev-smoke.config.ts
+++ b/packages/app/playwright.dev-smoke.config.ts
@@ -25,6 +25,19 @@ const stateDir =
   process.env.ELIZA_DEV_SMOKE_STATE_DIR ||
   path.join(os.tmpdir(), `eliza-dev-smoke-${process.pid}`);
 const cloudOnlyLane = process.env.ELIZA_DEV_SMOKE_CLOUD_ONLY === "1";
+const offlineLane = process.env.ELIZA_DEV_SMOKE_OFFLINE === "1";
+
+if (cloudOnlyLane && offlineLane) {
+  throw new Error(
+    "ELIZA_DEV_SMOKE_CLOUD_ONLY and ELIZA_DEV_SMOKE_OFFLINE are mutually exclusive",
+  );
+}
+
+const laneName = cloudOnlyLane
+  ? "cloud-only"
+  : offlineLane
+    ? "local"
+    : "staging";
 
 process.env.ELIZA_API_PORT = String(apiPort);
 process.env.ELIZA_UI_PORT = String(uiPort);
@@ -41,7 +54,10 @@ export default defineConfig({
   retries: 0,
   workers: 1,
   reporter: "list",
-  outputDir: "./test-results/dev-smoke",
+  // CI runs staging and local sequentially before one artifact upload.
+  // Playwright clears outputDir at invocation start, so each lane owns a
+  // directory and cannot erase the previous lane's screenshots/traces.
+  outputDir: `./test-results/dev-smoke-${laneName}`,
   use: {
     baseURL: `http://127.0.0.1:${uiPort}`,
     trace: "retain-on-failure",
@@ -57,7 +73,9 @@ export default defineConfig({
   webServer: {
     command: cloudOnlyLane
       ? "bun run --cwd packages/app dev:cloud-only"
-      : "bun run dev",
+      : offlineLane
+        ? "bun run dev:local"
+        : "bun run dev",
     cwd: repoRoot,
     env: {
       ...process.env,

--- a/packages/app/scripts/dev-cloud-only.mjs
+++ b/packages/app/scripts/dev-cloud-only.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Starts the ordinary Vite renderer with the hosted Cloud onboarding policy.
- * The default dev command intentionally keeps the local/cloud/remote chooser;
- * this explicit lane mirrors production Cloud sign-in without changing it.
+ * Compatibility entrypoint for the hosted Cloud onboarding policy. Ordinary
+ * local development now uses this policy against staging by default; keep the
+ * named lane for existing automation and explicit operator intent.
  */
 
 process.env.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "cloud";

--- a/packages/app/scripts/dev-server-registry.mjs
+++ b/packages/app/scripts/dev-server-registry.mjs
@@ -6,7 +6,7 @@
  * concurrent launchers from duplicating servers or overwriting newer owners.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -17,6 +17,79 @@ export const DEFAULT_UI_PORT_SPAN = 900;
 export const DEFAULT_API_PORT_OFFSET = 10_000;
 export const REGISTRY_VERSION = 1;
 const STARTUP_RESERVATION_GRACE_MS = 120_000;
+const CLOUD_PROFILE_FINGERPRINT_PREFIX = "cloud-v1:";
+
+function cloudProfileValue(value, field) {
+  if (value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new TypeError(`${field} must be a string when supplied`);
+  }
+  return value;
+}
+
+/**
+ * Build the non-secret identity of the Cloud environment baked into Vite.
+ *
+ * Only the explicitly listed public routing fields participate. The registry
+ * stores the digest, never the source values or any inherited credentials, so
+ * it is safe to keep under ~/.eliza while still preventing cross-target reuse.
+ */
+export function createDevServerCloudProfileFingerprint({
+  effectiveTarget,
+  serverApiBase,
+  rendererCloudBase,
+  stewardApiUrl,
+  stewardTenantId,
+  runtimeMode,
+}) {
+  if (typeof effectiveTarget !== "string" || !effectiveTarget) {
+    throw new TypeError("effectiveTarget must be a non-empty string");
+  }
+  const profile = {
+    version: 1,
+    effectiveTarget,
+    serverApiBase: cloudProfileValue(serverApiBase, "serverApiBase"),
+    rendererCloudBase: cloudProfileValue(
+      rendererCloudBase,
+      "rendererCloudBase",
+    ),
+    stewardApiUrl: cloudProfileValue(stewardApiUrl, "stewardApiUrl"),
+    stewardTenantId: cloudProfileValue(stewardTenantId, "stewardTenantId"),
+    runtimeMode: cloudProfileValue(runtimeMode, "runtimeMode"),
+  };
+  const digest = createHash("sha256")
+    .update(JSON.stringify(profile))
+    .digest("hex");
+  return `${CLOUD_PROFILE_FINGERPRINT_PREFIX}${digest}`;
+}
+
+function normalizeCloudProfileFingerprint(value) {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !/^cloud-v1:[0-9a-f]{64}$/.test(value)) {
+    throw new TypeError(
+      "cloudProfileFingerprint must be a createDevServerCloudProfileFingerprint() value",
+    );
+  }
+  return value;
+}
+
+function assertReusableCloudProfile(existing, requestedFingerprint, worktree) {
+  const existingFingerprint = existing.cloudProfileFingerprint;
+  if (existingFingerprint === requestedFingerprint) return;
+
+  const existingLabel =
+    typeof existingFingerprint === "string" &&
+    /^cloud-v1:[0-9a-f]{64}$/.test(existingFingerprint)
+      ? existingFingerprint
+      : "missing or invalid";
+  const requestedLabel = requestedFingerprint ?? "missing";
+  const pidHint = Number.isInteger(existing.pid)
+    ? ` (PID ${existing.pid})`
+    : "";
+  throw new Error(
+    `A shared dev server is already running for ${worktree}${pidHint} with a different or missing Cloud profile (existing=${existingLabel}, requested=${requestedLabel}). Stop it with Ctrl-C in its terminal, then restart with \`bun run --cwd packages/app dev:shared\`. The running server was left untouched.`,
+  );
+}
 
 export function defaultRegistryPath(env = process.env) {
   return (
@@ -248,9 +321,17 @@ export async function withRegistryLock(
 
 export async function reservePortsForWorktree(
   worktreePath,
-  { registryPath = defaultRegistryPath(), base, span } = {},
+  {
+    registryPath = defaultRegistryPath(),
+    base,
+    span,
+    cloudProfileFingerprint,
+  } = {},
 ) {
   const worktree = normalizeWorktreePath(worktreePath);
+  const requestedCloudProfile = normalizeCloudProfileFingerprint(
+    cloudProfileFingerprint,
+  );
   return await withRegistryLock(
     async () => {
       const current = readRegistry(registryPath);
@@ -261,6 +342,7 @@ export async function reservePortsForWorktree(
         // After that bounded window, require both the owner PID and listener so
         // one recycled PID or unrelated process on the port cannot mask Vite.
         if (canReuseEntry(existing, runtime)) {
+          assertReusableCloudProfile(existing, requestedCloudProfile, worktree);
           return { entry: existing, reused: true };
         }
       }
@@ -279,6 +361,9 @@ export async function reservePortsForWorktree(
           allocated.entry.reservationId = randomUUID();
           allocated.entry.startedAt = startedAt;
           allocated.entry.updatedAt = startedAt;
+          if (requestedCloudProfile !== undefined) {
+            allocated.entry.cloudProfileFingerprint = requestedCloudProfile;
+          }
           writeRegistry(allocated.registry, registryPath);
           return { entry: allocated.entry, reused: false };
         }

--- a/packages/app/scripts/dev-server-registry.mjs
+++ b/packages/app/scripts/dev-server-registry.mjs
@@ -17,7 +17,17 @@ export const DEFAULT_UI_PORT_SPAN = 900;
 export const DEFAULT_API_PORT_OFFSET = 10_000;
 export const REGISTRY_VERSION = 1;
 const STARTUP_RESERVATION_GRACE_MS = 120_000;
-const CLOUD_PROFILE_FINGERPRINT_PREFIX = "cloud-v1:";
+const CLOUD_PROFILE_FINGERPRINT_PREFIX = "cloud-v2:";
+const CLOUD_POLICY_ENV_KEYS = Object.freeze([
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_USE_INFERENCE",
+  "ELIZAOS_CLOUD_USE_TTS",
+  "ELIZAOS_CLOUD_USE_STT",
+  "ELIZAOS_CLOUD_USE_MEDIA",
+  "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+  "ELIZAOS_CLOUD_USE_RPC",
+  "ELIZA_CLOUD_PROVISIONED",
+]);
 
 function cloudProfileValue(value, field) {
   if (value === undefined) return null;
@@ -27,15 +37,115 @@ function cloudProfileValue(value, field) {
   return value;
 }
 
+function cloudCredentialIdentityDigest(identity) {
+  if (!identity || typeof identity !== "object" || Array.isArray(identity)) {
+    throw new TypeError("credentialIdentity must be an object");
+  }
+  const normalized = Object.fromEntries(
+    Object.entries(identity)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => {
+        if (
+          typeof value !== "string" &&
+          value !== undefined &&
+          value !== null
+        ) {
+          throw new TypeError(
+            `credentialIdentity.${key} must be a string when supplied`,
+          );
+        }
+        const trimmed = typeof value === "string" ? value.trim() : "";
+        return [key, trimmed || null];
+      }),
+  );
+  return createHash("sha256")
+    .update("eliza-dev-server-cloud-credentials-v1\0")
+    .update(JSON.stringify(normalized))
+    .digest("hex");
+}
+
+function firstConfiguredCloudEnvValue(env, ...keys) {
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+/** Resolve credential-bearing aliases to the effective identity hashed below. */
+export function resolveDevServerCloudCredentialIdentity(env) {
+  return {
+    apiKey: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZAOS_CLOUD_API_KEY",
+      "ELIZA_DEV_CLOUD_API_KEY",
+      "ELIZA_CLOUD_API_KEY",
+      "ELIZACLOUD_API_KEY",
+    ),
+    serviceKey: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZAOS_CLOUD_SERVICE_KEY",
+      "ELIZA_CLOUD_SERVICE_KEY",
+    ),
+    serviceToken: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZA_CLOUD_SERVICE_TOKEN",
+    ),
+    sessionToken: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZA_CLOUD_SESSION_TOKEN",
+    ),
+    cloudToken: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZA_CLOUD_TOKEN",
+      "ELIZACLOUD_TOKEN",
+    ),
+    authToken: firstConfiguredCloudEnvValue(env, "ELIZA_CLOUD_AUTH_TOKEN"),
+    sandboxToken: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZA_CLOUD_SANDBOX_TOKEN",
+    ),
+    embeddingApiKey: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZAOS_CLOUD_EMBEDDING_API_KEY",
+    ),
+    agentId: firstConfiguredCloudEnvValue(
+      env,
+      "ELIZAOS_CLOUD_AGENT_ID",
+      "ELIZA_CLOUD_AGENT_ID",
+      "WAIFU_ELIZA_CLOUD_AGENT_ID",
+    ),
+  };
+}
+
+/** Resolve non-secret Cloud activation policy to one stable effective identity. */
+export function resolveDevServerCloudPolicyIdentity(env) {
+  return Object.fromEntries(
+    CLOUD_POLICY_ENV_KEYS.map((key) => {
+      const value = env[key];
+      if (value !== undefined && typeof value !== "string") {
+        throw new TypeError(`${key} must be a string when supplied`);
+      }
+      const normalized =
+        typeof value === "string" ? value.trim().toLowerCase() : "";
+      return [key, normalized || null];
+    }),
+  );
+}
+
 /**
  * Build the non-secret identity of the Cloud environment baked into Vite.
  *
- * Only the explicitly listed public routing fields participate. The registry
- * stores the digest, never the source values or any inherited credentials, so
- * it is safe to keep under ~/.eliza while still preventing cross-target reuse.
+ * Public routing, launcher authority, and the opaque identity of effective
+ * credentials participate. The registry stores only the final digest, never
+ * source values or credentials, so it is safe to keep under ~/.eliza while
+ * preventing cross-target, default/explicit, and cross-account reuse.
  */
 export function createDevServerCloudProfileFingerprint({
   effectiveTarget,
+  authorityMode,
+  credentialIdentity,
+  policyIdentity,
   serverApiBase,
   rendererCloudBase,
   stewardApiUrl,
@@ -45,9 +155,22 @@ export function createDevServerCloudProfileFingerprint({
   if (typeof effectiveTarget !== "string" || !effectiveTarget) {
     throw new TypeError("effectiveTarget must be a non-empty string");
   }
+  if (typeof authorityMode !== "string" || !authorityMode) {
+    throw new TypeError("authorityMode must be a non-empty string");
+  }
+  if (
+    !policyIdentity ||
+    typeof policyIdentity !== "object" ||
+    Array.isArray(policyIdentity)
+  ) {
+    throw new TypeError("policyIdentity must be an object");
+  }
   const profile = {
-    version: 1,
+    version: 2,
     effectiveTarget,
+    authorityMode,
+    credentialIdentityDigest: cloudCredentialIdentityDigest(credentialIdentity),
+    policyIdentity,
     serverApiBase: cloudProfileValue(serverApiBase, "serverApiBase"),
     rendererCloudBase: cloudProfileValue(
       rendererCloudBase,
@@ -65,7 +188,7 @@ export function createDevServerCloudProfileFingerprint({
 
 function normalizeCloudProfileFingerprint(value) {
   if (value === undefined) return undefined;
-  if (typeof value !== "string" || !/^cloud-v1:[0-9a-f]{64}$/.test(value)) {
+  if (typeof value !== "string" || !/^cloud-v2:[0-9a-f]{64}$/.test(value)) {
     throw new TypeError(
       "cloudProfileFingerprint must be a createDevServerCloudProfileFingerprint() value",
     );
@@ -79,7 +202,7 @@ function assertReusableCloudProfile(existing, requestedFingerprint, worktree) {
 
   const existingLabel =
     typeof existingFingerprint === "string" &&
-    /^cloud-v1:[0-9a-f]{64}$/.test(existingFingerprint)
+    /^cloud-v2:[0-9a-f]{64}$/.test(existingFingerprint)
       ? existingFingerprint
       : "missing or invalid";
   const requestedLabel = requestedFingerprint ?? "missing";

--- a/packages/app/scripts/dev-server-registry.test.mjs
+++ b/packages/app/scripts/dev-server-registry.test.mjs
@@ -23,6 +23,8 @@ import {
   preferredUiPortForWorktree,
   readRegistry,
   reservePortsForWorktree,
+  resolveDevServerCloudCredentialIdentity,
+  resolveDevServerCloudPolicyIdentity,
   updateRegistryEntry,
   writeRegistry,
 } from "./dev-server-registry.mjs";
@@ -38,7 +40,19 @@ const CLEAN_DEV_CLOUD_ENV = {
   ELIZA_CLOUD_API_KEY: "",
   ELIZACLOUD_API_KEY: "",
   ELIZA_DEV_CLOUD_API_KEY: "",
+  ELIZAOS_CLOUD_SERVICE_KEY: "",
+  ELIZAOS_CLOUD_EMBEDDING_API_KEY: "",
+  ELIZAOS_CLOUD_AGENT_ID: "",
   ELIZA_CLOUD_PROVISIONED: "",
+  ELIZA_CLOUD_SERVICE_KEY: "",
+  ELIZA_CLOUD_SERVICE_TOKEN: "",
+  ELIZA_CLOUD_SESSION_TOKEN: "",
+  ELIZA_CLOUD_TOKEN: "",
+  ELIZACLOUD_TOKEN: "",
+  ELIZA_CLOUD_AUTH_TOKEN: "",
+  ELIZA_CLOUD_SANDBOX_TOKEN: "",
+  ELIZA_CLOUD_AGENT_ID: "",
+  WAIFU_ELIZA_CLOUD_AGENT_ID: "",
   VITE_ELIZA_CLOUD_BASE: "",
   VITE_STEWARD_API_URL: "",
   VITE_STEWARD_TENANT_ID: "",
@@ -48,6 +62,9 @@ const CLEAN_DEV_CLOUD_ENV = {
 function cloudProfileFromConfiguredEnvironment(configured) {
   return createDevServerCloudProfileFingerprint({
     effectiveTarget: configured.effectiveTarget,
+    authorityMode: configured.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY,
+    credentialIdentity: resolveDevServerCloudCredentialIdentity(configured.env),
+    policyIdentity: resolveDevServerCloudPolicyIdentity(configured.env),
     serverApiBase: configured.env.ELIZAOS_CLOUD_BASE_URL,
     rendererCloudBase: configured.env.VITE_ELIZA_CLOUD_BASE,
     stewardApiUrl: configured.env.VITE_STEWARD_API_URL,
@@ -67,6 +84,9 @@ function defaultDevSharedCloudProfile() {
 
 const TEST_CLOUD_PROFILE_INPUT = {
   effectiveTarget: "staging",
+  authorityMode: "staging-explicit",
+  credentialIdentity: { apiKey: "test-staging-key" },
+  policyIdentity: resolveDevServerCloudPolicyIdentity({}),
   serverApiBase: "https://api-staging.example.test/api/v1",
   rendererCloudBase: "https://cloud-staging.example.test",
   stewardApiUrl: "https://staging.example.test/steward",
@@ -78,6 +98,11 @@ const TEST_CLOUD_PROFILE = createDevServerCloudProfileFingerprint(
 );
 const OTHER_CLOUD_PROFILE = createDevServerCloudProfileFingerprint({
   effectiveTarget: "production",
+  authorityMode: "production",
+  credentialIdentity: { apiKey: "test-production-key" },
+  policyIdentity: resolveDevServerCloudPolicyIdentity({
+    ELIZAOS_CLOUD_ENABLED: "true",
+  }),
   serverApiBase: "https://api.example.test/api/v1",
   rendererCloudBase: "https://cloud.example.test",
   stewardApiUrl: "https://example.test/steward",
@@ -210,19 +235,25 @@ async function runNode(scriptPath, { env, timeoutMs = 3_000 } = {}) {
 }
 
 describe("shared dev server registry", () => {
-  it("fingerprints every public Cloud routing field without retaining credentials", () => {
-    assert.match(TEST_CLOUD_PROFILE, /^cloud-v1:[0-9a-f]{64}$/);
+  it("fingerprints routing, authority, and credential identity without retaining credentials", () => {
+    assert.match(TEST_CLOUD_PROFILE, /^cloud-v2:[0-9a-f]{64}$/);
     assert.equal(TEST_CLOUD_PROFILE.includes("example-staging"), false);
-    assert.equal(
+    assert.equal(TEST_CLOUD_PROFILE.includes("test-staging-key"), false);
+    assert.notEqual(
       createDevServerCloudProfileFingerprint({
         ...TEST_CLOUD_PROFILE_INPUT,
-        ELIZAOS_CLOUD_API_KEY: "must-never-enter-the-profile",
+        credentialIdentity: { apiKey: "different-staging-key" },
       }),
       TEST_CLOUD_PROFILE,
     );
 
     const replacements = {
       effectiveTarget: "production",
+      authorityMode: "staging-default",
+      credentialIdentity: { apiKey: "replacement-key" },
+      policyIdentity: resolveDevServerCloudPolicyIdentity({
+        ELIZAOS_CLOUD_USE_RPC: "false",
+      }),
       serverApiBase: "https://api-alt.example.test/api/v1",
       rendererCloudBase: "https://cloud-alt.example.test",
       stewardApiUrl: "https://identity-alt.example.test/steward",
@@ -369,6 +400,91 @@ describe("shared dev server registry", () => {
           assert.match(error.message, /running server was left untouched/);
           return true;
         },
+      );
+      assert.equal(fs.readFileSync(registryPath, "utf8"), before);
+      assert.equal(server.listening, true);
+    }
+  });
+
+  it("does not reuse across authority, credential, or activation-policy changes", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const server = await listenOnLoopback();
+    t.after(() => closeServer(server));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+
+    const defaultStaging = cloudProfileFromConfiguredEnvironment(
+      configureDevCloudEnvironment([], {
+        ...process.env,
+        ...CLEAN_DEV_CLOUD_ENV,
+      }),
+    );
+    const explicitStaging = cloudProfileFromConfiguredEnvironment(
+      configureDevCloudEnvironment(["--cloud-target=staging"], {
+        ...process.env,
+        ...CLEAN_DEV_CLOUD_ENV,
+      }),
+    );
+    const credentialA = cloudProfileFromConfiguredEnvironment(
+      configureDevCloudEnvironment(["--cloud-target=staging"], {
+        ...process.env,
+        ...CLEAN_DEV_CLOUD_ENV,
+        ELIZA_DEV_CLOUD_API_KEY: "credential-A-must-not-be-stored",
+      }),
+    );
+    const credentialB = cloudProfileFromConfiguredEnvironment(
+      configureDevCloudEnvironment(["--cloud-target=staging"], {
+        ...process.env,
+        ...CLEAN_DEV_CLOUD_ENV,
+        ELIZA_DEV_CLOUD_API_KEY: "credential-B-must-not-be-stored",
+      }),
+    );
+    const policyEnabled = cloudProfileFromConfiguredEnvironment(
+      configureDevCloudEnvironment(["--cloud-target=production"], {
+        ...process.env,
+        ...CLEAN_DEV_CLOUD_ENV,
+        ELIZAOS_CLOUD_API_KEY: "same-credential-must-not-be-stored",
+        ELIZAOS_CLOUD_USE_RPC: "true",
+      }),
+    );
+    const policyDisabled = cloudProfileFromConfiguredEnvironment(
+      configureDevCloudEnvironment(["--cloud-target=production"], {
+        ...process.env,
+        ...CLEAN_DEV_CLOUD_ENV,
+        ELIZAOS_CLOUD_API_KEY: "same-credential-must-not-be-stored",
+        ELIZAOS_CLOUD_USE_RPC: "false",
+      }),
+    );
+
+    assert.notEqual(defaultStaging, explicitStaging);
+    assert.notEqual(credentialA, credentialB);
+    assert.notEqual(policyEnabled, policyDisabled);
+    for (const [existingFingerprint, requestedFingerprint] of [
+      [defaultStaging, explicitStaging],
+      [credentialA, credentialB],
+      [policyEnabled, policyDisabled],
+    ]) {
+      const existing = registryEntry(worktree, address.port, {
+        cloudProfileFingerprint: existingFingerprint,
+      });
+      writeRegistry({ version: 1, entries: [existing] }, registryPath);
+      const before = fs.readFileSync(registryPath, "utf8");
+      assert.equal(before.includes("credential-A-must-not-be-stored"), false);
+      assert.equal(before.includes("credential-B-must-not-be-stored"), false);
+      assert.equal(
+        before.includes("same-credential-must-not-be-stored"),
+        false,
+      );
+
+      await assert.rejects(
+        reservePortsForWorktree(worktree, {
+          registryPath,
+          base: address.port,
+          span: 1,
+          cloudProfileFingerprint: requestedFingerprint,
+        }),
+        /different or missing Cloud profile/,
       );
       assert.equal(fs.readFileSync(registryPath, "utf8"), before);
       assert.equal(server.listening, true);

--- a/packages/app/scripts/dev-server-registry.test.mjs
+++ b/packages/app/scripts/dev-server-registry.test.mjs
@@ -13,8 +13,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
+import { configureDevCloudEnvironment } from "../../app-core/scripts/lib/dev-cloud-target.mjs";
 import {
   allocatePortsForWorktree,
+  createDevServerCloudProfileFingerprint,
   createEmptyRegistry,
   normalizeWorktreePath,
   portsForUiPort,
@@ -28,6 +30,60 @@ import {
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../..");
 const devSharedScript = path.join(here, "dev-shared.mjs");
+const CLEAN_DEV_CLOUD_ENV = {
+  ELIZA_DEV_CLOUD_TARGET: "",
+  ELIZAOS_CLOUD_BASE_URL: "",
+  ELIZAOS_CLOUD_API_KEY: "",
+  ELIZAOS_CLOUD_ENABLED: "",
+  ELIZA_CLOUD_API_KEY: "",
+  ELIZACLOUD_API_KEY: "",
+  ELIZA_DEV_CLOUD_API_KEY: "",
+  ELIZA_CLOUD_PROVISIONED: "",
+  VITE_ELIZA_CLOUD_BASE: "",
+  VITE_STEWARD_API_URL: "",
+  VITE_STEWARD_TENANT_ID: "",
+  VITE_ELIZA_DESKTOP_RUNTIME_MODE: "",
+};
+
+function cloudProfileFromConfiguredEnvironment(configured) {
+  return createDevServerCloudProfileFingerprint({
+    effectiveTarget: configured.effectiveTarget,
+    serverApiBase: configured.env.ELIZAOS_CLOUD_BASE_URL,
+    rendererCloudBase: configured.env.VITE_ELIZA_CLOUD_BASE,
+    stewardApiUrl: configured.env.VITE_STEWARD_API_URL,
+    stewardTenantId: configured.env.VITE_STEWARD_TENANT_ID,
+    runtimeMode: configured.env.VITE_ELIZA_DESKTOP_RUNTIME_MODE,
+  });
+}
+
+function defaultDevSharedCloudProfile() {
+  return cloudProfileFromConfiguredEnvironment(
+    configureDevCloudEnvironment([], {
+      ...process.env,
+      ...CLEAN_DEV_CLOUD_ENV,
+    }),
+  );
+}
+
+const TEST_CLOUD_PROFILE_INPUT = {
+  effectiveTarget: "staging",
+  serverApiBase: "https://api-staging.example.test/api/v1",
+  rendererCloudBase: "https://cloud-staging.example.test",
+  stewardApiUrl: "https://staging.example.test/steward",
+  stewardTenantId: "example-staging",
+  runtimeMode: "cloud",
+};
+const TEST_CLOUD_PROFILE = createDevServerCloudProfileFingerprint(
+  TEST_CLOUD_PROFILE_INPUT,
+);
+const OTHER_CLOUD_PROFILE = createDevServerCloudProfileFingerprint({
+  effectiveTarget: "production",
+  serverApiBase: "https://api.example.test/api/v1",
+  rendererCloudBase: "https://cloud.example.test",
+  stewardApiUrl: "https://example.test/steward",
+  stewardTenantId: "example-production",
+  runtimeMode: "cloud",
+});
 
 function makeRegistryPath(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-dev-registry-"));
@@ -154,6 +210,37 @@ async function runNode(scriptPath, { env, timeoutMs = 3_000 } = {}) {
 }
 
 describe("shared dev server registry", () => {
+  it("fingerprints every public Cloud routing field without retaining credentials", () => {
+    assert.match(TEST_CLOUD_PROFILE, /^cloud-v1:[0-9a-f]{64}$/);
+    assert.equal(TEST_CLOUD_PROFILE.includes("example-staging"), false);
+    assert.equal(
+      createDevServerCloudProfileFingerprint({
+        ...TEST_CLOUD_PROFILE_INPUT,
+        ELIZAOS_CLOUD_API_KEY: "must-never-enter-the-profile",
+      }),
+      TEST_CLOUD_PROFILE,
+    );
+
+    const replacements = {
+      effectiveTarget: "production",
+      serverApiBase: "https://api-alt.example.test/api/v1",
+      rendererCloudBase: "https://cloud-alt.example.test",
+      stewardApiUrl: "https://identity-alt.example.test/steward",
+      stewardTenantId: "example-alt",
+      runtimeMode: "",
+    };
+    for (const [field, value] of Object.entries(replacements)) {
+      assert.notEqual(
+        createDevServerCloudProfileFingerprint({
+          ...TEST_CLOUD_PROFILE_INPUT,
+          [field]: value,
+        }),
+        TEST_CLOUD_PROFILE,
+        `${field} must participate in the fingerprint`,
+      );
+    }
+  });
+
   it("allocates stable deterministic ports for a worktree", () => {
     const worktree = "/tmp/eliza-workers/wt-alpha";
     const first = allocatePortsForWorktree(worktree, {
@@ -205,6 +292,7 @@ describe("shared dev server registry", () => {
 
     const alpha = await reservePortsForWorktree("/tmp/eliza-workers/wt-alpha", {
       registryPath,
+      cloudProfileFingerprint: TEST_CLOUD_PROFILE,
     });
     const beta = await reservePortsForWorktree("/tmp/eliza-workers/wt-beta", {
       registryPath,
@@ -215,16 +303,27 @@ describe("shared dev server registry", () => {
     assert.equal(beta.reused, false);
     assert.equal(registry.entries.length, 2);
     assert.notEqual(alpha.entry.uiPort, beta.entry.uiPort);
+    assert.equal(alpha.entry.cloudProfileFingerprint, TEST_CLOUD_PROFILE);
+    assert.equal(
+      registry.entries.find(
+        (entry) =>
+          entry.worktree ===
+          normalizeWorktreePath("/tmp/eliza-workers/wt-alpha"),
+      )?.cloudProfileFingerprint,
+      TEST_CLOUD_PROFILE,
+    );
   });
 
-  it("reuses an established same-worktree server without rewriting it", async (t) => {
+  it("reuses an established same-worktree server only with the same Cloud profile", async (t) => {
     const registryPath = makeRegistryPath(t);
     const server = await listenOnLoopback();
     t.after(() => closeServer(server));
     const address = server.address();
     assert.ok(address && typeof address !== "string");
     const worktree = path.join(path.dirname(registryPath), "worktree");
-    const existing = registryEntry(worktree, address.port);
+    const existing = registryEntry(worktree, address.port, {
+      cloudProfileFingerprint: TEST_CLOUD_PROFILE,
+    });
     writeRegistry({ version: 1, entries: [existing] }, registryPath);
     const before = fs.readFileSync(registryPath, "utf8");
 
@@ -232,11 +331,48 @@ describe("shared dev server registry", () => {
       registryPath,
       base: address.port,
       span: 1,
+      cloudProfileFingerprint: TEST_CLOUD_PROFILE,
     });
 
     assert.equal(reservation.reused, true);
     assert.deepEqual(reservation.entry, existing);
     assert.equal(fs.readFileSync(registryPath, "utf8"), before);
+  });
+
+  it("refuses to reuse a live same-worktree server with a missing or different Cloud profile", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const server = await listenOnLoopback();
+    t.after(() => closeServer(server));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+
+    for (const existingFingerprint of [undefined, OTHER_CLOUD_PROFILE]) {
+      const existing = registryEntry(worktree, address.port, {
+        ...(existingFingerprint
+          ? { cloudProfileFingerprint: existingFingerprint }
+          : {}),
+      });
+      writeRegistry({ version: 1, entries: [existing] }, registryPath);
+      const before = fs.readFileSync(registryPath, "utf8");
+
+      await assert.rejects(
+        reservePortsForWorktree(worktree, {
+          registryPath,
+          base: address.port,
+          span: 1,
+          cloudProfileFingerprint: TEST_CLOUD_PROFILE,
+        }),
+        (error) => {
+          assert.match(error.message, /different or missing Cloud profile/);
+          assert.match(error.message, /Stop it with Ctrl-C/);
+          assert.match(error.message, /running server was left untouched/);
+          return true;
+        },
+      );
+      assert.equal(fs.readFileSync(registryPath, "utf8"), before);
+      assert.equal(server.listening, true);
+    }
   });
 
   it("does not reuse a stale reservation from its live PID alone", async (t) => {
@@ -435,12 +571,15 @@ describe("shared dev server registry", () => {
     t.after(() => closeServer(server));
     const address = server.address();
     assert.ok(address && typeof address !== "string");
-    const existing = registryEntry(repoRoot, address.port);
+    const existing = registryEntry(repoRoot, address.port, {
+      cloudProfileFingerprint: defaultDevSharedCloudProfile(),
+    });
     writeRegistry({ version: 1, entries: [existing] }, registryPath);
     const before = fs.readFileSync(registryPath, "utf8");
 
     const result = await runNode(devSharedScript, {
       env: {
+        ...CLEAN_DEV_CLOUD_ENV,
         ELIZA_DEV_SERVER_REGISTRY: registryPath,
         ELIZA_NODE_PATH: path.join(
           path.dirname(registryPath),
@@ -460,5 +599,37 @@ describe("shared dev server registry", () => {
       new RegExp(`ui=http://127\\.0\\.0\\.1:${address.port}`),
     );
     assert.equal(fs.readFileSync(registryPath, "utf8"), before);
+  });
+
+  it("dev:shared rejects a live server with another Cloud profile without stopping it", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const server = await listenOnLoopback();
+    t.after(() => closeServer(server));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const existing = registryEntry(repoRoot, address.port, {
+      cloudProfileFingerprint: OTHER_CLOUD_PROFILE,
+    });
+    writeRegistry({ version: 1, entries: [existing] }, registryPath);
+    const before = fs.readFileSync(registryPath, "utf8");
+
+    const result = await runNode(devSharedScript, {
+      env: {
+        ...CLEAN_DEV_CLOUD_ENV,
+        ELIZA_DEV_SERVER_REGISTRY: registryPath,
+        ELIZA_NODE_PATH: path.join(
+          path.dirname(registryPath),
+          "must-not-exist",
+        ),
+      },
+    });
+
+    assert.notEqual(result.code, 0);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, /different or missing Cloud profile/);
+    assert.match(result.stderr, /Stop it with Ctrl-C/);
+    assert.match(result.stderr, /running server was left untouched/);
+    assert.equal(fs.readFileSync(registryPath, "utf8"), before);
+    assert.equal(server.listening, true);
   });
 });

--- a/packages/app/scripts/dev-shared.mjs
+++ b/packages/app/scripts/dev-shared.mjs
@@ -8,13 +8,18 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { configureDevCloudEnvironment } from "../../app-core/scripts/lib/dev-cloud-target.mjs";
+import {
+  assertRendererOnlyDevCloudTargetSupported,
+  configureDevCloudEnvironment,
+} from "../../app-core/scripts/lib/dev-cloud-target.mjs";
 import { resolveViteCommand } from "../../app-core/scripts/lib/dev-ui-vite.mjs";
 import {
   createDevServerCloudProfileFingerprint,
   defaultRegistryPath,
   normalizeWorktreePath,
   reservePortsForWorktree,
+  resolveDevServerCloudCredentialIdentity,
+  resolveDevServerCloudPolicyIdentity,
   updateRegistryEntry,
 } from "./dev-server-registry.mjs";
 
@@ -26,8 +31,12 @@ const devCloud = configureDevCloudEnvironment(
   process.argv.slice(2),
   process.env,
 );
+assertRendererOnlyDevCloudTargetSupported(devCloud, "packages/app dev:shared");
 const cloudProfileFingerprint = createDevServerCloudProfileFingerprint({
   effectiveTarget: devCloud.effectiveTarget,
+  authorityMode: devCloud.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY,
+  credentialIdentity: resolveDevServerCloudCredentialIdentity(devCloud.env),
+  policyIdentity: resolveDevServerCloudPolicyIdentity(devCloud.env),
   serverApiBase: devCloud.env.ELIZAOS_CLOUD_BASE_URL,
   rendererCloudBase: devCloud.env.VITE_ELIZA_CLOUD_BASE,
   stewardApiUrl: devCloud.env.VITE_STEWARD_API_URL,

--- a/packages/app/scripts/dev-shared.mjs
+++ b/packages/app/scripts/dev-shared.mjs
@@ -8,8 +8,10 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { configureDevCloudEnvironment } from "../../app-core/scripts/lib/dev-cloud-target.mjs";
 import { resolveViteCommand } from "../../app-core/scripts/lib/dev-ui-vite.mjs";
 import {
+  createDevServerCloudProfileFingerprint,
   defaultRegistryPath,
   normalizeWorktreePath,
   reservePortsForWorktree,
@@ -20,12 +22,25 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(here, "..");
 const worktree = normalizeWorktreePath(path.resolve(appDir, "../.."));
 const registryPath = defaultRegistryPath();
+const devCloud = configureDevCloudEnvironment(
+  process.argv.slice(2),
+  process.env,
+);
+const cloudProfileFingerprint = createDevServerCloudProfileFingerprint({
+  effectiveTarget: devCloud.effectiveTarget,
+  serverApiBase: devCloud.env.ELIZAOS_CLOUD_BASE_URL,
+  rendererCloudBase: devCloud.env.VITE_ELIZA_CLOUD_BASE,
+  stewardApiUrl: devCloud.env.VITE_STEWARD_API_URL,
+  stewardTenantId: devCloud.env.VITE_STEWARD_TENANT_ID,
+  runtimeMode: devCloud.env.VITE_ELIZA_DESKTOP_RUNTIME_MODE,
+});
 
 const { entry, reused } = await reservePortsForWorktree(worktree, {
   registryPath,
+  cloudProfileFingerprint,
 });
 const env = {
-  ...process.env,
+  ...devCloud.env,
   ELIZA_UI_PORT: String(entry.uiPort),
   ELIZA_API_PORT: String(entry.apiPort),
   VITE_ELIZA_DEV_SHARED: "1",
@@ -34,13 +49,17 @@ const env = {
 console.log(
   `[dev:shared] worktree=${worktree}\n` +
     `[dev:shared] ui=http://127.0.0.1:${entry.uiPort} api=http://127.0.0.1:${entry.apiPort}\n` +
+    `[dev:shared] Cloud target=${devCloud.effectiveTarget} (${devCloud.source})\n` +
     `[dev:shared] registry=${registryPath}`,
 );
 
 if (reused) {
   console.log("[dev:shared] reusing existing server; Vite was not started");
 } else {
-  const viteCommand = resolveViteCommand({ appDir });
+  const viteCommand = resolveViteCommand({
+    appDir,
+    viteArgs: devCloud.passthroughArgs,
+  });
   const child = spawn(viteCommand.command, viteCommand.args, {
     cwd: appDir,
     env,

--- a/packages/app/scripts/dev.mjs
+++ b/packages/app/scripts/dev.mjs
@@ -8,16 +8,24 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { configureDevCloudEnvironment } from "../../app-core/scripts/lib/dev-cloud-target.mjs";
 import { resolveViteCommand } from "../../app-core/scripts/lib/dev-ui-vite.mjs";
 import { spawnMirroredChild } from "./lib/spawn-mirrored-child.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const devCloud = configureDevCloudEnvironment(
+  process.argv.slice(2),
+  process.env,
+);
 const viteCommand = resolveViteCommand({
   appDir,
-  viteArgs: process.argv.slice(2),
+  viteArgs: devCloud.passthroughArgs,
 });
+console.log(
+  `[dev] Cloud target=${devCloud.effectiveTarget} (${devCloud.source})`,
+);
 spawnMirroredChild(viteCommand.command, viteCommand.args, {
   cwd: appDir,
-  env: process.env,
+  env: devCloud.env,
   stdio: "inherit",
 });

--- a/packages/app/scripts/dev.mjs
+++ b/packages/app/scripts/dev.mjs
@@ -8,7 +8,10 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { configureDevCloudEnvironment } from "../../app-core/scripts/lib/dev-cloud-target.mjs";
+import {
+  assertRendererOnlyDevCloudTargetSupported,
+  configureDevCloudEnvironment,
+} from "../../app-core/scripts/lib/dev-cloud-target.mjs";
 import { resolveViteCommand } from "../../app-core/scripts/lib/dev-ui-vite.mjs";
 import { spawnMirroredChild } from "./lib/spawn-mirrored-child.mjs";
 
@@ -17,6 +20,7 @@ const devCloud = configureDevCloudEnvironment(
   process.argv.slice(2),
   process.env,
 );
+assertRendererOnlyDevCloudTargetSupported(devCloud, "packages/app dev");
 const viteCommand = resolveViteCommand({
   appDir,
   viteArgs: devCloud.passthroughArgs,

--- a/packages/app/scripts/lib/dev-vite-command.test.mjs
+++ b/packages/app/scripts/lib/dev-vite-command.test.mjs
@@ -180,7 +180,7 @@ describe("development Vite process commands", () => {
       "utf8",
     );
     assert.match(directDevSource, /resolveViteCommand\(\{/);
-    assert.match(directDevSource, /viteArgs: process\.argv\.slice\(2\)/);
+    assert.match(directDevSource, /viteArgs: devCloud\.passthroughArgs/);
     assert.match(directDevSource, /spawnMirroredChild\(/);
   });
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -68,6 +68,7 @@ import {
   isCloudPairLoopbackOrigin,
 } from "@elizaos/shared/contracts";
 import { isElizaDedicatedAgentHostname } from "@elizaos/shared/elizacloud";
+import { configureStoredStewardTokenScope } from "@elizaos/shared/steward-session-client";
 import { completeAndroidCloudSignIn } from "@elizaos/ui/android-cloud/android-cloud-auth";
 import { shouldAcknowledgeAndroidCloudCallback } from "@elizaos/ui/android-cloud/android-cloud-client";
 import { client } from "@elizaos/ui/api";
@@ -483,6 +484,7 @@ const isStoreBuild =
   typeof __ELIZA_BUILD_VARIANT__ === "string" &&
   __ELIZA_BUILD_VARIANT__ === "store";
 const IOS_RUNTIME_ENV_CONFIG = resolveIosRuntimeConfig(import.meta.env);
+configureStoredStewardTokenScope(IOS_RUNTIME_ENV_CONFIG.cloudApiBase);
 const DEVICE_BRIDGE_ID_KEY = `${APP_NAMESPACE}_device_bridge_id`;
 const BACKGROUND_RUNNER_LABEL = "eliza-tasks";
 const BACKGROUND_RUNNER_CONFIG_RETRY_MS = 5_000;

--- a/packages/app/src/main.web-entrypoint.test.ts
+++ b/packages/app/src/main.web-entrypoint.test.ts
@@ -6,6 +6,7 @@
  */
 import { Capacitor } from "@capacitor/core";
 import { runIosFullBunSmokeIfRequested } from "@elizaos/app-core/desktop-shell";
+import { STEWARD_ACTIVE_SCOPE_KEY } from "@elizaos/shared/steward-session-client";
 import {
   DEFAULT_BOOT_CONFIG,
   getBootConfig,
@@ -88,6 +89,7 @@ beforeEach(() => {
     }),
   );
   document.body.innerHTML = '<div id="root"></div>';
+  window.localStorage.clear();
 });
 
 describe("renderer web composition", () => {
@@ -110,6 +112,9 @@ describe("renderer web composition", () => {
       preferSharedCloudTier: true,
       autoUpgradeSharedToDedicated: true,
     });
+    expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBe(
+      "eliza-cloud:staging",
+    );
     expect(webBoot.initializeStorage).toHaveBeenCalledTimes(2);
     expect(webBoot.initializeCapacitor).toHaveBeenCalledOnce();
     expect(document.body.classList).toContain("platform-web");

--- a/packages/app/src/public-web-boot-config.test.ts
+++ b/packages/app/src/public-web-boot-config.test.ts
@@ -5,7 +5,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
-  config: { cloudApiBase: "https://eliza.app", marker: "preserved" },
+  config: {
+    cloudApiBase: "https://eliza.app",
+    marker: "preserved",
+  } as { cloudApiBase: string; marker: string },
   setCalls: [] as Array<Record<string, unknown>>,
 }));
 

--- a/packages/app/src/public-web-boot-config.ts
+++ b/packages/app/src/public-web-boot-config.ts
@@ -7,6 +7,7 @@
  * production default and can provision against the wrong Cloud API origin.
  */
 
+import { configureStoredStewardTokenScope } from "@elizaos/shared/steward-session-client";
 import { getBootConfig, setBootConfig } from "@elizaos/ui/config";
 import { resolveIosRuntimeConfig } from "./ios-runtime";
 
@@ -20,6 +21,7 @@ export function seedPublicWebBootConfig(
   env: RuntimeEnv = import.meta.env as RuntimeEnv,
 ): void {
   const runtime = resolveIosRuntimeConfig(env);
+  configureStoredStewardTokenScope(runtime.cloudApiBase);
   const current = getBootConfig();
   if (current.cloudApiBase === runtime.cloudApiBase) {
     return;

--- a/packages/app/test/dev-smoke/bun-dev-app-shell.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-app-shell.spec.ts
@@ -36,16 +36,12 @@ test.describe("bun run dev app shell renders", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
     // A blank `#root` means a module-eval crash blanked the tree (the #9452
-    // failure mode). Any startup/onboarding/app content satisfies this.
-    await expect
-      .poll(
-        () =>
-          page.evaluate(
-            () => document.getElementById("root")?.childElementCount ?? 0,
-          ),
-        { timeout: 60_000 },
-      )
-      .toBeGreaterThan(0);
+    // failure mode). Any startup/onboarding/app content satisfies this. Use a
+    // locator so the assertion survives an expected same-tab sign-in redirect,
+    // which replaces the page execution context during staging development.
+    await expect(page.locator("#root > *").first()).toBeAttached({
+      timeout: 60_000,
+    });
 
     expect(
       fatalErrors,

--- a/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
@@ -14,6 +14,11 @@ import {
 
 const RESPONSE_MARKER = "BUN_DEV_SMOKE_OK";
 
+test.skip(
+  process.env.ELIZA_DEV_SMOKE_OFFLINE !== "1",
+  "runs only through test:dev-smoke:local",
+);
+
 test.describe("bun run dev onboarding chat smoke", () => {
   test.describe.configure({ retries: process.env.CI ? 1 : 0 });
 

--- a/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
+++ b/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
@@ -1,9 +1,13 @@
 /**
- * Proves the explicit cloud-only development lane through the real Vite
- * transform and renderer, without changing the ordinary development default.
+ * Proves ordinary local development uses the staging Cloud tuple through the
+ * real Vite transform: Cloud-only onboarding, local `/login`, and staging
+ * Cloud/Steward boundaries. The compatibility `dev:cloud-only` lane exercises
+ * the same contract.
  */
 
 import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   expectNoRenderTelemetryErrors,
@@ -12,10 +16,14 @@ import {
   seedAppStorage,
 } from "../ui-smoke/helpers";
 
-test.skip(
-  process.env.ELIZA_DEV_SMOKE_CLOUD_ONLY !== "1",
-  "runs only through test:dev-smoke:cloud-only",
-);
+const stewardConfigAbsolutePath = path
+  .resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../ui/src/cloud/shell/steward-config.ts",
+  )
+  .split(path.sep)
+  .join("/");
+const STEWARD_CONFIG_MODULE_URL = `/@fs/${stewardConfigAbsolutePath.replace(/^\/+/, "")}`;
 
 async function fulfillJson(
   route: Route,
@@ -28,10 +36,17 @@ async function fulfillJson(
   });
 }
 
-async function routeFreshFirstRun(
-  page: Page,
-): Promise<{ loginStarts: number }> {
-  const state = { loginStarts: 0 };
+interface CloudAuthRouteState {
+  agentLoginPosts: number;
+  providerDiscoveryGets: number;
+}
+
+async function routeFreshFirstRun(page: Page): Promise<CloudAuthRouteState> {
+  const state: CloudAuthRouteState = {
+    agentLoginPosts: 0,
+    providerDiscoveryGets: 0,
+  };
+
   await page.route("**/api/auth/status", async (route) => {
     if (route.request().method() !== "GET") return route.fallback();
     await fulfillJson(route, {
@@ -63,7 +78,7 @@ async function routeFreshFirstRun(
   });
   await page.route("**/api/cloud/login", async (route) => {
     if (route.request().method() !== "POST") return route.fallback();
-    state.loginStarts += 1;
+    state.agentLoginPosts += 1;
     await fulfillJson(route, {
       ok: true,
       sessionId: "cloud-only-dev-smoke",
@@ -74,13 +89,78 @@ async function routeFreshFirstRun(
     if (route.request().method() !== "GET") return route.fallback();
     await fulfillJson(route, { status: "pending" });
   });
+
+  await page.route(
+    /^https:\/\/staging\.eliza\.app\/steward\/auth\/providers\/?(?:\?.*)?$/,
+    async (route) => {
+      const method = route.request().method();
+      const origin = route.request().headers().origin ?? "*";
+      const corsHeaders = {
+        "access-control-allow-headers": "content-type",
+        "access-control-allow-methods": "GET, OPTIONS",
+        "access-control-allow-origin": origin,
+        "cache-control": "no-store",
+      };
+
+      if (method === "OPTIONS") {
+        await route.fulfill({ status: 204, headers: corsHeaders, body: "" });
+        return;
+      }
+      if (method !== "GET") {
+        await route.abort("blockedbyclient");
+        return;
+      }
+
+      state.providerDiscoveryGets += 1;
+      await route.fulfill({
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          ok: true,
+          passkey: false,
+          email: true,
+          sms: false,
+          siwe: false,
+          siws: false,
+          google: false,
+          discord: false,
+          github: false,
+          twitter: false,
+          telegram: false,
+          oauth: [],
+        }),
+      });
+    },
+  );
+
   return state;
 }
 
-async function expectCloudOnlyAuth(page: Page): Promise<void> {
-  await expect(page.getByText("Opening secure sign in…")).toBeVisible({
-    timeout: 20_000,
-  });
+async function expectCloudOnlyAuth(
+  page: Page,
+  localOrigin: string,
+  extraPages: Page[],
+): Promise<void> {
+  await expect(page).toHaveURL(/\/login\?returnTo=/, { timeout: 20_000 });
+  const loginUrl = new URL(page.url());
+  expect(
+    loginUrl.origin,
+    "the original localhost page must own the Steward login surface",
+  ).toBe(localOrigin);
+  expect(loginUrl.pathname).toBe("/login");
+  expect(loginUrl.searchParams.get("returnTo")).toBe("/");
+  expect(
+    extraPages,
+    "same-tab Cloud sign-in must never open a popup or second page",
+  ).toHaveLength(0);
+  expect(page.context().pages()).toHaveLength(1);
+  expect(page.context().pages()[0]).toBe(page);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Sign in", exact: true }),
+  ).toBeVisible();
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
   for (const runtime of ["local", "remote"]) {
     await expect(
@@ -93,19 +173,55 @@ async function capture(page: Page, outputPath: string): Promise<void> {
   await page.screenshot({ path: outputPath, fullPage: true });
 }
 
-test("explicit cloud-only Vite development skips the runtime chooser", async ({
+test("ordinary Vite development defaults to staging Cloud sign-in", async ({
   page,
 }, testInfo) => {
   await installRenderTelemetryGuard(page);
   await installDefaultAppRoutes(page);
   const routeState = await routeFreshFirstRun(page);
+  const configuredBaseUrl = testInfo.project.use.baseURL;
+  if (typeof configuredBaseUrl !== "string") {
+    throw new Error("dev-smoke requires a string Playwright baseURL");
+  }
+  const localOrigin = new URL(configuredBaseUrl).origin;
+  const extraPages: Page[] = [];
+  page.context().on("page", (openedPage) => {
+    if (openedPage !== page) extraPages.push(openedPage);
+  });
   await seedAppStorage(page, {
     "eliza:first-run-complete": "",
   });
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await expectCloudOnlyAuth(page);
-  expect(routeState.loginStarts).toBeGreaterThan(0);
+  await expectCloudOnlyAuth(page, localOrigin, extraPages);
+  await expect.poll(() => routeState.providerDiscoveryGets).toBeGreaterThan(0);
+  expect(routeState.agentLoginPosts).toBe(0);
+  const stewardConfig = await page.evaluate(async (moduleUrl) => {
+    const loaded = (await import(/* @vite-ignore */ moduleUrl)) as {
+      configuredStewardApiUrlOverride: () => string | undefined;
+      configuredStewardTenantId: () => string | undefined;
+    };
+    return {
+      apiUrl: loaded.configuredStewardApiUrlOverride(),
+      tenantId: loaded.configuredStewardTenantId(),
+    };
+  }, STEWARD_CONFIG_MODULE_URL);
+  expect(stewardConfig).toEqual({
+    apiUrl: "https://staging.eliza.app/steward",
+    tenantId: "elizacloud-staging",
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __ELIZAOS_APP_BOOT_CONFIG__?: { cloudApiBase?: string };
+            }
+          ).__ELIZAOS_APP_BOOT_CONFIG__?.cloudApiBase ?? "",
+      ),
+    )
+    .toBe("https://cloud-staging.eliza.app");
   expect(
     await page.evaluate(() =>
       localStorage.getItem("eliza:enable-runtime-chooser"),
@@ -121,9 +237,14 @@ test("explicit cloud-only Vite development skips the runtime chooser", async ({
     contentType: "image/png",
   });
 
+  const desktopProviderDiscoveryGets = routeState.providerDiscoveryGets;
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.reload({ waitUntil: "domcontentloaded" });
-  await expectCloudOnlyAuth(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expectCloudOnlyAuth(page, localOrigin, extraPages);
+  await expect
+    .poll(() => routeState.providerDiscoveryGets)
+    .toBeGreaterThan(desktopProviderDiscoveryGets);
+  expect(routeState.agentLoginPosts).toBe(0);
   await expectNoRenderTelemetryErrors(
     page,
     "cloud-only Vite development mobile reload",

--- a/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
+++ b/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
@@ -1,13 +1,11 @@
 /**
  * Proves ordinary local development uses the staging Cloud tuple through the
- * real Vite transform: Cloud-only onboarding, local `/login`, and staging
- * Cloud/Steward boundaries. The compatibility `dev:cloud-only` lane exercises
- * the same contract.
+ * real Vite transform: Cloud-only onboarding and the hosted staging CLI-session
+ * boundary that safely returns to localhost. The compatibility
+ * `dev:cloud-only` lane exercises the same contract.
  */
 
 import { mkdir } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   expectNoRenderTelemetryErrors,
@@ -16,14 +14,7 @@ import {
   seedAppStorage,
 } from "../ui-smoke/helpers";
 
-const stewardConfigAbsolutePath = path
-  .resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "../../../ui/src/cloud/shell/steward-config.ts",
-  )
-  .split(path.sep)
-  .join("/");
-const STEWARD_CONFIG_MODULE_URL = `/@fs/${stewardConfigAbsolutePath.replace(/^\/+/, "")}`;
+const STAGING_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
 
 async function fulfillJson(
   route: Route,
@@ -38,12 +29,18 @@ async function fulfillJson(
 
 interface CloudAuthRouteState {
   agentLoginPosts: number;
+  directSessionOrigins: string[];
+  directSessionPosts: number;
+  hostedLoginGets: number;
   providerDiscoveryGets: number;
 }
 
 async function routeFreshFirstRun(page: Page): Promise<CloudAuthRouteState> {
   const state: CloudAuthRouteState = {
     agentLoginPosts: 0,
+    directSessionOrigins: [],
+    directSessionPosts: 0,
+    hostedLoginGets: 0,
     providerDiscoveryGets: 0,
   };
 
@@ -89,6 +86,46 @@ async function routeFreshFirstRun(page: Page): Promise<CloudAuthRouteState> {
     if (route.request().method() !== "GET") return route.fallback();
     await fulfillJson(route, { status: "pending" });
   });
+
+  await page.route(
+    /^https:\/\/api-staging\.eliza\.app\/api\/auth\/cli-session$/,
+    async (route) => {
+      const origin = route.request().headers().origin ?? "";
+      const corsHeaders = {
+        "access-control-allow-credentials": "true",
+        "access-control-allow-headers": "content-type",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-origin": origin,
+      };
+      if (route.request().method() === "OPTIONS") {
+        await route.fulfill({ status: 204, headers: corsHeaders, body: "" });
+        return;
+      }
+      if (route.request().method() !== "POST") return route.fallback();
+      state.directSessionPosts += 1;
+      state.directSessionOrigins.push(origin);
+      await route.fulfill({
+        status: 201,
+        headers: {
+          ...corsHeaders,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ sessionId: STAGING_SESSION_ID }),
+      });
+    },
+  );
+  await page.route(
+    /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?.*$/,
+    async (route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      state.hostedLoginGets += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><html><body><h1>Hosted staging sign-in</h1></body></html>",
+      });
+    },
+  );
 
   await page.route(
     /^https:\/\/staging\.eliza\.app\/steward\/auth\/providers\/?(?:\?.*)?$/,
@@ -144,14 +181,21 @@ async function expectCloudOnlyAuth(
   localOrigin: string,
   extraPages: Page[],
 ): Promise<void> {
-  await expect(page).toHaveURL(/\/login\?returnTo=/, { timeout: 20_000 });
+  await expect(page).toHaveURL(
+    /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?/,
+    { timeout: 20_000 },
+  );
   const loginUrl = new URL(page.url());
-  expect(
-    loginUrl.origin,
-    "the original localhost page must own the Steward login surface",
-  ).toBe(localOrigin);
-  expect(loginUrl.pathname).toBe("/login");
-  expect(loginUrl.searchParams.get("returnTo")).toBe("/");
+  expect(loginUrl.origin).toBe("https://staging.eliza.app");
+  expect(loginUrl.pathname).toBe("/auth/cli-login");
+  expect(loginUrl.searchParams.get("session")).toBe(STAGING_SESSION_ID);
+  const returnTo = new URL(loginUrl.searchParams.get("returnTo") ?? "");
+  expect(returnTo.origin).toBe(localOrigin);
+  expect(returnTo.pathname).toBe("/");
+  expect(returnTo.searchParams.get("elizaCloudLogin")).toBe("complete");
+  expect(returnTo.searchParams.get("elizaCloudLoginSession")).toBe(
+    STAGING_SESSION_ID,
+  );
   expect(
     extraPages,
     "same-tab Cloud sign-in must never open a popup or second page",
@@ -159,7 +203,11 @@ async function expectCloudOnlyAuth(
   expect(page.context().pages()).toHaveLength(1);
   expect(page.context().pages()[0]).toBe(page);
   await expect(
-    page.getByRole("heading", { level: 1, name: "Sign in", exact: true }),
+    page.getByRole("heading", {
+      level: 1,
+      name: "Hosted staging sign-in",
+      exact: true,
+    }),
   ).toBeVisible();
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
   for (const runtime of ["local", "remote"]) {
@@ -194,39 +242,11 @@ test("ordinary Vite development defaults to staging Cloud sign-in", async ({
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expectCloudOnlyAuth(page, localOrigin, extraPages);
-  await expect.poll(() => routeState.providerDiscoveryGets).toBeGreaterThan(0);
+  expect(routeState.directSessionPosts).toBe(1);
+  expect(routeState.directSessionOrigins).toEqual([localOrigin]);
+  expect(routeState.hostedLoginGets).toBe(1);
+  expect(routeState.providerDiscoveryGets).toBe(0);
   expect(routeState.agentLoginPosts).toBe(0);
-  const stewardConfig = await page.evaluate(async (moduleUrl) => {
-    const loaded = (await import(/* @vite-ignore */ moduleUrl)) as {
-      configuredStewardApiUrlOverride: () => string | undefined;
-      configuredStewardTenantId: () => string | undefined;
-    };
-    return {
-      apiUrl: loaded.configuredStewardApiUrlOverride(),
-      tenantId: loaded.configuredStewardTenantId(),
-    };
-  }, STEWARD_CONFIG_MODULE_URL);
-  expect(stewardConfig).toEqual({
-    apiUrl: "https://staging.eliza.app/steward",
-    tenantId: "elizacloud-staging",
-  });
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (
-            window as unknown as {
-              __ELIZAOS_APP_BOOT_CONFIG__?: { cloudApiBase?: string };
-            }
-          ).__ELIZAOS_APP_BOOT_CONFIG__?.cloudApiBase ?? "",
-      ),
-    )
-    .toBe("https://cloud-staging.eliza.app");
-  expect(
-    await page.evaluate(() =>
-      localStorage.getItem("eliza:enable-runtime-chooser"),
-    ),
-  ).toBeNull();
   await expectNoRenderTelemetryErrors(page, "cloud-only Vite development");
 
   await mkdir(testInfo.outputDir, { recursive: true });
@@ -237,13 +257,14 @@ test("ordinary Vite development defaults to staging Cloud sign-in", async ({
     contentType: "image/png",
   });
 
-  const desktopProviderDiscoveryGets = routeState.providerDiscoveryGets;
+  const desktopDirectSessionPosts = routeState.directSessionPosts;
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expectCloudOnlyAuth(page, localOrigin, extraPages);
-  await expect
-    .poll(() => routeState.providerDiscoveryGets)
-    .toBeGreaterThan(desktopProviderDiscoveryGets);
+  expect(routeState.directSessionPosts).toBe(desktopDirectSessionPosts + 1);
+  expect(routeState.directSessionOrigins.at(-1)).toBe(localOrigin);
+  expect(routeState.hostedLoginGets).toBe(2);
+  expect(routeState.providerDiscoveryGets).toBe(0);
   expect(routeState.agentLoginPosts).toBe(0);
   await expectNoRenderTelemetryErrors(
     page,

--- a/packages/app/test/dev-smoke/runtime-chooser-default.spec.ts
+++ b/packages/app/test/dev-smoke/runtime-chooser-default.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Proves the runtime chooser's default through the real `bun run dev` Vite
- * transform and renderer, with deterministic first-run HTTP boundaries.
+ * Proves the runtime chooser remains available through the explicit
+ * `bun run dev:local` escape hatch, with deterministic first-run boundaries.
  */
 
 import { mkdir } from "node:fs/promises";
@@ -11,6 +11,11 @@ import {
   installRenderTelemetryGuard,
   seedAppStorage,
 } from "../ui-smoke/helpers";
+
+test.skip(
+  process.env.ELIZA_DEV_SMOKE_OFFLINE !== "1",
+  "runs only through test:dev-smoke:local",
+);
 
 async function fulfillJson(
   route: Route,
@@ -43,7 +48,7 @@ async function routeFreshFirstRun(page: Page): Promise<void> {
   });
 }
 
-test("Vite development offers cloud, local, and remote without an override", async ({
+test("explicit local development offers cloud, local, and remote", async ({
   page,
 }, testInfo) => {
   await installRenderTelemetryGuard(page);

--- a/packages/app/test/dev-smoke/staging-live-auth-boundary.spec.ts
+++ b/packages/app/test/dev-smoke/staging-live-auth-boundary.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Opt-in, credential-free proof that the ordinary repo-root dev launcher
+ * crosses the real staging sign-in boundary. This deliberately leaves every
+ * Eliza staging route live and intercepts only the final Google page, before
+ * account selection or the OAuth callback can occur.
+ */
+
+import { expect, type Request, type Response, test } from "@playwright/test";
+
+const STAGING_API_ORIGIN = "https://api-staging.eliza.app";
+const STAGING_APP_ORIGIN = "https://staging.eliza.app";
+const SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+test.skip(
+  process.env.ELIZA_DEV_SMOKE_STAGING_LIVE_AUTH !== "1",
+  "set ELIZA_DEV_SMOKE_STAGING_LIVE_AUTH=1 via test:dev-smoke:staging-live-auth",
+);
+
+async function expectLiveTlsResponse(
+  response: Response,
+  label: string,
+  status: number,
+): Promise<void> {
+  expect(response.status(), `${label} status`).toBe(status);
+  expect(
+    response.fromServiceWorker(),
+    `${label} must not use a service worker`,
+  ).toBe(false);
+  expect(
+    await response.securityDetails(),
+    `${label} must be backed by a real TLS connection`,
+  ).not.toBeNull();
+  const headers = response.request().headers();
+  expect(headers.authorization, `${label} must be anonymous`).toBeUndefined();
+  expect(
+    headers["x-api-key"],
+    `${label} must not send an API key`,
+  ).toBeUndefined();
+}
+
+test("keyless local dev reaches staging provider authorization without following its callback", async ({
+  page,
+}, testInfo) => {
+  expect(process.env.ELIZA_DEV_CLOUD_TARGET).toBe("staging");
+  expect(process.env.ELIZA_DEV_CLOUD_API_KEY ?? "").toBe("");
+
+  const configuredBaseUrl = testInfo.project.use.baseURL;
+  if (typeof configuredBaseUrl !== "string") {
+    throw new Error("dev-smoke requires a string Playwright baseURL");
+  }
+  const localOrigin = new URL(configuredBaseUrl).origin;
+  const context = page.context();
+  await context.clearCookies();
+
+  const callbackRequests: string[] = [];
+  let googleAuthorizationRequest: Request | null = null;
+  context.on("request", (request) => {
+    const url = new URL(request.url());
+    if (
+      url.origin === STAGING_API_ORIGIN &&
+      url.pathname === "/steward/auth/oauth/google/callback"
+    ) {
+      callbackRequests.push(request.url());
+    }
+  });
+
+  // Stop at the third-party authorization boundary. No Google account page is
+  // contacted, no credentials are entered, and no callback can be followed.
+  await context.route(/^https:\/\/accounts\.google\.com\//, async (route) => {
+    googleAuthorizationRequest = route.request();
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><title>OAuth boundary reached</title><h1>OAuth boundary reached</h1>",
+    });
+  });
+
+  const firstRunResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.origin === localOrigin &&
+      url.pathname === "/api/first-run/status" &&
+      response.request().method() === "GET" &&
+      response.status() === 200
+    );
+  });
+  const cliSessionResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.origin === STAGING_API_ORIGIN &&
+      url.pathname === "/api/auth/cli-session" &&
+      response.request().method() === "POST"
+    );
+  });
+  const hostedLoginResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.origin === STAGING_APP_ORIGIN &&
+      url.pathname === "/auth/cli-login" &&
+      response.request().method() === "GET"
+    );
+  });
+  const providersResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.origin === STAGING_APP_ORIGIN &&
+      url.pathname === "/steward/auth/providers" &&
+      response.request().method() === "GET"
+    );
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await firstRunResponsePromise;
+
+  const cliSessionResponse = await cliSessionResponsePromise;
+  await expectLiveTlsResponse(cliSessionResponse, "staging CLI session", 201);
+  const cliHeaders = await cliSessionResponse.allHeaders();
+  expect(cliHeaders["access-control-allow-origin"]).toBe(localOrigin);
+  expect(cliHeaders["access-control-allow-credentials"]).toBe("true");
+
+  const hostedLoginResponse = await hostedLoginResponsePromise;
+  await expectLiveTlsResponse(hostedLoginResponse, "hosted staging login", 200);
+  const hostedLoginUrl = new URL(hostedLoginResponse.url());
+  const sessionId = hostedLoginUrl.searchParams.get("session");
+  expect(sessionId).toEqual(expect.stringMatching(SESSION_ID_PATTERN));
+  const returnTo = new URL(hostedLoginUrl.searchParams.get("returnTo") ?? "");
+  expect(returnTo.origin).toBe(localOrigin);
+  expect(returnTo.pathname).toBe("/");
+  expect(returnTo.searchParams.get("elizaCloudLogin")).toBe("complete");
+  expect(returnTo.searchParams.get("elizaCloudLoginSession")).toBe(sessionId);
+
+  const providersResponse = await providersResponsePromise;
+  await expectLiveTlsResponse(
+    providersResponse,
+    "staging provider discovery",
+    200,
+  );
+  const providers = (await providersResponse.json()) as {
+    google?: unknown;
+  };
+  expect(providers.google).toBe(true);
+
+  await expect(page).toHaveURL(/^https:\/\/staging\.eliza\.app\/login(?:\?|$)/);
+  const googleButton = page.getByRole("button", {
+    name: "Google",
+    exact: true,
+  });
+  await expect(googleButton).toBeVisible();
+
+  await googleButton.click();
+  await expect(page).toHaveURL(/^https:\/\/accounts\.google\.com\//);
+  await expect(
+    page.getByRole("heading", { name: "OAuth boundary reached", exact: true }),
+  ).toBeVisible();
+
+  const capturedAuthorizeRequest: Request | null = googleAuthorizationRequest;
+  expect(
+    capturedAuthorizeRequest,
+    "the hosted staging login must reach Google's authorization boundary",
+  ).not.toBeNull();
+  if (!capturedAuthorizeRequest) {
+    throw new Error("Google authorization request was not captured");
+  }
+  const authorizeHeaders = capturedAuthorizeRequest.headers();
+  expect(authorizeHeaders.authorization).toBeUndefined();
+  expect(authorizeHeaders["x-api-key"]).toBeUndefined();
+  const googleAuthorizationUrl = new URL(capturedAuthorizeRequest.url());
+  expect(googleAuthorizationUrl.origin).toBe("https://accounts.google.com");
+  expect(googleAuthorizationUrl.pathname).toBe("/o/oauth2/v2/auth");
+  expect(googleAuthorizationUrl.searchParams.get("client_id")).toMatch(
+    /^[a-z0-9-]+\.apps\.googleusercontent\.com$/i,
+  );
+  expect(googleAuthorizationUrl.searchParams.get("response_type")).toBe("code");
+  expect(googleAuthorizationUrl.searchParams.get("state")).toMatch(
+    /^[0-9a-f]{32}$/i,
+  );
+  expect(googleAuthorizationUrl.searchParams.get("redirect_uri")).toBe(
+    `${STAGING_API_ORIGIN}/steward/auth/oauth/google/callback`,
+  );
+
+  expect(context.pages()).toEqual([page]);
+  expect(callbackRequests).toEqual([]);
+});

--- a/packages/cloud/e2e/src/fixtures/stack.ts
+++ b/packages/cloud/e2e/src/fixtures/stack.ts
@@ -155,16 +155,24 @@ async function waitForTcp(
 
 async function waitForHttpOk(
   url: string,
-  opts: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
+  opts: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    requestTimeoutMs?: number;
+    label?: string;
+  } = {},
 ): Promise<void> {
   const timeoutMs = opts.timeoutMs ?? 90_000;
   const intervalMs = opts.intervalMs ?? 500;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 2_000;
   const label = opts.label ?? url;
   const start = Date.now();
   let lastErr: unknown;
   while (Date.now() - start < timeoutMs) {
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
       if (res.status < 500) return;
       lastErr = new Error(`status ${res.status}`);
     } catch (err) {
@@ -505,7 +513,14 @@ export async function startCloudStack(
         spawnLogged(
           "frontend",
           BUN,
-          ["run", "dev", "--", "--host", "127.0.0.1"],
+          [
+            "run",
+            "dev",
+            "--",
+            "--host",
+            "127.0.0.1",
+            "--cloud-target=offline",
+          ],
           {
             env: frontendEnv,
             cwd: frontendDir,
@@ -519,6 +534,10 @@ export async function startCloudStack(
     await withFakeStripeBootstrapRollback(fakeStripe, () =>
       waitForHttpOk(frontendUrl, {
         timeoutMs: 120_000,
+        // The first Vite document request may wait for dependency optimization
+        // and source transforms; aborting it every two seconds prevents the
+        // readiness probe itself from ever observing a healthy cold start.
+        requestTimeoutMs: 60_000,
         label: "frontend",
       }),
     );

--- a/packages/core/src/features/secrets/actions/request-secret.test.ts
+++ b/packages/core/src/features/secrets/actions/request-secret.test.ts
@@ -74,4 +74,41 @@ describe("SECRETS action=request", () => {
 		expect(result.text).not.toContain("set secret OPENAI_API_KEY");
 		expect(JSON.stringify(callbacks)).toContain("dm_or_owner_app_instruction");
 	});
+
+	test("falls back from a blank request base to the configured Cloud base", async () => {
+		const callbacks: Array<Record<string, unknown>> = [];
+		await requestSecretHandler(
+			createRuntime({
+				ELIZAOS_CLOUD_API_KEY: "cloud-key",
+				ELIZAOS_CLOUD_ENABLED: "true",
+				ELIZAOS_CLOUD_REQUEST_BASE_URL: "",
+				ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+			}) as never,
+			{
+				entityId: "user-1",
+				roomId: "room-1",
+				content: {
+					text: "Need my OpenAI key",
+					channelType: ChannelType.DM,
+					source: "telegram",
+				},
+			} as never,
+			undefined,
+			{ parameters: { key: "OPENAI_API_KEY" } } as never,
+			async (content) => {
+				callbacks.push(content as Record<string, unknown>);
+				return [];
+			},
+		);
+
+		const envelope = callbacks[0]?.content as {
+			secretRequest?: {
+				delivery?: { mode?: string; linkBaseUrl?: string };
+			};
+		};
+		expect(envelope.secretRequest?.delivery).toMatchObject({
+			mode: "cloud_authenticated_link",
+			linkBaseUrl: "https://api-staging.eliza.app/api/v1",
+		});
+	});
 });

--- a/packages/core/src/features/secrets/actions/request-secret.ts
+++ b/packages/core/src/features/secrets/actions/request-secret.ts
@@ -175,6 +175,14 @@ function runtimeSetting(runtime: IAgentRuntime, key: string): unknown {
 	return runtime.getSetting(key);
 }
 
+function nonEmptyRuntimeSetting(
+	runtime: IAgentRuntime,
+	key: string,
+): string | undefined {
+	const value = runtimeSetting(runtime, key);
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 function buildSecretRequestEnvironment(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -199,8 +207,8 @@ function buildSecretRequestEnvironment(
 		cloudApiKey: runtimeSetting(runtime, "ELIZAOS_CLOUD_API_KEY"),
 		cloudEnabled: runtimeSetting(runtime, "ELIZAOS_CLOUD_ENABLED"),
 		cloudBaseUrl:
-			runtimeSetting(runtime, "ELIZAOS_CLOUD_REQUEST_BASE_URL") ??
-			runtimeSetting(runtime, "ELIZAOS_CLOUD_BASE_URL"),
+			nonEmptyRuntimeSetting(runtime, "ELIZAOS_CLOUD_REQUEST_BASE_URL") ??
+			nonEmptyRuntimeSetting(runtime, "ELIZAOS_CLOUD_BASE_URL"),
 		tunnelActive,
 		tunnelUrl,
 		tunnelAuthenticated:

--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -10,7 +10,12 @@ import {
   isDevCloudTarget,
   normalizeCloudSiteUrl,
   resolveCloudApiBaseUrl,
+  resolveCloudRedirectScope,
 } from "./base-url";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "./dev-cloud-env-authority";
 
 describe("Eliza Cloud base URL normalization", () => {
   const savedConfig = getBootConfig();
@@ -88,6 +93,24 @@ describe("Eliza Cloud base URL normalization", () => {
   });
 });
 
+describe("Cloud redirect scopes", () => {
+  it("allows canonical HTTPS aliases only within the same deployment", () => {
+    expect(resolveCloudRedirectScope("https://api.eliza.app")).toBe(
+      resolveCloudRedirectScope("https://cloud.eliza.app"),
+    );
+    expect(resolveCloudRedirectScope("https://api-staging.eliza.app")).not.toBe(
+      resolveCloudRedirectScope("https://cloud.eliza.app"),
+    );
+  });
+
+  it("keeps hostile/custom origins distinct and rejects canonical HTTP", () => {
+    expect(resolveCloudRedirectScope("https://attacker.example")).not.toBe(
+      resolveCloudRedirectScope("https://api-staging.eliza.app"),
+    );
+    expect(resolveCloudRedirectScope("http://api.eliza.app")).toBeNull();
+  });
+});
+
 /**
  * The dev/production cloud split. `bun run dev` must not exercise production
  * credentials, billing, or agent state by default, so the unconfigured default
@@ -158,5 +181,71 @@ describe("default cloud target by environment", () => {
     expect(normalizeCloudSiteUrl("https://api-staging.elizacloud.ai")).toBe(
       "https://cloud-staging.eliza.app",
     );
+  });
+});
+
+describe("launcher-authoritative cloud base URL", () => {
+  const savedAuthorityEnv = {
+    source: process.env.ELIZA_DEV_SOURCE,
+    authority: process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY,
+    target: process.env.ELIZA_DEV_CLOUD_TARGET,
+    baseUrl: process.env.ELIZAOS_CLOUD_BASE_URL,
+  };
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ["ELIZA_DEV_SOURCE", savedAuthorityEnv.source],
+      ["ELIZA_DEV_CLOUD_ENV_AUTHORITY", savedAuthorityEnv.authority],
+      ["ELIZA_DEV_CLOUD_TARGET", savedAuthorityEnv.target],
+      ["ELIZAOS_CLOUD_BASE_URL", savedAuthorityEnv.baseUrl],
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it("keeps the staging-explicit launch base after process.env is polluted", () => {
+    resetDevCloudEnvAuthorityForTests();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(normalizeCloudSiteUrl()).toBe("https://cloud-staging.eliza.app");
+    expect(resolveCloudApiBaseUrl()).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+  });
+
+  it("keeps the self-hosted launch base after process.env is polluted", () => {
+    resetDevCloudEnvAuthorityForTests();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "self-hosted";
+    delete process.env.ELIZA_DEV_CLOUD_TARGET;
+    process.env.ELIZAOS_CLOUD_BASE_URL = "http://localhost:8787/api/v1";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(normalizeCloudSiteUrl()).toBe("http://localhost:8787");
+    expect(resolveCloudApiBaseUrl()).toBe("http://localhost:8787/api/v1");
+  });
+
+  it("preserves an accepted LAN HTTP origin and port for self-hosted authority", () => {
+    resetDevCloudEnvAuthorityForTests();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "self-hosted";
+    delete process.env.ELIZA_DEV_CLOUD_TARGET;
+    process.env.ELIZAOS_CLOUD_BASE_URL = "http://192.168.1.20:8787/api/v1";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(normalizeCloudSiteUrl()).toBe("http://192.168.1.20:8787");
+    expect(resolveCloudApiBaseUrl()).toBe("http://192.168.1.20:8787/api/v1");
   });
 });

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -4,6 +4,10 @@
 
 import { readAliasedEnv } from "../utils/env.js";
 import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "./dev-cloud-env-authority.js";
+import {
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
   type ElizaCloudEnvironment,
@@ -62,6 +66,27 @@ function controlPlaneEnvironment(
   }
 }
 
+/**
+ * Compare redirect targets using only the URLs being redirected, never ambient
+ * launcher configuration. Canonical HTTPS aliases within one deployment share
+ * a scope; custom hosts retain their exact origin and canonical HTTP is unsafe.
+ */
+export function resolveCloudRedirectScope(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    const environment = controlPlaneEnvironment(parsed.hostname.toLowerCase());
+    if (environment) {
+      return parsed.protocol === "https:" ? `eliza-cloud:${environment}` : null;
+    }
+    return `origin:${parsed.origin}`;
+  } catch {
+    return null;
+  }
+}
+
 function isLoopbackHost(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
   return (
@@ -94,18 +119,25 @@ function normalizeMalformedCandidate(candidate: string): string {
 
 export function normalizeCloudSiteUrl(rawUrl?: string): string {
   // Allow cloud-provisioned containers to override the base URL via env var
-  const envOverride = readAliasedEnv("ELIZAOS_CLOUD_BASE_URL");
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
+  const envOverride = devCloudAuthority
+    ? resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL")
+    : readAliasedEnv("ELIZAOS_CLOUD_BASE_URL");
   const candidate = envOverride || rawUrl?.trim() || defaultCloudSiteUrl();
 
   try {
     const parsed = new URL(candidate);
     const pathname = trimApiPath(parsed.pathname);
     const host = parsed.hostname.toLowerCase();
-    const preserveLocalOrigin = isLoopbackHost(host);
+    // A launcher-validated self-hosted tuple may intentionally use a LAN HTTP
+    // origin and non-default port. Preserve the frozen origin exactly so the
+    // backend cannot silently diverge from the renderer's accepted endpoint.
+    const preserveConfiguredOrigin =
+      isLoopbackHost(host) || devCloudAuthority === "self-hosted";
 
     parsed.hash = "";
     parsed.search = "";
-    if (!preserveLocalOrigin) {
+    if (!preserveConfiguredOrigin) {
       parsed.protocol = "https:";
       parsed.port = "";
     }

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -16,11 +16,11 @@ const STAGING_CLOUD_SITE_URL = ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin;
 /**
  * True when this process was started from the repo's dev entrypoint.
  *
- * `bun run dev` sets `ELIZA_DEV_SOURCE=1` (root `package.json`) and nothing
- * else does; `bun run start` sets neither it nor `NODE_ENV=development`. We key
- * on the explicit flag rather than `NODE_ENV` because `NODE_ENV=development`
- * is set by many harnesses (tests, benchmarks, tooling) that should keep
- * talking to whatever cloud they were configured for.
+ * The local dev launchers set `ELIZA_DEV_SOURCE=1` on their child processes;
+ * `bun run start` sets neither it nor `NODE_ENV=development`. We key on the
+ * explicit flag rather than `NODE_ENV` because `NODE_ENV=development` is set
+ * by many harnesses (tests, benchmarks, tooling) that should keep talking to
+ * whatever cloud they were configured for.
  */
 export function isDevCloudTarget(): boolean {
   return readAliasedEnv("ELIZA_DEV_SOURCE") === "1";

--- a/packages/shared/src/elizacloud/cloud-provisioning.test.ts
+++ b/packages/shared/src/elizacloud/cloud-provisioning.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config.js";
 import { isCloudProvisionedContainer } from "./cloud-provisioning.js";
+import { resetDevCloudEnvAuthorityForTests } from "./dev-cloud-env-authority.js";
 
 const CLOUD_PROVISIONING_KEYS = [
   "ACME_API_TOKEN",
@@ -13,6 +14,9 @@ const CLOUD_PROVISIONING_KEYS = [
   "ACME_CLOUD_ENABLED",
   "ACME_CLOUD_PROVISIONED",
   "ELIZA_API_TOKEN",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_DEV_SOURCE",
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_ENABLED",
   "ELIZA_CLOUD_PROVISIONED",
@@ -26,6 +30,7 @@ describe("isCloudProvisionedContainer", () => {
   );
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     setBootConfig(savedConfig);
     for (const key of CLOUD_PROVISIONING_KEYS) {
       delete process.env[key];
@@ -38,6 +43,7 @@ describe("isCloudProvisionedContainer", () => {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("requires the cloud flag plus at least one provisioning credential", () => {
@@ -82,4 +88,56 @@ describe("isCloudProvisionedContainer", () => {
     expect(process.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
     expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
   });
+
+  it.each(["staging-default", "offline"] as const)(
+    "forces %s to stay unprovisioned despite launch-time and late credential pollution",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZA_CLOUD_PROVISIONED = "1";
+      process.env.STEWARD_AGENT_TOKEN = "inherited-production-token";
+
+      expect(isCloudProvisionedContainer()).toBe(false);
+
+      process.env.ELIZA_API_TOKEN = "late-production-token";
+      process.env.ELIZAOS_CLOUD_ENABLED = "true";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+
+      expect(isCloudProvisionedContainer()).toBe(false);
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "%s cannot become provisioned through late env pollution",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+
+      expect(isCloudProvisionedContainer()).toBe(false);
+
+      process.env.ELIZA_CLOUD_PROVISIONED = "1";
+      process.env.ELIZAOS_CLOUD_ENABLED = "true";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-cloud-key";
+      process.env.STEWARD_AGENT_TOKEN = "late-steward-token";
+
+      expect(isCloudProvisionedContainer()).toBe(false);
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "%s keeps its launch-time provisioned classification after late clearing",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZA_CLOUD_PROVISIONED = "1";
+      process.env.ELIZA_API_TOKEN = "launch-api-token";
+
+      expect(isCloudProvisionedContainer()).toBe(true);
+
+      delete process.env.ELIZA_CLOUD_PROVISIONED;
+      delete process.env.ELIZA_API_TOKEN;
+
+      expect(isCloudProvisionedContainer()).toBe(true);
+    },
+  );
 });

--- a/packages/shared/src/elizacloud/cloud-provisioning.ts
+++ b/packages/shared/src/elizacloud/cloud-provisioning.ts
@@ -7,29 +7,51 @@
  */
 
 import { readAliasedEnv } from "../utils/env.js";
+import {
+  type DevCloudEnvAuthority,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "./dev-cloud-env-authority.js";
 
 function hasValue(value: string | undefined): boolean {
   return Boolean(value?.trim());
 }
 
-function hasCompatApiToken(): boolean {
-  return hasValue(readAliasedEnv("ELIZA_API_TOKEN"));
+function readProvisioningEnv(
+  key: string,
+  authority: DevCloudEnvAuthority | null,
+): string | undefined {
+  return authority
+    ? resolveDevCloudAuthorityEnvValue(key)
+    : readAliasedEnv(key);
 }
 
-function hasCloudApiKeyProvisioning(): boolean {
+function hasCompatApiToken(authority: DevCloudEnvAuthority | null): boolean {
+  return hasValue(readProvisioningEnv("ELIZA_API_TOKEN", authority));
+}
+
+function hasCloudApiKeyProvisioning(
+  authority: DevCloudEnvAuthority | null,
+): boolean {
   return (
-    readAliasedEnv("ELIZAOS_CLOUD_ENABLED") === "true" &&
-    hasValue(readAliasedEnv("ELIZAOS_CLOUD_API_KEY"))
+    readProvisioningEnv("ELIZAOS_CLOUD_ENABLED", authority) === "true" &&
+    hasValue(readProvisioningEnv("ELIZAOS_CLOUD_API_KEY", authority))
   );
 }
 
 export function isCloudProvisionedContainer(): boolean {
-  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
+  const authority = resolveDevCloudEnvAuthority();
+  if (authority === "staging-default" || authority === "offline") {
+    return false;
+  }
+
+  const hasCloudFlag =
+    readProvisioningEnv("ELIZA_CLOUD_PROVISIONED", authority) === "1";
 
   return (
     hasCloudFlag &&
-    (hasValue(process.env.STEWARD_AGENT_TOKEN) ||
-      hasCompatApiToken() ||
-      hasCloudApiKeyProvisioning())
+    (hasValue(readProvisioningEnv("STEWARD_AGENT_TOKEN", authority)) ||
+      hasCompatApiToken(authority) ||
+      hasCloudApiKeyProvisioning(authority))
   );
 }

--- a/packages/shared/src/elizacloud/dev-cloud-env-authority.test.ts
+++ b/packages/shared/src/elizacloud/dev-cloud-env-authority.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyDevCloudAuthoritySnapshotToEnv,
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+  resolveDevCloudStewardOperationalTuple,
+} from "./dev-cloud-env-authority.ts";
+
+const KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_API_TOKEN",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_SERVICE_KEY",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "STEWARD_TRADE_SESSION_ID",
+  "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+  "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+] as const;
+let saved: Record<(typeof KEYS)[number], string | undefined>;
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  saved = Object.fromEntries(
+    KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof KEYS)[number], string | undefined>;
+  for (const key of KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of KEYS) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("development Cloud environment authority", () => {
+  it("ignores an unowned marker", () => {
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+
+    expect(resolveDevCloudEnvAuthority()).toBeNull();
+  });
+
+  it.each(["staging-default", "offline"] as const)(
+    "freezes %s as connection-disabled and staging-pinned",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZA_DEV_CLOUD_TARGET =
+        authority === "offline" ? "offline" : "staging";
+      process.env.ELIZAOS_CLOUD_API_KEY = "inherited-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_SERVICE_KEY =
+        "inherited-production-service-key";
+
+      const snapshot = captureDevCloudEnvAuthoritySnapshot();
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://attacker.example/api/v1";
+
+      expect(snapshot?.authority).toBe(authority);
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+      expect(resolveDevCloudAuthorityEnvValue("ELIZA_DEV_CLOUD_TARGET")).toBe(
+        authority === "offline" ? "offline" : "staging",
+      );
+      expect(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")).toBe(
+        "",
+      );
+      expect(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_SERVICE_KEY"),
+      ).toBe("");
+      expect(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL")).toBe(
+        "https://api-staging.eliza.app/api/v1",
+      );
+    },
+  );
+
+  it("keeps the original explicit staging credential after live env mutation", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")).toBe(
+      "staging-launch-key",
+    );
+    expect(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL")).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+  });
+
+  it("projects only the frozen authority tuple into a restarted child", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZA_API_TOKEN = "desktop-loopback-token";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    process.env.STEWARD_AGENT_TOKEN = "staging-agent-token";
+    const snapshot = captureDevCloudEnvAuthoritySnapshot();
+
+    const childEnv: Record<string, string | undefined> = {
+      PATH: "/usr/bin",
+      ELIZA_DEV_SOURCE: "1",
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "production",
+      ELIZA_DEV_CLOUD_TARGET: "production",
+      ELIZAOS_CLOUD_API_KEY: "late-production-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://attacker.example/api/v1",
+      ELIZAOS_CLOUD_LATE_OVERRIDE: "late-attacker-key",
+      ELIZA_API_TOKEN: "late-loopback-token",
+      STEWARD_API_URL: "https://attacker.example/steward",
+      STEWARD_AGENT_TOKEN: "late-attacker-token",
+    };
+
+    expect(applyDevCloudAuthoritySnapshotToEnv(childEnv, snapshot)).toBe(true);
+    expect(childEnv).toMatchObject({
+      PATH: "/usr/bin",
+      ELIZA_DEV_SOURCE: "1",
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-explicit",
+      ELIZA_DEV_CLOUD_TARGET: "staging",
+      ELIZAOS_CLOUD_API_KEY: "staging-launch-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZA_API_TOKEN: "desktop-loopback-token",
+      STEWARD_API_URL: "https://staging.eliza.app/steward",
+      STEWARD_AGENT_TOKEN: "staging-agent-token",
+    });
+    expect(childEnv.ELIZAOS_CLOUD_LATE_OVERRIDE).toBeUndefined();
+  });
+
+  it("leaves an unowned child environment unchanged", () => {
+    const childEnv = { PATH: "/usr/bin", ELIZAOS_CLOUD_API_KEY: "direct-key" };
+
+    expect(applyDevCloudAuthoritySnapshotToEnv(childEnv, null)).toBe(false);
+    expect(childEnv).toEqual({
+      PATH: "/usr/bin",
+      ELIZAOS_CLOUD_API_KEY: "direct-key",
+    });
+  });
+
+  it.each(["staging-default", "offline"] as const)(
+    "keeps operational Steward disabled under %s after late credential pollution",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.STEWARD_API_URL = "https://eliza.app/steward";
+      process.env.STEWARD_TENANT_ID = "elizacloud";
+      process.env.STEWARD_AGENT_ID = "production-agent";
+      process.env.STEWARD_API_KEY = "production-key";
+      process.env.STEWARD_AGENT_TOKEN = "production-token";
+
+      captureDevCloudEnvAuthoritySnapshot();
+
+      process.env.STEWARD_API_URL = "https://attacker.example/steward";
+      process.env.STEWARD_TENANT_ID = "attacker";
+      process.env.STEWARD_AGENT_ID = "attacker-agent";
+      process.env.STEWARD_API_KEY = "attacker-key";
+      process.env.STEWARD_AGENT_TOKEN = "attacker-token";
+
+      expect(resolveDevCloudStewardOperationalTuple()).toEqual({
+        authority,
+        enabled: false,
+      });
+      expect(resolveDevCloudAuthorityEnvValue("STEWARD_API_URL")).toBe("");
+      expect(resolveDevCloudAuthorityEnvValue("STEWARD_AGENT_TOKEN")).toBe("");
+    },
+  );
+
+  it("uses one complete explicit Steward tuple after late URL, identity, and credential mutation", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    process.env.STEWARD_API_KEY = "staging-key";
+    process.env.STEWARD_AGENT_TOKEN = "staging-token";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud";
+    process.env.STEWARD_AGENT_ID = "production-agent";
+    process.env.STEWARD_API_KEY = "production-key";
+    process.env.STEWARD_AGENT_TOKEN = "production-token";
+
+    expect(resolveDevCloudStewardOperationalTuple()).toEqual({
+      authority: "staging-explicit",
+      enabled: true,
+      apiUrl: "https://staging.eliza.app/steward",
+      tenantId: "elizacloud-staging",
+      agentId: "staging-agent",
+      apiKey: "staging-key",
+      agentToken: "staging-token",
+    });
+  });
+
+  it("does not let late runtime values complete an insufficient explicit Steward launch tuple", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_API_KEY = "late-production-key";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+
+    expect(resolveDevCloudStewardOperationalTuple()).toEqual({
+      authority: "staging-explicit",
+      enabled: false,
+    });
+    expect(resolveDevCloudAuthorityEnvValue("STEWARD_API_URL")).toBe("");
+    expect(resolveDevCloudAuthorityEnvValue("STEWARD_AGENT_ID")).toBe("");
+  });
+
+  it.each(["[REDACTED]", "vault://steward/agent-token"])(
+    "rejects an explicit Steward placeholder credential: %s",
+    (placeholder) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "self-hosted";
+      process.env.STEWARD_API_URL = "https://steward.private.example";
+      process.env.STEWARD_AGENT_ID = "private-agent";
+      process.env.STEWARD_AGENT_TOKEN = placeholder;
+
+      expect(resolveDevCloudStewardOperationalTuple()).toEqual({
+        authority: "self-hosted",
+        enabled: false,
+      });
+      expect(resolveDevCloudAuthorityEnvValue("STEWARD_AGENT_TOKEN")).toBe("");
+    },
+  );
+});

--- a/packages/shared/src/elizacloud/dev-cloud-env-authority.ts
+++ b/packages/shared/src/elizacloud/dev-cloud-env-authority.ts
@@ -1,0 +1,330 @@
+/**
+ * Internal contract stamped by local-development launchers. A valid authority
+ * marker means persisted Cloud state must not replace the launcher's tuple.
+ */
+
+export type DevCloudEnvAuthority =
+  | "staging-default"
+  | "staging-explicit"
+  | "production"
+  | "offline"
+  | "self-hosted";
+
+const DEV_CLOUD_ENV_AUTHORITIES = new Set<DevCloudEnvAuthority>([
+  "staging-default",
+  "staging-explicit",
+  "production",
+  "offline",
+  "self-hosted",
+]);
+
+export interface DevCloudEnvAuthoritySnapshot {
+  readonly authority: DevCloudEnvAuthority;
+  readonly values: Readonly<Record<string, string | undefined>>;
+}
+
+type MutableEnvironment = Record<string, string | undefined>;
+
+let frozenProcessSnapshot: DevCloudEnvAuthoritySnapshot | undefined;
+
+const DEV_CLOUD_CONTROL_KEYS = new Set([
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+]);
+
+// These credentials participate in managed-container classification even
+// though their historical names do not use a Cloud-specific prefix. Capture
+// them with the launcher tuple so an explicit target cannot be reclassified by
+// late process.env mutation. They intentionally remain outside
+// isCloudAuthorityKey: ELIZA_API_TOKEN also protects local HTTP APIs, so the
+// staging-default/offline scrub must not globally erase it.
+const DEV_CLOUD_PROVISIONING_CREDENTIAL_KEYS = ["ELIZA_API_TOKEN"] as const;
+
+/**
+ * Steward values that can authorize wallet discovery, creation, signing, or
+ * trading. Development launchers own these alongside the Cloud tuple: a late
+ * config/keychain/runtime merge must never turn ordinary local development
+ * into an authenticated money path or redirect an explicit target.
+ */
+export const DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS = [
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "STEWARD_TRADE_SESSION_ID",
+  "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+  "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+] as const;
+
+const DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEY_SET = new Set<string>(
+  DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS,
+);
+
+export type DevCloudStewardOperationalTuple =
+  | Readonly<{
+      authority: DevCloudEnvAuthority;
+      enabled: false;
+    }>
+  | Readonly<{
+      authority: DevCloudEnvAuthority;
+      enabled: true;
+      apiUrl: string;
+      tenantId?: string;
+      agentId: string;
+      apiKey?: string;
+      agentToken?: string;
+    }>;
+
+function isStewardOperationalKey(key: string): boolean {
+  return DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEY_SET.has(key.toUpperCase());
+}
+
+function isCloudAuthorityKey(key: string): boolean {
+  const normalizedKey = key.toUpperCase();
+  if (DEV_CLOUD_CONTROL_KEYS.has(normalizedKey)) return false;
+  return (
+    normalizedKey.startsWith("ELIZAOS_CLOUD_") ||
+    normalizedKey.startsWith("ELIZA_CLOUD_") ||
+    normalizedKey.startsWith("ELIZA_DEV_CLOUD_") ||
+    normalizedKey.startsWith("ELIZACLOUD_") ||
+    normalizedKey.startsWith("WAIFU_ELIZA_CLOUD_")
+  );
+}
+
+function isDevCloudProjectionKey(key: string): boolean {
+  const normalizedKey = key.toUpperCase();
+  return (
+    DEV_CLOUD_CONTROL_KEYS.has(normalizedKey) ||
+    DEV_CLOUD_PROVISIONING_CREDENTIAL_KEYS.includes(
+      normalizedKey as (typeof DEV_CLOUD_PROVISIONING_CREDENTIAL_KEYS)[number],
+    ) ||
+    isCloudAuthorityKey(normalizedKey) ||
+    isStewardOperationalKey(normalizedKey)
+  );
+}
+
+function parseAuthority(env: NodeJS.ProcessEnv): DevCloudEnvAuthority | null {
+  if (env.ELIZA_DEV_SOURCE !== "1") return null;
+  const value = env.ELIZA_DEV_CLOUD_ENV_AUTHORITY?.trim().toLowerCase();
+  if (!value || !DEV_CLOUD_ENV_AUTHORITIES.has(value as DevCloudEnvAuthority)) {
+    return null;
+  }
+  return value as DevCloudEnvAuthority;
+}
+
+function freezeSnapshot(
+  authority: DevCloudEnvAuthority,
+  env: NodeJS.ProcessEnv,
+): DevCloudEnvAuthoritySnapshot {
+  const activationBlocked =
+    authority === "staging-default" || authority === "offline";
+  const keys = new Set([
+    ...Object.keys(env).filter(isCloudAuthorityKey),
+    ...DEV_CLOUD_CONTROL_KEYS,
+    ...DEV_CLOUD_PROVISIONING_CREDENTIAL_KEYS,
+    ...DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS,
+    "ELIZAOS_CLOUD_API_KEY",
+    "ELIZAOS_CLOUD_BASE_URL",
+    "ELIZAOS_CLOUD_SERVICE_KEY",
+    "ELIZA_CLOUD_SERVICE_KEY",
+    "ELIZA_CLOUD_WRITE_BASE_URL",
+  ]);
+  const values = Object.fromEntries(
+    [...keys].map((key) => {
+      if (key === "ELIZA_DEV_SOURCE") return [key, "1"];
+      if (key === "ELIZA_DEV_CLOUD_ENV_AUTHORITY") {
+        return [key, authority];
+      }
+      if (key === "ELIZA_DEV_CLOUD_TARGET") return [key, env[key]];
+      if (key === "ELIZAOS_CLOUD_BASE_URL") {
+        if (authority === "production") {
+          return [key, "https://api.eliza.app/api/v1"];
+        }
+        if (authority !== "self-hosted") {
+          return [key, "https://api-staging.eliza.app/api/v1"];
+        }
+      }
+      if (
+        activationBlocked &&
+        (isCloudAuthorityKey(key) || isStewardOperationalKey(key))
+      ) {
+        return [key, ""];
+      }
+      return [key, env[key]];
+    }),
+  );
+  return Object.freeze({
+    authority,
+    values: Object.freeze(values),
+  });
+}
+
+/** Ignore an authority marker outside a launcher-owned development process. */
+export function resolveDevCloudEnvAuthority(
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvAuthority | null {
+  if (env === process.env && frozenProcessSnapshot) {
+    return frozenProcessSnapshot.authority;
+  }
+  const authority = parseAuthority(env);
+  if (!authority) return null;
+  if (env === process.env && !frozenProcessSnapshot) {
+    frozenProcessSnapshot = freezeSnapshot(authority, env);
+  }
+  return env === process.env
+    ? (frozenProcessSnapshot?.authority ?? authority)
+    : authority;
+}
+
+/** Return the process-lifetime tuple captured on the first authority read. */
+export function captureDevCloudEnvAuthoritySnapshot(
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudEnvAuthoritySnapshot | null {
+  const authority = resolveDevCloudEnvAuthority(env);
+  if (!authority) return null;
+  if (env === process.env) return frozenProcessSnapshot ?? null;
+  return freezeSnapshot(authority, env);
+}
+
+/**
+ * Project the frozen launcher tuple into a child-process environment.
+ *
+ * A restarted child is a fresh JavaScript process, so it cannot inherit the
+ * parent's in-memory snapshot. Remove every authority-owned value from the
+ * late mutable environment first, then restore only the values captured by
+ * the parent. Unrelated process settings remain untouched.
+ */
+export function applyDevCloudAuthoritySnapshotToEnv(
+  target: MutableEnvironment,
+  snapshot: DevCloudEnvAuthoritySnapshot | null = captureDevCloudEnvAuthoritySnapshot(),
+): boolean {
+  if (!snapshot) return false;
+
+  for (const key of Object.keys(target)) {
+    if (isDevCloudProjectionKey(key)) delete target[key];
+  }
+  for (const [key, value] of Object.entries(snapshot.values)) {
+    if (value === undefined) delete target[key];
+    else target[key] = value;
+  }
+  return true;
+}
+
+/** Read a value from the immutable launcher tuple, never mutable live env. */
+export function resolveDevCloudAuthorityEnvValue(
+  key: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const snapshot = captureDevCloudEnvAuthoritySnapshot(env);
+  if (!snapshot) return env[key];
+  if (isStewardOperationalKey(key)) {
+    const stewardTuple = resolveDevCloudStewardOperationalTuple(env);
+    if (stewardTuple && !stewardTuple.enabled) return "";
+  }
+  if (
+    (snapshot.authority === "staging-default" ||
+      snapshot.authority === "offline") &&
+    isCloudAuthorityKey(key)
+  ) {
+    return key === "ELIZAOS_CLOUD_BASE_URL"
+      ? "https://api-staging.eliza.app/api/v1"
+      : "";
+  }
+  return snapshot.values[key];
+}
+
+function trimmedSnapshotValue(
+  snapshot: DevCloudEnvAuthoritySnapshot,
+  key: (typeof DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS)[number],
+): string | undefined {
+  const value = snapshot.values[key]?.trim();
+  return value || undefined;
+}
+
+function usableSnapshotCredential(
+  snapshot: DevCloudEnvAuthoritySnapshot,
+  key: "STEWARD_API_KEY" | "STEWARD_AGENT_TOKEN",
+): string | undefined {
+  const value = trimmedSnapshotValue(snapshot, key);
+  if (
+    !value ||
+    value.toUpperCase() === "[REDACTED]" ||
+    value.toLowerCase().startsWith("vault://")
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function isSecureStewardApiUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:") return true;
+    return (
+      url.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "::1", "[::1]"].includes(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the immutable launch-authorized Steward connection, when a
+ * development launcher owns the process. A null result means there is no dev
+ * authority and legacy consumers may use their normal sources. An authority
+ * result with `enabled: false` is an explicit fail-closed decision.
+ */
+export function resolveDevCloudStewardOperationalTuple(
+  env: NodeJS.ProcessEnv = process.env,
+): DevCloudStewardOperationalTuple | null {
+  const snapshot = captureDevCloudEnvAuthoritySnapshot(env);
+  if (!snapshot) return null;
+  if (
+    snapshot.authority === "staging-default" ||
+    snapshot.authority === "offline"
+  ) {
+    return Object.freeze({ authority: snapshot.authority, enabled: false });
+  }
+
+  const apiUrl = trimmedSnapshotValue(snapshot, "STEWARD_API_URL");
+  const primaryAgentId = trimmedSnapshotValue(snapshot, "STEWARD_AGENT_ID");
+  const aliasAgentId = trimmedSnapshotValue(snapshot, "ELIZA_STEWARD_AGENT_ID");
+  const agentId = primaryAgentId ?? aliasAgentId;
+  const tenantId = trimmedSnapshotValue(snapshot, "STEWARD_TENANT_ID");
+  const apiKey = usableSnapshotCredential(snapshot, "STEWARD_API_KEY");
+  const agentToken = usableSnapshotCredential(snapshot, "STEWARD_AGENT_TOKEN");
+  const agentIdsConflict = Boolean(
+    primaryAgentId && aliasAgentId && primaryAgentId !== aliasAgentId,
+  );
+  const hasAuthorizedCredential = Boolean(agentToken || (apiKey && tenantId));
+
+  if (
+    !apiUrl ||
+    !isSecureStewardApiUrl(apiUrl) ||
+    !agentId ||
+    agentIdsConflict ||
+    !hasAuthorizedCredential ||
+    (apiKey && !tenantId)
+  ) {
+    return Object.freeze({ authority: snapshot.authority, enabled: false });
+  }
+
+  return Object.freeze({
+    authority: snapshot.authority,
+    enabled: true,
+    apiUrl,
+    ...(tenantId ? { tenantId } : {}),
+    agentId,
+    ...(apiKey ? { apiKey } : {}),
+    ...(agentToken ? { agentToken } : {}),
+  });
+}
+
+/** @internal Test isolation for the process-lifetime launch snapshot. */
+export function resetDevCloudEnvAuthorityForTests(): void {
+  frozenProcessSnapshot = undefined;
+}

--- a/packages/shared/src/elizacloud/index.ts
+++ b/packages/shared/src/elizacloud/index.ts
@@ -2,6 +2,7 @@
 export * from "./base-url.js";
 export * from "./cloud-provisioning.js";
 export * from "./cloud-secrets.js";
+export * from "./dev-cloud-env-authority.js";
 export * from "./domain-contract.js";
 export * from "./is-cloud-reachable.js";
 export * from "./server-cloud-tts.js";

--- a/packages/shared/src/elizacloud/server-cloud-tts.test.ts
+++ b/packages/shared/src/elizacloud/server-cloud-tts.test.ts
@@ -6,17 +6,113 @@
  * model normalization, compat header bidirectional mirroring, and candidate URL builders.
  */
 
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  _resetCloudSecretsForTesting,
+  scrubCloudSecretsFromEnv,
+} from "./cloud-secrets.js";
+import { resetDevCloudEnvAuthorityForTests } from "./dev-cloud-env-authority.js";
+import {
+  _internalResolveCloudApiKey,
   ELIZA_CLOUD_TTS_MAX_TEXT_CHARS,
+  ensureCloudTtsApiKeyAlias,
   mirrorCompatHeaders,
   normalizeElizaCloudTtsModelId,
   resolveCloudProxyTtsModel,
+  resolveCloudTtsBaseUrl,
+  resolveElevenLabsApiKeyForCloudMode,
   resolveElizaCloudTtsVoiceId,
   shouldRetryCloudTtsUpstream,
 } from "./server-cloud-tts.js";
 
 describe("server-cloud-tts", () => {
+  describe("development Cloud environment authority", () => {
+    const originalConfigPath = process.env.ELIZA_CONFIG_PATH;
+    const originalCloudApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+    let testDirectory: string;
+
+    beforeEach(() => {
+      resetDevCloudEnvAuthorityForTests();
+      _resetCloudSecretsForTesting();
+      delete process.env.ELIZAOS_CLOUD_API_KEY;
+      testDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "server-cloud-tts-authority-"),
+      );
+      const configPath = path.join(testDirectory, "eliza.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          cloud: {
+            apiKey: "persisted-production-key",
+            baseUrl: "https://api.eliza.app/api/v1",
+          },
+          serviceRouting: {
+            tts: { backend: "elizacloud", transport: "cloud-proxy" },
+          },
+        }),
+      );
+      process.env.ELIZA_CONFIG_PATH = configPath;
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "sealed-production-key";
+      scrubCloudSecretsFromEnv();
+    });
+
+    afterEach(() => {
+      resetDevCloudEnvAuthorityForTests();
+      _resetCloudSecretsForTesting();
+      if (originalCloudApiKey === undefined) {
+        delete process.env.ELIZAOS_CLOUD_API_KEY;
+      } else {
+        process.env.ELIZAOS_CLOUD_API_KEY = originalCloudApiKey;
+      }
+      if (originalConfigPath === undefined) {
+        delete process.env.ELIZA_CONFIG_PATH;
+      } else {
+        process.env.ELIZA_CONFIG_PATH = originalConfigPath;
+      }
+      fs.rmSync(testDirectory, { recursive: true });
+    });
+
+    it.each(["staging-default", "offline"])(
+      "does not fall back to persisted or sealed production credentials for %s",
+      (authority) => {
+        const env: NodeJS.ProcessEnv = {
+          ELIZA_DEV_SOURCE: "1",
+          ELIZA_DEV_CLOUD_ENV_AUTHORITY: authority,
+        };
+
+        expect(_internalResolveCloudApiKey(env)).toBeNull();
+        expect(resolveElevenLabsApiKeyForCloudMode(env)).toBeNull();
+        expect(ensureCloudTtsApiKeyAlias(env)).toBe(false);
+        expect(env.ELEVENLABS_API_KEY).toBeUndefined();
+        expect(resolveCloudTtsBaseUrl(env)).toBe(
+          "https://api-staging.eliza.app/api/v1",
+        );
+      },
+    );
+
+    it("uses the explicit staging credential from the canonical launcher key", () => {
+      const env: NodeJS.ProcessEnv = {
+        ELIZA_DEV_SOURCE: "1",
+        ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-explicit",
+        ELIZAOS_CLOUD_API_KEY: "staging-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+        ELIZAOS_CLOUD_USE_TTS: "true",
+      };
+
+      expect(_internalResolveCloudApiKey(env)).toBe("staging-key");
+      expect(resolveElevenLabsApiKeyForCloudMode(env)).toBe("staging-key");
+      expect(ensureCloudTtsApiKeyAlias(env)).toBe(true);
+      expect(env.ELEVENLABS_API_KEY).toBe("staging-key");
+      expect(resolveCloudTtsBaseUrl(env)).toBe(
+        "https://api-staging.eliza.app/api/v1",
+      );
+    });
+  });
+
   describe("constants and retry heuristics", () => {
     it("defines ELIZA_CLOUD_TTS_MAX_TEXT_CHARS as 5000", () => {
       expect(ELIZA_CLOUD_TTS_MAX_TEXT_CHARS).toBe(5000);

--- a/packages/shared/src/elizacloud/server-cloud-tts.ts
+++ b/packages/shared/src/elizacloud/server-cloud-tts.ts
@@ -20,6 +20,10 @@ import {
 } from "@elizaos/core";
 import { isElizaCloudServiceSelectedInConfig } from "../contracts/cloud-topology.js";
 import { getCloudSecret } from "./cloud-secrets.js";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "./dev-cloud-env-authority.js";
 
 type ConfigLike = Record<string, unknown> & {
   cloud?: {
@@ -73,7 +77,15 @@ function normalizeSecretEnvValue(value: string | undefined): string | null {
 function resolveCloudApiKey(
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
-  const envKey = normalizeSecretEnvValue(env.ELIZAOS_CLOUD_API_KEY);
+  const devCloudAuthority = resolveDevCloudEnvAuthority(env);
+  const envKey = normalizeSecretEnvValue(
+    devCloudAuthority
+      ? resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY", env)
+      : env.ELIZAOS_CLOUD_API_KEY,
+  );
+  if (devCloudAuthority) {
+    return envKey;
+  }
   if (envKey) {
     return envKey;
   }
@@ -139,22 +151,33 @@ export function resolveElevenLabsApiKeyForCloudMode(
   if (directKey) {
     return directKey;
   }
+  const devCloudEnvIsAuthoritative = Boolean(resolveDevCloudEnvAuthority(env));
+  const cloudTtsSelection = devCloudEnvIsAuthoritative
+    ? resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_USE_TTS", env)
+    : env.ELIZAOS_CLOUD_USE_TTS;
   let configWantsCloudTts = false;
-  try {
-    configWantsCloudTts = isElizaCloudServiceSelectedInConfig(
-      loadElizaConfig() as Record<string, unknown>,
-      "tts",
-    );
-  } catch {
-    configWantsCloudTts = false;
+  if (!devCloudEnvIsAuthoritative) {
+    try {
+      configWantsCloudTts = isElizaCloudServiceSelectedInConfig(
+        loadElizaConfig() as Record<string, unknown>,
+        "tts",
+      );
+    } catch {
+      configWantsCloudTts = false;
+    }
   }
   const cloudTtsEnabled =
-    env.ELIZAOS_CLOUD_USE_TTS === "true" ||
-    (env.ELIZAOS_CLOUD_USE_TTS === undefined && configWantsCloudTts);
+    cloudTtsSelection === "true" ||
+    (!devCloudEnvIsAuthoritative &&
+      cloudTtsSelection === undefined &&
+      configWantsCloudTts);
   if (!cloudTtsEnabled) {
     return null;
   }
-  if (env.ELIZA_CLOUD_TTS_DISABLED === "true") {
+  const cloudTtsDisabled = devCloudEnvIsAuthoritative
+    ? resolveDevCloudAuthorityEnvValue("ELIZA_CLOUD_TTS_DISABLED", env)
+    : env.ELIZA_CLOUD_TTS_DISABLED;
+  if (cloudTtsDisabled === "true") {
     return null;
   }
   return resolveCloudApiKey(env);
@@ -178,9 +201,16 @@ export function ensureCloudTtsApiKeyAlias(
 export function resolveCloudTtsBaseUrl(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  const fromEnv = env.ELIZAOS_CLOUD_BASE_URL?.trim() ?? "";
+  const devCloudEnvIsAuthoritative = Boolean(resolveDevCloudEnvAuthority(env));
+  const fromEnv =
+    (devCloudEnvIsAuthoritative
+      ? resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL", env)
+      : env.ELIZAOS_CLOUD_BASE_URL
+    )?.trim() ?? "";
   const fromConfig =
-    fromEnv.length > 0 ? null : resolveCloudBaseUrlFromConfig();
+    fromEnv.length > 0 || devCloudEnvIsAuthoritative
+      ? null
+      : resolveCloudBaseUrlFromConfig();
   const configured = fromEnv.length > 0 ? fromEnv : (fromConfig?.trim() ?? "");
   const fallback = "https://api.eliza.app/api/v1";
   const base = configured.length > 0 ? configured : fallback;

--- a/packages/shared/src/local-inference/hf-proxy.test.ts
+++ b/packages/shared/src/local-inference/hf-proxy.test.ts
@@ -7,7 +7,11 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config.js";
-import { _resetCloudSecretsForTesting } from "../elizacloud/cloud-secrets.js";
+import {
+  _resetCloudSecretsForTesting,
+  scrubCloudSecretsFromEnv,
+} from "../elizacloud/cloud-secrets.js";
+import { resetDevCloudEnvAuthorityForTests } from "../elizacloud/dev-cloud-env-authority.js";
 import { ELIZA_DOMAIN_CONTRACTS } from "../elizacloud/domain-contract.js";
 import { resolveHfDownloadBase, resolveHfDownloadBases } from "./hf-proxy.js";
 
@@ -32,6 +36,8 @@ describe("resolveHfDownloadBase", () => {
   const savedConfig = getBootConfig();
   const savedEnv = {
     ACME_CLOUD_BASE_URL: process.env.ACME_CLOUD_BASE_URL,
+    ELIZA_DEV_CLOUD_ENV_AUTHORITY: process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY,
+    ELIZA_DEV_SOURCE: process.env.ELIZA_DEV_SOURCE,
     ELIZA_HF_BASE_URL: process.env.ELIZA_HF_BASE_URL,
     ELIZA_HF_BASE_URLS: process.env.ELIZA_HF_BASE_URLS,
     ELIZAOS_CLOUD_API_KEY: process.env.ELIZAOS_CLOUD_API_KEY,
@@ -39,9 +45,12 @@ describe("resolveHfDownloadBase", () => {
   };
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     _resetCloudSecretsForTesting();
     delete process.env.ELIZA_HF_BASE_URL;
     delete process.env.ELIZA_HF_BASE_URLS;
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+    delete process.env.ELIZA_DEV_SOURCE;
     delete process.env.ELIZAOS_CLOUD_API_KEY;
     delete process.env.ELIZAOS_CLOUD_BASE_URL;
     delete process.env.ACME_CLOUD_BASE_URL;
@@ -49,6 +58,7 @@ describe("resolveHfDownloadBase", () => {
   });
 
   afterEach(() => {
+    resetDevCloudEnvAuthorityForTests();
     _resetCloudSecretsForTesting();
     for (const [key, value] of Object.entries(savedEnv)) {
       if (value === undefined) delete process.env[key];
@@ -72,6 +82,34 @@ describe("resolveHfDownloadBase", () => {
     expect(resolveHfDownloadBase()).toEqual({
       base: CLOUD_HF_PROXY_BASE,
       authHeader: { authorization: "Bearer key-123" },
+      viaCloud: true,
+      label: "cloud",
+    });
+  });
+
+  it.each(["staging-default", "offline"])(
+    "does not route through Cloud with a sealed production key under %s authority",
+    (authority) => {
+      process.env.ELIZAOS_CLOUD_API_KEY = "sealed-production-key";
+      scrubCloudSecretsFromEnv();
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+
+      expect(resolveHfDownloadBases()).toEqual([
+        { base: "https://huggingface.co", viaCloud: false, label: "direct" },
+      ]);
+    },
+  );
+
+  it("uses the canonical launcher key for explicit staging", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://api-staging.eliza.app/api/v1/hf-proxy",
+      authHeader: { authorization: "Bearer staging-key" },
       viaCloud: true,
       label: "cloud",
     });

--- a/packages/shared/src/local-inference/hf-proxy.ts
+++ b/packages/shared/src/local-inference/hf-proxy.ts
@@ -20,6 +20,10 @@
 
 import { resolveCloudApiBaseUrl } from "../elizacloud/base-url.js";
 import { getCloudSecret } from "../elizacloud/cloud-secrets.js";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "../elizacloud/dev-cloud-env-authority.js";
 
 const DEFAULT_HF_HOST = "https://huggingface.co";
 
@@ -56,8 +60,13 @@ function parseMirrorBases(): string[] {
   return [...new Set(list)];
 }
 
-/** Read the Eliza Cloud API key from the sealed store (falls back to env). */
+/** Use launcher env under dev authority; otherwise use sealed/env compatibility. */
 function cloudApiKey(): string {
+  if (resolveDevCloudEnvAuthority()) {
+    return (
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")?.trim() ?? ""
+    );
+  }
   return getCloudSecret("ELIZAOS_CLOUD_API_KEY")?.trim() ?? "";
 }
 

--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -11,6 +11,7 @@ import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "./config/boot-config.js";
+import { resetDevCloudEnvAuthorityForTests } from "./elizacloud/dev-cloud-env-authority.js";
 import {
   isLoopbackRemoteAddress,
   isRemoteAddressInCidrList,
@@ -52,6 +53,9 @@ const TRUST_ENV_KEYS = [
   "ELIZA_REQUIRE_LOCAL_AUTH",
   "ELIZA_DEV_AUTH_BYPASS",
   "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_DEV_SOURCE",
   "STEWARD_AGENT_TOKEN",
   "ELIZA_API_TOKEN",
   "ELIZAOS_CLOUD_ENABLED",
@@ -61,6 +65,7 @@ const TRUST_ENV_KEYS = [
 
 function clearTrustEnv() {
   for (const key of TRUST_ENV_KEYS) delete process.env[key];
+  resetDevCloudEnvAuthorityForTests();
 }
 
 describe("isLoopbackRemoteAddress", () => {
@@ -504,6 +509,32 @@ describe("isTrustedLocalRequest — agent policy gates (cloudCheck=container, no
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     process.env.ELIZAOS_CLOUD_ENABLED = "true";
     process.env.ELIZAOS_CLOUD_API_KEY = "cloud-key";
+    expect(isTrustedLocalRequest(localReq(), AGENT_OPTIONS)).toBe(false);
+  });
+
+  it("cloudCheck=container: staging-default ignores late managed-env pollution", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+
+    expect(isTrustedLocalRequest(localReq(), AGENT_OPTIONS)).toBe(true);
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+
+    expect(isTrustedLocalRequest(localReq(), AGENT_OPTIONS)).toBe(true);
+  });
+
+  it("cloudCheck=container: explicit production stays managed after late env clearing", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_API_TOKEN = "launch-api-token";
+
+    expect(isTrustedLocalRequest(localReq(), AGENT_OPTIONS)).toBe(false);
+
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.ELIZA_API_TOKEN;
+
     expect(isTrustedLocalRequest(localReq(), AGENT_OPTIONS)).toBe(false);
   });
 });

--- a/packages/shared/src/steward-session-client/index.test.ts
+++ b/packages/shared/src/steward-session-client/index.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearStoredStewardToken,
+  configureStoredStewardTokenScope,
   exchangeStewardCode,
   hasStewardAuthedCookie,
   readStoredStewardToken,
@@ -15,6 +16,7 @@ import {
   STEWARD_REFRESH_TOKEN_KEY,
   STEWARD_SESSION_CHANGE_EVENT,
   STEWARD_TOKEN_KEY,
+  STEWARD_TOKEN_SCOPE_KEY,
   type StewardSessionChangeDetail,
   sanitizeTelegramAccountClaimContinuation,
   stewardAuthedCookieName,
@@ -107,6 +109,92 @@ describe("steward session marker cookie", () => {
 describe("Steward session storage transitions", () => {
   afterEach(() => {
     localStorage.clear();
+    const globalSlot = globalThis as Record<PropertyKey, unknown>;
+    delete globalSlot[Symbol.for("elizaos.app.boot-config")];
+    delete globalSlot.__ELIZAOS_APP_BOOT_CONFIG__;
+  });
+
+  function setLocalCloudTarget(cloudApiBase: string): void {
+    configureStoredStewardTokenScope(cloudApiBase);
+  }
+
+  it("quarantines a loopback token after switching Cloud environments", async () => {
+    setLocalCloudTarget("https://api.eliza.app/api/v1");
+    await writeStoredStewardToken("production-token");
+
+    expect(readStoredStewardToken()).toBe("production-token");
+    expect(localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+      "eliza-cloud:production",
+    );
+
+    setLocalCloudTarget("https://api-staging.eliza.app/api/v1");
+
+    expect(readStoredStewardToken()).toBeNull();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("production-token");
+  });
+
+  it("binds a new loopback login to the newly configured environment", async () => {
+    setLocalCloudTarget("https://api.eliza.app");
+    await writeStoredStewardToken("production-token");
+    setLocalCloudTarget("https://cloud-staging.eliza.app");
+
+    await writeStoredStewardToken("staging-token");
+
+    expect(readStoredStewardToken()).toBe("staging-token");
+    expect(localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+      "eliza-cloud:staging",
+    );
+  });
+
+  it("fails closed for a legacy unscoped token on a configured loopback app", () => {
+    setLocalCloudTarget("https://api-staging.eliza.app");
+    localStorage.setItem(STEWARD_TOKEN_KEY, "legacy-production-token");
+
+    expect(readStoredStewardToken()).toBeNull();
+  });
+
+  it("keeps custom loopback targets isolated by exact origin", async () => {
+    setLocalCloudTarget("http://127.0.0.1:8787/api/v1");
+    await writeStoredStewardToken("self-hosted-token");
+    expect(readStoredStewardToken()).toBe("self-hosted-token");
+
+    setLocalCloudTarget("http://127.0.0.1:8788/api/v1");
+    expect(readStoredStewardToken()).toBeNull();
+  });
+
+  it("does not publish a new scope before protected persistence succeeds", async () => {
+    setLocalCloudTarget("https://api.eliza.app");
+    await writeStoredStewardToken("production-token");
+    setLocalCloudTarget("https://api-staging.eliza.app");
+    let rejectPersistence: (error: Error) => void = () => {};
+    const pendingPersistence = new Promise<void>((_resolve, reject) => {
+      rejectPersistence = reject;
+    });
+    const unregister = registerStewardTokenPersistence(async (token) => {
+      await pendingPersistence;
+      window.localStorage.setItem(STEWARD_TOKEN_KEY, token);
+    });
+
+    try {
+      const write = writeStoredStewardToken("staging-token");
+      await Promise.resolve();
+      expect(readStoredStewardToken()).toBeNull();
+      expect(localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+        "eliza-cloud:production",
+      );
+
+      rejectPersistence(new Error("protected write rejected"));
+      await expect(write).rejects.toMatchObject({
+        name: "StewardTokenPersistenceError",
+      });
+
+      expect(readStoredStewardToken()).toBeNull();
+      expect(localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+        "eliza-cloud:production",
+      );
+    } finally {
+      unregister();
+    }
   });
 
   it("publishes ordered typed transitions after canonical writes and clears", async () => {

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -12,12 +12,25 @@
  * Browser-only helpers return cleanly under SSR (`typeof window === "undefined"`).
  */
 
+import { classifyElizaHostname } from "../elizacloud/domain-contract.js";
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 /** localStorage key for the Steward access token (JWT). */
 export const STEWARD_TOKEN_KEY = "steward_session_token";
+
+/**
+ * Deployment scope paired with the Steward access token on a loopback-rendered
+ * app. Hosted Cloud origins already isolate localStorage by origin; localhost
+ * does not, so this companion key prevents a token minted for one configured
+ * control plane from crossing into another after a local target switch.
+ */
+export const STEWARD_TOKEN_SCOPE_KEY = "steward_session_token_scope";
+
+/** Current loopback app target, stored separately from the token's mint scope. */
+export const STEWARD_ACTIVE_SCOPE_KEY = "steward_session_active_scope";
 
 /** Typed browser event emitted after a canonical Steward token mutation. */
 export const STEWARD_SESSION_CHANGE_EVENT = "steward-session-change";
@@ -307,21 +320,94 @@ export interface ClearOpts {
 // localStorage helpers
 // ---------------------------------------------------------------------------
 
+function isLoopbackRenderedApp(): boolean {
+  if (typeof window === "undefined") return false;
+  const protocol = window.location?.protocol?.toLowerCase() ?? "";
+  if (protocol !== "http:" && protocol !== "https:") return false;
+  const hostname = window.location?.hostname?.toLowerCase() ?? "";
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]" ||
+    hostname.startsWith("127.")
+  );
+}
+
+function stewardScopeForBase(configuredBase: string): string | null {
+  try {
+    const parsed = new URL(configuredBase);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    const classified = classifyElizaHostname(parsed.hostname);
+    if (classified.environment) {
+      return `eliza-cloud:${classified.environment}`;
+    }
+    return `origin:${parsed.origin}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bind this loopback page to its launcher-selected Cloud control plane before
+ * any auth reads. Hosted pages need no marker because browser origins already
+ * isolate their storage. Invalid local targets publish a fail-closed sentinel.
+ */
+export function configureStoredStewardTokenScope(
+  configuredBase: string | null | undefined,
+): void {
+  if (!isLoopbackRenderedApp()) return;
+  const scope = configuredBase?.trim()
+    ? stewardScopeForBase(configuredBase.trim())
+    : null;
+  window.localStorage.setItem(
+    STEWARD_ACTIVE_SCOPE_KEY,
+    scope ?? "invalid:unconfigured-cloud-target",
+  );
+}
+
+function configuredLoopbackStewardScope(): string | null {
+  if (!isLoopbackRenderedApp()) return null;
+  return window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY);
+}
+
 /**
  * Reads the canonical access token. Returns `null` for SSR or a missing token;
  * storage access failures propagate so callers cannot mistake them for logout.
  */
 export function readStoredStewardToken(): string | null {
   if (typeof window === "undefined") return null;
-  return window.localStorage.getItem(STEWARD_TOKEN_KEY);
+  const token = window.localStorage.getItem(STEWARD_TOKEN_KEY);
+  if (!token) return null;
+  const requiredScope = configuredLoopbackStewardScope();
+  if (!requiredScope) return token;
+  return window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY) === requiredScope
+    ? token
+    : null;
 }
 
-async function persistStoredStewardToken(token: string): Promise<void> {
+async function persistStoredStewardToken(
+  token: string,
+  requiredScope: string | null,
+): Promise<void> {
   try {
     if (stewardTokenPersistence) {
       await stewardTokenPersistence(token);
     } else {
       window.localStorage.setItem(STEWARD_TOKEN_KEY, token);
+    }
+    // Publish the scope only after the new token is durable. During an awaited
+    // protected-store write, the previous scope therefore keeps both the old
+    // token and any early secure-store mirror of the new token quarantined.
+    // If this write fails, the previous scope remains intact and the newly
+    // persisted token stays unreadable rather than inheriting false authority.
+    if (
+      requiredScope &&
+      window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY) !== requiredScope
+    ) {
+      window.localStorage.setItem(STEWARD_TOKEN_SCOPE_KEY, requiredScope);
     }
   } catch (error) {
     // error-policy:J2 callers must not publish authenticated state after a
@@ -338,9 +424,13 @@ async function persistStoredStewardToken(token: string): Promise<void> {
 export async function writeStoredStewardToken(token: string): Promise<void> {
   if (typeof window === "undefined") return;
   await serializeStewardTokenMutation(async () => {
-    const wasCurrent = window.localStorage.getItem(STEWARD_TOKEN_KEY) === token;
+    const requiredScope = configuredLoopbackStewardScope();
+    const wasCurrent =
+      window.localStorage.getItem(STEWARD_TOKEN_KEY) === token &&
+      (!requiredScope ||
+        window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY) === requiredScope);
     if (!stewardTokenPersistence && wasCurrent) return;
-    await persistStoredStewardToken(token);
+    await persistStoredStewardToken(token, requiredScope);
     if (!wasCurrent) dispatchStewardSessionChange("present");
   });
 }
@@ -356,9 +446,9 @@ export async function replaceStoredStewardTokenIfCurrent(
 ): Promise<boolean> {
   if (typeof window === "undefined") return false;
   return serializeStewardTokenMutation(async () => {
-    const current = window.localStorage.getItem(STEWARD_TOKEN_KEY);
+    const current = readStoredStewardToken();
     if (current !== expectedToken) return false;
-    await persistStoredStewardToken(token);
+    await persistStoredStewardToken(token, configuredLoopbackStewardScope());
     if (current !== token) dispatchStewardSessionChange("present");
     return true;
   });
@@ -384,6 +474,7 @@ export async function clearStoredStewardToken(): Promise<void> {
       throw new StewardTokenRemovalError(error);
     }
     dispatchStewardSessionChange("cleared");
+    window.localStorage.removeItem(STEWARD_TOKEN_SCOPE_KEY);
     window.localStorage.removeItem(STEWARD_REFRESH_TOKEN_KEY);
   });
 }

--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -161,7 +161,10 @@ describe("ElizaClient direct Cloud auth served from a cloud web host", () => {
       "session-1",
     );
 
-    expect(fetchSpy).toHaveBeenCalledWith("/api/auth/cli-session/session-1");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/auth/cli-session/session-1",
+      {},
+    );
     expect(result).toEqual({
       status: "authenticated",
       organizationId: "org-1",
@@ -276,6 +279,7 @@ describe("ElizaClient direct Cloud auth served from localhost dev (port-shift)",
 
     expect(fetchSpy).toHaveBeenCalledWith(
       `${STAGING_DIRECT_CLOUD_API_BASE_URL}/api/auth/cli-session/session-1`,
+      {},
     );
     expect(result).toEqual({
       status: "authenticated",

--- a/packages/ui/src/api/ios-local-agent-kernel.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.test.ts
@@ -3,11 +3,12 @@
  * Request/Response, no real device.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_DIRECT_CLOUD_API_BASE_URL } from "./direct-cloud-endpoints";
+import { STAGING_DIRECT_CLOUD_API_BASE_URL } from "./direct-cloud-endpoints";
 import {
   CLOUD_BRIDGE_REQUEST_TIMEOUT_MS,
   handleIosLocalAgentRequest,
   IOS_BUNDLE_MANIFEST_TIMEOUT_MS,
+  resolveIosLocalCloudApiBase,
 } from "./ios-local-agent-kernel";
 
 async function getJson(pathname: string): Promise<unknown> {
@@ -64,6 +65,15 @@ describe("handleIosLocalAgentRequest", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("resolves the iOS bridge from the staging boot target", () => {
+    expect(
+      resolveIosLocalCloudApiBase("eliza-local-agent://ipc", {
+        bootCloudApiBase: "https://api-staging.eliza.app/api/v1",
+        pageHostname: "localhost",
+      }),
+    ).toBe(STAGING_DIRECT_CLOUD_API_BASE_URL);
   });
 
   it("matches app catalog response contracts", async () => {
@@ -144,7 +154,7 @@ describe("handleIosLocalAgentRequest", () => {
         id: "cloud:agent-1",
         kind: "cloud",
         label: "Cloud Agent",
-        apiBase: "eliza-local-agent://ipc",
+        apiBase: "https://api-staging.eliza.app/api/v1/eliza/agents/agent-1",
         accessToken: "cloud-token",
       }),
     );
@@ -184,7 +194,7 @@ describe("handleIosLocalAgentRequest", () => {
       modelId: "cloud-model",
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      `${DEFAULT_DIRECT_CLOUD_API_BASE_URL}/api/v1/eliza/agents/agent-1/bridge`,
+      `${STAGING_DIRECT_CLOUD_API_BASE_URL}/api/v1/eliza/agents/agent-1/bridge`,
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -54,7 +54,9 @@ import type {
 } from "../services/local-inference/types";
 import { AGENT_MODEL_SLOTS } from "../services/local-inference/types";
 import { runAsPrivilegedShell } from "../surface-realm-channel";
+import { resolveCloudEnvironmentBase } from "../utils/cloud-agent-base";
 import type { MemoryBrowseItem } from "./client-types-chat";
+import { resolveDirectCloudAuthApiBase } from "./direct-cloud-endpoints";
 import {
   buildMobileLoadOptions,
   fallbackMobileTotalRamGb,
@@ -77,7 +79,7 @@ const BUNDLE_INDEX_KEY = `${STORAGE_PREFIX}:eliza-1-bundles:v1`;
 const ACTIVE_SERVER_STORAGE_KEY = "elizaos:active-server";
 const AGENT_NAME = "Eliza";
 const IOS_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
-const DIRECT_CLOUD_API_BASE = "https://api.eliza.app";
+const DEFAULT_DIRECT_CLOUD_SITE_BASE = "https://eliza.app";
 const DEFAULT_SYSTEM_PROMPT =
   "You are Eliza, a private on-device assistant. Answer directly and concisely.";
 const DEFAULT_CLOUD_MARKET_PREVIEW_BASE_URL = "https://eliza.app";
@@ -375,18 +377,46 @@ function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+/** Keep the in-renderer Cloud bridge on the boot/persisted Cloud environment. */
+export function resolveIosLocalCloudApiBase(
+  activeApiBase?: string | null,
+  options: {
+    bootCloudApiBase?: string | null;
+    pageHostname?: string | null;
+  } = {},
+): string {
+  const pageHostname =
+    options.pageHostname ??
+    (typeof window !== "undefined"
+      ? ((window as Window & { location?: Location }).location?.hostname ?? "")
+      : "");
+  const bootCloudApiBase =
+    options.bootCloudApiBase ?? getBootConfig().cloudApiBase;
+  return resolveDirectCloudAuthApiBase(
+    resolveCloudEnvironmentBase({
+      pageHostname,
+      apiBase: activeApiBase,
+      bootCloudApiBase,
+      fallback: DEFAULT_DIRECT_CLOUD_SITE_BASE,
+    }),
+  );
+}
+
 function readIosCloudPairing(): IosCloudPairing {
-  const fallback: IosCloudPairing = {
-    paired: false,
-    agentId: null,
-    token: null,
-    apiBase: DIRECT_CLOUD_API_BASE,
-    label: null,
-  };
   const activeServer = readJson<Record<string, unknown> | null>(
     ACTIVE_SERVER_STORAGE_KEY,
     null,
   );
+  const apiBase = resolveIosLocalCloudApiBase(
+    stringValue(activeServer?.apiBase),
+  );
+  const fallback: IosCloudPairing = {
+    paired: false,
+    agentId: null,
+    token: null,
+    apiBase,
+    label: null,
+  };
   if (activeServer?.kind !== "cloud") {
     return fallback;
   }
@@ -401,7 +431,7 @@ function readIosCloudPairing(): IosCloudPairing {
     paired: Boolean(agentId && token),
     agentId,
     token,
-    apiBase: DIRECT_CLOUD_API_BASE,
+    apiBase,
     label,
   };
 }

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -6,7 +6,6 @@
 import {
   clearStoredStewardToken,
   readStoredStewardToken,
-  STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
 import { DiscordIcon, GoogleIcon, StewardLogin, useAuth } from "@stwd/react";
 import type { StewardProviders } from "@stwd/sdk";
@@ -199,9 +198,7 @@ function parseMobileAuthorizeRequest(
 function readPlaywrightTestToken(): string {
   if (typeof window === "undefined") return "playwright-test-token";
   try {
-    return (
-      window.localStorage.getItem(STEWARD_TOKEN_KEY) ?? "playwright-test-token"
-    );
+    return readStoredStewardToken() ?? "playwright-test-token";
   } catch {
     return "playwright-test-token";
   }

--- a/packages/ui/src/cloud/join/lib/use-join-session.ts
+++ b/packages/ui/src/cloud/join/lib/use-join-session.ts
@@ -9,7 +9,7 @@
  * only what it needs: `{ ready, authenticated }`.
  */
 
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
 import { decodeJwtPayload } from "../../lib/jwt";
 import { LocalStewardAuthContext } from "../../shell/StewardProvider";
@@ -37,7 +37,7 @@ function tokenIsLive(token: string): boolean {
 function readStoredAuthenticated(): boolean {
   if (typeof window === "undefined") return false;
   try {
-    const token = window.localStorage.getItem(STEWARD_TOKEN_KEY);
+    const token = readStoredStewardToken();
     return token ? tokenIsLive(token) : false;
   } catch {
     // error-policy:J3 storage unavailable reads as unauthenticated

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -34,8 +34,10 @@ vi.mock("../../api/desktop-http-transport", () => ({
 }));
 
 import {
+  configureStoredStewardTokenScope,
   STEWARD_SESSION_CHANGE_EVENT,
   STEWARD_TOKEN_KEY,
+  STEWARD_TOKEN_SCOPE_KEY,
   type StewardSessionChangeDetail,
 } from "@elizaos/shared/steward-session-client";
 import { setBootConfig } from "../../config/boot-config";
@@ -84,12 +86,20 @@ async function expectCrossOriginThrow(
 
 describe("cloud api-client transport bridge", () => {
   beforeEach(() => {
-    setBootConfig({ branding: {}, cloudApiBase: "https://www.elizacloud.ai" });
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://www.elizacloud.ai",
+    });
+    configureStoredStewardTokenScope("https://www.elizacloud.ai");
     capacitorState.isNative = false;
     setElectrobun(false);
     capacitorMocks.request.mockReset();
     desktopTransportMocks.request.mockReset();
     window.localStorage.setItem(STEWARD_TOKEN_KEY, STEWARD_TOKEN);
+    window.localStorage.setItem(
+      STEWARD_TOKEN_SCOPE_KEY,
+      "eliza-cloud:production",
+    );
     setCookie("eliza_csrf=cloud-dashboard-csrf; path=/");
   });
 
@@ -145,6 +155,30 @@ describe("cloud api-client transport bridge", () => {
       expect(
         new Headers((calledInit as RequestInit).headers).get("x-eliza-csrf"),
       ).toBeNull();
+    });
+
+    it("never sends a token from the previous localhost Cloud target", async () => {
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://api-staging.eliza.app",
+      });
+      configureStoredStewardTokenScope("https://api-staging.eliza.app");
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ apps: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await api("/api/v1/apps");
+
+      const [, calledInit] = fetchSpy.mock.calls[0];
+      expect(
+        new Headers((calledInit as RequestInit).headers).get("Authorization"),
+      ).toBeNull();
+      expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+        STEWARD_TOKEN,
+      );
     });
   });
 

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -31,7 +31,6 @@ import { getElizaApiToken } from "@elizaos/shared";
 import {
   clearStoredStewardToken,
   readStoredStewardToken,
-  STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
 import { readCsrfTokenFromCookie } from "../../api/auth/csrf-cookie";
 import { CSRF_HEADER_NAME } from "../../api/auth/sessions";
@@ -150,7 +149,7 @@ function resolveApiUrl(path: string): string {
 function readStewardToken(): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return window.localStorage.getItem(STEWARD_TOKEN_KEY);
+    return readStoredStewardToken();
   } catch {
     // error-policy:J3 storage unavailable reads as signed-out (fail-closed).
     return null;

--- a/packages/ui/src/cloud/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/lib/use-session-auth.ts
@@ -15,7 +15,7 @@
 
 import { Capacitor } from "@capacitor/core";
 import { getElizaApiToken } from "@elizaos/shared";
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { getBootConfig } from "../../config/boot-config";
@@ -130,7 +130,7 @@ function decodeStewardToken(token: string): {
 function readStewardSessionFromStorage(): StewardSessionUser {
   if (typeof window === "undefined") return null;
   try {
-    const token = localStorage.getItem(STEWARD_TOKEN_KEY);
+    const token = readStoredStewardToken();
     if (!token) return null;
     const decoded = decodeStewardToken(token);
     if (!decoded?.id) return null;

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -4,9 +4,9 @@
  */
 import {
   clearStoredStewardToken,
+  readStoredStewardToken,
   STEWARD_REFRESH_ENDPOINT,
   STEWARD_SESSION_ENDPOINT,
-  STEWARD_TOKEN_KEY,
   StewardTokenRemovalError,
 } from "@elizaos/shared/steward-session-client";
 import { createContext } from "react";
@@ -139,7 +139,7 @@ export function clearServerStewardSessionCookies(): void {
 export function readStoredToken(): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return localStorage.getItem(STEWARD_TOKEN_KEY);
+    return readStoredStewardToken();
   } catch {
     // error-policy:J3 storage unavailable reads as signed-out (fail-closed).
     return null;

--- a/packages/ui/src/first-run/first-run-runtime-flag.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.ts
@@ -3,8 +3,8 @@
  *
  * The product onboards through Eliza Cloud only by default in production
  * (#13377/#15527): the chooser is OFF unless a developer/test build explicitly
- * enables it. In Vite dev mode (`bun run dev`), the chooser defaults to ON so
- * developers see the full local/cloud/remote options without manual flag-wiring.
+ * enables it. The `bun run dev:local` Vite lane supplies that opt-in so
+ * developers can still reach the full local/cloud/remote options.
  * The Play-Store cloud-locked Android variant can never enable the chooser
  * because that build must not expose a local backend regardless of developer
  * overrides. The local and remote paths stay in-tree for development: a
@@ -46,11 +46,11 @@ function readEnv(): Record<string, unknown> {
 }
 
 /**
- * True only when running under the Vite dev server (`bun run dev`). The
- * runtime chooser defaults to ON in this mode so developers can pick
- * local/cloud/remote without setting the localStorage override or the
- * VITE_ELIZA_ENABLE_RUNTIME_CHOOSER flag. Production builds compile
- * `import.meta.env.DEV` to `false`, so this is a no-op in shipped bundles.
+ * True only when running under a Vite development server. A non-cloud Vite
+ * lane may use this development default for the local/cloud/remote chooser;
+ * the ordinary Cloud-first lane remains disabled by `isCloudOnlyBuild` above.
+ * Production builds compile `import.meta.env.DEV` to `false`, so this is a
+ * no-op in shipped bundles.
  */
 function readDevMode(): boolean {
   const env = readEnv();
@@ -93,11 +93,11 @@ export function resolveRuntimeChooserEnabled({
  * Whether onboarding offers the full runtime chooser (cloud / local / remote).
  * False (the default on production builds) means cloud-only onboarding:
  * sign in to Eliza Cloud is the one and only path, and completing it completes
- * first-run. In Vite dev mode (`bun run dev`) the chooser defaults to ON so
- * developers can choose local without manual configuration. Production and
- * test builds opt into the local/remote chooser via the Vite flag or the
- * localStorage override; Android local sideloads no longer special-case the
- * production default.
+ * first-run. The explicit `bun run dev:local` lane opts into the chooser so
+ * developers can choose local without changing the Cloud-first default.
+ * Production and test builds opt in via the Vite flag or the localStorage
+ * override; Android local sideloads no longer special-case the production
+ * default.
  */
 export function isRuntimeChooserEnabled(isCloudOnlyBuild = false): boolean {
   return resolveRuntimeChooserEnabled({

--- a/packages/ui/src/state/cloud-login-launch.test.ts
+++ b/packages/ui/src/state/cloud-login-launch.test.ts
@@ -184,14 +184,15 @@ describe("shouldUseSameTabCloudLogin", () => {
     expect(shouldUseSameTabCloudLogin(makePopup(false))).toBe(false);
   });
 
-  it("always uses local /login on loopback staging, even with a live popup and agent proxy", () => {
+  it("never uses local /login on loopback staging", () => {
     stubHostname("localhost", "http:");
     vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
     vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
 
     expect(
       shouldUseSameTabCloudLogin(makePopup(false), { hasAgentProxy: true }),
-    ).toBe(true);
+    ).toBe(false);
+    expect(shouldUseSameTabCloudLogin(null)).toBe(false);
   });
 
   it("keeps explicit production loopback on agent-proxied device-code auth", () => {
@@ -318,8 +319,20 @@ describe("preOpenCloudLoginWindow", () => {
     expect(openSpy).toHaveBeenCalledWith("about:blank", CLOUD_LOGIN_POPUP_NAME);
   });
 
-  it("skips popup pre-open on configured loopback development", () => {
+  it("pre-opens hosted staging auth on non-touch loopback development", () => {
     stubHostname("127.0.0.1", "http:");
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+    const popup = makePopup(false);
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup);
+
+    expect(preOpenCloudLoginWindow()).toBe(popup);
+    expect(openSpy).toHaveBeenCalledWith("about:blank", CLOUD_LOGIN_POPUP_NAME);
+  });
+
+  it("keeps touch-primary loopback staging in one tab for the hosted CLI return", () => {
+    stubHostname("127.0.0.1", "http:");
+    stubMatchMedia(true);
     vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
     vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
     const openSpy = vi.spyOn(window, "open");

--- a/packages/ui/src/state/cloud-login-launch.test.ts
+++ b/packages/ui/src/state/cloud-login-launch.test.ts
@@ -91,6 +91,7 @@ afterEach(() => {
   // never leak into (or be closed by) the next test's claim.
   void takeClaimedCloudLoginWindow();
   __resetPreparedDesktopCloudLoginSessionForTests();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
   restoreDescriptor("location", originalLocationDescriptor);
   restoreDescriptor("matchMedia", originalMatchMediaDescriptor);
@@ -183,6 +184,39 @@ describe("shouldUseSameTabCloudLogin", () => {
     expect(shouldUseSameTabCloudLogin(makePopup(false))).toBe(false);
   });
 
+  it("always uses local /login on loopback staging, even with a live popup and agent proxy", () => {
+    stubHostname("localhost", "http:");
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+
+    expect(
+      shouldUseSameTabCloudLogin(makePopup(false), { hasAgentProxy: true }),
+    ).toBe(true);
+  });
+
+  it("keeps explicit production loopback on agent-proxied device-code auth", () => {
+    stubHostname("localhost", "http:");
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud");
+
+    expect(
+      shouldUseSameTabCloudLogin(makePopup(false), { hasAgentProxy: true }),
+    ).toBe(false);
+    expect(shouldUseSameTabCloudLogin(null)).toBe(false);
+  });
+
+  it("keeps hosted and self-hosted agent-proxied flows on device-code auth", () => {
+    expect(shouldUseSameTabCloudLogin(null, { hasAgentProxy: true })).toBe(
+      false,
+    );
+
+    stubHostname("self-hosted.example.test");
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://identity.example.test/steward");
+    expect(shouldUseSameTabCloudLogin(null, { hasAgentProxy: true })).toBe(
+      false,
+    );
+  });
+
   it("prefers same-tab outright on touch-primary browsers even with a live popup", () => {
     stubMatchMedia(true);
     expect(shouldUseSameTabCloudLogin(makePopup(false))).toBe(true);
@@ -212,6 +246,12 @@ describe("hasSameOriginStewardLogin", () => {
   it("is false on unknown origins with no Steward API override", () => {
     stubHostname("localhost");
     expect(hasSameOriginStewardLogin()).toBe(false);
+  });
+
+  it("is true on loopback with an explicit Steward API override", () => {
+    stubHostname("127.0.0.1", "http:");
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    expect(hasSameOriginStewardLogin()).toBe(true);
   });
 });
 
@@ -274,6 +314,28 @@ describe("preOpenCloudLoginWindow", () => {
   it("pre-opens the popup on non-touch web (desktop keeps the popup path)", () => {
     const popup = makePopup(false);
     const openSpy = vi.spyOn(window, "open").mockReturnValue(popup);
+    expect(preOpenCloudLoginWindow()).toBe(popup);
+    expect(openSpy).toHaveBeenCalledWith("about:blank", CLOUD_LOGIN_POPUP_NAME);
+  });
+
+  it("skips popup pre-open on configured loopback development", () => {
+    stubHostname("127.0.0.1", "http:");
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+    const openSpy = vi.spyOn(window, "open");
+
+    expect(preOpenCloudLoginWindow()).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("pre-opens production loopback auth for the device-code flow", () => {
+    stubHostname("127.0.0.1", "http:");
+    stubMatchMedia(true);
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud");
+    const popup = makePopup(false);
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup);
+
     expect(preOpenCloudLoginWindow()).toBe(popup);
     expect(openSpy).toHaveBeenCalledWith("about:blank", CLOUD_LOGIN_POPUP_NAME);
   });

--- a/packages/ui/src/state/cloud-login-launch.ts
+++ b/packages/ui/src/state/cloud-login-launch.ts
@@ -11,11 +11,11 @@
  * `/login?returnTo=…` page instead. Touch-primary web browsers skip the popup
  * attempt outright — a capability hint (coarse pointer + no hover), not a
  * user-agent sniff — because even a popup that opens there is a disorienting
- * tab switch. Loopback staging development also stays in the current tab: the
- * local `/login` route is the configured auth surface, even while the local
- * agent API is available. Native (Capacitor) keeps the external Browser plugin,
- * while desktop (Electrobun) keeps the RPC external-open; neither is
- * popup-hostile.
+ * tab switch. Loopback staging uses a hosted CLI session instead of local
+ * `/login`: the staging tenant intentionally rejects localhost OAuth callbacks,
+ * while the hosted flow can safely return its claimed session to localhost.
+ * Native (Capacitor) keeps the external Browser plugin, while desktop
+ * (Electrobun) keeps the RPC external-open; neither is popup-hostile.
  *
  * The same-tab round trip needs no new flow: the `/login` page sanitizes and
  * honors `returnTo` (login-return-to.ts), the Steward token lands in this
@@ -170,12 +170,9 @@ function isLoopbackHostname(hostname: string): boolean {
 }
 
 /**
- * Staging Vite development owns a real `/login` route whose Steward target is
- * injected explicitly. Prefer that route over the legacy agent-proxied
- * device-code handshake; the latter opens a second auth surface and does not
- * return the Steward session to the loopback origin. Keep this exception
- * staging-specific: production rejects loopback CORS and custom/self-hosted
- * agent proxies retain their device-code pairing contract.
+ * Classify an explicitly configured loopback Steward development target.
+ * Staging is special because its OAuth tenant rejects localhost callback URLs;
+ * callers route it through the hosted CLI-session exchange instead.
  */
 function loopbackStewardDevelopmentTarget(): "staging" | "other" | null {
   if (!isPlainWebPlatform()) return null;
@@ -197,6 +194,11 @@ function loopbackStewardDevelopmentTarget(): "staging" | "other" | null {
   }
 }
 
+/** True only for the launcher-stamped localhost → staging Steward target. */
+export function isLoopbackStagingStewardDevelopment(): boolean {
+  return loopbackStewardDevelopmentTarget() === "staging";
+}
+
 /**
  * Capability hint for popup-hostile browsers: a touch-primary device with no
  * hover (phones/tablets in any browser engine). Deliberately not a user-agent
@@ -215,9 +217,9 @@ export function isTouchPrimaryWebBrowser(): boolean {
 /**
  * Whether this page's origin can complete a same-origin Steward `/login` round
  * trip: the hosted elizacloud web hosts (steward-url.ts host map) or any host
- * with an explicit Steward API override. Elsewhere (self-hosted dashboards,
- * localhost dev) the `/login` page may have no reachable Steward API, so the
- * legacy device-code flow with its copyable fallback link stays the degrade.
+ * with an explicit Steward API override. A localhost staging override is
+ * deliberately handled by the hosted CLI-session flow because Steward does
+ * not allow localhost OAuth callbacks.
  */
 export function hasSameOriginStewardLogin(): boolean {
   if (typeof window === "undefined") return false;
@@ -239,7 +241,7 @@ export function preOpenCloudLoginWindow(): Window | null {
   if (isPlainWebPlatform() && hasSameOriginStewardLogin()) {
     const loopbackTarget = loopbackStewardDevelopmentTarget();
     if (
-      loopbackTarget === "staging" ||
+      (loopbackTarget === "staging" && isTouchPrimaryWebBrowser()) ||
       (loopbackTarget === null && isTouchPrimaryWebBrowser())
     ) {
       return null;
@@ -300,9 +302,9 @@ export function releaseClaimedCloudLoginWindow(): void {
  * `/login` page instead of driving the popup device-code flow. True on plain
  * web with a same-origin Steward login when the popup handle is dead (blocked
  * at pre-open — the browser-agnostic runtime signal — or never attempted) or
- * when the touch-primary hint prefers same-tab outright. Loopback staging
- * development always uses the local login route, even when an agent proxy and
- * a live popup are both available.
+ * when the touch-primary hint prefers same-tab outright. Loopback development
+ * never uses local `/login`: staging uses a hosted CLI session and other
+ * targets retain their agent-proxied pairing contract.
  */
 export function shouldUseSameTabCloudLogin(
   prePoppedWindow: Window | null,
@@ -311,7 +313,7 @@ export function shouldUseSameTabCloudLogin(
   if (!isPlainWebPlatform()) return false;
   if (!hasSameOriginStewardLogin()) return false;
   const loopbackTarget = loopbackStewardDevelopmentTarget();
-  if (loopbackTarget !== null) return loopbackTarget === "staging";
+  if (loopbackTarget !== null) return false;
   if (options.hasAgentProxy) return false;
   if (isTouchPrimaryWebBrowser()) return true;
   return !prePoppedWindow || prePoppedWindow.closed;

--- a/packages/ui/src/state/cloud-login-launch.ts
+++ b/packages/ui/src/state/cloud-login-launch.ts
@@ -11,8 +11,11 @@
  * `/login?returnTo=…` page instead. Touch-primary web browsers skip the popup
  * attempt outright — a capability hint (coarse pointer + no hover), not a
  * user-agent sniff — because even a popup that opens there is a disorienting
- * tab switch. Native (Capacitor) keeps the external Browser plugin and desktop
- * (Electrobun) keeps the RPC external-open; neither is popup-hostile.
+ * tab switch. Loopback staging development also stays in the current tab: the
+ * local `/login` route is the configured auth surface, even while the local
+ * agent API is available. Native (Capacitor) keeps the external Browser plugin,
+ * while desktop (Electrobun) keeps the RPC external-open; neither is
+ * popup-hostile.
  *
  * The same-tab round trip needs no new flow: the `/login` page sanitizes and
  * honors `returnTo` (login-return-to.ts), the Steward token lands in this
@@ -22,7 +25,10 @@
 
 import { resolveDirectCloudWebBase } from "../api/client-cloud";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
-import { configuredStewardApiUrlOverride } from "../cloud/shell/steward-config";
+import {
+  configuredStewardApiUrlOverride,
+  configuredStewardTenantId,
+} from "../cloud/shell/steward-config";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "../cloud/shell/steward-url";
 import { preOpenWindow } from "../utils/openExternalUrl";
 
@@ -151,6 +157,46 @@ function isPlainWebPlatform(): boolean {
   return true;
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  if (!/^127(?:\.\d{1,3}){3}$/.test(normalized)) return false;
+  return normalized
+    .split(".")
+    .every((octet) => Number.parseInt(octet, 10) <= 255);
+}
+
+/**
+ * Staging Vite development owns a real `/login` route whose Steward target is
+ * injected explicitly. Prefer that route over the legacy agent-proxied
+ * device-code handshake; the latter opens a second auth surface and does not
+ * return the Steward session to the loopback origin. Keep this exception
+ * staging-specific: production rejects loopback CORS and custom/self-hosted
+ * agent proxies retain their device-code pairing contract.
+ */
+function loopbackStewardDevelopmentTarget(): "staging" | "other" | null {
+  if (!isPlainWebPlatform()) return null;
+  if (!isLoopbackHostname(window.location.hostname)) return null;
+
+  const configuredUrl = configuredStewardApiUrlOverride();
+  if (!configuredUrl) return null;
+  try {
+    const parsed = new URL(configuredUrl);
+    const pathname = parsed.pathname.replace(/\/+$/, "");
+    const isStaging =
+      (parsed.hostname.toLowerCase() === "staging.eliza.app" ||
+        parsed.hostname.toLowerCase() === "staging.elizacloud.ai") &&
+      pathname === "/steward" &&
+      configuredStewardTenantId() === "elizacloud-staging";
+    return isStaging ? "staging" : "other";
+  } catch {
+    return "other";
+  }
+}
+
 /**
  * Capability hint for popup-hostile browsers: a touch-primary device with no
  * hover (phones/tablets in any browser engine). Deliberately not a user-agent
@@ -190,12 +236,14 @@ export function preOpenCloudLoginWindow(): Window | null {
   // the app WebView, not the system browser. The eventual login URL goes
   // through desktopOpenExternal instead (see useCloudState).
   if (isElectrobunRuntime()) return null;
-  if (
-    isPlainWebPlatform() &&
-    hasSameOriginStewardLogin() &&
-    isTouchPrimaryWebBrowser()
-  ) {
-    return null;
+  if (isPlainWebPlatform() && hasSameOriginStewardLogin()) {
+    const loopbackTarget = loopbackStewardDevelopmentTarget();
+    if (
+      loopbackTarget === "staging" ||
+      (loopbackTarget === null && isTouchPrimaryWebBrowser())
+    ) {
+      return null;
+    }
   }
   return preOpenWindow(CLOUD_LOGIN_POPUP_NAME);
 }
@@ -252,13 +300,19 @@ export function releaseClaimedCloudLoginWindow(): void {
  * `/login` page instead of driving the popup device-code flow. True on plain
  * web with a same-origin Steward login when the popup handle is dead (blocked
  * at pre-open — the browser-agnostic runtime signal — or never attempted) or
- * when the touch-primary hint prefers same-tab outright.
+ * when the touch-primary hint prefers same-tab outright. Loopback staging
+ * development always uses the local login route, even when an agent proxy and
+ * a live popup are both available.
  */
 export function shouldUseSameTabCloudLogin(
   prePoppedWindow: Window | null,
+  options: { hasAgentProxy?: boolean } = {},
 ): boolean {
   if (!isPlainWebPlatform()) return false;
   if (!hasSameOriginStewardLogin()) return false;
+  const loopbackTarget = loopbackStewardDevelopmentTarget();
+  if (loopbackTarget !== null) return loopbackTarget === "staging";
+  if (options.hasAgentProxy) return false;
   if (isTouchPrimaryWebBrowser()) return true;
   return !prePoppedWindow || prePoppedWindow.closed;
 }

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -10,6 +10,7 @@ import {
   isRecoverableRemoteBase,
   isTerminalDedicatedCloudAgentErrorState,
   type PollingBackendDeps,
+  resolveStartupCloudControlPlaneBase,
   runPollingBackend,
   shouldFallBackToLocalOrigin,
 } from "./startup-phase-poll";
@@ -176,6 +177,29 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   (globalThis as { window?: unknown }).window = originalWindow;
+});
+
+describe("resolveStartupCloudControlPlaneBase", () => {
+  it("keeps a staging agent recovery probe off the production control plane", () => {
+    expect(
+      resolveStartupCloudControlPlaneBase(
+        "https://agent-123.cloud-staging.eliza.app",
+        {
+          bootCloudApiBase: "https://api.eliza.app",
+          pageHostname: "localhost",
+        },
+      ),
+    ).toBe("https://api-staging.eliza.app");
+  });
+
+  it("lets an explicit staging boot target override a stale production agent", () => {
+    expect(
+      resolveStartupCloudControlPlaneBase("https://agent-123.cloud.eliza.app", {
+        bootCloudApiBase: "https://api-staging.eliza.app/api/v1",
+        pageHostname: "localhost",
+      }),
+    ).toBe("https://api-staging.eliza.app");
+  });
 });
 
 describe("runPollingBackend", () => {

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -20,6 +20,7 @@ import {
   getCloudAuthToken,
   isDirectCloudSharedAgentBase,
 } from "../api/client-cloud";
+import { resolveDirectCloudAuthApiBase } from "../api/direct-cloud-endpoints";
 import {
   appendIosBootTrace,
   isIosInProcessLocalAgentBase,
@@ -29,6 +30,7 @@ import {
 import { isPasswordAuthTransportConfidential } from "../api/password-auth-transport-policy";
 import { getBackendStartupTimeoutMs } from "../bridge";
 import { resumePendingCloudHandoff } from "../cloud/handoff/resume-pending-handoff";
+import { getBootConfig } from "../config/boot-config";
 import {
   ANDROID_LOCAL_AGENT_SERVER_ID,
   isMobileLocalAgentIpcBase,
@@ -47,7 +49,9 @@ import {
   dedicatedCloudAgentIdFromBase,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
+  isManagedCloudSharedAgentBase,
   isPersonalSharedElizaId,
+  resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
 import { isTerminalDedicatedCloudAgentErrorState as classifyTerminalDedicatedCloudAgentErrorState } from "./dedicated-cloud-agent-error";
 import {
@@ -229,10 +233,30 @@ export function isRecoverableRemoteBase(args: {
   return true;
 }
 
-// Direct elizaCloud control-plane API base, used to verify an agent record when
-// a per-agent base 404s. Mirrors DEFAULT_DIRECT_CLOUD_API_BASE_URL in
-// api/client-cloud.ts and DIRECT_CLOUD_API_BASE in startup-phase-restore.ts.
-const DIRECT_CLOUD_API_BASE = "https://api.eliza.app";
+const DEFAULT_DIRECT_CLOUD_SITE_BASE = "https://eliza.app";
+
+/** Resolve recovery probes onto the same Cloud environment as startup restore. */
+export function resolveStartupCloudControlPlaneBase(
+  agentBase: string,
+  options: {
+    bootCloudApiBase?: string | null;
+    pageHostname?: string | null;
+  } = {},
+): string {
+  const pageHostname =
+    options.pageHostname ??
+    (typeof window !== "undefined" ? window.location.hostname : "");
+  const bootCloudApiBase =
+    options.bootCloudApiBase ?? getBootConfig().cloudApiBase;
+  return resolveDirectCloudAuthApiBase(
+    resolveCloudEnvironmentBase({
+      pageHostname,
+      apiBase: agentBase,
+      bootCloudApiBase,
+      fallback: DEFAULT_DIRECT_CLOUD_SITE_BASE,
+    }),
+  );
+}
 
 function sharedCloudAgentIdFromBase(base: string): string | null {
   try {
@@ -272,7 +296,7 @@ async function dedicatedCloudAgentIsGone(base: string): Promise<boolean> {
   // getCloudCompatAgent resolves the control-plane via the client base, so point
   // the client at the control-plane (the dedicated subdomain is not a direct
   // cloud base and would route the lookup to the dead agent itself).
-  client.setBaseUrl(DIRECT_CLOUD_API_BASE);
+  client.setBaseUrl(resolveStartupCloudControlPlaneBase(base));
   try {
     const res = await client.getCloudCompatAgent(agentId);
     // success:false => the control-plane has no such agent record (deleted). A
@@ -292,6 +316,9 @@ async function dedicatedCloudAgentIsGone(base: string): Promise<boolean> {
 async function sharedCloudAgentIsMissingFromRunningSet(
   base: string,
 ): Promise<boolean> {
+  // A self-hosted server may expose the same path shape. Never forward a
+  // Steward token from that origin to a hosted control plane.
+  if (!isManagedCloudSharedAgentBase(base)) return false;
   const agentId = sharedCloudAgentIdFromBase(base);
   if (!agentId) return false;
   // The signed-in account's personal Eliza is rowless by design: it is served
@@ -304,7 +331,7 @@ async function sharedCloudAgentIsMissingFromRunningSet(
 
   const priorBaseUrl = client.getBaseUrl();
   const priorToken = client.hasToken();
-  client.setBaseUrl(DIRECT_CLOUD_API_BASE);
+  client.setBaseUrl(resolveStartupCloudControlPlaneBase(base));
   try {
     const res = await client.getCloudCompatAgents();
     if (!res.success) return false;

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -10,6 +10,10 @@
 // Real restore module under test; only the network / desktop-bridge
 // boundaries are stubbed.
 
+import {
+  readStoredStewardToken,
+  STEWARD_ACTIVE_SCOPE_KEY,
+} from "@elizaos/shared/steward-session-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_BOOT_CONFIG,
@@ -184,6 +188,8 @@ describe("cloud restore routes the client without waiting on the Steward refresh
   it("preserves a shared adapter with account authority regardless of the create default", async () => {
     const stewardToken = makeJwt(3600);
     localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken);
+    expect(localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBeNull();
+    expect(readStoredStewardToken()).toBe(stewardToken);
     const sharedApiBase = `https://api.eliza.app/api/v1/eliza/agents/${SHARED_AGENT_ID}`;
     const restored: PersistedActiveServer = {
       id: `cloud:${SHARED_AGENT_ID}`,
@@ -218,6 +224,8 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     });
     const stewardToken = makeJwt(3600);
     localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken);
+    expect(localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBeNull();
+    expect(readStoredStewardToken()).toBe(stewardToken);
     const restored: PersistedActiveServer = {
       id: `cloud:${STAGING_AGENT_ID}`,
       kind: "cloud",

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -582,6 +582,9 @@ export async function applyRestoredConnection(args: {
     const isAgentlessControlPlane = isElizaCloudControlPlaneAgentlessBase(
       resolved.apiBase,
     );
+    const isManagedSharedControlPlane = isManagedCloudSharedAgentBase(
+      resolved.apiBase,
+    );
     const initialToken = usesLocalDockerCredential
       ? resolved.accessToken || null
       : isAgentlessControlPlane
@@ -624,11 +627,7 @@ export async function applyRestoredConnection(args: {
     // refresh it BEFORE handing it to the client so a returning user never
     // boots into a permanently-401ing session (see resolveRestoredStewardToken).
     const stewardToken = await stewardTokenPromise;
-    if (
-      isManagedCloudSharedAgentBase(resolved.apiBase) &&
-      !stewardToken &&
-      !nativeOwnerApiKey
-    ) {
+    if (isManagedSharedControlPlane && !stewardToken && !nativeOwnerApiKey) {
       // Terminal refresh failure or a missing account session makes the saved
       // shared target unsafe. Clear every account-scoped mirror before startup
       // can reinstall the provision-time token or poll the previous agent.
@@ -641,11 +640,11 @@ export async function applyRestoredConnection(args: {
     // pre-refresh JWT can be expired, while native/Electrobun restores may
     // intentionally rely on a host-injected Cloud owner key instead.
     const controlPlaneOwnerToken = stewardToken ?? nativeOwnerApiKey;
-    const tierRepairPromise = isDedicatedCloudAgentBase(
-      restoredActiveServer.apiBase,
-    )
-      ? reconcileLegacyDedicatedCloudApiBase(resolved, controlPlaneOwnerToken)
-      : Promise.resolve(null);
+    const tierRepairPromise =
+      !isManagedSharedControlPlane &&
+      isDedicatedCloudAgentBase(restoredActiveServer.apiBase)
+        ? reconcileLegacyDedicatedCloudApiBase(resolved, controlPlaneOwnerToken)
+        : Promise.resolve(null);
     // Dedicated agent subdomains and explicit local-Docker pair targets use an
     // agent-local bearer for `/api/*`. The edge-owned dedicated path can keep
     // its Steward recovery fallback; a loopback process must never receive a
@@ -653,11 +652,16 @@ export async function applyRestoredConnection(args: {
     clientRef.setToken(
       usesLocalDockerCredential
         ? resolved.accessToken || null
-        : isDedicatedCloudAgentBase(resolved.apiBase)
-          ? resolved.accessToken || stewardToken || null
-          : isAgentlessControlPlane
-            ? stewardToken || nativeOwnerApiKey || null
-            : stewardToken || nativeOwnerApiKey || resolved.accessToken || null,
+        : isManagedSharedControlPlane
+          ? stewardToken || nativeOwnerApiKey || null
+          : isDedicatedCloudAgentBase(resolved.apiBase)
+            ? resolved.accessToken || stewardToken || null
+            : isAgentlessControlPlane
+              ? stewardToken || nativeOwnerApiKey || null
+              : stewardToken ||
+                nativeOwnerApiKey ||
+                resolved.accessToken ||
+                null,
     );
     void tierRepairPromise.then((repaired) => {
       if (!repaired || repaired.apiBase === resolved.apiBase) return;

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -95,6 +95,7 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     delete windowWithElectrobun.__ELIZA_DESKTOP_RUNTIME_MODE__;
     delete windowWithElectrobun.__ELIZA_ELECTROBUN_RPC__;
     __resetPreparedDesktopCloudLoginSessionForTests();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
     if (originalLocationDescriptor) {
       Object.defineProperty(window, "location", originalLocationDescriptor);
@@ -153,6 +154,93 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
 
     expect(assignSpy).not.toHaveBeenCalled();
     expect(cloudLoginDirectSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
+  });
+
+  it("uses local /login on configured loopback even when a live popup and local API backend exist", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: "http://127.0.0.1:2189/settings",
+        origin: "http://127.0.0.1:2189",
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        port: "2189",
+        pathname: "/settings",
+        search: "",
+        assign: assignSpy,
+      },
+    });
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+    vi.spyOn(client, "getBaseUrl").mockReturnValue("http://127.0.0.1:31337");
+    const getCloudStatusSpy = vi
+      .spyOn(client, "getCloudStatus")
+      .mockResolvedValue({
+        connected: false,
+        enabled: true,
+      } as Awaited<ReturnType<typeof client.getCloudStatus>>);
+    const popup = {
+      closed: false,
+      close: vi.fn(() => {
+        (popup as { closed: boolean }).closed = true;
+      }),
+      location: { href: "" },
+      opener: {},
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin(popup);
+    });
+
+    expect(getCloudStatusSpy).toHaveBeenCalled();
+    expect(assignSpy).toHaveBeenCalledWith("/login?returnTo=%2Fsettings");
+    expect(popup.close).toHaveBeenCalled();
+    expect(deviceCodeCalls()).toBe(0);
+    expect(result.current.elizaCloudLoginBusy).toBe(false);
+    expect(result.current.elizaCloudLoginError).toBeNull();
+  });
+
+  it("keeps production loopback on the agent-proxied device-code flow", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: "http://127.0.0.1:2189/settings",
+        origin: "http://127.0.0.1:2189",
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        port: "2189",
+        pathname: "/settings",
+        search: "",
+        assign: assignSpy,
+      },
+    });
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud");
+    vi.spyOn(client, "getBaseUrl").mockReturnValue("http://127.0.0.1:31337");
+    vi.spyOn(client, "getCloudStatus").mockResolvedValue({
+      connected: false,
+      enabled: true,
+    } as Awaited<ReturnType<typeof client.getCloudStatus>>);
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: { href: "" },
+      opener: {},
+    } as unknown as Window;
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin(popup);
+    });
+
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(cloudLoginSpy).toHaveBeenCalledTimes(1);
+    expect(cloudLoginDirectSpy).not.toHaveBeenCalled();
     expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
   });
 

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -13,6 +13,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { client } from "../api";
+import { getBootConfig, setBootConfig } from "../config/boot-config";
 import {
   markCloudLoginPending,
   readCloudLoginPending,
@@ -26,6 +27,7 @@ import { registerStewardLoginLauncher } from "./cloud-steward-login";
 import { useCloudState } from "./useCloudState";
 
 const DEVICE_CODE_SENTINEL = "device-code-flow-reached";
+const originalBootConfig = structuredClone(getBootConfig());
 const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
   window,
   "location",
@@ -56,9 +58,12 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
   let cloudLoginSpy: ReturnType<typeof vi.spyOn>;
   let cloudLoginDirectSpy: ReturnType<typeof vi.spyOn>;
   let cloudLoginPollDirectSpy: ReturnType<typeof vi.spyOn>;
+  let setBaseUrlSpy: ReturnType<typeof vi.spyOn>;
+  let setTokenSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     localStorage.clear();
+    setBootConfig(structuredClone(originalBootConfig));
     // jsdom's window.focus logs "Not implemented" through console.error; the
     // auth-return path calls it best-effort, so stub it out of the run.
     vi.spyOn(window, "focus").mockImplementation(() => {});
@@ -84,12 +89,17 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     cloudLoginPollDirectSpy = vi
       .spyOn(client, "cloudLoginPollDirect")
       .mockResolvedValue({ status: "pending" });
-    vi.spyOn(client, "setBaseUrl").mockImplementation(() => undefined);
-    vi.spyOn(client, "setToken").mockImplementation(() => undefined);
+    setBaseUrlSpy = vi
+      .spyOn(client, "setBaseUrl")
+      .mockImplementation(() => undefined);
+    setTokenSpy = vi
+      .spyOn(client, "setToken")
+      .mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     localStorage.clear();
+    setBootConfig(structuredClone(originalBootConfig));
     delete globalWithPlatform.Capacitor;
     delete windowWithElectrobun.__electrobunWindowId;
     delete windowWithElectrobun.__ELIZA_DESKTOP_RUNTIME_MODE__;
@@ -157,7 +167,8 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
   });
 
-  it("uses local /login on configured loopback even when a live popup and local API backend exist", async () => {
+  it("uses a hosted staging session with a local backend and preserves that backend after success", async () => {
+    vi.useFakeTimers();
     Object.defineProperty(window, "location", {
       configurable: true,
       value: {
@@ -174,6 +185,10 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     });
     vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
     vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api-staging.eliza.app",
+    });
     vi.spyOn(client, "getBaseUrl").mockReturnValue("http://127.0.0.1:31337");
     const getCloudStatusSpy = vi
       .spyOn(client, "getCloudStatus")
@@ -190,18 +205,111 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
       opener: {},
     } as unknown as Window;
     vi.spyOn(window, "open").mockReturnValue(popup);
+    const browserUrl =
+      "https://staging.eliza.app/auth/cli-login?session=hosted-session&returnTo=http%3A%2F%2F127.0.0.1%3A2189%2Fsettings%3FelizaCloudLogin%3Dcomplete%26elizaCloudLoginSession%3Dhosted-session";
+    cloudLoginDirectSpy.mockResolvedValue({
+      ok: true,
+      apiBase: "https://api-staging.eliza.app",
+      browserUrl,
+      sessionId: "hosted-session",
+    });
+    cloudLoginPollDirectSpy.mockResolvedValue({
+      status: "authenticated",
+      token: "staging-session-token",
+      organizationId: "org-staging",
+      userId: "user-staging",
+    });
+
+    try {
+      const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+      let login: Promise<void> | undefined;
+      await act(async () => {
+        login = result.current.handleCloudLogin(popup);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(getCloudStatusSpy).toHaveBeenCalled();
+      expect(cloudLoginDirectSpy).toHaveBeenCalledWith(
+        "https://api-staging.eliza.app",
+      );
+      expect(cloudLoginSpy).not.toHaveBeenCalled();
+      expect(assignSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("/login?returnTo="),
+      );
+      expect(popup.location.href).toBe(browserUrl);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+        await login;
+      });
+
+      expect(cloudLoginPollDirectSpy).toHaveBeenCalledWith(
+        "https://api-staging.eliza.app",
+        "hosted-session",
+      );
+      expect(localStorage.getItem("steward_session_token")).toBe(
+        "staging-session-token",
+      );
+      expect(setBaseUrlSpy).not.toHaveBeenCalled();
+      expect(setTokenSpy).not.toHaveBeenCalled();
+      expect(result.current.elizaCloudConnected).toBe(true);
+      unmount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("navigates popup-hostile loopback staging to the hosted CLI URL, never local /login", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: "http://127.0.0.1:2189/settings",
+        origin: "http://127.0.0.1:2189",
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        port: "2189",
+        pathname: "/settings",
+        search: "",
+        assign: assignSpy,
+      },
+    });
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api-staging.eliza.app",
+    });
+    vi.spyOn(client, "getBaseUrl").mockReturnValue("http://127.0.0.1:31337");
+    vi.spyOn(client, "getCloudStatus").mockResolvedValue({
+      connected: false,
+      enabled: true,
+    } as Awaited<ReturnType<typeof client.getCloudStatus>>);
+    const browserUrl =
+      "https://staging.eliza.app/auth/cli-login?session=hosted-session&returnTo=http%3A%2F%2F127.0.0.1%3A2189%2Fsettings%3FelizaCloudLogin%3Dcomplete%26elizaCloudLoginSession%3Dhosted-session";
+    cloudLoginDirectSpy.mockResolvedValue({
+      ok: true,
+      apiBase: "https://api-staging.eliza.app",
+      browserUrl,
+      sessionId: "hosted-session",
+    });
 
     const { result } = renderHook(() => useCloudState(makeParams()));
     await act(async () => {
-      await result.current.handleCloudLogin(popup);
+      await result.current.handleCloudLogin(null);
     });
 
-    expect(getCloudStatusSpy).toHaveBeenCalled();
-    expect(assignSpy).toHaveBeenCalledWith("/login?returnTo=%2Fsettings");
-    expect(popup.close).toHaveBeenCalled();
-    expect(deviceCodeCalls()).toBe(0);
-    expect(result.current.elizaCloudLoginBusy).toBe(false);
-    expect(result.current.elizaCloudLoginError).toBeNull();
+    expect(cloudLoginDirectSpy).toHaveBeenCalledTimes(1);
+    expect(cloudLoginSpy).not.toHaveBeenCalled();
+    expect(assignSpy).toHaveBeenCalledWith(browserUrl);
+    expect(assignSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("/login?returnTo="),
+    );
+    const returnTo = new URL(browserUrl).searchParams.get("returnTo");
+    expect(returnTo).toContain("http://127.0.0.1:2189/settings");
+    expect(setBaseUrlSpy).not.toHaveBeenCalled();
+    expect(setTokenSpy).not.toHaveBeenCalled();
   });
 
   it("keeps production loopback on the agent-proxied device-code flow", async () => {
@@ -424,6 +532,53 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
       "sess-return",
     );
     expect(params.setActionNotice).not.toHaveBeenCalled();
+  });
+
+  it("claims a hosted staging return without replacing the localhost backend", async () => {
+    const search =
+      "?elizaCloudLogin=complete&elizaCloudLoginSession=staging-return";
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: `http://127.0.0.1:2189/settings${search}`,
+        origin: "http://127.0.0.1:2189",
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        port: "2189",
+        pathname: "/settings",
+        search,
+        assign: assignSpy,
+      },
+    });
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api-staging.eliza.app",
+    });
+    vi.spyOn(client, "getBaseUrl").mockReturnValue("http://127.0.0.1:31337");
+    cloudLoginPollDirectSpy.mockResolvedValue({
+      status: "authenticated",
+      organizationId: "org-staging",
+      token: "staging-return-token",
+      userId: "user-staging",
+    });
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("steward_session_token")).toBe(
+        "staging-return-token",
+      );
+      expect(result.current.elizaCloudConnected).toBe(true);
+    });
+    expect(cloudLoginPollDirectSpy).toHaveBeenCalledWith(
+      "https://api-staging.eliza.app",
+      "staging-return",
+    );
+    expect(setBaseUrlSpy).not.toHaveBeenCalled();
+    expect(setTokenSpy).not.toHaveBeenCalled();
   });
 
   it("preserves the cloud auth popup opener and closes it on the matching completion message", async () => {
@@ -732,6 +887,10 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
   it("bypasses a registered Steward launcher on Capacitor native and uses external direct device-code polling", async () => {
     vi.useFakeTimers();
     globalWithPlatform.Capacitor = { isNativePlatform: () => true };
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api.elizacloud.ai",
+    });
     const launcher = vi.fn(async () => ({ token: "launcher-token" }));
     const unregister = registerStewardLoginLauncher(launcher);
     const popup = {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -75,6 +75,7 @@ import { scrubPersistedAgentProfileTokens } from "./agent-profiles";
 import { bindDirectCloudLoginToPersonalAgent } from "./bind-direct-cloud-login";
 import {
   CLOUD_LOGIN_POPUP_NAME,
+  isLoopbackStagingStewardDevelopment,
   navigateToSameTabCloudLogin,
   shouldUseSameTabCloudLogin,
   takeClaimedCloudLoginWindow,
@@ -1104,7 +1105,9 @@ export function useCloudState({
       // direct cloud auth (no local backend) or go through the agent proxy.
       const hasBackend = hasCloudLoginBackend();
       const cloudApiBase = getBootConfig().cloudApiBase ?? "https://eliza.app";
-      let useDirectAuth = !hasBackend;
+      const usesHostedLoopbackStagingSession =
+        isLoopbackStagingStewardDevelopment();
+      let useDirectAuth = !hasBackend || usesHostedLoopbackStagingSession;
 
       if (hasBackend) {
         // error-policy:J4 a null status here is a designed branch: a
@@ -1143,6 +1146,8 @@ export function useCloudState({
           return loginCompletion;
         }
       }
+      const shouldBindClientToDirectCloud =
+        useDirectAuth && !(usesHostedLoopbackStagingSession && hasBackend);
 
       // #15143 mobile-web sign-in: when the popup path cannot work — the
       // pre-opened handle came back null (popup blocked; the runtime signal on
@@ -1155,11 +1160,10 @@ export function useCloudState({
       // cloud targets normally require direct auth: an agent-proxied
       // (hasBackend) login stays on the device-code flow, whose copyable
       // fallback link is the designed degrade for blocked popups there. The
-      // narrow exception is loopback plain-web staging development: its local
-      // `/login` route is the configured auth surface and must receive the
-      // Steward token on this origin, regardless of whether the local agent API
-      // answered the status probe. Production and self-hosted agent proxies
-      // retain device-code auth because their CORS/pairing contracts differ.
+      // Loopback staging is intentionally excluded: its tenant rejects a local
+      // OAuth callback, so it uses the hosted CLI-session flow below. Production
+      // and self-hosted agent proxies retain device-code auth because their
+      // CORS/pairing contracts differ.
       if (
         shouldUseSameTabCloudLogin(prePoppedWindow, {
           hasAgentProxy: !useDirectAuth,
@@ -1239,6 +1243,20 @@ export function useCloudState({
         // open without crashing but never surface a usable window.
         if (resp.browserUrl && isSafeNavigationUrl(resp.browserUrl)) {
           setElizaCloudLoginFallbackUrl(resp.browserUrl);
+          // Popup-hostile localhost browsers carry this tab through hosted
+          // staging auth. The opaque CLI session returns to localhost for the
+          // mount-time poll below; Steward never receives localhost as its
+          // OAuth redirect_uri.
+          if (
+            usesHostedLoopbackStagingSession &&
+            (!prePoppedWindow || prePoppedWindow.closed)
+          ) {
+            window.location.assign(resp.browserUrl);
+            elizaCloudLoginBusyRef.current = false;
+            setElizaCloudLoginBusy(false);
+            completeLogin();
+            return loginCompletion;
+          }
           // Electrobun's `window.open` is another renderer/WebView surface,
           // not the user's browser. Sending Cloud authentication there makes a
           // click appear to activate Eliza while no system login window opens.
@@ -1364,7 +1382,7 @@ export function useCloudState({
                     cloudApiBase: authenticatedCloudApiBase,
                     token: poll.token,
                   });
-                } else {
+                } else if (shouldBindClientToDirectCloud) {
                   client.setBaseUrl(authenticatedCloudApiBase, {
                     persist: false,
                   });
@@ -1495,8 +1513,12 @@ export function useCloudState({
               ...getBootConfig(),
               cloudApiBase: authenticatedCloudApiBase,
             });
-            client.setBaseUrl(authenticatedCloudApiBase, { persist: false });
-            client.setToken(poll.token);
+            const preservesLocalBackend =
+              isLoopbackStagingStewardDevelopment() && hasCloudLoginBackend();
+            if (!preservesLocalBackend) {
+              client.setBaseUrl(authenticatedCloudApiBase, { persist: false });
+              client.setToken(poll.token);
+            }
             setElizaCloudConnected(true);
             setElizaCloudLoginError(null);
             if (poll.userId) {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -1152,10 +1152,19 @@ export function useCloudState({
       // session whose browser window would never open. The returnTo round
       // trip lands back here and the stored Steward token completes the login
       // (first-run resumes via its marker + mount-time token poll). Direct
-      // cloud targets only: an agent-proxied (hasBackend) login stays on the
-      // device-code flow, whose copyable fallback link is the designed
-      // degrade for blocked popups there.
-      if (useDirectAuth && shouldUseSameTabCloudLogin(prePoppedWindow)) {
+      // cloud targets normally require direct auth: an agent-proxied
+      // (hasBackend) login stays on the device-code flow, whose copyable
+      // fallback link is the designed degrade for blocked popups there. The
+      // narrow exception is loopback plain-web staging development: its local
+      // `/login` route is the configured auth surface and must receive the
+      // Steward token on this origin, regardless of whether the local agent API
+      // answered the status probe. Production and self-hosted agent proxies
+      // retain device-code auth because their CORS/pairing contracts differ.
+      if (
+        shouldUseSameTabCloudLogin(prePoppedWindow, {
+          hasAgentProxy: !useDirectAuth,
+        })
+      ) {
         closePrePoppedWindow();
         navigateToSameTabCloudLogin();
         elizaCloudLoginBusyRef.current = false;

--- a/plugins/plugin-agent-orchestrator/__tests__/shared-runtime-env.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/shared-runtime-env.ts
@@ -1,5 +1,6 @@
 /** Exposes the shared runtime helpers used by orchestrator tests without loading the generated-data barrel. */
 export * from "../../../packages/shared/src/contracts/coding-agent-capabilities.js";
+export * from "../../../packages/shared/src/elizacloud/dev-cloud-env-authority.js";
 export {
   isAndroidMobile,
   resolvePlatform,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/credential-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/credential-prompt.test.ts
@@ -21,15 +21,23 @@ function confirmedSendOutcome() {
 }
 
 function makeRuntime(
-  opts: { withSend?: boolean; appUrl?: string; unconfirmed?: boolean } = {},
+  opts: {
+    withSend?: boolean;
+    appUrl?: string;
+    cloudUrl?: string;
+    unconfirmed?: boolean;
+  } = {},
 ) {
   const send = vi.fn(async () =>
     opts.unconfirmed ? undefined : confirmedSendOutcome(),
   );
   const runtime = {
     agentId: "agent-1",
-    getSetting: (k: string) =>
-      k === "ELIZA_APP_URL" ? opts.appUrl : undefined,
+    getSetting: (k: string) => {
+      if (k === "ELIZA_APP_URL") return opts.appUrl;
+      if (k === "ELIZA_CLOUD_URL") return opts.cloudUrl;
+      return undefined;
+    },
     ...(opts.withSend === false ? {} : { sendMessageToTarget: send }),
   };
   return { runtime, send };
@@ -71,6 +79,23 @@ describe("emitCredentialPrompt (#8907)", () => {
     // Secrets never transit chat text: the dead "Reply here" fallback that
     // instructed pasting a secret nothing captures is gone.
     expect(content.text).not.toContain("Reply here");
+  });
+
+  it("uses the Cloud URL only as a fallback when the user-owned app URL is absent", async () => {
+    const { runtime, send } = makeRuntime({
+      cloudUrl: "https://cloud.test/",
+    });
+
+    await emitCredentialPrompt({
+      runtime: runtime as never,
+      metadata: { roomId: ROOM, source: "telegram" },
+      credentialKeys: ["KEY"],
+    });
+
+    const [, content] = send.mock.calls[0];
+    expect(content.text).toContain(
+      "https://cloud.test/settings?section=credentials",
+    );
   });
 
   it("is a no-op when the session has no origin room", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -8,6 +8,10 @@ import os from "node:os";
 import { join } from "node:path";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { getProjectById, upsertProject } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runParentAgentBroker } from "../services/parent-agent-broker.js";
 import {
@@ -48,6 +52,7 @@ describe("runParentAgentBroker", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    resetDevCloudEnvAuthorityForTests();
     resetSessionSpendUsd();
     configureSpendLedger(null);
   });
@@ -289,6 +294,73 @@ describe("runParentAgentBroker", () => {
       /^Bearer /,
     );
     expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("uses the frozen staging tuple after late process and runtime Cloud pollution", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-explicit");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "launch-staging-key");
+    vi.stubEnv(
+      "ELIZAOS_CLOUD_BASE_URL",
+      "https://api-staging.eliza.app/api/v1",
+    );
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    const runtime = createRuntime({
+      getSetting: vi.fn((key: string) => {
+        if (key.includes("API_KEY")) return "runtime-production-key";
+        if (key.includes("URL")) return "https://api.eliza.app/api/v1";
+        return undefined;
+      }),
+    } as Partial<IAgentRuntime>);
+    const fetchMock = vi.fn(async () => Response.json({ apps: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runParentAgentBroker({
+      runtime,
+      sessionId: "authority-staging",
+      args: { mode: "cloud-command", command: "apps.list" },
+    });
+
+    expect(result.success).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe("https://api-staging.eliza.app/api/v1/apps");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer launch-staging-key",
+      "X-API-Key": "launch-staging-key",
+    });
+  });
+
+  it("stays unconfigured in staging-default mode after late Cloud pollution", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-default");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "");
+    vi.stubEnv(
+      "ELIZAOS_CLOUD_BASE_URL",
+      "https://api-staging.eliza.app/api/v1",
+    );
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    const runtime = createRuntime({
+      getSetting: vi.fn(() => "runtime-production-key"),
+    } as Partial<IAgentRuntime>);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runParentAgentBroker({
+      runtime,
+      sessionId: "authority-default",
+      args: { mode: "cloud-command", command: "apps.list" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("API key is not configured");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("fails closed on a hung Cloud command hop instead of waiting forever", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -117,6 +117,7 @@ import {
 import { buildSkillsManifest } from "./skill-manifest.js";
 import { SMITHERS_DURABLE_RUN_METADATA_KEY } from "./smithers-task-integration.js";
 import {
+  applyDevCloudAuthorityToSubAgentEnv,
   forwardableSubAgentEnv as applySubAgentEnvPolicy,
   canonicalForwardedEnvKey,
   isCloudKeyForwardingOptIn,
@@ -5348,7 +5349,7 @@ export class AcpService extends Service {
         );
       }
     }
-    return env;
+    return applyDevCloudAuthorityToSubAgentEnv(env);
   }
 
   /**

--- a/plugins/plugin-agent-orchestrator/src/services/config-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/config-env.test.ts
@@ -1,8 +1,41 @@
 /**
  * Unit tests for config-env: validates reading env keys with process.env fallbacks.
  */
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.ts";
+
+const ENV_KEYS = [
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_URL",
+] as const;
+const savedEnv = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
 
 describe("config-env", () => {
   it("reads fallback key from process.env when present", () => {
@@ -18,5 +51,38 @@ describe("config-env", () => {
     expect(
       readConfigCloudKey("DEFINITELY_NON_EXISTENT_CLOUD_KEY"),
     ).toBeUndefined();
+  });
+
+  it("ignores durable production Cloud values under staging authority", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrator-cloud-"));
+    tempDirs.push(dir);
+    const configPath = path.join(dir, "eliza.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        cloud: {
+          apiKey: "persisted-production-key",
+          baseUrl: "https://api.eliza.app/api/v1",
+        },
+        env: {
+          ELIZA_CLOUD_URL: "https://api.eliza.app",
+        },
+      }),
+    );
+    process.env.ELIZA_CONFIG_PATH = configPath;
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZAOS_CLOUD_API_KEY = "";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZA_CLOUD_URL = "";
+
+    expect(readConfigCloudKey("apiKey")).toBeUndefined();
+    expect(readConfigCloudKey("baseUrl")).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+    expect(readConfigEnvKey("ELIZA_CLOUD_URL")).toBeUndefined();
+    expect(readConfigEnvKey("ELIZAOS_CLOUD_BASE_URL")).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/config-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/config-env.ts
@@ -11,7 +11,11 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { getElizaNamespace, resolveStateDir } from "@elizaos/core";
-import { readAliasedEnv } from "@elizaos/shared";
+import {
+  readAliasedEnv,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import type { AcpMcpServerConfig } from "./acp-native-transport.js";
 
 function readConfig(): Record<string, unknown> | undefined {
@@ -35,6 +39,17 @@ function readConfig(): Record<string, unknown> | undefined {
 }
 
 export function readConfigEnvKey(key: string): string | undefined {
+  if (
+    resolveDevCloudEnvAuthority() &&
+    (key.startsWith("ELIZAOS_CLOUD_") ||
+      key.startsWith("ELIZA_CLOUD_") ||
+      key.startsWith("ELIZACLOUD_") ||
+      key.startsWith("ELIZA_DEV_CLOUD_") ||
+      key.startsWith("WAIFU_ELIZA_CLOUD_"))
+  ) {
+    const authoritative = resolveDevCloudAuthorityEnvValue(key)?.trim();
+    return authoritative || undefined;
+  }
   // Prefer the config file's env section: the UI writes settings there and
   // changes take effect without a process restart. Fall back to process.env
   // so operators who set values via a systemd EnvironmentFile (service.env)
@@ -51,6 +66,20 @@ export function readConfigEnvKey(key: string): string | undefined {
 
 /** Read a key from the cloud section of the config (e.g. "apiKey"). */
 export function readConfigCloudKey(key: string): string | undefined {
+  if (resolveDevCloudEnvAuthority()) {
+    const normalized = key.trim().toLowerCase();
+    const envKey = ["apikey", "api_key"].includes(normalized)
+      ? "ELIZAOS_CLOUD_API_KEY"
+      : ["baseurl", "base_url", "url"].includes(normalized)
+        ? "ELIZAOS_CLOUD_BASE_URL"
+        : ["servicekey", "service_key"].includes(normalized)
+          ? "ELIZAOS_CLOUD_SERVICE_KEY"
+          : undefined;
+    const authoritative = envKey
+      ? resolveDevCloudAuthorityEnvValue(envKey)?.trim()
+      : undefined;
+    return authoritative || undefined;
+  }
   const config = readConfig();
   const val = (config?.cloud as Record<string, unknown> | undefined)?.[key];
   return typeof val === "string" ? val : undefined;

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -18,6 +18,10 @@ import type {
   Memory,
 } from "@elizaos/core";
 import { requireConfirmation, toWellFormedUnicode } from "@elizaos/core";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
 import { bindProjectCloudApp } from "./project-binding.js";
 import {
@@ -892,17 +896,27 @@ function runtimeSetting(
 }
 
 function resolveCloudBaseUrl(runtime: IAgentRuntime): string {
-  const raw =
-    readConfigEnvKey("ELIZA_CLOUD_BASE_URL") ??
-    readConfigEnvKey("ELIZA_CLOUD_URL") ??
-    readConfigEnvKey("ELIZAOS_CLOUD_URL") ??
-    runtimeSetting(runtime, "ELIZA_CLOUD_BASE_URL") ??
-    runtimeSetting(runtime, "ELIZA_CLOUD_URL") ??
-    runtimeSetting(runtime, "ELIZAOS_CLOUD_URL") ??
-    normalizeString(process.env.ELIZA_CLOUD_BASE_URL) ??
-    normalizeString(process.env.ELIZA_CLOUD_URL) ??
-    normalizeString(process.env.ELIZAOS_CLOUD_URL) ??
-    DEFAULT_CLOUD_BASE_URL;
+  const raw = resolveDevCloudEnvAuthority()
+    ? (normalizeString(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL"),
+      ) ??
+      normalizeString(
+        resolveDevCloudAuthorityEnvValue("ELIZA_CLOUD_BASE_URL"),
+      ) ??
+      normalizeString(resolveDevCloudAuthorityEnvValue("ELIZA_CLOUD_URL")) ??
+      normalizeString(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_URL")) ??
+      DEFAULT_CLOUD_BASE_URL)
+    : (readConfigEnvKey("ELIZAOS_CLOUD_BASE_URL") ??
+      readConfigEnvKey("ELIZA_CLOUD_BASE_URL") ??
+      readConfigEnvKey("ELIZA_CLOUD_URL") ??
+      readConfigEnvKey("ELIZAOS_CLOUD_URL") ??
+      runtimeSetting(runtime, "ELIZA_CLOUD_BASE_URL") ??
+      runtimeSetting(runtime, "ELIZA_CLOUD_URL") ??
+      runtimeSetting(runtime, "ELIZAOS_CLOUD_URL") ??
+      normalizeString(process.env.ELIZA_CLOUD_BASE_URL) ??
+      normalizeString(process.env.ELIZA_CLOUD_URL) ??
+      normalizeString(process.env.ELIZAOS_CLOUD_URL) ??
+      DEFAULT_CLOUD_BASE_URL);
 
   return raw
     .replace(/\/+$/, "")
@@ -911,6 +925,17 @@ function resolveCloudBaseUrl(runtime: IAgentRuntime): string {
 }
 
 function resolveCloudApiKey(runtime: IAgentRuntime): string | undefined {
+  if (resolveDevCloudEnvAuthority()) {
+    return (
+      normalizeString(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+      ) ??
+      normalizeString(
+        resolveDevCloudAuthorityEnvValue("ELIZA_CLOUD_API_KEY"),
+      ) ??
+      normalizeString(resolveDevCloudAuthorityEnvValue("ELIZACLOUD_API_KEY"))
+    );
+  }
   return (
     readConfigCloudKey("apiKey") ??
     readConfigCloudKey("api_key") ??

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.test.ts
@@ -2,11 +2,48 @@
  * Unit tests for sub-agent environment policy: validates deny list regex matching
  * and system essential keys.
  */
-import { describe, expect, it } from "vitest";
 import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyDevCloudAuthorityToSubAgentEnv,
+  forwardableSubAgentEnv,
   isDeniedSubAgentEnvKey,
   SUB_AGENT_SYSTEM_ENV_KEYS,
 } from "./sub-agent-env-policy.ts";
+
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_SERVICE_KEY",
+  "ELIZA_CLOUD_API_KEY",
+  "ELIZA_CLOUD_TOKEN",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZACLOUD_API_KEY",
+  "WAIFU_ELIZA_CLOUD_AGENT_ID",
+] as const;
+const savedAuthorityEnv = Object.fromEntries(
+  AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = savedAuthorityEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
 
 describe("sub-agent-env-policy", () => {
   it("denies sensitive tokens and credentials", () => {
@@ -29,4 +66,95 @@ describe("sub-agent-env-policy", () => {
     expect(SUB_AGENT_SYSTEM_ENV_KEYS).toContain("HOME");
     expect(SUB_AGENT_SYSTEM_ENV_KEYS).toContain("USER");
   });
+
+  it.each(["staging-default", "offline"] as const)(
+    "drops every Cloud credential under blocked %s authority even with opt-in and overlays",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+      const forwarded = forwardableSubAgentEnv(
+        {
+          PATH: "/usr/bin",
+          ELIZA_DEV_SOURCE: "1",
+          ELIZA_DEV_CLOUD_ENV_AUTHORITY: authority,
+          ELIZAOS_CLOUD_API_KEY: "late-production-key",
+          ELIZAOS_CLOUD_SERVICE_KEY: "late-service-key",
+          ELIZA_CLOUD_TOKEN: "legacy-production-token",
+          ELIZACLOUD_API_KEY: "legacy-production-key",
+        },
+        true,
+      );
+      applyDevCloudAuthorityToSubAgentEnv(
+        Object.assign(forwarded, {
+          ELIZAOS_CLOUD_API_KEY: "custom-overlay-key",
+          ELIZA_CLOUD_API_KEY: "custom-legacy-key",
+          ELIZA_CLOUD_BASE_URL: "https://api.eliza.app",
+        }),
+      );
+
+      expect(forwarded).toEqual({
+        PATH: "/usr/bin",
+        ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      });
+    },
+  );
+
+  it.each([
+    [
+      "staging-explicit",
+      "https://api-staging.eliza.app/api/v1",
+      "staging-launch-key",
+    ],
+    [
+      "self-hosted",
+      "https://cloud.internal.example/api/v1",
+      "selfhost-launch-key",
+    ],
+  ] as const)(
+    "projects only the frozen canonical tuple under %s authority",
+    (authority, launchBaseUrl, launchApiKey) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBaseUrl;
+      process.env.ELIZAOS_CLOUD_API_KEY = launchApiKey;
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+
+      const forwarded = forwardableSubAgentEnv(
+        {
+          PATH: "/usr/bin",
+          ELIZA_DEV_SOURCE: "1",
+          ELIZA_DEV_CLOUD_ENV_AUTHORITY: authority,
+          ELIZAOS_CLOUD_API_KEY: "late-production-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+          ELIZAOS_CLOUD_SERVICE_KEY: "late-service-key",
+          ELIZA_CLOUD_TOKEN: "legacy-production-token",
+          ELIZA_CLOUD_BASE_URL: "https://api.eliza.app",
+          WAIFU_ELIZA_CLOUD_AGENT_ID: "late-agent-id",
+        },
+        true,
+      );
+      applyDevCloudAuthorityToSubAgentEnv(
+        Object.assign(forwarded, {
+          ELIZAOS_CLOUD_API_KEY: "custom-overlay-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://custom.example/api/v1",
+          ELIZA_CLOUD_TOKEN: "custom-legacy-token",
+        }),
+      );
+
+      expect(forwarded).toEqual({
+        PATH: "/usr/bin",
+        ELIZAOS_CLOUD_API_KEY: launchApiKey,
+        ELIZAOS_CLOUD_BASE_URL: launchBaseUrl,
+      });
+    },
+  );
 });

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -3,7 +3,49 @@
  * consumes this as the single host-env projection before adding per-session
  * model gateway, credential bridge, and adapter-specific overrides.
  */
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import { isHostExecutionToolchainEnvKey } from "@elizaos/shared/host-execution-env";
+
+function isDevCloudControlledSubAgentEnvKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return (
+    normalized === "ELIZA_DEV_SOURCE" ||
+    normalized === "ELIZA_DEV_CLOUD_ENV_AUTHORITY" ||
+    normalized === "ELIZA_DEV_CLOUD_TARGET" ||
+    normalized.startsWith("ELIZAOS_CLOUD_") ||
+    normalized.startsWith("ELIZA_CLOUD_") ||
+    normalized.startsWith("ELIZA_DEV_CLOUD_") ||
+    normalized.startsWith("ELIZACLOUD_") ||
+    normalized.startsWith("WAIFU_ELIZA_CLOUD_")
+  );
+}
+
+/**
+ * Clamp a child environment to the immutable launcher tuple. Run this after
+ * every caller/adapter overlay so no late alias can replace the frozen values.
+ */
+export function applyDevCloudAuthorityToSubAgentEnv<
+  T extends NodeJS.ProcessEnv,
+>(env: T): T {
+  if (!resolveDevCloudEnvAuthority()) return env;
+  const mutableEnv: NodeJS.ProcessEnv = env;
+
+  for (const key of Object.keys(mutableEnv)) {
+    if (isDevCloudControlledSubAgentEnvKey(key)) delete mutableEnv[key];
+  }
+  const baseUrl = resolveDevCloudAuthorityEnvValue(
+    "ELIZAOS_CLOUD_BASE_URL",
+  )?.trim();
+  const apiKey = resolveDevCloudAuthorityEnvValue(
+    "ELIZAOS_CLOUD_API_KEY",
+  )?.trim();
+  if (baseUrl) mutableEnv.ELIZAOS_CLOUD_BASE_URL = baseUrl;
+  if (apiKey) mutableEnv.ELIZAOS_CLOUD_API_KEY = apiKey;
+  return env;
+}
 
 const DENY_ENV_PATTERNS = [
   /DISCORD.*TOKEN/i,
@@ -217,5 +259,5 @@ export function forwardableSubAgentEnv(
     if (!isEnvForwardableToSubAgent(key, forwardCloudKey)) continue;
     out[canonicalForwardedEnvKey(key)] = value;
   }
-  return out;
+  return applyDevCloudAuthorityToSubAgentEnv(out);
 }

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildSkillExecutionEnv,
   isInheritableSkillEnvKey,
@@ -16,6 +20,29 @@ const FLEET_SCOPED = {
   STEWARD_REFRESH_SERVICE_TOKEN: "mints-a-jwt-for-any-agent-id",
   DATABASE_URL: "postgres://shared",
 };
+
+const CLOUD_TEST_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_PUBLIC_URL",
+  "ELIZA_CLOUD_URL",
+] as const;
+
+const originalCloudTestEnv = Object.fromEntries(
+  CLOUD_TEST_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof CLOUD_TEST_ENV_KEYS)[number], string | undefined>;
+
+afterEach(() => {
+  for (const key of CLOUD_TEST_ENV_KEYS) {
+    const value = originalCloudTestEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
 
 describe("buildSkillExecutionEnv", () => {
   it("does not pass fleet-scoped credentials to a skill child process", () => {
@@ -47,6 +74,65 @@ describe("buildSkillExecutionEnv", () => {
     expect(env.ELIZAOS_CLOUD_BASE_URL).toBe("https://api.eliza.app");
     expect(env.ELIZA_CLOUD_BASE_URL).toBe("https://api.eliza.app");
   });
+
+  it.each(["staging-default", "offline"])(
+    "blocks hostile Cloud inheritance and overlays under %s authority",
+    (authority) => {
+      const env = buildSkillExecutionEnv(
+        {
+          ELIZA_DEV_SOURCE: "1",
+          ELIZA_DEV_CLOUD_ENV_AUTHORITY: authority,
+          ELIZAOS_CLOUD_API_KEY: "late-production-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+          ELIZA_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+          ELIZA_CLOUD_PUBLIC_URL: "https://cloud.eliza.app",
+          ELIZA_CLOUD_URL: "https://api.eliza.app/api/v1",
+          PATH: "/usr/bin",
+        },
+        {
+          ELIZAOS_CLOUD_API_KEY: "overlay-production-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://attacker.example/api/v1",
+        },
+      );
+
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBe("");
+      expect(env.ELIZAOS_CLOUD_BASE_URL).toBe(
+        "https://api-staging.eliza.app/api/v1",
+      );
+      expect(env.ELIZA_CLOUD_BASE_URL).toBe("");
+      expect(env.ELIZA_CLOUD_PUBLIC_URL).toBe("");
+      expect(env.ELIZA_CLOUD_URL).toBe("");
+    },
+  );
+
+  it.each([
+    ["staging-explicit", "https://api-staging.eliza.app/api/v1"],
+    ["self-hosted", "https://api.private.example/api/v1"],
+  ])(
+    "pins the launch Cloud tuple for %s authority after live env pollution",
+    (authority, launchBaseUrl) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBaseUrl;
+      process.env.ELIZA_CLOUD_BASE_URL = launchBaseUrl;
+      resolveDevCloudEnvAuthority();
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api.eliza.app/api/v1";
+      process.env.ELIZA_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+      const env = buildSkillExecutionEnv(process.env, {
+        ELIZAOS_CLOUD_API_KEY: "overlay-production-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://attacker.example/api/v1",
+      });
+
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBe("launch-key");
+      expect(env.ELIZAOS_CLOUD_BASE_URL).toBe(launchBaseUrl);
+      expect(env.ELIZA_CLOUD_BASE_URL).toBe(launchBaseUrl);
+    },
+  );
 
   it("passes the parent's own PATH through rather than a substitute", () => {
     const env = buildSkillExecutionEnv({ PATH: "/opt/custom/bin:/bin" }, {});

--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.ts
@@ -19,6 +19,10 @@
  * SCRIPTS read, not from what SKILL.md prose mentions.
  */
 import { sanitizeSpawnEnv } from "@elizaos/core";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 /** Process-level keys a child needs to run. None carries authority. */
 const HOST_ENV_KEYS = [
@@ -56,6 +60,18 @@ const AGENT_SCOPED_ENV_KEYS = [
   "ELIZA_CLOUD_URL",
   "ELIZA_APP_ID",
 ] as const;
+
+const DEV_CLOUD_OWNED_SKILL_ENV_KEYS: ReadonlySet<string> = new Set([
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_PUBLIC_URL",
+  "ELIZA_CLOUD_URL",
+]);
+
+function isDevCloudOwnedSkillEnvKey(key: string): boolean {
+  return DEV_CLOUD_OWNED_SKILL_ENV_KEYS.has(key.toUpperCase());
+}
 
 /**
  * Credentials a bundled skill script reads or declares in `requires.env`
@@ -95,12 +111,23 @@ export function buildSkillExecutionEnv(
   overlay: Record<string, string>,
 ): Record<string, string> {
   const result: Record<string, string> = {};
+  const devCloudAuthority = resolveDevCloudEnvAuthority(processEnv);
   for (const [key, value] of Object.entries(processEnv)) {
+    if (devCloudAuthority && isDevCloudOwnedSkillEnvKey(key)) continue;
     if (value !== undefined && isInheritableSkillEnvKey(key))
       result[key] = value;
   }
+  if (devCloudAuthority) {
+    for (const key of DEV_CLOUD_OWNED_SKILL_ENV_KEYS) {
+      const value = resolveDevCloudAuthorityEnvValue(key, processEnv);
+      if (value !== undefined) result[key] = value;
+    }
+  }
   for (const [key, value] of Object.entries(sanitizeSpawnEnv(overlay))) {
     if (value === undefined) continue;
+    // A skill-specific overlay must not replace the immutable launcher tuple
+    // or reactivate Cloud for staging-default/offline development.
+    if (devCloudAuthority && isDevCloudOwnedSkillEnvKey(key)) continue;
     // Drop any inherited entry that differs only in case before writing. POSIX
     // treats `GEMINI_API_KEY` and `Gemini_Api_Key` as two variables, so an
     // exact-name overwrite would ship both and a child reading the documented

--- a/plugins/plugin-cloud-apps/__tests__/client.authority.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/client.authority.test.ts
@@ -1,0 +1,152 @@
+/** Proves Cloud Apps cannot late-activate or redirect launcher-owned credentials. */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { ElizaCloudClient as RealElizaCloudClient } from "../../../packages/cloud/sdk/src/client";
+import { resolveCloudClientTuple } from "../src/client";
+
+const AUTHORITY_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  AUTHORITY_KEYS.map((key) => [key, process.env[key]]),
+);
+const realFetch = globalThis.fetch;
+
+function runtimeWith(settings: Record<string, unknown>): IAgentRuntime {
+  return {
+    getSetting: mock((key: string) => settings[key]),
+  } as unknown as IAgentRuntime;
+}
+
+function captureAuthority(
+  authority:
+    | "staging-default"
+    | "staging-explicit"
+    | "production"
+    | "offline"
+    | "self-hosted",
+): { apiKey: string; baseUrl: string } {
+  const baseUrl =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  const apiKey = "launch-cloud-key";
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_API_KEY = apiKey;
+  process.env.ELIZAOS_CLOUD_BASE_URL = baseUrl;
+  resetDevCloudEnvAuthorityForTests();
+  captureDevCloudEnvAuthoritySnapshot();
+  return { apiKey, baseUrl };
+}
+
+function poisonAfterCapture(settings: Record<string, unknown>): void {
+  process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL =
+    "https://process-collector.example/api/v1";
+  settings.ELIZAOS_CLOUD_API_KEY = "late-runtime-key";
+  settings.ELIZAOS_CLOUD_BASE_URL = "https://runtime-collector.example/api/v1";
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  for (const key of AUTHORITY_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("Cloud Apps launcher authority", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "keeps Cloud Apps disabled under %s after late activation",
+    (authority) => {
+      captureAuthority(authority);
+      const settings: Record<string, unknown> = {};
+      poisonAfterCapture(settings);
+      const fetch = mock(async () => new Response("{}", { status: 200 }));
+      globalThis.fetch = fetch as typeof globalThis.fetch;
+
+      expect(resolveCloudClientTuple(runtimeWith(settings)).apiKey).toBeNull();
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "uses only the frozen %s destination and credential after late pollution",
+    async (authority) => {
+      const launch = captureAuthority(authority);
+      const settings: Record<string, unknown> = {};
+      poisonAfterCapture(settings);
+      const fetch = mock(async () =>
+        Response.json({ success: true, apps: [] }),
+      );
+      globalThis.fetch = fetch as typeof globalThis.fetch;
+
+      const tuple = resolveCloudClientTuple(runtimeWith(settings));
+      expect(tuple.apiKey).toBe(launch.apiKey);
+      const client = new RealElizaCloudClient({
+        apiBaseUrl: tuple.apiBaseUrl,
+        baseUrl: tuple.apiBaseUrl.replace(/\/api\/v1\/?$/, ""),
+        apiKey: tuple.apiKey ?? undefined,
+        fetchImpl: fetch as typeof globalThis.fetch,
+      });
+      await client.listApps();
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const [input, init] = fetch.mock.calls[0] as [
+        string | URL | Request,
+        RequestInit,
+      ];
+      expect(String(input)).toBe(`${launch.baseUrl}/apps`);
+      const headers = new Headers(init.headers);
+      expect(headers.get("authorization")).toBe(`Bearer ${launch.apiKey}`);
+      expect(headers.get("x-api-key")).toBe(launch.apiKey);
+    },
+  );
+
+  it("preserves runtime configuration without launcher authority", async () => {
+    const fetch = mock(async () => Response.json({ success: true, apps: [] }));
+    globalThis.fetch = fetch as typeof globalThis.fetch;
+    const tuple = resolveCloudClientTuple(
+      runtimeWith({
+        ELIZAOS_CLOUD_API_KEY: "runtime-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://runtime-cloud.example/api/v1",
+      }),
+    );
+    const client = new RealElizaCloudClient({
+      apiBaseUrl: tuple.apiBaseUrl,
+      baseUrl: tuple.apiBaseUrl.replace(/\/api\/v1\/?$/, ""),
+      apiKey: tuple.apiKey ?? undefined,
+      fetchImpl: fetch as typeof globalThis.fetch,
+    });
+
+    await client.listApps();
+
+    const [input, init] = fetch.mock.calls[0] as [
+      string | URL | Request,
+      RequestInit,
+    ];
+    expect(String(input)).toBe("https://runtime-cloud.example/api/v1/apps");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer runtime-key",
+    );
+  });
+});

--- a/plugins/plugin-cloud-apps/package.json
+++ b/plugins/plugin-cloud-apps/package.json
@@ -65,7 +65,8 @@
     "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
-    "@elizaos/cloud-sdk": "workspace:*"
+    "@elizaos/cloud-sdk": "workspace:*",
+    "@elizaos/shared": "workspace:*"
   },
   "devDependencies": {
     "@elizaos/core": "workspace:*",

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -14,6 +14,7 @@ import type { AppDto } from "@elizaos/cloud-sdk";
 import { ElizaCloudClient } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { unwrapUserMessageText } from "@elizaos/core";
+import { captureDevCloudEnvAuthoritySnapshot } from "@elizaos/shared";
 
 /** Default Eliza Cloud API base URL (matches the cloud runtime default). */
 export const DEFAULT_CLOUD_API_BASE_URL = "https://api.eliza.app/api/v1";
@@ -41,17 +42,56 @@ function apiBaseToSiteBaseUrl(apiBaseUrl: string): string {
     : trimmed;
 }
 
+/** @internal Atomic inputs used to construct the authenticated SDK client. */
+export interface CloudClientTuple {
+  readonly apiBaseUrl: string;
+  readonly apiKey: string | null;
+}
+
+/**
+ * Resolve the Cloud client inputs atomically. In a launcher-owned development
+ * process, both values come exclusively from the immutable launch snapshot so
+ * a late config/runtime merge cannot pair a launch credential with a different
+ * destination. Default staging and offline development deliberately remain
+ * unauthenticated.
+ */
+export function resolveCloudClientTuple(
+  runtime: IAgentRuntime,
+): CloudClientTuple {
+  const snapshot = captureDevCloudEnvAuthoritySnapshot();
+  if (!snapshot) {
+    return Object.freeze({
+      apiBaseUrl:
+        normalizeSecret(runtime.getSetting(CLOUD_BASE_URL_SETTING)) ??
+        DEFAULT_CLOUD_API_BASE_URL,
+      apiKey: normalizeSecret(runtime.getSetting(CLOUD_API_KEY_SETTING)),
+    });
+  }
+
+  const activationBlocked =
+    snapshot.authority === "staging-default" ||
+    snapshot.authority === "offline";
+  const authorityBaseUrl = normalizeSecret(
+    snapshot.values.ELIZAOS_CLOUD_BASE_URL,
+  );
+  return Object.freeze({
+    apiBaseUrl: authorityBaseUrl ?? DEFAULT_CLOUD_API_BASE_URL,
+    apiKey: activationBlocked
+      ? null
+      : authorityBaseUrl
+        ? normalizeSecret(snapshot.values.ELIZAOS_CLOUD_API_KEY)
+        : null,
+  });
+}
+
 /** Resolve the Eliza Cloud API key from runtime settings. Returns null when unset. */
 export function resolveCloudApiKey(runtime: IAgentRuntime): string | null {
-  return normalizeSecret(runtime.getSetting(CLOUD_API_KEY_SETTING));
+  return resolveCloudClientTuple(runtime).apiKey;
 }
 
 /** Resolve the Eliza Cloud API base URL (ends at `/api/v1`). */
 export function resolveCloudApiBaseUrl(runtime: IAgentRuntime): string {
-  return (
-    normalizeSecret(runtime.getSetting(CLOUD_BASE_URL_SETTING)) ??
-    DEFAULT_CLOUD_API_BASE_URL
-  );
+  return resolveCloudClientTuple(runtime).apiBaseUrl;
 }
 
 /**
@@ -72,10 +112,11 @@ export function resolveCloudSiteBaseUrl(runtime: IAgentRuntime): string {
 export function getCloudClient(
   runtime: IAgentRuntime,
 ): ElizaCloudClient | null {
-  const apiKey = resolveCloudApiKey(runtime);
+  const tuple = resolveCloudClientTuple(runtime);
+  const apiKey = tuple.apiKey;
   if (!apiKey) return null;
 
-  const apiBaseUrl = trimTrailingSlash(resolveCloudApiBaseUrl(runtime));
+  const apiBaseUrl = trimTrailingSlash(tuple.apiBaseUrl);
   return new ElizaCloudClient({
     apiBaseUrl,
     baseUrl: apiBaseToSiteBaseUrl(apiBaseUrl),

--- a/plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts
@@ -1,9 +1,14 @@
 import * as http from "node:http";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
 import { afterEach, describe, expect, it } from "vitest";
-import { handleCloudBillingRoute } from "../src/routes/cloud-billing-routes";
+import { fetchUpstream, handleCloudBillingRoute } from "../src/routes/cloud-billing-routes";
 
 const originalNodeEnv = process.env.NODE_ENV;
 const originalCloudBaseUrl = process.env.ELIZAOS_CLOUD_BASE_URL;
+const originalCloudApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+const originalDevSource = process.env.ELIZA_DEV_SOURCE;
+const originalDevAuthority = process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+const originalDevTarget = process.env.ELIZA_DEV_CLOUD_TARGET;
 const originalFetch = globalThis.fetch;
 
 function listen(server: http.Server): Promise<string> {
@@ -32,9 +37,59 @@ afterEach(() => {
   } else {
     process.env.ELIZAOS_CLOUD_BASE_URL = originalCloudBaseUrl;
   }
+  for (const [key, value] of [
+    ["ELIZAOS_CLOUD_API_KEY", originalCloudApiKey],
+    ["ELIZA_DEV_SOURCE", originalDevSource],
+    ["ELIZA_DEV_CLOUD_ENV_AUTHORITY", originalDevAuthority],
+    ["ELIZA_DEV_CLOUD_TARGET", originalDevTarget],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("handleCloudBillingRoute money proxies", () => {
+  it("never forwards launcher credentials across a hostile redirect", async () => {
+    resetDevCloudEnvAuthorityForTests();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "frozen-staging-key";
+
+    const upstreamCalls: Array<{
+      authorization: string | null;
+      url: string;
+    }> = [];
+    globalThis.fetch = (async (input, init = {}) => {
+      upstreamCalls.push({
+        authorization: new Headers(init.headers).get("Authorization"),
+        url: String(input),
+      });
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://attacker.example/collect" },
+      });
+    }) as typeof fetch;
+
+    await expect(
+      fetchUpstream(
+        "https://cloud-staging.eliza.app/api/v1/credits/summary",
+        "GET",
+        { Authorization: "Bearer frozen-staging-key" },
+        undefined
+      )
+    ).rejects.toMatchObject({ code: "REDIRECT" });
+
+    expect(upstreamCalls).toEqual([
+      {
+        authorization: "Bearer frozen-staging-key",
+        url: "https://cloud-staging.eliza.app/api/v1/credits/summary",
+      },
+    ]);
+  });
+
   it("forwards x402 payment requests and preserves payment headers", async () => {
     process.env.NODE_ENV = "development";
     delete process.env.ELIZAOS_CLOUD_BASE_URL;

--- a/plugins/plugin-elizacloud/__tests__/cloud-login-persist-json.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-login-persist-json.test.ts
@@ -11,17 +11,29 @@
 
 import type http from "node:http";
 import { Readable } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { type CloudRouteState, handleCloudRoute } from "../src/routes/cloud-routes";
 
 const priorApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
 const priorEnabled = process.env.ELIZAOS_CLOUD_ENABLED;
+const priorDevSource = process.env.ELIZA_DEV_SOURCE;
+const priorDevCloudAuthority = process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
 
 afterEach(() => {
   if (priorApiKey === undefined) delete process.env.ELIZAOS_CLOUD_API_KEY;
   else process.env.ELIZAOS_CLOUD_API_KEY = priorApiKey;
   if (priorEnabled === undefined) delete process.env.ELIZAOS_CLOUD_ENABLED;
   else process.env.ELIZAOS_CLOUD_ENABLED = priorEnabled;
+  if (priorDevSource === undefined) delete process.env.ELIZA_DEV_SOURCE;
+  else process.env.ELIZA_DEV_SOURCE = priorDevSource;
+  if (priorDevCloudAuthority === undefined) {
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+  } else {
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = priorDevCloudAuthority;
+  }
+  resetDevCloudEnvAuthorityForTests();
+  vi.restoreAllMocks();
 });
 
 function requestWithRawBody(raw: string): http.IncomingMessage {
@@ -176,5 +188,89 @@ describe("POST /api/cloud/login/persist JSON body", () => {
       ok: false,
       error: "Cloud credential persistence was not applied",
     });
+  });
+
+  it("rejects even the launcher key before direct persistence side effects", async () => {
+    resetDevCloudEnvAuthorityForTests();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "launcher-staging-key";
+    const saveElizaConfig = vi.fn();
+    const replaceApiKey = vi.fn(async () => {});
+    const config = { cloud: { apiKey: "durable-production-key" } };
+
+    const result = await persistRaw(
+      JSON.stringify({ apiKey: "launcher-staging-key" }),
+      persistState({
+        config,
+        cloudManager: { replaceApiKey } as CloudRouteState["cloudManager"],
+        services: { saveElizaConfig },
+      })
+    );
+
+    expect(result.statusCode).toBe(409);
+    expect(result.body).toEqual({
+      ok: false,
+      error:
+        "Cloud login cannot persist credentials owned by the immutable local development launch target",
+    });
+    expect(config).toEqual({ cloud: { apiKey: "durable-production-key" } });
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+    expect(replaceApiKey).not.toHaveBeenCalled();
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("launcher-staging-key");
+  });
+
+  it("rejects an authenticated same-key poll before fetch or persistence side effects", async () => {
+    resetDevCloudEnvAuthorityForTests();
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "launcher-staging-key";
+    const saveElizaConfig = vi.fn();
+    const replaceApiKey = vi.fn(async () => {});
+    const config = { cloud: { apiKey: "durable-production-key" } };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "authenticated",
+          apiKey: "launcher-staging-key",
+          keyPrefix: "launcher",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    const req = {
+      headers: { host: "127.0.0.1:3000" },
+      method: "GET",
+      url: "/api/cloud/login/status?sessionId=same-key-session",
+    } as http.IncomingMessage;
+    const res = responseSink();
+
+    const handled = await handleCloudRoute(
+      req,
+      res,
+      "/api/cloud/login/status",
+      "GET",
+      persistState({
+        config,
+        cloudManager: { replaceApiKey } as CloudRouteState["cloudManager"],
+        services: {
+          saveElizaConfig,
+          validateCloudBaseUrl: async () => null,
+        },
+      })
+    );
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(409);
+    expect(res.jsonBody()).toEqual({
+      ok: false,
+      error:
+        "Cloud login cannot persist credentials owned by the immutable local development launch target",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(config).toEqual({ cloud: { apiKey: "durable-production-key" } });
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+    expect(replaceApiKey).not.toHaveBeenCalled();
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("launcher-staging-key");
   });
 });

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
@@ -82,7 +82,7 @@ describe("CLOUD_ACCOUNT_STATUS", () => {
     );
     expect(result.success).toBe(true);
     expect(replies[0]?.text).toContain("critically low");
-    expect(replies[0]?.text).toContain("cloud.eliza.app/cloud/billing");
+    expect(replies[0]?.text).toContain(`${server.url}/cloud/billing`);
   });
 
   it("re-guards in the handler when signed out (validate is advisory)", async () => {
@@ -244,7 +244,7 @@ describe("CLOUD_CREATE_API_KEY", () => {
     expect(result.success).toBe(false);
     expect(result.data).toMatchObject({ reason: "session_required" });
     expect(replies[0]?.text).toContain("signed-in session");
-    expect(replies[0]?.text).toContain("cloud.eliza.app/cloud/api-keys");
+    expect(replies[0]?.text).toContain(`${server.url}/cloud/api-keys`);
   });
 
   it("refuses the reserved agent-sandbox: prefix without any network call", async () => {

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay.authority.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay.authority.test.ts
@@ -1,0 +1,74 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CloudManagedGatewayRelayService } from "../../src/services/cloud-managed-gateway-relay";
+
+const ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_SOURCE",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+
+const savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+  (typeof ENV_KEYS)[number],
+  string | undefined
+>;
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    character: { name: "Relay Test" },
+    getService: () => null,
+    messageService: undefined,
+  } as unknown as IAgentRuntime;
+}
+
+async function relayStatus(): Promise<string> {
+  const service = (await CloudManagedGatewayRelayService.start(
+    makeRuntime()
+  )) as CloudManagedGatewayRelayService;
+  return service.getSessionInfo().status;
+}
+
+describe("CloudManagedGatewayRelayService development Cloud authority", () => {
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it("does not suppress the local relay after staging-default env pollution", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+
+    expect(await relayStatus()).toBe("idle");
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+
+    expect(await relayStatus()).toBe("idle");
+  });
+
+  it("keeps an explicit production relay suppressed after late env clearing", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_API_TOKEN = "launch-api-token";
+
+    expect(await relayStatus()).toBe("stopped");
+
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.ELIZA_API_TOKEN;
+
+    expect(await relayStatus()).toBe("stopped");
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/unit/lifeops-schedule-sync-client.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/lifeops-schedule-sync-client.test.ts
@@ -1,3 +1,7 @@
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   LifeOpsScheduleSyncClient,
@@ -8,7 +12,9 @@ import {
 } from "../../src/cloud/lifeops-schedule-sync-client";
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("LifeOpsScheduleSyncClient", () => {
@@ -156,5 +162,29 @@ describe("LifeOps schedule sync config", () => {
       apiKey: "eliza_test",
       agentId: "agent-1",
     });
+  });
+
+  it("stays unconfigured after staging-default launch state is polluted", () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-default");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "");
+    vi.stubEnv("ELIZAOS_CLOUD_AGENT_ID", "");
+    vi.stubEnv("ELIZAOS_CLOUD_BASE_URL", "https://api-staging.eliza.app/api/v1");
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_AGENT_ID = "late-production-agent";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(
+      resolveLifeOpsScheduleSyncConfig({
+        remoteApiBase: "https://production-agent.example",
+        remoteAccessToken: "persisted-production-token",
+        apiKey: "persisted-production-key",
+        baseUrl: "https://api.eliza.app/api/v1",
+        agentId: "persisted-production-agent",
+      })
+    ).toEqual({ configured: false, mode: "none" });
   });
 });

--- a/plugins/plugin-elizacloud/__tests__/unit/managed-payment-clients.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/managed-payment-clients.test.ts
@@ -3,7 +3,11 @@
  * credentials opaque, and reject malformed Cloud responses.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   PaypalManagedClient,
   PaypalManagedClientError,
@@ -12,11 +16,136 @@ import {
   resolveEnvElizaCloudManagedClientConfig,
 } from "../../src/cloud/managed-payment-clients";
 
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  savedEnv = Object.fromEntries(AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("managed payment clients", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "%s cannot be activated by late production env pollution",
+    async (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "";
+      expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      const fetchMock = vi.fn<typeof fetch>();
+      vi.stubGlobal("fetch", fetchMock);
+      const config = resolveEnvElizaCloudManagedClientConfig();
+      const plaid = new PlaidManagedClient();
+      const paypal = new PaypalManagedClient();
+
+      expect(config).toMatchObject({
+        configured: false,
+        apiKey: null,
+        apiBaseUrl: "https://api-staging.eliza.app/api/v1",
+      });
+      expect(plaid.configured).toBe(false);
+      expect(paypal.configured).toBe(false);
+      await expect(plaid.createLinkToken()).rejects.toMatchObject({
+        status: 409,
+      });
+      await expect(paypal.buildAuthorizeUrl({ state: "state" })).rejects.toMatchObject({
+        status: 409,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("keeps Plaid and PayPal on the frozen explicit-staging tuple", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    const fetchMock = vi.fn<typeof fetch>(async (input) =>
+      String(input).includes("/plaid/")
+        ? Response.json({
+            linkToken: "link-token",
+            expiration: "2026-01-01T00:00:00.000Z",
+            environment: "sandbox",
+          })
+        : Response.json({
+            url: "https://www.sandbox.paypal.com/connect",
+            scope: "openid",
+            environment: "sandbox",
+          })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const config = resolveEnvElizaCloudManagedClientConfig();
+
+    expect(config).toMatchObject({
+      configured: true,
+      apiKey: "staging-launch-key",
+      apiBaseUrl: "https://api-staging.eliza.app/api/v1",
+    });
+    await new PlaidManagedClient().createLinkToken();
+    await new PaypalManagedClient().buildAuthorizeUrl({ state: "state" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [url, init] of fetchMock.mock.calls) {
+      expect(String(url)).toMatch(
+        /^https:\/\/api-staging\.eliza\.app\/api\/v1\/eliza\/(plaid|paypal)\//
+      );
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer staging-launch-key");
+    }
+  });
+
+  it("preserves live env configuration when no dev authority is active", async () => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://legacy.example/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "legacy-live-key";
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        url: "https://www.paypal.com/connect",
+        scope: "openid",
+        environment: "live",
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const config = resolveEnvElizaCloudManagedClientConfig();
+    await new PaypalManagedClient().buildAuthorizeUrl({ state: "state" });
+
+    expect(config).toMatchObject({
+      configured: true,
+      apiKey: "legacy-live-key",
+      apiBaseUrl: "https://legacy.example/api/v1",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://legacy.example/api/v1/eliza/paypal/authorize",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer legacy-live-key",
+        }),
+      })
+    );
+  });
+
   it("normalizes cloud config from env without accepting redacted keys", () => {
     expect(
       resolveEnvElizaCloudManagedClientConfig({

--- a/plugins/plugin-elizacloud/__tests__/unit/sdk-client.authority.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/sdk-client.authority.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Pins SDK request construction to the immutable local-development Cloud tuple.
+ *
+ * These are outbound regressions: late runtime/process pollution must neither
+ * redirect a launch-authorized credential nor activate an intentionally
+ * unauthenticated staging-default/offline process.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getApiKey, resolveCloudSdkAuthorityTuple } from "../../src/utils/config";
+import { createCloudApiClient, createElizaCloudClient } from "../../src/utils/sdk-client";
+
+const ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_EMBEDDING_API_KEY",
+  "ELIZAOS_CLOUD_EMBEDDING_URL",
+] as const;
+
+const savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+  (typeof ENV_KEYS)[number],
+  string | undefined
+>;
+
+function makeRuntime(settings: Record<string, string | undefined>): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key],
+  } as unknown as IAgentRuntime;
+}
+
+function captureFetch(): Request[] {
+  const calls: Request[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(new Request(input as RequestInfo, init));
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    })
+  );
+  return calls;
+}
+
+function setLaunchAuthority(authority: string, baseUrl: string, apiKey: string): void {
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_BASE_URL = baseUrl;
+  process.env.ELIZAOS_CLOUD_API_KEY = apiKey;
+}
+
+describe("Cloud SDK development authority", () => {
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    for (const key of ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it.each([
+    {
+      authority: "staging-explicit",
+      launchBase: "https://api-staging.eliza.app/api/v1",
+    },
+    {
+      authority: "production",
+      launchBase: "https://api.eliza.app/api/v1",
+    },
+    {
+      authority: "self-hosted",
+      launchBase: "https://self-hosted.example/api/v1",
+    },
+  ])(
+    "keeps the $authority launcher base and key after late pollution",
+    async ({ authority, launchBase }) => {
+      const calls = captureFetch();
+      const settings: Record<string, string | undefined> = {};
+      const runtime = makeRuntime(settings);
+      setLaunchAuthority(authority, launchBase, "launch-key");
+
+      expect(resolveCloudSdkAuthorityTuple(runtime)).toMatchObject({
+        authority,
+        apiBaseUrl: launchBase,
+        apiKey: "launch-key",
+        outboundAllowed: true,
+      });
+
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://late-attacker.example/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+      settings.ELIZAOS_CLOUD_BASE_URL = "https://late-runtime.example/api/v1";
+      settings.ELIZAOS_CLOUD_API_KEY = "late-runtime-key";
+
+      await createCloudApiClient(runtime).requestRaw("GET", "/models");
+      await createElizaCloudClient(runtime).v1.requestRaw("GET", "/models");
+
+      expect(calls).toHaveLength(2);
+      for (const request of calls) {
+        expect(request.url).toBe(`${launchBase}/models`);
+        expect(request.headers.get("Authorization")).toBe("Bearer launch-key");
+      }
+    }
+  );
+
+  it("keeps the complete launcher embedding tuple after late pollution", async () => {
+    const calls = captureFetch();
+    const settings: Record<string, string | undefined> = {};
+    const runtime = makeRuntime(settings);
+    setLaunchAuthority(
+      "self-hosted",
+      "https://launch-general.example/api/v1",
+      "launch-general-key"
+    );
+    process.env.ELIZAOS_CLOUD_EMBEDDING_URL = "https://launch-embedding.example/api/v1";
+    process.env.ELIZAOS_CLOUD_EMBEDDING_API_KEY = "launch-embedding-key";
+
+    expect(resolveCloudSdkAuthorityTuple(runtime, true).apiKey).toBe("launch-embedding-key");
+
+    process.env.ELIZAOS_CLOUD_EMBEDDING_URL = "https://late-process.example/api/v1";
+    process.env.ELIZAOS_CLOUD_EMBEDDING_API_KEY = "late-process-key";
+    settings.ELIZAOS_CLOUD_EMBEDDING_URL = "https://late-runtime.example/api/v1";
+    settings.ELIZAOS_CLOUD_EMBEDDING_API_KEY = "late-runtime-key";
+
+    await createCloudApiClient(runtime, true).requestRaw("GET", "/models");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://launch-embedding.example/api/v1/models");
+    expect(calls[0].headers.get("Authorization")).toBe("Bearer launch-embedding-key");
+  });
+
+  it.each(["staging-default", "offline"])(
+    "keeps %s credential-free and prevents SDK requests after late pollution",
+    (authority) => {
+      const calls = captureFetch();
+      const settings: Record<string, string | undefined> = {};
+      const runtime = makeRuntime(settings);
+      setLaunchAuthority(authority, "https://api-staging.eliza.app/api/v1", "must-be-scrubbed");
+
+      expect(resolveCloudSdkAuthorityTuple(runtime)).toMatchObject({
+        authority,
+        apiKey: undefined,
+        outboundAllowed: false,
+      });
+
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "production";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://late-attacker.example/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+      settings.ELIZAOS_CLOUD_BASE_URL = "https://late-runtime.example/api/v1";
+      settings.ELIZAOS_CLOUD_API_KEY = "late-runtime-key";
+
+      expect(getApiKey(runtime)).toBeUndefined();
+      expect(() => createCloudApiClient(runtime)).toThrowError(
+        expect.objectContaining({
+          code: "ELIZA_CLOUD_DEV_AUTHORITY_OUTBOUND_BLOCKED",
+          context: { authority },
+        })
+      );
+      expect(() => createElizaCloudClient(runtime)).toThrowError(
+        expect.objectContaining({
+          code: "ELIZA_CLOUD_DEV_AUTHORITY_OUTBOUND_BLOCKED",
+          context: { authority },
+        })
+      );
+      expect(calls).toHaveLength(0);
+    }
+  );
+
+  it("preserves runtime base and key behavior without launcher authority", async () => {
+    const calls = captureFetch();
+    const runtime = makeRuntime({
+      ELIZAOS_CLOUD_BASE_URL: "https://legacy-runtime.example/api/v1",
+      ELIZAOS_CLOUD_API_KEY: "legacy-runtime-key",
+    });
+
+    await createElizaCloudClient(runtime).v1.requestRaw("GET", "/models");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://legacy-runtime.example/api/v1/models");
+    expect(calls[0].headers.get("Authorization")).toBe("Bearer legacy-runtime-key");
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/validate-url.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/validate-url.test.ts
@@ -1,3 +1,4 @@
+import { resetDevCloudEnvAuthorityForTests, resolveDevCloudEnvAuthority } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { validateCloudBaseUrl } from "../src/cloud/validate-url.js";
 
@@ -10,18 +11,41 @@ import { validateCloudBaseUrl } from "../src/cloud/validate-url.js";
 
 let savedNodeEnv: string | undefined;
 let savedDev: string | undefined;
+let savedDevSource: string | undefined;
+let savedDevCloudAuthority: string | undefined;
+let savedCloudBaseUrl: string | undefined;
 beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
   savedNodeEnv = process.env.NODE_ENV;
   savedDev = process.env.ELIZA_DEV;
+  savedDevSource = process.env.ELIZA_DEV_SOURCE;
+  savedDevCloudAuthority = process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+  savedCloudBaseUrl = process.env.ELIZAOS_CLOUD_BASE_URL;
   // Ensure the IP-range blocking path is active (not the dev-mode bypass).
   process.env.NODE_ENV = "production";
   delete process.env.ELIZA_DEV;
+  delete process.env.ELIZA_DEV_SOURCE;
+  delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+  delete process.env.ELIZAOS_CLOUD_BASE_URL;
 });
 afterEach(() => {
   if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
   else process.env.NODE_ENV = savedNodeEnv;
   if (savedDev === undefined) delete process.env.ELIZA_DEV;
   else process.env.ELIZA_DEV = savedDev;
+  if (savedDevSource === undefined) delete process.env.ELIZA_DEV_SOURCE;
+  else process.env.ELIZA_DEV_SOURCE = savedDevSource;
+  if (savedDevCloudAuthority === undefined) {
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+  } else {
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = savedDevCloudAuthority;
+  }
+  if (savedCloudBaseUrl === undefined) {
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  } else {
+    process.env.ELIZAOS_CLOUD_BASE_URL = savedCloudBaseUrl;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("validateCloudBaseUrl — format", () => {
@@ -69,5 +93,19 @@ describe("validateCloudBaseUrl — allowed", () => {
     expect(await validateCloudBaseUrl("https://10.0.0.1/")).toBeNull();
     // Format checks still apply even in dev mode.
     expect(await validateCloudBaseUrl("http://10.0.0.1/")).toMatch(/must use HTTPS/);
+  });
+
+  it("allows only the frozen LAN HTTP endpoint for self-hosted authority", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "self-hosted";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "http://192.168.1.20:8787/api/v1";
+    resolveDevCloudEnvAuthority();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(await validateCloudBaseUrl("http://192.168.1.20:8787/api/v1")).toBeNull();
+    expect(await validateCloudBaseUrl("http://192.168.1.20:8787")).toBeNull();
+    expect(await validateCloudBaseUrl("http://192.168.1.20:9999/api/v1")).toMatch(/does not match/);
+    expect(await validateCloudBaseUrl("https://api.eliza.app/api/v1")).toMatch(/does not match/);
   });
 });

--- a/plugins/plugin-elizacloud/src/actions/cloud-account-status.ts
+++ b/plugins/plugin-elizacloud/src/actions/cloud-account-status.ts
@@ -21,9 +21,9 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { isCloudAuthApiKeyService } from "../cloud/auth-service-types";
+import { resolveCloudBillingUrl } from "../cloud/base-url";
+import { getBaseURL } from "../utils/config";
 import { createElizaCloudClient } from "../utils/sdk-client";
-
-const TOP_UP_URL = "https://cloud.eliza.app/cloud/billing";
 
 export const NO_CLOUD_MESSAGE =
   "I'm not connected to Eliza Cloud right now — connect your account in Settings (or set ELIZAOS_CLOUD_API_KEY) and I can check your credits.";
@@ -70,12 +70,13 @@ export const cloudAccountStatusAction: Action = {
       });
       const low = balance < 2.0;
       const critical = balance < 0.5;
+      const topUpUrl = resolveCloudBillingUrl(getBaseURL(runtime));
 
       let reply = `Your Eliza Cloud balance is $${balance.toFixed(2)}.`;
       if (critical) {
-        reply += ` That's critically low — top up at ${TOP_UP_URL} to keep your agents running.`;
+        reply += ` That's critically low — top up at ${topUpUrl} to keep your agents running.`;
       } else if (low) {
-        reply += ` That's running low — you can top up at ${TOP_UP_URL}.`;
+        reply += ` That's running low — you can top up at ${topUpUrl}.`;
       }
 
       await callback?.({ text: reply, actions: ["CLOUD_ACCOUNT_STATUS"] });
@@ -89,7 +90,7 @@ export const cloudAccountStatusAction: Action = {
         // the already-delivered balance as a second message (same opt-in as
         // LIST_CLOUD_APPS). Error exits stay un-gated.
         turnComplete: true,
-        data: { balance, low, critical, topUpUrl: TOP_UP_URL },
+        data: { balance, low, critical, topUpUrl },
       };
     } catch (err) {
       logger.warn(

--- a/plugins/plugin-elizacloud/src/actions/create-cloud-api-key.ts
+++ b/plugins/plugin-elizacloud/src/actions/create-cloud-api-key.ts
@@ -21,12 +21,12 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { invalidateCloudAccountCache } from "../cloud-providers/cloud-account";
+import { resolveCloudApiKeysUrl } from "../cloud/base-url";
+import { getBaseURL } from "../utils/config";
 import { createElizaCloudClient } from "../utils/sdk-client";
 import { cloudAccountAuthenticated, NO_CLOUD_MESSAGE } from "./cloud-account-status";
 
 const RESERVED_PREFIX = "agent-sandbox:";
-const SESSION_REQUIRED_MESSAGE =
-  "Eliza Cloud only allows API keys to be created from a signed-in session — my agent credential can't mint them. Open Cloud in Eliza or visit cloud.eliza.app/cloud/api-keys to create one.";
 const ERROR_MESSAGE =
   "I couldn't create the API key right now — the Cloud API returned an error. Try again in a moment.";
 
@@ -87,6 +87,7 @@ export const createCloudApiKeyAction: Action = {
     }
 
     try {
+      const apiKeysUrl = resolveCloudApiKeysUrl(getBaseURL(runtime));
       const { apiKey, plainKey } = await createElizaCloudClient(runtime).createApiKey({
         name,
       });
@@ -97,7 +98,7 @@ export const createCloudApiKeyAction: Action = {
         "",
         plainKey,
         "",
-        "Copy it now — this is the only time the full key is shown. Manage or revoke it from Cloud in the Eliza app or cloud.eliza.app/cloud/api-keys.",
+        `Copy it now — this is the only time the full key is shown. Manage or revoke it from Cloud in the Eliza app or ${apiKeysUrl}.`,
       ].join("\n");
 
       await callback?.({ text: reply, actions: ["CLOUD_CREATE_API_KEY"] });
@@ -112,14 +113,16 @@ export const createCloudApiKeyAction: Action = {
       };
     } catch (err) {
       if (err instanceof CloudApiError && (err.statusCode === 401 || err.statusCode === 403)) {
+        const sessionRequiredMessage =
+          `Eliza Cloud only allows API keys to be created from a signed-in session — my agent credential can't mint them. Open Cloud in Eliza or visit ${resolveCloudApiKeysUrl(getBaseURL(runtime))} to create one.`;
         await callback?.({
-          text: SESSION_REQUIRED_MESSAGE,
+          text: sessionRequiredMessage,
           actions: ["CLOUD_CREATE_API_KEY"],
         });
         return {
           success: false,
           text: "Eliza Cloud API keys require a signed-in session to create.",
-          userFacingText: SESSION_REQUIRED_MESSAGE,
+          userFacingText: sessionRequiredMessage,
           data: { reason: "session_required" },
         };
       }

--- a/plugins/plugin-elizacloud/src/cloud-providers/cloud-account.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/cloud-account.ts
@@ -25,10 +25,11 @@ import type {
   State,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { resolveCloudBillingUrl } from "../cloud/base-url";
 import type { CloudAuthService } from "../services/cloud-auth";
+import { getBaseURL } from "../utils/config";
 import { createElizaCloudClient } from "../utils/sdk-client";
 
-const TOP_UP_URL = "https://cloud.eliza.app/cloud/billing";
 const TTL = 60_000;
 
 interface AccountSnapshot {
@@ -91,15 +92,19 @@ export function scheduleAccountSnapshotRefresh(runtime: IAgentRuntime): void {
 
 const EMPTY: ProviderResult = { text: "" };
 
-function render(snapshot: AccountSnapshot, organizationId?: string): ProviderResult {
+function render(
+  snapshot: AccountSnapshot,
+  topUpUrl: string,
+  organizationId?: string,
+): ProviderResult {
   const low = snapshot.balance < 2.0;
   const critical = snapshot.balance < 0.5;
 
   const lines: string[] = [];
   const orgSuffix = organizationId ? ` (org ${organizationId})` : "";
   let creditsLine = `Eliza Cloud account${orgSuffix}: $${snapshot.balance.toFixed(2)} credits`;
-  if (critical) creditsLine += ` (CRITICAL — top up at ${TOP_UP_URL})`;
-  else if (low) creditsLine += ` (LOW — top up at ${TOP_UP_URL})`;
+  if (critical) creditsLine += ` (CRITICAL — top up at ${topUpUrl})`;
+  else if (low) creditsLine += ` (LOW — top up at ${topUpUrl})`;
   lines.push(creditsLine);
 
   if (snapshot.agents.length === 0) {
@@ -122,7 +127,7 @@ function render(snapshot: AccountSnapshot, organizationId?: string): ProviderRes
       cloudCreditsLow: low,
       cloudCreditsCritical: critical,
       cloudAgentCount: snapshot.agents.length,
-      cloudTopUpUrl: TOP_UP_URL,
+      cloudTopUpUrl: topUpUrl,
     },
     data: {
       agents: snapshot.agents.map((agent) => ({
@@ -156,6 +161,7 @@ export const cloudAccountProvider: Provider = {
   ): Promise<ProviderResult> {
     const auth = runtime.getService("CLOUD_AUTH") as CloudAuthService | undefined;
     if (!auth?.isAuthenticated()) return EMPTY;
+    const topUpUrl = resolveCloudBillingUrl(getBaseURL(runtime));
 
     // Stale-while-revalidate: any snapshot renders immediately; expiry only
     // schedules a background refresh instead of blocking the turn on two WAN
@@ -165,12 +171,12 @@ export const cloudAccountProvider: Provider = {
       if (Date.now() - cached.at >= TTL) {
         scheduleAccountSnapshotRefresh(runtime);
       }
-      return render(cached.value, auth.getOrganizationId());
+      return render(cached.value, topUpUrl, auth.getOrganizationId());
     }
 
     try {
       const snapshot = await fetchAccountSnapshot(runtime);
-      return render(snapshot, auth.getOrganizationId());
+      return render(snapshot, topUpUrl, auth.getOrganizationId());
     } catch (err) {
       logger.warn(
         `[CloudAccount] Failed to fetch account summary: ${

--- a/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
@@ -2,11 +2,12 @@
 
 import type { IAgentRuntime, Memory, Provider, ProviderResult, State } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { resolveCloudBillingUrl } from "../cloud/base-url";
 import type { CloudAuthService } from "../services/cloud-auth";
 import type { CreditBalanceResponse } from "../types/cloud";
+import { getBaseURL } from "../utils/config";
 import { getCachedAccountSnapshot } from "./cloud-account";
 
-const TOP_UP_URL = "https://cloud.eliza.app/cloud/billing";
 const creditCaches = new WeakMap<IAgentRuntime, { value: number; at: number }>();
 const TTL = 60_000;
 
@@ -25,19 +26,20 @@ export const creditBalanceProvider: Provider = {
   async get(runtime: IAgentRuntime, _message: Memory, _state: State): Promise<ProviderResult> {
     const auth = runtime.getService("CLOUD_AUTH") as CloudAuthService | undefined;
     if (!auth?.isAuthenticated()) return { text: "" };
+    const topUpUrl = resolveCloudBillingUrl(getBaseURL(runtime));
 
     // CLOUD_ACCOUNT shares this contextGate and fetches the same balance in
     // the same compose; reuse its snapshot so the billing endpoint is hit
     // once per cache window instead of once per provider.
     const shared = getCachedAccountSnapshot(runtime);
     if (shared) {
-      const result = format(shared.balance);
+      const result = format(shared.balance, topUpUrl);
       return result;
     }
 
     const cached = creditCaches.get(runtime);
     if (cached && Date.now() - cached.at < TTL) {
-      const result = format(cached.value);
+      const result = format(cached.value, topUpUrl);
       return result;
     }
 
@@ -50,7 +52,7 @@ export const creditBalanceProvider: Provider = {
         `[CloudCredits] Failed to fetch balance: ${err instanceof Error ? err.message : err}`
       );
       if (cached) {
-        const result = format(cached.value);
+        const result = format(cached.value, topUpUrl);
         return result;
       }
       return { text: "", values: { cloudCreditsUnavailable: true }, data: {} };
@@ -58,24 +60,24 @@ export const creditBalanceProvider: Provider = {
     creditCaches.set(runtime, { value: balance, at: Date.now() });
 
     if (balance < 1.0) logger.warn(`[CloudCredits] Low balance: $${balance.toFixed(2)}`);
-    const result = format(balance);
+    const result = format(balance, topUpUrl);
     return result;
   },
 };
 
-function format(balance: number): ProviderResult {
+function format(balance: number, topUpUrl: string): ProviderResult {
   const low = balance < 2.0;
   const critical = balance < 0.5;
   let text = `ElizaCloud credits: $${balance.toFixed(2)}`;
-  if (critical) text += ` (CRITICAL — top up at ${TOP_UP_URL})`;
-  else if (low) text += ` (LOW — top up at ${TOP_UP_URL})`;
+  if (critical) text += ` (CRITICAL — top up at ${topUpUrl})`;
+  else if (low) text += ` (LOW — top up at ${topUpUrl})`;
   return {
     text,
     values: {
       cloudCredits: balance,
       cloudCreditsLow: low,
       cloudCreditsCritical: critical,
-      cloudTopUpUrl: TOP_UP_URL,
+      cloudTopUpUrl: topUpUrl,
     },
   };
 }

--- a/plugins/plugin-elizacloud/src/cloud/base-url.ts
+++ b/plugins/plugin-elizacloud/src/cloud/base-url.ts
@@ -3,4 +3,38 @@
  * `@elizaos/shared/elizacloud/base-url` so host-layer packages can normalize
  * URLs without reverse-importing this plugin.
  */
-export { normalizeCloudSiteUrl, resolveCloudApiBaseUrl } from "@elizaos/shared";
+import {
+  defaultCloudSiteUrl,
+  normalizeCloudSiteUrl,
+  resolveCloudRedirectScope,
+  resolveCloudApiBaseUrl,
+} from "@elizaos/shared";
+
+export {
+  normalizeCloudSiteUrl,
+  resolveCloudApiBaseUrl,
+  resolveCloudRedirectScope,
+};
+
+function resolveCloudSitePath(rawBaseUrl: string | undefined, path: string): string {
+  const siteUrl = normalizeCloudSiteUrl(rawBaseUrl);
+  try {
+    const parsed = new URL(siteUrl);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return `${siteUrl.replace(/\/+$/, "")}${path}`;
+    }
+  } catch {
+    // Fall through to the environment-aware canonical site.
+  }
+  return `${defaultCloudSiteUrl()}${path}`;
+}
+
+/** Resolve the account billing page from the same environment as Cloud API traffic. */
+export function resolveCloudBillingUrl(rawBaseUrl?: string): string {
+  return resolveCloudSitePath(rawBaseUrl, "/cloud/billing");
+}
+
+/** Resolve API-key management from the same environment as Cloud API traffic. */
+export function resolveCloudApiKeysUrl(rawBaseUrl?: string): string {
+  return resolveCloudSitePath(rawBaseUrl, "/cloud/api-keys");
+}

--- a/plugins/plugin-elizacloud/src/cloud/cloud-api-key.authority.test.ts
+++ b/plugins/plugin-elizacloud/src/cloud/cloud-api-key.authority.test.ts
@@ -1,0 +1,208 @@
+import {
+  _resetCloudSecretsForTesting,
+  resetDevCloudEnvAuthorityForTests,
+  scrubCloudSecretsFromEnv,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchCloudCredits,
+  resolveCloudApiKey as resolveConnectionCloudApiKey,
+  resolveCloudConnectionSnapshot,
+} from "../lib/cloud-connection.js";
+import {
+  resolveCloudApiKey as resolveRouteCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
+} from "./cloud-api-key.js";
+
+const ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "NODE_ENV",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+const cloudRoutedConfig = {
+  serviceRouting: {
+    llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+  },
+};
+
+describe("development Cloud environment authority", () => {
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    _resetCloudSecretsForTesting();
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "offline";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetDevCloudEnvAuthorityForTests();
+    _resetCloudSecretsForTesting();
+    for (const key of ENV_KEYS) {
+      const value = originalEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it.each([
+    {
+      source: "persisted config",
+      config: {
+        ...cloudRoutedConfig,
+        cloud: { apiKey: "persisted-production-key" },
+      },
+      runtime: {},
+    },
+    {
+      source: "runtime settings",
+      config: cloudRoutedConfig,
+      runtime: { getSetting: () => "runtime-production-key" },
+    },
+    {
+      source: "character secrets",
+      config: cloudRoutedConfig,
+      runtime: {
+        getSetting: () => undefined,
+        character: {
+          secrets: { ELIZAOS_CLOUD_API_KEY: "character-production-key" },
+        },
+      },
+    },
+  ])("does not resurrect a key from $source", ({ config, runtime }) => {
+    expect(resolveRouteCloudApiKey(config, runtime)).toBeNull();
+    expect(resolveConnectionCloudApiKey(config, runtime)).toBeUndefined();
+  });
+
+  it("does not resurrect a sealed key", () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "sealed-production-key";
+    scrubCloudSecretsFromEnv();
+
+    expect(resolveConnectionCloudApiKey(cloudRoutedConfig)).toBeUndefined();
+  });
+
+  it("does not let an authenticated runtime service override blocked authority", () => {
+    expect(
+      resolveCloudApiKeyWithRuntimeOverride(
+        "runtime-auth-production-key",
+        cloudRoutedConfig,
+      ),
+    ).toBeNull();
+  });
+
+  it("uses only the launcher's canonical key for an explicit staging target", () => {
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-key";
+    const config = {
+      ...cloudRoutedConfig,
+      cloud: { apiKey: "persisted-production-key" },
+    };
+    const runtime = {
+      getSetting: () => "runtime-production-key",
+      character: {
+        secrets: { ELIZAOS_CLOUD_API_KEY: "character-production-key" },
+      },
+    };
+
+    expect(resolveRouteCloudApiKey(config, runtime)).toBe("staging-key");
+    expect(resolveConnectionCloudApiKey(config, runtime)).toBe("staging-key");
+    expect(
+      resolveCloudApiKeyWithRuntimeOverride(
+        "runtime-auth-production-key",
+        config,
+        runtime,
+      ),
+    ).toBe("staging-key");
+  });
+
+  it.each(["staging-default", "offline"])(
+    "ignores stale authenticated runtime state under %s authority",
+    async (authority) => {
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api.eliza.app/api/v1";
+      const runtimeClientGet = vi.fn(async () => ({ balance: 99 }));
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      const runtime = {
+        getService: () => ({
+          isAuthenticated: () => true,
+          getClient: () => ({ get: runtimeClientGet }),
+          getOrganizationId: () => "production-org",
+          getUserId: () => "production-user",
+        }),
+        getSetting: () => "persisted-production-value",
+        character: { secrets: {} },
+      } as never;
+
+      expect(resolveCloudConnectionSnapshot(cloudRoutedConfig, runtime)).toMatchObject({
+        apiKey: undefined,
+        authConnected: false,
+        cloudAuth: null,
+        connected: false,
+        organizationId: undefined,
+        userId: undefined,
+      });
+      await expect(fetchCloudCredits(cloudRoutedConfig, runtime)).resolves.toEqual({
+        balance: null,
+        connected: false,
+      });
+      expect(runtimeClientGet).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["staging-explicit", "https://api-staging.eliza.app/api/v1"],
+    ["self-hosted", "https://self-hosted.example:8787/api/v1"],
+  ])(
+    "uses only the frozen %s key/base when stale runtime auth is connected",
+    async (authority, launchBaseUrl) => {
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "launcher-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBaseUrl;
+      process.env.NODE_ENV = "development";
+      resolveConnectionCloudApiKey(cloudRoutedConfig);
+
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api.eliza.app/api/v1";
+      const runtimeClientGet = vi.fn(async () => ({ balance: 99 }));
+      const runtime = {
+        getService: () => ({
+          isAuthenticated: () => true,
+          getClient: () => ({ get: runtimeClientGet }),
+          getOrganizationId: () => "production-org",
+          getUserId: () => "production-user",
+        }),
+        getSetting: () => "persisted-production-value",
+        character: { secrets: {} },
+      } as never;
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ balance: 12.5 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await expect(fetchCloudCredits(cloudRoutedConfig, runtime)).resolves.toMatchObject({
+        balance: 12.5,
+        connected: true,
+      });
+      expect(runtimeClientGet).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0] ?? [];
+      expect(url).toBe(`${launchBaseUrl}/credits/balance`);
+      expect((init as RequestInit | undefined)?.headers).toMatchObject({
+        Authorization: "Bearer launcher-key",
+      });
+    },
+  );
+});

--- a/plugins/plugin-elizacloud/src/cloud/cloud-api-key.ts
+++ b/plugins/plugin-elizacloud/src/cloud/cloud-api-key.ts
@@ -2,9 +2,10 @@
  * Cloud API key + base URL resolution.
  *
  * Resolves the Eliza Cloud API key and base URL from (in priority order):
- *   1. Explicit `config.cloud.apiKey` / `config.cloud.baseUrl`
- *   2. Runtime settings + character secrets (`ELIZAOS_CLOUD_API_KEY`)
- *   3. Process env (`ELIZAOS_CLOUD_API_KEY`, `ELIZAOS_CLOUD_BASE_URL`)
+ *   1. Launcher-owned canonical env when development Cloud authority is valid
+ *   2. Explicit `config.cloud.apiKey` / `config.cloud.baseUrl`
+ *   3. Runtime settings + character secrets (`ELIZAOS_CLOUD_API_KEY`)
+ *   4. Process env (`ELIZAOS_CLOUD_API_KEY`, `ELIZAOS_CLOUD_BASE_URL`)
  *
  * Previously these helpers lived in `packages/agent/src/api/wallet-rpc.ts`
  * because the wallet uses Cloud RPC proxies. They are NOT wallet-specific —
@@ -13,7 +14,11 @@
  * `cloud/` matches their actual ownership.
  */
 
-import { defaultCloudSiteUrl } from "@elizaos/shared";
+import {
+  defaultCloudSiteUrl,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 import type { ElizaConfig } from "../lib/config-like";
 
@@ -86,9 +91,29 @@ export function resolveCloudApiKey(
   config?: Pick<ElizaConfig, "cloud"> | null,
   runtime?: CloudApiKeyRuntimeLike,
 ): string | null {
+  if (resolveDevCloudEnvAuthority()) {
+    return normalizeCloudSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+  }
   return normalizeCloudSecret(
     config?.cloud?.apiKey ??
       resolveRuntimeCloudApiKey(runtime) ??
       process.env.ELIZAOS_CLOUD_API_KEY,
   );
+}
+
+/**
+ * Preserve a live CloudAuth-service key outside dev authority while making the
+ * frozen launcher tuple the sole credential source when authority is active.
+ */
+export function resolveCloudApiKeyWithRuntimeOverride(
+  runtimeApiKey: string | null | undefined,
+  config?: Pick<ElizaConfig, "cloud"> | null,
+  runtime?: CloudApiKeyRuntimeLike,
+): string | null {
+  const resolved = resolveCloudApiKey(config, runtime);
+  return resolveDevCloudEnvAuthority()
+    ? resolved
+    : (normalizeCloudSecret(runtimeApiKey) ?? resolved);
 }

--- a/plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts
+++ b/plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts
@@ -1,5 +1,9 @@
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import {
   normalizeCloudSiteUrl,
   resolveCloudApiBaseUrl,
 } from "./base-url.js";
@@ -72,6 +76,30 @@ export function normalizeLifeOpsScheduleSyncSecret(
 export function resolveLifeOpsScheduleSyncConfig(
   config: LifeOpsScheduleSyncConfigInput = {},
 ): ResolvedLifeOpsScheduleSyncConfig {
+  if (resolveDevCloudEnvAuthority()) {
+    const apiKey = normalizeLifeOpsScheduleSyncSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+    const agentId = normalizeLifeOpsScheduleSyncSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_AGENT_ID"),
+    );
+    if (!apiKey || !agentId) {
+      return {
+        configured: false,
+        mode: "none",
+      };
+    }
+    return {
+      configured: true,
+      mode: "cloud",
+      apiBaseUrl: resolveCloudApiBaseUrl(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL"),
+      ),
+      apiKey,
+      agentId,
+    };
+  }
+
   const remoteApiBase = normalizeOptionalString(config.remoteApiBase);
   if (remoteApiBase) {
     return {

--- a/plugins/plugin-elizacloud/src/cloud/managed-payment-clients.ts
+++ b/plugins/plugin-elizacloud/src/cloud/managed-payment-clients.ts
@@ -5,6 +5,10 @@
  */
 
 import { ElizaCloudClient } from "@elizaos/cloud-sdk";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import { z } from "zod";
 import {
   normalizeCloudSiteUrl,
@@ -32,8 +36,16 @@ export function resolveEnvElizaCloudManagedClientConfig(
   env: Record<string, string | undefined> =
     typeof process === "undefined" ? {} : process.env,
 ): ElizaCloudManagedClientConfig {
-  const apiKey = normalizeElizaCloudApiKey(env.ELIZAOS_CLOUD_API_KEY);
-  const baseUrl = env.ELIZAOS_CLOUD_BASE_URL;
+  const processEnv = typeof process === "undefined" ? undefined : process.env;
+  const authorityEnv =
+    processEnv && resolveDevCloudEnvAuthority(processEnv) ? processEnv : env;
+  const apiKey = normalizeElizaCloudApiKey(
+    resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY", authorityEnv),
+  );
+  const baseUrl = resolveDevCloudAuthorityEnvValue(
+    "ELIZAOS_CLOUD_BASE_URL",
+    authorityEnv,
+  );
   return {
     configured: Boolean(apiKey),
     apiKey,

--- a/plugins/plugin-elizacloud/src/cloud/validate-url.ts
+++ b/plugins/plugin-elizacloud/src/cloud/validate-url.ts
@@ -1,6 +1,10 @@
 import dns from "node:dns";
 import net from "node:net";
 import { promisify } from "node:util";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 const dnsLookupAll = promisify(dns.lookup);
 
@@ -122,6 +126,23 @@ function isBlockedIp(ip: string): boolean {
   return false;
 }
 
+function normalizeSelfHostedAuthorityUrl(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    parsed.hash = "";
+    parsed.search = "";
+    parsed.pathname = parsed.pathname
+      .replace(/\/api\/v1\/?$/i, "")
+      .replace(/\/+$/, "");
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
 export async function validateCloudBaseUrl(
   rawUrl: string,
 ): Promise<string | null> {
@@ -130,6 +151,24 @@ export async function validateCloudBaseUrl(
     parsed = new URL(rawUrl);
   } catch {
     return `Invalid cloud base URL: "${rawUrl}"`;
+  }
+
+  // The dev launcher has already validated and frozen a self-hosted endpoint.
+  // Permit that exact origin/path (including LAN HTTP and a custom port), but
+  // do not turn development mode into a generic SSRF bypass for request-supplied
+  // URLs: anything that differs from the launch tuple is rejected here.
+  if (resolveDevCloudEnvAuthority() === "self-hosted") {
+    const launcherBaseUrl = resolveDevCloudAuthorityEnvValue(
+      "ELIZAOS_CLOUD_BASE_URL",
+    );
+    const normalizedLauncher = launcherBaseUrl
+      ? normalizeSelfHostedAuthorityUrl(launcherBaseUrl)
+      : null;
+    const normalizedCandidate = normalizeSelfHostedAuthorityUrl(rawUrl);
+    if (normalizedLauncher && normalizedCandidate === normalizedLauncher) {
+      return null;
+    }
+    return `Cloud base URL "${rawUrl}" does not match the immutable self-hosted development launch target.`;
   }
 
   if (parsed.protocol !== "https:") {

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -132,8 +132,9 @@ export function registerTextInferenceModels(runtime: IAgentRuntime): void {
   // Host routing policy is process-owned. Read the captured environment first
   // so a packaged core resolver that lacks dotenv fallback cannot silently
   // re-enable the priority-50 Cloud brain inside a managed container.
+  const envFlag = env.ELIZAOS_CLOUD_USE_INFERENCE?.trim();
   const flag =
-    env.ELIZAOS_CLOUD_USE_INFERENCE ??
+    (envFlag ? envFlag : undefined) ??
     getSetting(runtime, "ELIZAOS_CLOUD_USE_INFERENCE");
   if (flag?.trim().toLowerCase() === "false") {
     logger.info(
@@ -571,6 +572,7 @@ export {
 export {
   normalizeCloudSecret,
   resolveCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
 } from "./cloud/cloud-api-key";
 export {
   clearCloudSecrets,

--- a/plugins/plugin-elizacloud/src/init.ts
+++ b/plugins/plugin-elizacloud/src/init.ts
@@ -1,5 +1,6 @@
 import { type IAgentRuntime, logger } from "@elizaos/core";
-import { getApiKey, isBrowser } from "./utils/config";
+import { resolveCloudApiKeysUrl } from "./cloud/base-url";
+import { getApiKey, getBaseURL, isBrowser } from "./utils/config";
 import { createCloudApiClient } from "./utils/sdk-client";
 
 export function initializeOpenAI(
@@ -12,7 +13,7 @@ export function initializeOpenAI(
         logger.warn(
           "ELIZAOS_CLOUD_API_KEY is not set in environment - ElizaOS Cloud functionality will be limited"
         );
-        logger.info("Get your API key from https://cloud.eliza.app/cloud/api-keys");
+        logger.info(`Get your API key from ${resolveCloudApiKeysUrl(getBaseURL(runtime))}`);
         return;
       }
       try {
@@ -33,7 +34,7 @@ export function initializeOpenAI(
       logger.warn(
         `ElizaOS Cloud plugin configuration issue: ${message} - You need to configure the ELIZAOS_CLOUD_API_KEY in your environment variables`
       );
-      logger.info("Get your API key from https://cloud.eliza.app/cloud/api-keys");
+      logger.info(`Get your API key from ${resolveCloudApiKeysUrl(getBaseURL(runtime))}`);
     }
   })();
 }

--- a/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
+++ b/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
@@ -4,7 +4,14 @@ import {
   migrateLegacyRuntimeConfig,
   settingsDebugCloudSummary,
 } from "@elizaos/core";
-import { resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl } from "../cloud/base-url.js";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import {
+  resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl,
+  resolveCloudBillingUrl,
+} from "../cloud/base-url.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 import type { AgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
@@ -226,6 +233,11 @@ export function resolveCloudApiKey(
     getSetting?: (key: string) => unknown;
   } | null,
 ): string | undefined {
+  if (resolveDevCloudEnvAuthority()) {
+    return normalizeEnvValue(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+  }
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
   // 1. Config file (disk)
   const configApiKey = normalizeEnvValue(
@@ -267,6 +279,7 @@ export function resolveCloudConnectionSnapshot(
   config: Partial<ElizaConfig>,
   runtime: AgentRuntime | null,
 ): CloudConnectionSnapshot {
+  const devCloudAuthority = resolveDevCloudEnvAuthority();
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
   const _cloudRecord =
     config.cloud && typeof config.cloud === "object"
@@ -276,10 +289,16 @@ export function resolveCloudConnectionSnapshot(
     config as Record<string, unknown>,
   );
   const apiKey = resolveCloudApiKey(config, runtime);
-  const cloudAuth = getCloudAuth(runtime);
+  // Runtime auth may hold a client and identity from a durable production
+  // session. A local launcher authority owns the operational connection, so
+  // never let that mutable service reactivate blocked modes or outrank the
+  // frozen explicit staging/self-hosted tuple.
+  const cloudAuth = devCloudAuthority ? null : getCloudAuth(runtime);
   const authConnected = Boolean(cloudAuth?.isAuthenticated?.());
   const hasApiKey = Boolean(apiKey);
-  const persistedIdentity = resolvePersistedCloudIdentity(runtime);
+  const persistedIdentity = devCloudAuthority
+    ? { organizationId: undefined, userId: undefined }
+    : resolvePersistedCloudIdentity(runtime);
   const shouldExposeIdentity = authConnected || hasApiKey;
 
   return {
@@ -382,13 +401,16 @@ const CREDIT_CRITICAL_THRESHOLD = Number(
   process.env.ELIZA_CREDIT_CRITICAL_THRESHOLD ?? "0.5",
 );
 
-function withCreditFlags(balance: number): CloudCreditsResponse {
+function withCreditFlags(
+  balance: number,
+  topUpUrl: string,
+): CloudCreditsResponse {
   return {
     connected: true,
     balance,
     low: balance < CREDIT_LOW_THRESHOLD,
     critical: balance < CREDIT_CRITICAL_THRESHOLD,
-    topUpUrl: CLOUD_BILLING_URL,
+    topUpUrl,
   };
 }
 
@@ -397,6 +419,7 @@ export async function fetchCloudCredits(
   runtime: AgentRuntime | null,
 ): Promise<CloudCreditsResponse> {
   const snapshot = resolveCloudConnectionSnapshot(config, runtime);
+  const topUpUrl = resolveCloudBillingUrl(config.cloud?.baseUrl);
   let authenticatedFailure: string | null = null;
   let authenticatedUnexpectedResponse = false;
 
@@ -416,7 +439,7 @@ export async function fetchCloudCredits(
         coerceCloudBalance(creditResponse?.data?.balance);
 
       if (typeof rawBalance === "number") {
-        return withCreditFlags(rawBalance);
+        return withCreditFlags(rawBalance, topUpUrl);
       }
 
       authenticatedUnexpectedResponse = true;
@@ -468,7 +491,7 @@ export async function fetchCloudCredits(
       };
     }
 
-    return withCreditFlags(balance);
+    return withCreditFlags(balance, topUpUrl);
   } catch (err) {
     if (err instanceof CloudCreditsAuthRejectedError) {
       logger.debug(`[cloud/credits] API key rejected: ${err.message}`);
@@ -477,7 +500,7 @@ export async function fetchCloudCredits(
         connected: true,
         authRejected: true,
         error: err.message,
-        topUpUrl: CLOUD_BILLING_URL,
+        topUpUrl,
       };
     }
     const msg = err instanceof Error ? err.message : "cloud API unreachable";

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -6,7 +6,9 @@
 
 import type { IAgentRuntime, ImageDescriptionParams, ImageGenerationParams } from "@elizaos/core";
 import { ElizaError, logger, ModelType } from "@elizaos/core";
+import { resolveCloudBillingUrl } from "../cloud/base-url";
 import {
+  getBaseURL,
   getImageDescriptionModel,
   getImageGenerationModel,
   getSetting,
@@ -283,7 +285,7 @@ export async function handleImageDescription(
       const status = finalResponse.status;
       if (status === 402) {
         throw new Error(
-          "Eliza Cloud credits exhausted — top up at https://cloud.eliza.app/cloud/billing"
+          `Eliza Cloud credits exhausted — top up at ${resolveCloudBillingUrl(getBaseURL(runtime))}`,
         );
       }
       if (status === 429) {

--- a/plugins/plugin-elizacloud/src/routes/cloud-billing-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-billing-routes.ts
@@ -1,11 +1,17 @@
 import type http from "node:http";
 import type { AgentRuntime, Service } from "@elizaos/core";
-import { normalizeCloudSiteUrl } from "../cloud/base-url.js";
+import {
+  normalizeCloudSiteUrl,
+  resolveCloudRedirectScope,
+} from "../cloud/base-url.js";
 import {
   type CloudAuthApiKeyService,
   normalizeCloudApiKey,
 } from "../cloud/auth-service-types";
-import { resolveCloudApiKey } from "../cloud/cloud-api-key.js";
+import {
+  resolveCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
+} from "../cloud/cloud-api-key.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 import type { CloudProxyConfigLike } from "../lib/config-like";
 import { sendJson, sendJsonError } from "../lib/http";
@@ -95,7 +101,11 @@ function resolveProxyApiKey(state: CloudBillingRouteState): string | null {
       ? normalizeCloudApiKey(cloudAuth.getApiKey?.())
       : null;
 
-  return runtimeApiKey ?? resolveCloudApiKey(state.config, state.runtime);
+  return resolveCloudApiKeyWithRuntimeOverride(
+    runtimeApiKey,
+    state.config,
+    state.runtime,
+  );
 }
 
 function buildAuthHeaders(
@@ -177,7 +187,7 @@ function readBody(req: http.IncomingMessage): Promise<string | undefined> {
   });
 }
 
-async function fetchUpstream(
+export async function fetchUpstream(
   url: string,
   method: string,
   headers: Record<string, string>,
@@ -210,11 +220,13 @@ async function fetchUpstream(
     }
 
     const nextUrl = new URL(location, currentUrl).toString();
-    const currentOrigin = normalizeCloudSiteUrl(new URL(currentUrl).origin);
-    const nextOrigin = normalizeCloudSiteUrl(new URL(nextUrl).origin);
+    const currentOrigin = new URL(currentUrl).origin;
+    const nextOrigin = new URL(nextUrl).origin;
+    const currentScope = resolveCloudRedirectScope(currentOrigin);
+    const nextScope = resolveCloudRedirectScope(nextOrigin);
     if (
-      new URL(currentUrl).origin !== new URL(nextUrl).origin &&
-      currentOrigin !== nextOrigin
+      currentOrigin !== nextOrigin &&
+      (currentScope === null || currentScope !== nextScope)
     ) {
       throw Object.assign(new Error("redirect"), { code: "REDIRECT" });
     }

--- a/plugins/plugin-elizacloud/src/routes/cloud-compat-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-compat-routes.ts
@@ -6,7 +6,10 @@ import {
   type CloudAuthApiKeyService,
   normalizeCloudApiKey,
 } from "../cloud/auth-service-types";
-import { resolveCloudApiKey } from "../cloud/cloud-api-key.js";
+import {
+  resolveCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
+} from "../cloud/cloud-api-key.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 import type { CloudProxyConfigLike } from "../lib/config-like";
 import { sendJson, sendJsonError } from "../lib/http";
@@ -33,7 +36,11 @@ function resolveProxyApiKey(state: CloudCompatRouteState): string | null {
       ? normalizeCloudApiKey(cloudAuth.getApiKey?.())
       : null;
 
-  return runtimeApiKey ?? resolveCloudApiKey(state.config, state.runtime);
+  return resolveCloudApiKeyWithRuntimeOverride(
+    runtimeApiKey,
+    state.config,
+    state.runtime,
+  );
 }
 
 function buildAuthHeaders(

--- a/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
@@ -1,39 +1,4 @@
-import { readAliasedEnv } from "@elizaos/shared";
-
-function hasValue(value: string | undefined): boolean {
-  return Boolean(value?.trim());
-}
-
-function hasCompatApiToken(): boolean {
-  return hasValue(readAliasedEnv("ELIZA_API_TOKEN"));
-}
-
-function hasCloudApiKeyProvisioning(): boolean {
-  return (
-    process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
-    hasValue(process.env.ELIZAOS_CLOUD_API_KEY)
-  );
-}
-
-/**
- * Platform-managed cloud containers should skip local pairing and onboarding UI.
- *
- * In production we may have either:
- * - a Steward sidecar token (older / sidecar-managed path),
- * - an inbound API token injected directly into the container, or
- * - cloud-managed API-key access injected into the runtime environment.
- *
- * Requiring the cloud flag plus one of those credentials keeps accidental local
- * env leakage from triggering cloud behavior, while still matching real deployed
- * cloud containers.
- */
-export function isCloudProvisionedContainer(): boolean {
-  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
-
-  return (
-    hasCloudFlag &&
-    (hasValue(process.env.STEWARD_AGENT_TOKEN) ||
-      hasCompatApiToken() ||
-      hasCloudApiKeyProvisioning())
-  );
-}
+// Keep the plugin's historical export path, but make the shared host-layer
+// detector the only implementation. This prevents route/UI consumers from
+// drifting away from the immutable local-development Cloud authority policy.
+export { isCloudProvisionedContainer } from "@elizaos/shared";

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes.authority.test.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes.authority.test.ts
@@ -1,0 +1,339 @@
+import type http from "node:http";
+import {
+  type DevCloudEnvAuthority,
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CloudRouteState,
+  handleCloudRoute,
+} from "./cloud-routes.js";
+
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZA_CLOUD_ORGANIZATION_ID",
+  "ELIZA_CLOUD_SERVICE_KEY",
+  "ELIZA_CLOUD_USER_ID",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof AUTHORITY_ENV_KEYS)[number], string | undefined>;
+
+const BLOCK_REASON =
+  "Cloud login cannot persist credentials owned by the immutable local development launch target";
+
+const GUARDED_ROUTES = [
+  {
+    label: "login",
+    method: "POST",
+    pathname: "/api/cloud/login",
+    url: "/api/cloud/login",
+  },
+  {
+    label: "login status",
+    method: "GET",
+    pathname: "/api/cloud/login/status",
+    url: "/api/cloud/login/status?sessionId=immutable-session",
+  },
+  {
+    label: "login persist",
+    method: "POST",
+    pathname: "/api/cloud/login/persist",
+    url: "/api/cloud/login/persist",
+  },
+  {
+    label: "disconnect",
+    method: "POST",
+    pathname: "/api/cloud/disconnect",
+    url: "/api/cloud/disconnect",
+  },
+] as const;
+
+function restoreAuthorityEnv(): void {
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function installAuthority(authority: DevCloudEnvAuthority): void {
+  resetDevCloudEnvAuthorityForTests();
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZA_DEV_CLOUD_TARGET = authority;
+  process.env.ELIZAOS_CLOUD_API_KEY = `launch-${authority}-key`;
+  process.env.ELIZAOS_CLOUD_BASE_URL =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  process.env.ELIZAOS_CLOUD_ENABLED = "true";
+  process.env.ELIZA_CLOUD_ORGANIZATION_ID = `launch-${authority}-org`;
+  process.env.ELIZA_CLOUD_SERVICE_KEY = `launch-${authority}-service-key`;
+  process.env.ELIZA_CLOUD_USER_ID = `launch-${authority}-user`;
+  expect(resolveDevCloudEnvAuthority()).toBe(authority);
+}
+
+function requestTrap(method: string, url: string): http.IncomingMessage {
+  return {
+    get body(): never {
+      throw new Error("guarded Cloud route read its request body");
+    },
+    headers: { host: "127.0.0.1:3000" },
+    method,
+    url,
+    [Symbol.asyncIterator](): never {
+      throw new Error("guarded Cloud route consumed its request stream");
+    },
+  } as unknown as http.IncomingMessage;
+}
+
+function responseSink(): http.ServerResponse & { jsonBody: () => unknown } {
+  let body = "";
+  const sink = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader: () => {},
+    end: (chunk?: unknown) => {
+      body = typeof chunk === "string" ? chunk : String(chunk ?? "");
+      sink.headersSent = true;
+      return sink;
+    },
+    jsonBody: () => (body ? JSON.parse(body) : undefined),
+  };
+  return sink as unknown as http.ServerResponse & {
+    jsonBody: () => unknown;
+  };
+}
+
+function createRouteState() {
+  const settings = {
+    ELIZAOS_CLOUD_API_KEY: "runtime-production-key",
+    ELIZA_CLOUD_USER_ID: "runtime-production-user",
+  };
+  const runtime = {
+    agentId: "11111111-2222-4333-8444-555555555555",
+    character: {
+      secrets: {
+        ELIZAOS_CLOUD_API_KEY: "runtime-production-key",
+        ELIZA_CLOUD_ORGANIZATION_ID: "runtime-production-org",
+      },
+      settings: { ...settings },
+    },
+    getService: vi.fn(() => null),
+    getSetting: vi.fn((key: string) => settings[key as keyof typeof settings]),
+    setSetting: vi.fn(),
+    updateAgent: vi.fn(async () => undefined),
+  };
+  const cloudManager = {
+    connect: vi.fn(),
+    disconnect: vi.fn(async () => undefined),
+    getActiveAgentId: vi.fn(() => null),
+    getClient: vi.fn(() => null),
+    getStatus: vi.fn(() => ({ connected: true })),
+    init: vi.fn(async () => undefined),
+    replaceApiKey: vi.fn(async () => undefined),
+  };
+  const sideEffects = {
+    applyCanonicalSetupConfig: vi.fn(),
+    handleAutonomousCloudRoute: vi.fn(async () => false),
+    normalizeCloudSiteUrl: vi.fn((value?: string) => value ?? ""),
+    saveElizaConfig: vi.fn(),
+    validateCloudBaseUrl: vi.fn(async () => null),
+  };
+  const state: CloudRouteState = {
+    config: {
+      cloud: {
+        apiKey: "durable-production-key",
+        baseUrl: "https://durable.example/api/v1",
+        enabled: true,
+      },
+      linkedAccounts: {
+        elizacloud: { source: "api-key", status: "linked" },
+      },
+    },
+    cloudManager:
+      cloudManager as unknown as CloudRouteState["cloudManager"],
+    runtime: runtime as unknown as CloudRouteState["runtime"],
+    services: sideEffects,
+  };
+  return { cloudManager, runtime, sideEffects, state };
+}
+
+function cloudEnvBytes(): string {
+  return JSON.stringify(
+    Object.entries(process.env)
+      .filter(
+        ([key]) =>
+          key === "ELIZA_DEV_SOURCE" ||
+          key.includes("CLOUD") ||
+          key.startsWith("ELIZACLOUD_"),
+      )
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function runtimeBytes(runtime: ReturnType<typeof createRouteState>["runtime"]): string {
+  return JSON.stringify({
+    agentId: runtime.agentId,
+    character: runtime.character,
+  });
+}
+
+function expectNoRouteSideEffects(
+  fixture: ReturnType<typeof createRouteState>,
+): void {
+  expect(fixture.cloudManager.connect).not.toHaveBeenCalled();
+  expect(fixture.cloudManager.disconnect).not.toHaveBeenCalled();
+  expect(fixture.cloudManager.getActiveAgentId).not.toHaveBeenCalled();
+  expect(fixture.cloudManager.getClient).not.toHaveBeenCalled();
+  expect(fixture.cloudManager.getStatus).not.toHaveBeenCalled();
+  expect(fixture.cloudManager.init).not.toHaveBeenCalled();
+  expect(fixture.cloudManager.replaceApiKey).not.toHaveBeenCalled();
+  expect(fixture.runtime.getService).not.toHaveBeenCalled();
+  expect(fixture.runtime.getSetting).not.toHaveBeenCalled();
+  expect(fixture.runtime.setSetting).not.toHaveBeenCalled();
+  expect(fixture.runtime.updateAgent).not.toHaveBeenCalled();
+  expect(fixture.sideEffects.applyCanonicalSetupConfig).not.toHaveBeenCalled();
+  expect(fixture.sideEffects.handleAutonomousCloudRoute).not.toHaveBeenCalled();
+  expect(fixture.sideEffects.normalizeCloudSiteUrl).not.toHaveBeenCalled();
+  expect(fixture.sideEffects.saveElizaConfig).not.toHaveBeenCalled();
+  expect(fixture.sideEffects.validateCloudBaseUrl).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  restoreAuthorityEnv();
+  resetDevCloudEnvAuthorityForTests();
+});
+
+afterEach(() => {
+  restoreAuthorityEnv();
+  resetDevCloudEnvAuthorityForTests();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("immutable development Cloud route authority", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "%s rejects login and disconnect routes without fetch or disconnect",
+    async (authority) => {
+      installAuthority(authority);
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("guarded route attempted fetch"));
+      const fixture = createRouteState();
+
+      for (const route of GUARDED_ROUTES) {
+        const response = responseSink();
+        const handled = await handleCloudRoute(
+          requestTrap(route.method, route.url),
+          response,
+          route.pathname,
+          route.method,
+          fixture.state,
+        );
+
+        expect(handled, route.label).toBe(true);
+        expect(response.statusCode, route.label).toBe(409);
+        expect(response.jsonBody(), route.label).toEqual({
+          ok: false,
+          error: BLOCK_REASON,
+        });
+      }
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expectNoRouteSideEffects(fixture);
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "%s preserves config, runtime, and env byte-for-byte",
+    async (authority) => {
+      installAuthority(authority);
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("guarded route attempted fetch"));
+      const fixture = createRouteState();
+      const configBefore = JSON.stringify(fixture.state.config);
+      const runtimeBefore = runtimeBytes(fixture.runtime);
+      const envBefore = cloudEnvBytes();
+
+      for (const route of GUARDED_ROUTES) {
+        const response = responseSink();
+        const handled = await handleCloudRoute(
+          requestTrap(route.method, route.url),
+          response,
+          route.pathname,
+          route.method,
+          fixture.state,
+        );
+
+        expect(handled, route.label).toBe(true);
+        expect(response.statusCode, route.label).toBe(409);
+        expect(response.jsonBody(), route.label).toEqual({
+          ok: false,
+          error: BLOCK_REASON,
+        });
+        expect(JSON.stringify(fixture.state.config), route.label).toBe(
+          configBefore,
+        );
+        expect(runtimeBytes(fixture.runtime), route.label).toBe(runtimeBefore);
+        expect(cloudEnvBytes(), route.label).toBe(envBefore);
+      }
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expectNoRouteSideEffects(fixture);
+    },
+  );
+
+  it("preserves the ordinary no-authority login delegation", async () => {
+    delete process.env.ELIZA_DEV_SOURCE;
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+    resetDevCloudEnvAuthorityForTests();
+    const fixture = createRouteState();
+    fixture.sideEffects.handleAutonomousCloudRoute.mockResolvedValue(true);
+    const response = responseSink();
+
+    const handled = await handleCloudRoute(
+      requestTrap("POST", "/api/cloud/login"),
+      response,
+      "/api/cloud/login",
+      "POST",
+      fixture.state,
+    );
+
+    expect(handled).toBe(true);
+    expect(fixture.sideEffects.handleAutonomousCloudRoute).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the ordinary no-authority disconnect behavior", async () => {
+    delete process.env.ELIZA_DEV_SOURCE;
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+    resetDevCloudEnvAuthorityForTests();
+    const fixture = createRouteState();
+    const response = responseSink();
+
+    const handled = await handleCloudRoute(
+      requestTrap("POST", "/api/cloud/disconnect"),
+      response,
+      "/api/cloud/disconnect",
+      "POST",
+      fixture.state,
+    );
+
+    expect(handled).toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(response.jsonBody()).toEqual({ ok: true, status: "disconnected" });
+    expect(fixture.cloudManager.disconnect).toHaveBeenCalledOnce();
+    expect(fixture.sideEffects.saveElizaConfig).toHaveBeenCalledOnce();
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes.ts
@@ -3,6 +3,7 @@ import {
   isCloudInferenceSelectedInConfig,
   migrateLegacyRuntimeConfig,
 } from "@elizaos/core";
+import { resolveDevCloudEnvAuthority } from "@elizaos/shared";
 import { type CloudRouteState as AutonomousCloudRouteState, handleCloudRoute as handleAutonomousCloudRoute, } from "./cloud-routes-autonomous.js";
 import {
   buildHomeRemoteRunnerAccessUrl,
@@ -74,6 +75,26 @@ type RelayStatusService = {
 };
 
 const CLOUD_LOGIN_POLL_TIMEOUT_MS = 10_000;
+
+function cloudLoginMutationBlockReason(): string | null {
+  return resolveDevCloudEnvAuthority()
+    ? "Cloud login cannot persist credentials owned by the immutable local development launch target"
+    : null;
+}
+
+function isCloudConnectionMutationRoute(
+  pathname: string,
+  method: string,
+): boolean {
+  return (
+    (method === "POST" &&
+      (pathname === "/api/cloud/login" ||
+        pathname === "/api/cloud/login/persist" ||
+        pathname === "/api/cloud/disconnect")) ||
+    (method === "GET" && pathname === "/api/cloud/login/status")
+  );
+}
+
 const DEFAULT_CLOUD_ROUTE_SERVICES: CloudRouteServices = {
   applyCanonicalSetupConfig,
   createIntegrationTelemetrySpan: () => undefined,
@@ -273,6 +294,13 @@ async function persistCloudLoginStatus(args: {
    */
   forceInferenceEnabled?: boolean;
 }): Promise<string | null> {
+  if (cloudLoginMutationBlockReason()) {
+    logger.warn(
+      "[cloud-login] Ignoring credential persistence that differs from the development launcher Cloud profile",
+    );
+    return null;
+  }
+
   if (
     args.epochAtPollStart !== undefined &&
     args.epochAtPollStart !== cloudDisconnectEpoch
@@ -477,6 +505,15 @@ export async function handleCloudRoute(
   method: string,
   state: CloudRouteState,
 ): Promise<boolean> {
+  const authorityBlockReason = cloudLoginMutationBlockReason();
+  if (
+    authorityBlockReason &&
+    isCloudConnectionMutationRoute(pathname, method)
+  ) {
+    sendJson(res, { ok: false, error: authorityBlockReason }, 409);
+    return true;
+  }
+
   const services = getCloudRouteServices(state);
 
   const codingContainerHandled = await handleCloudCodingContainerRoute(

--- a/plugins/plugin-elizacloud/src/routes/cloud-status-routes-autonomous.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-status-routes-autonomous.ts
@@ -9,14 +9,14 @@ import type {
   RouteRequestMeta,
   Service,
 } from "@elizaos/core";
-import { resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl } from "../cloud/base-url.js";
+import {
+  resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl,
+  resolveCloudBillingUrl,
+} from "../cloud/base-url.js";
 import { resolveCloudApiKey } from "../cloud/cloud-api-key.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 
 const DEFAULT_CLOUD_API_BASE_URL = "https://api.eliza.app/api/v1";
-const CLOUD_BILLING_URL =
-  "https://cloud.eliza.app/cloud/billing";
-
 interface CloudAuthIdentityService {
   isAuthenticated: () => boolean;
   getUserId?: () => string | undefined;
@@ -116,6 +116,7 @@ export async function handleCloudStatusRoutes(
   ctx: CloudStatusRouteContext,
 ): Promise<boolean> {
   const { res, method, pathname, config, runtime, json } = ctx;
+  const topUpUrl = resolveCloudBillingUrl(config.cloud?.baseUrl);
 
   if (method === "GET" && pathname === "/api/cloud/status") {
     migrateLegacyRuntimeConfig(config as Record<string, unknown>);
@@ -143,7 +144,7 @@ export async function handleCloudStatusRoutes(
         organizationId: authConnected
           ? cloudAuth?.getOrganizationId?.()
           : undefined,
-        topUpUrl: CLOUD_BILLING_URL,
+        topUpUrl,
         reason: authConnected
           ? undefined
           : runtime
@@ -207,7 +208,7 @@ export async function handleCloudStatusRoutes(
         balance,
         low,
         critical,
-        topUpUrl: CLOUD_BILLING_URL,
+        topUpUrl,
       });
       return true;
     }
@@ -233,7 +234,7 @@ export async function handleCloudStatusRoutes(
       balance,
       low,
       critical,
-      topUpUrl: CLOUD_BILLING_URL,
+      topUpUrl,
     });
     return true;
   }

--- a/plugins/plugin-elizacloud/src/routes/cloud-status-routes.authority.test.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-status-routes.authority.test.ts
@@ -1,0 +1,116 @@
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveCloudApiKeysUrl,
+  resolveCloudBillingUrl,
+} from "../cloud/base-url.js";
+import { handleCloudStatusRoutes as handleAutonomousCloudStatusRoutes } from "./cloud-status-routes-autonomous.js";
+import { handleCloudStatusRoutes } from "./cloud-status-routes.js";
+
+const authorityEnvKeys = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+
+const originalAuthorityEnv = Object.fromEntries(
+  authorityEnvKeys.map((key) => [key, process.env[key]]),
+) as Record<(typeof authorityEnvKeys)[number], string | undefined>;
+
+function installStagingAuthority(): void {
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+  process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+  process.env.ELIZAOS_CLOUD_API_KEY = "launcher-staging-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL =
+    "https://api-staging.eliza.app/api/v1";
+  captureDevCloudEnvAuthoritySnapshot();
+
+  process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+}
+
+async function readStatusBody(
+  handler: typeof handleCloudStatusRoutes,
+): Promise<Record<string, unknown>> {
+  const json = vi.fn();
+  const handled = await handler({
+    req: {} as never,
+    res: {} as never,
+    method: "GET",
+    pathname: "/api/cloud/status",
+    config: {
+      cloud: {
+        apiKey: "persisted-production-key",
+        baseUrl: "https://api.eliza.app/api/v1",
+      },
+    },
+    runtime: null,
+    json,
+  });
+  expect(handled).toBe(true);
+  expect(json).toHaveBeenCalledOnce();
+  return json.mock.calls[0]?.[1] as Record<string, unknown>;
+}
+
+describe("Cloud status billing URL authority", () => {
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    for (const key of authorityEnvKeys) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of authorityEnvKeys) {
+      const value = originalAuthorityEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it.each([
+    ["shared status", handleCloudStatusRoutes],
+    ["autonomous status", handleAutonomousCloudStatusRoutes],
+  ] as const)("keeps %s top-up links on staging", async (_name, handler) => {
+    installStagingAuthority();
+
+    const body = await readStatusBody(
+      handler as unknown as typeof handleCloudStatusRoutes,
+    );
+
+    expect(body).toMatchObject({
+      connected: true,
+      hasApiKey: true,
+      topUpUrl: "https://cloud-staging.eliza.app/cloud/billing",
+    });
+  });
+
+  it("uses a valid self-hosted site for billing", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "self-hosted";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "http://localhost:8787/api/v1";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+    expect(resolveCloudBillingUrl("https://api.eliza.app/api/v1")).toBe(
+      "http://localhost:8787/cloud/billing",
+    );
+    expect(resolveCloudApiKeysUrl("https://api.eliza.app/api/v1")).toBe(
+      "http://localhost:8787/cloud/api-keys",
+    );
+  });
+
+  it("keeps API-key management on staging after late endpoint pollution", () => {
+    installStagingAuthority();
+
+    expect(resolveCloudApiKeysUrl("https://api.eliza.app/api/v1")).toBe(
+      "https://cloud-staging.eliza.app/cloud/api-keys",
+    );
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-status-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-status-routes.ts
@@ -5,10 +5,10 @@ import type {
 import type { ElizaConfig } from "../lib/config-like";
 import { isElizaCloudServiceSelectedInConfig } from "@elizaos/core";
 import {
-  CLOUD_BILLING_URL,
   fetchCloudCredits,
   resolveCloudConnectionSnapshot,
 } from "../lib/cloud-connection";
+import { resolveCloudBillingUrl } from "../cloud/base-url.js";
 
 export type { CloudConfigLike, CloudStatusRouteContext };
 
@@ -17,6 +17,7 @@ export async function handleCloudStatusRoutes(
 ): Promise<boolean> {
   const { res, method, pathname, config, runtime, json } = ctx;
   const typedConfig = config as ElizaConfig;
+  const topUpUrl = resolveCloudBillingUrl(typedConfig.cloud?.baseUrl);
 
   if (method === "GET" && pathname === "/api/cloud/status") {
     const snapshot = resolveCloudConnectionSnapshot(typedConfig, runtime);
@@ -33,7 +34,7 @@ export async function handleCloudStatusRoutes(
         hasApiKey: snapshot.hasApiKey,
         userId: snapshot.userId,
         organizationId: snapshot.organizationId,
-        topUpUrl: CLOUD_BILLING_URL,
+        topUpUrl,
         reason: snapshot.authConnected
           ? undefined
           : runtime

--- a/plugins/plugin-elizacloud/src/routes/travel-provider-relay-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/travel-provider-relay-routes.ts
@@ -10,7 +10,10 @@ import {
   normalizeCloudApiKey,
 } from "../cloud/auth-service-types.js";
 import { normalizeCloudSiteUrl } from "../cloud/base-url.js";
-import { resolveCloudApiKey } from "../cloud/cloud-api-key.js";
+import {
+  resolveCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
+} from "../cloud/cloud-api-key.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 import type { CloudProxyConfigLike } from "../lib/config-like";
 
@@ -32,7 +35,11 @@ function resolveProxyApiKey(
     isCloudAuthApiKeyService(cloudAuth) && cloudAuth.isAuthenticated() === true
       ? normalizeCloudApiKey(cloudAuth.getApiKey?.())
       : null;
-  return runtimeApiKey ?? resolveCloudApiKey(state.config, state.runtime);
+  return resolveCloudApiKeyWithRuntimeOverride(
+    runtimeApiKey,
+    state.config,
+    state.runtime,
+  );
 }
 
 function buildAuthHeaders(

--- a/plugins/plugin-elizacloud/src/routes/x-relay-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/x-relay-routes.ts
@@ -25,7 +25,10 @@ import {
   normalizeCloudApiKey,
 } from "../cloud/auth-service-types.js";
 import { normalizeCloudSiteUrl } from "../cloud/base-url.js";
-import { resolveCloudApiKey } from "../cloud/cloud-api-key.js";
+import {
+  resolveCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
+} from "../cloud/cloud-api-key.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 import type { CloudProxyConfigLike } from "../lib/config-like";
 
@@ -44,7 +47,11 @@ function resolveProxyApiKey(state: XRelayRouteState): string | null {
     isCloudAuthApiKeyService(cloudAuth) && cloudAuth.isAuthenticated() === true
       ? normalizeCloudApiKey(cloudAuth.getApiKey?.())
       : null;
-  return runtimeApiKey ?? resolveCloudApiKey(state.config, state.runtime);
+  return resolveCloudApiKeyWithRuntimeOverride(
+    runtimeApiKey,
+    state.config,
+    state.runtime,
+  );
 }
 
 function buildAuthHeaders(

--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -12,7 +12,7 @@ import {
   Service,
   type UUID,
 } from "@elizaos/core";
-import { readAliasedEnv } from "@elizaos/shared";
+import { isCloudProvisionedContainer } from "@elizaos/shared";
 import type {
   GatewayRelayRequest,
   GatewayRelayRequestEnvelope,
@@ -58,13 +58,6 @@ function resolveChannelType(value: unknown): ChannelType {
   return candidate && candidate in ChannelType
     ? ChannelType[candidate as keyof typeof ChannelType]
     : ChannelType.DM;
-}
-
-function isCloudProvisionedRuntime(): boolean {
-  if (typeof process === "undefined") {
-    return false;
-  }
-  return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 function isNodeHost(): boolean {
@@ -256,7 +249,7 @@ export class CloudManagedGatewayRelayService extends Service {
       return;
     }
 
-    if (isCloudProvisionedRuntime()) {
+    if (isCloudProvisionedContainer()) {
       logger.debug(
         "[CloudManagedGatewayRelay] Skipping local relay inside provisioned cloud runtime"
       );

--- a/plugins/plugin-elizacloud/src/utils/config.ts
+++ b/plugins/plugin-elizacloud/src/utils/config.ts
@@ -5,6 +5,10 @@ import {
   DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
 } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  type DevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 export const DEFAULT_ELIZA_CLOUD_LARGE_MODEL =
   DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL;
@@ -39,6 +43,14 @@ export function isProxyMode(runtime: IAgentRuntime): boolean {
 
 export type EndpointSettingReader = (key: string) => string | undefined;
 
+/** Atomic Cloud endpoint and credential choice used by outbound SDK clients. */
+export interface CloudSdkAuthorityTuple {
+  readonly authority: DevCloudEnvAuthority | null;
+  readonly apiBaseUrl: string;
+  readonly apiKey: string | undefined;
+  readonly outboundAllowed: boolean;
+}
+
 /** Pure endpoint policy shared by inference and diagnostic surfaces. */
 export function resolveElizaCloudBaseURL(
   readSetting: EndpointSettingReader,
@@ -55,7 +67,7 @@ export function resolveElizaCloudBaseURL(
   );
 }
 
-export function getBaseURL(runtime: IAgentRuntime): string {
+function resolveUnmanagedBaseURL(runtime: IAgentRuntime): string {
   return resolveElizaCloudBaseURL(
     (key) => {
       const runtimeValue = runtime.getSetting(key);
@@ -69,7 +81,7 @@ export function getBaseURL(runtime: IAgentRuntime): string {
   );
 }
 
-export function getEmbeddingBaseURL(runtime: IAgentRuntime): string {
+function resolveUnmanagedEmbeddingBaseURL(runtime: IAgentRuntime): string {
   const embeddingURL = isBrowser()
     ? getSetting(runtime, "ELIZAOS_CLOUD_BROWSER_EMBEDDING_URL") ||
       getSetting(runtime, "ELIZAOS_CLOUD_BROWSER_BASE_URL")
@@ -79,11 +91,106 @@ export function getEmbeddingBaseURL(runtime: IAgentRuntime): string {
     return embeddingURL;
   }
   logger.debug("[ELIZAOS_CLOUD] Falling back to general base URL for embeddings.");
-  return getBaseURL(runtime);
+  return resolveUnmanagedBaseURL(runtime);
+}
+
+function resolveUnmanagedApiKey(runtime: IAgentRuntime): string | undefined {
+  return getSetting(runtime, "ELIZAOS_CLOUD_API_KEY");
+}
+
+function resolveUnmanagedEmbeddingApiKey(
+  runtime: IAgentRuntime,
+): string | undefined {
+  const embeddingApiKey = getSetting(runtime, "ELIZAOS_CLOUD_EMBEDDING_API_KEY");
+  if (embeddingApiKey) {
+    logger.debug("[ELIZAOS_CLOUD] Using specific embedding API key (present)");
+    return embeddingApiKey;
+  }
+  logger.debug("[ELIZAOS_CLOUD] Falling back to general API key for embeddings.");
+  return resolveUnmanagedApiKey(runtime);
+}
+
+function frozenValue(
+  values: Readonly<Record<string, string | undefined>>,
+  key: string,
+): string | undefined {
+  const value = values[key]?.trim();
+  return value || undefined;
+}
+
+/**
+ * Resolve one immutable endpoint/credential tuple for a Cloud SDK operation.
+ *
+ * A development launcher authority owns the complete tuple. Runtime settings
+ * and later `process.env` mutations must not replace either half. The two
+ * deliberately unauthenticated targets also block SDK traffic entirely.
+ */
+export function resolveCloudSdkAuthorityTuple(
+  runtime: IAgentRuntime,
+  embedding = false,
+): CloudSdkAuthorityTuple {
+  const snapshot =
+    !isBrowser() && typeof process !== "undefined"
+      ? captureDevCloudEnvAuthoritySnapshot(process.env)
+      : null;
+
+  if (!snapshot) {
+    const apiBaseUrl = embedding
+      ? resolveUnmanagedEmbeddingBaseURL(runtime)
+      : resolveUnmanagedBaseURL(runtime);
+    const apiKey = isBrowser()
+      ? undefined
+      : embedding
+        ? resolveUnmanagedEmbeddingApiKey(runtime)
+        : resolveUnmanagedApiKey(runtime);
+    return Object.freeze({
+      authority: null,
+      apiBaseUrl,
+      apiKey,
+      outboundAllowed: true,
+    });
+  }
+
+  const blocked =
+    snapshot.authority === "staging-default" || snapshot.authority === "offline";
+  const embeddingBaseUrl = embedding
+    ? frozenValue(snapshot.values, "ELIZAOS_CLOUD_EMBEDDING_URL")
+    : undefined;
+  const apiBaseUrl =
+    embeddingBaseUrl ??
+    frozenValue(snapshot.values, "ELIZAOS_CLOUD_BASE_URL") ??
+    "";
+  const embeddingApiKey = embedding
+    ? frozenValue(snapshot.values, "ELIZAOS_CLOUD_EMBEDDING_API_KEY")
+    : undefined;
+  const apiKey = blocked
+    ? undefined
+    : embeddingApiKey ?? frozenValue(snapshot.values, "ELIZAOS_CLOUD_API_KEY");
+
+  if (embeddingBaseUrl) {
+    logger.debug(
+      `[ELIZAOS_CLOUD] Using launcher-authorized embedding base URL: ${embeddingBaseUrl}`,
+    );
+  }
+
+  return Object.freeze({
+    authority: snapshot.authority,
+    apiBaseUrl,
+    apiKey,
+    outboundAllowed: !blocked && Boolean(apiBaseUrl),
+  });
+}
+
+export function getBaseURL(runtime: IAgentRuntime): string {
+  return resolveCloudSdkAuthorityTuple(runtime).apiBaseUrl;
+}
+
+export function getEmbeddingBaseURL(runtime: IAgentRuntime): string {
+  return resolveCloudSdkAuthorityTuple(runtime, true).apiBaseUrl;
 }
 
 export function getApiKey(runtime: IAgentRuntime): string | undefined {
-  return getSetting(runtime, "ELIZAOS_CLOUD_API_KEY");
+  return resolveCloudSdkAuthorityTuple(runtime).apiKey;
 }
 
 /**
@@ -162,13 +269,7 @@ export function isCloudSttAvailable(runtime: IAgentRuntime): boolean {
 }
 
 export function getEmbeddingApiKey(runtime: IAgentRuntime): string | undefined {
-  const embeddingApiKey = getSetting(runtime, "ELIZAOS_CLOUD_EMBEDDING_API_KEY");
-  if (embeddingApiKey) {
-    logger.debug("[ELIZAOS_CLOUD] Using specific embedding API key (present)");
-    return embeddingApiKey;
-  }
-  logger.debug("[ELIZAOS_CLOUD] Falling back to general API key for embeddings.");
-  return getApiKey(runtime);
+  return resolveCloudSdkAuthorityTuple(runtime, true).apiKey;
 }
 
 export function getSmallModel(runtime: IAgentRuntime): string {

--- a/plugins/plugin-elizacloud/src/utils/sdk-client.ts
+++ b/plugins/plugin-elizacloud/src/utils/sdk-client.ts
@@ -1,12 +1,9 @@
 import { CloudApiClient, ElizaCloudClient } from "@elizaos/cloud-sdk";
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import {
-  getApiKey,
+  type CloudSdkAuthorityTuple,
   getAppId,
-  getBaseURL,
-  getEmbeddingApiKey,
-  getEmbeddingBaseURL,
-  isBrowser,
+  resolveCloudSdkAuthorityTuple,
 } from "./config";
 
 function trimTrailingSlash(value: string): string {
@@ -18,9 +15,16 @@ function apiBaseToSiteBaseUrl(apiBaseUrl: string): string {
   return trimmed.endsWith("/api/v1") ? trimmed.slice(0, -"/api/v1".length) : trimmed;
 }
 
-function apiKeyForRuntime(runtime: IAgentRuntime, embedding = false): string | undefined {
-  if (isBrowser()) return undefined;
-  return embedding ? getEmbeddingApiKey(runtime) : getApiKey(runtime);
+function assertOutboundAllowed(tuple: CloudSdkAuthorityTuple): void {
+  if (tuple.outboundAllowed) return;
+  throw new ElizaError(
+    "Eliza Cloud SDK requests are disabled by the local development Cloud target",
+    {
+      code: "ELIZA_CLOUD_DEV_AUTHORITY_OUTBOUND_BLOCKED",
+      context: { authority: tuple.authority },
+      severity: "fatal",
+    },
+  );
 }
 
 /**
@@ -37,21 +41,24 @@ function appAttributionHeaders(
 }
 
 export function createCloudApiClient(runtime: IAgentRuntime, embedding = false): CloudApiClient {
-  const baseUrl = embedding ? getEmbeddingBaseURL(runtime) : getBaseURL(runtime);
+  const tuple = resolveCloudSdkAuthorityTuple(runtime, embedding);
+  assertOutboundAllowed(tuple);
   return new ElizaCloudClient({
-    apiBaseUrl: trimTrailingSlash(baseUrl),
-    baseUrl: apiBaseToSiteBaseUrl(baseUrl),
-    apiKey: apiKeyForRuntime(runtime, embedding),
+    apiBaseUrl: trimTrailingSlash(tuple.apiBaseUrl),
+    baseUrl: apiBaseToSiteBaseUrl(tuple.apiBaseUrl),
+    apiKey: tuple.apiKey,
     defaultHeaders: appAttributionHeaders(runtime),
   }).v1;
 }
 
 export function createElizaCloudClient(runtime: IAgentRuntime): ElizaCloudClient {
-  const apiBaseUrl = trimTrailingSlash(getBaseURL(runtime));
+  const tuple = resolveCloudSdkAuthorityTuple(runtime);
+  assertOutboundAllowed(tuple);
+  const apiBaseUrl = trimTrailingSlash(tuple.apiBaseUrl);
   return new ElizaCloudClient({
     apiBaseUrl,
     baseUrl: apiBaseToSiteBaseUrl(apiBaseUrl),
-    apiKey: apiKeyForRuntime(runtime),
+    apiKey: tuple.apiKey,
     defaultHeaders: appAttributionHeaders(runtime),
   });
 }

--- a/plugins/plugin-finances/src/finances-cloud-base-url.test.ts
+++ b/plugins/plugin-finances/src/finances-cloud-base-url.test.ts
@@ -8,23 +8,56 @@
  * constructor instead.
  */
 import { ElizaCloudClient } from "@elizaos/cloud-sdk";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveFinancesCloudManagedClientConfig } from "./finances-service";
 
+const configMocks = vi.hoisted(() => ({
+  durable: {} as Record<string, unknown>,
+  effective: {} as Record<string, unknown>,
+}));
+
 vi.mock("@elizaos/agent/config/config", () => ({
-  loadElizaConfig: () => ({}),
+  loadElizaConfig: () => configMocks.durable,
+  loadEffectiveElizaConfig: () => configMocks.effective,
 }));
 
 describe("finances cloud managed-client base URL", () => {
-  const previous = process.env.ELIZAOS_CLOUD_BASE_URL;
+  const previousBaseUrl = process.env.ELIZAOS_CLOUD_BASE_URL;
+  const previousApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+  const previousDevSource = process.env.ELIZA_DEV_SOURCE;
+  const previousDevAuthority = process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+  const previousDevTarget = process.env.ELIZA_DEV_CLOUD_TARGET;
 
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    delete process.env.ELIZA_DEV_SOURCE;
+    delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+    delete process.env.ELIZA_DEV_CLOUD_TARGET;
     process.env.ELIZAOS_CLOUD_BASE_URL = "https://cloud.example";
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    configMocks.durable = {};
+    configMocks.effective = {};
   });
 
   afterEach(() => {
-    if (previous === undefined) delete process.env.ELIZAOS_CLOUD_BASE_URL;
-    else process.env.ELIZAOS_CLOUD_BASE_URL = previous;
+    if (previousBaseUrl === undefined)
+      delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    else process.env.ELIZAOS_CLOUD_BASE_URL = previousBaseUrl;
+    if (previousApiKey === undefined) delete process.env.ELIZAOS_CLOUD_API_KEY;
+    else process.env.ELIZAOS_CLOUD_API_KEY = previousApiKey;
+    if (previousDevSource === undefined) delete process.env.ELIZA_DEV_SOURCE;
+    else process.env.ELIZA_DEV_SOURCE = previousDevSource;
+    if (previousDevAuthority === undefined)
+      delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+    else process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = previousDevAuthority;
+    if (previousDevTarget === undefined)
+      delete process.env.ELIZA_DEV_CLOUD_TARGET;
+    else process.env.ELIZA_DEV_CLOUD_TARGET = previousDevTarget;
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("produces a base the real SDK client accepts", () => {
@@ -46,5 +79,55 @@ describe("finances cloud managed-client base URL", () => {
         apiKey: "test-key",
       });
     }).toThrow(/must be an origin or end at \/api\/v1/);
+  });
+
+  it("uses the effective staging view instead of durable production Cloud config", () => {
+    configMocks.durable = {
+      cloud: {
+        apiKey: "persisted-production-key",
+        baseUrl: "https://api.eliza.app/api/v1",
+      },
+    };
+    configMocks.effective = {
+      cloud: {
+        apiKey: "staging-key",
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+      },
+    };
+    process.env.ELIZAOS_CLOUD_API_KEY = "ambient-production-key";
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+
+    expect(resolveFinancesCloudManagedClientConfig()).toEqual({
+      configured: true,
+      apiKey: "staging-key",
+      apiBaseUrl: "https://api-staging.eliza.app/api/v1",
+      siteUrl: "https://cloud-staging.eliza.app",
+    });
+  });
+
+  it("does not revive Cloud clients from late process.env pollution in staging-default", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    configMocks.effective = {
+      cloud: {
+        apiKey: "",
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+      },
+    };
+
+    expect(resolveFinancesCloudManagedClientConfig()).toEqual({
+      configured: false,
+      apiKey: null,
+      apiBaseUrl: "https://api-staging.eliza.app/api/v1",
+      siteUrl: "https://cloud-staging.eliza.app",
+    });
   });
 });

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -16,7 +16,7 @@
 
 import crypto from "node:crypto";
 import path from "node:path";
-import { loadElizaConfig } from "@elizaos/agent/config/config";
+import { loadEffectiveElizaConfig } from "@elizaos/agent/config/config";
 import { resolveOAuthDir } from "@elizaos/agent/config/paths";
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import {
@@ -35,6 +35,10 @@ import {
   type PlaidTransactionDto,
   resolveCloudApiBaseUrl,
 } from "@elizaos/plugin-elizacloud/cloud/managed-payment-clients";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import {
   FinancesRepository,
   PlaidSyncCursorConflictError,
@@ -124,10 +128,23 @@ export type FinancesServiceOptions = {
 };
 
 export function resolveFinancesCloudManagedClientConfig(): ElizaCloudManagedClientConfig {
+  if (resolveDevCloudEnvAuthority()) {
+    const apiKey = normalizeElizaCloudApiKey(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+    const baseUrl = resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL");
+    return {
+      configured: Boolean(apiKey),
+      apiKey,
+      apiBaseUrl: resolveCloudApiBaseUrl(baseUrl),
+      siteUrl: normalizeCloudSiteUrl(baseUrl),
+    };
+  }
+
   let configKey: string | null = null;
   let configBase: string | null = null;
   try {
-    const config = loadElizaConfig();
+    const config = loadEffectiveElizaConfig();
     const cloud =
       config.cloud && typeof config.cloud === "object"
         ? (config.cloud as Record<string, unknown>)

--- a/plugins/plugin-local-inference/src/services/vision/cloud-fallback.test.ts
+++ b/plugins/plugin-local-inference/src/services/vision/cloud-fallback.test.ts
@@ -18,6 +18,10 @@ import type {
 	ImageDescriptionParams,
 	ImageDescriptionResult,
 } from "@elizaos/core";
+import {
+	resetDevCloudEnvAuthorityForTests,
+	resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type LocalImageDescriptionHandler,
@@ -33,12 +37,17 @@ const ENV_KEYS = [
 	"ELIZA_CLOUD_TOKEN",
 	"ELIZA_CLOUD_API_KEY",
 	"ELIZA_CLOUD_BASE_URL",
+	"ELIZA_DEV_SOURCE",
+	"ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+	"ELIZAOS_CLOUD_API_KEY",
+	"ELIZAOS_CLOUD_BASE_URL",
 	"ELIZA_VAST_BASE_URL",
 	"ELIZA_VAST_API_KEY",
 ] as const;
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
+	resetDevCloudEnvAuthorityForTests();
 	for (const key of ENV_KEYS) {
 		savedEnv[key] = process.env[key];
 		delete process.env[key];
@@ -50,6 +59,7 @@ afterEach(() => {
 		if (savedEnv[key] === undefined) delete process.env[key];
 		else process.env[key] = savedEnv[key];
 	}
+	resetDevCloudEnvAuthorityForTests();
 });
 
 const PNG_URL = "https://example.invalid/cat.png";
@@ -175,6 +185,86 @@ describe("wrapImageDescriptionHandlerWithCloudFallback", () => {
 		expect(out).toMatchObject({ kind: "fallback", reason: "local-error" });
 		expect((out as { cause?: Error }).cause?.message ?? "").toContain("503");
 	});
+
+	it.each(["staging-default", "offline"] as const)(
+		"does not call Cloud under %s authority despite hostile late configuration",
+		async (authority) => {
+			process.env.ELIZA_DEV_SOURCE = "1";
+			process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+			process.env.ELIZAOS_CLOUD_API_KEY = "";
+			process.env.ELIZAOS_CLOUD_BASE_URL =
+				"https://api-staging.eliza.app/api/v1";
+			expect(resolveDevCloudEnvAuthority()).toBe(authority);
+			process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+			process.env.ELIZA_CLOUD_TOKEN = "late-legacy-production-token";
+			process.env.ELIZA_CLOUD_BASE_URL = "https://api.eliza.app";
+
+			const fetchMock = vi.fn();
+			const wrapped = wrapImageDescriptionHandlerWithCloudFallback(
+				fallbackLocal("local-unavailable"),
+				{
+					token: "hostile-options-token",
+					baseUrl: "https://api.eliza.app",
+					fetch: fetchMock,
+				},
+			);
+			const out = await wrapped({
+				imageUrl: PNG_URL,
+			} as ImageDescriptionParams);
+
+			expect(fetchMock).not.toHaveBeenCalled();
+			expect(out).toMatchObject({
+				kind: "fallback",
+				reason: "local-unavailable",
+			});
+		},
+	);
+
+	it.each([
+		[
+			"staging-explicit",
+			"https://api-staging.eliza.app/api/v1",
+			"https://api-staging.eliza.app/v1/vision/describe",
+		],
+		[
+			"self-hosted",
+			"https://cloud.internal.example/api/v1",
+			"https://cloud.internal.example/v1/vision/describe",
+		],
+	] as const)(
+		"uses the frozen %s key and base after late environment pollution",
+		async (authority, launchBaseUrl, expectedUrl) => {
+			process.env.ELIZA_DEV_SOURCE = "1";
+			process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+			process.env.ELIZAOS_CLOUD_API_KEY = "launcher-key";
+			process.env.ELIZAOS_CLOUD_BASE_URL = launchBaseUrl;
+			expect(resolveDevCloudEnvAuthority()).toBe(authority);
+			process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+			process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+			process.env.ELIZA_CLOUD_TOKEN = "late-legacy-production-token";
+			process.env.ELIZA_CLOUD_BASE_URL = "https://api.eliza.app";
+
+			const fetchMock = vi.fn(async () =>
+				jsonResponse({ title: "Frozen", description: "Launcher tuple." }),
+			);
+			const wrapped = wrapImageDescriptionHandlerWithCloudFallback(
+				fallbackLocal("local-unavailable"),
+				{
+					token: "hostile-options-token",
+					baseUrl: "https://api.eliza.app",
+					fetch: fetchMock,
+				},
+			);
+			await wrapped({ imageUrl: PNG_URL } as ImageDescriptionParams);
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(expectedUrl);
+			expect((init.headers as Record<string, string>).authorization).toBe(
+				"Bearer launcher-key",
+			);
+		},
+	);
 });
 
 describe("wrapImageDescriptionHandlerWithVastFallback", () => {

--- a/plugins/plugin-local-inference/src/services/vision/cloud-fallback.ts
+++ b/plugins/plugin-local-inference/src/services/vision/cloud-fallback.ts
@@ -11,6 +11,11 @@ import type {
 	ImageDescriptionParams,
 	ImageDescriptionResult,
 } from "@elizaos/core";
+import {
+	resolveCloudApiBaseUrl,
+	resolveDevCloudAuthorityEnvValue,
+	resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 export type VisionFallbackReason =
 	| "local-unavailable"
@@ -155,6 +160,11 @@ export function normalizeVisionDescription(
 }
 
 function resolveCloudToken(options: VisionCloudFallbackOptions): string | null {
+	if (resolveDevCloudEnvAuthority()) {
+		return (
+			resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")?.trim() || null
+		);
+	}
 	return (
 		options.token?.trim() ||
 		options.apiKey?.trim() ||
@@ -165,6 +175,13 @@ function resolveCloudToken(options: VisionCloudFallbackOptions): string | null {
 }
 
 function resolveCloudBaseUrl(options: VisionCloudFallbackOptions): string {
+	if (resolveDevCloudEnvAuthority()) {
+		// This legacy endpoint appends `/v1/vision/describe` below, while the
+		// shared resolver returns the canonical control-plane `/api/v1` base.
+		// Resolve through the authority-aware helper, then retain this client's
+		// established root-relative endpoint contract.
+		return resolveCloudApiBaseUrl().replace(/\/api\/v1\/?$/, "");
+	}
 	return (
 		options.baseUrl?.trim() ||
 		process.env.ELIZA_CLOUD_BASE_URL?.trim() ||

--- a/plugins/plugin-personal-assistant/src/lifeops/schedule-sync-config.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schedule-sync-config.test.ts
@@ -1,0 +1,134 @@
+/** Ensures LifeOps schedule sync consumes the launcher-authoritative operational Cloud view. */
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const configMocks = vi.hoisted(() => ({
+  durable: {} as Record<string, unknown>,
+  effective: {} as Record<string, unknown>,
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  loadElizaConfig: () => configMocks.durable,
+  loadEffectiveElizaConfig: () => configMocks.effective,
+}));
+
+import { resolveLifeOpsScheduleSyncConfigFromElizaConfig } from "./schedule-sync-config";
+
+const originalCloudEnv = {
+  apiKey: process.env.ELIZAOS_CLOUD_API_KEY,
+  agentId: process.env.ELIZAOS_CLOUD_AGENT_ID,
+  baseUrl: process.env.ELIZAOS_CLOUD_BASE_URL,
+  remoteToken: process.env.ELIZA_REMOTE_ACCESS_TOKEN,
+  devSource: process.env.ELIZA_DEV_SOURCE,
+  devAuthority: process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY,
+  devTarget: process.env.ELIZA_DEV_CLOUD_TARGET,
+};
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  delete process.env.ELIZA_DEV_SOURCE;
+  delete process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY;
+  delete process.env.ELIZA_DEV_CLOUD_TARGET;
+  configMocks.durable = {};
+  configMocks.effective = {};
+  delete process.env.ELIZAOS_CLOUD_API_KEY;
+  delete process.env.ELIZAOS_CLOUD_AGENT_ID;
+  delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  delete process.env.ELIZA_REMOTE_ACCESS_TOKEN;
+});
+
+afterEach(() => {
+  for (const [key, value] of [
+    ["ELIZAOS_CLOUD_API_KEY", originalCloudEnv.apiKey],
+    ["ELIZAOS_CLOUD_AGENT_ID", originalCloudEnv.agentId],
+    ["ELIZAOS_CLOUD_BASE_URL", originalCloudEnv.baseUrl],
+    ["ELIZA_REMOTE_ACCESS_TOKEN", originalCloudEnv.remoteToken],
+    ["ELIZA_DEV_SOURCE", originalCloudEnv.devSource],
+    ["ELIZA_DEV_CLOUD_ENV_AUTHORITY", originalCloudEnv.devAuthority],
+    ["ELIZA_DEV_CLOUD_TARGET", originalCloudEnv.devTarget],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("LifeOps schedule-sync Cloud authority", () => {
+  it("uses the effective staging view instead of durable production topology", () => {
+    configMocks.durable = {
+      cloud: {
+        remoteApiBase: "https://api.eliza.app/api/v1",
+        remoteAccessToken: "persisted-production-access-token",
+        apiKey: "persisted-production-key",
+        baseUrl: "https://api.eliza.app/api/v1",
+        agentId: "production-agent",
+      },
+    };
+    configMocks.effective = {
+      cloud: {
+        apiKey: "staging-key",
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+        agentId: "staging-agent",
+      },
+    };
+
+    expect(resolveLifeOpsScheduleSyncConfigFromElizaConfig()).toEqual({
+      configured: true,
+      mode: "cloud",
+      apiBaseUrl: "https://api-staging.eliza.app/api/v1",
+      apiKey: "staging-key",
+      agentId: "staging-agent",
+    });
+  });
+
+  it("does not revive durable remote sync in staging-default mode", () => {
+    configMocks.durable = {
+      cloud: {
+        remoteApiBase: "https://api.eliza.app/api/v1",
+        remoteAccessToken: "persisted-production-access-token",
+      },
+    };
+    configMocks.effective = {
+      cloud: {
+        enabled: false,
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+        apiKey: "",
+      },
+    };
+
+    expect(resolveLifeOpsScheduleSyncConfigFromElizaConfig()).toEqual({
+      configured: false,
+      mode: "none",
+    });
+  });
+
+  it("does not revive schedule sync from late process.env pollution", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZAOS_CLOUD_AGENT_ID;
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_AGENT_ID = "late-production-agent";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    configMocks.effective = {
+      cloud: {
+        enabled: false,
+        apiKey: "",
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+      },
+    };
+
+    expect(resolveLifeOpsScheduleSyncConfigFromElizaConfig()).toEqual({
+      configured: false,
+      mode: "none",
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/schedule-sync-config.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schedule-sync-config.ts
@@ -1,13 +1,40 @@
-/** Resolves the Cloud schedule-sync configuration from the persisted Eliza config for the sync client. */
-import { loadElizaConfig } from "@elizaos/agent";
+/** Resolves the Cloud schedule-sync configuration from the effective operational Eliza config for the sync client. */
+import { loadEffectiveElizaConfig } from "@elizaos/agent";
 import {
+  normalizeLifeOpsScheduleSyncSecret,
   type ResolvedLifeOpsScheduleSyncConfig,
   resolveLifeOpsScheduleSyncConfig,
 } from "@elizaos/plugin-elizacloud/cloud/lifeops-schedule-sync-client";
+import {
+  resolveCloudApiBaseUrl,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 
 export function resolveLifeOpsScheduleSyncConfigFromElizaConfig(): ResolvedLifeOpsScheduleSyncConfig {
+  if (resolveDevCloudEnvAuthority()) {
+    const apiKey = normalizeLifeOpsScheduleSyncSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+    const agentId = normalizeLifeOpsScheduleSyncSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_AGENT_ID"),
+    );
+    if (!apiKey || !agentId) {
+      return { configured: false, mode: "none" };
+    }
+    return {
+      configured: true,
+      mode: "cloud",
+      apiBaseUrl: resolveCloudApiBaseUrl(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL"),
+      ),
+      apiKey,
+      agentId,
+    };
+  }
+
   try {
-    const config = loadElizaConfig();
+    const config = loadEffectiveElizaConfig();
     const cloud =
       config.cloud && typeof config.cloud === "object"
         ? (config.cloud as Record<string, unknown>)

--- a/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.test.ts
@@ -7,10 +7,16 @@
  * (no live Cloud) — the parse boundary under test is deterministic.
  */
 
+import type { AgentRuntime } from "@elizaos/core";
+import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   it,
@@ -30,6 +36,28 @@ const BASE_STATE: CloudFeaturesRouteState = {
 
 let originalFetch: typeof globalThis.fetch;
 let originalElizaDev: string | undefined;
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+const originalAuthorityEnv = Object.fromEntries(
+  AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function cloudAuthRuntime(apiKey: string): AgentRuntime {
+  return {
+    getService: () => ({
+      isAuthenticated: () => true,
+      getApiKey: () => apiKey,
+    }),
+    getSetting: () => "runtime-setting-production-key",
+    character: {
+      secrets: { ELIZAOS_CLOUD_API_KEY: "runtime-secret-production-key" },
+    },
+  } as unknown as AgentRuntime;
+}
 
 function stubFetch(
   response: Partial<Response> & { json?: () => Promise<unknown> },
@@ -46,8 +74,19 @@ beforeAll(() => {
   process.env.ELIZA_DEV = "1";
 });
 
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
+});
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = originalAuthorityEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 afterAll(() => {
@@ -104,4 +143,80 @@ describe("fetchCloudFeatures", () => {
     expect(result.error).toBeNull();
     expect(result.rows).toHaveLength(0);
   });
+
+  it.each(["staging-default", "offline"] as const)(
+    "performs no Cloud fetch under blocked %s authority despite runtime auth",
+    async (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "";
+      process.env.ELIZAOS_CLOUD_BASE_URL =
+        "https://api-staging.eliza.app/api/v1";
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      const result = await fetchCloudFeatures({
+        config: {
+          cloud: {
+            apiKey: "persisted-production-key",
+            baseUrl: "https://api.eliza.app/api/v1",
+          },
+        },
+        runtime: cloudAuthRuntime("runtime-auth-production-key"),
+      });
+
+      expect(result.status).toBe(401);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [
+      "staging-explicit",
+      "https://api-staging.eliza.app/api/v1",
+      "https://cloud-staging.eliza.app/api/v1/features",
+    ],
+    [
+      "self-hosted",
+      "https://cloud.internal.example/api/v1",
+      "https://cloud.internal.example/api/v1/features",
+    ],
+  ] as const)(
+    "uses the frozen key and base for %s despite runtime and late env pollution",
+    async (authority, launchBaseUrl, expectedUrl) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "launcher-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = launchBaseUrl;
+      expect(resolveDevCloudEnvAuthority()).toBe(authority);
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      const fetchMock = stubFetch({
+        ok: true,
+        status: 200,
+        json: async () => ({ features: [] }),
+      });
+
+      const result = await fetchCloudFeatures({
+        config: {
+          cloud: {
+            apiKey: "persisted-production-key",
+            baseUrl: "https://api.eliza.app/api/v1",
+          },
+        },
+        runtime: cloudAuthRuntime("runtime-auth-production-key"),
+      });
+
+      expect(result.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(expectedUrl);
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer launcher-key",
+      );
+    },
+  );
 });

--- a/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.ts
@@ -24,7 +24,7 @@ import {
   type CloudAuthApiKeyService,
   normalizeCloudApiKey,
   normalizeCloudSiteUrl,
-  resolveCloudApiKey,
+  resolveCloudApiKeyWithRuntimeOverride,
   validateCloudBaseUrl,
 } from "@elizaos/plugin-elizacloud";
 import { createFeatureFlagService } from "../lifeops/feature-flags.js";
@@ -69,7 +69,11 @@ function resolveProxyApiKey(state: CloudFeaturesRouteState): string | null {
     cloudAuth?.isAuthenticated() === true
       ? normalizeCloudApiKey(cloudAuth.getApiKey?.())
       : null;
-  return runtimeApiKey ?? resolveCloudApiKey(state.config, state.runtime);
+  return resolveCloudApiKeyWithRuntimeOverride(
+    runtimeApiKey,
+    state.config,
+    state.runtime,
+  );
 }
 
 function buildAuthHeaders(

--- a/plugins/plugin-personal-assistant/src/routes/plugin.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.test.ts
@@ -8,7 +8,15 @@
 import type http from "node:http";
 import { _resetAuthRateLimiter } from "@elizaos/app-core/api/auth";
 import type { AgentRuntime, Route } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cloudRouteMocks = vi.hoisted(() => ({
+  handleCloudFeaturesRoute: vi.fn(async () => true),
+}));
 
 vi.mock("../lifeops/scheduled-task/service.js", () => ({
   getScheduledTaskRunner: () => null,
@@ -37,6 +45,10 @@ vi.mock("./sleep-routes.js", () => ({
 
 vi.mock("./website-blocker-routes.js", () => ({
   handleWebsiteBlockerRoutes: async () => undefined,
+}));
+
+vi.mock("./cloud-features-routes.js", () => ({
+  handleCloudFeaturesRoute: cloudRouteMocks.handleCloudFeaturesRoute,
 }));
 
 import {
@@ -129,12 +141,16 @@ function findRoute(
 
 describe("LifeOps raw route owner/admin gate", () => {
   beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    cloudRouteMocks.handleCloudFeaturesRoute.mockClear();
     _resetAuthRateLimiter();
     delete process.env.ELIZA_API_TOKEN;
     delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
+    resetDevCloudEnvAuthorityForTests();
     _resetAuthRateLimiter();
     delete process.env.ELIZA_API_TOKEN;
     delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
@@ -262,6 +278,110 @@ describe("LifeOps raw route owner/admin gate", () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body)).toEqual({
       error: "Missing OAuth state",
+    });
+  });
+
+  it("passes the frozen staging Cloud tuple after late env and runtime pollution", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "1");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "staging-explicit");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "launch-staging-key");
+    vi.stubEnv(
+      "ELIZAOS_CLOUD_BASE_URL",
+      "https://api-staging.eliza.app/api/v1",
+    );
+    vi.stubEnv("ELIZAOS_CLOUD_SERVICE_KEY", "launch-staging-service-key");
+    resetDevCloudEnvAuthorityForTests();
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_SERVICE_KEY = "late-production-service-key";
+    const runtime = createRuntime();
+    vi.mocked(runtime.getSetting).mockImplementation((key: string) => {
+      if (key === "ELIZA_ADMIN_ENTITY_ID") return "owner-1";
+      if (key.includes("API_KEY")) return "runtime-production-key";
+      if (key.includes("BASE_URL")) return "https://api.eliza.app/api/v1";
+      if (key.includes("SERVICE_KEY")) return "runtime-production-service-key";
+      return undefined;
+    });
+
+    const route = findRoute("GET", "/api/cloud/features");
+    await route.handler(
+      createRequest(
+        "/api/cloud/features",
+        {},
+        { remoteAddress: "127.0.0.1", host: "localhost:3000" },
+      ) as never,
+      createResponse() as never,
+      runtime as never,
+    );
+
+    const state = cloudRouteMocks.handleCloudFeaturesRoute.mock.calls[0]?.[4] as
+      | {
+          config?: {
+            cloud?: {
+              apiKey?: string;
+              baseUrl?: string;
+              serviceKey?: string;
+            };
+          };
+        }
+      | undefined;
+    expect(state?.config).toEqual({
+      cloud: {
+        apiKey: "launch-staging-key",
+        baseUrl: "https://api-staging.eliza.app/api/v1",
+        serviceKey: "launch-staging-service-key",
+      },
+    });
+  });
+
+  it("retains runtime-first Cloud proxy resolution without dev authority", async () => {
+    vi.stubEnv("ELIZA_DEV_SOURCE", "");
+    vi.stubEnv("ELIZA_DEV_CLOUD_ENV_AUTHORITY", "");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "process-key");
+    vi.stubEnv("ELIZAOS_CLOUD_BASE_URL", "https://process.example/api/v1");
+    vi.stubEnv("ELIZAOS_CLOUD_SERVICE_KEY", "process-service-key");
+    resetDevCloudEnvAuthorityForTests();
+    const runtime = createRuntime();
+    vi.mocked(runtime.getSetting).mockImplementation((key: string) => {
+      if (key === "ELIZA_ADMIN_ENTITY_ID") return "owner-1";
+      if (key === "ELIZAOS_CLOUD_API_KEY") return "runtime-key";
+      if (key === "ELIZAOS_CLOUD_BASE_URL") {
+        return "https://runtime.example/api/v1";
+      }
+      if (key === "ELIZAOS_CLOUD_SERVICE_KEY") return "runtime-service-key";
+      return undefined;
+    });
+
+    const route = findRoute("GET", "/api/cloud/features");
+    await route.handler(
+      createRequest(
+        "/api/cloud/features",
+        {},
+        { remoteAddress: "127.0.0.1", host: "localhost:3000" },
+      ) as never,
+      createResponse() as never,
+      runtime as never,
+    );
+
+    const state = cloudRouteMocks.handleCloudFeaturesRoute.mock.calls[0]?.[4] as
+      | {
+          config?: {
+            cloud?: {
+              apiKey?: string;
+              baseUrl?: string;
+              serviceKey?: string;
+            };
+          };
+        }
+      | undefined;
+    expect(state?.config).toEqual({
+      cloud: {
+        apiKey: "runtime-key",
+        baseUrl: "https://runtime.example/api/v1",
+        serviceKey: "runtime-service-key",
+      },
     });
   });
 });

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -35,7 +35,11 @@ import {
   sendJsonError as httpSendJsonError,
   resolveOwnerEntityIdOrDefault,
 } from "@elizaos/core";
-import { readJsonBody as httpReadJsonBody } from "@elizaos/shared";
+import {
+  readJsonBody as httpReadJsonBody,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import { getScheduledTaskRunner } from "../lifeops/scheduled-task/service.js";
 import { handleEntityRoutes } from "./entities.js";
 import type { LifeOpsRouteContext } from "./lifeops-routes.js";
@@ -219,6 +223,34 @@ function runtimeSetting(
 function buildCloudProxyConfig(
   runtime: AgentRuntime | null,
 ): CloudProxyConfigLike {
+  if (resolveDevCloudEnvAuthority()) {
+    const authorityValue = (...keys: string[]): string | undefined => {
+      for (const key of keys) {
+        const value = resolveDevCloudAuthorityEnvValue(key)?.trim();
+        if (value) return value;
+      }
+      return undefined;
+    };
+    return {
+      cloud: {
+        apiKey: authorityValue(
+          "ELIZAOS_CLOUD_API_KEY",
+          "ELIZA_CLOUD_API_KEY",
+          "ELIZACLOUD_API_KEY",
+        ),
+        baseUrl: authorityValue(
+          "ELIZAOS_CLOUD_BASE_URL",
+          "ELIZA_CLOUD_BASE_URL",
+          "ELIZA_CLOUD_URL",
+          "ELIZAOS_CLOUD_URL",
+        ),
+        serviceKey: authorityValue(
+          "ELIZAOS_CLOUD_SERVICE_KEY",
+          "ELIZA_CLOUD_SERVICE_KEY",
+        ),
+      },
+    };
+  }
   return {
     cloud: {
       apiKey:

--- a/plugins/plugin-personal-assistant/test/stubs/agent.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/agent.ts
@@ -296,6 +296,10 @@ export function loadElizaConfig(): Record<string, unknown> {
   return {};
 }
 
+export function loadEffectiveElizaConfig(): Record<string, unknown> {
+  return loadElizaConfig();
+}
+
 function readTestElizaConfig(): Record<string, unknown> {
   const configPath = process.env.ELIZA_CONFIG_PATH?.trim();
   if (!configPath) return {};

--- a/plugins/plugin-personal-assistant/test/stubs/plugin-elizacloud.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/plugin-elizacloud.ts
@@ -2,6 +2,12 @@
  * Test stub for the elizacloud plugin: cloud-site-URL and secret normalization helpers used
  * by LifeOps cloud-feature tests.
  */
+import {
+  normalizeCloudSiteUrl as normalizeSharedCloudSiteUrl,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+
 const DEFAULT_CLOUD_SITE_URL = "https://api.eliza.app";
 
 function normalizeSecret(value: unknown): string | null {
@@ -12,6 +18,9 @@ function normalizeSecret(value: unknown): string | null {
 }
 
 export function normalizeCloudSiteUrl(rawUrl?: string | null): string {
+  if (resolveDevCloudEnvAuthority()) {
+    return normalizeSharedCloudSiteUrl(rawUrl ?? undefined);
+  }
   const trimmed = rawUrl?.trim();
   if (!trimmed) return DEFAULT_CLOUD_SITE_URL;
   return trimmed.replace(/\/+$/, "");
@@ -28,11 +37,31 @@ export function resolveCloudApiKey(
     getSetting?: (key: string) => unknown;
   } | null,
 ): string | null {
+  if (resolveDevCloudEnvAuthority()) {
+    return normalizeSecret(
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+    );
+  }
   return (
     normalizeSecret(runtime?.getSetting?.("ELIZAOS_CLOUD_API_KEY")) ??
     normalizeSecret(config?.cloud?.apiKey) ??
     normalizeSecret(process.env.ELIZAOS_CLOUD_API_KEY)
   );
+}
+
+export function normalizeCloudApiKey(value: unknown): string | null {
+  return normalizeSecret(value);
+}
+
+export function resolveCloudApiKeyWithRuntimeOverride(
+  runtimeApiKey: string | null | undefined,
+  config?: { cloud?: { apiKey?: string | null } } | null,
+  runtime?: { getSetting?: (key: string) => unknown } | null,
+): string | null {
+  const resolved = resolveCloudApiKey(config, runtime);
+  return resolveDevCloudEnvAuthority()
+    ? resolved
+    : (normalizeSecret(runtimeApiKey) ?? resolved);
 }
 
 export async function validateCloudBaseUrl(

--- a/plugins/plugin-pty/lib/eliza-code-spec.ts
+++ b/plugins/plugin-pty/lib/eliza-code-spec.ts
@@ -6,11 +6,93 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
+import {
+  type DevCloudEnvAuthority,
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
 import type { PtySpawnSpec } from "../services/pty-types";
 
 export const ELIZA_CLOUD_DEFAULT_BASE_URL = "https://api.eliza.app/v1";
 export const ELIZA_CLOUD_FAST_MODEL = DEFAULT_CEREBRAS_TEXT_MODEL;
 export const ELIZA_CLOUD_SMART_MODEL = DEFAULT_CEREBRAS_TEXT_MODEL;
+
+export interface ElizaCodeCloudTuple {
+  /** Immutable launcher authority, or null for the legacy operator-controlled path. */
+  authority: DevCloudEnvAuthority | null;
+  /** False when the selected development target intentionally disables Cloud. */
+  enabled: boolean;
+  /** Credential the child must use when Cloud is enabled. */
+  apiKey?: string;
+  /** OpenAI-compatible inference base URL the child must use. */
+  baseUrl?: string;
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+/**
+ * Convert the canonical Cloud control-plane base (`/api/v1`) stamped by the
+ * launcher into the OpenAI-compatible inference base (`/v1`) consumed by
+ * eliza-code. Self-hosted roots that already expose another path are preserved.
+ */
+function toElizaCodeInferenceBaseUrl(
+  value: string | undefined,
+): string | undefined {
+  const normalized = trimmed(value)?.replace(/\/+$/, "");
+  return normalized?.replace(/\/api\/v1$/, "/v1");
+}
+
+/**
+ * Resolve the only Cloud tuple an eliza-code child may use. A valid launcher
+ * authority owns the tuple completely: blocked targets disable the Cloud lane,
+ * while explicit targets ignore caller/runtime/process overrides and read the
+ * process-lifetime snapshot. Without authority, preserve the historical
+ * per-session/operator inputs.
+ */
+export function resolveElizaCodeCloudTuple(input?: {
+  apiKey?: string;
+  baseUrl?: string;
+}): ElizaCodeCloudTuple {
+  const authority = resolveDevCloudEnvAuthority();
+  if (authority === "staging-default" || authority === "offline") {
+    return { authority, enabled: false };
+  }
+  if (authority) {
+    return {
+      authority,
+      enabled: true,
+      apiKey: trimmed(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"),
+      ),
+      baseUrl: toElizaCodeInferenceBaseUrl(
+        resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL"),
+      ),
+    };
+  }
+  return {
+    authority: null,
+    enabled: true,
+    apiKey: trimmed(input?.apiKey),
+    baseUrl: trimmed(input?.baseUrl) ?? ELIZA_CLOUD_DEFAULT_BASE_URL,
+  };
+}
+
+function isAuthorityControlledChildEnvKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return (
+    normalized === "OPENAI_API_KEY" ||
+    normalized === "OPENAI_BASE_URL" ||
+    normalized === "PTY_ELIZA_CLOUD_API_KEY" ||
+    normalized === "PTY_ELIZA_CLOUD_BASE_URL" ||
+    normalized.startsWith("ELIZAOS_CLOUD_") ||
+    normalized.startsWith("ELIZA_CLOUD_") ||
+    normalized.startsWith("ELIZACLOUD_") ||
+    normalized.startsWith("WAIFU_ELIZA_CLOUD_")
+  );
+}
 
 export interface ElizaCodeCerebrasOptions {
   /** Working directory the interactive session runs in (confined to this). */
@@ -37,11 +119,23 @@ export interface ElizaCodeCerebrasOptions {
   extraEnv?: Record<string, string | undefined>;
 }
 
-/** Builds the spawn spec. Pure — no I/O, no process spawn; validates inputs. */
+/**
+ * Builds the spawn spec. Performs no I/O or process spawn; when a development
+ * Cloud authority exists it reads only that immutable launcher snapshot.
+ */
 export function buildElizaCodeCerebrasSpec(
   opts: ElizaCodeCerebrasOptions,
 ): PtySpawnSpec {
-  const apiKey = opts.apiKey?.trim();
+  const cloud = resolveElizaCodeCloudTuple({
+    apiKey: opts.apiKey,
+    baseUrl: opts.baseUrl,
+  });
+  if (!cloud.enabled) {
+    throw new Error(
+      `eliza-code Cloud sessions are disabled for the ${cloud.authority} development target.`,
+    );
+  }
+  const apiKey = cloud.apiKey;
   if (!apiKey) {
     throw new Error(
       "eliza-code interactive session requires an Eliza Cloud API key (apiKey).",
@@ -56,7 +150,12 @@ export function buildElizaCodeCerebrasSpec(
     );
   }
 
-  const baseUrl = (opts.baseUrl ?? ELIZA_CLOUD_DEFAULT_BASE_URL).trim();
+  const baseUrl = cloud.baseUrl;
+  if (!baseUrl) {
+    throw new Error(
+      "eliza-code interactive session requires an Eliza Cloud base URL.",
+    );
+  }
   const fastModel = (opts.fastModel ?? ELIZA_CLOUD_FAST_MODEL).trim();
   const smartModel = (opts.smartModel ?? ELIZA_CLOUD_SMART_MODEL).trim();
   const tier = opts.tier ?? "fast";
@@ -80,6 +179,17 @@ export function buildElizaCodeCerebrasSpec(
     SHELL_ALLOWED_DIRECTORY: cwd,
     ...(opts.extraEnv ?? {}),
   };
+
+  // A direct library caller can otherwise smuggle a second Cloud tuple through
+  // extraEnv after the validated values. Clamp the final child projection too,
+  // so route validation is not the only authority boundary.
+  if (cloud.authority) {
+    for (const key of Object.keys(env)) {
+      if (isAuthorityControlledChildEnvKey(key)) delete env[key];
+    }
+    env.OPENAI_API_KEY = apiKey;
+    env.OPENAI_BASE_URL = baseUrl;
+  }
 
   return {
     command: runner,

--- a/plugins/plugin-pty/routes/pty-routes.ts
+++ b/plugins/plugin-pty/routes/pty-routes.ts
@@ -20,7 +20,9 @@ import {
 import {
   buildElizaCodeCerebrasSpec,
   ELIZA_CLOUD_DEFAULT_BASE_URL,
+  type ElizaCodeCloudTuple,
   resolveElizaCodeBin,
+  resolveElizaCodeCloudTuple,
 } from "../lib/eliza-code-spec";
 import {
   buildClaudeCliSpec,
@@ -203,15 +205,22 @@ function vendorCliEnabled(runtime: IAgentRuntime): boolean {
   return flag === "true" || flag === "1" || flag === "on" || flag === "yes";
 }
 
-/**
- * The Eliza Cloud API key eliza-code will authenticate with. Do not fall back
- * to the agent's primary OPENAI_API_KEY; terminal users can inspect their env.
- */
-function resolveCloudApiKey(
+function resolveRequestCloudTuple(
   runtime: IAgentRuntime,
-  bodyKey?: string,
-): string | undefined {
-  return bodyKey ?? getStr(runtime, "PTY_ELIZA_CLOUD_API_KEY");
+  body: Record<string, unknown>,
+): ElizaCodeCloudTuple {
+  // Resolve the launcher policy before touching untrusted per-request base URL
+  // input. Under authority, the body/runtime/process candidates are irrelevant
+  // and must not even trigger allowlist parsing that could diverge the target.
+  const launcherTuple = resolveElizaCodeCloudTuple();
+  if (launcherTuple.authority) return launcherTuple;
+
+  return resolveElizaCodeCloudTuple({
+    // Do not fall back to the agent's primary OPENAI_API_KEY; terminal users
+    // can inspect their child environment.
+    apiKey: str(body.apiKey) ?? getStr(runtime, "PTY_ELIZA_CLOUD_API_KEY"),
+    baseUrl: resolveAllowedBaseUrl(runtime, str(body.baseUrl)),
+  });
 }
 
 function defaultCwd(runtime: IAgentRuntime): string {
@@ -229,14 +238,17 @@ function elizaCodeSpecFromRequest(
   runtime: IAgentRuntime,
   body: Record<string, unknown>,
   cwd: string,
-  apiKey: string,
+  cloud: ElizaCodeCloudTuple,
 ): PtySpawnSpec {
+  if (!cloud.apiKey || !cloud.baseUrl) {
+    throw new Error("Eliza Cloud PTY tuple is incomplete.");
+  }
   return buildElizaCodeCerebrasSpec({
     cwd,
-    apiKey,
+    apiKey: cloud.apiKey,
     binPath: resolveElizaCodeBin(),
     tier: str(body.tier) === "smart" ? "smart" : "fast",
-    baseUrl: resolveAllowedBaseUrl(runtime, str(body.baseUrl)),
+    baseUrl: cloud.baseUrl,
     // Deployment knob (like PTY_ELIZA_CLOUD_API_KEY): pin the tier models
     // without a client change, e.g. while the deployed cloud's model
     // registry lags the repo's DEFAULT_CEREBRAS_TEXT_MODEL.
@@ -318,14 +330,27 @@ async function spawnHandler(
   try {
     let spec: PtySpawnSpec;
     if (kind === "eliza-code") {
-      const apiKey = resolveCloudApiKey(runtime, str(body.apiKey));
-      if (!apiKey) {
-        return json(400, {
-          error:
-            "No dedicated Eliza Cloud API key available. Pass { apiKey } or configure PTY_ELIZA_CLOUD_API_KEY.",
+      const cloud = resolveRequestCloudTuple(runtime, body);
+      if (!cloud.enabled) {
+        return json(403, {
+          error: `Eliza Cloud PTY sessions are disabled for the ${cloud.authority} development target.`,
         });
       }
-      spec = elizaCodeSpecFromRequest(runtime, body, cwd, apiKey);
+      if (!cloud.apiKey) {
+        return json(400, {
+          error: cloud.authority
+            ? `The ${cloud.authority} development target has no launcher-owned Eliza Cloud API key.`
+            : "No dedicated Eliza Cloud API key available. Pass { apiKey } or configure PTY_ELIZA_CLOUD_API_KEY.",
+        });
+      }
+      if (!cloud.baseUrl) {
+        return json(400, {
+          error: cloud.authority
+            ? `The ${cloud.authority} development target has no launcher-owned Eliza Cloud base URL.`
+            : "No Eliza Cloud base URL is available.",
+        });
+      }
+      spec = elizaCodeSpecFromRequest(runtime, body, cwd, cloud);
     } else {
       spec = vendorCliSpecFromRequest(runtime, kind, cwd);
     }

--- a/plugins/plugin-pty/test/eliza-code-spec.test.ts
+++ b/plugins/plugin-pty/test/eliza-code-spec.test.ts
@@ -5,14 +5,41 @@
  * predicate — no real PTY or process spawn.
  */
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildElizaCodeCerebrasSpec,
   ELIZA_CLOUD_DEFAULT_BASE_URL,
   ELIZA_CLOUD_FAST_MODEL,
   ELIZA_CLOUD_SMART_MODEL,
   resolveElizaCodeBin,
+  resolveElizaCodeCloudTuple,
 } from "../lib/eliza-code-spec";
+
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+const savedAuthorityEnv = Object.fromEntries(
+  AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof AUTHORITY_ENV_KEYS)[number], string | undefined>;
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of AUTHORITY_ENV_KEYS) {
+    const value = savedAuthorityEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
 
 describe("buildElizaCodeCerebrasSpec", () => {
   const base = {
@@ -84,6 +111,85 @@ describe("buildElizaCodeCerebrasSpec", () => {
     expect(() => buildElizaCodeCerebrasSpec({ ...base, binPath: "" })).toThrow(
       /binPath/i,
     );
+  });
+
+  it.each(["staging-default", "offline"] as const)(
+    "disables the Cloud child lane under %s authority despite caller overrides",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "inherited-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+
+      expect(resolveElizaCodeCloudTuple()).toEqual({
+        authority,
+        enabled: false,
+      });
+      expect(() =>
+        buildElizaCodeCerebrasSpec({
+          ...base,
+          apiKey: "body-key",
+          baseUrl: "https://attacker.example/v1",
+          extraEnv: {
+            OPENAI_API_KEY: "extra-key",
+            OPENAI_BASE_URL: "https://extra.example/v1",
+          },
+        }),
+      ).toThrow(/disabled/i);
+    },
+  );
+
+  it("projects the frozen explicit staging tuple after late process and child-env overrides", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+
+    expect(resolveElizaCodeCloudTuple()).toMatchObject({
+      authority: "staging-explicit",
+      enabled: true,
+      apiKey: "staging-launch-key",
+      baseUrl: "https://api-staging.eliza.app/v1",
+    });
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    const spec = buildElizaCodeCerebrasSpec({
+      ...base,
+      apiKey: "body-key",
+      baseUrl: "https://attacker.example/v1",
+      extraEnv: {
+        OPENAI_API_KEY: "extra-key",
+        OPENAI_BASE_URL: "https://extra.example/v1",
+        ELIZAOS_CLOUD_API_KEY: "alternate-cloud-key",
+        PTY_ELIZA_CLOUD_API_KEY: "alternate-pty-key",
+      },
+    });
+
+    expect(spec.env?.OPENAI_API_KEY).toBe("staging-launch-key");
+    expect(spec.env?.OPENAI_BASE_URL).toBe("https://api-staging.eliza.app/v1");
+    expect(spec.env?.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(spec.env?.PTY_ELIZA_CLOUD_API_KEY).toBeUndefined();
+  });
+
+  it("keeps a self-hosted launch tuple after the live env is cleared", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "self-hosted";
+    process.env.ELIZAOS_CLOUD_API_KEY = "selfhost-launch-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL =
+      "https://cloud.internal.example/api/v1";
+    expect(resolveElizaCodeCloudTuple().enabled).toBe(true);
+
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    const spec = buildElizaCodeCerebrasSpec({
+      ...base,
+      apiKey: "late-body-key",
+      baseUrl: "https://api.eliza.app/v1",
+    });
+
+    expect(spec.env?.OPENAI_API_KEY).toBe("selfhost-launch-key");
+    expect(spec.env?.OPENAI_BASE_URL).toBe("https://cloud.internal.example/v1");
   });
 });
 

--- a/plugins/plugin-pty/test/pty-routes.test.ts
+++ b/plugins/plugin-pty/test/pty-routes.test.ts
@@ -6,6 +6,7 @@
  */
 import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ptyRoutes } from "../routes/pty-routes";
 import { PtyService } from "../services/pty-service";
@@ -67,20 +68,35 @@ function ctx(
   };
 }
 
-// Keep the eliza-code bin resolution deterministic + isolate API-key env.
-let savedBin: string | undefined;
-let savedKey: string | undefined;
+// Keep the eliza-code bin resolution deterministic and isolate every Cloud
+// authority/key/base input the route or child-spec policy can consult.
+const CLOUD_ENV_KEYS = [
+  "ELIZA_CODE_BIN",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "PTY_ELIZA_CLOUD_API_KEY",
+  "PTY_ALLOWED_BASE_URLS",
+  "PTY_ELIZA_CLOUD_BASE_URL_ALLOWLIST",
+] as const;
+const savedCloudEnv = Object.fromEntries(
+  CLOUD_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof CLOUD_ENV_KEYS)[number], string | undefined>;
+
 beforeEach(() => {
-  savedBin = process.env.ELIZA_CODE_BIN;
-  savedKey = process.env.PTY_ELIZA_CLOUD_API_KEY;
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of CLOUD_ENV_KEYS) delete process.env[key];
   process.env.ELIZA_CODE_BIN = EXISTING_FILE;
-  delete process.env.PTY_ELIZA_CLOUD_API_KEY;
 });
 afterEach(() => {
-  if (savedBin === undefined) delete process.env.ELIZA_CODE_BIN;
-  else process.env.ELIZA_CODE_BIN = savedBin;
-  if (savedKey === undefined) delete process.env.PTY_ELIZA_CLOUD_API_KEY;
-  else process.env.PTY_ELIZA_CLOUD_API_KEY = savedKey;
+  for (const key of CLOUD_ENV_KEYS) {
+    const value = savedCloudEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("POST /api/pty/sessions", () => {
@@ -294,6 +310,86 @@ describe("POST /api/pty/sessions", () => {
     );
     expect(res.status).toBe(200);
     expect(h.calls[0].opts.env?.OPENAI_API_KEY).toBe("sk-body");
+  });
+
+  it.each(["staging-default", "offline"] as const)(
+    "403s the Eliza Cloud lane under %s authority despite body/runtime/process overrides",
+    async (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "inherited-production-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.PTY_ELIZA_CLOUD_API_KEY = "process-pty-key";
+      const h = makeHarness({
+        settings: {
+          ELIZAOS_CLOUD_API_KEY: "runtime-canonical-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://runtime.example/api/v1",
+          PTY_ELIZA_CLOUD_API_KEY: "runtime-pty-key",
+          PTY_ALLOWED_BASE_URLS: "https://attacker.example/v1",
+        },
+      });
+
+      const res = await routeByName("pty-spawn-session")(
+        ctx(h.runtime, {
+          kind: "eliza-code",
+          cwd: process.cwd(),
+          apiKey: "body-key",
+          baseUrl: "https://attacker.example/v1",
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      expect((res.body as { error: string }).error).toMatch(/disabled/i);
+      expect(h.calls).toHaveLength(0);
+    },
+  );
+
+  it("uses only the frozen explicit staging tuple across body/runtime/process overrides", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.PTY_ELIZA_CLOUD_API_KEY = "process-pty-key";
+    const h = makeHarness({
+      settings: {
+        ELIZAOS_CLOUD_API_KEY: "runtime-canonical-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://runtime.example/api/v1",
+        PTY_ELIZA_CLOUD_API_KEY: "runtime-pty-key",
+        PTY_ALLOWED_BASE_URLS: "https://attacker.example/v1",
+      },
+    });
+
+    const first = await routeByName("pty-spawn-session")(
+      ctx(h.runtime, {
+        kind: "eliza-code",
+        cwd: process.cwd(),
+        apiKey: "body-key",
+        // Deliberately not allowlisted by the route. Authority must ignore it
+        // before parsing rather than reject or adopt it.
+        baseUrl: "https://untrusted.example/v1",
+      }),
+    );
+    expect(first.status).toBe(200);
+    expect(h.calls[0].opts.env?.OPENAI_API_KEY).toBe("staging-launch-key");
+    expect(h.calls[0].opts.env?.OPENAI_BASE_URL).toBe(
+      "https://api-staging.eliza.app/v1",
+    );
+
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    const second = await routeByName("pty-spawn-session")(
+      ctx(h.runtime, {
+        kind: "eliza-code",
+        cwd: process.cwd(),
+        apiKey: "second-body-key",
+        baseUrl: "not a URL",
+      }),
+    );
+    expect(second.status).toBe(200);
+    expect(h.calls[1].opts.env?.OPENAI_API_KEY).toBe("staging-launch-key");
+    expect(h.calls[1].opts.env?.OPENAI_BASE_URL).toBe(
+      "https://api-staging.eliza.app/v1",
+    );
   });
 
   it("uses operator-pinned tier model fallbacks", async () => {

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  devCloudAuthority: null as string | null,
   ensureRouteAuthorized: vi.fn(),
   loadElizaConfig: vi.fn(),
   loadRegistry: vi.fn(),
@@ -68,6 +69,17 @@ vi.mock("@elizaos/core", () => ({
 }));
 
 vi.mock("@elizaos/shared", () => ({
+  DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS: [
+    "STEWARD_API_URL",
+    "STEWARD_TENANT_ID",
+    "STEWARD_AGENT_ID",
+    "ELIZA_STEWARD_AGENT_ID",
+    "STEWARD_API_KEY",
+    "STEWARD_AGENT_TOKEN",
+    "STEWARD_TRADE_SESSION_ID",
+    "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+    "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+  ],
   asRecord: (value: unknown) =>
     value && typeof value === "object" && !Array.isArray(value)
       ? (value as Record<string, unknown>)
@@ -75,6 +87,7 @@ vi.mock("@elizaos/shared", () => ({
   CONNECTOR_PLUGINS: {
     discord: "@elizaos/plugin-discord",
   },
+  resolveDevCloudEnvAuthority: vi.fn(() => mocks.devCloudAuthority),
 }));
 
 vi.mock("@elizaos/vault", () => ({
@@ -122,11 +135,53 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeStewardWalletPlugin() {
+  return makePlugin({
+    id: "wallet",
+    name: "Wallet",
+    envKey: "STEWARD_AGENT_TOKEN",
+    configKeys: [
+      "STEWARD_API_URL",
+      "STEWARD_AGENT_ID",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TENANT_ID",
+    ],
+    parameters: [
+      {
+        key: "STEWARD_API_URL",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+      {
+        key: "STEWARD_AGENT_ID",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+      {
+        key: "STEWARD_AGENT_TOKEN",
+        required: false,
+        sensitive: true,
+        type: "string",
+      },
+      {
+        key: "STEWARD_TENANT_ID",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+    ],
+    npmName: "@elizaos/plugin-wallet",
+  });
+}
+
 describe("app plugin compatibility routes", () => {
   let currentConfig: Record<string, unknown>;
   let savedConfig: Record<string, unknown> | undefined;
 
   beforeEach(() => {
+    mocks.devCloudAuthority = null;
     process.env = { ...originalEnv };
     delete process.env.DISCORD_API_TOKEN;
     currentConfig = {
@@ -136,6 +191,7 @@ describe("app plugin compatibility routes", () => {
       },
     };
     savedConfig = undefined;
+    mocks.saveElizaConfig.mockClear();
     mocks.loadElizaConfig.mockImplementation(() => currentConfig);
     mocks.loadRegistry.mockReturnValue({ all: [], byId: new Map() });
     mocks.loadRegistry.mockClear();
@@ -181,6 +237,192 @@ describe("app plugin compatibility routes", () => {
       },
     });
     expect(process.env.DISCORD_API_TOKEN).toBe("abc123");
+  });
+
+  it.each([
+    "staging-default",
+    "staging-explicit",
+    "production",
+    "offline",
+    "self-hosted",
+  ])(
+    "rejects Cloud plugin config without mutating compat state under %s authority",
+    (authority) => {
+      mocks.devCloudAuthority = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://launch.example/api/v1";
+      currentConfig = {
+        env: {
+          ELIZAOS_CLOUD_API_KEY: "launch-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://launch.example/api/v1",
+        },
+        plugins: {
+          entries: {
+            "cloud-apps": {
+              enabled: true,
+              config: { ELIZAOS_CLOUD_API_KEY: "launch-key" },
+            },
+          },
+        },
+      };
+      const configBefore = JSON.stringify(currentConfig);
+      const envBefore = JSON.stringify(Object.entries(process.env).sort());
+      const cloudPlugin = makePlugin({
+        id: "cloud-apps",
+        name: "Cloud Apps",
+        envKey: "ELIZAOS_CLOUD_API_KEY",
+        configKeys: ["ELIZAOS_CLOUD_API_KEY", "ELIZAOS_CLOUD_BASE_URL"],
+        parameters: [
+          {
+            key: "ELIZAOS_CLOUD_API_KEY",
+            required: false,
+            sensitive: true,
+            type: "string",
+          },
+          {
+            key: "ELIZAOS_CLOUD_BASE_URL",
+            required: false,
+            sensitive: false,
+            type: "string",
+          },
+        ],
+        npmName: "@elizaos/plugin-cloud-apps",
+      });
+
+      const result = persistCompatPluginMutation(
+        "cloud-apps",
+        {
+          config: {
+            ELIZAOS_CLOUD_API_KEY: "hostile-key",
+            ELIZAOS_CLOUD_BASE_URL: "https://hostile.example/api/v1",
+          },
+        },
+        cloudPlugin,
+      );
+
+      expect(result.status).toBe(409);
+      expect(result.payload.error).toEqual(
+        expect.stringContaining("launcher-owned Cloud parameters"),
+      );
+      expect(JSON.stringify(currentConfig)).toBe(configBefore);
+      expect(JSON.stringify(Object.entries(process.env).sort())).toBe(
+        envBefore,
+      );
+      expect(mocks.saveElizaConfig).not.toHaveBeenCalled();
+      expect(savedConfig).toBeUndefined();
+    },
+  );
+
+  it.each([
+    "staging-default",
+    "staging-explicit",
+    "production",
+    "offline",
+    "self-hosted",
+  ])(
+    "rejects Steward plugin config without mutating compat state under %s authority",
+    (authority) => {
+      mocks.devCloudAuthority = authority;
+      process.env.STEWARD_API_URL = "https://launch.example/steward";
+      process.env.STEWARD_AGENT_ID = "launch-agent";
+      process.env.STEWARD_AGENT_TOKEN = "launch-token";
+      process.env.STEWARD_TENANT_ID = "launch-tenant";
+      currentConfig = {
+        env: {
+          STEWARD_API_URL: "https://launch.example/steward",
+          STEWARD_AGENT_ID: "launch-agent",
+          STEWARD_AGENT_TOKEN: "launch-token",
+          STEWARD_TENANT_ID: "launch-tenant",
+        },
+        plugins: {
+          entries: {
+            wallet: {
+              enabled: true,
+              config: {
+                STEWARD_API_URL: "https://launch.example/steward",
+                STEWARD_AGENT_ID: "launch-agent",
+                STEWARD_AGENT_TOKEN: "launch-token",
+                STEWARD_TENANT_ID: "launch-tenant",
+              },
+            },
+          },
+        },
+      };
+      const configBefore = JSON.stringify(currentConfig);
+      const envBefore = JSON.stringify(Object.entries(process.env).sort());
+
+      const result = persistCompatPluginMutation(
+        "wallet",
+        {
+          config: {
+            STEWARD_API_URL: "https://hostile.example/steward",
+            STEWARD_AGENT_ID: "hostile-agent",
+            STEWARD_AGENT_TOKEN: "hostile-token",
+            STEWARD_TENANT_ID: "hostile-tenant",
+          },
+        },
+        makeStewardWalletPlugin(),
+      );
+
+      expect(result.status).toBe(409);
+      expect(result.payload.error).toEqual(
+        expect.stringContaining("launcher-owned Cloud parameters"),
+      );
+      expect(JSON.stringify(currentConfig)).toBe(configBefore);
+      expect(JSON.stringify(Object.entries(process.env).sort())).toBe(
+        envBefore,
+      );
+      expect(mocks.saveElizaConfig).not.toHaveBeenCalled();
+      expect(savedConfig).toBeUndefined();
+    },
+  );
+
+  it("rejects Cloud plugin enablement before compat runtime restoration", () => {
+    mocks.devCloudAuthority = "self-hosted";
+    const result = persistCompatPluginMutation(
+      "cloud-apps",
+      { enabled: true },
+      makePlugin({
+        id: "cloud-apps",
+        parameters: [
+          {
+            key: "ELIZAOS_CLOUD_API_KEY",
+            required: false,
+            sensitive: true,
+            type: "string",
+          },
+        ],
+        npmName: "@elizaos/plugin-cloud-apps",
+      }),
+    );
+
+    expect(result.status).toBe(409);
+    expect(mocks.saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("preserves compat Cloud plugin configuration without launcher authority", () => {
+    const result = persistCompatPluginMutation(
+      "cloud-apps",
+      { config: { ELIZAOS_CLOUD_API_KEY: "ordinary-key" } },
+      makePlugin({
+        id: "cloud-apps",
+        envKey: "ELIZAOS_CLOUD_API_KEY",
+        configKeys: ["ELIZAOS_CLOUD_API_KEY"],
+        parameters: [
+          {
+            key: "ELIZAOS_CLOUD_API_KEY",
+            required: false,
+            sensitive: true,
+            type: "string",
+          },
+        ],
+        npmName: "@elizaos/plugin-cloud-apps",
+      }),
+    );
+
+    expect(result.status).toBe(200);
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("ordinary-key");
+    expect(mocks.saveElizaConfig).toHaveBeenCalled();
   });
 
   it("removes optional blank values from persisted and process env", () => {

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -55,6 +55,7 @@ import {
   clearPluginParamValues,
   collectAgentScopedPluginParamValues,
 } from "./bridge-plugin-settings.ts";
+import { devCloudPluginMutationRejection } from "./dev-cloud-plugin-authority.ts";
 
 const require = createRequire(import.meta.url);
 
@@ -1512,6 +1513,17 @@ export function persistCompatPluginMutation(
   status: number;
   payload: Record<string, unknown>;
 } {
+  const authorityRejection = devCloudPluginMutationRejection(
+    plugin.parameters ?? [],
+    body,
+  );
+  if (authorityRejection) {
+    return {
+      status: 409,
+      payload: { ok: false, error: authorityRejection },
+    };
+  }
+
   const config = loadElizaConfig();
   const configRecord = config as Record<string, unknown>;
   config.plugins ??= {};

--- a/plugins/plugin-registry/src/api/dev-cloud-plugin-authority.ts
+++ b/plugins/plugin-registry/src/api/dev-cloud-plugin-authority.ts
@@ -1,0 +1,63 @@
+import {
+  DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+
+const CLOUD_AUTHORITY_PREFIXES = [
+  "ELIZAOS_CLOUD_",
+  "ELIZA_CLOUD_",
+  "ELIZA_DEV_CLOUD_",
+  "ELIZACLOUD_",
+  "WAIFU_ELIZA_CLOUD_",
+] as const;
+
+const STEWARD_AUTHORITY_KEYS = new Set<string>(
+  DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS,
+);
+
+type PluginParameterKey = { key: string };
+
+/** Launcher-owned Cloud and Steward settings cannot be rewritten through plugin config. */
+export function isLauncherOwnedCloudPluginKey(key: string): boolean {
+  const normalized = key.trim().toUpperCase();
+  return (
+    STEWARD_AUTHORITY_KEYS.has(normalized) ||
+    CLOUD_AUTHORITY_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  );
+}
+
+/**
+ * Return an actionable rejection before a plugin mutation can touch process,
+ * runtime, or persisted config state. Enabling/disabling a plugin is included:
+ * that path restores or clears its saved parameters through the runtime bridge.
+ */
+export function devCloudPluginMutationRejection(
+  parameters: readonly PluginParameterKey[],
+  body: { config?: unknown; enabled?: unknown },
+): string | null {
+  if (!resolveDevCloudEnvAuthority()) return null;
+
+  const ownedParameterKeys = new Set(
+    parameters
+      .map((parameter) => parameter.key)
+      .filter(isLauncherOwnedCloudPluginKey),
+  );
+  if (ownedParameterKeys.size === 0) return null;
+
+  const touched = new Set<string>();
+  if (typeof body.enabled === "boolean") {
+    for (const key of ownedParameterKeys) touched.add(key);
+  }
+  if (
+    body.config &&
+    typeof body.config === "object" &&
+    !Array.isArray(body.config)
+  ) {
+    for (const key of Object.keys(body.config)) {
+      if (ownedParameterKeys.has(key)) touched.add(key);
+    }
+  }
+  if (touched.size === 0) return null;
+
+  return `Plugin settings cannot modify launcher-owned Cloud parameters while the local development Cloud target is active: ${[...touched].sort().join(", ")}`;
+}

--- a/plugins/plugin-registry/src/api/plugin-routes.test.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   applyPluginRuntimeMutation: vi.fn(),
+  devCloudAuthority: null as string | null,
   loadElizaConfig: vi.fn(),
   saveElizaConfig: vi.fn(),
   validatePluginConfig: vi.fn(),
@@ -37,11 +38,23 @@ vi.mock("@elizaos/shared", () => {
   };
 
   return {
+    DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS: [
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "ELIZA_STEWARD_AGENT_ID",
+      "STEWARD_API_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TRADE_SESSION_ID",
+      "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+      "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+    ],
     asRecord: (value: unknown) =>
       value && typeof value === "object" && !Array.isArray(value)
         ? (value as Record<string, unknown>)
         : null,
     isElizaSettingsDebugEnabled: vi.fn(() => false),
+    resolveDevCloudEnvAuthority: vi.fn(() => mocks.devCloudAuthority),
     PostPluginCoreToggleRequestSchema: schema,
     PostPluginInstallRequestSchema: schema,
     PostPluginUninstallRequestSchema: schema,
@@ -60,7 +73,7 @@ import {
 
 const originalEnv = { ...process.env };
 
-function makePlugin() {
+function makePlugin(overrides: Record<string, unknown> = {}) {
   return {
     id: "discord",
     name: "Discord",
@@ -83,7 +96,73 @@ function makePlugin() {
     validationErrors: [],
     validationWarnings: [],
     npmName: "@elizaos/plugin-discord",
+    ...overrides,
   };
+}
+
+function makeCloudAppsPlugin() {
+  return makePlugin({
+    id: "cloud-apps",
+    name: "Cloud Apps",
+    envKey: "ELIZAOS_CLOUD_API_KEY",
+    configKeys: ["ELIZAOS_CLOUD_API_KEY", "ELIZAOS_CLOUD_BASE_URL"],
+    parameters: [
+      {
+        key: "ELIZAOS_CLOUD_API_KEY",
+        required: false,
+        sensitive: true,
+        type: "string",
+      },
+      {
+        key: "ELIZAOS_CLOUD_BASE_URL",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+    ],
+    npmName: "@elizaos/plugin-cloud-apps",
+  });
+}
+
+function makeStewardWalletPlugin() {
+  return makePlugin({
+    id: "wallet",
+    name: "Wallet",
+    envKey: "STEWARD_AGENT_TOKEN",
+    configKeys: [
+      "STEWARD_API_URL",
+      "STEWARD_AGENT_ID",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TENANT_ID",
+    ],
+    parameters: [
+      {
+        key: "STEWARD_API_URL",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+      {
+        key: "STEWARD_AGENT_ID",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+      {
+        key: "STEWARD_AGENT_TOKEN",
+        required: false,
+        sensitive: true,
+        type: "string",
+      },
+      {
+        key: "STEWARD_TENANT_ID",
+        required: false,
+        sensitive: false,
+        type: "string",
+      },
+    ],
+    npmName: "@elizaos/plugin-wallet",
+  });
 }
 
 function makeContext(
@@ -127,6 +206,7 @@ function makeContext(
 
 describe("handlePluginRoutes config persistence", () => {
   beforeEach(() => {
+    mocks.devCloudAuthority = null;
     process.env = { ...originalEnv };
     delete process.env.DISCORD_API_TOKEN;
     mocks.loadElizaConfig.mockImplementation(() => ({
@@ -134,6 +214,7 @@ describe("handlePluginRoutes config persistence", () => {
       plugins: { entries: {} },
     }));
     mocks.saveElizaConfig.mockClear();
+    mocks.applyPluginRuntimeMutation.mockClear();
     mocks.validatePluginConfig.mockReturnValue({
       valid: true,
       errors: [],
@@ -184,6 +265,202 @@ describe("handlePluginRoutes config persistence", () => {
       ctx.res,
       expect.objectContaining({ ok: true }),
     );
+  });
+
+  it.each([
+    "staging-default",
+    "staging-explicit",
+    "production",
+    "offline",
+    "self-hosted",
+  ])(
+    "rejects launcher-owned Cloud plugin config byte-for-byte under %s authority",
+    async (authority) => {
+      mocks.devCloudAuthority = authority;
+      process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://launch.example/api/v1";
+      const config = {
+        env: {
+          ELIZAOS_CLOUD_API_KEY: "launch-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://launch.example/api/v1",
+        },
+        plugins: {
+          entries: {
+            "cloud-apps": {
+              enabled: true,
+              config: { ELIZAOS_CLOUD_API_KEY: "launch-key" },
+            },
+          },
+        },
+      };
+      const ctx = makeContext(
+        {
+          config: {
+            ELIZAOS_CLOUD_API_KEY: "hostile-key",
+            ELIZAOS_CLOUD_BASE_URL: "https://hostile.example/api/v1",
+          },
+        },
+        config,
+        { pathname: "/api/plugins/cloud-apps" },
+      );
+      ctx.state.plugins = [makeCloudAppsPlugin() as never];
+      const setSetting = vi.fn();
+      ctx.state.runtime = { setSetting } as never;
+      const configBefore = JSON.stringify(config);
+      const pluginsBefore = JSON.stringify(ctx.state.plugins);
+      const envBefore = JSON.stringify(Object.entries(process.env).sort());
+
+      const handled = await handlePluginRoutes(ctx);
+
+      expect(handled).toBe(true);
+      expect(ctx.error).toHaveBeenCalledWith(
+        ctx.res,
+        expect.stringContaining("launcher-owned Cloud parameters"),
+        409,
+      );
+      expect(JSON.stringify(config)).toBe(configBefore);
+      expect(JSON.stringify(ctx.state.plugins)).toBe(pluginsBefore);
+      expect(JSON.stringify(Object.entries(process.env).sort())).toBe(
+        envBefore,
+      );
+      expect(setSetting).not.toHaveBeenCalled();
+      expect(mocks.saveElizaConfig).not.toHaveBeenCalled();
+      expect(mocks.applyPluginRuntimeMutation).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "staging-default",
+    "staging-explicit",
+    "production",
+    "offline",
+    "self-hosted",
+  ])(
+    "rejects launcher-owned Steward plugin config byte-for-byte under %s authority",
+    async (authority) => {
+      mocks.devCloudAuthority = authority;
+      process.env.STEWARD_API_URL = "https://launch.example/steward";
+      process.env.STEWARD_AGENT_ID = "launch-agent";
+      process.env.STEWARD_AGENT_TOKEN = "launch-token";
+      process.env.STEWARD_TENANT_ID = "launch-tenant";
+      const config = {
+        env: {
+          STEWARD_API_URL: "https://launch.example/steward",
+          STEWARD_AGENT_ID: "launch-agent",
+          STEWARD_AGENT_TOKEN: "launch-token",
+          STEWARD_TENANT_ID: "launch-tenant",
+        },
+        plugins: {
+          entries: {
+            wallet: {
+              enabled: true,
+              config: {
+                STEWARD_API_URL: "https://launch.example/steward",
+                STEWARD_AGENT_ID: "launch-agent",
+                STEWARD_AGENT_TOKEN: "launch-token",
+                STEWARD_TENANT_ID: "launch-tenant",
+              },
+            },
+          },
+        },
+      };
+      const ctx = makeContext(
+        {
+          config: {
+            STEWARD_API_URL: "https://hostile.example/steward",
+            STEWARD_AGENT_ID: "hostile-agent",
+            STEWARD_AGENT_TOKEN: "hostile-token",
+            STEWARD_TENANT_ID: "hostile-tenant",
+          },
+        },
+        config,
+        { pathname: "/api/plugins/wallet" },
+      );
+      ctx.state.plugins = [makeStewardWalletPlugin() as never];
+      const setSetting = vi.fn();
+      ctx.state.runtime = { setSetting } as never;
+      const configBefore = JSON.stringify(config);
+      const pluginsBefore = JSON.stringify(ctx.state.plugins);
+      const envBefore = JSON.stringify(Object.entries(process.env).sort());
+
+      const handled = await handlePluginRoutes(ctx);
+
+      expect(handled).toBe(true);
+      expect(ctx.error).toHaveBeenCalledWith(
+        ctx.res,
+        expect.stringContaining("launcher-owned Cloud parameters"),
+        409,
+      );
+      expect(JSON.stringify(config)).toBe(configBefore);
+      expect(JSON.stringify(ctx.state.plugins)).toBe(pluginsBefore);
+      expect(JSON.stringify(Object.entries(process.env).sort())).toBe(
+        envBefore,
+      );
+      expect(setSetting).not.toHaveBeenCalled();
+      expect(mocks.saveElizaConfig).not.toHaveBeenCalled();
+      expect(mocks.applyPluginRuntimeMutation).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects Cloud plugin enablement before saved values reach the runtime bridge", async () => {
+    mocks.devCloudAuthority = "staging-default";
+    const config = {
+      env: { ELIZAOS_CLOUD_API_KEY: "saved-hostile-key" },
+      plugins: {
+        entries: {
+          "cloud-apps": {
+            enabled: false,
+            config: { ELIZAOS_CLOUD_API_KEY: "saved-hostile-key" },
+          },
+        },
+      },
+    };
+    const ctx = makeContext({ enabled: true }, config, {
+      pathname: "/api/plugins/cloud-apps",
+    });
+    ctx.state.plugins = [makeCloudAppsPlugin() as never];
+    const setSetting = vi.fn();
+    ctx.state.runtime = { setSetting } as never;
+
+    await handlePluginRoutes(ctx);
+
+    expect(ctx.error).toHaveBeenCalledWith(ctx.res, expect.any(String), 409);
+    expect(setSetting).not.toHaveBeenCalled();
+    expect(mocks.saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects launcher-owned Cloud keys through the bulk secrets route", async () => {
+    mocks.devCloudAuthority = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_API_KEY = "launch-key";
+    const config = { env: {}, plugins: { entries: {} } };
+    const ctx = makeContext(
+      { secrets: { ELIZAOS_CLOUD_API_KEY: "hostile-key" } },
+      config,
+      { method: "PUT", pathname: "/api/secrets" },
+    );
+    ctx.state.plugins = [makeCloudAppsPlugin() as never];
+
+    await handlePluginRoutes(ctx);
+
+    expect(ctx.error).toHaveBeenCalledWith(ctx.res, expect.any(String), 409);
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("launch-key");
+    expect(ctx.json).not.toHaveBeenCalled();
+  });
+
+  it("preserves Cloud plugin configuration outside launcher authority", async () => {
+    const config = { env: {}, plugins: { entries: {} } };
+    const ctx = makeContext(
+      { config: { ELIZAOS_CLOUD_API_KEY: "ordinary-key" } },
+      config,
+      { pathname: "/api/plugins/cloud-apps" },
+    );
+    ctx.state.plugins = [makeCloudAppsPlugin() as never];
+
+    await handlePluginRoutes(ctx);
+
+    expect(ctx.error).not.toHaveBeenCalled();
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("ordinary-key");
+    expect(mocks.saveElizaConfig).toHaveBeenCalled();
   });
 
   it("preserves entry config when enabling a plugin", async () => {

--- a/plugins/plugin-registry/src/api/plugin-routes.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.ts
@@ -47,6 +47,7 @@ import {
   clearPluginParamValues,
   collectAgentScopedPluginParamValues,
 } from "./bridge-plugin-settings.ts";
+import { devCloudPluginMutationRejection } from "./dev-cloud-plugin-authority.ts";
 
 /** Normalize npm names to list/toggle ids. Handles both `@elizaos/plugin-*` (current) and legacy `@elizaos/app-*`. */
 function optionalPluginListId(npmName: string): string {
@@ -867,6 +868,7 @@ export async function handlePluginRoutes(
 
     // Search both bundled plugins AND store-installed plugins
     let plugin = state.plugins.find((p) => p.id === pluginId);
+    let discoveredPlugin = false;
     if (!plugin) {
       // Check store-installed plugins from config
       let freshCfg: ElizaConfig;
@@ -879,14 +881,26 @@ export async function handlePluginRoutes(
       const installed = discoverInstalledPlugins(freshCfg, bundledIds);
       const found = installed.find((p) => p.id === pluginId);
       if (found) {
-        // Temporarily add to state.plugins so toggle logic works the same way
-        state.plugins.push(found);
         plugin = found;
+        discoveredPlugin = true;
       }
     }
     if (!plugin) {
       error(res, `Plugin "${pluginId}" not found`, 404);
       return true;
+    }
+
+    const authorityRejection = devCloudPluginMutationRejection(
+      plugin.parameters,
+      body,
+    );
+    if (authorityRejection) {
+      error(res, authorityRejection, 409);
+      return true;
+    }
+    if (discoveredPlugin) {
+      // Only mutate the live catalog after every fail-closed guard passes.
+      state.plugins.push(plugin);
     }
 
     const previousConfig = structuredClone(state.config);
@@ -1276,6 +1290,14 @@ export async function handlePluginRoutes(
     const bundledIds = new Set(state.plugins.map((p) => p.id));
     const installedEntries = discoverInstalledPlugins(state.config, bundledIds);
     const allPlugins: PluginEntry[] = [...state.plugins, ...installedEntries];
+    const authorityRejection = devCloudPluginMutationRejection(
+      allPlugins.flatMap((plugin) => plugin.parameters),
+      { config: body.secrets },
+    );
+    if (authorityRejection) {
+      error(res, authorityRejection, 409);
+      return true;
+    }
     const allowedKeys = new Set<string>();
     for (const plugin of allPlugins) {
       for (const param of plugin.parameters) {

--- a/plugins/plugin-sql/package.json
+++ b/plugins/plugin-sql/package.json
@@ -92,6 +92,7 @@
     "@electric-sql/experimental": "1.0.14",
     "@electric-sql/pglite": "^0.4.0",
     "@electric-sql/pglite-sync": "0.5.6",
+    "@elizaos/shared": "workspace:*",
     "@neondatabase/serverless": "^1.1.0",
     "drizzle-orm": "0.45.2",
     "pg": "^8.23.0",

--- a/plugins/plugin-sql/src/__tests__/unit/write-back.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/write-back.test.ts
@@ -3,15 +3,48 @@
  * logic — with `fetch` mocked via `vi.spyOn`, no real PGlite WASM or network
  * calls involved.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WriteBackService } from "../../write-back";
+
+const MANAGED_ENV_KEYS = [
+  "AGENT_ID",
+  "ELIZA_CLOUD_SERVICE_KEY",
+  "ELIZA_CLOUD_WRITE_BASE_URL",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZA_DEV_SOURCE",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  MANAGED_ENV_KEYS.map((key) => [key, process.env[key]])
+) as Record<(typeof MANAGED_ENV_KEYS)[number], string | undefined>;
 
 describe("WriteBackService", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    for (const key of MANAGED_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
   afterEach(() => {
     fetchSpy?.mockRestore();
     vi.useRealTimers();
+    for (const key of MANAGED_ENV_KEYS) {
+      const original = originalEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+    resetDevCloudEnvAuthorityForTests();
   });
 
   it("is disabled when no options are provided", () => {
@@ -35,6 +68,80 @@ describe("WriteBackService", () => {
     });
     expect(wb.enabled).toBe(true);
   });
+
+  it.each(["staging-default", "offline"] as const)(
+    "stays disabled under %s authority after late env and option pollution",
+    async (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZA_DEV_CLOUD_TARGET = authority === "offline" ? "offline" : "staging";
+      expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+      process.env.ELIZA_CLOUD_WRITE_BASE_URL = "https://api.eliza.app";
+      process.env.ELIZA_CLOUD_SERVICE_KEY = "late-production-service-key";
+      fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(null, { status: 200 }));
+
+      const wb = new WriteBackService({
+        writeBaseUrl: "https://constructor-production.example",
+        agentId: "agent-1",
+        serviceKey: "constructor-production-service-key",
+      });
+
+      expect(wb.enabled).toBe(false);
+      wb.enqueue("memories", "insert", { id: "m-1" });
+      await wb.flush();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    {
+      authority: "staging-explicit",
+      target: "staging",
+      launchBaseUrl: "https://api-staging.eliza.app/",
+      launchServiceKey: "staging-service-key",
+    },
+    {
+      authority: "self-hosted",
+      target: "self-hosted",
+      launchBaseUrl: "http://127.0.0.1:8787/",
+      launchServiceKey: "self-hosted-service-key",
+    },
+  ])(
+    "uses the frozen $authority destination and key after late pollution",
+    async ({ authority, target, launchBaseUrl, launchServiceKey }) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZA_DEV_CLOUD_TARGET = target;
+      process.env.ELIZA_CLOUD_WRITE_BASE_URL = launchBaseUrl;
+      process.env.ELIZA_CLOUD_SERVICE_KEY = launchServiceKey;
+      expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+      process.env.ELIZA_CLOUD_WRITE_BASE_URL = "https://api.eliza.app";
+      process.env.ELIZA_CLOUD_SERVICE_KEY = "late-production-service-key";
+      fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(null, { status: 200 }));
+
+      const wb = new WriteBackService({
+        writeBaseUrl: "https://constructor-production.example",
+        agentId: "agent-1",
+        serviceKey: "constructor-production-service-key",
+      });
+      wb.enqueue("memories", "insert", { id: "m-1" });
+      await wb.flush();
+
+      expect(wb.enabled).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${launchBaseUrl.replace(/\/+$/, "")}/api/v1/eliza/agents/agent-1/write`
+      );
+      const headers = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(headers["X-Service-Key"]).toBe(launchServiceKey);
+    }
+  );
 
   it("builds the correct write URL", () => {
     const wb = new WriteBackService({

--- a/plugins/plugin-sql/src/build.ts
+++ b/plugins/plugin-sql/src/build.ts
@@ -90,6 +90,7 @@ export const nodeExternals = [
   "agentkeepalive",
   "uuid",
   "@elizaos/core",
+  "@elizaos/shared",
   "@electric-sql/pglite",
   "zod",
   "fs",
@@ -151,6 +152,7 @@ export async function buildPluginSql(
     minify: false,
     external: [
       "@elizaos/core",
+      "@elizaos/shared",
       "@electric-sql/pglite",
       "@electric-sql/pglite/vector",
       "@electric-sql/pglite/contrib/fuzzystrmatch",

--- a/plugins/plugin-sql/src/tsconfig.typecheck.json
+++ b/plugins/plugin-sql/src/tsconfig.typecheck.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@elizaos/core": ["../../../packages/core/dist/index.d.ts"]
+      "@elizaos/core": ["../../../packages/core/dist/index.d.ts"],
+      "@elizaos/shared": ["../../../packages/shared/dist/index.d.ts"],
+      "@elizaos/shared/*": ["../../../packages/shared/dist/*"]
     }
   }
 }

--- a/plugins/plugin-sql/src/write-back/index.ts
+++ b/plugins/plugin-sql/src/write-back/index.ts
@@ -21,6 +21,7 @@
  */
 
 import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { resolveDevCloudAuthorityEnvValue, resolveDevCloudEnvAuthority } from "@elizaos/shared";
 
 const MAX_BATCH = 100;
 const FLUSH_DEBOUNCE_MS = 200;
@@ -58,8 +59,13 @@ export class WriteBackService {
   private writeCounter = 0;
 
   constructor(opts: WriteBackOptions = {}) {
-    const baseUrl = opts.writeBaseUrl ?? process.env.ELIZA_CLOUD_WRITE_BASE_URL ?? null;
-    const key = opts.serviceKey ?? process.env.ELIZA_CLOUD_SERVICE_KEY ?? null;
+    const devCloudAuthority = resolveDevCloudEnvAuthority();
+    const baseUrl = devCloudAuthority
+      ? resolveDevCloudAuthorityEnvValue("ELIZA_CLOUD_WRITE_BASE_URL")
+      : (opts.writeBaseUrl ?? process.env.ELIZA_CLOUD_WRITE_BASE_URL ?? null);
+    const key = devCloudAuthority
+      ? resolveDevCloudAuthorityEnvValue("ELIZA_CLOUD_SERVICE_KEY")
+      : (opts.serviceKey ?? process.env.ELIZA_CLOUD_SERVICE_KEY ?? null);
     const agentId = opts.agentId ?? process.env.AGENT_ID ?? null;
 
     if (baseUrl && agentId && key) {

--- a/plugins/plugin-wallet/src/analytics/birdeye/service.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.ts
@@ -10,16 +10,13 @@
  * recurring `BIRDEYE_SYNC_WALLET` task when `BIRDEYE_WALLET_ADDR` is set, and
  * opportunistically registers Birdeye with `INTEL_DATAPROVIDER` if present.
  */
-import {
-  type RouteSpec,
-  resolveCloudRoute,
-  toRuntimeSettings,
-} from "@elizaos/cloud-routing";
+import { type RouteSpec, resolveCloudRoute } from "@elizaos/cloud-routing";
 import {
   type IAgentRuntime,
   Service,
   type ServiceTypeName,
 } from "@elizaos/core";
+import { toWalletCloudRoutingSettings } from "../cloud-routing-authority";
 import Birdeye from "./birdeye-task";
 import {
   BIRDEYE_ENDPOINTS,
@@ -124,7 +121,7 @@ export class BirdeyeService extends Service {
       throw new Error("BirdeyeService requires a runtime");
     }
     const route = resolveCloudRoute(
-      toRuntimeSettings(this.runtime),
+      toWalletCloudRoutingSettings(this.runtime),
       BIRDEYE_ROUTE_SPEC,
     );
     if (route.source === "disabled") {

--- a/plugins/plugin-wallet/src/analytics/cloud-routing-authority.test.ts
+++ b/plugins/plugin-wallet/src/analytics/cloud-routing-authority.test.ts
@@ -1,0 +1,211 @@
+/** Proves wallet analytics cannot redirect a launch-owned Cloud credential. */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BirdeyeService } from "./birdeye/service";
+import { DexScreenerService } from "./dexscreener/service";
+
+const AUTHORITY_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_ENABLED",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  AUTHORITY_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function runtimeWithSettings(settings: Record<string, unknown>): IAgentRuntime {
+  return {
+    getSetting: vi.fn((key: string) => settings[key]),
+    getCache: vi.fn(async () => undefined),
+    setCache: vi.fn(async () => undefined),
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function setAuthority(
+  authority:
+    | "staging-default"
+    | "offline"
+    | "staging-explicit"
+    | "production"
+    | "self-hosted",
+): { apiKey: string; baseUrl: string } {
+  const baseUrl =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  const apiKey = "launch-cloud-key";
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_API_KEY = apiKey;
+  process.env.ELIZAOS_CLOUD_BASE_URL = baseUrl;
+  process.env.ELIZAOS_CLOUD_ENABLED = "true";
+  resetDevCloudEnvAuthorityForTests();
+  captureDevCloudEnvAuthoritySnapshot();
+  return { apiKey, baseUrl };
+}
+
+function poisonCloudSettings(settings: Record<string, unknown>): void {
+  process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+  process.env.ELIZAOS_CLOUD_BASE_URL =
+    "https://process-collector.example/api/v1";
+  process.env.ELIZAOS_CLOUD_ENABLED = "true";
+  settings.ELIZAOS_CLOUD_API_KEY = "late-runtime-key";
+  settings.ELIZAOS_CLOUD_BASE_URL = "https://runtime-collector.example/api/v1";
+  settings.ELIZAOS_CLOUD_ENABLED = "true";
+}
+
+function stubJsonFetch() {
+  const fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ data: {}, pairs: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const key of AUTHORITY_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("wallet analytics Cloud routing authority", () => {
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "sends Birdeye requests only to the frozen %s route after late pollution",
+    async (authority) => {
+      const launch = setAuthority(authority);
+      const settings: Record<string, unknown> = {};
+      poisonCloudSettings(settings);
+      const fetch = stubJsonFetch();
+      const service = new BirdeyeService(runtimeWithSettings(settings));
+
+      await service.fetchTokenOverview({ address: "So111" } as never);
+
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledWith(
+        `${launch.baseUrl}/apis/birdeye/defi/token_overview?address=So111`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${launch.apiKey}`,
+          }),
+        }),
+      );
+    },
+  );
+
+  it.each(["staging-default", "offline"] as const)(
+    "keeps Birdeye Cloud fallback disabled under %s after late activation",
+    (authority) => {
+      setAuthority(authority);
+      const settings: Record<string, unknown> = {};
+      poisonCloudSettings(settings);
+      const fetch = stubJsonFetch();
+
+      expect(() => new BirdeyeService(runtimeWithSettings(settings))).toThrow(
+        "requires BIRDEYE_API_KEY or Eliza Cloud",
+      );
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "sends DexScreener requests only to the frozen %s route after late pollution",
+    async (authority) => {
+      const launch = setAuthority(authority);
+      const settings: Record<string, unknown> = {
+        DEXSCREENER_RATE_LIMIT_DELAY: "0",
+      };
+      poisonCloudSettings(settings);
+      const fetch = stubJsonFetch();
+      const service = await DexScreenerService.start(
+        runtimeWithSettings(settings),
+      );
+
+      await (service as DexScreenerService).search({ query: "SOL" });
+
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledWith(
+        `${launch.baseUrl}/apis/dexscreener/latest/dex/search?q=SOL`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${launch.apiKey}`,
+          }),
+        }),
+      );
+    },
+  );
+
+  it.each(["staging-default", "offline"] as const)(
+    "uses public DexScreener without Cloud credentials under %s",
+    async (authority) => {
+      setAuthority(authority);
+      const settings: Record<string, unknown> = {
+        DEXSCREENER_RATE_LIMIT_DELAY: "0",
+      };
+      poisonCloudSettings(settings);
+      const fetch = stubJsonFetch();
+      const service = await DexScreenerService.start(
+        runtimeWithSettings(settings),
+      );
+
+      await (service as DexScreenerService).search({ query: "SOL" });
+
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.dexscreener.com/latest/dex/search?q=SOL",
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Authorization: expect.anything(),
+          }),
+        }),
+      );
+    },
+  );
+
+  it("preserves direct Birdeye key precedence under launcher authority", async () => {
+    setAuthority("staging-explicit");
+    const fetch = stubJsonFetch();
+    const service = new BirdeyeService(
+      runtimeWithSettings({ BIRDEYE_API_KEY: "direct-birdeye-key" }),
+    );
+
+    await service.fetchTokenOverview({ address: "So111" } as never);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://public-api.birdeye.so/defi/token_overview?address=So111",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-API-KEY": "direct-birdeye-key" }),
+      }),
+    );
+  });
+});

--- a/plugins/plugin-wallet/src/analytics/cloud-routing-authority.ts
+++ b/plugins/plugin-wallet/src/analytics/cloud-routing-authority.ts
@@ -1,0 +1,53 @@
+/**
+ * Adapts wallet analytics routing to the immutable local-development Cloud
+ * launch tuple without changing direct-provider setting precedence.
+ */
+
+import {
+  type RuntimeSettings,
+  toRuntimeSettings,
+} from "@elizaos/cloud-routing";
+import { captureDevCloudEnvAuthoritySnapshot } from "@elizaos/shared";
+
+const AUTHORITY_OWNED_ROUTING_KEYS = new Set([
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_ENABLED",
+]);
+
+/**
+ * Return runtime settings with only the Cloud proxy tuple projected from the
+ * frozen launcher snapshot. Local provider keys and service-specific settings
+ * continue to come from the runtime.
+ */
+export function toWalletCloudRoutingSettings(runtime: {
+  getSetting(key: string): unknown;
+}): RuntimeSettings {
+  const delegated = toRuntimeSettings(runtime);
+  const snapshot = captureDevCloudEnvAuthoritySnapshot();
+  if (!snapshot) return delegated;
+
+  const activationBlocked =
+    snapshot.authority === "staging-default" ||
+    snapshot.authority === "offline";
+  const authorityValues: Readonly<
+    Record<string, string | boolean | undefined>
+  > = Object.freeze({
+    ELIZAOS_CLOUD_API_KEY: activationBlocked
+      ? undefined
+      : snapshot.values.ELIZAOS_CLOUD_API_KEY,
+    ELIZAOS_CLOUD_BASE_URL: snapshot.values.ELIZAOS_CLOUD_BASE_URL,
+    ELIZAOS_CLOUD_ENABLED: activationBlocked
+      ? false
+      : snapshot.values.ELIZAOS_CLOUD_ENABLED,
+  });
+
+  return {
+    getSetting(key: string): string | boolean | number | null | undefined {
+      if (AUTHORITY_OWNED_ROUTING_KEYS.has(key)) {
+        return authorityValues[key];
+      }
+      return delegated.getSetting(key);
+    },
+  };
+}

--- a/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
@@ -7,12 +7,10 @@
  * direct `DEXSCREENER_API_URL` is configured, and self rate-limits between
  * requests via `DEXSCREENER_RATE_LIMIT_DELAY`.
  */
-import {
-  cloudServiceApisBaseUrl,
-  toRuntimeSettings,
-} from "@elizaos/cloud-routing";
+import { cloudServiceApisBaseUrl } from "@elizaos/cloud-routing";
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { parseClampedInteger } from "@elizaos/shared/utils/number-parsing";
+import { toWalletCloudRoutingSettings } from "../cloud-routing-authority";
 import { dexScreenerErrorMessage } from "./errors";
 import type {
   DexScreenerBoostedToken,
@@ -64,7 +62,7 @@ export class DexScreenerService extends Service {
       apiUrl = customBase.replace(/\/+$/, "");
     } else {
       const cloud = cloudServiceApisBaseUrl(
-        toRuntimeSettings(runtime),
+        toWalletCloudRoutingSettings(runtime),
         "dexscreener",
       );
       if (cloud !== null) {

--- a/plugins/plugin-wallet/src/api/wallet-routes.authority.test.ts
+++ b/plugins/plugin-wallet/src/api/wallet-routes.authority.test.ts
@@ -1,0 +1,112 @@
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleWalletRoutes, type WalletRouteContext } from "./wallet-routes";
+
+const ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+
+function generationContext(): {
+  ctx: WalletRouteContext;
+  res: { statusCode?: number; body?: unknown };
+  generateWalletForChain: ReturnType<typeof vi.fn>;
+} {
+  const res: { statusCode?: number; body?: unknown } = {};
+  const generateWalletForChain = vi.fn(() => {
+    throw new Error("local generation must remain unreachable");
+  });
+  const ctx = {
+    req: { headers: {} },
+    res,
+    method: "POST",
+    pathname: "/api/wallet/generate",
+    config: {},
+    saveConfig: vi.fn(),
+    ensureWalletKeysInEnvAndConfig: vi.fn(),
+    resolveWalletExportRejection: vi.fn(),
+    deps: { generateWalletForChain },
+    readJsonBody: vi.fn(async () => ({ source: "steward", chain: "evm" })),
+    json(target: typeof res, data: unknown, status = 200) {
+      target.statusCode = status;
+      target.body = data;
+    },
+    error(target: typeof res, message: string, status = 400) {
+      target.statusCode = status;
+      target.body = { error: message };
+    },
+  } as unknown as WalletRouteContext;
+  return { ctx, res, generateWalletForChain };
+}
+
+describe("wallet generation route Steward authority", () => {
+  let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    saved = Object.fromEntries(
+      ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it("does not query or create with inherited production credentials in default staging", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud";
+    process.env.STEWARD_AGENT_ID = "production-agent";
+    process.env.STEWARD_AGENT_TOKEN = "production-token";
+    captureDevCloudEnvAuthoritySnapshot();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { ctx, res, generateWalletForChain } = generationContext();
+
+    await expect(handleWalletRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(generateWalletForChain).not.toHaveBeenCalled();
+  });
+
+  it("does not let late URL and token settings complete an explicit launch tuple", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+    process.env.STEWARD_API_KEY = "late-production-key";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { ctx, res, generateWalletForChain } = generationContext();
+
+    await expect(handleWalletRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(generateWalletForChain).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-wallet/src/api/wallet-routes.ts
+++ b/plugins/plugin-wallet/src/api/wallet-routes.ts
@@ -48,6 +48,7 @@ import {
   PostWalletGenerateRequestSchema,
   PostWalletImportRequestSchema,
   PostWalletPrimaryRequestSchema,
+  resolveDevCloudStewardOperationalTuple,
   type WalletConfigUpdateRequest,
   type WalletRpcSelections,
 } from "@elizaos/shared";
@@ -110,6 +111,49 @@ const WALLET_CONFIG_COMPAT_KEYS = new Set([
   "BSC_RPC_URL",
   "SOLANA_RPC_URL",
 ]);
+
+type WalletRouteStewardConnection = {
+  apiUrl: string;
+  tenantId?: string;
+  agentId: string;
+  apiKey?: string;
+  agentToken?: string;
+};
+
+function resolveWalletRouteStewardConnection(): WalletRouteStewardConnection | null {
+  const authoritative = resolveDevCloudStewardOperationalTuple();
+  if (authoritative) {
+    return authoritative.enabled
+      ? {
+          apiUrl: authoritative.apiUrl,
+          ...(authoritative.tenantId
+            ? { tenantId: authoritative.tenantId }
+            : {}),
+          agentId: authoritative.agentId,
+          ...(authoritative.apiKey ? { apiKey: authoritative.apiKey } : {}),
+          ...(authoritative.agentToken
+            ? { agentToken: authoritative.agentToken }
+            : {}),
+        }
+      : null;
+  }
+
+  const apiUrl = process.env.STEWARD_API_URL?.trim();
+  const agentId =
+    process.env.STEWARD_AGENT_ID?.trim() ||
+    process.env.ELIZA_STEWARD_AGENT_ID?.trim();
+  if (!apiUrl || !agentId) return null;
+  const tenantId = process.env.STEWARD_TENANT_ID?.trim();
+  const apiKey = process.env.STEWARD_API_KEY?.trim();
+  const agentToken = process.env.STEWARD_AGENT_TOKEN?.trim();
+  return {
+    apiUrl,
+    ...(tenantId ? { tenantId } : {}),
+    agentId,
+    ...(apiKey ? { apiKey } : {}),
+    ...(agentToken ? { agentToken } : {}),
+  };
+}
 
 function resolveWalletConfigUpdateRequest(
   body: unknown,
@@ -961,7 +1005,12 @@ export async function handleWalletRoutes(
       : deps.validatePrivateKey(body.privateKey).chain;
 
     // When steward is configured, warn that keys should be imported via vault
-    const stewardWarning = process.env.STEWARD_API_URL?.trim()
+    const stewardAuthority = resolveDevCloudStewardOperationalTuple();
+    const stewardWarning = (
+      stewardAuthority
+        ? stewardAuthority.enabled
+        : Boolean(process.env.STEWARD_API_URL?.trim())
+    )
       ? "Steward vault is configured. Consider importing keys directly into the vault instead of storing plaintext keys locally."
       : undefined;
 
@@ -1036,38 +1085,21 @@ export async function handleWalletRoutes(
     const targetChain = body.chain ?? "both";
 
     // ── Steward-first: delegate wallet generation to steward ──────────
-    const stewardApiUrl = process.env.STEWARD_API_URL?.trim();
-    if (stewardApiUrl && requestedSource !== "local") {
+    const stewardConnection = resolveWalletRouteStewardConnection();
+    if (stewardConnection && requestedSource !== "local") {
       try {
-        const agentId =
-          process.env.STEWARD_AGENT_ID?.trim() ||
-          process.env.ELIZA_STEWARD_AGENT_ID?.trim() ||
-          null;
-
-        if (!agentId) {
-          error(
-            res,
-            "Steward is configured but no agent ID is set (STEWARD_AGENT_ID).",
-            500,
-          );
-          return true;
-        }
-
         // Build auth headers
         const headers: Record<string, string> = {
           Accept: "application/json",
           "Content-Type": "application/json",
         };
-        const bearerToken = process.env.STEWARD_AGENT_TOKEN?.trim();
-        const apiKey = process.env.STEWARD_API_KEY?.trim();
-        const tenantId = process.env.STEWARD_TENANT_ID?.trim();
-        if (bearerToken) {
-          headers.Authorization = `Bearer ${bearerToken}`;
-        } else if (apiKey) {
-          headers["X-Steward-Key"] = apiKey;
+        if (stewardConnection.agentToken) {
+          headers.Authorization = `Bearer ${stewardConnection.agentToken}`;
+        } else if (stewardConnection.apiKey) {
+          headers["X-Steward-Key"] = stewardConnection.apiKey;
         }
-        if (tenantId) {
-          headers["X-Steward-Tenant"] = tenantId;
+        if (stewardConnection.tenantId) {
+          headers["X-Steward-Tenant"] = stewardConnection.tenantId;
         }
 
         // Check if agent already exists (has wallets)
@@ -1077,7 +1109,7 @@ export async function handleWalletRoutes(
 
         try {
           const agentRes = await fetch(
-            `${stewardApiUrl}/agents/${encodeURIComponent(agentId)}`,
+            `${stewardConnection.apiUrl}/agents/${encodeURIComponent(stewardConnection.agentId)}`,
             { headers: { ...headers }, signal: AbortSignal.timeout(15_000) },
           );
           if (agentRes.ok) {
@@ -1103,10 +1135,13 @@ export async function handleWalletRoutes(
 
         // If agent doesn't exist, create it (steward auto-generates wallets)
         if (!agentExists) {
-          const createRes = await fetch(`${stewardApiUrl}/agents`, {
+          const createRes = await fetch(`${stewardConnection.apiUrl}/agents`, {
             method: "POST",
             headers,
-            body: JSON.stringify({ id: agentId, name: agentId }),
+            body: JSON.stringify({
+              id: stewardConnection.agentId,
+              name: stewardConnection.agentId,
+            }),
             signal: AbortSignal.timeout(15_000),
           });
 
@@ -1133,7 +1168,7 @@ export async function handleWalletRoutes(
           agentSolana = created.walletAddresses?.solana?.trim() || null;
 
           logger.info(
-            `[wallet] Created steward agent "${agentId}" with wallets`,
+            `[wallet] Created steward agent "${stewardConnection.agentId}" with wallets`,
           );
         }
 
@@ -1160,11 +1195,24 @@ export async function handleWalletRoutes(
         });
         return true;
       } catch (err) {
+        if (requestedSource === "steward") {
+          error(res, `Steward wallet generation failed: ${String(err)}`, 502);
+          return true;
+        }
         logger.warn(
           `[wallet] Steward wallet generation failed, falling back to local: ${err}`,
         );
         // Fall through to local generation
       }
+    }
+
+    if (requestedSource === "steward" && !stewardConnection) {
+      error(
+        res,
+        "Steward wallet generation is unavailable for this launch target.",
+        503,
+      );
+      return true;
     }
 
     // ── Legacy local key generation (fallback) ────────────────────────

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/rpc-providers.authority.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/rpc-providers.authority.test.ts
@@ -1,0 +1,110 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { initRPCProviderManager } from "../../rpc-providers";
+
+const ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+let savedEnv: Record<string, string | undefined>;
+
+function runtime(
+  settings: Record<string, string | undefined> = {},
+  characterSecret?: string
+): IAgentRuntime {
+  return {
+    character: characterSecret ? { secrets: { ELIZAOS_CLOUD_API_KEY: characterSecret } } : {},
+    getSetting: (key: string) => settings[key],
+  } as unknown as IAgentRuntime;
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("Eliza Cloud RPC development authority", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "%s ignores late env, runtime, and character production credentials",
+    (authority) => {
+      process.env.ELIZA_DEV_SOURCE = "1";
+      process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "";
+      expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-production-env-key";
+      const manager = initRPCProviderManager(
+        runtime(
+          {
+            ELIZAOS_CLOUD_API_KEY: "persisted-runtime-key",
+            ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+          },
+          "persisted-character-key"
+        )
+      );
+
+      expect(manager.getConfiguredProviders()).not.toContain("elizacloud");
+      expect(manager.resolveForChain("mainnet")).toBeNull();
+    }
+  );
+
+  it("uses only the frozen explicit-staging tuple after late production pollution", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "staging-launch-key";
+    expect(captureDevCloudEnvAuthoritySnapshot()).not.toBeNull();
+
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "late-production-env-key";
+    const manager = initRPCProviderManager(
+      runtime(
+        {
+          ELIZAOS_CLOUD_API_KEY: "persisted-runtime-key",
+          ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+        },
+        "persisted-character-key"
+      )
+    );
+
+    expect(manager.getConfiguredProviders()).toContain("elizacloud");
+    expect(manager.resolveForChain("mainnet")).toEqual({
+      providerName: "elizacloud",
+      rpcUrl: "https://api-staging.eliza.app/api/v1/proxy/evm-rpc/mainnet",
+      headers: { Authorization: "Bearer staging-launch-key" },
+    });
+  });
+
+  it("preserves runtime Cloud RPC configuration without authority", () => {
+    const manager = initRPCProviderManager(
+      runtime({
+        ELIZAOS_CLOUD_API_KEY: "legacy-runtime-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://legacy.example/api/v1",
+      })
+    );
+
+    expect(manager.resolveForChain("base")).toMatchObject({
+      providerName: "elizacloud",
+      rpcUrl: "https://legacy.example/api/v1/proxy/evm-rpc/base",
+      headers: { Authorization: "Bearer legacy-runtime-key" },
+    });
+  });
+});

--- a/plugins/plugin-wallet/src/chains/evm/rpc-providers.ts
+++ b/plugins/plugin-wallet/src/chains/evm/rpc-providers.ts
@@ -2,6 +2,7 @@
 
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { resolveDevCloudAuthorityEnvValue, resolveDevCloudEnvAuthority } from "@elizaos/shared";
 
 function hasStringSetting(runtime: IAgentRuntime, key: string): boolean {
   const value = runtime.getSetting(key);
@@ -34,16 +35,23 @@ function getCharacterSecret(runtime: IAgentRuntime, key: string): string | undef
   );
 }
 
-function getCloudApiKey(runtime: IAgentRuntime): string | undefined {
-  return (
+function resolveCloudRpcConfig(runtime: IAgentRuntime): { apiKey: string; baseUrl: string } | null {
+  if (resolveDevCloudEnvAuthority()) {
+    const apiKey = resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")?.trim();
+    const baseUrl = resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL")?.trim();
+    return apiKey && baseUrl ? { apiKey, baseUrl } : null;
+  }
+
+  const apiKey =
     getStringSetting(runtime, "ELIZAOS_CLOUD_API_KEY") ??
     getCharacterSecret(runtime, "ELIZAOS_CLOUD_API_KEY") ??
-    (process.env.ELIZAOS_CLOUD_API_KEY?.trim() || undefined)
-  );
-}
-
-function hasCloudRpcAccess(runtime: IAgentRuntime): boolean {
-  return Boolean(getCloudApiKey(runtime));
+    (process.env.ELIZAOS_CLOUD_API_KEY?.trim() || undefined);
+  if (!apiKey) return null;
+  const baseUrl =
+    getStringSetting(runtime, "ELIZAOS_CLOUD_BASE_URL") ??
+    (process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || undefined) ??
+    "https://api.eliza.app/api/v1";
+  return { apiKey, baseUrl };
 }
 
 export type RPCProviderName = "alchemy" | "infura" | "ankr" | "elizacloud";
@@ -263,15 +271,9 @@ export function initRPCProviderManager(runtime: IAgentRuntime): RPCProviderManag
   const ankrKey = getStringSetting(runtime, "ANKR_API_KEY");
   if (ankrKey) providers.push(createAnkrProvider(ankrKey));
 
-  if (hasCloudRpcAccess(runtime)) {
-    const cloudKey = getCloudApiKey(runtime);
-    if (cloudKey) {
-      const cloudBase =
-        getStringSetting(runtime, "ELIZAOS_CLOUD_BASE_URL") ??
-        (process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || undefined) ??
-        "https://api.eliza.app/api/v1";
-      providers.push(createElizaCloudProvider(cloudKey, cloudBase));
-    }
+  const cloud = resolveCloudRpcConfig(runtime);
+  if (cloud) {
+    providers.push(createElizaCloudProvider(cloud.apiKey, cloud.baseUrl));
   }
 
   if (preferred) {
@@ -362,7 +364,7 @@ export function validateRPCProviderConfig(runtime: IAgentRuntime): {
   if (hasStringSetting(runtime, "ALCHEMY_API_KEY")) configuredProviders.push("alchemy");
   if (hasStringSetting(runtime, "INFURA_API_KEY")) configuredProviders.push("infura");
   if (hasStringSetting(runtime, "ANKR_API_KEY")) configuredProviders.push("ankr");
-  if (hasCloudRpcAccess(runtime)) configuredProviders.push("elizacloud");
+  if (resolveCloudRpcConfig(runtime)) configuredProviders.push("elizacloud");
 
   // Check for any per-chain custom RPC URLs
   let hasCustomRpc = false;

--- a/plugins/plugin-wallet/src/chains/solana/cloud-proxy-authority.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/cloud-proxy-authority.test.ts
@@ -1,0 +1,148 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSolanaCloudProxyTuple, SolanaService } from "./service";
+
+const AUTHORITY_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_ENABLED",
+] as const;
+
+const originalEnv = Object.fromEntries(AUTHORITY_KEYS.map((key) => [key, process.env[key]]));
+
+function runtimeWithSettings(settings: Record<string, string>) {
+  const fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ data: { items: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+  );
+  const runtime = {
+    fetch,
+    getSetting: vi.fn((key: string) => settings[key]),
+    getServiceLoadPromise: vi.fn(async () => undefined),
+    getService: vi.fn(() => null),
+    logger: {
+      error: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, fetch };
+}
+
+function setAuthority(
+  authority: "staging-default" | "offline" | "staging-explicit" | "production" | "self-hosted"
+): { baseUrl: string; apiKey: string } {
+  const baseUrl =
+    authority === "production"
+      ? "https://api.eliza.app/api/v1"
+      : authority === "self-hosted"
+        ? "http://127.0.0.1:8787/api/v1"
+        : "https://api-staging.eliza.app/api/v1";
+  const apiKey =
+    authority === "staging-default" || authority === "offline" ? "" : "launch-cloud-key";
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = authority;
+  process.env.ELIZAOS_CLOUD_BASE_URL = baseUrl;
+  process.env.ELIZAOS_CLOUD_API_KEY = apiKey;
+  process.env.ELIZAOS_CLOUD_ENABLED = "true";
+  resetDevCloudEnvAuthorityForTests();
+  captureDevCloudEnvAuthoritySnapshot();
+  return { baseUrl, apiKey };
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of AUTHORITY_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of AUTHORITY_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+describe("Solana Cloud proxy launch authority", () => {
+  it.each(["staging-default", "offline"] as const)(
+    "keeps %s disabled after late runtime activation",
+    (authority) => {
+      setAuthority(authority);
+      const { runtime, fetch } = runtimeWithSettings({
+        ELIZAOS_CLOUD_API_KEY: "late-production-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://collector.example/api/v1",
+        ELIZAOS_CLOUD_ENABLED: "true",
+      });
+
+      expect(resolveSolanaCloudProxyTuple(runtime)).toBeNull();
+      const service = new SolanaService(runtime);
+      const rpcEndpoint = (service as unknown as { connection: { rpcEndpoint: string } }).connection
+        .rpcEndpoint;
+      expect(rpcEndpoint).toBe("https://api.mainnet-beta.solana.com");
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"] as const)(
+    "uses the exact frozen %s tuple after late runtime/process pollution",
+    async (authority) => {
+      const launch = setAuthority(authority);
+      process.env.ELIZAOS_CLOUD_API_KEY = "late-process-key";
+      process.env.ELIZAOS_CLOUD_BASE_URL = "https://process-collector.example/api/v1";
+      const { runtime, fetch } = runtimeWithSettings({
+        ELIZAOS_CLOUD_API_KEY: "late-runtime-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://runtime-collector.example/api/v1",
+        ELIZAOS_CLOUD_ENABLED: "true",
+      });
+
+      expect(resolveSolanaCloudProxyTuple(runtime)).toEqual({
+        apiKey: launch.apiKey,
+        baseUrl: launch.baseUrl,
+      });
+      const service = new SolanaService(runtime);
+      const rpcEndpoint = (service as unknown as { connection: { rpcEndpoint: string } }).connection
+        .rpcEndpoint;
+      expect(rpcEndpoint).toBe(`${launch.baseUrl}/proxy/solana-rpc?api_key=${launch.apiKey}`);
+      await (
+        service as unknown as {
+          birdeyeFetchWithRetry: (url: string) => Promise<Record<string, unknown>>;
+        }
+      ).birdeyeFetchWithRetry("https://public-api.birdeye.so/defi/tokenlist");
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledWith(
+        `${launch.baseUrl}/proxy/birdeye/defi/tokenlist`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${launch.apiKey}`,
+          }),
+        })
+      );
+    }
+  );
+
+  it("preserves direct Birdeye and Solana RPC precedence", () => {
+    setAuthority("staging-explicit");
+    const { runtime } = runtimeWithSettings({
+      BIRDEYE_API_KEY: "direct-birdeye-key",
+      SOLANA_RPC_URL: "https://direct-solana.example",
+      ELIZAOS_CLOUD_API_KEY: "late-cloud-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://collector.example/api/v1",
+      ELIZAOS_CLOUD_ENABLED: "true",
+    });
+    const service = new SolanaService(runtime);
+    const rpcEndpoint = (service as unknown as { connection: { rpcEndpoint: string } }).connection
+      .rpcEndpoint;
+    expect(rpcEndpoint).toBe("https://direct-solana.example");
+  });
+});

--- a/plugins/plugin-wallet/src/chains/solana/service.ts
+++ b/plugins/plugin-wallet/src/chains/solana/service.ts
@@ -24,6 +24,7 @@ import {
   Service,
   type ServiceTypeName,
 } from "@elizaos/core";
+import { resolveDevCloudAuthorityEnvValue, resolveDevCloudEnvAuthority } from "@elizaos/shared";
 
 export interface WalletAsset {
   address: string;
@@ -108,6 +109,45 @@ const PROVIDER_CONFIG = {
     ETH: "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
   },
 };
+
+type SolanaCloudProxyTuple = {
+  baseUrl: string;
+  apiKey: string;
+};
+
+function nonEmptySetting(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function cloudEnabled(value: unknown): boolean {
+  return (
+    typeof value === "string" && (value.trim().toLowerCase() === "true" || value.trim() === "1")
+  );
+}
+
+/** Resolve Cloud base/key/activation from one ownership domain. */
+export function resolveSolanaCloudProxyTuple(
+  runtime: Pick<IAgentRuntime, "getSetting">
+): SolanaCloudProxyTuple | null {
+  const authority = resolveDevCloudEnvAuthority();
+  if (authority) {
+    if (authority === "staging-default" || authority === "offline") {
+      return null;
+    }
+    const apiKey = nonEmptySetting(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY"));
+    const baseUrl = nonEmptySetting(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_BASE_URL"));
+    const enabled = cloudEnabled(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_ENABLED"));
+    return apiKey && baseUrl && enabled ? { apiKey, baseUrl } : null;
+  }
+
+  const apiKey = nonEmptySetting(runtime.getSetting("ELIZAOS_CLOUD_API_KEY"));
+  if (!apiKey || !cloudEnabled(runtime.getSetting("ELIZAOS_CLOUD_ENABLED"))) {
+    return null;
+  }
+  const baseUrl =
+    nonEmptySetting(runtime.getSetting("ELIZAOS_CLOUD_BASE_URL")) ?? "https://api.eliza.app/api/v1";
+  return { apiKey, baseUrl };
+}
 
 export const SOLANA_WALLET_COMPAT_SERVICE_NAME = `${SOLANA_SERVICE_NAME}_wallet`;
 
@@ -928,23 +968,14 @@ export class SolanaService extends Service {
     }
 
     // Check if Eliza Cloud is available for proxy
-    const cloudKey = this.runtime.getSetting("ELIZAOS_CLOUD_API_KEY");
-    const cloudEnabled = this.runtime.getSetting("ELIZAOS_CLOUD_ENABLED");
-    if (
-      typeof cloudKey === "string" &&
-      cloudKey.length > 0 &&
-      (cloudEnabled === "true" || cloudEnabled === "1")
-    ) {
-      const cloudBaseRaw = this.runtime.getSetting("ELIZAOS_CLOUD_BASE_URL");
-      const cloudBase =
-        typeof cloudBaseRaw === "string" ? cloudBaseRaw : "https://api.eliza.app/api/v1";
-
+    const cloud = resolveSolanaCloudProxyTuple(this.runtime);
+    if (cloud) {
       return {
-        baseUrl: `${cloudBase}/proxy/birdeye`,
+        baseUrl: `${cloud.baseUrl}/proxy/birdeye`,
         headers: {
           Accept: "application/json",
           "x-chain": "solana",
-          Authorization: `Bearer ${cloudKey}`,
+          Authorization: `Bearer ${cloud.apiKey}`,
         },
         mode: "cloud",
       };
@@ -981,17 +1012,9 @@ export class SolanaService extends Service {
       return `https://mainnet.helius-rpc.com/?api-key=${heliusKey}`;
     }
 
-    const cloudKey = runtime.getSetting("ELIZAOS_CLOUD_API_KEY");
-    const cloudEnabled = runtime.getSetting("ELIZAOS_CLOUD_ENABLED");
-    if (
-      typeof cloudKey === "string" &&
-      cloudKey.length > 0 &&
-      (cloudEnabled === "true" || cloudEnabled === "1")
-    ) {
-      const cloudBaseRaw = runtime.getSetting("ELIZAOS_CLOUD_BASE_URL");
-      const cloudBase =
-        typeof cloudBaseRaw === "string" ? cloudBaseRaw : "https://api.eliza.app/api/v1";
-      return `${cloudBase}/proxy/solana-rpc?api_key=${cloudKey}`;
+    const cloud = resolveSolanaCloudProxyTuple(runtime);
+    if (cloud) {
+      return `${cloud.baseUrl}/proxy/solana-rpc?api_key=${encodeURIComponent(cloud.apiKey)}`;
     }
 
     return PROVIDER_CONFIG.DEFAULT_RPC;

--- a/plugins/plugin-wallet/src/plugin.ts
+++ b/plugins/plugin-wallet/src/plugin.ts
@@ -5,7 +5,7 @@
  * registers the Birdeye/DexScreener/TokenInfo analytics services. `init` and
  * `dispose` fan out to each composed piece in turn.
  */
-import { resolveCloudRoute, toRuntimeSettings } from "@elizaos/cloud-routing";
+import { resolveCloudRoute } from "@elizaos/cloud-routing";
 import {
   type IAgentRuntime,
   type Plugin,
@@ -21,6 +21,7 @@ import {
   BIRDEYE_ROUTE_SPEC,
   BirdeyeService,
 } from "./analytics/birdeye/service.js";
+import { toWalletCloudRoutingSettings } from "./analytics/cloud-routing-authority.js";
 import { registerDexScreenerSearchCategory } from "./analytics/dexscreener/search-category.js";
 import { DexScreenerService } from "./analytics/dexscreener/service.js";
 import { TokenInfoService } from "./analytics/token-info/service.js";
@@ -62,7 +63,7 @@ function concatPlugins<T>(...chunks: (readonly T[] | undefined)[]): T[] {
 
 async function initBirdeyeAnalytics(runtime: IAgentRuntime): Promise<void> {
   const birdeyeRoute = resolveCloudRoute(
-    toRuntimeSettings(runtime),
+    toWalletCloudRoutingSettings(runtime),
     BIRDEYE_ROUTE_SPEC,
   );
   registerBirdeyeSearchCategories(runtime, {

--- a/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
+++ b/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
@@ -3,8 +3,15 @@
  * real `/v1/trade` route envelopes while avoiding live credentials or venue
  * funds; these tests pin the Eliza-side retry, outcome, and method boundary.
  */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared/elizacloud";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", async () => {
   return await import("../__tests__/core-vitest-mock.js");
@@ -597,5 +604,176 @@ describe("StewardTradingService", () => {
       error: "ROUTE_NOT_FOUND",
       retryable: false,
     });
+  });
+});
+
+const AUTHORITY_ENV_KEYS = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "STEWARD_TRADE_SESSION_ID",
+  "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+  "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+] as const;
+
+describe("StewardTradingService dev launcher authority", () => {
+  let saved: Record<(typeof AUTHORITY_ENV_KEYS)[number], string | undefined>;
+  let stateDir: string;
+
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    saved = Object.fromEntries(
+      AUTHORITY_ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof AUTHORITY_ENV_KEYS)[number], string | undefined>;
+    for (const key of AUTHORITY_ENV_KEYS) delete process.env[key];
+    stateDir = mkdtempSync(
+      path.join(os.tmpdir(), "steward-trading-authority-"),
+    );
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    for (const key of AUTHORITY_ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+    rmSync(stateDir, { force: true, recursive: true });
+  });
+
+  it("does not trade from persisted or runtime production credentials in default staging", async () => {
+    writeFileSync(
+      path.join(stateDir, "steward-credentials.json"),
+      JSON.stringify({
+        apiUrl: "https://eliza.app/steward",
+        tenantId: "elizacloud",
+        agentId: "production-agent",
+        apiKey: "production-key",
+        agentToken: "production-token",
+      }),
+    );
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    captureDevCloudEnvAuthoritySnapshot();
+    const fetchMock = vi.fn();
+    const service = new StewardTradingService(
+      runtime({
+        STEWARD_API_URL: "https://eliza.app/steward",
+        STEWARD_AGENT_ID: "production-agent",
+        STEWARD_AGENT_TOKEN: "production-token",
+        STEWARD_HYPERLIQUID_TRADE_SESSION_ID: "production-session",
+      }),
+      { fetch: fetchMock as unknown as typeof fetch },
+    );
+
+    expect(service.capability()).toMatchObject({ canTrade: false });
+    await expect(service.resolveAccount("hyperliquid")).resolves.toMatchObject({
+      ok: false,
+      error: "SESSION_REQUIRED",
+    });
+    await expect(
+      service.submitOrder({
+        venue: "hyperliquid",
+        sessionId: "production-session",
+        coin: "BTC",
+        side: "buy",
+        size: 0.01,
+        idempotencyKey: "blocked-default-staging",
+      }),
+    ).rejects.toThrow(/not configured/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not let late runtime URL, token, and session values complete an explicit tuple", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_AGENT_TOKEN = "late-production-token";
+    process.env.STEWARD_HYPERLIQUID_TRADE_SESSION_ID = "late-session";
+    const fetchMock = vi.fn();
+    const service = new StewardTradingService(
+      runtime({
+        STEWARD_API_URL: "https://eliza.app/steward",
+        STEWARD_AGENT_ID: "production-agent",
+        STEWARD_AGENT_TOKEN: "runtime-production-token",
+        STEWARD_HYPERLIQUID_TRADE_SESSION_ID: "runtime-session",
+      }),
+      { fetch: fetchMock as unknown as typeof fetch },
+    );
+
+    expect(service.capability()).toMatchObject({ canTrade: false });
+    await expect(service.resolveAccount("hyperliquid")).resolves.toMatchObject({
+      ok: false,
+      error: "SESSION_REQUIRED",
+    });
+    await expect(
+      service.submitOrder({
+        venue: "hyperliquid",
+        sessionId: "late-session",
+        coin: "BTC",
+        side: "buy",
+        size: 0.01,
+        idempotencyKey: "blocked-late-runtime",
+      }),
+    ).rejects.toThrow(/not configured/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the frozen explicit URL, token, and governed session after late overrides", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    process.env.STEWARD_AGENT_TOKEN = "staging-token";
+    process.env.STEWARD_HYPERLIQUID_TRADE_SESSION_ID = "sess_hl_fixture";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://eliza.app/steward";
+    process.env.STEWARD_AGENT_TOKEN = "production-token";
+    process.env.STEWARD_HYPERLIQUID_TRADE_SESSION_ID = "production-session";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      );
+    const service = new StewardTradingService(
+      runtime({
+        STEWARD_API_URL: "https://eliza.app/steward",
+        STEWARD_AGENT_ID: "production-agent",
+        STEWARD_AGENT_TOKEN: "runtime-production-token",
+        STEWARD_HYPERLIQUID_TRADE_SESSION_ID: "runtime-session",
+      }),
+      { fetch: fetchMock as unknown as typeof fetch },
+    );
+
+    await expect(service.resolveAccount("hyperliquid")).resolves.toMatchObject({
+      ok: true,
+      audit: { sessionId: "sess_hl_fixture" },
+    });
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://staging.eliza.app/steward/v1/trade/token-status?agentId=staging-agent",
+      "https://staging.eliza.app/steward/v1/trade/sessions/sess_hl_fixture",
+    ]);
+    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders.Authorization).toBe("Bearer staging-token");
   });
 });

--- a/plugins/plugin-wallet/src/services/steward-trading-service.ts
+++ b/plugins/plugin-wallet/src/services/steward-trading-service.ts
@@ -9,6 +9,10 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { ElizaError, type IAgentRuntime, Service } from "@elizaos/core";
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudStewardOperationalTuple,
+} from "@elizaos/shared/elizacloud";
 import type {
   CancelOrderRequest,
   CancelResult,
@@ -660,13 +664,20 @@ export class StewardTradingService extends Service {
       venue === "hyperliquid"
         ? "STEWARD_HYPERLIQUID_TRADE_SESSION_ID"
         : "STEWARD_POLYMARKET_TRADE_SESSION_ID";
-    const sessionId =
-      normalizeOptionalString(this.runtime.getSetting(settingName)) ??
-      normalizeOptionalString(process.env[settingName]) ??
-      normalizeOptionalString(
-        this.runtime.getSetting("STEWARD_TRADE_SESSION_ID"),
-      ) ??
-      normalizeOptionalString(process.env.STEWARD_TRADE_SESSION_ID);
+    const authoritative = resolveDevCloudStewardOperationalTuple();
+    const sessionId = authoritative
+      ? (normalizeOptionalString(
+          resolveDevCloudAuthorityEnvValue(settingName),
+        ) ??
+        normalizeOptionalString(
+          resolveDevCloudAuthorityEnvValue("STEWARD_TRADE_SESSION_ID"),
+        ))
+      : (normalizeOptionalString(this.runtime.getSetting(settingName)) ??
+        normalizeOptionalString(process.env[settingName]) ??
+        normalizeOptionalString(
+          this.runtime.getSetting("STEWARD_TRADE_SESSION_ID"),
+        ) ??
+        normalizeOptionalString(process.env.STEWARD_TRADE_SESSION_ID));
     if (!sessionId) {
       return {
         ok: false,
@@ -739,6 +750,24 @@ export class StewardTradingService extends Service {
   }
 
   private resolveConfig(): StewardTradingConfig | null {
+    const authoritative = resolveDevCloudStewardOperationalTuple();
+    if (authoritative) {
+      if (
+        !authoritative.enabled ||
+        !authoritative.agentToken ||
+        !isSecureStewardApiUrl(authoritative.apiUrl)
+      ) {
+        return null;
+      }
+      return {
+        apiUrl: authoritative.apiUrl,
+        agentId: authoritative.agentId,
+        agentToken: authoritative.agentToken,
+        ...(authoritative.apiKey ? { apiKey: authoritative.apiKey } : {}),
+        ...(authoritative.tenantId ? { tenantId: authoritative.tenantId } : {}),
+      };
+    }
+
     const persisted = readPersistedStewardCredentials();
     const apiUrl =
       normalizeOptionalString(this.runtime.getSetting("STEWARD_API_URL")) ??

--- a/plugins/plugin-wallet/src/wallet/select-backend.authority.test.ts
+++ b/plugins/plugin-wallet/src/wallet/select-backend.authority.test.ts
@@ -1,0 +1,116 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  captureDevCloudEnvAuthoritySnapshot,
+  resetDevCloudEnvAuthorityForTests,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocalEoaBackend } from "./local-eoa-backend.js";
+import { resolveWalletBackend } from "./select-backend.js";
+import { StewardBackend } from "./steward-backend.js";
+
+const ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_WALLET_BACKEND",
+  "ELIZA_WALLET_STEWARD_AUTO",
+  "ELIZA_CLOUD_PROVISIONED",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+const saved = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+function runtime(mode: "local" | "steward" | "auto"): IAgentRuntime {
+  return {
+    getSetting: (key: string) =>
+      key === "ELIZA_WALLET_BACKEND" ? mode : undefined,
+  } as unknown as IAgentRuntime;
+}
+
+describe("wallet backend development Cloud authority", () => {
+  beforeEach(() => {
+    resetDevCloudEnvAuthorityForTests();
+    for (const key of ENV_KEYS) delete process.env[key];
+    vi.spyOn(LocalEoaBackend, "create").mockResolvedValue({
+      kind: "local",
+    } as never);
+    vi.spyOn(StewardBackend, "create").mockResolvedValue({
+      kind: "steward",
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetDevCloudEnvAuthorityForTests();
+  });
+
+  it("does not let late auto flags activate Steward in staging-default", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-default";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.ELIZA_WALLET_STEWARD_AUTO = "1";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_API_URL = "https://attacker.example/steward";
+    process.env.STEWARD_AGENT_ID = "attacker-agent";
+    process.env.STEWARD_AGENT_TOKEN = "attacker-token";
+
+    await expect(resolveWalletBackend(runtime("auto"))).resolves.toMatchObject({
+      kind: "local",
+    });
+    expect(StewardBackend.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit Steward mode when the launcher blocked it", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "offline";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_AGENT_TOKEN = "late-attacker-token";
+
+    await expect(resolveWalletBackend(runtime("steward"))).rejects.toThrow(
+      /launcher did not authorize/i,
+    );
+    expect(StewardBackend.create).not.toHaveBeenCalled();
+  });
+
+  it("passes only the frozen explicit Steward tuple to the backend", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.STEWARD_API_URL = "https://staging.eliza.app/steward";
+    process.env.STEWARD_TENANT_ID = "elizacloud-staging";
+    process.env.STEWARD_AGENT_ID = "staging-agent";
+    process.env.STEWARD_AGENT_TOKEN = "staging-token";
+    captureDevCloudEnvAuthoritySnapshot();
+
+    process.env.STEWARD_API_URL = "https://attacker.example/steward";
+    process.env.STEWARD_TENANT_ID = "attacker";
+    process.env.STEWARD_AGENT_ID = "attacker-agent";
+    process.env.STEWARD_AGENT_TOKEN = "attacker-token";
+
+    await expect(
+      resolveWalletBackend(runtime("steward")),
+    ).resolves.toMatchObject({
+      kind: "steward",
+    });
+    expect(StewardBackend.create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        authority: "staging-explicit",
+        enabled: true,
+        apiUrl: "https://staging.eliza.app/steward",
+        tenantId: "elizacloud-staging",
+        agentId: "staging-agent",
+        agentToken: "staging-token",
+      }),
+    );
+  });
+});

--- a/plugins/plugin-wallet/src/wallet/select-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/select-backend.ts
@@ -4,8 +4,12 @@
  * preferring Steward when the agent is cloud-provisioned.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { readAliasedEnv } from "@elizaos/shared";
+import {
+  readAliasedEnv,
+  resolveDevCloudStewardOperationalTuple,
+} from "@elizaos/shared";
 import type { WalletBackend } from "./backend.js";
+import { StewardUnavailableError } from "./errors.js";
 import { LocalEoaBackend } from "./local-eoa-backend.js";
 import { StewardBackend } from "./steward-backend.js";
 
@@ -40,6 +44,20 @@ export async function resolveWalletBackend(
   runtime: IAgentRuntime,
 ): Promise<WalletBackend> {
   const mode = readMode(runtime);
+  const launcherSteward = resolveDevCloudStewardOperationalTuple();
+  if (launcherSteward) {
+    if (mode === "local") return LocalEoaBackend.create(runtime);
+    if (!launcherSteward.enabled || !launcherSteward.agentToken) {
+      if (mode === "steward") {
+        throw new StewardUnavailableError(
+          "The development launcher did not authorize a complete Steward wallet tuple.",
+        );
+      }
+      return LocalEoaBackend.create(runtime);
+    }
+    return StewardBackend.create(runtime, launcherSteward);
+  }
+
   if (mode === "steward") {
     return StewardBackend.create(runtime);
   }

--- a/plugins/plugin-wallet/src/wallet/steward-backend.authority.test.ts
+++ b/plugins/plugin-wallet/src/wallet/steward-backend.authority.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { withProjectedStewardAuthority } from "./steward-backend.js";
+
+const KEYS = [
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+const saved = Object.fromEntries(
+  KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof KEYS)[number], string | undefined>;
+
+afterEach(() => {
+  for (const key of KEYS) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("Steward backend authority projection", () => {
+  it("holds one exact tuple for the complete asynchronous operation", async () => {
+    process.env.STEWARD_API_URL = "https://attacker.example/steward";
+    process.env.STEWARD_TENANT_ID = "attacker";
+    process.env.STEWARD_AGENT_ID = "attacker-agent";
+    process.env.ELIZA_STEWARD_AGENT_ID = "attacker-agent";
+    process.env.STEWARD_API_KEY = "attacker-key";
+    process.env.STEWARD_AGENT_TOKEN = "attacker-token";
+
+    await withProjectedStewardAuthority(
+      {
+        authority: "staging-explicit",
+        enabled: true,
+        apiUrl: "https://staging.eliza.app/steward",
+        tenantId: "elizacloud-staging",
+        agentId: "staging-agent",
+        agentToken: "staging-token",
+      },
+      async () => {
+        await Promise.resolve();
+        expect(process.env).toMatchObject({
+          STEWARD_API_URL: "https://staging.eliza.app/steward",
+          STEWARD_TENANT_ID: "elizacloud-staging",
+          STEWARD_AGENT_ID: "staging-agent",
+          ELIZA_STEWARD_AGENT_ID: "staging-agent",
+          STEWARD_AGENT_TOKEN: "staging-token",
+        });
+        expect(process.env.STEWARD_API_KEY).toBeUndefined();
+      },
+    );
+
+    expect(process.env).toMatchObject({
+      STEWARD_API_URL: "https://attacker.example/steward",
+      STEWARD_TENANT_ID: "attacker",
+      STEWARD_AGENT_ID: "attacker-agent",
+      ELIZA_STEWARD_AGENT_ID: "attacker-agent",
+      STEWARD_API_KEY: "attacker-key",
+      STEWARD_AGENT_TOKEN: "attacker-token",
+    });
+  });
+
+  it("restores the prior environment after a rejected operation", async () => {
+    process.env.STEWARD_API_URL = "https://prior.example/steward";
+
+    await expect(
+      withProjectedStewardAuthority(
+        {
+          authority: "production",
+          enabled: true,
+          apiUrl: "https://eliza.app/steward",
+          tenantId: "elizacloud",
+          agentId: "production-agent",
+          agentToken: "production-token",
+        },
+        async () => {
+          throw new Error("expected failure");
+        },
+      ),
+    ).rejects.toThrow("expected failure");
+
+    expect(process.env.STEWARD_API_URL).toBe("https://prior.example/steward");
+  });
+});

--- a/plugins/plugin-wallet/src/wallet/steward-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/steward-backend.ts
@@ -11,6 +11,7 @@
  * `getSolanaSigner()` always throws.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import type { DevCloudStewardOperationalTuple } from "@elizaos/shared";
 import { PublicKey } from "@solana/web3.js";
 import type { Account, Hex, TypedDataDefinition } from "viem";
 import { hexToBytes } from "viem";
@@ -49,6 +50,60 @@ interface StewardEvmAccountModule {
 }
 
 const STEWARD_MODULE_ID = ["@elizaos", "app-steward"].join("/");
+const STEWARD_ENV_KEYS = [
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_STEWARD_AGENT_ID",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+
+let stewardProjectionTail = Promise.resolve();
+
+/** @internal Exported for deterministic authority-boundary tests. */
+export async function withProjectedStewardAuthority<T>(
+  tuple: Extract<DevCloudStewardOperationalTuple, { enabled: true }>,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const predecessor = stewardProjectionTail;
+  let release = (): void => {};
+  stewardProjectionTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await predecessor;
+
+  const saved = Object.fromEntries(
+    STEWARD_ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof STEWARD_ENV_KEYS)[number], string | undefined>;
+  const projected: Record<
+    (typeof STEWARD_ENV_KEYS)[number],
+    string | undefined
+  > = {
+    STEWARD_API_URL: tuple.apiUrl,
+    STEWARD_TENANT_ID: tuple.tenantId,
+    STEWARD_AGENT_ID: tuple.agentId,
+    ELIZA_STEWARD_AGENT_ID: tuple.agentId,
+    STEWARD_API_KEY: tuple.apiKey,
+    STEWARD_AGENT_TOKEN: tuple.agentToken,
+  };
+
+  try {
+    for (const key of STEWARD_ENV_KEYS) {
+      const value = projected[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return await operation();
+  } finally {
+    for (const key of STEWARD_ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    release();
+  }
+}
 
 /**
  * Cloud / mobile signing via Steward for EVM. Solana addresses may be exposed from
@@ -70,8 +125,23 @@ export class StewardBackend implements WalletBackend {
     this.solanaPubkey = solanaPubkey;
   }
 
-  static async create(_runtime: IAgentRuntime): Promise<StewardBackend> {
+  static async create(
+    _runtime: IAgentRuntime,
+    authorityTuple?: Extract<
+      DevCloudStewardOperationalTuple,
+      { enabled: true }
+    >,
+  ): Promise<StewardBackend> {
     void _runtime;
+    if (authorityTuple) {
+      return withProjectedStewardAuthority(authorityTuple, () =>
+        StewardBackend.createUnmanaged(),
+      );
+    }
+    return StewardBackend.createUnmanaged();
+  }
+
+  private static async createUnmanaged(): Promise<StewardBackend> {
     let steward: StewardEvmAccountModule;
     try {
       steward = (await import(STEWARD_MODULE_ID)) as StewardEvmAccountModule;

--- a/plugins/plugin-wallet/tsconfig.json
+++ b/plugins/plugin-wallet/tsconfig.json
@@ -13,6 +13,10 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noEmit": true,
+    "paths": {
+      "@elizaos/shared": ["../../packages/shared/src/index.ts"],
+      "@elizaos/shared/*": ["../../packages/shared/src/*"]
+    },
     "types": ["node", "bun"]
   },
   "include": ["src/**/*.ts"],

--- a/plugins/plugin-wallet/vitest.config.ts
+++ b/plugins/plugin-wallet/vitest.config.ts
@@ -77,6 +77,13 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@elizaos\/shared\/elizacloud$/,
+        replacement: path.resolve(
+          rootDir,
+          "../../packages/shared/src/elizacloud/index.ts",
+        ),
+      },
+      {
         find: /^@elizaos\/shared$/,
         replacement: path.resolve(
           rootDir,

--- a/plugins/plugin-x/package.json
+++ b/plugins/plugin-x/package.json
@@ -692,6 +692,7 @@
     }
   },
   "peerDependencies": {
-    "@elizaos/core": "workspace:*"
+    "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*"
   }
 }

--- a/plugins/plugin-x/src/client/auth-providers/broker.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.test.ts
@@ -7,7 +7,11 @@ import type {
   GuardedFetchResult,
   IAgentRuntime,
 } from "@elizaos/core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BROKER_FETCH_TIMEOUT_MS,
   BROKER_RESPONSE_MAX_BYTES,
@@ -35,6 +39,36 @@ function newTestProvider(runtimeValue: IAgentRuntime): BrokerAuthProvider {
   return new BrokerAuthProvider(runtimeValue, testGuardedFetch);
 }
 
+const DEV_CLOUD_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_API_KEY",
+] as const;
+const ORIGINAL_DEV_CLOUD_ENV = Object.fromEntries(
+  DEV_CLOUD_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof DEV_CLOUD_ENV_KEYS)[number], string | undefined>;
+
+function installDevCloudAuthority(options: {
+  authority:
+    | "staging-default"
+    | "staging-explicit"
+    | "production"
+    | "offline"
+    | "self-hosted";
+  baseUrl: string;
+  apiKey: string;
+}): void {
+  resetDevCloudEnvAuthorityForTests();
+  process.env.ELIZA_DEV_SOURCE = "1";
+  process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = options.authority;
+  process.env.ELIZA_DEV_CLOUD_TARGET = options.authority;
+  process.env.ELIZAOS_CLOUD_BASE_URL = options.baseUrl;
+  process.env.ELIZAOS_CLOUD_API_KEY = options.apiKey;
+  resolveDevCloudEnvAuthority();
+}
+
 async function settleWithin<T>(
   promise: Promise<T>,
   milliseconds = 250,
@@ -58,10 +92,21 @@ async function settleWithin<T>(
   }
 }
 
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of DEV_CLOUD_ENV_KEYS) delete process.env[key];
+});
+
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  for (const key of DEV_CLOUD_ENV_KEYS) {
+    const original = ORIGINAL_DEV_CLOUD_ENV[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("BrokerAuthProvider", () => {
@@ -591,6 +636,132 @@ describe("BrokerAuthProvider", () => {
       code: "X_BROKER_CREDENTIAL_MISSING",
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "staging authority to production",
+      authority: "staging-explicit" as const,
+      authorityBase: "https://api-staging.eliza.app/api/v1",
+      brokerUrl: "https://api.eliza.app/api/v1/twitter",
+    },
+    {
+      label: "production authority to staging",
+      authority: "production" as const,
+      authorityBase: "https://api.eliza.app/api/v1",
+      brokerUrl: "https://api-staging.eliza.app/api/v1/twitter",
+    },
+    {
+      label: "production authority outside its frozen path",
+      authority: "production" as const,
+      authorityBase: "https://api.eliza.app/api/v1",
+      brokerUrl: "https://api.eliza.app/private/twitter",
+    },
+  ])("blocks Cloud-key crossover: $label", async (testCase) => {
+    installDevCloudAuthority({
+      authority: testCase.authority,
+      baseUrl: testCase.authorityBase,
+      apiKey: `${testCase.authority}-frozen-key`,
+    });
+    process.env.ELIZAOS_CLOUD_BASE_URL = testCase.brokerUrl;
+    process.env.ELIZAOS_CLOUD_API_KEY = "mutable-process-key";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = newTestProvider(
+      runtime({
+        ELIZAOS_CLOUD_API_KEY: "mutable-runtime-key",
+        TWITTER_BROKER_URL: testCase.brokerUrl,
+      }),
+    );
+
+    await expect(provider.getAccessToken()).rejects.toMatchObject({
+      code: "X_BROKER_CREDENTIAL_MISSING",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses only the frozen key for a self-hosted broker owned by the frozen base", async () => {
+    installDevCloudAuthority({
+      authority: "self-hosted",
+      baseUrl: "https://self-hosted.example/cloud/api/v1",
+      apiKey: "frozen-self-hosted-key",
+    });
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://mutable.example/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "mutable-process-key";
+    const fetchMock = vi.fn(async () =>
+      Response.json({ auth_mode: "oauth2", access_token: "x-token" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = newTestProvider(
+      runtime({
+        ELIZAOS_CLOUD_API_KEY: "mutable-runtime-key",
+        TWITTER_BROKER_URL: "https://self-hosted.example/cloud/api/v1/twitter/",
+      }),
+    );
+
+    await expect(provider.getAccessToken()).resolves.toBe("x-token");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://self-hosted.example/cloud/api/v1/twitter/token?connectionRole=agent",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer frozen-self-hosted-key",
+        }),
+      }),
+    );
+  });
+
+  it.each(["staging-default", "offline"] as const)(
+    "does not revive a mutable Cloud key in blocked %s mode",
+    async (authority) => {
+      installDevCloudAuthority({
+        authority,
+        baseUrl: "https://api.eliza.app/api/v1",
+        apiKey: "stale-process-key",
+      });
+      process.env.ELIZAOS_CLOUD_API_KEY = "mutated-process-key";
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const provider = newTestProvider(
+        runtime({
+          ELIZAOS_CLOUD_API_KEY: "stale-runtime-key",
+          TWITTER_BROKER_URL: "https://api-staging.eliza.app/api/v1/twitter",
+        }),
+      );
+
+      await expect(provider.getAccessToken()).rejects.toMatchObject({
+        code: "X_BROKER_CREDENTIAL_MISSING",
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows a custom broker only when it has an explicit broker token", async () => {
+    installDevCloudAuthority({
+      authority: "staging-explicit",
+      baseUrl: "https://api-staging.eliza.app/api/v1",
+      apiKey: "frozen-staging-key",
+    });
+    const fetchMock = vi.fn(async () =>
+      Response.json({ auth_mode: "oauth2", access_token: "x-token" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = newTestProvider(
+      runtime({
+        ELIZAOS_CLOUD_API_KEY: "mutable-runtime-key",
+        TWITTER_BROKER_TOKEN: "explicit-broker-token",
+        TWITTER_BROKER_URL: "https://broker.example/api/v1/twitter",
+      }),
+    );
+
+    await expect(provider.getAccessToken()).resolves.toBe("x-token");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://broker.example/api/v1/twitter/token?connectionRole=agent",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer explicit-broker-token",
+        }),
+      }),
+    );
   });
 
   it.each([

--- a/plugins/plugin-x/src/client/auth-providers/broker.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.ts
@@ -18,6 +18,7 @@ import {
   isPrivateIpAddress,
   logger,
 } from "@elizaos/core";
+import { resolveCloudApiKeyForXEndpoint } from "../../utils/cloud-credential-boundary";
 import { getSetting } from "../../utils/settings";
 import type { BrokerAuthCredentials, TwitterBrokerProvider } from "./types";
 
@@ -388,23 +389,15 @@ export class BrokerAuthProvider implements TwitterBrokerProvider {
 
   private brokerToken(baseUrl: string): string {
     const explicit = getSetting(this.runtime, "TWITTER_BROKER_TOKEN");
-    const origin = new URL(baseUrl).origin.toLowerCase();
-    const trustedCloudOrigin = new Set([
-      "https://api.eliza.app",
-      "https://api-staging.eliza.app",
-      "https://cloud.eliza.app",
-      "https://cloud-staging.eliza.app",
-    ]).has(origin);
     const token =
       explicit ??
-      (trustedCloudOrigin
-        ? getSetting(this.runtime, "ELIZAOS_CLOUD_API_KEY")
-        : undefined);
+      resolveCloudApiKeyForXEndpoint(
+        baseUrl,
+        getSetting(this.runtime, "ELIZAOS_CLOUD_API_KEY"),
+      );
     if (!token) {
       throw brokerError(
-        trustedCloudOrigin
-          ? "TWITTER_AUTH_MODE=broker requires TWITTER_BROKER_TOKEN or ELIZAOS_CLOUD_API_KEY"
-          : "A custom X broker requires an explicit TWITTER_BROKER_TOKEN",
+        "X broker requires an explicit TWITTER_BROKER_TOKEN unless it belongs to the selected Eliza Cloud target",
         "X_BROKER_CREDENTIAL_MISSING",
       );
     }

--- a/plugins/plugin-x/src/direct-messages.test.ts
+++ b/plugins/plugin-x/src/direct-messages.test.ts
@@ -9,7 +9,8 @@
  * PairingService, real core `checkPairingAllowed`).
  */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "./base";
 import type { AuthenticatedTwitterSession } from "./client/auth";
 import { isGroupDmEvent, TwitterDirectMessageClient } from "./direct-messages";
@@ -45,9 +46,50 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+const DEV_CLOUD_ENV_KEYS = [
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_TARGET",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_API_KEY",
+] as const;
+const ORIGINAL_DEV_CLOUD_ENV = Object.fromEntries(
+  DEV_CLOUD_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof DEV_CLOUD_ENV_KEYS)[number], string | undefined>;
+
+const PERSONAL_DM_PARAMS = {
+  recipientTwitterUserId: "222",
+  senderTwitterUserId: "111",
+  senderUsername: "alice",
+  displayName: "Alice",
+  dmEventId: "501",
+  message: "private question",
+};
+
+function routePersonalDmForTest(
+  client: TwitterDirectMessageClient,
+): Promise<string> {
+  return (
+    client as unknown as {
+      routePersonalDm(params: typeof PERSONAL_DM_PARAMS): Promise<string>;
+    }
+  ).routePersonalDm(PERSONAL_DM_PARAMS);
+}
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  for (const key of DEV_CLOUD_ENV_KEYS) delete process.env[key];
+});
+
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  for (const key of DEV_CLOUD_ENV_KEYS) {
+    const original = ORIGINAL_DEV_CLOUD_ENV[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  resetDevCloudEnvAuthorityForTests();
 });
 
 describe("X DM conversation classification", () => {
@@ -69,6 +111,105 @@ describe("X DM conversation classification", () => {
 });
 
 describe("TwitterDirectMessageClient", () => {
+  it("never sends a Cloud API key to an arbitrary personal-DM router", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = {
+      getSetting: vi.fn((key: string) =>
+        key === "ELIZAOS_CLOUD_API_KEY" ? "privileged-cloud-key" : undefined,
+      ),
+    } as unknown as IAgentRuntime;
+    const dmClient = new TwitterDirectMessageClient({} as ClientBase, runtime, {
+      TWITTER_PERSONAL_DM_ROUTER_URL: "https://router.example/personal-message",
+    } as TwitterClientState);
+
+    await expect(routePersonalDmForTest(dmClient)).rejects.toThrow(
+      "explicit TWITTER_BROKER_TOKEN",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the no-authority Cloud-key fallback for an Eliza-owned router", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ success: true, data: { reply: "personal reply" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = {
+      getSetting: vi.fn((key: string) =>
+        key === "ELIZAOS_CLOUD_API_KEY" ? "legacy-cloud-key" : undefined,
+      ),
+    } as unknown as IAgentRuntime;
+    const dmClient = new TwitterDirectMessageClient({} as ClientBase, runtime, {
+      TWITTER_PERSONAL_DM_ROUTER_URL:
+        "https://cloud.eliza.app/api/v1/twitter/personal-message",
+    } as TwitterClientState);
+
+    await expect(routePersonalDmForTest(dmClient)).resolves.toBe(
+      "personal reply",
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.eliza.app/api/v1/twitter/personal-message",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer legacy-cloud-key",
+        }),
+      }),
+    );
+  });
+
+  it("does not cross a frozen staging authority into the production personal-DM router", async () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZA_DEV_CLOUD_TARGET = "staging";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "frozen-staging-key";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = {
+      getSetting: vi.fn((key: string) =>
+        key === "ELIZAOS_CLOUD_API_KEY" ? "mutable-runtime-key" : undefined,
+      ),
+    } as unknown as IAgentRuntime;
+    const dmClient = new TwitterDirectMessageClient({} as ClientBase, runtime, {
+      TWITTER_PERSONAL_DM_ROUTER_URL:
+        "https://api.eliza.app/api/v1/twitter/personal-message",
+    } as TwitterClientState);
+
+    await expect(routePersonalDmForTest(dmClient)).rejects.toThrow(
+      "explicit TWITTER_BROKER_TOKEN",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows an arbitrary personal-DM router with an explicit broker token", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ success: true, data: { reply: "personal reply" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = {
+      getSetting: vi.fn((key: string) => {
+        if (key === "TWITTER_BROKER_TOKEN") return "explicit-broker-token";
+        if (key === "ELIZAOS_CLOUD_API_KEY") return "privileged-cloud-key";
+        return undefined;
+      }),
+    } as unknown as IAgentRuntime;
+    const dmClient = new TwitterDirectMessageClient({} as ClientBase, runtime, {
+      TWITTER_PERSONAL_DM_ROUTER_URL: "https://router.example/personal-message",
+    } as TwitterClientState);
+
+    await expect(routePersonalDmForTest(dmClient)).resolves.toBe(
+      "personal reply",
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://router.example/personal-message",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer explicit-broker-token",
+        }),
+      }),
+    );
+  });
+
   it("does not prefix-parse a partial DM polling interval", async () => {
     vi.useFakeTimers();
     const listDmEvents = vi.fn(async () => ({ events: [] }));

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -29,6 +29,7 @@ import type { AuthenticatedTwitterSession } from "./client/auth";
 import { checkTwitterDmAccess, resolveTwitterDmPolicy } from "./dm-policy";
 import { parseTwitterInterval } from "./environment";
 import type { TwitterClientState } from "./types";
+import { resolveCloudApiKeyForXEndpoint } from "./utils/cloud-credential-boundary";
 import { createMemorySafe, reconcileTwitterWorld } from "./utils/memory";
 import { normalizeXReceiptId } from "./utils/provider-receipt";
 import { getSetting } from "./utils/settings";
@@ -137,10 +138,13 @@ export class TwitterDirectMessageClient {
     if (!url) throw new Error("X personal DM router is not configured");
     const token =
       getSetting(this.runtime, "TWITTER_BROKER_TOKEN") ??
-      getSetting(this.runtime, "ELIZAOS_CLOUD_API_KEY");
+      resolveCloudApiKeyForXEndpoint(
+        url,
+        getSetting(this.runtime, "ELIZAOS_CLOUD_API_KEY"),
+      );
     if (!token) {
       throw new Error(
-        "X personal DM routing requires TWITTER_BROKER_TOKEN or ELIZAOS_CLOUD_API_KEY",
+        "X personal DM routing requires an explicit TWITTER_BROKER_TOKEN unless the router belongs to the selected Eliza Cloud target",
       );
     }
     const response = await fetch(url, {

--- a/plugins/plugin-x/src/utils/cloud-credential-boundary.ts
+++ b/plugins/plugin-x/src/utils/cloud-credential-boundary.ts
@@ -1,0 +1,85 @@
+import {
+  resolveDevCloudAuthorityEnvValue,
+  resolveDevCloudEnvAuthority,
+} from "@elizaos/shared";
+
+const LEGACY_ELIZA_CLOUD_ORIGINS = [
+  "https://api.eliza.app",
+  "https://api-staging.eliza.app",
+  "https://cloud.eliza.app",
+  "https://cloud-staging.eliza.app",
+] as const;
+
+function normalizedPathname(url: URL): string {
+  const pathname = url.pathname.replace(/\/+$/, "");
+  return pathname || "/";
+}
+
+/**
+ * Returns true only when `endpoint` stays on the base's normalized origin and
+ * at or below its path. The path-boundary check prevents `/api/v10` from being
+ * treated as a child of `/api/v1`.
+ */
+export function isEndpointOwnedByCloudBase(
+  endpoint: string,
+  cloudBase: string,
+): boolean {
+  let endpointUrl: URL;
+  let cloudBaseUrl: URL;
+  try {
+    endpointUrl = new URL(endpoint);
+    cloudBaseUrl = new URL(cloudBase);
+  } catch {
+    return false;
+  }
+  if (
+    endpointUrl.username ||
+    endpointUrl.password ||
+    cloudBaseUrl.username ||
+    cloudBaseUrl.password ||
+    endpointUrl.origin !== cloudBaseUrl.origin
+  ) {
+    return false;
+  }
+
+  const endpointPath = normalizedPathname(endpointUrl);
+  const basePath = normalizedPathname(cloudBaseUrl);
+  return (
+    basePath === "/" ||
+    endpointPath === basePath ||
+    endpointPath.startsWith(`${basePath}/`)
+  );
+}
+
+/**
+ * Resolves the Eliza Cloud credential that may be delegated to an X broker or
+ * personal-DM router. A launcher authority always wins over mutable runtime or
+ * process configuration: the endpoint must belong to the frozen Cloud base,
+ * and the credential comes only from the frozen tuple. Without an authority,
+ * preserve the legacy fallback for Eliza-owned Cloud origins while refusing
+ * to disclose the Cloud key to a custom endpoint.
+ */
+export function resolveCloudApiKeyForXEndpoint(
+  endpoint: string,
+  legacyCloudApiKey: string | undefined,
+): string | undefined {
+  if (resolveDevCloudEnvAuthority()) {
+    const cloudBase = resolveDevCloudAuthorityEnvValue(
+      "ELIZAOS_CLOUD_BASE_URL",
+    )?.trim();
+    if (!cloudBase || !isEndpointOwnedByCloudBase(endpoint, cloudBase)) {
+      return undefined;
+    }
+    return (
+      resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")?.trim() ||
+      undefined
+    );
+  }
+
+  const isLegacyElizaCloudEndpoint = LEGACY_ELIZA_CLOUD_ORIGINS.some((origin) =>
+    isEndpointOwnedByCloudBase(endpoint, origin),
+  );
+  return isLegacyElizaCloudEndpoint
+    ? legacyCloudApiKey?.trim() || undefined
+    : undefined;
+}


### PR DESCRIPTION
# Relates to

Fixes #29322.

## Outcome

Ordinary local development now connects to the staging Eliza Cloud control plane by default. A fresh `bun run dev` can enter the hosted staging sign-in flow and return the authenticated session to localhost without requiring a production credential or a localhost OAuth callback allowlist.

Explicit production, offline, and coherent self-hosted development remain supported. This PR does not relax production CORS or change deployed production defaults.

## What changed

- Centralized staging, production, offline, and self-hosted target resolution for the root, UI, shared, desktop, and package development entrypoints.
- Added explicit `--cloud-target=staging|production|offline`, `ELIZA_DEV_CLOUD_TARGET`, and `dev:local` overrides.
- Made the ordinary first-run renderer select staging and scope Steward session state to the staging control plane.
- Added a hosted staging CLI-session bridge for OAuth. Localhost opens the hosted staging login, provider discovery and authorization remain hosted, and the resulting session is bridged back to the local app.
- Fingerprinted every public Cloud-routing field before a shared local server can be reused, while never persisting credentials in the registry.
- Froze Cloud/Steward launch authority across config persistence, runtime startup, Electron/Electrobun child processes, desktop restarts, wallet backends, plugin resolution, and outbound Cloud clients.
- Made credential boundaries fail closed:
  - every staging selector scrubs generic Cloud and Steward credentials;
  - explicit staging accepts only the staging-specific `ELIZA_DEV_CLOUD_API_KEY`;
  - offline scrubs all Cloud activation material;
  - production and coherent self-hosted tuples remain explicit;
  - sensitive links, billing/API-key links, wallet RPC/proxy traffic, Cloud Apps, X, LifeOps, PTY, skills, and orchestrator children use the frozen target authority.
- Documented root-vs-renderer environment variables, staging-specific key semantics, and local/offline/production workflows.
- Added deterministic browser coverage plus an opt-in live staging authorization-boundary smoke.

## Risk and rollback

Risk is moderate because local routing and authentication span several runtimes. The change is constrained to development target selection and authority propagation; production deployment behavior is unchanged. Reverting the three commits in this PR restores the prior local behavior.

## Reviewer path

Start with:

1. `packages/app-core/scripts/lib/dev-cloud-target.mjs`
2. `packages/shared/src/elizacloud/dev-cloud-env-authority.ts`
3. `packages/app/scripts/dev.mjs` and `packages/app-core/scripts/dev-ui.mjs`
4. `packages/app/test/dev-smoke/staging-live-auth-boundary.spec.ts`
5. `packages/app-core/platforms/electrobun/src/native/agent.ts`

## Exact-head verification

Validated at `375e5a27d9df87ae3a4583e72d9a8a0d72eb9d39`, rebased without conflict onto `origin/develop` `198bc3f3513c1460c6d153f4ac02cf55f29ead6c`:

- `bun install --frozen-lockfile` — pass, no lockfile changes.
- Core typechecks — pass for `packages/agent`, `packages/app`, `packages/app-core`, `packages/core`, `packages/shared`, and `packages/ui`.
- Dev target helper — 35/35 pass.
- Dev server registry — 17/17 pass.
- Core request-secret authority — 3/3 pass.
- Orchestrator credential/environment — 18/18 pass.
- Electrobun authority/restart hygiene — 47/47 pass.
- Cloud Apps — 373/373 pass.
- Eliza Cloud authority/account/billing — 63/63 pass.
- Wallet authority/backend — 47/47 pass.
- Personal-assistant affected suites — 19/19 pass.
- `bun run --cwd packages/app test:dev-smoke:cloud-only` — 1/1 pass.
- `bun run --cwd packages/app test:dev-smoke:staging-live-auth` — 1/1 pass against the real staging CLI-session, hosted login, provider-discovery, and Google authorization boundary. The test enters no credentials and intentionally does not follow the Google callback.
- `bun run check:agents-claude` — pass, 160 tracked pairs identical.
- `git diff --check origin/develop...HEAD` and `git show --check HEAD` — pass.

The package-wide `plugin-personal-assistant` typecheck still reports the existing unresolved-workspace-module baseline (for example `@elizaos/agent`, blocker, finances, inbox, goals, and reminders) plus errors already present on `develop`. Building `packages/shared` removes this PR's new-export diagnostics, and all three affected personal-assistant suites pass.

## Blocking-review resolutions

- The earlier localhost OAuth concern is resolved by the hosted staging CLI-session bridge. The live smoke reaches a real Google authorization request using the staging-hosted callback; localhost is not submitted as the provider callback.
- Ambient selector/credential mixing is resolved. Staging no longer accepts generic inherited Cloud/Steward credentials; an explicit staging credential must use `ELIZA_DEV_CLOUD_API_KEY`.

# Evidence Gate

<!-- evidence-head:375e5a27d9df87ae3a4583e72d9a8a0d72eb9d39 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered layout, CSS, or component visual changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered visual surface changes; browser tests assert the visible login and routing behavior.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — deterministic and live Playwright lanes cover the interaction boundary.
<!-- evidence-row:backend-logs -->
- [x] Exact-head browser and focused integration results are listed above.
<!-- evidence-row:frontend-logs -->
- [x] Exact-head browser results are listed above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no prompt or model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database, memory, scheduled-task, or on-chain mutation.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual text or layout change.

## Live-smoke boundary

The live staging test performs a fresh credentialless local launch, obtains a real staging CLI session, loads the hosted staging login, discovers providers, and reaches the real Google authorization request. It intercepts only the transition to `accounts.google.com`; it neither enters credentials nor follows the callback.

