### PR TITLE
test(ui): repair Linux runtime accessibility acceptance

### DIFF
--- a/packages/ui/src/components/settings/__e2e__/devices-runtimes-a11y-fixture.tsx
+++ b/packages/ui/src/components/settings/__e2e__/devices-runtimes-a11y-fixture.tsx
@@ -56,7 +56,13 @@ function Fixture() {
           code: "420731",
           expiresAt: "2099-01-01T00:05:00.000Z",
           capabilities: ["agent.status", "agent.request"],
-          status: "pending",
+          status: "claimed",
+          controller: {
+            deviceId: "iphone-a11y-proof",
+            keyId: "controller-key-a11y-proof",
+            displayName: "Proof iPhone",
+            platform: "ios",
+          },
           qrPayload:
             "elizaos://remote/control-claim?session=session-a11y-proof&code=420731",
         }}

--- a/packages/ui/src/components/settings/__e2e__/run-devices-runtimes-a11y-e2e.mjs
+++ b/packages/ui/src/components/settings/__e2e__/run-devices-runtimes-a11y-e2e.mjs
@@ -16,6 +16,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const uiSrc = resolve(here, "../../..");
 const repoRoot = resolve(uiSrc, "../../..");
 const outDir = join(here, "output-devices-runtimes-a11y");
+const sharedLanguageModule = join(
+  repoRoot,
+  "packages/shared/src/i18n/language.ts",
+);
 await mkdir(outDir, { recursive: true });
 
 let failures = 0;
@@ -32,6 +36,16 @@ const bundle = await build({
   conditions: ["eliza-source", "browser"],
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
+  plugins: [
+    {
+      name: "narrow-shared-language-import",
+      setup(context) {
+        context.onResolve({ filter: /^@elizaos\/shared$/ }, () => ({
+          path: sharedLanguageModule,
+        }));
+      },
+    },
+  ],
   define: { "process.env.NODE_ENV": '"production"' },
   write: false,
   absWorkingDir: repoRoot,
@@ -115,13 +129,14 @@ for (const name of [
   "Copy session ID",
   "Refresh",
   "Use runtime",
-  "Pair device",
+  "Claim pairing",
   "Retry",
   "Revoke",
   "Remove",
   "Stop relay",
   "Revoke host",
-  "Approve this pairing on this Linux computer",
+  "Confirm controller on this Linux computer",
+  "Deny",
 ]) {
   assert(
     (await page.getByRole("button", { name, exact: true }).count()) === 1,
@@ -158,14 +173,14 @@ const expectedInitialOrder = [
   "button:Copy session ID",
   "button:Refresh",
   "button:Use runtime",
-  "button:Pair device",
+  "input:Mac's 6-digit code",
   "button:Retry",
   "button:Revoke",
   "button:Remove",
   "button:Stop relay",
   "button:Revoke host",
-  "button:Approve this pairing on this Linux computer",
-  "input:6-digit code",
+  "button:Confirm controller on this Linux computer",
+  "button:Deny",
   "summary:Advanced SSH",
 ];
 await page.locator("body").click({ position: { x: 2, y: 2 } });


### PR DESCRIPTION
## Summary

Follow-up to #25427 after its merged source head left the dedicated Devices & Runtimes browser acceptance non-runnable and stale against the shipped UI contract.

- resolve only the dependency-free shared language module in the browser fixture, avoiding the server-wide `@elizaos/shared` barrel and its Node built-ins
- exercise the claimed-controller confirmation state that the current UI actually renders
- align unique accessible names and keyboard order with the current Claim pairing / Confirm controller / Deny controls

## Verification

Exact source: `bee03a604ef8714d3c8ab30b8f818c8f17a3016f`
Base: `98f91f67f714ec25bda6fd02f6643c21ff072a8c`

- `bun run --cwd packages/ui test:devices-runtimes-a11y-e2e` — pass in real Chromium (reduced motion, focus visibility, screen-reader names, tab order, keyboard expansion, narrow/wide layout, 200% text, forced colors, no page errors)
- `bun run --cwd packages/ui lint:check` — pass
- `git diff --check origin/develop...HEAD` — pass
- `node --check packages/ui/src/components/settings/__e2e__/run-devices-runtimes-a11y-e2e.mjs` — pass

This is software/browser proof only. It does not claim physical GNOME, Wayland, Secret Service, packaged-Linux lifecycle, deployed relay, or second-host SSH/WAN evidence.