### PR TITLE
fix(plugin-coding-tools): grep count mode reports fabricated command failure on zero matches

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/grep.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.test.ts
@@ -225,6 +225,44 @@ describe("GREP", () => {
     ).toBe(0);
   });
 
+  it("returns matches_count:0 for count mode with an unmatched pattern", async () => {
+    const bundle = await buildRuntime();
+    if (!bundle) {
+      console.warn("no ripgrep available, skipping");
+      return;
+    }
+    const { runtime, message } = bundle;
+
+    const result = await grepHandler(runtime, message, state, {
+      parameters: {
+        pattern: "ZZZ_DEFINITELY_NO_MATCH_ZZZ",
+        output_mode: "count",
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("no matches");
+    expect(
+      (result.data as Record<string, unknown> | undefined)?.matches_count,
+    ).toBe(0);
+  });
+
+  it("still reports matches for count mode with a matched pattern", async () => {
+    const bundle = await buildRuntime();
+    if (!bundle) {
+      console.warn("no ripgrep available, skipping");
+      return;
+    }
+    const { runtime, message } = bundle;
+
+    const result = await grepHandler(runtime, message, state, {
+      parameters: { pattern: "NEEDLE", output_mode: "count" },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?.mode).toBe("count");
+    expect((data?.matches_count as number) > 0).toBe(true);
+  });
+
   it("fails when roomId is missing", async () => {
     const bundle = await buildRuntime();
     if (!bundle) {

--- a/plugins/plugin-coding-tools/src/actions/grep.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.ts
@@ -139,10 +139,7 @@ export async function grepHandler(
 
     const result = await rg.search(rgOptions, mode);
 
-    if (
-      result.exitCode === 1 &&
-      (mode === "content" || mode === "files_with_matches")
-    ) {
+    if (result.exitCode === 1) {
       const text = "no matches";
       return successActionResult(text, {
         matches_count: 0,


### PR DESCRIPTION
ripgrep exits with code 1 for "no matches" across all output modes, but the zero-match guard only recognized this for `content`/`files_with_matches`, so `count` mode fell through to error handling and returned `success:false "command_failed: ripgrep exited 1"` for a legitimate zero-match result.

Fixes #29305