### PR TITLE
fix(examples/code): use truncateWellFormed for task ID formatting in App

### DIFF
--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -3,6 +3,8 @@ import {
   type ActionEventPayload,
   type AgentRuntime,
   EventType,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   type AutocompleteItem,
@@ -286,7 +288,7 @@ function formatTaskList(tasks: CodeTask[]): string {
     const marker = task.id === currentTaskId ? "->" : "  ";
     const status = task.metadata?.status ?? "pending";
     const progress = task.metadata?.progress ?? 0;
-    const id = task.id ? task.id.slice(0, 8) : "no-id";
+    const id = task.id ? truncateWellFormed(toWellFormedUnicode(task.id), 8) : "no-id";
     return `${marker} ${index + 1}. ${task.name} [${status}, ${progress}%] ${id}`;
   });
   return `Tasks:\n${lines.join("\n")}`;
@@ -1158,7 +1160,7 @@ During a turn: Enter queues the message, Esc/Ctrl+C aborts (queued messages are 
           state.addMessage(
             state.currentRoomId,
             "system",
-            `Failed to start task ${taskId.slice(0, 8)}: ${msg}`,
+            `Failed to start task ${truncateWellFormed(toWellFormedUnicode(taskId), 8)}: ${msg}`,
           );
         });
       }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:cf164104078606455e6c503179be2d527760cfdb -->

## Summary
In `packages/examples/code/src/App.ts`:
1. `formatTaskList` displayed task IDs with raw `task.id.slice(0, 8)`.
2. Startup task resume error handling formatted error messages with raw `taskId.slice(0, 8)`.

## Proposed Changes
1. Replaced raw `.slice(0, 8)` with `truncateWellFormed(toWellFormedUnicode(...), 8)` from `@elizaos/core` across both task ID formatting sites in `App.ts`.

## Verification
- Verified well-formed Unicode output during task ID formatting and startup task error reporting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
