### PR TITLE
fix(agent): use truncateWellFormed for cloudApiKeyFingerprint and trajectory storage step diagnostic detail

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -155,6 +155,8 @@ import {
   subAgentCredentialsPlugin,
   type TargetInfo,
   type UUID,
+  toWellFormedUnicode,
+  truncateWellFormed,
   warnOnUnmatchedActionRolePolicyKeys,
 } from "@elizaos/core";
 import {
@@ -2348,7 +2350,8 @@ export function bindCloudGithubTokenToRuntime(
 export function cloudApiKeyFingerprint(value: string | undefined): string {
   const v = value?.trim();
   if (!v) return "(none)";
-  return `${v.slice(0, 6)}…(len ${v.length})`;
+  const wellFormed = toWellFormedUnicode(v);
+  return `${truncateWellFormed(wellFormed, 6)}…(len ${wellFormed.length})`;
 }
 
 /**

--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -22,6 +22,8 @@ import {
   recordedStageToSemanticStage,
   Service,
   sanitizeTrajectoryJsonObject,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type TrajectorySemanticStageRecord,
 } from "@elizaos/core";
 import type {
@@ -183,7 +185,7 @@ function reportLateTrajectoryCapture(
   entry.rejects += 1;
   const ageMs = Date.now() - entry.closedAt;
   const age = `${Math.round(ageMs / 1000)}s`;
-  const detail = `step=${stepId.slice(0, 12)} type=${captureType} purpose=${purpose ?? "unknown"} age=${age}`;
+  const detail = `step=${truncateWellFormed(toWellFormedUnicode(stepId), 12)} type=${captureType} purpose=${purpose ?? "unknown"} age=${age}`;
   // The voice-gate rephrase races its own turn's terminalization by design
   // (delivery does not wait for the diagnostic copy); a same-instant reject
   // is expected once per racy turn and had the overnight watch paging on


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:92442e3b2946a2ae07eca85a30073732e62bfc45 -->

## Summary
In `@elizaos/agent`:
1. In `packages/agent/src/runtime/eliza.ts`: `cloudApiKeyFingerprint` used raw `v.slice(0, 6)`. When cloud API keys or placeholder values contain surrogate pairs, raw slicing severed surrogate pairs.
2. In `packages/agent/src/runtime/trajectory-storage.ts`: `reportLateTrajectoryCapture` formatted diagnostic step summaries using raw `stepId.slice(0, 12)`.

## Proposed Changes
1. Updated `cloudApiKeyFingerprint` in `packages/agent/src/runtime/eliza.ts` to normalize with `toWellFormedUnicode(v)` and clamp with `truncateWellFormed(wellFormed, 6)`.
2. Updated `reportLateTrajectoryCapture` in `packages/agent/src/runtime/trajectory-storage.ts` to clamp step ID with `truncateWellFormed(toWellFormedUnicode(stepId), 12)` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/runtime/trajectory-storage.test.ts` (30/30 passed).
- Verified well-formed Unicode output in agent boot fingerprints and late trajectory diagnostic detail formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
