### PR TITLE
[android-auth-agent-chat] fix(voice): bind self-hosted realtime readiness

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts
@@ -179,6 +179,23 @@ if (process.env.ELIZA_PROCESS_ISOLATED_TEST === "1") {
       expect(health.status).toBe(200);
       expect((await health.json()) as unknown).toEqual({ ready: true });
 
+      const scopedHealth = await fetch(
+        `${server.httpUrl}/api/v1/voice/session/health?conversationId=${encodeURIComponent(CONVERSATION_ID)}`,
+      );
+      expect(scopedHealth.status).toBe(200);
+      expect((await scopedHealth.json()) as unknown).toEqual({
+        ready: true,
+        conversationId: CONVERSATION_ID,
+      });
+
+      const mismatchedHealth = await fetch(
+        `${server.httpUrl}/api/v1/voice/session/health?conversationId=another-conversation`,
+      );
+      expect(mismatchedHealth.status).toBe(200);
+      expect((await mismatchedHealth.json()) as unknown).toEqual({
+        ready: false,
+      });
+
       const consent = await fetch(
         `${server.httpUrl}/api/v1/voice/session/consent`,
         { method: "POST" },

--- a/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
+++ b/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
@@ -424,7 +424,18 @@ export async function startRealVoiceServer(
       req.method === "GET" &&
       url.pathname === "/api/v1/voice/session/health"
     ) {
-      writeJson(res, 200, { ready: true });
+      const requestedConversationIds =
+        url.searchParams.getAll("conversationId");
+      const conversationReady =
+        requestedConversationIds.length === 0 ||
+        (requestedConversationIds.length === 1 &&
+          requestedConversationIds[0] === config.conversationId);
+      writeJson(res, 200, {
+        ready: conversationReady,
+        ...(conversationReady && requestedConversationIds.length === 1
+          ? { conversationId: requestedConversationIds[0] }
+          : {}),
+      });
       return;
     }
     if (req.method === "POST" && url.pathname === "/api/v1/voice/tts") {

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -393,10 +393,10 @@ export function ChatView({
     : undefined;
   // Resolve the realtime-voice mint inputs (agent UUID + consent nonce) from the
   // same auth/runtime source the app uses for every other /api/v1 call. A
-  // local/self-hosted runtime yields a null agentId, so the realtime path never
-  // arms and the mic runs the batch flow unchanged.
+  // self-hosted runtime arms only when its gateway proves the active
+  // conversation; otherwise agentId stays null and batch owns the mic.
   const { agentId: realtimeAgentId, getConsentNonce: getRealtimeConsentNonce } =
-    useRealtimeVoiceMint();
+    useRealtimeVoiceMint({ conversationId: activeConversationId });
   const {
     beginVoiceCapture,
     composerVoice,

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -125,6 +125,7 @@ const realtimeVoiceMock = vi.hoisted(() => {
     options: null as {
       agentId?: string | null;
       conversationId?: string | null;
+      flagEnabled?: boolean;
       clientOptions?: {
         onServerEvent?: (event: ServerControlFrame) => void;
       };
@@ -180,13 +181,11 @@ const realtimeVoiceMock = vi.hoisted(() => {
 
 const realtimeVoiceMintMock = vi.hoisted(() => ({
   agentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee" as string | null,
+  getConsentNonce: vi.fn(async () => "consent-nonce"),
 }));
 
 vi.mock("../../../hooks/useRealtimeVoiceMint", () => ({
-  useRealtimeVoiceMint: () => ({
-    agentId: realtimeVoiceMintMock.agentId,
-    getConsentNonce: vi.fn(async () => "consent-nonce"),
-  }),
+  useRealtimeVoiceMint: () => realtimeVoiceMintMock,
 }));
 
 vi.mock("../../../hooks/useRealtimeVoiceSession", () => ({
@@ -194,6 +193,7 @@ vi.mock("../../../hooks/useRealtimeVoiceSession", () => ({
   useRealtimeVoiceSession: (options: {
     agentId?: string | null;
     conversationId?: string | null;
+    flagEnabled?: boolean;
     clientOptions?: {
       onServerEvent?: (event: ServerControlFrame) => void;
     };
@@ -288,14 +288,17 @@ const voiceOutputMock = vi.hoisted(() => ({
   // return), so this real consumer boundary is where the flag is observable.
   lastTurnVoiceSeen: undefined as boolean | undefined,
   cloudConnectedSeen: undefined as boolean | undefined,
+  realtimeVoiceEnabledSeen: undefined as boolean | undefined,
 }));
 vi.mock("../useShellVoiceOutput", () => ({
   useShellVoiceOutput: (opts?: {
     lastTurnVoice?: boolean;
     cloudConnected?: boolean;
+    realtimeVoiceEnabled?: boolean;
   }) => {
     voiceOutputMock.lastTurnVoiceSeen = opts?.lastTurnVoice;
     voiceOutputMock.cloudConnectedSeen = opts?.cloudConnected;
+    voiceOutputMock.realtimeVoiceEnabledSeen = opts?.realtimeVoiceEnabled;
     return voiceOutputMock;
   },
 }));
@@ -362,6 +365,7 @@ afterEach(() => {
   voiceOutputMock.stopSpeaking.mockClear();
   voiceOutputMock.lastTurnVoiceSeen = undefined;
   voiceOutputMock.cloudConnectedSeen = undefined;
+  voiceOutputMock.realtimeVoiceEnabledSeen = undefined;
   wakeListenMock.lastEnabled = undefined;
   wakeListenMock.onOpen = undefined;
   micPermissionMock.query.mockReset();
@@ -370,6 +374,7 @@ afterEach(() => {
   );
   realtimeVoiceMock.enabled = false;
   realtimeVoiceMintMock.agentId = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+  realtimeVoiceMintMock.getConsentNonce.mockClear();
   realtimeVoiceMock.options = null;
   realtimeVoiceMock.startOutcome = { kind: "live" };
   realtimeVoiceMock.startedConversationIds.length = 0;
@@ -2164,6 +2169,8 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     realtimeVoiceMock.startedConversationIds.length = 0;
     realtimeVoiceMock.start.mockClear();
     realtimeVoiceMock.stop.mockClear();
+    lastCaptureOpts = null;
+    captureHandles = [];
     createVoiceCaptureMock.mockReset();
     installFakeCapture();
     appMock.value.activeConversationId = conversationId;
@@ -2213,6 +2220,173 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     expect(result.current.handsFree).toBe(true);
     expect(result.current.realtimeVoice?.enabled).toBe(false);
     expect(result.current.realtimeVoice?.error).toBeNull();
+  });
+
+  it("routes a negative conversation probe to batch capture and output", async () => {
+    realtimeVoiceMock.state.available = false;
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+
+    expect(realtimeVoiceMock.start).not.toHaveBeenCalled();
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    expect(result.current.handsFree).toBe(true);
+    expect(result.current.realtimeVoice?.enabled).toBe(false);
+    expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(false);
+
+    act(() => fireFinalTranscript("continue in batch"));
+    expect(appMock.value.sendChatText).toHaveBeenCalledWith(
+      "continue in batch",
+      expect.objectContaining({ channelType: "VOICE_DM" }),
+    );
+  });
+
+  it("stops a latched batch fallback with one Talk tap", async () => {
+    realtimeVoiceMock.state.available = false;
+    const { result, rerender } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+    expect(result.current.handsFree).toBe(true);
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      realtimeVoiceMock.state.available = true;
+      rerender();
+      await Promise.resolve();
+    });
+    expect(realtimeVoiceMock.start).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+
+    expect(result.current.handsFree).toBe(false);
+    expect(captureHandles[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(realtimeVoiceMock.start).not.toHaveBeenCalled();
+  });
+
+  it("latches a recovered probe to batch until the current Talk session ends", async () => {
+    vi.useFakeTimers();
+    try {
+      const nextConversationId = "22222222-2222-4222-8222-222222222222";
+      const { result, rerender } = renderHook(() => useShellController());
+
+      await act(async () => {
+        result.current.toggleHandsFree();
+        await Promise.resolve();
+      });
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        realtimeVoiceMock.state.active = true;
+        realtimeVoiceMock.state.status = "listening";
+        rerender();
+      });
+
+      await act(async () => {
+        appMock.value.activeConversationId = nextConversationId;
+        realtimeVoiceMintMock.agentId = null;
+        realtimeVoiceMock.state.available = false;
+        realtimeVoiceMock.state.active = false;
+        realtimeVoiceMock.state.status = "idle";
+        rerender();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(result.current.handsFree).toBe(true);
+      expect(result.current.realtimeVoice?.enabled).toBe(false);
+      expect(realtimeVoiceMock.options?.flagEnabled).toBe(false);
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+      expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+      expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(false);
+
+      await act(async () => {
+        realtimeVoiceMintMock.agentId = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+        realtimeVoiceMock.state.available = true;
+        rerender();
+        await Promise.resolve();
+      });
+      // Do not overlap microphones or steal output: the entire current Talk
+      // session stays batch even though the probe recovered.
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+      expect(result.current.realtimeVoice?.enabled).toBe(false);
+      expect(realtimeVoiceMock.options?.flagEnabled).toBe(true);
+      expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(false);
+
+      // Ending batch Talk is not enough to release the latch while that turn's
+      // text is still streaming. Drive the composer's live source (not the
+      // stale AppContext mirror), then stop Talk and its capture.
+      composerMock.value.chatSending = true;
+      await act(async () => {
+        result.current.toggleHandsFree();
+        await Promise.resolve();
+      });
+      expect(result.current.handsFree).toBe(false);
+      expect(captureHandles[0]?.stop).toHaveBeenCalledTimes(1);
+      expect(result.current.responding).toBe(true);
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+      expect(result.current.realtimeVoice?.enabled).toBe(false);
+      expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(false);
+
+      // The same batch turn moves from streaming to TTS. With Talk already off,
+      // speaking is now the only remaining owner and must keep realtime latched.
+      await act(async () => {
+        composerMock.value.chatSending = false;
+        voiceOutputMock.speaking = true;
+        rerender();
+        await Promise.resolve();
+      });
+      expect(result.current.handsFree).toBe(false);
+      expect(result.current.responding).toBe(true);
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+      expect(result.current.realtimeVoice?.enabled).toBe(false);
+      expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(false);
+
+      // Once TTS settles, every batch owner is idle and the recovered probe may
+      // make realtime selectable again. It still must not auto-start the mic.
+      await act(async () => {
+        voiceOutputMock.speaking = false;
+        rerender();
+        await Promise.resolve();
+      });
+      expect(result.current.responding).toBe(false);
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+      expect(result.current.realtimeVoice?.enabled).toBe(true);
+      expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(true);
+
+      // The next explicit Talk gesture starts realtime against the newly active
+      // conversation; probe recovery alone never steals the microphone.
+      await act(async () => {
+        result.current.toggleHandsFree();
+        await Promise.resolve();
+      });
+
+      expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(2);
+      expect(realtimeVoiceMock.startedConversationIds).toEqual([
+        conversationId,
+        nextConversationId,
+      ]);
+      expect(result.current.handsFree).toBe(true);
+      expect(result.current.realtimeVoice?.enabled).toBe(true);
+      expect(voiceOutputMock.realtimeVoiceEnabledSeen).toBe(true);
+      expect(appMock.value.setActionNotice).not.toHaveBeenCalledWith(
+        expect.stringContaining("Cartesia voice is not ready"),
+        "error",
+        expect.any(Number),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("routes programmatic converse capture to one realtime session", async () => {

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -2272,6 +2272,69 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     expect(realtimeVoiceMock.start).not.toHaveBeenCalled();
   });
 
+  it("keeps recovered realtime parked until a deferred batch STT stop drains", async () => {
+    realtimeVoiceMock.state.available = false;
+    const { result, rerender } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("ptt");
+      await Promise.resolve();
+    });
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    expect(result.current.recording).toBe(true);
+
+    const captureOptions = lastCaptureOpts;
+    let releaseStop: (() => void) | undefined;
+    const stopDrain = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    captureHandles[0]?.stop.mockImplementation(async () => {
+      await stopDrain;
+      captureOptions?.onStateChange?.("stopped");
+    });
+
+    await act(async () => {
+      realtimeVoiceMock.state.available = true;
+      rerender();
+      await Promise.resolve();
+    });
+    expect(result.current.realtimeVoice?.enabled).toBe(false);
+
+    // Releasing PTT closes the visible mic immediately, but the batch owner is
+    // still draining STT. A recovered probe must stay latched to batch and a
+    // second Talk tap must not hand microphone/audio ownership to realtime.
+    await act(async () => {
+      result.current.stopRecording();
+      await Promise.resolve();
+    });
+    expect(result.current.recording).toBe(false);
+    expect(result.current.phase).toBe("processing");
+    expect(captureHandles[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(result.current.realtimeVoice?.enabled).toBe(false);
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+    expect(realtimeVoiceMock.start).not.toHaveBeenCalled();
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    expect(result.current.handsFree).toBe(false);
+
+    await act(async () => {
+      releaseStop?.();
+      await stopDrain;
+      await Promise.resolve();
+    });
+    expect(result.current.realtimeVoice?.enabled).toBe(true);
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+    expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+    expect(result.current.handsFree).toBe(true);
+  });
+
   it("latches a recovered probe to batch until the current Talk session ends", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -2025,7 +2025,7 @@ export function useShellController(): ShellController {
   const startRealtimeVoice = React.useCallback(async () => {
     if (authGateRef.current.gated) return;
     if (!realtimeVoiceCanStart) return;
-    if (captureRef.current || recording) return;
+    if (captureRef.current || recording || sttPending) return;
     if (
       realtimeVoiceWantedRef.current ||
       realtimeVoiceRef.current.active ||
@@ -2090,6 +2090,7 @@ export function useShellController(): ShellController {
     realtimeVoiceCanStart,
     recording,
     setActionNotice,
+    sttPending,
     stopCapture,
   ]);
   startRealtimeVoiceRef.current = () => {
@@ -2130,6 +2131,7 @@ export function useShellController(): ShellController {
       realtimeVoice.connecting ||
       captureRef.current ||
       recording ||
+      sttPending ||
       chatSending ||
       voiceOutput.speaking
     ) {
@@ -2146,6 +2148,7 @@ export function useShellController(): ShellController {
     realtimeVoice.connecting,
     realtimeVoiceEnabled,
     recording,
+    sttPending,
     voiceOutput.speaking,
   ]);
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -586,27 +586,53 @@ export function useShellController(): ShellController {
   );
 
   // The persistent shell is the mounted /chat surface, so it owns the one
-  // realtime session. ChatView may still consume the same hook on legacy
-  // embedding surfaces, but the visible shell Talk control must never hand a
-  // failed Cartesia interaction to the unrelated batch Cloud-ASR recorder.
+  // realtime session. The build flag advertises the capability, but only a
+  // resolved Dedicated identity plus a healthy conversation-bound probe may
+  // select realtime. Otherwise the same Talk control deliberately remains
+  // usable through the batch ASR/TTS path.
   const realtimeVoiceBuildEnabled = isRealtimeVoiceFlagEnabled();
   const { agentId: realtimeVoiceAgentId, getConsentNonce } =
-    useRealtimeVoiceMint();
-  // The build flag advertises the capability, but only a resolved Dedicated
-  // agent may own Talk. A stale Shared binding has no mintable UUID; retain the
-  // established batch path until signed-in routing repairs it to Dedicated.
-  const realtimeVoiceEnabled =
+    useRealtimeVoiceMint({ conversationId: activeConversationId });
+  // Keep the capability eligible while the first conversation is being
+  // created so a Talk gesture can queue against the UUID published by startup.
+  // The session hook still requires both ids before it reports `available`.
+  const realtimeVoiceCapabilityEnabled =
     realtimeVoiceBuildEnabled && Boolean(realtimeVoiceAgentId);
   const realtimeVoice = useRealtimeVoiceSession({
     agentId: realtimeVoiceAgentId,
     conversationId: activeConversationId,
-    flagEnabled: realtimeVoiceEnabled,
+    // Treat probe/identity loss as an operational flag-off edge. The session
+    // hook's flag effect cancels any pending automatic identity restart before
+    // a fast probe recovery can re-open the microphone without a new gesture.
+    flagEnabled: realtimeVoiceCapabilityEnabled,
     getConsentNonce,
     clientOptions: { onServerEvent: handleRealtimeVoiceServerEvent },
   });
+  const realtimeVoiceEnabled =
+    realtimeVoiceCapabilityEnabled && realtimeVoice.available;
+  // A resolved Dedicated identity may queue Talk while startup is still
+  // publishing the first conversation. Once a conversation exists, the
+  // conversation-bound availability probe is authoritative.
+  const realtimeVoiceCanStart =
+    realtimeVoiceEnabled ||
+    (realtimeVoiceCapabilityEnabled && !activeConversationId?.trim());
+  const [realtimeVoiceBatchFallback, setRealtimeVoiceBatchFallback] =
+    React.useState(!realtimeVoiceEnabled);
+  const realtimeVoiceSelected =
+    realtimeVoiceEnabled && !realtimeVoiceBatchFallback;
+  // During an identity handoff the availability probe disarms before the old
+  // client finishes teardown. Keep batch media out until that prior owner has
+  // actually released the microphone/audio path.
+  const realtimeVoiceOwnsMedia =
+    realtimeVoiceBuildEnabled &&
+    (realtimeVoiceSelected ||
+      realtimeVoice.active ||
+      realtimeVoice.connecting ||
+      realtimeVoice.agentSpeaking);
   const realtimeVoiceRef = React.useRef(realtimeVoice);
   realtimeVoiceRef.current = realtimeVoice;
   const realtimeVoiceWantedRef = React.useRef(false);
+  const realtimeVoiceWasEnabledRef = React.useRef(realtimeVoiceEnabled);
   // True once the CURRENT wanted session has reached live; distinguishes a
   // mid-session death (parked by the effect below startRealtimeVoice) from an
   // initial start failure (owned by startRealtimeVoice's outcome handling).
@@ -1258,16 +1284,15 @@ export function useShellController(): ShellController {
       // requestSignIn themselves; auto-engage must not pop a login from an
       // effect (that would lose the gesture and fall into same-tab).
       if (authGateRef.current.gated) return;
-      // Cartesia realtime owns conversational Talk end to end. Every legacy
-      // boot/re-listen/wake path converges here, so this guard is the hard
-      // boundary that prevents an effect from silently reopening batch Cloud
-      // ASR while realtime owns or wants the microphone. Explicit long-form
-      // transcription remains a separate, labeled recorder.
+      // Every legacy boot/re-listen/wake path converges here. Route a healthy,
+      // conversation-bound realtime seam to Cartesia, but keep batch closed
+      // while an old realtime owner is still releasing media after a probe or
+      // identity change. A steady negative probe falls through to batch.
       if (
-        realtimeVoiceEnabled &&
+        realtimeVoiceOwnsMedia &&
         (intent === undefined || intent === "converse")
       ) {
-        startRealtimeVoiceRef.current();
+        if (realtimeVoiceSelected) startRealtimeVoiceRef.current();
         return;
       }
       // Voice capture is independent of agent-respond readiness. A converse
@@ -1394,7 +1419,7 @@ export function useShellController(): ShellController {
               // the mic ON — resume the hands-free loop it paused on enter.
               if (resumeHandsFreeAfterTranscriptRef.current) {
                 resumeHandsFreeAfterTranscriptRef.current = false;
-                if (realtimeVoiceEnabled) {
+                if (realtimeVoiceSelected) {
                   startRealtimeVoiceRef.current();
                 } else {
                   setHandsFree(true);
@@ -1568,7 +1593,8 @@ export function useShellController(): ShellController {
         });
     },
     [
-      realtimeVoiceEnabled,
+      realtimeVoiceSelected,
+      realtimeVoiceOwnsMedia,
       send,
       stopCapture,
       finalizeTranscriptSession,
@@ -1683,16 +1709,19 @@ export function useShellController(): ShellController {
       recoverGatedCapture();
       return;
     }
-    if (realtimeVoiceEnabled) {
-      if (realtimeVoiceWantedRef.current) stopRealtimeVoiceRef.current();
-      else startRealtimeVoiceRef.current();
+    if (realtimeVoiceCanStart) {
+      if (recording || handsFreeRef.current || realtimeVoiceWantedRef.current) {
+        stopRealtimeVoiceRef.current();
+      } else {
+        startRealtimeVoiceRef.current();
+      }
       return;
     }
     if (recording) stopCapture();
     else startCapture();
   }, [
     authGate.gated,
-    realtimeVoiceEnabled,
+    realtimeVoiceCanStart,
     recording,
     recoverGatedCapture,
     startCapture,
@@ -1709,10 +1738,9 @@ export function useShellController(): ShellController {
   // at most once per mount so a later tap-off (which persists "off") isn't
   // re-engaged by this effect re-running.
   React.useEffect(() => {
-    // Realtime restoration is owned below by the Cartesia start boundary. The
-    // batch restore must remain completely inert or it can light a phantom
-    // hands-free state while startCapture correctly refuses Cloud ASR.
-    if (realtimeVoiceEnabled) return;
+    // Batch restore stays inert only while realtime is eligible or still owns
+    // media. A negative conversation probe intentionally restores batch.
+    if (realtimeVoiceOwnsMedia) return;
     if (autoEngagedHandsFreeRef.current) return;
     // Cloud-only signed out: leave the ref unset so a later sign-in retries
     // this restore; auto-engage must not light hands-free against the gate.
@@ -1752,6 +1780,7 @@ export function useShellController(): ShellController {
         return;
       }
       setHandsFree(true);
+      handsFreeRef.current = true;
       setIsOpen(true);
       startCapture("converse");
     });
@@ -1762,7 +1791,7 @@ export function useShellController(): ShellController {
     chatSending,
     startCapture,
     recheckMicPermission,
-    realtimeVoiceEnabled,
+    realtimeVoiceOwnsMedia,
     authGate.gated,
   ]);
 
@@ -1815,7 +1844,7 @@ export function useShellController(): ShellController {
       connected: elizaCloudConnected,
       proxyAvailable: elizaCloudVoiceProxyAvailable,
     }),
-    realtimeVoiceEnabled,
+    realtimeVoiceEnabled: realtimeVoiceOwnsMedia,
   });
   // Wire the forward ref so the conversation-switch / clear handlers (defined
   // above `voiceOutput`) can stop in-flight assistant speech at gesture time.
@@ -1835,17 +1864,18 @@ export function useShellController(): ShellController {
   // after the mic opens (which flips phase to "listening"), so the composer-send
   // and voice-gating logic both read one honest "a reply is in flight" signal.
   const realtimeVoiceResponding =
-    realtimeVoiceEnabled &&
+    realtimeVoiceOwnsMedia &&
     (realtimeVoice.status === "thinking" ||
       realtimeVoice.status === "speaking" ||
       realtimeVoice.status === "interrupting");
   const realtimeVoiceListening =
-    realtimeVoiceEnabled &&
+    realtimeVoiceOwnsMedia &&
     (realtimeVoice.connecting ||
       realtimeVoice.status === "listening" ||
       realtimeVoice.status === "transcribing");
   const realtimeVoiceRecording =
-    realtimeVoiceEnabled && (realtimeVoice.active || realtimeVoice.connecting);
+    realtimeVoiceOwnsMedia &&
+    (realtimeVoice.active || realtimeVoice.connecting);
   const responding =
     chatSending || voiceOutput.speaking || realtimeVoiceResponding;
 
@@ -1859,7 +1889,7 @@ export function useShellController(): ShellController {
     if (voiceOutput.speaking || realtimeVoice.agentSpeaking) {
       return { kind: "speaking" };
     }
-    if (realtimeVoiceEnabled && realtimeVoice.status === "thinking") {
+    if (realtimeVoiceOwnsMedia && realtimeVoice.status === "thinking") {
       return { kind: "thinking" };
     }
     if (
@@ -1876,7 +1906,7 @@ export function useShellController(): ShellController {
     voiceOutput.speaking,
     realtimeVoice.agentSpeaking,
     realtimeVoice.status,
-    realtimeVoiceEnabled,
+    realtimeVoiceOwnsMedia,
     serverTurnStatus,
     chatSending,
     chatFirstTokenReceived,
@@ -1994,7 +2024,8 @@ export function useShellController(): ShellController {
 
   const startRealtimeVoice = React.useCallback(async () => {
     if (authGateRef.current.gated) return;
-    if (!realtimeVoiceEnabled) return;
+    if (!realtimeVoiceCanStart) return;
+    if (captureRef.current || recording) return;
     if (
       realtimeVoiceWantedRef.current ||
       realtimeVoiceRef.current.active ||
@@ -2002,6 +2033,7 @@ export function useShellController(): ShellController {
     ) {
       return;
     }
+    setRealtimeVoiceBatchFallback(false);
 
     const prior = loadContinuousChatMode();
     if (prior !== "always-on") priorContinuousModeRef.current = prior;
@@ -2055,7 +2087,8 @@ export function useShellController(): ShellController {
     setActionNotice(message, "error", 6000);
   }, [
     ensureActiveConversationForVoice,
-    realtimeVoiceEnabled,
+    realtimeVoiceCanStart,
+    recording,
     setActionNotice,
     stopCapture,
   ]);
@@ -2063,6 +2096,58 @@ export function useShellController(): ShellController {
     void startRealtimeVoice();
   };
   stopRealtimeVoiceRef.current = stopRealtimeVoice;
+
+  // Availability is conversation-scoped. If the active conversation stops
+  // matching the local gateway, latch this Talk session onto batch ASR/TTS.
+  // A later positive probe must not steal a batch turn between capture, text,
+  // and playback; realtime becomes selectable again only after Talk is off and
+  // every batch owner is idle.
+  React.useEffect(() => {
+    const wasEnabled = realtimeVoiceWasEnabledRef.current;
+    realtimeVoiceWasEnabledRef.current = realtimeVoiceEnabled;
+
+    if (wasEnabled && !realtimeVoiceEnabled) {
+      const shouldContinue =
+        realtimeVoiceWantedRef.current ||
+        realtimeVoice.active ||
+        realtimeVoice.connecting;
+      realtimeVoiceWantedRef.current = false;
+      realtimeVoiceWasActiveRef.current = false;
+      setRealtimeVoiceBatchFallback(true);
+      setRealtimeVoiceBoundaryError(null);
+      if (shouldContinue) {
+        setHandsFree(true);
+        handsFreeRef.current = true;
+        setIsOpen(true);
+      }
+    }
+
+    if (!realtimeVoiceEnabled || !realtimeVoiceBatchFallback) return;
+    if (
+      authGate.gated ||
+      handsFree ||
+      realtimeVoice.active ||
+      realtimeVoice.connecting ||
+      captureRef.current ||
+      recording ||
+      chatSending ||
+      voiceOutput.speaking
+    ) {
+      return;
+    }
+
+    setRealtimeVoiceBatchFallback(false);
+  }, [
+    authGate.gated,
+    chatSending,
+    handsFree,
+    realtimeVoice.active,
+    realtimeVoiceBatchFallback,
+    realtimeVoice.connecting,
+    realtimeVoiceEnabled,
+    recording,
+    voiceOutput.speaking,
+  ]);
 
   const stopRecording = React.useCallback(() => {
     if (
@@ -2090,7 +2175,7 @@ export function useShellController(): ShellController {
     if (realtimeVoice.active) realtimeVoiceWasActiveRef.current = true;
   }, [realtimeVoice.active]);
   React.useEffect(() => {
-    if (!realtimeVoiceEnabled) return;
+    if (!realtimeVoiceSelected) return;
     if (!realtimeVoice.error) return;
     if (realtimeVoice.active || realtimeVoice.connecting) return;
     if (!realtimeVoiceWasActiveRef.current) return;
@@ -2102,24 +2187,24 @@ export function useShellController(): ShellController {
     handsFreeRef.current = false;
     setActionNotice(realtimeVoice.error.message, "error", 6000);
   }, [
-    realtimeVoiceEnabled,
+    realtimeVoiceSelected,
     realtimeVoice.error,
     realtimeVoice.active,
     realtimeVoice.connecting,
     setActionNotice,
   ]);
 
-  // Persisted always-on remains one setting across providers, but Cartesia owns
-  // its own restoration path. In particular, no batch recorder is opened while
-  // realtime is selected or waiting for its health/identity seam to settle.
+  // Persisted always-on remains one setting across providers. Once the
+  // conversation-bound probe is eligible, Cartesia reclaims an idle Talk loop;
+  // a negative probe leaves the batch restoration path authoritative.
   React.useEffect(() => {
-    if (!realtimeVoiceEnabled || autoEngagedHandsFreeRef.current) return;
+    if (!realtimeVoiceSelected || autoEngagedHandsFreeRef.current) return;
     if (!ready || chatSending || realtimeVoice.connecting) return;
     if (loadContinuousChatMode() !== "always-on") return;
     autoEngagedHandsFreeRef.current = true;
     priorContinuousModeRef.current = "off";
     startRealtimeVoiceRef.current();
-  }, [chatSending, ready, realtimeVoice.connecting, realtimeVoiceEnabled]);
+  }, [chatSending, ready, realtimeVoice.connecting, realtimeVoiceSelected]);
 
   // Tap-to-talk: toggle a hands-free conversation. Enabling unlocks audio (the
   // tap is the gesture) and opens the mic in "converse" mode; disabling stops
@@ -2129,8 +2214,9 @@ export function useShellController(): ShellController {
       recoverGatedCapture();
       return;
     }
-    if (realtimeVoiceEnabled) {
+    if (realtimeVoiceCanStart) {
       if (
+        handsFreeRef.current ||
         realtimeVoiceWantedRef.current ||
         realtimeVoiceRef.current.active ||
         realtimeVoiceRef.current.connecting
@@ -2146,6 +2232,7 @@ export function useShellController(): ShellController {
       // "vad-gated" choice survives) and stop the mic + any in-flight reply.
       saveContinuousChatMode(priorContinuousModeRef.current);
       setHandsFree(false);
+      handsFreeRef.current = false;
       if (captureRef.current) stopCapture();
       voiceOutput.stopSpeaking();
     } else {
@@ -2193,7 +2280,7 @@ export function useShellController(): ShellController {
     stopCapture,
     voiceOutput,
     gateEngageOnMicPermission,
-    realtimeVoiceEnabled,
+    realtimeVoiceCanStart,
     startRealtimeVoice,
     stopRealtimeVoice,
   ]);
@@ -2211,7 +2298,7 @@ export function useShellController(): ShellController {
         if (continuous === "always-on") {
           if (handsFreeRef.current) return;
           priorContinuousModeRef.current = "off";
-          if (realtimeVoiceEnabled) {
+          if (realtimeVoiceSelected) {
             startRealtimeVoiceRef.current();
             return;
           }
@@ -2224,7 +2311,7 @@ export function useShellController(): ShellController {
 
         priorContinuousModeRef.current = continuous;
         if (!handsFreeRef.current) return;
-        if (realtimeVoiceEnabled) {
+        if (realtimeVoiceSelected) {
           stopRealtimeVoiceRef.current();
           return;
         }
@@ -2234,7 +2321,7 @@ export function useShellController(): ShellController {
         voiceOutput.stopSpeaking();
       },
       [
-        realtimeVoiceEnabled,
+        realtimeVoiceSelected,
         responding,
         startCapture,
         stopCapture,
@@ -2267,7 +2354,7 @@ export function useShellController(): ShellController {
       // the subscription. The callback itself is the final boundary.
       if (authGateRef.current.gated) return;
       setIsOpen(true);
-      if (realtimeVoiceEnabled) {
+      if (realtimeVoiceSelected) {
         startRealtimeVoiceRef.current();
         return;
       }
@@ -2275,17 +2362,17 @@ export function useShellController(): ShellController {
       handsFreeRef.current = true;
       voiceOutput.unlockAudio();
       if (!responding && !captureRef.current) startCapture("converse");
-    }, [realtimeVoiceEnabled, responding, startCapture, voiceOutput]),
+    }, [realtimeVoiceSelected, responding, startCapture, voiceOutput]),
     onClose: React.useCallback(() => {
       // Close the temporary window without disturbing a persisted mode.
-      if (realtimeVoiceEnabled) {
+      if (realtimeVoiceSelected) {
         stopRealtimeVoiceRef.current();
         return;
       }
       setHandsFree(false);
       handsFreeRef.current = false;
       if (captureRef.current) stopCapture();
-    }, [realtimeVoiceEnabled, stopCapture]),
+    }, [realtimeVoiceSelected, stopCapture]),
   });
 
   // Toggle transcription mode (long-form, record-only — the agent never replies
@@ -2311,7 +2398,7 @@ export function useShellController(): ShellController {
       // button — handleMicClick → stopTranscriptionAndMic — turns the mic off.)
       if (resumeHandsFreeAfterTranscriptRef.current) {
         resumeHandsFreeAfterTranscriptRef.current = false;
-        if (realtimeVoiceEnabled) {
+        if (realtimeVoiceSelected) {
           startRealtimeVoiceRef.current();
         } else {
           setHandsFree(true);
@@ -2325,7 +2412,7 @@ export function useShellController(): ShellController {
       // disables the mic.
       resumeHandsFreeAfterTranscriptRef.current = handsFreeRef.current;
       if (handsFreeRef.current) {
-        if (realtimeVoiceEnabled) {
+        if (realtimeVoiceSelected) {
           stopRealtimeVoiceRef.current();
         } else {
           setHandsFree(false);
@@ -2351,7 +2438,7 @@ export function useShellController(): ShellController {
     voiceOutput,
     beginTranscriptSession,
     finalizeTranscriptSession,
-    realtimeVoiceEnabled,
+    realtimeVoiceSelected,
     recoverGatedCapture,
   ]);
 
@@ -2487,7 +2574,7 @@ export function useShellController(): ShellController {
   // Paused while the composer holds a draft (typing → always-on off), so a send
   // that clears the draft re-arms it and returns to the prior voice state.
   React.useEffect(() => {
-    if (realtimeVoiceEnabled) return;
+    if (realtimeVoiceOwnsMedia) return;
     if (!handsFree || !ready) return;
     if (recording || captureRef.current) return;
     if (chatSending || voiceOutput.speaking) return;
@@ -2513,7 +2600,7 @@ export function useShellController(): ShellController {
     voiceOutput.speaking,
     composerHasDraft,
     startCapture,
-    realtimeVoiceEnabled,
+    realtimeVoiceOwnsMedia,
   ]);
 
   // ── App suspend / resume: keep voice capture from getting stuck (#voice-V1) ──
@@ -2544,7 +2631,7 @@ export function useShellController(): ShellController {
     const onResume = (): void => {
       // The realtime client owns visibility suspend/resume for its socket,
       // AudioContext, and microphone. Never overlay a batch recorder on it.
-      if (realtimeVoiceEnabled) return;
+      if (realtimeVoiceOwnsMedia) return;
       const shouldReArm =
         (wasCapturingAtSuspendRef.current || handsFreeRef.current) &&
         !transcriptionModeRef.current;
@@ -2578,7 +2665,7 @@ export function useShellController(): ShellController {
     recording,
     chatSending,
     voiceOutput.speaking,
-    realtimeVoiceEnabled,
+    realtimeVoiceOwnsMedia,
   ]);
 
   const waveformMode =
@@ -2589,7 +2676,11 @@ export function useShellController(): ShellController {
         : "idle";
 
   let realtimeVoiceErrorMessage = realtimeVoiceBoundaryError;
-  if (!realtimeVoiceErrorMessage && realtimeVoice.error) {
+  if (
+    !realtimeVoiceErrorMessage &&
+    realtimeVoiceOwnsMedia &&
+    realtimeVoice.error
+  ) {
     if (realtimeVoice.error.kind === "consent") {
       realtimeVoiceErrorMessage =
         "Cartesia voice could not confirm microphone consent. Tap Talk to retry.";
@@ -2602,7 +2693,7 @@ export function useShellController(): ShellController {
   }
   const unlockVoiceAudio = React.useCallback(() => {
     if (
-      realtimeVoiceEnabled &&
+      realtimeVoiceOwnsMedia &&
       (realtimeVoiceWantedRef.current ||
         realtimeVoiceRef.current.active ||
         realtimeVoiceRef.current.connecting)
@@ -2611,7 +2702,7 @@ export function useShellController(): ShellController {
       return;
     }
     voiceOutput.unlockAudio();
-  }, [realtimeVoiceEnabled, voiceOutput.unlockAudio]);
+  }, [realtimeVoiceOwnsMedia, voiceOutput.unlockAudio]);
 
   // Accept input while the agent is still booting; pre-ready sends queue (see
   // `send`) and flush on ready. Send stays enabled mid-response: typing + sending
@@ -2700,7 +2791,7 @@ export function useShellController(): ShellController {
     cancelRecording: cancelCapture,
     handsFree,
     realtimeVoice: {
-      enabled: realtimeVoiceEnabled,
+      enabled: realtimeVoiceSelected,
       active: realtimeVoice.active,
       connecting: realtimeVoice.connecting,
       paused: realtimeVoice.paused,
@@ -2733,7 +2824,7 @@ export function useShellController(): ShellController {
     agentVoiceMuted: voiceOutput.agentVoiceMuted,
     toggleAgentVoiceMute: voiceOutput.toggleAgentVoiceMute,
     needsAudioUnlock:
-      (realtimeVoiceEnabled &&
+      (realtimeVoiceOwnsMedia &&
         (realtimeVoice.active || realtimeVoice.connecting) &&
         realtimeVoice.needsUnlock) ||
       voiceOutput.needsAudioUnlock,

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.test.tsx
@@ -29,6 +29,14 @@ import {
 } from "./useRealtimeVoiceMint";
 
 const UUID = "33333333-3333-3333-3333-333333333333";
+const CONVERSATION_ID = "voice/room?active=true";
+
+function jsonHealthResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
 
 describe("useRealtimeVoiceMint", () => {
   it("resolves a valid dedicated agent UUID", () => {
@@ -154,7 +162,7 @@ describe("useRealtimeVoiceMint", () => {
     it("flag ON + probe OK + no resolvable agent id → arms with the sentinel UUID", async () => {
       const fetch = vi
         .fn()
-        .mockResolvedValue(new Response("{}", { status: 200 }));
+        .mockResolvedValue(jsonHealthResponse({ ready: true }));
       const { result } = renderHook(() =>
         useRealtimeVoiceMint({
           resolveAgentId: () => null,
@@ -168,6 +176,41 @@ describe("useRealtimeVoiceMint", () => {
       await waitFor(() =>
         expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID),
       );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/v1/voice/session/health",
+        expect.objectContaining({ method: "GET", redirect: "error" }),
+      );
+    });
+
+    it("keeps an unscoped force probe armed across conversation switches", async () => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue(jsonHealthResponse({ ready: true }));
+      const resolveAgentId = () => null;
+      const { result, rerender } = renderHook(
+        ({ conversationId }) =>
+          useRealtimeVoiceMint({
+            resolveAgentId,
+            forceEnabled: true,
+            selfHostedEnabled: false,
+            conversationId,
+            fetch,
+          }),
+        { initialProps: { conversationId: "conversation-a" } },
+      );
+
+      await waitFor(() =>
+        expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID),
+      );
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      rerender({ conversationId: "conversation-b" });
+      expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID);
     });
 
     it("flag ON but a real agent id resolves → the REAL id wins, not the sentinel", () => {
@@ -200,7 +243,7 @@ describe("useRealtimeVoiceMint", () => {
       const fetch = vi
         .fn()
         // non-consuming health probe
-        .mockResolvedValueOnce(new Response("{}", { status: 200 }))
+        .mockResolvedValueOnce(jsonHealthResponse({ ready: true }))
         // fresh consent nonce on the visible start gesture
         .mockResolvedValueOnce(
           new Response(JSON.stringify({ consentNonce: "live-nonce" }), {
@@ -234,19 +277,65 @@ describe("useRealtimeVoiceMint", () => {
         expect.objectContaining({ method: "POST" }),
       );
     });
+
+    it.each([
+      ["a non-200 2xx", () => jsonHealthResponse({ ready: true }, 201)],
+      ["a 204", () => new Response(null, { status: 204 })],
+      [
+        "an HTML login page",
+        () =>
+          new Response("<html>sign in</html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+      ],
+      ["JSON ready:false", () => jsonHealthResponse({ ready: false })],
+      [
+        "a redirect response",
+        () =>
+          new Response(null, {
+            status: 302,
+            headers: { location: "/login" },
+          }),
+      ],
+      [
+        "a followed redirect",
+        () => {
+          const response = jsonHealthResponse({ ready: true });
+          Object.defineProperty(response, "redirected", { value: true });
+          return response;
+        },
+      ],
+    ])("does not arm from %s", async (_label, response) => {
+      const fetch = vi.fn().mockResolvedValue(response());
+      const { result } = renderHook(() =>
+        useRealtimeVoiceMint({
+          resolveAgentId: () => null,
+          forceEnabled: true,
+          fetch,
+        }),
+      );
+
+      await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+      expect(result.current.agentId).toBeNull();
+    });
   });
 
   describe("production self-hosted eligibility", () => {
-    it("arms only after the paired runtime proves its same-origin gateway", async () => {
-      const fetch = vi
-        .fn()
-        .mockResolvedValue(new Response('{"ready":true}', { status: 200 }));
+    it("arms only after the paired runtime proves the active conversation", async () => {
+      const fetch = vi.fn().mockResolvedValue(
+        jsonHealthResponse({
+          ready: true,
+          conversationId: CONVERSATION_ID,
+        }),
+      );
       const { result } = renderHook(() =>
         useRealtimeVoiceMint({
           resolveAgentId: () => null,
           resolveSelfHostedRuntime: () => true,
           selfHostedEnabled: true,
           forceEnabled: false,
+          conversationId: CONVERSATION_ID,
           fetch,
         }),
       );
@@ -256,9 +345,94 @@ describe("useRealtimeVoiceMint", () => {
         expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID),
       );
       expect(fetch).toHaveBeenCalledWith(
-        "/api/v1/voice/session/health",
-        expect.objectContaining({ method: "GET" }),
+        "/api/v1/voice/session/health?conversationId=voice%2Froom%3Factive%3Dtrue",
+        expect.objectContaining({ method: "GET", redirect: "error" }),
       );
+    });
+
+    it("rejects an older ready response that does not echo the requested conversation", async () => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue(jsonHealthResponse({ ready: true }));
+      const { result } = renderHook(() =>
+        useRealtimeVoiceMint({
+          resolveAgentId: () => null,
+          resolveSelfHostedRuntime: () => true,
+          selfHostedEnabled: true,
+          forceEnabled: false,
+          conversationId: CONVERSATION_ID,
+          fetch,
+        }),
+      );
+
+      await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+      expect(result.current.agentId).toBeNull();
+    });
+
+    it("does not arm when the gateway reports another conversation", async () => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue(jsonHealthResponse({ ready: false }));
+      const { result } = renderHook(() =>
+        useRealtimeVoiceMint({
+          resolveAgentId: () => null,
+          resolveSelfHostedRuntime: () => true,
+          selfHostedEnabled: true,
+          forceEnabled: false,
+          conversationId: CONVERSATION_ID,
+          fetch,
+        }),
+      );
+
+      await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+      expect(result.current.agentId).toBeNull();
+    });
+
+    it("disarms immediately while a switched conversation is reprobed", async () => {
+      let resolveSecondProbe: ((response: Response) => void) | undefined;
+      const secondProbe = new Promise<Response>((resolve) => {
+        resolveSecondProbe = resolve;
+      });
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonHealthResponse({
+            ready: true,
+            conversationId: "conversation-a",
+          }),
+        )
+        .mockReturnValueOnce(secondProbe);
+      const resolveAgentId = () => null;
+      const resolveSelfHostedRuntime = () => true;
+      const { result, rerender } = renderHook(
+        ({ conversationId }) =>
+          useRealtimeVoiceMint({
+            resolveAgentId,
+            resolveSelfHostedRuntime,
+            selfHostedEnabled: true,
+            forceEnabled: false,
+            conversationId,
+            fetch,
+          }),
+        { initialProps: { conversationId: "conversation-a" } },
+      );
+
+      await waitFor(() =>
+        expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID),
+      );
+
+      rerender({ conversationId: "conversation-b" });
+      expect(result.current.agentId).toBeNull();
+      await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+      expect(fetch).toHaveBeenLastCalledWith(
+        "/api/v1/voice/session/health?conversationId=conversation-b",
+        expect.objectContaining({ method: "GET", redirect: "error" }),
+      );
+
+      await act(async () => {
+        resolveSecondProbe?.(jsonHealthResponse({ ready: false }));
+        await secondProbe;
+      });
     });
 
     it("does not arm for a non-remote runtime under the self-hosted stamp", () => {
@@ -269,6 +443,7 @@ describe("useRealtimeVoiceMint", () => {
           resolveSelfHostedRuntime: () => false,
           selfHostedEnabled: true,
           forceEnabled: false,
+          conversationId: CONVERSATION_ID,
           fetch,
         }),
       );
@@ -287,6 +462,7 @@ describe("useRealtimeVoiceMint", () => {
           resolveSelfHostedRuntime: () => true,
           selfHostedEnabled: true,
           forceEnabled: false,
+          conversationId: CONVERSATION_ID,
           fetch,
         }),
       );

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.ts
@@ -2,7 +2,8 @@
  * Resolves the cloud agent identity and one-time consent required before
  * realtime voice may own the microphone. A production self-hosted build may
  * arm only after its paired same-origin runtime proves the voice-session
- * contract; failed consent or availability checks never fabricate eligibility.
+ * contract for the active conversation; failed consent or availability checks
+ * never fabricate eligibility.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -122,14 +123,54 @@ async function fetchConsentNonce(
 async function probeRealtimeVoiceAvailability(
   doFetch: (url: string, init?: RequestInit) => Promise<Response>,
   probePath: string,
+  expectedConversationId: string | null,
 ): Promise<boolean> {
   try {
-    const res = await doFetch(probePath, { method: "GET" });
-    return res.ok;
+    const res = await doFetch(probePath, {
+      method: "GET",
+      redirect: "error",
+    });
+    if (res.status !== 200 || res.redirected || res.type === "opaqueredirect") {
+      return false;
+    }
+    const mediaType = res.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (mediaType !== "application/json") return false;
+    const body: unknown = await res.json();
+    const ready =
+      typeof body === "object" &&
+      body !== null &&
+      !Array.isArray(body) &&
+      (body as { ready?: unknown }).ready === true;
+    if (!ready) return false;
+    return (
+      expectedConversationId === null ||
+      (body as { conversationId?: unknown }).conversationId ===
+        expectedConversationId
+    );
   } catch {
-    // error-policy:J4 An unreachable probe leaves realtime unavailable to the caller.
+    // error-policy:J4 An unreachable or malformed probe leaves realtime unavailable to the caller.
     return false;
   }
+}
+
+function normalizeRealtimeConversationId(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= 128 ? normalized : null;
+}
+
+function conversationScopedProbePath(
+  probePath: string,
+  conversationId: string,
+): string {
+  const separator = probePath.includes("?") ? "&" : "?";
+  return `${probePath}${separator}conversationId=${encodeURIComponent(conversationId)}`;
 }
 
 export function useRealtimeVoiceMint(options?: {
@@ -141,6 +182,12 @@ export function useRealtimeVoiceMint(options?: {
   consentPath?: string;
   /** Non-consuming availability probe path for force-arm builds. */
   probePath?: string;
+  /**
+   * Active conversation identity. Production self-hosted eligibility is bound
+   * to this exact value so a gateway pinned to another conversation cannot arm
+   * realtime and take the microphone before refusing the mint.
+   */
+  conversationId?: string | null;
   /**
    * Injectable force-arm flag (tests). Defaults to the VITE-side
    * `VITE_VOICE_REALTIME_FORCE` read. When true and normal resolution yields
@@ -182,33 +229,55 @@ export function useRealtimeVoiceMint(options?: {
     ? options.resolveSelfHostedRuntime()
     : persistedActiveServer?.kind === "remote";
 
-  const forceProbeEligible =
-    !resolvedAgentId &&
-    (forceEnabled || (selfHostedEnabled && selfHostedRuntime));
-  const [forceProbeArmed, setForceProbeArmed] = useState(false);
+  const probeConversationId = normalizeRealtimeConversationId(
+    options?.conversationId,
+  );
+  const selfHostedProbeEligible = Boolean(
+    selfHostedEnabled && selfHostedRuntime && probeConversationId,
+  );
+  const availabilityProbeEligible =
+    !resolvedAgentId && (forceEnabled || selfHostedProbeEligible);
+  const availabilityProbePath =
+    selfHostedProbeEligible && probeConversationId
+      ? conversationScopedProbePath(probePath, probeConversationId)
+      : probePath;
+  const availabilityProbeKey = availabilityProbeEligible
+    ? availabilityProbePath
+    : null;
+  const expectedProbeConversationId = selfHostedProbeEligible
+    ? probeConversationId
+    : null;
+  const [armedProbeKey, setArmedProbeKey] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!forceProbeEligible) {
-      setForceProbeArmed(false);
+    if (!availabilityProbeKey) {
+      setArmedProbeKey(null);
       return;
     }
 
     let cancelled = false;
-    setForceProbeArmed(false);
-    void probeRealtimeVoiceAvailability(doFetch, probePath).then(
-      (available) => {
-        if (!cancelled) setForceProbeArmed(available);
-      },
-    );
+    setArmedProbeKey(null);
+    void probeRealtimeVoiceAvailability(
+      doFetch,
+      availabilityProbeKey,
+      expectedProbeConversationId,
+    ).then((available) => {
+      if (!cancelled) {
+        setArmedProbeKey(available ? availabilityProbeKey : null);
+      }
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [doFetch, forceProbeEligible, probePath]);
+  }, [availabilityProbeKey, doFetch, expectedProbeConversationId]);
+
+  const availabilityProbeArmed =
+    availabilityProbeKey !== null && armedProbeKey === availabilityProbeKey;
 
   const agentId =
     resolvedAgentId ??
-    (forceProbeArmed ? REALTIME_FORCE_SENTINEL_AGENT_ID : null);
+    (availabilityProbeArmed ? REALTIME_FORCE_SENTINEL_AGENT_ID : null);
 
   const getConsentNonce = useCallback(async (): Promise<string | null> => {
     return fetchConsentNonce(doFetch, consentPath);

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -770,6 +770,91 @@ describe("useRealtimeVoiceSession", () => {
     expect(result.current.active).toBe(false);
   });
 
+  it("does not auto-restart after operational identity loss during deferred teardown", async () => {
+    const closeGate = deferred<void>();
+    const closeStarted = vi.fn();
+    class DeferredPlaybackCloseContext extends FakePlaybackAudioContext {
+      override async close(): Promise<void> {
+        closeStarted();
+        await closeGate.promise;
+        await super.close();
+      }
+    }
+    const { options, mint, ws } = makeOptions({
+      playbackContext: new DeferredPlaybackCloseContext(16_000),
+    });
+    const nextConversationId = "55555555-5555-4555-8555-555555555555";
+    const { result, rerender } = renderHook(
+      ({ agentId, conversationId, flagEnabled }) =>
+        useRealtimeVoiceSession({
+          ...options,
+          agentId,
+          conversationId,
+          flagEnabled,
+        }),
+      {
+        initialProps: {
+          agentId: AGENT_ID as string | null,
+          conversationId: CONV_ID,
+          flagEnabled: true,
+        },
+      },
+    );
+
+    const firstStart = beginStart(result);
+    await flushAsync();
+    await driveReady(ws, "s1", "T1");
+    await expect(firstStart).resolves.toEqual({ kind: "live" });
+
+    // The bound readiness probe disarms before the next conversation proves
+    // itself. Operational flag-off must synchronously revoke the hook's
+    // identity-restart ownership even though the old AudioContext is still
+    // closing.
+    act(() => {
+      rerender({
+        agentId: null,
+        conversationId: nextConversationId,
+        flagEnabled: false,
+      });
+    });
+    await waitFor(() => expect(closeStarted).toHaveBeenCalledTimes(1));
+
+    // A fast positive probe for B cannot resurrect realtime while teardown A
+    // is pending. Batch remains the owner until a later explicit user start.
+    act(() => {
+      rerender({
+        agentId: AGENT_ID,
+        conversationId: nextConversationId,
+        flagEnabled: true,
+      });
+    });
+    await flushAsync();
+    expect(mint.calls).toHaveLength(1);
+    expect(ws.sockets).toHaveLength(1);
+
+    closeGate.resolve();
+    await act(async () => {
+      await flushAsync();
+    });
+    await waitFor(() => expect(result.current.active).toBe(false));
+    expect(mint.calls).toHaveLength(1);
+    expect(ws.sockets).toHaveLength(1);
+
+    const explicitStart = beginStart(result);
+    await flushAsync();
+    expect(mint.calls).toHaveLength(2);
+    expect(mint.calls[1]).toMatchObject({
+      agentId: AGENT_ID,
+      conversationId: nextConversationId,
+    });
+    await driveReady(ws, "s2", "T2");
+    await expect(explicitStart).resolves.toEqual({ kind: "live" });
+
+    await act(async () => {
+      await result.current.stop();
+    });
+  });
+
   it("does not re-mint after unmount during identity-change teardown", async () => {
     const closeGate = deferred<void>();
     const closeStarted = vi.fn();


### PR DESCRIPTION
## Cause

The self-hosted realtime voice probe accepted weak readiness signals and was not bound to the active conversation. During a conversation handoff, a fast probe recovery could also let the realtime session restart its microphone behind an already-selected batch Talk fallback. A second race remained after PTT release: the visible capture owner cleared before deferred batch STT finished, so a recovered probe could release the batch latch and hand microphone/audio ownership to realtime while the prior stop was still draining. That made text/voice ownership nondeterministic on localhost and Android kiosk/launcher flows.

## Fix

- Require an exact HTTP 200, reject redirects, require JSON media type, and accept only a ready response.
- Bind self-hosted readiness to the active conversation and require the gateway to echo that exact conversation ID. Mismatches fail closed without disclosing the configured ID.
- Keep the explicit force-only development mode unscoped and stable across conversation switches.
- Latch the current Talk session to batch ASR/TTS when conversation-scoped realtime becomes unavailable; a recovered probe cannot steal capture or playback mid-turn.
- Release the latch only after Talk is off and all batch owners are idle, including a pending deferred STT stop.
- Guard the central realtime start path against `sttPending`, so a second Talk tap cannot acquire realtime media ownership before the prior batch teardown resolves.
- Treat probe/identity loss as an operational flag-off edge, cancelling the session hook pending identity restart before a fast recovery can reopen the microphone.
- Pass the active conversation through both mounted Shell and ChatView mint paths.

## Stack and limits

- The current GitHub base is `develop`. #29398 merged as `a19147bce3e` and its Dedicated-only identity gate plus Shared-startup and Personal Shared rejection regressions remain in the base/current tree.
- The current PR history is exactly two commits: the linear restack `a2d7a3c7edc` and the focused deferred-STT ownership fix `d35a39c0927`.
- The former empty-capture classification commit remains absent because `develop` already contains that patch through #29393.
- No physical APK/device, microphone, Google sign-in, localhost browser, or live gateway mutation was performed in this tranche. Those remain explicit end-to-end proof lanes.

## Validation

- The deferred-stop regression was first run against `a2d7a3c7edc` and failed at the premature `realtimeVoice.enabled === true` transition while `handle.stop()` was unresolved; it passes at `d35a39c0927`.
- Exact-head Shell controller suite: 100/100 passed, including the deferred-stop ownership regression.
- The broader pre-fix exact-head voice evidence remains 162/162 shell/mint/session plus a fresh Bun gateway harness 1/1; `d35a39c0927` changes only the Shell controller and its focused test.
- Exact-head UI typecheck passed.
- Exact-head Biome passed on both changed files; `git diff --check` passed.
- Merge-tree is clean against `origin/develop@56b31bea36b`.
- Hosted CI for exact head `d35a39c0927` is fully green: Source static smoke, Billing payment replay E2E, Windows security contracts, and the aggregate `All Tests Passed` gate all succeeded.

## Risk / rollback

Risk is limited to realtime-vs-batch voice ownership and the self-hosted readiness contract. The fallback remains the existing batch ASR/TTS path. Rollback requires reverting `d35a39c0927` and then `a2d7a3c7edc`. No deployment, migration, restart, container action, or live configuration change was performed.

## Final linear restack

Exact head: `d35a39c09279b624546f52ab5bef46709e5f4d5f`. Its parent `a2d7a3c7edc6d176700951e2e4e7cb91aeb5b0f3` is the single linear replay of the reviewed remote resolved tree onto `origin/develop@4b699268e7d16b48d18462155be063f684ab4aa5`; the parent eight-file tree is patch-equivalent to reviewed remote head `fff18eb99d6fbf278441ace488d3b40b11459cee`. The exact-head follow-up adds only the deferred-STT ownership guard and its regression.

Exact local evidence at `d35a39c0927`: Shell controller 100/100, UI typecheck, focused Biome, and diff integrity. The prior broader voice/gateway suites remain green as described above. `audit:app` was attempted once on the parent restack but timed out before capture because the renderer build exceeded 1080s/Playwright 1200s; it produced no PR assertion or visual verdict. Hosted CI for this exact head is fully green as recorded above.
