### PR TITLE
fix(auth): use truncateWellFormed for accountId in validation error context

### DIFF
--- a/packages/auth/src/account-storage.ts
+++ b/packages/auth/src/account-storage.ts
@@ -14,7 +14,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { ElizaError, logger, resolveStateDir } from "@elizaos/core";
+import { ElizaError, logger, resolveStateDir, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { decrypt, encrypt, loadDefaultMasterKeySync } from "@elizaos/vault";
 import {
   ACCOUNT_CREDENTIAL_PROVIDER_IDS,
@@ -691,7 +691,7 @@ export function assertCanonicalAccountId(accountId: string): void {
     throw storageError(
       "AUTH_CREDENTIAL_ACCOUNT_ID_INVALID",
       "Account id must be a canonical filename-safe identifier",
-      { accountId: String(accountId).slice(0, 160) },
+      { accountId: truncateWellFormed(toWellFormedUnicode(String(accountId)), 160) },
     );
   }
 }

--- a/packages/auth/src/subscription-auth/adopt-codex-cli-login.ts
+++ b/packages/auth/src/subscription-auth/adopt-codex-cli-login.ts
@@ -39,7 +39,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
-import { ElizaError, logger } from "@elizaos/core";
+import { ElizaError, logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type AccountStorageMutationScope,
   type AccountStoragePolicy,
@@ -92,7 +92,7 @@ function validateAccountId(accountId: string): void {
     throw adoptError(
       "adopt_codex.invalid_account_id",
       "Account id must be 1-64 chars of [A-Za-z0-9._-], starting alphanumeric, with no traversal sequences",
-      { accountId: String(accountId).slice(0, 80) },
+      { accountId: truncateWellFormed(toWellFormedUnicode(String(accountId)), 80) },
     );
   }
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c4ec0cce9a295a6b8d1a4a64ed3ce477c1309aab -->

## Summary
In `@elizaos/auth`:
1. `assertCanonicalAccountId` (`packages/auth/src/account-storage.ts`) formatted error context using raw `String(accountId).slice(0, 160)`.
2. `validateAccountId` (`packages/auth/src/subscription-auth/adopt-codex-cli-login.ts`) formatted error context using raw `String(accountId).slice(0, 80)`.

When invalid account ID strings contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs in error context payloads.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(String(accountId)), ...)` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run packages/auth/src/account-storage.test.ts packages/auth/src/subscription-auth/adopt-codex-cli-login.test.ts` (50/50 passed).
- Verified well-formed Unicode output in error context serialization.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
