### PR TITLE
[android-auth-agent-chat] fix(ci): redact live workflow diagnostics

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -128,7 +128,16 @@ jobs:
         run: bun run --cwd packages/app build:web
 
       - name: Run live agent chat (real model turn)
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/live-agent-chat.spec.ts --project=chromium -g "live agent"
+        shell: bash
+        run: |
+          set -euo pipefail
+          if bun run --cwd packages/app test:e2e test/ui-smoke/live-agent-chat.spec.ts --project=chromium -g "live agent" >/dev/null 2>&1; then
+            echo "Live agent chat passed (category=live-chat-passed; raw-output=suppressed)."
+          else
+            status=$?
+            echo "::error::Live agent chat failed (category=live-chat-failed; exit=${status}; raw-output=suppressed)."
+            exit "$status"
+          fi
 
       # Deep settings/vault round-trips that the keyless stub structurally
       # cannot serve (write→reload→read-back against the real on-disk vault +
@@ -136,23 +145,39 @@ jobs:
       # guards in these specs open. The two *-interactions specs also run keyless
       # in scenario-pr.yml (skipping their deep blocks); here they run them.
       - name: Run settings + vault live-stack deep e2e
+        shell: bash
         run: |
-          bun run --cwd packages/app test:e2e test/ui-smoke/vault-routing.spec.ts test/ui-smoke/wallet-keys.spec.ts test/ui-smoke/vault-modal-interactions.spec.ts test/ui-smoke/settings-sections-interactions.spec.ts --project=chromium
+          set -euo pipefail
+          run_closed_e2e() {
+            local category="$1"
+            shift
+            if "$@" >/dev/null 2>&1; then
+              echo "Credentialed E2E passed (category=${category}-passed; raw-output=suppressed)."
+            else
+              local status=$?
+              echo "::error::Credentialed E2E failed (category=${category}-failed; exit=${status}; raw-output=suppressed)."
+              return "$status"
+            fi
+          }
+          run_closed_e2e settings-vault \
+            bun run --cwd packages/app test:e2e test/ui-smoke/vault-routing.spec.ts test/ui-smoke/wallet-keys.spec.ts test/ui-smoke/vault-modal-interactions.spec.ts test/ui-smoke/settings-sections-interactions.spec.ts --project=chromium
           # Provider switching deliberately restarts the runtime. Run it in a
           # fresh final harness so its lifecycle cannot strand unrelated tests
           # behind the startup shell while the selected test provider restarts.
-          bun run --cwd packages/app test:e2e test/ui-smoke/provider-config.spec.ts --project=chromium
+          run_closed_e2e provider-config \
+            bun run --cwd packages/app test:e2e test/ui-smoke/provider-config.spec.ts --project=chromium
 
       - name: Upload live-chat artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: app-live-e2e-chat
-          path: |
-            packages/app/playwright-report/
-            packages/app/test-results/
-            e2e-recordings/app-live/backend.log
-          if-no-files-found: ignore
+          # The harness projects backend stdout/stderr into a fixed category +
+          # channel schema. Raw Playwright reports/results are intentionally
+          # excluded because these specs exercise chat, vault, wallet, and
+          # provider state with live credentials.
+          path: e2e-recordings/app-live/backend.log
+          if-no-files-found: error
           retention-days: 7
 
   # Full continuous walkthrough against the REAL backend agent + model: cold
@@ -309,7 +334,16 @@ jobs:
         run: bun run --cwd packages/app build:web
 
       - name: Run real cloud login + personal identity + chat
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium
+        shell: bash
+        run: |
+          set -euo pipefail
+          if bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium >/dev/null 2>&1; then
+            echo "Cloud login/chat passed (category=cloud-live-passed; raw-output=suppressed)."
+          else
+            status=$?
+            echo "::error::Cloud login/chat failed (category=cloud-live-failed; exit=${status}; raw-output=suppressed)."
+            exit "$status"
+          fi
 
   # STAGING counterpart of cloud-live (#18076): the same real login +
   # Personal Eliza identity + chat path, pinned to the staging control plane. Kept a
@@ -419,15 +453,20 @@ jobs:
         id: staging-cloud-smoke
         shell: bash
         run: |
-          set -uo pipefail
+          set -euo pipefail
           rm -f -- "$ELIZA_UI_SMOKE_STAGING_CHAT_LATENCY_EVIDENCE_PATH"
           rm -f -- "$ELIZA_UI_SMOKE_STAGING_CONTINUITY_EVIDENCE_PATH"
           started_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
           echo "started_ms=$started_ms" >> "$GITHUB_OUTPUT"
           set +e
-          bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium
+          bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium >/dev/null 2>&1
           test_status=$?
           set -e
+          if [ "$test_status" -eq 0 ]; then
+            echo "Staging Cloud login/chat passed (category=cloud-live-staging-passed; raw-output=suppressed)."
+          else
+            echo "::error::Staging Cloud login/chat failed (category=cloud-live-staging-failed; exit=${test_status}; raw-output=suppressed)."
+          fi
           completed_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
           echo "completed_ms=$completed_ms" >> "$GITHUB_OUTPUT"
           exit "$test_status"

--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -188,7 +188,39 @@ jobs:
               )
               ;;
           esac
