### PR TITLE
fix(core): prevent orphan direct tool-call stream rows

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -2168,6 +2168,12 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 			vi.fn<
 				(payload: import("../types/streaming").StreamingToolCallPayload) => void
 			>();
+		const onToolResult =
+			vi.fn<
+				(
+					payload: import("../types/streaming").StreamingToolResultPayload,
+				) => void
+			>();
 
 		const result = await runWithStreamingContext(
 			{
@@ -2175,6 +2181,10 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 				onToolCall: (payload) => {
 					order.push("onToolCall");
 					onToolCall(payload);
+				},
+				onToolResult: (payload) => {
+					order.push("onToolResult");
+					onToolResult(payload);
 				},
 			},
 			() =>
@@ -2189,8 +2199,9 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		expect(result.kind).toBe("planned_reply");
 		// The running_tool announcement precedes execution so the chat SSE
 		// surface shows activity while the tool runs, not after.
-		expect(order).toEqual(["onToolCall", "handler"]);
+		expect(order).toEqual(["onToolCall", "handler", "onToolResult"]);
 		expect(onToolCall).toHaveBeenCalledTimes(1);
+		expect(onToolResult).toHaveBeenCalledTimes(1);
 		const payload = onToolCall.mock.calls[0]?.[0];
 		expect(payload?.toolCall).toMatchObject({
 			name: "VIEWS",
@@ -2198,6 +2209,211 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 			arguments: { action: "show", view: "notes" },
 		});
 		expect(payload?.metadata).toMatchObject({ deterministic: true });
+		expect(onToolResult.mock.calls[0]?.[0]).toMatchObject({
+			toolCallId: payload?.toolCall.id,
+			status: "completed",
+		});
+	});
+
+	it("does not announce a deterministic parent that the dispatcher gate refuses", async () => {
+		const parent = makeMockAction({
+			name: "OWNER_PARENT",
+			roleGate: "OWNER",
+			subActions: ["OWNER_CHILD"],
+			handler: async () => ({ success: true, text: "must not run" }),
+		});
+		const evaluator = {
+			name: "test.force_refused_deterministic_parent",
+			priority: 10,
+			deterministicActions: ["OWNER_PARENT"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "OWNER_PARENT" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [parent],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["OWNER_PARENT"],
+						thought: "The parent is deterministic.",
+					}),
+				},
+			],
+		});
+		const calls: import("../types/streaming").StreamingToolCallPayload[] = [];
+		const results: import("../types/streaming").StreamingToolResultPayload[] =
+			[];
+
+		await runWithStreamingContext(
+			{
+				onToolCall: (payload) => calls.push(payload),
+				onToolResult: (payload) => results.push(payload),
+			},
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage("run owner parent"),
+					state: makeState(),
+					responseId: RESPONSE_ID,
+				}),
+		);
+
+		expect(
+			calls.filter((payload) =>
+				payload.toolCall.id.startsWith("response-handler:"),
+			),
+		).toHaveLength(0);
+		expect(
+			results.filter((payload) =>
+				payload.toolCallId?.startsWith("response-handler:"),
+			),
+		).toHaveLength(0);
+	});
+
+	it("lets a deterministic sub-planner own streaming without an orphan parent announcement", async () => {
+		const parent = makeMockAction({
+			name: "CALENDAR_PARENT",
+			subActions: ["CALENDAR_CHILD"],
+			handler: async () => ({ success: true, text: "must not run" }),
+		});
+		const child = makeMockAction({
+			name: "CALENDAR_CHILD",
+			handler: async () => ({ success: true, text: "child complete" }),
+		});
+		const evaluator = {
+			name: "test.force_deterministic_subplanner",
+			priority: 10,
+			deterministicActions: ["CALENDAR_PARENT"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "CALENDAR_PARENT" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [parent, child],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["CALENDAR_PARENT"],
+						thought: "Use the deterministic calendar parent.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "Run the child.",
+						toolCalls: [{ id: "child-1", name: "CALENDAR_CHILD", args: {} }],
+					},
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "The child completed.",
+						messageToUser: "Calendar complete.",
+					}),
+				},
+			],
+		});
+		const calls: import("../types/streaming").StreamingToolCallPayload[] = [];
+		const results: import("../types/streaming").StreamingToolResultPayload[] =
+			[];
+
+		await runWithStreamingContext(
+			{
+				onToolCall: (payload) => calls.push(payload),
+				onToolResult: (payload) => results.push(payload),
+			},
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage("check calendar"),
+					state: makeState(),
+					responseId: RESPONSE_ID,
+				}),
+		);
+
+		expect(
+			calls.some((payload) =>
+				payload.toolCall.id.startsWith("response-handler:"),
+			),
+		).toBe(false);
+		for (const call of calls) {
+			expect(
+				results.filter((result) => result.toolCallId === call.toolCall.id),
+			).toHaveLength(1);
+		}
+	});
+
+	it("settles a deterministic announcement exactly once when its handler throws", async () => {
+		const action = makeMockAction({
+			name: "THROWING_ACTION",
+			handler: async () => {
+				throw new Error("deterministic boom");
+			},
+		});
+		const evaluator = {
+			name: "test.force_throwing_deterministic_action",
+			priority: 10,
+			deterministicActions: ["THROWING_ACTION"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "THROWING_ACTION" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [action],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["THROWING_ACTION"],
+						thought: "Run the deterministic action.",
+					}),
+				},
+			],
+		});
+		const calls: import("../types/streaming").StreamingToolCallPayload[] = [];
+		const results: import("../types/streaming").StreamingToolResultPayload[] =
+			[];
+
+		await runWithStreamingContext(
+			{
+				onToolCall: (payload) => calls.push(payload),
+				onToolResult: (payload) => results.push(payload),
+			},
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage("run the throwing action"),
+					state: makeState(),
+					responseId: RESPONSE_ID,
+				}),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			toolCallId: calls[0]?.toolCall.id,
+			status: "failed",
+		});
 	});
 
 	// tj-a835d4c6da235f: an accepted, internal VIEWS effect must produce an

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -9,6 +9,7 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONNECTOR_ACCOUNT_SERVICE_TYPE } from "../connectors/account-manager";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import {
@@ -2413,6 +2414,80 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		expect(results[0]).toMatchObject({
 			toolCallId: calls[0]?.toolCall.id,
 			status: "failed",
+		});
+	});
+
+	it("settles a deterministic announcement exactly once when executor infrastructure throws", async () => {
+		const handler = vi.fn(async () => ({
+			success: true,
+			text: "must not run",
+		}));
+		const action = {
+			...makeMockAction({ name: "CONNECTOR_ACTION", handler }),
+			connectorAccountPolicy: { provider: "gmail" },
+		} as Action;
+		const evaluator = {
+			name: "test.force_infrastructure_failure",
+			priority: 10,
+			deterministicActions: ["CONNECTOR_ACTION"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "CONNECTOR_ACTION" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [action],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["CONNECTOR_ACTION"],
+						thought: "Run the deterministic connector action.",
+					}),
+				},
+			],
+		});
+		const infrastructureError = new Error("account storage unavailable");
+		Object.assign(runtime, {
+			getService: vi.fn((serviceType: string) => {
+				if (serviceType === CONNECTOR_ACCOUNT_SERVICE_TYPE) {
+					throw infrastructureError;
+				}
+				return null;
+			}),
+		});
+		const calls: import("../types/streaming").StreamingToolCallPayload[] = [];
+		const results: import("../types/streaming").StreamingToolResultPayload[] =
+			[];
+
+		await runWithStreamingContext(
+			{
+				onToolCall: (payload) => calls.push(payload),
+				onToolResult: (payload) => results.push(payload),
+			},
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage("run the connector action"),
+					state: makeState(),
+					responseId: RESPONSE_ID,
+				}),
+		);
+
+		expect(handler).not.toHaveBeenCalled();
+		expect(calls).toHaveLength(1);
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			toolCallId: calls[0]?.toolCall.id,
+			status: "failed",
+			result: expect.objectContaining({
+				success: false,
+				error: infrastructureError.message,
+			}),
 		});
 	});
 

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -608,6 +608,54 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		expect(settled.toolCallId).toBe(announced.toolCall?.id);
 	});
 
