### PR TITLE
[android-auth-agent-chat] fix(ci): redact device evidence diagnostics

### DIFF
--- a/.github/scripts/device-e2e/arm64-local-preflight.sh
+++ b/.github/scripts/device-e2e/arm64-local-preflight.sh
@@ -5,57 +5,52 @@
 
 set -euo pipefail
 
-[[ "$(node --version)" == "v24.15.0" ]] || {
-  echo "Android ARM64 lane requires Node v24.15.0" >&2
-  exit 1
-}
-[[ "$(bun --version)" == "1.3.14" ]] || {
-  echo "Android ARM64 lane requires Bun 1.3.14" >&2
-  exit 1
-}
-[[ "$(node -p 'process.arch')" == "arm64" ]] || {
-  echo "Android ARM64 lane requires an arm64 Node runtime" >&2
+fail_preflight() {
+  printf 'phase=preflight status=failed code=%s\n' "$1" >&2
   exit 1
 }
 
-host_arch=$(uname -m)
-[[ "$host_arch" == "aarch64" || "$host_arch" == "arm64" ]] || {
-  echo "Android ARM64 lane requires an ARM64 kernel host; found ${host_arch:-missing}" >&2
-  exit 1
-}
+command -v node >/dev/null || fail_preflight NODE_UNAVAILABLE
+command -v bun >/dev/null || fail_preflight BUN_UNAVAILABLE
+[[ "$(node --version 2>/dev/null)" == "v24.15.0" ]] \
+  || fail_preflight NODE_VERSION_INVALID
+[[ "$(bun --version 2>/dev/null)" == "1.3.14" ]] \
+  || fail_preflight BUN_VERSION_INVALID
+[[ "$(node -p 'process.arch' 2>/dev/null)" == "arm64" ]] \
+  || fail_preflight NODE_ARCH_INVALID
 
-command -v java >/dev/null
-command -v adb >/dev/null
+host_arch=$(uname -m 2>/dev/null) || fail_preflight HOST_ARCH_UNAVAILABLE
+[[ "$host_arch" == "aarch64" || "$host_arch" == "arm64" ]] \
+  || fail_preflight HOST_ARCH_INVALID
+
+command -v java >/dev/null || fail_preflight JAVA_UNAVAILABLE
+command -v adb >/dev/null || fail_preflight ADB_UNAVAILABLE
+command -v ffmpeg >/dev/null || fail_preflight FFMPEG_UNAVAILABLE
 
 java_major=$(java -XshowSettings:properties -version 2>&1 \
-  | awk -F= '$1 ~ /java.specification.version/ { gsub(/[[:space:]]/, "", $2); print $2; exit }')
-[[ "$java_major" == "21" ]] || {
-  echo "Android ARM64 lane requires Java 21; found ${java_major:-missing}" >&2
-  exit 1
-}
+  | awk -F= '$1 ~ /java.specification.version/ { gsub(/[[:space:]]/, "", $2); print $2; exit }') \
+  || fail_preflight JAVA_VERSION_UNAVAILABLE
+[[ "$java_major" == "21" ]] || fail_preflight JAVA_VERSION_INVALID
 
-mapfile -t attached_devices < <(adb devices | awk 'NR > 1 && $2 == "device" { print $1 }')
+mapfile -t attached_devices < <(adb devices 2>/dev/null \
+  | awk 'NR > 1 && $2 == "device" { print $1 }')
 if [[ -n "${ANDROID_SERIAL:-}" ]]; then
