### PR TITLE
[android-auth-agent-chat] fix(cloud): enforce effective worker database authority

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.test.ts
@@ -56,11 +56,101 @@ describe("assertProvisioningWorkerDatabaseConfigured", () => {
     ).toThrow(/postgres/);
   });
 
+  it("rejects TEST_DATABASE_URL as a deployed database-authority override", () => {
+    for (const testDatabaseUrl of [
+      "pglite://memory",
+      "postgresql://test:test@test-db.example/eliza",
+    ]) {
+      expect(() =>
+        assertProvisioningWorkerDatabaseConfigured({
+          NODE_ENV: "production",
+          DATABASE_URL: "postgresql://prod:prod@prod-db.example/eliza",
+          TEST_DATABASE_URL: testDatabaseUrl,
+        }),
+      ).toThrow(/TEST_DATABASE_URL is test-only/);
+    }
+  });
+
+  it("rejects database URLs with leading or trailing whitespace", () => {
+    for (const databaseUrl of [
+      " postgresql://user:pass@db.example/eliza",
+      "postgresql://user:pass@db.example/eliza ",
+    ]) {
+      expect(() =>
+        assertProvisioningWorkerDatabaseConfigured({
+          NODE_ENV: "production",
+          DATABASE_URL: databaseUrl,
+        }),
+      ).toThrow(/leading or trailing whitespace/);
+    }
+  });
+
+  it("rejects hostless, loopback, unspecified, and local-socket PostgreSQL targets", () => {
+    for (const databaseUrl of [
+      "postgresql:///eliza",
+      "postgresql://user:pass@localhost/eliza",
+      "postgresql://user:pass@service.localhost/eliza",
+      "postgresql://user:pass@127.0.0.1/eliza",
+      "postgresql://user:pass@127.1/eliza",
+      "postgresql://user:pass@2130706433/eliza",
+      "postgresql://user:pass@[::1]/eliza",
+      "postgresql://user:pass@[::ffff:127.0.0.1]/eliza",
+      "postgresql://user:pass@0.0.0.0/eliza",
+      "postgresql://user:pass@[::]/eliza",
+      "postgresql://user:pass@db.example/eliza?host=%2Fvar%2Frun%2Fpostgresql",
+    ]) {
+      expect(() =>
+        assertProvisioningWorkerDatabaseConfigured({
+          NODE_ENV: "production",
+          DATABASE_URL: databaseUrl,
+        }),
+      ).toThrow(/remote PostgreSQL host/);
+    }
+  });
+
+  it("validates the last effective pg host query override", () => {
+    expect(() =>
+      assertProvisioningWorkerDatabaseConfigured({
+        NODE_ENV: "production",
+        DATABASE_URL:
+          "postgresql://user:pass@db.example/eliza?host=remote-db.example&host=127.0.0.1",
+      }),
+    ).toThrow(/remote PostgreSQL host/);
+
+    expect(() =>
+      assertProvisioningWorkerDatabaseConfigured({
+        NODE_ENV: "production",
+        DATABASE_URL:
+          "postgresql://user:pass@db.example/eliza?host=127.0.0.1&host=remote-db.example",
+      }),
+    ).not.toThrow();
+  });
+
   it("accepts canonical remote PostgreSQL URLs", () => {
     expect(() =>
       assertProvisioningWorkerDatabaseConfigured({
         NODE_ENV: "staging",
         DATABASE_URL: "postgresql://user:pass@db.example/eliza?sslmode=require",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertProvisioningWorkerDatabaseConfigured({
+        NODE_ENV: "production",
+        DATABASE_URL:
+          "postgresql://user:pass@db.example/eliza?host=pooler.example",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertProvisioningWorkerDatabaseConfigured({
+        NODE_ENV: "production",
+        DATABASE_URL: "postgresql://user:pass@[2001:db8::42]/eliza",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertProvisioningWorkerDatabaseConfigured({
+        NODE_ENV: "production",
+        DATABASE_URL: "postgresql://user:pass@db.example/eliza",
+        TEST_DATABASE_URL: "",
       }),
     ).not.toThrow();
   });

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -12,8 +12,10 @@
  *   npx tsx packages/cloud/scripts/admin/daemons/provisioning-worker.ts --once
  */
 
+import { isIP } from "node:net";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveDatabaseUrl } from "@elizaos/cloud-shared/db/database-url";
 import type { AppOrphanReconcileResult } from "@elizaos/cloud-shared/lib/services/app-container-orphan-reconciler";
 import type { OrphanReconcileResult } from "@elizaos/cloud-shared/lib/services/docker-node-workloads";
 import {
@@ -408,6 +410,57 @@ export function formatErrorWithCause(error: unknown): string {
   return message;
 }
 
+function normalizeDatabaseHost(rawHostname: string): string {
+  let hostname = rawHostname.trim().toLowerCase();
+  const zoneIndex = hostname.indexOf("%");
+  if (zoneIndex >= 0) hostname = hostname.slice(0, zoneIndex);
+  hostname = hostname.replace(/\.$/, "");
+  if (!hostname || hostname.startsWith("/") || hostname.startsWith("\\")) {
+    return hostname;
+  }
+
+  try {
+    const urlHost =
+      hostname.includes(":") && !hostname.startsWith("[")
+        ? `[${hostname}]`
+        : hostname;
+    hostname = new URL(`http://${urlHost}/`).hostname.toLowerCase();
+  } catch {
+    // Keep the original value. Invalid remote hosts fail when pg connects;
+    // known local forms still fail closed below.
+  }
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    hostname = hostname.slice(1, -1);
+  }
+  return hostname.replace(/\.$/, "");
+}
+
+function isLocalDatabaseHost(rawHostname: string): boolean {
+  const hostname = normalizeDatabaseHost(rawHostname);
+  if (!hostname || hostname.startsWith("/") || hostname.startsWith("\\"))
+    return true;
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) return true;
+  if (isIP(hostname) === 4) {
+    return hostname === "0.0.0.0" || hostname.startsWith("127.");
+  }
+  if (isIP(hostname) !== 6) return false;
+  if (hostname === "::" || hostname === "::1") return true;
+  const mapped = /^::ffff:([0-9a-f]{1,4}):[0-9a-f]{1,4}$/.exec(hostname);
+  if (!mapped) return false;
+  const mappedFirstOctet = Number.parseInt(mapped[1] ?? "", 16) >> 8;
+  return mappedFirstOctet === 0 || mappedFirstOctet === 127;
+}
+
+function effectivePostgresHost(parsed: URL): string {
+  const queryHosts = parsed.searchParams.getAll("host");
+  const queryHost = queryHosts.at(-1);
+  // pg-connection-string applies query fields in order (last one wins), but an
+  // exactly empty `host=` falls back to the authority hostname.
+  return queryHost !== undefined && queryHost !== ""
+    ? queryHost
+    : parsed.hostname;
+}
+
 /**
  * Refuse to start a deployed provisioning daemon without the same remote
  * PostgreSQL authority used by the API. A missing URL otherwise falls through
@@ -419,10 +472,24 @@ export function assertProvisioningWorkerDatabaseConfigured(
 ): void {
   const nodeEnv = env.NODE_ENV;
   if (nodeEnv === "test" || nodeEnv === "development") return;
-  const raw = env.DATABASE_URL?.trim();
-  if (!raw) {
+  if (env.TEST_DATABASE_URL !== undefined && env.TEST_DATABASE_URL !== "") {
+    throw new Error(
+      "Provisioning worker TEST_DATABASE_URL is test-only and must be unset outside test/development; refusing a hidden database-authority override.",
+    );
+  }
+
+  // Use the same resolver as the database client. In deployed environments we
+  // additionally require an explicit DATABASE_URL so a local fallback can
+  // never become the worker's effective jobs-queue authority.
+  const raw = resolveDatabaseUrl(env);
+  if (env.DATABASE_URL === undefined || env.DATABASE_URL === "" || !raw) {
     throw new Error(
       "Provisioning worker DATABASE_URL is required outside test/development; refusing to advertise liveness against a local or implicit database.",
+    );
+  }
+  if (raw !== raw.trim()) {
+    throw new Error(
+      "Provisioning worker DATABASE_URL must not contain leading or trailing whitespace; the startup gate validates the exact URL consumed by the database client.",
     );
   }
   if (/^pglite:\/\//i.test(raw)) {
@@ -441,6 +508,12 @@ export function assertProvisioningWorkerDatabaseConfigured(
   if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
     throw new Error(
       "Provisioning worker DATABASE_URL must use postgres:// or postgresql:// outside test/development.",
+    );
+  }
+  const effectiveHost = effectivePostgresHost(parsed);
+  if (isLocalDatabaseHost(effectiveHost)) {
+    throw new Error(
+      "Provisioning worker DATABASE_URL must target a remote PostgreSQL host outside test/development; hostless, loopback, unspecified, and local-socket targets are forbidden.",
     );
   }
 }
@@ -2291,6 +2364,10 @@ async function armAppsDeployBackendIfEnabled(
 
 async function main(): Promise<void> {
   loadLocalEnv(import.meta.url);
+  // Validate the exact DB resolver inputs before importing repositories. That
+  // prevents a deployed worker from even constructing a client against a
+  // TEST_DATABASE_URL override or local fallback.
+  assertProvisioningWorkerDatabaseConfigured();
 
   const config = readWorkerConfig();
   const { logger, assertSSHKeyAvailable } = await loadDeps();
@@ -2310,7 +2387,6 @@ async function main(): Promise<void> {
     dbLivenessMaxAgeHours: config.dbLivenessMaxAgeHours,
   });
 
-  assertProvisioningWorkerDatabaseConfigured();
   await assertProvisioningWorkerPreflight({ logger });
 
   // Fail-fast on a missing SSH key BEFORE the first heartbeat for remote-node


### PR DESCRIPTION
## Cause

The provisioning worker's deployed database startup guard checked only whether `DATABASE_URL` existed. The shared database resolver can prefer `TEST_DATABASE_URL`, accept local PGlite fallback outside the intended environments, or consume a raw DSN whose authority differs from a normalized value. That lets the worker advertise Redis liveness while polling a different or unusable PostgreSQL jobs queue.

## Fix

- use the same database URL resolver as the database client;
- reject `TEST_DATABASE_URL` outside test/development;
- require an explicit remote `postgres://` or `postgresql://` URL before dependencies load;
- parse the exact raw DSN and reject leading/trailing whitespace;
- reject hostless, local-socket, localhost, loopback, unspecified, numeric-loopback, and IPv4-mapped-loopback targets;
- validate the last effective PostgreSQL `host=` query override.

## Limits

This PR gates the provisioning daemon startup authority only. It does not change credentials, databases, schema, jobs, deployment state, or any live service. Schema/relation gating is handled separately by #29427.

## Risk

A deployed worker with a previously tolerated local, overridden, malformed, or whitespace-padded DSN will now refuse startup. That is intentional fail-closed behavior; operators must correct the configuration before the worker can heartbeat or claim jobs.

## Rollback

Revert commit `48533421e57`. No data migration or live rollback step is required.

## Tests and proof

- `bun test packages/cloud/scripts/admin/daemons/provisioning-worker.test.ts` — 65 passed, 148 assertions
- `bun run typecheck:cloud` — 73/73 tasks (before the final whitespace-only authority regression; no type surface changed)
- Biome on the two changed files — no errors; 11 pre-existing undeclared-env warnings
- `git diff --check`
- independent final diff review: no blocker
- secret/key marker scan: clean

Stacked on #29345 at exact parent `f69c1dd7a2c3465561957248c0416af389161f06`. No deployment, restart, migration, configuration mutation, database write, or merge was performed.