-          "${args[@]}"
+          arm_stdout="$RUNNER_TEMP/headscale-arm.stdout"
+          arm_stderr="$RUNNER_TEMP/headscale-arm.stderr"
+          umask 077
+          cleanup_arm_output() {
+            local cleanup_paths=("$arm_stdout" "$arm_stderr")
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_arm_output EXIT
+
+          set +e
+          "${args[@]}" > "$arm_stdout" 2> "$arm_stderr"
+          arm_status=$?
+          set -e
+          if [ "$arm_status" -ne 0 ]; then
+            echo "::error::Headscale remote operation failed (category=headscale-remote-failed; exit=$arm_status; raw-output=suppressed)."
+            exit "$arm_status"
+          fi
+
+          if [ "$TARGET_OPERATION" = "inspect-legacy-vhost" ]; then
+            mapfile -t reviewed_sha_lines < <(
+              grep -E '^reviewed-sha256=[0-9a-f]{64}$' "$arm_stdout" || true
+            )
+            if [ "${#reviewed_sha_lines[@]}" -ne 1 ]; then
+              echo "::error::Headscale inspection returned an invalid receipt (category=headscale-inspection-receipt-invalid; raw-output=suppressed)."
+              exit 1
+            fi
+            echo "${reviewed_sha_lines[0]}"
+            echo "Headscale inspection passed (category=headscale-inspection-passed; raw-output=suppressed)."
+          else
+            echo "Headscale control-plane converge passed (category=headscale-converge-passed; raw-output=suppressed)."
+          fi
 
       - name: Verify dual-SAN public identity and health
         if: inputs.operation != 'inspect-legacy-vhost'

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -1501,12 +1501,48 @@ jobs:
             HEALTH_SINCE_TS="$(date -u '+%Y-%m-%d %H:%M:%S')"
             STABLE_THRESHOLD_SEC=20
             FATAL_LOG_PATTERN="\[(provisioning-worker|agent-router|backup-catalog-worker)\] (fatal|unhandled rejection)|node:internal/.*Error:|Error \[ERR_|^[A-Za-z]+Error:"
+            report_unit_diagnostic() {
+              local category="$1"
+              local label="$2"
+              local unit="$3"
+              local raw_load raw_active raw_result
+              local load_class active_class result_class
+              case "$label" in
+                worker|router|backup|nginx) ;;
+                *) label=unknown ;;
+              esac
+              raw_load=$(sudo systemctl show "$unit" --property=LoadState --value 2>/dev/null || true)
+              raw_active=$(sudo systemctl show "$unit" --property=ActiveState --value 2>/dev/null || true)
+              raw_result=$(sudo systemctl show "$unit" --property=Result --value 2>/dev/null || true)
+              case "$raw_load" in
+                loaded) load_class=loaded ;;
+                masked) load_class=masked ;;
+                not-found) load_class=missing ;;
+                *) load_class=other ;;
+              esac
+              case "$raw_active" in
+                active) active_class=active ;;
+                failed) active_class=failed ;;
+                inactive) active_class=inactive ;;
+                activating|deactivating|reloading) active_class=transitioning ;;
+                *) active_class=other ;;
+              esac
+              case "$raw_result" in
+                "") result_class=none ;;
+                success) result_class=success ;;
+                exit-code|signal|core-dump|watchdog|timeout|start-limit-hit|oom-kill) result_class=failure ;;
+                *) result_class=other ;;
+              esac
+              echo "::error::unit-state category=${category} component=${label} load=${load_class} active=${active_class} result=${result_class}"
+            }
             report_public_route_failure() {
-              sudo nginx -t || true
-              sudo systemctl status nginx --no-pager || true
-              sudo journalctl -u nginx --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
-              sudo systemctl status eliza-agent-router.service --no-pager || true
-              sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
+              local nginx_config_class=invalid
+              if sudo nginx -t >/dev/null 2>&1; then
+                nginx_config_class=valid
+              fi
+              echo "::error::nginx-config category=public-route verdict=${nginx_config_class}"
+              report_unit_diagnostic public-route nginx nginx
+              report_unit_diagnostic public-route router eliza-agent-router.service
             }
             validate_deletion_authority_backup_health() {
               # DynamicUser owns the mode-0700 RuntimeDirectory and mode-0600
@@ -1564,9 +1600,9 @@ jobs:
                 continue
               fi
               BACKUP_JOURNAL=$(sudo journalctl -u "$BACKUP_SYSTEMD_UNIT" --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
-              if echo "$BACKUP_JOURNAL" | grep -qE "$FATAL_LOG_PATTERN"; then
+              if grep -qE "$FATAL_LOG_PATTERN" <<<"$BACKUP_JOURNAL"; then
                 echo "::error::Backup catalogue worker logged a fatal error since deploy."
-                echo "$BACKUP_JOURNAL" | tail -n 50
+                report_unit_diagnostic fatal-log backup "$BACKUP_SYSTEMD_UNIT"
                 exit 1
               fi
               if ! validate_deletion_authority_backup_health; then
@@ -1576,9 +1612,9 @@ jobs:
               fi
               if sudo systemctl is-active --quiet "$SYSTEMD_UNIT"; then
                 JOURNAL=$(sudo journalctl -u "$SYSTEMD_UNIT" --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
-                if echo "$JOURNAL" | grep -qE "$FATAL_LOG_PATTERN"; then
+                if grep -qE "$FATAL_LOG_PATTERN" <<<"$JOURNAL"; then
                   echo "::error::Worker logged a fatal error since deploy."
-                  echo "$JOURNAL" | tail -n 50
+                  report_unit_diagnostic fatal-log worker "$SYSTEMD_UNIT"
                   exit 1
                 fi
                 # Active + uptime past the threshold = healthy. systemd's Restart=always
@@ -1594,9 +1630,9 @@ jobs:
                     continue
                   fi
                   ROUTER_JOURNAL=$(sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
-                  if echo "$ROUTER_JOURNAL" | grep -qE "$FATAL_LOG_PATTERN"; then
+                  if grep -qE "$FATAL_LOG_PATTERN" <<<"$ROUTER_JOURNAL"; then
                     echo "::error::Agent router logged a fatal error since activation."
-                    echo "$ROUTER_JOURNAL" | tail -n 50
+                    report_unit_diagnostic fatal-log router eliza-agent-router.service
                     exit 1
                   fi
                   ROUTER_UPTIME_SEC=$(systemctl show eliza-agent-router.service --property=ActiveEnterTimestampMonotonic --value | awk '{ print int($1 / 1e6) }')
@@ -1614,33 +1650,33 @@ jobs:
                     PUBLIC_READINESS=""
                     public_route_ok=false
                     for public_attempt in 1 2 3; do
-                      if PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz") && \
-                         PUBLIC_READINESS=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/readyz"); then
+                      if PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz" 2>/dev/null) && \
+                         PUBLIC_READINESS=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/readyz" 2>/dev/null); then
                         public_route_ok=true
                         break
                       fi
-                      echo "Canonical health/readiness attempt ${public_attempt}/3 failed for ${AGENT_ROUTER_PUBLIC_HOST}; retrying in 2s."
+                      echo "Canonical health/readiness attempt ${public_attempt}/3 failed; response suppressed; retrying in 2s."
                       sleep 2
                     done
                     if [ "$public_route_ok" != "true" ]; then
-                      echo "::error::Canonical agent-router host failed after local readiness: ${AGENT_ROUTER_PUBLIC_HOST}"
+                      echo "::error::Canonical agent-router route failed after local readiness (category=public-route-transport)."
                       report_public_route_failure
                       exit 1
                     fi
                     if ! printf '%s' "$PUBLIC_HEALTH" | validate_public_health_payload; then
-                      echo "::error::Canonical agent-router host returned an unexpected health payload: ${AGENT_ROUTER_PUBLIC_HOST}"
+                      echo "::error::Canonical agent-router health contract failed (category=public-route-payload)."
                       report_public_route_failure
                       exit 1
                     fi
                     if ! printf '%s' "$PUBLIC_READINESS" | validate_public_health_payload; then
-                      echo "::error::Canonical agent-router host returned an unexpected readiness payload: ${AGENT_ROUTER_PUBLIC_HOST}"
+                      echo "::error::Canonical agent-router readiness contract failed (category=public-route-payload)."
                       report_public_route_failure
                       exit 1
                     fi
                     echo "Provisioning/router stable and backup worker disabled/healthy (worker ${AGE}s, router ${ROUTER_AGE}s) on attempt $attempt."
                     exit 0
                   fi
-                  echo "Health check attempt $attempt/18: worker stable (${AGE}s), router ${ROUTER_AGE}s but health/readiness not ready on port ${ROUTER_PORT}."
+                  echo "Health check attempt $attempt/18: worker and router stable but local health/readiness not ready."
                   sleep 5
                   continue
                 fi
@@ -1651,13 +1687,10 @@ jobs:
               sleep 5
             done
 
-            echo "::error::$SYSTEMD_UNIT failed to become healthy within 90s."
-            sudo systemctl status "$SYSTEMD_UNIT" --no-pager || true
-            sudo journalctl -u "$SYSTEMD_UNIT" -n 200 --no-pager || true
-            sudo systemctl status eliza-agent-router.service --no-pager || true
-            sudo journalctl -u eliza-agent-router.service -n 200 --no-pager || true
-            sudo systemctl status "$BACKUP_SYSTEMD_UNIT" --no-pager || true
-            sudo journalctl -u "$BACKUP_SYSTEMD_UNIT" -n 200 --no-pager || true
+            echo "::error::Provisioning health deadline exceeded (category=health-timeout)."
+            report_unit_diagnostic health-timeout worker "$SYSTEMD_UNIT"
+            report_unit_diagnostic health-timeout router eliza-agent-router.service
+            report_unit_diagnostic health-timeout backup "$BACKUP_SYSTEMD_UNIT"
             exit 1
 
       - name: Notify Discord (Success)

--- a/.github/workflows/deploy-tunnel-proxy.yml
+++ b/.github/workflows/deploy-tunnel-proxy.yml
@@ -131,31 +131,49 @@ jobs:
         run: |
           set -euo pipefail
           status_path="$RUNNER_TEMP/railway-status.json"
+          provider_stderr="$RUNNER_TEMP/railway-status.stderr"
+          transform_stderr="$RUNNER_TEMP/railway-status-transform.stderr"
+          umask 077
+          cleanup_target_query() {
+            local cleanup_paths=("$status_path" "$provider_stderr" "$transform_stderr")
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_target_query EXIT
+
+          set +e
           railway status \
             --project "$RAILWAY_PROJECT_ID" \
             --environment "$RAILWAY_ENVIRONMENT_ID" \
-            --json > "$status_path"
+            --json > "$status_path" 2> "$provider_stderr"
+          railway_status=$?
+          set -e
+          if [ "$railway_status" -ne 0 ]; then
+            echo "::error::Railway target query failed (category=railway-target-query-failed; exit=$railway_status; provider-output=suppressed)."
+            exit "$railway_status"
+          fi
 
-          jq -e --arg id "$RAILWAY_PROJECT_ID" '.id == $id' "$status_path" >/dev/null || {
-            echo "::error::RAILWAY_PROJECT_ID did not resolve to the selected project"
+          jq -e --arg id "$RAILWAY_PROJECT_ID" '.id == $id' "$status_path" >/dev/null 2>> "$transform_stderr" || {
+            echo "::error::Railway target contract failed (category=railway-target-project-mismatch; provider-output=suppressed)."
             exit 1
           }
           jq -e \
             --arg id "$RAILWAY_ENVIRONMENT_ID" \
             --arg name "$TARGET_ENVIRONMENT" \
             'any(.environments.edges[]; .node.id == $id and .node.name == $name)' \
-            "$status_path" >/dev/null || {
-            echo "::error::RAILWAY_ENVIRONMENT_ID is not the canonical $TARGET_ENVIRONMENT Railway environment"
+            "$status_path" >/dev/null 2>> "$transform_stderr" || {
+            echo "::error::Railway target contract failed (category=railway-target-environment-mismatch; provider-output=suppressed)."
             exit 1
           }
           jq -e \
             --arg id "$RAILWAY_SERVICE_ID" \
             'any(.services.edges[]; .node.id == $id and .node.name == "tunnel-proxy")' \
-            "$status_path" >/dev/null || {
-            echo "::error::RAILWAY_SERVICE_ID is not the tunnel-proxy service"
+            "$status_path" >/dev/null 2>> "$transform_stderr" || {
+            echo "::error::Railway target contract failed (category=railway-target-service-mismatch; provider-output=suppressed)."
             exit 1
           }
-          echo "Railway project, environment, and tunnel-proxy service identities match."
+          echo "Railway target verified (category=railway-target-verified; provider-output=suppressed)."
 
       - name: Install control-plane SSH identity
         id: ssh
@@ -183,6 +201,18 @@ jobs:
           TUNNEL_HOSTNAME_SIGNING_SECRET: ${{ secrets.TUNNEL_HOSTNAME_SIGNING_SECRET }}
         run: |
           set -euo pipefail
+          provider_stdout="$RUNNER_TEMP/railway-variables.stdout"
+          provider_stderr="$RUNNER_TEMP/railway-variables.stderr"
+          umask 077
+          cleanup_variable_output() {
+            local cleanup_paths=("$provider_stdout" "$provider_stderr")
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_variable_output EXIT
+
+          set +e
           railway variable set \
             "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \
             "TUNNEL_PROXY_HOST=$TUNNEL_PROXY_HOST" \
@@ -194,7 +224,15 @@ jobs:
             --environment "$RAILWAY_ENVIRONMENT_ID" \
             --service "$RAILWAY_SERVICE_ID" \
             --skip-deploys \
-            --json >/dev/null
+            --json > "$provider_stdout" 2> "$provider_stderr"
+          railway_status=$?
+          set -e
+          if [ "$railway_status" -ne 0 ]; then
+            echo "::error::Railway variable publish failed (category=railway-variables-config-failed; exit=$railway_status; provider-output=suppressed)."
+            exit "$railway_status"
+          fi
+
+          set +e
           printf '%s' "$TUNNEL_HOSTNAME_SIGNING_SECRET" | railway variable set \
             TUNNEL_HOSTNAME_SIGNING_SECRET \
             --stdin \
@@ -202,8 +240,14 @@ jobs:
             --environment "$RAILWAY_ENVIRONMENT_ID" \
             --service "$RAILWAY_SERVICE_ID" \
             --skip-deploys \
-            --json >/dev/null
-          echo "Canonical non-secret variables and the protected signing secret were published without printing values."
+            --json > "$provider_stdout" 2> "$provider_stderr"
+          railway_status=$?
+          set -e
+          if [ "$railway_status" -ne 0 ]; then
+            echo "::error::Railway variable publish failed (category=railway-variables-secret-failed; exit=$railway_status; provider-output=suppressed)."
+            exit "$railway_status"
+          fi
+          echo "Railway variables published (category=railway-variables-published; values=suppressed; provider-output=suppressed)."
 
       - name: Converge persistent tsnet volume
         shell: bash
@@ -215,40 +259,80 @@ jobs:
             --service "$RAILWAY_SERVICE_ID"
           )
           volumes_path="$RUNNER_TEMP/railway-volumes.json"
+          mutation_stdout="$RUNNER_TEMP/railway-volume-mutation.stdout"
+          provider_stderr="$RUNNER_TEMP/railway-volume.stderr"
+          transform_stderr="$RUNNER_TEMP/railway-volume-transform.stderr"
           target_mount="/var/lib/tunnel-proxy"
+          umask 077
+          cleanup_volume_output() {
+            local cleanup_paths=(
+              "$volumes_path"
+              "$mutation_stdout"
+              "$provider_stderr"
+              "$transform_stderr"
+            )
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_volume_output EXIT
 
-          railway volume "${volume_args[@]}" list --json > "$volumes_path"
-          service_volume_count=$(jq \
-            '[.volumes[] | select(.deletedAt == null and .serviceName == "tunnel-proxy")] | length' \
-            "$volumes_path")
-          target_mount_count=$(jq --arg mount "$target_mount" \
-            '[.volumes[] | select(.deletedAt == null and .mountPath == $mount)] | length' \
-            "$volumes_path")
+          run_volume_list() {
+            set +e
+            railway volume "${volume_args[@]}" list --json \
+              > "$volumes_path" 2> "$provider_stderr"
+            railway_status=$?
+            set -e
+            if [ "$railway_status" -ne 0 ]; then
+              echo "::error::Railway volume query failed (category=railway-volume-query-failed; exit=$railway_status; provider-output=suppressed)."
+              exit "$railway_status"
+            fi
+          }
+
+          project_volume_counts() {
+            service_volume_count=$(jq \
+              '[.volumes[] | select(.deletedAt == null and .serviceName == "tunnel-proxy")] | length' \
+              "$volumes_path" 2>> "$transform_stderr") || {
+              echo "::error::Railway volume projection failed (category=railway-volume-projection-failed; provider-output=suppressed)."
+              exit 1
+            }
+            target_mount_count=$(jq --arg mount "$target_mount" \
+              '[.volumes[] | select(.deletedAt == null and .mountPath == $mount)] | length' \
+              "$volumes_path" 2>> "$transform_stderr") || {
+              echo "::error::Railway volume projection failed (category=railway-volume-projection-failed; provider-output=suppressed)."
+              exit 1
+            }
+          }
+
+          run_volume_list
+          project_volume_counts
 
           if [ "$service_volume_count" -gt 1 ] || [ "$target_mount_count" -gt 1 ]; then
-            echo "::error::tunnel-proxy must have exactly one persistent Railway volume"
+            echo "::error::Railway volume contract failed (category=railway-volume-duplicate; values=suppressed)."
             exit 1
           fi
           if [ "$service_volume_count" = "1" ] && [ "$target_mount_count" = "0" ]; then
-            echo "::error::the existing tunnel-proxy volume is mounted at the wrong path"
+            echo "::error::Railway volume contract failed (category=railway-volume-mount-mismatch; values=suppressed)."
             exit 1
           fi
           if [ "$service_volume_count" = "0" ] && [ "$target_mount_count" = "0" ]; then
+            set +e
             railway volume "${volume_args[@]}" add \
               --mount-path "$target_mount" \
-              --json >/dev/null
+              --json > "$mutation_stdout" 2> "$provider_stderr"
+            railway_status=$?
+            set -e
+            if [ "$railway_status" -ne 0 ]; then
+              echo "::error::Railway volume mutation failed (category=railway-volume-create-failed; exit=$railway_status; provider-output=suppressed)."
+              exit "$railway_status"
+            fi
           fi
 
           for attempt in $(seq 1 30); do
-            railway volume "${volume_args[@]}" list --json > "$volumes_path"
-            service_volume_count=$(jq \
-              '[.volumes[] | select(.deletedAt == null and .serviceName == "tunnel-proxy")] | length' \
-              "$volumes_path")
-            target_mount_count=$(jq --arg mount "$target_mount" \
-              '[.volumes[] | select(.deletedAt == null and .mountPath == $mount)] | length' \
-              "$volumes_path")
+            run_volume_list
+            project_volume_counts
             if [ "$service_volume_count" -gt 1 ] || [ "$target_mount_count" -gt 1 ]; then
-              echo "::error::tunnel-proxy volume convergence produced duplicate volumes"
+              echo "::error::Railway volume contract failed (category=railway-volume-duplicate; values=suppressed)."
               exit 1
             fi
             if jq -e --arg mount "$target_mount" \
@@ -257,12 +341,12 @@ jobs:
                 .serviceName == "tunnel-proxy" and
                 .mountPath == $mount and
                 .status == "Ready"
-              )] | length == 1' "$volumes_path" >/dev/null; then
-              echo "Persistent tsnet state volume is mounted at $target_mount."
+              )] | length == 1' "$volumes_path" >/dev/null 2>> "$transform_stderr"; then
+              echo "Railway volume ready (category=railway-volume-ready; attempt=$attempt; provider-output=suppressed)."
               break
             fi
             if [ "$attempt" = "30" ]; then
-              echo "::error::tunnel-proxy volume did not become ready at $target_mount"
+              echo "::error::Railway volume did not become ready (category=railway-volume-timeout; attempts=30; provider-output=suppressed)."
               exit 1
             fi
             sleep 2
@@ -277,6 +361,8 @@ jobs:
         run: |
           set -euo pipefail
           payload_path="$RUNNER_TEMP/tunnel-proxy-headscale-key.json"
+          railway_stdout="$RUNNER_TEMP/railway-proxy-key.stdout"
+          railway_stderr="$RUNNER_TEMP/railway-proxy-key.stderr"
           umask 077
           published=false
           new_id=""
@@ -292,10 +378,12 @@ jobs:
                 -o ConnectTimeout=15 \
                 "deploy@$DEPLOY_HOST" \
                 "sudo headscale preauthkeys expire --id $new_id -o json >/dev/null" \
+                >/dev/null 2>&1 \
                 || echo "::warning::Could not expire the unpublished replacement Headscale key"
             fi
-            if [ -f "$payload_path" ]; then
-              shred -u "$payload_path"
+            local cleanup_paths=("$payload_path" "$railway_stdout" "$railway_stderr")
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
             fi
             exit "$status"
           }
@@ -344,6 +432,7 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$new_key"
+          set +e
           printf '%s' "$new_key" | railway variable set \
             TUNNEL_PROXY_TS_AUTHKEY \
             --stdin \
@@ -351,24 +440,56 @@ jobs:
             --environment "$RAILWAY_ENVIRONMENT_ID" \
             --service "$RAILWAY_SERVICE_ID" \
             --skip-deploys \
-            --json >/dev/null
+            --json > "$railway_stdout" 2> "$railway_stderr"
+          railway_status=$?
+          set -e
+          if [ "$railway_status" -ne 0 ]; then
+            echo "::error::Railway proxy credential publish failed (category=railway-proxy-key-publish-failed; exit=$railway_status; provider-output=suppressed)."
+            exit "$railway_status"
+          fi
           published=true
           unset new_key
           echo "old_ids=$old_ids" >> "$GITHUB_OUTPUT"
-          echo "A reusable tag:eliza-proxy key was minted and published without printing its value."
+          echo "Proxy credential published (category=railway-proxy-key-published; value=suppressed; provider-output=suppressed)."
 
       - name: Deploy tunnel-proxy source to Railway
         working-directory: packages/cloud/services/tunnel-proxy
         shell: bash
         run: |
           set -euo pipefail
+          railway_stdout="$RUNNER_TEMP/railway-up.stdout"
+          railway_stderr="$RUNNER_TEMP/railway-up.stderr"
+          umask 077
+          cleanup_railway_output() {
+            local cleanup_paths=("$railway_stdout" "$railway_stderr")
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_railway_output EXIT
+
+          set +e
           railway up \
             --project "$RAILWAY_PROJECT_ID" \
             --environment "$RAILWAY_ENVIRONMENT_ID" \
             --service "$RAILWAY_SERVICE_ID" \
             --ci \
             --json \
-            --message "tunnel-proxy $GITHUB_SHA ($TARGET_ENVIRONMENT)"
+            --message "tunnel-proxy $GITHUB_SHA ($TARGET_ENVIRONMENT)" \
+            > "$railway_stdout" 2> "$railway_stderr"
+          railway_status=$?
+          set -e
+          if [ "$railway_status" -ne 0 ]; then
+            echo "::error::Railway tunnel-proxy deploy failed (category=railway-deploy-failed; exit=$railway_status; provider-output=suppressed)."
+            exit "$railway_status"
+          fi
+          {
+            echo "### Tunnel proxy deployment receipt"
+            echo
+            echo "- Railway deploy: passed"
+            echo "- Provider output: suppressed"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Railway tunnel-proxy deploy passed (category=railway-deploy-passed; provider-output=suppressed)."
 
       - name: Converge exact Railway custom domains
         id: domains
@@ -381,20 +502,61 @@ jobs:
             --service "$RAILWAY_SERVICE_ID"
           )
           domains_path="$RUNNER_TEMP/railway-domains.json"
+          created_path="$RUNNER_TEMP/railway-domain-created.json"
+          provider_stderr="$RUNNER_TEMP/railway-domain-converge.stderr"
+          transform_stderr="$RUNNER_TEMP/railway-domain-converge-transform.stderr"
+          umask 077
+          cleanup_domain_converge() {
+            local cleanup_paths=(
+              "$domains_path"
+              "$created_path"
+              "$provider_stderr"
+              "$transform_stderr"
+            )
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_domain_converge EXIT
           created=false
-          for domain in "$TUNNEL_PROXY_HOST" "*.$TUNNEL_PROXY_HOST"; do
-            railway domain list "${domain_args[@]}" --json > "$domains_path"
-            if jq -e --arg domain "$domain" \
+          for domain_role in apex wildcard; do
+            case "$domain_role" in
+              apex) requested_domain="$TUNNEL_PROXY_HOST" ;;
+              wildcard) requested_domain="*.$TUNNEL_PROXY_HOST" ;;
+            esac
+            set +e
+            railway domain list "${domain_args[@]}" --json \
+              > "$domains_path" 2> "$provider_stderr"
+            railway_status=$?
+            set -e
+            if [ "$railway_status" -ne 0 ]; then
+              echo "::error::Railway domain inventory failed (category=railway-domain-list-failed; role=$domain_role; exit=$railway_status; provider-output=suppressed)."
+              exit "$railway_status"
+            fi
+            if ! jq -e '.domains | type == "array"' \
+              "$domains_path" >/dev/null 2>> "$transform_stderr"; then
+              echo "::error::Railway domain inventory is invalid (category=railway-domain-list-invalid; role=$domain_role; provider-output=suppressed)."
+              exit 1
+            fi
+            if jq -e --arg domain "$requested_domain" \
               'any(.domains[]; .domain == $domain and .type == "custom" and .targetPort == 8080)' \
-              "$domains_path" >/dev/null; then
+              "$domains_path" >/dev/null 2>> "$transform_stderr"; then
+              echo "Railway custom domain already attached (category=railway-domain-present; role=$domain_role; provider-output=suppressed)."
               continue
             fi
-            railway domain "$domain" \
+            set +e
+            railway domain "$requested_domain" \
               --port 8080 \
               "${domain_args[@]}" \
-              --json > "$RUNNER_TEMP/railway-domain-created.json"
+              --json > "$created_path" 2> "$provider_stderr"
+            railway_status=$?
+            set -e
+            if [ "$railway_status" -ne 0 ]; then
+              echo "::error::Railway custom-domain mutation failed (category=railway-domain-create-failed; role=$domain_role; exit=$railway_status; provider-output=suppressed)."
+              exit "$railway_status"
+            fi
             created=true
-            echo "Attached Railway custom domain $domain; external DNS verification is still required."
+            echo "Railway custom domain attached (category=railway-domain-created; role=$domain_role; provider-output=suppressed)."
           done
           echo "created=$created" >> "$GITHUB_OUTPUT"
 
@@ -413,13 +575,47 @@ jobs:
           configured="$RUNNER_TEMP/configured-railway-tunnel-dns-records.json"
           normalized_inventory="$RUNNER_TEMP/normalized-railway-tunnel-dns-records.json"
           normalized_configured="$RUNNER_TEMP/normalized-configured-railway-tunnel-dns-records.json"
+          provider_stderr="$RUNNER_TEMP/railway-tunnel-domain-status.stderr"
+          transform_stderr="$RUNNER_TEMP/railway-tunnel-dns-transform.stderr"
+          umask 077
+          cleanup_dns_handoff() {
+            local cleanup_paths=(
+              "$apex_status" \
+              "$wildcard_status" \
+              "$inventory" \
+              "$configured" \
+              "$normalized_inventory" \
+              "$normalized_configured" \
+              "$provider_stderr" \
+              "$transform_stderr"
+            )
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_dns_handoff EXIT
 
-          railway domain status "$TUNNEL_PROXY_HOST" \
-            "${domain_args[@]}" --json > "$apex_status"
-          railway domain status "*.$TUNNEL_PROXY_HOST" \
-            "${domain_args[@]}" --json > "$wildcard_status"
+          run_domain_status() {
+            local domain_role="$1"
+            local requested_domain="$2"
+            local output_path="$3"
+            set +e
+            railway domain status "$requested_domain" \
+              "${domain_args[@]}" --json \
+              > "$output_path" 2>> "$provider_stderr"
+            railway_status=$?
+            set -e
+            if [ "$railway_status" -ne 0 ]; then
+              echo "::error::Railway domain status failed (category=railway-domain-status-failed; role=$domain_role; exit=$railway_status; provider-output=suppressed)."
+              exit "$railway_status"
+            fi
+            echo "Railway domain status received (category=railway-domain-status-received; role=$domain_role; provider-output=suppressed)."
+          }
 
-          jq -e -n \
+          run_domain_status apex "$TUNNEL_PROXY_HOST" "$apex_status"
+          run_domain_status wildcard "*.$TUNNEL_PROXY_HOST" "$wildcard_status"
+
+          if ! jq -e -n \
             --slurpfile apex "$apex_status" \
             --slurpfile wildcard "$wildcard_status" \
             --arg host "$TUNNEL_PROXY_HOST" '
@@ -517,33 +713,42 @@ jobs:
                     }
                 )
               | from_entries
-            ' > "$inventory"
+            ' > "$inventory" 2> "$transform_stderr"; then
+            echo "::error::Railway DNS inventory projection failed (category=dns-inventory-projection-failed; provider-output=suppressed)."
+            exit 1
+          fi
 
+          record_count=$(jq -er 'length' "$inventory" 2>> "$transform_stderr") || {
+            echo "::error::Railway DNS inventory count failed (category=dns-inventory-count-failed; provider-output=suppressed)."
+            exit 1
+          }
+          if [[ ! "$record_count" =~ ^[0-9]+$ ]] || [ "$record_count" -lt 1 ]; then
+            echo "::error::Railway DNS inventory count is invalid (category=dns-inventory-count-invalid; provider-output=suppressed)."
+            exit 1
+          fi
           {
-            echo "### Reviewed Railway tunnel DNS inventory"
+            echo "### Railway tunnel DNS handoff receipt"
             echo
-            echo "These are public DNS requirements, not runtime secrets. Copy the exact object to the protected \`RAILWAY_TUNNEL_DNS_RECORDS_JSON\` variable."
-            echo
-            echo '```json'
-            jq . "$inventory"
-            echo '```'
+            echo "- Inventory contract: generated"
+            echo "- Record count: $record_count"
+            echo "- Provider values: suppressed"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ -z "${RAILWAY_TUNNEL_DNS_RECORDS_JSON//[[:space:]]/}" ]; then
-            echo "::error::RAILWAY_TUNNEL_DNS_RECORDS_JSON is not configured on the protected $TARGET_ENVIRONMENT environment; copy the exact inventory from this run summary, apply pages-domains Terraform, and rerun."
+            echo "::error::Protected Railway DNS inventory is not configured (category=dns-inventory-unconfigured; values=suppressed). Review provider values through an authorized channel, apply pages-domains Terraform, and rerun."
             exit 1
           fi
           printf '%s' "$RAILWAY_TUNNEL_DNS_RECORDS_JSON" > "$configured"
-          jq -S -e . "$inventory" > "$normalized_inventory"
-          jq -S -e . "$configured" > "$normalized_configured" || {
-            echo "::error::RAILWAY_TUNNEL_DNS_RECORDS_JSON is not valid JSON"
+          jq -S -e . "$inventory" > "$normalized_inventory" 2>> "$transform_stderr"
+          jq -S -e . "$configured" > "$normalized_configured" 2>> "$transform_stderr" || {
+            echo "::error::Protected Railway DNS inventory is invalid (category=dns-inventory-invalid; values=suppressed)."
             exit 1
           }
           if ! cmp -s "$normalized_inventory" "$normalized_configured"; then
-            echo "::error::RAILWAY_TUNNEL_DNS_RECORDS_JSON does not exactly match Railway's current provider-owned DNS inventory; review the run summary, update the protected variable, apply pages-domains Terraform, and rerun."
+            echo "::error::Protected Railway DNS inventory does not match the provider projection (category=dns-inventory-mismatch; values=suppressed). Review provider values through an authorized channel, apply pages-domains Terraform, and rerun."
             exit 1
           fi
-          echo "Protected Railway tunnel DNS inventory exactly matches the provider response."
+          echo "Railway DNS inventory ready (category=dns-inventory-ready; records=$record_count; values=suppressed)."
 
       - name: Verify Railway domain ownership and certificates
         shell: bash
@@ -554,30 +759,60 @@ jobs:
             --environment "$RAILWAY_ENVIRONMENT_ID"
             --service "$RAILWAY_SERVICE_ID"
           )
-          for domain in "$TUNNEL_PROXY_HOST" "*.$TUNNEL_PROXY_HOST"; do
-            status_path="$RUNNER_TEMP/railway-domain-status.json"
+          status_path="$RUNNER_TEMP/railway-domain-verification.json"
+          provider_stderr="$RUNNER_TEMP/railway-domain-verification.stderr"
+          transform_stderr="$RUNNER_TEMP/railway-domain-verification-transform.stderr"
+          umask 077
+          cleanup_domain_verification() {
+            local cleanup_paths=("$status_path" "$provider_stderr" "$transform_stderr")
+            if ! shred -u -- "${cleanup_paths[@]}" 2>/dev/null; then
+              rm -f -- "${cleanup_paths[@]}"
+            fi
+          }
+          trap cleanup_domain_verification EXIT
+
+          for domain_role in apex wildcard; do
+            case "$domain_role" in
+              apex) requested_domain="$TUNNEL_PROXY_HOST" ;;
+              wildcard) requested_domain="*.$TUNNEL_PROXY_HOST" ;;
+            esac
             ready=false
