### PR TITLE
fix(core): use truncateWellFormed for agent and account ID input normalization in session-key

### DIFF
--- a/packages/core/src/sessions/session-key.ts
+++ b/packages/core/src/sessions/session-key.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed.js";
 /** Builds, parses, and normalizes `agent:{agentId}:{rest}` session identifiers. */
 
 // ============================================================================
@@ -15,7 +16,7 @@ const LEADING_DASH_RE = /^-+/;
 const TRAILING_DASH_RE = /-+$/;
 
 function trimOptionalString(value: string | undefined | null): string {
-	return value ? value.trim() : "";
+	return value ? truncateWellFormed(toWellFormedUnicode(value.trim()), 1024) : "";
 }
 
 // ============================================================================
@@ -185,8 +186,7 @@ export function normalizeAgentId(value: string | undefined | null): string {
 	if (!rawTrimmed) {
 		return DEFAULT_AGENT_ID;
 	}
-	const trimmed =
-		rawTrimmed.length > 1024 ? rawTrimmed.slice(0, 1024) : rawTrimmed;
+	const trimmed = rawTrimmed;
 	// Keep it path-safe + shell-friendly.
 	if (VALID_ID_RE.test(trimmed)) {
 		return trimmed.toLowerCase();
@@ -223,8 +223,7 @@ export function normalizeAccountId(value: string | undefined | null): string {
 	if (!rawTrimmed) {
 		return DEFAULT_ACCOUNT_ID;
 	}
-	const trimmed =
-		rawTrimmed.length > 1024 ? rawTrimmed.slice(0, 1024) : rawTrimmed;
+	const trimmed = rawTrimmed;
 	if (VALID_ID_RE.test(trimmed)) {
 		return trimmed.toLowerCase();
 	}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:90432e2d52d9cfcd598cea7ea4e60549ea07933e -->

## Summary
In `@elizaos/core` (`packages/core/src/sessions/session-key.ts`):
`normalizeAgentId` and `normalizeAccountId` clamped long raw inputs using raw `.slice(0, 1024)`. When inputs contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(value.trim()), 1024)` in `trimOptionalString` so all ID processing begins with well-formed, surrogate-safe inputs.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/sessions/session-key.test.ts` (7/7 passed).
- Verified well-formed Unicode output during session key agent/account ID normalization and building.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
