### PR TITLE
fix(ui): use truncateWellFormed in normalizeBaseUrl and ProfileForm name clamp

### DIFF
--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -5,6 +5,7 @@
  * without circular dependency issues.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import {
   extractAssistantReplyText,
@@ -267,7 +268,9 @@ type StreamChatState = {
 };
 
 function normalizeBaseUrl(value: string | null | undefined): string {
-  const trimmed = value?.slice(0, 4096).trim() ?? "";
+  if (!value) return "";
+  const wellFormed = toWellFormedUnicode(value);
+  const trimmed = truncateWellFormed(wellFormed, 4096).trim();
   let end = trimmed.length;
   while (end > 0 && trimmed.charCodeAt(end - 1) === 47) end--;
   return trimmed.slice(0, end);

--- a/packages/ui/src/cloud/account-security/components/profile-form.tsx
+++ b/packages/ui/src/cloud/account-security/components/profile-form.tsx
@@ -11,6 +11,7 @@
  * fields compose SettingsStack / SettingsGroup / SettingsInputRow.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { Loader2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -255,7 +256,7 @@ export function ProfileForm({ user }: ProfileFormProps) {
             label="Full name"
             type="text"
             value={name}
-            onValueChange={(value) => setName(value.slice(0, NAME_MAX_LENGTH))}
+            onValueChange={(value) => setName(truncateWellFormed(toWellFormedUnicode(value), NAME_MAX_LENGTH))}
             placeholder="Enter your full name"
             autoComplete="name"
             disabled={isPending}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:92bf9b512dbd313e48bcf1392bed036756ae2a4d -->

## Summary
In `@elizaos/ui`:
- `normalizeBaseUrl` (`packages/ui/src/api/client-base.ts`) clamped incoming base URLs using raw `value?.slice(0, 4096)`.
- `ProfileForm` (`packages/ui/src/cloud/account-security/components/profile-form.tsx`) clamped user full names using raw `value.slice(0, NAME_MAX_LENGTH)`.

When base URL strings or user full names contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(value), 4096)` in `normalizeBaseUrl`.
2. Used `truncateWellFormed(toWellFormedUnicode(value), NAME_MAX_LENGTH)` in `ProfileForm` `onValueChange`.

## Verification
- Ran vitest: `node packages/scripts/run-vitest.mjs run packages/ui/src/api/csrf-client.test.ts` (12/12 passed).
- Verified well-formed Unicode output during base URL resolution and user profile name entry.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
