### PR TITLE
fix(cloud): align develop production database authority binding

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -1009,7 +1009,7 @@ bucket_name = "eliza-cloud-blob"
 # WebSocket driver in client.ts, which bypasses this binding).
 [[env.production.hyperdrive]]
 binding = "HYPERDRIVE"
-id = "9f59e4ec65f048f7b87e29e7b9c5d728"
+id = "486bdc36737a4ad1b526fc3c08627658"
 
 # KV is the Worker's cache backend (CacheClient). Workers can't reliably open raw
 # TCP to an external Redis (Railway's public proxy hangs under load), so the Worker


### PR DESCRIPTION
## Summary

- composes the already-reviewed production Hyperdrive authority repair from #29496 onto current `develop`
- preserves the exact one-line binding change with stable patch ID `c3e47a9bbad93db07825d370d93397acae2ef545`
- enables the canonical staging-certification path required before the protected production deploy can mutate anything

## Exact source

- base: `d084b20e4109b52a0a2d5d04283bce39697afd9b`
- head: `3c82f17973215557ef21c5a2eff5ad5cc0c2f5df`
- tree: `ddb85b58d4e1db051e62a7d43a62b0dc0c93e3cd`
- production/main equivalent: #29496 / `3ecc5474ad2afc644ef28efd5454428e6ac36dbb`

## Verification

- 33 focused Cloud deployment/database/config tests passed
- exact Worker route/config assertion passed
- production Wrangler dry bundle passed and resolves the intended Hyperdrive binding
- `git diff --check` passed
- range-diff is exact (`=`)
- Cloud package typecheck remains blocked by the unrelated current-develop missing `@elizaos/plugin-doordash` workspace package; no TypeScript source is changed here

## Safety

The prior production run failed closed at the missing staging certification before environment authorization or mutation. This PR performs no deployment, database write, row mutation, quote, charge, compute, or adoption action.