### PR TITLE
fix(cloud): honor pinned production database authority

### DIFF
--- a/packages/cloud/scripts/admin/audit-production-railway-database-authority.test.ts
+++ b/packages/cloud/scripts/admin/audit-production-railway-database-authority.test.ts
@@ -14,6 +14,8 @@ import type { AppliedMigration, Migration } from "./canonical-migration-ledger";
 const PROJECT = "10000000-0000-4000-8000-000000000001";
 const ENVIRONMENT = "20000000-0000-4000-8000-000000000002";
 const SERVICE = "30000000-0000-4000-8000-000000000003";
+const OTHER_SERVICE = "40000000-0000-4000-8000-000000000004";
+const PINNED_IMAGE = `ghcr.io/railwayapp-templates/postgres-ssl@sha256:${"a".repeat(64)}`;
 const PRIVATE_URL =
   "postgresql://operator:private-password@canonical.example.test:5432/production";
 
@@ -186,9 +188,79 @@ describe("canonical Railway target", () => {
       resolveCanonicalRailwayTarget(evidence, {
         projectId: PROJECT,
         environmentId: ENVIRONMENT,
-        serviceId: "40000000-0000-4000-8000-000000000004",
+        serviceId: OTHER_SERVICE,
       }),
     ).toEqual({ verdict: "mismatch" });
+  });
+
+  test("accepts a digest-immutable Postgres image only through an exact protected pin", () => {
+    const evidence = railwayEvidence();
+    const digestPinned = {
+      ...evidence,
+      services: [{ id: SERVICE, source: { image: PINNED_IMAGE } }],
+    };
+    expect(
+      resolveCanonicalRailwayTarget(digestPinned, {
+        projectId: PROJECT,
+        environmentId: ENVIRONMENT,
+        serviceId: SERVICE,
+      }),
+    ).toEqual({ verdict: "match", serviceId: SERVICE });
+    expect(
+      resolveCanonicalRailwayTarget(digestPinned, {
+        projectId: PROJECT,
+        environmentId: ENVIRONMENT,
+      }),
+    ).toEqual({ verdict: "unavailable" });
+
+    expect(
+      resolveCanonicalRailwayTarget(
+        {
+          ...digestPinned,
+          services: [
+            ...digestPinned.services,
+            { id: OTHER_SERVICE, source: { image: "postgres:18" } },
+          ],
+          status: {
+            ...digestPinned.status,
+            services: {
+              edges: [
+                { node: { id: SERVICE, name: "Postgres" } },
+                { node: { id: OTHER_SERVICE, name: "Postgres Legacy" } },
+              ],
+            },
+          },
+        },
+        {
+          projectId: PROJECT,
+          environmentId: ENVIRONMENT,
+          serviceId: SERVICE,
+        },
+      ),
+    ).toEqual({ verdict: "match", serviceId: SERVICE });
+  });
+
+  test("fails closed when the protected pin is absent, duplicated, or not Postgres", () => {
+    const evidence = railwayEvidence();
+    for (const services of [
+      [],
+      [
+        { id: SERVICE, source: { image: PINNED_IMAGE } },
+        { id: SERVICE, source: { image: PINNED_IMAGE } },
+      ],
+      [{ id: SERVICE, source: { image: "redis:8" } }],
+    ]) {
+      expect(
+        resolveCanonicalRailwayTarget(
+          { ...evidence, services },
+          {
+            projectId: PROJECT,
+            environmentId: ENVIRONMENT,
+            serviceId: SERVICE,
+          },
+        ),
+      ).toEqual({ verdict: "mismatch" });
+    }
   });
 
   test("accepts only the selected service's public PostgreSQL URL", () => {
@@ -272,6 +344,21 @@ describe("read-only database audit", () => {
     expect(output).not.toContain("operator");
     expect(output).not.toContain(PROJECT);
     expect(output).not.toContain(PRIVATE_URL);
+  });
+
+  test("rejects a matching authority unless both targets run PostgreSQL 18", async () => {
+    for (const [protectedMajor, canonicalMajor] of [
+      ["170009", "180001"],
+      ["180001", "170009"],
+      ["170009", "170009"],
+    ]) {
+      const report = await audit(
+        new FakeClient(identity({ server_version_num: protectedMajor })),
+        new FakeClient(identity({ server_version_num: canonicalMajor })),
+      );
+      expect(report.verdict).toBe("fail");
+      expect(report.checks.protectedDatabaseAuthority).toBe("mismatch");
+    }
   });
 
   test("reports fixed table presence and pending ledger status", async () => {

--- a/packages/cloud/scripts/admin/audit-production-railway-database-authority.ts
+++ b/packages/cloud/scripts/admin/audit-production-railway-database-authority.ts
@@ -149,6 +149,14 @@ function resourceMatches(
   );
 }
 
+function isTaggedPostgres18(image: string): boolean {
+  return /(?:^|\/)postgres[^:]*:18(?:$|[-.])/.test(image);
+}
+
+function isDigestPinnedPostgres(image: string): boolean {
+  return /(?:^|\/)postgres[^:@]*@sha256:[0-9a-f]{64}$/i.test(image);
+}
+
 /** Resolves exactly one production Postgres 18 service, honoring an optional pin. */
 export function resolveCanonicalRailwayTarget(
   evidence: RailwayTargetEvidence,
@@ -164,19 +172,36 @@ export function resolveCanonicalRailwayTarget(
   ) {
     return { verdict: "mismatch" };
   }
+
+  if (expected.serviceId) {
+    if (!UUID.test(expected.serviceId)) return { verdict: "mismatch" };
+    const pinned = evidence.services.filter(
+      ({ id }) => id === expected.serviceId,
+    );
+    if (pinned.length !== 1) return { verdict: "mismatch" };
+    const image = pinned[0]?.source?.image;
+    if (
+      typeof image !== "string" ||
+      (!isTaggedPostgres18(image) && !isDigestPinnedPostgres(image))
+    ) {
+      return { verdict: "mismatch" };
+    }
+    if (!resourceMatches(evidence.status.services?.edges, expected.serviceId)) {
+      return { verdict: "mismatch" };
+    }
+    return { verdict: "match", serviceId: expected.serviceId };
+  }
+
   const candidates = evidence.services.filter(
     ({ id, source }) =>
       typeof id === "string" &&
       UUID.test(id) &&
       typeof source?.image === "string" &&
-      /(?:^|\/)postgres[^:]*:18(?:$|[-.])/.test(source.image),
+      isTaggedPostgres18(source.image),
   );
   if (candidates.length !== 1) return { verdict: "unavailable" };
   const serviceId = candidates[0]?.id;
   if (typeof serviceId !== "string") return { verdict: "unavailable" };
-  if (expected.serviceId && expected.serviceId !== serviceId) {
-    return { verdict: "mismatch" };
-  }
   if (!resourceMatches(evidence.status.services?.edges, serviceId)) {
     return { verdict: "mismatch" };
   }
@@ -291,7 +316,9 @@ export async function auditProductionDatabaseAuthority(input: {
     ]);
     const authorityMatches =
       canonicalIdentity.clusterSha256 === protectedIdentity.clusterSha256 &&
-      canonicalIdentity.authoritySha256 === protectedIdentity.authoritySha256;
+      canonicalIdentity.authoritySha256 === protectedIdentity.authoritySha256 &&
+      canonicalIdentity.postgresMajor === 18 &&
+      protectedIdentity.postgresMajor === 18;
     const [canonicalRequiredTables, protectedRequiredTables] =
       await Promise.all([
         relationPresence(input.canonicalClient),


### PR DESCRIPTION
Closes #29024

## What changed
- honor an explicitly configured Railway Postgres service when its image is digest-immutable
- keep unpinned discovery restricted to exactly one tagged PostgreSQL 18 service
- require both canonical and protected database authorities to report PostgreSQL 18
- fail closed for missing, duplicated, invalid, or non-Postgres pins

## Why
Production has two Railway Postgres services. The established production authority is digest-pinned, while the resolver only recognized tagged images and selected the newer wrong service. This prevented the canonical read-only authority audit and worker deployment from binding to the established production database.

## Evidence
- `bun test packages/cloud/scripts/admin/audit-production-railway-database-authority.test.ts` — 13/13 pass
- `bun run --cwd packages/cloud/shared typecheck` — pass
- exact Biome on both touched files — pass
- `git diff --check` — pass
- base `c7dd18422dfc1b6457341b8dce836cb55de1e24d`
- head `1b0e718bed8fbaf14ef4a01c672257883e316473`
- tree `314f802e9b478bf9881c72195bfc44174c746f62`

No Dedicated selection, adoption, job, compute, cutover, deletion, funding, or billing mutation occurred as part of this change. UI evidence is N/A because this is a server-side authority resolver contract.