### PR TITLE
fix(app): make active-view response context authoritative

### DIFF
--- a/packages/agent/src/api/builtin-views.test.ts
+++ b/packages/agent/src/api/builtin-views.test.ts
@@ -21,6 +21,9 @@ const SOURCE_ORDER_IDS = [
   "trajectories",
   "transcripts",
   "memories",
+  "files",
+  "stream",
+  "pendant-transcript",
   "database",
   "logs",
   "vault",
@@ -79,6 +82,9 @@ describe("BUILTIN_VIEWS", () => {
       "trajectories",
       "transcripts",
       "memories",
+      "files",
+      "stream",
+      "pendant-transcript",
       "database",
       "logs",
       "vault",
@@ -134,7 +140,16 @@ describe("BUILTIN_VIEWS", () => {
       "browser",
       "cloud-apps",
       "transcripts",
+      "files",
+      "stream",
+      "pendant-transcript",
     ]);
+  });
+
+  it("declares authoritative response context for every routable builtin", () => {
+    for (const view of BUILTIN_VIEWS.filter((entry) => entry.path)) {
+      expect(view.responseContext?.primaryContext, view.id).toBeTruthy();
+    }
   });
 
   it("marks developer views with both viewKind and developerOnly", () => {

--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -21,6 +21,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/camera",
     order: 3,
     tags: ["camera", "photo", "capture", "video", "vision"],
+    responseContext: { primaryContext: "media" },
     visibleInManager: true,
     desktopTabEnabled: true,
     platforms: ["android"],
@@ -35,6 +36,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     icon: "Flashlight",
     order: 4,
     tags: ["device", "flashlight", "torch", "hardware"],
+    responseContext: { primaryContext: "system" },
     capabilities: [
       {
         id: "set-flashlight",
@@ -65,6 +67,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/chat",
     order: 1,
     tags: ["messaging", "conversation", "agent"],
+    responseContext: { primaryContext: "general" },
     anticipatoryIntent:
       "Offer to pick up the most recent thread or surface anything the user left unfinished, and ask what they want to work on next.",
     visibleInManager: true,
@@ -80,6 +83,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/browser",
     order: 2,
     tags: ["browser", "web", "internet", "research", "tabs"],
+    responseContext: { primaryContext: "browser" },
     relatedActions: ["BROWSER"],
     visibleInManager: false,
     desktopTabEnabled: true,
@@ -96,6 +100,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/character",
     order: 50,
     tags: ["identity", "personality", "character"],
+    responseContext: { primaryContext: "character" },
     // CHARACTER/PERSONALITY are the semantic twins of the editor's field
     // writes; the scoped actions below add view-targeted fill/click verbs.
     relatedActions: ["CHARACTER", "PERSONALITY"],
@@ -197,6 +202,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
       "media",
       "attachments",
     ],
+    responseContext: { primaryContext: "documents" },
     // OWNER_DOCUMENTS is the personal-assistant signature/portal umbrella;
     // DOCUMENT (core documents feature) is the CRUD twin of the view's
     // upload/delete controls (#14369 guard mapping).
@@ -216,6 +222,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/automations",
     order: 55,
     tags: ["automation", "tasks", "scheduling"],
+    responseContext: { primaryContext: "automation" },
     // SCHEDULED_TASKS is the umbrella over the one scheduler (workflows are
     // ScheduledTask records); TRIGGER pairs the trigger editor (#14369).
     relatedActions: ["SCHEDULED_TASKS", "TRIGGER"],
@@ -233,6 +240,10 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/cloud-apps",
     order: 58,
     tags: ["cloud", "apps", "applications", "deploy", "monetize"],
+    responseContext: {
+      primaryContext: "connectors",
+      secondaryContexts: ["admin"],
+    },
     // The renderer registers the native studio in-process under this same id
     // and path. Keeping it in the server registry makes VIEWS/show resolve the
     // Projects Apps-segment navigation row instead of claiming an action that
@@ -258,6 +269,10 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
       "configuration",
       "extensions",
     ],
+    responseContext: {
+      primaryContext: "connectors",
+      secondaryContexts: ["settings"],
+    },
     // PLUGIN is the install/enable/configure twin of the plugin browser's
     // controls (#14369 guard mapping); RUNTIME stays per #13589.
     relatedActions: ["RUNTIME", "PLUGIN"],
@@ -276,6 +291,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/trajectories",
     order: 70,
     tags: ["training", "logs", "trajectories"],
+    responseContext: { primaryContext: "agent_internal" },
     visibleInManager: true,
   },
   {
@@ -293,6 +309,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/transcripts",
     order: 71,
     tags: ["transcript", "voice", "recording", "audio", "meeting"],
+    responseContext: { primaryContext: "documents" },
     anticipatoryIntent:
       "Offer to summarize or extract action items from the most recent voice transcripts, grounded in the recent-transcript count.",
     visibleInManager: false,
@@ -308,12 +325,52 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/memories",
     order: 72,
     tags: ["memory", "knowledge"],
+    responseContext: { primaryContext: "memory" },
     // MEMORY (op:create|search|update|delete) is the chat twin of the viewer's
     // browse/prune controls (#14366 closed it; #14369 pins the affinity).
     relatedActions: ["MEMORY"],
     anticipatoryIntent:
       "Offer to search, review, or prune the agent's stored memories, and point to what's worth revisiting.",
     visibleInManager: true,
+  },
+  {
+    id: "files",
+    viewKind: "system",
+    label: "Files",
+    description: "Stored files and attachments",
+    icon: "FolderOpen",
+    path: "/apps/files",
+    order: 73,
+    tags: ["files", "attachments", "uploads"],
+    responseContext: { primaryContext: "documents" },
+    visibleInManager: false,
+    desktopTabEnabled: true,
+  },
+  {
+    id: "stream",
+    viewKind: "system",
+    label: "Stream",
+    description: "Live activity and media stream",
+    icon: "Radio",
+    path: "/stream",
+    order: 74,
+    tags: ["stream", "live", "activity"],
+    responseContext: { primaryContext: "social_posting" },
+    visibleInManager: false,
+    desktopTabEnabled: true,
+  },
+  {
+    id: "pendant-transcript",
+    viewKind: "system",
+    label: "Pendant transcript",
+    description: "Live pendant voice transcript",
+    icon: "AudioLines",
+    path: "/pendant/transcript",
+    order: 75,
+    tags: ["pendant", "transcript", "voice"],
+    responseContext: { primaryContext: "documents" },
+    visibleInManager: false,
+    desktopTabEnabled: true,
   },
   {
     id: "database",
@@ -326,6 +383,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/database",
     order: 80,
     tags: ["database", "data", "debug"],
+    responseContext: { primaryContext: "system" },
     visibleInManager: true,
   },
   {
@@ -339,6 +397,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/logs",
     order: 81,
     tags: ["logs", "debug", "runtime"],
+    responseContext: { primaryContext: "system" },
     visibleInManager: true,
   },
   {
@@ -359,6 +418,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
       "connected accounts",
       "password manager",
     ],
+    responseContext: { primaryContext: "secrets" },
     relatedActions: ["SECRETS"],
     anticipatoryIntent:
       "Offer to inventory or safely configure the exact credential the user needs without exposing secret values, and distinguish local Vault entries from Eliza Cloud organization credentials.",
@@ -377,6 +437,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/settings",
     order: 90,
     tags: ["configuration", "preferences", "plugins"],
+    responseContext: { primaryContext: "system" },
     // SETTINGS is the consolidated section write action (#14364); RUNTIME
     // stays for the runtime/status affinity the #13589 stub migration pinned.
     relatedActions: ["RUNTIME", "SETTINGS"],
@@ -396,6 +457,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/background",
     order: 92,
     tags: ["background", "wallpaper", "color", "theme", "appearance", "image"],
+    responseContext: { primaryContext: "system" },
     // BACKGROUND is the one-write-two-triggers exemplar: the view controls and
     // the action drive the same store (#14369 pins the affinity).
     relatedActions: ["BACKGROUND"],

--- a/packages/agent/src/api/chat-view-metadata.test.ts
+++ b/packages/agent/src/api/chat-view-metadata.test.ts
@@ -35,6 +35,10 @@ const VIEWS = [
         authority: "human",
       },
     ],
+    responseContext: {
+      primaryContext: "health",
+      secondaryContexts: ["documents"],
+    },
     scopedActions: [
       {
         name: "HEALTH_OPEN_DETAIL",
@@ -82,6 +86,10 @@ describe("chat view metadata", () => {
         "OWNER_SCREENTIME",
         "HEALTH_OPEN_DETAIL",
       ],
+      __responseContext: {
+        primaryContext: "health",
+        secondaryContexts: ["documents"],
+      },
       keep: "caller-data",
     });
   });
