### PR TITLE
[android-auth-agent-chat] fix(android): settle Play TTS on playback lifecycle

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-core/platforms/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
         <intent>
             <action android:name="android.speech.RecognitionService" />
         </intent>
+        <!-- Android 11+ package visibility: expose installed system TTS
+             engines so ElizaPlayVoice can bind to the user's selected engine. -->
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
     </queries>
 
     <uses-feature

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -54,6 +54,9 @@ const AAPT_MANIFEST = `
       E: intent (line=5)
         E: action (line=6)
           A: android:name(0x01010003)="android.speech.RecognitionService" (Raw: "android.speech.RecognitionService")
+      E: intent (line=7)
+        E: action (line=8)
+          A: android:name(0x01010003)="android.intent.action.TTS_SERVICE" (Raw: "android.intent.action.TTS_SERVICE")
     E: uses-permission (line=7)
       A: android:name(0x01010003)="android.permission.INTERNET" (Raw: "android.permission.INTERNET")
     E: application (line=8)
@@ -267,6 +270,7 @@ describe("Android Play manifest policy", () => {
     expect(androidPlayManifestEvidenceFromAapt(AAPT_MANIFEST)).toEqual({
       actions: [
         "android.intent.action.MAIN",
+        "android.intent.action.TTS_SERVICE",
         "android.speech.RecognitionService",
       ],
       application: {
@@ -280,7 +284,10 @@ describe("Android Play manifest policy", () => {
       ],
       metadataNames: ["android.support.FILE_PROVIDER_PATHS"],
       permissions: ["android.permission.INTERNET"],
-      queryActions: ["android.speech.RecognitionService"],
+      queryActions: [
+        "android.intent.action.TTS_SERVICE",
+        "android.speech.RecognitionService",
+      ],
       queryPackages: [],
       targetSdkVersion: "36",
     });

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -261,11 +261,19 @@ describe("cloudSafeMainActivityJava", () => {
     );
   });
 
-  it("generates standard speech recognition and system TTS without local transports", () => {
+  it("generates callback-owned system TTS with an idempotent stop path", () => {
     const source = cloudSafePlayVoicePluginJava("ai.elizaos.app");
     const pluginThreadEntry = source.slice(
       source.indexOf("public void startDictation"),
       source.indexOf("private void startDictationOnMainThread"),
+    );
+    const speakEntry = source.slice(
+      source.indexOf("public void speak(PluginCall call)"),
+      source.indexOf("private void speakOnMainThread"),
+    );
+    const playbackLifecycle = source.slice(
+      source.indexOf("private void initializeSpeechOnMainThread"),
+      source.indexOf("private void resolvePermission"),
     );
 
     expect(source).toContain('@CapacitorPlugin(\n    name = "ElizaPlayVoice"');
@@ -275,9 +283,7 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain(
       "runOnMainThread(() -> startDictationOnMainThread(call, language));",
     );
-    expect(source).toContain(
-      "runOnMainThread(this::stopRecognizerOnMainThread);",
-    );
+    expect(source).toContain("stopRecognizerOnMainThread();");
     expect(source).toContain(
       "runOnMainThread(() -> speakOnMainThread(call, text, language));",
     );
@@ -286,7 +292,46 @@ describe("cloudSafeMainActivityJava", () => {
     );
     expect(pluginThreadEntry).not.toContain("recognizer.startListening");
     expect(source).toContain("SpeechRecognizer.createSpeechRecognizer");
-    expect(source).toContain("new TextToSpeech(getContext()");
+    expect(source).toContain("new TextToSpeech(");
+    expect(source).toContain("private SpeechSession activeSpeech;");
+    expect(source).toContain(
+      "mainHandler.post(() -> resolveActiveSpeechOnMainThread(session));",
+    );
+    expect(playbackLifecycle).toContain('"TTS_PLAYBACK_FAILED"');
+    expect(playbackLifecycle).toContain(
+      "@Override public void onStop(String id, boolean interrupted)",
+    );
+    expect(playbackLifecycle).toContain(
+      "if (listenerStatus != TextToSpeech.SUCCESS)",
+    );
+    expect(playbackLifecycle).toContain(
+      "armSpeechWatchdogOnMainThread(session, TTS_START_WATCHDOG_MS);",
+    );
+    expect(playbackLifecycle).toContain("mainHandler.postDelayed(");
+    expect(playbackLifecycle).toContain(
+      "@Override public void onRangeStart(String id, int start, int end, int frame)",
+    );
+    expect(playbackLifecycle).toContain("session.tts.isSpeaking()");
+    expect(playbackLifecycle).toContain("TTS_TERMINAL_GRACE_MS");
+    expect(playbackLifecycle).toContain('"TTS_TIMEOUT"');
+    expect(source).toContain("TTS_START_WATCHDOG_MS = 60_000L");
+    expect(source).toContain("TTS_STALL_POLL_MS = 30_000L");
+    expect(source).toContain("TTS_TERMINAL_GRACE_MS = 10_000L");
+    expect(playbackLifecycle).not.toContain("text.length()");
+    expect(playbackLifecycle).toContain(
+      "mainHandler.removeCallbacks(session.watchdog);",
+    );
+    expect(source).toContain("public void stop(PluginCall call)");
+    expect(source).toContain(
+      'stopActiveSpeechOnMainThread(\n                    "Speech playback was stopped.",\n                    "TTS_STOPPED");',
+    );
+    expect(source).toContain("session.tts.stop();");
+    expect(source).toContain("session.tts.shutdown();");
+    expect(speakEntry).not.toContain("call.resolve()");
+    expect(
+      playbackLifecycle.match(/session\.call\.resolve\(\);/g),
+    ).toHaveLength(1);
+    expect(playbackLifecycle).toContain("session.call.reject(message, code);");
     expect(source).toContain("Manifest.permission.RECORD_AUDIO");
     expect(source).not.toMatch(/LocalSocket|HttpURLConnection|apiKey|bionic/i);
     expect(source).not.toContain("http://");

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6163,6 +6163,7 @@ export const ANDROID_PLAY_ALLOWED_ACTIONS = Object.freeze([
   "android.intent.action.PROCESS_TEXT",
   "android.intent.action.QUICKBOOT_POWERON",
   "android.intent.action.SEND",
+  "android.intent.action.TTS_SERVICE",
   "android.intent.action.VIEW",
   "android.speech.RecognitionService",
   "android.support.customtabs.action.CustomTabsService",
@@ -6192,6 +6193,7 @@ export const ANDROID_PLAY_ALLOWED_METADATA_NAMES = Object.freeze([
 ]);
 
 export const ANDROID_PLAY_ALLOWED_QUERY_ACTIONS = Object.freeze([
+  "android.intent.action.TTS_SERVICE",
   "android.speech.RecognitionService",
   "android.support.customtabs.action.CustomTabsService",
 ]);
@@ -7230,8 +7232,26 @@ import java.util.UUID;
     permissions = @Permission(alias = "microphone", strings = { Manifest.permission.RECORD_AUDIO })
 )
 public final class ElizaPlayVoicePlugin extends Plugin implements RecognitionListener {
+    private static final long TTS_START_WATCHDOG_MS = 60_000L;
+    private static final long TTS_STALL_POLL_MS = 30_000L;
+    private static final long TTS_TERMINAL_GRACE_MS = 10_000L;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private SpeechRecognizer recognizer;
+    private SpeechSession activeSpeech;
+
+    private static final class SpeechSession {
+        private final PluginCall call;
+        private final String utteranceId;
+        private TextToSpeech tts;
+        private Runnable watchdog;
+        private boolean playbackStarted;
+        private boolean terminalGraceArmed;
+
+        private SpeechSession(PluginCall call) {
+            this.call = call;
+            this.utteranceId = UUID.randomUUID().toString();
+        }
+    }
 
     @PluginMethod
     public void requestPermission(PluginCall call) {
@@ -7304,39 +7324,219 @@ public final class ElizaPlayVoicePlugin extends Plugin implements RecognitionLis
     }
 
     private void speakOnMainThread(PluginCall call, String text, String language) {
-        final TextToSpeech[] holder = new TextToSpeech[1];
-        holder[0] = new TextToSpeech(getContext(), status -> {
-            TextToSpeech tts = holder[0];
-            if (status != TextToSpeech.SUCCESS || tts == null) {
-                if (tts != null) tts.shutdown();
-                call.reject("System text to speech is unavailable.", "TTS_UNAVAILABLE");
-                return;
+        stopActiveSpeechOnMainThread(
+                "Speech playback was replaced by a newer request.",
+                "TTS_REPLACED");
+        SpeechSession session = new SpeechSession(call);
+        activeSpeech = session;
+        try {
+            session.tts = new TextToSpeech(
+                    getContext(),
+                    status -> mainHandler.post(
+                            () -> initializeSpeechOnMainThread(session, text, language, status)));
+        } catch (RuntimeException error) {
+            // error-policy:J1 Translate native construction failures to the pending Capacitor call.
+            if (activeSpeech == session) activeSpeech = null;
+            call.reject("System text to speech is unavailable.", "TTS_UNAVAILABLE", error);
+        }
+    }
+
+    private void initializeSpeechOnMainThread(
+            SpeechSession session,
+            String text,
+            String language,
+            int status) {
+        if (activeSpeech != session) return;
+        TextToSpeech tts = session.tts;
+        if (status != TextToSpeech.SUCCESS || tts == null) {
+            rejectActiveSpeechOnMainThread(
+                    session,
+                    "System text to speech is unavailable.",
+                    "TTS_UNAVAILABLE");
+            return;
+        }
+        Locale locale = Locale.forLanguageTag(language == null ? "" : language);
+        if (tts.setLanguage(locale) < TextToSpeech.LANG_AVAILABLE) {
+            rejectActiveSpeechOnMainThread(
+                    session,
+                    "The selected speech language is unavailable.",
+                    "TTS_LANGUAGE_UNAVAILABLE");
+            return;
+        }
+        int listenerStatus = tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
+            @Override public void onStart(String id) {
+                markPlaybackProgress(session, id);
             }
-            Locale locale = Locale.forLanguageTag(language == null ? "" : language);
-            if (tts.setLanguage(locale) < TextToSpeech.LANG_AVAILABLE) {
-                tts.shutdown();
-                call.reject("The selected speech language is unavailable.", "TTS_LANGUAGE_UNAVAILABLE");
-                return;
+            @Override public void onRangeStart(String id, int start, int end, int frame) {
+                markPlaybackProgress(session, id);
             }
-            String utteranceId = UUID.randomUUID().toString();
-            tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
-                @Override public void onStart(String id) {}
-                @Override public void onDone(String id) { tts.shutdown(); }
-                @Override public void onError(String id) { tts.shutdown(); }
-            });
-            int accepted = tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId);
-            if (accepted != TextToSpeech.SUCCESS) {
-                tts.shutdown();
-                call.reject("System text to speech could not start.", "TTS_START_FAILED");
-                return;
+            @Override public void onDone(String id) {
+                if (!session.utteranceId.equals(id)) return;
+                mainHandler.post(() -> resolveActiveSpeechOnMainThread(session));
             }
+            @Override public void onError(String id) {
+                rejectPlayback(
+                        session,
+                        id,
+                        "System text to speech failed during playback.",
+                        "TTS_PLAYBACK_FAILED");
+            }
+            @Override public void onError(String id, int errorCode) {
+                rejectPlayback(
+                        session,
+                        id,
+                        "System text to speech failed during playback.",
+                        "TTS_PLAYBACK_FAILED");
+            }
+            @Override public void onStop(String id, boolean interrupted) {
+                rejectPlayback(
+                        session,
+                        id,
+                        "System text to speech was interrupted.",
+                        "TTS_INTERRUPTED");
+            }
+        });
+        if (listenerStatus != TextToSpeech.SUCCESS) {
+            rejectActiveSpeechOnMainThread(
+                    session,
+                    "System text to speech callbacks are unavailable.",
+                    "TTS_LISTENER_FAILED");
+            return;
+        }
+        int accepted = tts.speak(
+                text,
+                TextToSpeech.QUEUE_FLUSH,
+                null,
+                session.utteranceId);
+        if (accepted != TextToSpeech.SUCCESS) {
+            rejectActiveSpeechOnMainThread(
+                    session,
+                    "System text to speech could not start.",
+                    "TTS_START_FAILED");
+            return;
+        }
+        armSpeechWatchdogOnMainThread(session, TTS_START_WATCHDOG_MS);
+    }
+
+    private void rejectPlayback(
+            SpeechSession session,
+            String utteranceId,
+            String message,
+            String code) {
+        if (!session.utteranceId.equals(utteranceId)) return;
+        mainHandler.post(() -> rejectActiveSpeechOnMainThread(
+                session,
+                message,
+                code));
+    }
+
+    private void markPlaybackProgress(
+            SpeechSession session,
+            String utteranceId) {
+        if (!session.utteranceId.equals(utteranceId)) return;
+        mainHandler.post(() -> {
+            if (activeSpeech != session) return;
+            session.playbackStarted = true;
+            session.terminalGraceArmed = false;
+            armSpeechWatchdogOnMainThread(session, TTS_STALL_POLL_MS);
+        });
+    }
+
+    private void resolveActiveSpeechOnMainThread(SpeechSession session) {
+        if (activeSpeech != session) return;
+        cancelSpeechWatchdogOnMainThread(session);
+        activeSpeech = null;
+        if (session.tts != null) session.tts.shutdown();
+        session.call.resolve();
+    }
+
+    private void rejectActiveSpeechOnMainThread(
+            SpeechSession session,
+            String message,
+            String code) {
+        if (activeSpeech != session) return;
+        cancelSpeechWatchdogOnMainThread(session);
+        activeSpeech = null;
+        if (session.tts != null) {
+            session.tts.stop();
+            session.tts.shutdown();
+        }
+        session.call.reject(message, code);
+    }
+
+    private void stopActiveSpeechOnMainThread(String message, String code) {
+        SpeechSession session = activeSpeech;
+        if (session == null) return;
+        cancelSpeechWatchdogOnMainThread(session);
+        activeSpeech = null;
+        if (session.tts != null) {
+            session.tts.stop();
+            session.tts.shutdown();
+        }
+        session.call.reject(message, code);
+    }
+
+    private void armSpeechWatchdogOnMainThread(
+            SpeechSession session,
+            long delayMs) {
+        if (activeSpeech != session) return;
+        cancelSpeechWatchdogOnMainThread(session);
+        session.watchdog = () -> checkSpeechWatchdogOnMainThread(session);
+        mainHandler.postDelayed(session.watchdog, delayMs);
+    }
+
+    private void checkSpeechWatchdogOnMainThread(SpeechSession session) {
+        if (activeSpeech != session) return;
+        boolean speaking = false;
+        try {
+            speaking = session.tts != null && session.tts.isSpeaking();
+        } catch (RuntimeException ignored) {
+            // error-policy:J1 The watchdog translates a disconnected engine to
+            // the bounded TTS_TIMEOUT rejection below.
+            // A disconnected engine reports as stalled and follows the same
+            // bounded terminal-grace path below.
+        }
+        if (speaking) {
+            session.playbackStarted = true;
+            session.terminalGraceArmed = false;
+            armSpeechWatchdogOnMainThread(session, TTS_STALL_POLL_MS);
+            return;
+        }
+        if (session.playbackStarted && !session.terminalGraceArmed) {
+            session.terminalGraceArmed = true;
+            armSpeechWatchdogOnMainThread(session, TTS_TERMINAL_GRACE_MS);
+            return;
+        }
+        rejectActiveSpeechOnMainThread(
+                session,
+                "System text to speech did not report a terminal playback event.",
+                "TTS_TIMEOUT");
+    }
+
+    private void cancelSpeechWatchdogOnMainThread(SpeechSession session) {
+        if (session.watchdog == null) return;
+        mainHandler.removeCallbacks(session.watchdog);
+        session.watchdog = null;
+    }
+
+    @PluginMethod
+    public void stop(PluginCall call) {
+        runOnMainThread(() -> {
+            stopActiveSpeechOnMainThread(
+                    "Speech playback was stopped.",
+                    "TTS_STOPPED");
             call.resolve();
         });
     }
 
     @Override
     protected void handleOnDestroy() {
-        runOnMainThread(this::stopRecognizerOnMainThread);
+        runOnMainThread(() -> {
+            stopRecognizerOnMainThread();
+            stopActiveSpeechOnMainThread(
+                    "Speech playback stopped because the voice bridge was destroyed.",
+                    "TTS_DESTROYED");
+        });
         super.handleOnDestroy();
     }
 

--- a/packages/ui/src/bridge/native-plugins.ts
+++ b/packages/ui/src/bridge/native-plugins.ts
@@ -936,6 +936,7 @@ export interface ElizaPlayVoicePluginLike extends NativePlugin {
   }): Promise<{ started: boolean }>;
   stopDictation(): Promise<void>;
   speak(options: { text: string; language?: string }): Promise<void>;
+  stop(): Promise<void>;
 }
 
 /**

--- a/packages/ui/src/hooks/useVoiceChat.android-play-voice.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.android-play-voice.test.tsx
@@ -1,17 +1,31 @@
-/** Verifies remote-only Android builds route spoken replies through their Play-safe native bridge. */
+/**
+ * Exercises Android native speech routing, completion ordering, and cancellation
+ * with deterministic TalkMode and Play-voice bridge doubles.
+ */
 // @vitest-environment jsdom
 
+import { logger } from "@elizaos/logger";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
-  playSpeak: vi.fn(async () => undefined),
-  talkMode: {
-    checkPermissions: vi.fn(async () => ({
-      microphone: "granted",
-      speechRecognition: "not_supported",
-    })),
-  },
+  useTalkMode: false,
+  playSpeak: vi.fn(
+    async (_options: { text: string }): Promise<void> => undefined,
+  ),
+  playStop: vi.fn(async (): Promise<void> => undefined),
+  talkSpeak: vi.fn(
+    async (_options: { text: string; useLocalInferenceTts: boolean }) => ({
+      completed: true,
+      interrupted: false,
+      usedSystemTts: false,
+    }),
+  ),
+  talkStopSpeaking: vi.fn(async () => ({})),
+  checkPermissions: vi.fn(async () => ({
+    microphone: "granted",
+    speechRecognition: "not_supported",
+  })),
 }));
 
 vi.mock("@capacitor/core", () => ({
@@ -23,29 +37,70 @@ vi.mock("@capacitor/core", () => ({
 
 vi.mock("../bridge/native-plugins", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../bridge/native-plugins")>()),
-  getTalkModePlugin: () => h.talkMode as never,
-  getElizaPlayVoicePlugin: () => ({ speak: h.playSpeak }) as never,
+  getTalkModePlugin: () =>
+    ({
+      checkPermissions: h.checkPermissions,
+      ...(h.useTalkMode
+        ? {
+            speak: h.talkSpeak,
+            stopSpeaking: h.talkStopSpeaking,
+          }
+        : {}),
+    }) as never,
+  getElizaPlayVoicePlugin: () =>
+    ({ speak: h.playSpeak, stop: h.playStop }) as never,
 }));
 
 import { useVoiceChat } from "./useVoiceChat";
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderAndroidVoice() {
+  return renderHook(() =>
+    useVoiceChat({
+      onTranscript: vi.fn(),
+      voiceConfig: { provider: "edge" },
+    }),
+  );
+}
+
 describe("useVoiceChat Android Play-safe voice", () => {
   beforeEach(() => {
-    h.playSpeak.mockClear();
-    h.talkMode.checkPermissions.mockClear();
+    h.useTalkMode = false;
+    h.playSpeak.mockReset().mockResolvedValue(undefined);
+    h.playStop.mockReset().mockResolvedValue(undefined);
+    h.talkSpeak.mockReset().mockResolvedValue({
+      completed: true,
+      interrupted: false,
+      usedSystemTts: false,
+    });
+    h.talkStopSpeaking.mockReset().mockResolvedValue({});
+    h.checkPermissions.mockClear();
   });
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
-  it("uses ElizaPlayVoice when the stripped TalkMode plugin has no speak method", async () => {
-    const { result } = renderHook(() =>
-      useVoiceChat({
-        onTranscript: vi.fn(),
-        voiceConfig: { provider: "edge" },
-      }),
-    );
+  it("keeps the turn speaking until ElizaPlayVoice reports playback completion", async () => {
+    const completion = deferred<void>();
+    h.playSpeak.mockImplementation(() => completion.promise);
+    const { result } = renderAndroidVoice();
 
     act(() => {
       result.current.speak("Pixel VPS voice bridge proof");
@@ -56,6 +111,128 @@ describe("useVoiceChat Android Play-safe voice", () => {
         text: "Pixel VPS voice bridge proof",
       });
     });
+    expect(result.current.isSpeaking).toBe(true);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.isSpeaking).toBe(true);
+
+    await act(async () => {
+      completion.resolve(undefined);
+      await completion.promise;
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
     expect(result.current.ttsError).toBeNull();
+  });
+
+  it("stops ElizaPlayVoice when barge-in cancels a remote-only Android utterance", async () => {
+    const playback = deferred<void>();
+    let playbackStarted = false;
+    h.playSpeak.mockImplementation(() => {
+      playbackStarted = true;
+      return playback.promise;
+    });
+    h.playStop.mockImplementation(async () => {
+      if (!playbackStarted) return;
+      playbackStarted = false;
+      const interrupted = new Error("Native speech was interrupted");
+      interrupted.name = "AbortError";
+      playback.reject(interrupted);
+    });
+    const { result } = renderAndroidVoice();
+
+    act(() => {
+      result.current.speak("A response the user interrupts");
+    });
+    await waitFor(() => {
+      expect(h.playSpeak).toHaveBeenCalledTimes(1);
+      expect(result.current.isSpeaking).toBe(true);
+    });
+    h.playStop.mockClear();
+
+    act(() => {
+      result.current.stopSpeaking();
+    });
+
+    await waitFor(() => {
+      expect(h.playStop).toHaveBeenCalledTimes(1);
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(h.talkStopSpeaking).not.toHaveBeenCalled();
+    expect(result.current.ttsError).toBeNull();
+  });
+
+  it("reports a Play-voice teardown failure without leaving the turn speaking", async () => {
+    const playback = deferred<void>();
+    const stopError = new Error("native stop failed");
+    h.playSpeak.mockImplementation(() => playback.promise);
+    h.playStop.mockRejectedValue(stopError);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const { result } = renderAndroidVoice();
+
+    act(() => {
+      result.current.speak("A response whose native stop fails");
+    });
+    await waitFor(() => {
+      expect(h.playSpeak).toHaveBeenCalledTimes(1);
+      expect(result.current.isSpeaking).toBe(true);
+    });
+
+    act(() => {
+      result.current.stopSpeaking();
+    });
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        { error: stopError },
+        "[useVoiceChat] Native speech teardown failed during barge-in",
+      );
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError).toBeNull();
+  });
+
+  it("preserves TalkMode speak and stop ownership when that plugin is present", async () => {
+    h.useTalkMode = true;
+    const completion = deferred<{
+      completed: boolean;
+      interrupted: boolean;
+      usedSystemTts: boolean;
+    }>();
+    h.talkSpeak.mockImplementation(() => completion.promise);
+    const { result } = renderAndroidVoice();
+
+    act(() => {
+      result.current.speak("TalkMode remains authoritative");
+    });
+    await waitFor(() => {
+      expect(h.talkSpeak).toHaveBeenCalledWith({
+        text: "TalkMode remains authoritative",
+        useLocalInferenceTts: true,
+      });
+    });
+    expect(h.playSpeak).not.toHaveBeenCalled();
+    h.talkStopSpeaking.mockClear();
+    h.playStop.mockClear();
+
+    act(() => {
+      result.current.stopSpeaking();
+    });
+
+    await waitFor(() => {
+      expect(h.talkStopSpeaking).toHaveBeenCalledTimes(1);
+    });
+    expect(h.playStop).not.toHaveBeenCalled();
+    await act(async () => {
+      completion.resolve({
+        completed: true,
+        interrupted: true,
+        usedSystemTts: false,
+      });
+      await completion.promise;
+    });
   });
 });

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -1520,15 +1520,23 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       audioSourceRef.current = null;
     }
 
-    // Native TalkMode TTS — interrupt any in-flight native speak so barge-in
-    // actually silences the agent. Without this the awaited TalkMode.speak()
-    // plays to completion and the agent talks over the user.
+    // Interrupt the native engine that owns the in-flight speak so barge-in
+    // actually silences the agent. Remote-only Android builds omit TalkMode
+    // and use the Play-safe system TTS bridge instead.
     if (Capacitor.isNativePlatform()) {
       // error-policy:J6 best-effort interrupt/teardown of in-flight native speak
       // for barge-in; if the stop fails there is no further recourse here.
-      void getTalkModePlugin()
-        .stopSpeaking?.()
-        .catch(() => {});
+      const talkMode = getTalkModePlugin();
+      const stopNativePlayback =
+        typeof talkMode.stopSpeaking === "function"
+          ? talkMode.stopSpeaking()
+          : getElizaPlayVoicePlugin().stop?.();
+      void stopNativePlayback?.catch((error: unknown) => {
+        logger.warn(
+          { error },
+          "[useVoiceChat] Native speech teardown failed during barge-in",
+        );
+      });
     }
 
     clearSpeechTimers();


### PR DESCRIPTION
## Cause

Remote-only Android Play/VPS builds omit the heavyweight TalkMode plugin and use the Play-safe ElizaPlayVoice bridge. The bridge previously resolved speech as soon as Android accepted the utterance, allowing the renderer to advance before playback ended and leaving barge-in without an owned stop lifecycle.

## Fix

This PR is now one unique commit on current `develop`; the earlier native routing commit is already present upstream and was not replayed.

- retain the Play bridge call until `onDone` and reject terminal playback failures or interruptions;
- add idempotent stop, replacement, destruction, and bounded watchdog handling;
- expose installed TTS engines on Android 11+;
- route barge-in stop to TalkMode when available or ElizaPlayVoice otherwise;
- report best-effort native teardown rejection through the structured logger instead of swallowing it;
- classify a disconnected native engine at the generated boundary before the watchdog translates it to `TTS_TIMEOUT`.

## Scope and provenance

The repaired commit replays only the unique lifecycle delta formerly at `06c403c5f4b`; the prior merge commit and already-landed bridge routing are excluded. Current exact head: `603029a1b9bb7b6d992e100057a5c13f2da9d35d`, based on `origin/develop@01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`.

## Verification

- `packages/ui` Play-voice lifecycle suite: 4/4 pass, including observable teardown failure behavior.
- app-core generated Android/Play-policy suites: 32/32 pass, 230 assertions.
- `packages/ui` typecheck: pass.
- targeted Biome over the six JS/TS files: pass.
- `git diff --check`: pass.
- UI design-system audit: zero findings after the upstream baseline repair; exact hosted run required before merge.

## Risks and limits

Android Play voice calls now remain pending for the real playback lifetime. Missing terminal callbacks fail visibly after bounded stagnation checks. An OEM engine that reports `isSpeaking=true` forever remains indistinguishable from extremely slow healthy playback.

No APK or physical-device lane was available, so this does not claim physical Android audio, OEM engine, Bluetooth, kiosk launcher, or accessibility-speed proof.

## Rollback

Revert exact head `603029a1b9bb7b6d992e100057a5c13f2da9d35d`. No migration or live rollback is required.