### PR TITLE
fix(voice): suppress playback echo and smooth short realtime replies

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -537,6 +537,9 @@ async function connectSession(opts: {
   openingFallbackGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
   onClearAudio?: () => void;
+  acousticBargeInEnabled?: boolean;
+  halfDuplexPlaybackSettleMs?: number;
+  now?: () => number;
   fish?: {
     enabled?: boolean;
     firstAudioTimeoutMs?: number;
@@ -570,6 +573,16 @@ async function connectSession(opts: {
         fishAudioFirstAudioTimeoutMs: opts.fish?.firstAudioTimeoutMs,
         fishAudioWebSocketFactory:
           opts.fish?.socketFactory ?? (() => new FakeFishAudioSocket()),
+        // Legacy lifecycle cases exercise AEC-safe acoustic interruption. New
+        // half-duplex regressions opt out explicitly; production omits this
+        // flag and therefore takes the safe half-duplex default.
+        acousticBargeInEnabled: opts.acousticBargeInEnabled ?? true,
+        ...(opts.now ? { now: opts.now } : {}),
+        ...(opts.halfDuplexPlaybackSettleMs !== undefined
+          ? {
+              halfDuplexPlaybackSettleMs: opts.halfDuplexPlaybackSettleMs,
+            }
+          : {}),
         elizaEndpoint: "http://internal/api/v1/chat/completions",
         elizaAuthorization: "Bearer eliza-server",
         elizaModel: "gemma-4-31b",
@@ -2224,6 +2237,7 @@ describe("voice-session WS lifecycle", () => {
     await connectSession({
       client,
       fetchImpl: makeCanonicalChunkFetch(["This should fail in TTS."]),
+      acousticBargeInEnabled: false,
     });
     const ink = FakeInkSocket.instances.at(-1)!;
     ink.emitTurn("turn.start");
@@ -2251,6 +2265,10 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes().filter((t) => t === "usage").length).toBe(
       usageCount,
     );
+    const chunksBeforeResume = ink.sentChunks.length;
+    client.clientSend(pcmChunk(3_200));
+    await flush();
+    expect(ink.sentChunks.length).toBeGreaterThan(chunksBeforeResume);
   });
 
   test("barge-in cancels TTS with ZERO post-cancel binary frames", async () => {
@@ -2289,6 +2307,83 @@ describe("voice-session WS lifecycle", () => {
     // Flushing here proves no late frame leaks through after the barge-in.
     await flush();
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
+  });
+
+  test("half duplex drops speaker echo through playback and bounded settle", async () => {
+    let nowMs = Date.now();
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["Assistant audio must not become caller text."]),
+      acousticBargeInEnabled: false,
+      halfDuplexPlaybackSettleMs: 600,
+      now: () => nowMs,
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "say the answer");
+    await flush();
+    await flush();
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+
+    const providerChunksBeforeEcho = ink.sentChunks.length;
+    const finalsBeforeEcho = client.controlFrames.filter(
+      (frame) => frame.t === "stt_final",
+    ).length;
+    client.clientSend(pcmChunk(3_200));
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.update", "Assistant audio must not become caller text");
+    ink.emitTurn("turn.end", "Assistant audio must not become caller text");
+    await flush();
+
+    expect(ink.sentChunks).toHaveLength(providerChunksBeforeEcho);
+    expect(
+      client.controlFrames.filter((frame) => frame.t === "stt_final"),
+    ).toHaveLength(finalsBeforeEcho);
+    expect(client.controlFrames).not.toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+
+    cartesia.emitDone();
+    client.clientSend(pcmChunk(3_200));
+    expect(ink.sentChunks).toHaveLength(providerChunksBeforeEcho);
+
+    nowMs += 1_000;
+    client.clientSend(pcmChunk(3_200));
+    await flush();
+    expect(ink.sentChunks.length).toBeGreaterThan(providerChunksBeforeEcho);
+  });
+
+  test("explicit barge-in immediately releases half-duplex suppression", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["Speaking until the explicit stop control."]),
+      acousticBargeInEnabled: false,
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "start speaking");
+    await flush();
+    await flush();
+    expect(client.controlTypes()).toContain("speaking_start");
+
+    const providerChunksBeforeBargeIn = ink.sentChunks.length;
+    client.clientSend(pcmChunk(3_200));
+    expect(ink.sentChunks).toHaveLength(providerChunksBeforeBargeIn);
+
+    client.clientSend(JSON.stringify({ t: "barge_in" }));
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "explicit" }),
+    );
+
+    client.clientSend(pcmChunk(3_200));
+    await flush();
+    expect(ink.sentChunks.length).toBeGreaterThan(providerChunksBeforeBargeIn);
   });
 
   test("confirmed caller words interrupt immediately and get the next response", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -96,7 +96,7 @@ import {
 import { installVoiceSessionTestSigningKey } from "../../../../../shared/src/lib/voice-session/test-signing";
 import { attachVoiceWsHandler } from "../../../../../shared/src/lib/voice-session/ws-handler";
 import type { CartesiaInkWebSocket } from "../../stt/providers/cartesia-ink";
-import { VoiceSession } from "../lib/session";
+import { VoiceSession, type VoiceTurnMetricsReceipt } from "../lib/session";
 
 // --- signing setup --------------------------------------------------------
 
@@ -217,6 +217,12 @@ class FakeCartesiaSocket implements CartesiaWebSocketLike {
   emitDone() {
     this.fire("message", {
       data: JSON.stringify({ type: "done", done: true }),
+    });
+  }
+  emitAudio(bytes = new Uint8Array([1, 2, 3, 4])) {
+    const pcm = Buffer.from(bytes).toString("base64");
+    this.fire("message", {
+      data: JSON.stringify({ type: "chunk", data: pcm }),
     });
   }
   emitProviderError(code = "provider_failed") {
@@ -540,6 +546,7 @@ async function connectSession(opts: {
   acousticBargeInEnabled?: boolean;
   halfDuplexPlaybackSettleMs?: number;
   now?: () => number;
+  onTurnMetrics?: (receipt: VoiceTurnMetricsReceipt) => void;
   fish?: {
     enabled?: boolean;
     firstAudioTimeoutMs?: number;
@@ -583,6 +590,7 @@ async function connectSession(opts: {
               halfDuplexPlaybackSettleMs: opts.halfDuplexPlaybackSettleMs,
             }
           : {}),
+        ...(opts.onTurnMetrics ? { onTurnMetrics: opts.onTurnMetrics } : {}),
         elizaEndpoint: "http://internal/api/v1/chat/completions",
         elizaAuthorization: "Bearer eliza-server",
         elizaModel: "gemma-4-31b",
@@ -851,7 +859,9 @@ describe("voice-session WS lifecycle", () => {
       fetchImpl: controlled.fetchImpl,
     });
     await controlled.ready;
-    controlled.enqueueChunk("Welcome home friend.");
+    controlled.enqueueChunk(
+      "Welcome home friend. This contextual greeting is intentionally long enough to begin speaking before the upstream stream fails, proving the fallback cannot double-speak.",
+    );
     await flush();
     await flush();
 
@@ -1531,7 +1541,6 @@ describe("voice-session WS lifecycle", () => {
     expect(fish.sentText()).toBe(
       "Fish primary response reaches audio quickly.",
     );
-    expect(fish.sentFrames()).toContainEqual({ event: "flush" });
     expect(fish.sentFrames().at(-1)).toEqual({ event: "stop" });
     expect(client.audioFrames.at(-1)).toEqual(new Uint8Array([9, 8, 7, 6]));
   });
@@ -1682,13 +1691,15 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("speaking_start");
   });
 
-  test("starts TTS after 24 chars before an unpunctuated LLM stream completes", async () => {
+  test("starts TTS at the high word-safe ceiling before a long unpunctuated stream completes", async () => {
     let aborted = false;
     const client = new FakeClientSocket();
     await connectSession({
       client,
       fetchImpl: makeSseFetch(
-        ["This answer starts speaking now and keeps going"],
+        [
+          "This deliberately long answer crosses the bounded streaming threshold at a natural word boundary so speech begins without chopping a short reply into tiny phrases",
+        ],
         {
           hang: true,
           onAbort: () => {
@@ -1703,8 +1714,8 @@ describe("voice-session WS lifecycle", () => {
     await flush();
     await flush();
 
-    // No punctuation or stream-end was delivered, but the voice-specific
-    // clause ceiling must already have sent a continuation phrase to Cartesia.
+    // No punctuation or stream-end was delivered, but the bounded high
+    // ceiling must already have sent a word-safe continuation to Cartesia.
     const cartesia = FakeCartesiaSocket.instances.at(-1)!;
     const requests = cartesia.sent
       .map(
@@ -1721,7 +1732,7 @@ describe("voice-session WS lifecycle", () => {
     expect(aborted).toBe(true);
   });
 
-  test("starts TTS from a phrase prefix while retaining a non-empty terminal suffix", async () => {
+  test("sends a complete short reply as one terminal Sonic request", async () => {
     const client = new FakeClientSocket();
     await connectSession({
       client,
@@ -1740,12 +1751,11 @@ describe("voice-session WS lifecycle", () => {
           JSON.parse(entry) as { transcript?: string; continue?: boolean },
       )
       .filter((entry) => entry.transcript);
-    expect(requests.length).toBeGreaterThanOrEqual(2);
+    expect(requests).toHaveLength(1);
     expect(requests.map((request) => request.transcript).join("")).toBe(
       "Sunlight reaches Earth quickly.",
     );
-    expect(requests[0]?.continue).toBe(true);
-    expect(requests.at(-1)?.continue).toBe(false);
+    expect(requests[0]?.continue).toBe(false);
   });
 
   test("canonical chunk/done SSE frames are parsed into speakable LLM text", async () => {
@@ -1888,7 +1898,8 @@ describe("voice-session WS lifecycle", () => {
     ink.emitTurn("turn.end", "voice transcript");
     await controlled.ready;
 
-    const streamedChunk = "This first streamed phrase is speakable now ";
+    const streamedChunk =
+      "This first streamed phrase is intentionally long enough to cross the bounded streaming threshold at a natural word boundary before the response completes ";
     controlled.enqueueChunk(streamedChunk);
     await flush();
 
@@ -2094,7 +2105,7 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).not.toContain("error");
     expect(client.controlTypes()).toContain("llm_first_text");
     const cartesia = FakeCartesiaSocket.instances.at(-1)!;
-    expect(cartesia.sentText()).toBe("Cache warmed.Here is your answer.");
+    expect(cartesia.sentText()).toBe("Cache warmed. Here is your answer.");
     const latencyLog = fakeLogger.logger.info.mock.calls.findLast(
       ([message]) => message === "[voice-session] first-turn latency",
     );
@@ -2354,6 +2365,52 @@ describe("voice-session WS lifecycle", () => {
     client.clientSend(pcmChunk(3_200));
     await flush();
     expect(ink.sentChunks.length).toBeGreaterThan(providerChunksBeforeEcho);
+  });
+
+  test("emits bounded payload-free turn timing and half-duplex metrics", async () => {
+    let nowMs = Date.now();
+    const receipts: VoiceTurnMetricsReceipt[] = [];
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["Copy that.", " Bravo 913 noted."]),
+      acousticBargeInEnabled: false,
+      halfDuplexPlaybackSettleMs: 600,
+      now: () => nowMs,
+      onTurnMetrics: (receipt) => receipts.push(receipt),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "voice checkpoint");
+    await flush();
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+
+    nowMs += 45;
+    cartesia.emitAudio(new Uint8Array(8));
+    client.clientSend(pcmChunk(3_200));
+    nowMs += 30;
+    cartesia.emitDone();
+    await flush();
+
+    expect(receipts).toHaveLength(1);
+    const receipt = receipts[0]!;
+    expect(receipt.outcome).toBe("completed");
+    expect(receipt.llmDeltaCount).toBe(2);
+    expect(receipt.sonicRequestCount).toBe(1);
+    expect(receipt.sonicRequestOffsetsMs.length).toBeLessThanOrEqual(16);
+    expect(receipt.audioFrameCount).toBe(2);
+    expect(receipt.outboundAudioBytes).toBe(12);
+    expect(receipt.maxAudioFrameGapMs).toBe(45);
+    expect(receipt.completionOffsetMs).toBe(75);
+    expect(receipt.halfDuplexArmedCount).toBe(1);
+    expect(receipt.halfDuplexSettlingCount).toBe(1);
+    expect(receipt.halfDuplexSuppressedFrameCount).toBe(1);
+    expect(receipt.halfDuplexSuppressedBytes).toBe(3_200);
+    expect(Object.keys(receipt)).not.toContain("transcript");
+    expect(Object.keys(receipt)).not.toContain("text");
+    expect(Object.keys(receipt)).not.toContain("audio");
   });
 
   test("explicit barge-in immediately releases half-duplex suppression", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
+++ b/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
@@ -562,6 +562,8 @@ export async function startRealVoiceServer(
           // actually does. Once the poll's request-scoped store parameter
           // lands (#16669), forward `rawRedis` here the way the route does.
           isRevoked: (j) => isVoiceSessionTokenRevoked(j),
+          onTurnMetrics: (receipt) =>
+            hooks.log("info", "voice turn metrics", { ...receipt }),
           downlink,
         }),
     });

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -70,6 +70,12 @@ import {
 import { UplinkReframer } from "./uplink-reframer";
 
 const PCM16_BYTES_PER_SECOND = 16_000 * 2; // 16kHz mono linear16.
+/**
+ * Keep the microphone closed briefly after the final downlink sample should
+ * have played. Mobile speaker output can remain in the acoustic path for a
+ * small device-buffer tail even after the provider has finished streaming.
+ */
+const HALF_DUPLEX_PLAYBACK_SETTLE_MS = 600;
 /** Accrue metered minutes in whole seconds to keep the store's math simple. */
 const METER_FLUSH_SECONDS = 5;
 /** Nominal minutes charged on admission before ANY audio is forwarded (SEC-15). */
@@ -153,6 +159,13 @@ export interface VoiceSessionConfig {
   fishAudioSampleRate?: number;
   fishAudioFirstAudioTimeoutMs?: number;
   fishAudioWebSocketFactory?: FishAudioWebSocketFactory;
+  /**
+   * Opt in only when the client has proven echo cancellation. The safe default
+   * is half duplex: assistant playback never reaches Ink as caller speech.
+   */
+  acousticBargeInEnabled?: boolean;
+  /** Deterministic test override for the post-playback microphone settle. */
+  halfDuplexPlaybackSettleMs?: number;
 
   // LLM leg.
   elizaEndpoint: string;
@@ -234,6 +247,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private readonly cartesiaAdapter: CartesiaSonicTtsAdapter;
   private readonly fishAudioAdapter: FishAudioTtsAdapter | null = null;
   private ttsStream: RealtimeTtsStream | null = null;
+  private assistantPlaybackStartedAtMs: number | null = null;
+  private assistantPlaybackAudioBytes = 0;
+  private assistantPlaybackActive = false;
+  private assistantPlaybackSuppressedUntilMs = Number.NEGATIVE_INFINITY;
+  private assistantPlaybackDroppedUplinkBytes = 0;
+  private assistantPlaybackDropLogged = false;
 
   private state: SessionState = "ready";
   private started = false;
@@ -450,6 +469,23 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   pushUplinkAudio(bytes: Uint8Array): void {
     if (this.closed || this.meteredExhausted) return;
 
+    // No AEC is guaranteed on the mobile clients. During assistant playback,
+    // forwarding speaker echo to Ink makes the model transcribe and answer
+    // itself. Drop before re-framing and metering so suppressed echo is neither
+    // provider input nor billed caller audio. Explicit UI barge-in clears this
+    // gate synchronously; acoustic barge-in is available only to AEC-safe
+    // clients that opt in through the session config.
+    if (this.isAssistantPlaybackSuppressed()) {
+      this.assistantPlaybackDroppedUplinkBytes += bytes.byteLength;
+      if (!this.assistantPlaybackDropLogged) {
+        this.assistantPlaybackDropLogged = true;
+        logger.info("[voice-session] half-duplex uplink suppressed", {
+          traceId: this.currentVoiceTurnId,
+        });
+      }
+      return;
+    }
+
     // Fail-closed admission (SEC-15): NO audio is forwarded to the paid provider
     // until an initial quota check has PASSED. Frames that arrive before the
     // first admission resolves are re-framed and buffered (bounded); if
@@ -590,12 +626,97 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   /** Explicit UI barge-in (contract §7.2). */
   bargeIn(): void {
+    this.clearAssistantPlaybackSuppression();
     this.interrupt("explicit");
   }
 
   /** Client `bye`: complete the session cleanly. */
   bye(): void {
     this.teardown("completed");
+  }
+
+  private isAssistantPlaybackSuppressed(): boolean {
+    if (this.config.acousticBargeInEnabled === true) return false;
+    return (
+      this.assistantPlaybackActive ||
+      this.now() < this.assistantPlaybackSuppressedUntilMs
+    );
+  }
+
+  private armAssistantPlaybackSuppression(): void {
+    if (this.config.acousticBargeInEnabled === true) return;
+    this.assistantPlaybackActive = true;
+    this.assistantPlaybackStartedAtMs = this.now();
+    this.assistantPlaybackAudioBytes = 0;
+    this.assistantPlaybackSuppressedUntilMs = Number.POSITIVE_INFINITY;
+    this.assistantPlaybackDroppedUplinkBytes = 0;
+    this.assistantPlaybackDropLogged = false;
+    this.discardSuppressedUplinkState();
+    logger.info("[voice-session] half-duplex playback suppression armed", {
+      traceId: this.currentVoiceTurnId,
+    });
+  }
+
+  private noteAssistantPlaybackAudio(byteLength: number): void {
+    if (!this.assistantPlaybackActive || byteLength <= 0) return;
+    this.assistantPlaybackAudioBytes += byteLength;
+  }
+
+  private settleAssistantPlaybackSuppression(): void {
+    if (!this.assistantPlaybackActive) return;
+    const now = this.now();
+    const playbackStartedAt = this.assistantPlaybackStartedAtMs ?? now;
+    const estimatedPlaybackMs = Math.ceil(
+      (this.assistantPlaybackAudioBytes / PCM16_BYTES_PER_SECOND) * 1000,
+    );
+    const settleMs = Math.max(
+      0,
+      this.config.halfDuplexPlaybackSettleMs ?? HALF_DUPLEX_PLAYBACK_SETTLE_MS,
+    );
+    this.assistantPlaybackActive = false;
+    this.assistantPlaybackSuppressedUntilMs =
+      Math.max(now, playbackStartedAt + estimatedPlaybackMs) + settleMs;
+    this.discardSuppressedUplinkState();
+    logger.info("[voice-session] half-duplex playback suppression settling", {
+      traceId: this.currentVoiceTurnId,
+      estimatedPlaybackMs,
+      settleMs,
+      droppedUplinkBytes: this.assistantPlaybackDroppedUplinkBytes,
+    });
+  }
+
+  private clearAssistantPlaybackSuppression(): void {
+    const wasSuppressed = this.isAssistantPlaybackSuppressed();
+    this.assistantPlaybackActive = false;
+    this.assistantPlaybackStartedAtMs = null;
+    this.assistantPlaybackAudioBytes = 0;
+    this.assistantPlaybackSuppressedUntilMs = Number.NEGATIVE_INFINITY;
+    this.assistantPlaybackDroppedUplinkBytes = 0;
+    this.assistantPlaybackDropLogged = false;
+    if (wasSuppressed) this.discardSuppressedUplinkState();
+  }
+
+  private discardSuppressedUplinkState(): void {
+    this.preAdmissionFrames.length = 0;
+    this.providerPendingFrames.length = 0;
+    this.reframer.flush();
+    this.activeSttTurn = false;
+    this.sttTurnStartedAtMs = null;
+    this.sttFirstTranscriptAtMs = null;
+    this.sttLastTranscriptAtMs = null;
+    this.sttEagerEndAtMs = null;
+    this.resetSttPartialDelivery();
+  }
+
+  private shouldIgnoreAssistantEchoEvent(type: string): boolean {
+    if (!this.isAssistantPlaybackSuppressed()) return false;
+    return (
+      type === "start-of-turn" ||
+      type === "transcript-update" ||
+      type === "eager-end-of-turn" ||
+      type === "end-of-turn" ||
+      type === "turn-resumed"
+    );
   }
 
   // --- LiveVoiceSession (SEC-6) --------------------------------------------
@@ -637,6 +758,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     generation: number,
   ): void {
     if (this.closed || generation !== this.sttGeneration) return;
+    if (this.shouldIgnoreAssistantEchoEvent(event.type)) {
+      this.discardSuppressedUplinkState();
+      return;
+    }
     switch (event.type) {
       case "connected": {
         // Provider readiness is transport metadata; the client-facing session
@@ -968,6 +1093,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const stream = this.createTtsStream(traceId, {
       onFirstAudio: () => {
         if (this.currentVoiceTurnId !== traceId) return;
+        this.armAssistantPlaybackSuppression();
         const firstAudioAt = this.now();
         logger.info("[voice-session] opening greeting latency", {
           traceId,
@@ -984,6 +1110,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       },
       onAudioFrame: (frame) => {
         if (this.currentVoiceTurnId !== traceId) return;
+        this.noteAssistantPlaybackAudio(frame.bytes.byteLength);
         this.config.downlink.sendAudio(frame.bytes);
       },
       onComplete: () => {
@@ -993,6 +1120,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       },
       onProviderError: (error) => {
         if (this.currentVoiceTurnId !== traceId) return;
+        this.clearAssistantPlaybackSuppression();
         this.send({
           t: "error",
           code: error.code ?? "tts_error",
@@ -1130,6 +1258,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       const callbacks: RealtimeTtsStreamCallbacks = {
         onFirstAudio: () => {
           if (this.currentVoiceTurnId !== traceId) return;
+          this.armAssistantPlaybackSuppression();
           modelAudioStarted = true;
           const firstAudioAt = this.now();
           logger.info("[voice-session] first-turn latency", {
@@ -1166,6 +1295,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         onAudioFrame: (frame) => {
           // Guard: no post-cancel / stale-turn frames ever reach the client.
           if (this.currentVoiceTurnId !== traceId) return;
+          this.noteAssistantPlaybackAudio(frame.bytes.byteLength);
           this.config.downlink.sendAudio(frame.bytes);
         },
         onComplete: () => {
@@ -1175,6 +1305,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         },
         onProviderError: (err) => {
           if (this.currentVoiceTurnId !== traceId) return;
+          this.clearAssistantPlaybackSuppression();
           this.send({
             t: "error",
             code: err.code ?? "tts_error",
@@ -1459,6 +1590,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   private finishTurn(traceId: string): void {
     if (this.currentVoiceTurnId !== traceId || this.closed) return;
+    this.settleAssistantPlaybackSuppression();
     this.send({
       t: "usage",
       sttMs: this.turnSttMs,
@@ -1482,6 +1614,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
    * `interrupted`, so no post-cancel audio can leak to the client.
    */
   private interrupt(reason: "acoustic" | "explicit"): void {
+    this.clearAssistantPlaybackSuppression();
     const traceId = this.currentVoiceTurnId;
     if (!traceId) return; // nothing speaking/thinking to interrupt.
 
@@ -1579,6 +1712,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   private teardown(reason: VoiceSessionSeverReason): void {
     if (this.closed) return;
+    this.clearAssistantPlaybackSuppression();
     this.closed = true;
     this.state = "closed";
     logger.info("[voice-session] session closed", {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -94,13 +94,14 @@ const REVOCATION_POLL_MS = 400;
  */
 const MAX_OUTSTANDING_METER_WINDOWS = 2;
 /**
- * Voice cannot wait for the generic 180-character phrase ceiling: short spoken
- * replies often have no punctuation until the model's final token, which put
- * ~2.8s of generation after `llm_first_text` on the first-audio path. Emit a
- * speakable clause after a small token-sized prefix; Cartesia's continuation
- * context preserves prosody across the resulting chunks.
+ * Hold a short reply until the LLM finishes so Cartesia receives one terminal
+ * request and can render it with coherent prosody. Longer replies still begin
+ * streaming at a bounded prefix; after that point PhraseAggregator emits only
+ * at natural clause/sentence boundaries or this higher word-safe ceiling.
  */
-const VOICE_TTS_FIRST_CLAUSE_CHARS = 24;
+const VOICE_TTS_STREAMING_THRESHOLD_CHARS = 96;
+/** Keep every per-turn timing collection bounded even for pathological output. */
+const MAX_VOICE_METRIC_OFFSETS = 16;
 /** Human-readable interim captions do not benefit from provider-rate redraws. */
 const STT_PARTIAL_EMIT_INTERVAL_MS = 40;
 /**
@@ -137,6 +138,36 @@ const UNSPEAKABLE_RESPONSE_FALLBACK =
 
 export type { VoiceSessionDownlink } from "@/lib/voice-session/ws-handler";
 
+export interface VoiceTurnMetricsReceipt {
+  traceId: string;
+  startedAtMs: number;
+  outcome: "completed" | "interrupted" | "error";
+  llmDeltaCount: number;
+  firstLlmTextOffsetMs: number | null;
+  lastLlmTextOffsetMs: number | null;
+  maxLlmDeltaGapMs: number;
+  sonicRequestCount: number;
+  sonicRequestOffsetsMs: readonly number[];
+  sonicRequestsBeforeTransportReady: number;
+  maxSonicRequestGapMs: number;
+  firstAudioFrameOffsetMs: number | null;
+  lastAudioFrameOffsetMs: number | null;
+  audioFrameCount: number;
+  outboundAudioBytes: number;
+  maxAudioFrameGapMs: number;
+  completionOffsetMs: number | null;
+  halfDuplexArmedCount: number;
+  halfDuplexSettlingCount: number;
+  halfDuplexSuppressedFrameCount: number;
+  halfDuplexSuppressedBytes: number;
+}
+
+interface VoiceTurnMetricsState extends VoiceTurnMetricsReceipt {
+  lastLlmDeltaAtMs: number | null;
+  lastSonicRequestAtMs: number | null;
+  lastAudioFrameAtMs: number | null;
+}
+
 export interface VoiceSessionConfig {
   sessionId: string;
   jti: string;
@@ -166,6 +197,8 @@ export interface VoiceSessionConfig {
   acousticBargeInEnabled?: boolean;
   /** Deterministic test override for the post-playback microphone settle. */
   halfDuplexPlaybackSettleMs?: number;
+  /** Bounded payload-free timing receipt for observability and regression tests. */
+  onTurnMetrics?: (receipt: VoiceTurnMetricsReceipt) => void;
 
   // LLM leg.
   elizaEndpoint: string;
@@ -253,6 +286,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private assistantPlaybackSuppressedUntilMs = Number.NEGATIVE_INFINITY;
   private assistantPlaybackDroppedUplinkBytes = 0;
   private assistantPlaybackDropLogged = false;
+  private turnMetrics: VoiceTurnMetricsState | null = null;
 
   private state: SessionState = "ready";
   private started = false;
@@ -477,6 +511,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     // clients that opt in through the session config.
     if (this.isAssistantPlaybackSuppressed()) {
       this.assistantPlaybackDroppedUplinkBytes += bytes.byteLength;
+      if (this.turnMetrics) {
+        this.turnMetrics.halfDuplexSuppressedFrameCount += 1;
+        this.turnMetrics.halfDuplexSuppressedBytes += bytes.byteLength;
+      }
       if (!this.assistantPlaybackDropLogged) {
         this.assistantPlaybackDropLogged = true;
         logger.info("[voice-session] half-duplex uplink suppressed", {
@@ -529,6 +567,133 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     }
 
     for (const frame of frames) if (!this.forwardSttFrame(frame)) return;
+  }
+
+  private beginTurnMetrics(traceId: string, startedAtMs: number): void {
+    this.turnMetrics = {
+      traceId,
+      startedAtMs,
+      outcome: "completed",
+      llmDeltaCount: 0,
+      firstLlmTextOffsetMs: null,
+      lastLlmTextOffsetMs: null,
+      maxLlmDeltaGapMs: 0,
+      sonicRequestCount: 0,
+      sonicRequestOffsetsMs: [],
+      sonicRequestsBeforeTransportReady: 0,
+      maxSonicRequestGapMs: 0,
+      firstAudioFrameOffsetMs: null,
+      lastAudioFrameOffsetMs: null,
+      audioFrameCount: 0,
+      outboundAudioBytes: 0,
+      maxAudioFrameGapMs: 0,
+      completionOffsetMs: null,
+      halfDuplexArmedCount: 0,
+      halfDuplexSettlingCount: 0,
+      halfDuplexSuppressedFrameCount: 0,
+      halfDuplexSuppressedBytes: 0,
+      lastLlmDeltaAtMs: null,
+      lastSonicRequestAtMs: null,
+      lastAudioFrameAtMs: null,
+    };
+  }
+
+  private noteLlmDelta(traceId: string): void {
+    const metrics = this.turnMetrics;
+    if (!metrics || metrics.traceId !== traceId) return;
+    const now = this.now();
+    const offset = Math.max(0, now - metrics.startedAtMs);
+    metrics.llmDeltaCount += 1;
+    metrics.firstLlmTextOffsetMs ??= offset;
+    metrics.lastLlmTextOffsetMs = offset;
+    if (metrics.lastLlmDeltaAtMs !== null) {
+      metrics.maxLlmDeltaGapMs = Math.max(
+        metrics.maxLlmDeltaGapMs,
+        now - metrics.lastLlmDeltaAtMs,
+      );
+    }
+    metrics.lastLlmDeltaAtMs = now;
+  }
+
+  private noteSonicRequest(traceId: string, transportReady: boolean): void {
+    const metrics = this.turnMetrics;
+    if (!metrics || metrics.traceId !== traceId) return;
+    const now = this.now();
+    metrics.sonicRequestCount += 1;
+    if (metrics.sonicRequestOffsetsMs.length < MAX_VOICE_METRIC_OFFSETS) {
+      (metrics.sonicRequestOffsetsMs as number[]).push(
+        Math.max(0, now - metrics.startedAtMs),
+      );
+    }
+    if (!transportReady) metrics.sonicRequestsBeforeTransportReady += 1;
+    if (metrics.lastSonicRequestAtMs !== null) {
+      metrics.maxSonicRequestGapMs = Math.max(
+        metrics.maxSonicRequestGapMs,
+        now - metrics.lastSonicRequestAtMs,
+      );
+    }
+    metrics.lastSonicRequestAtMs = now;
+  }
+
+  private noteAudioFrame(traceId: string, byteLength: number): void {
+    const metrics = this.turnMetrics;
+    if (!metrics || metrics.traceId !== traceId) return;
+    const now = this.now();
+    const offset = Math.max(0, now - metrics.startedAtMs);
+    metrics.firstAudioFrameOffsetMs ??= offset;
+    metrics.lastAudioFrameOffsetMs = offset;
+    metrics.audioFrameCount += 1;
+    metrics.outboundAudioBytes += Math.max(0, byteLength);
+    if (metrics.lastAudioFrameAtMs !== null) {
+      metrics.maxAudioFrameGapMs = Math.max(
+        metrics.maxAudioFrameGapMs,
+        now - metrics.lastAudioFrameAtMs,
+      );
+    }
+    metrics.lastAudioFrameAtMs = now;
+  }
+
+  private emitTurnMetrics(
+    traceId: string,
+    outcome: VoiceTurnMetricsReceipt["outcome"],
+  ): void {
+    const metrics = this.turnMetrics;
+    if (!metrics || metrics.traceId !== traceId) return;
+    metrics.outcome = outcome;
+    metrics.completionOffsetMs = Math.max(0, this.now() - metrics.startedAtMs);
+    this.turnMetrics = null;
+    const receipt: VoiceTurnMetricsReceipt = {
+      traceId: metrics.traceId,
+      startedAtMs: metrics.startedAtMs,
+      outcome: metrics.outcome,
+      llmDeltaCount: metrics.llmDeltaCount,
+      firstLlmTextOffsetMs: metrics.firstLlmTextOffsetMs,
+      lastLlmTextOffsetMs: metrics.lastLlmTextOffsetMs,
+      maxLlmDeltaGapMs: metrics.maxLlmDeltaGapMs,
+      sonicRequestCount: metrics.sonicRequestCount,
+      sonicRequestOffsetsMs: [...metrics.sonicRequestOffsetsMs],
+      sonicRequestsBeforeTransportReady:
+        metrics.sonicRequestsBeforeTransportReady,
+      maxSonicRequestGapMs: metrics.maxSonicRequestGapMs,
+      firstAudioFrameOffsetMs: metrics.firstAudioFrameOffsetMs,
+      lastAudioFrameOffsetMs: metrics.lastAudioFrameOffsetMs,
+      audioFrameCount: metrics.audioFrameCount,
+      outboundAudioBytes: metrics.outboundAudioBytes,
+      maxAudioFrameGapMs: metrics.maxAudioFrameGapMs,
+      completionOffsetMs: metrics.completionOffsetMs,
+      halfDuplexArmedCount: metrics.halfDuplexArmedCount,
+      halfDuplexSettlingCount: metrics.halfDuplexSettlingCount,
+      halfDuplexSuppressedFrameCount: metrics.halfDuplexSuppressedFrameCount,
+      halfDuplexSuppressedBytes: metrics.halfDuplexSuppressedBytes,
+    };
+    try {
+      this.config.onTurnMetrics?.(receipt);
+    } catch (error) {
+      logger.warn("[voice-session] turn metrics hook failed", {
+        traceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /** Queue audio until Ink is ready, then preserve its original frame order. */
@@ -645,6 +810,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   private armAssistantPlaybackSuppression(): void {
     if (this.config.acousticBargeInEnabled === true) return;
+    if (this.turnMetrics) this.turnMetrics.halfDuplexArmedCount += 1;
     this.assistantPlaybackActive = true;
     this.assistantPlaybackStartedAtMs = this.now();
     this.assistantPlaybackAudioBytes = 0;
@@ -664,6 +830,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   private settleAssistantPlaybackSuppression(): void {
     if (!this.assistantPlaybackActive) return;
+    if (this.turnMetrics) this.turnMetrics.halfDuplexSettlingCount += 1;
     const now = this.now();
     const playbackStartedAt = this.assistantPlaybackStartedAtMs ?? now;
     const estimatedPlaybackMs = Math.ceil(
@@ -1224,6 +1391,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     } = {},
   ): Promise<void> {
     const responseStartedAt = this.now();
+    this.beginTurnMetrics(traceId, responseStartedAt);
     let firstModelTextAt: number | null = null;
     const upstreamAttempts: Array<{
       attempt: number;
@@ -1242,10 +1410,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const abort = new AbortController();
     this.llmAbort = abort;
     const phrase = new PhraseAggregator({
-      maxBufferChars: VOICE_TTS_FIRST_CLAUSE_CHARS,
+      maxBufferChars: VOICE_TTS_STREAMING_THRESHOLD_CHARS,
       preferWordBoundaryAtMax: true,
     });
     this.phrase = phrase;
+    let initialReplyBuffer = "";
+    let streamingReplyStarted = false;
 
     let tts: RealtimeTtsStream | null = null;
     // Held terminal suffix (see the streaming loop below): Cartesia requires a
@@ -1295,6 +1465,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         onAudioFrame: (frame) => {
           // Guard: no post-cancel / stale-turn frames ever reach the client.
           if (this.currentVoiceTurnId !== traceId) return;
+          this.noteAudioFrame(traceId, frame.bytes.byteLength);
           this.noteAssistantPlaybackAudio(frame.bytes.byteLength);
           this.config.downlink.sendAudio(frame.bytes);
         },
@@ -1317,12 +1488,42 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           abort.abort();
           // Close out the failed turn so the client gets usage + returns to
           // listening, instead of the session being stuck on a dead turn.
-          this.finishTurn(traceId);
+          this.finishTurn(traceId, "error");
         },
       };
       tts = this.createTtsStream(traceId, callbacks);
       this.ttsStream = tts;
       return tts;
+    };
+    const sendTtsPhrase = (
+      stream: RealtimeTtsStream,
+      input: RealtimeTtsPhraseInput,
+    ): void => {
+      this.noteSonicRequest(traceId, ttsTransportReadyAt !== null);
+      stream.sendPhrase(input);
+    };
+    const queueStreamingPhrases = (phrases: readonly string[]): void => {
+      for (const p of phrases) {
+        if (!SPOKEN_TRANSCRIPT_RE.test(p)) continue;
+        this.turnTtsChars += p.length;
+        const stream = ensureTts();
+        if (pendingPhrase !== null) {
+          sendTtsPhrase(stream, {
+            text: pendingPhrase,
+            continueContext: true,
+          });
+        }
+        const split = splitTerminalSuffix(p);
+        if (split) {
+          sendTtsPhrase(stream, {
+            text: split.prefix,
+            continueContext: true,
+          });
+          pendingPhrase = split.suffix;
+        } else {
+          pendingPhrase = p;
+        }
+      }
     };
 
     try {
@@ -1394,10 +1595,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           // same TTS context and normal terminal cleanup closes it.
           const stream = ensureTts();
           if (pendingPhrase !== null) {
-            stream.sendPhrase({ text: pendingPhrase, continueContext: true });
+            sendTtsPhrase(stream, {
+              text: pendingPhrase,
+              continueContext: true,
+            });
             pendingPhrase = null;
           }
-          stream.sendPhrase({ text, continueContext: true });
+          sendTtsPhrase(stream, { text, continueContext: true });
           logger.info("[voice-session] action progress cue", {
             traceId,
             elapsedMs: this.now() - responseStartedAt,
@@ -1406,6 +1610,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       };
       const onDelta = (delta: string) => {
         if (this.currentVoiceTurnId !== traceId) return;
+        this.noteLlmDelta(traceId);
         modelOutputChars += delta.length;
         if (SPOKEN_TRANSCRIPT_RE.test(delta)) {
           modelSpeakableContentSeen = true;
@@ -1415,28 +1620,23 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           firstModelTextAt = this.now();
           this.send({ t: "llm_first_text", traceId });
         }
-        // Cartesia closes a synthesis context via the FINAL non-empty phrase
-        // carrying continue:false. Holding a whole sentence until LLM stream
-        // completion added seconds to first audio for one-sentence replies.
-        // Send the speakable prefix immediately and retain only its last word
-        // as the eventual terminal phrase. A following phrase first flushes
-        // the retained suffix with continue:true.
-        const phrases = phrase.push(delta);
-        for (const p of phrases) {
-          if (!SPOKEN_TRANSCRIPT_RE.test(p)) continue;
-          this.turnTtsChars += p.length;
-          const stream = ensureTts();
-          if (pendingPhrase !== null) {
-            stream.sendPhrase({ text: pendingPhrase, continueContext: true });
+        // Short answers sound best as one coherent terminal request. Hold the
+        // initial reply until either the LLM completes or it crosses the
+        // bounded streaming threshold. Longer replies then use the shared
+        // phrase policy, which emits at natural boundaries or a high word-safe
+        // ceiling rather than arbitrary 24-character splits.
+        if (!streamingReplyStarted) {
+          initialReplyBuffer += delta;
+          if (initialReplyBuffer.length < VOICE_TTS_STREAMING_THRESHOLD_CHARS) {
+            return;
           }
-          const split = splitTerminalSuffix(p);
-          if (split) {
-            stream.sendPhrase({ text: split.prefix, continueContext: true });
-            pendingPhrase = split.suffix;
-          } else {
-            pendingPhrase = p;
-          }
+          streamingReplyStarted = true;
+          const buffered = initialReplyBuffer;
+          initialReplyBuffer = "";
+          queueStreamingPhrases(phrase.push(buffered));
+          return;
         }
+        queueStreamingPhrases(phrase.push(delta));
       };
       const retryDelays =
         this.config.cacheWarmingRetryDelaysMs ?? CACHE_WARMING_RETRY_DELAYS_MS;
@@ -1496,25 +1696,44 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         });
       }
 
+      if (!streamingReplyStarted) {
+        const completeShortReply = initialReplyBuffer.trim();
+        initialReplyBuffer = "";
+        if (SPOKEN_TRANSCRIPT_RE.test(completeShortReply)) {
+          this.turnTtsChars += completeShortReply.length;
+          sendTtsPhrase(ensureTts(), {
+            text: completeShortReply,
+            continueContext: false,
+          });
+          return;
+        }
+      }
+
       const tail = phrase.flush();
       if (tail && SPOKEN_TRANSCRIPT_RE.test(tail)) {
         // A trailing phrase remains. Flush any held phrase (continue:true), then
         // send the tail as the terminal phrase with continue:false.
         if (pendingPhrase !== null) {
-          ensureTts().sendPhrase({
+          sendTtsPhrase(ensureTts(), {
             text: pendingPhrase,
             continueContext: true,
           });
           pendingPhrase = null;
         }
         this.turnTtsChars += tail.length;
-        ensureTts().sendPhrase({ text: tail, continueContext: false });
+        sendTtsPhrase(ensureTts(), {
+          text: tail,
+          continueContext: false,
+        });
       } else if (pendingPhrase !== null) {
         // The held phrase is the LAST speakable unit: send it with
         // continue:false to close the context cleanly (yields `done` ->
         // onComplete). This replaces the empty-transcript finish() that the
         // LIVE Cartesia API rejects.
-        ensureTts().sendPhrase({ text: pendingPhrase, continueContext: false });
+        sendTtsPhrase(ensureTts(), {
+          text: pendingPhrase,
+          continueContext: false,
+        });
         pendingPhrase = null;
       } else {
         // No speakable output at all (empty LLM reply). The socket was opened
@@ -1580,7 +1799,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // stream fails before a terminal TTS phrase is sent. finishTurn has not
       // run yet, so ttsStream still belongs to this turn.
       this.ttsStream?.cancel("llm_error");
-      this.finishTurn(traceId);
+      this.finishTurn(traceId, "error");
       const fallbackGreeting = options.fallbackGreeting?.trim();
       if (fallbackGreeting && !modelAudioStarted) {
         this.speakOpeningGreeting(fallbackGreeting);
@@ -1588,9 +1807,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     }
   }
 
-  private finishTurn(traceId: string): void {
+  private finishTurn(
+    traceId: string,
+    outcome: VoiceTurnMetricsReceipt["outcome"] = "completed",
+  ): void {
     if (this.currentVoiceTurnId !== traceId || this.closed) return;
     this.settleAssistantPlaybackSuppression();
+    this.emitTurnMetrics(traceId, outcome);
     this.send({
       t: "usage",
       sttMs: this.turnSttMs,
@@ -1617,6 +1840,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     this.clearAssistantPlaybackSuppression();
     const traceId = this.currentVoiceTurnId;
     if (!traceId) return; // nothing speaking/thinking to interrupt.
+    this.emitTurnMetrics(traceId, "interrupted");
 
     // 1. Invalidate the turn id FIRST so any in-flight adapter callback that
     //    races this path is dropped by the `currentVoiceTurnId` guard.


### PR DESCRIPTION
## Summary
- suppress inbound microphone audio while assistant playback is active and through a bounded settle window
- preserve explicit barge-in and teardown/error release paths
- emit payload-free per-turn timing and suppression metrics
- send complete short replies as one terminal Sonic request; longer streaming replies flush at natural or bounded word-safe boundaries

## Provenance
Current-develop adaptation of the physically accepted gateway lineage:
- half-duplex source `561238b493ba714faaca90979d0f6163446c9350`
- smoothing/metrics source `ab31d4400d7bd8d49ac42b6aaf8be23dc142e9bc` / tree `f666d4edd56cd550ca3fcfeecfa3b06fd56d118d`

## Gates
- changed-behavior WS lifecycle tests: 6/6 pass
- changed-file Biome and diff check: pass
- broad Cloud API typecheck reached the known V8 heap ceiling before diagnostics; no source diagnostic was emitted

Source-only publication; no gateway, relay, runtime, or device process was changed.
