### PR TITLE
fix(android): keep chat composer anchored above IME

### DIFF
--- a/packages/app/test/android/touch-gesture.android.spec.ts
+++ b/packages/app/test/android/touch-gesture.android.spec.ts
@@ -815,6 +815,7 @@ test.describe
         );
         const rect = el?.getBoundingClientRect();
         return {
+          composerTop: rect ? rect.top : null,
           composerBottom: rect ? rect.bottom : null,
           viewportHeight: window.visualViewport?.height ?? window.innerHeight,
           innerHeight: window.innerHeight,
@@ -828,6 +829,10 @@ test.describe
         layout.composerBottom as number,
         "the composer must remain above the keyboard (within the visual viewport)",
       ).toBeLessThanOrEqual((layout.viewportHeight as number) + 4);
+      expect(
+        layout.composerBottom as number,
+        "the bottom-anchored composer must not double-lift to the status bar when adjustResize and keyboardWillShow race",
+      ).toBeGreaterThanOrEqual((layout.viewportHeight as number) - 128);
 
       matrixLog.push({ leg: "keyboard-avoidance", keyboardUp, ...layout });
       await testInfo.attach("keyboard avoidance leg", {

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -179,6 +179,7 @@ import {
 import {
   isShortLandscapeViewport,
   measureSafeAreaInsetTop,
+  resolveChatNativeKeyboardLift,
   resolveChatPanelHalfDetentHeight,
   resolveChatPanelLayout,
 } from "./chat-panel-layout";
@@ -2995,11 +2996,19 @@ export function ChatOverlay({
   // iOS the layout doesn't shrink (layoutShrink = 0), so the full native height
   // lifts the fixed composer above the keyboard. Web (no native plugin) keeps
   // the visualViewport-derived inset.
-  const layoutShrink = Math.max(
-    0,
-    baseInnerHeightRef.current - viewport.innerHeight,
-  );
-  const nativeLift = Math.max(0, nativeKeyboardHeight - layoutShrink);
+  // The shipped Android window uses adjustResize, so the native bridge height
+  // must never be applied as an additional fixed-overlay bottom offset. In the
+  // observed race the WebView resized 919→520 before keyboardWillShow; the
+  // effect above then captured 520 as its baseline and a later 398px bridge
+  // event lifted the composer a second time, all the way to the status bar.
+  // iOS keeps the explicit bridge lift because its native window is configured
+  // not to resize around the keyboard.
+  const nativeLift = resolveChatNativeKeyboardLift({
+    platformNeedsNativeLift: isIOS,
+    nativeKeyboardHeight,
+    keyboardDownInnerHeight: baseInnerHeightRef.current,
+    currentInnerHeight: viewport.innerHeight,
+  });
   const effectiveKeyboardInset = Math.max(keyboardInset, nativeLift);
   const keyboardLiftActive = effectiveKeyboardInset > 0;
   // A REAL keyboard (not the few-px inset mobile emulation reports) blocks the

--- a/packages/ui/src/components/shell/chat-panel-layout.test.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   type ChatPanelLayoutInput,
   isShortLandscapeViewport,
+  resolveChatNativeKeyboardLift,
   resolveChatPanelHalfDetentHeight,
   resolveChatPanelLayout,
   SHEET_GRABBER_TOP_CLEARANCE,
@@ -30,6 +31,42 @@ const SCREEN_H = 852; // iPhone 15 logical height
 const NOTCH = 59; // safe-area-inset-top on a Dynamic-Island device
 const KEYBOARD = 336; // iOS soft-keyboard height incl. accessory bar
 const BOTTOM_PAD = 34; // home-indicator safe area at rest
+
+describe("resolveChatNativeKeyboardLift", () => {
+  it("never double-lifts Android when adjustResize wins the event race", () => {
+    // Exact Pixel 11 Pro failure: the WebView had already shrunk 919→520, then
+    // keyboardWillShow delivered 398px. Because the resize arrived first, the
+    // component briefly observed 520 as its keyboard-down baseline. Android's
+    // platform contract must win over that stale baseline and keep bottom: 0.
+    expect(
+      resolveChatNativeKeyboardLift({
+        platformNeedsNativeLift: false,
+        nativeKeyboardHeight: 398,
+        keyboardDownInnerHeight: 520,
+        currentInnerHeight: 520,
+      }),
+    ).toBe(0);
+  });
+
+  it("keeps only the unabsorbed native lift on iOS", () => {
+    expect(
+      resolveChatNativeKeyboardLift({
+        platformNeedsNativeLift: true,
+        nativeKeyboardHeight: 336,
+        keyboardDownInnerHeight: 852,
+        currentInnerHeight: 852,
+      }),
+    ).toBe(336);
+    expect(
+      resolveChatNativeKeyboardLift({
+        platformNeedsNativeLift: true,
+        nativeKeyboardHeight: 336,
+        keyboardDownInnerHeight: 852,
+        currentInnerHeight: 700,
+      }),
+    ).toBe(184);
+  });
+});
 
 describe("resolveChatPanelLayout", () => {
   it("reserves the fixed top margin on web/desktop (no keyboard, no notch)", () => {

--- a/packages/ui/src/components/shell/chat-panel-layout.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.ts
@@ -66,6 +66,53 @@ export interface ChatPanelLayout {
   panelMaxH: number;
 }
 
+export interface ChatNativeKeyboardLiftInput {
+  /**
+   * True only when the native window does not resize around the keyboard.
+   * The shipped iOS shell needs an explicit fixed-overlay lift; Android's
+   * adjustResize window already moves fixed content above the IME.
+   */
+  platformNeedsNativeLift: boolean;
+  /** Keyboard height reported by the native Keyboard bridge. */
+  nativeKeyboardHeight: number;
+  /** Layout viewport height captured while the keyboard was down. */
+  keyboardDownInnerHeight: number;
+  /** Current layout viewport height. */
+  currentInnerHeight: number;
+}
+
+/**
+ * Return only the part of the native keyboard height that the layout viewport
+ * has not already absorbed.
+ *
+ * Android can deliver its resize before `keyboardWillShow`. In that ordering,
+ * a component may observe the shrunken height as both the keyboard-down and
+ * current baseline. Platform-gating is therefore required in addition to the
+ * height delta: the Android bridge height is a visibility signal, never an
+ * instruction to lift a fixed overlay a second time.
+ */
+export function resolveChatNativeKeyboardLift(
+  input: ChatNativeKeyboardLiftInput,
+): number {
+  if (!input.platformNeedsNativeLift) return 0;
+
+  const nativeKeyboardHeight = Number.isFinite(input.nativeKeyboardHeight)
+    ? Math.max(0, input.nativeKeyboardHeight)
+    : 0;
+  const keyboardDownInnerHeight = Number.isFinite(input.keyboardDownInnerHeight)
+    ? Math.max(0, input.keyboardDownInnerHeight)
+    : 0;
+  const currentInnerHeight = Number.isFinite(input.currentInnerHeight)
+    ? Math.max(0, input.currentInnerHeight)
+    : 0;
+  const layoutShrink = Math.max(
+    0,
+    keyboardDownInnerHeight - currentInnerHeight,
+  );
+
+  return Math.max(0, nativeKeyboardHeight - layoutShrink);
+}
+
 /**
  * Resolve the HALF detent without allowing its resting target to exceed the
  * current panel ceiling. Native keyboards can lift an overlay while leaving


### PR DESCRIPTION
## Summary
- prevent Android `adjustResize` from also consuming the native keyboard height as a fixed-overlay lift
- preserve the explicit native lift on iOS, where the shell disables native keyboard resizing
- add the exact Pixel 11 Pro 919→520px event-order regression and strengthen the real-device keyboard assertion

## Root cause
On Android, the WebView resize could commit before `keyboardWillShow`. `ChatOverlay` then captured the already-shrunken height as its keyboard-down baseline and applied the later 398px native height a second time, moving the composer beneath the status bar.

## Verification
- `chat-panel-layout.test.ts`: 23/23
- `ChatOverlay.test.tsx`: 211/211
- `packages/ui` typecheck
- Biome on all four changed files
- Android cloud-debug build + artifact audit
- Pixel 11 Pro: three consecutive Gboard cycles, overlay `bottom: 0`, composer 17.7px above the 520px visible viewport bottom each time
