### PR TITLE
[android-auth-agent-chat] fix(cloud): mark Dedicated fleet outage unhealthy

### DIFF
--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
@@ -21,7 +21,9 @@
  * Also asserts the failure-isolation boundary (#22548): the two monitors are
  * independent questions sharing a schedule, so a rejection in either one must
  * NOT prevent the other from running and alerting, while the cron still
- * answers with a structured failure.
+ * answers with a structured failure. A fulfilled unreachable fleet makes the
+ * aggregate response unhealthy even with a fresh daemon heartbeat, while the
+ * daemon-only sub-signal remains observable.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -225,6 +227,36 @@ describe("provisioning-worker-health cron route", () => {
     expect(body.stale).toBe(false);
 
     expect(fetchCalls.some((c) => c.url === SLACK_WEBHOOK)).toBe(false);
+  });
+
+  test("fresh heartbeat with an unreachable dedicated fleet -> overall unhealthy while heartbeat stays healthy", async () => {
+    checkProvisioningWorkerHealth.mockResolvedValueOnce({
+      ok: true,
+      required: true,
+      lastHeartbeatAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    fleetCensus = [
+      { execution_tier: "dedicated-always", status: "error", count: 26 },
+    ];
+
+    const response = await hitCron();
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      healthy: boolean;
+      heartbeatHealthy: boolean;
+      fleet: { unreachable: boolean };
+    };
+    expect(body.healthy).toBe(false);
+    expect(body.heartbeatHealthy).toBe(true);
+    expect(body.fleet.unreachable).toBe(true);
+
+    // Exercise the real fleet monitor's alert path, not a route-local stub.
+    const slackPost = fetchCalls.find((c) => c.url === SLACK_WEBHOOK);
+    expect(slackPost).toBeDefined();
+    expect(JSON.stringify(slackPost?.body)).toContain(
+      "Dedicated agent fleet is unreachable",
+    );
   });
 
   test("daemon not required (e.g. local) -> healthy:true, silent", async () => {

--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.ts
@@ -10,6 +10,8 @@
  * exist and none is serving" is invisible to the heartbeat sweep (which
  * iterates only running rows), so this cron asks it explicitly and publishes
  * provisioning success measured on the jobs ledger in its response and logs.
+ * The root `healthy` signal covers both monitors; `heartbeatHealthy` preserves
+ * the daemon-only signal for diagnosis.
  *
  * The two monitors are INDEPENDENT questions that merely share a schedule, so
  * they are settled independently: a Redis outage in the heartbeat gate, or a
@@ -74,11 +76,15 @@ async function runProvisioningWorkerHealthCheck(c: AppContext) {
     fleetResult.status === "fulfilled" ? fleetResult.value : null;
   const heartbeat =
     heartbeatResult.status === "fulfilled" ? heartbeatResult.value : null;
+  const heartbeatHealthy = heartbeat?.healthy ?? null;
+  const overallHealthy =
+    heartbeat && fleet ? heartbeat.healthy && !fleet.unreachable : null;
 
   logger.info("[Provisioning Worker Health Cron] Monitors settled", {
     heartbeatOk: heartbeatResult.status === "fulfilled",
     fleetOk: fleetResult.status === "fulfilled",
-    healthy: heartbeat?.healthy ?? null,
+    healthy: overallHealthy,
+    heartbeatHealthy,
     stale: heartbeat?.stale ?? null,
     required: heartbeat?.health.required ?? null,
     fleetExpectedReachable: fleet?.expectedReachableTotal ?? null,
@@ -99,9 +105,9 @@ async function runProvisioningWorkerHealthCheck(c: AppContext) {
         : { ok: false as const, error: describe(fleetResult.reason) },
   };
 
-  // `!heartbeat` is implied by a non-empty `failures`; it is spelled out so the
-  // destructure below is narrowed by control flow rather than by an assertion.
-  if (failures.length > 0 || !heartbeat) {
+  // Missing monitor values are implied by a non-empty `failures`; spelling
+  // them out narrows both results below without assertions.
+  if (failures.length > 0 || !heartbeat || !fleet) {
     return c.json(
       {
         success: false,
@@ -109,14 +115,23 @@ async function runProvisioningWorkerHealthCheck(c: AppContext) {
         code: "cron_monitor_failed" as const,
         monitors,
         ...(heartbeat ?? {}),
+        heartbeatHealthy,
         fleet,
       },
       500,
     );
   }
 
-  const { healthy, stale, health } = heartbeat;
-  return c.json({ healthy, stale, health, fleet, monitors });
+  const { healthy: currentHeartbeatHealthy, stale, health } = heartbeat;
+  const healthy = currentHeartbeatHealthy && !fleet.unreachable;
+  return c.json({
+    healthy,
+    heartbeatHealthy: currentHeartbeatHealthy,
+    stale,
+    health,
+    fleet,
+    monitors,
+  });
 }
 
 app.get("/", runProvisioningWorkerHealthCheck);


### PR DESCRIPTION
## Relates to

- #22547
- #25044
- #29024

## Outcome

The provisioning-worker health cron now reports `healthy: false` when the Dedicated fleet monitor proves the expected fleet is unreachable, even when the provisioning-daemon heartbeat is fresh. The daemon-only result remains available as the additive `heartbeatHealthy` field.

## Root cause

The cron ran the heartbeat and fleet monitors independently, but copied the root `healthy` field only from the heartbeat result. A fresh daemon heartbeat therefore masked a fulfilled fleet census showing that every expected Dedicated runtime was unavailable.

## Change

- Compute aggregate health as `heartbeatHealthy && !fleet.unreachable`.
- Preserve `heartbeatHealthy` as a separate diagnostic signal.
- Keep HTTP 200 when both monitors complete; monitor execution failures retain the structured HTTP 500 path.
- Add a regression through the real fleet monitor and Slack alert fan-out.

## Risk

Low. This changes only the truth value of an existing health response for the already-alerting unreachable-fleet condition and adds one response field. It does not provision, restart, stop, delete, or deploy anything.

## Rollback

Revert this PR to restore heartbeat-only root health semantics. No data or infrastructure rollback is required.

## Verification

Validated after rebasing on `origin/develop` at `50885b696e5af7c0b60a35127843c57779ff8eb1`:

- `bun test packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts` — 9 passed, 0 failed, 51 assertions.
- `bunx biome check packages/cloud/api/v1/cron/provisioning-worker-health/route.ts packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts` — passed.
- Targeted Node 24.15 / TypeScript 6 check of the two changed files — passed before rebase; rebase did not touch either file.
- `git diff --check origin/develop...HEAD` — passed.
- Added-line scan for credentials, private keys, DSNs, email/PII, and secret URLs — no findings.

The full Cloud API typecheck currently encounters the existing missing generated declaration for `@elizaos/plugin-doordash`; neither the import nor generated package is touched here.

## Evidence

The regression creates a fresh successful worker heartbeat plus 26 `dedicated-always/error` rows. It verifies:

- HTTP 200 because both monitors completed;
- root `healthy: false`;
- `heartbeatHealthy: true`;
- `fleet.unreachable: true`;
- the real Dedicated-fleet Slack alert path fires.

No live deployment or live infrastructure mutation was performed. Production/staging response verification remains a post-deploy operator step.

## Evidence applicability

- UI screenshots/video: N/A — no rendered UI changed.
- Frontend/backend logs: N/A — no deployed execution was authorized; deterministic route and alert-boundary evidence is above.
- LLM trajectory: N/A — no agent/model/prompt behavior changed.
- Domain artifacts: N/A — no database or infrastructure mutation.
