### PR TITLE
fix(app): stabilize native browser safe area

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -410,17 +410,10 @@
       -moz-osx-font-smoothing: grayscale;
     }
 
-    /* Safe area insets for notched devices. NB: no bottom inset — the
-       full-screen app background (ShaderBackground, fixed inset-0) must reach
-       the true screen bottom so the home-indicator zone shows the same field as
-       the rest of the screen (not the more-saturated body fallback color as a
-       bright band). Components that sit at the bottom (the chat composer) clear
-       the home indicator with their own env(safe-area-inset-bottom) padding. */
-    body {
-      padding-top: env(safe-area-inset-top);
-      padding-left: env(safe-area-inset-left);
-      padding-right: env(safe-area-inset-right);
-    }
+    /* The body remains full-bleed. Routed surfaces consume the shared safe-area
+       variables at their own interactive edges; applying the inset here as well
+       would shift every surface a second time once a native WebView resolves
+       env(safe-area-inset-*). */
 
     #root {
       min-height: 100dvh;

--- a/packages/app/src/web-entry-policy.test.ts
+++ b/packages/app/src/web-entry-policy.test.ts
@@ -94,6 +94,14 @@ function extractPolicyParamPatterns(policySource: string): RegExp[] {
 }
 
 describe("hosted public renderer entry policy", () => {
+  it("keeps the document canvas full-bleed while routed surfaces own safe areas", () => {
+    const indexHtml = readFileSync(resolve(appRoot, "index.html"), "utf8");
+
+    expect(indexHtml).not.toMatch(
+      /body\s*\{[^}]*padding-(?:top|left|right):\s*env\(safe-area-inset-/s,
+    );
+  });
+
   it("ships the selector as the HTML entry and keeps all renderers dynamic", () => {
     const indexHtml = readFileSync(resolve(appRoot, "index.html"), "utf8");
     const entrySource = readFileSync(resolve(appRoot, "src/entry.ts"), "utf8");

--- a/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
+++ b/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
@@ -16,7 +16,7 @@
  * chrome and reserving its measured resting footprint (see
  * `BROWSER_WORKSPACE_TAB_MASK_SELECTORS`).
  */
-import { Globe, Plus, X } from "lucide-react";
+import { Plus, SquareStack, X } from "lucide-react";
 import { useAgentElement } from "../../agent-surface";
 import { Button } from "../ui/button";
 import {
@@ -152,7 +152,11 @@ export function BrowserTabFoldControl({
       data-testid="browser-workspace-tab-fold-control"
       className="relative min-w-0 shrink-0 px-0 md:px-4"
     >
-      <Globe className="size-4 shrink-0 text-muted" aria-hidden />
+      <SquareStack
+        className="size-4 shrink-0 text-muted"
+        data-testid="browser-workspace-tabs-icon"
+        aria-hidden
+      />
       <span className="hidden min-w-0 max-w-[9rem] truncate font-medium md:inline">
         {activeLabel}
       </span>

--- a/packages/ui/src/components/pages/browser-tab-switcher.test.tsx
+++ b/packages/ui/src/components/pages/browser-tab-switcher.test.tsx
@@ -119,6 +119,9 @@ describe("BrowserTabFoldControl", () => {
       />,
     );
     const control = screen.getByTestId("browser-workspace-tab-fold-control");
+    expect(
+      screen.getByTestId("browser-workspace-tabs-icon").getAttribute("class"),
+    ).toContain("lucide-square-stack");
     expect(control.textContent).toContain("DuckDuckGo");
     expect(
       screen.getByTestId("browser-workspace-tab-count").textContent,


### PR DESCRIPTION
Closes #29451.\n\n## What changed\n- keep the Capacitor document body full-bleed so routed surfaces own safe-area insets exactly once\n- use a tabs glyph for the browser fold control\n- add focused policy and component regressions\n\n## Verification\n- app package script checks: 2/2 PASS\n- app web-entry policy: 29/29 PASS\n- browser tab switcher: 16/16 PASS\n- diff check: PASS\n\n## Evidence boundary\n- Source-only publication during the active demo freeze; no device, browser, APK, deployment, or live runtime was touched.\n- The broader BrowserWorkspace Chrome suite reached a machine ENOSPC transform failure before assertions; no assertion failed.\n- Required app visual audit and physical native screenshots are pending until the demo freeze is explicitly released.\n- No merge is requested until those gates are completed.