### PR TITLE
fix(cloud): accept decoded provisioning worker heartbeats

### DIFF
--- a/packages/cloud/shared/src/lib/services/provisioning-worker-health.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-worker-health.test.ts
@@ -89,6 +89,29 @@ describe("provisioning worker health (Redis heartbeat)", () => {
     });
   });
 
+  it("accepts a Redis client that decodes the heartbeat JSON before returning it", async () => {
+    const timestamp = new Date().toISOString();
+    const redis = {
+      async get() {
+        return {
+          timestamp,
+          capabilities: [REVIEWED_BACKUP_RESTORE_CAPABILITY],
+        };
+      },
+    } as unknown as CompatibleRedis;
+
+    const result = await withEnv({}, () =>
+      checkProvisioningWorkerCapability(REVIEWED_BACKUP_RESTORE_CAPABILITY, redis),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      required: true,
+      lastHeartbeatAt: timestamp,
+      capabilities: [REVIEWED_BACKUP_RESTORE_CAPABILITY],
+    });
+  });
+
   it("distinguishes legacy liveness from the reviewed-backup execution capability", async () => {
     const redis = makeMemoryRedis();
     await redis.set(PROVISIONING_WORKER_HEARTBEAT_KEY, new Date().toISOString());

--- a/packages/cloud/shared/src/lib/services/provisioning-worker-health.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-worker-health.ts
@@ -86,9 +86,9 @@ export async function checkProvisioningWorkerHealth(
     return { ok: true, required: false };
   }
 
-  let raw: string | null;
+  let raw: unknown;
   try {
-    raw = (await redis.get(PROVISIONING_WORKER_HEARTBEAT_KEY)) as string | null;
+    raw = await redis.get(PROVISIONING_WORKER_HEARTBEAT_KEY);
   } catch (error) {
     return {
       ok: false,
@@ -112,20 +112,25 @@ export async function checkProvisioningWorkerHealth(
     };
   }
 
-  let lastHeartbeatAt = raw;
+  let lastHeartbeatAt = typeof raw === "string" ? raw : undefined;
   let capabilities: readonly string[] = [];
+  let parsed: unknown = raw;
   try {
-    const parsed = JSON.parse(raw) as { timestamp?: unknown; capabilities?: unknown };
-    if (typeof parsed.timestamp === "string") lastHeartbeatAt = parsed.timestamp;
-    if (
-      Array.isArray(parsed.capabilities) &&
-      parsed.capabilities.every((capability) => typeof capability === "string")
-    ) {
-      capabilities = parsed.capabilities;
-    }
+    if (typeof raw === "string") parsed = JSON.parse(raw);
   } catch {
-    // Legacy workers publish a bare ISO timestamp. It remains a valid liveness
-    // signal but advertises no versioned execution capabilities.
+    // error-policy:J3 Legacy workers publish a bare ISO timestamp, which is
+    // valid liveness but intentionally carries no execution capabilities.
+    parsed = null;
+  }
+  if (parsed !== null && typeof parsed === "object") {
+    const heartbeat = parsed as { timestamp?: unknown; capabilities?: unknown };
+    if (typeof heartbeat.timestamp === "string") lastHeartbeatAt = heartbeat.timestamp;
+    if (
+      Array.isArray(heartbeat.capabilities) &&
+      heartbeat.capabilities.every((capability) => typeof capability === "string")
+    ) {
+      capabilities = heartbeat.capabilities;
+    }
   }
 
   return { ok: true, required: true, lastHeartbeatAt, capabilities };


### PR DESCRIPTION
## Summary
- accept both serialized and Redis-client-decoded provisioning worker heartbeat payloads
- preserve legacy bare-timestamp compatibility
- restore fail-closed recognition of `reviewed-backup-restore-v1` before Dedicated adoption

## Production evidence
- production worker service is active/enabled at `10fcb3f4d2130678651a6dc43f412e865655c4dc`
- the live Redis heartbeat was 3 seconds old and contained the required capability
- the existing reader lost that capability only because `SocketRedis.get()` decoded JSON into an object before the reader attempted `JSON.parse`
- no Dedicated adoption authority, lifecycle job, replacement attempt, billing record, rate change, or cutover was created while diagnosing

## Gates
- 7/7 focused worker-health tests pass
- `@elizaos/cloud-shared` typecheck passes
- exact Biome and `git diff --check` pass

Base: `9008d1782099471f4803c5f1e4b3f8f9d272ee63`
Head: `62e1ca8518278853b490f4ced4bdfa15bafe9ac4`
Tree: `02fad2f9f7d6bc0afd7366191e829f4ab328d6a0`

No selection, activation, funding, compute, deletion, or cutover occurred from this change. Tracks #29024. @lalalune for urgent review.