### PR TITLE
fix(plugin-discord): use truncateWellFormed and low-surrogate alignment in banner mask

### DIFF
--- a/plugins/plugin-discord/__tests__/banner-defaults.test.ts
+++ b/plugins/plugin-discord/__tests__/banner-defaults.test.ts
@@ -79,4 +79,10 @@ describe("printDiscordBanner conversational defaults", () => {
 		expect(prefix.isWellFormed()).toBe(true);
 		expect(prefix.length).toBe(6); // backed off by 1 unit to avoid splitting U+1D11E
 	});
+	it("preserves well-formed Unicode when masking sensitive secrets containing surrogate pairs", () => {
+		const surrogateSecret = "🚀abcSECRETVALUEdef🚀";
+		const masked = fmtVal(surrogateSecret, true, 40);
+		expect(masked.isWellFormed()).toBe(true);
+	});
+
 });

--- a/plugins/plugin-discord/banner.ts
+++ b/plugins/plugin-discord/banner.ts
@@ -7,6 +7,7 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import {
 	lifeOpsPassiveConnectorsEnabled,
+	toWellFormedUnicode,
 	truncateWellFormed,
 } from "@elizaos/core";
 import { listEnabledDiscordAccounts } from "./accounts";
@@ -264,10 +265,18 @@ export interface BannerOptions {
 }
 
 function mask(v: string): string {
-	if (!v || v.length <= 8) {
+	const wellFormed = toWellFormedUnicode(v);
+	if (!wellFormed || wellFormed.length <= 8) {
 		return "••••••••";
 	}
-	return `${v.slice(0, 4)}${"•".repeat(Math.min(12, v.length - 8))}${v.slice(-4)}`;
+	const start = truncateWellFormed(wellFormed, 4);
+	let endCut = wellFormed.length - 4;
+	const code = wellFormed.charCodeAt(endCut);
+	if (code >= 0xdc00 && code <= 0xdfff) {
+		endCut += 1;
+	}
+	const end = wellFormed.slice(endCut);
+	return `${start}${"•".repeat(Math.min(12, wellFormed.length - 8))}${end}`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c7bdedb064bb0eebfb78612789c67f79d66e8b7b -->

## Summary
In `@elizaos/plugin-discord` (`plugins/plugin-discord/banner.ts`):
The `mask(v)` helper used by `fmtVal` clamped sensitive configuration values at the prefix and suffix using raw `v.slice(0, 4)` and `v.slice(-4)`. If sensitive tokens contained multi-code-unit UTF-16 surrogate pairs at prefix or suffix boundaries, raw slicing severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(v), 4)` for the start segment.
2. Added low-surrogate detection on the tail offset to ensure the suffix segment does not start with an unpaired low surrogate.
3. Added unit tests in `plugins/plugin-discord/__tests__/banner-defaults.test.ts` verifying that masking sensitive secrets containing surrogate pairs preserves well-formed Unicode.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-discord/__tests__/banner-defaults.test.ts` (4/4 passed).
- Verified well-formed Unicode output during Discord banner formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
