### PR TITLE
fix(ui): use truncateWellFormed for launcher icon fallback monogram

### DIFF
--- a/packages/ui/stories/src/launcher-icons-preview.tsx
+++ b/packages/ui/stories/src/launcher-icons-preview.tsx
@@ -2,6 +2,7 @@
  * Interactive launcher icon-pack lab. It compares complete third-party packs,
  * supports per-app overrides, and queues bespoke icons for later generation.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { Button } from "@ui-src/components/ui/button.tsx";
 import { Sparkles } from "lucide-react";
 import { StrictMode, useEffect, useMemo, useState } from "react";
@@ -65,7 +66,7 @@ function PackIcon({
   return (
     <span className={`pack-icon-art ${className ?? ""}`} data-pack={choice}>
       <span className="pack-icon-fallback" aria-hidden="true">
-        {app.label.slice(0, 1)}
+        {truncateWellFormed(toWellFormedUnicode(app.label), 1)}
       </span>
       <img
         src={launcherIconUrl(app, choice)}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a8f135a3b65a4f2928c2625b3470416cc211bed5 -->

## Summary
In `@elizaos/ui` (`packages/ui/stories/src/launcher-icons-preview.tsx`):
`PackIcon` extracted fallback monograms using raw `app.label.slice(0, 1)`. When app labels begin with multi-code-unit UTF-16 surrogate pairs (e.g. emoji or astral symbols), raw slicing severed the surrogate pair.

## Proposed Changes
1. Replaced raw `.slice(0, 1)` with `truncateWellFormed(toWellFormedUnicode(app.label), 1)` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output in pack icon fallback monogram rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