@@ -103,6 +111,50 @@ describe("chat view metadata", () => {
     });
   });
 
+  it("does not trust renderer response context when the registry declares none", () => {
+    const neutralView = view({
+      id: "neutral",
+      label: "Neutral",
+      path: "/neutral",
+    });
+    expect(
+      enrichChatUiViewMetadata(
+        {
+          uiView: "neutral",
+          uiViewPath: "/neutral",
+          __responseContext: { primaryContext: "secrets" },
+        },
+        [...VIEWS, neutralView],
+      ),
+    ).toEqual({
+      uiView: "neutral",
+      uiViewPath: "/neutral",
+      uiViewCapabilities: [],
+      uiViewActionNames: [],
+    });
+  });
+
+  it("replaces a tampered response context with the registry declaration", () => {
+    expect(
+      enrichChatUiViewMetadata(
+        {
+          uiView: "health",
+          uiViewPath: "/health",
+          __responseContext: {
+            primaryContext: "wallet",
+            secondaryContexts: ["trading"],
+          },
+        },
+        VIEWS,
+      ),
+    ).toMatchObject({
+      __responseContext: {
+        primaryContext: "health",
+        secondaryContexts: ["documents"],
+      },
+    });
+  });
+
   it("does not reinterpret non-renderer or unknown-view metadata", () => {
     const apiMetadata = { requestId: "r1" };
     const unknown = {
@@ -114,10 +166,34 @@ describe("chat view metadata", () => {
     };
     expect(enrichChatUiViewMetadata(apiMetadata, VIEWS)).toBe(apiMetadata);
     expect(enrichChatUiViewMetadata(unknown, VIEWS)).toEqual({
-      uiView: "unknown",
-      uiViewPath: "/unknown",
       requestId: "r2",
     });
+  });
+
+  it("neutralizes unavailable views and their claimed response context", () => {
+    const unavailable = view({
+      id: "notes",
+      label: "Notes",
+      path: "/notes",
+      capabilities: [{ id: "read-notes", description: "Read notes" }],
+    });
+    unavailable.available = false;
+
+    expect(
+      enrichChatUiViewMetadata(
+        {
+          uiView: "notes",
+          uiViewPath: "/notes",
+          uiViewCapabilities: ["read-notes"],
+          __responseContext: {
+            primaryContext: "notes",
+            secondaryContexts: ["notes"],
+          },
+          uiTab: "views",
+        },
+        [...VIEWS, unavailable],
+      ),
+    ).toEqual({ uiTab: "views" });
   });
 
   it("strips action names when no authoritative renderer view resolves", () => {

--- a/packages/agent/src/api/chat-view-metadata.test.ts
+++ b/packages/agent/src/api/chat-view-metadata.test.ts
@@ -94,7 +94,7 @@ describe("chat view metadata", () => {
     });
   });
 
-  it("keeps renderer hints when a view has no declared capabilities", () => {
+  it("clears renderer hints when a registered view declares no capabilities", () => {
     expect(
       enrichChatUiViewMetadata(
         {
@@ -106,7 +106,7 @@ describe("chat view metadata", () => {
       ),
     ).toMatchObject({
       uiView: "chat",
-      uiViewCapabilities: ["general-chat"],
+      uiViewCapabilities: [],
       uiViewActionNames: [],
     });
   });

--- a/packages/agent/src/api/chat-view-metadata.ts
+++ b/packages/agent/src/api/chat-view-metadata.ts
@@ -72,6 +72,7 @@ export function resolveChatMetadataView(
   const candidatePath = normalizeViewPath(metadata.uiViewPath);
   if (candidatePath) {
     const byPath = views
+      .filter((view) => view.available !== false)
       .flatMap((view) => {
         const registeredPath = normalizeViewPath(view.path);
         return registeredPath && viewPathMatches(candidatePath, registeredPath)
@@ -84,7 +85,10 @@ export function resolveChatMetadataView(
 
   const candidateId = asString(metadata.uiView);
   if (!candidateId) return null;
-  return views.find((view) => view.id === candidateId) ?? null;
+  return (
+    views.find((view) => view.id === candidateId && view.available !== false) ??
+    null
+  );
 }
 
 /**
@@ -118,8 +122,13 @@ export function enrichChatUiViewMetadata(
 
   const view = resolveChatMetadataView(metadata, views);
   if (!view) {
-    const { uiViewCapabilities: _callerCapabilities, ...unresolvedMetadata } =
-      metadataWithoutActionNames;
+    const {
+      uiView: _callerView,
+      uiViewPath: _callerViewPath,
+      uiViewCapabilities: _callerCapabilities,
+      __responseContext: _callerResponseContext,
+      ...unresolvedMetadata
+    } = metadataWithoutActionNames;
     return unresolvedMetadata;
   }
 
@@ -133,9 +142,21 @@ export function enrichChatUiViewMetadata(
     ...(view.relatedActions ?? []),
     ...(view.scopedActions ?? []).map((action) => action.name),
   ]);
+  const declaredResponseContext = view.responseContext
+    ? {
+        primaryContext: view.responseContext.primaryContext,
+        secondaryContexts: uniqueStrings(
+          view.responseContext.secondaryContexts ?? [],
+        ),
+      }
+    : undefined;
+  const {
+    __responseContext: _callerResponseContext,
+    ...metadataWithoutResponseContext
+  } = metadataWithoutActionNames;
 
   return {
-    ...metadataWithoutActionNames,
+    ...metadataWithoutResponseContext,
     uiView: view.id,
     uiViewPath:
       normalizeViewPath(metadata.uiViewPath) ?? view.path ?? undefined,
@@ -144,5 +165,8 @@ export function enrichChatUiViewMetadata(
         ? declaredCapabilities
         : rendererCapabilities,
     uiViewActionNames: viewActionNames,
+    ...(declaredResponseContext
+      ? { __responseContext: declaredResponseContext }
+      : {}),
   };
 }

--- a/packages/agent/src/api/chat-view-metadata.ts
+++ b/packages/agent/src/api/chat-view-metadata.ts
@@ -15,14 +15,6 @@ function asString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function asStringList(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((entry) => {
-    const parsed = asString(entry);
-    return parsed ? [parsed] : [];
-  });
-}
-
 function uniqueStrings(values: readonly string[]): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
@@ -137,7 +129,6 @@ export function enrichChatUiViewMetadata(
       .filter((capability) => capability.authority !== "human")
       .map((capability) => capability.id),
   );
-  const rendererCapabilities = asStringList(metadata.uiViewCapabilities);
   const viewActionNames = uniqueStrings([
     ...(view.relatedActions ?? []),
     ...(view.scopedActions ?? []).map((action) => action.name),
@@ -160,10 +151,10 @@ export function enrichChatUiViewMetadata(
     uiView: view.id,
     uiViewPath:
       normalizeViewPath(metadata.uiViewPath) ?? view.path ?? undefined,
-    uiViewCapabilities:
-      declaredCapabilities.length > 0
-        ? declaredCapabilities
-        : rendererCapabilities,
+    // A resolved registry view is authoritative even when it declares zero
+    // capabilities. Falling back to renderer hints lets stale or invented
+    // names become planner facts for actions the server cannot execute.
+    uiViewCapabilities: declaredCapabilities,
     uiViewActionNames: viewActionNames,
     ...(declaredResponseContext
       ? { __responseContext: declaredResponseContext }

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -222,6 +222,7 @@ function makeRuntime(
 	}
 	return {
 		agentId: "00000000-0000-0000-0000-000000000003" as UUID,
+		getModelRegistrations: vi.fn(() => []),
 		character: {
 			name: "Test Agent",
 			system: "You are concise.",
@@ -3183,6 +3184,79 @@ describe("runV5MessageRuntimeStage1", () => {
 			expect(result.result.responseContent?.text).toBe("391");
 		}
 	});
+
+	it.each([
+		{
+			caseName: "currently-open adjective order",
+			prompt:
+				'Reply in one concise sentence beginning with "BUDGET-READONLY" and identify the currently open view. Do not use tools or change anything.',
+			reply:
+				"BUDGET-READONLY the notes view is open, where I can list notes or read one.",
+		},
+		{
+			caseName: "current-open adjective order",
+			prompt:
+				"Identify the current open view. Reply with the view name and exact nonce CEREBRAS-E1F-20260826-0952. Do not use tools or change anything.",
+			reply: "notes CEREBRAS-E1F-20260826-0952",
+		},
+	] as const)(
+		"keeps read-only current-view inspection direct when the view tool surface would overflow a planner call: $caseName",
+		async ({ prompt, reply }) => {
+			const runtime = makeRuntime([
+				stage1Response({
+					contexts: ["simple"],
+					replyText: reply,
+				}),
+			]);
+			const viewsHandler = vi.fn(async () => ({
+				success: true,
+				text: "unexpected navigation",
+			}));
+			runtime.actions = [
+				{
+					name: "VIEWS",
+					similes: ["VIEW", "SHOW_VIEW", "OPEN_VIEW", "OPEN_SETTINGS"],
+					tags: ["views", "ui", "panel", "view-capability", "notes"],
+					description: `Manage and navigate UI views. ${"x".repeat(500_000)}`,
+					parameters: [
+						{
+							name: "action",
+							description: "Operation",
+							required: true,
+							schema: { type: "string" },
+						},
+					],
+					examples: [],
+					validate: async () => true,
+					handler: viewsHandler,
+				},
+			] as never;
+			const message = makeMessage();
+			message.content = {
+				...message.content,
+				text: prompt,
+				mentionContext: { isMention: true },
+			};
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message,
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			});
+
+			expect(result.kind).toBe("direct_reply");
+			expect(viewsHandler).not.toHaveBeenCalled();
+			// The complete Stage-1 answer is the whole read-only turn. Adding the
+			// intentionally oversized tool definition to a planner request would cross
+			// the provider boundary, so this also fences the redundant-call overflow.
+			expect(useModelCalls(runtime)).toHaveLength(1);
+			expect(reportErrorCalls(runtime)).toHaveLength(0);
+			if (result.kind === "direct_reply") {
+				expect(result.result.responseContent?.text).toBe(reply);
+			}
+		},
+	);
 
 	it("keeps external-content armor out of deterministic action inference", async () => {
 		const directAnswer =

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -222,7 +222,6 @@ function makeRuntime(
 	}
 	return {
 		agentId: "00000000-0000-0000-0000-000000000003" as UUID,
-		getModelRegistrations: vi.fn(() => []),
 		character: {
 			name: "Test Agent",
 			system: "You are concise.",

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -958,6 +958,141 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 		).toEqual({ names: ["VIEWS"], kind: "view-navigation" });
 	});
 
+	it("does not treat read-only inspection of the already-open view as navigation", () => {
+		for (const message of [
+			"identify the currently open view",
+			"identify this open view and name two things available here",
+			"tell me which current screen I have open",
+			"name the active app view",
+			"Reply in one concise sentence and identify the currently open view. Do not use tools or change anything.",
+			"identify the current view; do not open anything",
+			"which current view is open? don't switch anything",
+			"name the current view and tell me what I can do here",
+			"identify the current view without closing it but don't switch anything",
+			"without closing the current window please don't open settings and identify the current view",
+			"without hiding this panel please don't pin it then name the active view",
+			"never close this window just don't switch to settings and identify the current view",
+			"identify the current view without accidentally closing it",
+			"name the active view and do not ever hide it",
+			"Identify the current open view. Reply with the view name and exact nonce CEREBRAS-E1F-20260826-0952. Do not use tools or change anything.",
+			"identify the current active view",
+			"name the open panel",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference([viewsAction], message),
+			).toEqual({ names: [], kind: null });
+		}
+	});
+
+	it.each([
+		[
+			"create / and / inspection-first",
+			"identify the current view and add a new panel",
+		],
+		["read / comma / action-first", "show settings, identify the current view"],
+		[
+			"update / semicolon / inspection-first",
+			"name the active view; change the layout",
+		],
+		[
+			"delete / period / action-first",
+			"remove this panel. identify the current view",
+		],
+		[
+			"open / and / action-first",
+			"open settings and tell me which current view is active",
+		],
+		[
+			"open / question / inspection-first",
+			"which current view is open? switch to settings",
+		],
+		[
+			"open / embedded / inspection-first",
+			"identify and open the current view",
+		],
+		[
+			"open / current-open adjective / inspection-first",
+			"identify the current open view and open settings",
+		],
+		[
+			"close / and / inspection-first",
+			"identify the current view and close it",
+		],
+		[
+			"close / embedded / inspection-first",
+			"identify and close the current view",
+		],
+		[
+			"close / comma / action-first",
+			"dismiss the active window, then name the current view",
+		],
+		["close / newline / inspection-first", "name the current view\nhide it"],
+		[
+			"layout / semicolon / action-first",
+			"arrange the windows; identify the current view",
+		],
+		[
+			"layout / then / inspection-first",
+			"identify the current view, then split it right",
+		],
+		[
+			"layout / period / action-first",
+			"tile the windows. name the active view",
+		],
+		["pin / comma / inspection-first", "name the active panel, then pin it"],
+		[
+			"pin / and / action-first",
+			"dock the view and identify the current panel",
+		],
+		[
+			"adversative but / inspection-first",
+			"identify the current view without closing it but switch to settings",
+		],
+		[
+			"adversative but after semicolon / inspection-first",
+			"name the active view; never hide it but split it right",
+		],
+		[
+			"adversative but / action-first",
+			"do not close this window but switch to settings, then identify the current view",
+		],
+		[
+			"adversative however / action-first",
+			"don't hide this panel; however, pin it, then name the active view",
+		],
+		[
+			"adversative yet / inspection-first",
+			"identify the current view and never close it, yet open settings",
+		],
+		[
+			"unpunctuated without / action-first",
+			"without closing the current window please open settings and identify the current view",
+		],
+		[
+			"unpunctuated without then / action-first",
+			"without hiding this panel please pin it then name the active view",
+		],
+		[
+			"unpunctuated never / action-first",
+			"never close this window just switch to settings and identify the current view",
+		],
+		[
+			"negated inspection / open",
+			"do not identify the current view just open settings",
+		],
+		[
+			"negated inspection / switch",
+			"do not name the active view just switch to settings",
+		],
+	] as const)(
+		"preserves actionable current-view compound: %s",
+		(_case, message) => {
+			expect(
+				inferDirectCurrentRequestCandidateInference([viewsAction], message),
+			).toEqual({ names: ["VIEWS"], kind: "view-surface" });
+		},
+	);
+
 	it("routes explicit voice preference writes to SETTINGS ahead of view navigation", () => {
 		const settingsAction: Pick<Action, "name" | "similes" | "tags"> = {
 			name: "SETTINGS",

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1845,7 +1845,12 @@ function findViewShellActionName(
 	actions: ReadonlyArray<Pick<Action, "name" | "tags">>,
 	messageText: string,
 ): string | undefined {
-	if (looksLikeInstructionalViewQuestion(messageText)) return undefined;
+	if (
+		looksLikeInstructionalViewQuestion(messageText) ||
+		looksLikeCurrentViewInspection(messageText)
+	) {
+		return undefined;
+	}
 	const viewActionName = findViewsActionName(actions);
 	if (!viewActionName) return undefined;
 
@@ -1889,7 +1894,12 @@ function findViewCapabilityActionName(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
 ): string | undefined {
-	if (looksLikeInstructionalViewQuestion(messageText)) return undefined;
+	if (
+		looksLikeInstructionalViewQuestion(messageText) ||
+		looksLikeCurrentViewInspection(messageText)
+	) {
+		return undefined;
+	}
 	const viewActionName = findViewsActionName(actions);
 	if (!viewActionName) return undefined;
 	const viewActions = collectViewActionMetadataEntries(actions, viewActionName);
@@ -1970,6 +1980,131 @@ function looksLikeInstructionalViewQuestion(messageText: string): boolean {
 	// message-routing-live-regression.test.ts).
 	return /^\s*(?:explain|describe|teach|what\s+(?:is|are)|how\s+(?:do|can|to)\b)/iu.test(
 		messageText,
+	);
+}
+
+/**
+ * A read-only question about the view that is already open is not a navigation
+ * command. The view detector otherwise reads the adjective "open" as an
+ * imperative operation and promotes an already-complete Stage-1 answer into a
+ * full planner call. Besides wasting a second model round, that false promotion
+ * can add the complete action catalog to a prompt that no longer fits the
+ * provider context window.
+ *
+ * Keep the guard deliberately grammatical: an inspection verb must precede a
+ * deictic/current-view noun phrase. Any non-negated view operation anywhere in
+ * the request is still actionable and falls through, regardless of clause
+ * order or separator.
+ */
+function looksLikeCurrentViewInspection(messageText: string): boolean {
+	const normalized = messageText.replace(/\s+/gu, " ").trim();
+	const inspectionSpans = [
+		...normalized.matchAll(
+			/\b(?:identify|name|tell\s+me|what|which)\b[^,;.!?\n]{0,160}?\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active|open)\s+(?:app\s+)?(?:panel|screen|ui|view|window)\b(?:\s+(?:(?:is|remains?|stays?)\s+(?:active|open)|i\s+have\s+open))?/giu,
+		),
+	].map((match) => ({
+		start: match.index ?? 0,
+		end: (match.index ?? 0) + match[0].length,
+	}));
+	if (inspectionSpans.length === 0) return false;
+
+	const operationOccurrences = [...normalized.matchAll(/\b[A-Za-z]+\b/gu)]
+		.map((match) => {
+			const word = match[0].toUpperCase();
+			const candidates = [word];
+			for (const suffix of ["ING", "ED", "ES", "S"] as const) {
+				if (!word.endsWith(suffix) || word.length <= suffix.length + 1)
+					continue;
+				const stem = word.slice(0, -suffix.length);
+				candidates.push(stem, `${stem}E`);
+				if (/([A-Z])\1$/u.test(stem)) candidates.push(stem.slice(0, -1));
+			}
+			const token = candidates.find(
+				(candidate) =>
+					candidate !== "WHAT" &&
+					candidate !== "WHICH" &&
+					VIEW_REQUEST_OPERATION_TOKENS.has(candidate),
+			);
+			if (!token) return undefined;
+			return {
+				token,
+				index: match.index ?? 0,
+			};
+		})
+		.filter(
+			(
+				event,
+			): event is {
+				token: string;
+				index: number;
+			} => event !== undefined,
+		);
+	for (const operation of operationOccurrences) {
+		const operationToken = operation.token;
+		const operationIndex = operation.index;
+		const beforeOperation = normalized.slice(0, operationIndex);
+		// OPEN is also an adjective/state in genuine inspection phrases. Exempt
+		// only those grammatical uses; an imperative OPEN elsewhere (including
+		// inside a longer inspection-looking clause) remains actionable.
+		if (
+			operationToken === "OPEN" &&
+			inspectionSpans.some(
+				(span) => operationIndex >= span.start && operationIndex < span.end,
+			) &&
+			/\b(?:are|current|currently|have|is|remains?|stays?|the|this|was|were)\s*$/iu.test(
+				beforeOperation,
+			)
+		) {
+			continue;
+		}
+		if (
+			isViewOperationLocallyNegated(normalized, operationIndex, operationToken)
+		) {
+			continue;
+		}
+		return false;
+	}
+	return true;
+}
+
+function isViewOperationLocallyNegated(
+	messageText: string,
+	operationIndex: number,
+	operationToken: string,
+): boolean {
+	const prefix = messageText.slice(
+		Math.max(0, operationIndex - 120),
+		operationIndex,
+	);
+	const localNegation = prefix.match(
+		/\b(?:without|never|do\s+not|don't)((?:\s+[A-Za-z]+){0,3})\s*$/iu,
+	);
+	if (localNegation) {
+		const modifiers = (localNegation[1] ?? "")
+			.trim()
+			.toUpperCase()
+			.split(/\s+/u)
+			.filter(Boolean);
+		const modifierOnly = modifiers.every(
+			(token) =>
+				token === "ALL" ||
+				token === "AT" ||
+				token === "EVER" ||
+				token === "JUST" ||
+				token === "PLEASE" ||
+				token.endsWith("LY"),
+		);
+		if (modifierOnly) return true;
+	}
+
+	// Preserve the explicit read-only acceptance constraint. This is modeled
+	// negative coordination, not free-floating polarity: the marker governs USE
+	// and the following CHANGE through a concrete "tools or" coordination.
+	return (
+		operationToken === "CHANGE" &&
+		/\b(?:do\s+not|don't|never)\s+(?:use|invoke|call)\s+(?:any\s+)?tools?\s+(?:or|nor)\s*$/iu.test(
+			prefix,
+		)
 	);
 }
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -925,6 +925,15 @@ export interface ViewDeclaration {
 	/** Tags for search and discovery (e.g. ["finance", "crypto"]). */
 	tags?: string[];
 	/**
+	 * Registry-owned response routing while this view is foreground. The server
+	 * replaces renderer-supplied context with this declaration, so chat and
+	 * voice share one truthful view contract.
+	 */
+	responseContext?: {
+		primaryContext: AgentContext;
+		secondaryContexts?: AgentContext[];
+	};
+	/**
 	 * Runtime action names especially relevant while this view is foreground.
 	 * Hosts use these as view-scoped affinity hints so plugins keep their own
 	 * view -> action relationship with the view declaration. Weighting only —

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -231,6 +231,7 @@ export const appControlPlugin: Plugin = {
 			description: "Browse and open available views contributed by plugins",
 			icon: "LayoutGrid",
 			path: "/views",
+			responseContext: { primaryContext: "system" },
 			modalities: ["gui"],
 			bundlePath: "dist/views/bundle.js",
 			// First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-blocker/src/plugin.ts
+++ b/plugins/plugin-blocker/src/plugin.ts
@@ -47,6 +47,7 @@ export const blockerPlugin: Plugin = {
         "Website + app blocking schedule and active session controls",
       icon: "ShieldOff",
       path: "/focus",
+      responseContext: { primaryContext: "productivity" },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-calendar/src/plugin.ts
+++ b/plugins/plugin-calendar/src/plugin.ts
@@ -71,6 +71,7 @@ export const calendarPlugin: Plugin = {
       },
       componentExport: "CalendarView",
       tags: ["calendar", "schedule", "events"],
+      responseContext: { primaryContext: "calendar" },
       relatedActions: ["CALENDAR", "CALENDAR_SOURCES", "CONFLICT_DETECT"],
       visibleInManager: true,
       desktopTabEnabled: true,

--- a/plugins/plugin-computeruse/src/index.ts
+++ b/plugins/plugin-computeruse/src/index.ts
@@ -176,6 +176,10 @@ export const computerUsePlugin: Plugin = {
         "Live host, browser, sandbox, and remote-guest computer-use sessions",
       icon: "MonitorUp",
       path: "/computer-use-sessions",
+      responseContext: {
+        primaryContext: "system",
+        secondaryContexts: ["browser"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       surface: { capabilities: ["agent-surface"] },

--- a/plugins/plugin-contacts/src/plugin.ts
+++ b/plugins/plugin-contacts/src/plugin.ts
@@ -35,6 +35,7 @@ export const appContactsPlugin: Plugin = {
       surface: { capabilities: ["agent-surface"] },
       componentExport: "ContactsView",
       tags: ["contacts", "android", "address-book"],
+      responseContext: { primaryContext: "contacts" },
       visibleInManager: true,
       desktopTabEnabled: true,
       nativeOs: true,

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -341,6 +341,10 @@ export const elizaOSCloudPlugin: Plugin = {
         "Your Eliza Cloud account — credits, hosted agents, API keys, and billing",
       icon: "Cloud",
       path: "/cloud",
+      responseContext: {
+        primaryContext: "admin",
+        secondaryContexts: ["settings"],
+      },
       // Plain array literal on purpose: plugin.ts is not part of the view
       // bundle, and a core runtime export reaching the bundle build breaks it
       // (the wallet-ui lesson).

--- a/plugins/plugin-finances/src/plugin.ts
+++ b/plugins/plugin-finances/src/plugin.ts
@@ -33,6 +33,7 @@ export const financesPlugin: Plugin = {
         "Owner finance dashboard — balance, transactions, recurring charges",
       icon: "CircleDollarSign",
       path: "/finances",
+      responseContext: { primaryContext: "finance" },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-goals/src/plugin.ts
+++ b/plugins/plugin-goals/src/plugin.ts
@@ -39,6 +39,10 @@ export const goalsPlugin: Plugin = {
         "Life goals, routines, today's reminders and alarms, self-care check-in.",
       icon: "Target",
       path: "/goals",
+      responseContext: {
+        primaryContext: "goals",
+        secondaryContexts: ["productivity"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-health/src/index.ts
+++ b/plugins/plugin-health/src/index.ts
@@ -80,6 +80,7 @@ export const healthPlugin: Plugin = {
         "Sleep, circadian, screen-time, activity, and connector status.",
       icon: "Heart",
       path: "/health",
+      responseContext: { primaryContext: "health" },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-inbox/src/plugin.ts
+++ b/plugins/plugin-inbox/src/plugin.ts
@@ -64,6 +64,10 @@ export const inboxPlugin: Plugin = {
       description: "Cross-channel inbox triage",
       icon: "Inbox",
       path: "/inbox",
+      responseContext: {
+        primaryContext: "messaging",
+        secondaryContexts: ["email"],
+      },
       // The shipped view is GUI-only. `modalities` is a plain literal here
       // (plugin.ts is not in the view bundle).
       modalities: ["gui"],

--- a/plugins/plugin-maps/src/plugin.ts
+++ b/plugins/plugin-maps/src/plugin.ts
@@ -36,6 +36,7 @@ export const mapsPlugin: Plugin = {
         "Explore places, compare route alternatives, and hand off map actions to Eliza.",
       icon: "Map",
       path: "/maps",
+      responseContext: { primaryContext: "world" },
       order: 925,
       viewKind: "release",
       modalities: ["gui"],

--- a/plugins/plugin-messages/src/plugin.ts
+++ b/plugins/plugin-messages/src/plugin.ts
@@ -36,6 +36,7 @@ export const appMessagesPlugin: Plugin = {
       surface: { capabilities: ["agent-surface"] },
       componentExport: "MessagesView",
       tags: ["messaging", "sms", "android"],
+      responseContext: { primaryContext: "messaging" },
       visibleInManager: true,
       desktopTabEnabled: true,
       nativeOs: true,

--- a/plugins/plugin-notes/src/plugin.ts
+++ b/plugins/plugin-notes/src/plugin.ts
@@ -62,6 +62,7 @@ export const notesPlugin: Plugin = {
         "scratchpad",
         "view switching",
       ],
+      responseContext: { primaryContext: "notes" },
       bundlePath: "dist/views/bundle.js",
       componentExport: "NotesView",
       surface: { header: "fullscreen" },

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -812,6 +812,10 @@ const rawPersonalAssistantPlugin: Plugin = {
         "Connect, seed, inspect, and recover Gmail, Google Calendar, and Apple Calendar.",
       icon: "Cable",
       path: "/lifeops/connections",
+      responseContext: {
+        primaryContext: "connectors",
+        secondaryContexts: ["email", "calendar"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       surface: { header: "fullscreen", capabilities: ["agent-surface"] },

--- a/plugins/plugin-phone/src/plugin.ts
+++ b/plugins/plugin-phone/src/plugin.ts
@@ -45,6 +45,7 @@ export const appPhonePlugin: Plugin = {
       surface: { capabilities: ["agent-surface"] },
       componentExport: "PhoneView",
       tags: ["phone", "calls", "android"],
+      responseContext: { primaryContext: "phone" },
       visibleInManager: true,
       desktopTabEnabled: true,
       nativeOs: true,

--- a/plugins/plugin-relationships/src/plugin.ts
+++ b/plugins/plugin-relationships/src/plugin.ts
@@ -32,6 +32,10 @@ export const relationshipsPlugin: Plugin = {
         "Entity and relationship knowledge-graph viewer: people, organizations, identities, and the typed edges between them.",
       icon: "Users",
       path: "/relationships",
+      responseContext: {
+        primaryContext: "social",
+        secondaryContexts: ["memory"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -246,6 +246,10 @@ export const schedulingPlugin: Plugin = {
         "Connect your model and accounts, then run a real LifeOps validation and watch it fire.",
       icon: "FlaskConical",
       path: "/lifeops-live-test",
+      responseContext: {
+        primaryContext: "automation",
+        secondaryContexts: ["calendar"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -235,6 +235,10 @@ const taskCoordinatorPlugin: Plugin = {
       description: "Coding agent task threads, sessions, and controls",
       icon: "SquareTerminal",
       path: "/task-coordinator",
+      responseContext: {
+        primaryContext: "code",
+        secondaryContexts: ["automation"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       componentExport: "TaskCoordinatorView",
@@ -294,6 +298,10 @@ const taskCoordinatorPlugin: Plugin = {
       description: "Multi-agent task orchestration workbench",
       icon: "Layers",
       path: "/orchestrator",
+      responseContext: {
+        primaryContext: "code",
+        secondaryContexts: ["automation", "admin"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the
@@ -318,6 +326,10 @@ const taskCoordinatorPlugin: Plugin = {
       description: "Mobile-first coding cockpit — your agents on one screen",
       icon: "TerminalSquare",
       path: "/cockpit",
+      responseContext: {
+        primaryContext: "code",
+        secondaryContexts: ["automation"],
+      },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-todos/src/index.ts
+++ b/plugins/plugin-todos/src/index.ts
@@ -16,6 +16,7 @@ export const todosPlugin: Plugin = {
       description: "Three-lane todo board: Today / Upcoming / Someday",
       icon: "ListChecks",
       path: "/todos",
+      responseContext: { primaryContext: "todos" },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the

--- a/plugins/plugin-trajectory-logger/src/plugin.ts
+++ b/plugins/plugin-trajectory-logger/src/plugin.ts
@@ -26,6 +26,7 @@ const trajectoryLoggerPlugin: Plugin = {
         "Realtime view of the agent's last and pending HANDLE / PLAN / ACTION / EVALUATE turns",
       icon: "Activity",
       path: "/trajectory-logger",
+      responseContext: { primaryContext: "agent_internal" },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       componentExport: "TrajectoryLoggerView",

--- a/plugins/plugin-wallet/src/ui/plugin.ts
+++ b/plugins/plugin-wallet/src/ui/plugin.ts
@@ -40,6 +40,7 @@ export const walletAppPlugin: Plugin = {
       description: "Non-custodial wallet inventory and token balances",
       icon: "Wallet",
       path: "/wallet",
+      responseContext: { primaryContext: "wallet" },
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       // First-party instrumented view (data-agent-id controls): grant the


### PR DESCRIPTION
## Summary

Current-develop extraction of the two still-useful source contracts from #29278. The original branch's broad UI/chat/notes/demo changes are intentionally excluded because #29064 and later merged repairs superseded them.

- declare typed response context on the canonical view registry and first-party views
- resolve only available registered views, discard unresolved renderer view claims, and replace caller-supplied response context/capabilities with registry-owned values
- keep read-only questions about the already-open view on the direct-answer path instead of incorrectly offering the navigation tool (including oversized-tool regression coverage)

## Verification

Exact source: `a55e9f57dd9e4c2cbc4ee4b351b9a0309605ce2f`
Base: `b9d9c7488a42d73a1a5ac3b92f55aee845559f22`

- direct-action heuristics: 120/120
- focused Stage-1 current-view overflow cases: 2/2
- builtin-view and chat-view metadata: 35/35
- `packages/core` typecheck: pass
- `packages/agent` typecheck: pass
- Biome on all 28 changed TS files: pass
- `git diff --check`: pass

Closes the remaining source-contract portion of #29278 without replaying its stale design-review assets, chat chrome, notes, launcher, character-route, or conflicted UI changes.