### PR TITLE
[android-auth-agent-chat] test(android): gate real Google return and streamed chat

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -128,8 +128,8 @@ bun run --cwd packages/app test:e2e:ios              # Boot sim, build, auth smo
 bun run --cwd packages/app test:e2e:ios:cloud        # iOS e2e plus cloud provisioning probe
 ELIZA_DEVICE_CLOUD_ONBOARDING_LIVE=1 bun run --cwd packages/app test:e2e:ios:cloud-onboarding
                                                        # iOS sim fresh cloud sign-in + e2e SIWE wallet, tap + autologin
-ELIZA_CLOUD_AUTH_TOKEN=<live-token> bun run --cwd packages/app test:e2e:android:cloud-onboarding
-                                                       # Android system-browser smoke + Keystore-backed authenticated chat/reload proof
+bun run --cwd packages/app test:e2e:android:cloud-onboarding
+                                                       # enforced physical Android Google mobile-PKCE (serial + ro.kernel.qemu gate); lane taps Google, operator completes the private account chooser, then automatic callback + streamed chat/reload proof
 bun run --cwd packages/app test:sim:local-chat        # iOS simulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:local-chat:android # Android emulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:auth:ios         # auth/callback deep-link DELIVERY + in-app handler classification (not login)

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -128,8 +128,8 @@ bun run --cwd packages/app test:e2e:ios              # Boot sim, build, auth smo
 bun run --cwd packages/app test:e2e:ios:cloud        # iOS e2e plus cloud provisioning probe
 ELIZA_DEVICE_CLOUD_ONBOARDING_LIVE=1 bun run --cwd packages/app test:e2e:ios:cloud-onboarding
                                                        # iOS sim fresh cloud sign-in + e2e SIWE wallet, tap + autologin
-ELIZA_CLOUD_AUTH_TOKEN=<live-token> bun run --cwd packages/app test:e2e:android:cloud-onboarding
-                                                       # Android system-browser smoke + Keystore-backed authenticated chat/reload proof
+bun run --cwd packages/app test:e2e:android:cloud-onboarding
+                                                       # enforced physical Android Google mobile-PKCE (serial + ro.kernel.qemu gate); lane taps Google, operator completes the private account chooser, then automatic callback + streamed chat/reload proof
 bun run --cwd packages/app test:sim:local-chat        # iOS simulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:local-chat:android # Android emulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:auth:ios         # auth/callback deep-link DELIVERY + in-app handler classification (not login)

--- a/packages/app/scripts/android-cloud-onboarding-command.test.mjs
+++ b/packages/app/scripts/android-cloud-onboarding-command.test.mjs
@@ -1,42 +1,206 @@
 /**
- * Pins the Android cloud-onboarding command to the cloud-only runtime contract
- * so it cannot wait for the local agent that cloud builds intentionally omit.
+ * Executes the Android Cloud-onboarding package commands across a controlled
+ * process boundary, recording the child argv and lane environment without
+ * building, installing, or connecting to a device. The Playwright collection
+ * check then proves those arguments select only the operator-driven live spec.
  */
-import fs from "node:fs";
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
 
