### PR TITLE
fix(app-test): seed scoped Steward sessions

### DIFF
--- a/packages/app/docs/TEST_AUTH.md
+++ b/packages/app/docs/TEST_AUTH.md
@@ -9,9 +9,12 @@ surface instead.
 Chromium renderer tests that need a Steward session use
 `test/ui-smoke/helpers/test-auth.ts`.
 
-- `seedStewardSession(page)` seeds the canonical
-  `steward_session_token` localStorage key before React boots.
-- `setStewardSession(page)` writes the same key after the page has loaded.
+- `seedStewardSession(page)` seeds the canonical `steward_session_token` and
+  `steward_session_token_scope` localStorage pair before React boots.
+- `setStewardSession(page)` writes the same pair after the page has loaded.
+- The helper pairs tokens with `eliza-cloud:production` by default. Pass an
+  explicit `scope` only for a staging or self-hosted renderer fixture. It never
+  writes `steward_session_active_scope`; the renderer owns the active target.
 - The default token is opaque (`ui-smoke-onboarding-cloud-token`). Use it for
   mocked cloud login flows where refresh churn would obscure the test.
 - Pass `{ jwt: true }` only when the spec intentionally needs a decodable JWT

--- a/packages/app/test/ui-smoke-test-auth.test.ts
+++ b/packages/app/test/ui-smoke-test-auth.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression coverage for the browser storage authority paired by the shared
+ * Playwright Steward-session helpers.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  configureStoredStewardTokenScope,
+  readStoredStewardToken,
+} from "../../shared/src/steward-session-client/index.js";
+import {
+  seedStewardSession,
+  setStewardSession,
+} from "./ui-smoke/helpers/test-auth";
+
+const STEWARD_TOKEN_KEY = "steward_session_token";
+const STEWARD_TOKEN_SCOPE_KEY = "steward_session_token_scope";
+const STEWARD_ACTIVE_SCOPE_KEY = "steward_session_active_scope";
+const PRODUCTION_SCOPE = "eliza-cloud:production";
+
+type BrowserStorageScript = (arg: Record<string, string>) => unknown;
+
+function fakePage() {
+  const addInitScript = vi.fn(
+    async (script: BrowserStorageScript, arg: Record<string, string>) => {
+      script(arg);
+    },
+  );
+  const evaluate = vi.fn(
+    async (script: BrowserStorageScript, arg: Record<string, string>) => {
+      script(arg);
+    },
+  );
+
+  return {
+    addInitScript,
+    evaluate,
+    page: {
+      addInitScript,
+      evaluate,
+    } as unknown as Parameters<typeof seedStewardSession>[0],
+  };
+}
+
+describe("UI-smoke Steward session storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("pairs a preboot token with the production scope by default", async () => {
+    const { addInitScript, evaluate, page } = fakePage();
+    window.localStorage.setItem(
+      STEWARD_ACTIVE_SCOPE_KEY,
+      "eliza-cloud:staging",
+    );
+
+    await seedStewardSession(page, { token: "seeded-token" });
+
+    expect(addInitScript).toHaveBeenCalledOnce();
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("seeded-token");
+    expect(window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+      PRODUCTION_SCOPE,
+    );
+    expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBe(
+      "eliza-cloud:staging",
+    );
+  });
+
+  it("pairs a post-load token with the production scope by default", async () => {
+    const { addInitScript, evaluate, page } = fakePage();
+    window.localStorage.setItem(
+      STEWARD_ACTIVE_SCOPE_KEY,
+      "origin:http://127.0.0.1:8787",
+    );
+
+    await setStewardSession(page, { token: "post-load-token" });
+
+    expect(evaluate).toHaveBeenCalledOnce();
+    expect(addInitScript).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+      "post-load-token",
+    );
+    expect(window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+      PRODUCTION_SCOPE,
+    );
+    expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBe(
+      "origin:http://127.0.0.1:8787",
+    );
+  });
+
+  it("matches the canonical reader and quarantines a wrong scope", async () => {
+    const { page } = fakePage();
+    configureStoredStewardTokenScope("https://api.eliza.app/api/v1");
+
+    await seedStewardSession(page, { token: "accepted-token" });
+    expect(readStoredStewardToken()).toBe("accepted-token");
+
+    await setStewardSession(page, {
+      token: "wrong-scope-token",
+      scope: "eliza-cloud:staging",
+    });
+    expect(readStoredStewardToken()).toBeNull();
+    expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBe(
+      PRODUCTION_SCOPE,
+    );
+  });
+
+  it("honors an explicit preboot scope without claiming the active target", async () => {
+    const { page } = fakePage();
+    const options = {
+      token: "staging-token",
+      scope: "eliza-cloud:staging",
+    };
+
+    await seedStewardSession(page, options);
+
+    expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+      "staging-token",
+    );
+    expect(window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+      "eliza-cloud:staging",
+    );
+    expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBeNull();
+  });
+
+  it("honors an explicit post-load scope without claiming the active target", async () => {
+    const { page } = fakePage();
+    const options = {
+      token: "self-hosted-token",
+      scope: "origin:https://cloud.example.test",
+    };
+
+    await setStewardSession(page, options);
+
+    expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+      "self-hosted-token",
+    );
+    expect(window.localStorage.getItem(STEWARD_TOKEN_SCOPE_KEY)).toBe(
+      "origin:https://cloud.example.test",
+    );
+    expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBeNull();
+  });
+});

