### PR TITLE
fix(plugin-personal-assistant): use truncateWellFormed in normalizeSemanticReason

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts
@@ -4,6 +4,7 @@
  * and the owner's channel preferences. Shared by the reminder domain and
  * contact-route policy.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   LifeOpsActivitySignal,
   LifeOpsReminderAttempt,
@@ -1376,7 +1377,7 @@ function normalizeSemanticConfidence(value: unknown): number {
 
 function normalizeSemanticReason(value: unknown): string {
   return typeof value === "string" && value.trim().length > 0
-    ? value.trim().slice(0, 120)
+    ? truncateWellFormed(toWellFormedUnicode(value.trim()), 120)
     : "semantic_classifier";
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:99889f2c5d30187e01458b0fb0b6f4f369b696fe -->

## Summary
In `@elizaos/plugin-personal-assistant` (`plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts`):
`normalizeSemanticReason` clamped classifier explanation reasons using raw `value.trim().slice(0, 120)`. When semantic classifier outputs contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Replaced raw `.slice(0, 120)` with `truncateWellFormed(toWellFormedUnicode(value.trim()), 120)` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output during reminder response semantic classification and reason normalization.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
