### PR TITLE
[android-auth-agent-chat] fix(app): keep staging key out of production

### DIFF
--- a/packages/agent/src/config/dev-cloud-env-authority.ts
+++ b/packages/agent/src/config/dev-cloud-env-authority.ts
@@ -396,10 +396,16 @@ export function applyDevCloudConfigAuthority(
     delete existingCloud[key];
   }
 
+  const stagingSpecificApiKey =
+    env.ELIZA_DESKTOP_PACKAGED_RUNTIME !== "1" &&
+    (snapshot.authority === "staging-explicit" ||
+      snapshot.authority === "self-hosted")
+      ? usableCredential(snapshot.values.ELIZA_DEV_CLOUD_API_KEY)
+      : undefined;
   const apiKey = activationBlocked
     ? undefined
     : (usableCredential(snapshot.values.ELIZAOS_CLOUD_API_KEY) ??
-      usableCredential(snapshot.values.ELIZA_DEV_CLOUD_API_KEY) ??
+      stagingSpecificApiKey ??
       usableCredential(snapshot.values.ELIZA_CLOUD_API_KEY) ??
       usableCredential(snapshot.values.ELIZACLOUD_API_KEY));
   const baseUrl = trimmed(snapshot.values.ELIZAOS_CLOUD_BASE_URL);

--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -45,6 +45,7 @@ const ENV_KEYS: readonly string[] = [
   ...DEV_CLOUD_ENV_RESTORE_KEYS,
   "ELIZA_DEV_SOURCE",
   DEV_CLOUD_ENV_AUTHORITY_KEY,
+  "ELIZA_DESKTOP_PACKAGED_RUNTIME",
   "ELIZA_CLOUD_PROVISIONED",
   "ELIZAOS_CLOUD_USE_INFERENCE",
   "ELIZAOS_CLOUD_USE_EMBEDDINGS",
@@ -640,6 +641,64 @@ describe("launcher-owned local development Cloud policy", () => {
       );
     },
   );
