### PR TITLE
fix(plugin-discord): use truncateWellFormed for command descriptions and thread names

### DIFF
--- a/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
+++ b/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
@@ -4,8 +4,10 @@
  */
 
 import { ElizaError } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mapOption } from "../catalog-commands";
+import { transformCommandToDiscordApi } from "../discord-commands";
+import type { DiscordSlashCommand } from "../types";
 import {
 	buildCommandArgCustomId,
 	buildCommandArgMenu,
@@ -241,5 +243,17 @@ describe("Discord command projection Unicode safety", () => {
 				code: "DISCORD_COMMAND_CUSTOM_ID_TOO_LONG",
 			}),
 		);
+	});
+
+	it("preserves well-formed Unicode when clamping overlong command descriptions containing surrogate pairs", () => {
+		const longDesc = "a".repeat(98) + "🚀" + "tail";
+		const cmd: DiscordSlashCommand = {
+			name: "test-cmd",
+			description: longDesc,
+			execute: vi.fn() as never,
+		};
+		const transformed = transformCommandToDiscordApi(cmd) as { description: string };
+		expect(transformed.description.isWellFormed()).toBe(true);
+		expect(transformed.description.endsWith("…")).toBe(true);
 	});
 });

--- a/plugins/plugin-discord/discord-commands.ts
+++ b/plugins/plugin-discord/discord-commands.ts
@@ -7,6 +7,8 @@ import {
 	createUniqueUuid,
 	type EventPayload,
 	EventType,
+	toWellFormedUnicode,
+	truncateWellFormed,
 	type World,
 } from "@elizaos/core";
 import type {
@@ -53,9 +55,10 @@ const INTEGRATION_USER_INSTALL = 1;
 const DISCORD_DESCRIPTION_MAX = 100;
 
 function clampDescription(description: string): string {
-	return description.length > DISCORD_DESCRIPTION_MAX
-		? `${description.slice(0, DISCORD_DESCRIPTION_MAX - 1)}…`
-		: description;
+	const wellFormed = toWellFormedUnicode(description);
+	return wellFormed.length > DISCORD_DESCRIPTION_MAX
+		? `${truncateWellFormed(wellFormed, DISCORD_DESCRIPTION_MAX - 1)}…`
+		: wellFormed;
 }
 
 export function transformCommandToDiscordApi(

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -24,6 +24,8 @@ import {
 	logInboundDrop,
 	type Media,
 	type Memory,
+	toWellFormedUnicode,
+	truncateWellFormed,
 	MemoryType,
 	type MessageConnectorChatContext,
 	type MessageConnectorCreateThreadParams,
@@ -3279,7 +3281,7 @@ export class DiscordService extends Service implements IDiscordService {
 				`Discord channel ${channel.id} does not support thread creation.`,
 			);
 		}
-		const name = (params.name ?? "thread").slice(0, 100);
+		const name = truncateWellFormed(toWellFormedUnicode(params.name ?? "thread"), 100);
 		let startMessage: Message | undefined;
 		if (params.parentMessageId) {
 			try {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:28277b7821e0cf7a4f4e0884ce42a053c3b12362 -->

## Summary
In `@elizaos/plugin-discord`:
- `clampDescription` (`plugins/plugin-discord/discord-commands.ts`) clamped command descriptions using raw `.slice(0, DISCORD_DESCRIPTION_MAX - 1)`.
- `createThread` (`plugins/plugin-discord/service.ts`) clamped thread names using raw `.slice(0, 100)`.

When command descriptions or thread names contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(...))` in `clampDescription` (`discord-commands.ts`).
2. Used `truncateWellFormed(toWellFormedUnicode(...))` for thread `name` in `service.ts`.
3. Added unit tests in `plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts` verifying that command descriptions containing surrogate pairs at length boundaries remain well-formed when clamped.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts` (16/16 passed).
- Verified well-formed Unicode output during Discord slash command transformation and thread creation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
