### PR TITLE
fix(agent): use truncateWellFormed in cloudApiKeyFingerprint

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -131,6 +131,8 @@ export {
 // Keep this here as a single sentinel: if we ever need a static reference,
 // add `as const` data only — never an `import * as` of these packages.
 import {
+  toWellFormedUnicode,
+  truncateWellFormed,
   AgentRuntime,
   AUTONOMY_SERVICE_TYPE,
   AutonomyService,
@@ -2348,7 +2350,7 @@ export function bindCloudGithubTokenToRuntime(
 export function cloudApiKeyFingerprint(value: string | undefined): string {
   const v = value?.trim();
   if (!v) return "(none)";
-  return `${v.slice(0, 6)}…(len ${v.length})`;
+  return `${truncateWellFormed(toWellFormedUnicode(v), 6)}…(len ${v.length})`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5c4bdb3ede594552f2be59852785354d36d182ad -->

## Summary
In `@elizaos/agent` (`packages/agent/src/runtime/eliza.ts`):
`cloudApiKeyFingerprint` formatted non-secret cloud API key fingerprints using raw `v.slice(0, 6)`. When cloud API keys contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs.

## Proposed Changes
1. Replaced raw `.slice(0, 6)` with `truncateWellFormed(toWellFormedUnicode(v), 6)` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output during cloud API key fingerprint formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
