### PR TITLE
fix(remote): route iOS controller claims through native bridge

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		EKBD00010000000000000005 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EKBD00010000000000000107 /* PrivacyInfo.xcprivacy */; };
 		ELIZAKBDBRIDGE0000000001 /* ElizaKeyboardBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = ELIZAKBDBRIDGE0000000002 /* ElizaKeyboardBridge.swift */; };
 		GLASSBRIDGE0000000000001 /* GlassBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = GLASSBRIDGE0000000000002 /* GlassBridge.swift */; };
+		REMOTECTRL00000000000001 /* RemoteControllerIdentityPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = REMOTECTRL00000000000002 /* RemoteControllerIdentityPlugin.swift */; };
 		WBCB00010000000000000001 /* ActionRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = WBCB00010000000000000102 /* ActionRequestHandler.swift */; };
 		WBCB00010000000000000002 /* WebsiteBlockerContentExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = WBCB00010000000000000101 /* WebsiteBlockerContentExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AUIT00010000000000000001 /* BootCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000002 /* BootCaptureUITests.swift */; };
@@ -167,6 +168,7 @@
 		ELIZALIVEACT000000000002 /* ElizaLiveActivityBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaLiveActivityBridge.swift; sourceTree = "<group>"; };
 		ELIZAKBDBRIDGE0000000002 /* ElizaKeyboardBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaKeyboardBridge.swift; sourceTree = "<group>"; };
 		GLASSBRIDGE0000000000002 /* GlassBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassBridge.swift; sourceTree = "<group>"; };
+		REMOTECTRL00000000000002 /* RemoteControllerIdentityPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteControllerIdentityPlugin.swift; sourceTree = "<group>"; };
 		EKBD00010000000000000101 /* ElizaKeyboard.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ElizaKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		EKBD00010000000000000102 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		EKBD00010000000000000103 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				ELIZALIVEACT000000000002 /* ElizaLiveActivityBridge.swift */,
 				ELIZAKBDBRIDGE0000000002 /* ElizaKeyboardBridge.swift */,
 				GLASSBRIDGE0000000000002 /* GlassBridge.swift */,
+				REMOTECTRL00000000000002 /* RemoteControllerIdentityPlugin.swift */,
 				AWDG00010000000000000002 /* AgentWatchdog.swift */,
 				NTRN00010000000000000002 /* NativeTranscriptReducer.swift */,
 				NTRN00010000000000000004 /* NativeTranscriptBridge.swift */,
@@ -718,6 +721,7 @@
 				NTPY00010000000000000001 /* ElizaNotificationTriggerPolicy.swift in Sources */,
 				ELIZALIVEACT000000000001 /* ElizaLiveActivityBridge.swift in Sources */,
 				ELIZAKBDBRIDGE0000000001 /* ElizaKeyboardBridge.swift in Sources */,
+				REMOTECTRL00000000000001 /* RemoteControllerIdentityPlugin.swift in Sources */,
 				GLASSBRIDGE0000000000001 /* GlassBridge.swift in Sources */,
 				EWDG00010000000000000004 /* ElizaDictationAttributes.swift in Sources */,
 				EKBD00010000000000000004 /* ElizaKeyboardDictationState.swift in Sources */,

--- a/packages/app-core/platforms/ios/App/App/ElizaBridgeViewController.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaBridgeViewController.swift
@@ -29,6 +29,7 @@ class ElizaBridgeViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(ElizaKeyboardPlugin())
         bridge?.registerPluginInstance(ElizaLiveActivityPlugin())
         bridge?.registerPluginInstance(NativeTranscriptPlugin())
+        bridge?.registerPluginInstance(RemoteControllerIdentityPlugin())
         NSLog("[ElizaStartupTrace] iOS startupTraceId=%@", ElizaStartupTrace.currentId)
     }
 }

