### PR TITLE
fix(core): use truncateWellFormed for zip folder name sanitization and duplicate message logging

### DIFF
--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -6,6 +6,7 @@
 import { sql } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { ElizaError } from "../../errors";
+import { truncateWellFormed } from "../../utils/well-formed";
 import { logger } from "../../logger";
 import { serializeTrajectoryExport } from "../../services/trajectory-export";
 import {
@@ -3388,7 +3389,7 @@ export class TrajectoriesService extends Service {
 
 	private sanitizeZipFolderName(value: string): string {
 		const trimmed = value.trim();
-		const safe = trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed;
+		const safe = trimmed.length > 256 ? truncateWellFormed(trimmed, 256) : trimmed;
 		const sanitized = safe
 			.replace(/[^a-zA-Z0-9._-]+/g, "_")
 			.replace(/^_+|_+$/g, "");

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -354,7 +354,7 @@ import {
 	extractFirstSentence,
 } from "../utils/text-splitting";
 import { isObjectRecord as isRecord } from "../utils/type-guards";
-import { toWellFormedUnicode } from "../utils/well-formed";
+import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed";
 import { maybeHandleAnalysisActivation } from "./analysis-mode-handler";
 import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
@@ -12711,7 +12711,7 @@ export function wrapSingleTurnVisibleCallback(
 		if (typeof response?.text === "string" && response.text.trim()) {
 			if (nearDuplicateOfDeliveredThisTurn(response.text)) {
 				fullRuntime.logger?.debug?.(
-					{ actionName, text: response.text.slice(0, 120) },
+					{ actionName, text: truncateWellFormed(response.text, 120) },
 					"[message] suppressed near-duplicate delivery within the turn",
 				);
 				recordDeliveredVisibleText?.(response.text);


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d400bd615efa2a601697eb9d5d0e165e34b56695 -->

## Summary
In `@elizaos/core`:
- `sanitizeZipFolderName` (`src/features/trajectories/TrajectoriesService.ts`) clamped folder names using raw `.slice(0, 256)`.
- `wrapSingleTurnVisibleCallback` (`src/services/message.ts`) clamped near-duplicate debug logs using raw `.slice(0, 120)`.

When names or message strings contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed` in `sanitizeZipFolderName` (`TrajectoriesService.ts`).
2. Used `truncateWellFormed` in near-duplicate debug logging (`message.ts`).

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/message.surrogate.test.ts` (7/7 passed).
- Verified well-formed Unicode output during trajectory export folder sanitization and duplicate delivery logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
