### PR TITLE
fix(plugin-computeruse): use truncateWellFormed for authorization header token extraction in compat routes

### DIFF
--- a/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts
@@ -9,7 +9,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
-import { ModelType, resolveAliasedEnvValue } from "@elizaos/core";
+import { ModelType, resolveAliasedEnvValue, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { AppDescriptor, AppState } from "../app-control/types.js";
 import { ComputerUseSessionError } from "../sessions/session-manager.js";
 import type {
@@ -52,9 +52,10 @@ function getCompatApiToken(): string | null {
 function getProvidedApiToken(
   req: Pick<http.IncomingMessage, "headers">,
 ): string | null {
-  const authHeader = firstHeaderValue(req.headers.authorization)
-    ?.slice(0, 1024)
-    ?.trim();
+  const rawAuth = firstHeaderValue(req.headers.authorization);
+  const authHeader = rawAuth
+    ? truncateWellFormed(toWellFormedUnicode(rawAuth), 1024).trim()
+    : null;
   if (authHeader) {
     const match = /^Bearer\s{1,8}(.+)$/i.exec(authHeader);
     if (match?.[1]) return match[1].trim();


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a9ed6b89dafa51bdc14a753a01e67299910c4697 -->

## Summary
In `@elizaos/plugin-computeruse` (`plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts`):
`getProvidedApiToken` clamped the raw authorization header with `firstHeaderValue(req.headers.authorization)?.slice(0, 1024)?.trim()`. If an incoming authorization header contains UTF-16 surrogate pairs at character clamp boundaries, raw slicing severs surrogate pairs before regex parsing.

## Proposed Changes
1. Normalized `req.headers.authorization` with `toWellFormedUnicode(...)`.
2. Replaced `.slice(0, 1024)` with `truncateWellFormed(..., 1024)` from `@elizaos/core`.

## Verification
- Ran vitest on plugin compatibility route test suite.
- Verified well-formed Unicode output during API token extraction from authorization headers.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