-            for _ in $(seq 1 30); do
-              railway domain status "$domain" "${domain_args[@]}" --json > "$status_path"
-              if jq -e --arg domain "$domain" \
+            for attempt in $(seq 1 30); do
+              set +e
+              railway domain status "$requested_domain" \
+                "${domain_args[@]}" --json \
+                > "$status_path" 2> "$provider_stderr"
+              railway_status=$?
+              set -e
+              if [ "$railway_status" -ne 0 ]; then
+                echo "::error::Railway domain verification query failed (category=railway-domain-verification-query-failed; role=$domain_role; exit=$railway_status; provider-output=suppressed)."
+                exit "$railway_status"
+              fi
+              if ! jq -e '.domain | type == "object"' \
+                "$status_path" >/dev/null 2>> "$transform_stderr"; then
+                echo "::error::Railway domain verification response is invalid (category=railway-domain-verification-invalid; role=$domain_role; provider-output=suppressed)."
+                exit 1
+              fi
+              if jq -e --arg domain "$requested_domain" \
                 '.domain.domain == $domain
                   and .domain.type == "custom"
                   and .domain.targetPort == 8080
                   and .domain.syncStatus == "ACTIVE"
                   and .domain.verification.verified == true
                   and .domain.certificate.status == "CERTIFICATE_STATUS_TYPE_VALID"' \
-                "$status_path" >/dev/null; then
+                "$status_path" >/dev/null 2>> "$transform_stderr"; then
                 ready=true
