### PR TITLE
[android-auth-agent-chat] fix(ui): verify Cloud login for pinned remotes

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -218,9 +218,11 @@ function isDedicatedCloudAgentClient(client: ElizaClient): boolean {
   return isDedicatedCloudAgentBase(client.getBaseUrl());
 }
 
-function resolveConfiguredDirectCloudApiBase(): string | null {
+function resolveConfiguredDirectCloudApiBase(
+  configuredCloudApiBase = getBootConfig().cloudApiBase,
+): string | null {
   const configured =
-    getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL;
+    configuredCloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL;
   const known = resolveKnownDirectCloudApiBase(configured);
   if (known) return known;
   // Local app development intentionally points at an isolated loopback Cloud
@@ -1021,6 +1023,121 @@ function directCloudResponseErrorMessage(
   return detail
     ? `Cloud request failed (${status}): ${detail}`
     : `Cloud request failed (${status})`;
+}
+
+export interface DirectCloudSessionVerification {
+  credits: CloudCredits | null;
+  status: CloudStatus;
+}
+
+/**
+ * Verify a Steward session against an explicit Cloud control-plane authority.
+ *
+ * Dedicated Android builds keep the app client pinned to their remote agent,
+ * so account verification must not temporarily repoint that client or reuse its
+ * agent bearer. This narrow request boundary resolves only a known Cloud API
+ * environment (or first-party loopback development), and sends only the
+ * caller-provided Steward token to the account + credits endpoints.
+ */
+export async function verifyDirectCloudStewardSession(options: {
+  cloudApiBase: string;
+  stewardToken: string;
+}): Promise<DirectCloudSessionVerification> {
+  const stewardToken = options.stewardToken.trim();
+  const apiBase = resolveConfiguredDirectCloudApiBase(options.cloudApiBase);
+  if (!apiBase) {
+    throw new Error("Eliza Cloud control-plane authority is not trusted");
+  }
+  if (!stewardToken) {
+    return {
+      credits: null,
+      status: {
+        connected: false,
+        enabled: true,
+        hasApiKey: false,
+        reason: "not-authenticated",
+        topUpUrl: directTopUpUrl(),
+      },
+    };
+  }
+
+  const headers = {
+    Accept: "application/json",
+    Authorization: `Bearer ${stewardToken}`,
+  };
+  const rejected = async (): Promise<DirectCloudSessionVerification> => {
+    await clearStoredStewardTokenIfCurrent(stewardToken);
+    return {
+      credits: null,
+      status: {
+        connected: false,
+        enabled: true,
+        hasApiKey: true,
+        reason: "auth-rejected",
+        topUpUrl: directTopUpUrl(),
+      },
+    };
+  };
+
+  const userResponse = await directCloudJsonResponse<Record<string, unknown>>(
+    `${apiBase}/api/v1/user`,
+    { headers },
+  );
+  if (userResponse.status === 401 || userResponse.status === 403) {
+    return rejected();
+  }
+  if (!userResponse.ok) {
+    throw Object.assign(
+      new Error(
+        directCloudResponseErrorMessage(userResponse.status, userResponse.data),
+      ),
+      { status: userResponse.status, url: `${apiBase}/api/v1/user` },
+    );
+  }
+  const userEnvelope = recordOrNull(userResponse.data);
+  const user = recordOrNull(userEnvelope?.data) ?? userEnvelope;
+
+  const creditsResponse = await directCloudJsonResponse<
+    Record<string, unknown>
+  >(`${apiBase}/api/v1/credits/balance`, { headers });
+  if (creditsResponse.status === 401 || creditsResponse.status === 403) {
+    return rejected();
+  }
+  if (!creditsResponse.ok) {
+    throw Object.assign(
+      new Error(
+        directCloudResponseErrorMessage(
+          creditsResponse.status,
+          creditsResponse.data,
+        ),
+      ),
+      {
+        status: creditsResponse.status,
+        url: `${apiBase}/api/v1/credits/balance`,
+      },
+    );
+  }
+
+  const creditsData = recordOrNull(creditsResponse.data);
+  const balance = numberOrNull(creditsData?.balance);
+  return {
+    credits: {
+      balance: Number.isFinite(balance) ? balance : null,
+      connected: true,
+      critical: typeof balance === "number" ? balance < 0.5 : undefined,
+      low: typeof balance === "number" ? balance < 2 : undefined,
+      topUpUrl: directTopUpUrl(),
+    },
+    status: {
+      connected: true,
+      enabled: true,
+      hasApiKey: true,
+      cloudVoiceProxyAvailable: true,
+      organizationId: stringOrNull(user?.organization_id) ?? undefined,
+      topUpUrl: directTopUpUrl(),
+      userId: stringOrNull(user?.id) ?? undefined,
+    },
+  };
 }
 
 async function directCloudRequest<T>(

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -24,7 +24,7 @@ import {
   prepareDesktopCloudLoginSession,
 } from "./cloud-login-launch";
 import { registerStewardLoginLauncher } from "./cloud-steward-login";
-import { canPollCloudStatus, useCloudState } from "./useCloudState";
+import { useCloudState } from "./useCloudState";
 
 const DEVICE_CODE_SENTINEL = "device-code-flow-reached";
 const originalBootConfig = structuredClone(getBootConfig());
@@ -35,6 +35,11 @@ const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
 const globalWithPlatform = globalThis as typeof globalThis & {
   Capacitor?: { isNativePlatform?: () => boolean };
 };
+const runtimeWithPinnedRemote = globalThis as typeof globalThis & {
+  __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: string;
+};
+const originalPinnedRemote =
+  runtimeWithPinnedRemote.__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__;
 const windowWithElectrobun = window as Window & {
   __electrobunWindowId?: number;
   __ELIZA_DESKTOP_RUNTIME_MODE__?: string;
@@ -51,6 +56,25 @@ function makeParams() {
     loadWalletConfig: vi.fn(async () => {}),
     t: (key: string) => key,
   };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    json: async () => body,
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? "OK" : "Error",
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function restorePinnedRemote(): void {
+  if (originalPinnedRemote === undefined) {
+    delete runtimeWithPinnedRemote.__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__;
+  } else {
+    runtimeWithPinnedRemote.__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__ =
+      originalPinnedRemote;
+  }
 }
 
 describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", () => {
@@ -104,6 +128,7 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     delete windowWithElectrobun.__electrobunWindowId;
     delete windowWithElectrobun.__ELIZA_DESKTOP_RUNTIME_MODE__;
     delete windowWithElectrobun.__ELIZA_ELECTROBUN_RPC__;
+    restorePinnedRemote();
     __resetPreparedDesktopCloudLoginSessionForTests();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
@@ -954,6 +979,155 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
       vi.useRealTimers();
     }
   });
+
+  it("verifies a pinned-remote login only against the Cloud control plane and preserves the ambient snapshot without polling", async () => {
+    runtimeWithPinnedRemote.__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__ =
+      "https://bot.nubs.site";
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: "http://localhost:2138/settings",
+        origin: "http://localhost:2138",
+        protocol: "http:",
+        hostname: "localhost",
+        port: "2138",
+        pathname: "/settings",
+        search: "",
+        assign: assignSpy,
+      },
+    });
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api-staging.eliza.app",
+    });
+    const stewardToken = "steward-session-token";
+    const requests: Array<{ init?: RequestInit; url: string }> = [];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          requests.push({ init, url });
+          if (url === "https://api-staging.eliza.app/api/v1/user") {
+            return jsonResponse(200, {
+              data: { id: "user-pinned", organization_id: "org-pinned" },
+            });
+          }
+          if (url === "https://api-staging.eliza.app/api/v1/credits/balance") {
+            return jsonResponse(200, { balance: 8.5 });
+          }
+          throw new Error(`unexpected request: ${url}`);
+        },
+      );
+    const agentStatusSpy = vi.spyOn(client, "getCloudStatus");
+    const agentCreditsSpy = vi.spyOn(client, "getCloudCredits");
+    const launcher = vi.fn(async () => {
+      localStorage.setItem("steward_session_token", stewardToken);
+      return { token: stewardToken };
+    });
+    const unregister = registerStewardLoginLauncher(launcher);
+
+    try {
+      const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+
+      let ambientConnected = true;
+      await act(async () => {
+        ambientConnected = await result.current.pollCloudCredits();
+      });
+      expect(ambientConnected).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(agentStatusSpy).not.toHaveBeenCalled();
+      expect(agentCreditsSpy).not.toHaveBeenCalled();
+      expect(result.current.elizaCloudPollInterval.current).toBeNull();
+
+      await act(async () => {
+        await result.current.handleCloudLogin();
+      });
+
+      expect(launcher).toHaveBeenCalledTimes(1);
+      expect(result.current.elizaCloudConnected).toBe(true);
+      expect(result.current.elizaCloudCredits).toBe(8.5);
+      expect(result.current.elizaCloudUserId).toBe("user-pinned");
+      expect(result.current.elizaCloudLoginError).toBeNull();
+      expect(requests.map(({ url }) => url)).toEqual([
+        "https://api-staging.eliza.app/api/v1/user",
+        "https://api-staging.eliza.app/api/v1/credits/balance",
+      ]);
+      for (const request of requests) {
+        expect(new Headers(request.init?.headers).get("Authorization")).toBe(
+          `Bearer ${stewardToken}`,
+        );
+      }
+      expect(setBaseUrlSpy).not.toHaveBeenCalled();
+      expect(setTokenSpy).not.toHaveBeenCalled();
+      expect(agentStatusSpy).not.toHaveBeenCalled();
+      expect(agentCreditsSpy).not.toHaveBeenCalled();
+      expect(result.current.elizaCloudPollInterval.current).toBeNull();
+
+      fetchSpy.mockClear();
+      await act(async () => {
+        ambientConnected = await result.current.pollCloudCredits();
+      });
+      expect(ambientConnected).toBe(true);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.current.lastElizaCloudPollConnectedRef.current).toBe(true);
+      expect(result.current.elizaCloudPollInterval.current).toBeNull();
+      unmount();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("fails pinned-remote login verification on a control-plane 401", async () => {
+    runtimeWithPinnedRemote.__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__ =
+      "https://bot.nubs.site";
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: "http://localhost:2138/settings",
+        origin: "http://localhost:2138",
+        protocol: "http:",
+        hostname: "localhost",
+        port: "2138",
+        pathname: "/settings",
+        search: "",
+        assign: assignSpy,
+      },
+    });
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api-staging.eliza.app",
+    });
+    const stewardToken = "rejected-steward-session-token";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(401, { error: "unauthorized" }));
+    const launcher = vi.fn(async () => {
+      localStorage.setItem("steward_session_token", stewardToken);
+      return { token: stewardToken };
+    });
+    const unregister = registerStewardLoginLauncher(launcher);
+
+    try {
+      const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+      await act(async () => {
+        await result.current.handleCloudLogin();
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.elizaCloudConnected).toBe(false);
+      expect(result.current.elizaCloudLoginError).toBe(
+        "Could not verify your Eliza Cloud session. Please sign in again.",
+      );
+      expect(localStorage.getItem("steward_session_token")).toBeNull();
+      expect(result.current.elizaCloudPollInterval.current).toBeNull();
+      unmount();
+    } finally {
+      unregister();
+    }
+  });
 });
 
 // The same-tab login leg lands back in the app with only a session token; the
