### PR TITLE
fix(core): use truncateWellFormed for stepId diagnostics and zip folder names in TrajectoriesService

### DIFF
--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "../../utils/well-formed";
 /**
  * Persists runtime trajectories, step indexes, model calls, and reward metadata
  * for replay, UI inspection, export, and training-data collection.
@@ -1122,8 +1123,9 @@ export class TrajectoriesService extends Service {
 		// (30s grace, then 120s). The age names the class directly.
 		const age =
 			typeof ageMs === "number" ? `${Math.round(ageMs / 1000)}s` : "unknown";
+		const safeStepId = truncateWellFormed(toWellFormedUnicode(stepId), 12);
 		const error = new ElizaError(
-			`Trajectory capture arrived after terminalization (step=${stepId.slice(0, 12)} type=${captureType} age=${age})`,
+			`Trajectory capture arrived after terminalization (step=${safeStepId} type=${captureType} age=${age})`,
 			{
 				code: "TRAJECTORY_OWNER_CLOSED",
 				context: { stepId, captureType, ageMs },
@@ -1131,7 +1133,7 @@ export class TrajectoriesService extends Service {
 		);
 		logger.warn(
 			{ err: error, stepId, captureType, ageMs },
-			`[trajectory-logger] Rejected late trajectory capture (step=${stepId.slice(0, 12)} type=${captureType} age=${age})`,
+			`[trajectory-logger] Rejected late trajectory capture (step=${safeStepId} type=${captureType} age=${age})`,
 		);
 		this.runtime.reportError("TrajectoriesService.lateCapture", error, {
 			stepId,
@@ -3387,8 +3389,11 @@ export class TrajectoriesService extends Service {
 	}
 
 	private sanitizeZipFolderName(value: string): string {
-		const trimmed = value.trim();
-		const safe = trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed;
+		const wellFormed = toWellFormedUnicode(value.trim());
+		const safe =
+			wellFormed.length > 256
+				? truncateWellFormed(wellFormed, 256)
+				: wellFormed;
 		const sanitized = safe
 			.replace(/[^a-zA-Z0-9._-]+/g, "_")
 			.replace(/^_+|_+$/g, "");


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:049bae932ae7b40219419a49e599fb1b0330f6f4 -->

## Summary
In `@elizaos/core` (`packages/core/src/features/trajectories/TrajectoriesService.ts`):
1. Late trajectory rejection logs formatted diagnostic messages using raw `stepId.slice(0, 12)`.
2. `sanitizeZipFolderName` clamped folder names using raw `trimmed.slice(0, 256)`.

## Proposed Changes
1. Normalized `stepId` and used `truncateWellFormed(toWellFormedUnicode(stepId), 12)` in late trajectory rejection errors and warnings.
2. Normalized `value` and used `truncateWellFormed(wellFormed, 256)` in `sanitizeZipFolderName`.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/features/trajectories/trajectory-json-export.test.ts packages/core/src/services/trajectories.test.ts` (17/17 passed).
- Verified well-formed Unicode output during trajectory diagnostic logging and zip folder name sanitization.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
