### PR TITLE
perf(core): skip redundant planner state for deterministic tools

### DIFF
--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -554,6 +554,16 @@ export async function executePlannedToolCall(
 	options: ExecutePlannedToolCallOptions = {},
 ): Promise<ActionResult> {
 	options.abortSignal?.throwIfAborted();
+	// Perf probe (#latency): per-segment wall clock for one executed tool call,
+	// logged as a single summary line. Diagnostic only; never alters behavior.
+	const perfT0 = Date.now();
+	const perfMarks: [string, number][] = [];
+	let perfPrev = perfT0;
+	const perfMark = (label: string) => {
+		const now = Date.now();
+		perfMarks.push([label, now - perfPrev]);
+		perfPrev = now;
+	};
 	// Diagnostic projection for every copy of the arguments that leaves the
 	// execution path (streaming observers, lifecycle events, trajectories).
 	// The handler itself receives the exact validated values.
@@ -580,6 +590,7 @@ export async function executePlannedToolCall(
 	}
 
 	const executorCtx = await withResolvedUserRoles(runtime, ctx);
+	perfMark("roles");
 	const gateFailure = actionGateFailure(action, executorCtx);
 	if (gateFailure) {
 		return emitToolResult(
@@ -630,6 +641,7 @@ export async function executePlannedToolCall(
 			executorCtx.state,
 			executorCtx.userRoles,
 		));
+	perfMark("aliases");
 	const validation = validateToolArgs(
 		action,
 		resolveEntityAliasRefs(entityAliases, argsForValidation),
@@ -726,6 +738,7 @@ export async function executePlannedToolCall(
 		}
 	}
 
+	perfMark("validate");
 	const accountPolicy = await evaluateConnectorAccountPolicies(
 		runtime,
 		action,
@@ -745,6 +758,7 @@ export async function executePlannedToolCall(
 			),
 		);
 	}
+	perfMark("accountPolicy");
 	options.abortSignal?.throwIfAborted();
 
 	const messageId = executorCtx.message.id as UUID | undefined;
@@ -821,6 +835,7 @@ export async function executePlannedToolCall(
 					);
 				}
 			: executorCtx.callback;
+	perfMark("startedEvent");
 	let resultForEvent = await runWithMessageTrajectoryContext(
 		runtime,
 		executorCtx.message,
@@ -890,6 +905,7 @@ export async function executePlannedToolCall(
 	);
 	// The handler result is the completion barrier. Publish it before event
 	// emission or disclosure revalidation can strand a committed side effect.
+	perfMark("handler");
 	publishSettledResult(runtime, action, resultForEvent, onSettledResult);
 	if (ownerExclusive) {
 		const disclosure = await revalidateOwnerExclusiveDisclosure(
@@ -964,6 +980,19 @@ export async function executePlannedToolCall(
 				privacyDenied: true,
 				privacyReason: disclosure.reason,
 			});
+		}
+	}
+	perfMark("post");
+	{
+		const perfTotal = Date.now() - perfT0;
+		if (perfTotal > 400) {
+			runtime.logger.info(
+				{ src: "execute-planned-tool-call" },
+				`[perf-probe] tool=${action.name} total=${perfTotal}ms ${perfMarks
+					.filter(([, ms]) => ms >= 5)
+					.map(([label, ms]) => `${label}=${ms}ms`)
+					.join(" ")}`,
+			);
 		}
 	}
 	return emitToolResult(toolCall, redactDiagnosticText, resultForEvent, {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9570,6 +9570,10 @@ export async function runV5MessageRuntimeStage1(args: {
 			});
 			earlyReplySent = delivered !== false;
 		}
+		// A deterministic tool call skips the planner entirely, so the planner
+		// provider recompose (~600ms of planner-only providers) buys nothing the
+		// executor or the structured-effect confirmation reads — Stage-1 state is
+		// the executor state for that path.
 		const plannerProviderNames = selectV5PlannerStateProviderNames({
 			runtime: args.runtime,
 			message: args.message,
@@ -9577,7 +9581,8 @@ export async function runV5MessageRuntimeStage1(args: {
 			userRoles: [senderRole],
 		});
 		const recomposedPlannerState =
-			typeof args.runtime.composeState === "function"
+			typeof args.runtime.composeState === "function" &&
+			!messageHandler.plan.deterministicToolCall
 				? // Reuse what the Stage-1 compose already ran for this message;
 					// refresh RECENT_MESSAGES only when an early reply actually
 					// changed history. An empty refresh set means maximum reuse;


### PR DESCRIPTION
## Summary
- reuse Stage-1 state when a deterministic tool call skips the planner instead of recomposing planner-only providers
- add bounded payload-free per-segment executor timing for slow tool calls
- leave nondeterministic planner turns unchanged

## Provenance
Minimal current-develop publication of the accepted live latency source `84b10fac085259b808d98a20df2e5fea545dc7a8`.

The c9ff-only synthesized-receipt follow-up `1ea1182f...` is intentionally omitted: current develop already has the stronger merged structured-read behavior from PR #29328, so republishing it would duplicate semantics.

## Gates
- focused core matrix: 118/118 pass
- `packages/core` typecheck: pass
- changed-file Biome and diff check: pass

Source-only publication; no runtime restart or device interaction was performed.
