### PR TITLE
fix(core): ensure trimEndCharacters and trimEndWhitespace normalize to well-formed Unicode and preserve surrogate pair integrity

### DIFF
--- a/packages/core/src/utils/string-boundaries.test.ts
+++ b/packages/core/src/utils/string-boundaries.test.ts
@@ -11,6 +11,11 @@ describe("core string boundary scanners", () => {
 		expect(trimEndWhitespace("answer \t\n")).toBe("answer");
 	});
 
+	it("preserves well-formed Unicode when trimming whitespace and surrogate pairs", () => {
+		expect(trimEndWhitespace("hello 🤖  ")).toBe("hello 🤖");
+		expect(trimEndCharacters("hello 🤖///", "/")).toBe("hello 🤖");
+	});
+
 	it("handles 100k-character suffixes in linear time", () => {
 		expect(trimEndCharacters(`root${"/".repeat(100_000)}`, "/")).toBe("root");
 		expect(trimEndWhitespace(`root${"\t".repeat(100_000)}`)).toBe("root");

--- a/packages/core/src/utils/string-boundaries.ts
+++ b/packages/core/src/utils/string-boundaries.ts
@@ -1,23 +1,32 @@
 /** Provides linear boundary trimming for explicit character sets and whitespace. */
+import { toWellFormedUnicode } from "./well-formed.js";
 
 export function trimEndCharacters(value: string, characters: string): string {
+	const wellFormed = toWellFormedUnicode(value);
 	const accepted = new Set(characters);
-	let end = value.length;
+	let end = wellFormed.length;
 	while (end > 0) {
 		let start = end - 1;
-		const last = value.charCodeAt(start);
+		const last = wellFormed.charCodeAt(start);
 		if (last >= 0xdc00 && last <= 0xdfff && start > 0) {
-			const previous = value.charCodeAt(start - 1);
+			const previous = wellFormed.charCodeAt(start - 1);
 			if (previous >= 0xd800 && previous <= 0xdbff) start -= 1;
 		}
-		if (!accepted.has(value.slice(start, end))) break;
+		if (!accepted.has(wellFormed.slice(start, end))) break;
 		end = start;
 	}
-	return end === value.length ? value : value.slice(0, end);
+	return end === wellFormed.length ? wellFormed : wellFormed.slice(0, end);
 }
 
 export function trimEndWhitespace(value: string): string {
-	let end = value.length;
-	while (end > 0 && /\s/u.test(value[end - 1])) end -= 1;
-	return end === value.length ? value : value.slice(0, end);
+	const wellFormed = toWellFormedUnicode(value);
+	let end = wellFormed.length;
+	while (end > 0 && /\s/u.test(wellFormed[end - 1])) end -= 1;
+	if (end > 0) {
+		const code = wellFormed.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return end === wellFormed.length ? wellFormed : wellFormed.slice(0, end);
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c4f3351c76e37750f7e935237c0c5a6925ff83a6 -->

## Summary
In `@elizaos/core` (`packages/core/src/utils/string-boundaries.ts`):
`trimEndCharacters` and `trimEndWhitespace` operated on raw input strings. If the input contained unpaired lone surrogates or if `trimEndWhitespace` reached a high surrogate whose low surrogate was adjacent, boundary cuts could sever surrogate pairs or output non-well-formed Unicode.

## Proposed Changes
1. Normalized input `value` to `toWellFormedUnicode(value)` in both `trimEndCharacters` and `trimEndWhitespace`.
2. Added high-surrogate boundary alignment in `trimEndWhitespace`.
3. Added unit test verifying well-formed Unicode output when trimming whitespace and character suffixes on strings with emojis.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/utils/string-boundaries.test.ts` (4/4 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
