### PR TITLE
fix(voice): gate realtime Talk on Dedicated identity

### DIFF
--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -178,9 +178,13 @@ const realtimeVoiceMock = vi.hoisted(() => {
   });
 });
 
+const realtimeVoiceMintMock = vi.hoisted(() => ({
+  agentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee" as string | null,
+}));
+
 vi.mock("../../../hooks/useRealtimeVoiceMint", () => ({
   useRealtimeVoiceMint: () => ({
-    agentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    agentId: realtimeVoiceMintMock.agentId,
     getConsentNonce: vi.fn(async () => "consent-nonce"),
   }),
 }));
@@ -365,6 +369,7 @@ afterEach(() => {
     async () => micPermissionMock.state,
   );
   realtimeVoiceMock.enabled = false;
+  realtimeVoiceMintMock.agentId = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
   realtimeVoiceMock.options = null;
   realtimeVoiceMock.startOutcome = { kind: "live" };
   realtimeVoiceMock.startedConversationIds.length = 0;
@@ -374,6 +379,7 @@ afterEach(() => {
   realtimeVoiceMock.bargeIn.mockClear();
   realtimeVoiceMock.toggleMicrophoneMute.mockClear();
   realtimeVoiceMock.state.active = false;
+  realtimeVoiceMock.state.available = true;
   realtimeVoiceMock.state.connecting = false;
   realtimeVoiceMock.state.status = "idle";
   realtimeVoiceMock.state.transcriptPartial = "";
@@ -2158,7 +2164,8 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     realtimeVoiceMock.startedConversationIds.length = 0;
     realtimeVoiceMock.start.mockClear();
     realtimeVoiceMock.stop.mockClear();
-    createVoiceCaptureMock.mockClear();
+    createVoiceCaptureMock.mockReset();
+    installFakeCapture();
     appMock.value.activeConversationId = conversationId;
     try {
       window.localStorage.clear();
@@ -2189,6 +2196,23 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps batch Talk authoritative while a stale Shared binding has no Dedicated identity", async () => {
+    realtimeVoiceMintMock.agentId = null;
+    realtimeVoiceMock.state.available = false;
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+
+    expect(realtimeVoiceMock.start).not.toHaveBeenCalled();
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    expect(result.current.handsFree).toBe(true);
+    expect(result.current.realtimeVoice?.enabled).toBe(false);
+    expect(result.current.realtimeVoice?.error).toBeNull();
   });
 
   it("routes programmatic converse capture to one realtime session", async () => {

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -589,9 +589,14 @@ export function useShellController(): ShellController {
   // realtime session. ChatView may still consume the same hook on legacy
   // embedding surfaces, but the visible shell Talk control must never hand a
   // failed Cartesia interaction to the unrelated batch Cloud-ASR recorder.
-  const realtimeVoiceEnabled = isRealtimeVoiceFlagEnabled();
+  const realtimeVoiceBuildEnabled = isRealtimeVoiceFlagEnabled();
   const { agentId: realtimeVoiceAgentId, getConsentNonce } =
     useRealtimeVoiceMint();
+  // The build flag advertises the capability, but only a resolved Dedicated
+  // agent may own Talk. A stale Shared binding has no mintable UUID; retain the
+  // established batch path until signed-in routing repairs it to Dedicated.
+  const realtimeVoiceEnabled =
+    realtimeVoiceBuildEnabled && Boolean(realtimeVoiceAgentId);
   const realtimeVoice = useRealtimeVoiceSession({
     agentId: realtimeVoiceAgentId,
     conversationId: activeConversationId,

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.test.tsx
@@ -51,6 +51,16 @@ describe("useRealtimeVoiceMint", () => {
     expect(result.current.agentId).toBeNull();
   });
 
+  it("rejects Personal Shared because signed-in realtime requires Dedicated", () => {
+    const { result } = renderHook(() =>
+      useRealtimeVoiceMint({
+        resolveAgentId: () => "personal:00000000-0000-5000-8000-000000000001",
+        fetch: vi.fn(),
+      }),
+    );
+    expect(result.current.agentId).toBeNull();
+  });
+
   it("getConsentNonce returns the nonce on a 200 consent response", async () => {
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ consentNonce: "nonce-abc" }), {


### PR DESCRIPTION
Fixes #29346.

Depends on #29345 for the signed-in routing invariant. #29343 already provides the Dedicated realtime proxy/voice handoff.

## Outcome

The persistent shell gives realtime Talk ownership only to a resolved Dedicated agent UUID. If an older signed-in session is still bound to Personal Shared, realtime stays disabled and the established batch voice path remains authoritative instead of presenting the misleading pre-network `Cartesia voice is not ready yet` error.

This PR does **not** admit Personal Shared identities to realtime minting. Shared remains public and connector ingress; signed-in app and Cloud sessions are repaired to Dedicated by #29345.

## Root cause

The shell selected realtime solely from the build flag. `useRealtimeVoiceMint` correctly returned `null` for a Personal Shared binding, but the shell still intercepted Talk and called an unavailable realtime session before any consent, mint, or WebSocket request could occur.

## Changes

- require both the build flag and a resolved Dedicated mint identity before realtime owns Talk
- prove the mint hook rejects the `personal:*` namespace for signed-in realtime
- preserve batch Talk when the Dedicated identity is absent
- cover the stale Shared binding regression, including no realtime start and no false error

## Verification

- shell controller + realtime mint suites: 112 passed
- `bun run --cwd packages/ui typecheck`
- Biome on all three touched files
- `git diff --check`
- affected chat captures from `bun run --cwd packages/app audit:app`: mobile portrait, mobile landscape, desktop landscape, and iPad portrait passed before the broader unaffected 215-view audit was stopped after the product invariant correction
- repository `bun run verify` remains stopped by the unrelated branch-wide i18n backlog on current `develop`

## Exact restack evidence

Exact head: `0aa1ab32975a1ebe93d0131acdfcd3845a461e78`, replayed as the single unique commit on `origin/develop@eaca601284dce67273fc06ab0d11ce6d1ddc9a34`. Focused suites, UI typecheck, targeted Biome, and diff integrity passed after replay. Hosted checks for this exact head are required before merge.