### PR TITLE
fix(ui): use surrogate-safe truncation in formatAddressForDisplay

### DIFF
--- a/packages/ui/src/components/pages/browser-wallet-consent-format.test.ts
+++ b/packages/ui/src/components/pages/browser-wallet-consent-format.test.ts
@@ -5,7 +5,7 @@
 
 import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { truncateMessageForDisplay } from "./browser-wallet-consent-format";
+import { formatAddressForDisplay, truncateMessageForDisplay } from "./browser-wallet-consent-format";
 
 function isWellFormed(value: string): boolean {
   if (!value) return true;
@@ -97,5 +97,19 @@ describe("truncateMessageForDisplay well-formed", () => {
     const out = truncateMessageForDisplay(lone, 240);
     expect(isWellFormed(out)).toBe(true);
     expect(out).toContain("more chars");
+  });
+});
+
+describe("formatAddressForDisplay surrogate safety", () => {
+  it("preserves well-formed Unicode when address ends or starts on surrogate pairs", () => {
+    const addressWithSurrogates = "0x123🚀567890abcdef🚀xyz";
+    const formatted = formatAddressForDisplay(addressWithSurrogates);
+    expect(formatted.isWellFormed()).toBe(true);
+    expect(formatted).toContain("…");
+  });
+
+  it("handles unknown or empty address gracefully", () => {
+    expect(formatAddressForDisplay("")).toBe("(unknown)");
+    expect(formatAddressForDisplay("0x123456")).toBe("0x123456");
   });
 });

--- a/packages/ui/src/components/pages/browser-wallet-consent-format.ts
+++ b/packages/ui/src/components/pages/browser-wallet-consent-format.ts
@@ -8,12 +8,15 @@
  * without standing up a renderer.
  */
 
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 export function formatAddressForDisplay(address: string): string {
   if (!address) return "(unknown)";
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(address);
+  if (wellFormed.length <= 12) return wellFormed;
+  const start = truncateWellFormed(wellFormed, 6);
+  const end = tailWellFormed(wellFormed, 4);
+  return `${start}…${end}`;
 }
 
 const ONE_ETH_WEI = 1_000_000_000_000_000_000n;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7dbc50558bf464739df5d1647ee4916e7606bb06 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/pages/browser-wallet-consent-format.ts`):
`formatAddressForDisplay` performed raw slicing `${address.slice(0, 6)}…${address.slice(-4)}` without normalizing inputs to well-formed Unicode or aligning to UTF-16 surrogate pair boundaries. If an address contains astral or surrogate characters, raw slicing produces lone surrogates.

## Proposed Changes
1. Normalized `address` via `toWellFormedUnicode(address)`.
2. Truncated head with `truncateWellFormed(wellFormed, 6)`.
3. Truncated tail with `tailWellFormed(wellFormed, 4)` from `@elizaos/core`.
4. Added surrogate-safety unit test suite in `packages/ui/src/components/pages/browser-wallet-consent-format.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/components/pages/browser-wallet-consent-format.test.ts` (11/11 passed).
- Verified well-formed Unicode output during wallet consent address display formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
