### PR TITLE
fix(plugin-local-inference): use truncateWellFormed for authorization header token extraction in compat helpers

### DIFF
--- a/plugins/plugin-local-inference/src/routes/compat-helpers.ts
+++ b/plugins/plugin-local-inference/src/routes/compat-helpers.ts
@@ -12,7 +12,7 @@
 import crypto from "node:crypto";
 import type http from "node:http";
 import { isIP } from "node:net";
-import type { AgentRuntime } from "@elizaos/core";
+import { type AgentRuntime, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
 	isLoopbackBindHost,
 	readAliasedEnv,
@@ -40,9 +40,10 @@ export function getCompatApiToken(): string | null {
 export function getProvidedApiToken(
 	req: Pick<http.IncomingMessage, "headers">,
 ): string | null {
-	const authHeader = firstHeaderValue(req.headers.authorization)
-		?.slice(0, 1024)
-		.trim();
+	const rawAuth = firstHeaderValue(req.headers.authorization);
+	const authHeader = rawAuth
+		? truncateWellFormed(toWellFormedUnicode(rawAuth), 1024).trim()
+		: null;
 	if (authHeader) {
 		const match = /^Bearer\s{1,8}(.+)$/i.exec(authHeader);
 		if (match?.[1]) return match[1].trim();


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2e151a655ee737fd633aad9b27c1cc23c2af57b6 -->

## Summary
In `@elizaos/plugin-local-inference` (`plugins/plugin-local-inference/src/routes/compat-helpers.ts`):
`getProvidedApiToken` clamped the raw authorization header with `firstHeaderValue(req.headers.authorization)?.slice(0, 1024).trim()`. When an authorization header contains multi-code-unit UTF-16 surrogate pairs at the 1024 character clamp boundary, raw slicing severs surrogate pairs before bearer token extraction.

## Proposed Changes
1. Normalized `req.headers.authorization` with `toWellFormedUnicode(...)`.
2. Replaced `.slice(0, 1024)` with `truncateWellFormed(..., 1024)` from `@elizaos/core`.

## Verification
- Ran vitest on local-inference compat routes test suite.
- Verified well-formed Unicode output during API token extraction from authorization headers.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
