### PR TITLE
fix(app): default local gateway to realtime voice

### DIFF
--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -13,10 +13,41 @@ import appViteConfig, {
   findAndroidCloudEmittedRoutingFindings,
   resolveAndroidCloudPrebootLockupDataUri,
   resolveAppShellLocalCspSources,
+  resolveLocalRealtimeVoiceDefines,
   selectAndroidCloudRendererEntry,
   stripAndroidCloudIpcBootstrap,
   stripAndroidCloudPublicAssetReferences,
 } from "./vite.config";
+
+describe("local realtime voice defaults", () => {
+  test("enables the realtime client and local force path when the dev gateway is configured", () => {
+    expect(resolveLocalRealtimeVoiceDefines("serve", 31_338, {})).toEqual({
+      "import.meta.env.VITE_VOICE_REALTIME_FORCE": JSON.stringify("1"),
+      "import.meta.env.VITE_VOICE_REALTIME_WS": JSON.stringify("1"),
+    });
+  });
+
+  test("preserves explicit client flag values", () => {
+    expect(
+      resolveLocalRealtimeVoiceDefines("serve", 31_338, {
+        VITE_VOICE_REALTIME_WS: "0",
+        VITE_VOICE_REALTIME_FORCE: "false",
+      }),
+    ).toEqual({});
+    expect(
+      resolveLocalRealtimeVoiceDefines("serve", 31_338, {
+        VITE_VOICE_REALTIME_WS: "1",
+      }),
+    ).toEqual({
+      "import.meta.env.VITE_VOICE_REALTIME_FORCE": JSON.stringify("1"),
+    });
+  });
+
+  test("does not change builds or dev servers without a gateway", () => {
+    expect(resolveLocalRealtimeVoiceDefines("build", 31_338, {})).toEqual({});
+    expect(resolveLocalRealtimeVoiceDefines("serve", null, {})).toEqual({});
+  });
+});
 
 describe("appDevWsBasePlugin", () => {
   test("injects same-origin ws/wss bases without a machine-local address", () => {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1719,6 +1719,30 @@ function resolveOptionalLocalVoiceGatewayPort(
   return port;
 }
 
+/**
+ * A configured loopback voice gateway is an explicit local-development opt-in
+ * to the realtime voice stack. Keep deployed builds staged behind their
+ * existing flags, while making the supported local gateway command sufficient
+ * to exercise the same realtime UI without two easy-to-miss Vite flags.
+ * Explicit client flag values always win, including an explicit opt-out.
+ */
+export function resolveLocalRealtimeVoiceDefines(
+  command: string,
+  gatewayPort: number | null,
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  if (command !== "serve" || gatewayPort === null) return {};
+
+  const defines: Record<string, string> = {};
+  if (env.VITE_VOICE_REALTIME_WS === undefined) {
+    defines["import.meta.env.VITE_VOICE_REALTIME_WS"] = JSON.stringify("1");
+  }
+  if (env.VITE_VOICE_REALTIME_FORCE === undefined) {
+    defines["import.meta.env.VITE_VOICE_REALTIME_FORCE"] = JSON.stringify("1");
+  }
+  return defines;
+}
+
 export function appDevWsBasePlugin(): Plugin {
   const brandedWsBaseKey = `__${APP_ENV_PREFIX}_WS_BASE__`;
 
@@ -2410,6 +2434,11 @@ export default defineConfig(({ command }) => ({
     : path.resolve(here, "public"),
   define: {
     global: "globalThis",
+    ...resolveLocalRealtimeVoiceDefines(
+      command,
+      localVoiceGatewayPort,
+      process.env,
+    ),
     // Build variant — set at signing time by desktop-build.mjs and embedded
     // here so the renderer can branch on store vs direct without an API call.
     __ELIZA_BUILD_VARIANT__: JSON.stringify(

--- a/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
+++ b/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
@@ -59,8 +59,6 @@ CARTESIA_API_KEY=… \
 ELIZA_LOCAL_VOICE_GATEWAY_PORT=31338 \
 bun run --cwd packages/cloud/api voice:local-gateway
 
-VITE_VOICE_REALTIME_WS=1 \
-VITE_VOICE_REALTIME_FORCE=1 \
 ELIZA_LOCAL_VOICE_GATEWAY_PORT=31338 \
 bun run --cwd packages/app dev
 ```
@@ -69,7 +67,10 @@ Vite sends only `/api/v1/voice/session` HTTP and WebSocket traffic to the
 loopback gateway; all other `/api` traffic remains on `31337`. The provider
 loop is Cartesia Ink 2 STT → local runtime/model route → Cartesia Sonic 3.5 TTS.
 The Cartesia key remains in the gateway process and is never exposed to Vite or
-the browser.
+the browser. In dev-server mode, configuring `ELIZA_LOCAL_VOICE_GATEWAY_PORT`
+also defaults the staged realtime client and local force flags on. Explicit
+`VITE_VOICE_REALTIME_WS` or `VITE_VOICE_REALTIME_FORCE` values still win, and
+production/mobile builds keep their existing staged defaults.
 
 ## Flag retirement
 


### PR DESCRIPTION
## Summary
- make ELIZA_LOCAL_VOICE_GATEWAY_PORT the single local-dev opt-in for realtime voice
- preserve explicit client flag overrides and keep build/mobile defaults unchanged
- document the one-setting local Cartesia loop

## Verification
- packages/app vite config: 18 tests passed
- packages/app typecheck passed
- Biome and git diff-check passed
- exact-head in-app browser proof at http://127.0.0.1:2342/chat with only ELIZA_LOCAL_VOICE_GATEWAY_PORT=12343: Listening status, mute microphone, and end conversation controls present; legacy batch Stop absent; session ended cleanly

## Scope
This does not modify the active phone/cloud voice handoff. It only removes the hidden two-flag footgun from the supported local dev-server workflow.