### PR TITLE
fix(plugin-agent-orchestrator): use truncateWellFormed for progress logging of sessionId, roomId, and text

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -26,6 +26,7 @@ import {
   promoteSubactionsToActions,
   requireConfirmedSendHandlerDelivery,
   toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 // Register coding-agent HTTP routes with the runtime route registry.
@@ -2231,12 +2232,12 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         runtime.logger?.debug?.(
           {
             src: "@elizaos/plugin-agent-orchestrator",
-            sessionId: sessionId.slice(0, 8),
+            sessionId: truncateWellFormed(sessionId, 8),
             ev: evName,
             source,
-            room: roomId.slice(0, 8),
+            room: truncateWellFormed(roomId, 8),
           },
-          `posting: "${text.slice(0, 80)}"`,
+          `posting: "${truncateWellFormed(toWellFormedUnicode(text), 80)}"`,
         );
         await emitProgress(sessionId, { source, roomId }, text, label);
       } catch (err) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:8a779603cf2655524b5d798111875147a8e8fdef -->

## Summary
In `@elizaos/plugin-agent-orchestrator` (`plugins/plugin-agent-orchestrator/src/index.ts`):
`registerProgressHook` clamped sub-agent progress debug logs using raw `sessionId.slice(0, 8)`, `roomId.slice(0, 8)`, and `text.slice(0, 80)`. If session/room identifiers or progress text contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Replaced raw `.slice()` calls in `registerProgressHook` with `truncateWellFormed` and `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-agent-orchestrator/src/services/session-event-queue.test.ts` (2/2 passed).
- Verified well-formed Unicode output during sub-agent progress logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
