### PR TITLE
fix(cloud): restore deterministic migration test gate

### DIFF
--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -89,6 +89,7 @@ describe("managed dedicated live-smoke workflow contract", () => {
       "all",
       "app",
       "scenarios",
+      "group-chat",
       "live-information",
       "cloud",
       "voice",

--- a/packages/cloud/scripts/admin/migrate-database.ts
+++ b/packages/cloud/scripts/admin/migrate-database.ts
@@ -34,6 +34,17 @@ import {
   phoneErrorDiagnostic,
   phoneErrorHasCode,
 } from "../../shared/src/lib/services/phone-error-diagnostics";
+import {
+  requirePhoneJsonObject,
+  validatePhoneMediaUrls,
+} from "../../shared/src/lib/services/phone-payload-validation";
+import { putTrajectoryPayload } from "../../shared/src/lib/services/trajectory-object-storage";
+import { ObjectNamespaces } from "../../shared/src/lib/storage/object-namespace";
+import {
+  buildObjectFieldKey,
+  putObjectText,
+} from "../../shared/src/lib/storage/object-store";
+import { objectStorageConfigured } from "../../shared/src/lib/storage/s3-compatible-client";
 import { runCleanupSteps } from "./error-preserving-cleanup";
 import { loadEnvFiles } from "./local-dev-helpers";
 import {
@@ -51,23 +62,6 @@ import {
 // Existing shell env wins so a one-off `NEW_POSTGRES_URL=… bun run …` works.
 // Then .env.local fills gaps; then .env fills the rest.
 loadEnvFiles([".env.local", ".env"]);
-
-// Imports below depend on env being loaded first because they read process.env at module init.
-const { buildObjectFieldKey, putObjectText } = await import(
-  "../../shared/src/lib/storage/object-store"
-);
-const { ObjectNamespaces } = await import(
-  "../../shared/src/lib/storage/object-namespace"
-);
-const { requirePhoneJsonObject, validatePhoneMediaUrls } = await import(
-  "../../shared/src/lib/services/phone-payload-validation"
-);
-const { putTrajectoryPayload } = await import(
-  "../../shared/src/lib/services/trajectory-object-storage"
-);
-const { objectStorageConfigured } = await import(
-  "../../shared/src/lib/storage/s3-compatible-client"
-);
 
 const { Client } = pg;
 export type PgClient = pg.Client;

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
@@ -579,7 +579,9 @@ describe("usage-quotas migration release barrier", () => {
     ) as { entries?: Array<{ tag?: string }> };
 
     expect(runMigrationsStep).toContain("bun run db:cloud:migrate");
-    expect(deployApiJob).toMatch(/^ {4}needs: migrate-db$/m);
+    expect(deployApiJob).toMatch(
+      /^ {4}needs: \[resolve-pages-environment-config, migrate-db\]$/m,
+    );
     expect(rootPackage.scripts?.["db:cloud:migrate"]).toContain(
       "packages/cloud/scripts/admin/migrate-with-diagnostics.ts",
     );


### PR DESCRIPTION
Closes #29374

## Summary
- replace concurrent top-level dynamic imports in the migration CLI with static imports, preserving environment loading before runtime configuration is consulted
- update the release-barrier workflow contract test for the environment-resolution dependency
- update managed canary coverage for the required group-chat suite

## Failure reproduced
The exact cloud unit batch on the #29280 merge state intermittently entered partially initialized ESM modules under Bun, producing TDZ errors such as `Cannot access R2_TABLES before initialization`. The workflow contract assertions had also drifted from the deployed workflow.

## Validation
- `bun test ...migrate... ...workflow... --timeout 120000 --isolate`: 47 pass, 0 fail
- `bun run verify:cloud`: 84/84 tasks successful
- `bun install --frozen-lockfile`: passed
- Biome on touched files: passed (existing environment-variable warnings only)
- `git diff --check`: passed
- root `bun run verify` advanced through repository audit, lint, build, and cloud Worker dry-run before being stopped to rebase onto the latest `origin/develop`; no attributable failure was observed

## Evidence
| Evidence | Result |
| --- | --- |
| UI screenshots / MP4 / frontend logs | N/A — no UI change |
| Backend proof | Focused 47/47 unit batch and 84/84 cloud verification tasks |
| Live-model trajectories | N/A — no agent behavior change |
| Native/device evidence | N/A — no native path change |
| Production mutation | N/A — none performed |

Unrelated failures currently present in broader develop cloud lanes are intentionally out of scope for this focused remediation.