+                echo "Railway domain verified (category=railway-domain-verified; role=$domain_role; attempt=$attempt; provider-output=suppressed)."
                 break
               fi
               sleep 10
             done
             if [ "$ready" != "true" ]; then
-              echo "::error::Railway domain $domain is not DNS-verified with an issued certificate. Copy its exact CNAME/TXT inventory to the protected RAILWAY_TUNNEL_DNS_RECORDS_JSON variable, apply the pages-domains Terraform plan, then rerun."
+              echo "::error::Railway domain verification timed out (category=railway-domain-verification-timeout; role=$domain_role; attempts=30; provider-output=suppressed)."
               exit 1
             fi
           done
-          echo "Both canonical Railway custom domains are verified with issued certificates."
+          echo "Railway custom domains verified (category=railway-domains-verified; provider-output=suppressed)."
 
       - name: Verify canonical health and unsigned-host rejection
         shell: bash

--- a/packages/app-core/scripts/lib/live-stack-safe-diagnostics.test.ts
+++ b/packages/app-core/scripts/lib/live-stack-safe-diagnostics.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Exercises the live-stack child-output privacy boundary with hostile bytes.
+ * The helper is deterministic and writes only schema-owned categories.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import {
+  attachSafeChildOutputObserver,
+  createSafeChildOutputObserver,
+  formatSafeLiveStackDiagnostic,
+  formatSafeLiveStackStartupFailure,
+} from "./live-stack-safe-diagnostics.ts";
+
+const HOSTILE_CHILD_OUTPUT =
+  "agent_config={apiKey:sk-live-secret,email:user@example.com,wallet:0x1234,agentId:550e8400-e29b-41d4-a716-446655440000}";
+
+describe("live-stack safe diagnostics", () => {
+  test("projects hostile child output to one allowlisted event per channel", () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), "live-stack-safe-diagnostics-"),
+    );
+    const artifactPath = join(directory, "backend.log");
+    const consoleLines: string[] = [];
+
+    try {
+      const observer = createSafeChildOutputObserver({
+        artifactPath,
+        component: "live-runtime",
+        writeConsole: (line) => consoleLines.push(line),
+      });
+
+      expect(consoleLines).toHaveLength(1);
+      expect(JSON.parse(readFileSync(artifactPath, "utf8"))).toEqual({
+        schema: "elizaos.live-stack-diagnostic/v1",
+        category: "capture-started",
+        component: "live-runtime",
+      });
+
+      observer.observe("stdout");
+      (observer.observe as (untrustedChannel: string) => void)(
+        HOSTILE_CHILD_OUTPUT,
+      );
+      for (let index = 0; index < 10_000; index += 1) {
+        observer.observe("stdout");
+        observer.observe("stderr");
+      }
+
+      const artifactLines = readFileSync(artifactPath, "utf8")
+        .trim()
+        .split("\n");
+      expect(consoleLines).toHaveLength(3);
+      expect(artifactLines).toEqual(consoleLines);
+      expect(readFileSync(artifactPath).byteLength).toBeLessThan(512);
+
+      const events = artifactLines.map((line) => JSON.parse(line));
+      expect(events).toEqual([
+        {
+          schema: "elizaos.live-stack-diagnostic/v1",
+          category: "capture-started",
+          component: "live-runtime",
+        },
+        {
+          schema: "elizaos.live-stack-diagnostic/v1",
+          category: "child-output-observed",
+          component: "live-runtime",
+          channel: "stdout",
+        },
+        {
+          schema: "elizaos.live-stack-diagnostic/v1",
+          category: "child-output-observed",
+          component: "live-runtime",
+          channel: "stderr",
+        },
+      ]);
+
+      const emitted = `${consoleLines.join("\n")}\n${artifactLines.join("\n")}`;
+      expect(emitted).not.toContain(HOSTILE_CHILD_OUTPUT);
+      expect(emitted).not.toContain("sk-live-secret");
+      expect(emitted).not.toContain("user@example.com");
+      expect(emitted).not.toContain("0x1234");
+      expect(emitted).not.toContain("550e8400-e29b-41d4-a716-446655440000");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("consumes hostile child streams without forwarding their bytes", () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), "live-stack-safe-child-streams-"),
+    );
+    const artifactPath = join(directory, "backend.log");
+    const consoleLines: string[] = [];
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    try {
+      attachSafeChildOutputObserver({
+        artifactPath,
+        child: { stderr, stdout },
+        component: "live-runtime",
+        writeConsole: (line) => consoleLines.push(line),
+      });
+
+      stdout.write(HOSTILE_CHILD_OUTPUT);
+      stdout.write(HOSTILE_CHILD_OUTPUT);
+      stderr.write(HOSTILE_CHILD_OUTPUT);
+
+      const artifactLines = readFileSync(artifactPath, "utf8")
+        .trim()
+        .split("\n");
+      expect(artifactLines).toEqual(consoleLines);
+      expect(artifactLines.map((line) => JSON.parse(line))).toEqual([
+        {
+          schema: "elizaos.live-stack-diagnostic/v1",
+          category: "capture-started",
+          component: "live-runtime",
+        },
+        {
+          schema: "elizaos.live-stack-diagnostic/v1",
+          category: "child-output-observed",
+          component: "live-runtime",
+          channel: "stdout",
+        },
+        {
+          schema: "elizaos.live-stack-diagnostic/v1",
+          category: "child-output-observed",
+          component: "live-runtime",
+          channel: "stderr",
+        },
+      ]);
+      expect(artifactLines.join("\n")).not.toContain(HOSTILE_CHILD_OUTPUT);
+    } finally {
+      stdout.destroy();
+      stderr.destroy();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("formats process and startup failures from closed fields only", () => {
+    const diagnostic = formatSafeLiveStackDiagnostic({
+      category: "process-failed",
+      component: "renderer-build",
+      exitCode: 17,
+      hostileExtraField: HOSTILE_CHILD_OUTPUT,
+    } as Parameters<typeof formatSafeLiveStackDiagnostic>[0]);
+
+    expect(JSON.parse(diagnostic)).toEqual({
+      schema: "elizaos.live-stack-diagnostic/v1",
+      category: "process-failed",
+      component: "renderer-build",
+      exitCode: 17,
+    });
+    expect(diagnostic).not.toContain(HOSTILE_CHILD_OUTPUT);
+    const hostileStartupFailure = new TypeError(HOSTILE_CHILD_OUTPUT);
+    hostileStartupFailure.name = HOSTILE_CHILD_OUTPUT;
+    hostileStartupFailure.stack = HOSTILE_CHILD_OUTPUT;
+    const startupDiagnostic = formatSafeLiveStackStartupFailure(
+      "optional-plugin-build",
+      hostileStartupFailure,
+    );
+    expect(JSON.parse(startupDiagnostic)).toEqual({
+      schema: "elizaos.live-stack-diagnostic/v1",
+      category: "startup-failed",
+      component: "optional-plugin-build",
+      failureClass: "type-error",
+    });
+    expect(startupDiagnostic).not.toContain(HOSTILE_CHILD_OUTPUT);
+    expect(
+      JSON.parse(formatSafeLiveStackStartupFailure("live-runtime", {})),
+    ).toEqual({
+      schema: "elizaos.live-stack-diagnostic/v1",
+      category: "startup-failed",
+      component: "live-runtime",
+      failureClass: "non-error",
+    });
+    const hostileProxy = new Proxy(
+      {},
+      {
+        getPrototypeOf: () => {
+          throw new Error(HOSTILE_CHILD_OUTPUT);
+        },
+      },
+    );
+    expect(
+      JSON.parse(
+        formatSafeLiveStackStartupFailure("stub-runtime", hostileProxy),
+      ),
+    ).toEqual({
+      schema: "elizaos.live-stack-diagnostic/v1",
+      category: "startup-failed",
+      component: "stub-runtime",
+      failureClass: "non-error",
+    });
+    expect(() =>
+      formatSafeLiveStackDiagnostic({
+        category: "process-failed",
+        component: HOSTILE_CHILD_OUTPUT,
+        exitCode: 17,
+      } as unknown as Parameters<typeof formatSafeLiveStackDiagnostic>[0]),
+    ).toThrow("Unsupported live-stack diagnostic component.");
+    expect(() =>
+      formatSafeLiveStackDiagnostic({
+        category: HOSTILE_CHILD_OUTPUT,
+        component: "renderer-build",
+      } as unknown as Parameters<typeof formatSafeLiveStackDiagnostic>[0]),
+    ).toThrow("Unsupported live-stack diagnostic category.");
+  });
+});

