### PR TITLE
fix(agent): use surrogate-safe truncation in agent status wallet addresses and token fingerprints

### DIFF
--- a/packages/agent/src/api/agent-status-routes.ts
+++ b/packages/agent/src/api/agent-status-routes.ts
@@ -3,7 +3,7 @@
  */
 
 import type http from "node:http";
-import type { AgentRuntime, ReadJsonBodyOptions } from "@elizaos/core";
+import { type AgentRuntime, type ReadJsonBodyOptions, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { TradePermissionMode } from "@elizaos/shared";
 import {
   PostRegistryRegisterRequestSchema,
@@ -227,12 +227,12 @@ export async function handleAgentStatusRoutes(
         evmAddress,
         evmAddressShort:
           evmAddress && evmAddress.length >= 12
-            ? `${evmAddress.slice(0, 6)}...${evmAddress.slice(-4)}`
+            ? `${truncateWellFormed(toWellFormedUnicode(evmAddress), 6)}...${tailWellFormed(toWellFormedUnicode(evmAddress), 4)}`
             : evmAddress,
         solanaAddress: addrs.solanaAddress ?? null,
         solanaAddressShort:
           addrs.solanaAddress && addrs.solanaAddress.length >= 12
-            ? `${addrs.solanaAddress.slice(0, 4)}...${addrs.solanaAddress.slice(-4)}`
+            ? `${truncateWellFormed(toWellFormedUnicode(addrs.solanaAddress), 4)}...${tailWellFormed(toWellFormedUnicode(addrs.solanaAddress), 4)}`
             : (addrs.solanaAddress ?? null),
         localSignerAvailable: capability.localSignerAvailable,
         managedBscRpcReady: bscRpcReady,

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -4,7 +4,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
-import { logger } from "@elizaos/core";
+import { logger, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   isCloudProvisionedContainer,
   isLoopbackBindHost,
@@ -515,7 +515,7 @@ export function ensureApiTokenForBindHost(host: string): void {
       `[eliza-api] ELIZA_API_BIND=${host} is non-loopback and ELIZA_API_TOKEN is unset.`,
     );
   }
-  const tokenFingerprint = `${generated.slice(0, 4)}...${generated.slice(-4)}`;
+  const tokenFingerprint = `${truncateWellFormed(toWellFormedUnicode(generated), 4)}...${tailWellFormed(toWellFormedUnicode(generated), 4)}`;
   logger.warn(
     `[eliza-api] Generated temporary API token (${tokenFingerprint}) for this process. Set ELIZA_API_TOKEN explicitly to override.`,
   );


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:fe118f9d4145a6c3c1a8c3dc453cdbcf34e6e58d -->

## Summary
In `@elizaos/agent`:
1. In `packages/agent/src/api/agent-status-routes.ts`: `evmAddressShort` and `solanaAddressShort` used raw slicing `${evmAddress.slice(0, 6)}...${evmAddress.slice(-4)}` and `${addrs.solanaAddress.slice(0, 4)}...${addrs.solanaAddress.slice(-4)}`.
2. In `packages/agent/src/api/server-helpers-auth.ts`: `ensureApiTokenForBindHost` formatted token fingerprints using raw `${generated.slice(0, 4)}...${generated.slice(-4)}`.

## Proposed Changes
1. Updated `agent-status-routes.ts` to format short EVM/Solana addresses using `truncateWellFormed` and `tailWellFormed` on normalized Unicode inputs.
2. Updated `server-helpers-auth.ts` to format token fingerprints using `truncateWellFormed` and `tailWellFormed` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/api/wallet-mask-secret.test.ts` (3/3 passed).
- Verified well-formed Unicode output during agent status response serialization and server token fingerprint logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