--- a/packages/app-core/platforms/ios/App/App/RemoteControllerIdentityPlugin.swift
+++ b/packages/app-core/platforms/ios/App/App/RemoteControllerIdentityPlugin.swift
@@ -1,0 +1,754 @@
+/**
+ Owns the iOS remote-controller identity, protocol signing, envelope crypto, and
+ durable per-session sequence state. Private P-256 material is stored in the
+ Keychain and never crosses the Capacitor bridge.
+ */
+import Capacitor
+import CryptoKit
+import Foundation
+import Security
+
+private enum RemoteControllerError: Error, LocalizedError {
+    case invalid(String)
+    case unavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalid(let message), .unavailable(let message): return message
+        }
+    }
+}
+
+enum RemoteControllerCodec {
+    static let maxBytes = 1_048_576
+
+    static func base64url(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    static func decodeBase64url(_ value: Any?) throws -> Data {
+        guard let value = value as? String, !value.isEmpty else {
+            throw RemoteControllerError.invalid("Remote controller base64url value is invalid.")
+        }
+        var encoded = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        encoded += String(repeating: "=", count: (4 - encoded.count % 4) % 4)
+        guard let data = Data(base64Encoded: encoded) else {
+            throw RemoteControllerError.invalid("Remote controller base64url value is invalid.")
+        }
+        return data
+    }
+
+    static func canonicalData(_ value: Any) throws -> Data {
+        var budget = maxBytes
+        let text = try canonical(value, depth: 0, budget: &budget)
+        guard let data = text.data(using: .utf8), data.count <= maxBytes else {
+            throw RemoteControllerError.invalid("Remote controller value exceeds canonical JSON limits.")
+        }
+        return data
+    }
+
+    private static func canonical(_ value: Any, depth: Int, budget: inout Int) throws -> String {
+        guard depth <= 64, budget > 0 else {
+            throw RemoteControllerError.invalid("Remote controller value exceeds canonical JSON limits.")
+        }
+        budget -= 1
+        if value is NSNull { return "null" }
+        if let value = value as? String { return try jsonScalar(value) }
+        if let value = value as? NSNumber {
+            if CFGetTypeID(value) == CFBooleanGetTypeID() { return value.boolValue ? "true" : "false" }
+            guard value.doubleValue.isFinite else {
+                throw RemoteControllerError.invalid("Remote controller number is invalid.")
+            }
+            return try jsonScalar(value)
+        }
+        if let value = value as? [Any] {
+            return "[" + (try value.map { try canonical($0, depth: depth + 1, budget: &budget) }).joined(separator: ",") + "]"
+        }
+        guard let value = value as? [String: Any] else {
+            throw RemoteControllerError.invalid("Remote controller JSON value is invalid.")
+        }
+        let keys = value.keys.sorted { left, right in
+            left.utf16.lexicographicallyPrecedes(right.utf16)
+        }
+        let fields = try keys.map { key -> String in
+            guard let member = value[key] else {
+                throw RemoteControllerError.invalid("Remote controller object is invalid.")
+            }
+            return try jsonScalar(key) + ":" + canonical(member, depth: depth + 1, budget: &budget)
+        }
+        return "{" + fields.joined(separator: ",") + "}"
+    }
+
+    private static func jsonScalar(_ value: Any) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: [value], options: [.withoutEscapingSlashes])
+        guard var text = String(data: data, encoding: .utf8), text.count >= 2 else {
+            throw RemoteControllerError.invalid("Remote controller JSON value is invalid.")
+        }
+        text.removeFirst()
+        text.removeLast()
+        return text
+    }
+
+    static func digest(_ value: Any) throws -> String {
+        base64url(Data(SHA256.hash(data: try canonicalData(value))))
+    }
+}
+
+private final class RemoteControllerKeychain {
+    private let service = "ai.eliza.remote-controller.v1"
+
+    func read(_ account: String) throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw RemoteControllerError.unavailable("Secure controller storage is unavailable.")
+        }
+        return data
+    }
+
+    func write(_ data: Data, account: String) throws {
+        let key: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let values: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let update = SecItemUpdate(key as CFDictionary, values as CFDictionary)
+        if update == errSecItemNotFound {
+            var created = key
+            values.forEach { created[$0.key] = $0.value }
+            guard SecItemAdd(created as CFDictionary, nil) == errSecSuccess else {
+                throw RemoteControllerError.unavailable("Secure controller storage is unavailable.")
+            }
+            return
+        }
+        guard update == errSecSuccess else {
+            throw RemoteControllerError.unavailable("Secure controller storage is unavailable.")
+        }
+    }
+}
+
+private final class RemoteControllerStore {
+    private let keychain = RemoteControllerKeychain()
+    private let queue = DispatchQueue(label: "ai.eliza.remote-controller.identity")
+    private let deviceAccount = "controller-device-id"
+
+    func mutate<T>(_ operation: () throws -> T) throws -> T { try queue.sync(execute: operation) }
+
+    func deviceId() throws -> String {
+        if let data = try keychain.read(deviceAccount) {
+            guard let value = String(data: data, encoding: .utf8), Self.identifier(value) else {
+                throw RemoteControllerError.invalid("Stored controller device identity is corrupt.")
+            }
+            return value
+        }
+        let created = UUID().uuidString.lowercased()
+        try keychain.write(Data(created.utf8), account: deviceAccount)
+        return created
+    }
+
+    func load(ownerId: String, deviceId: String) throws -> [String: Any]? {
+        guard let data = try keychain.read(account(ownerId: ownerId, deviceId: deviceId)) else { return nil }
+        guard let record = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              try valid(record: record, ownerId: ownerId, deviceId: deviceId) else {
+            throw RemoteControllerError.invalid("Stored controller identity is corrupt.")
+        }
+        return record
+    }
+
+    func save(_ record: [String: Any], ownerId: String, deviceId: String) throws {
+        let data = try JSONSerialization.data(withJSONObject: record, options: [.sortedKeys, .withoutEscapingSlashes])
+        try keychain.write(data, account: account(ownerId: ownerId, deviceId: deviceId))
+    }
+
+    private func account(ownerId: String, deviceId: String) -> String {
+        let digest = SHA256.hash(data: Data("\(ownerId)\0\(deviceId)".utf8))
+        return "identity-" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func identifier(_ value: Any?) -> Bool {
+        guard let value = value as? String, !value.isEmpty, value.count <= 256 else { return false }
+        return value.range(of: "^[A-Za-z0-9._:-]+$", options: .regularExpression) != nil
+    }
+
+    private func valid(record: [String: Any], ownerId: String, deviceId: String) throws -> Bool {
+        guard (record["version"] as? NSNumber)?.intValue == 1,
+              let identity = record["identity"] as? [String: Any],
+              (identity["version"] as? NSNumber)?.intValue == 1,
+              identity["role"] as? String == "controller",
+              identity["ownerId"] as? String == ownerId,
+              identity["deviceId"] as? String == deviceId,
+              identity["platform"] as? String == "ios",
+              Self.identifier(identity["keyId"]),
+              Self.identifier(identity["ownerId"]),
+              Self.identifier(identity["deviceId"]),
+              Self.displayName(identity["displayName"], max: 128),
+              let createdAt = identity["createdAt"] as? NSNumber,
+              createdAt.int64Value >= 0,
+              let signingEncoded = record["signingPrivateKey"] as? String,
+              let encryptionEncoded = record["encryptionPrivateKey"] as? String else { return false }
+        let signingData = try RemoteControllerCodec.decodeBase64url(signingEncoded)
+        let encryptionData = try RemoteControllerCodec.decodeBase64url(encryptionEncoded)
+        guard signingData.count == 32, encryptionData.count == 32,
+              let signing = try? P256.Signing.PrivateKey(rawRepresentation: signingData),
+              let encryption = try? P256.KeyAgreement.PrivateKey(rawRepresentation: encryptionData),
+              let signingJwk = identity["signingPublicKeyJwk"] as? [String: Any],
+              let encryptionJwk = identity["encryptionPublicKeyJwk"] as? [String: Any],
+              try publicJwk(signing.publicKey.rawRepresentation) == RemoteControllerCodec.canonicalData(signingJwk),
+              try publicJwk(encryption.publicKey.rawRepresentation) == RemoteControllerCodec.canonicalData(encryptionJwk),
+              identity["keyId"] as? String == "p256:" + (try RemoteControllerCodec.digest([
+                  "signingPublicKeyJwk": signingJwk,
+                  "encryptionPublicKeyJwk": encryptionJwk,
+              ])) else { return false }
+
+        guard let sessions = record["sessionSequences"] as? [String: Any], sessions.count <= 256 else {
+            return false
+        }
+        return sessions.allSatisfy { sessionId, value in
+            guard Self.identifier(sessionId), let entry = value as? [String: Any],
+                  Self.digest(entry["bindingDigest"]),
+                  let sequence = entry["sequence"] as? NSNumber,
+                  sequence.intValue >= 1, Double(sequence.intValue) == sequence.doubleValue else { return false }
+            guard let pendingValue = entry["pending"] else { return true }
+            guard let pending = pendingValue as? [String: Any],
+                  Self.digest(pending["requestDigest"]),
+                  Self.identifier(pending["commandId"]),
+                  let expiresAt = pending["expiresAt"] as? NSNumber,
+                  expiresAt.int64Value >= 0,
+                  let command = pending["command"] as? [String: Any],
+                  let body = command["body"] as? [String: Any],
+                  let envelope = pending["envelope"] as? [String: Any],
+                  envelope["messageKind"] as? String == "command",
+                  command["signatureAlgorithm"] as? String == "ECDSA-P256-SHA256",
+                  Self.identifier(command["signature"]),
+                  body["commandId"] as? String == pending["commandId"] as? String,
+                  envelope["commandId"] as? String == pending["commandId"] as? String,
+                  (body["sequence"] as? NSNumber)?.intValue == sequence.intValue,
+                  (envelope["sequence"] as? NSNumber)?.intValue == sequence.intValue,
+                  (body["expiresAt"] as? NSNumber)?.int64Value == expiresAt.int64Value,
+                  (envelope["expiresAt"] as? NSNumber)?.int64Value == expiresAt.int64Value,
+                  Self.sameBinding(body, envelope) else { return false }
+            return true
+        }
+    }
+
+    private func publicJwk(_ raw: Data) throws -> Data {
+        guard raw.count == 65, raw.first == 0x04 else { return Data() }
+        return try RemoteControllerCodec.canonicalData([
+            "kty": "EC", "crv": "P-256",
+            "x": RemoteControllerCodec.base64url(raw[1..<33]),
+            "y": RemoteControllerCodec.base64url(raw[33..<65]),
+        ])
+    }
+
+    private static func digest(_ value: Any?) -> Bool {
+        guard let value = value as? String else { return false }
+        return value.range(of: "^[A-Za-z0-9_-]{43}$", options: .regularExpression) != nil
+    }
+
+    static func displayName(_ value: Any?, max: Int = 256) -> Bool {
+        guard let value = value as? String, !value.isEmpty, value.count <= max,
+              value == value.trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+        return value.unicodeScalars.allSatisfy { $0.value > 0x1f && $0.value != 0x7f }
+    }
+
+    private static func sameBinding(_ left: [String: Any], _ right: [String: Any]) -> Bool {
+        let keys = [
+            "version", "ownerId", "grantId", "grantRevision", "sessionId", "controllerDeviceId",
+            "controllerKeyId", "targetRuntimeId", "targetKeyId", "commandId",
+        ]
+        let first = Dictionary(uniqueKeysWithValues: keys.map { ($0, left[$0] ?? NSNull()) })
+        let second = Dictionary(uniqueKeysWithValues: keys.map { ($0, right[$0] ?? NSNull()) })
+        return (try? RemoteControllerCodec.canonicalData(first)) == (try? RemoteControllerCodec.canonicalData(second))
+    }
+}
+
+@objc(RemoteControllerIdentityPlugin)
+public final class RemoteControllerIdentityPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "RemoteControllerIdentityPlugin"
+    public let jsName = "RemoteControllerIdentity"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getOrCreateIdentity", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "createCommand", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "acknowledgeEnqueue", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "openResult", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "openStartReceipt", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearSessionState", returnType: CAPPluginReturnPromise),
+    ]
+
+    private let store = RemoteControllerStore()
+    private let actions: Set<String> = [
+        "agent.request", "agent.message", "agent.pause", "agent.resume", "agent.stop", "agent.status",
+    ]
+
+    @objc public func getOrCreateIdentity(_ call: CAPPluginCall) {
+        resolve(call) {
+            try self.store.mutate {
+                let ownerId = try self.requiredIdentifier(call, "ownerId")
+                let displayName = try self.requiredString(call, "displayName", max: 128)
+                guard call.getString("platform") == "ios" else {
+                    throw RemoteControllerError.invalid("Controller platform must be ios.")
+                }
+                let deviceId = try self.store.deviceId()
+                if let existing = try self.store.load(ownerId: ownerId, deviceId: deviceId),
+                   let identity = existing["identity"] as? [String: Any] {
+                    return identity
+                }
+                let signing = P256.Signing.PrivateKey()
+                let encryption = P256.KeyAgreement.PrivateKey()
+                let signingJwk = try self.publicJwk(signing.publicKey.rawRepresentation)
+                let encryptionJwk = try self.publicJwk(encryption.publicKey.rawRepresentation)
+                let keyId = "p256:" + (try RemoteControllerCodec.digest([
+                    "signingPublicKeyJwk": signingJwk,
+                    "encryptionPublicKeyJwk": encryptionJwk,
+                ]))
+                let identity: [String: Any] = [
+                    "version": 1, "role": "controller", "ownerId": ownerId,
+                    "deviceId": deviceId, "keyId": keyId, "displayName": displayName,
+                    "platform": "ios", "signingPublicKeyJwk": signingJwk,
+                    "encryptionPublicKeyJwk": encryptionJwk,
+                    "createdAt": Int64(Date().timeIntervalSince1970 * 1_000),
+                ]
+                try self.store.save([
+                    "version": 1, "identity": identity,
+                    "signingPrivateKey": RemoteControllerCodec.base64url(signing.rawRepresentation),
+                    "encryptionPrivateKey": RemoteControllerCodec.base64url(encryption.rawRepresentation),
+                    "sessionSequences": [String: Any](),
+                ], ownerId: ownerId, deviceId: deviceId)
+                return identity
+            }
+        }
+    }
+
+    @objc public func createCommand(_ call: CAPPluginCall) {
+        resolve(call) {
+            try self.store.mutate {
+                let ownerId = try self.requiredIdentifier(call, "ownerId")
+                let controllerDeviceId = try self.requiredIdentifier(call, "controllerDeviceId")
+                let identifiers = ["grantId", "sessionId", "controllerKeyId", "targetRuntimeId", "targetKeyId"]
+                var input: [String: String] = [:]
+                for name in identifiers { input[name] = try self.requiredIdentifier(call, name) }
+                guard let revision = call.getInt("grantRevision"), revision >= 1,
+                      let action = call.getString("action"), self.actions.contains(action),
+                      let payload = call.options["payload"],
+                      let targetJwk = call.getObject("targetEncryptionPublicKeyJwk") else {
+                    throw RemoteControllerError.invalid("Remote command authority is invalid.")
+                }
+                _ = try RemoteControllerCodec.canonicalData(payload)
+                guard var record = try self.store.load(ownerId: ownerId, deviceId: controllerDeviceId),
+                      let identity = record["identity"] as? [String: Any],
+                      identity["keyId"] as? String == input["controllerKeyId"],
+                      let signingData = try? RemoteControllerCodec.decodeBase64url(record["signingPrivateKey"]),
+                      let signing = try? P256.Signing.PrivateKey(rawRepresentation: signingData) else {
+                    throw RemoteControllerError.unavailable("Controller identity is unavailable or changed.")
+                }
+                let binding: [String: Any] = [
+                    "ownerId": ownerId, "grantId": input["grantId"]!, "grantRevision": revision,
+                    "sessionId": input["sessionId"]!, "controllerDeviceId": controllerDeviceId,
+                    "controllerKeyId": input["controllerKeyId"]!, "targetRuntimeId": input["targetRuntimeId"]!,
+                    "targetKeyId": input["targetKeyId"]!,
+                ]
+                let bindingDigest = try RemoteControllerCodec.digest(binding)
+                let requestDigest = try RemoteControllerCodec.digest(["action": action, "payload": payload])
+                var sessions = record["sessionSequences"] as? [String: Any] ?? [:]
+                let sessionId = input["sessionId"]!
+                if let previous = sessions[sessionId] as? [String: Any],
+                   previous["bindingDigest"] as? String == bindingDigest,
+                   let pending = previous["pending"] as? [String: Any],
+                   let command = pending["command"] as? [String: Any],
+                   let envelope = pending["envelope"] as? [String: Any],
+                   let commandId = pending["commandId"] as? String,
+                   let expiresAt = pending["expiresAt"] as? NSNumber {
+                    return [
+                        "commandId": commandId, "expiresAt": expiresAt,
+                        "command": command, "envelope": envelope,
+                        "recoveredPending": pending["requestDigest"] as? String != requestDigest,
+                        "bindingDigest": bindingDigest,
+                    ]
+                }
+                let previous = sessions[sessionId] as? [String: Any]
+                if previous == nil && sessions.count >= 256 {
+                    throw RemoteControllerError.unavailable("Secure remote session capacity is exhausted.")
+                }
+                let sequence = previous?["bindingDigest"] as? String == bindingDigest
+                    ? ((previous?["sequence"] as? NSNumber)?.intValue ?? 0) + 1 : 1
+                let issuedAt = Int64(Date().timeIntervalSince1970 * 1_000)
+                let commandId = UUID().uuidString.lowercased()
+                var body = binding
+                body["version"] = 1; body["commandId"] = commandId; body["sequence"] = sequence
+                body["nonce"] = UUID().uuidString.lowercased(); body["issuedAt"] = issuedAt
+                body["expiresAt"] = issuedAt + 60_000; body["action"] = action; body["payload"] = payload
+                body["payloadDigest"] = try RemoteControllerCodec.digest(payload)
+                let signature = try signing.signature(for: RemoteControllerCodec.canonicalData(body))
+                let command: [String: Any] = [
+                    "body": body, "signatureAlgorithm": "ECDSA-P256-SHA256",
+                    "signature": RemoteControllerCodec.base64url(signature.derRepresentation),
+                ]
+                let envelope = try self.seal(command: command, body: body, targetJwk: targetJwk)
+                let pending: [String: Any] = [
+                    "requestDigest": requestDigest, "commandId": commandId,
+                    "expiresAt": issuedAt + 60_000, "command": command, "envelope": envelope,
+                ]
+                sessions[sessionId] = ["bindingDigest": bindingDigest, "sequence": sequence, "pending": pending]
+                record["sessionSequences"] = sessions
+                try self.store.save(record, ownerId: ownerId, deviceId: controllerDeviceId)
+                return [
+                    "commandId": commandId, "expiresAt": issuedAt + 60_000,
+                    "command": command, "envelope": envelope,
+                    "recoveredPending": false, "bindingDigest": bindingDigest,
+                ]
+            }
+        }
+    }
+
+    @objc public func acknowledgeEnqueue(_ call: CAPPluginCall) {
+        resolve(call) {
+            try self.store.mutate {
+                let ownerId = try self.requiredIdentifier(call, "ownerId")
+                let deviceId = try self.requiredIdentifier(call, "controllerDeviceId")
+                let sessionId = try self.requiredIdentifier(call, "sessionId")
+                let commandId = try self.requiredIdentifier(call, "commandId")
+                let bindingDigest = try self.requiredString(call, "bindingDigest", max: 128)
+                guard var record = try self.store.load(ownerId: ownerId, deviceId: deviceId),
+                      var sessions = record["sessionSequences"] as? [String: Any],
+                      let entry = sessions[sessionId] as? [String: Any],
+                      let pending = entry["pending"] as? [String: Any] else { return ["acknowledged": false] }
+                guard entry["bindingDigest"] as? String == bindingDigest,
+                      pending["commandId"] as? String == commandId else {
+                    throw RemoteControllerError.invalid("Remote enqueue acknowledgement does not match the pending command.")
+                }
+                sessions[sessionId] = ["bindingDigest": bindingDigest, "sequence": entry["sequence"]!]
+                record["sessionSequences"] = sessions
+                try self.store.save(record, ownerId: ownerId, deviceId: deviceId)
+                return ["acknowledged": true]
+            }
+        }
+    }
+
+    @objc public func clearSessionState(_ call: CAPPluginCall) {
+        resolve(call) {
+            try self.store.mutate {
+                let ownerId = try self.requiredIdentifier(call, "ownerId")
+                let deviceId = try self.requiredIdentifier(call, "controllerDeviceId")
+                let sessionId = try self.requiredIdentifier(call, "sessionId")
+                guard var record = try self.store.load(ownerId: ownerId, deviceId: deviceId),
+                      var sessions = record["sessionSequences"] as? [String: Any],
+                      let entry = sessions[sessionId] as? [String: Any] else { return ["cleared": false] }
+                guard entry["pending"] == nil else {
+                    throw RemoteControllerError.invalid("A remote command is still awaiting enqueue acknowledgement.")
+                }
+                sessions.removeValue(forKey: sessionId); record["sessionSequences"] = sessions
+                try self.store.save(record, ownerId: ownerId, deviceId: deviceId)
+                return ["cleared": true]
+            }
+        }
+    }
+
+    @objc public func openResult(_ call: CAPPluginCall) {
+        open(call, kind: "result") { message in
+            guard let body = message["body"] as? [String: Any], let status = body["status"] as? String else {
+                throw RemoteControllerError.invalid("Remote result plaintext is invalid.")
+            }
+            var output: [String: Any] = ["status": status]
+            if let result = body["result"] { output["result"] = result }
+            if let code = body["errorCode"] { output["errorCode"] = code }
+            return output
+        }
+    }
+
+    @objc public func openStartReceipt(_ call: CAPPluginCall) {
+        open(call, kind: "start_receipt") { message in
+            guard let body = message["body"] as? [String: Any],
+                  let startedAt = body["startedAt"] as? NSNumber,
+                  let executionId = body["executionId"] as? String else {
+                throw RemoteControllerError.invalid("Remote start receipt plaintext is invalid.")
+            }
+            return ["startedAt": startedAt, "executionId": executionId]
+        }
+    }
+
+    private func open(_ call: CAPPluginCall, kind: String, project: @escaping ([String: Any]) throws -> [String: Any]) {
+        resolve(call) {
+            let ownerId = try self.requiredIdentifier(call, "ownerId")
+            let deviceId = try self.requiredIdentifier(call, "controllerDeviceId")
+            guard let envelope = call.getObject("envelope"), envelope["messageKind"] as? String == kind,
+                  self.validEnvelope(envelope, kind: kind),
+                  let command = call.getObject("command"), self.validCommand(command),
+                  let commandBody = command["body"] as? [String: Any],
+                  let target = call.getObject("targetIdentity"), self.validTarget(target),
+                  let record = try self.store.mutate({ try self.store.load(ownerId: ownerId, deviceId: deviceId) }),
+                  let identity = record["identity"] as? [String: Any],
+                  identity["keyId"] as? String == envelope["recipientKeyId"] as? String,
+                  let privateData = try? RemoteControllerCodec.decodeBase64url(record["encryptionPrivateKey"]),
+                  let privateKey = try? P256.KeyAgreement.PrivateKey(rawRepresentation: privateData),
+                  self.equalBinding(envelope, commandBody),
+                  envelope["senderKeyId"] as? String == commandBody["targetKeyId"] as? String,
+                  envelope["recipientKeyId"] as? String == commandBody["controllerKeyId"] as? String else {
+                throw RemoteControllerError.invalid("Remote result authority is invalid.")
+            }
+            let message = try self.decrypt(envelope: envelope, commandBody: commandBody, privateKey: privateKey)
+            try self.verify(message: message, target: target, commandBody: commandBody)
+            return try project(message)
+        }
+    }
+
+    private func seal(command: [String: Any], body: [String: Any], targetJwk: [String: Any]) throws -> [String: Any] {
+        let recipient = try P256.KeyAgreement.PublicKey(rawRepresentation: publicRaw(targetJwk))
+        let ephemeral = P256.KeyAgreement.PrivateKey()
+        let shared = try ephemeral.sharedSecretFromKeyAgreement(with: recipient)
+        var header = binding(from: body)
+        header["algorithm"] = "ECDH-P256-HKDF-SHA256+A256GCM"; header["messageKind"] = "command"
+        header["senderKeyId"] = body["controllerKeyId"]; header["recipientKeyId"] = body["targetKeyId"]
+        header["messageDigest"] = try RemoteControllerCodec.digest(command)
+        for key in ["sequence", "nonce", "issuedAt", "expiresAt"] { header[key] = body[key] }
+        let aad = try RemoteControllerCodec.canonicalData(header)
+        let salt = try randomData(count: 32); let nonceData = try randomData(count: 12)
+        let info = Data(SHA256.hash(data: Data("eliza-remote-control-v1\0".utf8) + aad))
+        let key = shared.hkdfDerivedSymmetricKey(using: SHA256.self, salt: salt, sharedInfo: info, outputByteCount: 32)
+        let nonce = try AES.GCM.Nonce(data: nonceData)
+        let sealed = try AES.GCM.seal(RemoteControllerCodec.canonicalData(command), using: key, nonce: nonce, authenticating: aad)
+        var envelope = header
+        envelope["ephemeralPublicKeyJwk"] = try publicJwk(ephemeral.publicKey.rawRepresentation)
+        envelope["salt"] = RemoteControllerCodec.base64url(salt); envelope["iv"] = RemoteControllerCodec.base64url(nonceData)
+        envelope["ciphertext"] = RemoteControllerCodec.base64url(sealed.ciphertext + sealed.tag)
+        return envelope
+    }
+
+    private func decrypt(envelope: [String: Any], commandBody: [String: Any], privateKey: P256.KeyAgreement.PrivateKey) throws -> [String: Any] {
+        guard let ephemeralJwk = envelope["ephemeralPublicKeyJwk"] as? [String: Any] else {
+            throw RemoteControllerError.invalid("Remote envelope key is invalid.")
+        }
+        let ephemeral = try P256.KeyAgreement.PublicKey(rawRepresentation: publicRaw(ephemeralJwk))
+        let shared = try privateKey.sharedSecretFromKeyAgreement(with: ephemeral)
+        var header = binding(from: envelope)
+        for key in ["algorithm", "messageKind", "senderKeyId", "recipientKeyId", "messageDigest"] { header[key] = envelope[key] }
+        let aad = try RemoteControllerCodec.canonicalData(header)
+        let salt = try RemoteControllerCodec.decodeBase64url(envelope["salt"])
+        let iv = try RemoteControllerCodec.decodeBase64url(envelope["iv"])
+        let combined = try RemoteControllerCodec.decodeBase64url(envelope["ciphertext"])
+        guard combined.count > 16 else { throw RemoteControllerError.invalid("Remote ciphertext is invalid.") }
+        let info = Data(SHA256.hash(data: Data("eliza-remote-control-v1\0".utf8) + aad))
+        let key = shared.hkdfDerivedSymmetricKey(using: SHA256.self, salt: salt, sharedInfo: info, outputByteCount: 32)
+        let box = try AES.GCM.SealedBox(nonce: AES.GCM.Nonce(data: iv), ciphertext: combined.dropLast(16), tag: combined.suffix(16))
+        let plaintext = try AES.GCM.open(box, using: key, authenticating: aad)
+        guard let message = try JSONSerialization.jsonObject(with: plaintext) as? [String: Any],
+              try RemoteControllerCodec.digest(message) == envelope["messageDigest"] as? String,
+              equalBinding(message["body"] as? [String: Any], commandBody) else {
+            throw RemoteControllerError.invalid("Remote plaintext binding is invalid.")
+        }
+        return message
+    }
+
+    private func verify(message: [String: Any], target: [String: Any], commandBody: [String: Any]) throws {
+        let commandDigest = try RemoteControllerCodec.digest(commandBody)
+        guard let body = message["body"] as? [String: Any], equalBinding(body, commandBody),
+              Set(message.keys) == ["body", "signatureAlgorithm", "signature"],
+              message["signatureAlgorithm"] as? String == "ECDSA-P256-SHA256",
+              let signatureData = try? RemoteControllerCodec.decodeBase64url(message["signature"]),
+              let signature = try? P256.Signing.ECDSASignature(derRepresentation: signatureData),
+              let jwk = target["signingPublicKeyJwk"] as? [String: Any],
+              let publicKey = try? P256.Signing.PublicKey(rawRepresentation: publicRaw(jwk)),
+              publicKey.isValidSignature(signature, for: try RemoteControllerCodec.canonicalData(body)),
+              target["role"] as? String == "target", target["ownerId"] as? String == body["ownerId"] as? String,
+              target["runtimeId"] as? String == body["targetRuntimeId"] as? String,
+              target["keyId"] as? String == body["targetKeyId"] as? String,
+              body["commandDigest"] as? String == commandDigest else {
+            throw RemoteControllerError.invalid("Remote signature or command binding is invalid.")
+        }
+        if body["status"] != nil {
+            guard let status = body["status"] as? String,
+                  ["completed", "rejected", "cancelled", "execution_ambiguous"].contains(status),
+                  Set(body.keys).isSubset(of: Set(bindingKeys + [
+                      "commandDigest", "status", "executionId", "startedAt", "completedAt",
+                      "result", "errorCode", "resultDigest",
+                  ])),
+                  let completedAt = body["completedAt"] as? NSNumber,
+                  self.integer(completedAt, minimum: 0),
+                  self.digest(body["resultDigest"]),
+                  body["errorCode"] == nil || RemoteControllerStore.identifier(body["errorCode"]) else {
+                throw RemoteControllerError.invalid("Remote result status is invalid.")
+            }
+            let executionId = body["executionId"]
+            let startedAt = body["startedAt"]
+            let hasExecution = RemoteControllerStore.identifier(executionId)
+                && (startedAt as? NSNumber).map { self.integer($0, minimum: 0) } == true
+            let hasNoExecution = executionId is NSNull && startedAt is NSNull
+            guard (hasExecution || hasNoExecution), status == "rejected" || hasExecution,
+                  !hasExecution || completedAt.int64Value >= (startedAt as! NSNumber).int64Value else {
+                throw RemoteControllerError.invalid("Remote result execution metadata is invalid.")
+            }
+            var resultValue: [String: Any] = [:]
+            if let result = body["result"] { resultValue["result"] = result }
+            if let errorCode = body["errorCode"] { resultValue["errorCode"] = errorCode }
+            let resultDigest = try RemoteControllerCodec.digest(resultValue)
+            guard body["resultDigest"] as? String == resultDigest else {
+                throw RemoteControllerError.invalid("Remote result digest is invalid.")
+            }
+        } else {
+            guard let startedAt = body["startedAt"] as? NSNumber,
+                  self.integer(startedAt, minimum: 0),
+                  RemoteControllerStore.identifier(body["executionId"]),
+                  body["status"] as? String == "started",
+                  Set(body.keys) == Set(bindingKeys + ["status", "commandDigest", "executionId", "startedAt"]) else {
+                throw RemoteControllerError.invalid("Remote start receipt is invalid.")
+            }
+        }
+    }
+
+    private var bindingKeys: [String] {
+        [
+            "version", "ownerId", "grantId", "grantRevision", "sessionId", "controllerDeviceId",
+            "controllerKeyId", "targetRuntimeId", "targetKeyId", "commandId",
+        ]
+    }
+
+    private func validBinding(_ value: [String: Any]) -> Bool {
+        guard (value["version"] as? NSNumber)?.intValue == 1,
+              let revision = value["grantRevision"] as? NSNumber,
+              integer(revision, minimum: 1) else { return false }
+        return bindingKeys.filter { $0 != "version" && $0 != "grantRevision" }
+            .allSatisfy { RemoteControllerStore.identifier(value[$0]) }
+    }
+
+    private func validCommand(_ value: [String: Any]) -> Bool {
+        guard Set(value.keys) == ["body", "signatureAlgorithm", "signature"],
+              value["signatureAlgorithm"] as? String == "ECDSA-P256-SHA256",
+              let signature = value["signature"] as? String, !signature.isEmpty, signature.count <= 512,
+              let body = value["body"] as? [String: Any], validBinding(body),
+              Set(body.keys) == Set(bindingKeys + [
+                  "sequence", "nonce", "issuedAt", "expiresAt", "action", "payload", "payloadDigest",
+              ]),
+              let sequence = body["sequence"] as? NSNumber, integer(sequence, minimum: 1),
+              RemoteControllerStore.identifier(body["nonce"]),
+              let issuedAt = body["issuedAt"] as? NSNumber, integer(issuedAt, minimum: 0),
+              let expiresAt = body["expiresAt"] as? NSNumber, integer(expiresAt, minimum: 0),
+              expiresAt.int64Value > issuedAt.int64Value,
+              expiresAt.int64Value - issuedAt.int64Value <= 60_000,
+              let action = body["action"] as? String, actions.contains(action),
+              let payload = body["payload"], digest(body["payloadDigest"]),
+              (try? RemoteControllerCodec.digest(payload)) == body["payloadDigest"] as? String else { return false }
+        return true
+    }
+
+    private func validEnvelope(_ value: [String: Any], kind: String) -> Bool {
+        guard validBinding(value),
+              Set(value.keys) == Set(bindingKeys + [
+                  "algorithm", "messageKind", "senderKeyId", "recipientKeyId", "messageDigest",
+                  "ephemeralPublicKeyJwk", "salt", "iv", "ciphertext",
+              ]),
+              value["algorithm"] as? String == "ECDH-P256-HKDF-SHA256+A256GCM",
+              value["messageKind"] as? String == kind,
+              RemoteControllerStore.identifier(value["senderKeyId"]),
+              RemoteControllerStore.identifier(value["recipientKeyId"]),
+              digest(value["messageDigest"]),
+              let jwk = value["ephemeralPublicKeyJwk"] as? [String: Any],
+              (try? publicRaw(jwk)) != nil,
+              (try? RemoteControllerCodec.decodeBase64url(value["salt"]).count) == 32,
+              (try? RemoteControllerCodec.decodeBase64url(value["iv"]).count) == 12,
+              (try? RemoteControllerCodec.decodeBase64url(value["ciphertext"]).count).map({ $0 > 16 }) == true else {
+            return false
+        }
+        return true
+    }
+
+    private func validTarget(_ value: [String: Any]) -> Bool {
+        guard Set(value.keys) == [
+            "version", "role", "ownerId", "runtimeId", "keyId", "displayName", "platform",
+            "signingPublicKeyJwk", "encryptionPublicKeyJwk", "createdAt",
+        ],
+              (value["version"] as? NSNumber)?.intValue == 1,
+              value["role"] as? String == "target",
+              RemoteControllerStore.identifier(value["ownerId"]),
+              RemoteControllerStore.identifier(value["runtimeId"]),
+              RemoteControllerStore.identifier(value["keyId"]),
+              RemoteControllerStore.displayName(value["displayName"]),
+              ["ios", "macos", "windows", "linux", "android", "web"].contains(value["platform"] as? String),
+              let signing = value["signingPublicKeyJwk"] as? [String: Any],
+              let encryption = value["encryptionPublicKeyJwk"] as? [String: Any],
+              (try? publicRaw(signing)) != nil, (try? publicRaw(encryption)) != nil,
+              let createdAt = value["createdAt"] as? NSNumber, integer(createdAt, minimum: 0) else { return false }
+        return true
+    }
+
+    private func integer(_ value: NSNumber, minimum: Int64) -> Bool {
+        value.doubleValue.isFinite && value.doubleValue.rounded(.towardZero) == value.doubleValue
+            && value.doubleValue <= 9_007_199_254_740_991 && value.int64Value >= minimum
+    }
+
+    private func digest(_ value: Any?) -> Bool {
+        guard let value = value as? String else { return false }
+        return value.range(of: "^[A-Za-z0-9_-]{43}$", options: .regularExpression) != nil
+    }
+
+    private func binding(from value: [String: Any]) -> [String: Any] {
+        var output: [String: Any] = [:]
+        for key in bindingKeys {
+            output[key] = value[key]
+        }
+        return output
+    }
+
+    private func equalBinding(_ left: [String: Any]?, _ right: [String: Any]?) -> Bool {
+        guard let left, let right else { return false }
+        return (try? RemoteControllerCodec.canonicalData(binding(from: left))) == (try? RemoteControllerCodec.canonicalData(binding(from: right)))
+    }
+
+    private func publicRaw(_ jwk: [String: Any]) throws -> Data {
+        guard jwk["kty"] as? String == "EC", jwk["crv"] as? String == "P-256" else {
+            throw RemoteControllerError.invalid("Remote P-256 public key is invalid.")
+        }
+        let x = try RemoteControllerCodec.decodeBase64url(jwk["x"]), y = try RemoteControllerCodec.decodeBase64url(jwk["y"])
+        guard x.count == 32, y.count == 32 else { throw RemoteControllerError.invalid("Remote P-256 public key is invalid.") }
+        return Data([0x04]) + x + y
+    }
+
+    private func publicJwk(_ raw: Data) throws -> [String: Any] {
+        guard raw.count == 65, raw.first == 0x04 else { throw RemoteControllerError.invalid("Generated P-256 key is invalid.") }
+        return ["kty": "EC", "crv": "P-256", "x": RemoteControllerCodec.base64url(raw[1..<33]), "y": RemoteControllerCodec.base64url(raw[33..<65])]
+    }
+
+    private func randomData(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        guard SecRandomCopyBytes(kSecRandomDefault, count, &bytes) == errSecSuccess else {
+            throw RemoteControllerError.unavailable("Secure random generation is unavailable.")
+        }
+        return Data(bytes)
+    }
+
+    private func requiredIdentifier(_ call: CAPPluginCall, _ name: String) throws -> String {
+        guard let value = call.getString(name), RemoteControllerStore.identifier(value) else {
+            throw RemoteControllerError.invalid("Remote controller \(name) is invalid.")
+        }
+        return value
+    }
+
+    private func requiredString(_ call: CAPPluginCall, _ name: String, max: Int) throws -> String {
+        guard let value = call.getString(name)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty, value.count <= max else {
+            throw RemoteControllerError.invalid("Remote controller \(name) is invalid.")
+        }
+        return value
+    }
+
+    private func resolve(_ call: CAPPluginCall, operation: @escaping () throws -> [String: Any]) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do { call.resolve(try operation()) }
+            // error-policy:J1 Capacitor is the native transport boundary.
+            catch { call.reject(error.localizedDescription) }
+        }
+    }
+}

