### PR TITLE
fix(core): use truncateWellFormed for suppressed duplicate delivery logging in DefaultMessageService

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed";
 /**
  * Built-in `DefaultMessageService` (the runtime's `IMessageService` singleton) and
  * the helpers it composes, implementing the full inbound-message pipeline: memory
@@ -12711,7 +12712,7 @@ export function wrapSingleTurnVisibleCallback(
 		if (typeof response?.text === "string" && response.text.trim()) {
 			if (nearDuplicateOfDeliveredThisTurn(response.text)) {
 				fullRuntime.logger?.debug?.(
-					{ actionName, text: response.text.slice(0, 120) },
+					{ actionName, text: truncateWellFormed(toWellFormedUnicode(response.text), 120) },
 					"[message] suppressed near-duplicate delivery within the turn",
 				);
 				recordDeliveredVisibleText?.(response.text);


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5645de5b4897c71ea5081fe4d628b17bdb32346d -->

## Summary
In `@elizaos/core` (`packages/core/src/services/message.ts`):
`wrapSingleTurnVisibleCallback` logged suppressed near-duplicate turn text with raw `response.text.slice(0, 120)`. When responses contain multi-code-unit UTF-16 surrogate pairs at index 120, raw slicing produced lone surrogate code units in debug logs.

## Proposed Changes
1. Replaced raw `.slice(0, 120)` with `truncateWellFormed(toWellFormedUnicode(response.text), 120)` from `packages/core/src/utils/well-formed.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/services/message.surrogate.test.ts` (7/7 passed).
- Verified well-formed Unicode output during suppressed duplicate turn log formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
