### PR TITLE
fix(plugin-local-inference): prevent severing UTF-16 surrogate pairs at stream filter chunk boundary

### DIFF
--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
@@ -49,9 +49,15 @@ function createThinkTagStreamFilter(): {
 
 			const openAt = indexOfIgnoreCase(buffer, openMarker);
 			if (openAt === -1) {
-				const emitLength = final
+				let emitLength = final
 					? buffer.length
 					: Math.max(0, buffer.length - safeOpenTail);
+				if (!final && emitLength > 0 && emitLength < buffer.length) {
+					const code = buffer.charCodeAt(emitLength - 1);
+					if (code >= 0xd800 && code <= 0xdbff) {
+						emitLength -= 1;
+					}
+				}
 				if (emitLength > 0) {
 					out.push(buffer.slice(0, emitLength));
 					buffer = buffer.slice(emitLength);


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:849d5b8147a1f68b15176b61dbb9f955a64c3e49 -->

## Summary
In `@elizaos/plugin-local-inference` (`plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts`):
`createThinkTagStreamFilter` emitted non-final chunks by calculating `emitLength = Math.max(0, buffer.length - safeOpenTail)`. If `buffer[emitLength - 1]` happened to be a UTF-16 high surrogate (code `0xD800..0xDBFF`), slicing at `emitLength` split the surrogate pair across two yielded stream chunks, producing temporary lone surrogates in streaming downstreams.

## Proposed Changes
1. Added high-surrogate detection on `emitLength - 1` when `emitLength < buffer.length`, decrementing `emitLength` by 1 to retain the whole surrogate pair in `buffer` for the next chunk.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts` (5/5 passed).
- Verified chunk boundaries preserve UTF-16 surrogate pairs during streaming text generation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