--- a/packages/app/test/ui-smoke/helpers/test-auth.ts
+++ b/packages/app/test/ui-smoke/helpers/test-auth.ts
@@ -1,16 +1,19 @@
 /**
  * Shared Playwright auth seed helpers for UI smoke tests. Keeping the Steward
- * session key and token shape here prevents cloud/onboarding/mobile specs from
- * each inventing their own localStorage contract, which is how the Android
- * auth summary drift escaped review.
+ * session keys and token shape here prevents cloud/onboarding/mobile specs
+ * from each inventing their own localStorage contract, which is how the
+ * Android auth summary drift escaped review.
  */
 import type { Page } from "@playwright/test";
 
 export const STEWARD_SESSION_TOKEN_KEY = "steward_session_token";
+export const STEWARD_SESSION_TOKEN_SCOPE_KEY = "steward_session_token_scope";
+export const UI_SMOKE_DEFAULT_STEWARD_SCOPE = "eliza-cloud:production";
 export const UI_SMOKE_STEWARD_OPAQUE_TOKEN = "ui-smoke-onboarding-cloud-token";
 
 type StewardSessionOptions = {
   token?: string;
+  scope?: string;
   jwt?: boolean;
   subject?: string;
   userId?: string;
@@ -52,26 +55,40 @@ export async function seedStewardSession(
   opts: StewardSessionOptions = {},
 ): Promise<string> {
   const token = createStewardSessionToken(opts);
+  const scope = opts.scope ?? UI_SMOKE_DEFAULT_STEWARD_SCOPE;
   await page.addInitScript(
-    ({ key, value }) => {
+    ({ key, scopeKey, value, scope }) => {
       window.localStorage.setItem(key, value);
+      window.localStorage.setItem(scopeKey, scope);
     },
-    { key: STEWARD_SESSION_TOKEN_KEY, value: token },
+    {
+      key: STEWARD_SESSION_TOKEN_KEY,
+      scopeKey: STEWARD_SESSION_TOKEN_SCOPE_KEY,
+      value: token,
+      scope,
+    },
   );
   return token;
 }
 
-/** Set the same canonical steward-session key after the page has loaded. */
+/** Set the same canonical Steward session pair after the page has loaded. */
 export async function setStewardSession(
   page: Page,
   opts: StewardSessionOptions = {},
 ): Promise<string> {
   const token = createStewardSessionToken(opts);
+  const scope = opts.scope ?? UI_SMOKE_DEFAULT_STEWARD_SCOPE;
   await page.evaluate(
-    ({ key, value }) => {
+    ({ key, scopeKey, value, scope }) => {
       window.localStorage.setItem(key, value);
+      window.localStorage.setItem(scopeKey, scope);
     },
-    { key: STEWARD_SESSION_TOKEN_KEY, value: token },
+    {
+      key: STEWARD_SESSION_TOKEN_KEY,
+      scopeKey: STEWARD_SESSION_TOKEN_SCOPE_KEY,
+      value: token,
+      scope,
+    },
   );
   return token;
 }


### PR DESCRIPTION
# Relates to

Fixes #29491.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `develop` at `d084b20e4109b52a0a2d5d04283bce39697afd9b`; live `develop` later advanced to `cd2bb056ae27cb46d124e9e288a4e51f7127b141` through non-overlapping paths.
- [ ] `bun run verify` was not run. Focused contract tests, isolated TypeScript, a real-browser serialization check, Biome, and diff hygiene are recorded below; GitHub's source static smoke is the authoritative clean-install lint/typecheck/build check; that workflow does not execute this unit file.
- [x] The changed storage contract is covered through both helper entrypoints, the canonical scoped-token reader, wrong-scope resistance, and a real Playwright browser.

# Sync with develop

- [x] Based on `develop` at `d084b20e4109b52a0a2d5d04283bce39697afd9b`; zero conflicts. GitHub reports this head cleanly mergeable against live `develop` at `cd2bb056ae27cb46d124e9e288a4e51f7127b141`.
- [x] The intervening `develop` commits do not touch the helper, its test, or `TEST_AUTH.md`.

# Risks

Low and test-only. The helper now writes the companion scope required by the production reader. It defaults existing UI-smoke callers to the production renderer scope and accepts an explicit scope for staging/self-hosted fixtures. It deliberately does not write `steward_session_active_scope`, so the renderer remains authoritative and mismatches continue to fail closed.

# Background

## What does this PR do?

It repairs the shared UI-smoke auth helper after #29342 introduced loopback Steward-token scoping. Both `seedStewardSession` and `setStewardSession` now write the canonical token/scope pair in one Playwright browser operation.

The regression test proves:

- preboot and post-load writes use the production scope by default;
- explicit staging/self-hosted scopes are honored;
- the helper never claims the renderer's active target;
- Eliza's canonical `readStoredStewardToken()` accepts the matching production pair and rejects a deliberately wrong scope.

`packages/app/docs/TEST_AUTH.md` now documents the paired authority contract and override.

## What kind of change is this?

Bug fix for the app UI-smoke test harness; no production/runtime behavior changes.

# Documentation changes needed?

Included: `packages/app/docs/TEST_AUTH.md`.

# Testing

## Where should a reviewer start?

`packages/app/test/ui-smoke-test-auth.test.ts`, especially `matches the canonical reader and quarantines a wrong scope`.

## Detailed testing steps

1. Deterministic RED before the helper change:

   ```text
   UI-smoke Steward session storage
   4 tests | 4 failed
   expected steward_session_token_scope, received null
   ```

2. GREEN on exact head `60831cfaed018ef6924d1df07270788a72aeef01`:

   ```text
   vitest run packages/app/test/ui-smoke-test-auth.test.ts
   Test Files  1 passed (1)
   Tests       5 passed (5)
   ```

   Command: `node node_modules/vitest/vitest.mjs run --config packages/app/vitest.config.ts packages/app/test/ui-smoke-test-auth.test.ts`. This uses the repository's official app Vitest configuration and shared setup.

3. Exact-file TypeScript:

   ```text
   tsc --noEmit <helper + regression test, shared source alias>
   exit 0
   ```

4. Real Playwright serialization on headless Chrome:

   ```text
   serializes the Steward scope pair in a real browser
   1 passed (1.9s)
   ```

   This credential-free check executed the actual `page.addInitScript` and `page.evaluate` callbacks, verified the default and explicit scopes, and verified the active-scope key stayed renderer-owned.

5. Formatting and diff hygiene:

   ```text
   @biomejs/biome check <helper + regression test>
   Checked 2 files. No fixes applied.

   git diff HEAD^ HEAD --check
   exit 0
   ```

# Evidence Gate

<!-- evidence-head:60831cfaed018ef6924d1df07270788a72aeef01 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — this is a non-visual test-harness contract; the deterministic RED output is recorded above.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no product UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interactive product flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] The credential-free real-browser contract passed with no page/runtime failure.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Canonical-reader unit proof and real Playwright serialization proof are reproduced above.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual or OCR surface changed.

# Evidence Details

## Known gaps / failures

- GitHub's current PR admission workflow runs clean-install source lint/typecheck/build but does not execute app unit files. The new test therefore relies on the exact-head official-config local receipt above rather than a GitHub unit-test job.
- The full all-views audit was not rerun. Its previously reproduced `POST /api/cloud/login` failure is the motivating integration symptom; this PR is narrowly covered at the shared helper and canonical-reader boundary.
- `bun run verify` was not run.

## Maintainer CI exception record

N/A — no exception requested.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->


