### PR TITLE
fix(plugin-wallet): use surrogate-safe truncation for Steer vault and token names

### DIFF
--- a/plugins/plugin-wallet/src/analytics/lpinfo/steer/services/steerLiquidityService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/steer/services/steerLiquidityService.ts
@@ -11,7 +11,7 @@
  * `getTokenPrices` currently has no wired price feed and always returns null.
  */
 import type { IAgentRuntime, JsonValue } from "@elizaos/core";
-import { logger, Service } from "@elizaos/core";
+import { logger, Service, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { StakingPool } from "@steerprotocol/sdk";
 import {
   AMMType,
@@ -793,7 +793,7 @@ export class SteerLiquidityService extends Service {
 
       const processedVault: SteerVaultDetailInput = {
         address: vaultAddress,
-        name: vault.name || `Steer Vault ${vaultAddress.slice(0, 8)}...`,
+        name: vault.name || `Steer Vault ${truncateWellFormed(toWellFormedUnicode(vaultAddress), 8)}...`,
         chainId,
         token0: vault.token0 || "Unknown",
         token1: vault.token1 || "Unknown",
@@ -1307,7 +1307,7 @@ export class SteerLiquidityService extends Service {
 
   private getTokenName(tokenIdentifier: string): string {
     if (tokenIdentifier.startsWith("0x")) {
-      return `Token ${tokenIdentifier.slice(0, 8)}...${tokenIdentifier.slice(-6)}`;
+      return `Token ${truncateWellFormed(toWellFormedUnicode(tokenIdentifier), 8)}...${tailWellFormed(toWellFormedUnicode(tokenIdentifier), 6)}`;
     }
 
     return tokenIdentifier;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a1247d5ef19f7e412fe453f593ef659a59669d32 -->

## Summary
In `@elizaos/plugin-wallet` (`plugins/plugin-wallet/src/analytics/lpinfo/steer/services/steerLiquidityService.ts`):
1. `processedVault.name` formatted fallback vault names using raw `vaultAddress.slice(0, 8)`.
2. `getTokenName` formatted hexadecimal token identifiers using raw `${tokenIdentifier.slice(0, 8)}...${tokenIdentifier.slice(-6)}`.

When identifiers contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing produced lone surrogate code units.

## Proposed Changes
1. Refactored both sites with `truncateWellFormed` and `tailWellFormed` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output during Steer vault and token name formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
