### PR TITLE
fix(plugin-local-inference): use truncateWellFormed for auth header clamping and sha256 logging

### DIFF
--- a/plugins/plugin-local-inference/src/routes/compat-helpers.ts
+++ b/plugins/plugin-local-inference/src/routes/compat-helpers.ts
@@ -12,7 +12,7 @@
 import crypto from "node:crypto";
 import type http from "node:http";
 import { isIP } from "node:net";
-import type { AgentRuntime } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed, type AgentRuntime } from "@elizaos/core";
 import {
 	isLoopbackBindHost,
 	readAliasedEnv,
@@ -40,9 +40,10 @@ export function getCompatApiToken(): string | null {
 export function getProvidedApiToken(
 	req: Pick<http.IncomingMessage, "headers">,
 ): string | null {
-	const authHeader = firstHeaderValue(req.headers.authorization)
-		?.slice(0, 1024)
-		.trim();
+	const rawAuth = firstHeaderValue(req.headers.authorization);
+	const authHeader = rawAuth
+		? truncateWellFormed(toWellFormedUnicode(rawAuth), 1024).trim()
+		: undefined;
 	if (authHeader) {
 		const match = /^Bearer\s{1,8}(.+)$/i.exec(authHeader);
 		if (match?.[1]) return match[1].trim();

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -21,7 +21,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { Readable, type Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { ensureDefaultAssignment } from "./assignments";
 import {
 	buildHuggingFaceResolveUrlCandidatesForPath,
@@ -530,10 +530,11 @@ async function resumableStartByte(
 		recorded = undefined;
 	}
 	if (recorded === expectedSha256) return size;
+	const recPreview = recorded ? `sha256 ${truncateWellFormed(toWellFormedUnicode(recorded), 12)}…` : "unknown content";
+	const expPreview = truncateWellFormed(toWellFormedUnicode(expectedSha256), 12);
 	logger.warn(
 		`[Downloader] discarding stale partial ${path.basename(stagingPath)} ` +
-			`(started against ${recorded ? `sha256 ${recorded.slice(0, 12)}…` : "unknown content"}, ` +
-			`manifest now expects ${expectedSha256.slice(0, 12)}…)`,
+			`(started against ${recPreview}, manifest now expects ${expPreview}…)`,
 	);
 	// error-policy:J6 best-effort discard of a stale partial + its sidecar; a
 	// cleanup failure just means we redownload from 0 (return 0), never accept it.
@@ -1509,9 +1510,11 @@ export class Downloader {
 					}
 					// Same filename, different content: the hub re-published this
 					// path. The stale blob must never be kept — discard and re-fetch.
+					const currPreview = truncateWellFormed(toWellFormedUnicode(currentSha256), 12);
+					const expRemotePreview = truncateWellFormed(toWellFormedUnicode(expectedSha256), 12);
 					logger.warn(
 						`[Downloader] stale ${remotePath} on disk ` +
-							`(sha256 ${currentSha256.slice(0, 12)}… != manifest ${expectedSha256.slice(0, 12)}…); re-downloading`,
+							`(sha256 ${currPreview}… != manifest ${expRemotePreview}…); re-downloading`,
 					);
 					await fsp.rm(finalPath, { force: true });
 				}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9ac9cf1d4d974737c7e099e455950b01eacd63ac -->

## Summary
In `@elizaos/plugin-local-inference`:
- `getProvidedApiToken` (`plugins/plugin-local-inference/src/routes/compat-helpers.ts`) clamped incoming Authorization headers using raw `?.slice(0, 1024)`.
- `Downloader` (`plugins/plugin-local-inference/src/services/downloader.ts`) clamped partial file and expected SHA256 hashes using raw `.slice(0, 12)`.

When headers or hash strings contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(...), 1024)` for authorization header reading in `compat-helpers.ts`.
2. Used `truncateWellFormed(toWellFormedUnicode(...), 12)` for SHA-256 warning log previews in `downloader.ts`.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts` (5/5 passed).
- Verified well-formed Unicode output during API token extraction and downloader hash mismatch warnings.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
