### PR TITLE
fix(core): use truncateWellFormed for responseBodyExcerpt in modelProviderErrorDetail

### DIFF
--- a/packages/core/src/utils/model-errors.ts
+++ b/packages/core/src/utils/model-errors.ts
@@ -10,6 +10,7 @@
  * instead of dead turns.
  */
 import { ElizaError } from "../errors";
+import { toWellFormedUnicode, truncateWellFormed } from "./well-formed";
 
 const TRANSIENT_MODEL_ERROR_PATTERNS = [
 	"service temporarily unavailable",
@@ -234,10 +235,11 @@ export function modelProviderErrorDetail(
 		if (responseBodyExcerpt === undefined) {
 			const body = (node as { responseBody?: unknown }).responseBody;
 			if (typeof body === "string" && body.trim().length > 0) {
-				responseBodyExcerpt = body
-					.replace(/\s+/g, " ")
-					.trim()
-					.slice(0, RESPONSE_BODY_EXCERPT_MAX_CHARS);
+				const cleaned = body.replace(/\s+/g, " ").trim();
+				responseBodyExcerpt = truncateWellFormed(
+					toWellFormedUnicode(cleaned),
+					RESPONSE_BODY_EXCERPT_MAX_CHARS,
+				);
 				providerMessage = providerMessageFromBody(body);
 			}
 		}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d7860326fce46a6cd0844a8e78ee8d75935712ed -->

## Summary
In `@elizaos/core` (`packages/core/src/utils/model-errors.ts`):
`modelProviderErrorDetail` extracted response error excerpts using raw `body.replace(/\s+/g, " ").trim().slice(0, RESPONSE_BODY_EXCERPT_MAX_CHARS)`. When upstream provider error response bodies contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Replaced raw `.slice(0, RESPONSE_BODY_EXCERPT_MAX_CHARS)` with `truncateWellFormed(toWellFormedUnicode(cleaned), RESPONSE_BODY_EXCERPT_MAX_CHARS)` in `modelProviderErrorDetail`.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/utils/model-errors.test.ts` (41/41 passed).
- Verified well-formed Unicode output during model provider error response body excerpt extraction.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