-  printf '%s\n' "${attached_devices[@]}" | grep -Fx -- "$ANDROID_SERIAL" >/dev/null || {
-    echo "ANDROID_SERIAL=$ANDROID_SERIAL is not an attached authorized device" >&2
-    exit 1
-  }
+  printf '%s\n' "${attached_devices[@]}" | grep -Fx -- "$ANDROID_SERIAL" >/dev/null \
+    || fail_preflight DEVICE_SELECTION_INVALID
 elif [[ ${#attached_devices[@]} -eq 1 ]]; then
   ANDROID_SERIAL=${attached_devices[0]}
 else
-  echo "Set ANDROID_SERIAL when the runner does not have exactly one attached device" >&2
-  exit 1
+  fail_preflight DEVICE_SELECTION_INVALID
 fi
 
-device_abi=$(adb -s "$ANDROID_SERIAL" shell getprop ro.product.cpu.abi | tr -d '\r')
-[[ "$device_abi" == "arm64-v8a" ]] || {
-  echo "Android local-runtime lane requires arm64-v8a; found ${device_abi:-missing}" >&2
-  exit 1
-}
-[[ "$(adb -s "$ANDROID_SERIAL" shell getprop sys.boot_completed | tr -d '\r')" == "1" ]] || {
-  echo "Android device $ANDROID_SERIAL has not completed boot" >&2
-  exit 1
-}
+device_abi=$(adb -s "$ANDROID_SERIAL" shell getprop ro.product.cpu.abi 2>/dev/null \
+  | tr -d '\r') || fail_preflight DEVICE_ABI_UNAVAILABLE
+[[ "$device_abi" == "arm64-v8a" ]] || fail_preflight DEVICE_ABI_INVALID
+boot_completed=$(adb -s "$ANDROID_SERIAL" shell getprop sys.boot_completed 2>/dev/null \
+  | tr -d '\r') || fail_preflight DEVICE_BOOT_STATUS_UNAVAILABLE
+[[ "$boot_completed" == "1" ]] || fail_preflight DEVICE_NOT_BOOTED
 
-printf 'ANDROID_SERIAL=%s\n' "$ANDROID_SERIAL" >> "${GITHUB_ENV:?GITHUB_ENV is required}"
-printf 'Validated ARM64 host and Android target %s (%s)\n' "$ANDROID_SERIAL" "$device_abi"
+[[ -n "${GITHUB_ENV:-}" ]] || fail_preflight GITHUB_ENV_MISSING
+printf 'ANDROID_SERIAL=%s\n' "$ANDROID_SERIAL" >> "$GITHUB_ENV" \
+  || fail_preflight GITHUB_ENV_WRITE_FAILED
+printf 'phase=preflight status=passed code=ARM64_DEVICE_READY checks=8\n'

--- a/.github/scripts/device-e2e/arm64-local-preflight.sh
+++ b/.github/scripts/device-e2e/arm64-local-preflight.sh
@@ -32,7 +32,10 @@ java_major=$(java -XshowSettings:properties -version 2>&1 \
   || fail_preflight JAVA_VERSION_UNAVAILABLE
 [[ "$java_major" == "21" ]] || fail_preflight JAVA_VERSION_INVALID
 
-mapfile -t attached_devices < <(adb devices 2>/dev/null \
+attached_devices=()
+while IFS= read -r attached_device; do
+  [[ -n "$attached_device" ]] && attached_devices+=("$attached_device")
+done < <(adb devices 2>/dev/null \
   | awk 'NR > 1 && $2 == "device" { print $1 }')
 if [[ -n "${ANDROID_SERIAL:-}" ]]; then
   printf '%s\n' "${attached_devices[@]}" | grep -Fx -- "$ANDROID_SERIAL" >/dev/null \

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -136,11 +136,11 @@ Representative examples:
   an explicit trusted caller.
   Artifact names include the run ID and attempt so reruns cannot overwrite or
   link a prior attempt's bundle. Both jobs initialize a revision-bound artifact
-  root after checkout, then run the bundle-owning runners with `--output`. A
-  started runner finalizes the full bundle (`inline/`, `logs/`, `summary.json`,
-  `junit.xml`) on success and failure; an earlier toolchain or device failure
-  retains the bootstrap record plus the Actions log. No job reads a repository
-  secret.
+  root after checkout, then run the bundle-owning runners with `--output`.
+  Android retains its bootstrap record under `android/logs/` and atomically
+  publishes its allowlisted proof under `android/evidence/`; iOS retains its
+  existing full bundle layout. An earlier toolchain or device failure retains
+  the bootstrap record plus the Actions log. No job reads a repository secret.
 - `android-arm64-local-e2e.yml` is the separate trusted repository-dispatch
   self-hosted physical-device lane for the embedded Bun + GGUF agent. Its
   `[self-hosted, Linux, ARM64, android-device]` labels are an infrastructure

--- a/.github/workflows/android-arm64-local-e2e.yml
+++ b/.github/workflows/android-arm64-local-e2e.yml
@@ -32,7 +32,7 @@ env:
   ELIZA_ANDROID_BACKEND: "local"
   ELIZA_ANDROID_REQUIRE_AGENT: "1"
   ELIZA_PAIRING_DISABLED: "1"
-  ELIZA_DEVICE_BUNDLE_ROOT: ${{ github.workspace }}/device-e2e-artifacts
+  ELIZA_DEVICE_BUNDLE_ROOT: ${{ github.workspace }}/device-e2e-artifacts/${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   android-arm64-local-runtime:
@@ -46,9 +46,14 @@ jobs:
 
       - name: Fail-closed ARM64 device preflight
         run: |
-          mkdir -p "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local/logs"
-          bash .github/scripts/device-e2e/arm64-local-preflight.sh 2>&1 \
-            | tee "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local/logs/arm64-preflight.log"
+          mkdir -p "$ELIZA_DEVICE_BUNDLE_ROOT/preflight"
+          if bash .github/scripts/device-e2e/arm64-local-preflight.sh \
+            > "$ELIZA_DEVICE_BUNDLE_ROOT/preflight/arm64-preflight.log" 2>&1; then
+            cat "$ELIZA_DEVICE_BUNDLE_ROOT/preflight/arm64-preflight.log"
+          else
+            cat "$ELIZA_DEVICE_BUNDLE_ROOT/preflight/arm64-preflight.log"
+            exit 1
+          fi
 
       - name: Install pinned workspace
         run: bun install --frozen-lockfile
@@ -59,13 +64,13 @@ jobs:
           --build
           --no-emulator-boot
           --arm64-local-probes
-          --output "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local"
+          --output "$ELIZA_DEVICE_BUNDLE_ROOT/runtime"
 
       - name: Upload ARM64 local-runtime bundle
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: android-arm64-local-runtime-bundle-${{ github.run_id }}-${{ github.run_attempt }}
-          path: device-e2e-artifacts/android-arm64-local/**
+          path: device-e2e-artifacts/${{ github.run_id }}-${{ github.run_attempt }}/**
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -5,13 +5,14 @@ name: Device E2E
 # producers were deleted by the CI consolidation (926dc8b58a1); this workflow
 # owns the current hosted-device route without reviving that sprawl. Each job
 # hands the whole lane to the single bundle-owning runner
-# (android-e2e.mjs / ios-e2e.mjs --output) so
-# build, install, and drive failures after the runner starts land inside one
-# finalized bundle root (inline/, logs/, summary.json, junit.xml). Each job
-# initializes its artifact root immediately after checkout, so a later
-# toolchain or emulator/simulator infrastructure failure still leaves a
-# revision-bound bootstrap record alongside the Actions log. No repository
-# secrets are read anywhere, so fork PRs stay credential-free.
+# (android-e2e.mjs / ios-e2e.mjs --output). Android keeps its bootstrap record
+# at android/logs/workflow-bootstrap.txt and atomically publishes the allowlisted
+# runner proof at android/evidence/{summary.json,junit.xml,media/}; iOS retains
+# its existing full bundle root. Each job initializes its artifact root
+# immediately after checkout, so a later toolchain or emulator/simulator
+# infrastructure failure still leaves a revision-bound bootstrap record
+# alongside the Actions log. No repository secrets are read anywhere, so fork
+# PRs stay credential-free.
 #
 # Reachability: repository policy forbids direct pull-request triggers
 # (audit:workflow-triggers), so canonical ci.yml calls this workflow behind the
@@ -125,7 +126,7 @@ jobs:
           emulator-options: -no-window -no-snapshot -no-boot-anim -gpu swiftshader_indirect -qemu -cpu qemu64,+avx,+avx2,+f16c,+fma
           # The runner invokes each physical line separately, so keep the
           # branch on one line and delegate the focused proof to a script.
-          script: if [ "$ELIZA_ANDROID_RELEASE_MINIFY_SMOKE" = "1" ]; then bash packages/app/scripts/android-release-minify-smoke.sh; else node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --start-host-agent --host-emulator-probes --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"; fi
+          script: if [ "$ELIZA_ANDROID_RELEASE_MINIFY_SMOKE" = "1" ]; then bash packages/app/scripts/android-release-minify-smoke.sh; else node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --start-host-agent --host-emulator-probes --output "$ELIZA_DEVICE_BUNDLE_ROOT/android/evidence"; fi
 
       - name: Upload Android device bundle
         if: always()

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -157,7 +157,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-platform-matrix-index
-          path: ${{ runner.temp }}/voice-platform-matrix
+          path: |
+            ${{ runner.temp }}/voice-platform-matrix/voice-matrix.json
+            ${{ runner.temp }}/voice-platform-matrix/voice-matrix.md
+            ${{ runner.temp }}/voice-platform-matrix/index.html
           if-no-files-found: error
 
   # Live contract against the two Railway voice services (Kokoro TTS + Whisper
@@ -192,7 +195,14 @@ jobs:
       - name: Run live Railway voice contract
         run: |
           set -euo pipefail
-          bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-railway-contract.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts > "$PRIVATE_LOG" 2>&1; then
+            echo "phase=railway-contract status=passed code=VOICE_CONTRACT_PASSED"
+          else
+            echo "phase=railway-contract status=failed code=VOICE_CONTRACT_FAILED" >&2
+            exit 1
+          fi
 
   # The service contract above does not exercise the shipped browser surface.
   # This separately gated job runs the exact live matrix cell from #16937 only
@@ -301,7 +311,8 @@ jobs:
           ffmpeg -y -v error \
             -f pulse -i eliza_voice_evidence.monitor \
             -ac 2 -ar 48000 \
-            "$RUNNER_TEMP/voice-web-live/system-loopback.wav" &
+            "$RUNNER_TEMP/voice-web-live/system-loopback.wav" \
+            > "$RUNNER_TEMP/voice-web-live/loopback-recorder.log" 2>&1 &
           echo "VOICE_LOOPBACK_PID=$!" >> "$GITHUB_ENV"
           sleep 1
           if ! kill -0 "$!" 2>/dev/null; then
@@ -311,7 +322,7 @@ jobs:
 
       - name: Run the provisioned live browser matrix cell
         env:
-          ELIZA_UI_SMOKE_BACKEND_LOG_PATH: ${{ runner.temp }}/voice-web-live/backend.log
+          ELIZA_UI_SMOKE_BACKEND_LOG_PATH: ${{ runner.temp }}/voice-web-live/private-backend.log
         run: |
           set -euo pipefail
           bun run voice:matrix -- \
@@ -354,7 +365,7 @@ jobs:
             --failures "$RUNNER_TEMP/voice-web-failure-results" \
             --loopback "$RUNNER_TEMP/voice-web-live/system-loopback.wav" \
             --loopback-clock "$RUNNER_TEMP/voice-web-live/system-loopback-clock.json" \
-            --backend "$RUNNER_TEMP/voice-web-live/backend.log" \
+            --backend "$RUNNER_TEMP/voice-web-live/private-backend.log" \
             --matrix "$RUNNER_TEMP/voice-web-live-matrix/voice-matrix.json" \
             --out "$RUNNER_TEMP/voice-web-final"
 
@@ -363,16 +374,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-web-live-railway
-          path: |
-            ${{ runner.temp }}/voice-web-live-ungated
-            ${{ runner.temp }}/voice-web-live-matrix
-            ${{ runner.temp }}/voice-web-live
-            ${{ runner.temp }}/voice-web-final
-            ${{ runner.temp }}/voice-web-failures-matrix
-            ${{ runner.temp }}/voice-web-failure-results
-            packages/app/playwright-report/
-            packages/app/test-results/
-            e2e-recordings/app/test-results/
+          path: ${{ runner.temp }}/voice-web-final
           if-no-files-found: ignore
           retention-days: 14
 
@@ -507,14 +509,32 @@ jobs:
           fused-lib-dir: ${{ runner.temp }}/fused-lib
 
       - name: Pre-Gemma ASR compatibility FFI smoke (bun:ffi)
-        run: bun run --cwd plugins/plugin-local-inference test:asr:real
+        run: |
+          set -euo pipefail
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-asr-smoke.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd plugins/plugin-local-inference test:asr:real > "$PRIVATE_LOG" 2>&1; then
+            echo "phase=asr-compatibility status=passed code=ASR_COMPATIBILITY_PASSED"
+          else
+            echo "phase=asr-compatibility status=failed code=ASR_COMPATIBILITY_FAILED" >&2
+            exit 1
+          fi
 
       # Designed key-gated step: the mixed round-trip crosses two external
       # paid services. Absence of the keys is surfaced loudly below instead of
       # a silent skip.
       - name: Optional mixed real round-trip test
         if: env.ELEVENLABS_API_KEY != '' && env.CEREBRAS_API_KEY != ''
-        run: bun run --cwd plugins/plugin-local-inference roundtrip:real
+        run: |
+          set -euo pipefail
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-mixed-roundtrip.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd plugins/plugin-local-inference roundtrip:real > "$PRIVATE_LOG" 2>&1; then
+            echo "phase=mixed-roundtrip status=passed code=MIXED_ROUNDTRIP_PASSED"
+          else
+            echo "phase=mixed-roundtrip status=failed code=MIXED_ROUNDTRIP_FAILED" >&2
+            exit 1
+          fi
 
       - name: Note skipped mixed round-trip (keys absent)
         if: env.ELEVENLABS_API_KEY == '' || env.CEREBRAS_API_KEY == ''
@@ -552,23 +572,16 @@ jobs:
       - name: Prepare matrix output dir + environment probe
         run: |
           set -euo pipefail
-          VOICE_REAL_MATRIX_OUT="$RUNNER_TEMP/voice-real-matrix"
+          VOICE_REAL_MATRIX_OUT="$RUNNER_TEMP/voice-real-private"
+          VOICE_REAL_MATRIX_PROOF="$RUNNER_TEMP/voice-real-proof"
           echo "VOICE_REAL_MATRIX_OUT=$VOICE_REAL_MATRIX_OUT" >> "$GITHUB_ENV"
-          mkdir -p "$VOICE_REAL_MATRIX_OUT"
-          {
-            echo "runner=$(hostname)"
-            echo "workspace=$GITHUB_WORKSPACE"
-            echo "runnerTemp=$RUNNER_TEMP"
-            # Keyless by design (#9577): the owner/impostor/agent corpus is
-            # synthesized locally with distinct fused Kokoro voice packs, so no
-            # ElevenLabs secret is required. The key only upgrades the
-            # human-turn rows to real voices.
-            if [ -z "${ELEVENLABS_API_KEY:-}" ]; then
-              echo "ELEVENLABS_API_KEY not set — keyless local-Kokoro corpus (#9577)"
-            else
-              echo "ELEVENLABS_API_KEY present — human-turn rows use real ElevenLabs voices"
-            fi
-          } 2>&1 | tee "$VOICE_REAL_MATRIX_OUT/probe.log"
+          echo "VOICE_REAL_MATRIX_PROOF=$VOICE_REAL_MATRIX_PROOF" >> "$GITHUB_ENV"
+          mkdir -p "$VOICE_REAL_MATRIX_OUT" "$VOICE_REAL_MATRIX_PROOF"
+          if [ -n "${ELEVENLABS_API_KEY:-}" ]; then credential_ready=true; else credential_ready=false; fi
+          jq -n --argjson credentialReady "$credential_ready" \
+            '{phase:"environment",status:"passed",code:"VOICE_ENVIRONMENT_READY",credentialReady:$credentialReady}' \
+            > "$VOICE_REAL_MATRIX_PROOF/environment.json"
+          echo "phase=environment status=passed code=VOICE_ENVIRONMENT_READY"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -604,36 +617,62 @@ jobs:
       - name: Record provisioning evidence
         run: |
           set -euo pipefail
-          {
-            echo "bundle=$ELIZA_ASR_BUNDLE"
-            echo "fusedLib=$ELIZA_INFERENCE_LIBRARY"
-            find "$ELIZA_ASR_BUNDLE" -type f -printf '%P %s bytes\n' | sort
-            sha256sum "$ELIZA_INFERENCE_LIBRARY"
-          } | tee "$VOICE_REAL_MATRIX_OUT/provisioning.txt"
+          PRIVATE_QUERY_LOG=$(mktemp "$RUNNER_TEMP/voice-assets-query.XXXXXX")
+          trap 'rm -f "$PRIVATE_QUERY_LOG"' EXIT
+          if bundle_file_count=$(find "$ELIZA_ASR_BUNDLE" -type f 2> "$PRIVATE_QUERY_LOG" | wc -l | tr -d ' '); then
+            rm -f "$PRIVATE_QUERY_LOG"
+          else
+            rm -f "$PRIVATE_QUERY_LOG"
+            echo "phase=provisioning status=failed code=VOICE_ASSETS_QUERY_FAILED" >&2
+            exit 1
+          fi
+          if [ -f "$ELIZA_INFERENCE_LIBRARY" ]; then library_ready=true; else library_ready=false; fi
+          jq -n --argjson bundleFileCount "$bundle_file_count" --argjson libraryReady "$library_ready" \
+            '{phase:"provisioning",status:"passed",code:"VOICE_ASSETS_READY",bundleFileCount:$bundleFileCount,libraryReady:$libraryReady}' \
+            > "$VOICE_REAL_MATRIX_PROOF/provisioning.json"
+          echo "phase=provisioning status=passed code=VOICE_ASSETS_READY bundleFileCount=$bundle_file_count"
 
       - name: Real Kokoro GGUF synth smoke
         run: |
           set -euo pipefail
-          bun run --cwd plugins/plugin-local-inference test:kokoro:real \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/kokoro-real-smoke.log"
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-kokoro.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd plugins/plugin-local-inference test:kokoro:real > "$PRIVATE_LOG" 2>&1; then
+            jq -n '{phase:"kokoro",status:"passed",code:"KOKORO_SMOKE_PASSED"}' > "$VOICE_REAL_MATRIX_PROOF/kokoro.json"
+            echo "phase=kokoro status=passed code=KOKORO_SMOKE_PASSED"
+          else
+            echo "phase=kokoro status=failed code=KOKORO_SMOKE_FAILED" >&2
+            exit 1
+          fi
 
       - name: Real fused attribution smoke
         run: |
           set -euo pipefail
-          bun packages/app-core/scripts/voice-attribution-smoke.ts \
-            --models "$ELIZA_VOICE_REAL_MODEL_DIR" \
-            --require-real \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/voice-attribution-smoke.log"
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-attribution.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun packages/app-core/scripts/voice-attribution-smoke.ts \
+            --models "$ELIZA_VOICE_REAL_MODEL_DIR" --require-real > "$PRIVATE_LOG" 2>&1; then
+            jq -n '{phase:"attribution",status:"passed",code:"ATTRIBUTION_SMOKE_PASSED"}' > "$VOICE_REAL_MATRIX_PROOF/attribution.json"
+            echo "phase=attribution status=passed code=ATTRIBUTION_SMOKE_PASSED"
+          else
+            echo "phase=attribution status=failed code=ATTRIBUTION_SMOKE_FAILED" >&2
+            exit 1
+          fi
 
       - name: Real plugin voice stack matrix
         run: |
           set -euo pipefail
-          bun run --cwd plugins/plugin-local-inference voicestack:real \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/voicestack-real.log"
-          bun run --cwd plugins/plugin-local-inference agentvoice:real \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/agentvoice-real.log"
-          bun run --cwd plugins/plugin-local-inference robustness:real \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/robustness-real.log"
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-plugin-stack.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd plugins/plugin-local-inference voicestack:real > "$PRIVATE_LOG" 2>&1 \
+            && bun run --cwd plugins/plugin-local-inference agentvoice:real >> "$PRIVATE_LOG" 2>&1 \
+            && bun run --cwd plugins/plugin-local-inference robustness:real >> "$PRIVATE_LOG" 2>&1; then
+            jq -n '{phase:"plugin-stack",status:"passed",code:"PLUGIN_STACK_PASSED",cellCount:3}' > "$VOICE_REAL_MATRIX_PROOF/plugin-stack.json"
+            echo "phase=plugin-stack status=passed code=PLUGIN_STACK_PASSED cellCount=3"
+          else
+            echo "phase=plugin-stack status=failed code=PLUGIN_STACK_FAILED" >&2
+            exit 1
+          fi
 
       # Hard-real authority (#16972): the workbench consumes provider-produced
       # diarization boundaries across the full stream and fails closed when an
@@ -642,9 +681,16 @@ jobs:
       - name: Real voice workbench scenario matrix
         run: |
           set -euo pipefail
-          bun run --cwd plugins/plugin-local-inference voice:workbench --real \
-            --out "$VOICE_REAL_MATRIX_OUT/voice-workbench-real" \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/voice-workbench-real.log"
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-workbench.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd plugins/plugin-local-inference voice:workbench --real \
+            --out "$VOICE_REAL_MATRIX_OUT/voice-workbench-real" > "$PRIVATE_LOG" 2>&1; then
+            jq -n '{phase:"workbench",status:"passed",code:"VOICE_WORKBENCH_PASSED"}' > "$VOICE_REAL_MATRIX_PROOF/workbench.json"
+            echo "phase=workbench status=passed code=VOICE_WORKBENCH_PASSED"
+          else
+            echo "phase=workbench status=failed code=VOICE_WORKBENCH_FAILED" >&2
+            exit 1
+          fi
 
       # bun test, NOT vitest: these suites need bun:ffi, and vitest's node
       # workers make every one of them skip — a green-skip lie this lane bans.
@@ -653,27 +699,42 @@ jobs:
       - name: Fused component compatibility FFI test lanes (bun:ffi)
         run: |
           set -euo pipefail
-          bun test \
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-fused-ffi.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if ! bun test \
             plugins/plugin-local-inference/src/services/voice/speaker/encoder-fused.real.test.ts \
             plugins/plugin-local-inference/src/services/voice/speaker/diarizer-fused.real.test.ts \
             plugins/plugin-local-inference/src/services/voice/asr-timed.real.test.ts \
             plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-engine-bridge.real.test.ts \
-            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log"
+            > "$PRIVATE_LOG" 2>&1; then
+            echo "phase=fused-ffi status=failed code=FUSED_FFI_FAILED" >&2
+            exit 1
+          fi
           # Per-cell accounting: ANY nonzero skip count means some matrix cell
           # did not execute against the staged lib — a partial skip is as much
           # a green-skip lie as a full-lane skip, so it fails the same way.
-          if grep -Eq "(^| )0 pass" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log" \
-            || grep -Eq "(^| )[1-9][0-9]* skip" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log"; then
-            echo "::error title=Fused FFI lanes skipped::one or more compatibility FFI suite cells did not execute — staging or bun:ffi is broken"
+          if grep -Eq "(^| )0 pass" "$PRIVATE_LOG" \
+            || grep -Eq "(^| )[1-9][0-9]* skip" "$PRIVATE_LOG"; then
+            echo "phase=fused-ffi status=failed code=FUSED_FFI_INCOMPLETE" >&2
             exit 1
           fi
+          jq -n '{phase:"fused-ffi",status:"passed",code:"FUSED_FFI_PASSED"}' > "$VOICE_REAL_MATRIX_PROOF/fused-ffi.json"
+          echo "phase=fused-ffi status=passed code=FUSED_FFI_PASSED"
 
-      - name: Upload real voice matrix logs
+      - name: Remove private voice matrix diagnostics
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${VOICE_REAL_MATRIX_OUT:-}" = "$RUNNER_TEMP/voice-real-private" ]; then
+            rm -rf -- "$RUNNER_TEMP/voice-real-private"
+          fi
+
+      - name: Upload privacy-safe real voice matrix proof
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-real-acoustic-matrix
-          path: ${{ runner.temp }}/voice-real-matrix
+          path: ${{ runner.temp }}/voice-real-proof
           if-no-files-found: error
 
   voice-macos-electrobun-matrix:
@@ -720,10 +781,18 @@ jobs:
       - name: Run macOS Electrobun matrix inside synchronized hardware capture
         run: |
           set -euo pipefail
-          bun run --cwd packages/app voice:evidence:desktop:capture -- \
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-macos-capture.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd packages/app voice:evidence:desktop:capture -- \
             --platform darwin \
             --out "$RUNNER_TEMP/voice-macos-hardware-capture" \
-            -- bun run voice:matrix -- --run --require-green --platform macos-electrobun --out "$RUNNER_TEMP/voice-macos-electrobun-matrix"
+            -- bun run voice:matrix -- --run --require-green --platform macos-electrobun --out "$RUNNER_TEMP/voice-macos-electrobun-matrix" \
+            > "$PRIVATE_LOG" 2>&1; then
+            echo "phase=macos-capture status=passed code=DESKTOP_CAPTURE_PASSED"
+          else
+            echo "phase=macos-capture status=failed code=DESKTOP_CAPTURE_FAILED" >&2
+            exit 1
+          fi
 
       - name: Finalize real macOS microphone and speaker evidence
         env:
@@ -749,10 +818,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-macos-electrobun-matrix
-          path: |
-            ${{ runner.temp }}/voice-macos-electrobun-matrix
-            ${{ runner.temp }}/voice-macos-hardware-capture
-            ${{ runner.temp }}/voice-macos-electrobun-final
+          path: ${{ runner.temp }}/voice-macos-electrobun-final
           if-no-files-found: error
 
   voice-windows-electrobun-matrix:
@@ -797,10 +863,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bun run --cwd packages/app voice:evidence:desktop:capture -- \
+          PRIVATE_LOG=$(mktemp "$RUNNER_TEMP/voice-windows-capture.XXXXXX")
+          trap 'rm -f "$PRIVATE_LOG"' EXIT
+          if bun run --cwd packages/app voice:evidence:desktop:capture -- \
             --platform win32 \
             --out "$RUNNER_TEMP/voice-windows-hardware-capture" \
-            -- bun run voice:matrix -- --run --require-green --platform windows-electrobun --out "$RUNNER_TEMP/voice-windows-electrobun-matrix"
+            -- bun run voice:matrix -- --run --require-green --platform windows-electrobun --out "$RUNNER_TEMP/voice-windows-electrobun-matrix" \
+            > "$PRIVATE_LOG" 2>&1; then
+            echo "phase=windows-capture status=passed code=DESKTOP_CAPTURE_PASSED"
+          else
+            echo "phase=windows-capture status=failed code=DESKTOP_CAPTURE_FAILED" >&2
+            exit 1
+          fi
 
       - name: Finalize real Windows microphone and speaker evidence
         shell: bash
@@ -827,10 +901,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-windows-electrobun-matrix
-          path: |
-            ${{ runner.temp }}/voice-windows-electrobun-matrix
-            ${{ runner.temp }}/voice-windows-hardware-capture
-            ${{ runner.temp }}/voice-windows-electrobun-final
+          path: ${{ runner.temp }}/voice-windows-electrobun-final
           if-no-files-found: error
 
   voice-ios-matrix:
@@ -874,7 +945,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-ios-matrix
-          path: ${{ runner.temp }}/voice-ios-matrix
+          path: |
+            ${{ runner.temp }}/voice-ios-matrix/voice-matrix.json
+            ${{ runner.temp }}/voice-ios-matrix/voice-matrix.md
+            ${{ runner.temp }}/voice-ios-matrix/index.html
           if-no-files-found: error
 
   voice-android-matrix:
@@ -922,5 +996,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voice-android-matrix
-          path: ${{ runner.temp }}/voice-android-matrix
+          path: |
+            ${{ runner.temp }}/voice-android-matrix/voice-matrix.json
+            ${{ runner.temp }}/voice-android-matrix/voice-matrix.md
+            ${{ runner.temp }}/voice-android-matrix/index.html
           if-no-files-found: error

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -218,6 +218,7 @@ jobs:
       E2E_RECORD: "1"
       ELIZA_UI_SMOKE_LIVE_STACK: "1"
       ELIZA_VOICE_LIVE_RAILWAY: "1"
+      ELIZA_VOICE_MATRIX_SESSION_ID: ${{ github.run_id }}-${{ github.run_attempt }}-web-live
       ELIZA_PROVIDER: "cerebras"
       KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
       WHISPER_STT_URL: ${{ vars.ELIZA_VOICE_WHISPER_STT_URL }}

--- a/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
@@ -26,21 +26,28 @@ function runVoiceMatrix(args: string[], env: NodeJS.ProcessEnv = {}) {
   return { outDir, report, result };
 }
 
+function executable(file: string, source: string) {
+  fs.writeFileSync(file, source, { mode: 0o755 });
+}
+
 describe("voice matrix CLI", () => {
   test("fails closed when a platform/id filter selects no cells", () => {
+    const filterCanary = "FILTER_CANARY_room-private-9911";
     const { report, result } = runVoiceMatrix([
       "--platform",
-      "ios.sim.voice-roundtrip",
+      filterCanary,
       "--require-green",
     ]);
 
     expect(result.status).toBe(1);
+    expect(report.schema).toBe("eliza_voice_live_matrix_v2");
     expect(report.selection).toEqual({
-      platformFilters: ["ios.sim.voice-roundtrip"],
+      filterCount: 1,
       matched: 0,
-      error: "no voice matrix cells matched --platform=ios.sim.voice-roundtrip",
+      errorCode: "NO_MATCH",
     });
     expect(report.cells).toHaveLength(0);
+    expect(JSON.stringify(report)).not.toContain(filterCanary);
   });
 
   test("accepts the iOS voice roundtrip cell id filter", () => {
@@ -51,9 +58,9 @@ describe("voice matrix CLI", () => {
 
     expect(result.status).toBe(0);
     expect(report.selection).toEqual({
-      platformFilters: ["ios.sim-or-device.voice-roundtrip"],
+      filterCount: 1,
       matched: 1,
-      error: null,
+      errorCode: null,
     });
     expect(report.cells).toHaveLength(1);
     expect(report.cells[0].id).toBe("ios.sim-or-device.voice-roundtrip");
@@ -72,8 +79,7 @@ describe("voice matrix CLI", () => {
     expect(missingCloud.result.status).toBe(0);
     expect(missingCloud.report.cells[0].probe).toEqual({
       available: false,
-      reason:
-        "ELIZAOS_CLOUD_API_KEY is required for the live Railway browser round-trip",
+      code: "WEB_LIVE_CREDENTIAL_MISSING",
     });
 
     const provisioned = runVoiceMatrix(
@@ -121,5 +127,53 @@ describe("voice matrix CLI", () => {
     expect(report.cells[0].command).toEqual(
       expect.arrayContaining(["--grep", "voice failure paths"]),
     );
+  });
+
+  test("projects command diagnostics without host identity or raw output", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "voice-matrix-bin-"));
+    const stdoutCanary = "MODEL_RESPONSE_CANARY_room-7788";
+    const stderrCanary = "STDERR_CANARY_trajectory-9911";
+    executable(
+      path.join(binDir, "bun"),
+      `#!/bin/sh\nprintf '%s\\n' '${stdoutCanary}'\nprintf '%s\\n' '${stderrCanary}' >&2\nkill -TERM $$\n`,
+    );
+
+    const runnerOsCanary = "RUNNER_OS_CANARY_private-host";
+    const runnerArchCanary = "RUNNER_ARCH_CANARY_private-host";
+
+    const { outDir, report, result } = runVoiceMatrix(
+      ["--run", "--platform", "web.failure-paths"],
+      {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        RUNNER_OS: runnerOsCanary,
+        RUNNER_ARCH: runnerArchCanary,
+      },
+    );
+    const serialized = [
+      JSON.stringify(report),
+      fs.readFileSync(path.join(outDir, "voice-matrix.md"), "utf8"),
+      fs.readFileSync(path.join(outDir, "index.html"), "utf8"),
+      result.stdout,
+      result.stderr,
+    ].join("\n");
+
+    expect(result.status).toBe(1);
+    expect(report.host).not.toHaveProperty("hostname");
+    expect(report.cells[0].execution).toEqual({
+      exitCode: null,
+      signalCode: "TERMINATED",
+      code: "COMMAND_SIGNALLED",
+    });
+    expect(report.cells[0].probe).toEqual({
+      available: true,
+      code: "WEB_FAKE_DEVICE_AVAILABLE",
+    });
+    expect(serialized).not.toContain(os.hostname());
+    expect(serialized).not.toContain(stdoutCanary);
+    expect(serialized).not.toContain(stderrCanary);
+    expect(serialized).not.toContain(runnerOsCanary);
+    expect(serialized).not.toContain(runnerArchCanary);
+    expect(serialized).not.toContain("stdoutTail");
+    expect(serialized).not.toContain("stderrTail");
   });
 });

--- a/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
@@ -33,14 +33,15 @@ function executable(file: string, source: string) {
 describe("voice matrix CLI", () => {
   test("fails closed when a platform/id filter selects no cells", () => {
     const filterCanary = "FILTER_CANARY_room-private-9911";
-    const { report, result } = runVoiceMatrix([
-      "--platform",
-      filterCanary,
-      "--require-green",
-    ]);
+    const { report, result } = runVoiceMatrix(
+      ["--platform", filterCanary, "--require-green"],
+      { ELIZA_VOICE_MATRIX_SESSION_ID: "voice-matrix-session-123" },
+    );
 
     expect(result.status).toBe(1);
     expect(report.schema).toBe("eliza_voice_live_matrix_v2");
+    expect(report.revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(report.sessionId).toBe("voice-matrix-session-123");
     expect(report.selection).toEqual({
       filterCount: 1,
       matched: 0,

--- a/packages/app-core/scripts/voice/voice-matrix.mjs
+++ b/packages/app-core/scripts/voice/voice-matrix.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-// Drives repo automation voice matrix with explicit CLI and CI behavior.
+/** Drives repo automation voice matrix with explicit CLI and CI behavior. */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -711,7 +710,7 @@ function runCapture(command, cwd, extraEnv = {}, context = {}) {
   return {
     startedAt,
     finishedAt: new Date().toISOString(),
-    exitCode: result.status ?? 1,
+    exitCode: result.status,
     signal: result.signal,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",
@@ -1023,18 +1022,100 @@ function statusFor(args, probe, execution) {
   return execution.exitCode === 0 ? "pass" : "fail";
 }
 
+const AVAILABLE_PROBE_CODES = {
+  web: "WEB_FAKE_DEVICE_AVAILABLE",
+  webLiveRailway: "WEB_LIVE_READY",
+  linuxFused: "LINUX_FUSED_READY",
+  openWakeWord: "OPENWAKEWORD_REPORT_READY",
+  macosElectrobun: "MACOS_ELECTROBUN_READY",
+  windowsElectrobun: "WINDOWS_ELECTROBUN_READY",
+  ios: "IOS_DEVICE_READY",
+  swiftPackage: "SWIFT_TOOLCHAIN_READY",
+  android: "ANDROID_DEVICE_READY",
+  androidGradle: "ANDROID_GRADLE_READY",
+  stageBSttApple: "APPLE_STT_READY",
+  stageBStt: "STAGE_B_REPORT_READY",
+};
+
+const UNAVAILABLE_PROBE_CODES = {
+  web: "WEB_FAKE_DEVICE_UNAVAILABLE",
+  webLiveRailway: "WEB_LIVE_UNAVAILABLE",
+  linuxFused: "LINUX_FUSED_UNAVAILABLE",
+  openWakeWord: "OPENWAKEWORD_REPORT_UNAVAILABLE",
+  macosElectrobun: "MACOS_ELECTROBUN_UNAVAILABLE",
+  windowsElectrobun: "WINDOWS_ELECTROBUN_UNAVAILABLE",
+  ios: "IOS_DEVICE_UNAVAILABLE",
+  swiftPackage: "SWIFT_TOOLCHAIN_UNAVAILABLE",
+  android: "ANDROID_DEVICE_UNAVAILABLE",
+  androidGradle: "ANDROID_GRADLE_UNAVAILABLE",
+  stageBSttApple: "APPLE_STT_UNAVAILABLE",
+  stageBStt: "STAGE_B_REPORT_UNAVAILABLE",
+};
+
+function projectProbe(cell, probe) {
+  if (probe.reason === "bun is not available on PATH") {
+    return { available: false, code: "BUN_UNAVAILABLE" };
+  }
+  if (
+    cell.probe === "webLiveRailway" &&
+    /is required for the live Railway browser round-trip/.test(probe.reason)
+  ) {
+    return { available: false, code: "WEB_LIVE_CREDENTIAL_MISSING" };
+  }
+  return {
+    available: probe.available,
+    code: probe.available
+      ? (AVAILABLE_PROBE_CODES[cell.probe] ?? "PROBE_AVAILABLE")
+      : (UNAVAILABLE_PROBE_CODES[cell.probe] ?? "PROBE_UNAVAILABLE"),
+  };
+}
+
+function projectExecution(execution) {
+  if (!execution) return null;
+  return {
+    exitCode: execution.exitCode,
+    signalCode:
+      {
+        SIGTERM: "TERMINATED",
+        SIGKILL: "KILLED",
+        SIGINT: "INTERRUPTED",
+      }[execution.signal] ?? (execution.signal ? "OTHER_SIGNAL" : null),
+    code:
+      execution.exitCode === 0
+        ? "COMMAND_PASSED"
+        : execution.signal
+          ? "COMMAND_SIGNALLED"
+          : "COMMAND_EXIT_NONZERO",
+  };
+}
+
+function hostClass() {
+  const platformCode =
+    {
+      darwin: "MACOS",
+      linux: "LINUX",
+      win32: "WINDOWS",
+    }[process.platform] ?? "OTHER_PLATFORM";
+  const archCode =
+    {
+      arm64: "ARM64",
+      x64: "X64",
+    }[process.arch] ?? "OTHER_ARCH";
+  return { platformCode, archCode };
+}
+
 function renderMarkdown(report) {
   const rows = report.cells.map((cell) => {
     const cmd = cell.command
       .map((part) => (part.includes(" ") ? JSON.stringify(part) : part))
       .join(" ");
-    return `| \`${cell.id}\` | ${cell.status} | ${cell.platform} | ${cell.class} | ${cell.probe.reason.replaceAll("|", "\\|")} | \`${cmd.replaceAll("|", "\\|")}\` |`;
+    return `| \`${cell.id}\` | ${cell.status} | ${cell.platform} | ${cell.class} | ${cell.probe.code} | \`${cmd.replaceAll("|", "\\|")}\` |`;
   });
   return [
     "# Voice Live Matrix",
     "",
     `Generated: ${report.generatedAt}`,
-    `Host: ${report.host.platform} ${report.host.arch} (${report.host.hostname})`,
+    `Host class: ${report.host.platformCode} ${report.host.archCode}`,
     "",
     "| Cell | Status | Platform | Class | Probe / Result | Command |",
     "|---|---:|---|---|---|---|",
@@ -1066,7 +1147,7 @@ function renderHtml(report) {
           Object.entries(cell.dimensions)
             .map(([k, v]) => `${k}=${v}`)
             .join("\n"),
-        )}</td><td>${esc(cell.probe.reason)}</td><td><code>${esc(cell.command.join(" "))}</code></td><td>${esc(cell.evidence.join("\n"))}</td></tr>`,
+        )}</td><td>${esc(cell.probe.code)}</td><td><code>${esc(cell.command.join(" "))}</code></td><td>${esc(cell.evidence.join("\n"))}</td></tr>`,
     )
     .join("\n");
   return `<!doctype html>
@@ -1083,7 +1164,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated ${esc(report.generatedAt)} on ${esc(report.host.platform)} ${esc(report.host.arch)} (${esc(report.host.hostname)}).</p>
+<p>Generated ${esc(report.generatedAt)} for ${esc(report.host.platformCode)} ${esc(report.host.archCode)}.</p>
 <p>Pass ${report.summary.pass} · Fail ${report.summary.fail} · Pending ${report.summary.pending} · Skip ${report.summary.skip}</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
@@ -1105,34 +1186,22 @@ async function main() {
       : null;
   const cells = [];
   for (const cell of selected) {
-    const probe = probeCell(cell);
+    const rawProbe = probeCell(cell);
     let execution = null;
-    if (args.run && probe.available) {
+    if (args.run && rawProbe.available) {
       execution = runCapture(cell.command, cell.cwd, cell.env, {
         matrixOut: outDir,
         cellId: cell.id,
       });
-      probe.reason =
-        execution.exitCode === 0
-          ? `command passed (${execution.finishedAt})`
-          : `command failed with exit ${execution.exitCode}${execution.signal ? ` signal ${execution.signal}` : ""}`;
     }
+    const probe = projectProbe(cell, rawProbe);
     cells.push({
       ...cell,
       cwd: cell.cwd ?? ".",
       env: cell.env ?? {},
       probe,
-      execution: execution
-        ? {
-            exitCode: execution.exitCode,
-            signal: execution.signal,
-            startedAt: execution.startedAt,
-            finishedAt: execution.finishedAt,
-            stdoutTail: execution.stdout.slice(-4000),
-            stderrTail: execution.stderr.slice(-4000),
-          }
-        : null,
-      status: statusFor(args, probe, execution),
+      execution: projectExecution(execution),
+      status: statusFor(args, rawProbe, execution),
     });
   }
 
@@ -1140,23 +1209,17 @@ async function main() {
   for (const cell of cells) summary[cell.status] += 1;
 
   const report = {
-    schema: "eliza_voice_live_matrix_v1",
+    schema: "eliza_voice_live_matrix_v2",
     issue: Number(ISSUE),
     generatedAt: new Date().toISOString(),
     mode: args.run ? "run" : "probe",
     dimensions: DIMENSIONS,
     selection: {
-      platformFilters,
+      filterCount: platformFilters.length,
       matched: selected.length,
-      error: selectionError,
+      errorCode: selectionError ? "NO_MATCH" : null,
     },
-    host: {
-      platform: process.platform,
-      arch: process.arch,
-      hostname: os.hostname(),
-      runnerOs: process.env.RUNNER_OS ?? null,
-      runnerArch: process.env.RUNNER_ARCH ?? null,
-    },
+    host: hostClass(),
     summary,
     cells,
   };
@@ -1172,12 +1235,14 @@ async function main() {
   );
   fs.writeFileSync(path.join(outDir, "index.html"), renderHtml(report));
   console.log(
-    `[voice:matrix] wrote ${path.relative(REPO_ROOT, outDir)}/voice-matrix.json`,
+    "[voice:matrix] phase=report status=passed code=MATRIX_REPORT_WRITTEN fileCount=3",
   );
   console.log(
     `[voice:matrix] pass=${summary.pass} fail=${summary.fail} pending=${summary.pending} skip=${summary.skip}`,
   );
-  if (selectionError) console.error(`[voice:matrix] ${selectionError}`);
+  if (selectionError) {
+    console.error("[voice:matrix] phase=selection status=failed code=NO_MATCH");
+  }
 
   if (
     selectionError ||
@@ -1189,8 +1254,9 @@ async function main() {
 }
 
 main().catch((error) => {
+  void error;
   console.error(
-    `[voice:matrix] ${error instanceof Error ? error.stack : String(error)}`,
+    "[voice:matrix] phase=runner status=failed code=UNHANDLED_ERROR",
   );
   process.exit(1);
 });

--- a/packages/app-core/scripts/voice/voice-matrix.mjs
+++ b/packages/app-core/scripts/voice/voice-matrix.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /** Drives repo automation voice matrix with explicit CLI and CI behavior. */
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +14,27 @@ const REPO_ROOT = path.resolve(
   "..",
 );
 const ISSUE = "9958";
+
+function exactRevision() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  const revision = result.status === 0 ? result.stdout.trim() : "";
+  if (!/^[0-9a-f]{40}$/.test(revision)) {
+    throw new Error("Voice matrix requires an exact Git revision.");
+  }
+  return revision;
+}
+
+function matrixSessionId() {
+  const sessionId =
+    process.env.ELIZA_VOICE_MATRIX_SESSION_ID?.trim() || randomUUID();
+  if (!/^[A-Za-z0-9-]{12,128}$/.test(sessionId)) {
+    throw new Error("Voice matrix session ID is not a safe closed identifier.");
+  }
+  return sessionId;
+}
 
 const DIMENSIONS = {
   platform: [
@@ -1210,6 +1232,8 @@ async function main() {
 
   const report = {
     schema: "eliza_voice_live_matrix_v2",
+    revision: exactRevision(),
+    sessionId: matrixSessionId(),
     issue: Number(ISSUE),
     generatedAt: new Date().toISOString(),
     mode: args.run ? "run" : "probe",

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -13,20 +13,16 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  captureAndroidLogcat,
-  captureAndroidScreenshot,
-  startAndroidScreenRecord,
-} from "./lib/android-capture.mjs";
+import { startAndroidScreenRecord } from "./lib/android-capture.mjs";
 import {
   androidApkNeedsBuild,
   androidDistNeedsBuild,
   androidInstallDecision,
   ensureEmulatorBooted,
   ensureEmulatorPermissive,
-  installApk,
   listDevices,
   readFreshAndroidRendererStamp,
   readInstalledRendererStamp,
@@ -38,14 +34,18 @@ import {
 } from "./lib/android-device.mjs";
 import { resolveAndroidE2eBuildScript } from "./lib/android-e2e-build.mjs";
 import {
+  createAndroidEvidenceBoundary,
+  projectAndroidDeviceEvidenceBundle,
+  settleAndroidEvidenceTeardown,
+} from "./lib/android-e2e-evidence-policy.mjs";
+import {
   captureFailureForensics,
   createDeviceE2eBundle,
+  defaultDeviceE2eOutputDir,
   finalizeDeviceE2eBundle,
   finishBundleStep,
-  formatFailureForensicsBlock,
   parseOutputDirArg,
   recordBundleArtifact,
-  runBundledCommand,
   setBundleBuild,
   setBundleDevice,
   startBundleStep,
@@ -61,7 +61,19 @@ const val = (flag, fb) => {
   const i = process.argv.indexOf(flag);
   return i >= 0 ? process.argv[i + 1] : fb;
 };
-const log = (m) => console.log(`[android-e2e] ${m}`);
+const evidenceBoundary = createAndroidEvidenceBoundary();
+const log = evidenceBoundary.callback("runner");
+
+function defaultAndroidEvidenceOutputDir() {
+  if (process.platform === "win32") {
+    const trustedTempRoot = process.env.RUNNER_TEMP?.trim() || os.tmpdir();
+    return path.join(
+      trustedTempRoot,
+      `eliza-android-evidence-${randomBytes(12).toString("hex")}`,
+    );
+  }
+  return defaultDeviceE2eOutputDir({ appDir, lane: "android" });
+}
 
 // These lists are intentionally explicit. The hosted x86_64 emulator must not
 // accidentally inherit a new local-runtime, destructive lifecycle, or voice
@@ -174,7 +186,7 @@ function stageVoiceModels(adb, serial) {
   for (const m of toStage) {
     log(`staging voice model ${path.basename(m.host)}…`);
     const res = spawnSync(adb, ["-s", serial, "push", m.host, m.dev], {
-      stdio: "inherit",
+      stdio: "ignore",
     });
     if (res.status !== 0) {
       throw new Error(`adb push ${m.host} exited with code ${res.status}`);
@@ -200,55 +212,48 @@ function stageVoiceModels(adb, serial) {
 }
 
 function run(bundle, name, cmd, args, env = {}) {
-  return runBundledCommand(bundle, name, cmd, args, {
+  const step = startBundleStep(bundle, name);
+  evidenceBoundary.event("runner", "started", "PHASE_STARTED");
+  const result = spawnSync(cmd, args, {
     cwd: appDir,
-    env,
-    onFailure: (step, error) => captureAndroidFailure(bundle, step, error),
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
   });
+  if (result.status === 0 && !result.error && !result.signal) {
+    finishBundleStep(bundle, step, "passed");
+    evidenceBoundary.event("runner", "passed", "PHASE_PASSED");
+    return result;
+  }
+  const safeError = new Error("Android E2E phase failed.");
+  captureAndroidFailure(bundle, step);
+  finishBundleStep(bundle, step, "failed", safeError);
+  evidenceBoundary.event("runner", "failed", "PHASE_FAILED");
+  throw safeError;
 }
 
-let activeAndroidContext = { adb: null, serial: null };
-
-function captureAndroidFailure(bundle, step, error) {
-  const { adb, serial } = activeAndroidContext;
+function captureAndroidFailure(bundle, step) {
+  const safeError = new Error("Android E2E phase failed.");
   return captureFailureForensics(
     bundle,
     step,
     ({ failureDir }) => {
-      const files = [];
-      const causePath = path.join(failureDir, "failure-cause.txt");
-      fs.writeFileSync(causePath, `${error?.message ?? error}\n`);
-      files.push(causePath);
-      if (adb && serial) {
-        files.push(
-          captureAndroidScreenshot({
-            adb,
-            serial,
-            artifactDir: failureDir,
-            filename: "screen.png",
-            log,
-          }),
-        );
-        files.push(
-          captureAndroidLogcat({
-            adb,
-            serial,
-            artifactDir: failureDir,
-            filename: "logcat.txt",
-            lines: 2000,
-            log,
-          }),
-        );
-      }
-      return files;
+      const proofPath = path.join(failureDir, "failure-proof.json");
+      fs.writeFileSync(
+        proofPath,
+        `${JSON.stringify({ phase: "runner", code: "PHASE_FAILED" })}\n`,
+      );
+      return [proofPath];
     },
-    error,
+    safeError,
   );
 }
 
 function failAndroidStep(bundle, step, error) {
-  captureAndroidFailure(bundle, step, error);
-  finishBundleStep(bundle, step, "failed", error);
+  void error;
+  const safeError = new Error("Android E2E phase failed.");
+  captureAndroidFailure(bundle, step);
+  finishBundleStep(bundle, step, "failed", safeError);
 }
 
 function currentHeadCommit() {
@@ -359,7 +364,14 @@ function ensureFreshApkInstalled(bundle, adb, serial, backend) {
     log(`${installDecision.reason} — installing ${apk}`);
     const step = startBundleStep(bundle, "install Android APK");
     try {
-      installApk(adb, serial, apk);
+      const install = spawnSync(
+        adb,
+        ["-s", serial, "install", "-r", "-d", apk],
+        { stdio: "ignore" },
+      );
+      if (install.status !== 0 || install.error || install.signal) {
+        throw new Error("Android APK install failed.");
+      }
       const hash = verifyInstalledApkMatches(adb, serial, apk);
       log(`installed APK bytes verified: sha256=${hash.sha256.slice(0, 12)}…`);
       finishBundleStep(bundle, step, "passed");
@@ -396,7 +408,7 @@ function ensureSmokeModelCached() {
   fs.mkdirSync(SMOKE_MODEL.cacheDir, { recursive: true });
   log(`downloading smoke model ${SMOKE_MODEL.id} via curl…`);
   execFileSync("curl", ["-fsSL", "-o", dest, SMOKE_MODEL.url], {
-    stdio: "inherit",
+    stdio: "ignore",
   });
   const actualSize = fs.statSync(dest).size;
   if (actualSize !== SMOKE_MODEL.sizeBytes) {
@@ -408,11 +420,22 @@ function ensureSmokeModelCached() {
 }
 
 async function main() {
-  const bundle = createDeviceE2eBundle({
-    appDir,
-    lane: "android",
-    outputDir: parseOutputDirArg(process.argv),
-  });
+  const outputDir =
+    parseOutputDirArg(process.argv) ?? defaultAndroidEvidenceOutputDir();
+  const privateRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "eliza-android-e2e-private-"),
+  );
+  let bundle;
+  try {
+    bundle = createDeviceE2eBundle({
+      appDir,
+      lane: "android",
+      outputDir: path.join(privateRoot, "bundle"),
+    });
+  } catch {
+    fs.rmSync(privateRoot, { recursive: true, force: true });
+    throw new Error("Android evidence initialization failed.");
+  }
   let adb = null;
   let serial;
   let lease = null;
@@ -469,7 +492,6 @@ async function main() {
       const step = startBundleStep(bundle, "resolve Android SDK");
       try {
         adb = resolveAdb();
-        activeAndroidContext = { adb, serial: null };
         finishBundleStep(bundle, step, "passed");
       } catch (error) {
         failAndroidStep(bundle, step, error);
@@ -492,7 +514,7 @@ async function main() {
             serial = await ensureEmulatorBooted({
               adb,
               avd: val("--avd"),
-              log,
+              log: evidenceBoundary.callback("device-boot"),
             });
             finishBundleStep(bundle, bootStep, "passed");
           } catch (error) {
@@ -501,7 +523,6 @@ async function main() {
           }
         }
         serial = resolveSerial(adb, serial);
-        activeAndroidContext = { adb, serial };
         finishBundleStep(bundle, step, "passed");
       } catch (error) {
         failAndroidStep(bundle, step, error);
@@ -509,18 +530,20 @@ async function main() {
       }
     }
     process.env.ANDROID_SERIAL = serial;
-    activeAndroidContext = { adb, serial };
-    setBundleDevice(bundle, { serial, kind: "android" });
-    log(`device serial=${serial}`);
+    setBundleDevice(bundle, { kind: "android", attached: true });
+    evidenceBoundary.event("device-resolve", "passed", "DEVICE_READY");
     lease = await acquireDeviceLease(`android:${serial}`, {
       waitMs: has("--no-wait") ? 0 : undefined,
-      log,
+      log: evidenceBoundary.callback("device-lease"),
     });
+    evidenceBoundary.event("device-lease", "passed", "DEVICE_LEASED");
 
     {
       const step = startBundleStep(bundle, "prepare Android device");
       try {
-        await ensureEmulatorPermissive(adb, serial, { log });
+        await ensureEmulatorPermissive(adb, serial, {
+          log: evidenceBoundary.callback("device-prepare"),
+        });
         finishBundleStep(bundle, step, "passed");
       } catch (error) {
         failAndroidStep(bundle, step, error);
@@ -543,7 +566,7 @@ async function main() {
           ),
           env: { ...process.env, ELIZA_API_TOKEN: hostAgentToken },
           pairingDisabled: false,
-          log,
+          log: evidenceBoundary.callback("host-agent-start"),
         });
         process.env.ELIZA_ANDROID_HOST_AGENT_PORT = String(hostAgent.port);
         process.env.ELIZA_ANDROID_HOST_AGENT_TOKEN = hostAgentToken;
@@ -596,7 +619,7 @@ async function main() {
         artifactDir: bundle.rawDir,
         filename: "android-route-coverage.mp4",
         remotePath: "/sdcard/eliza-android-route-coverage.mp4",
-        log,
+        log: evidenceBoundary.callback("route-capture"),
       });
       try {
         const selectedProbes = hostEmulatorProbes
@@ -688,78 +711,73 @@ async function main() {
       ]);
     }
     finalResult = "passed";
-    log("ALL ANDROID E2E PASSED ✅");
+    evidenceBoundary.event("runner", "passed", "ANDROID_E2E_PASSED");
   } catch (error) {
     finalError = error;
   } finally {
-    if (routeRecording) {
-      const videoPath = await routeRecording.stop();
-      if (videoPath) recordBundleArtifact(bundle, videoPath, "video");
-    }
-    if (hostAgent) {
-      const step = startBundleStep(bundle, "stop deterministic host agent");
-      try {
-        await hostAgent.stop();
-        finishBundleStep(bundle, step, "passed");
-      } catch (error) {
-        // error-policy:J1 runner boundary records teardown failure before exiting
-        finishBundleStep(bundle, step, "failed", error);
+    await settleAndroidEvidenceTeardown({
+      operations: [
+        {
+          phase: "route-capture",
+          run: async () => {
+            if (!routeRecording) return;
+            const recording = routeRecording;
+            routeRecording = null;
+            const videoPath = await recording.stop();
+            if (videoPath) recordBundleArtifact(bundle, videoPath, "video");
+          },
+        },
+        {
+          phase: "host-agent-stop",
+          run: async () => {
+            if (!hostAgent) return;
+            const step = startBundleStep(
+              bundle,
+              "stop deterministic host agent",
+            );
+            try {
+              await hostAgent.stop();
+              finishBundleStep(bundle, step, "passed");
+            } catch {
+              const safeError = new Error("Android host teardown failed.");
+              finishBundleStep(bundle, step, "failed", safeError);
+              throw safeError;
+            }
+          },
+        },
+        {
+          phase: "device-lease",
+          run: () => lease?.release(),
+        },
+      ],
+      project: ({ failureCount }) => {
+        if (failureCount > 0) finalResult = "failed";
+        finalizeDeviceE2eBundle(bundle, finalResult);
+        const projected = projectAndroidDeviceEvidenceBundle({
+          bundle,
+          outputDir,
+          result: finalResult,
+        });
+        evidenceBoundary.event(
+          "evidence-projection",
+          "passed",
+          "EVIDENCE_PROJECTED",
+          { mediaArtifactCount: projected.summary.counts.mediaArtifacts },
+        );
+      },
+      cleanup: () => fs.rmSync(privateRoot, { recursive: true, force: true }),
+      onFailure: (phase) => {
         finalResult = "failed";
-        if (!finalError) {
-          finalError = error;
-        }
-      }
-    }
-    if (adb && serial) {
-      try {
-        recordBundleArtifact(
-          bundle,
-          captureAndroidScreenshot({
-            adb,
-            serial,
-            artifactDir: bundle.rawDir,
-            filename: "android-final.png",
-            log,
-          }),
-          "screenshot",
-        );
-      } catch (error) {
-        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
-        bundle.warnings.push(
-          `final Android screenshot failed: ${error?.message ?? error}`,
-        );
-      }
-      try {
-        recordBundleArtifact(
-          bundle,
-          captureAndroidLogcat({
-            adb,
-            serial,
-            artifactDir: bundle.logsDir,
-            filename: "android-logcat.txt",
-            log,
-          }),
-          "log",
-        );
-      } catch (error) {
-        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
-        bundle.warnings.push(
-          `Android logcat capture failed: ${error?.message ?? error}`,
-        );
-      }
-    }
-    lease?.release();
-    const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
-    if (finalError) {
-      const block = formatFailureForensicsBlock(bundle, finalError);
-      if (block) process.stderr.write(`\n${block}`);
-    }
-    log(`bundle: ${bundleRoot}`);
+        if (!finalError) finalError = new Error("Android teardown failed.");
+        evidenceBoundary.event(phase, "failed", "PHASE_FAILED");
+      },
+    });
   }
   if (finalError) throw finalError;
 }
 
 main().catch((error) => {
-  console.error(`[android-e2e] FAILED: ${error?.message ?? error}`);
+  void error;
+  evidenceBoundary.event("runner", "failed", "ANDROID_E2E_FAILED");
   process.exit(1);
 });

--- a/packages/app/scripts/device-evidence-workflows.test.mjs
+++ b/packages/app/scripts/device-evidence-workflows.test.mjs
@@ -1,0 +1,145 @@
+/** Guards the physical voice and Android workflows against archiving raw diagnostics. */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const voiceWorkflow = fs.readFileSync(
+  path.join(repoRoot, ".github/workflows/voice-live-e2e.yml"),
+  "utf8",
+);
+const androidWorkflow = fs.readFileSync(
+  path.join(repoRoot, ".github/workflows/android-arm64-local-e2e.yml"),
+  "utf8",
+);
+const androidRunner = fs.readFileSync(
+  path.join(repoRoot, "packages/app/scripts/android-e2e.mjs"),
+  "utf8",
+);
+const preflight = path.join(
+  repoRoot,
+  ".github/scripts/device-e2e/arm64-local-preflight.sh",
+);
+const runnerTempExpression = "$" + "{{ runner.temp }}";
+const runIdentityExpression =
+  "$" + "{{ github.run_id }}-$" + "{{ github.run_attempt }}";
+
+function executable(file, source) {
+  fs.writeFileSync(file, source, { mode: 0o755 });
+}
+
+function preflightFixture(serial) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "arm64-preflight-"));
+  const bin = path.join(root, "bin");
+  const githubEnv = path.join(root, "github-env");
+  fs.mkdirSync(bin);
+  executable(
+    path.join(bin, "node"),
+    '#!/bin/sh\nif [ "$1" = "--version" ]; then echo v24.15.0; else echo arm64; fi\n',
+  );
+  executable(path.join(bin, "bun"), "#!/bin/sh\necho 1.3.14\n");
+  executable(path.join(bin, "uname"), "#!/bin/sh\necho aarch64\n");
+  executable(
+    path.join(bin, "java"),
+    '#!/bin/sh\necho "    java.specification.version = 21" >&2\n',
+  );
+  executable(path.join(bin, "ffmpeg"), "#!/bin/sh\nexit 0\n");
+  executable(
+    path.join(bin, "adb"),
+    `#!/bin/sh\ncase "$*" in\n  devices) printf 'List of devices attached\\n%s\\tdevice\\n' '${serial}' ;;\n  *ro.product.cpu.abi*) echo arm64-v8a ;;\n  *sys.boot_completed*) echo 1 ;;\nesac\n`,
+  );
+  return { root, bin, githubEnv };
+}
+
+describe("device evidence workflow privacy", () => {
+  test("voice uploads exclude raw model, backend, matrix-cell, and runner logs", () => {
+    expect(voiceWorkflow).not.toContain("runner=$(hostname)");
+    expect(voiceWorkflow).not.toMatch(/2>&1\s*\|\s*tee/);
+    expect(voiceWorkflow).not.toContain("voice-web-live/backend.log\n");
+    expect(voiceWorkflow).not.toContain(
+      `${runnerTempExpression}/voice-macos-hardware-capture\n`,
+    );
+    expect(voiceWorkflow).not.toContain(
+      `${runnerTempExpression}/voice-windows-hardware-capture\n`,
+    );
+    expect(voiceWorkflow).not.toContain(
+      `path: ${runnerTempExpression}/voice-real-matrix\n`,
+    );
+    expect(voiceWorkflow).toContain(
+      "phase=provisioning status=failed code=VOICE_ASSETS_QUERY_FAILED",
+    );
+    expect(voiceWorkflow).toContain(
+      'find "$ELIZA_ASR_BUNDLE" -type f 2> "$PRIVATE_QUERY_LOG"',
+    );
+    expect(voiceWorkflow).toContain(
+      'voice-web-live/loopback-recorder.log" 2>&1 &',
+    );
+  });
+
+  test("Android workflow does not archive a raw preflight stream", () => {
+    expect(androidWorkflow).not.toMatch(/2>&1\s*\\?\s*\n?\s*\|\s*tee/);
+    expect(androidWorkflow).toContain(runIdentityExpression);
+  });
+
+  test("Android runner routes helper and process diagnostics through the privacy boundary", () => {
+    expect(androidRunner).toContain("createAndroidEvidenceBoundary");
+    expect(androidRunner).toContain("projectAndroidDeviceEvidenceBundle");
+    expect(androidRunner).toContain("settleAndroidEvidenceTeardown");
+    expect(androidRunner).toContain("eliza-android-e2e-private-");
+    expect(androidRunner).not.toContain("runBundledCommand");
+    expect(androidRunner).not.toContain("formatFailureForensicsBlock");
+    expect(androidRunner).not.toMatch(/console\.(?:log|error|warn)/);
+    expect(androidRunner).not.toContain('stdio: "inherit"');
+    expect(androidRunner).not.toContain("captureAndroidLogcat");
+    expect(androidRunner).not.toMatch(/setBundleDevice\([^)]*serial/s);
+  });
+
+  test("ARM64 preflight keeps the selected serial internal to GITHUB_ENV", () => {
+    const serial = "PHYSICAL_SERIAL_CANARY-R58N9933";
+    const fixture = preflightFixture(serial);
+    const result = spawnSync("bash", [preflight], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        ANDROID_SERIAL: serial,
+        GITHUB_ENV: fixture.githubEnv,
+      },
+    });
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain(serial);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(
+      /phase=preflight status=passed code=ARM64_DEVICE_READY checks=8/,
+    );
+  });
+
+  test("ARM64 preflight rejects an unknown serial without echoing it", () => {
+    const attached = "PHYSICAL_SERIAL_CANARY-attached";
+    const requested = "PHYSICAL_SERIAL_CANARY-untrusted";
+    const fixture = preflightFixture(attached);
+    const result = spawnSync("bash", [preflight], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        ANDROID_SERIAL: requested,
+        GITHUB_ENV: fixture.githubEnv,
+      },
+    });
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain(requested);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain(attached);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(
+      /phase=preflight status=failed code=DEVICE_SELECTION_INVALID/,
+    );
+  });
+});

--- a/packages/app/scripts/lib/android-e2e-evidence-policy.mjs
+++ b/packages/app/scripts/lib/android-e2e-evidence-policy.mjs
@@ -1,0 +1,790 @@
+/**
+ * Privacy boundary for physical Android diagnostics. Raw device output remains
+ * in the private runner workspace; exported evidence is an allowlisted proof.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+const PHASES = new Set([
+  "lane-selection",
+  "sdk-resolve",
+  "device-resolve",
+  "device-boot",
+  "device-lease",
+  "device-prepare",
+  "apk-build",
+  "apk-install",
+  "host-agent-start",
+  "host-agent-stop",
+  "model-cache",
+  "voice-model-stage",
+  "local-chat",
+  "route-capture",
+  "launcher-loop",
+  "cloud-provisioning",
+  "evidence-projection",
+  "runner",
+]);
+
+const STATUSES = new Set(["started", "passed", "failed", "skipped"]);
+const COUNTERS = new Set(["mediaArtifactCount"]);
+
+const CODES = new Set([
+  "PHASE_STARTED",
+  "PHASE_PASSED",
+  "PHASE_FAILED",
+  "DEVICE_READY",
+  "DEVICE_LEASED",
+  "MODEL_CACHE_READY",
+  "MODEL_CACHE_MISSING",
+  "MEDIA_RETAINED",
+  "EVIDENCE_PROJECTED",
+  "ANDROID_E2E_PASSED",
+  "ANDROID_E2E_FAILED",
+  "UNHANDLED_ERROR",
+]);
+
+const STEP_PHASES = new Map([
+  ["validate Android lane selection", "lane-selection"],
+  ["resolve Android SDK", "sdk-resolve"],
+  ["resolve Android device", "device-resolve"],
+  ["boot Android device", "device-boot"],
+  ["prepare Android device", "device-prepare"],
+  ["build Android APK", "apk-build"],
+  ["install Android APK", "apk-install"],
+  ["start deterministic host agent", "host-agent-start"],
+  ["stop deterministic host agent", "host-agent-stop"],
+  ["stage Android voice models", "voice-model-stage"],
+  ["local chat smoke", "local-chat"],
+  ["Android route coverage", "route-capture"],
+  ["Android launcher loop", "launcher-loop"],
+  ["cloud provisioning", "cloud-provisioning"],
+]);
+
+function requireAllowlisted(set, value, label) {
+  if (!set.has(value)) {
+    throw new Error(`${label} must be allowlisted.`);
+  }
+  return value;
+}
+
+function safeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return value;
+}
+
+function exactHexIdentifier(value, length, label) {
+  if (
+    typeof value !== "string" ||
+    !new RegExp(`^[a-f0-9]{${length}}$`).test(value)
+  ) {
+    throw new Error(`${label} must be an exact lowercase hexadecimal value.`);
+  }
+  return value;
+}
+
+function sha256File(file) {
+  return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Returns a logger that never forwards helper text. Callers may report only an
+ * allowlisted phase/status/code tuple plus explicitly named numeric counters.
+ */
+export function createAndroidEvidenceBoundary({
+  write = (chunk) => process.stdout.write(chunk),
+} = {}) {
+  let discardedMessages = 0;
+  return {
+    callback(phase) {
+      requireAllowlisted(PHASES, phase, "Android evidence phase");
+      return () => {
+        discardedMessages += 1;
+      };
+    },
+    event(phase, status, code, counters = {}) {
+      requireAllowlisted(PHASES, phase, "Android evidence phase");
+      requireAllowlisted(STATUSES, status, "Android evidence status");
+      requireAllowlisted(CODES, code, "Android evidence code");
+      const fields = [];
+      for (const [name, value] of Object.entries(counters)) {
+        if (!COUNTERS.has(name)) {
+          throw new Error("Android evidence counter name must be allowlisted.");
+        }
+        fields.push(`${name}=${safeInteger(value, name)}`);
+      }
+      write(
+        `[android-e2e] phase=${phase} status=${status} code=${code}${fields.length > 0 ? ` ${fields.join(" ")}` : ""}\n`,
+      );
+    },
+    snapshot() {
+      return { discardedMessageCount: discardedMessages };
+    },
+  };
+}
+
+/**
+ * Runs teardown phases without letting an earlier device failure bypass lease
+ * release, evidence projection, or deletion of the private workspace.
+ */
+export async function settleAndroidEvidenceTeardown({
+  operations = [],
+  project,
+  cleanup,
+  onFailure = () => {},
+}) {
+  let failureCount = 0;
+  const recordFailure = (phase) => {
+    requireAllowlisted(PHASES, phase, "Android teardown phase");
+    failureCount += 1;
+    try {
+      onFailure(phase);
+    } catch {
+      // A reporting callback must not bypass the remaining cleanup phases.
+    }
+  };
+
+  try {
+    for (const operation of operations) {
+      requireAllowlisted(PHASES, operation.phase, "Android teardown phase");
+      try {
+        await operation.run();
+      } catch {
+        recordFailure(operation.phase);
+      }
+    }
+    try {
+      await project({ failureCount });
+    } catch {
+      recordFailure("evidence-projection");
+    }
+  } finally {
+    await cleanup();
+  }
+
+  return { failureCount };
+}
+
+function projectStep(step) {
+  const phase = STEP_PHASES.get(step?.name) ?? "runner";
+  const status = step?.status === "passed" ? "passed" : "failed";
+  return {
+    phase,
+    status,
+    code: status === "passed" ? "PHASE_PASSED" : "PHASE_FAILED",
+  };
+}
+
+function lstatIfPresent(file) {
+  try {
+    return fs.lstatSync(file);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function establishAndroidPublicationTrust(parent) {
+  if (process.platform === "win32") {
+    // Node does not expose a portable Windows DACL API. Treat the canonical,
+    // per-user runner temp directory as the explicit Windows trust boundary;
+    // android-e2e chooses a fresh direct child there by default.
+    const configuredRoot = process.env.RUNNER_TEMP?.trim() || os.tmpdir();
+    const root = fs.realpathSync(configuredRoot);
+    const rootStat = fs.lstatSync(root);
+    const relative = path.relative(root, parent);
+    if (
+      rootStat.isSymbolicLink() ||
+      !rootStat.isDirectory() ||
+      relative.startsWith("..") ||
+      path.isAbsolute(relative)
+    ) {
+      throw new Error(
+        "Android evidence output must remain inside the canonical runner temp root.",
+      );
+    }
+    return {
+      kind: "windows",
+      root,
+      rootDev: rootStat.dev,
+      rootIno: rootStat.ino,
+    };
+  }
+
+  const currentUid = process.getuid?.();
+  const ancestors = [];
+  let current = parent;
+  while (true) {
+    const stat = fs.lstatSync(current);
+    const writableByOthers = (stat.mode & 0o022) !== 0;
+    const sticky = (stat.mode & 0o1000) !== 0;
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error(
+        "Android evidence publication ancestry is not canonical.",
+      );
+    }
+    if (currentUid !== undefined && stat.uid !== currentUid && stat.uid !== 0) {
+      throw new Error(
+        "Android evidence publication ancestry is owned by another principal.",
+      );
+    }
+    if (writableByOthers && !sticky) {
+      throw new Error(
+        "Android evidence publication ancestry is writable by another principal.",
+      );
+    }
+    ancestors.push({ path: current, dev: stat.dev, ino: stat.ino });
+    const container = path.dirname(current);
+    if (container === current) break;
+    current = container;
+  }
+  return { kind: "posix", ancestors };
+}
+
+function assertAndroidPublicationTrust(parent, trust) {
+  if (trust?.kind === "windows") {
+    const rootStat = lstatIfPresent(trust.root);
+    const relative = path.relative(trust.root, parent);
+    if (
+      !rootStat ||
+      rootStat.isSymbolicLink() ||
+      !rootStat.isDirectory() ||
+      rootStat.dev !== trust.rootDev ||
+      rootStat.ino !== trust.rootIno ||
+      relative.startsWith("..") ||
+      path.isAbsolute(relative)
+    ) {
+      throw new Error("Android evidence runner temp root changed identity.");
+    }
+    return;
+  }
+  if (trust?.kind !== "posix" || trust.ancestors?.[0]?.path !== parent) {
+    throw new Error("Android evidence publication ancestry trust is missing.");
+  }
+  const currentUid = process.getuid?.();
+  for (const expected of trust.ancestors) {
+    const stat = lstatIfPresent(expected.path);
+    const writableByOthers = stat ? (stat.mode & 0o022) !== 0 : false;
+    const sticky = stat ? (stat.mode & 0o1000) !== 0 : false;
+    if (
+      !stat ||
+      stat.isSymbolicLink() ||
+      !stat.isDirectory() ||
+      stat.dev !== expected.dev ||
+      stat.ino !== expected.ino ||
+      (currentUid !== undefined && stat.uid !== currentUid && stat.uid !== 0) ||
+      (writableByOthers && !sticky)
+    ) {
+      throw new Error(
+        "Android evidence publication ancestry changed identity or trust.",
+      );
+    }
+  }
+}
+
+function prepareOutputPublication(outputDir) {
+  if (!outputDir) {
+    throw new Error("Android evidence output directory is required.");
+  }
+  const requestedDestination = path.resolve(outputDir);
+  if (requestedDestination === path.parse(requestedDestination).root) {
+    throw new Error(
+      "Android evidence output directory cannot be a filesystem root.",
+    );
+  }
+  const requestedDestinationStat = lstatIfPresent(requestedDestination);
+  if (requestedDestinationStat?.isSymbolicLink()) {
+    throw new Error("Android evidence output directory cannot be a symlink.");
+  }
+  if (requestedDestinationStat) {
+    throw new Error(
+      "Android evidence output directory must not already exist.",
+    );
+  }
+  const requestedParent = path.dirname(requestedDestination);
+  const requestedParentStat = lstatIfPresent(requestedParent);
+  let parent;
+  if (requestedParentStat) {
+    if (
+      requestedParentStat.isSymbolicLink() ||
+      !requestedParentStat.isDirectory()
+    ) {
+      throw new Error(
+        "Android evidence output parent must be a real directory.",
+      );
+    }
+    parent = fs.realpathSync(requestedParent);
+  } else {
+    const requestedContainer = path.dirname(requestedParent);
+    const requestedContainerStat = lstatIfPresent(requestedContainer);
+    if (
+      !requestedContainerStat ||
+      requestedContainerStat.isSymbolicLink() ||
+      !requestedContainerStat.isDirectory()
+    ) {
+      throw new Error(
+        "Android evidence output parent container must already be a real directory.",
+      );
+    }
+    const container = fs.realpathSync(requestedContainer);
+    establishAndroidPublicationTrust(container);
+    parent = path.join(container, path.basename(requestedParent));
+    if (lstatIfPresent(parent)) {
+      throw new Error(
+        "Android evidence output parent appeared before creation.",
+      );
+    }
+    fs.mkdirSync(parent, { mode: 0o700 });
+  }
+  const parentStat = fs.lstatSync(parent);
+  if (parentStat.isSymbolicLink() || !parentStat.isDirectory()) {
+    throw new Error("Android evidence output parent must be a real directory.");
+  }
+  const trust = establishAndroidPublicationTrust(parent);
+  const destination = path.join(parent, path.basename(requestedDestination));
+  if (lstatIfPresent(destination)) {
+    throw new Error(
+      "Android evidence output directory must not already exist.",
+    );
+  }
+  const stagingPrefix = `.${path.basename(destination)}.android-evidence-staging-`;
+  const staging = fs.mkdtempSync(path.join(parent, stagingPrefix));
+  fs.chmodSync(staging, 0o700);
+  const stagingStat = fs.lstatSync(staging);
+  const publication = {
+    destination,
+    parent,
+    parentStat,
+    staging,
+    stagingPrefix,
+    stagingStat,
+    trust,
+  };
+  assertPublicationParentIdentity(publication);
+  assertStagingIdentity(publication);
+  return publication;
+}
+
+function assertPublicationParentIdentity(publication) {
+  const {
+    destination,
+    parent,
+    parentStat: expectedParentStat,
+    staging,
+  } = publication;
+  if (
+    path.dirname(destination) !== parent ||
+    path.dirname(staging) !== parent
+  ) {
+    throw new Error(
+      "Android evidence publication paths escaped their owned parent.",
+    );
+  }
+  const parentStat = lstatIfPresent(parent);
+  if (
+    !parentStat ||
+    parentStat.isSymbolicLink() ||
+    !parentStat.isDirectory() ||
+    parentStat.dev !== expectedParentStat.dev ||
+    parentStat.ino !== expectedParentStat.ino
+  ) {
+    throw new Error("Android evidence publication parent changed identity.");
+  }
+  assertAndroidPublicationTrust(parent, publication.trust);
+}
+
+function assertStagingIdentity(publication, { allowMissing = false } = {}) {
+  const {
+    parent,
+    staging,
+    stagingPrefix,
+    stagingStat: expectedStagingStat,
+  } = publication;
+  assertPublicationParentIdentity(publication);
+  if (
+    path.dirname(staging) !== parent ||
+    !path.basename(staging).startsWith(stagingPrefix)
+  ) {
+    throw new Error("Refusing to clean an unowned Android staging path.");
+  }
+  const stagingStat = lstatIfPresent(staging);
+  if (!stagingStat) {
+    if (allowMissing) return undefined;
+    throw new Error("Android evidence staging directory disappeared.");
+  }
+  if (
+    stagingStat.isSymbolicLink() ||
+    !stagingStat.isDirectory() ||
+    stagingStat.dev !== expectedStagingStat.dev ||
+    stagingStat.ino !== expectedStagingStat.ino
+  ) {
+    throw new Error("Android evidence staging directory changed identity.");
+  }
+  return stagingStat;
+}
+
+function removeOwnedStagingDirectory(publication) {
+  if (!assertStagingIdentity(publication, { allowMissing: true })) return;
+  const tombstone = `${publication.staging}.cleanup`;
+  if (lstatIfPresent(tombstone)) {
+    throw new Error("Android evidence cleanup tombstone already exists.");
+  }
+  fs.renameSync(publication.staging, tombstone);
+  const tombstoneStat = fs.lstatSync(tombstone);
+  if (
+    tombstoneStat.isSymbolicLink() ||
+    !tombstoneStat.isDirectory() ||
+    tombstoneStat.dev !== publication.stagingStat.dev ||
+    tombstoneStat.ino !== publication.stagingStat.ino
+  ) {
+    throw new Error("Android evidence cleanup tombstone changed identity.");
+  }
+  fs.rmSync(tombstone, { recursive: true, force: true, maxRetries: 2 });
+}
+
+function publicationChildPath(root, file, label) {
+  const relative = path.relative(root, path.resolve(file));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} is outside the Android staging directory.`);
+  }
+  return relative;
+}
+
+function verifyStagedAndroidEvidence(publication, result) {
+  assertStagingIdentity(publication);
+  const { staging } = publication;
+  const summaryRelative = publicationChildPath(
+    staging,
+    result.summaryPath,
+    "Android evidence summary",
+  );
+  const junitRelative = publicationChildPath(
+    staging,
+    result.junitPath,
+    "Android evidence JUnit report",
+  );
+  if (summaryRelative !== "summary.json" || junitRelative !== "junit.xml") {
+    throw new Error("Android evidence report paths are not canonical.");
+  }
+  const summaryStat = fs.lstatSync(result.summaryPath);
+  const junitStat = fs.lstatSync(result.junitPath);
+  if (
+    summaryStat.isSymbolicLink() ||
+    !summaryStat.isFile() ||
+    junitStat.isSymbolicLink() ||
+    !junitStat.isFile()
+  ) {
+    throw new Error("Android evidence reports must be regular files.");
+  }
+  const persistedSummary = JSON.parse(fs.readFileSync(result.summaryPath));
+  if (
+    JSON.stringify(persistedSummary) !== JSON.stringify(result.summary) ||
+    persistedSummary.schema !== "eliza_android_private_input_projection_v1" ||
+    persistedSummary.lane !== "android" ||
+    !Array.isArray(persistedSummary.media)
+  ) {
+    throw new Error("Android evidence summary is incomplete or divergent.");
+  }
+  if (fs.readFileSync(result.junitPath, "utf8") !== result.junit) {
+    throw new Error("Android evidence JUnit report changed after staging.");
+  }
+
+  const mediaDir = path.join(staging, "media");
+  const mediaDirStat = fs.lstatSync(mediaDir);
+  if (mediaDirStat.isSymbolicLink() || !mediaDirStat.isDirectory()) {
+    throw new Error("Android evidence media path must be a real directory.");
+  }
+  const expectedMedia = new Set();
+  for (const media of persistedSummary.media) {
+    if (media.path !== "media/android-route-coverage.mp4") {
+      throw new Error("Android evidence media path is not allowlisted.");
+    }
+    const file = path.join(staging, media.path);
+    publicationChildPath(staging, file, "Android evidence media");
+    const fileStat = fs.lstatSync(file);
+    if (
+      fileStat.isSymbolicLink() ||
+      !fileStat.isFile() ||
+      fileStat.size !== media.byteCount ||
+      sha256File(file) !== media.sha256
+    ) {
+      throw new Error("Android evidence media hash verification failed.");
+    }
+    if (expectedMedia.has(path.basename(media.path))) {
+      throw new Error("Android evidence media contains a duplicate path.");
+    }
+    expectedMedia.add(path.basename(media.path));
+  }
+  const mediaEntries = fs.readdirSync(mediaDir, { withFileTypes: true });
+  if (
+    mediaEntries.length !== expectedMedia.size ||
+    mediaEntries.some((entry) => {
+      const fileStat = fs.lstatSync(path.join(mediaDir, entry.name));
+      return (
+        entry.isSymbolicLink() ||
+        !fileStat.isFile() ||
+        !expectedMedia.has(entry.name)
+      );
+    })
+  ) {
+    throw new Error("Android evidence media contains unmanifested files.");
+  }
+  const rootEntries = fs.readdirSync(staging, { withFileTypes: true });
+  const expectedRootEntries = new Set(["junit.xml", "media", "summary.json"]);
+  if (
+    rootEntries.length !== expectedRootEntries.size ||
+    rootEntries.some((entry) => {
+      const entryStat = fs.lstatSync(path.join(staging, entry.name));
+      if (!expectedRootEntries.has(entry.name) || entryStat.isSymbolicLink()) {
+        return true;
+      }
+      return entry.name === "media"
+        ? !entryStat.isDirectory()
+        : !entryStat.isFile();
+    })
+  ) {
+    throw new Error("Android evidence staging contains unmanifested entries.");
+  }
+}
+
+function publishStagedAndroidEvidence(publication, result) {
+  verifyStagedAndroidEvidence(publication, result);
+  assertStagingIdentity(publication);
+  const publishedResult = {
+    summary: result.summary,
+    summaryPath: path.join(
+      publication.destination,
+      publicationChildPath(
+        publication.staging,
+        result.summaryPath,
+        "Android evidence summary",
+      ),
+    ),
+    junitPath: path.join(
+      publication.destination,
+      publicationChildPath(
+        publication.staging,
+        result.junitPath,
+        "Android evidence JUnit report",
+      ),
+    ),
+  };
+  if (lstatIfPresent(publication.destination)) {
+    throw new Error(
+      "Android evidence output path appeared before atomic publication.",
+    );
+  }
+  assertPublicationParentIdentity(publication);
+  assertStagingIdentity(publication);
+  fs.renameSync(publication.staging, publication.destination);
+  return publishedResult;
+}
+
+function atomicallyPublishAndroidEvidence(outputDir, build) {
+  const publication = prepareOutputPublication(outputDir);
+  let published = false;
+  try {
+    const result = build(publication.staging);
+    const publishedResult = publishStagedAndroidEvidence(publication, result);
+    published = true;
+    return publishedResult;
+  } finally {
+    if (!published) removeOwnedStagingDirectory(publication);
+  }
+}
+
+function privateRegularFile(bundleRoot, artifactPath) {
+  const root = `${path.resolve(bundleRoot)}${path.sep}`;
+  const candidate = path.resolve(artifactPath);
+  if (!candidate.startsWith(root)) return false;
+  try {
+    return fs.lstatSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function packagedFfmpeg() {
+  try {
+    const loaded = require("ffmpeg-static");
+    return typeof loaded === "string" ? loaded : loaded?.path;
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultRedactVideo(source, destination) {
+  const candidates = [
+    process.env.ELIZA_FFMPEG_BIN,
+    packagedFfmpeg(),
+    "ffmpeg",
+  ].filter(Boolean);
+  for (const command of candidates) {
+    const result = spawnSync(
+      command,
+      [
+        "-y",
+        "-i",
+        source,
+        "-map",
+        "0:v:0",
+        "-map_metadata",
+        "-1",
+        "-map_chapters",
+        "-1",
+        "-vf",
+        "drawbox=x=0:y=0:w=iw:h=ih:color=black:t=fill",
+        "-an",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "ultrafast",
+        "-movflags",
+        "+faststart",
+        destination,
+      ],
+      { stdio: "ignore" },
+    );
+    if (
+      result.status === 0 &&
+      fs.existsSync(destination) &&
+      fs.statSync(destination).size > 0
+    ) {
+      return;
+    }
+    fs.rmSync(destination, { force: true });
+  }
+  throw new Error("Android evidence video redaction failed.");
+}
+
+/**
+ * Projects a private Android run into upload-safe evidence. Correlation and
+ * failure details stay in memory; only the synthetic route video and safe
+ * phase/counter proof cross this boundary.
+ */
+export function projectAndroidDeviceEvidenceBundle({
+  bundle,
+  outputDir,
+  result,
+  redactVideo = defaultRedactVideo,
+}) {
+  if (!bundle?.root || bundle.lane !== "android") {
+    throw new Error("A private Android evidence bundle is required.");
+  }
+  requireAllowlisted(new Set(["passed", "failed"]), result, "Android result");
+  const revision = exactHexIdentifier(
+    bundle.build?.commit,
+    40,
+    "Android evidence revision",
+  );
+  const rendererBuildId = exactHexIdentifier(
+    bundle.build?.buildId,
+    64,
+    "Android renderer build ID",
+  );
+  const phases = (bundle.steps ?? []).map(projectStep);
+  const canonicalRouteVideo = path.resolve(
+    bundle.root,
+    "raw",
+    "android-route-coverage.mp4",
+  );
+  const routeMedia = (bundle.artifacts ?? []).filter(
+    (artifact) =>
+      artifact?.kind === "video" &&
+      path.resolve(artifact.path ?? "") === canonicalRouteVideo &&
+      privateRegularFile(bundle.root, artifact.path),
+  );
+  const passedRouteCapture = phases.some(
+    (phase) => phase.phase === "route-capture" && phase.status === "passed",
+  );
+  if (passedRouteCapture && routeMedia.length !== 1) {
+    throw new Error(
+      "Passed Android route capture requires exactly one private video.",
+    );
+  }
+  return atomicallyPublishAndroidEvidence(outputDir, (stagingDir) => {
+    fs.mkdirSync(path.join(stagingDir, "media"), { mode: 0o700 });
+    const retainedMedia = [];
+
+    for (const artifact of routeMedia) {
+      const destination = path.join(
+        stagingDir,
+        "media",
+        "android-route-coverage.mp4",
+      );
+      redactVideo(artifact.path, destination);
+      const projectedStat = fs.lstatSync(destination);
+      if (projectedStat.isSymbolicLink() || !projectedStat.isFile()) {
+        throw new Error(
+          "Android evidence video projection must create a regular file.",
+        );
+      }
+      retainedMedia.push({
+        role: "synthetic-route-signal",
+        path: "media/android-route-coverage.mp4",
+        byteCount: projectedStat.size,
+        sha256: sha256File(destination),
+      });
+      break;
+    }
+
+    const counts = {
+      passed: phases.filter((phase) => phase.status === "passed").length,
+      failed: phases.filter((phase) => phase.status === "failed").length,
+      mediaArtifacts: retainedMedia.length,
+    };
+    const summary = {
+      schema: "eliza_android_private_input_projection_v1",
+      lane: "android",
+      result,
+      revision,
+      rendererBuildId,
+      device: { kind: "android", attached: true },
+      counts,
+      phases,
+      media: retainedMedia,
+    };
+    const summaryPath = path.join(stagingDir, "summary.json");
+    writeJson(summaryPath, summary);
+
+    const cases =
+      phases.length > 0
+        ? phases
+            .map((phase) => {
+              const failure =
+                phase.status === "failed"
+                  ? `<failure message="${phase.code}" />`
+                  : "";
+              return `<testcase classname="android" name="${xmlEscape(phase.phase)}">${failure}</testcase>`;
+            })
+            .join("\n")
+        : '<testcase classname="android" name="runner" />';
+    const junitPath = path.join(stagingDir, "junit.xml");
+    const junit = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="android" tests="${phases.length || 1}" failures="${counts.failed}" result="${result}">\n${cases}\n</testsuite>\n`;
+    fs.writeFileSync(junitPath, junit);
+
+    return { summary, summaryPath, junitPath, junit };
+  });
+}

