### PR TITLE
test(app): cover character-catalog

### DIFF
--- a/packages/app/test/character-catalog.test.ts
+++ b/packages/app/test/character-catalog.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Exercises the app's default character catalog module — the thin re-export of
+ * `buildElizaCharacterCatalog()` from `@elizaos/shared` cast to
+ * `CharacterCatalogData`. Verifies the public shape, deduplication, ordering,
+ * and idempotency that consuming views and boot-config wiring depend on.
+ */
+
+import type {
+  CharacterAssetEntry,
+  InjectedCharacterEntry,
+} from "@elizaos/ui/config";
+import { describe, expect, it } from "vitest";
+
+import { APP_CHARACTER_CATALOG } from "../src/character-catalog.js";
+
+describe("APP_CHARACTER_CATALOG", () => {
+  it("is a non-null object with assets and injectedCharacters arrays", () => {
+    expect(APP_CHARACTER_CATALOG).toBeDefined();
+    expect(typeof APP_CHARACTER_CATALOG).toBe("object");
+    expect(Array.isArray(APP_CHARACTER_CATALOG.assets)).toBe(true);
+    expect(Array.isArray(APP_CHARACTER_CATALOG.injectedCharacters)).toBe(true);
+  });
+
+  it("has at least one asset and one injected character", () => {
+    expect(APP_CHARACTER_CATALOG.assets.length).toBeGreaterThanOrEqual(1);
+    expect(
+      APP_CHARACTER_CATALOG.injectedCharacters.length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  describe("assets", () => {
+    it("have numeric id, string slug, string title, and string sourceName", () => {
+      for (const asset of APP_CHARACTER_CATALOG.assets) {
+        expect(typeof asset.id).toBe("number");
+        expect(typeof asset.slug).toBe("string");
+        expect(typeof asset.title).toBe("string");
+        expect(typeof asset.sourceName).toBe("string");
+      }
+    });
+
+    it("carry unique ids", () => {
+      const ids = APP_CHARACTER_CATALOG.assets.map(
+        (a: CharacterAssetEntry) => a.id,
+      );
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("carry unique slugs", () => {
+      const slugs = APP_CHARACTER_CATALOG.assets.map(
+        (a: CharacterAssetEntry) => a.slug,
+      );
+      expect(new Set(slugs).size).toBe(slugs.length);
+    });
+
+    it("are sorted ascending by id", () => {
+      const ids = APP_CHARACTER_CATALOG.assets.map(
+        (a: CharacterAssetEntry) => a.id,
+      );
+      for (let i = 1; i < ids.length; i++) {
+        expect(ids[i]).toBeGreaterThanOrEqual(ids[i - 1]);
+      }
+    });
+
+    it("have slugs prefixed with eliza-", () => {
+      for (const asset of APP_CHARACTER_CATALOG.assets) {
+        expect(asset.slug).toMatch(/^eliza-/);
+      }
+    });
+  });
+
+  describe("injectedCharacters", () => {
+    it("have string catchphrase, string name, and numeric avatarAssetId", () => {
+      for (const character of APP_CHARACTER_CATALOG.injectedCharacters) {
+        expect(typeof character.catchphrase).toBe("string");
+        expect(typeof character.name).toBe("string");
+        expect(typeof character.avatarAssetId).toBe("number");
+      }
+    });
+
+    it("each avatarAssetId matches an asset id in the catalog", () => {
+      const assetIds = new Set(
+        APP_CHARACTER_CATALOG.assets.map((a: CharacterAssetEntry) => a.id),
+      );
+      for (const character of APP_CHARACTER_CATALOG.injectedCharacters) {
+        expect(assetIds.has(character.avatarAssetId)).toBe(true);
+      }
+    });
+
+    it("have unique names", () => {
+      const names = APP_CHARACTER_CATALOG.injectedCharacters.map(
+        (c: InjectedCharacterEntry) => c.name,
+      );
+      expect(new Set(names).size).toBe(names.length);
+    });
+
+    it("have non-empty catchphrases", () => {
+      for (const character of APP_CHARACTER_CATALOG.injectedCharacters) {
+        expect(character.catchphrase.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("cross-references", () => {
+    it("has at least as many injected characters as assets (multi-persona avatars share one asset)", () => {
+      expect(
+        APP_CHARACTER_CATALOG.injectedCharacters.length,
+      ).toBeGreaterThanOrEqual(APP_CHARACTER_CATALOG.assets.length);
+    });
+
+    it("each asset has sourceName equal to its title", () => {
+      for (const asset of APP_CHARACTER_CATALOG.assets) {
+        expect(asset.sourceName).toBe(asset.title);
+      }
+    });
+  });
+
+  describe("idempotency", () => {
+    it("multiple accesses return a structurally identical catalog", () => {
+      const { assets: a1, injectedCharacters: c1 } = APP_CHARACTER_CATALOG;
+      const { assets: a2, injectedCharacters: c2 } = APP_CHARACTER_CATALOG;
+      expect(a1).toEqual(a2);
+      expect(c1).toEqual(c2);
+    });
+  });
+});


### PR DESCRIPTION

## Summary

Adds real unit test coverage for `packages/app/src/character-catalog.ts` — the app's default character catalog re-export.

## What is tested

`APP_CHARACTER_CATALOG` is exercised against the live `buildElizaCharacterCatalog()` output from `@elizaos/shared`:

- **Shape validation** — the export is a non-null object with `assets` and `injectedCharacters` arrays, each element carrying the expected typed fields (`id`, `slug`, `title`, `sourceName`, `catchphrase`, `name`, `avatarAssetId`).
- **Deduplication** — asset `id` and `slug` are unique across the catalog; character `name` is unique across injected characters.
- **Ordering** — assets are sorted ascending by `id`.
- **Cross-references** — every `injectedCharacters[].avatarAssetId` matches an existing `assets[].id`; every asset's `sourceName` equals its `title`.
- **Slug convention** — all slugs are prefixed with `eliza-`.
- **Non-empty fields** — catchphrases are non-empty strings.
- **Idempotency** — repeated access to the module-level constant returns a structurally identical catalog.

No mocks — the real module is imported and the real catalog builder is driven end-to-end.

## Evidence

- `bunx vitest run packages/app/test/character-catalog.test.ts` — **1 test file, 14 tests passed**
- `bunx biome check --write packages/app/test/character-catalog.test.ts` — clean
- `bunx tsc --noEmit` in `packages/app/` — zero errors from the new test file (the pre-existing `src/main.tsx` TS2835 is unrelated)
- Diff is a new file only (+125 lines, 0 deletions)

This is a fork contributor PR; hosted CI does not run on our PRs. The quoted vitest/biome/tsc evidence is collected locally.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1b8a2cf48cbcd5ca6b5b07a227d5871e71cde301 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
