### PR TITLE
fix(plugin-wallet): use truncateWellFormed for Kamino marketName

### DIFF
--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoService.ts
@@ -9,7 +9,7 @@
  * exact on-chain values.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger, Service } from "@elizaos/core";
+import { logger, Service, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const KAMINO_API_BASE_URL = "https://api.kamino.finance";
 const KAMINO_LEND_PROGRAM_ID = "GzFgdRJXmawPhGeBsyRCDLx4jAKPsvbUqoqitzppkzkW";
@@ -428,7 +428,7 @@ export class KaminoService extends Service {
             const borrowApy = await this.calculateLimoBorrowApy(trade);
             reserves.push({
               market: pairKey,
-              marketName: `Limo-${pairKey.slice(0, 16)}`,
+              marketName: `Limo-${truncateWellFormed(toWellFormedUnicode(pairKey), 16)}`,
               dataSize: 0,
               lamports: 0,
               owner: KAMINO_LEND_PROGRAM_ID,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f1b940e306ebd38fb1b3972936d6e91984a48d6a -->

## Summary
In `@elizaos/plugin-wallet` (`plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoService.ts`):
`KaminoService` formatted reserve market names using raw `pairKey.slice(0, 16)`. When pair keys contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs.

## Proposed Changes
1. Replaced raw `.slice(0, 16)` with `truncateWellFormed(toWellFormedUnicode(pairKey), 16)` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output during Kamino market reserve formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
