### PR TITLE
fix(agent): use surrogate-safe boundaries for token fingerprints and search snippets

### DIFF
--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -20,7 +20,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import type http from "node:http";
 import path from "node:path";
-import type { RouteRequestContext } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed, type RouteRequestContext } from "@elizaos/core";
 import {
   type AgentRuntime,
   attestAuthenticatedApiDeliveryAudience,
@@ -2713,19 +2713,29 @@ function parseMessageSearchTime(
 
 /** A `…keyword…` excerpt around the first match, or a head-truncated fallback. */
 function buildMessageSearchSnippet(text: string, query: string): string {
-  const normalizedText = text.replace(/\s+/g, " ").trim();
+  const normalizedText = toWellFormedUnicode(text.replace(/\s+/g, " ").trim());
   if (!normalizedText) return "";
   const index = normalizedText.toLowerCase().indexOf(query.toLowerCase());
   if (index < 0) {
     return normalizedText.length <= MESSAGE_SEARCH_SNIPPET_RADIUS * 2
       ? normalizedText
-      : `${normalizedText.slice(0, MESSAGE_SEARCH_SNIPPET_RADIUS * 2).trimEnd()}...`;
+      : `${truncateWellFormed(normalizedText, MESSAGE_SEARCH_SNIPPET_RADIUS * 2).trimEnd()}...`;
   }
-  const start = Math.max(0, index - MESSAGE_SEARCH_SNIPPET_RADIUS);
-  const end = Math.min(
+  let start = Math.max(0, index - MESSAGE_SEARCH_SNIPPET_RADIUS);
+  const startCode = normalizedText.charCodeAt(start);
+  if (startCode >= 0xdc00 && startCode <= 0xdfff) {
+    start += 1;
+  }
+  let end = Math.min(
     normalizedText.length,
     index + query.length + MESSAGE_SEARCH_SNIPPET_RADIUS,
   );
+  if (end > 0) {
+    const endLead = normalizedText.charCodeAt(end - 1);
+    if (endLead >= 0xd800 && endLead <= 0xdbff) {
+      end -= 1;
+    }
+  }
   const prefix = start > 0 ? "..." : "";
   const suffix = end < normalizedText.length ? "..." : "";
   return `${prefix}${normalizedText.slice(start, end).trim()}${suffix}`;

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -4,7 +4,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   isCloudProvisionedContainer,
   isLoopbackBindHost,
@@ -515,7 +515,15 @@ export function ensureApiTokenForBindHost(host: string): void {
       `[eliza-api] ELIZA_API_BIND=${host} is non-loopback and ELIZA_API_TOKEN is unset.`,
     );
   }
-  const tokenFingerprint = `${generated.slice(0, 4)}...${generated.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(generated);
+  const start = truncateWellFormed(wellFormed, 4);
+  let endCut = wellFormed.length - 4;
+  const code = wellFormed.charCodeAt(endCut);
+  if (code >= 0xdc00 && code <= 0xdfff) {
+    endCut += 1;
+  }
+  const end = wellFormed.slice(endCut);
+  const tokenFingerprint = `${start}...${end}`;
   logger.warn(
     `[eliza-api] Generated temporary API token (${tokenFingerprint}) for this process. Set ELIZA_API_TOKEN explicitly to override.`,
   );


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:16f3ab801a83b596f344a27361f4e813c9476641 -->

## Summary
In `@elizaos/agent`:
- `ensureApiTokenForBindHost` (`src/api/server-helpers-auth.ts`) formatted token fingerprints using raw `.slice(0, 4)` and `.slice(-4)`.
- `buildMessageSearchSnippet` (`src/api/conversation-routes.ts`) extracted message search snippet bounds using raw `.slice()`.

When token strings or conversation messages contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries (e.g. emojis or extended Unicode), raw slicing severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed` and low-surrogate alignment in `server-helpers-auth.ts`.
2. Added surrogate-pair boundary detection in `buildMessageSearchSnippet` (`conversation-routes.ts`) to ensure snippet windows never start with a low surrogate or end with a high surrogate.

## Verification
- Ran vitest: `node ../scripts/run-vitest.mjs run src/api/__tests__/conversation-message-search.test.ts` (15/15 passed).
- Verified well-formed Unicode output during message search snippet generation and API token logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
