### PR TITLE
fix(plugin-cloud-apps): use truncateWellFormed in appReferenceLogView

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
@@ -289,4 +289,10 @@ describe("describeAppReference / appReferenceLogView — reference display seam"
     expect(view).toBe(`${"a".repeat(120)}…`);
     expect(view.length).toBe(121);
   });
+  it("appReferenceLogView preserves well-formed Unicode when clamping references containing surrogate pairs", () => {
+    const longRefWithSurrogate = "a".repeat(119) + "🚀" + "tail";
+    const view = appReferenceLogView(longRefWithSurrogate);
+    expect(view.isWellFormed?.()).not.toBe(false);
+    expect(view.endsWith("…")).toBe(true);
+  });
 });

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -13,7 +13,7 @@
 import type { AppDto } from "@elizaos/cloud-sdk";
 import { ElizaCloudClient } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { unwrapUserMessageText } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed, unwrapUserMessageText } from "@elizaos/core";
 
 /** Default Eliza Cloud API base URL (matches the cloud runtime default). */
 export const DEFAULT_CLOUD_API_BASE_URL = "https://api.eliza.app/api/v1";
@@ -403,8 +403,8 @@ export function describeAppReference(
  * whitespace to one line and clamp to 120 chars with a trailing ellipsis.
  */
 export function appReferenceLogView(reference: string): string {
-  const collapsed = reference.replace(/\s+/g, " ").trim();
-  return collapsed.length > 120 ? `${collapsed.slice(0, 120)}…` : collapsed;
+  const collapsed = toWellFormedUnicode(reference.replace(/\s+/g, " ").trim());
+  return collapsed.length > 120 ? `${truncateWellFormed(collapsed, 120)}…` : collapsed;
 }
 
 export interface ResolvedApp {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b40ef3a3c5eac20742d4a50e0b8ddd4e4b3c2e82 -->

## Summary
In `@elizaos/plugin-cloud-apps` (`plugins/plugin-cloud-apps/src/client.ts`):
`appReferenceLogView` clamped overlong references using raw `collapsed.slice(0, 120)`. When app references contained multi-code-unit UTF-16 surrogate pairs at character index 120, raw slicing severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(reference), 120)` in `appReferenceLogView`.
2. Added unit tests in `plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts` verifying that references containing surrogate pairs at clamp boundaries remain well-formed when clamped with a trailing ellipsis.

## Verification
- Ran unit tests: `appReferenceLogView preserves well-formed Unicode when clamping references containing surrogate pairs` (passed).
- Verified well-formed Unicode output during cloud app reference logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