@@ -961,10 +1135,6 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
 // These pin that snapshot application: connected+balance, auth-rejected, and
 // the disconnected reset — never a fabricated healthy-empty.
 describe("useCloudState — pollCloudCredits status snapshot", () => {
-  it("does not poll Cloud billing for a build-pinned remote runtime", () => {
-    expect(canPollCloudStatus("https://bot.nubs.site")).toBe(false);
-  });
-
   let getCloudStatusSpy: ReturnType<typeof vi.spyOn>;
   let getCloudCreditsSpy: ReturnType<typeof vi.spyOn>;
 
@@ -979,6 +1149,7 @@ describe("useCloudState — pollCloudCredits status snapshot", () => {
   afterEach(() => {
     localStorage.clear();
     delete globalWithPlatform.Capacitor;
+    restorePinnedRemote();
     vi.restoreAllMocks();
   });
 

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -37,7 +37,7 @@ import {
   signOutAndroidCloud,
   takeLatestAndroidCloudCompletion,
 } from "../android-cloud/android-cloud-auth";
-import { client } from "../api";
+import { type CloudCredits, type CloudStatus, client } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import {
   cloudTokenSecsRemaining,
@@ -45,6 +45,7 @@ import {
   refreshCloudStewardSession,
   resolveDirectCloudAuthApiBase,
   resolveDirectCloudWebBase,
+  verifyDirectCloudStewardSession,
 } from "../api/client-cloud";
 import {
   invokeDesktopBridgeRequestWithTimeout,
@@ -415,13 +416,11 @@ function hasCloudLoginBackend(): boolean {
   return isSameOriginLocalHttpBackend();
 }
 
-export function canPollCloudStatus(
-  configuredRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl(),
-): boolean {
+function canPollCloudStatus(): boolean {
   // A dedicated remote build gets models and voice from its paired runtime.
   // Polling that runtime's optional Cloud billing integration misclassifies an
   // unrelated server credential as the mobile app's own authentication state.
-  if (configuredRemoteApiBase) return false;
+  if (getBuildConfiguredRemoteApiBaseUrl()) return false;
 
   const explicitBase =
     typeof client.getBaseUrl === "function" ? client.getBaseUrl().trim() : "";
@@ -429,6 +428,8 @@ export function canPollCloudStatus(
   if (explicitBase && isConfiguredCloudSiteBase(explicitBase)) return true;
   return hasCloudLoginBackend() && supportsFullAppShellRoutes(explicitBase);
 }
+
+type PollIntent = "ambient" | "session-verification";
 
 /**
  * Resolve the Steward refresh endpoint for the current target. On hosted web
@@ -555,8 +556,11 @@ export function useCloudState({
 
   // ── Callbacks ──────────────────────────────────────────────────────
 
-  const pollCloudCredits = useCallback(async (): Promise<boolean> => {
-    if (!canPollCloudStatus()) {
+  async function runCloudPoll(
+    intent: PollIntent = "ambient",
+  ): Promise<boolean> {
+    const buildPinnedRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl();
+    if (intent === "ambient" && !canPollCloudStatus()) {
       if (elizaCloudPollInterval.current) {
         clearInterval(elizaCloudPollInterval.current);
         elizaCloudPollInterval.current = null;
@@ -566,10 +570,33 @@ export function useCloudState({
     if (elizaCloudDisconnectInFlightRef.current) {
       return lastElizaCloudPollConnectedRef.current;
     }
-    // error-policy:J4 transient poll failure degrades to the last known
-    // snapshot (below) rather than flapping the UI into a false "disconnected"
-    // state; a persistent failure surfaces via that stale-but-visible state.
-    const cloudStatus = await client.getCloudStatus().catch(() => null);
+
+    let cloudStatus: CloudStatus | null;
+    let prefetchedCloudCredits: CloudCredits | null | undefined;
+    if (intent === "session-verification" && buildPinnedRemoteApiBase) {
+      const stewardToken = readStoredStewardToken()?.trim();
+      const cloudApiBase =
+        getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL;
+      if (!stewardToken) return false;
+      const verification = await verifyDirectCloudStewardSession({
+        cloudApiBase,
+        stewardToken,
+      }).catch((err: unknown) => {
+        logger.warn(
+          { err },
+          "[useCloudState] direct Cloud session verification failed",
+        );
+        return null;
+      });
+      if (!verification) return false;
+      cloudStatus = verification.status;
+      prefetchedCloudCredits = verification.credits;
+    } else {
+      // error-policy:J4 transient poll failure degrades to the last known
+      // snapshot (below) rather than flapping the UI into a false "disconnected"
+      // state; a persistent failure surfaces via that stale-but-visible state.
+      cloudStatus = await client.getCloudStatus().catch(() => null);
+    }
     if (elizaCloudDisconnectInFlightRef.current) {
       return lastElizaCloudPollConnectedRef.current;
     }
@@ -620,11 +647,18 @@ export function useCloudState({
       // state below — the balance widget renders a real error, never
       // healthy-empty; the next poll interval retries.
       let creditsFetchError: string | null = null;
-      const credits = await client.getCloudCredits().catch((err: unknown) => {
-        creditsFetchError = err instanceof Error ? err.message : String(err);
-        logger.warn({ err }, "[useCloudState] cloud credits fetch failed");
-        return null;
-      });
+      const credits =
+        prefetchedCloudCredits !== undefined
+          ? prefetchedCloudCredits
+          : await client.getCloudCredits().catch((err: unknown) => {
+              creditsFetchError =
+                err instanceof Error ? err.message : String(err);
+              logger.warn(
+                { err },
+                "[useCloudState] cloud credits fetch failed",
+              );
+              return null;
+            });
       if (elizaCloudDisconnectInFlightRef.current) {
         return lastElizaCloudPollConnectedRef.current;
       }
@@ -667,9 +701,14 @@ export function useCloudState({
     }
     lastElizaCloudPollConnectedRef.current = isConnected;
     // Self-manage the recurring poll interval: start when connected, stop when not.
-    // This covers login during first-run setup (interval wasn't started at mount) and
-    // disconnect (interval should stop to avoid useless API calls).
-    if (isConnected && !elizaCloudPollInterval.current) {
+    // A build-pinned remote may verify a deliberate login against the Cloud
+    // control plane, but must never turn that one request into ambient polling.
+    const canScheduleAmbientPolling = canPollCloudStatus();
+    if (
+      isConnected &&
+      canScheduleAmbientPolling &&
+      !elizaCloudPollInterval.current
+    ) {
       elizaCloudPollInterval.current = window.setInterval(() => {
         if (
           typeof document !== "undefined" &&
@@ -677,14 +716,18 @@ export function useCloudState({
         ) {
           return;
         }
-        void pollCloudCredits();
+        void runCloudPoll();
       }, 60_000);
-    } else if (!isConnected && elizaCloudPollInterval.current) {
+    } else if (
+      (!isConnected || !canScheduleAmbientPolling) &&
+      elizaCloudPollInterval.current
+    ) {
       clearInterval(elizaCloudPollInterval.current);
       elizaCloudPollInterval.current = null;
     }
     return isConnected;
-  }, []);
+  }
+  const pollCloudCredits = useCallback(runCloudPoll, []);
 
   const reconcileAndroidCloudSession = useCallback(
     async (cloudApiBase?: string): Promise<boolean> => {
@@ -699,9 +742,11 @@ export function useCloudState({
         ...getBootConfig(),
         cloudApiBase: authenticatedCloudApiBase,
       });
-      client.setBaseUrl(authenticatedCloudApiBase, { persist: false });
-      client.setToken(token);
-      const connected = await pollCloudCredits();
+      if (!getBuildConfiguredRemoteApiBaseUrl()) {
+        client.setBaseUrl(authenticatedCloudApiBase, { persist: false });
+        client.setToken(token);
+      }
+      const connected = await pollCloudCredits("session-verification");
       try {
         await loadWalletConfig();
       } catch (err) {
@@ -992,7 +1037,7 @@ export function useCloudState({
           const apiKey = await siweLoginWithInjectedWallet(siweBase);
           if (apiKey) {
             closePrePoppedWindow();
-            const connected = await pollCloudCredits();
+            const connected = await pollCloudCredits("session-verification");
             // error-policy:J4 wallet config is a secondary panel; a failed
             // load must not undo a verified login.
             await loadWalletConfig().catch(() => undefined);
@@ -1049,7 +1094,7 @@ export function useCloudState({
           // declaring "connected" + toasting here would be a false success that
           // 401s the agent picker in a loop. Only celebrate a verified session;
           // otherwise surface the re-auth path the login UI already renders.
-          let connected = await pollCloudCredits();
+          let connected = await pollCloudCredits("session-verification");
           // A direct identity 401 clears only the exact rejected Steward
           // credential. When launchStewardLogin reused that credential, invoke
           // the mounted sign-in surface now and verify the replacement on this
@@ -1062,7 +1107,7 @@ export function useCloudState({
             if (hasStewardLoginLauncher()) {
               closePrePoppedWindow();
               await launchStewardLogin();
-              connected = await pollCloudCredits();
+              connected = await pollCloudCredits("session-verification");
             } else {
               // The opaque token was the only reason this branch was usable.
               // With it authoritatively rejected and no in-app provider,
@@ -1137,7 +1182,7 @@ export function useCloudState({
           hasRequiredClientAuth()
         ) {
           closePrePoppedWindow();
-          await pollCloudCredits();
+          await pollCloudCredits("session-verification");
           await loadWalletConfig().catch((err: unknown) => {
             // error-policy:J4 already-authenticated login has succeeded; a
             // wallet config refresh failure must not wedge the login button.


### PR DESCRIPTION
## Cause

A build pinned to a dedicated remote runtime must not poll that agent for Cloud account or billing state. The previous ambient early return enforced that boundary, but `pollCloudCredits` is also the post-login verification oracle. Returning the cached false value therefore made successful SIWE, Steward, and Android Cloud logins look rejected.

## Fix

- Give Cloud polling an explicit `ambient` versus `session-verification` intent.
- Keep pinned-remote ambient polling at zero network I/O and never arm its recurring interval.
- Verify deliberate pinned-remote logins against the configured Cloud control plane with the independently stored Steward bearer.
- Never repoint the immutable remote client or attach the Steward token to its agent authority.
- Treat control-plane 401/403 as a failed verification and clear only the rejected Steward session.
- Preserve the verified connected snapshot so later ambient reads remain stable without polling.
- Remove the test-only `canPollCloudStatus` export and cover the real login behavior instead.

## Limits

This changes only Cloud account/credits verification and scheduling. It does not change the build-pinned remote target, its agent credential, provisioning, voice, deployments, or live configuration.

## Risk

Scoped to Cloud login/status handling in build-pinned remotes. Standard Cloud, localhost, Capacitor, Electrobun, and agent-backed modes keep their existing transport path. The explicit control-plane helper reuses the existing bounded browser/native Cloud transport and accepts only the configured known Cloud environment or first-party loopback development authority.

## Rollback

Revert commit `ca0b5b3e8f0`.

## Tests

- `useCloudState.same-tab-login.test.tsx` — 24 passed
- all 9 `useCloudState` suites — 55 passed
- 6 related Cloud/native suites — 61 passed
- post-rebase focused verification — 4 files, 41 passed
- `bun run --cwd packages/ui typecheck`
- Biome on all 3 changed files
- `git diff --check`

## Relations

The original ambient-polling delta was already absorbed into `develop` through #29393. This branch is restacked on current `develop` and now contains only the review follow-up that preserves that boundary while restoring honest post-login verification.

No merge or deployment performed.
