### PR TITLE
fix(cloud): harden inference standing fast path

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -246,6 +246,34 @@ describe("Miniflare Durable Object integration", () => {
     expect([first.status, second.status].sort()).toEqual([200, 402]);
   }, 120_000);
 
+  test("credential checks bypass a blocked billing queue on the same object", async () => {
+    expect((await post("/test-block-billing-queue", {})).status).toBe(202);
+    const credentialCheck = await Promise.race([
+      post("/credential/check", {
+        organizationId: "org-miniflare",
+        kind: "api_key",
+        credentialId: "00000000-0000-0000-0000-000000000104",
+        userId: "00000000-0000-0000-0000-000000000204",
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("credential check waited behind billing")),
+          500,
+        );
+      }),
+    ]);
+    expect(credentialCheck.status).toBe(200);
+    expect((await post("/test-release-billing-queue", {})).status).toBe(204);
+  });
+
+  test("the revocation queue preserves read-write ordering", async () => {
+    const response = await post("/test-revocation-queue-order", {});
+    expect(response.status).toBe(200);
+    expect(JSON.parse(await response.text())).toEqual({
+      order: ["first:start", "first:end", "second"],
+    });
+  });
+
   test("independent callers observe API-key revocation immediately", async () => {
     const credential = {
       organizationId: "org-miniflare",

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -182,6 +182,21 @@ function createGate(
   return new InferenceAdmissionGate(state, env as never);
 }
 
+class QueueTestGate extends InferenceAdmissionGate {
+  runBillingQueueOperation(operation: () => Promise<void>): Promise<void> {
+    return this.serialize(operation);
+  }
+
+  runRevocationQueueOperation(operation: () => Promise<void>): Promise<void> {
+    return this.serializeRevocation(operation);
+  }
+}
+
+function createQueueTestGate(storage = new TestStorage()): QueueTestGate {
+  const state = { storage } as unknown as DurableObjectState;
+  return new QueueTestGate(state, {} as never);
+}
+
 function post(
   gate: InferenceAdmissionGate,
   path:
@@ -193,7 +208,13 @@ function post(
     | "/rate-limit"
     | "/rate-limit-v2-cutover"
     | "/rate-limit-warm"
-    | "/rate-limit-handoff",
+    | "/rate-limit-handoff"
+    | "/credential/check"
+    | "/credential/revoke"
+    | "/subject/set-active"
+    | "/session/revoke-through"
+    | "/session/set-binding-active"
+    | "/organization/set-active",
   body: Record<string, unknown>,
 ): Promise<Response> {
   const payload =
@@ -318,6 +339,71 @@ describe("InferenceAdmissionGate", () => {
   afterAll(() => {
     recoverExpiredLease.mockRestore();
     getOrganizationBalanceSnapshot.mockRestore();
+  });
+
+  test("credential checks do not wait behind a blocked billing operation", async () => {
+    const gate = createQueueTestGate();
+    let enterBilling: () => void = () => undefined;
+    const billingEntered = new Promise<void>((resolve) => {
+      enterBilling = resolve;
+    });
+    let releaseBilling: () => void = () => undefined;
+    const billingReleased = new Promise<void>((resolve) => {
+      releaseBilling = resolve;
+    });
+    const blockedBilling = gate.runBillingQueueOperation(async () => {
+      enterBilling();
+      await billingReleased;
+    });
+    await billingEntered;
+
+    const response = await Promise.race([
+      post(gate, "/credential/check", {
+        organizationId: "org-a",
+        kind: "api_key",
+        credentialId: "key-a",
+        userId: "user-a",
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("credential check waited behind billing")),
+          100,
+        );
+      }),
+    ]);
+    expect(response.status).toBe(200);
+
+    releaseBilling();
+    await blockedBilling;
+  });
+
+  test("revocation reads and writes retain one ordered queue", async () => {
+    const gate = createQueueTestGate();
+    const order: string[] = [];
+    let enterFirst: () => void = () => undefined;
+    const firstEntered = new Promise<void>((resolve) => {
+      enterFirst = resolve;
+    });
+    let releaseFirst: () => void = () => undefined;
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = gate.runRevocationQueueOperation(async () => {
+      order.push("first:start");
+      enterFirst();
+      await firstReleased;
+      order.push("first:end");
+    });
+    await firstEntered;
+    const second = gate.runRevocationQueueOperation(async () => {
+      order.push("second");
+    });
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second"]);
   });
 
   test("serializes and persists an exact fixed endpoint window", async () => {

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -477,6 +477,9 @@ export class InferenceAdmissionGate {
   private ledger: GateLedger | undefined;
   private rateLimitWindows: RateLimitWindows | undefined;
   private operationQueue: Promise<void> = Promise.resolve();
+  // Credential decisions and lifecycle fences must remain ordered with each
+  // other, but may not wait behind slower billing lease or settlement work.
+  private revocationOperationQueue: Promise<void> = Promise.resolve();
   // This queue orders calls within a rate-only identity. Cross-lane isolation
   // comes from the distinct Durable Object identity selected by the caller.
   private rateLimitOperationQueue: Promise<void> = Promise.resolve();
@@ -671,10 +674,26 @@ export class InferenceAdmissionGate {
     return Response.json({ cutoverAt });
   }
 
-  private async serialize<T>(operation: () => Promise<T>): Promise<T> {
+  protected async serialize<T>(operation: () => Promise<T>): Promise<T> {
     const previous = this.operationQueue;
     let release: () => void = () => undefined;
     this.operationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  protected async serializeRevocation<T>(
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.revocationOperationQueue;
+    let release: () => void = () => undefined;
+    this.revocationOperationQueue = new Promise<void>((resolve) => {
       release = resolve;
     });
     await previous;
@@ -1281,32 +1300,32 @@ export class InferenceAdmissionGate {
       );
     }
     if (path === "/credential/check") {
-      return await this.serialize(() =>
+      return await this.serializeRevocation(() =>
         this.credentialCheck(body as CredentialCheckRequest),
       );
     }
     if (path === "/credential/revoke") {
-      return await this.serialize(() =>
+      return await this.serializeRevocation(() =>
         this.revokeCredential(body as CredentialRevokeRequest),
       );
     }
     if (path === "/subject/set-active") {
-      return await this.serialize(() =>
+      return await this.serializeRevocation(() =>
         this.setSubjectActive(body as SubjectStateRequest),
       );
     }
     if (path === "/session/revoke-through") {
-      return await this.serialize(() =>
+      return await this.serializeRevocation(() =>
         this.revokeSessionsThrough(body as SessionRevokeRequest),
       );
     }
     if (path === "/session/set-binding-active") {
-      return await this.serialize(() =>
+      return await this.serializeRevocation(() =>
         this.setSessionBindingActive(body as SessionBindingStateRequest),
       );
     }
     if (path === "/organization/set-active") {
-      return await this.serialize(() =>
+      return await this.serializeRevocation(() =>
         this.setOrganizationActive(body as OrganizationStateRequest),
       );
     }

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -906,6 +906,44 @@ describe("requireGenerativeRouteCaller", () => {
     });
   });
 
+  test("returns the cached account-standing reason without another lookup", async () => {
+    const { c } = workerContext();
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "rejected",
+      status: 403,
+      reason: "organization_inactive",
+    });
+    await expect(
+      requireGenerativeRouteCaller(c as never),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: "access_denied",
+      message: "Organization is inactive",
+      details: { reason: "organization_inactive" },
+    });
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(requireAuthOrApiKeyWithOrg).not.toHaveBeenCalled();
+  });
+
+  test("explains an inactive cached API key without another lookup", async () => {
+    const { c } = workerContext();
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "rejected",
+      status: 403,
+      reason: "credential_inactive",
+    });
+    await expect(
+      requireGenerativeRouteCaller(c as never),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: "access_denied",
+      message: "API key is inactive",
+      details: { reason: "credential_inactive" },
+    });
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(requireAuthOrApiKeyWithOrg).not.toHaveBeenCalled();
+  });
+
   test("falls through slow_path to raw compatibility auth", async () => {
     const { c } = workerContext();
     resolveInferenceAuthContext.mockResolvedValueOnce({

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -282,13 +282,36 @@ export async function requireGenerativeRouteCaller(
     );
   }
   if (resolution.kind === "suspended") {
-    throw new ApiError(403, "access_denied", "Account suspended");
+    const reason = resolution.reason;
+    const message =
+      reason === "moderation_blocked"
+        ? "Account access is blocked by policy moderation"
+        : reason === "organization_inactive"
+          ? "Organization is inactive"
+          : reason === "account_inactive"
+            ? "Account is inactive"
+            : "Account suspended";
+    throw new ApiError(403, "access_denied", message, {
+      reason: reason ?? "account_suspended",
+    });
   }
   if (resolution.kind === "rejected") {
+    const reason = resolution.reason;
     throw new ApiError(
       resolution.status,
       resolution.status === 403 ? "access_denied" : "authentication_required",
-      resolution.status === 403 ? "Forbidden" : "Authentication required",
+      reason === "organization_inactive"
+        ? "Organization is inactive"
+        : reason === "account_inactive"
+          ? "Account is inactive"
+          : reason === "credential_inactive"
+            ? "API key is inactive"
+            : reason === "membership_missing"
+              ? "Account is not associated with an active organization"
+              : resolution.status === 403
+                ? "Forbidden"
+                : "Authentication required",
+      { reason: reason ?? "authentication_rejected" },
     );
   }
 

--- a/packages/cloud/api/test/fixtures/inference-admission-gate-worker.ts
+++ b/packages/cloud/api/test/fixtures/inference-admission-gate-worker.ts
@@ -7,6 +7,7 @@ import { InferenceAdmissionGate } from "../../src/inference-admission-gate";
 
 export class TestInferenceAdmissionGate extends InferenceAdmissionGate {
   private readonly testState: DurableObjectState;
+  private releaseBillingQueueBlock: (() => void) | undefined;
 
   constructor(state: DurableObjectState, env: Record<string, unknown>) {
     super(state, env as never);
@@ -14,7 +15,42 @@ export class TestInferenceAdmissionGate extends InferenceAdmissionGate {
   }
 
   override async fetch(request: Request): Promise<Response> {
-    if (new URL(request.url).pathname !== "/test-block-ledger") {
+    const path = new URL(request.url).pathname;
+    if (path === "/test-block-billing-queue") {
+      let entered: () => void = () => undefined;
+      const started = new Promise<void>((resolve) => {
+        entered = resolve;
+      });
+      const released = new Promise<void>((resolve) => {
+        this.releaseBillingQueueBlock = resolve;
+      });
+      const blocked = this.serialize(async () => {
+        entered();
+        await released;
+      });
+      this.testState.waitUntil(blocked);
+      await started;
+      return new Response(null, { status: 202 });
+    }
+    if (path === "/test-release-billing-queue") {
+      this.releaseBillingQueueBlock?.();
+      this.releaseBillingQueueBlock = undefined;
+      return new Response(null, { status: 204 });
+    }
+    if (path === "/test-revocation-queue-order") {
+      const order: string[] = [];
+      const first = this.serializeRevocation(async () => {
+        order.push("first:start");
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        order.push("first:end");
+      });
+      const second = this.serializeRevocation(async () => {
+        order.push("second");
+      });
+      await Promise.all([first, second]);
+      return Response.json({ order });
+    }
+    if (path !== "/test-block-ledger") {
       return await super.fetch(request);
     }
     let entered: () => void = () => undefined;

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -320,7 +320,7 @@ export const CacheTTL = {
     authContext: 60, // 1 min physical bound; active entries refresh off-response after 30s
     orgAdmission: 30, // shared-runtime combined balance + rate policy projection
     orgBalance: 15, // 15 seconds - FRESHNESS window: getGateBalanceUsd serves a hint older than this stale-while-revalidate (background refresh) instead of blocking on an authoritative read
-    orgBalanceStale: 300, // 5 min - PHYSICAL KV lifetime so a stale hint can be served + background-refreshed; over-admit stays bounded by the debit settler's lowerOrgBalanceHint + top-up invalidate, exactly as before
+    orgBalanceStale: 300, // 5 min - physical KV lifetime for stale-while-revalidate; authoritative admission is revisioned/serialized or synchronous
     pendingCharge: 3600, // 60 min - sweep window = TTL - grace(20m) = 40m, survives cron hiccups
   },
   /**

--- a/packages/cloud/shared/src/lib/services/inference-api-key-auth.ts
+++ b/packages/cloud/shared/src/lib/services/inference-api-key-auth.ts
@@ -12,6 +12,7 @@ import type { ApiKey } from "../../db/schemas/api-keys";
 import type { Organization } from "../../db/schemas/organizations";
 import { AuthenticationError, ForbiddenError } from "../api/errors";
 import { apiKeysService } from "./api-keys";
+import type { InferenceAuthRejectionReason } from "./inference-auth-cache";
 import { usersService } from "./users";
 
 export interface InferenceApiKeyAuthTimingObserver {
@@ -24,7 +25,7 @@ export interface InferenceApiKeyAuthOptions {
   bypassCache?: boolean;
   timing?: InferenceApiKeyAuthTimingObserver;
   /** Marks typed credential/account rejection without intercepting the throw. */
-  rejected?(): void;
+  rejected?(reason: InferenceAuthRejectionReason): void;
 }
 
 export interface InferenceApiKeyAuthResult {
@@ -39,8 +40,9 @@ export interface InferenceApiKeyAuthResult {
 function reject(
   options: InferenceApiKeyAuthOptions,
   error: AuthenticationError | ForbiddenError,
+  reason: InferenceAuthRejectionReason,
 ): never {
-  options.rejected?.();
+  options.rejected?.(reason);
   throw error;
 }
 
@@ -77,13 +79,13 @@ export async function requireInferenceApiKeyWithOrg(
     options.timing?.keyLookup(performance.now() - keyStartedAt);
   }
   if (!apiKey) {
-    reject(options, new AuthenticationError("Invalid or expired API key"));
+    reject(options, new AuthenticationError("Invalid or expired API key"), "credential_invalid");
   }
   if (!apiKey.is_active) {
-    reject(options, new ForbiddenError("API key is inactive"));
+    reject(options, new ForbiddenError("API key is inactive"), "credential_inactive");
   }
   if (apiKey.expires_at && new Date(apiKey.expires_at) < new Date()) {
-    reject(options, new AuthenticationError("API key has expired"));
+    reject(options, new AuthenticationError("API key has expired"), "credential_invalid");
   }
 
   const userStartedAt = performance.now();
@@ -94,18 +96,23 @@ export async function requireInferenceApiKeyWithOrg(
     options.timing?.userOrgLookup(performance.now() - userStartedAt);
   }
   if (!user) {
-    reject(options, new AuthenticationError("User associated with API key not found"));
+    reject(
+      options,
+      new AuthenticationError("User associated with API key not found"),
+      "membership_missing",
+    );
   }
   if (!user.is_active) {
-    reject(options, new ForbiddenError("User account is inactive"));
+    reject(options, new ForbiddenError("User account is inactive"), "account_inactive");
   }
   if (!user.organization?.is_active) {
-    reject(options, new ForbiddenError("Organization is inactive"));
+    reject(options, new ForbiddenError("Organization is inactive"), "organization_inactive");
   }
   if (!user.organization_id || !user.organization) {
     reject(
       options,
       new ForbiddenError("This feature requires a full account. Please sign up to continue."),
+      "membership_missing",
     );
   }
 

--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
@@ -69,7 +69,26 @@ export interface InferenceApiKeyAuthRejection {
   keyHash: string;
   decision: "rejected" | "suspended";
   status: 401 | 403;
+  /** Bounded account-standing category safe to return without a DB read. */
+  reason?: InferenceAuthRejectionReason;
 }
+
+export type InferenceAuthRejectionReason =
+  | "credential_invalid"
+  | "credential_inactive"
+  | "account_inactive"
+  | "organization_inactive"
+  | "membership_missing"
+  | "moderation_blocked";
+
+const INFERENCE_AUTH_REJECTION_REASONS = new Set<InferenceAuthRejectionReason>([
+  "credential_invalid",
+  "credential_inactive",
+  "account_inactive",
+  "organization_inactive",
+  "membership_missing",
+  "moderation_blocked",
+]);
 
 /**
  * A cached, fully-authorized Steward session identity. The JWT is still
@@ -92,6 +111,7 @@ export interface InferenceSessionAuthRejection {
   stewardUserId: string;
   decision: "rejected" | "suspended";
   status: 401 | 403;
+  reason?: InferenceAuthRejectionReason;
 }
 
 export type InferenceSessionAuthDecision =
@@ -132,6 +152,7 @@ export type InferenceAuthCacheReadOutcome =
       kind: "rejected";
       decision: "rejected" | "suspended";
       status: 401 | 403;
+      reason?: InferenceAuthRejectionReason;
       backend: CacheBackendKind;
     }
   | {
@@ -199,7 +220,15 @@ function isInferenceApiKeyAuthRejection(value: unknown): value is InferenceApiKe
     typeof v.keyHash === "string" &&
     /^[0-9a-f]{64}$/.test(v.keyHash) &&
     (v.decision === "rejected" || v.decision === "suspended") &&
-    (v.status === 401 || v.status === 403)
+    (v.status === 401 || v.status === 403) &&
+    (v.reason === undefined || isInferenceAuthRejectionReason(v.reason))
+  );
+}
+
+function isInferenceAuthRejectionReason(value: unknown): value is InferenceAuthRejectionReason {
+  return (
+    typeof value === "string" &&
+    INFERENCE_AUTH_REJECTION_REASONS.has(value as InferenceAuthRejectionReason)
   );
 }
 
@@ -238,7 +267,8 @@ function isInferenceSessionAuthRejection(value: unknown): value is InferenceSess
     typeof v.stewardUserId === "string" &&
     v.stewardUserId.length > 0 &&
     (v.decision === "rejected" || v.decision === "suspended") &&
-    (v.status === 401 || v.status === 403)
+    (v.status === 401 || v.status === 403) &&
+    (v.reason === undefined || isInferenceAuthRejectionReason(v.reason))
   );
 }
 
@@ -293,6 +323,7 @@ export async function readInferenceAuthContextWithOutcome(
       kind: "rejected",
       decision: outcome.value.decision,
       status: outcome.value.status,
+      reason: outcome.value.reason,
       backend: outcome.backend,
     };
   }
@@ -321,6 +352,7 @@ export async function writeInferenceApiKeyAuthRejection(
   keyHash: string,
   decision: "rejected" | "suspended",
   status: 401 | 403,
+  reason?: InferenceAuthRejectionReason,
 ): Promise<CacheWriteOutcome> {
   return await cache.setWithOutcome(
     CacheKeys.inference.authContext(keyHash),
@@ -330,6 +362,7 @@ export async function writeInferenceApiKeyAuthRejection(
       keyHash,
       decision,
       status,
+      ...(reason ? { reason } : {}),
     } satisfies InferenceApiKeyAuthRejection,
     CacheTTL.inference.authContext,
     { keyClass: "inference_auth" },
@@ -534,19 +567,18 @@ export async function lowerOrgBalanceHint(
 }
 
 /**
- * Publish an AUTHORITATIVE balance snapshot as the gate hint without ever
- * raising the gate above a lower value another writer already published.
+ * Publish one authoritative post-debit balance snapshot with a single cache
+ * write and no cache readback.
  *
- * Unlike {@link lowerOrgBalanceHint} this seeds an entry when none exists,
- * which is what the post-debit settlers need: the committed debit's
- * `onCreditMutation` DELETES the hint, and a lower-only repair is a no-op on an
- * absent key, so the next Worker turn hit a `cacheOnly` miss and fail-closed
- * with a user-visible cache-warming 503.
- *
- * The min-clamp preserves the over-admit bound: a concurrent debit that
- * committed and lowered the hint between this caller's authoritative read and
- * its write must not be undone. Equal-or-higher cached values are replaced,
- * since the authoritative snapshot is the source of truth for those.
+ * Unlike {@link lowerOrgBalanceHint}, this seeds an entry after the committed
+ * debit's invalidation deletes the old hint, preventing the next Worker turn
+ * from failing closed on an avoidable cache miss. The projection is not the
+ * monetary authority: Worker provider dispatch is serialized by the
+ * revision-aware InferenceAdmissionGate Durable Object. Non-Worker paths use
+ * the atomic DB-ledger admission or reserve credits synchronously; the legacy
+ * KV lane cannot dispatch from this projection. A delayed projection write can
+ * therefore be stale, but it cannot authorize spend by itself; the next Durable
+ * Object admission applies only a newer revision and accounts for active holds.
  */
 export async function republishOrgBalanceHint(
   orgId: string,
@@ -554,11 +586,5 @@ export async function republishOrgBalanceHint(
   balanceAt: number,
   balanceRevision: string,
 ): Promise<void> {
-  const existing = await readOrgBalanceHint(orgId);
-  if (existing && existing.balanceUsd < balanceUsd) {
-    // A concurrent debit already published a stricter gate. Keep it — but keep
-    // it PRESENT, which is the whole point of republishing.
-    return;
-  }
   await writeOrgBalanceHint(orgId, balanceUsd, balanceAt, balanceRevision);
 }

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -113,6 +113,7 @@ const {
 } = await import("./inference-auth-context");
 const { cache } = await import("../cache/client");
 const { CacheKeys } = await import("../cache/keys");
+const { logger } = await import("../utils/logger");
 const {
   hashApiKey,
   readInferenceAuthContext,
@@ -383,12 +384,29 @@ describe("resolveInferenceAuthContext", () => {
     await Promise.all(waited);
     expect(chainCalls).toBe(1);
 
+    const errorSpy = spyOn(logger, "error").mockImplementation(() => undefined);
     const retry = await resolveInferenceAuthContext(reqWithApiKey(), {
       cacheOnly: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
-    expect(retry).toEqual({ kind: "rejected", status: 401 });
+    expect(retry).toEqual({ kind: "rejected", status: 401, reason: "credential_invalid" });
     expect(chainCalls).toBe(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[InferenceAuth] account standing denied inference",
+      expect.objectContaining({
+        status: 401,
+        reason: "credential_invalid",
+        authSource: "x_api_key",
+        cacheBackend: "memory",
+        cacheRead: "rejected",
+        source: "cache",
+      }),
+    );
+    const logged = JSON.stringify(errorSpy.mock.calls);
+    expect(logged).not.toContain(KEY);
+    expect(logged).not.toContain("user-1");
+    errorSpy.mockRestore();
   });
 
   test("authoritative suspension converges to a cached fail-closed decision", async () => {
@@ -410,12 +428,13 @@ describe("resolveInferenceAuthContext", () => {
     const retry = await resolveInferenceAuthContext(reqWithApiKey(), {
       cacheOnly: true,
     });
-    expect(retry).toEqual({ kind: "suspended" });
+    expect(retry).toEqual({ kind: "suspended", reason: "moderation_blocked" });
     expect(moderationCalls).toBe(1);
   });
 
   test("Worker execution context defers positive cache population and observes its outcome", async () => {
     let finishWrite = (): void => {};
+    const readSpy = spyOn(cache, "getWithOutcome");
     const writeSpy = spyOn(cache, "setWithOutcome").mockImplementation(
       async () =>
         await new Promise((resolve) => {
@@ -458,8 +477,11 @@ describe("resolveInferenceAuthContext", () => {
         cacheWrite: "written",
       });
       expect(cacheWriteTelemetry?.durationMs).toBeGreaterThanOrEqual(0);
+      expect(readSpy).toHaveBeenCalledTimes(1);
+      expect(writeSpy).toHaveBeenCalledTimes(1);
     } finally {
       finishWrite();
+      readSpy.mockRestore();
       writeSpy.mockRestore();
     }
   });
@@ -493,7 +515,11 @@ describe("resolveInferenceAuthContext", () => {
 
     const result = await resolveInferenceAuthContext(reqWithApiKey());
 
-    expect(result).toEqual({ kind: "rejected", status: 401 });
+    expect(result).toEqual({
+      kind: "rejected",
+      status: 401,
+      reason: "credential_inactive",
+    });
     expect(chainCalls).toBe(0);
   });
 

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -35,6 +35,7 @@ import { contentModerationService } from "./content-moderation";
 import { loadInferenceAdmissionSnapshot } from "./inference-admission-snapshot";
 import { requireInferenceApiKeyWithOrg } from "./inference-api-key-auth";
 import { loadInferenceAppKeyScope } from "./inference-app-key-scope";
+import type { InferenceAuthRejectionReason } from "./inference-auth-cache";
 import {
   hashApiKey,
   INFERENCE_AUTH_CONTEXT_VERSION,
@@ -139,6 +140,8 @@ export interface ResolveInferenceAuthOptions {
   cacheOnly?: boolean;
   /** Internal background refresh: bypass the combined decision and revalidate. */
   forceAuthoritative?: boolean;
+  /** Internal hook preserving a bounded authoritative standing reason. */
+  onAuthoritativeRejection?(reason: InferenceAuthRejectionReason): void;
 }
 
 interface MutableInferenceAuthTrace {
@@ -161,6 +164,8 @@ interface MutableInferenceAuthTrace {
   };
 }
 
+type InferenceStandingDecisionSource = "authoritative" | "cache" | "session_resolution";
+
 const apiKeyHydrations = new Map<string, Promise<void>>();
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
 const DEFAULT_HYDRATION_DEADLINE_MS = 10_000;
@@ -176,6 +181,23 @@ function boundedTraceId(traceId: string | undefined): string {
 
 function durationSince(startedAt: number): number {
   return Math.round((performance.now() - startedAt) * 100) / 100;
+}
+
+function rejectionReasonForRevocation(reason: string): InferenceAuthRejectionReason {
+  switch (reason) {
+    case "organization_disabled":
+      return "organization_inactive";
+    case "subject_account_disabled":
+      return "account_inactive";
+    case "subject_membership_disabled":
+      return "membership_missing";
+    case "subject_moderation_disabled":
+      return "moderation_blocked";
+    case "credential_revoked":
+      return "credential_inactive";
+    default:
+      return "credential_invalid";
+  }
 }
 
 function controlledProbeDiscriminator(req: Request): string | null {
@@ -244,8 +266,8 @@ export type InferenceAuthResolution =
       ctx: ResolvedInferenceAuthContext;
       source: "cache" | "origin";
     }
-  | { kind: "suspended"; userId?: string }
-  | { kind: "rejected"; status: 401 | 403 }
+  | { kind: "suspended"; userId?: string; reason?: InferenceAuthRejectionReason }
+  | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason }
   | { kind: "warming"; hydration?: Promise<unknown> }
   | { kind: "slow_path"; reason: "mobile_api_key" | "non_api_key" };
 
@@ -351,6 +373,8 @@ function getOrCreateApiKeyHydration(
   const existing = apiKeyHydrations.get(keyHash);
   if (existing) return existing;
 
+  let authoritativeRejectionReason: InferenceAuthRejectionReason | undefined;
+
   // The outer Worker waitUntil retains this whole operation, so the
   // authoritative resolver intentionally runs without an execution context:
   // it must finish the cache write before releasing the single-flight slot.
@@ -358,10 +382,18 @@ function getOrCreateApiKeyHydration(
     traceId,
     cacheOnly: false,
     forceAuthoritative: true,
+    onAuthoritativeRejection: (reason) => {
+      authoritativeRejectionReason = reason;
+    },
   })
     .then(async (result) => {
       if (result.kind === "suspended") {
-        const write = await writeInferenceApiKeyAuthRejection(keyHash, "suspended", 403);
+        const write = await writeInferenceApiKeyAuthRejection(
+          keyHash,
+          "suspended",
+          403,
+          result.reason ?? "moderation_blocked",
+        );
         if (write.kind !== "written") {
           throw new Error(`Suspended inference-auth decision cache write failed: ${write.kind}`);
         }
@@ -371,7 +403,8 @@ function getOrCreateApiKeyHydration(
     .catch(async (error) => {
       const status = getErrorStatusCode(error);
       if (status === 401 || status === 403) {
-        const write = await writeInferenceApiKeyAuthRejection(keyHash, "rejected", status);
+        const reason = authoritativeRejectionReason ?? "credential_invalid";
+        const write = await writeInferenceApiKeyAuthRejection(keyHash, "rejected", status, reason);
         if (write.kind !== "written") {
           logger.warn("[InferenceAuth] rejected decision cache write failed", {
             traceId: boundedTraceId(traceId),
@@ -457,6 +490,28 @@ export async function resolveInferenceAuthContext(
       cacheWriteMs: null,
     },
   };
+  let standingDenialLogged = false;
+  let authoritativeStandingReason: InferenceAuthRejectionReason | undefined;
+  const logStandingDenial = (params: {
+    status: 401 | 403;
+    reason: unknown;
+    source: InferenceStandingDecisionSource;
+  }): void => {
+    standingDenialLogged = true;
+    const reason =
+      typeof params.reason === "string" && /^[a-z0-9_:-]{1,64}$/.test(params.reason)
+        ? params.reason
+        : "unavailable";
+    logger.error("[InferenceAuth] account standing denied inference", {
+      traceId: boundedTraceId(options.traceId),
+      status: params.status,
+      reason,
+      authSource: trace.authSource,
+      cacheBackend: trace.cacheBackend,
+      cacheRead: trace.cacheRead,
+      source: params.source,
+    });
+  };
 
   try {
     const authCacheEnabled = isInferenceAuthCacheEnabled();
@@ -490,10 +545,20 @@ export async function resolveInferenceAuthContext(
       if (session.kind === "suspended") {
         trace.cacheRead = "hit";
         trace.result = "suspended";
+        logStandingDenial({
+          status: 403,
+          reason: session.reason,
+          source: "session_resolution",
+        });
         return session;
       }
       trace.cacheRead = "hit";
       trace.result = "rejected";
+      logStandingDenial({
+        status: session.status,
+        reason: session.reason,
+        source: "session_resolution",
+      });
       return session;
     }
     trace.authSource = credential.source;
@@ -530,9 +595,15 @@ export async function resolveInferenceAuthContext(
         } catch (error) {
           if (error instanceof InferenceCredentialRevokedError) {
             trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
+            const reason = rejectionReasonForRevocation(error.reason);
+            logStandingDenial({
+              status: error.reason === "credential_revoked" ? 401 : 403,
+              reason,
+              source: "authoritative",
+            });
             return error.reason === "credential_revoked"
-              ? { kind: "rejected", status: 401 }
-              : { kind: "suspended", userId: cached.ctx.userId };
+              ? { kind: "rejected", status: 401, reason }
+              : { kind: "suspended", userId: cached.ctx.userId, reason };
           }
           throw error;
         }
@@ -561,9 +632,14 @@ export async function resolveInferenceAuthContext(
       }
       if (cached.kind === "rejected") {
         trace.result = cached.decision === "suspended" ? "suspended" : "rejected";
+        logStandingDenial({
+          status: cached.status,
+          reason: cached.reason,
+          source: "cache",
+        });
         return cached.decision === "suspended"
-          ? { kind: "suspended" }
-          : { kind: "rejected", status: cached.status };
+          ? { kind: "suspended", reason: cached.reason }
+          : { kind: "rejected", status: cached.status, reason: cached.reason };
       }
     } else {
       trace.cacheRead = "unavailable";
@@ -608,7 +684,9 @@ export async function resolveInferenceAuthContext(
           trace.timings.userOrgLookupMs = Math.round(durationMs * 100) / 100;
         },
       },
-      rejected: () => {
+      rejected: (reason) => {
+        authoritativeStandingReason = reason;
+        options.onAuthoritativeRejection?.(reason);
         trace.authoritative = "rejected";
         trace.result = "rejected";
       },
@@ -624,7 +702,12 @@ export async function resolveInferenceAuthContext(
     if (suspended) {
       trace.authoritative = "suspended";
       trace.result = "suspended";
-      return { kind: "suspended", userId: user.id };
+      logStandingDenial({
+        status: 403,
+        reason: "moderation_blocked",
+        source: "authoritative",
+      });
+      return { kind: "suspended", userId: user.id, reason: "moderation_blocked" };
     }
 
     const [admission, appScopeId] = authCacheEnabled
@@ -652,9 +735,15 @@ export async function resolveInferenceAuthContext(
     } catch (error) {
       if (error instanceof InferenceCredentialRevokedError) {
         trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
+        const reason = rejectionReasonForRevocation(error.reason);
+        logStandingDenial({
+          status: error.reason === "credential_revoked" ? 401 : 403,
+          reason,
+          source: "authoritative",
+        });
         return error.reason === "credential_revoked"
-          ? { kind: "rejected", status: 401 }
-          : { kind: "suspended", userId: ctx.userId };
+          ? { kind: "rejected", status: 401, reason }
+          : { kind: "suspended", userId: ctx.userId, reason };
       }
       throw error;
     }
@@ -682,6 +771,27 @@ export async function resolveInferenceAuthContext(
       trace.cacheBackend = write.backend;
     }
     return { kind: "authorized", ctx, source: "origin" };
+  } catch (error) {
+    if (authoritativeStandingReason && !standingDenialLogged) {
+      const status = getErrorStatusCode(error);
+      logStandingDenial({
+        status: status === 401 ? 401 : 403,
+        reason: authoritativeStandingReason,
+        source: "authoritative",
+      });
+    }
+    if (!standingDenialLogged) {
+      logger.error("[InferenceAuth] authorization flow failed", {
+        traceId: boundedTraceId(options.traceId),
+        authSource: trace.authSource,
+        cacheBackend: trace.cacheBackend,
+        cacheRead: trace.cacheRead,
+        authoritative: trace.authoritative,
+        result: trace.result,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    throw error;
   } finally {
     const telemetry = freezeTrace(options.traceId, trace, totalStartedAt);
     logger.info("[InferenceAuth] trace", telemetry);

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -41,9 +41,12 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * next request's critical path, and it keeps the revision fresh rather than
  * preserving a stale one.
  *
- * The write is min-clamped (`republishOrgBalanceHint`) so the #9899 over-admit
- * bound survives: a concurrent debit that published a STRICTER gate while this
- * snapshot was in flight is never raised back up.
+ * Republication is one write with no cache readback. The cache is a projection,
+ * not the monetary authority: Worker dispatch is fenced by the serialized,
+ * revision-aware InferenceAdmissionGate Durable Object. Non-Worker callers use
+ * the atomic DB-ledger admission or reserve synchronously; the legacy KV lane
+ * is never allowed to dispatch from this projection. Older snapshots therefore
+ * cannot reopen an active gate even if concurrent writers reach Redis out of order.
  */
 export async function republishOrgBalanceHintAfterDebit(organizationId: string): Promise<void> {
   // Captured BEFORE the authoritative read, matching `refreshOrgBalanceHint`:

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -696,19 +696,20 @@ describe("#9899 hardening: backstop durability, lower-only hint, claim atomicity
     expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(4);
   });
 
-  // Clamp direction: if a concurrent debit published a STRICTER gate between
-  // this settler's authoritative read and its write, that stricter value must
-  // survive — while the entry still stays PRESENT (never absent).
-  test("republish is min-clamped against a concurrent stricter gate", async () => {
+  test("republish issues one direct authoritative write without a cache read", async () => {
     const { republishOrgBalanceHint } = await import("./inference-auth-cache");
     const orgId = uid("org");
     await writeOrgBalanceHint(orgId, 2, Date.now(), "5");
-    // An authoritative snapshot that is HIGHER than what a concurrent debit
-    // already published must not raise the gate back up.
-    await republishOrgBalanceHint(orgId, 9, Date.now(), "6");
+    const get = spyOn(cache, "get");
+    try {
+      await republishOrgBalanceHint(orgId, 9, Date.now(), "6");
+      expect(get).not.toHaveBeenCalled();
+    } finally {
+      get.mockRestore();
+    }
+
     const hint = await readOrgBalanceHint(orgId);
-    expect(hint?.balanceUsd).toBe(2);
-    expect(hint).not.toBeNull();
+    expect(hint).toMatchObject({ balanceUsd: 9, balanceRevision: "6" });
   });
 
   test("two concurrent inline claims of one request charge exactly once (atomic getAndDelete)", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -439,9 +439,9 @@ export async function debitInferenceCost(
     }
     // The committed debit already evicted the gate hint via onCreditMutation.
     // Republish authoritative balance + revision so the NEXT turn hits a warm
-    // entry instead of a fail-closed cache-warming 503. A concurrent debit can
-    // only lower the value afterwards (lowerOrgBalanceHint), so this can never
-    // raise the gate above authoritative state.
+    // entry instead of a fail-closed cache-warming 503. The revision-aware
+    // Durable Object remains the Worker dispatch authority if concurrent cache
+    // writers arrive out of order.
     try {
       await republishOrgBalanceHintAfterDebit(ctx.organizationId);
     } catch (cause) {

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -97,9 +97,8 @@ mock.module("./api-keys", () => ({
   isMobileApiKeySecret: () => false,
 }));
 const { resolveInferenceAuthContext } = await import("./inference-auth-context");
-const { hashApiKey, invalidateInferenceAuthContextByKeyHash } = await import(
-  "./inference-auth-cache"
-);
+const { hashApiKey, invalidateInferenceAuthContextByKeyHash, writeInferenceApiKeyAuthRejection } =
+  await import("./inference-auth-cache");
 const { cache } = await import("../cache/client");
 
 const KEY = "eliza_bench_key";
@@ -203,5 +202,30 @@ describe("inference hot-path benchmark", () => {
     expect(revocationBoundaryCalls).toBe(N);
 
     getSpy.mockRestore();
+  });
+
+  test("bad standing is explained from the same single cache read", async () => {
+    const keyHash = hashApiKey(KEY);
+    await writeInferenceApiKeyAuthRejection(keyHash, "rejected", 403, "organization_inactive");
+
+    const getSpy = spyOn(cache, "getWithOutcome");
+    const setSpy = spyOn(cache, "setWithOutcome");
+    authChainCalls = 0;
+    moderationCalls = 0;
+    revocationBoundaryCalls = 0;
+
+    expect(await resolveInferenceAuthContext(req())).toEqual({
+      kind: "rejected",
+      status: 403,
+      reason: "organization_inactive",
+    });
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledTimes(0);
+    expect(authChainCalls).toBe(0);
+    expect(moderationCalls).toBe(0);
+    expect(revocationBoundaryCalls).toBe(0);
+
+    getSpy.mockRestore();
+    setSpy.mockRestore();
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
@@ -13,9 +13,11 @@
  */
 
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { logger } from "../utils/logger";
 import { isInferenceStrongRevocationEnabled } from "./inference-credential-revocation";
 
 type EnvLike = Record<string, unknown>;
+let warnedUnsafeAuthCacheConfiguration = false;
 
 export function isHotPathCachesEnabled(env: EnvLike = getCloudAwareEnv()): boolean {
   const flag = env.INFERENCE_HOT_PATH_CACHES;
@@ -29,7 +31,15 @@ export function isHotPathCachesEnabled(env: EnvLike = getCloudAwareEnv()): boole
  */
 export function isInferenceAuthCacheEnabled(env: EnvLike = getCloudAwareEnv()): boolean {
   const flag = env.INFERENCE_AUTH_CACHE_ENABLED;
-  return (
-    typeof flag === "string" && flag.trim() === "true" && isInferenceStrongRevocationEnabled(env)
-  );
+  const requested = typeof flag === "string" && flag.trim() === "true";
+  const strongRevocation = isInferenceStrongRevocationEnabled(env);
+  if (requested && !strongRevocation && !warnedUnsafeAuthCacheConfiguration) {
+    warnedUnsafeAuthCacheConfiguration = true;
+    logger.error("[InferenceAuth] positive cache requested without strong revocation", {
+      authCacheEnabled: true,
+      strongRevocationEnabled: false,
+      effectiveAuthCacheEnabled: false,
+    });
+  }
+  return requested && strongRevocation;
 }

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -23,6 +23,7 @@ import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { adminService } from "./admin";
 import { loadInferenceAdmissionSnapshot } from "./inference-admission-snapshot";
+import type { InferenceAuthRejectionReason } from "./inference-auth-cache";
 import {
   INFERENCE_AUTH_CONTEXT_VERSION,
   type InferenceSessionAuthContext,
@@ -52,8 +53,8 @@ export type InferenceSessionAuthResolution =
       ctx: InferenceSessionAuthContext;
       source: "cache" | "origin";
     }
-  | { kind: "suspended"; userId?: string }
-  | { kind: "rejected"; status: 401 | 403 }
+  | { kind: "suspended"; userId?: string; reason?: InferenceAuthRejectionReason }
+  | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason }
   | {
       kind: "warming";
       hydration?: Promise<InferenceSessionAuthDecision | undefined>;
@@ -77,13 +78,18 @@ export function extractInferenceSessionCredential(req: Request): string | null {
   return readStewardAccessCookieFromHeader(req.headers.get("cookie"), env.ENVIRONMENT) ?? null;
 }
 
-function rejection(stewardUserId: string, status: 401 | 403): InferenceSessionAuthDecision {
+function rejection(
+  stewardUserId: string,
+  status: 401 | 403,
+  reason?: InferenceAuthRejectionReason,
+): InferenceSessionAuthDecision {
   return {
     v: INFERENCE_AUTH_CONTEXT_VERSION,
     cachedAt: Date.now(),
     stewardUserId,
     decision: "rejected",
     status,
+    ...(reason ? { reason } : {}),
   };
 }
 
@@ -104,12 +110,12 @@ async function hydrateAuthoritativeDecision(params: {
     });
   }
   if (!user) return rejection(params.stewardUserId, 401);
-  if (!user.is_active) return rejection(params.stewardUserId, 403);
+  if (!user.is_active) return rejection(params.stewardUserId, 403, "account_inactive");
   if (!user.organization_id || !user.organization) {
-    return rejection(params.stewardUserId, 403);
+    return rejection(params.stewardUserId, 403, "membership_missing");
   }
   if (!user.organization.is_active) {
-    return rejection(params.stewardUserId, 403);
+    return rejection(params.stewardUserId, 403, "organization_inactive");
   }
   if (await adminService.shouldBlockUser(user.id)) {
     return {
@@ -118,6 +124,7 @@ async function hydrateAuthoritativeDecision(params: {
       stewardUserId: params.stewardUserId,
       decision: "suspended",
       status: 403,
+      reason: "moderation_blocked",
     };
   }
   return {
@@ -138,9 +145,9 @@ function toResolution(
     return { kind: "authorized", ctx: decision, source };
   }
   if (decision.decision === "suspended") {
-    return { kind: "suspended" };
+    return { kind: "suspended", reason: decision.reason };
   }
-  return { kind: "rejected", status: decision.status };
+  return { kind: "rejected", status: decision.status, reason: decision.reason };
 }
 
 async function enforceStrongSessionBoundary(

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -755,3 +755,17 @@ test("non-Worker affiliate admission keeps synchronous reservation compatibility
   expect(pairReads).toBe(0);
   expect(affiliateReads).toBe(0);
 });
+
+test("non-Worker KV-ledger admission reserves instead of trusting a balance projection", async () => {
+  const model = nextModel();
+  const admission = await admitOrganizationInference({
+    ...admissionParams(model, []),
+    executionCtx: undefined,
+  });
+
+  expect(admission.mode).toBe("synchronous_reservation");
+  expect(reserveCredits).toHaveBeenCalledTimes(1);
+  expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+  expect(admitInferenceChargeViaLedger).not.toHaveBeenCalled();
+  expect(isOptimisticEligible).not.toHaveBeenCalled();
+});

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -262,6 +262,14 @@ export async function admitOrganizationInference(
   if (workerHotPath && !canDefer) {
     throw new InferenceAdmissionUnavailableError();
   }
+  // The legacy KV pending-charge lane cannot make an authoritative balance
+  // decision before provider dispatch. A delayed post-debit projection write
+  // may temporarily replace a newer hint, so non-Worker callers without the
+  // atomic DB ledger must reserve against Postgres synchronously. Workers are
+  // independently fenced by the revision-aware Durable Object.
+  if (!workerHotPath && !useDbLedger) {
+    return await reserveSynchronously(params);
+  }
 
   const normalizedModel = normalizeModelName(params.context.model);
   let estimatedCostUsd: number;

--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -33,6 +33,10 @@ function creditError(): Error & { statusCode: number } {
 	return Object.assign(new Error("insufficient_credits"), { statusCode: 402 });
 }
 
+function authError(): Error & { statusCode: number } {
+	return Object.assign(new Error("account access denied"), { statusCode: 403 });
+}
+
 function makeRuntimeReturning(responses: unknown[]): IAgentRuntime {
 	const queue = [...responses];
 	return {
@@ -84,6 +88,26 @@ describe("DefaultMessageService structured failure replies", () => {
 		await expect(
 			service.generateFailureReplyText(runtime, "recent messages", "test"),
 		).resolves.toEqual({ kind: "creditsExhausted" });
+	});
+
+	it("preserves account authorization failure when later model slots fail generically", async () => {
+		const service = new DefaultMessageService() as unknown as {
+			generateFailureReplyText(
+				runtime: IAgentRuntime,
+				prompt: string,
+				stage: string,
+			): Promise<{ kind: string }>;
+		};
+		const runtime = makeRuntimeThrowing([
+			authError(),
+			new Error("TEXT_LARGE fallback failed"),
+			new Error("TEXT_SMALL fallback failed"),
+			new Error("TEXT_NANO fallback failed"),
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({ kind: "authFailed" });
 	});
 
 	it("extracts the user-facing text from a structured envelope reply", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -16246,9 +16246,9 @@ export class DefaultMessageService implements IMessageService {
 				) {
 					return { kind: "noProvider" };
 				}
-				// Credit exhaustion is sticky across slots because no later
-				// fallback model can make a drained account retryable. The
-				// rate/auth flags still track the most recent slot's cause:
+				// Credit exhaustion and account authorization are sticky across
+				// slots because no later model tier can heal the shared account.
+				// The rate-limit flag still tracks the most recent slot's cause:
 				// reporting "rate-limited" only when the LAST attempted slot was
 				// a 429 avoids misleading the user in a mixed-failure run.
 				// Credits are classified before rate limits below: a 429 *with*
@@ -16256,7 +16256,7 @@ export class DefaultMessageService implements IMessageService {
 				// transient throttle ("try again in a few seconds").
 				sawCreditsExhausted ||= isInsufficientCreditsError(error);
 				sawRateLimit = isRateLimitError(error);
-				sawAuthError = isAuthError(error);
+				sawAuthError ||= isAuthError(error);
 				runtime.logger.warn(
 					{
 						src: "service:message",


### PR DESCRIPTION
Closes #29340

## Outcome

- Carries bounded bad-standing reasons through API-key and session inference caches so one cache read returns the safe explanation.
- Defers cache population with Worker waitUntil and performs no write readback.
- Adds structured denial and authorization-flow logs with trace, source, cache backend, status, and bounded reason without credentials or user PII.
- Maps credential/account/organization/membership/moderation denials to stable user-facing errors.
- Preserves authorization failures across core model fallback tiers.
- Makes non-Worker KV-ledger admission reserve synchronously instead of trusting a stale balance projection.
- Splits Durable Object revocation operations from the billing queue while preserving FIFO revocation ordering.
- Republishes authoritative balance with one direct cache write and no preliminary/readback lookup.

## Architecture and latency finding

The frontend-compatible path is:

Browser -> Cloudflare API/session auth -> one inference-auth cache read -> strong-revocation Durable Object check -> organization admission lease -> personal-agent bridge -> Cerebras -> async settlement/cache publish.

Direct Cerebras, 5 runs:
- first token: 119.52 to 1176.14 ms; median about 222 ms
- provider compute: 16.9 to 36.1 ms; median about 22.8 ms

Frontend-compatible staging path:
- expired session rejection: 4 ms
- observed full turns: 1.655 s, 1.930 s, 2.008 s
- successful trace: turn admission 53 ms, personal-agent bridge 1908 ms

A Cloudflare Durable Object rate-limit admission was about 85 ms in a live trace. Railway is not in this personal-agent inference critical path. The dominant additional latency observed is the personal-agent bridge plus edge/network variability, not Cerebras compute.

## Verification

- 105 Cloud API focused tests pass, including real Miniflare SQLite Durable Object tests.
- 45 inference auth-context tests pass.
- 42 inference billing fast-path tests pass.
- 4 inference hot-path benchmark contracts pass.
- 14 organization admission tests pass.
- 10 core message failure-reply tests pass.
- Cloud shared, Cloud API, and core typechecks pass.
- Cloud API Wrangler production dry-run passes.
- Biome passes on all 21 changed files.
- Full prior-base Turbo typecheck/lint graph: 375/375 tasks pass; downstream repository audits pass.
- On current exact base 8cf0b2ea9c3e, check:i18n passes. The root graph reaches unrelated failures in packages/synthetic-world/test/cloud-command-journal.pglite.test.ts because drizzle-kit/api and drizzle-orm cannot resolve; the UI design graph process was then canceled after that upstream failure. Neither package is changed here.

Cloud shared files use module-level mocks and must run as isolated Bun invocations. Each owning suite passes independently.

## Staging rollout

1. Merge to develop and verify canonical staging deployment uses the exact merge SHA.
2. Repeat direct Cerebras and frontend-compatible measurements with correlated Cloudflare traces.
3. Exercise cached bad-standing reasons and inspect the detailed denial log.
4. Canary strong revocation while concurrently leasing/settling billing operations; verify credential-check latency remains independent.
5. Exercise key revoke, logout cutoff, and account/moderation/organization disable and re-enable paths.
6. Roll back by setting INFERENCE_STRONG_REVOCATION_ENABLED=false if any invariant fails.
7. Promote through main only after staging certification.