### PR TITLE
fix(plugin-local-inference): ensure joinTranscriptParts normalizes head and tail to well-formed Unicode

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/transcriber.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.ts
@@ -31,7 +31,7 @@
  * (AGENTS.md §3 + §9).
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode } from "@elizaos/core";
 
 import type {
 	ElizaInferenceContextHandle,
@@ -680,8 +680,8 @@ function concatFloat32(a: Float32Array, b: Float32Array): Float32Array {
  * both sides clearly continue the same token-ish run.
  */
 function joinTranscriptParts(head: string, tail: string): string {
-	const h = head.trimEnd();
-	const t = tail.trimStart();
+	const h = toWellFormedUnicode(head).trimEnd();
+	const t = toWellFormedUnicode(tail).trimStart();
 	if (!h) return t;
 	if (!t) return h;
 	// If `tail` starts with a continuation of `head`'s last word, prefer


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:18021191fcd19e05bf570abcc55056de61910e82 -->

## Summary
In `@elizaos/plugin-local-inference` (`plugins/plugin-local-inference/src/services/voice/transcriber.ts`):
`joinTranscriptParts` trimmed and spliced partial transcript pieces on raw strings. If streaming ASR yielded chunks containing lone surrogates or unaligned multi-code-unit UTF-16 surrogate pairs, raw slicing could emit severed surrogate pairs into output transcripts.

## Proposed Changes
1. Normalized `head` and `tail` via `toWellFormedUnicode(...)` in `joinTranscriptParts`.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-local-inference/src/services/voice/transcriber.test.ts plugins/plugin-local-inference/src/services/voice/transcriber.asr-backend.test.ts` (23/23 passed).
- Verified well-formed Unicode output during streaming transcript segment stitching.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
