### PR TITLE
fix(voice): enable probed realtime for pinned self-hosted apps

### DIFF
--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -34,8 +34,18 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
       .trim()
       .toLowerCase(),
   );
+  const isVpsSidecar = ["1", "true", "yes"].includes(
+    String(env.ELIZA_ANDROID_VPS_SIDECAR ?? "")
+      .trim()
+      .toLowerCase(),
+  );
   return {
     VITE_VOICE_REALTIME_WS: "1",
+    // A production self-hosted artifact may arm realtime only after its paired
+    // same-origin runtime proves the authenticated voice-session contract is
+    // available. This is distinct from the developer force override: the
+    // runtime remains authoritative and provider credentials stay server-side.
+    VITE_VOICE_REALTIME_SELF_HOSTED: isVpsSidecar ? "1" : "0",
     // Never inherit an ambient debug-force flag into a device artifact. A
     // Cloud mobile build may use realtime only when the normal eligibility
     // contract and server gate both pass.

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -45,7 +45,8 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
     // same-origin runtime proves the authenticated voice-session contract is
     // available. This is distinct from the developer force override: the
     // runtime remains authoritative and provider credentials stay server-side.
-    VITE_VOICE_REALTIME_SELF_HOSTED: isVpsSidecar ? "1" : "0",
+    VITE_VOICE_REALTIME_SELF_HOSTED:
+      isVpsSidecar || (isLp3Debug && isLp3RemoteFallback) ? "1" : "0",
     // Never inherit an ambient debug-force flag into a device artifact. A
     // Cloud mobile build may use realtime only when the normal eligibility
     // contract and server gate both pass.

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -68,7 +68,7 @@ describe("resolveMobileRendererFeatureEnv", () => {
       VITE_VOICE_REALTIME_FORCE: "0",
     });
   });
