### PR TITLE
[android-auth-agent-chat] fix(cloud): enforce Personal Shared ownership

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts
@@ -17,9 +17,13 @@ const getAgent = mock(async () => ({ id: "sandbox-agent-1" }));
 const approveTransaction = mock(async () => ({ ok: true, txId: "tx-1" }));
 const denyTransaction = mock(async () => ({}));
 const setPolicies = mock(async () => undefined);
+const stewardGetAgent = mock(async () => ({
+  walletAddress: "0x1",
+  walletAddresses: {},
+}));
 const createStewardClient = mock(async () => ({
   getAddresses: async () => ({ addresses: [] }),
-  getAgent: async () => ({ walletAddress: "0x1", walletAddresses: {} }),
+  getAgent: stewardGetAgent,
   getBalance: async () => ({
     balances: { native: "0", chainId: 56, symbol: "BNB" },
   }),
@@ -62,6 +66,9 @@ mock.module("@/lib/utils/logger", () => ({
 }));
 
 const { handleDirectWalletRequest } = await import("./route");
+const { personalSharedAgentId } = await import(
+  "@/lib/services/shared-runtime/personal-shared-agent"
+);
 
 function context(bodyText: string) {
   return {
@@ -111,5 +118,130 @@ describe("wallet-path malformed JSON", () => {
     );
     expect(response.status).toBe(200);
     expect(approveTransaction).toHaveBeenCalled();
+  });
+
+  test("canonical Personal id bypasses UUID-backed sandbox and wallet repositories", async () => {
+    getAgent.mockClear();
+    dbSelect.mockClear();
+    const personalId = personalSharedAgentId({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({ agentId: personalId, path: ["addresses"] }),
+      "GET",
+    );
+
+    expect(response.status).toBe(200);
+    expect(getAgent).not.toHaveBeenCalled();
+    expect(dbSelect).not.toHaveBeenCalled();
+  });
+
+  test("canonical Personal id without a Steward agent returns the existing typed 404", async () => {
+    getAgent.mockClear();
+    dbSelect.mockClear();
+    stewardGetAgent.mockImplementationOnce(async () => {
+      throw new Error("Steward agent unavailable");
+    });
+    const personalId = personalSharedAgentId({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({ agentId: personalId, path: ["addresses"] }),
+      "GET",
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "No Steward-managed wallet found for this agent",
+    });
+    expect(getAgent).not.toHaveBeenCalled();
+    expect(dbSelect).not.toHaveBeenCalled();
+  });
+
+  test("cross-user Personal id is indistinguishable from a missing agent", async () => {
+    getAgent.mockClear();
+    dbSelect.mockClear();
+    createStewardClient.mockClear();
+    const otherAccountId = personalSharedAgentId({
+      userId: "other-user",
+      organizationId: "org-1",
+    });
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({ agentId: otherAccountId, path: ["addresses"] }),
+      "GET",
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Agent not found",
+    });
+    expect(getAgent).not.toHaveBeenCalled();
+    expect(dbSelect).not.toHaveBeenCalled();
+    expect(createStewardClient).not.toHaveBeenCalled();
+  });
+
+  test("cross-organization Personal id is indistinguishable from a missing agent", async () => {
+    getAgent.mockClear();
+    dbSelect.mockClear();
+    const otherOrganizationId = personalSharedAgentId({
+      userId: "user-1",
+      organizationId: "other-org",
+    });
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({ agentId: otherOrganizationId, path: ["addresses"] }),
+      "GET",
+    );
+
+    expect(response.status).toBe(404);
+    expect(getAgent).not.toHaveBeenCalled();
+    expect(dbSelect).not.toHaveBeenCalled();
+  });
+
+  test("normal sandbox id keeps the organization-scoped sandbox lookup", async () => {
+    getAgent.mockClear();
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({ agentId: "sandbox-agent-1", path: ["addresses"] }),
+      "GET",
+    );
+
+    expect(response.status).toBe(200);
+    expect(getAgent).toHaveBeenCalledWith("sandbox-agent-1", "org-1");
+  });
+
+  test("canonical Personal optional wallet response remains capability-specific", async () => {
+    getAgent.mockClear();
+    createStewardClient.mockClear();
+    const personalId = personalSharedAgentId({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({ agentId: personalId, path: ["nfts"] }),
+      "GET",
+    );
+
+    expect(response.status).toBe(501);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "wallet_nfts_unavailable",
+      capability: "nfts",
+    });
+    expect(getAgent).not.toHaveBeenCalled();
+    expect(createStewardClient).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.json.test.ts
@@ -139,6 +139,26 @@ describe("wallet-path malformed JSON", () => {
     expect(dbSelect).not.toHaveBeenCalled();
   });
 
+  test("canonical Personal id is normalized before Steward lookup", async () => {
+    stewardGetAgent.mockClear();
+    const personalId = personalSharedAgentId({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    const response = await handleDirectWalletRequest(
+      context(""),
+      Promise.resolve({
+        agentId: personalId.toUpperCase(),
+        path: ["addresses"],
+      }),
+      "GET",
+    );
+
+    expect(response.status).toBe(200);
+    expect(stewardGetAgent).toHaveBeenCalledWith(personalId);
+  });
+
   test("canonical Personal id without a Steward agent returns the existing typed 404", async () => {
     getAgent.mockClear();
     dbSelect.mockClear();

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -17,6 +17,10 @@ import {
 } from "@/lib/auth/workers-hono-auth";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import {
+  isPersonalSharedAgentId,
+  personalSharedAgentId,
+} from "@/lib/services/shared-runtime/personal-shared-agent";
 import { createStewardClient } from "@/lib/services/steward-client";
 import { parseClampedLimit, parseClampedOffset } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
@@ -210,6 +214,20 @@ async function resolveStewardAgentIdForProxy(
   sandboxAgentId: string,
   organizationId: string,
 ): Promise<string | null> {
+  // Personal Shared identities are rowless, so they must not enter the
+  // UUID-backed agent_server_wallets lookup. Ownership was already bound to
+  // the authenticated account before this resolver is called.
+  if (isPersonalSharedAgentId(sandboxAgentId)) {
+    try {
+      await client.getAgent(sandboxAgentId);
+      return sandboxAgentId;
+    } catch {
+      // error-policy:J4 Steward treats an unknown Personal id as unavailable;
+      // preserve the route's indistinguishable-not-found contract.
+      return null;
+    }
+  }
+
   const stewardAgentId = await resolveStewardAgentId(
     sandboxAgentId,
     organizationId,
@@ -387,12 +405,28 @@ export async function handleDirectWalletRequest(
     );
   }
 
-  const agent = await elizaSandboxService.getAgent(
-    agentId,
-    user.organization_id,
-  );
-  if (!agent) {
-    return json({ success: false, error: "Agent not found" }, { status: 404 });
+  if (isPersonalSharedAgentId(agentId)) {
+    const expectedPersonalId = personalSharedAgentId({
+      userId: user.id,
+      organizationId: user.organization_id,
+    });
+    if (agentId !== expectedPersonalId) {
+      return json(
+        { success: false, error: "Agent not found" },
+        { status: 404 },
+      );
+    }
+  } else {
+    const agent = await elizaSandboxService.getAgent(
+      agentId,
+      user.organization_id,
+    );
+    if (!agent) {
+      return json(
+        { success: false, error: "Agent not found" },
+        { status: 404 },
+      );
+    }
   }
 
   if (method === "GET" && isOptionalWalletCapability(walletPath)) {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -212,15 +212,21 @@ export async function resolveStewardAgentId(
 async function resolveStewardAgentIdForProxy(
   client: StewardClient,
   sandboxAgentId: string,
+  userId: string,
   organizationId: string,
 ): Promise<string | null> {
   // Personal Shared identities are rowless, so they must not enter the
-  // UUID-backed agent_server_wallets lookup. Ownership was already bound to
-  // the authenticated account before this resolver is called.
+  // UUID-backed agent_server_wallets lookup. Re-derive ownership here so a
+  // future caller cannot rely only on call-site discipline.
   if (isPersonalSharedAgentId(sandboxAgentId)) {
+    const expectedPersonalId = personalSharedAgentId({
+      userId,
+      organizationId,
+    });
+    if (sandboxAgentId.toLowerCase() !== expectedPersonalId) return null;
     try {
-      await client.getAgent(sandboxAgentId);
-      return sandboxAgentId;
+      await client.getAgent(expectedPersonalId);
+      return expectedPersonalId;
     } catch {
       // error-policy:J4 Steward treats an unknown Personal id as unavailable;
       // preserve the route's indistinguishable-not-found contract.
@@ -405,17 +411,19 @@ export async function handleDirectWalletRequest(
     );
   }
 
+  let ownedAgentId = agentId;
   if (isPersonalSharedAgentId(agentId)) {
     const expectedPersonalId = personalSharedAgentId({
       userId: user.id,
       organizationId: user.organization_id,
     });
-    if (agentId !== expectedPersonalId) {
+    if (agentId.toLowerCase() !== expectedPersonalId) {
       return json(
         { success: false, error: "Agent not found" },
         { status: 404 },
       );
     }
+    ownedAgentId = expectedPersonalId;
   } else {
     const agent = await elizaSandboxService.getAgent(
       agentId,
@@ -462,7 +470,8 @@ export async function handleDirectWalletRequest(
 
   const stewardAgentId = await resolveStewardAgentIdForProxy(
     client,
-    agentId,
+    ownedAgentId,
+    user.id,
     user.organization_id,
   );
   if (!stewardAgentId) {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.contract.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.contract.test.ts
@@ -73,6 +73,9 @@ mock.module("@/lib/utils/logger", () => ({
 }));
 
 const { default: agentDetailRoute } = await import("./route");
+const { personalSharedAgentId } = await import(
+  "@/lib/services/shared-runtime/personal-shared-agent"
+);
 
 const app = new Hono<AppEnv>();
 app.route("/api/v1/eliza/agents/:agentId", agentDetailRoute);
@@ -115,9 +118,12 @@ function dedicatedAgent() {
   };
 }
 
-async function getDetail(canonicalAgentBaseDomain?: string) {
+async function getDetail(
+  canonicalAgentBaseDomain?: string,
+  agentId = AGENT_ID,
+) {
   return app.fetch(
-    new Request(`https://api.example.test/api/v1/eliza/agents/${AGENT_ID}`),
+    new Request(`https://api.example.test/api/v1/eliza/agents/${agentId}`),
     {
       ELIZA_CLOUD_AGENT_BASE_DOMAIN: canonicalAgentBaseDomain,
     } as AppEnv["Bindings"],
@@ -178,4 +184,21 @@ describe("owned agent detail private-address contract", () => {
       expect(JSON.stringify(body)).not.toMatch(/100\.64|10\.0|192\.168/);
     },
   );
+
+  test("Personal detail is rejected before the UUID-backed repository", async () => {
+    getAgent.mockClear();
+    const personalId = personalSharedAgentId({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    const response = await getDetail(undefined, personalId);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Agent not found",
+    });
+    expect(getAgent).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.contract.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.contract.test.ts
@@ -201,4 +201,26 @@ describe("owned agent detail private-address contract", () => {
     });
     expect(getAgent).not.toHaveBeenCalled();
   });
+
+  test.each(["PATCH", "DELETE"])(
+    "%s rejects Personal identity before parsing or UUID-backed repository access",
+    async (method) => {
+      getAgent.mockClear();
+      const personalId = personalSharedAgentId({
+        userId: "user-1",
+        organizationId: "org-1",
+      });
+
+      const response = await app.request(`/api/v1/eliza/agents/${personalId}`, {
+        method,
+      });
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({
+        success: false,
+        error: "Agent not found",
+      });
+      expect(getAgent).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -291,6 +291,9 @@ app.patch("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
+    if (isPersonalSharedAgentId(agentId)) {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
     const body = await c.req.json().catch(() => null);
 
     // A body without `action` is an in-place profile edit (rename / config
@@ -471,6 +474,9 @@ app.delete("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
+    if (isPersonalSharedAgentId(agentId)) {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
     let expectedIdentity:
       | {
           agentName: string;

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -21,6 +21,7 @@ import { adminService } from "@/lib/services/admin";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { publicJobErrorSummary } from "@/lib/services/job-error-text";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
+import { isPersonalSharedAgentId } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { getStewardAgent } from "@/lib/services/steward-client";
 import type {
   AgentAdminDetailsDto,
@@ -136,6 +137,13 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
+
+    // Personal Shared identities are rowless namespaced ids. Reject them
+    // before the UUID-backed repository so this endpoint remains a uniform
+    // not-found boundary during Shared-to-Dedicated handoff polling.
+    if (isPersonalSharedAgentId(agentId)) {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
 
     const agent = await elizaSandboxService.getAgent(
       agentId,


### PR DESCRIPTION
## Cause

Personal Shared agent IDs are tenant-derived, but the wallet and detail routes could route an arbitrary Personal ID into UUID-backed repositories before proving that it belongs to the authenticated user and organization. That left a cross-user/cross-organization authorization gap and unstable behavior for the virtual Personal agent.

## Fix

- Derive the canonical Personal Shared ID from the authenticated user and organization.
- Re-derive and enforce that ownership inside the wallet resolver, so future callers cannot bypass the boundary through call-site assumptions.
- Normalize the case-insensitive Personal ID form to the canonical lower-case Steward identity.
- Return the same 404 before repository or Steward access when a Personal ID does not match that canonical ID.
- Bypass UUID-backed repositories for the canonical virtual Personal agent.
- Reject Personal IDs from GET, PATCH, and DELETE agent-detail paths before repository I/O; mutations fail before body parsing.
- Preserve tenant-scoped Steward behavior, optional wallet capability responses, and ordinary sandbox agent lookups.

## Scope and stack

- Rebased directly on develop at `01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`.
- Exact candidate: `b73bcd82a6d`.
- Supersedes the conflicted ownership work in #28985, carrying forward its intended guard and the follow-up repair onto current develop.
- Related to #28500; this PR intentionally does not close it because widget provisioning coverage and staging verification remain separate acceptance criteria.

## Validation

- Wallet route: 11/11 passed, 34 assertions.
- Agent detail route: 9/9 passed, 32 assertions.
- Cloud API TypeScript check and Worker production bundle dry-run passed.
- Four-file Biome check and `git diff --check` passed.
- Independent exact-head authorization review requested for `b73bcd82a6d`.

## Risk / rollback

Risk is limited to Personal Shared wallet/detail routing. Ordinary sandbox routing remains covered. Rollback is a revert of the two PR commits. No deployment, migration, restart, or live configuration change was performed.
