### PR TITLE
fix(cloud): restore production database authority binding

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -1009,7 +1009,7 @@ bucket_name = "eliza-cloud-blob"
 # WebSocket driver in client.ts, which bypasses this binding).
 [[env.production.hyperdrive]]
 binding = "HYPERDRIVE"
-id = "9f59e4ec65f048f7b87e29e7b9c5d728"
+id = "486bdc36737a4ad1b526fc3c08627658"
 
 # KV is the Worker's cache backend (CacheClient). Workers can't reliably open raw
 # TCP to an external Redis (Railway's public proxy hangs under load), so the Worker


### PR DESCRIPTION
## Summary

- repoint only the production Cloud API Hyperdrive binding to the already-created canonical production database config
- preserve the existing binding unchanged as an immediate rollback target
- make no schema, tenant-row, billing, compute, worker, or activation change

## Authority evidence (sanitized)

- pinned Railway service, live provisioning worker, and corrected protected production `DATABASE_URL` resolve to the same full cluster+database authority receipt
- protected audit: Railway target `match`, protected authority `match`, every required Cloud/Steward table present
- exact-main audit: migration ledger `current/current` through main migration 0340
- the only pending migration in the develop-based audit is unrelated develop-only 0341 (`agent_backup_admission_cursors`) and is intentionally not promoted here
- rollback Hyperdrive config hash: `77690c46aa27`; candidate config hash: `9bef97f079e8`
- both configs use the same host/user/port authority; database hashes differ (`612b629a669e` rollback vs `e34d1c9011e0` canonical)

## Exact source

- base: `c99c3896cfb06c331f1a531fda03a99193fd49c0`
- head: `3ecc5474ad2afc644ef28efd5454428e6ac36dbb`
- tree: `7222f4cbf8c8040487275617f8c8d8d3c89f2a88`
- diff: one file, one production binding line replacement

## Verification

- `bun run build:core`: 60/60 packages
- focused Wrangler/config parity: 8/8 tests
- production Worker bundle dry-run: PASS with the candidate Hyperdrive binding
- exact-main read-only database audit: PASS
- `git diff --check`: PASS

## Rollout gates

After exact hosted checks and merge, use only the canonical production Cloud deploy. Before any paid adoption, prove post-deploy API+worker authority equality, accepted worker heartbeat, funded legacy tenant (`$115.540590`), exactly two Dedicated rows, and zero jobs/authorities/compute. No activation POST is included in this PR.