### PR TITLE
test(cloud): fix billing migration contract paths

### DIFF
--- a/packages/cloud/shared/src/db/migrations/billing-resource-cancel-receipts.test.ts
+++ b/packages/cloud/shared/src/db/migrations/billing-resource-cancel-receipts.test.ts
@@ -6,11 +6,11 @@ import { PGlite } from "@electric-sql/pglite";
 const migration = (
   await Promise.all(
     [
-      "0330_billing_cancel_intent_authority.sql",
-      "0331_billing_cancel_commands.sql",
-      "0332_billing_cancel_command_keys.sql",
-      "0333_billing_cancel_guard_functions.sql",
-      "0334_billing_cancel_guards.sql",
+      "0334_billing_cancel_intent_authority.sql",
+      "0335_billing_cancel_commands.sql",
+      "0336_billing_cancel_command_keys.sql",
+      "0337_billing_cancel_guard_functions.sql",
+      "0338_billing_cancel_guards.sql",
     ].map((name) => Bun.file(new URL(`./${name}`, import.meta.url)).text()),
   )
 ).join("\n--> statement-breakpoint\n");


### PR DESCRIPTION
## Summary

- Updates the post-#25372 PGlite contract to load the canonical renumbered billing cancellation migrations `0334`–`0338`.
- Restores execution of the existing authorization, tenant, idempotency, and guard assertions; no production behavior or migration SQL changes.

Closes #29359.

## Verification

Exact head: `3f4f7f798d4885452637e24ecd0181f8531cbe70`
Base: `8cd98136cccd7c28146b1fccfa653c8aadcfc747`

- Affected migration contracts: 8 passed, 0 failed, 32 assertions.
- `@elizaos/cloud-shared` typecheck passed.
- Targeted Biome passed.
- `git diff --check` passed.
- Migration journal `idx`, `when`, and `tag` uniqueness checks passed through `0340_synthetic_world_commands`.

## Evidence

- UI screenshots/video: N/A — test path repair only.
- Live provider/deployment evidence: N/A — no runtime, provider, credential, migration SQL, or deployment behavior changed.
- Domain artifact: the exact PGlite migration contracts execute all canonical migration files and pass.