### PR TITLE
fix(plugin-local-inference): gate resumed download on 206 to prevent silent GGUF corruption

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Regression coverage for the resumed-download data-integrity fix (#29454)
+ * against the real exported `applyLocalInferenceManagementMutation` /
+ * `startDownload` path with a temp `ELIZA_STATE_DIR`. `node:https` is mocked so
+ * the test controls whether the server honors the `Range` header:
+ *
+ *  - When the server IGNORES Range and returns `200 OK` with the full body (as
+ *    many CDNs/mirrors/proxies do), `downloadModel` must discard the pre-staged
+ *    `.part` bytes and write a byte-exact full GGUF — never concatenate the full
+ *    body onto the partial, which previously produced an oversized corrupt file
+ *    that still passed the "GGUF" magic check and got registered as installed.
+ *  - When the server HONORS Range and returns `206 Partial Content` with only
+ *    the remaining bytes, the fast-resume path must still append and produce the
+ *    same byte-exact full GGUF.
+ *
+ * The mock buffers the response body in a real `PassThrough`, so the download
+ * loop consumes it through the true async-iterator path.
+ */
+import { EventEmitter } from "node:events";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Per-test controller for the mocked https server. `handler` receives the
+// request headers and returns the status, headers, and body the fake server
+// should send. Hoisted so the vi.mock factory can close over it.
+const httpsController = vi.hoisted(() => ({
+	handler: null as
+		| null
+		| ((requestHeaders: Record<string, string>) => {
+				statusCode: number;
+				statusMessage?: string;
+				headers: Record<string, string>;
+				body: Buffer;
+		  }),
+}));
+
+vi.mock("node:https", () => {
+	function get(
+		_urlOrOptions: unknown,
+		optionsOrCb: unknown,
+		maybeCb?: unknown,
+	) {
+		const callback = (
+			typeof optionsOrCb === "function" ? optionsOrCb : maybeCb
+		) as (response: PassThrough & Record<string, unknown>) => void;
+		const options = (typeof optionsOrCb === "function" ? {} : optionsOrCb) as {
+			headers?: Record<string, string>;
+		};
+		const req = new EventEmitter() as EventEmitter & {
+			destroy: (error?: Error) => void;
+		};
+		req.destroy = (error?: Error) => {
+			req.emit("error", error ?? new Error("aborted"));
+		};
+		setImmediate(() => {
+			if (!httpsController.handler) {
+				throw new Error("httpsController.handler not configured");
+			}
+			const config = httpsController.handler(options.headers ?? {});
+			const res = new PassThrough() as PassThrough & Record<string, unknown>;
+			res.statusCode = config.statusCode;
+			res.statusMessage = config.statusMessage ?? "";
+			res.headers = config.headers;
+			callback(res);
+			res.end(config.body);
+			req.emit("close");
+		});
+		return req;
+	}
+	return { default: { get }, get };
+});
+
+const { applyLocalInferenceManagementMutation } = await import(
+	"./local-inference-routes.js"
+);
+
+const MODEL_ID = "eliza-1-2b";
+// FULL is the correct, complete file the server ultimately holds; its first
+// four bytes are the real "GGUF" magic so the corrupt path also passes
+// isGgufFile().
+const FULL_BODY = Buffer.concat([
+	Buffer.from("GGUF", "ascii"),
+	Buffer.alloc(2048, 0x41),
+]);
+
+const originalStateDir = process.env.ELIZA_STATE_DIR;
+let tempStateDir: string;
+
+function localInferenceRoot(): string {
+	return path.join(tempStateDir, "local-inference");
+}
+
+function partialPath(): string {
+	return path.join(localInferenceRoot(), "downloads", `${MODEL_ID}.part`);
+}
+
+function finalPath(): string {
+	return path.join(localInferenceRoot(), "models", `${MODEL_ID}.gguf`);
+}
+
+function seedPartial(bytes: Buffer): void {
+	mkdirSync(path.dirname(partialPath()), { recursive: true });
+	writeFileSync(partialPath(), bytes);
+}
+
+async function waitForFinalFile(timeoutMs = 5000): Promise<Buffer> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (existsSync(finalPath()) && !existsSync(partialPath())) {
+			return readFileSync(finalPath());
+		}
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	throw new Error(
+		`final model file did not appear within ${timeoutMs}ms (final exists=${existsSync(
+			finalPath(),
+		)}, part exists=${existsSync(partialPath())})`,
+	);
+}
+
+function readRegistry(): { models: Array<{ id: string; sizeBytes: number }> } {
+	return JSON.parse(
+		readFileSync(path.join(localInferenceRoot(), "registry.json"), "utf8"),
+	);
+}
+
+describe("local-inference resumed download integrity (#29454)", () => {
+	beforeEach(() => {
+		tempStateDir = mkdtempSync(path.join(tmpdir(), "eliza-li-resume-"));
+		process.env.ELIZA_STATE_DIR = tempStateDir;
+		httpsController.handler = null;
+	});
+
+	afterEach(() => {
+		rmSync(tempStateDir, { recursive: true, force: true });
+		if (originalStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+		else process.env.ELIZA_STATE_DIR = originalStateDir;
+		vi.clearAllMocks();
+	});
+
+	it("restarts cleanly when the server ignores Range and returns 200 with the full body", async () => {
+		// Distinct partial bytes (0x99 filler, NOT a prefix of FULL) so a clean
+		// restart is provable: after the fix the final file must equal FULL exactly
+		// with none of these bytes retained.
+		const partial = Buffer.concat([
+			Buffer.from("GGUF", "ascii"),
+			Buffer.alloc(512, 0x99),
+		]);
+		seedPartial(partial);
+
+		// Server ignores the Range request entirely: 200 OK, whole body.
+		httpsController.handler = () => ({
+			statusCode: 200,
+			statusMessage: "OK",
+			headers: { "content-length": String(FULL_BODY.length) },
+			body: FULL_BODY,
+		});
+
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+		const finalBytes = await waitForFinalFile();
+
+		// The corruption bug produced partial.length + FULL_BODY.length bytes; the
+		// fix must produce exactly FULL_BODY.
+		expect(finalBytes.length).toBe(FULL_BODY.length);
+		expect(finalBytes.length).not.toBe(partial.length + FULL_BODY.length);
+		expect(finalBytes.equals(FULL_BODY)).toBe(true);
+		expect(finalBytes.subarray(0, 4).toString("ascii")).toBe("GGUF");
+
+		// The model is registered with the correct (full) byte size, not the
+		// oversized corrupt size.
+		const registry = readRegistry();
+		const entry = registry.models.find((model) => model.id === MODEL_ID);
+		expect(entry?.sizeBytes).toBe(FULL_BODY.length);
+	});
+
+	it("fast-resumes when the server honors Range and returns 206 with the remainder", async () => {
+		// A real interrupted download leaves the true prefix of FULL on disk.
+		const resumeFrom = 516;
+		const partial = FULL_BODY.subarray(0, resumeFrom);
+		seedPartial(Buffer.from(partial));
+
+		let observedRange: string | undefined;
+		httpsController.handler = (requestHeaders) => {
+			observedRange = requestHeaders.range;
+			const remainder = FULL_BODY.subarray(resumeFrom);
+			return {
+				statusCode: 206,
+				statusMessage: "Partial Content",
+				headers: {
+					"content-length": String(remainder.length),
+					"content-range": `bytes ${resumeFrom}-${
+						FULL_BODY.length - 1
+					}/${FULL_BODY.length}`,
+				},
+				body: Buffer.from(remainder),
+			};
+		};
+
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+		const finalBytes = await waitForFinalFile();
+
+		// The client actually requested a resume from the staged offset...
+		expect(observedRange).toBe(`bytes=${resumeFrom}-`);
+		// ...and the appended remainder reconstructs the byte-exact full file.
+		expect(finalBytes.length).toBe(FULL_BODY.length);
+		expect(finalBytes.equals(FULL_BODY)).toBe(true);
+
+		const registry = readRegistry();
+		const entry = registry.models.find((model) => model.id === MODEL_ID);
+		expect(entry?.sizeBytes).toBe(FULL_BODY.length);
+	});
+});

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -745,16 +745,27 @@ async function downloadModel(
 		if (statusCode < 200 || statusCode >= 300) {
 			throw new Error(`HTTP ${statusCode} ${response.statusMessage ?? ""}`);
 		}
+		// Resume only when the server confirmed the Range with 206 Partial Content.
+		// Many CDNs, mirrors, and proxies (e.g. a ModelScope base or a corporate
+		// proxy) ignore `Range` and answer 200 OK with the *entire* body. Appending
+		// that full body onto the existing partial bytes yields an oversized, corrupt
+		// GGUF that still begins with the real "GGUF" magic — so isGgufFile() passes,
+		// sha256 is computed over the corrupt bytes, and the file is registered as an
+		// installed model whose later verify_model recomputes the same sha and
+		// reports "ok". The corruption is then silent and permanent (#29454). On a
+		// 200 we discard the partial and restart the write from byte 0.
+		const isResume = existingPartial > 0 && statusCode === 206;
+		record.received = isResume ? existingPartial : 0;
 		const contentLength = Number.parseInt(
 			String(response.headers["content-length"] ?? "0"),
 			10,
 		);
 		if (Number.isFinite(contentLength) && contentLength > 0) {
-			record.total = existingPartial + contentLength;
+			record.total = isResume ? existingPartial + contentLength : contentLength;
 		}
 
 		const stream = fs.createWriteStream(partialPath, {
-			flags: existingPartial > 0 ? "a" : "w",
+			flags: isResume ? "a" : "w",
 		});
 		let lastSampleAt = Date.now();
 		let lastSampleBytes = record.received;


### PR DESCRIPTION
# Relates to

Closes #29454

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; owning-package `test`, `typecheck`, and
      `lint` pass. Repo-wide `bun run verify` is not completed on this machine
      (see **Known gaps / failures**); the change is a self-contained ~13-line
      edit to one function plus one new test file.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after `vitest` evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (HEAD `7a286d1b3a`); zero conflicts.
- [ ] `bun run verify` passes post-sync — not run in full here; see
      **Known gaps / failures**. Owning-package gates pass.

# Risks

Low. The change is confined to the resume branch of `downloadModel` in
`plugins/plugin-local-inference/src/local-inference-routes.ts`. It makes the
resume path strictly safer: a `206 Partial Content` still fast-resumes exactly
as before, while a `200 OK` (Range ignored) now restarts the write instead of
corrupting the file. No public types, exports, or route shapes change.

# Background

## What does this PR do?

`downloadModel` resumes an interrupted model download by sending
`Range: bytes=<partial>-` and opening the staging `.part` file in **append**
mode whenever a partial file exists — without verifying the server honored the
Range request. The `statusCode < 200 || statusCode >= 300` guard accepts `200`.

Many CDNs, mirrors, and proxies (e.g. a ModelScope base or a corporate proxy)
ignore `Range` and answer `200 OK` with the **entire** body. The old code then
appended that full body onto the existing partial bytes, producing an
oversized, corrupt GGUF. Because the leftover partial still begins with the real
`GGUF` magic, `isGgufFile()` passed, `sha256` was computed over the corrupt
bytes and stored, and the file was registered as an installed model with a
`lastVerifiedAt` timestamp. A later `verify_model` recomputed the same sha and
reported `ok`, so the corruption was **silent and permanent** — the model then
fails to load or yields garbage at inference time.

The fix gates the resume on explicit confirmation:

```ts
const isResume = existingPartial > 0 && statusCode === 206;
record.received = isResume ? existingPartial : 0;
// record.total from existingPartial + contentLength only when isResume, else contentLength
const stream = fs.createWriteStream(partialPath, { flags: isResume ? "a" : "w" });
```

On a `200` response the partial is discarded (`flags: "w"` truncates) and the
write restarts from byte 0, so the final GGUF is byte-exact. The existing `206`
fast-resume path is preserved unchanged.

## What kind of change is this?

Bug fix (non-breaking data-integrity fix on the download path).

# Documentation changes needed?

No. Behavior of a documented route is unchanged; only the internal resume
correctness is fixed.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts` — two
cases driving the real exported `applyLocalInferenceManagementMutation`
(`start_download`) path with `node:https` mocked so the test controls whether
the server honors `Range`.

## Detailed testing steps

```bash
cd plugins/plugin-local-inference
NODE_OPTIONS='--experimental-sqlite' ../../node_modules/.bin/vitest run \
  src/local-inference-routes.resume.test.ts --reporter=verbose
```

- **200 ignores Range** → asserts the final file is byte-exact `FULL` (2052),
  NOT `PARTIAL + FULL` (2568), the first 4 bytes are `GGUF`, and the registry
  records the correct full size. The pre-staged partial uses distinct `0x99`
  filler (not a prefix of `FULL`) so a clean restart is provable.
- **206 honors Range** → asserts the client sent `Range: bytes=516-`, the
  appended remainder reconstructs the byte-exact full GGUF (2052), and the
  registry records the correct size.

Before the fix, the 200 case fails on develop with `expected 2568 to be 2052`;
after the fix both pass. Existing route tests (29) still pass.

# Evidence Gate

<!-- evidence-head:e5028f14c569a91ed428810e0914505ccdab28b5 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend download-path data-integrity fix; no UI surface changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend download-path data-integrity fix; no UI surface changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the behavior is a file-write correctness fix covered by the vitest reproduction.`
<!-- evidence-row:backend-logs -->
- [x] Vitest against the real exported `applyLocalInferenceManagementMutation` download path, passing after the 206-gate fix (full re-verified run at head `e5028f14` — focused resume suite, full 31-test route suite, typecheck and lint — attached as an immutable revision-pinned artifact: [backend-logs, gist rev 651cb16](https://gist.githubusercontent.com/agent-cortex/ce1915e51618f76284636d185ebd7b1f/raw/651cb168db74a6faad65ae83ee44243ea998b79c/29456-backend-logs.txt)):
<details><summary>backend logs — vitest run output (after fix, 2 passed)</summary>

```

 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-29454/plugins/plugin-local-inference

 ✓ src/local-inference-routes.resume.test.ts > local-inference resumed download integrity (#29454) > restarts cleanly when the server ignores Range and returns 200 with the full body 28ms
 ✓ src/local-inference-routes.resume.test.ts > local-inference resumed download integrity (#29454) > fast-resumes when the server honors Range and returns 206 with the remainder 22ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  03:29:52
   Duration  15.05s (transform 11.84s, setup 0ms, import 14.78s, tests 53ms, environment 0ms)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved in the fixed path.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is the HTTP download orchestration path.`
<!-- evidence-row:domain-artifacts -->
- [x] Failing-then-passing reproduction: the same test run against the file at `origin/develop` fails, asserting the on-disk GGUF is the corrupt 2568-byte concatenation instead of the byte-exact 2052-byte full file (re-verified at head `e5028f14` by reverting only the production source to its pre-fix parent while keeping the new test, then restoring — attached as an immutable revision-pinned artifact: [domain-artifacts, gist rev 4c1a1a3](https://gist.githubusercontent.com/agent-cortex/7864236ab75ca71e7d64ddfdfc82b5b2/raw/4c1a1a3de81d72e64e543aee16634d18dc464030/29456-domain-artifacts.txt)):
<details><summary>domain artifact — reproduction output (before/develop, 1 failed)</summary>

```

 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-29454/plugins/plugin-local-inference

 × src/local-inference-routes.resume.test.ts > local-inference resumed download integrity (#29454) > restarts cleanly when the server ignores Range and returns 200 with the full body 34ms
   → expected 2568 to be 2052 // Object.is equality
 ✓ src/local-inference-routes.resume.test.ts > local-inference resumed download integrity (#29454) > fast-resumes when the server honors Range and returns 206 with the remainder 23ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/local-inference-routes.resume.test.ts > local-inference resumed download integrity (#29454) > restarts cleanly when the server ignores Range and returns 200 with the full body
AssertionError: expected 2568 to be 2052 // Object.is equality

- Expected
+ Received

- 2052
+ 2568

 ❯ src/local-inference-routes.resume.test.ts:177:29
    175|   // The corruption bug produced partial.length + FULL_BODY.length byt…
    176|   // fix must produce exactly FULL_BODY.
    177|   expect(finalBytes.length).toBe(FULL_BODY.length);
       |                             ^
    178|   expect(finalBytes.length).not.toBe(partial.length + FULL_BODY.length…
    179|   expect(finalBytes.equals(FULL_BODY)).toBe(true);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
   Start at  03:30:34
   Duration  14.84s (transform 11.58s, setup 0ms, import 14.60s, tests 59ms, environment 0ms)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend: `vitest` output driving the real exported download path.

_Before (file at `origin/develop`, new test present) — the 200-ignores-Range case fails:_

```
 → expected 2568 to be 2052 // Object.is equality
 FAIL  src/local-inference-routes.resume.test.ts > ... > restarts cleanly when the server ignores Range and returns 200 with the full body
AssertionError: expected 2568 to be 2052 // Object.is equality
      Tests  1 failed | 1 passed (2)
```

_After (with the 206-gated fix) — both cases pass:_

```
 ✓ src/local-inference-routes.resume.test.ts > ... > restarts cleanly when the server ignores Range and returns 200 with the full body
 ✓ src/local-inference-routes.resume.test.ts > ... > fast-resumes when the server honors Range and returns 206 with the remainder
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Full logs attached as artifacts in the evidence rows above.

Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

`N/A - backend data-integrity fix; no rendered UI.`

### Before

`N/A - no UI.`

### After

`N/A - no UI.`

### Walkthrough video

`N/A - no UI flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this machine; it drives
  the full Turbo graph across all workspaces and is disproportionate for a
  ~13-line single-function fix plus one test file. The owning package's `test`
  (31 tests incl. the 2 new), `typecheck` (`tsc --noEmit`), and `lint`
  (`biome check`) all pass, and the changed file compiles and lints clean.
- `bun install` required `--minimum-release-age=0` because a newly published
  transitive dependency (`@cloudflare/playwright@1.3.6`, unrelated to this
  package) is younger than the machine's default install-age guard. This affects
  install only, not the fix.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@e5028f14c569a91ed428810e0914505ccdab28b5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@e5028f14c569a91ed428810e0914505ccdab28b5:packages/skills/skills/contribute-to-eliza"} -->

