### PR TITLE
fix(scenario-runner): use truncateWellFormed for calendar assertion payload failure previews and deterministic dispatch render text

### DIFF
--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -18,6 +18,8 @@ import {
   ModelType,
   NotificationService,
   trajectoriesPlugin,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   createDeterministicModelPlugin,
@@ -574,10 +576,11 @@ export function deterministicScheduledDispatchRenderText(
   // contains) the raw instruction. Prefix the de-framed instruction and clamp
   // long instructions so the deterministic copy always passes that guard.
   if (!ownerMessage) return "checking in.";
+  const wellFormed = toWellFormedUnicode(ownerMessage);
   const clamped =
-    ownerMessage.length >= 64
-      ? `${ownerMessage.slice(0, 60).trimEnd()}…`
-      : ownerMessage;
+    wellFormed.length >= 64
+      ? `${truncateWellFormed(wellFormed, 60).trimEnd()}…`
+      : wellFormed;
   return `Heads up: ${clamped}`;
 }
 

--- a/packages/scenario-runner/src/scenario-assertions/calendar-assertions.ts
+++ b/packages/scenario-runner/src/scenario-assertions/calendar-assertions.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /** Provides calendar action-result assertions for executable scenarios. */
 import type {
   ScenarioCheckResult,
@@ -27,7 +28,7 @@ function validateBlob(
 ): ScenarioCheckResult {
   for (const pattern of expectation.includesAll ?? []) {
     if (!matchesPattern(blob, pattern)) {
-      return `Expected ${expectation.description}: missing ${String(pattern)}. Payload: ${blob.slice(0, 600)}`;
+      return `Expected ${expectation.description}: missing ${String(pattern)}. Payload: ${truncateWellFormed(toWellFormedUnicode(blob), 600)}`;
     }
   }
 
@@ -36,7 +37,7 @@ function validateBlob(
       matchesPattern(blob, pattern),
     );
     if (!matched) {
-      return `Expected ${expectation.description}: missing any of [${expectation.includesAny.map(String).join(", ")}]. Payload: ${blob.slice(0, 600)}`;
+      return `Expected ${expectation.description}: missing any of [${expectation.includesAny.map(String).join(", ")}]. Payload: ${truncateWellFormed(toWellFormedUnicode(blob), 600)}`;
     }
   }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:aa6aee3fd9a9e77b81c2f09303b2fbeba36a744c -->

## Summary
In `@elizaos/scenario-runner`:
- `validateBlob` (`packages/scenario-runner/src/scenario-assertions/calendar-assertions.ts`) clamped failed payload previews using raw `blob.slice(0, 600)`.
- `deterministicScheduledDispatchRenderText` (`packages/scenario-runner/src/runtime-factory.ts`) clamped long owner instruction messages using raw `ownerMessage.slice(0, 60)`.

When payloads or instructions contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Replaced raw `.slice(0, 600)` in `calendar-assertions.ts` with `truncateWellFormed(toWellFormedUnicode(blob), 600)`.
2. Normalized `ownerMessage` to well-formed Unicode and clamped via `truncateWellFormed(wellFormed, 60)` in `deterministicScheduledDispatchRenderText`.

## Verification
- Ran vitest: `bunx vitest run packages/scenario-runner/src/scenario-assertions/__tests__/calendar-assertions.test.ts` (19/19 passed).
- Verified well-formed Unicode output during calendar assertion failure message generation and deterministic dispatch copy rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