-  it("permanently hides Stream only in the dedicated LP3 VPS fallback", () => {
+  it("enables probed realtime and hides Stream only in the dedicated LP3 VPS fallback", () => {
     expect(
       resolveMobileRendererFeatureEnv({
         platform: "android-cloud-debug",
@@ -79,7 +79,7 @@ describe("resolveMobileRendererFeatureEnv", () => {
       }),
     ).toEqual({
       VITE_VOICE_REALTIME_WS: "1",
-      VITE_VOICE_REALTIME_SELF_HOSTED: "0",
+      VITE_VOICE_REALTIME_SELF_HOSTED: "1",
       VITE_VOICE_REALTIME_FORCE: "0",
       VITE_ENABLE_STREAM: "false",
       VITE_ELIZA_ANDROID_LP3_SHARED_BROWSER_STORAGE: "1",

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -24,6 +24,7 @@ describe("resolveMobileRendererFeatureEnv", () => {
     for (const platform of ["android-cloud", "android-cloud-debug"]) {
       expect(resolveMobileRendererFeatureEnv({ platform })).toEqual({
         VITE_VOICE_REALTIME_WS: "1",
+        VITE_VOICE_REALTIME_SELF_HOSTED: "0",
         VITE_VOICE_REALTIME_FORCE: "0",
       });
     }
@@ -35,6 +36,7 @@ describe("resolveMobileRendererFeatureEnv", () => {
       }),
     ).toEqual({
       VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_SELF_HOSTED: "0",
       VITE_VOICE_REALTIME_FORCE: "0",
     });
   });
@@ -48,11 +50,24 @@ describe("resolveMobileRendererFeatureEnv", () => {
         }),
       ).toEqual({
         VITE_VOICE_REALTIME_WS: "1",
+        VITE_VOICE_REALTIME_SELF_HOSTED: "0",
         VITE_VOICE_REALTIME_FORCE: "0",
       });
     }
   });
 
+  it("enables server-probed realtime for the self-hosted VPS sidecar", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({
+        platform: "android-cloud-debug",
+        env: { ELIZA_ANDROID_VPS_SIDECAR: "1" },
+      }),
+    ).toEqual({
+      VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_SELF_HOSTED: "1",
+      VITE_VOICE_REALTIME_FORCE: "0",
+    });
+  });
   it("permanently hides Stream only in the dedicated LP3 VPS fallback", () => {
     expect(
       resolveMobileRendererFeatureEnv({
@@ -64,6 +79,7 @@ describe("resolveMobileRendererFeatureEnv", () => {
       }),
     ).toEqual({
       VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_SELF_HOSTED: "0",
       VITE_VOICE_REALTIME_FORCE: "0",
       VITE_ENABLE_STREAM: "false",
       VITE_ELIZA_ANDROID_LP3_SHARED_BROWSER_STORAGE: "1",
@@ -84,6 +100,7 @@ describe("resolveMobileRendererFeatureEnv", () => {
       }),
     ).toEqual({
       VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_SELF_HOSTED: "0",
       VITE_VOICE_REALTIME_FORCE: "0",
     });
   });

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.test.tsx
@@ -225,4 +225,64 @@ describe("useRealtimeVoiceMint", () => {
       );
     });
   });
+
+  describe("production self-hosted eligibility", () => {
+    it("arms only after the paired runtime proves its same-origin gateway", async () => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue(new Response('{"ready":true}', { status: 200 }));
+      const { result } = renderHook(() =>
+        useRealtimeVoiceMint({
+          resolveAgentId: () => null,
+          resolveSelfHostedRuntime: () => true,
+          selfHostedEnabled: true,
+          forceEnabled: false,
+          fetch,
+        }),
+      );
+
+      expect(result.current.agentId).toBeNull();
+      await waitFor(() =>
+        expect(result.current.agentId).toBe(REALTIME_FORCE_SENTINEL_AGENT_ID),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/v1/voice/session/health",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("does not arm for a non-remote runtime under the self-hosted stamp", () => {
+      const fetch = vi.fn();
+      const { result } = renderHook(() =>
+        useRealtimeVoiceMint({
+          resolveAgentId: () => null,
+          resolveSelfHostedRuntime: () => false,
+          selfHostedEnabled: true,
+          forceEnabled: false,
+          fetch,
+        }),
+      );
+
+      expect(result.current.agentId).toBeNull();
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when the paired runtime lacks the gateway", async () => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue(new Response("{}", { status: 404 }));
+      const { result } = renderHook(() =>
+        useRealtimeVoiceMint({
+          resolveAgentId: () => null,
+          resolveSelfHostedRuntime: () => true,
+          selfHostedEnabled: true,
+          forceEnabled: false,
+          fetch,
+        }),
+      );
+
+      await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+      expect(result.current.agentId).toBeNull();
+    });
+  });
 });

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.ts
@@ -1,8 +1,8 @@
 /**
  * Resolves the cloud agent identity and one-time consent required before
- * realtime voice may own the microphone. Self-hosted runtimes stay on batch
- * voice unless an explicit force build also passes its same-origin health
- * probe; failed consent or availability checks never fabricate eligibility.
+ * realtime voice may own the microphone. A production self-hosted build may
+ * arm only after its paired same-origin runtime proves the voice-session
+ * contract; failed consent or availability checks never fabricate eligibility.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -35,6 +35,21 @@ export function isRealtimeVoiceForceEnabled(): boolean {
     return v === "1" || v === "true" || v === "yes" || v === "on";
   } catch {
     // error-policy:J4 An unreadable build flag leaves force-arming explicitly disabled.
+    return false;
+  }
+}
+
+/** Read the production self-hosted realtime capability stamp. */
+export function isRealtimeVoiceSelfHostedEnabled(): boolean {
+  try {
+    const raw = import.meta.env?.VITE_VOICE_REALTIME_SELF_HOSTED as unknown;
+    if (typeof raw !== "string") return false;
+    const value = raw.trim().toLowerCase();
+    return (
+      value === "1" || value === "true" || value === "yes" || value === "on"
+    );
+  } catch {
+    // error-policy:J4 An unreadable build stamp leaves self-hosted realtime disabled.
     return false;
   }
 }
