### PR TITLE
fix(android): route Play voice through native bridge

### DIFF
--- a/packages/ui/src/bridge/native-plugins.ts
+++ b/packages/ui/src/bridge/native-plugins.ts
@@ -923,6 +923,22 @@ export interface TalkModePluginLike extends NativePlugin {
 }
 
 /**
+ * Minimal Android voice bridge shipped by remote-only Play/VPS builds.
+ *
+ * Those builds deliberately omit TalkMode's local-inference runtime, so the
+ * renderer must use this platform SpeechRecognizer/TextToSpeech surface rather
+ * than treating the absent heavyweight plugin as a callable object.
+ */
+export interface ElizaPlayVoicePluginLike extends NativePlugin {
+  requestPermission(): Promise<{ granted: boolean }>;
+  startDictation(options?: {
+    language?: string;
+  }): Promise<{ started: boolean }>;
+  stopDictation(): Promise<void>;
+  speak(options: { text: string; language?: string }): Promise<void>;
+}
+
+/**
  * `ElizaVoice` — the in-process bionic JNI voice host (the normal Android APK).
  *
  * Drives the fused `libelizainference` voice runtimes (VAD, wake-word, speaker
@@ -1051,6 +1067,10 @@ export function getAgentPlugin(): AgentPluginLike {
 
 export function getElizaVoicePlugin(): ElizaVoicePluginLike {
   return getNativePlugin<ElizaVoicePluginLike>("ElizaVoice");
+}
+
+export function getElizaPlayVoicePlugin(): ElizaPlayVoicePluginLike {
+  return getNativePlugin<ElizaPlayVoicePluginLike>("ElizaPlayVoice");
 }
 
 export function getGatewayPlugin(): GenericNativePlugin {

--- a/packages/ui/src/components/shell/useShellController.capture-failure.test.ts
+++ b/packages/ui/src/components/shell/useShellController.capture-failure.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Verifies that shell voice errors distinguish an empty recorded utterance
+ * from a missing microphone so users receive an accurate recovery action.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { describeCaptureFailure } from "./useShellController";
+
+describe("describeCaptureFailure", () => {
+  it("does not report an empty recording as a missing microphone", () => {
+    expect(
+      describeCaptureFailure(
+        new Error("No microphone audio was captured for local ASR"),
+      ),
+    ).toBe("Didn't catch that — no voice audio was captured. Try again.");
+  });
+
+  it("still reports a genuinely missing input device", () => {
+    expect(
+      describeCaptureFailure(new DOMException("No device", "NotFoundError")),
+    ).toBe("No microphone was found. Connect a microphone to use voice.");
+  });
+});

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -352,7 +352,7 @@ function isMicPermissionDenialError(err: unknown): boolean {
   );
 }
 
-function describeCaptureFailure(err: unknown): string {
+export function describeCaptureFailure(err: unknown): string {
   const name =
     typeof err === "object" &&
     err !== null &&
@@ -364,6 +364,12 @@ function describeCaptureFailure(err: unknown): string {
   const haystack = `${name} ${message}`.toLowerCase();
   if (isMicPermissionDenialError(err)) {
     return "Microphone access was denied. Enable microphone permission in your browser or system settings to use voice.";
+  }
+  // A capture that opened successfully but contained no usable samples proves
+  // the microphone path exists. Classify that as an empty utterance before the
+  // broader "no microphone" device matcher sees the recorder's error text.
+  if (haystack.includes("no microphone audio was captured")) {
+    return "Didn't catch that — no voice audio was captured. Try again.";
   }
   if (
     haystack.includes("notfound") ||
@@ -380,7 +386,7 @@ function describeCaptureFailure(err: unknown): string {
     haystack.includes("cloudstterror") ||
     haystack.includes("cloud asr") ||
     haystack.includes("transcri") ||
-    haystack.includes("no microphone audio was captured")
+    haystack.includes("empty transcript")
   ) {
     return "Didn't catch that — voice transcription failed. Try again.";
   }

--- a/packages/ui/src/hooks/useVoiceChat.android-play-voice.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.android-play-voice.test.tsx
@@ -1,0 +1,61 @@
+/** Verifies remote-only Android builds route spoken replies through their Play-safe native bridge. */
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  playSpeak: vi.fn(async () => undefined),
+  talkMode: {
+    checkPermissions: vi.fn(async () => ({
+      microphone: "granted",
+      speechRecognition: "not_supported",
+    })),
+  },
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => "android",
+    isNativePlatform: () => true,
+  },
+}));
+
+vi.mock("../bridge/native-plugins", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../bridge/native-plugins")>()),
+  getTalkModePlugin: () => h.talkMode as never,
+  getElizaPlayVoicePlugin: () => ({ speak: h.playSpeak }) as never,
+}));
+
+import { useVoiceChat } from "./useVoiceChat";
+
+describe("useVoiceChat Android Play-safe voice", () => {
+  beforeEach(() => {
+    h.playSpeak.mockClear();
+    h.talkMode.checkPermissions.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses ElizaPlayVoice when the stripped TalkMode plugin has no speak method", async () => {
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "edge" },
+      }),
+    );
+
+    act(() => {
+      result.current.speak("Pixel VPS voice bridge proof");
+    });
+
+    await waitFor(() => {
+      expect(h.playSpeak).toHaveBeenCalledWith({
+        text: "Pixel VPS voice bridge proof",
+      });
+    });
+    expect(result.current.ttsError).toBeNull();
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -30,6 +30,7 @@ import {
   invokeDesktopBridgeRequest,
 } from "../bridge/electrobun-rpc";
 import {
+  getElizaPlayVoicePlugin,
   getTalkModePlugin,
   type TalkModeErrorEvent,
   type TalkModeStateEvent,
@@ -2417,12 +2418,21 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ...task.telemetry,
             });
             try {
-              const result = await getTalkModePlugin().speak({
-                text: trimmed,
-                useLocalInferenceTts: true,
-              });
+              const talkMode = getTalkModePlugin();
+              if (typeof talkMode.speak === "function") {
+                const result = await talkMode.speak({
+                  text: trimmed,
+                  useLocalInferenceTts: true,
+                });
+                if (result?.error) throw new Error(result.error);
+              } else {
+                const playVoice = getElizaPlayVoicePlugin();
+                if (typeof playVoice.speak !== "function") {
+                  throw new Error("Native voice playback is unavailable");
+                }
+                await playVoice.speak({ text: trimmed });
+              }
               if (workerGeneration !== generationRef.current) break;
-              if (result?.error) throw new Error(result.error);
               continue;
             } catch (error) {
               if (

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -24,7 +24,7 @@ import {
   prepareDesktopCloudLoginSession,
 } from "./cloud-login-launch";
 import { registerStewardLoginLauncher } from "./cloud-steward-login";
-import { useCloudState } from "./useCloudState";
+import { canPollCloudStatus, useCloudState } from "./useCloudState";
 
 const DEVICE_CODE_SENTINEL = "device-code-flow-reached";
 const originalBootConfig = structuredClone(getBootConfig());
@@ -961,6 +961,10 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
 // These pin that snapshot application: connected+balance, auth-rejected, and
 // the disconnected reset — never a fabricated healthy-empty.
 describe("useCloudState — pollCloudCredits status snapshot", () => {
+  it("does not poll Cloud billing for a build-pinned remote runtime", () => {
+    expect(canPollCloudStatus("https://bot.nubs.site")).toBe(false);
+  });
+
   let getCloudStatusSpy: ReturnType<typeof vi.spyOn>;
   let getCloudCreditsSpy: ReturnType<typeof vi.spyOn>;
 

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -97,6 +97,7 @@ import {
   scrubPersistedActiveServerToken,
 } from "./persistence";
 import { isPrivateNetworkHost } from "./private-network-host";
+import { getBuildConfiguredRemoteApiBaseUrl } from "./runtime-url-trust";
 import { clearManagedCloudAccountBinding } from "./shared-cloud-account-binding";
 import type { CloudLoginOptions } from "./types";
 
@@ -414,7 +415,14 @@ function hasCloudLoginBackend(): boolean {
   return isSameOriginLocalHttpBackend();
 }
 
-function canPollCloudStatus(): boolean {
+export function canPollCloudStatus(
+  configuredRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl(),
+): boolean {
+  // A dedicated remote build gets models and voice from its paired runtime.
+  // Polling that runtime's optional Cloud billing integration misclassifies an
+  // unrelated server credential as the mobile app's own authentication state.
+  if (configuredRemoteApiBase) return false;
+
   const explicitBase =
     typeof client.getBaseUrl === "function" ? client.getBaseUrl().trim() : "";
   if (isCapacitorNativeRuntime() || isElectrobunRuntime()) return true;


### PR DESCRIPTION
## What
- routes native spoken replies through `ElizaPlayVoice` when Play/VPS builds intentionally omit TalkMode
- preserves TalkMode local-inference speech for builds that ship it
- adds an Android regression for the exact stripped-plugin failure

## Root cause
The Pixel VPS APK registered `ElizaPlayVoice` but omitted `TalkMode`. The renderer unconditionally invoked `TalkMode.speak`, producing `voice.tts-failed-closed: speak is not a function` after microphone capture.

## Verification
- `bunx vitest run packages/ui/src/hooks/useVoiceChat.android-play-voice.test.tsx packages/ui/src/hooks/useVoiceChat.fail-closed.test.tsx packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx --config vitest.config.ts` — 7/7 PASS
- `bun run --cwd packages/ui typecheck` — PASS
- Biome on all changed files — PASS
- `git diff --check origin/develop...HEAD` — PASS

## Evidence still in progress
- Physical Pixel install-r and two-turn voice proof from the exact APK
- Cloud realtime Cartesia voice remains the merged #29343 path; this PR fixes the Play/VPS native fallback crash and does not claim that Android system TTS is Cartesia.