### PR TITLE
fix(app-core): use truncateWellFormed in getProvidedApiToken for authorization header extraction

### DIFF
--- a/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
+++ b/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
@@ -41,6 +41,14 @@ describe("getProvidedApiToken", () => {
     expect(getProvidedApiToken(req)).toBe("tok-1");
   });
 
+
+  it("preserves well-formed Unicode when authorization header contains surrogate pairs at boundary", () => {
+    const longToken = "Bearer " + "a".repeat(1015) + "🚀" + "tail";
+    const req = { headers: { authorization: longToken } } as never;
+    const token = getProvidedApiToken(req);
+    expect(token).toBeTruthy();
+    expect(token!.isWellFormed()).toBe(true);
+  });
   it("falls back to x-api-key and returns null when absent", () => {
     const req = { headers: { "x-api-key": "k" } } as never;
     expect(getProvidedApiToken(req)).toBe("k");

--- a/packages/app-core/src/api/auth/tokens.ts
+++ b/packages/app-core/src/api/auth/tokens.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Constant-time token equality for API auth. `tokenMatches` compares an expected
  * secret/bearer token against a provided one without leaking length or content
@@ -43,9 +44,10 @@ export function extractHeaderValue(
 export function getProvidedApiToken(
   req: Pick<http.IncomingMessage, "headers">,
 ): string | null {
-  const authHeader = extractHeaderValue(req.headers.authorization)
-    ?.slice(0, 1024)
-    ?.trim();
+  const rawAuth = extractHeaderValue(req.headers.authorization);
+  const authHeader = rawAuth
+    ? truncateWellFormed(toWellFormedUnicode(rawAuth), 1024).trim()
+    : null;
   if (authHeader) {
     const match = /^Bearer\s{1,8}(.+)$/i.exec(authHeader);
     if (match?.[1]) return match[1].trim();


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d5b8c8b1abd57d89164fccc592cc2a6e23090312 -->

## Summary
In `@elizaos/app-core` (`packages/app-core/src/api/auth/tokens.ts`):
`getProvidedApiToken` clamped the raw `Authorization` header string using `.slice(0, 1024)`. When authorization header strings contain multi-code-unit UTF-16 surrogate pairs at index 1024, raw slicing produced lone surrogate code units.

## Proposed Changes
1. Replaced raw `.slice(0, 1024)` with `truncateWellFormed(toWellFormedUnicode(rawAuth), 1024)` from `@elizaos/core`.
2. Added test in `packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts` (7/7 passed).
- Verified well-formed Unicode output during token extraction.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
