### PR TITLE
fix(ui): use truncateWellFormed for segment keys in MessageContent and bug report descriptions in StartupFailureView

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -14,7 +14,7 @@
  * exports here drive their own mutations through the typed `ElizaClient`.
  */
 
-import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
+import { stripUnclaimedInteractionMarkup, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
 import { Check, ShieldCheck } from "lucide-react";
 import {
@@ -1594,9 +1594,9 @@ export function MessageContent({
         return segments.map((seg) => {
           const baseKey =
             seg.kind === "text"
-              ? `text:${seg.text.slice(0, 80)}`
+              ? `text:${truncateWellFormed(toWellFormedUnicode(seg.text), 80)}`
               : seg.kind === "code"
-                ? `code:${seg.code.slice(0, 80)}`
+                ? `code:${truncateWellFormed(toWellFormedUnicode(seg.code), 80)}`
                 : seg.kind === "config"
                   ? `config:${seg.pluginId}`
                   : seg.kind === "widget"
@@ -1606,7 +1606,7 @@ export function MessageContent({
                       ? `permission:${seg.payload.feature}`
                       : seg.kind === "analysis-xml"
                         ? `analysis:${seg.tag}`
-                        : `ui:${seg.raw.slice(0, 80)}`;
+                        : `ui:${truncateWellFormed(toWellFormedUnicode(seg.raw), 80)}`;
           const segmentKey = nextKey(baseKey);
 
           switch (seg.kind) {

--- a/packages/ui/src/components/shell/StartupFailureView.tsx
+++ b/packages/ui/src/components/shell/StartupFailureView.tsx
@@ -7,6 +7,7 @@
  */
 
 import { AlertCircle } from "lucide-react";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { useBranding } from "../../config/branding";
 import { type BugReportDraft, useOptionalBugReport } from "../../hooks";
 import { startFreshFirstRunReload } from "../../platform";
@@ -70,7 +71,7 @@ function buildStartupBugReportDraft(
     .join("\n");
 
   return {
-    description: `${reasonLabel}: ${error.message}`.slice(0, 80),
+    description: truncateWellFormed(toWellFormedUnicode(`${reasonLabel}: ${error.message}`), 80),
     stepsToReproduce:
       "1. Launch the desktop app.\n2. Wait for startup to fail.\n3. Observe the startup failure screen.",
     expectedBehavior: "The app should finish startup and show the main shell.",


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:605be79f561cddf92f9d4908cd8fed76274c766d -->

## Summary
In `@elizaos/ui`:
- `MessageContent` (`src/components/chat/MessageContent.tsx`) generated React keys for text, code, and UI blocks using raw `.slice(0, 80)`.
- `buildStartupBugReportDraft` (`src/components/shell/StartupFailureView.tsx`) clamped startup error summaries using raw `.slice(0, 80)`.

When message content or error messages contained multi-code-unit UTF-16 surrogate pairs at character offset 80 (such as emojis or extended Unicode), raw slicing severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Replaced raw `.slice()` calls in `MessageContent.tsx` with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.
2. Replaced raw `.slice(0, 80)` in `StartupFailureView.tsx` with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/components/shell/StartupFailureView.test.tsx packages/ui/src/components/chat/message-parser-code.test.ts` (12/12 passed).
- Verified well-formed Unicode output during message segment rendering and bug report generation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
