### PR TITLE
fix(core): ensure truncateToCompleteSentence operates on well-formed Unicode and uses truncateWellFormed at period and space cut points

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1007,17 +1007,21 @@ export function truncateToCompleteSentence(
 	maxLength: number,
 ): string {
 	if (maxLength <= 0) return "";
-	if (text.length <= maxLength) {
-		return text;
+	const wellFormed = toWellFormedUnicode(text);
+	if (wellFormed.length <= maxLength) {
+		return wellFormed;
 	}
 	if (maxLength <= 3) {
-		return truncateWellFormed(text, maxLength);
+		return truncateWellFormed(wellFormed, maxLength);
 	}
 
 	// Attempt to truncate at the last period within the limit
-	const lastPeriodIndex = text.lastIndexOf(".", maxLength - 1);
+	const lastPeriodIndex = wellFormed.lastIndexOf(".", maxLength - 1);
 	if (lastPeriodIndex !== -1) {
-		const truncatedAtPeriod = text.slice(0, lastPeriodIndex + 1).trim();
+		const truncatedAtPeriod = truncateWellFormed(
+			wellFormed,
+			lastPeriodIndex + 1,
+		).trim();
 		if (truncatedAtPeriod.length > 0) {
 			return truncatedAtPeriod;
 		}
@@ -1026,16 +1030,19 @@ export function truncateToCompleteSentence(
 	// If no period, truncate to the nearest whitespace within the limit.
 	// Search from maxLength - 3 so the appended ellipsis still fits the cap,
 	// matching the hard-truncate fallback below.
-	const lastSpaceIndex = text.lastIndexOf(" ", maxLength - 3);
+	const lastSpaceIndex = wellFormed.lastIndexOf(" ", maxLength - 3);
 	if (lastSpaceIndex !== -1) {
-		const truncatedAtSpace = text.slice(0, lastSpaceIndex).trim();
+		const truncatedAtSpace = truncateWellFormed(
+			wellFormed,
+			lastSpaceIndex,
+		).trim();
 		if (truncatedAtSpace.length > 0) {
 			return `${truncatedAtSpace}...`;
 		}
 	}
 
 	// Fallback: Hard truncate (surrogate-safe) and add ellipsis
-	const hardTruncated = truncateWellFormed(text, maxLength - 3).trim();
+	const hardTruncated = truncateWellFormed(wellFormed, maxLength - 3).trim();
 	return `${hardTruncated}...`;
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:bd1060e1f2ee2a6c3b95a06b2aded2bb6feb8b31 -->

## Summary
In `@elizaos/core` (`packages/core/src/utils.ts`):
`truncateToCompleteSentence` performed period and whitespace boundary truncations using raw `text.slice(0, lastPeriodIndex + 1)` and `text.slice(0, lastSpaceIndex)`. While the length-3 and fallback paths were surrogate-safe, slicing on raw input at period or space indices without prior well-formed Unicode normalization could emit lone surrogates if input contained lone surrogates or surrogate pairs near boundaries.

## Proposed Changes
1. Normalized input `text` to `toWellFormedUnicode(text)` at the start of `truncateToCompleteSentence`.
2. Used `truncateWellFormed(wellFormed, lastPeriodIndex + 1)` and `truncateWellFormed(wellFormed, lastSpaceIndex)` for period and whitespace cuts.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/utils.parsing.test.ts` (15/15 passed).
- Verified well-formed Unicode output across all sentence truncation paths (exact length, period match, space match, and hard truncation fallback).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
