### PR TITLE
[android-auth-agent-chat] fix(web): align localhost sign-in return policy

### DIFF
--- a/packages/ui/src/state/cloud-login-launch.test.ts
+++ b/packages/ui/src/state/cloud-login-launch.test.ts
@@ -17,6 +17,7 @@ import {
   canNavigateSameTabForBlockedPopup,
   claimCloudLoginWindow,
   hasSameOriginStewardLogin,
+  isCliReturnLoopbackWebOrigin,
   isTouchPrimaryWebBrowser,
   preOpenCloudLoginWindow,
   prepareDesktopCloudLoginSession,
@@ -253,6 +254,29 @@ describe("hasSameOriginStewardLogin", () => {
     stubHostname("127.0.0.1", "http:");
     vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
     expect(hasSameOriginStewardLogin()).toBe(true);
+  });
+});
+
+describe("isCliReturnLoopbackWebOrigin", () => {
+  it.each(["localhost", "ui.localhost", "127.0.0.1", "::1"])(
+    "accepts the hosted CLI returnTo loopback host %s",
+    (hostname) => {
+      stubHostname(hostname, "http:");
+      expect(isCliReturnLoopbackWebOrigin()).toBe(true);
+    },
+  );
+
+  it.each(["127.0.0.2", "192.168.1.8", "attacker.example"])(
+    "does not broaden the hosted CLI returnTo allowlist to %s",
+    (hostname) => {
+      stubHostname(hostname, "http:");
+      expect(isCliReturnLoopbackWebOrigin()).toBe(false);
+    },
+  );
+
+  it("rejects a localhost name outside HTTP(S)", () => {
+    stubHostname("localhost", "file:");
+    expect(isCliReturnLoopbackWebOrigin()).toBe(false);
   });
 });
 

--- a/packages/ui/src/state/cloud-login-launch.ts
+++ b/packages/ui/src/state/cloud-login-launch.ts
@@ -157,16 +157,31 @@ function isPlainWebPlatform(): boolean {
   return true;
 }
 
-function isLoopbackHostname(hostname: string): boolean {
+function isCliReturnLoopbackHostname(hostname: string): boolean {
   const normalized = hostname
     .trim()
     .toLowerCase()
     .replace(/^\[|\]$/g, "");
-  if (normalized === "localhost" || normalized === "::1") return true;
-  if (!/^127(?:\.\d{1,3}){3}$/.test(normalized)) return false;
-  return normalized
-    .split(".")
-    .every((octet) => Number.parseInt(octet, 10) <= 255);
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1"
+  );
+}
+
+/**
+ * Plain-web origin accepted by the hosted CLI-login returnTo sanitizer.
+ * Keep this policy exact: a launch origin that the hosted page would discard
+ * cannot complete the bridge back to the local app.
+ */
+export function isCliReturnLoopbackWebOrigin(): boolean {
+  return (
+    isPlainWebPlatform() &&
+    (window.location.protocol === "http:" ||
+      window.location.protocol === "https:") &&
+    isCliReturnLoopbackHostname(window.location.hostname)
+  );
 }
 
 /**
@@ -175,8 +190,7 @@ function isLoopbackHostname(hostname: string): boolean {
  * callers route it through the hosted CLI-session exchange instead.
  */
 function loopbackStewardDevelopmentTarget(): "staging" | "other" | null {
-  if (!isPlainWebPlatform()) return null;
-  if (!isLoopbackHostname(window.location.hostname)) return null;
+  if (!isCliReturnLoopbackWebOrigin()) return null;
 
   const configuredUrl = configuredStewardApiUrlOverride();
   if (!configuredUrl) return null;


### PR DESCRIPTION
## Cause

#29342 now owns the localhost-to-staging hosted CLI-session flow. Its launch classifier still diverged from the hosted `/auth/cli-login` return sanitizer:

- it accepted the wider `127.0.0.0/8` range, including `127.0.0.2`, even though the hosted page rejects that return target;
- it did not accept `*.localhost`, even though the hosted page allows those local development origins.

On a touch-primary/kiosk-style browser, that mismatch can select an auth path whose hosted bridge cannot return to the local app.

## Resolution

- Define the launch-side loopback web-origin policy as HTTP(S) plain web on exactly `localhost`, `*.localhost`, `127.0.0.1`, or `::1`.
- Use that classifier for the staging Steward development target that selects the hosted CLI-session bridge.
- Cover the accepted set, including `ui.localhost`, and rejected hosts, including `127.0.0.2`.
- Reject non-HTTP(S) localhost origins, matching the hosted sanitizer protocol boundary.

This is now an intentionally minimal direct delta on `develop`. The broader staging session, polling, persistence, and returnTo implementation from the former stacked version was absorbed by merged #29342 and is not replayed here.

## Tests and evidence

Exact head: `e73e83b1122222be2accc4f2ad28c5e27faa8826` (rebased onto `origin/develop@d453dde92c9d3a51e1174befe27b20deea4d287b`)

- `bunx vitest run --config vitest.config.ts src/state/cloud-login-launch.test.ts src/state/useCloudState.same-tab-login.test.tsx src/api/client-cloud-direct-auth-web.test.ts src/cloud/public-pages/pages/auth/cli-login-page.test.tsx src/cloud/sso-bridge/sso-bridge.test.ts src/cloud/sso-bridge/SsoBridgeRoute.test.tsx` (from `packages/ui`) — 6 files, 153/153 tests pass.
- `bunx tsc --noEmit -p packages/ui/tsconfig.json` — pass.
- `bunx biome check packages/ui/src/state/cloud-login-launch.ts packages/ui/src/state/cloud-login-launch.test.ts` — pass.
- `git diff --check origin/develop...HEAD` — pass.
- Repository-pinned Gitleaks over `origin/develop..HEAD` — 1 commit scanned, no leaks.

## Limits

No live Google account, hosted Steward PKCE completion, Android APK, or physical kiosk/touch device was exercised. Existing targeted tests prove the launch/bridge/returnTo boundary with mocked external completion.

## Risk and rollback

Risk is limited to classifying local plain-web staging launch origins. Hosted, Capacitor, Electrobun, production/self-hosted proxy auth, schema, infrastructure, and live configuration are unchanged.

Roll back by reverting `e73e83b1122222be2accc4f2ad28c5e27faa8826`.

Relates to #29322, #29114, and merged #29342.
