### PR TITLE
fix(cloud): prevent staging deploy starvation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -220,6 +220,7 @@ Representative examples:
   deployment branch/tag policy, and adding any credential are owner-only
   actions taken in the GitHub UI with authorized confirmation at action time.
   No automation in this repository creates them.
+
 - `infra.yml` is the only Terraform plan, apply, and state-edit entry point.
   Each protected Environment supplies a distinct RSA public-key variable
   `TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY` and apply-only private-key secret
@@ -285,14 +286,15 @@ Representative examples:
   The dispatch choice and selected GitHub Environment use the same exact name;
   Railway service names are separate targets:
 
-  | Dispatch / GitHub Environment | Source branch | Railway service |
-  | --- | --- | --- |
-  | `staging` | `develop` | `gateway-webhook-stg` |
-  | `production` | `main` | `gateway-webhook` |
+  | Dispatch / GitHub Environment | Source branch | Railway service       |
+  | ----------------------------- | ------------- | --------------------- |
+  | `staging`                     | `develop`     | `gateway-webhook-stg` |
+  | `production`                  | `main`        | `gateway-webhook`     |
 
   The pinned Railway CLI is invoked without a relative path so its explicit
   project selector archives the absolute current repository root. Passing `.`
   with Railway CLI v5.38.0 fails its pre-upload archive-prefix check.
+
 - `voice-code-bench.yml` retains the bounded real-ASR benchmark.
 
 These workflows use `workflow_dispatch` and never run for pull requests.
@@ -338,6 +340,14 @@ resolve that tree's non-expired artifact from a completed successful
 reachable. The artifact id, GitHub digest, owning run, payload, current workflow
 bytes, and expiry are all checked. Different merge commits are accepted only
 when their root trees are byte-identical; `force` never bypasses this gate.
+
+Protected staging releases also preserve monotonic forward progress during
+sustained `develop` merge traffic. If a release was current when admitted and
+`develop` advances before a later mutation boundary, the source guard may
+continue only after proving both ancestry edges: the currently served staging
+commit is an ancestor of the release SHA, and the release SHA is an ancestor of
+the new `develop` head. Missing served identity, divergence, rollback, and
+unverifiable ancestry still fail closed. Production never enables this mode.
 
 Cloudflare application deploys require Workers and Pages write access. The
 Terraform domain workflow additionally requires zone-scoped DNS write and

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -221,6 +221,8 @@ jobs:
           FORCE: ${{ inputs.force }}
           GITHUB_TOKEN: ${{ github.token }}
           NEUTRAL_WHEN_SUPERSEDED: ${{ inputs.target_environment == 'staging' && github.event_name == 'push' }}
