### PR TITLE
fix(scenario-runner): use truncateWellFormed for action call summaries and selected action argument failure details in final-checks

### DIFF
--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { IAgentRuntime } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed, type IAgentRuntime } from "@elizaos/core";
 import {
   FINAL_CHECK_KEYS,
   type ScenarioContext,
@@ -1114,12 +1114,17 @@ function actionCallSummary(
             : undefined,
       }
     : undefined;
-  return JSON.stringify({
-    actionName: action.actionName,
-    parameters: action.parameters,
-    result,
-    error: action.error?.message,
-  }).slice(0, 500);
+  return truncateWellFormed(
+    toWellFormedUnicode(
+      JSON.stringify({
+        actionName: action.actionName,
+        parameters: action.parameters,
+        result,
+        error: action.error?.message,
+      }),
+    ),
+    500,
+  );
 }
 
 type TrustedObservationCheck = {
@@ -1432,7 +1437,7 @@ registerFinalCheckHandler("selectedActionArguments", (check, { ctx }) => {
       if (!matchesPattern(blob, pattern)) {
         return {
           status: "failed",
-          detail: `selectedActionArguments: expected arguments to include ${String(pattern)}, saw ${JSON.stringify(blob.slice(0, 500))}`,
+          detail: `selectedActionArguments: expected arguments to include ${String(pattern)}, saw ${JSON.stringify(truncateWellFormed(toWellFormedUnicode(blob), 500))}`,
         };
       }
     }
@@ -1442,7 +1447,7 @@ registerFinalCheckHandler("selectedActionArguments", (check, { ctx }) => {
     if (!ok) {
       return {
         status: "failed",
-        detail: `selectedActionArguments: expected arguments to include any of [${includesAny.map(String).join(",")}], saw ${JSON.stringify(blob.slice(0, 500))}`,
+        detail: `selectedActionArguments: expected arguments to include any of [${includesAny.map(String).join(",")}], saw ${JSON.stringify(truncateWellFormed(toWellFormedUnicode(blob), 500))}`,
       };
     }
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:32a1395c0dc6556c3fbcc54c79b75b967ebff750 -->

## Summary
In `@elizaos/scenario-runner` (`packages/scenario-runner/src/final-checks/index.ts`):
- `actionCallSummary` clamped JSON-serialized action descriptors using raw `.slice(0, 500)`.
- `selectedActionArguments` check handler clamped failed argument blobs using raw `blob.slice(0, 500)`.

When action parameters or argument blobs contained multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(...), 500)` in `actionCallSummary`.
2. Used `truncateWellFormed(toWellFormedUnicode(blob), 500)` in `selectedActionArguments` failure message details.

## Verification
- Ran vitest: `bunx vitest run packages/scenario-runner/src/final-checks/index.test.ts` (10/10 passed).
- Verified well-formed Unicode output during scenario final check failure reporting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
