### PR TITLE
fix(cloud): preflight shared smoke credits

### DIFF
--- a/packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts
+++ b/packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts
@@ -32,6 +32,7 @@ interface RequestRecord {
 
 interface HarnessOptions {
   asyncDelete?: boolean;
+  creditBalance?: number | "invalid";
   bridgeReply?:
     | "valid"
     | "invalid"
@@ -121,6 +122,15 @@ function makeHarness(options: HarnessOptions = {}) {
         status: "ok",
         region: "test",
         commit: DEPLOY_COMMIT,
+      });
+    }
+
+    if (parsedUrl.pathname === "/api/v1/credits/balance" && method === "GET") {
+      return Response.json({
+        balance:
+          options.creditBalance === "invalid"
+            ? null
+            : (options.creditBalance ?? 100),
       });
     }
 
@@ -530,6 +540,32 @@ describe("shared staging onboarding smoke", () => {
     expect(
       harness.requests.some((request) => request.method === "DELETE"),
     ).toBe(false);
+  });
+
+  test("requires a funded credential before creating anything", async () => {
+    const harness = makeHarness({ creditBalance: 0 });
+    const evidence = await runSharedStagingOnboardingSmoke(harness.options);
+
+    expect(evidence.failure).toEqual({
+      phase: "preflight",
+      code: "insufficient_credits",
+    });
+    expect(evidence.path.credentialPreflight).toBe(false);
+    expect(evidence.capacity.createdAgents).toBe(0);
+    expect(harness.requests.some((request) => request.method === "POST")).toBe(
+      false,
+    );
+  });
+
+  test("fails closed when the credential balance response is malformed", async () => {
+    const harness = makeHarness({ creditBalance: "invalid" });
+    const evidence = await runSharedStagingOnboardingSmoke(harness.options);
+
+    expect(evidence.failure).toEqual({
+      phase: "preflight",
+      code: "invalid_credit_balance",
+    });
+    expect(evidence.capacity.createdAgents).toBe(0);
   });
 
   test("does not delete an idempotently reused agent after a concurrent race", async () => {

--- a/packages/cloud/scripts/admin/live-cloud-provision-smoke.ts
+++ b/packages/cloud/scripts/admin/live-cloud-provision-smoke.ts
@@ -845,6 +845,18 @@ export async function runSharedStagingOnboardingSmoke(
       }
       evidence.deployedCommit = commit;
 
+      const credits = await request(
+        "preflight",
+        "/api/v1/credits/balance?fresh=true",
+      );
+      const balance = credits.body.balance;
+      if (typeof balance !== "number" || !Number.isFinite(balance)) {
+        throw new SharedSmokeFailure("preflight", "invalid_credit_balance");
+      }
+      if (balance <= 0) {
+        throw new SharedSmokeFailure("preflight", "insufficient_credits");
+      }
+
       const existingAgents = await listAgents("preflight");
       if (existingAgents.length !== 0) {
         throw new SharedSmokeFailure("preflight", "credential_not_isolated");


### PR DESCRIPTION
## Summary

- query the isolated staging smoke credential credit balance before creating an agent
- fail closed with privacy-safe `preflight:insufficient_credits` or `invalid_credit_balance` evidence
- preserve the zero-resource contract when the credential is depleted

Closes the diagnostic gap tracked in #29339; funding the staging smoke organization remains an operator billing-state action.

## Verification

- `bun test packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts` (26 pass)
- `bunx biome check packages/cloud/scripts/admin/live-cloud-provision-smoke.ts packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts`
- live diagnostic: https://github.com/elizaOS/eliza/actions/runs/33042063118 (`preflight:insufficient_credits`, 0 agents, 0 chat requests)
- `bun run verify` reaches the pre-existing repository i18n failure on untouched translation files (missing keys across locale catalogs); this branch changes only the two smoke files