-const appRoot = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-);
-const packageJson = JSON.parse(
-  fs.readFileSync(path.join(appRoot, "package.json"), "utf8"),
+const appRoot = path.resolve(import.meta.dirname, "..");
+const playwrightCli = path.resolve(
+  appRoot,
+  "../../node_modules/playwright/cli.js",
 );
 
-describe("Android cloud-onboarding command", () => {
-  it("builds, installs, and drives authenticated chat without a local-agent gate", () => {
-    const command = packageJson.scripts["test:e2e:android:cloud-onboarding"];
+function installRecorder(fakeBin, tool, recorderPath) {
+  const executable = path.join(
+    fakeBin,
+    process.platform === "win32" ? `${tool}.cmd` : tool,
+  );
+  const command =
+    process.platform === "win32"
+      ? `@"${process.execPath}" "${recorderPath}" "${tool}" %*\r\n`
+      : `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(recorderPath)} ${JSON.stringify(tool)} "$@"\n`;
+  writeFileSync(executable, command);
+  if (process.platform !== "win32") chmodSync(executable, 0o755);
+}
 
-    expect(command).toMatch(/build:android:cloud:debug/);
-    expect(command).toMatch(/install:android:adb/);
-    expect(command).toMatch(/ELIZA_ANDROID_ALLOW_FIRST_RUN=1/);
-    expect(command).toMatch(/ELIZA_ANDROID_REQUIRE_AGENT=0/);
-    expect(command).toMatch(/ELIZA_ANDROID_CLEAR_APP_DATA=1/);
-    expect(command).toMatch(/cloud-onboarding\.android\.spec\.ts/);
-  });
+function runPackageScript(scriptName, interceptedTools) {
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), "android-cloud-command-"),
+  );
+  const recordPath = path.join(fixtureRoot, "calls.jsonl");
+  const recorderPath = path.join(fixtureRoot, "record.mjs");
+  writeFileSync(
+    recorderPath,
+    `import { appendFileSync } from "node:fs";
+const [tool, ...argv] = process.argv.slice(2);
+appendFileSync(process.env.ELIZA_COMMAND_RECORD, JSON.stringify({
+  tool,
+  argv,
+  env: {
+    live: process.env.ELIZA_DEVICE_CLOUD_ONBOARDING_LIVE ?? null,
+    allowFirstRun: process.env.ELIZA_ANDROID_ALLOW_FIRST_RUN ?? null,
+    requireAgent: process.env.ELIZA_ANDROID_REQUIRE_AGENT ?? null,
+    clearAppData: process.env.ELIZA_ANDROID_CLEAR_APP_DATA ?? null,
+    privilegedTokenPresent: Boolean(process.env.ELIZA_CLOUD_AUTH_TOKEN),
+  },
+}) + "\\n");
+`,
+  );
+  for (const tool of interceptedTools) {
+    installRecorder(fixtureRoot, tool, recorderPath);
+  }
 
-  it("keeps browser-handoff smoke and authenticated onboarding distinct in the live spec", () => {
-    const spec = fs.readFileSync(
-      path.join(appRoot, "test/android/cloud-onboarding.android.spec.ts"),
-      "utf8",
-    );
+  const env = {
+    ...process.env,
+    ELIZA_COMMAND_RECORD: recordPath,
+    PATH: `${fixtureRoot}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+  delete env.ELIZA_CLOUD_AUTH_TOKEN;
+  try {
+    const result = spawnSync(process.execPath, ["run", scriptName], {
+      cwd: appRoot,
+      encoding: "utf8",
+      env,
+      timeout: 20_000,
+    });
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+    return readFileSync(recordPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+}
 
-    expect(spec).toContain("browser-handoff smoke");
-    expect(spec).toContain("authenticated browser return");
-    expect(spec).toContain("ELIZA_CLOUD_AUTH_TOKEN");
-    expect(spec).toContain("buildAndroidCloudLoginCompletionRequest");
-    expect(spec).toContain('trace: "off"');
-  });
+test("the public lane executes build, install, and one locked Playwright spec", () => {
+  expect(
+    runPackageScript("test:e2e:android:cloud-onboarding", ["bun", "bunx"]),
+  ).toEqual([
+    {
+      tool: "bun",
+      argv: ["run", "build:android:cloud:debug"],
+      env: {
+        live: "1",
+        allowFirstRun: null,
+        requireAgent: null,
+        clearAppData: null,
+        privilegedTokenPresent: false,
+      },
+    },
+    {
+      tool: "bun",
+      argv: ["run", "install:android:adb"],
+      env: {
+        live: null,
+        allowFirstRun: null,
+        requireAgent: null,
+        clearAppData: null,
+        privilegedTokenPresent: false,
+      },
+    },
+    {
+      tool: "bunx",
+      argv: [
+        "playwright",
+        "test",
+        "--config",
+        "playwright.android.config.ts",
+        "test/android/cloud-onboarding.android.spec.ts",
+      ],
+      env: {
+        live: "1",
+        allowFirstRun: "1",
+        requireAgent: "0",
+        clearAppData: "1",
+        privilegedTokenPresent: false,
+      },
+    },
+  ]);
+});
+
+test("the build and install aliases dispatch their executable argv", () => {
+  expect(runPackageScript("build:android:cloud:debug", ["node"])).toEqual([
+    {
+      tool: "node",
+      argv: [
+        "../../packages/app-core/scripts/run-mobile-build.mjs",
+        "android-cloud-debug",
+      ],
+      env: {
+        live: null,
+        allowFirstRun: null,
+        requireAgent: null,
+        clearAppData: null,
+        privilegedTokenPresent: false,
+      },
+    },
+  ]);
+  expect(runPackageScript("install:android:adb", ["node"])).toEqual([
+    {
+      tool: "node",
+      argv: ["scripts/android-adb-install.mjs"],
+      env: {
+        live: null,
+        allowFirstRun: null,
+        requireAgent: null,
+        clearAppData: null,
+        privilegedTokenPresent: false,
+      },
+    },
+  ]);
+});
+
+test("the executable Playwright argv collects only the three live acceptance legs", () => {
+  const result = spawnSync(
+    process.platform === "win32" ? "node.exe" : "node",
+    [
+      playwrightCli,
+      "test",
+      "--config",
+      "playwright.android.config.ts",
+      "test/android/cloud-onboarding.android.spec.ts",
+      "--list",
+    ],
+    {
+      cwd: appRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZA_DEVICE_CLOUD_ONBOARDING_LIVE: "1",
+        ELIZA_ANDROID_ALLOW_FIRST_RUN: "1",
+        ELIZA_ANDROID_REQUIRE_AGENT: "0",
+        ELIZA_ANDROID_CLEAR_APP_DATA: "1",
+      },
+      timeout: 20_000,
+    },
+  );
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  expect(result.error, output).toBeUndefined();
+  expect(result.status, output).toBe(0);
+  expect(output).toContain(
+    "stale local and embedded-wallet state cannot bypass Cloud sign-in",
+  );
+  expect(output).toContain(
+    "mobile-PKCE handoff closes into signed-out recovery",
+  );
+  expect(output).toContain(
+    "Google returns by PKCE callback and reaches streamed chat",
+  );
+  expect(output).toMatch(/Total:\s+3 tests/);
 });

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -255,15 +255,45 @@ fills the host-agent URL, submits first-run, and writes
 ## Cloud-onboarding lane hygiene
 
 The live Android cloud-onboarding lane
-(`test:e2e:android:cloud-onboarding`) requires `ELIZA_CLOUD_AUTH_TOKEN`. It
-opens the production system-browser handoff, completes that exact short-lived
-CLI session through the authenticated Cloud completion endpoint, waits for the
-Play shell's poll to persist the returned credential, reloads to prove secure
-session recovery, and requires a real runtime-bound chat reply. Its positive
-run must attach `sign-in-greeting.jpg`, `home-landing.jpg`,
-`reply-liveness.jpg`, and the complete MP4 walkthrough. The separately named
-browser-handoff test in the same lane proves only browser launch and
-cancellation and is not positive onboarding evidence.
+(`test:e2e:android:cloud-onboarding`) is an operator-driven physical Google
+acceptance lane. Before every leg it rejects an `emulator-*` ADB serial and any
+truthy `ro.kernel.qemu` result, then attaches a boolean physical-device receipt
+that contains no serial, model, fingerprint, or account data. Each fresh leg
+clears Preferences, pending PKCE state, the secure Steward credential, and the
+secure active-server record through their native plugins. A unique one-use
+document-start bootstrap resets the remaining renderer keys before the
+surface-realm guard mounts; its URL token is consumed immediately, so retained
+serial-page init scripts cannot erase the credential on the later proof reload.
+
+On a fresh load, the Play build opens the production login in the Android
+system browser; after forcing a fresh provider choice, the lane locates and taps
+the Google control through Android accessibility. The operator completes only
+the private test-account chooser **without pressing Android Back or manually
+foregrounding Eliza**. The lane then requires the OS callback to resume
+`MainActivity` automatically, observes successful mobile-PKCE config/token/ack
+phases, reloads to prove Keystore-backed session recovery by reaching Personal
+again, and requires a real reply sent through `POST .../messages/stream`.
+
+The browser handoff and Google accessibility hierarchy are validated in memory,
+but the hierarchy, PKCE state, challenge, callback code, complete URL, mobile
+credential, runtime IDs, and conversation IDs are never returned or attached.
+Playwright tracing is off. Screen recording starts only after the app has
+returned, so Google account chooser details, e-mail addresses, and credentials
+cannot enter CI evidence. The positive run attaches the identifier-free
+physical-device receipt, redacted PKCE and Google-selection receipts, a
+phase-only response receipt,
+`sign-in-greeting.jpg`, `home-landing.jpg`, `reply-liveness.jpg`, and
+`cloud-onboarding-post-callback-chat.mp4`.
+
+The separately named handoff test proves only that a structurally valid mobile
+PKCE request opens the system browser and that closing it returns to the real
+signed-out recovery screen. Unit tests and a green PR check do not prove Google
+login, automatic device return, or live chat: cite this lane only after
+inspecting artifacts produced on the current revision. It builds the Play
+cloud-debug variant, so it is not physical proof for the pinned launcher/kiosk
+in-WebView return path. Provider availability for phone and e-mail likewise
+remains a live Steward configuration check rather than an inference from this
+Google run.
 
 The iOS Cloud-onboarding lane still uses the shared deterministic e2e SIWE
 wallet against real Eliza Cloud. A red provisioning run can strand the

--- a/packages/app/test/android/cloud-onboarding-evidence.test.ts
+++ b/packages/app/test/android/cloud-onboarding-evidence.test.ts
@@ -1,19 +1,152 @@
 /**
- * Locks the Android Cloud-onboarding evidence descriptors to the issue's JPG
- * contract without executing the credential- and emulator-gated live lane.
+ * Exercises the deterministic redaction boundary used by the physical Android
+ * Cloud-onboarding lane. These tests validate real wire-shaped URLs without
+ * executing the operator- and device-gated Google flow.
  */
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
   ANDROID_CLOUD_ONBOARDING_STILL_NAMES,
-  buildAndroidCloudLoginCompletionRequest,
+  applyAndroidCloudOnboardingDocumentBootstrap,
+  buildAndroidCloudOnboardingBootstrapPlan,
   buildAndroidCloudOnboardingJpegArtifact,
-  extractAndroidCloudLoginHandoff,
-  isTrustedAndroidCloudResponseUrl,
+  buildAndroidCloudResponseEvidence,
+  extractAndroidCloudPkceHandoffEvidence,
+  findAndroidGoogleProviderTapPoint,
+  requirePhysicalAndroidDevice,
 } from "./cloud-onboarding-evidence";
 
+function mobilePkceLoginUrl(
+  environment: "production" | "staging",
+  options: {
+    challenge?: string;
+    state?: string;
+    returnToOverride?: string;
+  } = {},
+): string {
+  const origin =
+    environment === "staging"
+      ? "https://cloud-staging.eliza.app"
+      : "https://cloud.eliza.app";
+  const authorize = new URL("/app-auth/authorize", origin);
+  authorize.searchParams.set("flow", "mobile_pkce");
+  authorize.searchParams.set("client_id", "ai.elizaos.app");
+  authorize.searchParams.set("environment", environment);
+  authorize.searchParams.set("redirect_uri", "https://eliza.app/auth/callback");
+  authorize.searchParams.set("state", options.state ?? "s".repeat(64));
+  authorize.searchParams.set(
+    "code_challenge",
+    options.challenge ?? "c".repeat(43),
+  );
+  authorize.searchParams.set("code_challenge_method", "S256");
+  authorize.searchParams.set("device_name", "Android");
+  const login = new URL("/login", origin);
+  login.searchParams.set(
+    "returnTo",
+    options.returnToOverride ?? `${authorize.pathname}${authorize.search}`,
+  );
+  return login.toString();
+}
+
 describe("Android Cloud-onboarding still evidence", () => {
+  it("applies each storage reset once and preserves the callback credential on reload", () => {
+    const values = new Map<string, string>([
+      ["elizaos:active-server", "stale-local-agent"],
+      ["eliza:e2e-wallet:pk", "stale-wallet"],
+      ["unrelated-preference", "keep"],
+    ]);
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    const plan = buildAndroidCloudOnboardingBootstrapPlan("a".repeat(32), {
+      switchAccount: true,
+    });
+    let visibleUrl = plan.navigationPath;
+    const firstRuntime = {
+      href: `https://localhost${visibleUrl}`,
+      replaceUrl: (value: string) => {
+        visibleUrl = value;
+      },
+      storage,
+    };
+
+    expect(
+      applyAndroidCloudOnboardingDocumentBootstrap(plan, firstRuntime),
+    ).toBe(true);
+    expect(values.get("elizaos:active-server")).toBeUndefined();
+    expect(values.get("eliza:e2e-wallet:pk")).toBeUndefined();
+    expect(values.get("eliza:android-cloud:account-switch-pending:v1")).toBe(
+      "1",
+    );
+    expect(values.get("unrelated-preference")).toBe("keep");
+    expect(visibleUrl).toBe("/");
+
+    // The real callback stores this through Android secure storage. Model its
+    // visible cache entry after the one-shot bootstrap has consumed its token:
+    // the retained init script must be inert on the credential-verifying reload.
+    values.set("steward_session_token", "callback-mobile-credential");
+    expect(
+      applyAndroidCloudOnboardingDocumentBootstrap(plan, {
+        ...firstRuntime,
+        href: `https://localhost${visibleUrl}`,
+      }),
+    ).toBe(false);
+    expect(values.get("steward_session_token")).toBe(
+      "callback-mobile-credential",
+    );
+  });
+
+  it("rejects ambiguous bootstrap URLs and malformed reset tokens", () => {
+    expect(() => buildAndroidCloudOnboardingBootstrapPlan("short")).toThrow(
+      /128-bit lowercase hex/,
+    );
+    const plan = buildAndroidCloudOnboardingBootstrapPlan("b".repeat(32));
+    const values = new Map([["steward_session_token", "keep"]]);
+    const runtime = {
+      href: `https://localhost${plan.navigationPath}&${plan.queryKey}=${plan.token}`,
+      replaceUrl: () => {
+        throw new Error("ambiguous bootstrap must not rewrite the URL");
+      },
+      storage: {
+        getItem: (key: string) => values.get(key) ?? null,
+        removeItem: (key: string) => values.delete(key),
+        setItem: (key: string, value: string) => values.set(key, value),
+      },
+    };
+
+    expect(applyAndroidCloudOnboardingDocumentBootstrap(plan, runtime)).toBe(
+      false,
+    );
+    expect(values.get("steward_session_token")).toBe("keep");
+  });
+
+  it("accepts only a physical ADB target and emits no device identifier", () => {
+    const receipt = requirePhysicalAndroidDevice("RF8N30ABCDE", "\n");
+    expect(receipt).toEqual({
+      deviceClass: "physical",
+      emulatorSerialPattern: false,
+      kernelQemuTruthy: false,
+    });
+    expect(JSON.stringify(receipt)).not.toContain("RF8N30ABCDE");
+
+    expect(() => requirePhysicalAndroidDevice("emulator-5554", "0")).toThrow(
+      /physical device.*emulator-style ADB serial/i,
+    );
+    for (const truthyProperty of ["1", "true", "yes", "qemu"]) {
+      expect(() =>
+        requirePhysicalAndroidDevice("RF8N30ABCDE", truthyProperty),
+      ).toThrow(/ro\.kernel\.qemu reports an emulator/i);
+    }
+    for (const falseProperty of ["0", "false", "no", "off"]) {
+      expect(
+        requirePhysicalAndroidDevice("RF8N30ABCDE", falseProperty),
+      ).toEqual(receipt);
+    }
+  });
+
   it("emits greeting, authenticated home, and live-reply captures as JPEG artifacts", () => {
     expect(ANDROID_CLOUD_ONBOARDING_STILL_NAMES).toEqual([
       "sign-in-greeting",
@@ -38,69 +171,155 @@ describe("Android Cloud-onboarding still evidence", () => {
     }
   });
 
-  it("extracts production and staging browser handoffs from Capacitor logcat", () => {
-    const production = extractAndroidCloudLoginHandoff(
-      'pluginId: Browser, url: "https:\\/\\/cloud.eliza.app\\/auth\\/cli-login?session=123e4567-e89b-42d3-a456-426614174000"',
+  it("validates production and staging mobile-PKCE handoffs without returning bindings", () => {
+    const state = "s".repeat(64);
+    const challenge = "c".repeat(43);
+    const productionUrl = mobilePkceLoginUrl("production", {
+      state,
+      challenge,
+    });
+    const production = extractAndroidCloudPkceHandoffEvidence(
+      `pluginId: Browser, url: "${productionUrl.replaceAll("/", "\\/")}"`,
     );
     expect(production).toEqual({
-      browserUrl:
-        "https://cloud.eliza.app/auth/cli-login?session=123e4567-e89b-42d3-a456-426614174000",
-      sessionId: "123e4567-e89b-42d3-a456-426614174000",
-      apiBase: "https://api.eliza.app",
+      authorizePath: "/app-auth/authorize",
+      browserHost: "cloud.eliza.app",
+      codeChallengeShapeValid: true,
+      clientId: "ai.elizaos.app",
+      codeChallengeMethod: "S256",
+      deviceName: "Android",
+      environment: "production",
+      redirectUri: "https://eliza.app/auth/callback",
+      stateShapeValid: true,
+      switchAccount: false,
     });
+    expect(JSON.stringify(production)).not.toContain(state);
+    expect(JSON.stringify(production)).not.toContain(challenge);
 
+    const stagingUrl = new URL(mobilePkceLoginUrl("staging"));
+    stagingUrl.searchParams.set("switchAccount", "1");
     expect(
-      extractAndroidCloudLoginHandoff(
-        "https://cloud-staging.eliza.app/auth/cli-login?session=aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-      )?.apiBase,
-    ).toBe("https://api-staging.eliza.app");
+      extractAndroidCloudPkceHandoffEvidence(stagingUrl.toString()),
+    ).toMatchObject({
+      browserHost: "cloud-staging.eliza.app",
+      environment: "staging",
+      switchAccount: true,
+    });
+  });
+
+  it("rejects legacy, cross-origin, incomplete, and ambiguous handoffs", () => {
+    const missingChallenge = new URL(mobilePkceLoginUrl("production"));
+    const missingChallengeReturn = new URL(
+      missingChallenge.searchParams.get("returnTo") ?? "",
+      missingChallenge.origin,
+    );
+    missingChallengeReturn.searchParams.delete("code_challenge");
+    missingChallenge.searchParams.set(
+      "returnTo",
+      `${missingChallengeReturn.pathname}${missingChallengeReturn.search}`,
+    );
+
+    const duplicateReturn = new URL(mobilePkceLoginUrl("production"));
+    duplicateReturn.searchParams.append(
+      "returnTo",
+      "/app-auth/authorize?flow=mobile_pkce",
+    );
+
+    for (const value of [
+      "https://cloud.eliza.app/auth/cli-login?session=legacy",
+      mobilePkceLoginUrl("production", {
+        returnToOverride:
+          "https://attacker.example/app-auth/authorize?flow=mobile_pkce",
+      }),
+      missingChallenge.toString(),
+      duplicateReturn.toString(),
+      mobilePkceLoginUrl("production", { state: "short" }),
+    ]) {
+      expect(extractAndroidCloudPkceHandoffEvidence(value)).toBeNull();
+    }
+  });
+
+  it("reduces the Android accessibility hierarchy to the Google tap point", () => {
+    const privateEmail = "device-owner@example.test";
+    const hierarchy = `<hierarchy>
+      <node text="${privateEmail}" bounds="[0,0][300,80]" />
+      <node text="Google" content-desc="" clickable="true" enabled="true" bounds="[24,400][456,520]" />
+    </hierarchy>`;
+    const point = findAndroidGoogleProviderTapPoint(hierarchy);
+    expect(point).toEqual({ x: 240, y: 460 });
+    expect(JSON.stringify(point)).not.toContain(privateEmail);
     expect(
-      extractAndroidCloudLoginHandoff(
-        "https://attacker.example/auth/cli-login?session=123e4567-e89b-42d3-a456-426614174000",
+      findAndroidGoogleProviderTapPoint(
+        '<node text="Discord" clickable="true" bounds="[24,400][456,520]" />',
+      ),
+    ).toBeNull();
+    expect(
+      findAndroidGoogleProviderTapPoint(
+        '<node text="Google" clickable="false" enabled="true" bounds="[24,400][456,520]" />',
+      ),
+    ).toBeNull();
+    expect(
+      findAndroidGoogleProviderTapPoint(
+        '<node text="Google" clickable="true" enabled="false" bounds="[24,400][456,520]" />',
       ),
     ).toBeNull();
   });
 
-  it("builds an authenticated completion request and rejects a missing secret", () => {
-    const handoff = extractAndroidCloudLoginHandoff(
-      "https://cloud.eliza.app/auth/cli-login?session=123e4567-e89b-42d3-a456-426614174000",
-    );
-    if (!handoff) throw new Error("Expected a valid test handoff");
+  it("reduces auth, identity, and streamed-chat responses without route identifiers", () => {
     expect(
-      buildAndroidCloudLoginCompletionRequest(handoff, " test-token "),
-    ).toEqual({
-      url: "https://api.eliza.app/api/auth/cli-session/123e4567-e89b-42d3-a456-426614174000/complete",
-      init: {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-        body: "{}",
-      },
-    });
-    expect(() =>
-      buildAndroidCloudLoginCompletionRequest(handoff, "  "),
-    ).toThrow(/ELIZA_CLOUD_AUTH_TOKEN/);
-  });
+      buildAndroidCloudResponseEvidence(
+        "https://api.eliza.app/api/v1/app-auth/mobile/config?clientId=ai.elizaos.app",
+        "GET",
+        200,
+      ),
+    ).toEqual({ method: "GET", phase: "mobile-config", status: 200 });
+    expect(
+      buildAndroidCloudResponseEvidence(
+        "https://api.eliza.app/api/v1/app-auth/mobile/token",
+        "POST",
+        201,
+      ),
+    ).toEqual({ method: "POST", phase: "mobile-token", status: 201 });
+    expect(
+      buildAndroidCloudResponseEvidence(
+        "https://api.eliza.app/api/v1/app-auth/mobile/ack",
+        "POST",
+        200,
+      ),
+    ).toEqual({ method: "POST", phase: "mobile-ack", status: 200 });
+    expect(
+      buildAndroidCloudResponseEvidence(
+        "https://api-staging.eliza.app/api/v1/eliza/personal",
+        "GET",
+        200,
+      ),
+    ).toEqual({ method: "GET", phase: "personal-agent", status: 200 });
 
-  it("accepts shared and dedicated response authorities without trusting lookalikes", () => {
-    for (const url of [
-      "https://api.eliza.app/api/v1/eliza/personal",
-      "https://api-staging.eliza.app/api/v1/eliza/personal",
-      "https://123e4567-e89b-42d3-a456-426614174000.cloud.eliza.app/api/conversations/1/messages",
-      "https://aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee.cloud-staging.eliza.app/api/conversations/1/messages",
-    ]) {
-      expect(isTrustedAndroidCloudResponseUrl(url)).toBe(true);
-    }
-    for (const url of [
-      "https://not-a-uuid.cloud.eliza.app/api/conversations/1/messages",
-      "https://123e4567-e89b-42d3-a456-426614174000.cloud.eliza.app.attacker.example/api/conversations/1/messages",
-      "http://api.eliza.app/api/v1/eliza/personal",
-      "https://api.eliza.app:8443/api/v1/eliza/personal",
-      "https://user@api.eliza.app/api/v1/eliza/personal",
-    ]) {
-      expect(isTrustedAndroidCloudResponseUrl(url)).toBe(false);
+    const conversationId = "private-conversation-id";
+    const streamed = buildAndroidCloudResponseEvidence(
+      `https://123e4567-e89b-42d3-a456-426614174000.cloud.eliza.app/api/conversations/${conversationId}/messages/stream`,
+      "POST",
+      200,
+    );
+    expect(streamed).toEqual({
+      method: "POST",
+      phase: "message-stream",
+      status: 200,
+    });
+    expect(JSON.stringify(streamed)).not.toContain(conversationId);
+
+    for (const [url, method] of [
+      [
+        "https://123e4567-e89b-42d3-a456-426614174000.cloud.eliza.app.attacker.example/api/conversations/private/messages/stream",
+        "POST",
+      ],
+      ["http://api.eliza.app/api/v1/eliza/personal", "GET"],
+      ["https://api.eliza.app:8443/api/v1/eliza/personal", "GET"],
+      ["https://user@api.eliza.app/api/v1/eliza/personal", "GET"],
+      ["https://api.eliza.app/api/v1/eliza/personal", "POST"],
+      ["https://api.eliza.app/api/conversations/private/messages", "POST"],
+    ] as const) {
+      expect(buildAndroidCloudResponseEvidence(url, method, 200)).toBeNull();
     }
   });
 });

--- a/packages/app/test/android/cloud-onboarding-evidence.ts
+++ b/packages/app/test/android/cloud-onboarding-evidence.ts
@@ -1,23 +1,225 @@
 /**
- * Defines the inline Android Cloud-onboarding stills required by the device
- * evidence contract. The Playwright capture and attachment metadata share one
- * descriptor so a filename or MIME-type edit cannot silently produce PNGs.
+ * Reduces Android Cloud-onboarding traffic to privacy-safe device evidence.
+ * Raw browser handoffs contain PKCE bindings and runtime routes contain user
+ * identifiers, so callers receive only validated protocol facts and phase
+ * names that are safe to persist in CI artifacts.
  */
 import path from "node:path";
 
-const CLOUD_LOGIN_SESSION_ID =
-  "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
-const CLOUD_LOGIN_URL = new RegExp(
-  `https://(cloud(?:-staging)?\\.eliza\\.app)/auth/cli-login\\?session=(${CLOUD_LOGIN_SESSION_ID})`,
-  "i",
-);
+const CLOUD_LOGIN_URL =
+  /https:\/\/cloud(?:-staging)?\.eliza\.app\/login\?[^\s"'<>]+/gi;
+const CLOUD_LOGIN_HOSTS = new Set([
+  "cloud.eliza.app",
+  "cloud-staging.eliza.app",
+]);
 const CLOUD_RESPONSE_HOST =
   /^(?:api(?:-staging)?|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.cloud(?:-staging)?)\.eliza\.app$/i;
+const MOBILE_CLIENT_ID = "ai.elizaos.app";
+const MOBILE_REDIRECT_URI = "https://eliza.app/auth/callback";
+const PKCE_CHALLENGE = /^[A-Za-z0-9_-]{43}$/;
+const PKCE_STATE = /^[A-Za-z0-9_-]{43,128}$/;
+const ANDROID_EMULATOR_SERIAL = /^emulator(?:-|$)/i;
+const ANDROID_CLOUD_BOOTSTRAP_QUERY = "__eliza_cloud_bootstrap";
+const ANDROID_CLOUD_ACCOUNT_SWITCH_KEY =
+  "eliza:android-cloud:account-switch-pending:v1";
+const ANDROID_CLOUD_RESET_KEYS = [
+  "eliza:first-run",
+  "eliza:first-run-complete",
+  "eliza:onboarding-complete",
+  "eliza:setup:step",
+  "eliza:ui-shell-mode",
+  "eliza:mobile-runtime-mode",
+  "eliza:enable-runtime-chooser",
+  "eliza:first-run:cloud-resume",
+  "elizaos:first-run:force-fresh",
+  "elizaos:active-server",
+  "steward_session_token",
+  "eliza:android-cloud:pending-login:v1",
+  ANDROID_CLOUD_ACCOUNT_SWITCH_KEY,
+  "eliza:e2e-wallet:autologin",
+  "eliza:e2e-wallet:pk",
+] as const;
 
-export interface AndroidCloudLoginHandoff {
-  browserUrl: string;
-  sessionId: string;
-  apiBase: string;
+export interface AndroidCloudPkceHandoffEvidence {
+  authorizePath: "/app-auth/authorize";
+  browserHost: "cloud.eliza.app" | "cloud-staging.eliza.app";
+  codeChallengeShapeValid: true;
+  clientId: typeof MOBILE_CLIENT_ID;
+  codeChallengeMethod: "S256";
+  deviceName: "Android";
+  environment: "production" | "staging";
+  redirectUri: typeof MOBILE_REDIRECT_URI;
+  stateShapeValid: true;
+  switchAccount: boolean;
+}
+
+export type AndroidCloudResponsePhase =
+  | "mobile-config"
+  | "mobile-token"
+  | "mobile-ack"
+  | "personal-agent"
+  | "message-stream";
+
+export interface AndroidCloudResponseEvidence {
+  method: "GET" | "POST";
+  phase: AndroidCloudResponsePhase;
+  status: number;
+}
+
+export interface AndroidTapPoint {
+  x: number;
+  y: number;
+}
+
+export interface AndroidPhysicalDeviceReceipt {
+  deviceClass: "physical";
+  emulatorSerialPattern: false;
+  kernelQemuTruthy: false;
+}
+
+export interface AndroidCloudOnboardingBootstrapPlan {
+  navigationPath: string;
+  queryKey: typeof ANDROID_CLOUD_BOOTSTRAP_QUERY;
+  resetKeys: readonly string[];
+  seedEntries: readonly (readonly [string, string])[];
+  token: string;
+}
+
+interface AndroidCloudOnboardingBootstrapRuntime {
+  href: string;
+  replaceUrl(value: string): void;
+  storage: Pick<Storage, "getItem" | "removeItem" | "setItem">;
+}
+
+function androidSystemPropertyIsTruthy(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized.length > 0 &&
+    !new Set(["0", "false", "no", "off"]).has(normalized)
+  );
+}
+
+/** Reject emulator identity without retaining a device serial or fingerprint. */
+export function requirePhysicalAndroidDevice(
+  serial: string,
+  kernelQemuProperty: string,
+): AndroidPhysicalDeviceReceipt {
+  if (ANDROID_EMULATOR_SERIAL.test(serial.trim())) {
+    throw new Error(
+      "Android Cloud onboarding requires a physical device; an emulator-style ADB serial was detected.",
+    );
+  }
+  if (androidSystemPropertyIsTruthy(kernelQemuProperty)) {
+    throw new Error(
+      "Android Cloud onboarding requires a physical device; ro.kernel.qemu reports an emulator.",
+    );
+  }
+  return {
+    deviceClass: "physical",
+    emulatorSerialPattern: false,
+    kernelQemuTruthy: false,
+  };
+}
+
+/**
+ * Build a one-navigation storage reset. The token is removed from the URL at
+ * document start, so init scripts retained by a serial Playwright page cannot
+ * erase the mobile credential on the later post-login reload.
+ */
+export function buildAndroidCloudOnboardingBootstrapPlan(
+  token: string,
+  options: { switchAccount?: boolean } = {},
+): AndroidCloudOnboardingBootstrapPlan {
+  if (!/^[a-f0-9]{32}$/.test(token)) {
+    throw new Error(
+      "Android Cloud bootstrap token must be 128-bit lowercase hex.",
+    );
+  }
+  const query = new URLSearchParams({
+    [ANDROID_CLOUD_BOOTSTRAP_QUERY]: token,
+  });
+  return {
+    navigationPath: `/?${query.toString()}`,
+    queryKey: ANDROID_CLOUD_BOOTSTRAP_QUERY,
+    resetKeys: ANDROID_CLOUD_RESET_KEYS,
+    seedEntries: options.switchAccount
+      ? [[ANDROID_CLOUD_ACCOUNT_SWITCH_KEY, "1"]]
+      : [],
+    token,
+  };
+}
+
+/**
+ * Apply the exact reset contract at document start, before the shell installs
+ * the surface-realm guard. This function is passed directly to
+ * `page.addInitScript`, and is also executable with an injected runtime in unit
+ * tests; it deliberately has no module-scope dependencies.
+ */
+export function applyAndroidCloudOnboardingDocumentBootstrap(
+  plan: AndroidCloudOnboardingBootstrapPlan,
+  injectedRuntime?: AndroidCloudOnboardingBootstrapRuntime,
+): boolean {
+  const runtime =
+    injectedRuntime ??
+    ({
+      href: window.location.href,
+      replaceUrl: (value: string) =>
+        window.history.replaceState(null, "", value),
+      storage: window.localStorage,
+    } satisfies AndroidCloudOnboardingBootstrapRuntime);
+  const url = new URL(runtime.href);
+  const tokens = url.searchParams.getAll(plan.queryKey);
+  if (tokens.length !== 1 || tokens[0] !== plan.token) return false;
+
+  for (const key of plan.resetKeys) runtime.storage.removeItem(key);
+  for (const [key, value] of plan.seedEntries) {
+    runtime.storage.setItem(key, value);
+  }
+  url.searchParams.delete(plan.queryKey);
+  runtime.replaceUrl(`${url.pathname}${url.search}${url.hash}`);
+  return true;
+}
+
+function singleValue(url: URL, key: string): string | null {
+  const values = url.searchParams.getAll(key);
+  return values.length === 1 ? values[0] : null;
+}
+
+function hasOnlyKeys(url: URL, keys: ReadonlySet<string>): boolean {
+  return [...url.searchParams.keys()].every((key) => keys.has(key));
+}
+
+function xmlAttribute(node: string, name: string): string | null {
+  return node.match(new RegExp(`\\b${name}="([^"]*)"`, "i"))?.[1] ?? null;
+}
+
+/** Find the Google control without returning the surrounding account hierarchy. */
+export function findAndroidGoogleProviderTapPoint(
+  hierarchy: string,
+): AndroidTapPoint | null {
+  for (const match of hierarchy.matchAll(/<node\b[^>]*>/gi)) {
+    const node = match[0];
+    const contentDescription = xmlAttribute(node, "content-desc")?.trim();
+    const text = xmlAttribute(node, "text")?.trim();
+    const label = contentDescription || text || "";
+    if (!/^(?:continue with )?google$/i.test(label.trim())) continue;
+    if (xmlAttribute(node, "clickable")?.toLowerCase() !== "true") continue;
+    if (xmlAttribute(node, "enabled")?.toLowerCase() === "false") continue;
+    const bounds = xmlAttribute(node, "bounds")?.match(
+      /^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$/,
+    );
+    if (!bounds) continue;
+    const left = Number(bounds[1]);
+    const top = Number(bounds[2]);
+    const right = Number(bounds[3]);
+    const bottom = Number(bounds[4]);
+    if (right <= left || bottom <= top) continue;
+    return {
+      x: Math.floor((left + right) / 2),
+      y: Math.floor((top + bottom) / 2),
+    };
+  }
+  return null;
 }
 
 /** Accept response evidence only from the control plane or managed runtime. */
@@ -32,50 +234,154 @@ export function isTrustedAndroidCloudResponseUrl(value: string | URL): boolean {
       CLOUD_RESPONSE_HOST.test(url.hostname)
     );
   } catch {
+    // error-policy:J3 A malformed candidate is an explicit untrusted URL.
     return false;
   }
 }
 
-/** Extract the real browser handoff without accepting unrelated logcat URLs. */
-export function extractAndroidCloudLoginHandoff(
+/**
+ * Validate a browser launch found in logcat without returning its state,
+ * challenge, returnTo value, or complete URL.
+ */
+export function extractAndroidCloudPkceHandoffEvidence(
   logcat: string,
-): AndroidCloudLoginHandoff | null {
+): AndroidCloudPkceHandoffEvidence | null {
   const normalized = logcat.replaceAll("\\/", "/");
-  const match = normalized.match(CLOUD_LOGIN_URL);
-  if (!match) return null;
-  const [, appHost, sessionId] = match;
-  const apiHost =
-    appHost.toLowerCase() === "cloud-staging.eliza.app"
-      ? "api-staging.eliza.app"
-      : "api.eliza.app";
-  return {
-    browserUrl: match[0],
-    sessionId,
-    apiBase: `https://${apiHost}`,
-  };
+  for (const match of normalized.matchAll(CLOUD_LOGIN_URL)) {
+    let login: URL;
+    try {
+      login = new URL(match[0].replace(/[),;}\]]+$/, ""));
+    } catch {
+      // error-policy:J3 Ignore malformed logcat candidates and keep scanning.
+      continue;
+    }
+    const browserHost = login.hostname.toLowerCase();
+    if (
+      login.protocol !== "https:" ||
+      !CLOUD_LOGIN_HOSTS.has(browserHost) ||
+      login.pathname !== "/login" ||
+      login.username ||
+      login.password ||
+      login.port ||
+      login.hash ||
+      !hasOnlyKeys(login, new Set(["returnTo", "switchAccount"]))
+    ) {
+      continue;
+    }
+    const switchAccountValues = login.searchParams.getAll("switchAccount");
+    if (
+      switchAccountValues.length > 1 ||
+      (switchAccountValues.length === 1 && switchAccountValues[0] !== "1")
+    ) {
+      continue;
+    }
+    const returnTo = singleValue(login, "returnTo");
+    if (!returnTo) continue;
+
+    let authorize: URL;
+    try {
+      authorize = new URL(returnTo, login.origin);
+    } catch {
+      // error-policy:J3 An invalid nested return target is not a valid handoff.
+      continue;
+    }
+    const authorizeKeys = new Set([
+      "flow",
+      "client_id",
+      "environment",
+      "redirect_uri",
+      "state",
+      "code_challenge",
+      "code_challenge_method",
+      "device_name",
+    ]);
+    if (
+      authorize.origin !== login.origin ||
+      authorize.pathname !== "/app-auth/authorize" ||
+      authorize.hash ||
+      !hasOnlyKeys(authorize, authorizeKeys) ||
+      [...authorizeKeys].some(
+        (key) => authorize.searchParams.getAll(key).length !== 1,
+      )
+    ) {
+      continue;
+    }
+
+    const environment =
+      browserHost === "cloud-staging.eliza.app" ? "staging" : "production";
+    if (
+      singleValue(authorize, "flow") !== "mobile_pkce" ||
+      singleValue(authorize, "client_id") !== MOBILE_CLIENT_ID ||
+      singleValue(authorize, "environment") !== environment ||
+      singleValue(authorize, "redirect_uri") !== MOBILE_REDIRECT_URI ||
+      singleValue(authorize, "code_challenge_method") !== "S256" ||
+      singleValue(authorize, "device_name") !== "Android" ||
+      !PKCE_STATE.test(singleValue(authorize, "state") ?? "") ||
+      !PKCE_CHALLENGE.test(singleValue(authorize, "code_challenge") ?? "")
+    ) {
+      continue;
+    }
+
+    return {
+      authorizePath: "/app-auth/authorize",
+      browserHost:
+        browserHost as AndroidCloudPkceHandoffEvidence["browserHost"],
+      codeChallengeShapeValid: true,
+      clientId: MOBILE_CLIENT_ID,
+      codeChallengeMethod: "S256",
+      deviceName: "Android",
+      environment,
+      redirectUri: MOBILE_REDIRECT_URI,
+      stateShapeValid: true,
+      switchAccount: switchAccountValues.length === 1,
+    };
+  }
+  return null;
 }
 
-/** Build the authenticated server-side approval used by the device login poll. */
-export function buildAndroidCloudLoginCompletionRequest(
-  handoff: AndroidCloudLoginHandoff,
-  authToken: string | undefined,
-) {
-  const token = authToken?.trim();
-  if (!token) {
-    throw new Error(
-      "ELIZA_CLOUD_AUTH_TOKEN is required for the positive Android Cloud onboarding lane",
-    );
+/** Reduce one recognized Cloud response to a route- and identifier-free receipt. */
+export function buildAndroidCloudResponseEvidence(
+  value: string | URL,
+  method: string,
+  status: number,
+): AndroidCloudResponseEvidence | null {
+  if (!isTrustedAndroidCloudResponseUrl(value)) return null;
+  const url = value instanceof URL ? value : new URL(value);
+  const normalizedMethod = method.toUpperCase();
+  let phase: AndroidCloudResponsePhase | null = null;
+  if (
+    normalizedMethod === "GET" &&
+    url.pathname === "/api/v1/app-auth/mobile/config"
+  ) {
+    phase = "mobile-config";
+  } else if (
+    normalizedMethod === "POST" &&
+    url.pathname === "/api/v1/app-auth/mobile/token"
+  ) {
+    phase = "mobile-token";
+  } else if (
+    normalizedMethod === "POST" &&
+    url.pathname === "/api/v1/app-auth/mobile/ack"
+  ) {
+    phase = "mobile-ack";
+  } else if (
+    normalizedMethod === "GET" &&
+    url.pathname === "/api/v1/eliza/personal"
+  ) {
+    phase = "personal-agent";
+  } else if (
+    normalizedMethod === "POST" &&
+    /\/api\/conversations\/[^/]+\/messages\/stream$/.test(url.pathname)
+  ) {
+    phase = "message-stream";
+  }
+  if (!phase || !Number.isInteger(status) || status < 100 || status > 599) {
+    return null;
   }
   return {
-    url: `${handoff.apiBase}/api/auth/cli-session/${encodeURIComponent(handoff.sessionId)}/complete`,
-    init: {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: "{}",
-    } satisfies RequestInit,
+    method: normalizedMethod as AndroidCloudResponseEvidence["method"],
+    phase,
+    status,
   };
 }
 

--- a/packages/app/test/android/cloud-onboarding.android.spec.ts
+++ b/packages/app/test/android/cloud-onboarding.android.spec.ts
@@ -1,9 +1,10 @@
 /**
- * Production Google Play Cloud sign-in checks on the real Android WebView.
- *
- * The Play shell deliberately has no embedded wallet, private-key autologin,
- * local-agent setup, or in-WebView account authentication. Authentication is
- * delegated to the system browser through a short-lived Cloud CLI session.
+ * Operator-driven Google sign-in checks on the real Android Play shell.
+ * Authentication stays in the system browser while the app retains its PKCE
+ * verifier in Keystore; only a genuine OS callback may return automatically,
+ * activate the mobile credential, restore the same agent, and reach chat.
+ * Browser authentication is deliberately excluded from recorded artifacts so
+ * account details and credentials cannot enter CI evidence.
  */
 
 import { randomBytes } from "node:crypto";
@@ -17,10 +18,14 @@ import {
 } from "../liveness-contract";
 import { expect, ORIGIN, test } from "./android-harness";
 import {
-  buildAndroidCloudLoginCompletionRequest,
+  type AndroidCloudResponseEvidence,
+  applyAndroidCloudOnboardingDocumentBootstrap,
+  buildAndroidCloudOnboardingBootstrapPlan,
   buildAndroidCloudOnboardingJpegArtifact,
-  extractAndroidCloudLoginHandoff,
-  isTrustedAndroidCloudResponseUrl,
+  buildAndroidCloudResponseEvidence,
+  extractAndroidCloudPkceHandoffEvidence,
+  findAndroidGoogleProviderTapPoint,
+  requirePhysicalAndroidDevice,
 } from "./cloud-onboarding-evidence";
 import {
   ANDROID_CLOUD_SIGN_IN_RESUMED_ACTIVITY,
@@ -32,78 +37,186 @@ const ARTIFACT_DIR = path.join(
   "test-results",
   "android-cloud-onboarding",
 );
+const STALE_ACTIVE_SERVER = JSON.stringify({
+  id: "local:android",
+  kind: "remote",
+  apiBase: "eliza-local-agent://ipc",
+});
 
-// This live lane passes a credential to the Cloud completion endpoint. Disable
-// Playwright tracing so evaluation/network metadata cannot serialize it; the
-// required review artifacts are the explicit JPG and Android MP4 captures.
+// The genuine callback exchange carries one-time codes and mobile credentials.
+// Disable tracing so request bodies and URLs cannot serialize them; explicit
+// artifacts begin only after the private system-browser step has completed.
 test.use({ trace: "off" });
 
-async function clearBrowserState(page: import("@playwright/test").Page) {
-  await page.evaluate(async () => {
-    localStorage.clear();
-    const plugins = (
-      window as Window & {
-        Capacitor?: {
-          Plugins?: {
-            Preferences?: { clear(): Promise<void> };
+interface NativeCloudStateOptions {
+  seedStaleLocalState?: boolean;
+}
+
+async function resetNativeCloudState(
+  page: import("@playwright/test").Page,
+  options: NativeCloudStateOptions = {},
+) {
+  await page.evaluate(
+    async ({ seedStaleLocalState, staleActiveServer }) => {
+      const plugins = (
+        window as Window & {
+          Capacitor?: {
+            Plugins?: {
+              ElizaSecureCredentials?: {
+                remove(options: { slot: "pending_login" }): Promise<void>;
+              };
+              ElizaSecureStore?: {
+                remove(options: {
+                  key: "runtime.active_server" | "session.steward_token";
+                }): Promise<{ error?: string; ok: boolean }>;
+                set(options: {
+                  key: "runtime.active_server";
+                  value: string;
+                }): Promise<{ error?: string; ok: boolean }>;
+              };
+              Preferences?: {
+                clear(): Promise<void>;
+                set(options: { key: string; value: string }): Promise<void>;
+              };
+            };
           };
-        };
+        }
+      ).Capacitor?.Plugins;
+      const preferences = plugins?.Preferences;
+      const pendingCredentials = plugins?.ElizaSecureCredentials;
+      const secureStore = plugins?.ElizaSecureStore;
+      if (!preferences || !pendingCredentials || !secureStore) {
+        throw new Error("Android Cloud native reset plugins are unavailable");
       }
-    ).Capacitor?.Plugins;
-    if (!plugins?.Preferences) {
-      throw new Error("Android Cloud Preferences plugin is unavailable");
-    }
-    await plugins.Preferences.clear();
-  });
+
+      await preferences.clear();
+      await pendingCredentials.remove({ slot: "pending_login" });
+      for (const key of [
+        "runtime.active_server",
+        "session.steward_token",
+      ] as const) {
+        const result = await secureStore.remove({ key });
+        if (!result.ok && result.error !== "not_found") {
+          throw new Error(`Android secure state reset failed for ${key}`);
+        }
+      }
+
+      if (seedStaleLocalState) {
+        const activeServerResult = await secureStore.set({
+          key: "runtime.active_server",
+          value: staleActiveServer,
+        });
+        if (!activeServerResult.ok) {
+          throw new Error("Android stale active-server seed was rejected");
+        }
+        await preferences.set({
+          key: "eliza:e2e-wallet:autologin",
+          value: "1",
+        });
+        await preferences.set({
+          key: "eliza:e2e-wallet:pk",
+          value: "legacy-test-wallet-key",
+        });
+      }
+    },
+    {
+      seedStaleLocalState: options.seedStaleLocalState === true,
+      staleActiveServer: STALE_ACTIVE_SERVER,
+    },
+  );
 }
 
-async function seedStaleBrowserState(page: import("@playwright/test").Page) {
-  // Reserved shell keys are realm-guarded after the renderer boots. Seed the
-  // adversarial legacy state at document start so this exercises hydration
-  // instead of being rejected by the view-storage facade before navigation.
-  await page.addInitScript(() => {
-    localStorage.setItem(
-      "elizaos:active-server",
-      JSON.stringify({
-        id: "local:android",
-        kind: "remote",
-        apiBase: "eliza-local-agent://ipc",
-      }),
-    );
-    localStorage.setItem("eliza:e2e-wallet:autologin", "1");
-    localStorage.setItem("eliza:e2e-wallet:pk", "legacy-test-wallet-key");
-  });
-}
-
-async function loadSignedOutShell(page: import("@playwright/test").Page) {
-  await page.goto(`${ORIGIN}/?androidPlayCloudSignIn=1`, {
+async function loadFreshCloudAuthFirstScreen(
+  page: import("@playwright/test").Page,
+  options: NativeCloudStateOptions & { switchAccount?: boolean } = {},
+) {
+  await resetNativeCloudState(page, options);
+  const bootstrap = buildAndroidCloudOnboardingBootstrapPlan(
+    randomBytes(16).toString("hex"),
+    { switchAccount: options.switchAccount },
+  );
+  // The exact helper is installed once per reset. Its unique URL token is
+  // consumed and removed at document start, so older scripts retained by this
+  // serial page and the successful credential reload are both inert.
+  await page.addInitScript(
+    applyAndroidCloudOnboardingDocumentBootstrap,
+    bootstrap,
+  );
+  await page.goto(`${ORIGIN}${bootstrap.navigationPath}`, {
     waitUntil: "domcontentloaded",
     timeout: 60_000,
   });
-  await expect(page.getByRole("heading", { name: "Eliza" })).toBeVisible({
-    timeout: 30_000,
-  });
-  await expect(page.getByRole("button", { name: /^Sign in$/ })).toBeVisible();
+  await expect(page.getByTestId("startup-shell-loading")).toContainText(
+    "Opening secure sign in…",
+    {
+      timeout: 30_000,
+    },
+  );
 }
 
-interface CloudResponseEvidence {
-  method: string;
-  pathname: string;
-  status: number;
+async function closeBrowserAndExpectSignedOutRecovery(
+  page: import("@playwright/test").Page,
+  device: import("@playwright/test").AndroidDevice,
+) {
+  await page.evaluate(async () => {
+    const browser = (
+      window as Window & {
+        Capacitor?: {
+          Plugins?: { Browser?: { close?: () => Promise<void> } };
+        };
+      }
+    ).Capacitor?.Plugins?.Browser;
+    if (!browser?.close) {
+      throw new Error("Android Browser.close is unavailable");
+    }
+    await browser.close();
+  });
+  await expect
+    .poll(
+      async () =>
+        resumedAndroidActivityComponent(
+          (await device.shell("dumpsys activity activities")).toString(),
+        ),
+      { timeout: 30_000 },
+    )
+    .toBe(`${APP_ID}/.MainActivity`);
+
+  await expect(page.getByTestId("cloud-sign-in-recovery")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByRole("heading", { name: "Sign in to Eliza Cloud" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Sign in again" }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign out" })).toHaveCount(0);
+  await expect(page.getByTestId("home-launcher-surface")).toHaveCount(0);
 }
 
 function observeCloudResponses(page: import("@playwright/test").Page) {
-  const responses: CloudResponseEvidence[] = [];
+  const responses: AndroidCloudResponseEvidence[] = [];
   page.on("response", (response) => {
-    const url = new URL(response.url());
-    if (!isTrustedAndroidCloudResponseUrl(url)) return;
-    responses.push({
-      method: response.request().method(),
-      pathname: url.pathname,
-      status: response.status(),
-    });
+    const evidence = buildAndroidCloudResponseEvidence(
+      response.url(),
+      response.request().method(),
+      response.status(),
+    );
+    if (evidence) responses.push(evidence);
   });
   return responses;
+}
+
+function successfulPhaseCount(
+  responses: readonly AndroidCloudResponseEvidence[],
+  phase: AndroidCloudResponseEvidence["phase"],
+): number {
+  return responses.filter(
+    (response) =>
+      response.phase === phase &&
+      response.status >= 200 &&
+      response.status < 300,
+  ).length;
 }
 
 async function attachJpeg(
@@ -126,14 +239,29 @@ test.describe
       "Set ELIZA_DEVICE_CLOUD_ONBOARDING_LIVE=1 to exercise the live Cloud sign-in handoff.",
     );
 
+    test.beforeEach(async ({ device }, testInfo) => {
+      const kernelQemuProperty = (
+        await device.shell("getprop ro.kernel.qemu")
+      ).toString();
+      const receipt = requirePhysicalAndroidDevice(
+        device.serial(),
+        kernelQemuProperty,
+      );
+      await testInfo.attach("physical Android device receipt", {
+        body: JSON.stringify(receipt, null, 2),
+        contentType: "application/json",
+      });
+    });
+
     test("stale local and embedded-wallet state cannot bypass Cloud sign-in", async ({
       page,
       device,
     }, testInfo) => {
-      await clearBrowserState(page);
-      await seedStaleBrowserState(page);
+      await device.shell("logcat -c");
 
-      await loadSignedOutShell(page);
+      await loadFreshCloudAuthFirstScreen(page, {
+        seedStaleLocalState: true,
+      });
       await expect(page.getByTestId("home-launcher-surface")).toHaveCount(0);
       await expect(page.getByText(/where should your agent run/i)).toHaveCount(
         0,
@@ -146,6 +274,17 @@ test.describe
         "android.permission.RECORD_AUDIO: granted=false",
       );
 
+      await expect
+        .poll(
+          async () =>
+            resumedAndroidActivityComponent(
+              (await device.shell("dumpsys activity activities")).toString(),
+            ),
+          { timeout: 30_000 },
+        )
+        .toMatch(ANDROID_CLOUD_SIGN_IN_RESUMED_ACTIVITY);
+      await closeBrowserAndExpectSignedOutRecovery(page, device);
+
       const screenshotPath = path.join(ARTIFACT_DIR, "play-signed-out.png");
       await page.screenshot({ path: screenshotPath, fullPage: true });
       await testInfo.attach("Play signed-out shell", {
@@ -154,27 +293,28 @@ test.describe
       });
     });
 
-    test("browser-handoff smoke creates a short-lived Cloud session and opens the system browser", async ({
+    test("mobile-PKCE handoff closes into signed-out recovery", async ({
       page,
       device,
     }) => {
-      await clearBrowserState(page);
-      await loadSignedOutShell(page);
       await device.shell("logcat -c");
-
-      await page.getByRole("button", { name: /^Sign in$/ }).click();
-      await expect(
-        page.getByRole("button", { name: "Cancel sign-in" }),
-      ).toBeVisible({ timeout: 30_000 });
+      await loadFreshCloudAuthFirstScreen(page);
 
       await expect
         .poll(
-          async () => (await device.shell("logcat -d -v brief")).toString(),
+          async () =>
+            extractAndroidCloudPkceHandoffEvidence(
+              (await device.shell("logcat -d -v brief")).toString(),
+            ),
           { timeout: 30_000 },
         )
-        .toMatch(
-          /pluginId: Browser[\s\S]*https:\\?\/\\?\/cloud\.eliza\.app\\?\/auth\\?\/cli-login\?session=[0-9a-f-]{36}/i,
-        );
+        .toMatchObject({
+          browserHost: "cloud.eliza.app",
+          codeChallengeShapeValid: true,
+          codeChallengeMethod: "S256",
+          environment: "production",
+          stateShapeValid: true,
+        });
 
       await expect
         .poll(
@@ -185,126 +325,130 @@ test.describe
           { timeout: 15_000 },
         )
         .toMatch(ANDROID_CLOUD_SIGN_IN_RESUMED_ACTIVITY);
-
-      await device.shell("input keyevent BACK");
-      await page.getByRole("button", { name: "Cancel sign-in" }).click();
-      await expect(
-        page.getByRole("button", { name: /^Sign in$/ }),
-      ).toBeVisible();
+      await closeBrowserAndExpectSignedOutRecovery(page, device);
     });
 
-    test("authenticated browser return provisions Cloud and reaches live chat", async ({
+    test("Google returns by PKCE callback and reaches streamed chat", async ({
       page,
       device,
     }, testInfo) => {
-      test.setTimeout(420_000);
-      const authToken = process.env.ELIZA_CLOUD_AUTH_TOKEN;
-      // Resolve before recording or navigation so a misconfigured operator run
-      // fails visibly without producing evidence that looks like a live pass.
-      buildAndroidCloudLoginCompletionRequest(
-        {
-          browserUrl:
-            "https://cloud.eliza.app/auth/cli-login?session=123e4567-e89b-42d3-a456-426614174000",
-          sessionId: "123e4567-e89b-42d3-a456-426614174000",
-          apiBase: "https://api.eliza.app",
-        },
-        authToken,
-      );
-
+      test.setTimeout(660_000);
+      testInfo.annotations.push({
+        type: "operator-action",
+        description:
+          "After the lane taps Google, complete the private test-account chooser without pressing Android Back.",
+      });
       const evidenceResponses = observeCloudResponses(page);
+      await device.shell("logcat -c");
+      await loadFreshCloudAuthFirstScreen(page, { switchAccount: true });
+      await attachJpeg(page, testInfo, "sign-in-greeting");
+
+      await expect
+        .poll(
+          async () =>
+            extractAndroidCloudPkceHandoffEvidence(
+              (await device.shell("logcat -d -v brief")).toString(),
+            ),
+          { timeout: 30_000 },
+        )
+        .not.toBeNull();
+      const handoff = extractAndroidCloudPkceHandoffEvidence(
+        (await device.shell("logcat -d -v brief")).toString(),
+      );
+      if (!handoff) throw new Error("Mobile-PKCE browser handoff was not seen");
+      expect(handoff.switchAccount).toBe(true);
+      await testInfo.attach("mobile PKCE handoff receipt", {
+        body: JSON.stringify(handoff, null, 2),
+        contentType: "application/json",
+      });
+
+      await expect
+        .poll(() => successfulPhaseCount(evidenceResponses, "mobile-config"), {
+          timeout: 30_000,
+        })
+        .toBeGreaterThanOrEqual(1);
+      await expect
+        .poll(
+          async () =>
+            resumedAndroidActivityComponent(
+              (await device.shell("dumpsys activity activities")).toString(),
+            ),
+          { timeout: 15_000 },
+        )
+        .toMatch(ANDROID_CLOUD_SIGN_IN_RESUMED_ACTIVITY);
+
+      await expect
+        .poll(
+          async () => {
+            const point = findAndroidGoogleProviderTapPoint(
+              (await device.shell("uiautomator dump /dev/tty")).toString(),
+            );
+            return point ? { googleProviderAvailable: true } : null;
+          },
+          { timeout: 90_000 },
+        )
+        .not.toBeNull();
+      const googleTapPoint = findAndroidGoogleProviderTapPoint(
+        (await device.shell("uiautomator dump /dev/tty")).toString(),
+      );
+      if (!googleTapPoint) {
+        throw new Error("Google was not available in the Android login picker");
+      }
+      await device.shell(`input tap ${googleTapPoint.x} ${googleTapPoint.y}`);
+      await testInfo.attach("Google provider selection receipt", {
+        body: JSON.stringify({ accessibilityTargetTapped: true }),
+        contentType: "application/json",
+      });
+
+      // The operator completes the private Google account chooser. The test
+      // never sends Back or foregrounds the package: only the genuine custom
+      // scheme callback may make MainActivity resume and complete token/ACK.
+      await expect
+        .poll(
+          async () =>
+            resumedAndroidActivityComponent(
+              (await device.shell("dumpsys activity activities")).toString(),
+            ),
+          { timeout: 360_000 },
+        )
+        .toBe(`${APP_ID}/.MainActivity`);
+
+      await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible({
+        timeout: 180_000,
+      });
+      await expect(page.getByPlaceholder("Message Eliza")).toBeVisible();
+      for (const phase of ["mobile-token", "mobile-ack"] as const) {
+        await expect
+          .poll(() => successfulPhaseCount(evidenceResponses, phase), {
+            timeout: 30_000,
+          })
+          .toBeGreaterThanOrEqual(1);
+      }
+      await expect
+        .poll(() => successfulPhaseCount(evidenceResponses, "personal-agent"), {
+          timeout: 30_000,
+        })
+        .toBeGreaterThanOrEqual(1);
+
+      // Recording starts only after authentication so account chooser, email,
+      // credentials, callback parameters, and authorization codes stay private.
       const recording = await startChunkedAndroidScreenRecord({
         serial: device.serial(),
         artifactDir: path.join(ARTIFACT_DIR, "authenticated-browser-return"),
-        filename: "cloud-onboarding-authenticated-browser-return.mp4",
+        filename: "cloud-onboarding-post-callback-chat.mp4",
         requireComplete: true,
       });
       let videoPath: string | null = null;
-
       try {
-        await clearBrowserState(page);
-        await loadSignedOutShell(page);
-        await attachJpeg(page, testInfo, "sign-in-greeting");
-        await device.shell("logcat -c");
-
-        await page.getByRole("button", { name: /^Sign in$/ }).click();
-        await expect(
-          page.getByRole("button", { name: "Cancel sign-in" }),
-        ).toBeVisible({ timeout: 30_000 });
-
-        let handoff: ReturnType<typeof extractAndroidCloudLoginHandoff> = null;
-        await expect
-          .poll(
-            async () => {
-              handoff = extractAndroidCloudLoginHandoff(
-                (await device.shell("logcat -d -v brief")).toString(),
-              );
-              return handoff;
-            },
-            { timeout: 30_000 },
-          )
-          .not.toBeNull();
-        if (!handoff) throw new Error("Cloud browser handoff was not captured");
-
-        await expect
-          .poll(
-            async () =>
-              resumedAndroidActivityComponent(
-                (await device.shell("dumpsys activity activities")).toString(),
-              ),
-            { timeout: 15_000 },
-          )
-          .toMatch(ANDROID_CLOUD_SIGN_IN_RESUMED_ACTIVITY);
-
-        const completion = buildAndroidCloudLoginCompletionRequest(
-          handoff,
-          authToken,
-        );
-        const completionResponse = await fetch(completion.url, completion.init);
-        if (!completionResponse.ok) {
-          throw new Error(
-            `Cloud login completion failed (${completionResponse.status})`,
-          );
-        }
-
-        // Return from the authenticated system-browser handoff. Foregrounding
-        // the app is required on devices that suspend WebView timers while the
-        // Custom Tab owns the resumed activity; the resumed poll must then
-        // consume this exact completed session and close the browser adapter.
-        await device.shell("input keyevent BACK");
-        await expect
-          .poll(
-            async () =>
-              resumedAndroidActivityComponent(
-                (await device.shell("dumpsys activity activities")).toString(),
-              ),
-            { timeout: 30_000 },
-          )
-          .toBe(`${APP_ID}/.MainActivity`);
-
-        await expect(
-          page.getByRole("button", { name: "Sign out" }),
-        ).toBeVisible({
-          timeout: 180_000,
-        });
-        await expect(page.getByPlaceholder("Message Eliza")).toBeVisible();
-        await expect
-          .poll(
-            () =>
-              evidenceResponses.filter(
-                (response) =>
-                  response.method === "GET" &&
-                  response.pathname === "/api/v1/eliza/personal" &&
-                  response.status === 200,
-              ).length,
-            { timeout: 30_000 },
-          )
-          .toBeGreaterThanOrEqual(1);
-
         await attachJpeg(page, testInfo, "home-landing");
 
         // A reload can only recover through the Keystore-backed credential
-        // written by pollLogin; this guards token persistence independently of
-        // the first in-memory ready state.
+        // committed by mobile token/ACK; this guards persistence independently
+        // of the first in-memory ready state and must restore Personal again.
+        const personalAgentCountBeforeReload = successfulPhaseCount(
+          evidenceResponses,
+          "personal-agent",
+        );
         await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
         await expect(
           page.getByRole("button", { name: "Sign out" }),
@@ -313,16 +457,10 @@ test.describe
         });
         await expect
           .poll(
-            () =>
-              evidenceResponses.filter(
-                (response) =>
-                  response.method === "GET" &&
-                  response.pathname === "/api/v1/eliza/personal" &&
-                  response.status === 200,
-              ).length,
+            () => successfulPhaseCount(evidenceResponses, "personal-agent"),
             { timeout: 30_000 },
           )
-          .toBeGreaterThanOrEqual(2);
+          .toBeGreaterThan(personalAgentCountBeforeReload);
 
         const challenge = buildLivenessChallenge(
           randomBytes(4).toString("hex"),
@@ -330,6 +468,10 @@ test.describe
         const challengeToken = extractLivenessChallengeToken(challenge);
         const composer = page.getByPlaceholder("Message Eliza");
         await composer.fill(challenge);
+        const streamCountBeforeSend = successfulPhaseCount(
+          evidenceResponses,
+          "message-stream",
+        );
         await page.getByRole("button", { name: /^Send$/ }).click();
         const userRow = page
           .locator("ol > li")
@@ -343,15 +485,21 @@ test.describe
         await expect
           .poll(
             async () => {
-              const candidate = await assistantText
-                .textContent()
-                .catch(() => null);
+              let candidate: string | null = null;
+              try {
+                candidate = await assistantText.textContent();
+              } catch {
+                // error-policy:J4 A transiently detached streaming row remains
+                // visibly pending until this bounded assertion poll expires.
+              }
               try {
                 reply = assertLiveChallengeReply(candidate, {
                   challengeToken,
                   label: "android-cloud-onboarding",
                 });
               } catch {
+                // error-policy:J3 Partial streamed text is explicitly not yet
+                // a valid liveness reply; the bounded poll retries it.
                 reply = null;
               }
               return reply;
@@ -367,22 +515,13 @@ test.describe
 
         await expect
           .poll(
-            () =>
-              evidenceResponses.some(
-                (response) =>
-                  response.method === "POST" &&
-                  /\/api\/conversations\/[^/]+\/messages$/.test(
-                    response.pathname,
-                  ) &&
-                  response.status >= 200 &&
-                  response.status < 300,
-              ),
+            () => successfulPhaseCount(evidenceResponses, "message-stream"),
             { timeout: 30_000 },
           )
-          .toBe(true);
-        await testInfo.attach("liveness reply", {
-          body: reply,
-          contentType: "text/plain",
+          .toBeGreaterThan(streamCountBeforeSend);
+        await testInfo.attach("liveness receipt", {
+          body: JSON.stringify({ matchedFreshChallenge: true }),
+          contentType: "application/json",
         });
         await testInfo.attach("Cloud response evidence", {
           body: JSON.stringify(evidenceResponses, null, 2),
@@ -392,7 +531,7 @@ test.describe
       } finally {
         videoPath = await recording.stop();
         if (videoPath) {
-          await testInfo.attach("authenticated browser return walkthrough", {
+          await testInfo.attach("post-callback chat walkthrough", {
             path: videoPath,
             contentType: "video/mp4",
           });
@@ -401,7 +540,7 @@ test.describe
 
       if (!videoPath) {
         throw new Error(
-          "Android Cloud onboarding passed without the required MP4 walkthrough",
+          "Android Cloud onboarding passed without the required post-callback MP4",
         );
       }
     });


### PR DESCRIPTION
## Evidence gap

The Android Play source already contains the mobile-PKCE callback and cold-start replay path, but the existing cloud-onboarding lane bypassed Google with a privileged token, manually returned from the browser, and did not prove the production streaming transport. A green unit suite could therefore be cited as Android sign-in proof without an installed phone ever completing Google → custom-scheme callback → persisted session → live agent reply.

## Resolution

This test-only PR turns the lane into an explicit physical-device acceptance contract:

- Reject ADB emulator serials and truthy `ro.kernel.qemu`, while attaching only an identifier-free boolean receipt.
- Reset Preferences, pending login, secure credential, secure active-server state, and renderer state without writing reserved storage after the surface-realm guard mounts.
- Force a fresh provider choice, locate an enabled/clickable Google accessibility target, and require the operator to complete only the private account chooser.
- Forbid Android Back or manual app foregrounding in the positive leg; only the genuine custom-scheme callback may resume `MainActivity`.
- Record only redacted mobile-PKCE shape and phase receipts; never attach the state, challenge, code, callback URL, account, credential, runtime ID, conversation ID, or reply text.
- Reload after callback to require Keystore-backed recovery, re-resolve Personal, and require a fresh liveness reply over `POST /api/conversations/:id/messages/stream`.
- Start screen recording only after authentication, so the Google chooser and account details cannot enter artifacts.
- Execute the public package scripts across a recorded process boundary so command, environment, physical-device policy, and exact Playwright collection are tested rather than mirrored from package.json strings.

Exact head: `90917bdee34d5a680a91f5271c392c69b92f137a`, based on `origin/develop@f55862ba19f8d65f356e56b9052318da74066243`.

## Verification

- Android command contract: 3/3 pass, 15 assertions.
- Redaction/evidence helpers: 8/8 pass.
- Android mobile-auth contract: 5/5 pass.
- Startup and signed-out recovery UI: 12/12 pass.
- Playwright collection: exactly 3 live acceptance legs in one spec.
- Current-head build core: 60/60 packages; app typecheck: pass.
- Current-head error-policy review: all retained URL/parser/poll catches are classified and the prior silent promise catch was removed.
- Targeted Biome, `git diff --check`, and AGENTS/CLAUDE synchronization: pass.
- Independent exact-diff review found no actionable correctness or privacy blocker.

## Required physical evidence and limits

The live lane was **not** executed in this environment. This PR does not claim that Google sign-in, automatic device return, Keystore recovery, or live streamed chat has passed on a phone. Acceptance still requires running the current revision on a physical Android device and inspecting the redacted receipts, three screenshots, and post-callback MP4.

This is the Play cloud-debug path. It does not constitute physical proof for the pinned launcher/kiosk in-WebView return path, and it does not validate phone/e-mail provider configuration or voice. Those remain separate live/product boundaries.

## Risk and rollback

The lane intentionally depends on Android accessibility and an operator-completed private Google chooser, so provider UI drift can fail the acceptance test without changing application behavior. It is opt-in and does not run against live identity by default. Roll back by reverting commit `90917bdee34d5a680a91f5271c392c69b92f137a`; there are no schema, runtime, deployment, or live configuration changes.

Relates to #28888, #29114, and #29024.
