### PR TITLE
[android-auth-agent-chat] fix(app): default local gateway to realtime voice

### DIFF
--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -1,7 +1,8 @@
 /** Verifies app-shell WebSocket origins for dev proxies and native remotes. */
 
 import { describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path, { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runInNewContext } from "node:vm";
@@ -15,6 +16,8 @@ import appViteConfig, {
   findAndroidCloudEmittedRoutingFindings,
   resolveAndroidCloudPrebootLockupDataUri,
   resolveAppShellLocalCspSources,
+  resolveLocalRealtimeVoiceDefines,
+  resolveLocalRealtimeVoiceDefinesFromEnv,
   selectAndroidCloudRendererEntry,
   stripAndroidCloudIpcBootstrap,
   stripAndroidCloudPublicAssetReferences,
@@ -82,6 +85,68 @@ describe("devViewStudioPlugin", () => {
     expect(headers.get("Content-Type")).toBe("text/css; charset=utf-8");
     expect(headers.get("Cache-Control")).toBe("no-store");
     expect(body?.toString()).toContain("data-eliza-studio-proposed");
+  });
+});
+
+describe("local realtime voice defaults", () => {
+  test("enables the realtime client without force-arming unresolved agents", () => {
+    expect(resolveLocalRealtimeVoiceDefines("serve", 31_338, {})).toEqual({
+      "import.meta.env.VITE_VOICE_REALTIME_WS": JSON.stringify("1"),
+    });
+  });
+
+  test("preserves explicit client flag values", () => {
+    expect(
+      resolveLocalRealtimeVoiceDefines("serve", 31_338, {
+        VITE_VOICE_REALTIME_WS: "0",
+        VITE_VOICE_REALTIME_FORCE: "false",
+      }),
+    ).toEqual({});
+    expect(
+      resolveLocalRealtimeVoiceDefines("serve", 31_338, {
+        VITE_VOICE_REALTIME_WS: "1",
+      }),
+    ).toEqual({});
+  });
+
+  test("does not change builds or dev servers without a gateway", () => {
+    expect(resolveLocalRealtimeVoiceDefines("build", 31_338, {})).toEqual({});
+    expect(resolveLocalRealtimeVoiceDefines("serve", null, {})).toEqual({});
+  });
+
+  test("preserves explicit opt-outs loaded from .env.local", () => {
+    const envDir = mkdtempSync(path.join(os.tmpdir(), "eliza-voice-env-"));
+    const previousWs = process.env.VITE_VOICE_REALTIME_WS;
+    const previousForce = process.env.VITE_VOICE_REALTIME_FORCE;
+    delete process.env.VITE_VOICE_REALTIME_WS;
+    delete process.env.VITE_VOICE_REALTIME_FORCE;
+
+    try {
+      writeFileSync(
+        path.join(envDir, ".env.local"),
+        "VITE_VOICE_REALTIME_WS=0\nVITE_VOICE_REALTIME_FORCE=false\n",
+      );
+      expect(
+        resolveLocalRealtimeVoiceDefinesFromEnv(
+          "serve",
+          "development",
+          31_338,
+          envDir,
+        ),
+      ).toEqual({});
+    } finally {
+      if (previousWs === undefined) {
+        delete process.env.VITE_VOICE_REALTIME_WS;
+      } else {
+        process.env.VITE_VOICE_REALTIME_WS = previousWs;
+      }
+      if (previousForce === undefined) {
+        delete process.env.VITE_VOICE_REALTIME_FORCE;
+      } else {
+        process.env.VITE_VOICE_REALTIME_FORCE = previousForce;
+      }
+      rmSync(envDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1752,6 +1752,42 @@ function resolveOptionalLocalVoiceGatewayPort(
   return port;
 }
 
+/**
+ * A configured loopback voice gateway is an explicit local-development opt-in
+ * to the realtime voice stack. Keep deployed builds staged behind their
+ * existing flags, while making the supported local gateway command sufficient
+ * to enable the staged realtime client without an easy-to-miss Vite flag.
+ * The force flag stays an explicit diagnostic bypass, so a missing agent id or
+ * failed capability resolution remains visible. Explicit client flag values
+ * always win, including an explicit opt-out.
+ */
+export function resolveLocalRealtimeVoiceDefines(
+  command: string,
+  gatewayPort: number | null,
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  if (command !== "serve" || gatewayPort === null) return {};
+
+  const defines: Record<string, string> = {};
+  if (env.VITE_VOICE_REALTIME_WS === undefined) {
+    defines["import.meta.env.VITE_VOICE_REALTIME_WS"] = JSON.stringify("1");
+  }
+  return defines;
+}
+
+export function resolveLocalRealtimeVoiceDefinesFromEnv(
+  command: string,
+  mode: string,
+  gatewayPort: number | null,
+  envDir: string,
+): Record<string, string> {
+  return resolveLocalRealtimeVoiceDefines(
+    command,
+    gatewayPort,
+    loadEnv(mode, envDir, "VITE_VOICE_REALTIME_"),
+  );
+}
+
 export function appDevWsBasePlugin(): Plugin {
   const brandedWsBaseKey = `__${APP_ENV_PREFIX}_WS_BASE__`;
 
@@ -2416,7 +2452,7 @@ const optimizerNodePolyfills: Readonly<Record<string, string>> = (() => {
   return resolved;
 })();
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command, mode }) => ({
   root: here,
   customLogger: viteLogger,
   // Native shells (Electrobun `views://`, Capacitor `file://`) load assets
@@ -2443,6 +2479,12 @@ export default defineConfig(({ command }) => ({
     : path.resolve(here, "public"),
   define: {
     global: "globalThis",
+    ...resolveLocalRealtimeVoiceDefinesFromEnv(
+      command,
+      mode,
+      localVoiceGatewayPort,
+      here,
+    ),
     // Build variant — set at signing time by desktop-build.mjs and embedded
     // here so the renderer can branch on store vs direct without an API call.
     __ELIZA_BUILD_VARIANT__: JSON.stringify(

--- a/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
+++ b/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
@@ -39,7 +39,8 @@ server mint), the mic runs the existing batch ASR path completely unchanged.
 
 ## Flags
 
-- Client: `VITE_VOICE_REALTIME_WS` = `1|true|yes|on` (default OFF).
+- Client: `VITE_VOICE_REALTIME_WS` = `1|true|yes|on` (default OFF for builds;
+  the local dev gateway defaults it ON unless explicitly configured).
 - Self-hosted client capability: `VITE_VOICE_REALTIME_SELF_HOSTED` =
   `1|true|yes|on` (default OFF). It still requires a paired `remote` runtime and
   a successful same-origin `/api/v1/voice/session/health` probe.
@@ -64,8 +65,6 @@ CARTESIA_API_KEY=… \
 ELIZA_LOCAL_VOICE_GATEWAY_PORT=31338 \
 bun run --cwd packages/cloud/api voice:local-gateway
 
-VITE_VOICE_REALTIME_WS=1 \
-VITE_VOICE_REALTIME_FORCE=1 \
 ELIZA_LOCAL_VOICE_GATEWAY_PORT=31338 \
 bun run --cwd packages/app dev
 ```
@@ -74,7 +73,11 @@ Vite sends only `/api/v1/voice/session` HTTP and WebSocket traffic to the
 loopback gateway; all other `/api` traffic remains on `31337`. The provider
 loop is Cartesia Ink 2 STT → local runtime/model route → Cartesia Sonic 3.5 TTS.
 The Cartesia key remains in the gateway process and is never exposed to Vite or
-the browser.
+the browser. In dev-server mode, configuring `ELIZA_LOCAL_VOICE_GATEWAY_PORT`
+also defaults the staged realtime client flag on. An explicit
+`VITE_VOICE_REALTIME_WS` value still wins, the diagnostic
+`VITE_VOICE_REALTIME_FORCE` bypass remains explicit-only, and
+production/mobile builds keep their existing staged defaults.
 
 ## Flag retirement
 


### PR DESCRIPTION
## Cause

The supported localhost voice gateway still required a separate Vite client feature flag. This made the local Android/web chat path look configured while realtime voice remained disabled.

## Fix

- When Vite is serving locally and `ELIZA_LOCAL_VOICE_GATEWAY_PORT` is valid, default only `VITE_VOICE_REALTIME_WS` to enabled.
- Keep `VITE_VOICE_REALTIME_FORCE` explicit-only so missing agent identity or capability resolution remains visible instead of falling back to the sentinel.
- Preserve every explicit client value, including opt-outs from `.env.local`.
- Load the Vite-prefixed environment with `loadEnv(mode, envDir, prefix)`, so config-time defaults follow Vite precedence.
- Keep builds, mobile artifacts, and dev servers without a gateway unchanged.
- Update the local voice wiring guide so the client default and explicit debug bypass are not contradictory.

## Scope and limits

This is a localhost developer default only. It does not deploy, mutate staging or production, configure providers, or prove microphone/speaker behavior on a physical Android device.

## Risk

Low and isolated to Vite serve mode with an explicitly configured loopback voice gateway. Explicit client flags continue to win. Agent identity/capability failures continue to fail visibly unless a developer explicitly enables the debug force bypass.

## Rollback

Revert commit `58365a22026`.

## Validation

- rebased onto current `develop` `53f267ae71a`
- `bun test` from a config-neutral directory: **20 pass, 0 fail, 67 assertions**
- packages/app typecheck: pass
- Biome on changed TypeScript: pass
- `git diff --check`: pass

## Relationship

This PR owns the Vite local-gateway default. #29387 touches different cloud voice-session/proxy paths and should not duplicate this documentation behavior. No merge requested or performed.