### PR TITLE
fix(plugin-agent-skills): use truncateWellFormed for fallback matchEvidence in scanCodeSource

### DIFF
--- a/plugins/plugin-agent-skills/src/security/skill-scanner.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-scanner.ts
@@ -3,6 +3,7 @@
  * Adapted from openclaw/src/security/skill-scanner.ts.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { LineRule, SkillScanFinding, SourceRule } from "./types";
 import { truncateEvidence } from "./types";
 
@@ -137,7 +138,7 @@ export function scanCodeSource(
 		}
 		if (matchLine === 0) {
 			matchLine = 1;
-			matchEvidence = source.slice(0, 120);
+			matchEvidence = truncateWellFormed(toWellFormedUnicode(source), 120);
 		}
 
 		findings.push({


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:4ba1e6c3eef4c9409db2720f50f92195cf38d717 -->

## Summary
In `@elizaos/plugin-agent-skills` (`plugins/plugin-agent-skills/src/security/skill-scanner.ts`):
`scanCodeSource` used raw `source.slice(0, 120)` when generating fallback `matchEvidence` for source-level findings where no single line matched. If code source files contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Replaced raw `source.slice(0, 120)` with `truncateWellFormed(toWellFormedUnicode(source), 120)` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-agent-skills/src/security/skill-scanner.test.ts plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts` (10/10 passed).
- Verified well-formed Unicode output during skill security scanning and evidence formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