--- a/packages/app/scripts/lib/android-e2e-evidence-policy.test.mjs
+++ b/packages/app/scripts/lib/android-e2e-evidence-policy.test.mjs
@@ -1,0 +1,639 @@
+/** Exercises the Android physical-evidence privacy boundary with adversarial device diagnostics. */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  createAndroidEvidenceBoundary,
+  projectAndroidDeviceEvidenceBundle,
+  settleAndroidEvidenceTeardown,
+} from "./android-e2e-evidence-policy.mjs";
+
+const roots = [];
+const ffmpegAvailable =
+  spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function fixtureRoot() {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "android-evidence-policy-"),
+  );
+  roots.push(root);
+  return root;
+}
+
+function allPublicBytes(root) {
+  return Buffer.concat(
+    fs
+      .readdirSync(root, { recursive: true })
+      .map((entry) => path.join(root, entry))
+      .filter((entry) => fs.statSync(entry).isFile())
+      .map((entry) => fs.readFileSync(entry)),
+  ).toString("utf8");
+}
+
+describe("Android evidence diagnostics boundary", () => {
+  test("helper callbacks never serialize adversarial device output", () => {
+    const chunks = [];
+    const serial = "PHYSICAL_SERIAL_CANARY-R58N9911";
+    const response = "MODEL_RESPONSE_CANARY-android-private";
+    const boundary = createAndroidEvidenceBoundary({
+      write: (chunk) => chunks.push(chunk),
+    });
+
+    boundary.callback("device-resolve")(
+      `reusing attached device ${serial}; logcat=${response}`,
+    );
+    boundary.callback("route-capture")(
+      `adb -s ${serial} stdout=${response} stderr=private`,
+    );
+    boundary.event("device-resolve", "passed", "DEVICE_READY");
+
+    const output = chunks.join("");
+    expect(output).toContain(
+      "phase=device-resolve status=passed code=DEVICE_READY",
+    );
+    expect(output).not.toContain(serial);
+    expect(output).not.toContain(response);
+    expect(output).not.toMatch(/stdout|stderr|logcat/i);
+    expect(() =>
+      boundary.event("unknown-phase", "passed", "DEVICE_READY"),
+    ).toThrow(/allowlisted/);
+    expect(() =>
+      boundary.event("runner", "passed", "PHASE_PASSED", {
+        arbitraryCount: 1,
+      }),
+    ).toThrow(/counter name must be allowlisted/);
+  });
+
+  test("public bundle keeps allowlisted media and projects only safe phase codes", () => {
+    const root = fixtureRoot();
+    const privateRoot = path.join(root, "private");
+    const outputDir = path.join(root, "public");
+    const serial = "PHYSICAL_SERIAL_CANARY-R58N9922";
+    fs.mkdirSync(path.join(privateRoot, "raw"), { recursive: true });
+    fs.mkdirSync(path.join(privateRoot, "logs"), { recursive: true });
+    const video = path.join(privateRoot, "raw", "android-route-coverage.mp4");
+    const logcat = path.join(privateRoot, "logs", "android-logcat.txt");
+    fs.writeFileSync(
+      video,
+      `synthetic-mp4-signal ${serial} MODEL_RESPONSE_CANARY`,
+    );
+    fs.writeFileSync(
+      logcat,
+      `${serial} roomId=room-private MODEL_RESPONSE_CANARY\n`,
+    );
+    const bundle = {
+      root: privateRoot,
+      lane: "android",
+      build: { commit: "a".repeat(40), buildId: "b".repeat(64) },
+      steps: [
+        {
+          name: "resolve Android device",
+          status: "passed",
+          durationMs: 12,
+          artifacts: [],
+        },
+        {
+          name: "Android route coverage",
+          status: "failed",
+          durationMs: 34,
+          error: `${serial} stderr MODEL_RESPONSE_CANARY`,
+          artifacts: [],
+        },
+      ],
+      artifacts: [
+        { kind: "video", path: video },
+        { kind: "log", path: logcat },
+      ],
+      warnings: [`logcat from ${serial}`],
+    };
+
+    const result = projectAndroidDeviceEvidenceBundle({
+      bundle,
+      outputDir,
+      result: "failed",
+      redactVideo: (_source, destination) =>
+        fs.writeFileSync(destination, "redacted-synthetic-mp4-signal"),
+    });
+    const files = fs.readdirSync(outputDir, { recursive: true });
+    const serialized = files
+      .filter((file) => /\.(?:json|xml|txt|log)$/i.test(file))
+      .map((file) => fs.readFileSync(path.join(outputDir, file), "utf8"))
+      .join("\n");
+
+    expect(result.summary.device).toEqual({ kind: "android", attached: true });
+    expect(result.summary.revision).toBe("a".repeat(40));
+    expect(result.summary.rendererBuildId).toBe("b".repeat(64));
+    expect(result.summary.counts).toMatchObject({
+      passed: 1,
+      failed: 1,
+      mediaArtifacts: 1,
+    });
+    expect(files).toContain("media/android-route-coverage.mp4");
+    expect(result.summary.media[0].sha256).toBe(
+      createHash("sha256")
+        .update("redacted-synthetic-mp4-signal")
+        .digest("hex"),
+    );
+    expect(
+      fs.readFileSync(
+        path.join(outputDir, "media/android-route-coverage.mp4"),
+        "utf8",
+      ),
+    ).not.toContain(serial);
+    expect(files).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/logcat/i),
+        expect.stringMatching(/runner\.log/i),
+      ]),
+    );
+    expect(serialized).not.toContain(serial);
+    expect(serialized).not.toContain("MODEL_RESPONSE_CANARY");
+    expect(serialized).not.toMatch(
+      /roomId|messageId|trajectoryId|stdout|stderr/i,
+    );
+    expect(() =>
+      projectAndroidDeviceEvidenceBundle({
+        bundle,
+        outputDir,
+        result: "failed",
+        redactVideo: (_source, destination) =>
+          fs.writeFileSync(destination, "redacted"),
+      }),
+    ).toThrow(/must not already exist/);
+  });
+
+  test("publishes beside an existing workflow bootstrap without replacing it", () => {
+    const root = fixtureRoot();
+    const privateRoot = path.join(root, "private-workflow-bundle");
+    const androidArtifactRoot = path.join(root, "android");
+    const logsDir = path.join(androidArtifactRoot, "logs");
+    const bootstrap = path.join(logsDir, "workflow-bootstrap.txt");
+    const outputDir = path.join(androidArtifactRoot, "evidence");
+    fs.mkdirSync(privateRoot);
+    fs.mkdirSync(logsDir, { recursive: true });
+    fs.writeFileSync(bootstrap, "revision=trusted-workflow-revision\n");
+
+    projectAndroidDeviceEvidenceBundle({
+      bundle: {
+        root: privateRoot,
+        lane: "android",
+        build: { commit: "c".repeat(40), buildId: "d".repeat(64) },
+        steps: [],
+        artifacts: [],
+      },
+      outputDir,
+      result: "failed",
+    });
+
+    expect(fs.readFileSync(bootstrap, "utf8")).toBe(
+      "revision=trusted-workflow-revision\n",
+    );
+    expect(fs.readdirSync(androidArtifactRoot).sort()).toEqual([
+      "evidence",
+      "logs",
+    ]);
+    expect(fs.readdirSync(outputDir).sort()).toEqual([
+      "junit.xml",
+      "media",
+      "summary.json",
+    ]);
+  });
+
+  test("fails closed before export when build identifiers are absent or malformed", () => {
+    const root = fixtureRoot();
+    const privateRoot = path.join(root, "private-build-identity");
+    const outputDir = path.join(root, "public-build-identity");
+    fs.mkdirSync(privateRoot);
+    const baseBundle = {
+      root: privateRoot,
+      lane: "android",
+      steps: [],
+      artifacts: [],
+    };
+
+    expect(() =>
+      projectAndroidDeviceEvidenceBundle({
+        bundle: {
+          ...baseBundle,
+          build: {
+            commit: "PHYSICAL_SERIAL_CANARY-not-a-revision",
+            buildId: "b".repeat(64),
+          },
+        },
+        outputDir,
+        result: "failed",
+      }),
+    ).toThrow(/revision/);
+    expect(fs.existsSync(outputDir)).toBe(false);
+
+    expect(() =>
+      projectAndroidDeviceEvidenceBundle({
+        bundle: {
+          ...baseBundle,
+          build: {
+            commit: "a".repeat(40),
+            buildId: "MODEL_RESPONSE_CANARY-not-a-renderer-build",
+          },
+        },
+        outputDir,
+        result: "failed",
+      }),
+    ).toThrow(/renderer build ID/);
+    expect(fs.existsSync(outputDir)).toBe(false);
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "rejects a symlink destination without writing through it",
+    () => {
+      const root = fixtureRoot();
+      const privateRoot = path.join(root, "private-symlink-output");
+      const outputDir = path.join(root, "public-symlink-output");
+      const externalTarget = path.join(root, "external-target");
+      fs.mkdirSync(privateRoot);
+      fs.mkdirSync(externalTarget);
+      fs.symlinkSync(externalTarget, outputDir, "dir");
+
+      expect(() =>
+        projectAndroidDeviceEvidenceBundle({
+          bundle: {
+            root: privateRoot,
+            lane: "android",
+            build: { commit: "1".repeat(40), buildId: "2".repeat(64) },
+            steps: [],
+            artifacts: [],
+          },
+          outputDir,
+          result: "failed",
+        }),
+      ).toThrow(/cannot be a symlink/);
+      expect(fs.readdirSync(externalTarget)).toEqual([]);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "rejects a symlink output parent without creating external entries",
+    () => {
+      const root = fixtureRoot();
+      const privateRoot = path.join(root, "private-symlink-parent");
+      const externalTarget = path.join(root, "external-parent-target");
+      const outputParent = path.join(root, "public-parent-alias");
+      const outputDir = path.join(outputParent, "public");
+      fs.mkdirSync(privateRoot);
+      fs.mkdirSync(externalTarget);
+      fs.symlinkSync(externalTarget, outputParent, "dir");
+
+      expect(() =>
+        projectAndroidDeviceEvidenceBundle({
+          bundle: {
+            root: privateRoot,
+            lane: "android",
+            build: { commit: "b".repeat(40), buildId: "c".repeat(64) },
+            steps: [],
+            artifacts: [],
+          },
+          outputDir,
+          result: "failed",
+        }),
+      ).toThrow(/output parent must be a real directory/);
+      expect(fs.readdirSync(externalTarget)).toEqual([]);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "rejects destination substitution and removes the verified staging tree",
+    () => {
+      const root = fixtureRoot();
+      const privateRoot = path.join(root, "private-destination-race");
+      const rawDir = path.join(privateRoot, "raw");
+      const source = path.join(rawDir, "android-route-coverage.mp4");
+      const outputDir = path.join(root, "public-destination-race");
+      const externalTarget = path.join(root, "external-race-target");
+      fs.mkdirSync(rawDir, { recursive: true });
+      fs.mkdirSync(externalTarget);
+      fs.writeFileSync(source, "private-route-video");
+      let stagingRoot;
+
+      expect(() =>
+        projectAndroidDeviceEvidenceBundle({
+          bundle: {
+            root: privateRoot,
+            lane: "android",
+            build: { commit: "3".repeat(40), buildId: "4".repeat(64) },
+            steps: [{ name: "Android route coverage", status: "passed" }],
+            artifacts: [{ kind: "video", path: source }],
+          },
+          outputDir,
+          result: "passed",
+          redactVideo: (_source, destination) => {
+            stagingRoot = path.dirname(path.dirname(destination));
+            fs.writeFileSync(destination, "projected-route-video");
+            fs.symlinkSync(externalTarget, outputDir, "dir");
+          },
+        }),
+      ).toThrow(/appeared before atomic publication/);
+      expect(fs.readdirSync(externalTarget)).toEqual([]);
+      expect(fs.existsSync(stagingRoot)).toBe(false);
+      expect(
+        fs
+          .readdirSync(root)
+          .some((entry) => entry.includes("android-evidence-staging")),
+      ).toBe(false);
+    },
+  );
+
+  test("projection failure leaves no public or partial staging directory", () => {
+    const root = fixtureRoot();
+    const privateRoot = path.join(root, "private-projection-failure");
+    const rawDir = path.join(privateRoot, "raw");
+    const source = path.join(rawDir, "android-route-coverage.mp4");
+    const outputDir = path.join(root, "public-projection-failure");
+    fs.mkdirSync(rawDir, { recursive: true });
+    fs.writeFileSync(source, "private-route-video");
+
+    expect(() =>
+      projectAndroidDeviceEvidenceBundle({
+        bundle: {
+          root: privateRoot,
+          lane: "android",
+          build: { commit: "5".repeat(40), buildId: "6".repeat(64) },
+          steps: [{ name: "Android route coverage", status: "passed" }],
+          artifacts: [{ kind: "video", path: source }],
+        },
+        outputDir,
+        result: "passed",
+        redactVideo: (_source, destination) => {
+          fs.writeFileSync(destination, "partial-projected-route-video");
+          throw new Error("injected projection failure");
+        },
+      }),
+    ).toThrow(/injected projection failure/);
+    expect(fs.existsSync(outputDir)).toBe(false);
+    expect(
+      fs
+        .readdirSync(root)
+        .some((entry) => entry.includes("android-evidence-staging")),
+    ).toBe(false);
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "rejects publication ancestry writable by another principal",
+    () => {
+      const root = fixtureRoot();
+      const privateRoot = path.join(root, "private-untrusted-parent");
+      const unsafeParent = path.join(root, "unsafe-parent");
+      const outputDir = path.join(unsafeParent, "public");
+      fs.mkdirSync(privateRoot);
+      fs.mkdirSync(unsafeParent, { mode: 0o700 });
+      fs.chmodSync(unsafeParent, 0o777);
+      try {
+        expect(() =>
+          projectAndroidDeviceEvidenceBundle({
+            bundle: {
+              root: privateRoot,
+              lane: "android",
+              build: { commit: "7".repeat(40), buildId: "8".repeat(64) },
+              steps: [],
+              artifacts: [],
+            },
+            outputDir,
+            result: "failed",
+          }),
+        ).toThrow(/writable by another principal/);
+        expect(fs.existsSync(outputDir)).toBe(false);
+      } finally {
+        fs.chmodSync(unsafeParent, 0o700);
+      }
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "detects publication parent identity substitution",
+    () => {
+      const root = fixtureRoot();
+      const privateRoot = path.join(root, "private-parent-race");
+      const rawDir = path.join(privateRoot, "raw");
+      const source = path.join(rawDir, "android-route-coverage.mp4");
+      const publicationParent = path.join(root, "publication-parent");
+      const displacedParent = path.join(root, "publication-parent-displaced");
+      const outputDir = path.join(publicationParent, "public");
+      fs.mkdirSync(rawDir, { recursive: true });
+      fs.mkdirSync(publicationParent, { mode: 0o700 });
+      fs.writeFileSync(source, "private-route-video");
+
+      expect(() =>
+        projectAndroidDeviceEvidenceBundle({
+          bundle: {
+            root: privateRoot,
+            lane: "android",
+            build: { commit: "9".repeat(40), buildId: "a".repeat(64) },
+            steps: [{ name: "Android route coverage", status: "passed" }],
+            artifacts: [{ kind: "video", path: source }],
+          },
+          outputDir,
+          result: "passed",
+          redactVideo: (_source, destination) => {
+            fs.writeFileSync(destination, "projected-route-video");
+            fs.renameSync(publicationParent, displacedParent);
+            fs.mkdirSync(publicationParent, { mode: 0o700 });
+          },
+        }),
+      ).toThrow(/publication parent changed identity/);
+      expect(fs.readdirSync(publicationParent)).toEqual([]);
+      expect(fs.existsSync(outputDir)).toBe(false);
+      expect(allPublicBytes(displacedParent)).not.toContain(
+        "private-route-video",
+      );
+    },
+  );
+
+  test("requires one redacted video only when route capture passed", () => {
+    const root = fixtureRoot();
+    const privateRoot = path.join(root, "private-route-proof");
+    const missingOutput = path.join(root, "public-missing-route-proof");
+    const canonicalOutput = path.join(root, "public-canonical-route-proof");
+    const skippedOutput = path.join(root, "public-skipped-route-proof");
+    const rawDir = path.join(privateRoot, "raw");
+    const inlineDir = path.join(privateRoot, "inline");
+    fs.mkdirSync(rawDir, { recursive: true });
+    fs.mkdirSync(inlineDir, { recursive: true });
+    const identity = {
+      commit: "e".repeat(40),
+      buildId: "f".repeat(64),
+    };
+
+    expect(() =>
+      projectAndroidDeviceEvidenceBundle({
+        bundle: {
+          root: privateRoot,
+          lane: "android",
+          build: identity,
+          steps: [{ name: "Android route coverage", status: "passed" }],
+          artifacts: [],
+        },
+        outputDir: missingOutput,
+        result: "passed",
+      }),
+    ).toThrow(/exactly one private video/);
+    expect(fs.existsSync(missingOutput)).toBe(false);
+
+    const canonicalVideo = path.join(rawDir, "android-route-coverage.mp4");
+    const inlineDuplicate = path.join(inlineDir, "android-route-coverage.mp4");
+    fs.writeFileSync(canonicalVideo, "canonical-private-video");
+    fs.writeFileSync(
+      inlineDuplicate,
+      "PHYSICAL_SERIAL_CANARY-inline-duplicate",
+    );
+    let projectedSource = null;
+    const canonical = projectAndroidDeviceEvidenceBundle({
+      bundle: {
+        root: privateRoot,
+        lane: "android",
+        build: identity,
+        steps: [{ name: "Android route coverage", status: "passed" }],
+        artifacts: [
+          { kind: "video", path: canonicalVideo },
+          { kind: "video", path: inlineDuplicate },
+        ],
+      },
+      outputDir: canonicalOutput,
+      result: "passed",
+      redactVideo: (source, destination) => {
+        projectedSource = source;
+        fs.writeFileSync(destination, "redacted-canonical-video");
+      },
+    });
+    expect(canonical.summary.counts.mediaArtifacts).toBe(1);
+    expect(projectedSource).toBe(canonicalVideo);
+    expect(allPublicBytes(canonicalOutput)).not.toContain(
+      "PHYSICAL_SERIAL_CANARY-inline-duplicate",
+    );
+
+    const skipped = projectAndroidDeviceEvidenceBundle({
+      bundle: {
+        root: privateRoot,
+        lane: "android",
+        build: identity,
+        steps: [{ name: "local chat smoke", status: "passed" }],
+        artifacts: [],
+      },
+      outputDir: skippedOutput,
+      result: "passed",
+    });
+    expect(skipped.summary.counts.mediaArtifacts).toBe(0);
+    expect(skipped.summary.phases).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ phase: "route-capture" }),
+      ]),
+    );
+  });
+
+  test("teardown failures cannot bypass lease release, projection, or private cleanup", async () => {
+    const root = fixtureRoot();
+    const privateRoot = path.join(root, "private-teardown-canary");
+    fs.mkdirSync(privateRoot);
+    fs.writeFileSync(
+      path.join(privateRoot, "raw.log"),
+      "PHYSICAL_SERIAL_CANARY teardown MODEL_RESPONSE_CANARY",
+    );
+    const calls = [];
+
+    const result = await settleAndroidEvidenceTeardown({
+      operations: [
+        {
+          phase: "route-capture",
+          run: async () => {
+            calls.push("stop");
+            throw new Error("PHYSICAL_SERIAL_CANARY stop failed");
+          },
+        },
+        {
+          phase: "device-lease",
+          run: () => calls.push("release"),
+        },
+      ],
+      project: ({ failureCount }) => {
+        calls.push(`project-${failureCount}`);
+        throw new Error("MODEL_RESPONSE_CANARY projection failed");
+      },
+      cleanup: () => {
+        calls.push("cleanup");
+        fs.rmSync(privateRoot, { recursive: true, force: true });
+      },
+      onFailure: (phase) => calls.push(`failed-${phase}`),
+    });
+
+    expect(result).toEqual({ failureCount: 2 });
+    expect(calls).toEqual([
+      "stop",
+      "failed-route-capture",
+      "release",
+      "project-1",
+      "failed-evidence-projection",
+      "cleanup",
+    ]);
+    expect(fs.existsSync(privateRoot)).toBe(false);
+  });
+
+  test.skipIf(!ffmpegAvailable)(
+    "default video projector removes source metadata and trailing-byte canaries",
+    () => {
+      const root = fixtureRoot();
+      const privateRoot = path.join(root, "private-real-media");
+      const outputDir = path.join(root, "public-real-media");
+      const rawDir = path.join(privateRoot, "raw");
+      const source = path.join(rawDir, "android-route-coverage.mp4");
+      const canary = "PHYSICAL_SERIAL_CANARY-METADATA-R58N9944";
+      fs.mkdirSync(rawDir, { recursive: true });
+      const generated = spawnSync(
+        "ffmpeg",
+        [
+          "-y",
+          "-v",
+          "error",
+          "-f",
+          "lavfi",
+          "-i",
+          "color=c=red:s=64x64:d=1",
+          "-metadata",
+          `comment=${canary}`,
+          "-c:v",
+          "libx264",
+          "-pix_fmt",
+          "yuv420p",
+          source,
+        ],
+        { stdio: "ignore" },
+      );
+      expect(generated.status).toBe(0);
+      fs.appendFileSync(source, `\n${canary}\n`);
+
+      projectAndroidDeviceEvidenceBundle({
+        bundle: {
+          root: privateRoot,
+          lane: "android",
+          build: { commit: "c".repeat(40), buildId: "d".repeat(64) },
+          steps: [{ name: "Android route coverage", status: "passed" }],
+          artifacts: [{ kind: "video", path: source }],
+        },
+        outputDir,
+        result: "passed",
+      });
+
+      const publicBytes = fs
+        .readdirSync(outputDir, { recursive: true })
+        .filter((entry) => fs.statSync(path.join(outputDir, entry)).isFile())
+        .map((entry) => fs.readFileSync(path.join(outputDir, entry)));
+      expect(Buffer.concat(publicBytes).includes(canary)).toBe(false);
+    },
+  );
+});

