### PR TITLE
fix(agent): use surrogate-safe truncation in maskSecret and shortenMint

### DIFF
--- a/packages/agent/src/api/wallet-mask-secret.test.ts
+++ b/packages/agent/src/api/wallet-mask-secret.test.ts
@@ -26,6 +26,13 @@ describe("maskSecret", () => {
     expect(maskSecret("0xABCDEF0123456789")).toBe("0xAB...6789");
   });
 
+
+  it("preserves well-formed Unicode when secret boundary straddles surrogate pairs", () => {
+    const secret = "abc🚀SECRETMIDDLE🚀xyz";
+    const masked = maskSecret(secret);
+    expect(masked.isWellFormed()).toBe(true);
+    expect(masked).not.toContain("SECRETMIDDLE");
+  });
   it("never reveals the middle of a long secret", () => {
     const secret = `sk-${"M".repeat(40)}END`; // "sk-" + 40×M + "END"
     const masked = maskSecret(secret);

--- a/packages/agent/src/api/wallet.ts
+++ b/packages/agent/src/api/wallet.ts
@@ -9,7 +9,7 @@
  */
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { logger, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   KeyValidationResult,
   SolanaTokenBalance,
@@ -460,8 +460,12 @@ export function validatePrivateKey(key: string): KeyValidationResult {
 
 /** Mask a secret string for safe display (e.g. logs, UI). */
 export function maskSecret(value: string): string {
-  if (!value || value.length <= 8) return "****";
-  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+  if (!value) return "****";
+  const wellFormed = toWellFormedUnicode(value);
+  if (wellFormed.length <= 8) return "****";
+  const start = truncateWellFormed(wellFormed, 4);
+  const end = tailWellFormed(wellFormed, 4);
+  return `${start}...${end}`;
 }
 
 // ── Key generation ────────────────────────────────────────────────────
@@ -849,8 +853,11 @@ interface SolanaDexMeta {
 }
 
 function shortenMint(mint: string): string {
-  if (mint.length <= 10) return mint;
-  return `${mint.slice(0, 4)}...${mint.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(mint);
+  if (wellFormed.length <= 10) return wellFormed;
+  const start = truncateWellFormed(wellFormed, 4);
+  const end = tailWellFormed(wellFormed, 4);
+  return `${start}...${end}`;
 }
 
 async function fetchSolanaDexMeta(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7812edf05dd57be783dda517b35f7aee38a8df86 -->

## Summary
In `@elizaos/agent` (`packages/agent/src/api/wallet.ts`):
`maskSecret` and `shortenMint` used raw `.slice(0, 4)` and `.slice(-4)` without normalizing inputs to well-formed Unicode or preserving UTF-16 surrogate pair boundaries. When secrets or mint strings contain multi-code-unit surrogate pairs at boundary cut points, raw slicing leaves lone surrogate code units in UI displays and log outputs.

## Proposed Changes
1. Updated `maskSecret` to normalize with `toWellFormedUnicode(value)` and clamp head/tail boundaries using `truncateWellFormed(wellFormed, 4)` and `tailWellFormed(wellFormed, 4)`.
2. Updated `shortenMint` to normalize with `toWellFormedUnicode(mint)` and clamp using `truncateWellFormed(wellFormed, 4)` and `tailWellFormed(wellFormed, 4)`.
3. Added boundary straddling surrogate pair regression test in `packages/agent/src/api/wallet-mask-secret.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/api/wallet-mask-secret.test.ts` (4/4 passed).
- Verified well-formed Unicode output during secret masking and mint shortening.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