--- a/packages/app-core/scripts/lib/live-stack-safe-diagnostics.ts
+++ b/packages/app-core/scripts/lib/live-stack-safe-diagnostics.ts
@@ -1,0 +1,197 @@
+/**
+ * Projects live-stack subprocess diagnostics into a closed event schema.
+ * Child bytes are deliberately not accepted by this boundary.
+ */
+import { appendFileSync } from "node:fs";
+import type { Readable } from "node:stream";
+
+export type LiveStackDiagnosticChannel = "stdout" | "stderr";
+
+export type LiveStackDiagnosticComponent =
+  | "live-runtime"
+  | "optional-plugin-build"
+  | "real-local-runtime"
+  | "renderer-build"
+  | "stub-runtime";
+
+type LiveStackDiagnosticEvent =
+  | {
+      category: "capture-started";
+      component: LiveStackDiagnosticComponent;
+    }
+  | {
+      category: "child-output-observed";
+      channel: LiveStackDiagnosticChannel;
+      component: LiveStackDiagnosticComponent;
+    }
+  | {
+      category: "process-failed";
+      component: LiveStackDiagnosticComponent;
+      exitCode: number;
+    }
+  | {
+      category: "process-timed-out";
+      component: LiveStackDiagnosticComponent;
+    };
+
+type LiveStackStartupFailureClass =
+  | "aggregate-error"
+  | "error"
+  | "non-error"
+  | "range-error"
+  | "reference-error"
+  | "syntax-error"
+  | "type-error";
+
+const LIVE_STACK_DIAGNOSTIC_COMPONENTS = new Set<LiveStackDiagnosticComponent>([
+  "live-runtime",
+  "optional-plugin-build",
+  "real-local-runtime",
+  "renderer-build",
+  "stub-runtime",
+]);
+
+function requireSafeComponent(
+  component: LiveStackDiagnosticComponent,
+): LiveStackDiagnosticComponent {
+  if (!LIVE_STACK_DIAGNOSTIC_COMPONENTS.has(component)) {
+    throw new Error("Unsupported live-stack diagnostic component.");
+  }
+  return component;
+}
+
+export function formatSafeLiveStackDiagnostic(
+  event: LiveStackDiagnosticEvent,
+): string {
+  const base = {
+    schema: "elizaos.live-stack-diagnostic/v1",
+    component: requireSafeComponent(event.component),
+  } as const;
+  switch (event.category) {
+    case "capture-started":
+      return JSON.stringify({
+        ...base,
+        category: "capture-started",
+      });
+    case "child-output-observed":
+      if (event.channel !== "stdout" && event.channel !== "stderr") {
+        throw new Error("Unsupported live-stack diagnostic channel.");
+      }
+      return JSON.stringify({
+        ...base,
+        category: "child-output-observed",
+        channel: event.channel,
+      });
+    case "process-failed":
+      return JSON.stringify({
+        ...base,
+        category: "process-failed",
+        exitCode:
+          Number.isInteger(event.exitCode) &&
+          event.exitCode >= 0 &&
+          event.exitCode <= 255
+            ? event.exitCode
+            : 1,
+      });
+    case "process-timed-out":
+      return JSON.stringify({
+        ...base,
+        category: "process-timed-out",
+      });
+    default:
+      throw new Error("Unsupported live-stack diagnostic category.");
+  }
+}
+
+function classifyStartupFailure(error: unknown): LiveStackStartupFailureClass {
+  try {
+    if (error instanceof AggregateError) return "aggregate-error";
+    if (error instanceof TypeError) return "type-error";
+    if (error instanceof ReferenceError) return "reference-error";
+    if (error instanceof SyntaxError) return "syntax-error";
+    if (error instanceof RangeError) return "range-error";
+    if (error instanceof Error) return "error";
+  } catch {
+    // A hostile Proxy can throw from [[GetPrototypeOf]] during instanceof.
+    return "non-error";
+  }
+  return "non-error";
+}
+
+/** Projects an arbitrary startup failure without reading its properties. */
+export function formatSafeLiveStackStartupFailure(
+  component: LiveStackDiagnosticComponent,
+  error: unknown,
+): string {
+  return JSON.stringify({
+    schema: "elizaos.live-stack-diagnostic/v1",
+    category: "startup-failed",
+    component: requireSafeComponent(component),
+    failureClass: classifyStartupFailure(error),
+  });
+}
+
+export function createSafeChildOutputObserver(args: {
+  artifactPath?: string | null;
+  component: LiveStackDiagnosticComponent;
+  writeConsole?: (line: string) => void;
+}): {
+  observe: (channel: LiveStackDiagnosticChannel) => void;
+} {
+  const observedChannels = new Set<LiveStackDiagnosticChannel>();
+  const writeConsole =
+    args.writeConsole ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const writeDiagnostic = (line: string): void => {
+    writeConsole(line);
+    if (args.artifactPath) {
+      appendFileSync(args.artifactPath, `${line}\n`, "utf8");
+    }
+  };
+  writeDiagnostic(
+    formatSafeLiveStackDiagnostic({
+      category: "capture-started",
+      component: args.component,
+    }),
+  );
+
+  return {
+    observe(channel): void {
+      if (channel !== "stdout" && channel !== "stderr") return;
+      if (observedChannels.has(channel)) return;
+      observedChannels.add(channel);
+
+      const line = formatSafeLiveStackDiagnostic({
+        category: "child-output-observed",
+        component: args.component,
+        channel,
+      });
+      writeDiagnostic(line);
+    },
+  };
+}
+
+/**
+ * Attaches the closed diagnostic projection directly to child streams.
+ *
+ * The data callbacks deliberately accept no chunk argument, so untrusted child
+ * bytes never cross this boundary or become available to a console/artifact
+ * writer. Keeping this adapter beside the projector also makes the real stream
+ * wiring behavior testable without booting the credentialed live harness.
+ */
+export function attachSafeChildOutputObserver(args: {
+  artifactPath?: string | null;
+  child: {
+    stderr: Readable;
+    stdout: Readable;
+  };
+  component: LiveStackDiagnosticComponent;
+  writeConsole?: (line: string) => void;
+}): void {
+  const observer = createSafeChildOutputObserver({
+    artifactPath: args.artifactPath,
+    component: args.component,
+    writeConsole: args.writeConsole,
+  });
+  args.child.stdout.on("data", () => observer.observe("stdout"));
+  args.child.stderr.on("data", () => observer.observe("stderr"));
+}

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -6,11 +6,11 @@
  * playwright-ui-smoke-api-stub.mjs.
  */
 import {
-  type ChildProcessWithoutNullStreams,
+  type ChildProcessByStdio,
   execFileSync,
   spawn,
 } from "node:child_process";
