### PR TITLE
fix(agent): use truncateWellFormed in sanitizeToken for integration observability

### DIFF
--- a/packages/agent/src/diagnostics/integration-observability.test.ts
+++ b/packages/agent/src/diagnostics/integration-observability.test.ts
@@ -85,6 +85,22 @@ describe("integration-observability", () => {
     expect(event.errorKind).toBe("timeout");
   });
 
+
+  it("preserves well-formed Unicode when inferring errorKind from overlong string containing surrogate pairs", () => {
+    const loggerMock = { info: vi.fn(), warn: vi.fn() };
+    const span = createIntegrationTelemetrySpan(
+      { boundary: "cloud", operation: "sync" },
+      { sink: loggerMock },
+    );
+    const longErr = "a".repeat(1023) + "🚀" + "tail_error";
+    span.failure({ error: longErr });
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+    const line = loggerMock.warn.mock.calls[0][0] as string;
+    const event: IntegrationObservabilityEvent = JSON.parse(
+      line.replace("[integration] ", ""),
+    );
+    expect(event.errorKind?.isWellFormed()).toBe(true);
+  });
   it("emits expected transient failure at info level instead of warn", () => {
     const loggerMock = {
       info: vi.fn(),

--- a/packages/agent/src/diagnostics/integration-observability.ts
+++ b/packages/agent/src/diagnostics/integration-observability.ts
@@ -5,7 +5,7 @@
  * failure, and emits a single `[integration]` JSON line to the logger — at info
  * level for successes and known-transient failures, at warn level otherwise.
  */
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 export type IntegrationBoundary =
   | "cloud"
@@ -79,7 +79,11 @@ function inferErrorKind(error: unknown): string | undefined {
 
 function sanitizeToken(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const safe = value.length > 1024 ? value.slice(0, 1024) : value;
+  const wellFormed = toWellFormedUnicode(value);
+  const safe =
+    wellFormed.length > 1024
+      ? truncateWellFormed(wellFormed, 1024)
+      : wellFormed;
   const token = safe.toLowerCase().replace(/[^a-z0-9_-]/g, "_");
   const normalized = token
     .replace(/_{1,1024}/g, "_")


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:873e1464b5b38e5ed8197da9ccffe721b7417eaf -->

## Summary
In `@elizaos/agent` (`packages/agent/src/diagnostics/integration-observability.ts`):
`sanitizeToken` clamped input string values using raw `value.slice(0, 1024)`. When error strings contain multi-code-unit UTF-16 surrogate pairs straddling index 1024, raw slicing produced lone surrogate code units before character normalization.

## Proposed Changes
1. Normalized `value` with `toWellFormedUnicode(value)`.
2. Clamped overlong strings using `truncateWellFormed(wellFormed, 1024)` from `@elizaos/core`.
3. Added test in `packages/agent/src/diagnostics/integration-observability.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/diagnostics/integration-observability.test.ts` (4/4 passed).
- Verified well-formed Unicode output during error token sanitization in integration telemetry spans.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
