### PR TITLE
fix(shared): use surrogate-safe truncation in getAppHeroMonogram

### DIFF
--- a/packages/shared/src/app-hero-art.test.ts
+++ b/packages/shared/src/app-hero-art.test.ts
@@ -32,6 +32,8 @@ describe("app-hero-art", () => {
       "CS",
     );
     expect(getAppHeroMonogram({ name: "" })).toBe("?");
+    expect(getAppHeroMonogram({ name: "🚀Rocket Space" }).isWellFormed()).toBe(true);
+
   });
 
   it("categorizes apps into appropriate theme keys", () => {

--- a/packages/shared/src/app-hero-art.ts
+++ b/packages/shared/src/app-hero-art.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Deterministically derives hero artwork (theme + gradient) for an app from its
  * name/category so every app gets stable, distinct placeholder art without a
@@ -86,12 +87,14 @@ export function getAppHeroDisplayLabel(app: AppHeroArtworkSource): string {
 
 export function getAppHeroMonogram(app: AppHeroArtworkSource): string {
   const label = trimPackagePrefix(app.displayName ?? app.name);
-  const words = label.split(/[\s._/-]+/).filter(Boolean);
+  const wellFormed = toWellFormedUnicode(label);
+  const words = wellFormed.split(/[\s._/-]+/).filter(Boolean);
   const initials = words
     .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? "")
+    .map((word) => truncateWellFormed(word, 1).toUpperCase())
     .join("");
-  return (initials || label.slice(0, 2).toUpperCase() || "?").slice(0, 2);
+  const fallback = truncateWellFormed(wellFormed, 2).toUpperCase() || "?";
+  return truncateWellFormed(initials || fallback, 2);
 }
 
 export function getAppHeroThemeKey(app: AppHeroArtworkSource): AppHeroThemeKey {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:e69289fa331fec56a04c28c924b5c5a13f3fb91b -->

## Summary
In `@elizaos/shared` (`packages/shared/src/app-hero-art.ts`):
`getAppHeroMonogram` formatted 2-character app hero monograms using `word[0]` and raw `.slice(0, 2)`. When app names or display names begin with multi-code-unit UTF-16 surrogate pairs, raw slicing severed surrogate pairs.

## Proposed Changes
1. Normalized `label` with `toWellFormedUnicode(label)`.
2. Replaced `word[0]` with `truncateWellFormed(word, 1)`.
3. Clamped monogram output using `truncateWellFormed(..., 2)` from `@elizaos/core`.
4. Added test in `packages/shared/src/app-hero-art.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/app-hero-art.test.ts` (5/5 passed).
- Verified well-formed Unicode output during app hero monogram generation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
