### PR TITLE
fix(plugin-sql): use truncateWellFormed for rlsServerId and managerKey logging

### DIFF
--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -8,7 +8,7 @@
  * live-query / Electric Sync status/reset/close accessors used by hosts.
  */
 import type { IDatabaseAdapter, UUID } from "@elizaos/core";
-import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
+import { type IAgentRuntime, logger, type Plugin, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   createAdapterReadinessError,
   describeAdapterReadinessError,
@@ -138,7 +138,7 @@ export function createDatabaseAdapter(
       logger.debug(
         {
           src: "plugin:sql",
-          rlsServerId: rlsServerId.slice(0, 8),
+          rlsServerId: truncateWellFormed(toWellFormedUnicode(rlsServerId), 8),
           serverIdString: rlsServerIdString,
         },
         "Using connection pool for RLS server"
@@ -152,7 +152,7 @@ export function createDatabaseAdapter(
     let manager = globalSingletons.postgresConnectionManagers.get(managerKey);
     if (!shouldReusePostgresManager(manager)) {
       logger.debug(
-        { src: "plugin:sql", managerKey: managerKey.slice(0, 8) },
+        { src: "plugin:sql", managerKey: truncateWellFormed(toWellFormedUnicode(managerKey), 8) },
         "Creating new connection pool"
       );
       manager = new PostgresConnectionManager(config.postgresUrl, rlsServerId);

--- a/plugins/plugin-sql/src/rls.ts
+++ b/plugins/plugin-sql/src/rls.ts
@@ -7,7 +7,7 @@
  * table, so new schema tables need no manual RLS wiring. PGlite has no RLS
  * support, so these helpers are only invoked on the Postgres adapter.
  */
-import { type IDatabaseAdapter, logger, validateUuid } from "@elizaos/core";
+import { type IDatabaseAdapter, logger, toWellFormedUnicode, truncateWellFormed, validateUuid } from "@elizaos/core";
 import { eq, sql } from "drizzle-orm";
 import { agentTable } from "./schema/agent";
 import { serverTable } from "./schema/server";
@@ -128,7 +128,7 @@ export async function getOrCreateRlsServer(
     })
     .onConflictDoNothing();
 
-  logger.info({ src: "plugin:sql", serverId: serverId.slice(0, 8) }, "RLS server registered");
+  logger.info({ src: "plugin:sql", serverId: truncateWellFormed(toWellFormedUnicode(serverId), 8) }, "RLS server registered");
   return serverId;
 }
 
@@ -144,7 +144,7 @@ export async function setServerContext(adapter: IDatabaseAdapter, serverId: stri
     throw new Error(`Server ${serverId} does not exist`);
   }
 
-  logger.info({ src: "plugin:sql", serverId: serverId.slice(0, 8) }, "RLS context configured");
+  logger.info({ src: "plugin:sql", serverId: truncateWellFormed(toWellFormedUnicode(serverId), 8) }, "RLS context configured");
 }
 
 export async function assignAgentToServer(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:84e6e5a67287c7afd92193205719f6285a56788e -->

## Summary
In `@elizaos/plugin-sql`:
1. In `plugins/plugin-sql/src/rls.ts`: `getOrCreateRlsServer` and `setServerContext` logged `serverId.slice(0, 8)` directly.
2. In `plugins/plugin-sql/src/index.node.ts`: `createDatabaseAdapter` logged `rlsServerId.slice(0, 8)` and `managerKey.slice(0, 8)` directly.

## Proposed Changes
1. Replaced raw `.slice(0, 8)` with `truncateWellFormed(toWellFormedUnicode(...), 8)` from `@elizaos/core` across all 4 logging sites in `plugins/plugin-sql/src/rls.ts` and `plugins/plugin-sql/src/index.node.ts`.

## Verification
- Ran vitest on plugin-sql package suites.
- Verified well-formed Unicode output during RLS server ID and database manager key log formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
