### PR TITLE
fix(scenario-runner): use truncateWellFormed for JudgeParseError preview and deterministic dispatch render text

### DIFF
--- a/packages/scenario-runner/src/judge.ts
+++ b/packages/scenario-runner/src/judge.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { logger, ModelType, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   CerebrasJudge,
   extractBalancedJsonObject,
@@ -96,10 +96,18 @@ function parseJudgeJson(raw: string): JudgeResult | null {
 export class JudgeParseError extends Error {
   readonly raw: string;
   constructor(attempts: number, raw: string) {
+    const wellFormed = toWellFormedUnicode(raw);
+    const start = truncateWellFormed(wellFormed, 150);
+    let endCut = wellFormed.length - 100;
+    const code = wellFormed.charCodeAt(endCut);
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      endCut += 1;
+    }
+    const end = wellFormed.slice(endCut);
     const preview =
-      raw.length <= 300
-        ? raw
-        : `${raw.slice(0, 150)} … ${raw.slice(-100)} (${raw.length} chars)`;
+      wellFormed.length <= 300
+        ? wellFormed
+        : `${start} … ${end} (${wellFormed.length} chars)`;
     super(
       `[scenario-judge] model did not return a parseable JSON object after ${attempts} attempt(s). Raw: ${preview}`,
     );

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -18,6 +18,8 @@ import {
   ModelType,
   NotificationService,
   trajectoriesPlugin,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   createDeterministicModelPlugin,
@@ -576,7 +578,7 @@ export function deterministicScheduledDispatchRenderText(
   if (!ownerMessage) return "checking in.";
   const clamped =
     ownerMessage.length >= 64
-      ? `${ownerMessage.slice(0, 60).trimEnd()}…`
+      ? `${truncateWellFormed(toWellFormedUnicode(ownerMessage), 60).trimEnd()}…`
       : ownerMessage;
   return `Heads up: ${clamped}`;
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9dee62b69205aa81adaa38f87aca5110cec3234c -->

## Summary
In `@elizaos/scenario-runner`:
- `JudgeParseError` (`src/judge.ts`) formatted raw model output previews using raw `raw.slice(0, 150)` and `raw.slice(-100)`.
- `deterministicScheduledDispatchRenderText` (`src/runtime-factory.ts`) clamped dispatch copy using raw `ownerMessage.slice(0, 60)`.

When raw responses or instructions contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed` and low-surrogate alignment in `JudgeParseError` (`judge.ts`).
2. Used `truncateWellFormed(toWellFormedUnicode(...))` in `deterministicScheduledDispatchRenderText` (`runtime-factory.ts`).

## Verification
- Ran vitest: `bunx vitest run packages/scenario-runner/src/judge.test.ts` (2/2 passed).
- Verified well-formed Unicode output during LLM-as-judge error reporting and deterministic dispatch formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
