### PR TITLE
fix(ui): use truncateWellFormed for monograms and workflow execution IDs

### DIFF
--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Native Smithers workflow studio for source authoring, visual structure,
  * widgets, revisions, and live run inspection through elizaOS Cloud APIs.
@@ -701,7 +702,7 @@ export function WorkflowEditor({
                     <span className="sr-only">{execution.status}</span>
                   </span>
                   <span className="min-w-0 flex-1 truncate font-mono text-2xs text-muted-foreground">
-                    {execution.id.slice(0, 12)}
+                    {truncateWellFormed(toWellFormedUnicode(execution.id), 12)}
                   </span>
                   <span className="text-2xs text-muted-foreground/70">
                     {new Date(execution.startedAt).toLocaleTimeString([], {
@@ -733,7 +734,7 @@ export function WorkflowEditor({
                     <span className="sr-only">{selectedRun.status}</span>
                   </span>
                   <span className="font-mono text-xs text-muted-foreground">
-                    {selectedRun.id.slice(0, 12)}
+                    {truncateWellFormed(toWellFormedUnicode(selectedRun.id), 12)}
                   </span>
                   <div className="flex-1" />
                   {!terminal(selectedRun.status) ? (

--- a/packages/ui/src/components/pages/plugin-list-utils.test.ts
+++ b/packages/ui/src/components/pages/plugin-list-utils.test.ts
@@ -12,6 +12,7 @@ import type { PluginInfo } from "../../api";
 import {
   buildPluginListState,
   iconImageSource,
+  pluginMonogram,
   resolveIcon,
 } from "./plugin-list-utils";
 
@@ -194,5 +195,12 @@ describe("buildPluginListState", () => {
       "needs-config",
       "disabled",
     ]);
+  });
+});
+
+describe("pluginMonogram", () => {
+  it("preserves well-formed Unicode when plugin name starts with surrogate pairs", () => {
+    const mono = pluginMonogram(plugin({ id: "emoji-plugin", name: "🚀Rocket Plugin" }));
+    expect(mono.isWellFormed()).toBe(true);
   });
 });

--- a/packages/ui/src/components/pages/plugin-list-utils.ts
+++ b/packages/ui/src/components/pages/plugin-list-utils.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Plugin list utilities — pure functions, constants, and type aliases
  * shared across the plugin management UI.
@@ -617,7 +618,7 @@ export function pluginMonogram(plugin: PluginInfo): string {
     return (words[0][0] + words[1][0]).toUpperCase();
   }
   const single = words[0] ?? source;
-  return single.slice(0, 2).toUpperCase() || "·";
+  return truncateWellFormed(toWellFormedUnicode(single), 2).toUpperCase() || "·";
 }
 
 /**

--- a/packages/ui/src/components/pages/trigger-form-utils.ts
+++ b/packages/ui/src/components/pages/trigger-form-utils.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Pure form model and constants for the Triggers feature: the trigger form
  * state shape and empty default, duration-unit math (best-fit unit, ms
@@ -217,7 +218,7 @@ export function railMonogram(label: string): string {
     .slice(0, 2)
     .map((word) => word[0]?.toUpperCase() ?? "")
     .join("");
-  return (initials || label.slice(0, 1).toUpperCase() || "?").slice(0, 2);
+  return truncateWellFormed(toWellFormedUnicode(initials || label.slice(0, 1).toUpperCase() || "?"), 2);
 }
 
 export { parsePositiveInteger };


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2bb3a1c5efe00f87bc0665b07faca594acd2d54d -->

## Summary
In `@elizaos/ui`:
1. In `packages/ui/src/components/pages/WorkflowEditor.tsx`: execution and selected run IDs were sliced with raw `.slice(0, 12)`.
2. In `packages/ui/src/components/pages/trigger-form-utils.ts`: `railMonogram` formatted 2-character initials using raw `.slice(0, 2)`.
3. In `packages/ui/src/components/pages/plugin-list-utils.ts`: `pluginMonogram` formatted 2-character plugin monograms using raw `single.slice(0, 2)`.

## Proposed Changes
1. Updated `WorkflowEditor.tsx` with `truncateWellFormed(toWellFormedUnicode(id), 12)`.
2. Updated `railMonogram` with `truncateWellFormed(toWellFormedUnicode(...), 2)`.
3. Updated `pluginMonogram` with `truncateWellFormed(toWellFormedUnicode(single), 2)`.
4. Added test in `packages/ui/src/components/pages/plugin-list-utils.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/components/pages/plugin-list-utils.test.ts` (6/6 passed).
- Verified well-formed Unicode output during monogram generation and workflow run ID rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