--- a/packages/app/scripts/voice-evidence-media.mjs
+++ b/packages/app/scripts/voice-evidence-media.mjs
@@ -1,7 +1,8 @@
 /**
- * Finalizes live voice captures into revision-bound evidence. The web path
- * muxes a real system-sink recording, while desktop requires separate physical
- * microphone and speaker-loopback captures; payload bytes remain diagnostics.
+ * Finalizes live voice captures into revision-bound evidence. Web and desktop
+ * privately validate their real acoustic captures, then publish only black
+ * video and non-intelligible, duration-only tone projections. Source waveforms,
+ * speech, transcripts, and correlation inputs never enter public artifacts.
  */
 
 import { execFileSync, spawnSync } from "node:child_process";
@@ -95,6 +96,16 @@ export function classifyPhysicalMicrophoneEndpoint(
 
 const require = createRequire(import.meta.url);
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const ACOUSTIC_PROJECTION = Object.freeze({
+  schema: "eliza_voice_duration_only_acoustic_projection_v1",
+  privacyClass: "non-intelligible-non-reconstructible",
+  sourceFeature: "duration-only",
+  signal: "fixed-frequency-sine",
+  frequencyHz: 997,
+  sampleRateHz: 48_000,
+  channels: 1,
+  peakAmplitude: 0.03125,
+});
 
 function executable(command) {
   if (!command) return false;
@@ -560,13 +571,6 @@ function revision(expected) {
   return head;
 }
 
-function copy(file, outDir, name = path.basename(file)) {
-  requireFile(file, "evidence artifact");
-  const destination = path.join(outDir, name);
-  fs.copyFileSync(file, destination);
-  return destination;
-}
-
 export function snapshotEvidenceFile(
   file,
   root,
@@ -731,14 +735,361 @@ function assertFreshCapture(file, startedAt, label) {
   }
 }
 
-function manifest(outDir, kind, head, media, artifacts) {
+function projectedMedia(inspected, synchronizationCode) {
+  return {
+    acousticProjection: ACOUSTIC_PROJECTION,
+    durationMs: Math.round(inspected.duration * 1_000),
+    maxVolumeMilliDb: Math.round(inspected.maxVolumeDb * 1_000),
+    audioStreamCount: inspected.streams.filter(
+      (stream) => stream.codec_type === "audio",
+    ).length,
+    videoStreamCount: inspected.streams.filter(
+      (stream) => stream.codec_type === "video",
+    ).length,
+    synchronizationCode,
+  };
+}
+
+function lstatIfPresent(file) {
+  try {
+    return fs.lstatSync(file);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function establishPublicationTrust(parent) {
+  if (process.platform === "win32") {
+    const configuredRoot = process.env.RUNNER_TEMP?.trim() || os.tmpdir();
+    const root = fs.realpathSync(configuredRoot);
+    const rootStat = fs.lstatSync(root);
+    const relative = path.relative(root, parent);
+    if (
+      rootStat.isSymbolicLink() ||
+      !rootStat.isDirectory() ||
+      relative.startsWith("..") ||
+      path.isAbsolute(relative)
+    ) {
+      throw new Error(
+        "Voice evidence output must remain inside the canonical runner temp root.",
+      );
+    }
+    return { root, rootDev: rootStat.dev, rootIno: rootStat.ino };
+  }
+  const currentUid = process.getuid?.();
+  let current = parent;
+  while (true) {
+    const stat = fs.lstatSync(current);
+    const writableByOthers = (stat.mode & 0o022) !== 0;
+    const sticky = (stat.mode & 0o1000) !== 0;
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error("Voice evidence publication ancestry is not canonical.");
+    }
+    if (currentUid !== undefined && stat.uid !== currentUid && stat.uid !== 0) {
+      throw new Error(
+        "Voice evidence publication ancestry is owned by another principal.",
+      );
+    }
+    if (writableByOthers && !sticky) {
+      throw new Error(
+        "Voice evidence publication ancestry is writable by another principal.",
+      );
+    }
+    const container = path.dirname(current);
+    if (container === current) break;
+    current = container;
+  }
+  return null;
+}
+
+function assertPublicationTrust(parent, trust) {
+  if (process.platform !== "win32") {
+    establishPublicationTrust(parent);
+    return;
+  }
+  if (!trust) {
+    throw new Error("Voice evidence runner temp trust is missing.");
+  }
+  const rootStat = lstatIfPresent(trust.root);
+  const relative = path.relative(trust.root, parent);
+  if (
+    !rootStat ||
+    rootStat.isSymbolicLink() ||
+    !rootStat.isDirectory() ||
+    rootStat.dev !== trust.rootDev ||
+    rootStat.ino !== trust.rootIno ||
+    relative.startsWith("..") ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error("Voice evidence runner temp root changed identity.");
+  }
+}
+
+function prepareOutputPublication(outDir) {
+  if (!outDir) throw new Error("Voice evidence output directory is required.");
+  const requestedDestination = path.resolve(outDir);
+  if (requestedDestination === path.parse(requestedDestination).root) {
+    throw new Error(
+      "Voice evidence output directory cannot be a filesystem root.",
+    );
+  }
+  const requestedDestinationStat = lstatIfPresent(requestedDestination);
+  if (requestedDestinationStat?.isSymbolicLink()) {
+    throw new Error("Voice evidence output directory cannot be a symlink.");
+  }
+  if (requestedDestinationStat && !requestedDestinationStat.isDirectory()) {
+    throw new Error("Voice evidence output path must be a directory.");
+  }
+  const requestedParent = path.dirname(requestedDestination);
+  fs.mkdirSync(requestedParent, { recursive: true, mode: 0o700 });
+  const parent = fs.realpathSync(requestedParent);
+  const parentStat = fs.lstatSync(parent);
+  if (parentStat.isSymbolicLink() || !parentStat.isDirectory()) {
+    throw new Error(
+      "Voice evidence output parent must be a real directory, not a symlink.",
+    );
+  }
+  const trust = establishPublicationTrust(parent);
+  const destination = path.join(parent, path.basename(requestedDestination));
+  if (lstatIfPresent(destination)) {
+    throw new Error("Voice evidence output directory must not already exist.");
+  }
+  const stagingPrefix = `.${path.basename(destination)}.voice-evidence-staging-`;
+  const staging = fs.mkdtempSync(path.join(parent, stagingPrefix));
+  fs.chmodSync(staging, 0o700);
+  const stagingStat = fs.lstatSync(staging);
+  return {
+    destination,
+    parent,
+    parentStat,
+    trust,
+    staging,
+    stagingPrefix,
+    stagingStat,
+  };
+}
+
+function assertPublicationParentIdentity(publication) {
+  const {
+    destination,
+    parent,
+    parentStat: expectedParentStat,
+    staging,
+  } = publication;
+  if (
+    path.dirname(destination) !== parent ||
+    path.dirname(staging) !== parent
+  ) {
+    throw new Error("Evidence publication paths escaped their owned parent.");
+  }
+  const parentStat = lstatIfPresent(parent);
+  if (
+    !parentStat ||
+    parentStat.isSymbolicLink() ||
+    !parentStat.isDirectory() ||
+    parentStat.dev !== expectedParentStat.dev ||
+    parentStat.ino !== expectedParentStat.ino
+  ) {
+    throw new Error("Evidence publication parent changed identity.");
+  }
+  assertPublicationTrust(parent, publication.trust);
+  return parentStat;
+}
+
+function assertStagingIdentity(publication, { allowMissing = false } = {}) {
+  const {
+    parent,
+    staging,
+    stagingPrefix,
+    stagingStat: expectedStagingStat,
+  } = publication;
+  assertPublicationParentIdentity(publication);
+  if (
+    path.dirname(staging) !== parent ||
+    !path.basename(staging).startsWith(stagingPrefix)
+  ) {
+    throw new Error("Refusing to clean an unowned evidence staging path.");
+  }
+  const stagingStat = lstatIfPresent(staging);
+  if (!stagingStat) {
+    if (allowMissing) return undefined;
+    throw new Error("Evidence staging directory disappeared.");
+  }
+  if (
+    stagingStat.isSymbolicLink() ||
+    !stagingStat.isDirectory() ||
+    stagingStat.dev !== expectedStagingStat.dev ||
+    stagingStat.ino !== expectedStagingStat.ino
+  ) {
+    throw new Error("Evidence staging directory changed identity.");
+  }
+  return stagingStat;
+}
+
+function removeOwnedStagingDirectory(publication) {
+  if (!assertStagingIdentity(publication, { allowMissing: true })) return;
+  const tombstone = `${publication.staging}.cleanup`;
+  if (lstatIfPresent(tombstone)) {
+    throw new Error("Evidence cleanup tombstone already exists.");
+  }
+  fs.renameSync(publication.staging, tombstone);
+  const tombstoneStat = fs.lstatSync(tombstone);
+  if (
+    tombstoneStat.isSymbolicLink() ||
+    !tombstoneStat.isDirectory() ||
+    tombstoneStat.dev !== publication.stagingStat.dev ||
+    tombstoneStat.ino !== publication.stagingStat.ino
+  ) {
+    throw new Error("Evidence cleanup tombstone changed identity.");
+  }
+  // `fs.rm` unlinks directory symlinks instead of traversing them. The root is
+  // the exact inode created above and atomically moved to this private name.
+  fs.rmSync(tombstone, { recursive: true, force: true, maxRetries: 2 });
+}
+
+function childPath(root, file, label) {
+  const relative = path.relative(root, path.resolve(file));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} is outside the evidence staging directory.`);
+  }
+  return relative;
+}
+
+function verifyStagedEvidence(publication, result) {
+  assertStagingIdentity(publication);
+  const { staging } = publication;
+  const manifestRelative = childPath(
+    staging,
+    result.manifestPath,
+    "Evidence manifest",
+  );
+  const persistedManifest = readJson(result.manifestPath, "evidence manifest");
+  if (
+    JSON.stringify(persistedManifest) !== JSON.stringify(result.manifest) ||
+    persistedManifest.schema !== "eliza_voice_evidence_v1" ||
+    persistedManifest.privacy?.publicAudio !==
+      "non-intelligible-duration-only-fixed-tone" ||
+    persistedManifest.privacy?.privateAudioPublished !== false ||
+    !Array.isArray(persistedManifest.artifacts) ||
+    persistedManifest.artifacts.length !== result.manifest.artifacts.length
+  ) {
+    throw new Error(
+      "Staged evidence manifest is incomplete or privacy-unsafe.",
+    );
+  }
+  const expectedFiles = new Set([manifestRelative]);
+  for (const artifact of persistedManifest.artifacts) {
+    if (path.basename(artifact.path) !== artifact.path) {
+      throw new Error(`Evidence artifact path is not flat: ${artifact.path}`);
+    }
+    const file = path.join(staging, artifact.path);
+    const relative = childPath(staging, file, "Evidence artifact");
+    if (expectedFiles.has(relative)) {
+      throw new Error(`Evidence manifest contains a duplicate: ${relative}`);
+    }
+    const fileStat = fs.lstatSync(file);
+    if (
+      fileStat.isSymbolicLink() ||
+      !fileStat.isFile() ||
+      fileStat.size !== artifact.bytes ||
+      sha256(file) !== artifact.sha256
+    ) {
+      throw new Error(`Evidence artifact hash verification failed: ${file}`);
+    }
+    expectedFiles.add(relative);
+  }
+  const stagedFiles = fs
+    .readdirSync(staging, { withFileTypes: true })
+    .map((entry) => {
+      const file = path.join(staging, entry.name);
+      const fileStat = fs.lstatSync(file);
+      if (fileStat.isSymbolicLink() || !fileStat.isFile()) {
+        throw new Error(`Evidence staging contains a non-file: ${file}`);
+      }
+      return childPath(staging, file, "Staged evidence file");
+    });
+  if (
+    stagedFiles.length !== expectedFiles.size ||
+    stagedFiles.some((file) => !expectedFiles.has(file))
+  ) {
+    throw new Error("Evidence staging contains unmanifested public files.");
+  }
+}
+
+function publishStagedEvidence(publication, result) {
+  verifyStagedEvidence(publication, result);
+  assertStagingIdentity(publication);
+  const publishedResult = {
+    ...result,
+    mp4: path.join(
+      publication.destination,
+      childPath(publication.staging, result.mp4, "Evidence MP4"),
+    ),
+    manifestPath: path.join(
+      publication.destination,
+      childPath(publication.staging, result.manifestPath, "Evidence manifest"),
+    ),
+  };
+  const currentDestination = lstatIfPresent(publication.destination);
+  if (currentDestination) {
+    throw new Error(
+      "Voice evidence output path appeared before atomic publication.",
+    );
+  }
+  assertPublicationParentIdentity(publication);
+  assertStagingIdentity(publication);
+  fs.renameSync(publication.staging, publication.destination);
+  return publishedResult;
+}
+
+function atomicallyPublishEvidence(outDir, build) {
+  const publication = prepareOutputPublication(outDir);
+  let published = false;
+  try {
+    const result = build(publication.staging);
+    const publishedResult = publishStagedEvidence(publication, result);
+    published = true;
+    return publishedResult;
+  } finally {
+    if (!published) removeOwnedStagingDirectory(publication);
+  }
+}
+
+function writeProof(outDir, kind, head, proof) {
+  const file = path.join(outDir, `voice-${kind}-proof.json`);
+  fs.writeFileSync(
+    file,
+    `${JSON.stringify(
+      {
+        schema: "eliza_voice_private_input_projection_v1",
+        revision: head,
+        kind,
+        phase: "correlation",
+        code: `VOICE_${kind.toUpperCase()}_CORRELATED`,
+        checks: proof,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return file;
+}
+
+function manifest(outDir, kind, head, media, proof, artifacts) {
   const value = {
     schema: "eliza_voice_evidence_v1",
     issue: 16937,
     kind,
     revision: head,
     generatedAt: new Date().toISOString(),
+    privacy: {
+      publicAudio: "non-intelligible-duration-only-fixed-tone",
+      privateAudioPublished: false,
+      sourceFeaturePublished: "duration-only",
+    },
     media,
+    proof,
     artifacts: artifacts.map(({ file, role }) => ({
       role,
       path: path.basename(file),
@@ -778,6 +1129,12 @@ function mux(video, audioInputs, output, tools) {
       "0:v:0",
       "-map",
       "[a]",
+      "-map_metadata",
+      "-1",
+      "-map_chapters",
+      "-1",
+      "-vf",
+      "drawbox=x=0:y=0:w=iw:h=ih:color=black:t=fill",
       "-c:v",
       "libx264",
       "-pix_fmt",
@@ -791,6 +1148,40 @@ function mux(video, audioInputs, output, tools) {
     ],
     "voice recording mux",
   );
+}
+
+function projectAcousticSignal(duration, output, tools) {
+  if (!Number.isFinite(duration) || duration < 0.25) {
+    throw new Error(
+      `Cannot project an invalid acoustic duration: ${String(duration)}.`,
+    );
+  }
+  runChecked(
+    tools.ffmpeg,
+    [
+      "-y",
+      "-v",
+      "error",
+      "-f",
+      "lavfi",
+      "-i",
+      `sine=frequency=${ACOUSTIC_PROJECTION.frequencyHz}:sample_rate=${ACOUSTIC_PROJECTION.sampleRateHz}:duration=${duration.toFixed(6)}`,
+      "-af",
+      "volume=0.25",
+      "-ac",
+      String(ACOUSTIC_PROJECTION.channels),
+      "-map_metadata",
+      "-1",
+      "-map_chapters",
+      "-1",
+      "-vn",
+      "-c:a",
+      "pcm_s16le",
+      output,
+    ],
+    "privacy-safe acoustic projection",
+  );
+  return output;
 }
 
 function transcodeFailures(root, outDir, tools) {
@@ -817,6 +1208,12 @@ function transcodeFailures(root, outDir, tools) {
         input,
         "-map",
         "0:v:0",
+        "-map_metadata",
+        "-1",
+        "-map_chapters",
+        "-1",
+        "-vf",
+        "drawbox=x=0:y=0:w=iw:h=ih:color=black:t=fill",
         "-c:v",
         "libx264",
         "-pix_fmt",
@@ -908,7 +1305,7 @@ function finalizeWebVoiceEvidenceSnapshot({
     (file) => path.basename(file) === "video.webm" && file.startsWith(liveRoot),
     "live Playwright video",
   );
-  const trace = requireOne(
+  requireOne(
     files,
     (file) => path.basename(file) === "trace.zip" && file.startsWith(liveRoot),
     "live Playwright trace",
@@ -939,7 +1336,9 @@ function finalizeWebVoiceEvidenceSnapshot({
     throw new Error("Live matrix report is not an executed single-cell pass.");
   }
   assertFreshCapture(systemLoopback, networkValue.startedAt, "system loopback");
-  inspectAudibleMedia(systemLoopback, tools);
+  const loopbackInspection = inspectAudibleMedia(systemLoopback, tools);
+  const micInspection = inspectAudibleMedia(mic, tools);
+  const ttsInspection = inspectAudibleMedia(tts, tools);
   const audioSegments = assertLoopbackSegments(
     systemLoopback,
     loopbackClock,
@@ -949,53 +1348,85 @@ function finalizeWebVoiceEvidenceSnapshot({
     tools,
   );
   requireFile(backendLog, "backend log");
-  fs.mkdirSync(outDir, { recursive: true });
-  const mp4 = path.join(outDir, "voice-web-live-roundtrip.mp4");
-  mux(video, [systemLoopback], mp4, tools);
-  const inspected = inspectAudibleMp4(mp4, tools);
-  const failures = transcodeFailures(failureResultsDir, outDir, tools);
-  const artifacts = [
-    {
-      file: mp4,
-      role: "web-screen-plus-system-loopback-composite-unsynchronized",
-    },
-    {
-      file: copy(systemLoopback, outDir, "voice-web-system-loopback.wav"),
-      role: "browser-system-loopback",
-    },
-    {
-      file: copy(loopbackClock, outDir, "voice-web-loopback-clock.json"),
-      role: "loopback-clock",
-    },
-    { file: copy(mic, outDir), role: "captured-microphone-payload" },
-    { file: copy(tts, outDir), role: "returned-tts-payload" },
-    { file: copy(trajectory, outDir), role: "live-llm-trajectory" },
-    { file: copy(network, outDir), role: "frontend-network" },
-    { file: copy(trace, outDir), role: "frontend-trace" },
-    {
-      file: copy(backendLog, outDir, "voice-web-backend.log"),
-      role: "backend-log",
-    },
-    {
-      file: copy(matrixReport, outDir, "voice-web-matrix.json"),
-      role: "matrix-report",
-    },
-    ...failures.map((file) => ({ file, role: "failure-path-video" })),
-  ];
-  return {
-    mp4,
-    ...manifest(
-      outDir,
-      "web",
-      revision(expectedRevision),
+  const head = revision(expectedRevision);
+  return atomicallyPublishEvidence(outDir, (stagingDir) => {
+    const safeLoopback = projectAcousticSignal(
+      loopbackInspection.duration,
+      path.join(stagingDir, "voice-web-projected-loopback.wav"),
+      tools,
+    );
+    const safeMic = projectAcousticSignal(
+      micInspection.duration,
+      path.join(stagingDir, "voice-web-projected-input.wav"),
+      tools,
+    );
+    const safeTts = projectAcousticSignal(
+      ttsInspection.duration,
+      path.join(stagingDir, "voice-web-projected-tts.wav"),
+      tools,
+    );
+    const mp4 = path.join(stagingDir, "voice-web-live-roundtrip.mp4");
+    mux(video, [safeLoopback], mp4, tools);
+    const inspected = inspectAudibleMp4(mp4, tools);
+    const failures = transcodeFailures(failureResultsDir, stagingDir, tools);
+    const proof = {
+      modelResponsePresent: true,
+      networkStagePassCount: 3,
+      trajectoryMatched: true,
+      roomMatched: true,
+      messageMatched: true,
+      matrixCellCount: 1,
+      matrixPassCount: 1,
+      backendEvidencePresent: true,
+      referenceAudioMatched: true,
+      ttsAudioMatched: true,
+      publicAudioProjectedFromDurationOnly: true,
+      privateAudioPublished: false,
+      failurePathCount: failures.length,
+    };
+    const proofFile = writeProof(stagingDir, "web", head, proof);
+    const artifacts = [
       {
-        ...inspected,
-        synchronization: "not-established-between-screen-and-loopback",
-        segments: audioSegments,
+        file: mp4,
+        role: "privacy-safe-black-video-plus-projected-loopback-tone",
       },
-      artifacts,
-    ),
-  };
+      {
+        file: safeLoopback,
+        role: "privacy-safe-projected-loopback-duration-tone",
+      },
+      {
+        file: safeMic,
+        role: "privacy-safe-projected-microphone-duration-tone",
+      },
+      {
+        file: safeTts,
+        role: "privacy-safe-projected-tts-duration-tone",
+      },
+      { file: proofFile, role: "privacy-safe-correlation-proof" },
+      ...failures.map((file) => ({
+        file,
+        role: "privacy-safe-black-failure-path-video",
+      })),
+    ];
+    return {
+      mp4,
+      ...manifest(
+        stagingDir,
+        "web",
+        head,
+        {
+          ...projectedMedia(
+            inspected,
+            "SCREEN_AUDIO_SYNCHRONIZATION_NOT_ESTABLISHED",
+          ),
+          audibleSegmentCount: 2,
+          correlatedSignalCount: Object.keys(audioSegments.correlations).length,
+        },
+        proof,
+        artifacts,
+      ),
+    };
+  });
 }
 
 function assertDesktopReport(file, head) {
@@ -1303,7 +1734,12 @@ function finalizeDesktopVoiceEvidenceSnapshot({
     );
   }
   inspectAudibleMedia(microphoneAudio, tools);
-  inspectAudibleMedia(speakerLoopbackAudio, tools);
+  const speakerLoopbackInspection = inspectAudibleMedia(
+    speakerLoopbackAudio,
+    tools,
+  );
+  const referenceInspection = inspectAudibleMedia(referencePayload, tools);
+  const ttsInspection = inspectAudibleMedia(ttsPayload, tools);
   const asrStage = desktopEvidence.report.stages.find(
     (stage) => stage.stage === "asr",
   );
@@ -1367,44 +1803,82 @@ function finalizeDesktopVoiceEvidenceSnapshot({
     ),
     tools,
   );
-  fs.mkdirSync(outDir, { recursive: true });
-  const mp4 = path.join(outDir, "voice-desktop-live-roundtrip.mp4");
-  mux(screenRecording, [microphoneAudio, speakerLoopbackAudio], mp4, tools);
-  const inspected = inspectAudibleMp4(mp4, tools);
-  const artifacts = [
-    { file: mp4, role: "desktop-mic-and-speaker-loopback-walkthrough" },
-    { file: copy(report, outDir), role: "packaged-desktop-report" },
-    { file: copy(trajectory, outDir), role: "live-llm-trajectory" },
-    { file: copy(backendLog, outDir), role: "backend-log" },
-    { file: copy(microphoneAudio, outDir), role: "physical-microphone" },
-    { file: copy(speakerLoopbackAudio, outDir), role: "speaker-loopback" },
-    { file: copy(microphonePayload, outDir), role: "app-microphone-payload" },
-    { file: copy(referencePayload, outDir), role: "known-phrase-reference" },
-    { file: copy(ttsPayload, outDir), role: "returned-tts-payload" },
-    {
-      file: copy(captureProvenance, outDir),
-      role: "physical-hardware-capture-provenance",
-    },
-  ];
-  return {
-    mp4,
-    ...manifest(
-      outDir,
-      "desktop",
-      head,
+  return atomicallyPublishEvidence(outDir, (stagingDir) => {
+    const safeSpeakerLoopback = projectAcousticSignal(
+      speakerLoopbackInspection.duration,
+      path.join(stagingDir, "voice-desktop-projected-speaker-loopback.wav"),
+      tools,
+    );
+    const safeReference = projectAcousticSignal(
+      referenceInspection.duration,
+      path.join(stagingDir, "voice-desktop-projected-reference.wav"),
+      tools,
+    );
+    const safeTts = projectAcousticSignal(
+      ttsInspection.duration,
+      path.join(stagingDir, "voice-desktop-projected-tts.wav"),
+      tools,
+    );
+    const mp4 = path.join(stagingDir, "voice-desktop-live-roundtrip.mp4");
+    mux(screenRecording, [safeSpeakerLoopback], mp4, tools);
+    const inspected = inspectAudibleMp4(mp4, tools);
+    const proof = {
+      modelResponsePresent: true,
+      trajectoryMatched: true,
+      physicalMicrophoneClassified: true,
+      backendEvidencePresent: true,
+      packagedStageCount: desktopEvidence.report.stages.length,
+      packagedStagePassCount: desktopEvidence.report.stages.filter(
+        (stage) => stage.status === "pass",
+      ).length,
+      synchronizedCaptureCount: 3,
+      audioCorrelationCount: 4,
+      publicAudioProjectedFromDurationOnly: true,
+      privateAudioPublished: false,
+    };
+    const proofFile = writeProof(stagingDir, "desktop", head, proof);
+    const artifacts = [
       {
-        ...inspected,
-        synchronization: "session-clock-aligned-within-250ms",
-        correlations: {
-          microphone: microphoneCorrelation,
-          acousticReference: acousticReferenceCorrelation,
-          loopbackReference: loopbackReferenceCorrelation,
-          tts: ttsCorrelation,
-        },
+        file: mp4,
+        role: "privacy-safe-black-video-plus-projected-loopback-tone",
       },
-      artifacts,
-    ),
-  };
+      {
+        file: safeSpeakerLoopback,
+        role: "privacy-safe-projected-speaker-loopback-duration-tone",
+      },
+      {
+        file: safeReference,
+        role: "privacy-safe-projected-reference-duration-tone",
+      },
+      {
+        file: safeTts,
+        role: "privacy-safe-projected-tts-duration-tone",
+      },
+      {
+        file: proofFile,
+        role: "privacy-safe-correlation-proof",
+      },
+    ];
+    return {
+      mp4,
+      ...manifest(
+        stagingDir,
+        "desktop",
+        head,
+        {
+          ...projectedMedia(inspected, "SESSION_CLOCK_ALIGNED_WITHIN_250MS"),
+          correlatedSignalCount: [
+            microphoneCorrelation,
+            acousticReferenceCorrelation,
+            loopbackReferenceCorrelation,
+            ttsCorrelation,
+          ].length,
+        },
+        proof,
+        artifacts,
+      ),
+    };
+  });
 }
 
 function options(argv) {
@@ -1456,8 +1930,9 @@ function main() {
               "Usage: voice-evidence-media.mjs web|desktop --<artifact> <path> ...",
             );
           })();
-  console.log(`[voice-evidence] manifest=${result.manifestPath}`);
-  console.log(`[voice-evidence] mp4=${result.mp4}`);
+  console.log(
+    `[voice-evidence] phase=finalize status=passed code=EVIDENCE_READY artifacts=${result.manifest.artifacts.length}`,
+  );
 }
 
 if (
@@ -1468,8 +1943,9 @@ if (
     main();
   } catch (error) {
     // error-policy:J1 CLI boundary — incomplete evidence exits non-zero.
+    void error;
     console.error(
-      `[voice-evidence] ${error instanceof Error ? error.message : String(error)}`,
+      "[voice-evidence] phase=finalize status=failed code=EVIDENCE_REJECTED",
     );
     process.exitCode = 1;
   }

--- a/packages/app/scripts/voice-evidence-media.mjs
+++ b/packages/app/scripts/voice-evidence-media.mjs
@@ -1272,6 +1272,38 @@ export function finalizeWebVoiceEvidence(args) {
   }
 }
 
+export function assertLiveMatrixReport(matrix, head, expectedSession) {
+  if (
+    matrix?.schema !== "eliza_voice_live_matrix_v2" ||
+    matrix?.revision !== head ||
+    typeof expectedSession !== "string" ||
+    !/^[A-Za-z0-9-]{12,128}$/.test(expectedSession) ||
+    matrix?.sessionId !== expectedSession ||
+    matrix?.mode !== "run" ||
+    matrix?.selection?.filterCount !== 1 ||
+    matrix?.selection?.matched !== 1 ||
+    matrix?.selection?.errorCode !== null ||
+    matrix?.summary?.pass !== 1 ||
+    matrix?.summary?.fail !== 0 ||
+    matrix?.summary?.pending !== 0 ||
+    matrix?.summary?.skip !== 0 ||
+    !Array.isArray(matrix?.cells) ||
+    matrix.cells.length !== 1 ||
+    matrix.cells[0]?.id !== "web.live.railway-roundtrip" ||
+    matrix.cells[0]?.platform !== "web" ||
+    matrix.cells[0]?.status !== "pass" ||
+    matrix.cells[0]?.probe?.available !== true ||
+    matrix.cells[0]?.probe?.code !== "WEB_LIVE_READY" ||
+    matrix.cells[0]?.execution?.exitCode !== 0 ||
+    matrix.cells[0]?.execution?.signalCode !== null ||
+    matrix.cells[0]?.execution?.code !== "COMMAND_PASSED"
+  ) {
+    throw new Error(
+      "Live matrix report is not the revision- and session-bound Railway cell pass.",
+    );
+  }
+}
+
 function finalizeWebVoiceEvidenceSnapshot({
   resultsDir,
   failureResultsDir,
@@ -1281,6 +1313,7 @@ function finalizeWebVoiceEvidenceSnapshot({
   matrixReport,
   outDir,
   expectedRevision,
+  expectedSession,
   tools = resolveMediaTools(),
 }) {
   const files = walkFiles(resultsDir);
@@ -1327,14 +1360,8 @@ function finalizeWebVoiceEvidenceSnapshot({
     );
   }
   const matrix = readJson(matrixReport, "live matrix report");
-  if (
-    matrix?.selection?.matched !== 1 ||
-    matrix?.summary?.pass !== 1 ||
-    matrix?.summary?.fail !== 0 ||
-    matrix?.summary?.skip !== 0
-  ) {
-    throw new Error("Live matrix report is not an executed single-cell pass.");
-  }
+  const head = revision(expectedRevision);
+  assertLiveMatrixReport(matrix, head, expectedSession);
   assertFreshCapture(systemLoopback, networkValue.startedAt, "system loopback");
   const loopbackInspection = inspectAudibleMedia(systemLoopback, tools);
   const micInspection = inspectAudibleMedia(mic, tools);
@@ -1348,7 +1375,6 @@ function finalizeWebVoiceEvidenceSnapshot({
     tools,
   );
   requireFile(backendLog, "backend log");
-  const head = revision(expectedRevision);
   return atomicallyPublishEvidence(outDir, (stagingDir) => {
     const safeLoopback = projectAcousticSignal(
       loopbackInspection.duration,
@@ -1901,6 +1927,7 @@ function main() {
     outDir: values.out,
     backendLog: values.backend,
     expectedRevision: process.env.ELIZA_VOICE_EVIDENCE_REVISION,
+    expectedSession: process.env.ELIZA_VOICE_MATRIX_SESSION_ID,
   };
   const result =
     command === "web"

--- a/packages/app/scripts/voice-evidence-media.test.mjs
+++ b/packages/app/scripts/voice-evidence-media.test.mjs
@@ -132,7 +132,7 @@ test("media tool resolution fails closed and matches the skip probe", () => {
 // to a skip: a present-but-broken ffmpeg (wrong arch, missing shared library,
 // nonzero `-version` exit) probes exactly like an absent one. Provisioned
 // lanes export ELIZA_REQUIRE_MEDIA_TOOLS=1 so a lost or corrupted install
-// fails loudly instead of turning nine media contracts into silent skips.
+// fails loudly instead of turning the media contracts into silent skips.
 test.skipIf(process.env.ELIZA_REQUIRE_MEDIA_TOOLS !== "1")(
   "this lane provisioned working ffmpeg/ffprobe",
   () => {
@@ -181,6 +181,144 @@ function audio(file, tools, frequency = 440, seconds = 1) {
 function writeJson(file, value) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function textualEvidence(root) {
+  const textExtensions = new Set([".json", ".log", ".md", ".txt", ".xml"]);
+  const files = [];
+  const queue = [root];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const file = path.join(current, entry.name);
+      if (entry.isDirectory()) queue.push(file);
+      else if (textExtensions.has(path.extname(entry.name))) files.push(file);
+    }
+  }
+  return files.map((file) => fs.readFileSync(file, "utf8")).join("\n");
+}
+
+function allEvidenceBytes(root) {
+  const chunks = [];
+  const queue = [root];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const file = path.join(current, entry.name);
+      if (entry.isDirectory()) queue.push(file);
+      else chunks.push(fs.readFileSync(file));
+    }
+  }
+  return Buffer.concat(chunks);
+}
+
+function decodedAudioSamples(file, tools) {
+  const result = spawnSync(
+    tools.ffmpeg,
+    [
+      "-v",
+      "error",
+      "-i",
+      file,
+      "-map",
+      "0:a:0",
+      "-t",
+      "1",
+      "-ac",
+      "1",
+      "-ar",
+      "8000",
+      "-f",
+      "f32le",
+      "-",
+    ],
+    { encoding: null, maxBuffer: 8 * 1024 * 1024 },
+  );
+  expect(result.error).toBeUndefined();
+  expect(result.status, String(result.stderr)).toBe(0);
+  const samples = [];
+  for (let offset = 0; offset + 4 <= result.stdout.length; offset += 4) {
+    samples.push(result.stdout.readFloatLE(offset));
+  }
+  expect(samples.length).toBeGreaterThanOrEqual(4_000);
+  return samples;
+}
+
+function expectBlackVideo(file, tools) {
+  const result = spawnSync(
+    tools.ffmpeg,
+    [
+      "-v",
+      "error",
+      "-i",
+      file,
+      "-frames:v",
+      "1",
+      "-vf",
+      "scale=32:32",
+      "-pix_fmt",
+      "rgb24",
+      "-f",
+      "rawvideo",
+      "-",
+    ],
+    { encoding: null, maxBuffer: 1024 * 1024 },
+  );
+  expect(result.error).toBeUndefined();
+  expect(result.status, String(result.stderr)).toBe(0);
+  expect(result.stdout.length).toBe(32 * 32 * 3);
+  const maxChannel = result.stdout.reduce(
+    (maximum, channel) => Math.max(maximum, channel),
+    0,
+  );
+  expect(maxChannel).toBeLessThanOrEqual(8);
+}
+
+function spectralMagnitude(samples, frequencyHz, sampleRateHz = 8_000) {
+  let real = 0;
+  let imaginary = 0;
+  for (let index = 0; index < samples.length; index += 1) {
+    const phase = (2 * Math.PI * frequencyHz * index) / sampleRateHz;
+    real += samples[index] * Math.cos(phase);
+    imaginary -= samples[index] * Math.sin(phase);
+  }
+  return (2 * Math.hypot(real, imaginary)) / samples.length;
+}
+
+function expectOnlyProjectedTone(
+  file,
+  tools,
+  projectedFrequencyHz,
+  privateFrequenciesHz,
+) {
+  const samples = decodedAudioSamples(file, tools);
+  const projectedMagnitude = spectralMagnitude(samples, projectedFrequencyHz);
+  expect(projectedMagnitude).toBeGreaterThan(0.01);
+  for (const privateFrequencyHz of privateFrequenciesHz) {
+    expect(
+      spectralMagnitude(samples, privateFrequencyHz) / projectedMagnitude,
+    ).toBeLessThan(0.03);
+  }
+}
+
+function expectManifestIntegrity(outDir, result) {
+  const persisted = JSON.parse(fs.readFileSync(result.manifestPath, "utf8"));
+  expect(persisted).toEqual(result.manifest);
+  for (const artifact of persisted.artifacts) {
+    const file = path.join(outDir, artifact.path);
+    const bytes = fs.readFileSync(file);
+    expect(bytes.length).toBe(artifact.bytes);
+    expect(crypto.createHash("sha256").update(bytes).digest("hex")).toBe(
+      artifact.sha256,
+    );
+  }
+}
+
+function evidenceStagingSiblings(outDir) {
+  const prefix = `.${path.basename(outDir)}.voice-evidence-staging-`;
+  return fs
+    .readdirSync(path.dirname(outDir))
+    .filter((entry) => entry.startsWith(prefix));
 }
 
 function currentHead() {
@@ -278,22 +416,154 @@ function webFixture(root, tools) {
 }
 
 describeWithMedia("web voice media evidence", () => {
-  test("muxes actual system loopback into a revision-bound MP4", () => {
+  test("publishes only duration-projected audio in a revision-bound MP4", () => {
     const tools = resolveMediaTools();
     const root = fixtureRoot();
-    const result = finalizeWebVoiceEvidence(webFixture(root, tools));
+    const fixture = webFixture(root, tools);
+    const trajectory = path.join(
+      fixture.resultsDir,
+      "live-roundtrip",
+      "attachments",
+      "voice-live-trajectory-abc123.json",
+    );
+    const network = path.join(
+      fixture.resultsDir,
+      "live-roundtrip",
+      "attachments",
+      "voice-live-network-abc123.json",
+    );
+    const canaries = {
+      response: "MODEL_RESPONSE_CANARY_web-private-text",
+      room: "ROOM_CANARY_web-4455",
+      message: "MESSAGE_CANARY_web-5566",
+      trajectory: "TRAJECTORY_CANARY_web-6677",
+      backend: "BACKEND_CANARY_web-7788",
+      mediaMetadata: "MEDIA_METADATA_CANARY_web-8899",
+    };
+    fs.appendFileSync(fixture.systemLoopback, canaries.mediaMetadata);
+    for (const file of [
+      path.join(
+        fixture.resultsDir,
+        "live-roundtrip",
+        "attachments",
+        "voice-live-input-deadbeef.wav",
+      ),
+      path.join(
+        fixture.resultsDir,
+        "live-roundtrip",
+        "attachments",
+        "voice-live-tts-cafebabe.wav",
+      ),
+      ...[
+        "mic-permission-denied",
+        "silent-empty-capture",
+        "tts-dropped-mid-stream",
+      ].map((name) => path.join(fixture.failureResultsDir, name, "video.webm")),
+    ]) {
+      fs.appendFileSync(file, canaries.mediaMetadata);
+    }
+    writeJson(trajectory, {
+      trajectory: {
+        id: canaries.trajectory,
+        roomId: canaries.room,
+        metadata: { messageId: canaries.message },
+      },
+      llmCalls: [{ model: "private-model", response: canaries.response }],
+    });
+    const networkValue = JSON.parse(fs.readFileSync(network, "utf8"));
+    networkValue.agent.roomId = canaries.room;
+    networkValue.agent.userMessageId = canaries.message;
+    networkValue.agent.trajectoryId = canaries.trajectory;
+    writeJson(network, networkValue);
+    fs.writeFileSync(fixture.backendLog, `${canaries.backend}\n`);
+
+    const result = finalizeWebVoiceEvidence(fixture);
     expect(result.manifest.revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.manifest.privacy).toEqual({
+      publicAudio: "non-intelligible-duration-only-fixed-tone",
+      privateAudioPublished: false,
+      sourceFeaturePublished: "duration-only",
+    });
     expect(result.manifest.artifacts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          role: "web-screen-plus-system-loopback-composite-unsynchronized",
+          role: "privacy-safe-black-video-plus-projected-loopback-tone",
         }),
-        expect.objectContaining({ role: "failure-path-video" }),
+        expect.objectContaining({
+          role: "privacy-safe-black-failure-path-video",
+        }),
       ]),
     );
     expect(inspectAudibleMp4(result.mp4, tools).maxVolumeDb).toBeGreaterThan(
       -60,
     );
+    expect(result.manifest.proof).toEqual(
+      expect.objectContaining({
+        modelResponsePresent: true,
+        trajectoryMatched: true,
+        roomMatched: true,
+        messageMatched: true,
+        backendEvidencePresent: true,
+        publicAudioProjectedFromDurationOnly: true,
+        privateAudioPublished: false,
+      }),
+    );
+    const artifactRoles = result.manifest.artifacts.map(({ role }) => role);
+    expect(artifactRoles).not.toEqual(
+      expect.arrayContaining([
+        "live-llm-trajectory",
+        "frontend-network",
+        "frontend-trace",
+        "backend-log",
+      ]),
+    );
+    const serialized = textualEvidence(fixture.outDir);
+    for (const canary of Object.values(canaries)) {
+      expect(serialized).not.toContain(canary);
+      expect(allEvidenceBytes(fixture.outDir).includes(canary)).toBe(false);
+    }
+    const projectedFrequencyHz =
+      result.manifest.media.acousticProjection.frequencyHz;
+    expect(
+      spectralMagnitude(
+        decodedAudioSamples(
+          path.join(
+            fixture.resultsDir,
+            "live-roundtrip",
+            "attachments",
+            "voice-live-input-deadbeef.wav",
+          ),
+          tools,
+        ),
+        440,
+      ),
+    ).toBeGreaterThan(0.01);
+    for (const artifact of result.manifest.artifacts.filter(
+      ({ role }) =>
+        role.includes("projected") &&
+        (role.includes("tone") || role.includes("video")),
+    )) {
+      expectOnlyProjectedTone(
+        path.join(fixture.outDir, artifact.path),
+        tools,
+        projectedFrequencyHz,
+        [440, 660],
+      );
+    }
+    for (const artifact of result.manifest.artifacts.filter(({ role }) =>
+      role.includes("video"),
+    )) {
+      expectBlackVideo(path.join(fixture.outDir, artifact.path), tools);
+    }
+    const projectedMic = result.manifest.artifacts.find(({ role }) =>
+      role.includes("projected-microphone"),
+    );
+    const projectedTts = result.manifest.artifacts.find(({ role }) =>
+      role.includes("projected-tts"),
+    );
+    expect(projectedMic.sha256).toBe(projectedTts.sha256);
+    expectManifestIntegrity(fixture.outDir, result);
+    expect(evidenceStagingSiblings(fixture.outDir)).toEqual([]);
   });
 
   test("refuses payload-only evidence without system loopback", () => {
@@ -368,12 +638,103 @@ describeWithMedia("web voice media evidence", () => {
   test("refuses evidence requested for a different revision", () => {
     const tools = resolveMediaTools();
     const root = fixtureRoot();
+    const fixture = webFixture(root, tools);
     expect(() =>
       finalizeWebVoiceEvidence({
-        ...webFixture(root, tools),
+        ...fixture,
         expectedRevision: "0".repeat(40),
       }),
     ).toThrow(/does not match HEAD/);
+    expect(fs.existsSync(fixture.outDir)).toBe(false);
+    expect(evidenceStagingSiblings(fixture.outDir)).toEqual([]);
+  });
+
+  test("removes staging after a transcode fails and publishes nothing", () => {
+    const tools = resolveMediaTools();
+    const root = fixtureRoot();
+    const fixture = webFixture(root, tools);
+    fs.writeFileSync(
+      path.join(
+        fixture.failureResultsDir,
+        "silent-empty-capture",
+        "video.webm",
+      ),
+      "injected failure after the first failure-path transcode",
+    );
+
+    expect(() => finalizeWebVoiceEvidence(fixture)).toThrow(
+      /silence failure recording transcode failed/,
+    );
+    expect(fs.existsSync(fixture.outDir)).toBe(false);
+    expect(evidenceStagingSiblings(fixture.outDir)).toEqual([]);
+  });
+
+  test("rejects a staged manifest that diverges from the verified result", () => {
+    const tools = resolveMediaTools();
+    const root = fixtureRoot();
+    const fixture = webFixture(root, tools);
+    const originalWrite = fs.writeFileSync;
+    let mutated = false;
+    const writeSpy = vi
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation((file, data, ...rest) => {
+        originalWrite(file, data, ...rest);
+        if (
+          !mutated &&
+          typeof file === "string" &&
+          file.endsWith("voice-web-evidence-manifest.json")
+        ) {
+          mutated = true;
+          const manifest = JSON.parse(String(data));
+          manifest.revision = "0".repeat(40);
+          originalWrite(file, `${JSON.stringify(manifest, null, 2)}\n`);
+        }
+      });
+    try {
+      expect(() => finalizeWebVoiceEvidence(fixture)).toThrow(
+        /manifest is incomplete or privacy-unsafe/,
+      );
+    } finally {
+      writeSpy.mockRestore();
+    }
+    expect(mutated).toBe(true);
+    expect(fs.existsSync(fixture.outDir)).toBe(false);
+    expect(evidenceStagingSiblings(fixture.outDir)).toEqual([]);
+  });
+
+  test("refuses root, existing, and symlink publication destinations", () => {
+    const tools = resolveMediaTools();
+    const root = fixtureRoot();
+    const fixture = webFixture(root, tools);
+    const empty = path.join(root, "empty-publication");
+    const nonempty = path.join(root, "nonempty-publication");
+    const target = path.join(root, "symlink-target");
+    const symlink = path.join(root, "symlink-publication");
+    fs.mkdirSync(empty);
+    fs.mkdirSync(nonempty);
+    fs.writeFileSync(path.join(nonempty, "existing.txt"), "owned by caller");
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, symlink, "dir");
+
+    expect(() =>
+      finalizeWebVoiceEvidence({
+        ...fixture,
+        outDir: path.parse(root).root,
+      }),
+    ).toThrow(/cannot be a filesystem root/);
+    expect(() =>
+      finalizeWebVoiceEvidence({ ...fixture, outDir: empty }),
+    ).toThrow(/must not already exist/);
+    expect(() =>
+      finalizeWebVoiceEvidence({ ...fixture, outDir: nonempty }),
+    ).toThrow(/must not already exist/);
+    expect(() =>
+      finalizeWebVoiceEvidence({ ...fixture, outDir: symlink }),
+    ).toThrow(/cannot be a symlink/);
+    expect(fs.readFileSync(path.join(nonempty, "existing.txt"), "utf8")).toBe(
+      "owned by caller",
+    );
+    expect(fs.readdirSync(target)).toEqual([]);
   });
 
   test("refuses an MP4 without an audio stream", () => {
@@ -464,10 +825,21 @@ describeWithMedia("packaged desktop voice media evidence", () => {
     const referencePayload = path.join(root, "known-reference.wav");
     video(screenRecording, tools, 3);
     audio(microphoneAudio, tools, 440, 3);
+    const microphoneCanary = "PHYSICAL_MIC_CANARY_private-ambient-speech";
+    fs.appendFileSync(microphoneAudio, microphoneCanary);
     audio(speakerLoopbackAudio, tools, 440, 3);
     audio(microphonePayload, tools, 440, 3);
     audio(ttsPayload, tools, 440, 3);
     audio(referencePayload, tools, 440, 3);
+    const mediaMetadataCanary = "MEDIA_METADATA_CANARY_desktop-private";
+    for (const file of [
+      speakerLoopbackAudio,
+      microphonePayload,
+      ttsPayload,
+      referencePayload,
+    ]) {
+      fs.appendFileSync(file, mediaMetadataCanary);
+    }
     writeJson(captureProvenance, {
       kind: "physical-hardware",
       revision: currentHead(),
@@ -527,13 +899,82 @@ describeWithMedia("packaged desktop voice media evidence", () => {
     const result = finalizeDesktopVoiceEvidence(fixture);
     expect(result.manifest.artifacts).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ role: "physical-microphone" }),
-        expect.objectContaining({ role: "speaker-loopback" }),
         expect.objectContaining({
-          role: "physical-hardware-capture-provenance",
+          role: "privacy-safe-black-video-plus-projected-loopback-tone",
+        }),
+        expect.objectContaining({
+          role: "privacy-safe-projected-speaker-loopback-duration-tone",
+        }),
+        expect.objectContaining({
+          role: "privacy-safe-correlation-proof",
         }),
       ]),
     );
+    expect(result.manifest.proof).toEqual(
+      expect.objectContaining({
+        modelResponsePresent: true,
+        trajectoryMatched: true,
+        physicalMicrophoneClassified: true,
+        backendEvidencePresent: true,
+        publicAudioProjectedFromDurationOnly: true,
+        privateAudioPublished: false,
+      }),
+    );
+    const artifactRoles = result.manifest.artifacts.map(({ role }) => role);
+    expect(artifactRoles).not.toEqual(
+      expect.arrayContaining([
+        "packaged-desktop-report",
+        "live-llm-trajectory",
+        "backend-log",
+        "physical-hardware-capture-provenance",
+        "physical-microphone",
+        "app-synthetic-microphone-signal",
+      ]),
+    );
+    expect(allEvidenceBytes(fixture.outDir).includes(microphoneCanary)).toBe(
+      false,
+    );
+    expect(allEvidenceBytes(fixture.outDir).includes(mediaMetadataCanary)).toBe(
+      false,
+    );
+    const serialized = textualEvidence(fixture.outDir);
+    for (const canary of [
+      "It is noon.",
+      "desktop-trajectory-1",
+      "desktop-conversation-1",
+      "desktop-user-message-1",
+      "[voice] local ASR and TTS complete",
+    ]) {
+      expect(serialized).not.toContain(canary);
+    }
+    const projectedFrequencyHz =
+      result.manifest.media.acousticProjection.frequencyHz;
+    expect(
+      spectralMagnitude(decodedAudioSamples(speakerLoopbackAudio, tools), 440),
+    ).toBeGreaterThan(0.01);
+    for (const artifact of result.manifest.artifacts.filter(
+      ({ role }) =>
+        role.includes("projected") &&
+        (role.includes("tone") || role.includes("video")),
+    )) {
+      expectOnlyProjectedTone(
+        path.join(fixture.outDir, artifact.path),
+        tools,
+        projectedFrequencyHz,
+        [440],
+      );
+    }
+    for (const artifact of result.manifest.artifacts.filter(({ role }) =>
+      role.includes("video"),
+    )) {
+      expectBlackVideo(path.join(fixture.outDir, artifact.path), tools);
+    }
+    const durationProjectionHashes = result.manifest.artifacts
+      .filter(({ role }) => role.endsWith("duration-tone"))
+      .map(({ sha256 }) => sha256);
+    expect(new Set(durationProjectionHashes).size).toBe(1);
+    expectManifestIntegrity(fixture.outDir, result);
+    expect(evidenceStagingSiblings(fixture.outDir)).toEqual([]);
     const validReport = fs.readFileSync(report, "utf8");
     const abbreviatedRevision = JSON.parse(validReport);
     abbreviatedRevision.packagedRevision = currentHead().slice(0, 10);
@@ -556,6 +997,7 @@ describeWithMedia("packaged desktop voice media evidence", () => {
       (stage) => stage.stage === "asr",
     ).detail.inputDeviceLabel = "microphone, USB TEST";
     writeJson(report, punctuationEquivalentDevice);
+    fixture.outDir = path.join(root, "desktop-final-punctuation");
     expect(() => finalizeDesktopVoiceEvidence(fixture)).not.toThrow();
     fs.writeFileSync(report, validReport);
     const genericCollisionDevice = JSON.parse(validReport);
@@ -608,6 +1050,10 @@ describeWithMedia("packaged desktop voice media evidence", () => {
     const unsynchronized = JSON.parse(
       fs.readFileSync(captureProvenance, "utf8"),
     );
+    unsynchronized.captures.speakerLoopback.sha256 = crypto
+      .createHash("sha256")
+      .update(fs.readFileSync(speakerLoopbackAudio))
+      .digest("hex");
     const unsynchronizedSpeakerStart = new Date(
       Date.parse(unsynchronized.captures.screen.startedAt) + 500,
     ).toISOString();

--- a/packages/app/scripts/voice-evidence-media.test.mjs
+++ b/packages/app/scripts/voice-evidence-media.test.mjs
@@ -15,6 +15,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  assertLiveMatrixReport,
   correlateAudioWindow,
   finalizeDesktopVoiceEvidence,
   finalizeWebVoiceEvidence,
@@ -399,9 +400,28 @@ function webFixture(root, tools) {
   const backend = path.join(root, "backend.log");
   fs.writeFileSync(backend, "[voice] live route complete\n");
   const matrix = path.join(root, "voice-matrix.json");
+  const revision = currentHead();
+  const sessionId = "voice-web-live-session-123456";
   writeJson(matrix, {
-    selection: { matched: 1 },
+    schema: "eliza_voice_live_matrix_v2",
+    revision,
+    sessionId,
+    mode: "run",
+    selection: { filterCount: 1, matched: 1, errorCode: null },
     summary: { pass: 1, fail: 0, pending: 0, skip: 0 },
+    cells: [
+      {
+        id: "web.live.railway-roundtrip",
+        platform: "web",
+        status: "pass",
+        probe: { available: true, code: "WEB_LIVE_READY" },
+        execution: {
+          exitCode: 0,
+          signalCode: null,
+          code: "COMMAND_PASSED",
+        },
+      },
+    ],
   });
   return {
     resultsDir: path.join(root, "results"),
@@ -410,6 +430,8 @@ function webFixture(root, tools) {
     loopbackClock,
     backendLog: backend,
     matrixReport: matrix,
+    expectedRevision: revision,
+    expectedSession: sessionId,
     outDir: path.join(root, "final"),
     tools,
   };
@@ -647,6 +669,44 @@ describeWithMedia("web voice media evidence", () => {
     ).toThrow(/does not match HEAD/);
     expect(fs.existsSync(fixture.outDir)).toBe(false);
     expect(evidenceStagingSiblings(fixture.outDir)).toEqual([]);
+  });
+
+  test.each([
+    ["revision", "0".repeat(40)],
+    ["sessionId", "replayed-voice-session"],
+    ["cell", "web.failure-paths"],
+    ["execution", "COMMAND_EXIT_NONZERO"],
+  ])("refuses a matrix report with mismatched %s authority", (field, value) => {
+    const revision = currentHead();
+    const sessionId = "voice-web-live-session-123456";
+    const matrix = {
+      schema: "eliza_voice_live_matrix_v2",
+      revision,
+      sessionId,
+      mode: "run",
+      selection: { filterCount: 1, matched: 1, errorCode: null },
+      summary: { pass: 1, fail: 0, pending: 0, skip: 0 },
+      cells: [
+        {
+          id: "web.live.railway-roundtrip",
+          platform: "web",
+          status: "pass",
+          probe: { available: true, code: "WEB_LIVE_READY" },
+          execution: {
+            exitCode: 0,
+            signalCode: null,
+            code: "COMMAND_PASSED",
+          },
+        },
+      ],
+    };
+    if (field === "cell") matrix.cells[0].id = value;
+    else if (field === "execution") matrix.cells[0].execution.code = value;
+    else matrix[field] = value;
+
+    expect(() => assertLiveMatrixReport(matrix, revision, sessionId)).toThrow(
+      /revision- and session-bound Railway cell pass/,
+    );
   });
 
   test("removes staging after a transcode fails and publishes nothing", () => {

--- a/packages/scripts/__tests__/device-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/device-e2e-workflow.test.ts
@@ -7,11 +7,11 @@
  * the `ci:device` label actually reaches BOTH bundle-owning runners
  * (android-e2e.mjs / ios-e2e.mjs) with `--output` inside the uploaded artifact
  * root, that the uploads run `if: always()` so an induced failure still ships
- * a bundle, that the bundle producers emit the required inline/, logs/,
- * summary.json, and junit.xml members, and that the Android-only cadence has a
- * least-privilege stable-issue failure signal without scheduling iOS. The
- * workflow stays credential-free for fork PRs with pinned toolchains and
- * SHA-pinned actions.
+ * a bundle, that Android keeps bootstrap logs beside an atomically published
+ * allowlisted evidence directory, that the bundle producers emit their
+ * required members, and that the Android-only cadence has a least-privilege
+ * stable-issue failure signal without scheduling iOS. The workflow stays
+ * credential-free for fork PRs with pinned toolchains and SHA-pinned actions.
  * Parses the real workflow YAML; deterministic, no network or devices.
  */
 import { describe, expect, test } from "bun:test";
@@ -179,7 +179,9 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     );
     const script = runner.with?.script ?? "";
     expect(script).toContain("packages/app/scripts/android-e2e.mjs");
-    expect(script).toContain('--output "$ELIZA_DEVICE_BUNDLE_ROOT/android"');
+    expect(script).toContain(
+      '--output "$ELIZA_DEVICE_BUNDLE_ROOT/android/evidence"',
+    );
     expect(script).toContain("--start-host-agent");
     expect(script).toContain("--host-emulator-probes");
     expect(script).toContain("--skip-local-chat");
@@ -205,13 +207,16 @@ describe("device-e2e workflow trigger reaches both bundle producers (#19640)", (
     );
   });
 
-  test("both uploads run if: always() and cover the exact --output roots", () => {
+  test("both uploads run if: always() and cover their runner evidence", () => {
     const androidBootstrap = findStep(
       requireJob(androidJob, "android-device-bundle"),
       (step) => step.name === "Initialize Android artifact root",
       "Android artifact bootstrap",
     );
     expect(androidBootstrap.run).toContain("workflow-bootstrap.txt");
+    expect(androidBootstrap.run).toContain(
+      '"$ELIZA_DEVICE_BUNDLE_ROOT/android/logs"',
+    );
     expect(androidBootstrap.run).toContain('"$GITHUB_SHA"');
     const android = findStep(
       requireJob(androidJob, "android-device-bundle"),
@@ -285,7 +290,7 @@ describe("Android probe partitioning (#13580)", () => {
     );
   });
 
-  test("invalid host/local selection exits nonzero with a finalized failed bundle", () => {
+  test("invalid host/local selection exits nonzero without exporting unbound diagnostics", () => {
     const output = mkdtempSync(path.join(os.tmpdir(), "eliza-android-lane-"));
     try {
       const result = spawnSync(
@@ -308,24 +313,27 @@ describe("Android probe partitioning (#13580)", () => {
       );
 
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain(
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        "phase=runner status=failed code=ANDROID_E2E_FAILED",
+      );
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain(
         "--host-emulator-probes requires ELIZA_ANDROID_BACKEND=host",
       );
-      expect(existsSync(path.join(output, "summary.json"))).toBe(true);
-      expect(existsSync(path.join(output, "junit.xml"))).toBe(true);
-      const summary = JSON.parse(
-        readFileSync(path.join(output, "summary.json"), "utf8"),
-      ) as { result: string; steps: Array<{ name: string; status: string }> };
-      expect(summary.result).toBe("failed");
-      expect(summary.steps).toContainEqual(
-        expect.objectContaining({
-          name: "validate Android lane selection",
-          status: "failed",
-        }),
-      );
+      // The lane-selection failure precedes an installed renderer identity.
+      // The privacy projection therefore refuses to publish an unbound bundle.
+      expect(existsSync(path.join(output, "summary.json"))).toBe(false);
+      expect(existsSync(path.join(output, "junit.xml"))).toBe(false);
     } finally {
       rmSync(output, { recursive: true, force: true });
     }
+  });
+
+  test("the Windows default evidence output is a fresh runner-temp child", () => {
+    expect(androidRunnerSource).toContain('process.platform === "win32"');
+    expect(androidRunnerSource).toContain(
+      "process.env.RUNNER_TEMP?.trim() || os.tmpdir()",
+    );
+    expect(androidRunnerSource).toContain("eliza-android-evidence-");
   });
 });
 
@@ -374,7 +382,11 @@ describe("ARM64 local-runtime workflow (#13580)", () => {
       (step) => step.name === "Fail-closed ARM64 device preflight",
       "ARM64 preflight",
     );
-    expect(preflight.run).toContain("arm64-local-preflight.sh 2>&1");
+    expect(preflight.run).toContain("arm64-local-preflight.sh");
+    expect(preflight.run).toContain(
+      '> "$ELIZA_DEVICE_BUNDLE_ROOT/preflight/arm64-preflight.log" 2>&1',
+    );
+    expect(preflight.run).not.toMatch(/\|\s*tee/);
     expect(preflight.run).toContain("arm64-preflight.log");
     const runner = findStep(
       job,
@@ -384,7 +396,7 @@ describe("ARM64 local-runtime workflow (#13580)", () => {
     expect(runner.run).toContain("packages/app/scripts/android-e2e.mjs");
     expect(runner.run).toContain("--no-emulator-boot");
     expect(runner.run).toContain(
-      '--output "$ELIZA_DEVICE_BUNDLE_ROOT/android-arm64-local"',
+      '--output "$ELIZA_DEVICE_BUNDLE_ROOT/runtime"',
     );
     const upload = findStep(
       job,
@@ -396,7 +408,7 @@ describe("ARM64 local-runtime workflow (#13580)", () => {
       `android-arm64-local-runtime-bundle-${workflowExpression("github.run_id")}-${workflowExpression("github.run_attempt")}`,
     );
     expect(upload.with?.path).toContain(
-      "device-e2e-artifacts/android-arm64-local/**",
+      `device-e2e-artifacts/${workflowExpression("github.run_id")}-${workflowExpression("github.run_attempt")}/**`,
     );
     expect(upload.with?.["if-no-files-found"]).toBe("error");
   });

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -3,8 +3,8 @@
 Issue #9958 defines the live-voice verification product surface. This document
 is the canonical matrix and `bun run voice:matrix` is the canonical artifact
 producer. The matrix is evidence-oriented: every cell is either `pass`, `fail`,
-`pending`, or `skip` with a hardware-unavailable reason. A skipped cell is never
-platform coverage.
+`pending`, or `skip` with an allowlisted availability code. A skipped cell is
+never platform coverage.
 
 ## Dimensions
 
@@ -39,6 +39,10 @@ test-results/evidence/9958-voice-matrix/
   index.html
 ```
 
+The JSON report uses `eliza_voice_live_matrix_v2`. Version 2 replaces raw host,
+probe, filter, and child-process diagnostics with closed codes and aggregate
+counters suitable for uploaded CI evidence.
+
 Use `--run` to execute available cell commands:
 
 ```bash
@@ -52,7 +56,7 @@ Use `--require-green` on any opted-in hardware lane; it turns `pending` or
 while a device, app install, model, or reviewed report is missing.
 `--platform` accepts a platform value or exact cell ID; a supplied filter that
 matches no cells is a failing configuration and is recorded in
-`selection.error`.
+`selection.errorCode` without echoing the caller-supplied filter.
 
 To validate the Stage-B STT benchmark cell, point the matrix at the reviewed
 report:
@@ -109,8 +113,10 @@ developer laptop:
 | `ELIZA_INFERENCE_LIBRARY` + `ELIZA_ASR_BUNDLE` | Linux fused real-service runner has the provisioned local-inference bundle |
 | `ELIZA_VOICE_STAGE_B_REPORT` | reviewed Stage-B JSON report using schema `eliza_voice_stage_b_stt_eval_v1`; required backends are `ios-sfspeechrecognizer`, `android-speechrecognizer`, and `fused-asr` |
 
-The matrix report records these gates in the `probe.reason` field. This keeps
-Linux green separate from missing macOS/iOS/Android evidence.
+The matrix report records these gates as closed, allowlisted values in the
+`probe.code` field. Raw device identifiers, provider output, host identity, and
+probe failure text stay private to the runner. This keeps Linux green separate
+from missing macOS/iOS/Android evidence without publishing device diagnostics.
 
 The openWakeWord report must mark `realHardware: true` and `realHead: true`.
 Each required case must identify the device/build/openWakeWord model, record the

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -41,7 +41,9 @@ test-results/evidence/9958-voice-matrix/
 
 The JSON report uses `eliza_voice_live_matrix_v2`. Version 2 replaces raw host,
 probe, filter, and child-process diagnostics with closed codes and aggregate
-counters suitable for uploaded CI evidence.
+counters suitable for uploaded CI evidence. Every report also carries the exact
+Git revision and a per-execution session ID so downstream finalizers can reject
+stale or cross-cell evidence instead of relabeling it as the current run.
 
 Use `--run` to execute available cell commands:
 


### PR DESCRIPTION
## Cause

The Android and live-voice evidence paths could publish device serials, raw logcat/command diagnostics, provider/model/backend/provenance values, and captured physical/system audio through logs or uploaded artifacts. The `always()` upload paths could also expose partially written evidence, and the existing voice matrix v1 schema still carried raw diagnostic fields.

## Resolution

- project Android workflow output through a closed, allowlisted status/code boundary; keep serials, logcat, screenshots, raw console output, and runner state private
- bind published Android evidence to the exact revision/build identity and SHA-256 manifest; emit black, audio-free video only
- move voice evidence to `eliza_voice_live_matrix_v2` and remove raw host/filter/probe/child diagnostics
- derive public voice audio only as a fixed 997 Hz synthetic tone from duration; publish black video plus that projected tone, never captured mic/system audio
- stage, verify, and atomically rename the exact manifest-bound Android and voice artifact sets into absent destinations
- reject symlink destinations and parent substitution; pin and revalidate publication ancestry, parent, and staging identities
- keep the hosted Android bootstrap at `android/logs/` while atomically publishing its allowlisted proof at `android/evidence/`
- use the canonical per-user runner temp directory as the explicit Windows publication trust boundary, with a fresh absent default child
- isolate workflow roots by run id/attempt and make teardown sequential and bounded

## Verification

- `bun install --frozen-lockfile`
- targeted Android/voice suite: **64 passed, 1 intentional inverse-toolchain skip, 0 failed, 577 assertions**
- adversarial coverage includes destination and parent symlinks, destination/parent substitution, partial projection cleanup, untrusted POSIX ancestry, bootstrap/evidence coexistence, and manifest/hash verification
- `actionlint` on all edited workflows
- `shellcheck` and `bash -n` on the ARM64 preflight
- `node --check` on edited runtime scripts
- Biome: pass (three pre-existing string-literal warnings in `device-e2e-workflow.test.ts`)
- `git diff --check`
- independent final review: zero P1/P2/P3 findings
- open-PR overlap audit: no overlap for `device-e2e.yml`; README overlap with #28878 is in a disjoint documentation section

No physical phone run, workflow dispatch, deployment, infrastructure mutation, or merge was performed.

## Review notes

The intentionally reduced diagnostics make failures less human-readable. Published audio is no longer a recording of the session; it proves only duration-bound media plumbing. Consumers must use the v2 matrix schema and the new artifact roles. Publication requires an absent destination. On Windows, an explicit output outside the canonical runner/user temp boundary fails closed.

Rollback is a single-commit revert.

Complementary: #29437, #29485  
Related tracking: #13580, #16937