### PR TITLE
fix(cloud): complete dedicated realtime voice handoff

### DIFF
--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -3,12 +3,15 @@
  * Local iOS artifacts expose the existing runtime chooser so a sideload can
  * select its bundled agent without Cloud authentication. Every iOS renderer
  * also compiles the optional APNs transport gate, which is recorded in the
- * renderer manifest. LP3 debug artifacts enable the realtime voice client.
+ * renderer manifest. Cloud-only Android artifacts enable the realtime voice
+ * client without forcing eligibility; the server and normal client gates stay
+ * authoritative.
  * Lanes with feature values that remain unstamped start from a fresh renderer,
  * and explicit reuse requires a stale-risk acknowledgement.
  */
 
 const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
+const ANDROID_CLOUD = "android-cloud";
 
 export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
@@ -20,10 +23,12 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   if (platform === "android-launcher") {
     return { VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" };
   }
+  const cloudAndroid =
+    platform === ANDROID_CLOUD || platform === ANDROID_CLOUD_DEBUG;
   const isLp3Debug =
     platform === ANDROID_CLOUD_DEBUG &&
     env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED === "1";
-  if (!isLp3Debug) return {};
+  if (!cloudAndroid) return {};
   const isLp3RemoteFallback = ["1", "true", "yes"].includes(
     String(env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED ?? "")
       .trim()
@@ -31,8 +36,11 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   );
   return {
     VITE_VOICE_REALTIME_WS: "1",
-    VITE_VOICE_REALTIME_FORCE: "1",
-    ...(isLp3RemoteFallback
+    // Never inherit an ambient debug-force flag into a device artifact. A
+    // Cloud mobile build may use realtime only when the normal eligibility
+    // contract and server gate both pass.
+    VITE_VOICE_REALTIME_FORCE: "0",
+    ...(isLp3Debug && isLp3RemoteFallback
       ? {
           VITE_ENABLE_STREAM: "false",
           VITE_ELIZA_ANDROID_LP3_SHARED_BROWSER_STORAGE: "1",
@@ -46,6 +54,7 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
     throw new Error("mobileRendererRequiresFreshBuild: platform is required");
   }
   return (
+    platform === ANDROID_CLOUD ||
     platform === ANDROID_CLOUD_DEBUG ||
     platform === "android-launcher" ||
     platform === "ios" ||
@@ -65,6 +74,9 @@ export function mobileRendererUnstampedFeatureProblem({ platform } = {}) {
   }
   if (platform === ANDROID_CLOUD_DEBUG) {
     return "dist cannot prove the Android cloud-debug realtime voice flags because they are not stamped";
+  }
+  if (platform === ANDROID_CLOUD) {
+    return "dist cannot prove the Android cloud realtime voice flags because they are not stamped";
   }
   if (platform === "android-launcher") {
     return "dist cannot prove the Android launcher in-app auth contract because it is not stamped";

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -20,7 +20,14 @@ describe("resolveMobileRendererFeatureEnv", () => {
     }
   });
 
-  it("enables the realtime voice client for the LP3 cloud-debug lane", () => {
+  it("enables realtime without forced eligibility for both Android Cloud lanes", () => {
+    for (const platform of ["android-cloud", "android-cloud-debug"]) {
+      expect(resolveMobileRendererFeatureEnv({ platform })).toEqual({
+        VITE_VOICE_REALTIME_WS: "1",
+        VITE_VOICE_REALTIME_FORCE: "0",
+      });
+    }
+
     expect(
       resolveMobileRendererFeatureEnv({
         platform: "android-cloud-debug",
@@ -28,8 +35,22 @@ describe("resolveMobileRendererFeatureEnv", () => {
       }),
     ).toEqual({
       VITE_VOICE_REALTIME_WS: "1",
-      VITE_VOICE_REALTIME_FORCE: "1",
+      VITE_VOICE_REALTIME_FORCE: "0",
     });
+  });
+
+  it("overrides an ambient force flag in Android Cloud artifacts", () => {
+    for (const platform of ["android-cloud", "android-cloud-debug"]) {
+      expect(
+        resolveMobileRendererFeatureEnv({
+          platform,
+          env: { VITE_VOICE_REALTIME_FORCE: "1" },
+        }),
+      ).toEqual({
+        VITE_VOICE_REALTIME_WS: "1",
+        VITE_VOICE_REALTIME_FORCE: "0",
+      });
+    }
   });
 
   it("permanently hides Stream only in the dedicated LP3 VPS fallback", () => {
@@ -43,19 +64,10 @@ describe("resolveMobileRendererFeatureEnv", () => {
       }),
     ).toEqual({
       VITE_VOICE_REALTIME_WS: "1",
-      VITE_VOICE_REALTIME_FORCE: "1",
+      VITE_VOICE_REALTIME_FORCE: "0",
       VITE_ENABLE_STREAM: "false",
       VITE_ELIZA_ANDROID_LP3_SHARED_BROWSER_STORAGE: "1",
     });
-  });
-
-  it("does not change ordinary Android cloud-debug builds", () => {
-    expect(
-      resolveMobileRendererFeatureEnv({
-        platform: "android-cloud-debug",
-        env: {},
-      }),
-    ).toEqual({});
   });
 
   it("stamps the launcher-only in-app auth renderer contract", () => {
@@ -64,13 +76,16 @@ describe("resolveMobileRendererFeatureEnv", () => {
     ).toEqual({ VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" });
   });
 
-  it("does not leak LP3 renderer flags into another lane", () => {
+  it("does not leak LP3-only fallback flags into the Android Cloud release lane", () => {
     expect(
       resolveMobileRendererFeatureEnv({
         platform: "android-cloud",
         env: { ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1" },
       }),
-    ).toEqual({});
+    ).toEqual({
+      VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_FORCE: "0",
+    });
   });
 
   it("requires an explicit platform", () => {
@@ -82,13 +97,16 @@ describe("resolveMobileRendererFeatureEnv", () => {
 
 describe("mobileRendererRequiresFreshBuild", () => {
   it("rebuilds renderers whose optional flags are not stamped", () => {
-    expect(
-      mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
-    ).toBe(true);
-    for (const platform of ["android-launcher", "ios", "ios-local"]) {
+    for (const platform of [
+      "android-cloud",
+      "android-cloud-debug",
+      "android-launcher",
+      "ios",
+      "ios-local",
+    ]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(true);
     }
-    for (const platform of ["android", "android-cloud", "ios-overlay"]) {
+    for (const platform of ["android", "ios-overlay"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
     }
   });
@@ -105,9 +123,12 @@ describe("mobileRendererUnstampedFeatureProblem", () => {
       }),
     ).toContain("realtime voice flags");
     expect(
+      mobileRendererUnstampedFeatureProblem({ platform: "android-cloud" }),
+    ).toContain("realtime voice flags");
+    expect(
       mobileRendererUnstampedFeatureProblem({ platform: "android-launcher" }),
     ).toContain("in-app auth contract");
-    for (const platform of ["ios", "ios-overlay", "android", "android-cloud"]) {
+    for (const platform of ["ios", "ios-overlay", "android"]) {
       expect(mobileRendererUnstampedFeatureProblem({ platform })).toBeNull();
     }
   });

--- a/packages/app/src/main.android-entrypoint.test.ts
+++ b/packages/app/src/main.android-entrypoint.test.ts
@@ -5,6 +5,11 @@
  */
 import { Capacitor } from "@capacitor/core";
 import { runIosFullBunSmokeIfRequested } from "@elizaos/app-core/desktop-shell";
+import {
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  setBootConfig,
+} from "@elizaos/ui/config";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const androidBoot = vi.hoisted(() => ({
@@ -140,6 +145,7 @@ beforeEach(() => {
     "requestAnimationFrame",
     vi.fn(() => 1),
   );
+  setBootConfig(DEFAULT_BOOT_CONFIG);
   window.localStorage.setItem("eliza:mobile-runtime-mode", "local");
   document.body.innerHTML = '<div id="root"></div>';
 });
@@ -166,6 +172,10 @@ describe("renderer Android local composition", () => {
 
     expect(main.isAndroid).toBe(true);
     expect(main.isNative).toBe(true);
+    expect(getBootConfig()).toMatchObject({
+      preferSharedCloudTier: true,
+      autoUpgradeSharedToDedicated: true,
+    });
     expect(androidBoot.installAndroidFetch).toHaveBeenCalledOnce();
     expect(androidBoot.installDiarization).toHaveBeenCalledOnce();
     expect(androidBoot.installJniVoice).toHaveBeenCalledOnce();

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -883,6 +883,7 @@ function buildAppBootConfig(): AppBootConfig {
       (import.meta.env.VITE_ASSET_BASE_URL as string | undefined)?.trim() ||
       undefined,
     cloudApiBase: IOS_RUNTIME_ENV_CONFIG.cloudApiBase,
+    autoUpgradeSharedToDedicated: true,
     vrmAssets: APP_VRM_ASSETS,
     firstRunStyles: APP_STYLE_PRESETS,
     codingAgentTasksPanel: CodingAgentTasksPanel,

--- a/packages/app/src/main.web-entrypoint.test.ts
+++ b/packages/app/src/main.web-entrypoint.test.ts
@@ -6,7 +6,11 @@
  */
 import { Capacitor } from "@capacitor/core";
 import { runIosFullBunSmokeIfRequested } from "@elizaos/app-core/desktop-shell";
-import { DEFAULT_BOOT_CONFIG, setBootConfig } from "@elizaos/ui/config";
+import {
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  setBootConfig,
+} from "@elizaos/ui/config";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const webBoot = vi.hoisted(() => ({
@@ -102,6 +106,10 @@ describe("renderer web composition", () => {
     expect(webBoot.cloudApiBaseAtServiceWorkerModuleLoad).toBe(
       "https://cloud-staging.eliza.app",
     );
+    expect(getBootConfig()).toMatchObject({
+      preferSharedCloudTier: true,
+      autoUpgradeSharedToDedicated: true,
+    });
     expect(webBoot.initializeStorage).toHaveBeenCalledTimes(2);
     expect(webBoot.initializeCapacitor).toHaveBeenCalledOnce();
     expect(document.body.classList).toContain("platform-web");

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -114,6 +114,13 @@ export default defineConfig({
           "../../plugins/plugin-task-coordinator/src/register.ts",
         ),
       },
+      {
+        find: /^@elizaos\/plugin-relationships\/register$/,
+        replacement: path.join(
+          here,
+          "../../plugins/plugin-relationships/src/register.ts",
+        ),
+      },
       ...(Array.isArray(baseConfig.resolve?.alias)
         ? baseConfig.resolve.alias
         : []),

--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -344,6 +344,30 @@ describe("dedicated-agent-proxy — scoped voice conversation transport", () => 
     });
     expect(captured).toBeNull();
   });
+
+  test("fails closed for an unrecognized non-container execution tier", async () => {
+    sandboxResult = {
+      ...runningDedicated,
+      organization_id: ORGANIZATION_ID,
+      user_id: USER_ID,
+      execution_tier: "future-runtime-tier",
+    };
+    const denied = await createOwnedDedicatedVoiceConversationFetch(
+      ENV,
+      claims,
+    );
+    expect(denied.kind).toBe("dedicated");
+    if (denied.kind !== "dedicated") {
+      throw new Error("expected a terminal fail-closed response");
+    }
+
+    const response = await denied.fetch("https://voice.internal/ignored");
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "agent_unavailable",
+    });
+    expect(captured).toBeNull();
+  });
 });
 
 function executePairHandoff(html: string): {
@@ -987,16 +1011,19 @@ describe("dedicated-agent-proxy — unified auth", () => {
     expect(captured).toBeNull();
   });
 
-  test("shared-tier row on a dedicated host → 403 at the edge, no injection", async () => {
+  test("non-container row on a dedicated host → 403 at the edge, no injection", async () => {
     authResult = { user: { id: "u1", organization_id: "org1" } };
-    sandboxResult = {
-      ...runningDedicated,
-      execution_tier: "shared",
-    };
-    const r = makeRequest("cloud-token");
-    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
-    expect(res.status).toBe(403);
-    expect(captured).toBeNull();
+    for (const executionTier of ["shared", "future-runtime-tier"]) {
+      captured = null;
+      sandboxResult = {
+        ...runningDedicated,
+        execution_tier: executionTier,
+      };
+      const r = makeRequest("cloud-token");
+      const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+      expect(res.status).toBe(403);
+      expect(captured).toBeNull();
+    }
   });
 
   test("static asset pass-through strips parent-domain Cloud cookies", async () => {

--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -150,6 +150,7 @@ afterAll(() => {
 
 const {
   handleDedicatedAgentProxy,
+  createOwnedDedicatedVoiceConversationFetch,
   dedicatedProxyOriginHeadersTimeoutMs,
   __dedicatedProxyTestHooks,
 } = await import("../src/dedicated-agent-proxy");
@@ -247,6 +248,102 @@ beforeEach(() => {
   rateLimitResult = { success: true };
   rateLimitError = null;
   rateLimitKeys.length = 0;
+});
+
+describe("dedicated-agent-proxy — scoped voice conversation transport", () => {
+  const ORGANIZATION_ID = "22222222-2222-4222-8222-222222222222";
+  const USER_ID = "33333333-3333-4333-8333-333333333333";
+  const CONVERSATION_ID = "44444444-4444-4444-8444-444444444444";
+  const claims = {
+    agentId: AGENT,
+    conversationId: CONVERSATION_ID,
+    organizationId: ORGANIZATION_ID,
+    userId: USER_ID,
+  };
+
+  test("reuses the owned agent-router stream and swaps every Cloud credential", async () => {
+    sandboxResult = {
+      ...runningDedicated,
+      organization_id: ORGANIZATION_ID,
+      user_id: USER_ID,
+    };
+    const resolved = await createOwnedDedicatedVoiceConversationFetch(
+      {
+        AGENT_ROUTER_ORIGIN_HOST: "cp.example.test",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      } as never,
+      claims,
+    );
+    expect(resolved.kind).toBe("dedicated");
+    if (resolved.kind !== "dedicated") {
+      throw new Error("expected an owned Dedicated voice transport");
+    }
+
+    const response = await resolved.fetch(
+      `https://voice.internal/api/v1/eliza/agents/${AGENT}/api/conversations/${CONVERSATION_ID}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          Cookie: "cloud-session=secret",
+          "Content-Type": "application/json",
+          "X-API-Key": "cloud-api-key",
+          "X-Eliza-Csrf": "cloud-csrf",
+        },
+        body: JSON.stringify({ text: "go to settings" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const upstream = requireCapturedRequest();
+    expect(upstream.url).toBe(
+      `https://cp.example.test/api/conversations/${CONVERSATION_ID}/messages/stream`,
+    );
+    expect(upstream.headers.get("authorization")).toBe(
+      "Bearer agent-secret-token",
+    );
+    expect(upstream.headers.get("x-forwarded-host")).toBe(
+      `${AGENT}.cloud.eliza.app`,
+    );
+    expect(upstream.headers.get("cookie")).toBeNull();
+    expect(upstream.headers.get("x-api-key")).toBeNull();
+    expect(upstream.headers.get("x-eliza-csrf")).toBeNull();
+    await expect(upstream.json()).resolves.toEqual({
+      text: "go to settings",
+    });
+  });
+
+  test("falls through only for the exact owned Shared tier", async () => {
+    sandboxResult = {
+      ...runningDedicated,
+      organization_id: ORGANIZATION_ID,
+      user_id: USER_ID,
+      execution_tier: "shared",
+    };
+    await expect(
+      createOwnedDedicatedVoiceConversationFetch(ENV, claims),
+    ).resolves.toEqual({ kind: "not_dedicated" });
+
+    sandboxResult = {
+      ...runningDedicated,
+      organization_id: ORGANIZATION_ID,
+      user_id: "different-user",
+    };
+    const denied = await createOwnedDedicatedVoiceConversationFetch(
+      ENV,
+      claims,
+    );
+    expect(denied.kind).toBe("dedicated");
+    if (denied.kind !== "dedicated") {
+      throw new Error("expected a terminal scoped response");
+    }
+    const response = await denied.fetch("https://voice.internal/ignored");
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "agent_not_found",
+    });
+    expect(captured).toBeNull();
+  });
 });
 
 function executePairHandoff(html: string): {

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -21,6 +21,7 @@ import {
   ELIZA_DOMAIN_CONTRACTS,
   elizaCloudEnvironmentForHostname,
 } from "@elizaos/shared/elizacloud";
+import { runWithDbCacheAsync } from "@/db/client";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { AuthenticationError, ForbiddenError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -36,6 +37,10 @@ import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { getPairingTokenService } from "@/lib/services/pairing-token";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { checkProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health";
+import {
+  dedicatedAgentTransportToken,
+  personalDedicatedAgentApiBase,
+} from "@/lib/services/shared-runtime/personal-shared-agent";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -417,6 +422,141 @@ async function proxyToOrigin(
 type Sandbox = NonNullable<
   Awaited<ReturnType<typeof agentSandboxesRepository.findByIdAndOrg>>
 >;
+
+export interface OwnedDedicatedVoiceConversationClaims {
+  agentId: string;
+  conversationId: string;
+  organizationId: string;
+  userId: string;
+}
+
+export type OwnedDedicatedVoiceConversationResolution =
+  | { kind: "not_dedicated" }
+  | { kind: "dedicated"; fetch: typeof fetch };
+
+function fixedOwnedDedicatedVoiceResponse(
+  body: Record<string, unknown>,
+  status: number,
+  headers?: HeadersInit,
+): OwnedDedicatedVoiceConversationResolution {
+  return {
+    kind: "dedicated",
+    fetch: (async () =>
+      Response.json(body, { status, headers })) as unknown as typeof fetch,
+  };
+}
+
+/**
+ * Resolve the same owner-scoped Dedicated runtime transport used by the public
+ * agent subdomain, but for a short-lived server-authenticated voice session.
+ *
+ * The caller already verified the voice JWT and the internal service headers;
+ * this boundary re-checks the authoritative sandbox row (org + user + tier)
+ * before retaining the container credential in a session-local closure. The
+ * returned fetch maps only the canonical conversation stream to the runtime;
+ * no Cloud credential crosses into the tenant container.
+ */
+export async function createOwnedDedicatedVoiceConversationFetch(
+  env: Bindings,
+  claims: OwnedDedicatedVoiceConversationClaims,
+): Promise<OwnedDedicatedVoiceConversationResolution> {
+  return runWithDbCacheAsync(async () => {
+    const sandbox = await agentSandboxesRepository.findByIdAndOrg(
+      claims.agentId,
+      claims.organizationId,
+    );
+    if (!sandbox || sandbox.user_id !== claims.userId) {
+      return fixedOwnedDedicatedVoiceResponse(
+        {
+          success: false,
+          error: "Agent not found",
+          code: "agent_not_found",
+        },
+        404,
+      );
+    }
+    if (sandbox.execution_tier === "shared") {
+      return { kind: "not_dedicated" };
+    }
+    if (sandbox.status !== "running") {
+      return fixedOwnedDedicatedVoiceResponse(
+        {
+          success: false,
+          code: "agent_not_running",
+          error: "Dedicated agent is not running yet",
+          data: { status: sandbox.status },
+        },
+        503,
+        { "Retry-After": String(RETRY_AFTER_SECONDS) },
+      );
+    }
+
+    const localSentinel = env.ELIZA_CLOUD_AGENT_BASE_DOMAIN === "https://";
+    const headscaleIp = (sandbox.headscale_ip ?? "").trim();
+    if (!localSentinel && !headscaleIp && !isBridgeHostFallbackEnabled(env)) {
+      return fixedOwnedDedicatedVoiceResponse(
+        {
+          success: false,
+          code: "agent_unroutable",
+          error:
+            "Agent is running but has no routable network ingress yet (mesh join incomplete). Retry shortly.",
+        },
+        503,
+        { "Retry-After": String(RETRY_AFTER_SECONDS) },
+      );
+    }
+
+    const runtimeBase = personalDedicatedAgentApiBase(
+      sandbox,
+      env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+    );
+    const agentToken = dedicatedAgentTransportToken(sandbox);
+    if (!runtimeBase || !agentToken) {
+      return fixedOwnedDedicatedVoiceResponse(
+        {
+          success: false,
+          code: "agent_unavailable",
+          error: "Dedicated agent connection is unavailable",
+        },
+        503,
+      );
+    }
+
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const incoming = new Request(input, init);
+      const target = new URL(runtimeBase);
+      target.pathname = `/api/conversations/${encodeURIComponent(
+        claims.conversationId,
+      )}/messages/stream`;
+      target.search = new URL(incoming.url).search;
+      target.hash = "";
+
+      const headers = new Headers(incoming.headers);
+      headers.delete("host");
+      stripCloudOnlyCredentials(headers);
+      headers.delete("x-api-key");
+      headers.set("authorization", `Bearer ${agentToken}`);
+      const method = incoming.method.toUpperCase();
+      const requestInit: RequestInit = {
+        method,
+        headers,
+        redirect: "manual",
+        signal: incoming.signal,
+      };
+      if (method !== "GET" && method !== "HEAD") {
+        requestInit.body = await incoming.arrayBuffer();
+      }
+      const runtimeRequest = new Request(target, requestInit);
+
+      // The local cloud harness deliberately has no agent-router hostname;
+      // its canonical transport is the loopback base resolved above.
+      if (localSentinel) return fetch(runtimeRequest);
+      return proxyToOrigin(runtimeRequest, env, target, agentToken);
+    }) as typeof fetch;
+
+    return { kind: "dedicated", fetch: fetchImpl };
+  });
+}
 
 /**
  * A non-`running` dedicated agent can't be reached. Kick off (or detect an

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -37,6 +37,7 @@ import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { getPairingTokenService } from "@/lib/services/pairing-token";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { checkProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health";
+import { isContainerBackedExecutionTier } from "@/lib/services/sandbox-provider-types";
 import {
   dedicatedAgentTransportToken,
   personalDedicatedAgentApiBase,
@@ -477,6 +478,16 @@ export async function createOwnedDedicatedVoiceConversationFetch(
     }
     if (sandbox.execution_tier === "shared") {
       return { kind: "not_dedicated" };
+    }
+    if (!isContainerBackedExecutionTier(sandbox.execution_tier)) {
+      return fixedOwnedDedicatedVoiceResponse(
+        {
+          success: false,
+          code: "agent_unavailable",
+          error: "Dedicated agent connection is unavailable",
+        },
+        503,
+      );
     }
     if (sandbox.status !== "running") {
       return fixedOwnedDedicatedVoiceResponse(
@@ -1085,7 +1096,7 @@ async function proxyDedicatedAgent(
       agentId,
       orgId,
     );
-    if (!sandbox || sandbox.execution_tier === "shared") {
+    if (!sandbox || !isContainerBackedExecutionTier(sandbox.execution_tier)) {
       return Response.json(
         {
           success: false,

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1170,6 +1170,71 @@ describe("voice-session WS lifecycle", () => {
     }
   });
 
+  test("concurrent Dedicated prewarm and lifecycle start never writes into Shared history", async () => {
+    const claims = {
+      organizationId: "55555555-5555-4555-8555-555555555555",
+      userId: "66666666-6666-4666-8666-666666666666",
+      agentId: "77777777-7777-4777-8777-777777777777",
+      conversationId: "88888888-8888-4888-8888-888888888888",
+    };
+    dedicatedVoiceSandbox = {
+      id: claims.agentId,
+      organization_id: claims.organizationId,
+      user_id: claims.userId,
+      execution_tier: "dedicated-always",
+      status: "running",
+      headscale_ip: "100.64.0.22",
+      bridge_url: null,
+      health_url: null,
+      environment_vars: { ELIZA_API_TOKEN: "agent-runtime-token" },
+    };
+
+    const previousMockRedis = process.env.MOCK_REDIS;
+    process.env.MOCK_REDIS = "1";
+    let sharedCoordinatorCalls = 0;
+    try {
+      const { createInternalElizaConversationFetch } = await import(
+        "../lib/internal-eliza-conversation-fetch"
+      );
+      const elizaFetch = createInternalElizaConversationFetch(
+        {
+          CACHE_ENABLED: "true",
+          DATABASE_URL: "postgresql://must-not-connect.invalid/eliza",
+          VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer eliza-server",
+          AGENT_ROUTER_ORIGIN_HOST: "cp.example.test",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+          SHARED_RUNTIME_CONVERSATIONS: {
+            getByName() {
+              return {
+                async fetch() {
+                  sharedCoordinatorCalls += 1;
+                  return new Response(null, { status: 204 });
+                },
+              };
+            },
+          },
+        } as unknown as Parameters<
+          typeof createInternalElizaConversationFetch
+        >[0],
+        claims,
+      );
+
+      await Promise.all([
+        elizaFetch.prewarm(),
+        elizaFetch.recordLifecycleEvent({
+          id: "twilio-call:CA-dedicated:started",
+          content: "Call lifecycle event: the phone call started.",
+          createdAt: Date.now(),
+        }),
+      ]);
+
+      expect(sharedCoordinatorCalls).toBe(0);
+    } finally {
+      if (previousMockRedis === undefined) delete process.env.MOCK_REDIS;
+      else process.env.MOCK_REDIS = previousMockRedis;
+    }
+  });
+
   test("forwards a successful terminal VIEWS handoff without exposing arbitrary actions", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import { decode, encode } from "@msgpack/msgpack";
+import * as agentSandboxesActual from "@/db/repositories/agent-sandboxes";
 import * as workerCoreStub from "../../../../src/stubs/elizaos-core";
 import * as coreTestContract from "../../../../src/stubs/elizaos-core-test-contract";
 
@@ -55,6 +56,31 @@ mock.module("@elizaos/core", () => ({
   validateUuid: coreTestContract.validateUuid,
 }));
 
+type DedicatedVoiceSandbox = {
+  id: string;
+  organization_id: string;
+  user_id: string;
+  execution_tier: string;
+  status: string;
+  headscale_ip: string | null;
+  bridge_url: string | null;
+  health_url: string | null;
+  environment_vars: Record<string, string>;
+};
+let dedicatedVoiceSandbox: DedicatedVoiceSandbox | null = null;
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  ...agentSandboxesActual,
+  agentSandboxesRepository: {
+    ...agentSandboxesActual.agentSandboxesRepository,
+    findByIdAndOrg: async (id: string, organizationId: string) => {
+      const sandbox = dedicatedVoiceSandbox;
+      return sandbox?.id === id && sandbox.organization_id === organizationId
+        ? sandbox
+        : undefined;
+    },
+  },
+}));
+
 import type { CartesiaWebSocketLike } from "../../../../../shared/src/lib/services/cartesia-sonic-tts";
 import type { FishAudioWebSocketLike } from "../../../../../shared/src/lib/services/fish-audio-tts";
 import { InMemoryVoiceUsageStore } from "../../../../../shared/src/lib/services/voice-usage-meter";
@@ -80,6 +106,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   __resetVoiceSessionRegistryForTests();
+  dedicatedVoiceSandbox = null;
 });
 
 // --- fake Cartesia Ink socket (drives the real STT adapter) ----------------
@@ -497,6 +524,7 @@ const CLAIMS = {
 async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
+  claims?: typeof CLAIMS;
   inkSocketFactory?: () => CartesiaInkWebSocket;
   sttReconnectDelaysMs?: readonly number[];
   sttConnectTimeoutMs?: number;
@@ -515,11 +543,12 @@ async function connectSession(opts: {
     socketFactory?: () => FakeFishAudioSocket;
   };
 }): Promise<{ sessionId: string }> {
-  const minted = await mintVoiceSessionToken(CLAIMS);
+  const claims = opts.claims ?? CLAIMS;
+  const minted = await mintVoiceSessionToken(claims);
   const usageStore = new InMemoryVoiceUsageStore();
 
   attachVoiceWsHandler(opts.client, {
-    requestedSessionId: CLAIMS.sessionId,
+    requestedSessionId: claims.sessionId,
     buildSession: ({ claims, jti, tokenExpSeconds, downlink }) =>
       new VoiceSession({
         sessionId: claims.sessionId,
@@ -595,7 +624,7 @@ async function connectSession(opts: {
     }),
   );
   await flush();
-  return { sessionId: CLAIMS.sessionId };
+  return { sessionId: claims.sessionId };
 }
 
 // The fake Ink/Cartesia sockets and the SSE mock advance the session pipeline
@@ -1013,6 +1042,132 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBeGreaterThan(0);
     expect(client.controlTypes()).toContain("speaking_end");
     expect(client.controlTypes()).toContain("usage");
+  });
+
+  test("owned Dedicated transport completes the realtime LLM leg and forwards canonical VIEWS navigation", async () => {
+    const claims = {
+      sessionId: "sess-dedicated-navigation",
+      organizationId: "11111111-1111-4111-8111-111111111111",
+      userId: "22222222-2222-4222-8222-222222222222",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      conversationId: "44444444-4444-4444-8444-444444444444",
+    };
+    dedicatedVoiceSandbox = {
+      id: claims.agentId,
+      organization_id: claims.organizationId,
+      user_id: claims.userId,
+      execution_tier: "dedicated-always",
+      status: "running",
+      headscale_ip: "100.64.0.21",
+      bridge_url: null,
+      health_url: null,
+      environment_vars: { ELIZA_API_TOKEN: "agent-runtime-token" },
+    };
+
+    const previousMockRedis = process.env.MOCK_REDIS;
+    process.env.MOCK_REDIS = "1";
+    const originalFetch = globalThis.fetch;
+    const upstreamCalls: Array<{
+      url: string;
+      headers: Headers;
+      body: unknown;
+    }> = [];
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const request = new Request(input, init);
+      upstreamCalls.push({
+        url: request.url,
+        headers: new Headers(request.headers),
+        body: JSON.parse(await request.text()),
+      });
+      return makeCanonicalChunkFetch(["Opened Settings."], {
+        actionResults: [
+          {
+            actionName: "VIEWS",
+            success: true,
+            values: {
+              mode: "show",
+              viewId: "settings",
+              viewPath: "/settings",
+            },
+          },
+        ],
+      })(request.url);
+    }) as typeof fetch;
+
+    try {
+      const { createInternalElizaConversationFetch } = await import(
+        "../lib/internal-eliza-conversation-fetch"
+      );
+      const elizaFetch = createInternalElizaConversationFetch(
+        {
+          CACHE_ENABLED: "true",
+          DATABASE_URL: "postgresql://must-not-connect.invalid/eliza",
+          VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer eliza-server",
+          AGENT_ROUTER_ORIGIN_HOST: "cp.example.test",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+        } as Parameters<typeof createInternalElizaConversationFetch>[0],
+        {
+          agentId: claims.agentId,
+          conversationId: claims.conversationId,
+          organizationId: claims.organizationId,
+          userId: claims.userId,
+        },
+      );
+      const client = new FakeClientSocket();
+      await connectSession({
+        client,
+        claims,
+        fetchImpl: elizaFetch,
+        prewarmElizaContext: elizaFetch.prewarm,
+      });
+
+      const ink = FakeInkSocket.instances.at(-1)!;
+      ink.emitTurn("turn.start");
+      ink.emitTurn("turn.end", "go to settings");
+      for (
+        let attempt = 0;
+        attempt < 10 &&
+        !client.controlFrames.some((frame) => frame.t === "navigate_view");
+        attempt += 1
+      ) {
+        await flush();
+      }
+
+      expect(upstreamCalls).toHaveLength(1);
+      expect(upstreamCalls[0]?.url).toBe(
+        `https://cp.example.test/api/conversations/${claims.conversationId}/messages/stream`,
+      );
+      expect(upstreamCalls[0]?.headers.get("authorization")).toBe(
+        "Bearer agent-runtime-token",
+      );
+      expect(upstreamCalls[0]?.headers.get("x-forwarded-host")).toBe(
+        `${claims.agentId}.cloud.eliza.app`,
+      );
+      expect(upstreamCalls[0]?.body).toMatchObject({
+        text: "go to settings",
+        metadata: { clientTransport: "realtime_voice" },
+        streamProtocol: "delta-v2",
+      });
+      expect(client.controlTypes()).toContain("stt_final");
+      expect(client.controlTypes()).toContain("llm_first_text");
+      expect(
+        client.controlFrames.filter((frame) => frame.t === "navigate_view"),
+      ).toEqual([
+        {
+          t: "navigate_view",
+          viewId: "settings",
+          viewPath: "/settings",
+          traceId: expect.any(String),
+        },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (previousMockRedis === undefined) delete process.env.MOCK_REDIS;
+      else process.env.MOCK_REDIS = previousMockRedis;
+    }
   });
 
   test("forwards a successful terminal VIEWS handoff without exposing arbitrary actions", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -56,11 +56,16 @@ export type InternalElizaConversationFetchFactory = (
 ) => InternalElizaConversationFetch;
 
 interface InternalVoiceSharedRuntime {
+  dedicatedFetch?: typeof fetch;
   executionCtx?: BridgeExecutionContext;
   namespace?: RuntimeDurableObjectNamespace;
   readCachedAgent(): Promise<SharedRuntimeAgent | null>;
   scheduleHydration(): boolean;
 }
+
+type OwnedDedicatedVoiceConversationResolution =
+  | { kind: "not_dedicated" }
+  | { kind: "dedicated"; fetch: typeof fetch };
 
 function isCachedVoiceAgent(
   agent: SharedRuntimeAgent | null,
@@ -112,6 +117,10 @@ export function createInternalElizaConversationFetchFactory(
       claims.agentId,
     );
     let hydrationPromise: Promise<void> | null = null;
+    let dedicatedResolution: OwnedDedicatedVoiceConversationResolution | null =
+      null;
+    let dedicatedResolutionPromise: Promise<OwnedDedicatedVoiceConversationResolution> | null =
+      null;
 
     const personalAgent = isPersonalSharedAgentId(claims.agentId)
       ? personalSharedAgent({
@@ -120,9 +129,14 @@ export function createInternalElizaConversationFetchFactory(
         })
       : null;
     const readCachedAgent = async (): Promise<SharedRuntimeAgent | null> => {
-      if (personalAgent?.id === claims.agentId) return personalAgent;
+      if (personalAgent?.id === claims.agentId) {
+        dedicatedResolution ??= { kind: "not_dedicated" };
+        return personalAgent;
+      }
       const cached = await cache.get<SharedRuntimeAgent>(cacheKey);
-      return isCachedVoiceAgent(cached, claims) ? cached : null;
+      const agent = isCachedVoiceAgent(cached, claims) ? cached : null;
+      if (agent) dedicatedResolution ??= { kind: "not_dedicated" };
+      return agent;
     };
 
     const scheduleHydration = (): boolean => {
@@ -151,15 +165,36 @@ export function createInternalElizaConversationFetchFactory(
       return true;
     };
 
+    const resolveDedicatedConversation =
+      async (): Promise<OwnedDedicatedVoiceConversationResolution> => {
+        if (dedicatedResolution) return dedicatedResolution;
+        if (dedicatedResolutionPromise) return dedicatedResolutionPromise;
+
+        const resolution = import("../../../../src/dedicated-agent-proxy")
+          .then(({ createOwnedDedicatedVoiceConversationFetch }) =>
+            createOwnedDedicatedVoiceConversationFetch(env, claims),
+          )
+          .then((target) => {
+            dedicatedResolution = target;
+            return target;
+          })
+          .finally(() => {
+            if (dedicatedResolutionPromise === resolution) {
+              dedicatedResolutionPromise = null;
+            }
+          });
+        dedicatedResolutionPromise = resolution;
+        return resolution;
+      };
+
     const prewarm = async (): Promise<void> => {
       const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
-      if (!namespace || !executionCtx) return;
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
         async () => {
           let agent = await readCachedAgent();
           let conversationPrewarmAttemptedByHydration = false;
-          if (!agent) {
+          if (!agent && namespace && executionCtx) {
             scheduleHydration();
             // Capture before awaiting: the hydration's finally block clears the
             // shared slot. Joining this exact promise lets the first voice turn
@@ -171,12 +206,21 @@ export function createInternalElizaConversationFetchFactory(
             }
             agent = await readCachedAgent();
           }
-          if (!agent || conversationPrewarmAttemptedByHydration) return;
-          await coordinateSharedConversationPrewarm(
-            agent.id,
-            claims.conversationId,
-            { namespace },
-          );
+          if (agent) {
+            if (!namespace || conversationPrewarmAttemptedByHydration) return;
+            await coordinateSharedConversationPrewarm(
+              agent.id,
+              claims.conversationId,
+              { namespace },
+            );
+            return;
+          }
+
+          // A Shared miss can be an owned Dedicated sandbox. Resolve it under
+          // a fresh request-local DB context while the caller is beginning to
+          // speak, then retain only its scoped transport closure for this
+          // short-lived voice session.
+          await resolveDedicatedConversation();
         },
       );
     };
@@ -190,18 +234,65 @@ export function createInternalElizaConversationFetchFactory(
         env as unknown as Record<string, unknown>,
         async () => {
           try {
-            const response = await dispatchInternalElizaConversationFetch(
+            const runtime: InternalVoiceSharedRuntime = {
+              executionCtx,
+              namespace: env.SHARED_RUNTIME_CONVERSATIONS,
+              readCachedAgent,
+              scheduleHydration,
+              ...(dedicatedResolution?.kind === "dedicated"
+                ? { dedicatedFetch: dedicatedResolution.fetch }
+                : {}),
+            };
+            let response = await dispatchInternalElizaConversationFetch(
               env,
               claims,
               input,
               init,
-              {
-                executionCtx,
-                namespace: env.SHARED_RUNTIME_CONVERSATIONS,
-                readCachedAgent,
-                scheduleHydration,
-              },
+              runtime,
             );
+            let sharedScopeWarming = false;
+            if (response.status === 503 && !runtime.dedicatedFetch) {
+              try {
+                const body = (await response.clone().json()) as {
+                  code?: unknown;
+                };
+                sharedScopeWarming = body.code === "agent_cache_warming";
+              } catch {
+                // error-policy:J3 a non-JSON 503 is not the typed scope-miss
+                // signal and must not trigger an authoritative tier lookup.
+              }
+            }
+            if (
+              response.status === 503 &&
+              dedicatedResolution?.kind !== "not_dedicated" &&
+              !runtime.dedicatedFetch &&
+              (sharedScopeWarming || dedicatedResolutionPromise !== null)
+            ) {
+              try {
+                const target = await resolveDedicatedConversation();
+                if (target.kind === "dedicated") {
+                  response = await dispatchInternalElizaConversationFetch(
+                    env,
+                    claims,
+                    input,
+                    init,
+                    { ...runtime, dedicatedFetch: target.fetch },
+                  );
+                }
+              } catch (error) {
+                // error-policy:J7 retain the typed Shared warming response;
+                // its bounded retry gives a transient authoritative lookup a
+                // chance to recover without exposing repository failures.
+                logger.warn(
+                  "[voice-sse-context] dedicated scope resolution failed",
+                  {
+                    agentId: claims.agentId,
+                    error:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                );
+              }
+            }
             logger.info("[voice-sse-context] before response", {
               cloudBindingsContext: hasCloudBindingsContext(),
               status: response.status,
@@ -222,6 +313,7 @@ export function createInternalElizaConversationFetchFactory(
     }) as InternalElizaConversationFetch;
     fetchImpl.prewarm = prewarm;
     fetchImpl.recordLifecycleEvent = async (event) => {
+      if (dedicatedResolution?.kind === "dedicated") return;
       const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
       if (!namespace) {
         throw new Error(
@@ -303,6 +395,10 @@ async function dispatchInternalElizaConversationFetch(
       { success: false, error: "Agent not found", code: "agent_not_found" },
       { status: 404 },
     );
+  }
+
+  if (runtime?.dedicatedFetch) {
+    return runtime.dedicatedFetch(request);
   }
 
   if (!runtime?.namespace || !runtime.executionCtx) {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -187,6 +187,26 @@ export function createInternalElizaConversationFetchFactory(
         return resolution;
       };
 
+    const resolveConversationRuntime =
+      async (): Promise<OwnedDedicatedVoiceConversationResolution> => {
+        if (dedicatedResolutionPromise) return dedicatedResolutionPromise;
+        if (dedicatedResolution) return dedicatedResolution;
+
+        // Preserve the rowless personal agent and hot Shared cache paths before
+        // consulting the sandbox row. A concurrent prewarm may start the
+        // authoritative lookup while this cache read is in flight; join it
+        // before trusting a stale Shared result.
+        const agent = await readCachedAgent();
+        if (dedicatedResolutionPromise) return dedicatedResolutionPromise;
+        if (dedicatedResolution) return dedicatedResolution;
+        if (agent) {
+          const shared = { kind: "not_dedicated" } as const;
+          dedicatedResolution = shared;
+          return shared;
+        }
+        return resolveDedicatedConversation();
+      };
+
     const prewarm = async (): Promise<void> => {
       const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
       await runWithCloudBindingsAsync(
@@ -313,22 +333,29 @@ export function createInternalElizaConversationFetchFactory(
     }) as InternalElizaConversationFetch;
     fetchImpl.prewarm = prewarm;
     fetchImpl.recordLifecycleEvent = async (event) => {
-      if (dedicatedResolution?.kind === "dedicated") return;
-      const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
-      if (!namespace) {
-        throw new Error(
-          "Shared runtime conversation coordinator is unavailable.",
-        );
-      }
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
-        () =>
-          coordinateSharedLifecycleEvent(
+        async () => {
+          // Twilio starts prewarm and lifecycle persistence concurrently. The
+          // lifecycle decision must join or establish tier authority before it
+          // can write, otherwise a cold Dedicated call deposits its start
+          // marker into an orphaned Shared conversation.
+          const target = await resolveConversationRuntime();
+          if (target.kind === "dedicated") return;
+
+          const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
+          if (!namespace) {
+            throw new Error(
+              "Shared runtime conversation coordinator is unavailable.",
+            );
+          }
+          await coordinateSharedLifecycleEvent(
             claims.agentId,
             claims.conversationId,
             event,
             { namespace },
-          ),
+          );
+        },
       );
     };
     return fetchImpl;


### PR DESCRIPTION
## Summary
- route realtime voice turns for owned Dedicated agents through the existing agent-router conversation stream while preserving the Shared in-process fast path
- stamp realtime WebSocket voice on for Android Cloud release/debug artifacts and force the debug-only override off
- keep Eliza onboarding shared-first for first-message latency, then opt the host into the canonical background Shared-to-Dedicated handoff

The host opt-in intentionally creates a billable/credit-consuming Dedicated agent after the instant Shared landing. This is the explicit Eliza product policy requested for account-owned agents; framework defaults remain unchanged.

## Focused verification
- dedicated agent proxy + voice WS lifecycle: 118 passed, 0 failed (includes real scoped Dedicated LLM stream and navigate_view /settings contract)
- Android Cloud renderer feature env: 10 passed, 0 failed
- hosted web + native Android renderer composition: 2 passed, 0 failed
- Biome on changed app boot files: clean
- git diff --check: clean