### PR TITLE
fix(plugin-local-inference): ensure PartialStabilizer preserves surrogate pair integrity and normalizes to well-formed Unicode

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.test.ts
@@ -10,6 +10,14 @@ describe("PartialStabilizer (LocalAgreement-n)", () => {
 		expect(out.pending).toBe("the cat");
 	});
 
+	it("preserves UTF-16 surrogate pairs and never severs them at agreement boundary", () => {
+		const s = new PartialStabilizer();
+		s.feed("hello 🤖 world");
+		const out = s.feed("hello 🤖 friends");
+		expect(out.stable).toBe("hello 🤖 ");
+		expect(out.pending).toBe("friends");
+	});
+
 	it("commits the common prefix once a second partial agrees", () => {
 		const s = new PartialStabilizer();
 		s.feed("the cat sa");

--- a/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode } from "@elizaos/core";
 /**
  * A2 — LocalAgreement-n streaming-ASR partial stabilizer.
  *
@@ -61,6 +62,12 @@ function commonPrefixLength(a: string, b: string): number {
 	const n = Math.min(a.length, b.length);
 	let i = 0;
 	while (i < n && a.charCodeAt(i) === b.charCodeAt(i)) i++;
+	if (i > 0) {
+		const code = a.charCodeAt(i - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			i -= 1;
+		}
+	}
 	return i;
 }
 
@@ -92,7 +99,8 @@ export class PartialStabilizer {
 	 * later partial briefly disagrees (the ASR will catch up; rolling back
 	 * would cause downstream stutter).
 	 */
-	feed(partial: string): StabilizerOutput {
+	feed(rawPartial: string): StabilizerOutput {
+		const partial = toWellFormedUnicode(rawPartial);
 		this.history.push(partial);
 		if (this.history.length > this.agreementCount) {
 			this.history.shift();


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5770289eb27b8d23f2d5329b5cdfe6be8c667634 -->

## Summary
In `@elizaos/plugin-local-inference` (`plugins/plugin-local-inference/src/services/voice/partial-stabilizer.ts`):
`PartialStabilizer.feed` processed raw input strings and computed prefix intersections via `commonPrefixLength`. When streaming ASR yielded partials sharing a high surrogate at the prefix boundary but differing on the subsequent code unit (or ending after the high surrogate), `agreed.slice(0, sharedLen)` severed the UTF-16 surrogate pair and committed lone surrogates to downstream consumers.

## Proposed Changes
1. Normalized fed inputs to `toWellFormedUnicode(rawPartial)` in `PartialStabilizer.feed`.
2. Added high-surrogate boundary detection and offset adjustment in `commonPrefixLength` so common prefix boundaries never cut between surrogate pairs.
3. Added unit tests in `partial-stabilizer.test.ts` verifying UTF-16 surrogate pair preservation across agreement updates.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-local-inference/src/services/voice/partial-stabilizer.test.ts` (8/8 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