@@ -133,11 +148,20 @@ export function useRealtimeVoiceMint(options?: {
    * health probe succeeds. Never overrides a real resolved agent id.
    */
   forceEnabled?: boolean;
+  /** Production self-hosted capability stamp (tests may inject it). */
+  selfHostedEnabled?: boolean;
+  /** Whether the selected runtime is a paired self-hosted remote. */
+  resolveSelfHostedRuntime?: () => boolean;
 }): UseRealtimeVoiceMintResult {
   const doFetch = options?.fetch ?? defaultConsentFetch;
   const consentPath = options?.consentPath ?? "/api/v1/voice/session/consent";
   const probePath = options?.probePath ?? "/api/v1/voice/session/health";
   const forceEnabled = options?.forceEnabled ?? isRealtimeVoiceForceEnabled();
+  const selfHostedEnabled =
+    options?.selfHostedEnabled ?? isRealtimeVoiceSelfHostedEnabled();
+  const persistedActiveServer = options?.resolveAgentId
+    ? null
+    : loadPersistedActiveServer();
 
   const resolvedAgentId = useMemo(() => {
     // A real, resolvable cloud agent id ALWAYS wins over the sentinel.
@@ -145,15 +169,22 @@ export function useRealtimeVoiceMint(options?: {
       const id = options.resolveAgentId();
       return isUuid(id) ? id : null;
     }
-    const active = loadPersistedActiveServer();
-    const id = active ? resolveDedicatedAgentId(active) : null;
+    const id = persistedActiveServer
+      ? resolveDedicatedAgentId(persistedActiveServer)
+      : null;
     return isUuid(id) ? id : null;
     // resolveAgentId identity is stable in practice; the persisted server read
     // is intentionally per-mount (a runtime switch remounts the chat surface).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options?.resolveAgentId]);
+  }, [options?.resolveAgentId, persistedActiveServer]);
 
-  const forceProbeEligible = forceEnabled && !resolvedAgentId;
+  const selfHostedRuntime = options?.resolveSelfHostedRuntime
+    ? options.resolveSelfHostedRuntime()
+    : persistedActiveServer?.kind === "remote";
+
+  const forceProbeEligible =
+    !resolvedAgentId &&
+    (forceEnabled || (selfHostedEnabled && selfHostedRuntime));
   const [forceProbeArmed, setForceProbeArmed] = useState(false);
 
   useEffect(() => {

--- a/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
+++ b/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
@@ -15,8 +15,10 @@ server mint), the mic runs the existing batch ASR path completely unchanged.
   the persisted active server) + `getConsentNonce` (POST
   `/api/v1/voice/session/consent` via the same `fetchWithCsrf` every other
   `/api/v1` call uses). The client obtains a fresh one-use nonce immediately
-  before every initial or reconnect mint. A local/self-hosted runtime yields no
-  UUID → realtime never arms.
+  before every initial or reconnect mint. A production self-hosted build may
+  instead arm against a paired runtime only after its same-origin
+  voice-session health route succeeds; the runtime binds its fixed identity
+  server-side.
 - `useContinuousVoiceSession` — composes the batch continuous-chat engine with
   the realtime session; tries realtime when eligible, else batch UNCHANGED.
   Eligibility is not proof that mint or WebSocket setup has succeeded.
@@ -38,11 +40,14 @@ server mint), the mic runs the existing batch ASR path completely unchanged.
 ## Flags
 
 - Client: `VITE_VOICE_REALTIME_WS` = `1|true|yes|on` (default OFF).
+- Self-hosted client capability: `VITE_VOICE_REALTIME_SELF_HOSTED` =
+  `1|true|yes|on` (default OFF). It still requires a paired `remote` runtime and
+  a successful same-origin `/api/v1/voice/session/health` probe.
 - Server: `VOICE_REALTIME_WS_ENABLED` on the cloud worker (default OFF; a 404
   mint = feature disabled → the client falls back to batch, no error).
 
-Both must be on AND a dedicated cloud agent UUID must resolve for the realtime
-path to arm.
+Both must be on AND either a dedicated cloud agent UUID must resolve or the
+self-hosted capability and health-probe contract must pass.
 
 - Debug: `VITE_VOICE_REALTIME_FORCE` = `1|true|yes|on` (default OFF). A
 local-verification debug affordance only — it force-arms the realtime path


### PR DESCRIPTION
## Summary
- enable health-probed realtime voice for immutable self-hosted remote targets without forcing realtime globally
- resolve the authenticated remote agent ID before minting a realtime session
- keep the LP3 fallback policy explicit while preserving normal Cloud and local behavior

## Provenance
This is the minimal current-develop publication of accepted LP3 source `5b0cd9b62a458da7b2ab11168f69d9f47d5d3108` / tree `65fd20f12d43c441bd5ea00867e8709df7fd64dd`.

The generic immutable-remote Cloud billing/auth poll gate is intentionally omitted here because its exact patch is already reachable in open PR #29393.

## Gates
- focused mobile renderer + realtime mint tests: 26/26 pass
- `packages/ui` typecheck: pass
- changed-file Biome and diff check: pass

Source-only publication; no build install, device mutation, or deployment was performed by this PR lane.
