### PR TITLE
fix(app-core): use truncateWellFormed for bootstrap display names, error messages, and iOS paths

### DIFF
--- a/packages/app-core/src/api/auth-bootstrap-routes.ts
+++ b/packages/app-core/src/api/auth-bootstrap-routes.ts
@@ -10,7 +10,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
-import { logger as Logger } from "@elizaos/core";
+import { logger as Logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { AuthStore, type DrizzleDatabase } from "../services/auth-store";
 import {
   appendAuditEvent,
@@ -159,7 +159,7 @@ export async function handleAuthBootstrapRoutes(
     await store.createIdentity({
       id: identityId,
       kind: "owner",
-      displayName: `Cloud user ${claims.sub.slice(0, 8)}`,
+      displayName: `Cloud user ${truncateWellFormed(toWellFormedUnicode(claims.sub), 8)}`,
       createdAt: now,
       passwordHash: null,
       cloudUserId: claims.sub,

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -892,7 +892,7 @@ async function tryFullBunStreamingResponse(
     { call: runtime.call, addListener: runtime.addListener },
     (error) => {
       console.warn("[ios-local-agent] stream request failed after head", {
-        path: options.path?.slice(0, 120) ?? null,
+        path: options.path ? truncateWellFormed(toWellFormedUnicode(options.path), 120) : null,
         error: error instanceof Error ? error.message : String(error),
       });
     },
@@ -945,7 +945,7 @@ export async function handleIosLocalAgentNativeRequest(
     appendIosBootTrace("native-request", {
       copy: "app-core",
       n: tracedNativeRequests,
-      path: options.path?.slice(0, 120) ?? null,
+      path: options.path ? truncateWellFormed(toWellFormedUnicode(options.path), 120) : null,
     });
   }
   const path = options.path?.trim();

--- a/packages/app-core/src/runtime/startup/pglite-recovery.ts
+++ b/packages/app-core/src/runtime/startup/pglite-recovery.ts
@@ -13,7 +13,7 @@ import {
   resolveDefaultAgentWorkspaceDir,
   resolveUserPath,
 } from "@elizaos/agent";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { PGLITE_ERROR_CODES } from "@elizaos/plugin-sql";
 import { formatError } from "@elizaos/shared";
 import { resetPluginSqlPgliteSingleton } from "../pglite-auto-reset.js";
@@ -100,8 +100,11 @@ function getPgliteDataDirFromError(err: unknown): string | null {
   }
 
   for (const rawMessage of collectErrorMessages(err)) {
+    const wellFormed = toWellFormedUnicode(rawMessage);
     const message =
-      rawMessage.length > 4096 ? rawMessage.slice(0, 4096) : rawMessage;
+      wellFormed.length > 4096
+        ? truncateWellFormed(wellFormed, 4096)
+        : wellFormed;
     const retryPathMatch = message.match(
       /before retrying:[ \t]{0,16}([^\n]{1,1024}?)(?:[ \t]*$|\.)/,
     );


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:dc69bc368f8a908bd6d6a95270bd7781b620954b -->

## Summary
In `@elizaos/app-core`:
1. `handleAuthBootstrapRoutes` (`packages/app-core/src/api/auth-bootstrap-routes.ts`) created default user display names using raw `claims.sub.slice(0, 8)`.
2. `getPgliteDataDirFromError` (`packages/app-core/src/runtime/startup/pglite-recovery.ts`) clamped error messages using raw `rawMessage.slice(0, 4096)`.
3. `iosLocalAgentRequest` error logging and boot tracing (`packages/app-core/src/api/ios-local-agent-transport.ts`) formatted request paths using raw `options.path?.slice(0, 120)`.

When any of these strings contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing produced lone surrogate code units.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core` across all three modules.

## Verification
- Verified well-formed Unicode output during cloud user display name formatting, PGlite error parsing, and iOS request path logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