+	it("settles the shortcut announcement exactly once when infrastructure throws", async () => {
+		const connectorAction = {
+			...echoAction(),
+			connectorAccountPolicy: { provider: "gmail" },
+		} as Action;
+		const { runtime } = makeRuntime({ actions: [connectorAction] });
+		const infrastructureError = new Error("account storage unavailable");
+		Object.assign(runtime, {
+			getService: vi.fn(() => {
+				throw infrastructureError;
+			}),
+		});
+		const onToolCall = vi.fn();
+		const onToolResult = vi.fn();
+
+		await expect(
+			runWithStreamingContext(
+				{
+					onToolCall,
+					onToolResult,
+				} as never,
+				() =>
+					runShortcutGate({
+						// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+						runtime: runtime as any,
+						message: msg("/echo hi"),
+						state: {} as State,
+						responseId,
+						senderRole: "OWNER",
+					}),
+			),
+		).rejects.toBe(infrastructureError);
+
+		expect(onToolCall).toHaveBeenCalledTimes(1);
+		expect(onToolResult).toHaveBeenCalledTimes(1);
+		const announced = onToolCall.mock.calls[0]?.[0] as {
+			toolCall?: { id?: string };
+		};
+		expect(onToolResult.mock.calls[0]?.[0]).toMatchObject({
+			toolCallId: announced.toolCall?.id,
+			status: "failed",
+			result: expect.objectContaining({
+				success: false,
+				error: infrastructureError.message,
+			}),
+		});
+	});
+
 	it("allows an OWNER to trigger the same OWNER-gated shortcut action", async () => {
 		const handler = vi.fn(
 			async (

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7641,6 +7641,12 @@ interface ExecuteV5PlannedToolCallParams {
 	 * must retain the turn's original contexts for the canonical gate.
 	 */
 	activateActionContexts?: boolean;
+	/**
+	 * Deterministic response-handler calls announce only after this dispatcher
+	 * has selected direct execution. Parent actions handled by a sub-planner or
+	 * rejected by the dispatcher must not create an orphan pending stream row.
+	 */
+	announceDirectExecution?: boolean;
 }
 
 interface BuildV5ExecutorContextParams {
@@ -7827,12 +7833,23 @@ async function executeV5PlannedToolCall(
 		return subPlannerResultToPlannerToolResult(subResult);
 	}
 
-	const rawActionResult = await executePlannedToolCall(
-		args.runtime,
-		executorCtx,
-		toolCall,
-		{ ...(args.executorOptions ?? {}), actions: executionActions },
-	);
+	if (args.announceDirectExecution) {
+		await announceDirectToolCallToStream(args.runtime, toolCall);
+	}
+	let rawActionResult: ActionResult;
+	try {
+		rawActionResult = await executePlannedToolCall(
+			args.runtime,
+			executorCtx,
+			toolCall,
+			{ ...(args.executorOptions ?? {}), actions: executionActions },
+		);
+	} catch (error) {
+		if (args.announceDirectExecution) {
+			await settleFailedDirectToolCallOnStream(args.runtime, toolCall, error);
+		}
+		throw error;
+	}
 	invalidateEvidenceSensitiveProviderCache(
 		args.runtime,
 		args.executorCtx.message,
@@ -8281,6 +8298,40 @@ async function announceDirectToolCallToStream(
 			) ?? {}) as Record<string, JsonValue>,
 			status: "pending",
 		},
+		...(streamingContext.messageId
+			? { messageId: streamingContext.messageId }
+			: {}),
+		metadata: { deterministic: true },
+	});
+}
+
+/** Settles a direct-call announcement when the canonical executor throws. */
+async function settleFailedDirectToolCallOnStream(
+	runtime: IAgentRuntime,
+	toolCall: PlannerToolCall,
+	error: unknown,
+): Promise<void> {
+	const streamingContext = getStreamingContext();
+	if (!streamingContext?.onToolResult) return;
+	const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
+	const id = toolCall.id ?? toolCall.name;
+	const message = redactDiagnosticText(
+		error instanceof Error ? error.message : String(error),
+	);
+	await emitStreamingHook(streamingContext, "onToolResult", {
+		toolCall: {
+			id,
+			name: toolCall.name,
+			arguments: (projectToolDiagnosticArgs(
+				toolCall.params ?? {},
+				redactDiagnosticText,
+			) ?? {}) as Record<string, JsonValue>,
+			status: "failed",
+			result: { success: false, text: message, error: message },
+		},
+		toolCallId: id,
+		result: { success: false, text: message, error: message },
+		status: "failed",
 		...(streamingContext.messageId
 			? { messageId: streamingContext.messageId }
 			: {}),
@@ -10193,7 +10244,6 @@ export async function runV5MessageRuntimeStage1(args: {
 					name: action?.name ?? selected.name,
 					...(selected.params ? { params: selected.params } : {}),
 				};
-				await announceDirectToolCallToStream(args.runtime, toolCall);
 				const startedAt = Date.now();
 				let callbackDelivered = false;
 				const deterministicCallback: HandlerCallback | undefined =
@@ -10237,6 +10287,7 @@ export async function runV5MessageRuntimeStage1(args: {
 							trajectoryId,
 							plannerLoopConfig: args.plannerLoopConfig,
 							activateActionContexts: false,
+							announceDirectExecution: true,
 						}),
 					);
 				} catch (error) {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8396,28 +8396,38 @@ export async function runShortcutGate(args: {
 	// Shortcuts enter the same executor as planner-selected tools so component
 	// gates, argument validation, callback buffering, audience revalidation, and
 	// action events remain one non-bypassable contract.
-	const shortcutActionResult = await executePlannedToolCall(
-		args.runtime,
-		{
-			message: args.message,
-			state: args.state,
-			userRoles: [args.senderRole],
-			activeContexts: ["general"],
-			callback: async (content) => {
-				if (typeof content?.text === "string" && content.text) {
-					captured = content.text;
-				}
-				return [];
+	let shortcutActionResult: ActionResult;
+	try {
+		shortcutActionResult = await executePlannedToolCall(
+			args.runtime,
+			{
+				message: args.message,
+				state: args.state,
+				userRoles: [args.senderRole],
+				activeContexts: ["general"],
+				callback: async (content) => {
+					if (typeof content?.text === "string" && content.text) {
+						captured = content.text;
+					}
+					return [];
+				},
 			},
-		},
-		shortcutToolCall,
-		{
-			actions: [action],
-			...(args.onSettledActionResult
-				? { onSettledResult: args.onSettledActionResult }
-				: {}),
-		},
-	);
+			shortcutToolCall,
+			{
+				actions: [action],
+				...(args.onSettledActionResult
+					? { onSettledResult: args.onSettledActionResult }
+					: {}),
+			},
+		);
+	} catch (error) {
+		await settleFailedDirectToolCallOnStream(
+			args.runtime,
+			shortcutToolCall,
+			error,
+		);
+		throw error;
+	}
 	if (captured === undefined) {
 		const executionError = shortcutActionResult.data?.error;
 		if (executionError !== undefined) {


### PR DESCRIPTION
## Summary

Prevents deterministic and shortcut executions that bypass the planner loop from leaving an orphan `running_tool` row when routing selects another execution owner or the canonical executor throws unexpectedly.

The direct-call announcement feature and planner-recompose latency work are already on `develop`; this PR contains only the remaining stream-lifecycle correctness fixes and their regressions.

## Changes

- Moves deterministic parent announcement behind dispatcher routing through `announceDirectExecution`, so dispatcher refusal and sub-planner ownership do not create a parent pending row that cannot settle.
- Settles an announced deterministic call with one failed terminal result, using the same call ID, when direct executor infrastructure throws.
- Reuses one `PlannerToolCall` for shortcut announcement and execution so pending and terminal frames correlate by the exact same ID.
- Settles an announced shortcut with one failed terminal result before rethrowing an unexpected executor infrastructure error.

## Regression coverage

The focused suites exercise the real streaming hooks and canonical executor boundary:

- direct deterministic pending → handler → terminal ordering and ID correlation;
- dispatcher refusal emits no parent pending row;
- sub-planner ownership emits no orphan parent row;
- ordinary handler failure settles exactly once;
- deterministic connector-account infrastructure failure settles exactly once;
- shortcut pending/result correlation and shortcut infrastructure failure settlement.

The deterministic infrastructure regression was mutation-checked: removing the executor-path settlement makes the new test fail because the pending call has no terminal result.

## Verification

- `vitest` focused suites: 65/65 pass.
- `@elizaos/core` typecheck: pass.
- Biome on all three changed files: pass.
- `git diff --check`: pass.
- Root `bun run verify`: required on the final rebased head before merge.
- Hosted exact-head checks and maintainer re-review are required; no gate bypass.

Generated with Codex.