### PR TITLE
fix(scenario-runner): use truncateWellFormed for planner preview in turn assertions failure reports

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -34,6 +34,8 @@ import {
   postDeliveryTaskQuarantineReason,
   revalidateOwnerExclusiveDisclosure,
   stringToUuid,
+  toWellFormedUnicode,
+  truncateWellFormed,
   validateUuid,
 } from "@elizaos/core";
 import type { DeterministicModelDiagnostics } from "@elizaos/core/testing";
@@ -2621,7 +2623,7 @@ async function runTurnAssertions(
     plannerExcludes.length > 0
   ) {
     const plannerBlob = buildPlannerAssertionBlob(execution);
-    const plannerPreview = JSON.stringify(plannerBlob.slice(0, 500));
+    const plannerPreview = JSON.stringify(truncateWellFormed(toWellFormedUnicode(plannerBlob), 500));
     if (plannerIncludesAll.length > 0) {
       const missing = plannerIncludesAll.filter(
         (pattern) => !matchesTurnMatcher(plannerBlob, pattern),


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:bd287505fa539299454e476810251d1fb8470528 -->

## Summary
In `@elizaos/scenario-runner` (`packages/scenario-runner/src/executor.ts`):
`runTurnAssertions` clamped `plannerBlob` using raw `.slice(0, 500)` when constructing `plannerPreview` for test failure messages. When planner traces or thoughts contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs into lone surrogates.

## Proposed Changes
1. Replaced raw `.slice(0, 500)` with `truncateWellFormed(toWellFormedUnicode(plannerBlob), 500)` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run packages/scenario-runner/src/scenario-assertions/__tests__/action-assertions.test.ts` (40/40 passed).
- Verified well-formed Unicode output during scenario runner turn assertion failure report construction.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
