### PR TITLE
fix(cloud): default video generation to MiniMax H3 Max

### DIFF
--- a/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
@@ -44,8 +44,9 @@ const originalFetch = globalThis.fetch;
 
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
-const FAL_MODEL = "fal-ai/veo3";
-const ATLAS_MODEL = "vidu/q3-turbo/text-to-video";
+const FAL_MODEL = "minimax/h3-max/image-to-video";
+const ATLAS_MODEL = "vidu/image-to-video-2.0";
+const REFERENCE_URL = "https://example.com/start.png";
 const FAL_COST = 0.8;
 const ATLAS_COST = 0.3;
 
@@ -77,10 +78,10 @@ mock.module("@/lib/services/ai-pricing", () => ({
   ...aiPricingActual,
   calculateVideoGenerationCostFromCatalog,
   getDefaultVideoBillingDimensions: (model: string) => ({
-    durationSeconds: model === FAL_MODEL ? 8 : 5,
+    durationSeconds: model === FAL_MODEL ? 5 : 4,
     dimensions:
       model === FAL_MODEL
-        ? { audio: true }
+        ? { resolution: "768P", audio: true }
         : { resolution: "720p", audio: false },
   }),
 }));
@@ -181,7 +182,10 @@ function atlasSuccess(url = "https://atlas.media/video.mp4") {
 
 function post(
   env: Record<string, unknown>,
-  body: Record<string, unknown> = { prompt: "a neon cat" },
+  body: Record<string, unknown> = {
+    prompt: "a neon cat",
+    referenceUrl: REFERENCE_URL,
+  },
 ) {
   return videoRoute.request(
     "/",
@@ -230,6 +234,23 @@ beforeEach(() => {
 });
 
 describe("generate-video — default provider fallback", () => {
+  test("requires an image for the image-to-video default chain", async () => {
+    const response = await post(
+      { FAL_KEY: "fal-key", ATLASCLOUD_API_KEY: "atlas-key" },
+      { prompt: "a neon cat" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      error: "referenceUrl is required for image-to-video generation",
+    });
+    expect(calculateVideoGenerationCostFromCatalog).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("rejects an unconfigured default chain before pricing or credit work", async () => {
     const response = await post({});
 
@@ -304,7 +325,11 @@ describe("generate-video — default provider fallback", () => {
   test("keeps an explicit model request pinned to its provider", async () => {
     const response = await post(
       { ATLASCLOUD_API_KEY: "atlas-key" },
-      { model: FAL_MODEL, prompt: "a neon cat" },
+      {
+        model: FAL_MODEL,
+        prompt: "a neon cat",
+        referenceUrl: REFERENCE_URL,
+      },
     );
 
     expect(response.status).toBe(503);
@@ -351,13 +376,13 @@ describe("generate-video — default provider fallback", () => {
     expect(reserve).toHaveBeenCalledTimes(2);
     expect(reserve.mock.calls[0]?.[0]).toMatchObject({
       amount: FAL_COST,
-      model: "veo3",
+      model: "h3-max",
       provider: "fal",
       billingSource: "fal",
     });
     expect(reserve.mock.calls[1]?.[0]).toMatchObject({
       amount: ATLAS_COST,
-      model: "q3-turbo",
+      model: "image-to-video-2.0",
       provider: "vidu",
       billingSource: "atlascloud",
     });

--- a/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
@@ -306,29 +306,128 @@ describe("generate-video — default provider fallback", () => {
     expect(ledger.lastActual).toBeCloseTo(ATLAS_COST, 10);
   });
 
-  test("preserves silent default requests with a model that supports audio controls", async () => {
-    const ledger = makeLedgerReservation(100, ATLAS_COST);
+  test.each([undefined, REFERENCE_URL])(
+    "preserves silent default media with reference %j",
+    async (referenceUrl) => {
+      const ledger = makeLedgerReservation(100, ATLAS_COST);
+      reserve.mockResolvedValue(ledger.reservation);
+      subscribe.mockResolvedValue({
+        data: { video: { url: "https://fal.media/silent.mp4" } },
+        requestId: "fal-silent-request",
+      });
+
+      const response = await post(
+        { FAL_KEY: "fal-key" },
+        {
+          prompt: "a neon cat",
+          audio: false,
+          voiceControl: false,
+          durationSeconds: 5,
+          referenceUrl,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(subscribe.mock.calls[0]?.[0]).toBe(
+        referenceUrl
+          ? "bytedance/seedance-2.5/image-to-video"
+          : "bytedance/seedance-2.5/text-to-video",
+      );
+      expect(subscribe.mock.calls[0]?.[1]?.input).toMatchObject({
+        prompt: "a neon cat",
+        duration: "5",
+        resolution: "720p",
+        generate_audio: false,
+        ...(referenceUrl ? { image_url: referenceUrl } : {}),
+      });
+      expect(subscribe.mock.calls[0]?.[1]?.input).not.toHaveProperty(
+        "voice_control",
+      );
+      expect(subscribe.mock.calls[0]?.[1]?.input).not.toHaveProperty("audio");
+      expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+        model: referenceUrl
+          ? "bytedance/seedance-2.5/image-to-video"
+          : "bytedance/seedance-2.5/text-to-video",
+        provider: "fal",
+      });
+      expect(
+        calculateVideoGenerationCostFromCatalog.mock.calls[0]?.[0],
+      ).toMatchObject({
+        model: referenceUrl
+          ? "bytedance/seedance-2.5/image-to-video"
+          : "bytedance/seedance-2.5/text-to-video",
+        durationSeconds: 5,
+      });
+      expect(ledger.lastActual).toBeCloseTo(ATLAS_COST, 10);
+    },
+  );
+
+  test.each([
+    undefined,
+    "bytedance/seedance-2.5/text-to-video",
+    "bytedance/seedance-2.5/image-to-video",
+  ])(
+    "rejects unsupported voice selection for %j before pricing or billing",
+    async (model) => {
+      const response = await post(
+        { FAL_KEY: "fal-key" },
+        {
+          prompt: "a neon cat",
+          model,
+          referenceUrl: REFERENCE_URL,
+          audio: false,
+          voiceControl: true,
+        },
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("voice control");
+      expect(calculateVideoGenerationCostFromCatalog).not.toHaveBeenCalled();
+      expect(reserve).not.toHaveBeenCalled();
+      expect(subscribe).not.toHaveBeenCalled();
+    },
+  );
+  test.each([
+    undefined,
+    "bytedance/seedance-2.5/text-to-video",
+    "bytedance/seedance-2.5/image-to-video",
+  ])(
+    "rejects a too-short Seedance request %j before credit work",
+    async (model) => {
+      const response = await post(
+        { FAL_KEY: "fal-key" },
+        {
+          prompt: "a cat",
+          referenceUrl: REFERENCE_URL,
+          model,
+          audio: false,
+          durationSeconds: 3,
+        },
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("durationSeconds");
+      expect(calculateVideoGenerationCostFromCatalog).not.toHaveBeenCalled();
+      expect(reserve).not.toHaveBeenCalled();
+      expect(subscribe).not.toHaveBeenCalled();
+    },
+  );
+
+  test("accepts no voice selection without changing the primary model", async () => {
+    const ledger = makeLedgerReservation(100, FAL_COST);
     reserve.mockResolvedValue(ledger.reservation);
     subscribe.mockResolvedValue({
-      data: { video: { url: "https://fal.media/silent.mp4" } },
-      requestId: "fal-silent-request",
+      data: { video: { url: "https://fal.media/out.mp4" } },
+      requestId: "fal-no-voice",
     });
-
     const response = await post(
       { FAL_KEY: "fal-key" },
-      {
-        prompt: "a neon cat",
-        audio: false,
-      },
+      { prompt: "a neon cat", voiceControl: false },
     );
-
     expect(response.status).toBe(200);
-    expect(subscribe.mock.calls[0]?.[0]).toBe("fal-ai/veo3");
-    expect(subscribe.mock.calls[0]?.[1]?.input).toMatchObject({
-      audio: false,
-      generate_audio: false,
-    });
-    expect(ledger.lastActual).toBeCloseTo(ATLAS_COST, 10);
+    expect(subscribe.mock.calls[0]?.[0]).toBe(FAL_MODEL);
+    expect(subscribe.mock.calls[0]?.[1]?.input).not.toHaveProperty(
+      "voice_control",
+    );
+    expect(ledger.lastActual).toBeCloseTo(FAL_COST, 10);
   });
 
   test.each([{ audio: false }, { voiceControl: true }])(

--- a/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
@@ -86,6 +86,12 @@ mock.module("@/lib/services/ai-pricing", () => ({
   }),
 }));
 
+// This provider failover fixture uses prepaid credits; subscription funding
+// is exercised by the billing authority integration suite.
+mock.module("@/db/repositories/subscription-entitlements", () => ({
+  subscriptionEntitlementsRepository: { find: async () => undefined },
+}));
+
 const reserve = mock();
 mock.module("@/lib/services/credits", () => ({
   ...creditsActual,
@@ -234,10 +240,10 @@ beforeEach(() => {
 });
 
 describe("generate-video — default provider fallback", () => {
-  test("requires an image for the image-to-video default chain", async () => {
+  test("requires an image for an explicitly image-only model", async () => {
     const response = await post(
       { FAL_KEY: "fal-key", ATLASCLOUD_API_KEY: "atlas-key" },
-      { prompt: "a neon cat" },
+      { model: ATLAS_MODEL, prompt: "a neon cat" },
     );
 
     expect(response.status).toBe(400);
@@ -250,6 +256,99 @@ describe("generate-video — default provider fallback", () => {
     expect(subscribe).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  test("generates a prompt-only request with H3 Max without fabricating an image", async () => {
+    const ledger = makeLedgerReservation(100, FAL_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockResolvedValue({
+      data: { video: { url: "https://fal.media/video.mp4" } },
+      requestId: "fal-text-request",
+    });
+
+    const response = await post(
+      { FAL_KEY: "fal-key" },
+      { prompt: "a neon cat" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(subscribe.mock.calls[0]?.[0]).toBe(FAL_MODEL);
+    expect(subscribe.mock.calls[0]?.[1]?.input).toMatchObject({
+      prompt: "a neon cat",
+      prompt_expansion_mode: "balanced",
+    });
+    expect(subscribe.mock.calls[0]?.[1]?.input).not.toHaveProperty("image_url");
+    expect(ledger.lastActual).toBeCloseTo(FAL_COST, 10);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: FAL_MODEL,
+      storage_url: "https://fal.media/video.mp4",
+    });
+  });
+
+  test("retains a text-to-video fallback for prompt-only requests", async () => {
+    const ledger = makeLedgerReservation(100, ATLAS_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    fetchMock.mockResolvedValue(atlasSuccess());
+
+    const response = await post(
+      { ATLASCLOUD_API_KEY: "atlas-key" },
+      { prompt: "a neon cat" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: "vidu/q3-turbo/text-to-video",
+      provider: "vidu",
+      storage_url: "https://atlas.media/video.mp4",
+    });
+    expect(ledger.lastActual).toBeCloseTo(ATLAS_COST, 10);
+  });
+
+  test("preserves silent default requests with a model that supports audio controls", async () => {
+    const ledger = makeLedgerReservation(100, ATLAS_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockResolvedValue({
+      data: { video: { url: "https://fal.media/silent.mp4" } },
+      requestId: "fal-silent-request",
+    });
+
+    const response = await post(
+      { FAL_KEY: "fal-key" },
+      {
+        prompt: "a neon cat",
+        audio: false,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(subscribe.mock.calls[0]?.[0]).toBe("fal-ai/veo3");
+    expect(subscribe.mock.calls[0]?.[1]?.input).toMatchObject({
+      audio: false,
+      generate_audio: false,
+    });
+    expect(ledger.lastActual).toBeCloseTo(ATLAS_COST, 10);
+  });
+
+  test.each([{ audio: false }, { voiceControl: true }])(
+    "rejects unsupported explicit controls %j before pricing or billing",
+    async (controls) => {
+      const response = await post(
+        { FAL_KEY: "fal-key" },
+        {
+          model: FAL_MODEL,
+          prompt: "a neon cat",
+          ...controls,
+        },
+      );
+
+      expect(response.status).toBe(400);
+      expect(calculateVideoGenerationCostFromCatalog).not.toHaveBeenCalled();
+      expect(reserve).not.toHaveBeenCalled();
+      expect(subscribe).not.toHaveBeenCalled();
+    },
+  );
 
   test("rejects an unconfigured default chain before pricing or credit work", async () => {
     const response = await post({});

--- a/packages/cloud/api/fal/proxy/route.h3-wire.test.ts
+++ b/packages/cloud/api/fal/proxy/route.h3-wire.test.ts
@@ -1,0 +1,132 @@
+/** Exercises real Hono/Fal proxy transport and HTML catalog arithmetic with synthetic caller admission and a closed provider transport. */
+import { afterAll, expect, mock, spyOn, test } from "bun:test";
+import type { FlatBillingCost } from "@/lib/services/ai-billing";
+
+let admitted: FlatBillingCost | undefined;
+let wire: Record<string, unknown> | undefined;
+let settled: number | undefined;
+const originalKey = process.env.FAL_KEY;
+mock.module("@/db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntries: async () => [],
+    listActiveEntriesForProviderModelPairs: async () => [],
+  },
+}));
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller: async () => ({
+    user: { id: "synthetic-user", organization_id: "synthetic-org" },
+    apiKeyId: "synthetic-key",
+    credential: undefined,
+  }),
+  admitFlatGenerativeOperation: async ({ cost }: { cost: FlatBillingCost }) => {
+    admitted = cost;
+    return {
+      markProviderDispatched: async () => undefined,
+      settle: async (amount: number) => {
+        settled = amount;
+      },
+      settleUnknown: async () => {
+        throw new Error("Unexpected ambiguous transport");
+      },
+    };
+  },
+  asGenerativeCacheApiError: (error: Error) => error,
+  getGenerativeExecutionContext: () => undefined,
+}));
+const { fetchFalCatalogEntries } = await import(
+  "@/lib/services/ai-pricing/providers/fal"
+);
+mock.module("@/lib/services/ai-pricing/providers/gateway", () => ({
+  fetchEntriesForSource: async (source: string) =>
+    source === "fal" ? fetchFalCatalogEntries() : [],
+}));
+process.env.FAL_KEY = "synthetic-closed-transport";
+const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+  Object.assign(
+    async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === "https://fal.ai/models/minimax/h3-max/image-to-video") {
+        return new Response(
+          "<p>Video costs $0.0125 per second at 480p, $0.02 per second at 768p, and $0.04 per second at 1080p.</p>",
+        );
+      }
+      if (url.startsWith("https://fal.ai/models/"))
+        return new Response("Unrelated model", { status: 404 });
+      if (url === "https://queue.fal.run/minimax/h3-max/image-to-video") {
+        const request =
+          input instanceof Request ? input : new Request(url, init);
+        wire = (await request.json()) as Record<string, unknown>;
+        return Response.json({ request_id: "synthetic-unpaid-job" });
+      }
+      throw new Error(`Closed transport rejected ${url}`);
+    },
+    { preconnect: fetch.preconnect },
+  ),
+);
+const { default: route } = await import("./route");
+afterAll(() => {
+  fetchSpy.mockRestore();
+  if (originalKey === undefined) delete process.env.FAL_KEY;
+  else process.env.FAL_KEY = originalKey;
+});
+async function post(body: unknown) {
+  admitted = undefined;
+  wire = undefined;
+  settled = undefined;
+  return route.request("/", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "https://queue.fal.run/minimax/h3-max/image-to-video",
+    },
+    body: JSON.stringify(body),
+  });
+}
+test.each([
+  [{ prompt: "synthetic" }, 5, 0.02],
+  [{ prompt: "synthetic", duration: 15, resolution: "768P" }, 15, 0.02],
+  [{ prompt: "synthetic", duration: 5, resolution: "1080P" }, 5, 0.04],
+] as const)(
+  "quotes the exact native H3 duration and resolution forwarded: %j",
+  async (body, duration, rate) => {
+    const response = await post(body);
+    expect(response.status).toBe(200);
+    expect(wire).toEqual(body);
+    expect(admitted?.baseTotalCost).toBeCloseTo(duration * rate, 6);
+    expect(settled).toBeCloseTo(duration * rate * 1.2, 6);
+  },
+);
+test.each([
+  { durationSeconds: 1, duration: 15 },
+  { duration_seconds: 1, duration: 15 },
+  { durationSeconds: 1 },
+  { duration: 0 },
+  { duration: -1 },
+  { duration: 1.5 },
+  { duration: "15" },
+  { duration: null },
+  { duration: Number.MAX_SAFE_INTEGER + 1 },
+  { resolution: "768p" },
+  { resolution: ["768P"] },
+  { generate_audio: false },
+  { audio: false },
+  { voice_control: true },
+])(
+  "rejects noncanonical H3 controls before admission or proxy dispatch: %j",
+  async (parameters) => {
+    const response = await post({ prompt: "synthetic", ...parameters });
+    expect(response.status).toBe(400);
+    expect(admitted).toBeUndefined();
+    expect(wire).toBeUndefined();
+    expect(settled).toBeUndefined();
+  },
+);
+test.each([null, [], "invalid body"])(
+  "rejects non-object H3 body before admission: %j",
+  async (body) => {
+    const response = await post(body);
+    expect(response.status).toBe(400);
+    expect(admitted).toBeUndefined();
+    expect(wire).toBeUndefined();
+  },
+);

--- a/packages/cloud/api/fal/proxy/route.standing.test.ts
+++ b/packages/cloud/api/fal/proxy/route.standing.test.ts
@@ -57,11 +57,21 @@ mock.module("@fal-ai/server-proxy/hono", () => ({
 }));
 mock.module("@/lib/services/ai-pricing", () => ({
   ...aiPricingActual,
-  calculateVideoGenerationCostFromCatalog: async () => ({
-    totalCost: 0.1,
-    baseTotalCost: 0.1,
-    platformMarkup: 0,
-  }),
+  calculateVideoGenerationCostFromCatalog: async ({
+    model,
+    dimensions,
+  }: {
+    model: string;
+    dimensions?: Record<string, unknown>;
+  }) => {
+    if (
+      model === "minimax/h3-max/image-to-video" &&
+      dimensions?.resolution !== "768P"
+    ) {
+      throw new Error("Pricing unavailable for the requested resolution");
+    }
+    return { totalCost: 0.1, baseTotalCost: 0.1, platformMarkup: 0 };
+  },
 }));
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   admitFlatGenerativeOperation,
@@ -208,5 +218,37 @@ test("fal dispatch receipt failure releases before provider invocation", async (
   expect(response.status).toBe(500);
   expect(invokeFalProxy).not.toHaveBeenCalled();
   expect(settle).toHaveBeenCalledWith(0);
+  expect(settleUnknown).not.toHaveBeenCalled();
+});
+
+test("H3 Max proxy submission preserves the provider resolution used for billing", async () => {
+  routeCallerError = null;
+  admissionError = null;
+  admissionEnabled = true;
+  dispatchReceiptError = null;
+  falProxyError = null;
+  falResponseStatus = 200;
+  invokeFalProxy.mockClear();
+  settle.mockClear();
+  settleUnknown.mockClear();
+  markProviderDispatched.mockClear();
+
+  const response = await app.request("/fal/proxy", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "minimax/h3-max/image-to-video",
+    },
+    body: JSON.stringify({
+      prompt: "a neon cat",
+      resolution: "768P",
+      duration: 5,
+    }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe("upstream");
+  expect(invokeFalProxy).toHaveBeenCalledTimes(1);
+  expect(settle).toHaveBeenCalledWith(0.1);
   expect(settleUnknown).not.toHaveBeenCalled();
 });

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -118,7 +118,7 @@ function readString(body: unknown, keys: string[]): string | undefined {
   for (const key of keys) {
     const value = (body as Record<string, unknown>)[key];
     if (typeof value === "string" && value.trim().length > 0) {
-      return value.trim().toLowerCase();
+      return value.trim();
     }
   }
 

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -36,7 +36,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const falHandler = createRouteHandler({
   allowedUrlPatterns: DEFAULT_ALLOWED_URL_PATTERNS,
-  allowedEndpoints: ["fal-ai/**", "bytedance/**", "wan/**"],
+  allowedEndpoints: ["fal-ai/**", "bytedance/**", "minimax/**", "wan/**"],
   allowUnauthorizedRequests: false,
   isAuthenticated: async () => true,
   resolveFalAuth: resolveApiKeyFromEnv,
@@ -50,6 +50,10 @@ const invokeFalProxy = (c: Context<AppEnv>): Promise<Response> =>
 const app = new Hono<AppEnv>();
 
 function normalizeFalPricingModel(endpoint: string): string | null {
+  if (getSupportedVideoModelDefinition(endpoint)) {
+    return endpoint;
+  }
+
   const variantSuffixes = [
     "/image-to-video",
     "/first-last-frame-to-video",

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -22,7 +22,7 @@ import {
   getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { BillingContext } from "@/lib/services/ai-billing";
 import {
   calculateVideoGenerationCostFromCatalog,
@@ -91,6 +91,28 @@ function readNumber(body: unknown, keys: string[]): number | undefined {
   return undefined;
 }
 
+function readH3Duration(
+  body: Record<string, unknown>,
+  defaultDuration: number,
+): number {
+  // The raw proxy forwards provider JSON unchanged. Host-route aliases cannot
+  // select the quote because the provider does not consume those fields.
+  if ("durationSeconds" in body || "duration_seconds" in body) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      "Use the provider duration field",
+    );
+  }
+  if (!("duration" in body)) return defaultDuration;
+  const value = body.duration;
+  const duration = typeof value === "number" ? value : Number.NaN;
+  if (!Number.isSafeInteger(duration) || duration <= 0) {
+    throw new ApiError(400, "validation_error", "Invalid provider duration");
+  }
+  return duration;
+}
+
 function readBoolean(body: unknown, keys: string[]): boolean | undefined {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return undefined;
@@ -141,13 +163,46 @@ async function priceFalMutation(c: Context<AppEnv>): Promise<{
   }
 
   const defaults = getDefaultVideoBillingDimensions(model);
-  const body = await c.req.raw
+  const isH3Max = model === "minimax/h3-max/image-to-video";
+  const body: unknown = await c.req.raw
     .clone()
     .json()
-    .catch(() => ({}));
-  const durationSeconds =
-    readNumber(body, ["durationSeconds", "duration_seconds", "duration"]) ??
-    defaults.durationSeconds;
+    .catch(() => {
+      // error-policy:J3 H3 rejects malformed JSON below before any admission.
+      return undefined;
+    });
+  if (isH3Max && (!body || typeof body !== "object" || Array.isArray(body))) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      "Provider body must be a JSON object",
+    );
+  }
+  const h3Body = isH3Max ? (body as Record<string, unknown>) : undefined;
+  if (h3Body) {
+    if (
+      "resolution" in h3Body &&
+      (typeof h3Body.resolution !== "string" ||
+        !["480P", "768P", "1080P"].includes(h3Body.resolution))
+    ) {
+      throw new ApiError(400, "validation_error", "Invalid H3 Max resolution");
+    }
+    if (
+      ["audio", "generate_audio", "voiceControl", "voice_control"].some(
+        (key) => key in h3Body,
+      )
+    ) {
+      throw new ApiError(
+        400,
+        "validation_error",
+        "H3 Max does not support audio controls",
+      );
+    }
+  }
+  const durationSeconds = h3Body
+    ? readH3Duration(h3Body, defaults.durationSeconds)
+    : (readNumber(body, ["durationSeconds", "duration_seconds", "duration"]) ??
+      defaults.durationSeconds);
   const dimensions = {
     ...defaults.dimensions,
     ...(readString(body, ["resolution"])
@@ -202,7 +257,9 @@ const handle: Handler<AppEnv> = async (c) => {
     } catch (error) {
       // error-policy:J1 translate pricing input and catalog failures at the
       // route boundary before any credit admission or provider dispatch.
-      if (error instanceof Error && error.message === "missing_target") {
+      if (error instanceof ApiError) {
+        pendingResponse = failureResponse(c, error);
+      } else if (error instanceof Error && error.message === "missing_target") {
         pendingResponse = c.json({ error: "Invalid request" }, 400);
       } else if (
         error instanceof Error &&

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -1,6 +1,10 @@
 /** Handles authenticated video generation, billing, and pending-job reconciliation. */
 
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+  ElizaError,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
@@ -39,6 +43,7 @@ import {
   getDefaultVideoBillingDimensions,
 } from "@/lib/services/ai-pricing";
 import {
+  DEFAULT_IMAGE_TO_VIDEO_MODEL_IDS,
   DEFAULT_VIDEO_MODEL_IDS,
   getSupportedVideoModelDefinition,
   SUPPORTED_VIDEO_MODEL_IDS,
@@ -99,11 +104,34 @@ function providerDisplayName(
   return definition.provider === "fal" ? "Fal" : definition.provider;
 }
 
-function requireDefaultVideoModelDefinitions(): SupportedVideoModelDefinition[] {
-  return DEFAULT_VIDEO_MODEL_IDS.map((modelId) => {
+function requireDefaultVideoModelDefinitions(
+  referenceUrl?: string,
+  audio?: boolean,
+  voiceControl?: boolean,
+): SupportedVideoModelDefinition[] {
+  const modelIds = referenceUrl
+    ? DEFAULT_IMAGE_TO_VIDEO_MODEL_IDS
+    : DEFAULT_VIDEO_MODEL_IDS;
+  return modelIds.map((modelId) => {
     const definition = getSupportedVideoModelDefinition(modelId);
     if (!definition) {
       throw new Error(`Default video model is not supported: ${modelId}`);
+    }
+    if (
+      (audio !== undefined &&
+        definition.fixedAudio !== undefined &&
+        audio !== definition.fixedAudio) ||
+      (voiceControl !== undefined && definition.supportsVoiceControl === false)
+    ) {
+      // Preserve the existing audio-control contract when the new primary
+      // cannot honor a silent request.
+      const compatible = getSupportedVideoModelDefinition("fal-ai/veo3");
+      if (!compatible)
+        throw new ElizaError("The default with media controls is unavailable", {
+          code: "VIDEO_DEFAULT_MODEL_UNAVAILABLE",
+          context: { modelId: "fal-ai/veo3" },
+        });
+      return compatible;
     }
     return definition;
   });
@@ -180,7 +208,11 @@ app.post("/", async (c) => {
         ? [requestedDefinition]
         : request?.model
           ? []
-          : requireDefaultVideoModelDefinitions()
+          : requireDefaultVideoModelDefinitions(
+              request?.referenceUrl,
+              request?.audio,
+              request?.voiceControl,
+            )
       : [];
     const apiKeys = collectVideoProviderApiKeys(c.env);
     const providerCandidates = getConfiguredVideoProviderCandidates(
@@ -197,6 +229,37 @@ app.post("/", async (c) => {
         `Unsupported video model: ${requestResult.data.model}`,
         "validation_error",
         { supportedModels: SUPPORTED_VIDEO_MODEL_IDS },
+      );
+    } else if (
+      requestedDefinition?.requiresReferenceImage &&
+      !requestResult.data.referenceUrl
+    ) {
+      pendingResponse = jsonError(
+        c,
+        400,
+        "referenceUrl is required for image-to-video generation",
+        "validation_error",
+      );
+    } else if (
+      requestedDefinition?.fixedAudio !== undefined &&
+      requestResult.data.audio !== undefined &&
+      requestResult.data.audio !== requestedDefinition.fixedAudio
+    ) {
+      pendingResponse = jsonError(
+        c,
+        400,
+        "The selected video model cannot change its audio setting",
+        "validation_error",
+      );
+    } else if (
+      requestedDefinition?.supportsVoiceControl === false &&
+      requestResult.data.voiceControl !== undefined
+    ) {
+      pendingResponse = jsonError(
+        c,
+        400,
+        "The selected video model does not support voice control",
+        "validation_error",
       );
     } else if (providerCandidates.length === 0) {
       const message = requestedDefinition

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -107,7 +107,6 @@ function providerDisplayName(
 function requireDefaultVideoModelDefinitions(
   referenceUrl?: string,
   audio?: boolean,
-  voiceControl?: boolean,
 ): SupportedVideoModelDefinition[] {
   const modelIds = referenceUrl
     ? DEFAULT_IMAGE_TO_VIDEO_MODEL_IDS
@@ -118,18 +117,20 @@ function requireDefaultVideoModelDefinitions(
       throw new Error(`Default video model is not supported: ${modelId}`);
     }
     if (
-      (audio !== undefined &&
-        definition.fixedAudio !== undefined &&
-        audio !== definition.fixedAudio) ||
-      (voiceControl !== undefined && definition.supportsVoiceControl === false)
+      audio !== undefined &&
+      definition.fixedAudio !== undefined &&
+      audio !== definition.fixedAudio
     ) {
       // Preserve the existing audio-control contract when the new primary
       // cannot honor a silent request.
-      const compatible = getSupportedVideoModelDefinition("fal-ai/veo3");
+      const compatibleModelId = referenceUrl
+        ? "bytedance/seedance-2.5/image-to-video"
+        : "bytedance/seedance-2.5/text-to-video";
+      const compatible = getSupportedVideoModelDefinition(compatibleModelId);
       if (!compatible)
         throw new ElizaError("The default with media controls is unavailable", {
           code: "VIDEO_DEFAULT_MODEL_UNAVAILABLE",
-          context: { modelId: "fal-ai/veo3" },
+          context: { modelId: compatibleModelId },
         });
       return compatible;
     }
@@ -211,13 +212,18 @@ app.post("/", async (c) => {
           : requireDefaultVideoModelDefinitions(
               request?.referenceUrl,
               request?.audio,
-              request?.voiceControl,
             )
       : [];
     const apiKeys = collectVideoProviderApiKeys(c.env);
-    const providerCandidates = getConfiguredVideoProviderCandidates(
+    const configuredProviderCandidates = getConfiguredVideoProviderCandidates(
       definitions,
       apiKeys,
+    );
+    const providerCandidates = configuredProviderCandidates.filter(
+      ({ definition }) =>
+        request?.durationSeconds === undefined ||
+        definition.minDurationSeconds === undefined ||
+        request.durationSeconds >= definition.minDurationSeconds,
     );
     let pendingResponse: Response | undefined;
     if (!requestResult.success) {
@@ -252,13 +258,29 @@ app.post("/", async (c) => {
         "validation_error",
       );
     } else if (
-      requestedDefinition?.supportsVoiceControl === false &&
-      requestResult.data.voiceControl !== undefined
+      requestResult.data.voiceControl === true &&
+      definitions.some(
+        (definition) => definition.supportsVoiceControl === false,
+      )
     ) {
       pendingResponse = jsonError(
         c,
         400,
         "The selected video model does not support voice control",
+        "validation_error",
+      );
+    } else if (
+      requestResult.data.durationSeconds !== undefined &&
+      ((requestedDefinition?.minDurationSeconds !== undefined &&
+        requestResult.data.durationSeconds <
+          requestedDefinition.minDurationSeconds) ||
+        (configuredProviderCandidates.length > 0 &&
+          providerCandidates.length === 0))
+    ) {
+      pendingResponse = jsonError(
+        c,
+        400,
+        "durationSeconds is below the selected video model's minimum; Seedance 2.5 requires at least 4 seconds",
         "validation_error",
       );
     } else if (providerCandidates.length === 0) {

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
@@ -55,6 +55,26 @@ describe("FAL video provider", () => {
     });
   });
 
+  test("builds the MiniMax H3 Max image-to-video input contract", () => {
+    expect(
+      buildFalVideoInput({
+        model: "minimax/h3-max/image-to-video",
+        prompt: "the subject turns toward the camera",
+        referenceUrl: "https://example.com/start.png",
+        durationSeconds: 5,
+        resolution: "768P",
+        audio: true,
+        apiKeys: { FAL_KEY: "fal-key" },
+      }),
+    ).toEqual({
+      prompt: "the subject turns toward the camera",
+      image_url: "https://example.com/start.png",
+      duration: 5,
+      resolution: "768P",
+      prompt_expansion_mode: "balanced",
+    });
+  });
+
   test("maps Seedance 2.5 controls to its exact fal schema", () => {
     expect(
       buildFalVideoInput({

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
@@ -444,3 +444,19 @@ describe("generateFalVideo — post-enqueue failures never present as refundable
     expect(queueStatus).not.toHaveBeenCalled();
   });
 });
+
+test.each([{ audio: false }, { voiceControl: true }, { voiceControl: false }])(
+  "rejects unsupported H3 Max controls %j before a billable provider submission",
+  async (controls) => {
+    subscribe.mockClear();
+    await expect(
+      generateFalVideo({
+        model: "minimax/h3-max/image-to-video",
+        prompt: "a silent city timelapse",
+        ...controls,
+        apiKeys: { FAL_KEY: "fal-key" },
+      }),
+    ).rejects.toBeInstanceOf(VideoGenerationTerminalError);
+    expect(subscribe).not.toHaveBeenCalled();
+  },
+);

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
@@ -101,6 +101,38 @@ describe("FAL video provider", () => {
     });
   });
 
+  test.each([
+    "minimax/h3-max/image-to-video",
+    "bytedance/seedance-2.5/text-to-video",
+    "bytedance/seedance-2.5/image-to-video",
+  ])("does not send a nonexistent voice control for %s", (model) => {
+    const request = {
+      model,
+      prompt: "motion",
+      referenceUrl: "https://example.com/frame.png",
+      durationSeconds: 5,
+      voiceControl: false,
+      apiKeys: { FAL_KEY: "fal-key" },
+    };
+    expect(buildFalVideoInput(request)).not.toHaveProperty("voice_control");
+    expect(() => buildFalVideoInput({ ...request, voiceControl: true })).toThrow("voice control");
+  });
+
+  test.each(["bytedance/seedance-2.5/text-to-video", "bytedance/seedance-2.5/image-to-video"])(
+    "enforces Seedance duration without rounding for %s",
+    (model) => {
+      const request = { model, prompt: "motion", apiKeys: { FAL_KEY: "fal-key" } };
+      for (const durationSeconds of [3, 31])
+        expect(() => buildFalVideoInput({ ...request, durationSeconds })).toThrow(
+          "durationSeconds",
+        );
+      for (const durationSeconds of [4, 5, 30])
+        expect(buildFalVideoInput({ ...request, durationSeconds }).duration).toBe(
+          String(durationSeconds),
+        );
+    },
+  );
+
   test("normalizes FAL video responses with request id fallback", () => {
     expect(
       normalizeFalVideoResult(
@@ -445,7 +477,7 @@ describe("generateFalVideo — post-enqueue failures never present as refundable
   });
 });
 
-test.each([{ audio: false }, { voiceControl: true }, { voiceControl: false }])(
+test.each([{ audio: false }, { voiceControl: true }])(
   "rejects unsupported H3 Max controls %j before a billable provider submission",
   async (controls) => {
     subscribe.mockClear();

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
@@ -103,12 +103,15 @@ export function normalizeFalVideoResult(result: unknown, requestId?: string): Ge
 export function buildFalVideoInput(request: VideoGenerationRequest): Record<string, unknown> {
   const input: Record<string, unknown> = { prompt: request.prompt };
   const isSeedance25 = request.model.startsWith("bytedance/seedance-2.5/");
+  const isH3MaxImageToVideo = request.model === "minimax/h3-max/image-to-video";
   if (request.referenceUrl) {
     input.image_url = request.referenceUrl;
   }
   if (request.durationSeconds) {
     input.duration = isSeedance25 ? String(request.durationSeconds) : request.durationSeconds;
-    if (!isSeedance25) input.duration_seconds = request.durationSeconds;
+    if (!isSeedance25 && !isH3MaxImageToVideo) {
+      input.duration_seconds = request.durationSeconds;
+    }
   }
   if (request.resolution) {
     input.resolution = request.resolution;
@@ -122,6 +125,12 @@ export function buildFalVideoInput(request: VideoGenerationRequest): Record<stri
   if (request.endUserId) input.end_user_id = request.endUserId;
   if (request.voiceControl !== undefined) {
     input.voice_control = request.voiceControl;
+  }
+  if (isH3MaxImageToVideo) {
+    input.prompt_expansion_mode = "balanced";
+    delete input.audio;
+    delete input.generate_audio;
+    delete input.voice_control;
   }
   return input;
 }

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
@@ -1,4 +1,5 @@
 /** Implements fal.ai video submission, queue polling, and status reconciliation. */
+import { ElizaError } from "@elizaos/core";
 import { ApiError, createFalClient } from "@fal-ai/client";
 import { getAiProviderConfigurationError } from "../language-model";
 import {
@@ -104,6 +105,12 @@ export function buildFalVideoInput(request: VideoGenerationRequest): Record<stri
   const input: Record<string, unknown> = { prompt: request.prompt };
   const isSeedance25 = request.model.startsWith("bytedance/seedance-2.5/");
   const isH3MaxImageToVideo = request.model === "minimax/h3-max/image-to-video";
+  if (isH3MaxImageToVideo && (request.audio === false || request.voiceControl !== undefined)) {
+    throw new ElizaError("MiniMax H3 Max does not support the requested audio controls", {
+      code: "VIDEO_CONTROLS_UNSUPPORTED",
+      context: { model: request.model, audio: request.audio, voiceControl: request.voiceControl },
+    });
+  }
   if (request.referenceUrl) {
     input.image_url = request.referenceUrl;
   }
@@ -206,6 +213,9 @@ export async function generateFalVideo(request: VideoGenerationRequest): Promise
   } catch (error) {
     // error-policy:J1 the provider adapter translates submission/poll outcomes
     // into the typed states required by route billing and reconciliation.
+    if (error instanceof ElizaError && error.code === "VIDEO_CONTROLS_UNSUPPORTED") {
+      throw new VideoGenerationTerminalError(error.message, error);
+    }
     if (!requestId) {
       // The client only raises ApiError from a real HTTP error response, and
       // fal issues a request_id only inside a 2xx submit body, so ANY error

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
@@ -1,6 +1,7 @@
 /** Implements fal.ai video submission, queue polling, and status reconciliation. */
 import { ElizaError } from "@elizaos/core";
 import { ApiError, createFalClient } from "@fal-ai/client";
+import { getSupportedVideoModelDefinition } from "../../services/ai-pricing-definitions";
 import { getAiProviderConfigurationError } from "../language-model";
 import {
   type GeneratedVideo,
@@ -104,11 +105,30 @@ export function normalizeFalVideoResult(result: unknown, requestId?: string): Ge
 export function buildFalVideoInput(request: VideoGenerationRequest): Record<string, unknown> {
   const input: Record<string, unknown> = { prompt: request.prompt };
   const isSeedance25 = request.model.startsWith("bytedance/seedance-2.5/");
+  const minimumDuration = getSupportedVideoModelDefinition(request.model)?.minDurationSeconds;
+  if (
+    isSeedance25 &&
+    request.durationSeconds !== undefined &&
+    (!Number.isInteger(request.durationSeconds) ||
+      (minimumDuration !== undefined && request.durationSeconds < minimumDuration) ||
+      request.durationSeconds > 30)
+  ) {
+    throw new ElizaError("Seedance durationSeconds must be an integer from 4 through 30", {
+      code: "VIDEO_DURATION_UNSUPPORTED",
+      context: { model: request.model, durationSeconds: request.durationSeconds },
+    });
+  }
   const isH3MaxImageToVideo = request.model === "minimax/h3-max/image-to-video";
-  if (isH3MaxImageToVideo && (request.audio === false || request.voiceControl !== undefined)) {
-    throw new ElizaError("MiniMax H3 Max does not support the requested audio controls", {
+  if (isH3MaxImageToVideo && (request.audio === false || request.voiceControl === true)) {
+    throw new ElizaError("MiniMax H3 Max does not support silent audio or voice control", {
       code: "VIDEO_CONTROLS_UNSUPPORTED",
       context: { model: request.model, audio: request.audio, voiceControl: request.voiceControl },
+    });
+  }
+  if (isSeedance25 && request.voiceControl === true) {
+    throw new ElizaError("Seedance 2.5 does not support voice control", {
+      code: "VIDEO_CONTROLS_UNSUPPORTED",
+      context: { model: request.model, voiceControl: request.voiceControl },
     });
   }
   if (request.referenceUrl) {
@@ -130,7 +150,7 @@ export function buildFalVideoInput(request: VideoGenerationRequest): Record<stri
   if (request.aspectRatio) input.aspect_ratio = request.aspectRatio;
   if (request.seed !== undefined) input.seed = request.seed;
   if (request.endUserId) input.end_user_id = request.endUserId;
-  if (request.voiceControl !== undefined) {
+  if (!isSeedance25 && request.voiceControl !== undefined) {
     input.voice_control = request.voiceControl;
   }
   if (isH3MaxImageToVideo) {

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -148,6 +148,7 @@ export interface SupportedVideoModelDefinition {
     | "veo"
     | "veo31"
     | "veo31lite"
+    | "h3_max"
     | "kling"
     | "hailuo_standard"
     | "hailuo_pro"
@@ -162,6 +163,7 @@ export interface SupportedVideoModelDefinition {
     audio?: boolean;
     voiceControl?: boolean;
   };
+  requiresReferenceImage?: boolean;
 }
 
 export interface SupportedMusicModelDefinition {
@@ -325,7 +327,10 @@ export const DEFAULT_IMAGE_MODEL_ID = "google/nano-banana-2/text-to-image";
  * is primary and later entries are terminal-failure fallbacks; explicit model
  * requests never use this chain.
  */
-export const DEFAULT_VIDEO_MODEL_IDS = ["fal-ai/veo3", "vidu/q3-turbo/text-to-video"] as const;
+export const DEFAULT_VIDEO_MODEL_IDS = [
+  "minimax/h3-max/image-to-video",
+  "vidu/image-to-video-2.0",
+] as const;
 
 export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
   {
@@ -353,6 +358,21 @@ export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
       resolution: "720p",
       audio: false,
     },
+    requiresReferenceImage: true,
+  },
+  {
+    modelId: "minimax/h3-max/image-to-video",
+    provider: "fal",
+    billingSource: "fal",
+    label: "MiniMax H3 Max Image-to-Video",
+    pageUrl: "https://fal.ai/models/minimax/h3-max/image-to-video",
+    pricingParser: "h3_max",
+    defaultParameters: {
+      durationSeconds: 5,
+      resolution: "768P",
+      audio: true,
+    },
+    requiresReferenceImage: true,
   },
   {
     modelId: "fal-ai/veo3",

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -164,6 +164,9 @@ export interface SupportedVideoModelDefinition {
     voiceControl?: boolean;
   };
   requiresReferenceImage?: boolean;
+  /** Set only when the provider cannot toggle audio generation. */
+  fixedAudio?: boolean;
+  supportsVoiceControl?: boolean;
 }
 
 export interface SupportedMusicModelDefinition {
@@ -329,6 +332,12 @@ export const DEFAULT_IMAGE_MODEL_ID = "google/nano-banana-2/text-to-image";
  */
 export const DEFAULT_VIDEO_MODEL_IDS = [
   "minimax/h3-max/image-to-video",
+  "vidu/q3-turbo/text-to-video",
+] as const;
+
+/** Image-bearing requests retain the image through every fallback. */
+export const DEFAULT_IMAGE_TO_VIDEO_MODEL_IDS = [
+  DEFAULT_VIDEO_MODEL_IDS[0],
   "vidu/image-to-video-2.0",
 ] as const;
 
@@ -367,12 +376,13 @@ export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
     label: "MiniMax H3 Max Image-to-Video",
     pageUrl: "https://fal.ai/models/minimax/h3-max/image-to-video",
     pricingParser: "h3_max",
+    fixedAudio: true,
+    supportsVoiceControl: false,
     defaultParameters: {
       durationSeconds: 5,
       resolution: "768P",
       audio: true,
     },
-    requiresReferenceImage: true,
   },
   {
     modelId: "fal-ai/veo3",

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -167,6 +167,7 @@ export interface SupportedVideoModelDefinition {
   /** Set only when the provider cannot toggle audio generation. */
   fixedAudio?: boolean;
   supportsVoiceControl?: boolean;
+  minDurationSeconds?: number;
 }
 
 export interface SupportedMusicModelDefinition {
@@ -587,6 +588,8 @@ export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
   },
   {
     modelId: "bytedance/seedance-2.5/text-to-video",
+    minDurationSeconds: 4,
+    supportsVoiceControl: false,
     provider: "fal",
     billingSource: "fal",
     label: "Seedance 2.5 Text to Video",
@@ -600,6 +603,9 @@ export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
   },
   {
     modelId: "bytedance/seedance-2.5/image-to-video",
+    minDurationSeconds: 4,
+    supportsVoiceControl: false,
+    requiresReferenceImage: true,
     provider: "fal",
     billingSource: "fal",
     label: "Seedance 2.5 Image to Video",

--- a/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.ts
@@ -1,14 +1,15 @@
-// Coordinates cloud service dimensions behavior behind route handlers.
+/** Normalizes catalog identities and dimensions for exact pricing lookup and billing. */
 import { createHash } from "node:crypto";
 import Decimal from "decimal.js";
 import type { AiPricingEntry, NewAiPricingEntry } from "../../../db/repositories/ai-pricing";
 import type { PricingDimensions } from "../../../db/schemas/ai-pricing";
 import { PLATFORM_MARKUP_MULTIPLIER } from "../../pricing-constants";
 import { normalizeProviderKey } from "../../providers/model-id-translation";
-import type {
-  PricingBillingSource,
-  PricingChargeUnit,
-  PricingProductFamily,
+import {
+  getSupportedVideoModelDefinition,
+  type PricingBillingSource,
+  type PricingChargeUnit,
+  type PricingProductFamily,
 } from "../ai-pricing-definitions";
 import { EXTERNAL_CACHE_TTL_MS, type PreparedPricingEntry, type PriceLookupSource } from "./types";
 
@@ -141,6 +142,10 @@ export function inferProviderFromCanonicalModel(model: string): string {
 
 /** Provider column for a catalog `model` row; cross-provider aliases use the target id prefix, not the request gateway. */
 export function providerForPricingCandidate(modelId: string, requestProvider: string): string {
+  // Fal endpoint namespaces identify model authors; the catalog records the
+  // configured serving provider, including minimax and bytedance endpoints.
+  const videoProvider = getSupportedVideoModelDefinition(modelId)?.provider;
+  if (videoProvider) return videoProvider;
   const inferred = inferProviderFromCanonicalModel(modelId);
   return inferred !== "unknown" ? inferred : requestProvider;
 }

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal-h3-max-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal-h3-max-pricing.test.ts
@@ -1,15 +1,24 @@
 /** Verifies the external MiniMax H3 Max pricing text maps to billable resolution rows. */
 
-import { expect, mock, test } from "bun:test";
+import { expect, mock, spyOn, test } from "bun:test";
 import { getSupportedVideoModelDefinition } from "../../ai-pricing-definitions";
 
 mock.module("../../../../db/repositories/ai-pricing", () => ({
   aiPricingRepository: {
     listActiveEntries: async () => [],
+    listActiveEntriesForProviderModelPairs: async () => [],
   },
 }));
 
-const { parseFalPricingEntries } = await import("./fal");
+const { fetchFalCatalogEntries, parseFalPricingEntries } = await import("./fal");
+
+mock.module("./gateway", () => ({
+  fetchEntriesForSource: async (source: string) =>
+    source === "fal" ? fetchFalCatalogEntries() : [],
+}));
+const { calculateVideoGenerationCostFromCatalog, getDefaultVideoBillingDimensions } = await import(
+  "../lookup"
+);
 
 test("parses MiniMax H3 Max per-second prices by resolution", () => {
   const model = getSupportedVideoModelDefinition("minimax/h3-max/image-to-video");
@@ -37,4 +46,39 @@ test("parses MiniMax H3 Max per-second prices by resolution", () => {
       }),
     ]),
   );
+});
+
+test("resolves published HTML pricing through the same catalog lookup used before video dispatch", async () => {
+  const modelId = "minimax/h3-max/image-to-video";
+  const pageUrl = "https://fal.ai/models/minimax/h3-max/image-to-video";
+  // The published model page wraps both prices and resolutions in strong tags.
+  const pricingHtml =
+    "<p>Video costs <strong>$0.0125</strong> per second at <strong>480p</strong>, <strong>$0.02</strong> per second at <strong>768p</strong>.</p>";
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+    return url === pageUrl
+      ? new Response(pricingHtml, { headers: { "content-type": "text/html" } })
+      : new Response("No fixture for this unrelated model", { status: 404 });
+  });
+
+  try {
+    const defaults = getDefaultVideoBillingDimensions(modelId);
+    for (const [resolution, baseTotalCost, totalCost] of [
+      ["480P", 0.0625, 0.075],
+      ["768P", 0.1, 0.12],
+    ] as const) {
+      const cost = await calculateVideoGenerationCostFromCatalog({
+        model: modelId,
+        billingSource: "fal",
+        durationSeconds: 5,
+        dimensions: { ...defaults.dimensions, resolution },
+      });
+      expect(cost.matchedEntry.provider).toBe("fal");
+      expect(cost.matchedEntry.sourceUrl).toBe(pageUrl);
+      expect(cost.baseTotalCost).toBeCloseTo(baseTotalCost, 6);
+      expect(cost.totalCost).toBeCloseTo(totalCost, 6);
+    }
+  } finally {
+    fetchSpy.mockRestore();
+  }
 });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal-h3-max-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal-h3-max-pricing.test.ts
@@ -1,0 +1,40 @@
+/** Verifies the external MiniMax H3 Max pricing text maps to billable resolution rows. */
+
+import { expect, mock, test } from "bun:test";
+import { getSupportedVideoModelDefinition } from "../../ai-pricing-definitions";
+
+mock.module("../../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntries: async () => [],
+  },
+}));
+
+const { parseFalPricingEntries } = await import("./fal");
+
+test("parses MiniMax H3 Max per-second prices by resolution", () => {
+  const model = getSupportedVideoModelDefinition("minimax/h3-max/image-to-video");
+  expect(model).toBeDefined();
+
+  const entries = parseFalPricingEntries(
+    model!,
+    "Video costs $0.025 per second at 480p, $0.04 per second at 768p.",
+  );
+
+  expect(entries).toHaveLength(2);
+  expect(entries).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        model: "minimax/h3-max/image-to-video",
+        unit: "second",
+        unitPrice: 0.025,
+        dimensions: { resolution: "480P" },
+      }),
+      expect.objectContaining({
+        model: "minimax/h3-max/image-to-video",
+        unit: "second",
+        unitPrice: 0.04,
+        dimensions: { resolution: "768P" },
+      }),
+    ]),
+  );
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal-h3-max-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal-h3-max-pricing.test.ts
@@ -53,7 +53,7 @@ test("resolves published HTML pricing through the same catalog lookup used befor
   const pageUrl = "https://fal.ai/models/minimax/h3-max/image-to-video";
   // The published model page wraps both prices and resolutions in strong tags.
   const pricingHtml =
-    "<p>Video costs <strong>$0.0125</strong> per second at <strong>480p</strong>, <strong>$0.02</strong> per second at <strong>768p</strong>.</p>";
+    "<p>Video costs <strong>$0.0125</strong> per second at <strong>480p</strong>, <strong>$0.02</strong> per second at <strong>768p</strong>, and <strong>$0.04</strong> per second at <strong>1080p</strong>.</p>";
   const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
     return url === pageUrl
@@ -66,6 +66,7 @@ test("resolves published HTML pricing through the same catalog lookup used befor
     for (const [resolution, baseTotalCost, totalCost] of [
       ["480P", 0.0625, 0.075],
       ["768P", 0.1, 0.12],
+      ["1080P", 0.2, 0.24],
     ] as const) {
       const cost = await calculateVideoGenerationCostFromCatalog({
         model: modelId,

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service fal behavior behind route handlers.
+/** Loads Fal model prices and maps published rates to authoritative billing dimensions. */
 import { aiPricingRepository } from "../../../../db/repositories/ai-pricing";
 import type { PricingDimensions } from "../../../../db/schemas/ai-pricing";
 import { logger } from "../../../utils/logger";
@@ -187,7 +187,7 @@ export function parseFalPricingEntries(
     }
     case "h3_max": {
       const match = paragraph.match(
-        /Video costs\s+\$([\d.]+)\s+per second at 480p,\s+\$([\d.]+)\s+per second at 768p/i,
+        /Video costs\s+\$([\d.]+)\s+per second at 480p\s*,\s+\$([\d.]+)\s+per second at 768p/i,
       );
       if (!match) {
         throw new Error(`Unable to parse MiniMax H3 Max pricing paragraph: ${paragraph}`);

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
@@ -18,7 +18,7 @@ import { buildMusicSnapshotEntries } from "./suno";
 
 function extractFalPricingParagraph(html: string): string {
   const match = html.match(
-    /(?:For every second of video.*?<\/p>|Your request will cost.*?<\/p>|For a 5s video without audio.*?<\/p>)/is,
+    /(?:For every second of video.*?<\/p>|Your request will cost.*?<\/p>|For a 5s video without audio.*?<\/p>|Video costs.*?<\/p>)/is,
   );
 
   if (!match) {
@@ -181,6 +181,26 @@ export function parseFalPricingEntries(
         buildFalEntry(model, "second", Number(match[4]), {
           resolution: "1080p",
           audio: false,
+        }),
+      );
+      break;
+    }
+    case "h3_max": {
+      const match = paragraph.match(
+        /Video costs\s+\$([\d.]+)\s+per second at 480p,\s+\$([\d.]+)\s+per second at 768p/i,
+      );
+      if (!match) {
+        throw new Error(`Unable to parse MiniMax H3 Max pricing paragraph: ${paragraph}`);
+      }
+
+      entries.push(
+        buildFalEntry(model, "second", Number(match[1]), {
+          resolution: "480P",
+        }),
+      );
+      entries.push(
+        buildFalEntry(model, "second", Number(match[2]), {
+          resolution: "768P",
         }),
       );
       break;

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
@@ -203,6 +203,14 @@ export function parseFalPricingEntries(
           resolution: "768P",
         }),
       );
+      const refinedResolution = paragraph.match(/\$([\d.]+)\s+per second at 1080p/i);
+      if (refinedResolution) {
+        entries.push(
+          buildFalEntry(model, "second", Number(refinedResolution[1]), {
+            resolution: "1080P",
+          }),
+        );
+      }
       break;
     }
     case "kling": {

--- a/packages/cloud/shared/src/lib/services/media-model-roster.ts
+++ b/packages/cloud/shared/src/lib/services/media-model-roster.ts
@@ -108,17 +108,19 @@ export const MEDIA_MODEL_ROSTER: readonly MediaModelRosterEntry[] = [
     surfaces: ["video", "music"],
     status: "wired",
     sourceUrls: [
+      "https://fal.ai/models/minimax/h3-max/image-to-video",
       "https://fal.ai/models/fal-ai/minimax/hailuo-2.3/standard/text-to-video",
       "https://fal.ai/models/fal-ai/minimax/hailuo-2.3/pro/text-to-video",
       "https://fal.ai/models/fal-ai/minimax-music/v2.6/api",
     ],
     wiredModelIds: [
+      "minimax/h3-max/image-to-video",
       "fal-ai/minimax/hailuo-2.3/standard/text-to-video",
       "fal-ai/minimax/hailuo-2.3/pro/text-to-video",
       "fal-ai/minimax-music/v2.6",
     ],
     rationale:
-      "Hailuo 2.3 video and MiniMax Music 2.6 have supported pricing definitions; music is cataloged for pricing while video is routed.",
+      "MiniMax H3 Max image-to-video is the primary Cloud video model; Hailuo 2.3 video and MiniMax Music 2.6 remain supported, with music cataloged for pricing while video is routed.",
   },
   {
     family: "ElevenLabs Music",


### PR DESCRIPTION
Implements #29368. Default video generation now uses Fal MiniMax H3 Max for both prompt-only requests and requests with a reference image. The provider adapter preserves the complete prompt and forwards the reference image when supplied.

H3 Max pricing is resolved from the current Fal catalog for 480P, 768P, and 1080P. Production code parses published rates instead of embedding promotional prices. The catalog currently publishes $0.0125, $0.02, and $0.04 per second respectively; these are time-sensitive observations, not fixed application prices. [Fal model and pricing](https://fal.ai/models/minimax/h3-max/image-to-video), [provider schema](https://fal.ai/models/minimax/h3-max/image-to-video/api).

An explicit silent request selects the supported Seedance 2.5 text-to-video or image-to-video endpoint, preserving the reference image and sending the native audio setting. Seedance requests retain their requested integer duration within the supported 4–30 second range. For these H3 Max and Seedance models, voice selection is unsupported: `voiceControl: true` returns an actionable validation error before credit admission; `false` means no selection and does not emit an unsupported provider field. [Seedance text schema](https://fal.ai/models/bytedance/seedance-2.5/text-to-video/api), [image schema](https://fal.ai/models/bytedance/seedance-2.5/image-to-video/api).

The host route and H3 Max raw-proxy path validate the selected provider's supported request shape before credit admission or provider dispatch. Pricing uses the provider fields actually forwarded. Invalid requests receive a structured error rather than proceeding with a quote that describes different work.

**Review source:** `e673fc05bf7ac4a88c6f25390a3df9658ac941ee`, tree `560b1e036993907f085500300bdaaa05082294b3`, based on develop `d7df7af187f05ec744b57c01799cfbabcc5fd325`. Historical branch results are excluded from this source's success claims.

Validation completed on the frozen bytes committed as this head:

- 340 tests passed across 41 isolated API/shared video and pricing files. These exercise the real Hono route, provider payload construction, catalog parsing, billing selection, and persistence contracts using controlled external transport/authentication/billing collaborators.
- The final test-transport typing adjustment passed its 20-case proxy replay. It preserves Bun's fetch shape and restores the spy after the suite.
- Cloud shared typecheck and lint passed (2,754 files); Cloud API typecheck, router contract, worker bundle dry-run, and lint passed (1,497 files).
- Normal root verification passed: **373/373 tasks**, exit 0. Normal pinned installation had completed before qualification. Node 24.15.0 and Bun 1.3.14 were used.

**Merge hold — live provider acceptance is incomplete.** An earlier real call through the production Fal adapter returned HTTP 403 because the account balance was exhausted. No job was accepted, no request ID or video was produced, and there is no generated video to inspect. The failed diagnostic records its historical adapter hash; it is not exact-head success evidence. No further live submission was made. Successful generation and inspection on the final source remain required before merge.

Evidence assets are attached below with their own source and result boundaries:

| Evidence | Artifact | Result |
| --- | --- | --- |
| Exact source and changed-file hashes | [29405-e673fc05bf7ac-source-proof.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29405-e673fc05bf7ac-source-proof.json) | Reviewed source identified |
| Source gates, per-file results, original-log hashes | [29405-e673fc05bf7ac-qualification.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29405-e673fc05bf7ac-qualification.json) | Pass; controlled integrations, not paid execution |
| Redacted historical live diagnostic | [29405-e673fc05bf7ac-live-blocked-diagnostic.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29405-e673fc05bf7ac-live-blocked-diagnostic.json) | HTTP 403; exhausted balance; no job/video |
| Asset integrity | [29405-e673fc05bf7ac-manifest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29405-e673fc05bf7ac-manifest.json) | SHA-256 and byte sizes, verified against uploaded assets |
| Screenshots / walkthrough | N/A | Backend provider and pricing change; no frontend changes |
| Generated video / live acceptance | Blocked | No artifact exists from the failed provider attempt |

<!-- evidence-head:e673fc05bf7ac4a88c6f25390a3df9658ac941ee -->
<!-- evidence-row:before-screenshots -->
- [x] N/A: backend provider and pricing changes, no frontend view changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A: no frontend view changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A: no frontend interaction changes; generated provider video remains blocked below.
<!-- evidence-row:backend-logs -->
- [x] Source qualification includes per-file outcomes and log hashes; historical redacted live provider diagnostic is linked and excluded from success claims.
<!-- evidence-row:frontend-logs -->
- [x] N/A: no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Live video-model inputs/output acceptance blocked by exhausted provider balance; no accepted job or output.
<!-- evidence-row:domain-artifacts -->
- [ ] Source/billing/provider contract evidence is linked; successful generated-video inspection remains outstanding.
