### PR TITLE
fix(app-audit): trust stable Maps OCR anchors

### DIFF
--- a/packages/app/test/audit/ocr-view-expectations.test.ts
+++ b/packages/app/test/audit/ocr-view-expectations.test.ts
@@ -12,6 +12,10 @@ import {
   buildAuditViewCases,
 } from "../ui-smoke/aesthetic-audit-view-cases";
 import {
+  evaluateOcrContent,
+  type OcrResult,
+} from "../ui-smoke/ocr-content-rules";
+import {
   resolveViewOcrPolicy,
   VIEW_OCR_POLICIES,
 } from "../ui-smoke/ocr-view-expectations";
@@ -32,6 +36,25 @@ const NAVIGATION_SOURCE = resolve(
   APP_DIR,
   "../ui/src/navigation/builtin-route-descriptors.ts",
 );
+
+function ocr(text: string, over: Partial<OcrResult> = {}): OcrResult {
+  return {
+    ok: true,
+    text,
+    lines: text.split("\n").filter(Boolean),
+    words: text.split(/\s+/).filter(Boolean).length,
+    meanConfidence: 1,
+    ...over,
+  };
+}
+
+function mapsExpectation() {
+  const policy = resolveViewOcrPolicy("plugin-maps-gui");
+  if (policy.kind !== "expectation") {
+    throw new Error("Expected plugin Maps to declare an OCR expectation");
+  }
+  return policy.expectation;
+}
 
 describe("aesthetic audit semantic OCR policy coverage", () => {
   it("declares exactly one policy for every captured view slug", () => {
@@ -141,6 +164,71 @@ describe("aesthetic audit semantic OCR policy coverage", () => {
       "search",
     ]);
   });
+
+  it("accepts the recorded Maps landscape OCR through stable semantic anchors", () => {
+    const finding = evaluateOcrContent({
+      ocr: ocr(
+        "EXPLORE - PROVIDER-NEUTRAL MAP / MOPS Find somewhere worth going",
+        { meanConfidence: 0.71, pixelBlank: false },
+      ),
+      expectation: mapsExpectation(),
+    });
+
+    expect(finding.verdict).toBe("verified");
+    expect(finding.missingRequired).toEqual([]);
+    expect(finding.forbiddenPresent).toEqual([]);
+  });
+
+  it("still rejects blank and wrong-view Maps captures", () => {
+    const blank = evaluateOcrContent({
+      ocr: ocr("", {
+        words: 0,
+        meanConfidence: 0,
+        pixelBlank: true,
+        pixelBlankReasons: ["screenshot is one color"],
+      }),
+      expectation: mapsExpectation(),
+    });
+    expect(blank.verdict).toBe("broken");
+    expect(blank.blankPixels).toBe(true);
+
+    const wrongView = evaluateOcrContent({
+      ocr: ocr("Calendar Upcoming events Today", { pixelBlank: false }),
+      expectation: mapsExpectation(),
+    });
+    expect(wrongView.verdict).toBe("broken");
+    expect(wrongView.missingRequired).toEqual([
+      "Find somewhere worth going",
+      "provider-neutral | Search a place",
+    ]);
+  });
+
+  it("still rejects developer residue in an otherwise healthy Maps capture", () => {
+    const finding = evaluateOcrContent({
+      ocr: ocr(
+        "MOPS Find somewhere worth going provider-neutral [object Object]",
+      ),
+      expectation: mapsExpectation(),
+    });
+
+    expect(finding.verdict).toBe("broken");
+    expect(finding.errorLeaks).toContain("[object Object]");
+  });
+
+  it.each(["Google Maps", "Mapbox"])(
+    "keeps the %s provider leak out of the verified Maps lane",
+    (provider) => {
+      const finding = evaluateOcrContent({
+        ocr: ocr(
+          `MOPS Find somewhere worth going provider-neutral ${provider}`,
+        ),
+        expectation: mapsExpectation(),
+      });
+
+      expect(finding.verdict).toBe("needs-eyeball");
+      expect(finding.forbiddenPresent).toEqual([provider]);
+    },
+  );
 
   it("fails closed for an unknown captured slug", () => {
     expect(() => resolveViewOcrPolicy("plugin-newly-registered-gui")).toThrow(

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -297,7 +297,7 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Set default SMS", "bridge-only", "compose"],
   }),
   "plugin-maps-gui": expected({
-    requireAll: ["Maps", "Find somewhere worth going"],
+    requireAll: ["Find somewhere worth going"],
     requireAny: ["provider-neutral", "Search a place"],
     forbid: ["Google Maps", "Mapbox"],
   }),


### PR DESCRIPTION
# Relates to

Fixes #24792.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `develop` at `46f60feb47e2fd615dae4df6ddf021929029a8ba` with zero conflicts; live `develop` later advanced to `cd2bb056ae27cb46d124e9e288a4e51f7127b141` through non-overlapping paths.
- [ ] `bun run verify` was not run. The focused policy suite, pre-rebase renderer build, target browser audit, packaged OCR pass, Biome, and diff hygiene are recorded below.
- [x] The changed contract is covered by a deterministic captured-transcript fixture and resistance tests.

# Sync with develop

- [x] Rebased onto `develop` at `46f60feb47e2fd615dae4df6ddf021929029a8ba`; zero conflicts. GitHub reports this exact green/approved head cleanly mergeable against live `develop` at `cd2bb056ae27cb46d124e9e288a4e51f7127b141`.
- [x] The only upstream edit to `ocr-view-expectations.ts` was an unrelated Trajectories alternate phrase; no Maps policy or Maps plugin changes overlapped this fix.

# Risks

Low. The change removes only the brittle short `Maps` title from the positive OCR contract. The longer, distinctive product semantics remain mandatory, blank/wrong-view/developer-residue cases still fail, and `Google Maps` / `Mapbox` remain forbidden-provider inspection triggers. There is no general fuzzy matching and no Maps UI change.

# Background

## What does this PR do?

It makes `Find somewhere worth going` the required Maps anchor and keeps `provider-neutral` or `Search a place` as the alternate positive anchor. This allows the recorded mobile-landscape transcript beginning `... / MOPS Find somewhere worth going` to verify without weakening the rest of the semantic contract.

The regression suite evaluates that exact historical transcript and proves blank pixels, a wrong view, `[object Object]`, and provider-specific copy do not enter the verified lane.

## What kind of change is this?

Bug fix (non-breaking), limited to app-audit policy and tests.

# Documentation changes needed?

No. This repairs an internal visual-audit contract and does not change product behavior or a public API.

# Testing

## Where should a reviewer start?

`packages/app/test/audit/ocr-view-expectations.test.ts`, at `accepts the recorded Maps landscape OCR through stable semantic anchors`.

## Detailed testing steps

1. Deterministic RED before the policy change: the new captured-transcript fixture was classified `broken` because `Maps` was missing; the provider-leak fixture also remained outside the intended lane for the wrong reason.

2. GREEN on exact head `e78ffbe77a75a766e67d5b5752ccd17d4fef7178`:

   ```text
   bun test packages/app/test/audit/ocr-view-expectations.test.ts
   11 pass
   0 fail
   ```

3. Pre-rebase renderer provenance (subsequent base advances did not touch any Maps/app-audit path):

   ```text
   packages/app/dist/eliza-renderer-build.json
   commit: 1c31b825a7c4a8b6b034bbf333a0c0c233c20ef8
   assetCount: 1232
   indexHtmlSha256: ab60528cb537e2f349d7d82937bd9b75a5af8beb8ed7f32e5a1cfb991675434f
   ```

4. Target browser audit on head `1c31b825a7c4a8b6b034bbf333a0c0c233c20ef8` before subsequent non-overlapping base advances:

   ```text
   audit-app › plugin-maps-gui mobile-landscape
   1 passed (9.1s)
   broken=0 needs-work=0 needs-eyeball=1 good=0
   consoleErrors=[] renderStateIssues=[] horizontalOverflowPx=0
   semanticReady=true overlayPresent=true qualityIssues=[]
   screenshot SHA256: 04dac581aa8c6b9e89018ffb5380511221ad2ac2e38a775e9c3887ba8a05d1ed
   ```

5. Packaged OCR over that exact target capture:

   ```text
   ELIZA_MVP_OCR_ENGINE=packaged bun run --cwd packages/app audit:ocr
   [ocr-triage] 1 views | verified 1 | broken 0 | needs-eyeball 0
   ```

6. Formatting and diff hygiene:

   ```text
   @biomejs/biome check <both changed files>
   Checked 2 files. No fixes applied.

   git diff --check
   exit 0
   ```

# Evidence Gate

<!-- evidence-head:e78ffbe77a75a766e67d5b5752ccd17d4fef7178 -->

<!-- evidence-row:before-screenshots -->
- [x] Historical failing capture is recorded in #24792: healthy pixels/DOM, but OCR read the compact title as `MOPS` and the exact-title rule marked it broken.
<!-- evidence-row:after-screenshots -->
- [x] 844×390 capture from predecessor head `1c31b825a7c4a8b6b034bbf333a0c0c233c20ef8` inspected locally; subsequent base advances did not touch any Maps/app-audit path: the `Maps` title, provider-neutral eyebrow, search controls, Places panel, and chat overlay are visible without clipping. SHA256 `04dac581aa8c6b9e89018ffb5380511221ad2ac2e38a775e9c3887ba8a05d1ed`.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — this is a static rest-state audit contract; the authoritative browser capture is the relevant artifact.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] Target capture reports zero console errors and zero render-state issues.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, action, or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic transcript fixture plus target `report.json` and packaged `ocr-triage.json` summaries are reproduced above.
<!-- evidence-row:ocr-review -->
- [x] Packaged OCR verifies the exact target capture: `verified=1, broken=0, needs-eyeball=0`.

# Evidence Details

## Known gaps / failures

- Bare `bun run --cwd packages/app audit:app` on current `develop` is independently blocked before any audited view renders. Upstream commit `e508808078` added loopback Steward-token scoping, while `packages/app/test/ui-smoke/helpers/test-auth.ts` still seeds only `steward_session_token`. The current harness therefore shows `Sign in to Eliza Cloud` and receives `501 Unhandled UI smoke API route: POST /api/cloud/login` before the Maps lifecycle slot exists.
- To isolate this PR on the current base, the target run temporarily seeded the matching `eliza-cloud:production` scope locally. The one Maps case then passed; that temporary helper edit was reverted, and the pushed branch contains exactly the two OCR policy/test files claimed above.
- A complete earlier matrix on base `b100682147cb13235db728ada7b1696d74e0d2a3` executed all 215 cases and produced the healthy Maps capture, but Windows sandbox cleanup returned `browserContext.close: spawn EPERM` after cases. No full-suite pass is claimed from that run.
- Focused TypeScript checking remains blocked by unchanged current-base errors in `packages/app/test/ui-smoke/plugin-view-cases.ts` lines 63–64. The touched files' Vitest and Biome checks pass.
- `bun run verify` was not run.

## Maintainer CI exception record

N/A — no exception requested.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->



