### PR TITLE
fix(i18n): catalog browser more-actions label

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -444,6 +444,7 @@
   "browserworkspace.LastSeen": "Last seen {{time}}",
   "browserworkspace.LoadFailed": "Failed to load browser workspace.",
   "browserworkspace.Loading": "Loading browser workspace",
+  "browserworkspace.MoreActions": "More browser actions",
   "browserworkspace.NewTab": "New tab",
   "browserworkspace.NoActiveTab": "No tab",
   "browserworkspace.NoAgentTabs": "No Agent Tabs",


### PR DESCRIPTION
Closes #29378.

## Summary

- catalogs the existing `browserworkspace.MoreActions` accessible label in the English source locale
- restores the `Validate i18n source catalog contract` gate on `develop`

## Verification

- `node packages/app-core/scripts/check-i18n.mjs`
- `bun x @biomejs/biome check packages/ui/src/i18n/locales/en.json`
- `git diff --check`