--- a/packages/app-core/platforms/ios/tests/RemoteControllerIdentityConformance.swift
+++ b/packages/app-core/platforms/ios/tests/RemoteControllerIdentityConformance.swift
@@ -1,0 +1,46 @@
+/**
+ Command-line native conformance checks for the controller bridge's canonical
+ JSON and P-256 signature representation. It compiles with the tracked plugin
+ so native protocol drift fails before an iOS package is claimed as usable.
+ */
+import CryptoKit
+import Foundation
+
+enum RemoteControllerIdentityConformanceError: Error {
+    case mismatch(String)
+}
+
+@main
+enum RemoteControllerIdentityConformance {
+    static func main() throws {
+        let value: [String: Any] = [
+            "z": [3, NSNull(), true] as [Any],
+            "a": ["slash": "https://example.test/a/b", "quote": "\"line\n"] as [String: Any],
+        ]
+        let canonical = String(decoding: try RemoteControllerCodec.canonicalData(value), as: UTF8.self)
+        let expected = #"{"a":{"quote":"\"line\n","slash":"https://example.test/a/b"},"z":[3,null,true]}"#
+        guard canonical == expected else {
+            throw RemoteControllerIdentityConformanceError.mismatch("canonical JSON differs: \(canonical)")
+        }
+
+        let privateKey = P256.Signing.PrivateKey()
+        let body: [String: Any] = ["commandId": "command-1", "sequence": 1, "payload": value]
+        let bytes = try RemoteControllerCodec.canonicalData(body)
+        let signature = try privateKey.signature(for: bytes)
+        let roundTrip = try P256.Signing.ECDSASignature(derRepresentation: signature.derRepresentation)
+        guard privateKey.publicKey.isValidSignature(roundTrip, for: bytes) else {
+            throw RemoteControllerIdentityConformanceError.mismatch("P-256 DER signature did not round-trip")
+        }
+
+        let plugin = RemoteControllerIdentityPlugin()
+        let methods = Set(plugin.pluginMethods.map(\.name))
+        let expectedMethods: Set<String> = [
+            "getOrCreateIdentity", "createCommand", "acknowledgeEnqueue",
+            "openResult", "openStartReceipt", "clearSessionState",
+        ]
+        guard methods == expectedMethods else {
+            throw RemoteControllerIdentityConformanceError.mismatch("Capacitor method contract differs")
+        }
+        print("iOS remote controller native conformance passed")
+    }
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2237,12 +2237,15 @@ function handleDeepLink(url: string): undefined | Promise<boolean> {
     APP_URL_SCHEME,
   );
   if (remotePairing) {
-    if (
-      !isElectrobunRuntime() ||
-      !navigator.platform.toLowerCase().includes("linux")
-    ) {
+    const isLinuxDesktop =
+      isElectrobunRuntime() &&
+      typeof navigator !== "undefined" &&
+      navigator.platform.toLowerCase().includes("linux");
+    const isNativeIOS =
+      Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
+    if (!isLinuxDesktop && !isNativeIOS) {
       console.warn(
-        `${APP_LOG_PREFIX} Remote target pairing is available only on the enrolled Linux desktop target`,
+        `${APP_LOG_PREFIX} Remote controller pairing is available only on an enrolled Linux desktop or signed-in iPhone`,
       );
       return;
     }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2248,7 +2248,7 @@ function handleDeepLink(url: string): undefined | Promise<boolean> {
       })
     ) {
       console.warn(
-        `${APP_LOG_PREFIX} Remote controller pairing is available only on an enrolled Linux desktop or signed-in iPhone`,
+        `${APP_LOG_PREFIX} Remote controller pairing is available only on an enrolled Linux desktop or a compatible signed-in iPhone`,
       );
       return;
     }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -247,6 +247,7 @@ import {
   SIDE_EFFECT_APP_MODULE_LOADERS,
   type SideEffectAppModuleLoader,
 } from "./plugin-registrations";
+import { isRemoteControllerPairingRuntimeAllowed } from "./remote-controller-deep-link";
 import {
   PHONE_COMPANION_AGENT_VIEW_ID,
   resolveRendererShellKind,
@@ -2237,13 +2238,15 @@ function handleDeepLink(url: string): undefined | Promise<boolean> {
     APP_URL_SCHEME,
   );
   if (remotePairing) {
-    const isLinuxDesktop =
-      isElectrobunRuntime() &&
-      typeof navigator !== "undefined" &&
-      navigator.platform.toLowerCase().includes("linux");
-    const isNativeIOS =
-      Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
-    if (!isLinuxDesktop && !isNativeIOS) {
+    if (
+      !isRemoteControllerPairingRuntimeAllowed({
+        isElectrobun: isElectrobunRuntime(),
+        navigatorPlatform:
+          typeof navigator === "undefined" ? "" : navigator.platform,
+        nativePlatform: Capacitor.getPlatform(),
+        native: Capacitor.isNativePlatform(),
+      })
+    ) {
       console.warn(
         `${APP_LOG_PREFIX} Remote controller pairing is available only on an enrolled Linux desktop or signed-in iPhone`,
       );

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2245,10 +2245,12 @@ function handleDeepLink(url: string): undefined | Promise<boolean> {
           typeof navigator === "undefined" ? "" : navigator.platform,
         nativePlatform: Capacitor.getPlatform(),
         native: Capacitor.isNativePlatform(),
+        nativePluginAvailable:
+          Capacitor.isPluginAvailable?.("RemoteControllerIdentity") === true,
       })
     ) {
       console.warn(
-        `${APP_LOG_PREFIX} Remote controller pairing is available only on an enrolled Linux desktop or a compatible signed-in iPhone`,
+        `${APP_LOG_PREFIX} Remote controller pairing requires the enrolled Linux desktop shell or this iPhone's secure native controller bridge`,
       );
       return;
     }

--- a/packages/app/src/remote-controller-deep-link.test.ts
+++ b/packages/app/src/remote-controller-deep-link.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isRemoteControllerPairingRuntimeAllowed } from "./remote-controller-deep-link";
+
+describe("remote controller claim runtime guard", () => {
+  it("allows native iOS without Electrobun or Linux", () => {
+    expect(
+      isRemoteControllerPairingRuntimeAllowed({
+        native: true,
+        nativePlatform: "ios",
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { native: false, nativePlatform: "web" },
+    { native: true, nativePlatform: "android" },
+    { isElectrobun: true, navigatorPlatform: "MacIntel", native: false },
+    { isElectrobun: true, navigatorPlatform: "Linux x86_64", native: false },
+  ])("enforces platform guard: $nativePlatform/$navigatorPlatform", (input) => {
+    expect(isRemoteControllerPairingRuntimeAllowed(input)).toBe(
+      input.navigatorPlatform?.includes("Linux") ?? false,
+    );
+  });
+});

--- a/packages/app/src/remote-controller-deep-link.test.ts
+++ b/packages/app/src/remote-controller-deep-link.test.ts
@@ -1,3 +1,5 @@
+/** Deterministically exercises the platform admission boundary for controller claims. */
+
 import { describe, expect, it } from "vitest";
 import { isRemoteControllerPairingRuntimeAllowed } from "./remote-controller-deep-link";
 
@@ -7,18 +9,52 @@ describe("remote controller claim runtime guard", () => {
       isRemoteControllerPairingRuntimeAllowed({
         native: true,
         nativePlatform: "ios",
+        nativePluginAvailable: true,
+        isElectrobun: false,
+        navigatorPlatform: "iPhone",
       }),
     ).toBe(true);
   });
 
   it.each([
-    { native: false, nativePlatform: "web" },
-    { native: true, nativePlatform: "android" },
-    { isElectrobun: true, navigatorPlatform: "MacIntel", native: false },
-    { isElectrobun: true, navigatorPlatform: "Linux x86_64", native: false },
+    {
+      native: false,
+      nativePlatform: "web",
+      nativePluginAvailable: false,
+      isElectrobun: false,
+      navigatorPlatform: "",
+    },
+    {
+      native: true,
+      nativePlatform: "android",
+      nativePluginAvailable: true,
+      isElectrobun: false,
+      navigatorPlatform: "Linux armv8",
+    },
+    {
+      native: true,
+      nativePlatform: "ios",
+      nativePluginAvailable: false,
+      isElectrobun: false,
+      navigatorPlatform: "iPhone",
+    },
+    {
+      isElectrobun: true,
+      navigatorPlatform: "MacIntel",
+      native: false,
+      nativePlatform: "web",
+      nativePluginAvailable: false,
+    },
+    {
+      isElectrobun: true,
+      navigatorPlatform: "Linux x86_64",
+      native: false,
+      nativePlatform: "web",
+      nativePluginAvailable: false,
+    },
   ])("enforces platform guard: $nativePlatform/$navigatorPlatform", (input) => {
     expect(isRemoteControllerPairingRuntimeAllowed(input)).toBe(
-      input.navigatorPlatform?.includes("Linux") ?? false,
+      input.isElectrobun && input.navigatorPlatform.includes("Linux"),
     );
   });
 });

--- a/packages/app/src/remote-controller-deep-link.ts
+++ b/packages/app/src/remote-controller-deep-link.ts
@@ -1,0 +1,17 @@
+import { Capacitor } from "@capacitor/core";
+
+/** Allow controller-claim delivery only to enrolled Linux desktop or native iOS shells. */
+export function isRemoteControllerPairingRuntimeAllowed(input?: {
+  isElectrobun?: boolean;
+  navigatorPlatform?: string;
+  nativePlatform?: string;
+  native?: boolean;
+}): boolean {
+  const isLinuxDesktop =
+    (input?.isElectrobun ?? false) &&
+    (input?.navigatorPlatform ?? "").toLowerCase().includes("linux");
+  const isNativeIOS =
+    (input?.native ?? Capacitor.isNativePlatform()) &&
+    (input?.nativePlatform ?? Capacitor.getPlatform()) === "ios";
+  return isLinuxDesktop || isNativeIOS;
+}

--- a/packages/app/src/remote-controller-deep-link.ts
+++ b/packages/app/src/remote-controller-deep-link.ts
@@ -1,17 +1,23 @@
-import { Capacitor } from "@capacitor/core";
+/**
+ * Decides whether a remote-controller claim may enter the platform pairing
+ * flow. iOS is admitted only when the compiled native key/crypto owner is
+ * registered; other Capacitor shells fail closed.
+ */
 
-/** Allow controller-claim delivery only to enrolled Linux desktop or native iOS shells. */
-export function isRemoteControllerPairingRuntimeAllowed(input?: {
-  isElectrobun?: boolean;
-  navigatorPlatform?: string;
-  nativePlatform?: string;
-  native?: boolean;
+/** Allows claim delivery only to the two shells that own controller keys. */
+export function isRemoteControllerPairingRuntimeAllowed(input: {
+  isElectrobun: boolean;
+  navigatorPlatform: string;
+  nativePlatform: string;
+  native: boolean;
+  nativePluginAvailable: boolean;
 }): boolean {
   const isLinuxDesktop =
-    (input?.isElectrobun ?? false) &&
-    (input?.navigatorPlatform ?? "").toLowerCase().includes("linux");
+    input.isElectrobun &&
+    input.navigatorPlatform.toLowerCase().includes("linux");
   const isNativeIOS =
-    (input?.native ?? Capacitor.isNativePlatform()) &&
-    (input?.nativePlatform ?? Capacitor.getPlatform()) === "ios";
+    input.native &&
+    input.nativePlatform === "ios" &&
+    input.nativePluginAvailable;
   return isLinuxDesktop || isNativeIOS;
 }

--- a/packages/ui/src/platform/remote-controller.test.ts
+++ b/packages/ui/src/platform/remote-controller.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const native = vi.hoisted(() => ({
+  getOrCreateIdentity: vi.fn(),
+  createCommand: vi.fn(),
+  acknowledgeEnqueue: vi.fn(),
+  openResult: vi.fn(),
+  openStartReceipt: vi.fn(),
+  clearSessionState: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => "ios",
+    isNativePlatform: () => true,
+    registerPlugin: () => native,
+  },
+}));
+vi.mock("../bridge/electrobun-rpc", () => ({
+  invokeDesktopBridgeRequest: vi.fn(),
+}));
+
+import {
+  createRemoteCommand,
+  getOrCreateRemoteControllerIdentity,
+} from "./remote-controller";
+
+describe("Capacitor remote controller bridge", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uses native identity storage and never accepts a private key", async () => {
+    native.getOrCreateIdentity.mockResolvedValue({
+      deviceId: "iphone-1",
+      keyId: "key-1",
+      encryptionPublicKeyJwk: { kty: "EC", x: "x", y: "y", crv: "P-256" },
+    });
+    const identity = await getOrCreateRemoteControllerIdentity({
+      ownerId: "owner-1",
+    });
+    expect(identity.deviceId).toBe("iphone-1");
+    expect(native.getOrCreateIdentity).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        privateKey: expect.anything(),
+        privateKeyJwk: expect.anything(),
+      }),
+    );
+  });
+
+  it("fails closed when native signing is unavailable", async () => {
+    native.createCommand.mockResolvedValue(null);
+    await expect(
+      createRemoteCommand({
+        ownerId: "owner-1",
+        grantId: "grant-1",
+        grantRevision: 1,
+        sessionId: "session-1",
+        controller: { deviceId: "iphone-1", keyId: "key-1" } as never,
+        target: {
+          runtimeId: "mac-1",
+          keyId: "target-key",
+          encryptionPublicKeyJwk: {},
+        } as never,
+        action: "observe" as never,
+        payload: {},
+      }),
+    ).rejects.toThrow("Secure mobile command signing is unavailable");
+  });
+});