+          MONOTONIC_FORWARD_PROGRESS: ${{ inputs.target_environment == 'staging' }}
+          SERVED_SOURCE_URL: ${{ inputs.target_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
         run: |
           set -euo pipefail
           # --neutral-when-superseded: this is the first mutation of the whole
@@ -233,6 +235,9 @@ jobs:
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
           if [ "$NEUTRAL_WHEN_SUPERSEDED" = "true" ]; then
             source_args+=(--neutral-when-superseded)
+          fi
+          if [ "$MONOTONIC_FORWARD_PROGRESS" = "true" ]; then
+            source_args+=(--allow-monotonic-forward-progress --served-url "$SERVED_SOURCE_URL" --served-path /api/health)
           fi
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
@@ -464,6 +469,8 @@ jobs:
           DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}
           CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
+          MONOTONIC_FORWARD_PROGRESS: ${{ inputs.target_environment == 'staging' }}
+          SERVED_SOURCE_URL: ${{ inputs.target_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
         run: |
           set -euo pipefail
           # The migrate entry imports @elizaos/core, whose i18n barrel pulls in the
@@ -474,6 +481,9 @@ jobs:
           # can advance between workflow steps. Once this step is running, any
           # mismatch must fail immediately before the database mutation.
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$MONOTONIC_FORWARD_PROGRESS" = "true" ]; then
+            source_args+=(--allow-monotonic-forward-progress --served-url "$SERVED_SOURCE_URL" --served-path /api/health)
+          fi
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
           fi
@@ -852,9 +862,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CANONICAL_REF: ${{ steps.env.outputs.deploy_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
+          MONOTONIC_FORWARD_PROGRESS: ${{ steps.env.outputs.deploy_environment == 'staging' }}
+          SERVED_SOURCE_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
         run: |
           set -euo pipefail
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$MONOTONIC_FORWARD_PROGRESS" = "true" ]; then
+            source_args+=(--allow-monotonic-forward-progress --served-url "$SERVED_SOURCE_URL" --served-path /api/health)
+          fi
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
           fi
@@ -1530,10 +1545,15 @@ jobs:
           WORKER_SECRETS_FILE: ${{ steps.worker-secrets.outputs.secrets_file }}
           CANONICAL_REF: ${{ steps.env.outputs.deploy_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
+          MONOTONIC_FORWARD_PROGRESS: ${{ steps.env.outputs.deploy_environment == 'staging' }}
+          SERVED_SOURCE_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
         run: |
           set -euo pipefail
           legacy_onboarding_secret_removed=false
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$MONOTONIC_FORWARD_PROGRESS" = "true" ]; then
+            source_args+=(--allow-monotonic-forward-progress --served-url "$SERVED_SOURCE_URL" --served-path /api/health)
+          fi
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
           fi
@@ -2375,10 +2395,15 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
+          MONOTONIC_FORWARD_PROGRESS: ${{ inputs.target_environment == 'staging' }}
+          SERVED_SOURCE_URL: ${{ inputs.target_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" != "pull_request" ]; then
             source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+            if [ "$MONOTONIC_FORWARD_PROGRESS" = "true" ]; then
+              source_args+=(--allow-monotonic-forward-progress --served-url "$SERVED_SOURCE_URL" --served-path /api/health)
+            fi
             if [ "$FORCE" = "true" ]; then
               source_args+=(--force)
             fi
@@ -2428,6 +2453,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
+          MONOTONIC_FORWARD_PROGRESS: ${{ inputs.target_environment == 'staging' }}
+          SERVED_SOURCE_URL: ${{ inputs.target_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
         # Do NOT pass a positional `dist` argument: wrangler.toml already sets
         # `pages_build_output_dir = "./dist"`, and passing both makes wrangler
         # ignore wrangler.toml — which silently drops the `functions/` upload.
@@ -2446,6 +2473,9 @@ jobs:
           trap cleanup_wrangler_output EXIT
           trap 'exit 1' HUP INT TERM
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$MONOTONIC_FORWARD_PROGRESS" = "true" ]; then
+            source_args+=(--allow-monotonic-forward-progress --served-url "$SERVED_SOURCE_URL" --served-path /api/health)
+          fi
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
           fi

--- a/packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts
+++ b/packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts
@@ -87,6 +87,53 @@ describe("canonical deploy source decision", () => {
     });
   });
 
+  it("allows only monotonic staging progress during canonical head churn", () => {
+    const served = "cccccccccccccccccccccccccccccccccccccccc";
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/develop",
+        canonicalHead: HEAD,
+        runShaIsAncestorOfHead: true,
+        allowMonotonicForwardProgress: true,
+        servedCommit: served,
+        servedCommitIsAncestorOfRun: true,
+      }),
+    ).toMatchObject({
+      allowed: true,
+      reason: "monotonic_forward_progress",
+      servedCommit: served,
+    });
+
+    for (const rejected of [
+      { servedCommit: null, servedCommitIsAncestorOfRun: null },
+      { servedCommit: served, servedCommitIsAncestorOfRun: false },
+    ]) {
+      expect(
+        decideCanonicalDeploySource({
+          runSha: RUN,
+          canonicalRef: "refs/heads/develop",
+          canonicalHead: HEAD,
+          runShaIsAncestorOfHead: true,
+          allowMonotonicForwardProgress: true,
+          ...rejected,
+        }).allowed,
+      ).toBe(false);
+    }
+
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/main",
+        canonicalHead: HEAD,
+        runShaIsAncestorOfHead: true,
+        allowMonotonicForwardProgress: true,
+        servedCommit: served,
+        servedCommitIsAncestorOfRun: true,
+      }).allowed,
+    ).toBe(false);
+  });
+
   it("requires an exact active successor release run", () => {
     const eligible = {
       id: 200,
@@ -378,4 +425,28 @@ describe("canonical deploy source CLI", () => {
       rmSync(root, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("wires monotonic proof into every Cloudflare mutation recheck", () => {
+    const workflow = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../../../../.github/workflows/cloud-cf-release.yml",
+      ),
+      "utf8",
+    );
+    const sourceRechecks = workflow
+      .split("\n")
+      .map((line, index, lines) =>
+        line.includes('source_args=(--run-sha "$GITHUB_SHA"')
+          ? lines.slice(index, index + 12).join("\n")
+          : null,
+      )
+      .filter((block): block is string => block !== null);
+
+    expect(sourceRechecks).toHaveLength(6);
+    for (const block of sourceRechecks) {
+      expect(block).toContain("--allow-monotonic-forward-progress");
+      expect(block).toContain("--served-path /api/health");
+    }
+  });
 });

--- a/packages/cloud/scripts/canonical-deploy-source-guard.mjs
+++ b/packages/cloud/scripts/canonical-deploy-source-guard.mjs
@@ -12,6 +12,10 @@
  * Cloud CF Deploy push run for that exact head. Ancestry alone is insufficient:
  * path-filtered commits and manual production dispatches may have no successor.
  * Divergence, missing successor proof, and unverifiable state all fail hard.
+ * With --allow-monotonic-forward-progress, protected staging may continue
+ * after develop advances only when the served commit is an ancestor of the run
+ * SHA and the run SHA is an ancestor of the new develop head. This prevents
+ * sustained merge traffic from starving staging without permitting rollback.
  */
 import { appendFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -19,6 +23,7 @@ import {
   execFileSync,
   spawnSync,
 } from "../../scripts/lib/spawn-sync-captured.mjs";
+import { fetchServedCommit } from "./deploy-freshness-guard.mjs";
 
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
 const CANONICAL_REFS = new Set(["refs/heads/develop", "refs/heads/main"]);
@@ -72,6 +77,9 @@ export function parseCanonicalRemoteHead(output, canonicalRef) {
  * @param {boolean} [input.force]
  * @param {boolean|null} [input.runShaIsAncestorOfHead]
  * @param {boolean} [input.successorRunOwnsHead]
+ * @param {boolean} [input.allowMonotonicForwardProgress]
+ * @param {string|null|undefined} [input.servedCommit]
+ * @param {boolean|null} [input.servedCommitIsAncestorOfRun]
  */
 export function decideCanonicalDeploySource({
   runSha,
@@ -80,6 +88,9 @@ export function decideCanonicalDeploySource({
   force = false,
   runShaIsAncestorOfHead = null,
   successorRunOwnsHead = false,
+  allowMonotonicForwardProgress = false,
+  servedCommit = null,
+  servedCommitIsAncestorOfRun = null,
 }) {
   const normalizedRun = normalizeSha(runSha);
   const normalizedHead = normalizeSha(canonicalHead);
@@ -118,6 +129,36 @@ export function decideCanonicalDeploySource({
         runSha: normalizedRun,
         canonicalRef: normalizedRef,
         canonicalHead: normalizedHead,
+      };
+    }
+    const normalizedServed = normalizeSha(servedCommit);
+    if (
+      allowMonotonicForwardProgress &&
+      normalizedRef === "refs/heads/develop" &&
+      runShaIsAncestorOfHead === true &&
+      normalizedServed &&
+      servedCommitIsAncestorOfRun === true
+    ) {
+      return {
+        allowed: true,
+        reason: "monotonic_forward_progress",
+        runSha: normalizedRun,
+        canonicalRef: normalizedRef,
+        canonicalHead: normalizedHead,
+        servedCommit: normalizedServed,
+      };
+    }
+    if (allowMonotonicForwardProgress && runShaIsAncestorOfHead === true) {
+      return {
+        allowed: false,
+        neutral: false,
+        reason: normalizedServed
+          ? "non_monotonic_source"
+          : "served_commit_unresolved",
+        runSha: normalizedRun,
+        canonicalRef: normalizedRef,
+        canonicalHead: normalizedHead,
+        servedCommit: normalizedServed,
       };
     }
     return {
@@ -223,11 +264,16 @@ function parseArgs(argv) {
     canonicalRef: null,
     force: false,
     neutralWhenSuperseded: false,
+    allowMonotonicForwardProgress: false,
+    servedUrl: null,
+    servedPath: "/api/health",
   };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--force") {
       parsed.force = true;
+    } else if (argument === "--allow-monotonic-forward-progress") {
+      parsed.allowMonotonicForwardProgress = true;
     } else if (argument === "--neutral-when-superseded") {
       parsed.neutralWhenSuperseded = true;
     } else if (argument === "--run-sha") {
@@ -236,10 +282,20 @@ function parseArgs(argv) {
     } else if (argument === "--canonical-ref") {
       parsed.canonicalRef = argv[index + 1] ?? null;
       index += 1;
+    } else if (argument === "--served-url") {
+      parsed.servedUrl = argv[index + 1] ?? null;
+      index += 1;
+    } else if (argument === "--served-path") {
+      parsed.servedPath = argv[index + 1] ?? null;
+      index += 1;
     } else if (argument.startsWith("--run-sha=")) {
       parsed.runSha = argument.slice("--run-sha=".length);
     } else if (argument.startsWith("--canonical-ref=")) {
       parsed.canonicalRef = argument.slice("--canonical-ref=".length);
+    } else if (argument.startsWith("--served-url=")) {
+      parsed.servedUrl = argument.slice("--served-url=".length);
+    } else if (argument.startsWith("--served-path=")) {
+      parsed.servedPath = argument.slice("--served-path=".length);
     } else {
       throw new Error(`Unsupported argument: ${argument}`);
     }
@@ -264,14 +320,14 @@ function resolveCanonicalHead(canonicalRef) {
 }
 
 /**
- * Probes whether the run SHA is a strict git ancestor of the canonical head.
- * Fetches the head commit's history treelessly so the probe stays cheap in a
+ * Probes whether one commit is a strict-or-equal git ancestor of another.
+ * Fetches the descendant's history treelessly so the probe stays cheap in a
  * shallow CI checkout; any probe failure propagates so the caller fails closed.
- * @param {string} runSha
- * @param {string} canonicalHead
+ * @param {string} ancestorSha
+ * @param {string} descendantSha
  * @returns {boolean}
  */
-function runShaIsAncestorOfCanonicalHead(runSha, canonicalHead) {
+function isAncestorOf(ancestorSha, descendantSha) {
   execFileSync(
     "git",
     [
@@ -280,19 +336,19 @@ function runShaIsAncestorOfCanonicalHead(runSha, canonicalHead) {
       "--no-recurse-submodules",
       "--filter=tree:0",
       "origin",
-      canonicalHead,
+      descendantSha,
     ],
     { stdio: ["ignore", "pipe", "pipe"], timeout: 120000 },
   );
   const probe = spawnSync(
     "git",
-    ["merge-base", "--is-ancestor", runSha, canonicalHead],
+    ["merge-base", "--is-ancestor", ancestorSha, descendantSha],
     { encoding: "utf8", timeout: 60000 },
   );
   if (probe.status === 0) return true;
   if (probe.status === 1) return false;
   throw new Error(
-    `Ancestry probe for ${runSha} under ${canonicalHead} failed: ${probe.stderr || probe.error?.message || `exit ${probe.status}`}`,
+    `Ancestry probe for ${ancestorSha} under ${descendantSha} failed: ${probe.stderr || probe.error?.message || `exit ${probe.status}`}`,
   );
 }
 
@@ -308,6 +364,8 @@ function reportDecision(decision, { neutralized = false } = {}) {
     console.log(`canonicalRef=${decision.canonicalRef}`);
   if (decision.canonicalHead)
     console.log(`canonicalHead=${decision.canonicalHead}`);
+  if (decision.servedCommit)
+    console.log(`servedCommit=${decision.servedCommit}`);
 }
 
 function emitNeutralSupersession(decision, environment = process.env) {
@@ -349,21 +407,36 @@ async function main() {
   if (
     !decision.allowed &&
     decision.reason === "superseded_source" &&
-    args.neutralWhenSuperseded
+    (args.neutralWhenSuperseded || args.allowMonotonicForwardProgress)
   ) {
-    const runShaIsAncestorOfHead = runShaIsAncestorOfCanonicalHead(
-      decision.runSha,
-      canonicalHead,
-    );
+    const runShaIsAncestorOfHead = isAncestorOf(decision.runSha, canonicalHead);
     const successorRunOwnsHead =
+      args.neutralWhenSuperseded &&
       runShaIsAncestorOfHead &&
       args.canonicalRef === "refs/heads/develop" &&
       (await proveSuccessorReleaseRun(canonicalHead));
+    let servedCommit = null;
+    let servedCommitIsAncestorOfRun = null;
+    if (args.allowMonotonicForwardProgress && runShaIsAncestorOfHead) {
+      servedCommit = normalizeSha(
+        await fetchServedCommit(args.servedUrl, {
+          stampPath: args.servedPath,
+        }),
+      );
+      if (servedCommit) {
+        servedCommitIsAncestorOfRun = isAncestorOf(
+          servedCommit,
+          decision.runSha,
+        );
+      }
+    }
     decision = decideCanonicalDeploySource({
       ...args,
       canonicalHead,
       runShaIsAncestorOfHead,
       successorRunOwnsHead,
+      servedCommit,
+      servedCommitIsAncestorOfRun,
     });
   }
   const neutralized =


### PR DESCRIPTION
# Relates to

Closes #29339

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated base failure is recorded below.
- [x] A reviewer can confirm the changed contract from the deterministic source-guard tests and the three linked live failure runs.

# Sync with develop

- [x] Rebased onto `origin/develop` at `e608d7ac89fd93eecb2f42d95180257de39c250b`; zero conflicts.
- [x] `bun run verify` was run post-sync; its pre-existing i18n blocker is documented below.

# Risks

Medium. This changes protected staging release admission at mutation boundaries. The new path is staging-only and remains fail-closed unless Git proves `served commit -> release SHA -> current develop head`. Production, divergence, rollback, missing served identity, and force semantics are unchanged.

# Background

## What does this PR do?

Prevents sustained `develop` merge traffic from starving staging deployments. A release that was canonical when admitted may continue as a monotonic forward step after `develop` advances, but only with both ancestry edges proven from the live staging health commit.

All six Cloudflare mutation rechecks use the same proof. The source guard and workflow documentation describe the new contract.

## What kind of change is this?

Bug fix (non-breaking operational safety fix).

# Documentation changes needed?

Updated `.github/workflows/README.md` with the monotonic staging contract.

# Testing

## Where should a reviewer start?

`packages/cloud/scripts/canonical-deploy-source-guard.mjs` and its focused test, then the six call sites in `.github/workflows/cloud-cf-release.yml`.

## Detailed testing steps

- `bun test packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts` — 10 pass, 0 fail.
- `bun test packages/scripts/__tests__/actionlint-config.test.ts packages/cloud/scripts/__tests__/verify-steward-upstream-binding.test.ts packages/cloud/scripts/__tests__/verify-webhook-gateway-binding.test.ts` — 36 pass, 0 fail.
- pinned `actionlint` against `.github/workflows/cloud-cf-release.yml` — pass.
- `bunx biome check` for both changed source/test files — pass.
- `bun run audit:workflow-triggers` — pass, 63 workflows verified.
- `node scripts/check-markdown-links.mjs .github/workflows/README.md` — pass.
- `bun install --frozen-lockfile` — pass.

# Evidence Gate

<!-- evidence-head:bace4b02498d0623f4f178c21a776689f59baa26 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] [29344-source-guard-contract.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29344-source-guard-contract.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [29344-source-guard-change.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29344-source-guard-change.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior.

## Backend + frontend logs

Backend: the three failed staging runs above prove the sustained-head-churn starvation at the protected mutation boundary. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - workflow and release guard only.

## Audio / voice walkthrough

N/A - no voice behavior.

## Known gaps / failures

- `bun run verify` stops at `bun run check:i18n`: `en.json` is already missing `browserworkspace.MoreActions`, alongside existing locale gaps. The same failure reproduces on the earlier untouched base `69e8b3a8d9be3a5350359b8b60ab36816ed68785`; this diff touches no i18n source or locale file.
- The broader existing `production-deploy-admission-lock.test.mjs` has an unrelated base contract drift (`missing job build-pages`). The affected source-guard, actionlint, routing, and webhook workflow suites pass.
- Real success evidence can only be collected after merge because protected staging executes trusted workflow bytes from `develop`. Post-merge acceptance is exact served SHA plus shared staging live smoke.

## Maintainer CI exception record

N/A - no exception requested.

# Deploy Notes

After merge, allow the reconciled staging release to run under normal non-forced policy. Verify `https://staging.eliza.app/api/health` reports the deployed commit or a descendant, then run the Cloud shared onboarding smoke and attach its privacy-safe evidence to #29339.


