### PR TITLE
fix(agent): use truncateWellFormed for skillId in validateSkillId

### DIFF
--- a/packages/agent/src/api/server-helpers-config.test.ts
+++ b/packages/agent/src/api/server-helpers-config.test.ts
@@ -17,6 +17,7 @@ import {
   MAX_CONFIG_SECRET_FILTER_DEPTH,
   redactConfigSecrets,
   stripRedactedPlaceholderValuesDeep,
+  validateSkillId,
 } from "./server-helpers-config";
 
 describe("isSafeResetStateDir", () => {
@@ -155,5 +156,22 @@ describe("redactConfigSecrets fail-closed walk", () => {
       env: { SAFE_FLAG: "1" },
       cloud: { region: "us" },
     });
+  });
+});
+
+describe("validateSkillId", () => {
+  it("safely handles overlong skill ID containing surrogate pairs", () => {
+    let responseBody = "";
+    const fakeRes = {
+      statusCode: 200,
+      setHeader: () => {},
+      end: (body: string) => { responseBody = body; },
+    } as any;
+
+    const overlong = "skill_" + "a".repeat(75) + "🚀" + "tail";
+    const res = validateSkillId(overlong, fakeRes);
+    expect(res).toBeNull();
+    expect(fakeRes.statusCode).toBe(400);
+    expect(responseBody.isWellFormed()).toBe(true);
   });
 });

--- a/packages/agent/src/api/server-helpers-config.ts
+++ b/packages/agent/src/api/server-helpers-config.ts
@@ -4,7 +4,7 @@
 
 import type http from "node:http";
 import path from "node:path";
-import { ElizaError, logger, sendJsonError } from "@elizaos/core";
+import { ElizaError, logger, sendJsonError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   getDefaultStylePreset,
   getStylePresets,
@@ -280,7 +280,7 @@ export function validateSkillId(
     skillId === "." ||
     skillId.includes("..")
   ) {
-    const safeDisplay = skillId.slice(0, 80).replace(/[^\x20-\x7e]/g, "?");
+    const safeDisplay = truncateWellFormed(toWellFormedUnicode(skillId), 80).replace(/[^\x20-\x7e]/g, "?");
     sendJsonError(res, `Invalid skill ID: "${safeDisplay}"`, 400);
     return null;
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:02461a045b56585b855a421875c297287c42745d -->

## Summary
In `@elizaos/agent` (`packages/agent/src/api/server-helpers-config.ts`):
`validateSkillId` formatted error response messages using raw `skillId.slice(0, 80)`. When an invalid skill ID string contains multi-code-unit UTF-16 surrogate pairs straddling index 80, raw slicing severed surrogate pairs.

## Proposed Changes
1. Normalized `skillId` and used `truncateWellFormed(toWellFormedUnicode(skillId), 80)` from `@elizaos/core`.
2. Added test in `packages/agent/src/api/server-helpers-config.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/api/server-helpers-config.test.ts` (13/13 passed).
- Verified well-formed Unicode output during skill ID validation error formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