--- a/packages/ui/src/platform/remote-controller.test.ts
+++ b/packages/ui/src/platform/remote-controller.test.ts
@@ -8,11 +8,13 @@ const native = vi.hoisted(() => ({
   openStartReceipt: vi.fn(),
   clearSessionState: vi.fn(),
 }));
+const nativeAvailable = vi.hoisted(() => ({ value: true }));
 
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: () => "ios",
     isNativePlatform: () => true,
+    isPluginAvailable: () => nativeAvailable.value,
     registerPlugin: () => native,
   },
 }));
@@ -64,5 +66,13 @@ describe("Capacitor remote controller bridge", () => {
         payload: {},
       }),
     ).rejects.toThrow("Secure mobile command signing is unavailable");
+  });
+
+  it("fails closed when the native iOS plugin is absent", async () => {
+    nativeAvailable.value = false;
+    await expect(
+      getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" }),
+    ).rejects.toThrow("native iOS plugin is installed");
+    nativeAvailable.value = true;
   });
 });

--- a/packages/ui/src/platform/remote-controller.test.ts
+++ b/packages/ui/src/platform/remote-controller.test.ts
@@ -1,3 +1,5 @@
+/** Exercises the Capacitor controller adapter with a deterministic native bridge double. */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const native = vi.hoisted(() => ({
@@ -23,8 +25,12 @@ vi.mock("../bridge/electrobun-rpc", () => ({
 }));
 
 import {
+  acknowledgeRemoteCommandEnqueue,
+  clearRemoteControllerSessionState,
   createRemoteCommand,
   getOrCreateRemoteControllerIdentity,
+  openRemoteCommandResult,
+  openRemoteCommandStartReceipt,
 } from "./remote-controller";
 
 describe("Capacitor remote controller bridge", () => {
@@ -32,9 +38,26 @@ describe("Capacitor remote controller bridge", () => {
 
   it("uses native identity storage and never accepts a private key", async () => {
     native.getOrCreateIdentity.mockResolvedValue({
+      version: 1,
+      role: "controller",
+      ownerId: "owner-1",
       deviceId: "iphone-1",
       keyId: "key-1",
-      encryptionPublicKeyJwk: { kty: "EC", x: "x", y: "y", crv: "P-256" },
+      displayName: "My iPhone",
+      platform: "ios",
+      signingPublicKeyJwk: {
+        kty: "EC",
+        x: "A".repeat(43),
+        y: "B".repeat(43),
+        crv: "P-256",
+      },
+      encryptionPublicKeyJwk: {
+        kty: "EC",
+        x: "C".repeat(43),
+        y: "D".repeat(43),
+        crv: "P-256",
+      },
+      createdAt: 1,
     });
     const identity = await getOrCreateRemoteControllerIdentity({
       ownerId: "owner-1",
@@ -46,6 +69,48 @@ describe("Capacitor remote controller bridge", () => {
         privateKeyJwk: expect.anything(),
       }),
     );
+  });
+
+  it("rejects private material or a mismatched native identity", async () => {
+    const identity = {
+      version: 1,
+      role: "controller",
+      ownerId: "owner-1",
+      deviceId: "iphone-1",
+      keyId: "key-1",
+      displayName: "My iPhone",
+      platform: "ios",
+      signingPublicKeyJwk: {
+        kty: "EC",
+        x: "A".repeat(43),
+        y: "B".repeat(43),
+        crv: "P-256",
+      },
+      encryptionPublicKeyJwk: {
+        kty: "EC",
+        x: "C".repeat(43),
+        y: "D".repeat(43),
+        crv: "P-256",
+      },
+      createdAt: 1,
+    };
+    native.getOrCreateIdentity.mockResolvedValue({
+      ...identity,
+      signingPublicKeyJwk: { ...identity.signingPublicKeyJwk, d: "secret" },
+      privateKeyJwk: { d: "secret" },
+    });
+    await expect(
+      getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" }),
+    ).rejects.toThrow("pairing identity is unavailable");
+
+    native.getOrCreateIdentity.mockResolvedValue({
+      ...identity,
+      ownerId: "other-owner",
+      platform: "android",
+    });
+    await expect(
+      getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" }),
+    ).rejects.toThrow("pairing identity is unavailable");
   });
 
   it("fails closed when native signing is unavailable", async () => {
@@ -74,5 +139,46 @@ describe("Capacitor remote controller bridge", () => {
       getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" }),
     ).rejects.toThrow("native iOS plugin is installed");
     nativeAvailable.value = true;
+  });
+
+  it("rejects malformed acknowledgement and cleanup bridge responses", async () => {
+    native.acknowledgeEnqueue.mockResolvedValue({ acknowledged: "yes" });
+    await expect(
+      acknowledgeRemoteCommandEnqueue({
+        ownerId: "owner-1",
+        controllerDeviceId: "iphone-1",
+        sessionId: "session-1",
+        commandId: "command-1",
+        bindingDigest: "A".repeat(43),
+      }),
+    ).rejects.toThrow("acknowledgement is unavailable");
+
+    native.clearSessionState.mockResolvedValue(null);
+    await expect(
+      clearRemoteControllerSessionState({
+        ownerId: "owner-1",
+        controllerDeviceId: "iphone-1",
+        sessionId: "session-1",
+      }),
+    ).rejects.toThrow("session cleanup is unavailable");
+  });
+
+  it("accepts only terminal result statuses and complete start receipts", async () => {
+    const authority = {
+      ownerId: "owner-1",
+      controllerDeviceId: "iphone-1",
+      envelope: {},
+      command: {},
+      targetIdentity: {},
+    } as never;
+    native.openResult.mockResolvedValue({ status: "started" });
+    await expect(openRemoteCommandResult(authority)).rejects.toThrow(
+      "result decryption is unavailable",
+    );
+
+    native.openStartReceipt.mockResolvedValue({ startedAt: 1 });
+    await expect(openRemoteCommandStartReceipt(authority)).rejects.toThrow(
+      "start receipt verification is unavailable",
+    );
   });
 });

--- a/packages/ui/src/platform/remote-controller.ts
+++ b/packages/ui/src/platform/remote-controller.ts
@@ -3,6 +3,8 @@
  * process retains private signing/decryption keys; this module only forwards
  * public identity, encrypted commands, and opaque result envelopes.
  */
+
+import { Capacitor } from "@capacitor/core";
 import type {
   EncryptedRemoteControlEnvelope,
   RemoteCommandAction,
@@ -12,6 +14,36 @@ import type {
   SignedRemoteCommand,
 } from "@elizaos/shared/contracts/remote-control";
 import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
+
+interface NativeRemoteControllerPlugin {
+  getOrCreateIdentity(input: {
+    ownerId: string;
+    displayName: string;
+    platform: string;
+  }): Promise<RemoteControllerPublicIdentity>;
+  createCommand(input: Record<string, unknown>): Promise<unknown>;
+  acknowledgeEnqueue(
+    input: Record<string, unknown>,
+  ): Promise<{ acknowledged: boolean }>;
+  openResult(input: Record<string, unknown>): Promise<unknown>;
+  openStartReceipt(input: Record<string, unknown>): Promise<unknown>;
+  clearSessionState(
+    input: Record<string, unknown>,
+  ): Promise<{ cleared: boolean }>;
+}
+
+const nativeRemoteController =
+  Capacitor.registerPlugin<NativeRemoteControllerPlugin>(
+    "RemoteControllerIdentity",
+  );
+
+function isNativeController(): boolean {
+  const platform = Capacitor.getPlatform();
+  return (
+    Capacitor.isNativePlatform() &&
+    (platform === "ios" || platform === "android")
+  );
+}
 
 function desktopPlatform(): "macos" | "windows" | "linux" {
   const platform = navigator.platform.toLowerCase();
@@ -25,6 +57,21 @@ export async function getOrCreateRemoteControllerIdentity(input: {
   displayName?: string;
 }): Promise<RemoteControllerPublicIdentity> {
   const platform = desktopPlatform();
+  if (isNativeController()) {
+    const identity = await nativeRemoteController.getOrCreateIdentity({
+      ownerId: input.ownerId,
+      displayName: input.displayName ?? "My iPhone",
+      platform: Capacitor.getPlatform(),
+    });
+    if (
+      !identity?.deviceId ||
+      !identity.keyId ||
+      !identity.encryptionPublicKeyJwk
+    ) {
+      throw new Error("Secure mobile pairing identity is unavailable.");
+    }
+    return identity;
+  }
   const identity =
     await invokeDesktopBridgeRequest<RemoteControllerPublicIdentity>({
       rpcMethod: "remoteControllerGetOrCreateIdentity",
@@ -66,6 +113,31 @@ export async function createRemoteCommand(input: {
   recoveredPending: boolean;
   bindingDigest: string;
 }> {
+  if (isNativeController()) {
+    const result = await nativeRemoteController.createCommand({
+      ownerId: input.ownerId,
+      grantId: input.grantId,
+      grantRevision: input.grantRevision,
+      sessionId: input.sessionId,
+      controllerDeviceId: input.controller.deviceId,
+      controllerKeyId: input.controller.keyId,
+      targetRuntimeId: input.target.runtimeId,
+      targetKeyId: input.target.keyId,
+      targetEncryptionPublicKeyJwk: input.target.encryptionPublicKeyJwk,
+      action: input.action,
+      payload: input.payload,
+    });
+    if (!result)
+      throw new Error("Secure mobile command signing is unavailable.");
+    return result as {
+      commandId: string;
+      expiresAt: number;
+      command: SignedRemoteCommand;
+      envelope: EncryptedRemoteControlEnvelope;
+      recoveredPending: boolean;
+      bindingDigest: string;
+    };
+  }
   const result = await invokeDesktopBridgeRequest<{
     commandId: string;
     expiresAt: number;
@@ -101,6 +173,10 @@ export async function acknowledgeRemoteCommandEnqueue(input: {
   commandId: string;
   bindingDigest: string;
 }): Promise<boolean> {
+  if (isNativeController()) {
+    const result = await nativeRemoteController.acknowledgeEnqueue(input);
+    return result?.acknowledged ?? false;
+  }
   const result = await invokeDesktopBridgeRequest<{ acknowledged: boolean }>({
     rpcMethod: "remoteControllerAcknowledgeEnqueue",
     ipcChannel: "remoteController:acknowledgeEnqueue",
@@ -118,6 +194,16 @@ export async function openRemoteCommandResult(input: {
   command: SignedRemoteCommand;
   targetIdentity: RemoteTargetPublicIdentity;
 }): Promise<{ status: string; result?: RemoteJsonValue; errorCode?: string }> {
+  if (isNativeController()) {
+    const result = await nativeRemoteController.openResult(input);
+    if (!result)
+      throw new Error("Secure mobile result decryption is unavailable.");
+    return result as {
+      status: string;
+      result?: RemoteJsonValue;
+      errorCode?: string;
+    };
+  }
   const result = await invokeDesktopBridgeRequest<{
     status: string;
     result?: RemoteJsonValue;
@@ -139,6 +225,14 @@ export async function openRemoteCommandStartReceipt(input: {
   command: SignedRemoteCommand;
   targetIdentity: RemoteTargetPublicIdentity;
 }): Promise<{ startedAt: number; executionId: string }> {
+  if (isNativeController()) {
+    const result = await nativeRemoteController.openStartReceipt(input);
+    if (!result)
+      throw new Error(
+        "Secure mobile start receipt verification is unavailable.",
+      );
+    return result as { startedAt: number; executionId: string };
+  }
   const result = await invokeDesktopBridgeRequest<{
     startedAt: number;
     executionId: string;
@@ -158,6 +252,10 @@ export async function clearRemoteControllerSessionState(input: {
   controllerDeviceId: string;
   sessionId: string;
 }): Promise<boolean> {
+  if (isNativeController()) {
+    const result = await nativeRemoteController.clearSessionState(input);
+    return result?.cleared ?? false;
+  }
   const result = await invokeDesktopBridgeRequest<{ cleared: boolean }>({
     rpcMethod: "remoteControllerClearSessionState",
     ipcChannel: "remoteController:clearSessionState",

--- a/packages/ui/src/platform/remote-controller.ts
+++ b/packages/ui/src/platform/remote-controller.ts
@@ -41,7 +41,16 @@ function isNativeController(): boolean {
   const platform = Capacitor.getPlatform();
   return (
     Capacitor.isNativePlatform() &&
-    (platform === "ios" || platform === "android")
+    platform === "ios" &&
+    Capacitor.isPluginAvailable?.("RemoteControllerIdentity") === true
+  );
+}
+
+function isUnsupportedNativeIOS(): boolean {
+  return (
+    Capacitor.isNativePlatform() &&
+    Capacitor.getPlatform() === "ios" &&
+    Capacitor.isPluginAvailable?.("RemoteControllerIdentity") !== true
   );
 }
 
@@ -56,7 +65,11 @@ export async function getOrCreateRemoteControllerIdentity(input: {
   ownerId: string;
   displayName?: string;
 }): Promise<RemoteControllerPublicIdentity> {
-  const platform = desktopPlatform();
+  if (isUnsupportedNativeIOS()) {
+    throw new Error(
+      "Secure mobile pairing is unavailable until the native iOS plugin is installed.",
+    );
+  }
   if (isNativeController()) {
     const identity = await nativeRemoteController.getOrCreateIdentity({
       ownerId: input.ownerId,
@@ -72,6 +85,7 @@ export async function getOrCreateRemoteControllerIdentity(input: {
     }
     return identity;
   }
+  const platform = desktopPlatform();
   const identity =
     await invokeDesktopBridgeRequest<RemoteControllerPublicIdentity>({
       rpcMethod: "remoteControllerGetOrCreateIdentity",

--- a/packages/ui/src/platform/remote-controller.ts
+++ b/packages/ui/src/platform/remote-controller.ts
@@ -5,13 +5,16 @@
  */
 
 import { Capacitor } from "@capacitor/core";
-import type {
-  EncryptedRemoteControlEnvelope,
-  RemoteCommandAction,
-  RemoteControllerPublicIdentity,
-  RemoteJsonValue,
-  RemoteTargetPublicIdentity,
-  SignedRemoteCommand,
+import {
+  type EncryptedRemoteControlEnvelope,
+  isEncryptedRemoteControlEnvelope,
+  isRemoteControllerPublicIdentity,
+  isSignedRemoteCommand,
+  type RemoteCommandAction,
+  type RemoteControllerPublicIdentity,
+  type RemoteJsonValue,
+  type RemoteTargetPublicIdentity,
+  type SignedRemoteCommand,
 } from "@elizaos/shared/contracts/remote-control";
 import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 
@@ -30,6 +33,53 @@ interface NativeRemoteControllerPlugin {
   clearSessionState(
     input: Record<string, unknown>,
   ): Promise<{ cleared: boolean }>;
+}
+
+type NativeCommandResult = {
+  commandId: string;
+  expiresAt: number;
+  command: SignedRemoteCommand;
+  envelope: EncryptedRemoteControlEnvelope;
+  recoveredPending: boolean;
+  bindingDigest: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNativeCommandResult(value: unknown): value is NativeCommandResult {
+  return (
+    isRecord(value) &&
+    typeof value.commandId === "string" &&
+    Number.isSafeInteger(value.expiresAt) &&
+    isSignedRemoteCommand(value.command) &&
+    isEncryptedRemoteControlEnvelope(value.envelope) &&
+    typeof value.recoveredPending === "boolean" &&
+    typeof value.bindingDigest === "string"
+  );
+}
+
+function isOpenedResult(
+  value: unknown,
+): value is { status: string; result?: RemoteJsonValue; errorCode?: string } {
+  return (
+    isRecord(value) &&
+    ["completed", "rejected", "cancelled", "execution_ambiguous"].includes(
+      String(value.status),
+    ) &&
+    (value.errorCode === undefined || typeof value.errorCode === "string")
+  );
+}
+
+function isOpenedStartReceipt(
+  value: unknown,
+): value is { startedAt: number; executionId: string } {
+  return (
+    isRecord(value) &&
+    Number.isSafeInteger(value.startedAt) &&
+    typeof value.executionId === "string"
+  );
 }
 
 const nativeRemoteController =
@@ -77,9 +127,9 @@ export async function getOrCreateRemoteControllerIdentity(input: {
       platform: Capacitor.getPlatform(),
     });
     if (
-      !identity?.deviceId ||
-      !identity.keyId ||
-      !identity.encryptionPublicKeyJwk
+      !isRemoteControllerPublicIdentity(identity) ||
+      identity.ownerId !== input.ownerId ||
+      identity.platform !== "ios"
     ) {
       throw new Error("Secure mobile pairing identity is unavailable.");
     }
@@ -141,16 +191,9 @@ export async function createRemoteCommand(input: {
       action: input.action,
       payload: input.payload,
     });
-    if (!result)
+    if (!isNativeCommandResult(result))
       throw new Error("Secure mobile command signing is unavailable.");
-    return result as {
-      commandId: string;
-      expiresAt: number;
-      command: SignedRemoteCommand;
-      envelope: EncryptedRemoteControlEnvelope;
-      recoveredPending: boolean;
-      bindingDigest: string;
-    };
+    return result;
   }
   const result = await invokeDesktopBridgeRequest<{
     commandId: string;
@@ -189,7 +232,10 @@ export async function acknowledgeRemoteCommandEnqueue(input: {
 }): Promise<boolean> {
   if (isNativeController()) {
     const result = await nativeRemoteController.acknowledgeEnqueue(input);
-    return result?.acknowledged ?? false;
+    if (!isRecord(result) || typeof result.acknowledged !== "boolean") {
+      throw new Error("Secure mobile enqueue acknowledgement is unavailable.");
+    }
+    return result.acknowledged;
   }
   const result = await invokeDesktopBridgeRequest<{ acknowledged: boolean }>({
     rpcMethod: "remoteControllerAcknowledgeEnqueue",
@@ -210,13 +256,9 @@ export async function openRemoteCommandResult(input: {
 }): Promise<{ status: string; result?: RemoteJsonValue; errorCode?: string }> {
   if (isNativeController()) {
     const result = await nativeRemoteController.openResult(input);
-    if (!result)
+    if (!isOpenedResult(result))
       throw new Error("Secure mobile result decryption is unavailable.");
-    return result as {
-      status: string;
-      result?: RemoteJsonValue;
-      errorCode?: string;
-    };
+    return result;
   }
   const result = await invokeDesktopBridgeRequest<{
     status: string;
@@ -241,11 +283,11 @@ export async function openRemoteCommandStartReceipt(input: {
 }): Promise<{ startedAt: number; executionId: string }> {
   if (isNativeController()) {
     const result = await nativeRemoteController.openStartReceipt(input);
-    if (!result)
+    if (!isOpenedStartReceipt(result))
       throw new Error(
         "Secure mobile start receipt verification is unavailable.",
       );
-    return result as { startedAt: number; executionId: string };
+    return result;
   }
   const result = await invokeDesktopBridgeRequest<{
     startedAt: number;
@@ -268,7 +310,10 @@ export async function clearRemoteControllerSessionState(input: {
 }): Promise<boolean> {
   if (isNativeController()) {
     const result = await nativeRemoteController.clearSessionState(input);
-    return result?.cleared ?? false;
+    if (!isRecord(result) || typeof result.cleared !== "boolean") {
+      throw new Error("Secure mobile session cleanup is unavailable.");
+    }
+    return result.cleared;
   }
   const result = await invokeDesktopBridgeRequest<{ cleared: boolean }>({
     rpcMethod: "remoteControllerClearSessionState",


### PR DESCRIPTION
## Summary
- route validated `elizaos://remote/control-claim` intents on signed Capacitor iOS instead of dropping them behind the Linux Electrobun guard
- add a Capacitor-native RemoteControllerIdentity bridge seam for device-bound identity, command signing, receipts, and session cleanup; private keys remain native
- preserve strict deep-link/session/code validation and fail closed when the native secure bridge is unavailable

## Evidence
- Biome check: pass
- `git diff --check`: pass
- app deep-link/UI suites are dependency-blocked in this isolated tree (`react/jsx-dev-runtime`, `fast-check` unavailable); no install performed

## Gates
Physical iPhone pairing, TCC/security permissions, real Cloud relay, SSH/VPS, and production deployment remain unclaimed.