-import { appendFileSync, existsSync } from "node:fs";
+import { existsSync } from "node:fs";
 import {
   access,
   cp,
@@ -27,6 +27,7 @@ import {
 } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import type { Readable } from "node:stream";
 import { setTimeout as sleep } from "node:timers/promises";
 import { WebSocket, WebSocketServer } from "ws";
 import { buildFirstRunRuntimeConfig } from "../src/first-run/first-run-config.ts";
@@ -39,6 +40,12 @@ import {
   selectLiveProviderAsync,
 } from "../test/helpers/live-provider.ts";
 import { resolveMainAppDir } from "./lib/app-dir.mjs";
+import {
+  attachSafeChildOutputObserver,
+  formatSafeLiveStackDiagnostic,
+  formatSafeLiveStackStartupFailure,
+  type LiveStackDiagnosticComponent,
+} from "./lib/live-stack-safe-diagnostics.ts";
 import { shouldForceStubStack } from "./lib/ui-smoke-stub-decision.mjs";
 import {
   rendererDistMatchesPlaywrightTestAuth,
@@ -147,14 +154,39 @@ const LIVE_STACK_OPTIONAL_VIEW_PLUGIN_PACKAGES: ReadonlyArray<{
 ];
 const pendingStateDirs = new Set<string>();
 const ownedStateDirs = new Set<string>();
+type CapturedChildProcess = ChildProcessByStdio<null, Readable, Readable>;
 
 type StartedStack = {
   apiBase: string;
-  apiChild: ChildProcessWithoutNullStreams;
+  apiChild: CapturedChildProcess;
   stateDir: string;
   uiBase: string;
   uiServer: Server;
 };
+
+function reportSafeProcessFailure(
+  component: LiveStackDiagnosticComponent,
+  exitCode: number | null,
+): void {
+  process.stderr.write(
+    `${formatSafeLiveStackDiagnostic({
+      category: "process-failed",
+      component,
+      exitCode: exitCode ?? 1,
+    })}\n`,
+  );
+}
+
+function reportSafeProcessTimeout(
+  component: LiveStackDiagnosticComponent,
+): void {
+  process.stderr.write(
+    `${formatSafeLiveStackDiagnostic({
+      category: "process-timed-out",
+      component,
+    })}\n`,
+  );
+}
 
 async function createStateDir(prefix: string): Promise<string> {
   const stateDir = await mkdtemp(path.join(os.tmpdir(), prefix));
@@ -674,14 +706,16 @@ async function startUiProxyServer(args: {
         response,
         uiDistDir: args.uiDistDir,
       });
-    } catch (error) {
+    } catch {
       if (response.headersSent || response.writableEnded) {
         if (!response.writableEnded) {
           response.end();
         }
         return;
       }
-      console.error("[playwright-ui-live-stack] proxy error:", error);
+      console.error(
+        "[playwright-ui-live-stack] proxy request failed (category=proxy-failed).",
+      );
       response.writeHead(500, {
         "Content-Type": "application/json; charset=utf-8",
       });
@@ -719,7 +753,7 @@ async function startUiProxyServer(args: {
 }
 
 async function waitForChildExit(
-  child: ChildProcessWithoutNullStreams,
+  child: CapturedChildProcess,
   timeoutMs: number,
 ): Promise<boolean> {
   if (child.exitCode != null) {
@@ -760,7 +794,7 @@ async function closeUiServer(uiServer: Server | null): Promise<void> {
 }
 
 async function stopApiChild(
-  apiChild: ChildProcessWithoutNullStreams | null,
+  apiChild: CapturedChildProcess | null,
 ): Promise<void> {
   if (!apiChild || apiChild.exitCode != null) return;
   apiChild.kill("SIGTERM");
@@ -925,7 +959,6 @@ async function ensureUiDistReady(): Promise<void> {
 
   await removePathRecursive(path.join(APP_DIR, ".vite"));
 
-  const logs: string[] = [];
   const child = spawn(resolveBunCommand(), ["run", "build:web"], {
     cwd: APP_DIR,
     env: {
@@ -944,8 +977,7 @@ async function ensureUiDistReady(): Promise<void> {
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  child.stdout.on("data", (chunk) => logs.push(String(chunk)));
-  child.stderr.on("data", (chunk) => logs.push(String(chunk)));
+  attachSafeChildOutputObserver({ child, component: "renderer-build" });
 
   // Cold renderer build transforms ~3000 modules and measures ~12 min on a
   // clean dist; cap at 18 min so a legitimately slow first build is not killed
@@ -954,14 +986,12 @@ async function ensureUiDistReady(): Promise<void> {
   const exited = await waitForChildExit(child, RENDERER_BUILD_TIMEOUT_MS);
   if (!exited) {
     child.kill("SIGKILL");
-    throw new Error(
-      `app renderer build timed out after ${RENDERER_BUILD_TIMEOUT_MS}ms.\n${logs.join("").slice(-8_000)}`,
-    );
+    reportSafeProcessTimeout("renderer-build");
+    throw new Error("App renderer build timed out; raw output suppressed.");
   }
   if (child.exitCode !== 0) {
-    throw new Error(
-      `app renderer build failed (exit ${child.exitCode}).\n${logs.join("").slice(-8_000)}`,
-    );
+    reportSafeProcessFailure("renderer-build", child.exitCode);
+    throw new Error("App renderer build failed; raw output suppressed.");
   }
   if (
     !rendererDistMatchesPlaywrightTestAuth(
@@ -1034,9 +1064,11 @@ async function submitFirstRun(apiBase: string): Promise<void> {
   });
 
   if (!response.ok) {
-    throw new Error(
-      `Onboarding failed with ${response.status}: ${await response.text()}`,
+    await response.body?.cancel();
+    console.error(
+      `[ui-smoke] onboarding rejected (category=first-run-rejected; status=${response.status}; response-body=suppressed).`,
     );
+    throw new Error("Onboarding failed; response body suppressed.");
   }
 
   await waitForJsonPredicate<{ complete: boolean }>(
@@ -1086,7 +1118,6 @@ async function ensureLiveStackOptionalViewPluginsReady(): Promise<void> {
     }
     if (missingOutputPaths.length === 0) continue;
 
-    const logs: string[] = [];
     const child = spawn(resolveBunCommand(), ["run", "build"], {
       cwd: pluginDir,
       env: {
@@ -1099,20 +1130,24 @@ async function ensureLiveStackOptionalViewPluginsReady(): Promise<void> {
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
-    child.stdout.on("data", (chunk) => logs.push(String(chunk)));
-    child.stderr.on("data", (chunk) => logs.push(String(chunk)));
+    attachSafeChildOutputObserver({
+      child,
+      component: "optional-plugin-build",
+    });
 
     const BUILD_TIMEOUT_MS = 300_000;
     const exited = await waitForChildExit(child, BUILD_TIMEOUT_MS);
     if (!exited) {
       child.kill("SIGKILL");
+      reportSafeProcessTimeout("optional-plugin-build");
       throw new Error(
-        `Timed out building optional live-stack plugin ${plugin.id} after ${BUILD_TIMEOUT_MS}ms.\n${logs.join("").slice(-8_000)}`,
+        "Optional live-stack plugin build timed out; raw output suppressed.",
       );
     }
     if (child.exitCode !== 0) {
+      reportSafeProcessFailure("optional-plugin-build", child.exitCode);
       throw new Error(
-        `Failed to build optional live-stack plugin ${plugin.id}.\n${logs.join("").slice(-8_000)}`,
+        "Optional live-stack plugin build failed; raw output suppressed.",
       );
     }
     for (const outputPath of outputPaths) {
@@ -1123,7 +1158,7 @@ async function ensureLiveStackOptionalViewPluginsReady(): Promise<void> {
 
 async function startStubStack(): Promise<StartedStack> {
   const stateDir = await createStateDir("eliza-ui-smoke-stub-");
-  let apiChild: ChildProcessWithoutNullStreams | null = null;
+  let apiChild: CapturedChildProcess | null = null;
   let uiServer: Server | null = null;
   try {
     const uiDistDir = await snapshotUiDist(stateDir);
@@ -1139,11 +1174,9 @@ async function startStubStack(): Promise<StartedStack> {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    apiChild.stdout.on("data", (chunk) => {
-      process.stdout.write(`[ui-smoke][stub] ${chunk}`);
-    });
-    apiChild.stderr.on("data", (chunk) => {
-      process.stdout.write(`[ui-smoke][stub-err] ${chunk}`);
+    attachSafeChildOutputObserver({
+      child: apiChild,
+      component: "stub-runtime",
     });
 
     await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
@@ -1186,7 +1219,7 @@ async function startStubStack(): Promise<StartedStack> {
 
 async function startRealLocalStack(): Promise<StartedStack> {
   const stateDir = await createStateDir("eliza-ui-smoke-real-local-");
-  let apiChild: ChildProcessWithoutNullStreams | null = null;
+  let apiChild: CapturedChildProcess | null = null;
   let uiServer: Server | null = null;
   try {
     const backendLogPath = BACKEND_LOG_PATH
@@ -1217,15 +1250,10 @@ async function startRealLocalStack(): Promise<StartedStack> {
       },
     );
 
-    apiChild.stdout.on("data", (chunk) => {
-      const output = `[ui-smoke][real-local] ${chunk}`;
-      process.stdout.write(output);
-      if (backendLogPath) appendFileSync(backendLogPath, output);
-    });
-    apiChild.stderr.on("data", (chunk) => {
-      const output = `[ui-smoke][real-local-err] ${chunk}`;
-      process.stdout.write(output);
-      if (backendLogPath) appendFileSync(backendLogPath, output);
+    attachSafeChildOutputObserver({
+      artifactPath: backendLogPath,
+      child: apiChild,
+      component: "real-local-runtime",
     });
 
     await waitForJsonPredicate<{ state?: string }>(
@@ -1264,20 +1292,25 @@ async function startRealLocalStack(): Promise<StartedStack> {
 }
 
 async function startRealStack(): Promise<StartedStack> {
+  activeStartupComponent = "renderer-build";
   await ensureUiDistReady();
 
   if (REAL_LOCAL_STACK) {
+    activeStartupComponent = "real-local-runtime";
     return startRealLocalStack();
   }
 
   if (FORCE_STUB_STACK || !LIVE_PROVIDER) {
+    activeStartupComponent = "stub-runtime";
     return startStubStack();
   }
 
+  activeStartupComponent = "optional-plugin-build";
   await ensureLiveStackOptionalViewPluginsReady();
+  activeStartupComponent = "live-runtime";
 
   const stateDir = await createStateDir("eliza-ui-smoke-live-");
-  let apiChild: ChildProcessWithoutNullStreams | null = null;
+  let apiChild: CapturedChildProcess | null = null;
   let uiServer: Server | null = null;
   try {
     const backendLogPath = BACKEND_LOG_PATH
@@ -1312,15 +1345,10 @@ async function startRealStack(): Promise<StartedStack> {
       },
     );
 
-    apiChild.stdout.on("data", (chunk) => {
-      const output = `[ui-smoke][api] ${chunk}`;
-      process.stdout.write(output);
-      if (backendLogPath) appendFileSync(backendLogPath, output);
-    });
-    apiChild.stderr.on("data", (chunk) => {
-      const output = `[ui-smoke][api-err] ${chunk}`;
-      process.stdout.write(output);
-      if (backendLogPath) appendFileSync(backendLogPath, output);
+    attachSafeChildOutputObserver({
+      artifactPath: backendLogPath,
+      child: apiChild,
+      component: "live-runtime",
     });
 
     await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
@@ -1400,6 +1428,7 @@ async function stopRealStack(stack: StartedStack | null): Promise<void> {
 
 let stack: StartedStack | null = null;
 let shuttingDown = false;
+let activeStartupComponent: LiveStackDiagnosticComponent = "renderer-build";
 
 process.once("exit", cleanupKnownStateDirsSync);
 
@@ -1434,10 +1463,8 @@ try {
   console.log(`[ui-smoke] live UI ready at ${stack.uiBase}`);
   await new Promise(() => {});
 } catch (error) {
-  console.error(
-    `[ui-smoke] failed to start live stack: ${
-      error instanceof Error ? (error.stack ?? error.message) : String(error)
-    }`,
+  process.stderr.write(
+    `${formatSafeLiveStackStartupFailure(activeStartupComponent, error)}\n`,
   );
   await stopRealStack(stack);
   await cleanupPendingStateDirs();

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1128,7 +1128,7 @@ echo "public Headscale overlap is healthy on one exact dual-SAN leaf"
 const cpRouterSteps = skipCpRouter
   ? `echo "skip-cp-router set: leaving CP tailscale enrollment untouched"`
   : `
-echo "--- CP self-enrollment: ${cpRouterHostname} (tag:eliza-proxy) ---"
+echo "--- CP self-enrollment: role=eliza-proxy ---"
 CP_ROUTER_HOST=${shellQuote(cpRouterHostname)}
 LOGIN_SERVER=${shellQuote(publicUrl)}
 
@@ -1139,18 +1139,18 @@ sudo systemctl enable --now tailscaled
 # headscale node 'name'). If so, this whole step is a no-op.
 if sudo headscale nodes list -o json 2>/dev/null \\
     | jq -e --arg h "$CP_ROUTER_HOST" 'any(.[]; .name == $h)' >/dev/null 2>&1; then
-  echo "$CP_ROUTER_HOST already enrolled in headscale; skipping tailscale up"
+  echo "CP router enrollment already present (category=cp-router-already-enrolled)"
 else
   # Resolve the 'tunnel' user id (preauthkeys create -u wants a uint in v0.28).
   TUNNEL_UID=$(sudo headscale users list -o json 2>/dev/null \\
     | jq -r '.[] | select(.name == "tunnel") | .id')
-  [ -n "$TUNNEL_UID" ] || { echo "tunnel user not found; cannot mint preauth key"; exit 1; }
+  [ -n "$TUNNEL_UID" ] || { echo "required Headscale role is absent (category=cp-router-role-missing)"; exit 1; }
 
   # Short-lived, single-use, pre-tagged preauth key. Tagged tag:eliza-proxy so
   # the node lands tagged at join (ownership enforced by acl.hujson tagOwners).
   PREAUTH_KEY=$(sudo headscale preauthkeys create -u "$TUNNEL_UID" \\
     --tags tag:eliza-proxy --expiration 1h -o json 2>/dev/null | jq -r '.key')
-  [ -n "$PREAUTH_KEY" ] || { echo "failed to mint preauth key for cp-router"; exit 1; }
+  [ -n "$PREAUTH_KEY" ] || { echo "CP router enrollment credential could not be minted (category=cp-router-key-failed)"; exit 1; }
 
   # This branch already proved the expected router is absent and minted a
   # fresh, single-use key. Force reauthentication so a daemon still signed in
@@ -1161,12 +1161,15 @@ else
     --authkey="$PREAUTH_KEY" \\
     --hostname="$CP_ROUTER_HOST" \\
     --advertise-tags=tag:eliza-proxy \\
-    --accept-routes
-  echo "$CP_ROUTER_HOST enrolled"
+    --accept-routes >/dev/null 2>&1
+  echo "CP router enrollment completed (category=cp-router-enrolled)"
 fi
 
-sudo tailscale status 2>/dev/null | grep -F "$CP_ROUTER_HOST" \\
-  || echo "WARN: $CP_ROUTER_HOST not visible in tailscale status yet"
+if sudo tailscale status 2>/dev/null | grep -F "$CP_ROUTER_HOST" >/dev/null; then
+  echo "CP router visibility check passed (category=cp-router-visible)"
+else
+  echo "WARN: CP router visibility is pending (category=cp-router-visibility-pending)"
+fi
 `;
 
 const legacyVhostInspectionRemote = `
@@ -1301,15 +1304,24 @@ sudo chmod 0640 ${HEADSCALE_CONFIG} || true
 sudo systemctl enable --now headscale
 sudo systemctl restart headscale
 
+report_headscale_unit_state() {
+  local active_class="other"
+  if sudo systemctl is-active --quiet headscale; then
+    active_class="active"
+  elif sudo systemctl is-failed --quiet headscale; then
+    active_class="failed"
+  fi
+  echo "headscale-unit-state category=headscale-unit-state active=$active_class"
+}
+
 for attempt in $(seq 1 30); do
   if curl -sf -m 3 "$API_URL/health" >/dev/null; then
     echo "headscale local health passed on attempt $attempt"
     break
   fi
   if [ "$attempt" = 30 ]; then
-    echo "headscale local health failed"
-    sudo systemctl status headscale --no-pager || true
-    sudo journalctl -u headscale -n 80 --no-pager || true
+    echo "headscale local health failed (category=headscale-local-health-failed; attempts=30)"
+    report_headscale_unit_state
     exit 1
   fi
   sleep 2
@@ -1317,7 +1329,7 @@ done
 
 for user in agent tunnel; do
   if ! sudo headscale users list -o json 2>/dev/null | grep -q "\\"name\\"[[:space:]]*:[[:space:]]*\\"$user\\""; then
-    sudo headscale users create "$user"
+    sudo headscale users create "$user" >/dev/null
   fi
 done
 

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -158,7 +158,7 @@ describe("Headscale control-plane self-enrollment", () => {
     expect(forceReauth).toBeLessThan(loginServer);
     expect(remote.match(/--force-reauth/g)).toHaveLength(1);
     expect(remote).toContain(
-      "already enrolled in headscale; skipping tailscale up",
+      "CP router enrollment already present (category=cp-router-already-enrolled)",
     );
   });
 

--- a/packages/scripts/__tests__/mission-workflow-diagnostics-redaction.test.ts
+++ b/packages/scripts/__tests__/mission-workflow-diagnostics-redaction.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Locks the mission-critical live/provisioning workflows to closed diagnostics
+ * without executing provider, deployment, or infrastructure mutations.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../../..");
+const cleanupArrayExpansion = '"$' + '{cleanup_paths[@]}"';
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+  with?: Record<string, string>;
+}
+
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function read(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), "utf8");
+}
+
+function parseWorkflow(relativePath: string): Workflow {
+  return Bun.YAML.parse(read(relativePath)) as Workflow;
+}
+
+function workflowStep(
+  workflow: Workflow,
+  jobName: string,
+  stepName: string,
+): WorkflowStep {
+  const step = workflow.jobs?.[jobName]?.steps?.find(
+    (candidate) => candidate.name === stepName,
+  );
+  if (!step) throw new Error(`Missing workflow step ${jobName}:${stepName}`);
+  return step;
+}
+
+describe("mission workflow diagnostic redaction", () => {
+  test("app live suppresses credentialed output and uploads only the closed backend receipt", () => {
+    const workflow = parseWorkflow(".github/workflows/app-live-e2e.yml");
+    const missionSpec =
+      /test\/ui-smoke\/(?:live-agent-chat|vault-routing|wallet-keys|vault-modal-interactions|settings-sections-interactions|provider-config|cloud-live)\.spec\.ts/;
+    const credentialedSteps = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .filter((step) => missionSpec.test(step.run ?? ""));
+    expect(credentialedSteps).toHaveLength(4);
+    for (const step of credentialedSteps) {
+      const run = step.run ?? "";
+      expect(run).toMatch(/^set -euo pipefail/);
+      expect(run).toContain(">/dev/null 2>&1");
+      expect(run).toContain("category=");
+      expect(run).toContain("raw-output=suppressed");
+    }
+
+    const upload = workflowStep(
+      workflow,
+      "app-live-chat",
+      "Upload live-chat artifacts",
+    );
+    const artifactPaths = (upload.with?.path ?? "")
+      .split("\n")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    expect(artifactPaths).toEqual(["e2e-recordings/app-live/backend.log"]);
+  });
+
+  test("settings failure stops the second credentialed run without exposing child bytes", () => {
+    const workflow = parseWorkflow(".github/workflows/app-live-e2e.yml");
+    const run = workflowStep(
+      workflow,
+      "app-live-chat",
+      "Run settings + vault live-stack deep e2e",
+    ).run;
+    if (!run) throw new Error("Missing settings/vault run script");
+
+    const directory = mkdtempSync(join(tmpdir(), "closed-e2e-workflow-"));
+    const binDirectory = join(directory, "bin");
+    const callLog = join(directory, "bun-calls.log");
+    mkdirSync(binDirectory);
+    writeFileSync(
+      join(binDirectory, "bun"),
+      `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$CALL_LOG"
+printf '%s\\n' 'agent_config={apiKey:sk-live,email:user@example.com}'
+printf '%s\\n' 'provider response with wallet and agent identifier' >&2
+exit 17
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = spawnSync("bash", ["-c", run], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CALL_LOG: callLog,
+          PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+        },
+      });
+      expect(result.status).toBe(17);
+      expect(readFileSync(callLog, "utf8").trim().split("\n")).toHaveLength(1);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        "category=settings-vault-failed",
+      );
+      expect(`${result.stdout}${result.stderr}`).not.toContain("sk-live");
+      expect(`${result.stdout}${result.stderr}`).not.toContain(
+        "user@example.com",
+      );
+      expect(`${result.stdout}${result.stderr}`).not.toContain(
+        "provider response",
+      );
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  test("shared app harness never forwards child bytes or onboarding bodies", () => {
+    const harness = read(
+      "packages/app-core/scripts/playwright-ui-live-stack.ts",
+    );
+    expect(harness).toContain("attachSafeChildOutputObserver");
+    expect(harness).not.toMatch(/\.(?:stdout|stderr)\.on\(["']data["']/);
+    expect(harness).not.toMatch(/\.(?:stdout|stderr)\.pipe\(/);
+    expect(harness).not.toContain("process.stdout.write(output)");
+    expect(harness).not.toContain("appendFileSync(backendLogPath, output)");
+    expect(harness).not.toContain('logs.join("")');
+    expect(harness).not.toContain("await response.text()");
+    expect(harness).toContain("category=first-run-rejected");
+    expect(harness).toContain("response-body=suppressed");
+    expect(harness).not.toContain(
+      'console.error("[playwright-ui-live-stack] proxy error:", error)',
+    );
+  });
+
+  test("provisioning keeps journals private and emits allowlisted unit state", () => {
+    const workflow = read(
+      ".github/workflows/deploy-eliza-provisioning-worker.yml",
+    );
+    const health = workflow.slice(workflow.indexOf("- name: Health check"));
+
+    expect(health).toContain("report_unit_diagnostic() {");
+    expect(health).toContain("--property=LoadState");
+    expect(health).toContain("--property=ActiveState");
+    expect(health).toContain("--property=Result");
+    expect(health).toContain("unit-state category=");
+    expect(health).toContain("worker|router|backup|nginx");
+    expect(health).toContain("component=$" + "{label}");
+    expect(health).not.toMatch(/echo[^\n]*\$\{unit\}/);
+    expect(health).not.toMatch(/systemctl status\b/);
+    expect(health).not.toMatch(/echo "\$(?:BACKUP_|ROUTER_)?JOURNAL"/);
+    expect(health).not.toMatch(/journalctl[^\n]*\|\s*tail/);
+    expect(health).not.toMatch(/echo[^\n]*\$\{AGENT_ROUTER_PUBLIC_HOST\}/);
+
+    expect(health).toContain("BACKUP_JOURNAL=$(sudo journalctl");
+    expect(health).toContain("JOURNAL=$(sudo journalctl");
+    expect(health).toContain("ROUTER_JOURNAL=$(sudo journalctl");
+    expect(health).toContain('grep -qE "$FATAL_LOG_PATTERN"');
+  });
+
+  test("Headscale projects remote output to fixed receipts and never prints node or journal lines", () => {
+    const workflow = parseWorkflow(
+      ".github/workflows/arm-headscale-control-plane.yml",
+    );
+    const converge = workflowStep(
+      workflow,
+      "arm",
+      "Inspect or converge Headscale control plane",
+    ).run;
+    expect(converge).toContain('> "$arm_stdout" 2> "$arm_stderr"');
+    expect(converge).toContain("category=headscale-converge-passed");
+    expect(converge).toContain("category=headscale-remote-failed");
+    expect(converge).toContain('rm -f -- "$' + '{cleanup_paths[@]}"');
+    expect(converge).not.toContain('cat "$arm_stdout"');
+    expect(converge).not.toContain('cat "$arm_stderr"');
+
+    const script = read(
+      "packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
+    );
+    expect(script).not.toMatch(/systemctl status headscale\b/);
+    expect(script).not.toMatch(/journalctl -u headscale\b/);
+    expect(script).not.toMatch(/echo "\$CP_ROUTER_HOST/);
+    expect(script).toContain(
+      'tailscale status 2>/dev/null | grep -F "$CP_ROUTER_HOST" >/dev/null',
+    );
+    expect(script).toContain('headscale users create "$user" >/dev/null');
+  });
+
+  test("Railway deploy and DNS handoff retain raw provider output only in private files", () => {
+    const workflow = parseWorkflow(".github/workflows/deploy-tunnel-proxy.yml");
+    const deploy = workflowStep(
+      workflow,
+      "deploy",
+      "Deploy tunnel-proxy source to Railway",
+    ).run;
+    expect(deploy).toContain('> "$railway_stdout" 2> "$railway_stderr"');
+    expect(deploy).toContain("category=railway-deploy-passed");
+    expect(deploy).toContain("provider-output=suppressed");
+    expect(deploy).toContain('rm -f -- "$' + '{cleanup_paths[@]}"');
+    expect(deploy).not.toContain('cat "$railway_stdout"');
+    expect(deploy).not.toContain('cat "$railway_stderr"');
+
+    const handoff = workflowStep(
+      workflow,
+      "deploy",
+      "Validate reviewed Railway DNS handoff",
+    ).run;
+    const summary = handoff.slice(handoff.indexOf("GITHUB_STEP_SUMMARY") - 500);
+    expect(summary).not.toContain('jq . "$inventory"');
+    expect(handoff).toContain("category=dns-inventory-ready");
+    expect(handoff).toContain("values=suppressed");
+    expect(handoff).toContain('rm -f -- "$' + '{cleanup_paths[@]}"');
+    expect(handoff).not.toContain(
+      "copy the exact inventory from this run summary",
+    );
+  });
+
+  test("mission Railway steps close provider streams and destroy private captures", () => {
+    const workflow = parseWorkflow(".github/workflows/deploy-tunnel-proxy.yml");
+    const checks = [
+      {
+        name: "Verify exact Railway target",
+        category: "railway-target-verified",
+        privatePaths: ["$status_path", "$provider_stderr"],
+      },
+      {
+        name: "Converge non-secret Railway variables and signing secret",
+        category: "railway-variables-published",
+        privatePaths: ["$provider_stdout", "$provider_stderr"],
+      },
+      {
+        name: "Converge persistent tsnet volume",
+        category: "railway-volume-ready",
+        privatePaths: ["$volumes_path", "$provider_stderr"],
+      },
+      {
+        name: "Mint proxy key and publish it without exposing the value",
+        category: "railway-proxy-key-published",
+        privatePaths: ["$railway_stdout", "$railway_stderr"],
+      },
+      {
+        name: "Converge exact Railway custom domains",
+        category: "railway-domain-created",
+        privatePaths: ["$domains_path", "$created_path", "$provider_stderr"],
+      },
+      {
+        name: "Validate reviewed Railway DNS handoff",
+        category: "dns-inventory-ready",
+        privatePaths: ["$apex_status", "$wildcard_status", "$provider_stderr"],
+      },
+      {
+        name: "Verify Railway domain ownership and certificates",
+        category: "railway-domains-verified",
+        privatePaths: ["$status_path", "$provider_stderr"],
+      },
+    ] as const;
+
+    for (const check of checks) {
+      const run = workflowStep(workflow, "deploy", check.name).run ?? "";
+      expect(run).toContain("umask 077");
+      expect(run).toContain(`category=${check.category}`);
+      expect(run).toContain("provider-output=suppressed");
+      expect(run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+      expect(run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
+      for (const privatePath of check.privatePaths) {
+        expect(run).not.toContain(`cat "${privatePath}"`);
+      }
+    }
+
+    for (const stepName of [
+      "Converge exact Railway custom domains",
+      "Validate reviewed Railway DNS handoff",
+      "Verify Railway domain ownership and certificates",
+    ]) {
+      const run = workflowStep(workflow, "deploy", stepName).run ?? "";
+      expect(run).not.toMatch(
+        /echo[^\n]*\$(?:domain(?!_)|requested_domain\b|TUNNEL_PROXY_HOST\b)/,
+      );
+    }
+  });
+
+  test("hostile Railway variable output cannot reach logs and is removed", () => {
+    const workflow = parseWorkflow(".github/workflows/deploy-tunnel-proxy.yml");
+    const run =
+      workflowStep(
+        workflow,
+        "deploy",
+        "Converge non-secret Railway variables and signing secret",
+      ).run ?? "";
+    const directory = mkdtempSync(join(tmpdir(), "railway-vars-redaction-"));
+    const binDirectory = join(directory, "bin");
+    mkdirSync(binDirectory);
+    writeFileSync(
+      join(binDirectory, "railway"),
+      `#!/usr/bin/env bash
+printf '%s\\n' 'provider-json agent_config token=provider-secret-canary user=private.person+ci@example.invalid id=11111111-2222-4333-8444-555555555555'
+printf '%s\\n' 'provider-stderr wallet=provider-wallet-canary' >&2
+exit "\${RAILWAY_STUB_EXIT:-0}"
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const baseEnv = {
+        ...process.env,
+        HEADSCALE_PUBLIC_URL: "https://headscale.example.invalid",
+        PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+        RAILWAY_ENVIRONMENT_ID: "environment-canary",
+        RAILWAY_PROJECT_ID: "project-canary",
+        RAILWAY_SERVICE_ID: "service-canary",
+        RUNNER_TEMP: directory,
+        TARGET_ENVIRONMENT: "staging",
+        TUNNEL_HOSTNAME_SIGNING_SECRET:
+          "signing-secret-canary-that-is-long-enough",
+        TUNNEL_PROXY_HOST: "tunnel.example.invalid",
+      };
+      for (const [stubExit, expectedStatus, expectedCategory] of [
+        [undefined, 0, "category=railway-variables-published"],
+        ["23", 23, "category=railway-variables-config-failed"],
+      ] as const) {
+        const result = spawnSync("bash", ["-c", run], {
+          encoding: "utf8",
+          env: {
+            ...baseEnv,
+            ...(stubExit ? { RAILWAY_STUB_EXIT: stubExit } : {}),
+          },
+        });
+        const output = `${result.stdout}${result.stderr}`;
+        expect(result.status).toBe(expectedStatus);
+        expect(output).toContain(expectedCategory);
+        for (const canary of [
+          "provider-secret-canary",
+          "private.person+ci@example.invalid",
+          "11111111-2222-4333-8444-555555555555",
+          "provider-wallet-canary",
+        ]) {
+          expect(output).not.toContain(canary);
+        }
+        expect(existsSync(join(directory, "railway-variables.stdout"))).toBe(
+          false,
+        );
+        expect(existsSync(join(directory, "railway-variables.stderr"))).toBe(
+          false,
+        );
+      }
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  test("hostile Railway domain output is reduced to fixed roles and removed", () => {
+    const workflow = parseWorkflow(".github/workflows/deploy-tunnel-proxy.yml");
+    const converge =
+      workflowStep(workflow, "deploy", "Converge exact Railway custom domains")
+        .run ?? "";
+    const verify =
+      workflowStep(
+        workflow,
+        "deploy",
+        "Verify Railway domain ownership and certificates",
+      ).run ?? "";
+    const directory = mkdtempSync(join(tmpdir(), "railway-domain-redaction-"));
+    const binDirectory = join(directory, "bin");
+    const outputPath = join(directory, "github-output");
+    mkdirSync(binDirectory);
+    writeFileSync(outputPath, "");
+    writeFileSync(
+      join(binDirectory, "railway"),
+      `#!/usr/bin/env bash
+if [ "$1" != "domain" ]; then
+  exit 64
+fi
+case "$2" in
+  list)
+    printf '%s\\n' '{"domains":[],"agent_config":"provider-domain-secret-canary"}'
+    ;;
+  status)
+    printf '{"domain":{"domain":"%s","type":"custom","targetPort":8080,"syncStatus":"ACTIVE","verification":{"verified":true,"token":"provider-token-canary"},"certificate":{"status":"CERTIFICATE_STATUS_TYPE_VALID"}},"ownerEmail":"domain.owner@example.invalid"}\\n' "$3"
+    ;;
+  *)
+    printf '%s\\n' '{"domainId":"66666666-7777-4888-8999-000000000000","providerResponse":"provider-create-canary"}'
+    ;;
+esac
+printf '%s\\n' 'provider-stderr nodeId=provider-node-canary wallet=provider-wallet-canary' >&2
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const env = {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+      PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+      RAILWAY_ENVIRONMENT_ID: "environment-canary",
+      RAILWAY_PROJECT_ID: "project-canary",
+      RAILWAY_SERVICE_ID: "service-canary",
+      RUNNER_TEMP: directory,
+      TUNNEL_PROXY_HOST: "private-tunnel.example.invalid",
+    };
+
+    try {
+      for (const [script, expectedCategory] of [
+        [converge, "category=railway-domain-created"],
+        [verify, "category=railway-domains-verified"],
+      ] as const) {
+        const result = spawnSync("bash", ["-c", script], {
+          encoding: "utf8",
+          env,
+        });
+        const output = `${result.stdout}${result.stderr}`;
+        expect(result.status).toBe(0);
+        expect(output).toContain(expectedCategory);
+        expect(output).toContain("role=apex");
+        expect(output).toContain("role=wildcard");
+        for (const canary of [
+          "private-tunnel.example.invalid",
+          "provider-domain-secret-canary",
+          "provider-token-canary",
+          "domain.owner@example.invalid",
+          "66666666-7777-4888-8999-000000000000",
+          "provider-create-canary",
+          "provider-node-canary",
+          "provider-wallet-canary",
+        ]) {
+          expect(output).not.toContain(canary);
+        }
+      }
+
+      for (const privateFile of [
+        "railway-domains.json",
+        "railway-domain-created.json",
+        "railway-domain-converge.stderr",
+        "railway-domain-converge-transform.stderr",
+        "railway-domain-verification.json",
+        "railway-domain-verification.stderr",
+        "railway-domain-verification-transform.stderr",
+      ]) {
+        expect(existsSync(join(directory, privateFile))).toBe(false);
+      }
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -829,17 +829,13 @@ describe("provisioning worker deployment contract", () => {
       `"https://${publicHost}/healthz"`,
     );
     expect(workflow).toContain(
-      "Canonical agent-router host failed after local readiness",
+      "Canonical agent-router route failed after local readiness",
     );
+    expect(workflow).toContain("Canonical agent-router health contract failed");
     expect(workflow).toContain(
-      "Canonical agent-router host returned an unexpected health payload",
+      "Canonical agent-router readiness contract failed",
     );
-    expect(workflow).toContain(
-      "Canonical agent-router host returned an unexpected readiness payload",
-    );
-    expect(workflow).toContain(
-      "sudo systemctl status eliza-agent-router.service --no-pager || true",
-    );
+    expect(workflow).toContain("report_unit_diagnostic public-route");
   });
 
   it("settles both public-route failure branches with diagnostics then exit 1", () => {

--- a/packages/scripts/__tests__/tunnel-proxy-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/tunnel-proxy-deploy-workflow.test.ts
@@ -11,6 +11,7 @@ const workflowPath = new URL(
   repoRoot,
 );
 const source = readFileSync(workflowPath, "utf8");
+const cleanupArrayExpansion = '"$' + '{cleanup_paths[@]}"';
 
 interface WorkflowStep {
   env?: Record<string, string>;
@@ -90,6 +91,14 @@ describe("protected tunnel-proxy deployment workflow", () => {
       '--environment "$RAILWAY_ENVIRONMENT_ID"',
     );
     expect(verifyTarget.run).toContain('.node.name == "tunnel-proxy"');
+    expect(verifyTarget.run).toContain(
+      '> "$status_path" 2> "$provider_stderr"',
+    );
+    expect(verifyTarget.run).toContain("category=railway-target-verified");
+    expect(verifyTarget.run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+    expect(verifyTarget.run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
+    expect(verifyTarget.run).not.toContain('cat "$status_path"');
+    expect(verifyTarget.run).not.toContain('cat "$provider_stderr"');
 
     const volume = step("Converge persistent tsnet volume");
     expect(volume.run).toContain("railway volume");
@@ -99,6 +108,13 @@ describe("protected tunnel-proxy deployment workflow", () => {
     expect(volume.run).toContain('.status == "Ready"');
     expect(volume.run).toContain('.serviceName == "tunnel-proxy"');
     expect(volume.run).toContain("target_mount_count");
+    expect(volume.run).toContain('> "$volumes_path" 2> "$provider_stderr"');
+    expect(volume.run).toContain('> "$mutation_stdout" 2> "$provider_stderr"');
+    expect(volume.run).toContain("category=railway-volume-ready");
+    expect(volume.run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+    expect(volume.run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
+    expect(volume.run).not.toContain('cat "$volumes_path"');
+    expect(volume.run).not.toContain('cat "$provider_stderr"');
 
     const volumeIndex = steps.findIndex(
       (candidate) => candidate.name === "Converge persistent tsnet volume",
@@ -129,6 +145,14 @@ describe("protected tunnel-proxy deployment workflow", () => {
     expect(variables.run).toContain("TUNNEL_HOSTNAME_SIGNING_SECRET");
     expect(variables.run).toContain("--stdin");
     expect(variables.run).toContain('"TUNNEL_ALLOW_UNSIGNED_HOSTNAMES=false"');
+    expect(variables.run).toContain(
+      '> "$provider_stdout" 2> "$provider_stderr"',
+    );
+    expect(variables.run).toContain("category=railway-variables-published");
+    expect(variables.run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+    expect(variables.run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
+    expect(variables.run).not.toContain('cat "$provider_stdout"');
+    expect(variables.run).not.toContain('cat "$provider_stderr"');
 
     const headscale = step(
       "Mint proxy key and publish it without exposing the value",
@@ -146,7 +170,13 @@ describe("protected tunnel-proxy deployment workflow", () => {
     );
     expect(headscale.run).toContain("TUNNEL_PROXY_TS_AUTHKEY");
     expect(headscale.run).toContain("--stdin");
+    expect(headscale.run).toContain('> "$railway_stdout" 2> "$railway_stderr"');
+    expect(headscale.run).toContain("category=railway-proxy-key-published");
+    expect(headscale.run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+    expect(headscale.run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
     expect(headscale.run).not.toContain('echo "$new_key"');
+    expect(headscale.run).not.toContain('cat "$railway_stdout"');
+    expect(headscale.run).not.toContain('cat "$railway_stderr"');
     expect(source).not.toContain("ssh-keyscan");
     expect(source).not.toContain("StrictHostKeyChecking=accept-new");
 
@@ -156,21 +186,41 @@ describe("protected tunnel-proxy deployment workflow", () => {
 
   test("attaches and verifies the exact apex and wildcard domains", () => {
     const converge = step("Converge exact Railway custom domains");
+    expect(converge.run).toContain("for domain_role in apex wildcard");
     expect(converge.run).toContain(
-      'for domain in "$TUNNEL_PROXY_HOST" "*.$TUNNEL_PROXY_HOST"',
+      'apex) requested_domain="$TUNNEL_PROXY_HOST"',
+    );
+    expect(converge.run).toContain(
+      'wildcard) requested_domain="*.$TUNNEL_PROXY_HOST"',
     );
     expect(converge.run).toContain("railway domain list");
-    expect(converge.run).toContain('railway domain "$domain"');
+    expect(converge.run).toContain('railway domain "$requested_domain"');
     expect(converge.run).toContain("--port 8080");
+    expect(converge.run).toContain('> "$domains_path" 2> "$provider_stderr"');
+    expect(converge.run).toContain('> "$created_path" 2> "$provider_stderr"');
+    expect(converge.run).toContain("role=$domain_role");
+    expect(converge.run).toContain("category=railway-domain-created");
+    expect(converge.run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+    expect(converge.run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
+    expect(converge.run).not.toMatch(
+      /echo[^\n]*\$(?:domain(?!_)|requested_domain\b|TUNNEL_PROXY_HOST\b)/,
+    );
+    expect(converge.run).not.toContain('cat "$domains_path"');
+    expect(converge.run).not.toContain('cat "$created_path"');
+    expect(converge.run).not.toContain('cat "$provider_stderr"');
 
     const handoff = step("Validate reviewed Railway DNS handoff");
     expect(deploy?.env?.RAILWAY_TUNNEL_DNS_RECORDS_JSON).toContain(
       "vars.RAILWAY_TUNNEL_DNS_RECORDS_JSON",
     );
-    expect(handoff.run).toContain('railway domain status "$TUNNEL_PROXY_HOST"');
+    expect(handoff.run).toContain('railway domain status "$requested_domain"');
     expect(handoff.run).toContain(
-      'railway domain status "*.$TUNNEL_PROXY_HOST"',
+      'run_domain_status apex "$TUNNEL_PROXY_HOST" "$apex_status"',
     );
+    expect(handoff.run).toContain(
+      'run_domain_status wildcard "*.$TUNNEL_PROXY_HOST" "$wildcard_status"',
+    );
+    expect(handoff.run).toContain("role=$domain_role");
     for (const logicalKey of [
       "apex-routing",
       "apex-verification",
@@ -194,14 +244,23 @@ describe("protected tunnel-proxy deployment workflow", () => {
     );
 
     const verify = step("Verify Railway domain ownership and certificates");
-    expect(verify.run).toContain('railway domain status "$domain"');
+    expect(verify.run).toContain("for domain_role in apex wildcard");
+    expect(verify.run).toContain('railway domain status "$requested_domain"');
     expect(verify.run).toContain(".domain.verification.verified == true");
     expect(verify.run).toContain('.domain.syncStatus == "ACTIVE"');
     expect(verify.run).toContain(
       '.domain.certificate.status == "CERTIFICATE_STATUS_TYPE_VALID"',
     );
-    expect(verify.run).toContain("RAILWAY_TUNNEL_DNS_RECORDS_JSON");
-    expect(verify.run).toContain("pages-domains Terraform plan");
+    expect(verify.run).toContain('> "$status_path" 2> "$provider_stderr"');
+    expect(verify.run).toContain("role=$domain_role");
+    expect(verify.run).toContain("category=railway-domain-verified");
+    expect(verify.run).toContain(`shred -u -- ${cleanupArrayExpansion}`);
+    expect(verify.run).toContain(`rm -f -- ${cleanupArrayExpansion}`);
+    expect(verify.run).not.toMatch(
+      /echo[^\n]*\$(?:domain(?!_)|requested_domain\b|TUNNEL_PROXY_HOST\b)/,
+    );
+    expect(verify.run).not.toContain('cat "$status_path"');
+    expect(verify.run).not.toContain('cat "$provider_stderr"');
   });
 
   test("proves live health and 404 before revoking superseded keys", () => {


### PR DESCRIPTION
## Goal

Close the mission-scoped diagnostics exposure in the credentialed app-live, provisioning, Headscale, and tunnel-proxy paths without changing deployment targets or runtime behavior.

## Cause

These workflows could forward raw child stdout/stderr, journals, systemd output, Railway JSON/DNS provider responses, and credentialed Playwright artifacts into GitHub logs or uploaded artifacts. That made auth-to-agent and provisioning failures observable, but not safely reviewable.

## Resolution

- project app-live child output into a closed bounded event schema and upload only the safe backend receipt
- report startup phase and failure class through allowlisted fields only; behavior-test the real stream adapter with hostile bytes and discover mission specs across all jobs
- suppress credentialed Playwright stdout/stderr and response bodies
- replace provisioning journal/systemd dumps with allowlisted component and state classes
- capture Headscale remote output privately and emit only fixed receipts
- capture every mission Railway provider stream in mode-0600 temporary files, emit fixed role/category receipts, and securely remove the raw files
- add hostile-output regression tests for secrets, identifiers, provider JSON, email-like values, and unbounded output

## Validation

- rebased onto current `develop` `53f267ae71a1e0f752daa95b0be8ad1bfac40aab`
- **51/51 targeted tests passed, 816 assertions**
- actionlint passed for all 4 changed workflows
- Biome, Node syntax, and `git diff --check` passed
- the concurrent provisioning checkout cleanup hardening from develop is retained; its contract and this PR diagnostic-redaction contract both pass
- merge-tree is clean on the rebased head

## Scope and limits

No workflow was dispatched, no deployment or infrastructure mutation was performed, and this PR does not prove a physical Android or fresh staging provisioning run. Those remain explicit acceptance steps for the goal.

## Risk and rollback

The functional risk is reduced diagnostic detail on failure. Fixed categories preserve triage routing while raw values remain available only through an authorized local/provider channel. Roll back by reverting commit `f7db511eca0`.