### PR TITLE
fix(shared): use surrogate-safe truncation in sanitizeApiKey and parseMeetingUrl

### DIFF
--- a/packages/shared/src/meetings.test.ts
+++ b/packages/shared/src/meetings.test.ts
@@ -68,6 +68,11 @@ describe("parseMeetingUrl", () => {
     );
   });
 
+  it("preserves well-formed Unicode when Teams native meeting id contains surrogate pairs", () => {
+    const encoded = encodeURIComponent("meeting_id_" + "a".repeat(115) + "🚀" + "tail");
+    const parsed = parseMeetingUrl(`https://teams.microsoft.com/l/meetup-join/${encoded}`);
+    expect(parsed?.nativeMeetingId?.isWellFormed()).toBe(true);
+  });
   it("returns null for an unrecognized URL", () => {
     expect(parseMeetingUrl("https://example.com/not-a-meeting")).toBeNull();
     expect(parseMeetingUrl("")).toBeNull();

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Meetings — the canonical contract for agent-attended meetings.
  *
@@ -274,7 +275,7 @@ export function parseMeetingUrl(raw: string): ParsedMeetingUrl | null {
     return {
       platform: "teams",
       meetingUrl: url,
-      nativeMeetingId: decoded.slice(0, 128),
+      nativeMeetingId: truncateWellFormed(toWellFormedUnicode(decoded), 128),
     };
   }
   return null;

--- a/packages/shared/src/voice.test.ts
+++ b/packages/shared/src/voice.test.ts
@@ -18,6 +18,12 @@ describe("voice", () => {
     expect(sanitizeApiKey("  key123456789  ")).toContain("...");
     expect(sanitizeApiKey("[REDACTED]")).toBe("[REDACTED]");
   });
+  it("preserves well-formed Unicode when apiKey contains surrogate pairs", () => {
+    const key = "abc🚀SECRETMIDDLE🚀xyz";
+    const sanitized = sanitizeApiKey(key);
+    expect(sanitized?.isWellFormed()).toBe(true);
+    expect(sanitized).toContain("...");
+  });
   it("checks configured", () => {
     expect(hasConfiguredApiKey("abc")).toBe(true);
     expect(hasConfiguredApiKey(undefined)).toBe(false);

--- a/packages/shared/src/voice.ts
+++ b/packages/shared/src/voice.ts
@@ -1,3 +1,5 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 /**
  * Shared voice contracts and voice-selection data consumed across runtime,
  * cloud, plugins, and UI surfaces.
@@ -39,11 +41,14 @@ export interface VoicePreset {
 export function sanitizeApiKey(apiKey: string | undefined): string | undefined {
   if (!apiKey) return apiKey;
   if (apiKey === "[REDACTED]") return apiKey;
+  const wellFormed = toWellFormedUnicode(apiKey);
   // If the key is long enough to be real, mask the middle
-  if (apiKey.length > 8) {
-    return `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`;
+  if (wellFormed.length > 8) {
+    const start = truncateWellFormed(wellFormed, 4);
+    const end = tailWellFormed(wellFormed, 4);
+    return `${start}...${end}`;
   }
-  return apiKey;
+  return wellFormed;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1bd5570ee955553e8350112aaa6ebe7a57d83b4a -->

## Summary
In `@elizaos/shared`:
1. In `packages/shared/src/voice.ts`: `sanitizeApiKey` performed raw slicing `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}` without normalizing inputs or aligning to UTF-16 surrogate pair boundaries.
2. In `packages/shared/src/meetings.ts`: `parseMeetingUrl` clamped decoded native Teams meeting IDs with raw `decoded.slice(0, 128)`.

## Proposed Changes
1. Updated `sanitizeApiKey` in `packages/shared/src/voice.ts` using `toWellFormedUnicode(apiKey)`, `truncateWellFormed(wellFormed, 4)`, and `tailWellFormed(wellFormed, 4)`.
2. Updated `parseMeetingUrl` in `packages/shared/src/meetings.ts` to clamp decoded meeting ID using `truncateWellFormed(toWellFormedUnicode(decoded), 128)`.
3. Added surrogate pair regression tests in `packages/shared/src/voice.test.ts` and `packages/shared/src/meetings.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/voice.test.ts packages/shared/src/meetings.test.ts` (12/12 passed).
- Verified well-formed Unicode output during API key sanitization and meeting ID URL parsing.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
