### PR TITLE
fix(plugin-agent-orchestrator): use truncateWellFormed for session IDs and posting logs

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -19,6 +19,8 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
+  toWellFormedUnicode,
+  truncateWellFormed,
   createUniqueUuid,
   EventType,
   isLocalCodeExecutionAllowed,
@@ -1951,7 +1953,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       runtime.logger?.debug?.(
         {
           src: "@elizaos/plugin-agent-orchestrator",
-          sessionId: sessionId.slice(0, 8),
+          sessionId: truncateWellFormed(toWellFormedUnicode(sessionId), 8),
           ev: evName,
         },
         "session event",
@@ -2231,12 +2233,12 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         runtime.logger?.debug?.(
           {
             src: "@elizaos/plugin-agent-orchestrator",
-            sessionId: sessionId.slice(0, 8),
+            sessionId: truncateWellFormed(toWellFormedUnicode(sessionId), 8),
             ev: evName,
             source,
-            room: roomId.slice(0, 8),
+            room: truncateWellFormed(toWellFormedUnicode(roomId), 8),
           },
-          `posting: "${text.slice(0, 80)}"`,
+          `posting: "${truncateWellFormed(toWellFormedUnicode(text), 80)}"`,
         );
         await emitProgress(sessionId, { source, roomId }, text, label);
       } catch (err) {

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -19,8 +19,6 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
-  toWellFormedUnicode,
-  truncateWellFormed,
   createUniqueUuid,
   EventType,
   isLocalCodeExecutionAllowed,
@@ -28,6 +26,7 @@ import {
   promoteSubactionsToActions,
   requireConfirmedSendHandlerDelivery,
   toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 // Register coding-agent HTTP routes with the runtime route registry.


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c1dd2c1abec8ba277def7d36fca3c00d99b6ea15 -->

## Summary
In `@elizaos/plugin-agent-orchestrator` (`plugins/plugin-agent-orchestrator/src/index.ts`):
`registerProgressHook` logged progress events and session events using raw `sessionId.slice(0, 8)`, `roomId.slice(0, 8)`, and `text.slice(0, 80)`. When any of these strings contain UTF-16 surrogate pairs at boundary indices, raw slicing severed surrogate pairs.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output during orchestrator session event and progress log formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
