### PR TITLE
fix(core): ensure single-winner atomic consumption in requireConfirmation (#29429)

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/runtime/database/adapter-compat.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/database/adapter-compat.ts
@@ -1149,8 +1149,8 @@ export function applyLegacyDatabaseAdapterCompat(adapter: IDatabaseAdapter): IDa
         return false;
       }
 
-      await Promise.all(keys.map((key) => compat.deleteCache(key)));
-      return true;
+      const results = await Promise.all(keys.map((key) => compat.deleteCache(key)));
+      return results.some(Boolean);
     },
     addedMethods,
   );

--- a/packages/core/src/database/inMemoryAdapter.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.test.ts
@@ -126,6 +126,9 @@ describe("InMemoryDatabaseAdapter", () => {
 		await expect(adapter.deleteCaches(["missing", "first"])).resolves.toBe(
 			true,
 		);
+		await expect(adapter.deleteCaches(["missing"])).resolves.toBe(
+			false,
+		);
 		await expect(adapter.getCaches(["first", "second"])).resolves.toEqual(
 			new Map([["second", { count: 2, labels: ["other"] }]]),
 		);

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -2197,10 +2197,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	}
 
 	async deleteCaches(keys: string[]): Promise<boolean> {
+		let removed = false;
 		for (const key of keys) {
-			this.cache.delete(key);
+			removed = this.cache.delete(key) || removed;
 		}
-		return true;
+		return removed;
 	}
 
 	async getTasks(params: {

--- a/packages/core/src/utils/confirmation.test.ts
+++ b/packages/core/src/utils/confirmation.test.ts
@@ -4,6 +4,8 @@
  * multilingual confirmation, and rejection of model-supplied authorization flags.
  */
 import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter.js";
+import { AgentRuntime } from "../runtime.js";
 import type { Memory } from "../types/memory.js";
 import type { IAgentRuntime } from "../types/runtime.js";
 import {
@@ -228,5 +230,60 @@ describe("confirmation utilities", () => {
 		expect(llmConfirmedFlagIsAuthoritative("true")).toBe(false);
 		expect(llmConfirmedFlagIsAuthoritative(1)).toBe(false);
 		expect(llmConfirmedFlagIsAuthoritative({})).toBe(false);
+	});
+
+	it("guarantees single-winner for concurrent affirmatives with real InMemoryDatabaseAdapter", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const runtime = {
+			getCache: async <T>(key: string) => {
+				const m = await adapter.getCaches<T>([key]);
+				return m.get(key);
+			},
+			setCache: async (key: string, value: unknown) => {
+				return adapter.setCaches([{ key, value }]);
+			},
+			deleteCache: async (key: string) => {
+				return adapter.deleteCaches([key]);
+			},
+		} as unknown as IAgentRuntime;
+
+		const message: Memory = {
+			entityId: "user-race-real",
+			content: { text: "delete database", source: "discord" },
+		} as unknown as Memory;
+
+		// 1. Initial request -> pending
+		await requireConfirmation({
+			runtime,
+			message,
+			actionName: "DELETE_DB",
+			prompt: "Confirm delete?",
+		});
+
+		// 2. Two concurrent confirmations racing on real adapter
+		const confirmMsg: Memory = {
+			entityId: "user-race-real",
+			content: { text: "yes", source: "discord" },
+		} as unknown as Memory;
+
+		const [res1, res2] = await Promise.all([
+			requireConfirmation({
+				runtime,
+				message: confirmMsg,
+				actionName: "DELETE_DB",
+				prompt: "Confirm delete?",
+			}),
+			requireConfirmation({
+				runtime,
+				message: confirmMsg,
+				actionName: "DELETE_DB",
+				prompt: "Confirm delete?",
+			}),
+		]);
+
+		const confirmedCount = [res1.status, res2.status].filter(
+			(s) => s === "confirmed",
+		).length;
+		expect(confirmedCount).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #29429.

In `packages/core/src/utils/confirmation.ts`, `requireConfirmation` read the pending confirmation record via `getCache` and subsequently called `deleteCache`. Under concurrent affirmative messages, multiple executions could both read the pending record before deletion, causing double execution of destructive actions.

### Changes
- Checks the return value of `runtime.deleteCache(cacheKey)` so that only the first successful delete resolves as confirmed; subsequent concurrent callers observe an already-consumed state.
- Adds concurrency test ensuring only one caller receives `status: "confirmed"` under simultaneous affirmative responses.