### PR TITLE
fix(ci): clean worker deploy checkout before migrations

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -331,6 +331,12 @@ jobs:
             echo "::error::Migration checkout resolved $actual_sha, expected $EXPECTED_DEPLOY_SHA"
             exit 1
           }
+          # Self-hosted runners can retain files created after checkout's own
+          # cleanup hook. Re-establish the exact immutable tree immediately
+          # before migrations; suppress removed paths so runner-local names do
+          # not enter deployment logs.
+          git reset --hard --quiet "$EXPECTED_DEPLOY_SHA"
+          git clean -ffdx -q
           [ -z "$(git status --porcelain)" ] || {
             echo "::error::Migration checkout is not clean"
             exit 1

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -143,6 +143,23 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain(
       '[ "$actual_sha" = "$EXPECTED_DEPLOY_SHA" ] || {',
     );
+    const exactSourceCheck = workflow.indexOf(
+      '[ "$actual_sha" = "$EXPECTED_DEPLOY_SHA" ] || {',
+      verify,
+    );
+    const reset = workflow.indexOf(
+      'git reset --hard --quiet "$EXPECTED_DEPLOY_SHA"',
+      verify,
+    );
+    const clean = workflow.indexOf("git clean -ffdx -q", verify);
+    const cleanVerdict = workflow.indexOf(
+      '[ -z "$(git status --porcelain)" ] || {',
+      verify,
+    );
+    expect(reset).toBeGreaterThan(exactSourceCheck);
+    expect(clean).toBeGreaterThan(reset);
+    expect(cleanVerdict).toBeGreaterThan(clean);
+    expect(migration).toBeGreaterThan(cleanVerdict);
     expect(workflow).toContain("bun run db:cloud:migrate");
   });
 


### PR DESCRIPTION
## Summary

- re-establish the immutable deployment tree after checkout on persistent self-hosted runners
- run reset and ignored/untracked cleanup before the existing clean-tree verdict and before migrations
- assert ordering relative to exact-SHA verification, migrations, runner routing, and host serialization

## Safety boundary

Cleanup runs only in the Actions repository checkout immediately after exact-SHA equality is established. Protected environment admission, production main-only dispatch, per-run concurrency, and the remote host flock are unchanged. This PR does not deploy, merge, touch the production host, or submit Dedicated adoption.

## Exact source

- base: c0a8de04019f62a96c5f6bf21ee7c15ee554cafe
- head: abe3de749760b4a9fe2b6d8de46477f1d1c78d45
- tree: 34a8547d2ca813086d7be02d5a9c4c547e6e7816

## Verification

- 4 focused workflow contract tests: pass
- actionlint: pass
- Biome error-level check on touched TypeScript: pass
- git diff-check: pass

The entire existing workflow test file still has four unrelated backup-worker expectation failures on the main baseline; this two-file patch does not touch those assertions or backup behavior.

Relates #29024.