### PR TITLE
fix(app-core): use truncateWellFormed for keyPrefix in account pool consumer metering

### DIFF
--- a/packages/app-core/src/services/account-pool-consumer-metering.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.ts
@@ -20,7 +20,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { resolveStateDir } from "@elizaos/core";
+import { resolveStateDir, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const STORE_DIR = "account-pool";
 const KEY_FILE = "consumer-keys.json";
@@ -388,7 +388,7 @@ export function createAccountPoolConsumerKey(
     enabled,
     dailyTokenQuota: quota,
     keyDigest: digestConsumerKey(key),
-    keyPrefix: key.slice(0, 18),
+    keyPrefix: truncateWellFormed(toWellFormedUnicode(key), 18),
     createdAt: now,
     updatedAt: now,
   };
@@ -441,7 +441,7 @@ export function rotateAccountPoolConsumerKey(
   const next: AccountPoolConsumerKey = {
     ...current,
     keyDigest: digestConsumerKey(key),
-    keyPrefix: key.slice(0, 18),
+    keyPrefix: truncateWellFormed(toWellFormedUnicode(key), 18),
     updatedAt: Date.now(),
   };
   file.keys[index] = next;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1d3830c779099aaf0188489483032f5d5174774a -->

## Summary
In `@elizaos/app-core` (`packages/app-core/src/services/account-pool-consumer-metering.ts`):
`createAccountPoolConsumerKey` and `rotateAccountPoolConsumerKey` formatted stored consumer key prefix identifiers with raw `key.slice(0, 18)`.

## Proposed Changes
1. Replaced raw `.slice(0, 18)` with `truncateWellFormed(toWellFormedUnicode(key), 18)` from `@elizaos/core`.

## Verification
- Ran vitest: `bunx vitest run packages/app-core/src/services/account-pool-consumer-metering.test.ts` (10/10 passed).
- Verified well-formed Unicode output in key prefix persistence.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