+
+  it("does not activate production authority from a staging-specific credential", () => {
+    setDevCloudAuthority("production", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app/api/v1",
+      ELIZA_DEV_CLOUD_API_KEY: "staging-specific-key",
+    });
+
+    const view = createDevCloudConfigAuthorityView(
+      hostilePersistedCloudConfig(),
+    );
+
+    expect(view.cloud?.enabled).toBe(false);
+    expect(view.cloud?.apiKey).toBe("");
+    expect(collectPluginNames(view).has("@elizaos/plugin-elizacloud")).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ["staging-explicit", "https://api-staging.eliza.app/api/v1"],
+    ["self-hosted", "https://api.private.example/api/v1"],
+  ] as const)(
+    "%s authority may consume its target-scoped development credential",
+    (authority, baseUrl) => {
+      setDevCloudAuthority(authority, {
+        ELIZAOS_CLOUD_BASE_URL: baseUrl,
+        ELIZA_DEV_CLOUD_API_KEY: "target-scoped-key",
+      });
+
+      const view = createDevCloudConfigAuthorityView(
+        hostilePersistedCloudConfig(),
+      );
+
+      expect(view.cloud).toMatchObject({
+        enabled: true,
+        apiKey: "target-scoped-key",
+        baseUrl,
+      });
+    },
+  );
+
+  it("does not activate a packaged runtime from a staging-specific credential", () => {
+    setDevCloudAuthority("staging-explicit", {
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app/api/v1",
+      ELIZA_DEV_CLOUD_API_KEY: "staging-specific-key",
+    });
+    process.env.ELIZA_DESKTOP_PACKAGED_RUNTIME = "1";
+
+    const view = createDevCloudConfigAuthorityView(
+      hostilePersistedCloudConfig(),
+    );
+
+    expect(view.cloud?.enabled).toBe(false);
+    expect(view.cloud?.apiKey).toBe("");
+    expect(collectPluginNames(view).has("@elizaos/plugin-elizacloud")).toBe(
+      false,
+    );
+  });
 
   it("ignores an authority marker that was not stamped by a dev launcher", () => {
     process.env[DEV_CLOUD_ENV_AUTHORITY_KEY] = "staging-default";

--- a/packages/app-core/AGENTS.md
+++ b/packages/app-core/AGENTS.md
@@ -81,7 +81,7 @@ Run from repo root with `--cwd packages/app-core`:
 - Ports: `ELIZA_API_PORT`/`ELIZA_PORT`/`ELIZA_UI_PORT` are read via `@elizaos/shared` `resolveDesktopApiPort`/`resolveServerOnlyPort`/`syncResolvedApiPort`. Never hardcode; the orchestrator shifts and syncs them.
 - `LOG_LEVEL` / `--debug` / `--verbose` / `--no-color` — set in `entry.ts` before runtime imports; also drives `NODE_LLAMA_CPP_LOG_LEVEL`.
 - `DATABASE_URL` → bridged to `POSTGRES_URL` for `plugin-sql` (cloud/sandbox provisioners inject `DATABASE_URL`).
-- `ELIZAOS_CLOUD_API_KEY` (dev fallback `ELIZA_DEV_CLOUD_API_KEY` in non-prod).
+- `ELIZAOS_CLOUD_API_KEY` (`ELIZA_DEV_CLOUD_API_KEY` is accepted only by explicit staging or self-hosted development launchers).
 - `ELIZA_API_PROCESS_SPAWNED_AT_MS` / `ELIZA_PROCESS_SPAWNED_AT_MS` — startup timing (dev-server).
 - `/api/dev/stack` response schema tag is the `ELIZA_DEV_STACK_SCHEMA` constant (`"elizaos.dev.stack/v1"`) from `api/dev-stack.ts` — it is a code constant, not an env var. State dir via `@elizaos/core` `resolveStateDir`. Provider key aliases normalized in `run-main.ts` (`Z_AI_API_KEY`→`ZAI_API_KEY`, `KIMI_API_KEY`→`MOONSHOT_API_KEY`).
 - **App-route boot knobs** (owned by `runtime/startup/app-contributors.ts`):

--- a/packages/app-core/CLAUDE.md
+++ b/packages/app-core/CLAUDE.md
@@ -81,7 +81,7 @@ Run from repo root with `--cwd packages/app-core`:
 - Ports: `ELIZA_API_PORT`/`ELIZA_PORT`/`ELIZA_UI_PORT` are read via `@elizaos/shared` `resolveDesktopApiPort`/`resolveServerOnlyPort`/`syncResolvedApiPort`. Never hardcode; the orchestrator shifts and syncs them.
 - `LOG_LEVEL` / `--debug` / `--verbose` / `--no-color` — set in `entry.ts` before runtime imports; also drives `NODE_LLAMA_CPP_LOG_LEVEL`.
 - `DATABASE_URL` → bridged to `POSTGRES_URL` for `plugin-sql` (cloud/sandbox provisioners inject `DATABASE_URL`).
-- `ELIZAOS_CLOUD_API_KEY` (dev fallback `ELIZA_DEV_CLOUD_API_KEY` in non-prod).
+- `ELIZAOS_CLOUD_API_KEY` (`ELIZA_DEV_CLOUD_API_KEY` is accepted only by explicit staging or self-hosted development launchers).
 - `ELIZA_API_PROCESS_SPAWNED_AT_MS` / `ELIZA_PROCESS_SPAWNED_AT_MS` — startup timing (dev-server).
 - `/api/dev/stack` response schema tag is the `ELIZA_DEV_STACK_SCHEMA` constant (`"elizaos.dev.stack/v1"`) from `api/dev-stack.ts` — it is a code constant, not an env var. State dir via `@elizaos/core` `resolveStateDir`. Provider key aliases normalized in `run-main.ts` (`Z_AI_API_KEY`→`ZAI_API_KEY`, `KIMI_API_KEY`→`MOONSHOT_API_KEY`).
 - **App-route boot knobs** (owned by `runtime/startup/app-contributors.ts`):

--- a/packages/app-core/scripts/lib/dev-cloud-target.mjs
+++ b/packages/app-core/scripts/lib/dev-cloud-target.mjs
@@ -139,17 +139,22 @@ function usableCloudCredential(env, key) {
   return value;
 }
 
-function selectedCanonicalCloudApiKey(env) {
+function selectedCanonicalCloudApiKey(
+  env,
+  { includeStagingSpecific = false } = {},
+) {
   return (
     usableCloudCredential(env, "ELIZAOS_CLOUD_API_KEY") ??
-    usableCloudCredential(env, "ELIZA_DEV_CLOUD_API_KEY") ??
+    (includeStagingSpecific
+      ? usableCloudCredential(env, "ELIZA_DEV_CLOUD_API_KEY")
+      : undefined) ??
     usableCloudCredential(env, "ELIZA_CLOUD_API_KEY") ??
     usableCloudCredential(env, "ELIZACLOUD_API_KEY")
   );
 }
 
-function promoteCanonicalCloudApiKey(env) {
-  const selected = selectedCanonicalCloudApiKey(env);
+function promoteCanonicalCloudApiKey(env, options) {
+  const selected = selectedCanonicalCloudApiKey(env, options);
   if (selected) env.ELIZAOS_CLOUD_API_KEY = selected;
   // Downstream legacy consumers use different precedence orders. Leave one
   // canonical credential so they cannot select a conflicting inherited alias.
@@ -364,7 +369,7 @@ function buildDevCloudPlan(env, resolution) {
   }
 
   if (selfHosted) {
-    if (!selectedCanonicalCloudApiKey(env)) {
+    if (!selectedCanonicalCloudApiKey(env, { includeStagingSpecific: true })) {
       throw new Error(
         "Self-hosted local development requires ELIZAOS_CLOUD_API_KEY (or a supported legacy alias). The immutable launcher target cannot acquire or replace its server credential through the local agent proxy.",
       );
@@ -449,7 +454,7 @@ export function applyDevCloudTarget(env, resolution) {
   }
 
   if (plan.selfHosted) {
-    promoteCanonicalCloudApiKey(nextEnv);
+    promoteCanonicalCloudApiKey(nextEnv, { includeStagingSpecific: true });
     enforceCoherentOperationalStewardTuple(nextEnv);
     nextEnv.VITE_ELIZA_DESKTOP_RUNTIME_MODE =
       configuredValue(env, "VITE_ELIZA_DESKTOP_RUNTIME_MODE") ?? "cloud";

--- a/packages/app-core/scripts/lib/dev-cloud-target.test.mjs
+++ b/packages/app-core/scripts/lib/dev-cloud-target.test.mjs
@@ -211,6 +211,27 @@ describe("local development Cloud target", () => {
     expect(configured.env.ELIZA_DEV_CLOUD_API_KEY).toBe("");
   });
 
+  it("rejects a production target whose only credential is staging-specific", () => {
+    expect(() =>
+      configureDevCloudEnvironment([], {
+        ELIZA_DEV_CLOUD_TARGET: "production",
+        ELIZA_DEV_CLOUD_API_KEY: "staging-only-key",
+      }),
+    ).toThrow(/production.*requires ELIZAOS_CLOUD_API_KEY/i);
+  });
+
+  it("ignores the staging-specific credential when selecting a production alias", () => {
+    const configured = configureDevCloudEnvironment([], {
+      ELIZA_DEV_CLOUD_TARGET: "production",
+      ELIZA_DEV_CLOUD_API_KEY: "staging-only-key",
+      ELIZA_CLOUD_API_KEY: "production-legacy-key",
+    });
+
+    expect(configured.env.ELIZAOS_CLOUD_API_KEY).toBe("production-legacy-key");
+    expect(configured.env.ELIZA_DEV_CLOUD_API_KEY).toBe("");
+    expect(configured.env.ELIZA_CLOUD_API_KEY).toBe("");
+  });
+
   it.each([
     ["ELIZAOS_CLOUD_API_KEY", "generic-key"],
     ["ELIZA_CLOUD_API_KEY", "legacy-alias-key"],

--- a/packages/app-core/src/entry-cloud-api-key.test.ts
+++ b/packages/app-core/src/entry-cloud-api-key.test.ts
@@ -1,0 +1,109 @@
+import {
+  resetDevCloudEnvAuthorityForTests,
+  resolveDevCloudAuthorityEnvValue,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promoteLauncherScopedDevCloudApiKey } from "./entry-cloud-api-key";
+
+const PROCESS_ENV_KEYS = [
+  "NODE_ENV",
+  "ELIZA_DEV_SOURCE",
+  "ELIZA_DEV_CLOUD_ENV_AUTHORITY",
+  "ELIZA_DEV_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZA_DESKTOP_PACKAGED_RUNTIME",
+] as const;
+
+let savedProcessEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  resetDevCloudEnvAuthorityForTests();
+  savedProcessEnv = Object.fromEntries(
+    PROCESS_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+  for (const key of PROCESS_ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of PROCESS_ENV_KEYS) {
+    const value = savedProcessEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetDevCloudEnvAuthorityForTests();
+});
+
+function explicitAuthority(
+  authority: "staging-explicit" | "self-hosted" | "production",
+): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: "development",
+    ELIZA_DEV_SOURCE: "1",
+    ELIZA_DEV_CLOUD_ENV_AUTHORITY: authority,
+    ELIZA_DEV_CLOUD_API_KEY: "staging-specific-key",
+  };
+}
+
+describe("entry Cloud API key promotion", () => {
+  it("does not promote a staging-specific key when direct entry defaults to production", () => {
+    const env: NodeJS.ProcessEnv = {
+      ELIZA_DEV_CLOUD_API_KEY: "staging-specific-key",
+    };
+
+    expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+  });
+
+  it("does not promote a staging-specific key under production authority", () => {
+    const env = explicitAuthority("production");
+
+    expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+  });
+
+  it.each(["staging-explicit", "self-hosted"] as const)(
+    "promotes the staging-specific key for %s launcher authority",
+    (authority) => {
+      const env = explicitAuthority(authority);
+
+      expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(true);
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBe("staging-specific-key");
+    },
+  );
+
+  it("does not overwrite an existing canonical credential", () => {
+    const env = explicitAuthority("staging-explicit");
+    env.ELIZAOS_CLOUD_API_KEY = "canonical-key";
+
+    expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBe("canonical-key");
+  });
+
+  it("does not promote from a production process even with compatible authority", () => {
+    const env = explicitAuthority("staging-explicit");
+    env.NODE_ENV = "production";
+
+    expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+  });
+
+  it("does not promote inside a packaged desktop runtime", () => {
+    const env = explicitAuthority("staging-explicit");
+    env.ELIZA_DESKTOP_PACKAGED_RUNTIME = "1";
+
+    expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+  });
+
+  it("promotes before the process authority snapshot freezes", () => {
+    process.env.NODE_ENV = "development";
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZA_DEV_CLOUD_ENV_AUTHORITY = "staging-explicit";
+    process.env.ELIZA_DEV_CLOUD_API_KEY = "staging-specific-key";
+
+    expect(promoteLauncherScopedDevCloudApiKey(process.env)).toBe(true);
+    expect(resolveDevCloudAuthorityEnvValue("ELIZAOS_CLOUD_API_KEY")).toBe(
+      "staging-specific-key",
+    );
+  });
+});

--- a/packages/app-core/src/entry-cloud-api-key.test.ts
+++ b/packages/app-core/src/entry-cloud-api-key.test.ts
@@ -1,3 +1,5 @@
+/** Verifies that only launcher-scoped usable development credentials reach Cloud boot. */
+
 import {
   resetDevCloudEnvAuthorityForTests,
   resolveDevCloudAuthorityEnvValue,
@@ -77,6 +79,25 @@ describe("entry Cloud API key promotion", () => {
 
     expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
     expect(env.ELIZAOS_CLOUD_API_KEY).toBe("canonical-key");
+  });
+
+  it.each(["   ", "[REDACTED]", "vault://cloud/staging-key"])(
+    "does not promote an unusable staging credential %j",
+    (credential) => {
+      const env = explicitAuthority("staging-explicit");
+      env.ELIZA_DEV_CLOUD_API_KEY = credential;
+
+      expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(false);
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    },
+  );
+
+  it("normalizes a usable staging credential before promotion", () => {
+    const env = explicitAuthority("staging-explicit");
+    env.ELIZA_DEV_CLOUD_API_KEY = "  staging-specific-key  ";
+
+    expect(promoteLauncherScopedDevCloudApiKey(env)).toBe(true);
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBe("staging-specific-key");
   });
 
   it("does not promote from a production process even with compatible authority", () => {

--- a/packages/app-core/src/entry-cloud-api-key.ts
+++ b/packages/app-core/src/entry-cloud-api-key.ts
@@ -1,0 +1,29 @@
+/**
+ * Promote the staging-specific development credential only inside a launcher
+ * process that explicitly selected a compatible target. Direct and packaged
+ * entrypoints default to production, so NODE_ENV alone is not an authority.
+ */
+export function promoteLauncherScopedDevCloudApiKey(
+  env: NodeJS.ProcessEnv,
+): boolean {
+  // Read the launch markers directly: the shared resolver freezes the process
+  // authority snapshot on first access, so promotion must happen before it.
+  const authority =
+    env.ELIZA_DEV_SOURCE === "1"
+      ? env.ELIZA_DEV_CLOUD_ENV_AUTHORITY?.trim().toLowerCase()
+      : undefined;
+  const permitsStagingCredential =
+    authority === "staging-explicit" || authority === "self-hosted";
+  if (
+    env.NODE_ENV === "production" ||
+    env.ELIZA_DESKTOP_PACKAGED_RUNTIME === "1" ||
+    !permitsStagingCredential ||
+    !env.ELIZA_DEV_CLOUD_API_KEY ||
+    env.ELIZAOS_CLOUD_API_KEY
+  ) {
+    return false;
+  }
+
+  env.ELIZAOS_CLOUD_API_KEY = env.ELIZA_DEV_CLOUD_API_KEY;
+  return true;
+}

--- a/packages/app-core/src/entry-cloud-api-key.ts
+++ b/packages/app-core/src/entry-cloud-api-key.ts
@@ -3,6 +3,18 @@
  * process that explicitly selected a compatible target. Direct and packaged
  * entrypoints default to production, so NODE_ENV alone is not an authority.
  */
+function usableCredential(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (
+    !trimmed ||
+    trimmed.toUpperCase() === "[REDACTED]" ||
+    trimmed.toLowerCase().startsWith("vault://")
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export function promoteLauncherScopedDevCloudApiKey(
   env: NodeJS.ProcessEnv,
 ): boolean {
@@ -14,16 +26,17 @@ export function promoteLauncherScopedDevCloudApiKey(
       : undefined;
   const permitsStagingCredential =
     authority === "staging-explicit" || authority === "self-hosted";
+  const stagingCredential = usableCredential(env.ELIZA_DEV_CLOUD_API_KEY);
   if (
     env.NODE_ENV === "production" ||
     env.ELIZA_DESKTOP_PACKAGED_RUNTIME === "1" ||
     !permitsStagingCredential ||
-    !env.ELIZA_DEV_CLOUD_API_KEY ||
-    env.ELIZAOS_CLOUD_API_KEY
+    !stagingCredential ||
+    usableCredential(env.ELIZAOS_CLOUD_API_KEY)
   ) {
     return false;
   }
 
-  env.ELIZAOS_CLOUD_API_KEY = env.ELIZA_DEV_CLOUD_API_KEY;
+  env.ELIZAOS_CLOUD_API_KEY = stagingCredential;
   return true;
 }

--- a/packages/app-core/src/entry.ts
+++ b/packages/app-core/src/entry.ts
@@ -10,6 +10,7 @@ import process from "node:process";
 import { formatErrorWithStack, getLogPrefix } from "@elizaos/shared";
 import { bootLap } from "./boot-profile";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile";
+import { promoteLauncherScopedDevCloudApiKey } from "./entry-cloud-api-key";
 
 bootLap("entry:body (Bun load of entry.js + @elizaos/shared)");
 
@@ -20,20 +21,13 @@ if (process.argv.includes("--no-color")) {
   process.env.FORCE_COLOR = "0";
 }
 
-// Build-testing bridge: when ELIZA_DEV_CLOUD_API_KEY is set in non-production,
-// promote it to ELIZAOS_CLOUD_API_KEY so the cloud plugin's env-fallback chain
-// (plugins/plugin-elizacloud/src/cloud/cloud-api-key.ts) authenticates without
-// the browser SIWE handshake. Production never sets ELIZA_DEV_*, so this is
-// inactive there. See scripts/cloud-siwe-login.mjs to mint a fresh key.
-if (
-  process.env.NODE_ENV !== "production" &&
-  process.env.ELIZA_DEV_CLOUD_API_KEY &&
-  !process.env.ELIZAOS_CLOUD_API_KEY
-) {
-  process.env.ELIZAOS_CLOUD_API_KEY = process.env.ELIZA_DEV_CLOUD_API_KEY;
+// Explicit staging and self-hosted launchers may bridge their target-scoped
+// development credential for the cloud plugin. Direct and packaged entrypoints
+// default to production and must not infer authority from NODE_ENV.
+if (promoteLauncherScopedDevCloudApiKey(process.env)) {
   // Stderr only — logger isn't initialized yet at this point in boot.
   process.stderr.write(
-    "[entry] ELIZA_DEV_CLOUD_API_KEY detected (dev mode): promoted to ELIZAOS_CLOUD_API_KEY\n",
+    "[entry] launcher-scoped Cloud development credential promoted to ELIZAOS_CLOUD_API_KEY\n",
   );
 }
 


### PR DESCRIPTION
## Cause

#29342 establishes `ELIZA_DEV_CLOUD_API_KEY` as a staging-specific launcher credential, but three readers weakened that boundary:

1. the shared launcher selector admitted the alias in the production target gate and promotion path;
2. `packages/app-core/src/entry.ts` promoted it whenever `NODE_ENV !== "production"`, even though direct and packaged entrypoints default to production when no launcher authority exists;
3. the agent authority projection selected the alias for production, and could still consume it inside an Electrobun packaged runtime after the entry bridge refused promotion.

A staging-only credential could therefore activate production Cloud or a packaged runtime through paths that bypassed the development launcher.

## Fix

- Exclude the staging-specific alias from production credential selection.
- Move the entry bridge behind an explicit launcher authority gate and run it before the immutable authority snapshot is captured.
- Permit the alias only for non-packaged `staging-explicit` and `self-hosted` launcher authorities.
- Apply the same authority and packaged-runtime rule in the agent config projection.
- Preserve canonical and supported legacy production credential precedence.
- Keep explicit staging and self-hosted development behavior intact.
- Update the app-core credential contract documentation.

## Limits

This changes local/direct/packaged process credential authority only. It does not change Cloud endpoints, rotate credentials, deploy configuration, mutate a live environment, or prove that a credential stored under a generic production-compatible alias belongs to a particular environment.

## Risk

Fail-closed. A direct or packaged process that previously relied on `ELIZA_DEV_CLOUD_API_KEY` without a compatible launcher authority no longer activates Cloud from that alias. Explicit non-packaged staging and self-hosted launchers retain the established behavior; canonical and supported legacy production credentials keep their precedence.

## Rollback

Revert commits `d391a28eee3` and `fb3b0ad203d` to restore the previous selector and entry behavior.

## Tests

- `bun run dev:prepare` — 99/99 build tasks for the original launcher correction
- `bunx vitest run packages/app-core/src/entry-cloud-api-key.test.ts packages/app-core/scripts/lib/dev-cloud-target.test.mjs packages/shared/src/elizacloud/dev-cloud-env-authority.test.ts packages/agent/src/runtime/eliza-cloud-config.test.ts packages/app-core/src/api/server-cloud-authority.test.ts` — 120/120
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/agent typecheck`
- Biome on all five changed TypeScript source/test files
- `bun run check:agents-claude` — 160 documentation pairs identical
- `git diff --check`
- gitleaks staged diff and `origin/develop..HEAD` — no leaks
- independent fresh-process review: direct/default-production, production authority, packaged runtime, staging-explicit, self-hosted, and frozen-snapshot paths all replayed

## Relation

Direct follow-up to the production credential-authority finding on #29342, now merged into `develop`.
