### PR TITLE
ci: certify bounded production Hyperdrive recovery

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -57,6 +57,21 @@ on:
         required: false
         default: false
         type: boolean
+      production_binding_only_recovery:
+        description: Admit only the bounded production Hyperdrive binding recovery against the currently served certified base
+        required: false
+        default: false
+        type: boolean
+      certified_production_base_sha:
+        description: Exact currently served production SHA whose staging tree certificate anchors a binding-only recovery
+        required: false
+        default: ""
+        type: string
+      certified_recovery_policy_sha:
+        description: Exact develop SHA whose successful staging certificate anchors the byte-identical recovery policy
+        required: false
+        default: ""
+        type: string
       source_sha:
         description: Exact develop SHA supplied by the effect reconciler
         required: false
@@ -105,6 +120,9 @@ jobs:
           SOURCE_REF: ${{ github.ref }}
           FORCE: ${{ inputs.force == true }}
           RUN_DEPLOYED_RENDERER_STAGING: ${{ inputs.run_deployed_renderer_staging == true }}
+          PRODUCTION_BINDING_ONLY_RECOVERY: ${{ inputs.production_binding_only_recovery == true }}
+          CERTIFIED_PRODUCTION_BASE_SHA: ${{ inputs.certified_production_base_sha }}
+          CERTIFIED_RECOVERY_POLICY_SHA: ${{ inputs.certified_recovery_policy_sha }}
         run: |
           set -euo pipefail
 
@@ -121,6 +139,28 @@ jobs:
               echo "::error::The deployed-renderer proof must keep the canonical freshness guards enabled."
               exit 1
             fi
+          fi
+
+          if [ "$PRODUCTION_BINDING_ONLY_RECOVERY" = "true" ]; then
+            [ "$TARGET_ENVIRONMENT" = "production" ] || {
+              echo "::error::Production binding-only recovery may target only production."
+              exit 1
+            }
+            [ "$FORCE" = "false" ] || {
+              echo "::error::Production binding-only recovery forbids force."
+              exit 1
+            }
+            [[ "$CERTIFIED_PRODUCTION_BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Production binding-only recovery requires an exact certified base SHA."
+              exit 1
+            }
+            [[ "$CERTIFIED_RECOVERY_POLICY_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Production binding-only recovery requires an exact certified policy SHA."
+              exit 1
+            }
+          elif [ -n "$CERTIFIED_PRODUCTION_BASE_SHA" ] || [ -n "$CERTIFIED_RECOVERY_POLICY_SHA" ]; then
+            echo "::error::Certified base and policy SHAs are valid only for binding-only recovery."
+            exit 1
           fi
 
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
@@ -212,6 +252,10 @@ jobs:
       contents: read
     outputs:
       tree_sha: ${{ steps.identity.outputs.tree_sha }}
+      certification_mode: ${{ steps.identity.outputs.certification_mode }}
+      certified_base_sha: ${{ steps.identity.outputs.certified_base_sha }}
+      policy_tree_sha: ${{ steps.identity.outputs.policy_tree_sha }}
+      policy_artifact_name: ${{ steps.identity.outputs.policy_artifact_name }}
       artifact_id: ${{ steps.resolve.outputs.artifact_id }}
       artifact_digest: ${{ steps.resolve.outputs.artifact_digest }}
       staging_run_id: ${{ steps.resolve.outputs.staging_run_id }}
@@ -220,13 +264,21 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
 
       - name: Bind production candidate to its Git tree
         id: identity
         env:
           EXPECTED_SHA: ${{ github.sha }}
+          FORCE: ${{ inputs.force == true }}
+          PRODUCTION_BINDING_ONLY_RECOVERY: ${{ inputs.production_binding_only_recovery == true }}
+          CERTIFIED_PRODUCTION_BASE_SHA: ${{ inputs.certified_production_base_sha }}
+          CERTIFIED_RECOVERY_POLICY_SHA: ${{ inputs.certified_recovery_policy_sha }}
         run: |
           set -euo pipefail
           actual_sha="$(git rev-parse HEAD)"
@@ -238,10 +290,69 @@ jobs:
             echo "::error::Production certification checkout is not clean"
             exit 1
           }
-          tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          certification_mode="exact_tree"
+          certified_base_sha="$EXPECTED_SHA"
+          if [ "$PRODUCTION_BINDING_ONLY_RECOVERY" = "true" ]; then
+            [ "$FORCE" = "false" ] || {
+              echo "::error::Binding-only recovery forbids force."
+              exit 1
+            }
+            [[ "$CERTIFIED_PRODUCTION_BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Binding-only recovery requires an exact certified base SHA."
+              exit 1
+            }
+            [[ "$CERTIFIED_RECOVERY_POLICY_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Binding-only recovery requires an exact certified policy SHA."
+              exit 1
+            }
+            git cat-file -e "${CERTIFIED_PRODUCTION_BASE_SHA}^{commit}" || {
+              echo "::error::Certified production base commit is unavailable."
+              exit 1
+            }
+            git merge-base --is-ancestor "$CERTIFIED_PRODUCTION_BASE_SHA" "$EXPECTED_SHA" || {
+              echo "::error::Certified production base is not an ancestor of the candidate."
+              exit 1
+            }
+            git fetch --no-tags \
+              "https://github.com/${GITHUB_REPOSITORY}.git" \
+              develop:refs/remotes/origin/develop
+            git cat-file -e "${CERTIFIED_RECOVERY_POLICY_SHA}^{commit}" || {
+              echo "::error::Certified recovery policy commit is unavailable."
+              exit 1
+            }
+            git merge-base --is-ancestor \
+              "$CERTIFIED_RECOVERY_POLICY_SHA" refs/remotes/origin/develop || {
+              echo "::error::Certified recovery policy is not contained in develop."
+              exit 1
+            }
+
+            health_file="${RUNNER_TEMP}/production-binding-recovery-health.json"
+            curl --fail --silent --show-error --location --retry 3 \
+              --header "Cache-Control: no-cache" \
+              --output "$health_file" \
+              "https://api.eliza.app/api/health?admission_run=${GITHUB_RUN_ID}"
+            jq -e --arg base "$CERTIFIED_PRODUCTION_BASE_SHA" \
+              '.status == "ok" and .environment == "production" and .commit == $base' \
+              "$health_file" >/dev/null || {
+              echo "::error::Certified base does not match the currently served production API."
+              exit 1
+            }
+
+            certification_mode="binding_only"
+            certified_base_sha="$CERTIFIED_PRODUCTION_BASE_SHA"
+          fi
+
+          tree_sha="$(git rev-parse "${certified_base_sha}^{tree}")"
           artifact_name="cloud-staging-certification-v1-${tree_sha}"
           echo "tree_sha=$tree_sha" >> "$GITHUB_OUTPUT"
           echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          echo "certification_mode=$certification_mode" >> "$GITHUB_OUTPUT"
+          echo "certified_base_sha=$certified_base_sha" >> "$GITHUB_OUTPUT"
+          if [ "$certification_mode" = "binding_only" ]; then
+            policy_tree_sha="$(git rev-parse "${CERTIFIED_RECOVERY_POLICY_SHA}^{tree}")"
+            echo "policy_tree_sha=$policy_tree_sha" >> "$GITHUB_OUTPUT"
+            echo "policy_artifact_name=cloud-staging-certification-v1-${policy_tree_sha}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Resolve immutable successful staging artifact
         id: resolve
@@ -324,6 +435,8 @@ jobs:
           ARTIFACT_ID: ${{ steps.resolve.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ steps.resolve.outputs.artifact_digest }}
           STAGING_RUN_ID: ${{ steps.resolve.outputs.staging_run_id }}
+          CERTIFICATION_MODE: ${{ steps.identity.outputs.certification_mode }}
+          CERTIFIED_BASE_SHA: ${{ steps.identity.outputs.certified_base_sha }}
         run: |
           set -euo pipefail
           certification_dir="${RUNNER_TEMP}/staging-certification"
@@ -334,6 +447,12 @@ jobs:
               exit 1
             }
 
+          workflow_file=".github/workflows/cloud-cf-deploy.yml"
+          if [ "$CERTIFICATION_MODE" = "binding_only" ]; then
+            workflow_file="${RUNNER_TEMP}/certified-base-cloud-cf-deploy.yml"
+            git show "${CERTIFIED_BASE_SHA}:.github/workflows/cloud-cf-deploy.yml" > "$workflow_file"
+          fi
+
           result="$(
             node packages/cloud/scripts/staging-release-certification.mjs verify \
               --cert "${files[0]}" \
@@ -341,7 +460,7 @@ jobs:
               --artifact-json "${RUNNER_TEMP}/staging-certification-artifact.json" \
               --expected-repository "$EXPECTED_REPOSITORY" \
               --expected-tree-sha "$EXPECTED_TREE_SHA" \
-              --workflow-file .github/workflows/cloud-cf-deploy.yml
+              --workflow-file "$workflow_file"
           )"
           jq -e \
             --arg artifact_id "$ARTIFACT_ID" \
@@ -351,18 +470,359 @@ jobs:
               and .artifactDigest == $artifact_digest
               and .runId == $staging_run_id' \
             <<<"$result" >/dev/null
-          echo "Staging certification admitted tree ${EXPECTED_TREE_SHA} from run ${STAGING_RUN_ID}, artifact ${ARTIFACT_ID} (${ARTIFACT_DIGEST})." >> "$GITHUB_STEP_SUMMARY"
+          echo "Staging certification admitted ${CERTIFICATION_MODE} tree ${EXPECTED_TREE_SHA} from run ${STAGING_RUN_ID}, artifact ${ARTIFACT_ID} (${ARTIFACT_DIGEST})." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve immutable successful recovery-policy artifact
+        id: resolve-policy
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: ${{ steps.identity.outputs.policy_artifact_name }}
+        run: |
+          set -euo pipefail
+          candidates_file="${RUNNER_TEMP}/recovery-policy-certification-candidates.json"
+          artifact_file="${RUNNER_TEMP}/recovery-policy-certification-artifact.json"
+          run_file="${RUNNER_TEMP}/recovery-policy-certification-run.json"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
+            > "$candidates_file"
+          selected=""
+          while IFS= read -r candidate; do
+            [ -n "$candidate" ] || continue
+            artifact_id="$(jq -r '.id' <<<"$candidate")"
+            run_id="$(jq -r '.workflow_run.id // empty' <<<"$candidate")"
+            [ -n "$artifact_id" ] && [ -n "$run_id" ] || continue
+            if ! gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" > "$run_file"; then
+              continue
+            fi
+            if ! jq -e \
+              --arg repo "$GITHUB_REPOSITORY" \
+              '.status == "completed"
+                and .conclusion == "success"
+                and (.event == "push" or .event == "workflow_dispatch")
+                and .head_branch == "develop"
+                and .path == ".github/workflows/cloud-cf-deploy.yml"
+                and .repository.full_name == $repo' \
+              "$run_file" >/dev/null; then
+              continue
+            fi
+            selected="$candidate"
+            break
+          done < <(
+            jq -c \
+              --arg name "$ARTIFACT_NAME" \
+              '[.artifacts[]
+                | select(.name == $name)
+                | select(.expired == false)
+                | select((.digest // "") | test("^sha256:[0-9a-f]{64}$"))]
+               | sort_by(.created_at)
+               | reverse[]' \
+              "$candidates_file"
+          )
+          [ -n "$selected" ] || {
+            echo "::error::No unexpired successful develop certification exists for the recovery policy tree."
+            exit 1
+          }
+          printf '%s\n' "$selected" > "$artifact_file"
+          echo "artifact_id=$(jq -r '.id' "$artifact_file")" >> "$GITHUB_OUTPUT"
+          echo "artifact_digest=$(jq -r '.digest' "$artifact_file")" >> "$GITHUB_OUTPUT"
+          echo "staging_run_id=$(jq -r '.workflow_run.id' "$artifact_file")" >> "$GITHUB_OUTPUT"
+
+      - name: Download selected recovery-policy certification by id
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          artifact-ids: ${{ steps.resolve-policy.outputs.artifact_id }}
+          path: ${{ runner.temp }}/recovery-policy-certification
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.resolve-policy.outputs.staging_run_id }}
+          digest-mismatch: error
+
+      - name: Verify certified recovery policy and admit candidate with trusted bytes
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          EXPECTED_POLICY_TREE_SHA: ${{ steps.identity.outputs.policy_tree_sha }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          POLICY_SHA: ${{ inputs.certified_recovery_policy_sha }}
+          BASE_SHA: ${{ inputs.certified_production_base_sha }}
+          CANDIDATE_SHA: ${{ github.sha }}
+          ARTIFACT_ID: ${{ steps.resolve-policy.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ steps.resolve-policy.outputs.artifact_digest }}
+          STAGING_RUN_ID: ${{ steps.resolve-policy.outputs.staging_run_id }}
+        run: |
+          set -euo pipefail
+          certification_dir="${RUNNER_TEMP}/recovery-policy-certification"
+          mapfile -t files < <(find "$certification_dir" -type f -print)
+          [ "${#files[@]}" -eq 1 ] \
+            && [ "$(basename "${files[0]}")" = "staging-cloud-certification.json" ] || {
+              echo "::error::Recovery policy artifact must contain exactly staging-cloud-certification.json"
+              exit 1
+            }
+          policy_workflow="${RUNNER_TEMP}/trusted-policy-cloud-cf-deploy.yml"
+          trusted_admission="${RUNNER_TEMP}/trusted-production-hyperdrive-binding-admission.mjs"
+          git show "${POLICY_SHA}:.github/workflows/cloud-cf-deploy.yml" > "$policy_workflow"
+          git show "${POLICY_SHA}:packages/cloud/scripts/production-hyperdrive-binding-admission.mjs" > "$trusted_admission"
+          chmod 0500 "$trusted_admission"
+          result="$(
+            node packages/cloud/scripts/staging-release-certification.mjs verify \
+              --cert "${files[0]}" \
+              --run-json "${RUNNER_TEMP}/recovery-policy-certification-run.json" \
+              --artifact-json "${RUNNER_TEMP}/recovery-policy-certification-artifact.json" \
+              --expected-repository "$EXPECTED_REPOSITORY" \
+              --expected-tree-sha "$EXPECTED_POLICY_TREE_SHA" \
+              --workflow-file "$policy_workflow"
+          )"
+          jq -e \
+            --arg artifact_id "$ARTIFACT_ID" \
+            --arg artifact_digest "$ARTIFACT_DIGEST" \
+            --arg staging_run_id "$STAGING_RUN_ID" \
+            '.artifactId == $artifact_id
+              and .artifactDigest == $artifact_digest
+              and .runId == $staging_run_id' \
+            <<<"$result" >/dev/null
+          bun "$trusted_admission" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --policy-sha "$POLICY_SHA" \
+            --base-sha "$BASE_SHA" \
+            --candidate-sha "$CANDIDATE_SHA"
+          echo "Certified develop policy bytes admitted the bounded production candidate." >> "$GITHUB_STEP_SUMMARY"
 
   authorize-production:
     name: Authorize production environment
     needs: [validate-deploy-source, validate-staging-certification]
     if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && github.event_name != 'pull_request' && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 20
     # Approval only. This job must not share a mutation concurrency group, or
     # a waiting reviewer holds the release lock (#18092).
     environment: production
     steps:
+      - name: Checkout exact production candidate for bounded recovery audit
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - if: ${{ inputs.production_binding_only_recovery == true }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - if: ${{ inputs.production_binding_only_recovery == true }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies without lifecycle mutation
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        run: bun install --frozen-lockfile --no-save --ignore-scripts
+
+      - name: Validate protected bounded-recovery configuration
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          HAS_DATABASE_URL: ${{ secrets.DATABASE_URL != '' }}
+          HAS_RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN != '' }}
+          HAS_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ "$HAS_DATABASE_URL" = "true" ] || missing+=(DATABASE_URL)
+          [ "$HAS_RAILWAY_TOKEN" = "true" ] || missing+=(RAILWAY_TOKEN)
+          [ "$HAS_CLOUDFLARE_API_TOKEN" = "true" ] || missing+=(CLOUDFLARE_API_TOKEN)
+          [[ "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]] || missing+=(CLOUDFLARE_ACCOUNT_ID)
+          for name in RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID; do
+            value="${!name:-}"
+            if [[ ! "$value" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+              missing+=("$name")
+            fi
+          done
+          if [ -n "${RAILWAY_POSTGRES_SERVICE_ID:-}" ] && \
+            [[ ! "$RAILWAY_POSTGRES_SERVICE_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+            missing+=(RAILWAY_POSTGRES_SERVICE_ID)
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing or invalid protected bounded-recovery setting name(s): ${missing[*]}"
+            exit 1
+          fi
+          echo "Protected bounded-recovery settings are configured; values were not printed."
+
+      - name: Verify candidate Hyperdrive origin equals protected database authority
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          POLICY_SHA: ${{ inputs.certified_recovery_policy_sha }}
+        run: |
+          set -euo pipefail
+          umask 077
+          evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
+          mkdir -m 0700 "$evidence_dir"
+          candidate_id="$(
+            bun -e '
+              const source = await Bun.file("packages/cloud/api/wrangler.toml").text();
+              const config = Bun.TOML.parse(source);
+              const bindings = config?.env?.production?.hyperdrive;
+              if (!Array.isArray(bindings) || bindings.length !== 1) process.exit(1);
+              const binding = bindings[0];
+              if (binding?.binding !== "HYPERDRIVE" || !/^[0-9a-f]{32}$/.test(binding?.id)) process.exit(1);
+              process.stdout.write(binding.id);
+            '
+          )"
+          echo "::add-mask::$candidate_id"
+          response="$evidence_dir/hyperdrive.json"
+          curl --fail --silent --show-error --location --retry 3 \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --output "$response" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/hyperdrive/configs/${candidate_id}"
+          chmod 0600 "$response"
+          git fetch --no-tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            develop:refs/remotes/origin/develop
+          git merge-base --is-ancestor "$POLICY_SHA" refs/remotes/origin/develop || {
+            echo "::error::Certified recovery policy is no longer contained in develop."
+            exit 1
+          }
+          trusted_admission="$evidence_dir/trusted-production-hyperdrive-binding-admission.mjs"
+          git show "${POLICY_SHA}:packages/cloud/scripts/production-hyperdrive-binding-admission.mjs" \
+            > "$trusted_admission"
+          chmod 0500 "$trusted_admission"
+          bun "$trusted_admission" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --hyperdrive-json "$response"
+          candidate_id=""
+
+      - name: Install pinned Railway CLI
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli-production-binding-recovery"
+          archive="$RUNNER_TEMP/railway-v5.38.0-production-binding-recovery.tar.gz"
+          mkdir -m 0700 "$cli_root"
+          curl --fail --silent --show-error --location --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' \
+            "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e" \
+            "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
+      - name: Capture private read-only Railway authority evidence
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          umask 077
+          evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
+          mkdir -m 0700 "$evidence_dir"
+          capture() {
+            local label="$1"
+            local output="$2"
+            shift 2
+            if ! "$@" > "$output" 2>"$evidence_dir/${label}.stderr"; then
+              echo "::error::Railway $label read failed; raw output was not printed"
+              exit 1
+            fi
+            chmod 0600 "$output" "$evidence_dir/${label}.stderr"
+          }
+          common=(--project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID")
+          capture status "$evidence_dir/status.json" railway status "${common[@]}" --json
+          capture services "$evidence_dir/services.json" railway service list "${common[@]}" --json
+          bun packages/cloud/scripts/admin/resolve-production-railway-postgres-service.ts \
+            --status-json "$evidence_dir/status.json" \
+            --services-json "$evidence_dir/services.json" \
+            --service-id-output "$evidence_dir/resolved-service-id"
+          resolved_service_id="$(<"$evidence_dir/resolved-service-id")"
+          echo "::add-mask::$resolved_service_id"
+          capture variables "$evidence_dir/variables.json" \
+            railway variable list "${common[@]}" --service "$resolved_service_id" --json
+          resolved_service_id=""
+          echo "Captured private Railway authority evidence without printing inventory or variables."
+
+      - name: Audit current-main database authority and migration ledger
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          umask 077
+          evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
+          report="$evidence_dir/report.json"
+          if ! GITHUB_TOKEN='${{ github.token }}' \
+            node packages/cloud/scripts/canonical-deploy-source-guard.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --canonical-ref refs/heads/main \
+            > "$evidence_dir/freshness.stdout" \
+            2> "$evidence_dir/freshness.stderr"; then
+            echo "::error::Bounded recovery source is no longer canonical main"
+            exit 1
+          fi
+          set +e
+          env -u GITHUB_STEP_SUMMARY \
+            bun packages/cloud/scripts/admin/audit-production-railway-database-authority.ts \
+            --status-json "$evidence_dir/status.json" \
+            --services-json "$evidence_dir/services.json" \
+            --variables-json "$evidence_dir/variables.json" \
+            --resolved-service-id-file "$evidence_dir/resolved-service-id" \
+            > "$report"
+          audit_status="$?"
+          set -e
+          chmod 0600 "$report"
+          tee -a "$GITHUB_STEP_SUMMARY" < "$report"
+          exit "$audit_status"
+
+      - name: Build and dry-run the exact production Worker
+        if: ${{ inputs.production_binding_only_recovery == true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output_dir="$RUNNER_TEMP/production-binding-recovery-worker"
+          mkdir -m 0700 "$output_dir"
+          bun run build:core > "$output_dir/build.stdout" 2> "$output_dir/build.stderr"
+          (
+            cd packages/cloud/api
+            bunx wrangler deploy --env production --dry-run \
+              --outdir "$output_dir/bundle"
+          ) > "$output_dir/dry-run.stdout" 2> "$output_dir/dry-run.stderr"
+          node packages/cloud/scripts/canonical-deploy-source-guard.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --canonical-ref refs/heads/main \
+            > "$output_dir/freshness.stdout" \
+            2> "$output_dir/freshness.stderr"
+          echo "Exact production Worker build and dry-run passed."
+
+      - name: Destroy private bounded-recovery evidence
+        if: ${{ always() && inputs.production_binding_only_recovery == true }}
+        run: |
+          set +e
+          for evidence_dir in \
+            "$RUNNER_TEMP/production-binding-recovery-authority" \
+            "$RUNNER_TEMP/production-binding-recovery-worker"; do
+            if [ -d "$evidence_dir" ]; then
+              find "$evidence_dir" -type f -exec shred -u -- {} +
+              find "$evidence_dir" -depth -type d -empty -delete
+            fi
+          done
+          exit 0
+
       - name: Record production authorization
         run: echo "production environment authorized for this run"
 
@@ -385,6 +845,9 @@ jobs:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
       run_deployed_renderer_staging: ${{ github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true }}
+      production_binding_only_recovery: ${{ github.event_name == 'workflow_dispatch' && inputs.production_binding_only_recovery == true }}
+      certified_production_base_sha: ${{ inputs.certified_production_base_sha }}
+      certified_recovery_policy_sha: ${{ inputs.certified_recovery_policy_sha }}
 
   certify-staging-release:
     name: Certify successful staging Cloud tree

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -21,6 +21,21 @@ on:
         required: false
         type: boolean
         default: false
+      production_binding_only_recovery:
+        description: Re-run the trusted production Hyperdrive recovery audit inside the mutation job
+        required: false
+        type: boolean
+        default: false
+      certified_production_base_sha:
+        description: Exact currently served base admitted by the caller
+        required: false
+        type: string
+        default: ""
+      certified_recovery_policy_sha:
+        description: Exact certified develop policy SHA admitted by the caller
+        required: false
+        type: string
+        default: ""
     outputs:
       superseded:
         description: >-
@@ -160,7 +175,7 @@ jobs:
     # while cancel/force-cancel returned HTTP 500 (see #16705).
     # Release serialization is the caller job lock in cloud-cf-deploy.yml (#18092).
     environment: ${{ inputs.target_environment }}
-    timeout-minutes: 10
+    timeout-minutes: 25
     env:
       MIGRATION_DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
       DATABASE_RESILIENCE_GATE_MODE: ${{ vars.DATABASE_RESILIENCE_GATE_MODE || 'off' }}
@@ -176,6 +191,9 @@ jobs:
       superseded: ${{ steps.source_guard.outputs.superseded }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -454,6 +472,174 @@ jobs:
             fi
           done
           echo "Production database identity enforcement is configured; receipt values were not printed."
+
+      - name: Re-admit bounded Hyperdrive recovery immediately before mutation
+        if: ${{ inputs.production_binding_only_recovery && steps.source_guard.outputs.superseded != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          BASE_SHA: ${{ inputs.certified_production_base_sha }}
+          POLICY_SHA: ${{ inputs.certified_recovery_policy_sha }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DATABASE_IDENTITY_GATE_MODE: ${{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}
+          DATABASE_IDENTITY_ENVIRONMENT: production
+          DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}
+          DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          evidence_dir="$RUNNER_TEMP/production-binding-recovery-mutation-gate"
+          mkdir -m 0700 "$evidence_dir"
+          cleanup() {
+            set +e
+            if [ -d "$evidence_dir" ]; then
+              find "$evidence_dir" -type f -exec shred -u -- {} +
+              find "$evidence_dir" -depth -type d -empty -delete
+            fi
+          }
+          trap cleanup EXIT
+
+          [ "$TARGET_ENVIRONMENT" = "production" ] || {
+            echo "::error::Binding-only recovery mutation gate requires production."
+            exit 1
+          }
+          [ "$FORCE" = "false" ] || {
+            echo "::error::Binding-only recovery mutation gate forbids force."
+            exit 1
+          }
+          [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] \
+            && [[ "$POLICY_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Binding-only recovery mutation gate requires exact base and policy SHAs."
+              exit 1
+            }
+          [ -n "$DATABASE_URL" ] && [ "$DATABASE_URL" = "$MIGRATION_DATABASE_URL" ] || {
+            echo "::error::Protected audit and migration database authorities differ."
+            exit 1
+          }
+          [ -n "$CLOUDFLARE_API_TOKEN" ] \
+            && [[ "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]] \
+            && [ "$DATABASE_IDENTITY_GATE_MODE" = "enforce" ] \
+            && [[ "$DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+            && [[ "$DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+              echo "::error::Protected recovery authority settings are incomplete."
+              exit 1
+            }
+
+          git fetch --no-tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            develop:refs/remotes/origin/develop
+          git cat-file -e "${POLICY_SHA}^{commit}"
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git merge-base --is-ancestor "$POLICY_SHA" refs/remotes/origin/develop || {
+            echo "::error::Certified recovery policy is no longer contained in develop."
+            exit 1
+          }
+          trusted_admission="$evidence_dir/trusted-production-hyperdrive-binding-admission.mjs"
+          git show "${POLICY_SHA}:packages/cloud/scripts/production-hyperdrive-binding-admission.mjs" \
+            > "$trusted_admission"
+          chmod 0500 "$trusted_admission"
+          bun "$trusted_admission" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --policy-sha "$POLICY_SHA" \
+            --base-sha "$BASE_SHA" \
+            --candidate-sha "$GITHUB_SHA"
+
+          health_file="$evidence_dir/production-health.json"
+          curl --fail --silent --show-error --location --retry 3 \
+            --header "Cache-Control: no-cache" \
+            --output "$health_file" \
+            "https://api.eliza.app/api/health?mutation_gate_run=${GITHUB_RUN_ID}"
+          jq -e --arg base "$BASE_SHA" \
+            '.status == "ok" and .environment == "production" and .commit == $base' \
+            "$health_file" >/dev/null || {
+              echo "::error::Served production base drifted before mutation."
+              exit 1
+            }
+
+          candidate_id="$(
+            bun -e '
+              const source = await Bun.file("packages/cloud/api/wrangler.toml").text();
+              const config = Bun.TOML.parse(source);
+              const bindings = config?.env?.production?.hyperdrive;
+              if (!Array.isArray(bindings) || bindings.length !== 1) process.exit(1);
+              const binding = bindings[0];
+              if (binding?.binding !== "HYPERDRIVE" || !/^[0-9a-f]{32}$/.test(binding?.id)) process.exit(1);
+              process.stdout.write(binding.id);
+            '
+          )"
+          echo "::add-mask::$candidate_id"
+          hyperdrive_file="$evidence_dir/hyperdrive.json"
+          curl --fail --silent --show-error --location --retry 3 \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --output "$hyperdrive_file" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/hyperdrive/configs/${candidate_id}"
+          chmod 0600 "$hyperdrive_file"
+          bun "$trusted_admission" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --hyperdrive-json "$hyperdrive_file"
+          candidate_id=""
+
+          env -u GITHUB_STEP_SUMMARY \
+            bun packages/cloud/scripts/admin/preflight-database-identity.ts \
+            > "$evidence_dir/database-identity.stdout" \
+            2> "$evidence_dir/database-identity.stderr"
+          bun -e '
+            import { createRequire } from "node:module";
+            import { enforceTlsForRemote } from "./packages/cloud/shared/src/db/postgres-tls.ts";
+            import {
+              loadCanonicalMigrations,
+              validateAppliedMigrationLedger,
+            } from "./packages/cloud/scripts/admin/canonical-migration-ledger.ts";
+            const { Client } = createRequire(import.meta.url)("pg");
+            const databaseUrl = process.env.DATABASE_URL;
+            if (!databaseUrl) throw new Error("protected_database_url_missing");
+            const { url, ssl } = enforceTlsForRemote(databaseUrl);
+            const client = new Client({
+              application_name: "eliza-production-binding-recovery-ledger",
+              connectionString: url,
+              connectionTimeoutMillis: 8000,
+              options: "-c default_transaction_read_only=on",
+              query_timeout: 8000,
+              statement_timeout: 8000,
+              ...(ssl ? { ssl } : {}),
+            });
+            try {
+              await client.connect();
+              await client.query("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
+              const migrations = await loadCanonicalMigrations();
+              const result = await client.query(
+                "SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC",
+              );
+              const ledger = validateAppliedMigrationLedger(result.rows, migrations);
+              if (ledger.lastAppliedJournalIndex !== migrations.length - 1) {
+                throw new Error("production_migration_ledger_not_current");
+              }
+              await client.query("COMMIT");
+              process.stdout.write("Production migration ledger matches exact current main.\n");
+            } catch (error) {
+              await client.query("ROLLBACK").catch(() => {});
+              throw error;
+            } finally {
+              await client.end().catch(() => {});
+            }
+          ' > "$evidence_dir/migration-ledger.stdout" \
+            2> "$evidence_dir/migration-ledger.stderr"
+
+          bun run build:core > "$evidence_dir/build.stdout" 2> "$evidence_dir/build.stderr"
+          (
+            cd packages/cloud/api
+            bunx wrangler deploy --env production --dry-run \
+              --outdir "$evidence_dir/worker-bundle"
+          ) > "$evidence_dir/dry-run.stdout" 2> "$evidence_dir/dry-run.stderr"
+          node packages/cloud/scripts/canonical-deploy-source-guard.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --canonical-ref refs/heads/main \
+            > "$evidence_dir/freshness.stdout" \
+            2> "$evidence_dir/freshness.stderr"
+          echo "Bounded Hyperdrive recovery re-admitted inside the mutation job."
 
       - name: Run migrations
         if: ${{ steps.source_guard.outputs.superseded != 'true' }}

--- a/packages/cloud/scripts/production-hyperdrive-binding-admission.mjs
+++ b/packages/cloud/scripts/production-hyperdrive-binding-admission.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env bun
+
+/**
+ * Fail-closed admission for the one production-only Hyperdrive recovery seam.
+ *
+ * This does not replace staging certification. It permits a candidate only
+ * when the currently served base has an immutable staging certificate and the
+ * complete source delta is limited to the production Hyperdrive id plus the
+ * reviewed, non-runtime policy/workflow files needed to perform this check.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { isDeepStrictEqual, parseArgs } from "node:util";
+
+export const WRANGLER_PATH = "packages/cloud/api/wrangler.toml";
+
+export const ALLOWED_NON_RUNTIME_CHANGES = new Map([
+  [".github/workflows/cloud-cf-deploy.yml", new Set(["M"])],
+  [".github/workflows/cloud-cf-release.yml", new Set(["M"])],
+  [".github/workflows/deploy-eliza-provisioning-worker.yml", new Set(["M"])],
+  [
+    "packages/cloud/scripts/production-hyperdrive-binding-admission.mjs",
+    new Set(["A", "M"]),
+  ],
+  [
+    "packages/cloud/scripts/production-hyperdrive-binding-admission.test.mjs",
+    new Set(["A", "M"]),
+  ],
+  [
+    "packages/cloud/scripts/staging-release-certification.test.mjs",
+    new Set(["M"]),
+  ],
+  [
+    "packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts",
+    new Set(["M"]),
+  ],
+]);
+
+export const TRUSTED_POLICY_PATHS = [
+  ".github/workflows/cloud-cf-deploy.yml",
+  ".github/workflows/cloud-cf-release.yml",
+  "packages/cloud/scripts/production-hyperdrive-binding-admission.mjs",
+  "packages/cloud/scripts/production-hyperdrive-binding-admission.test.mjs",
+  "packages/cloud/scripts/staging-release-certification.test.mjs",
+];
+
+export const PINNED_EXISTING_MAIN_TRANSITIONS = new Map([
+  [
+    ".github/workflows/deploy-eliza-provisioning-worker.yml",
+    [
+      "ca21ddcc79058357594872fc60cbf4bc64adbd3a",
+      "9e8ecb1f91fdb6db79b8e6c6a5588509804c12c5",
+    ],
+  ],
+  [
+    "packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts",
+    [
+      "2cfd3cf834dae09bb285b9292928f906602181fc",
+      "f0f54a609f8e918a59b9adfbcc24c6e2cebd18e7",
+    ],
+  ],
+]);
+
+const HEX_32 = /^[0-9a-f]{32}$/;
+const SHA_40 = /^[0-9a-f]{40}$/;
+
+function fail(code) {
+  throw new Error(`production_hyperdrive_binding_admission:${code}`);
+}
+
+function parseConfig(source, label) {
+  let parsed;
+  try {
+    parsed = Bun.TOML.parse(source);
+  } catch {
+    fail(`${label}_toml_invalid`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    fail(`${label}_toml_invalid`);
+  }
+  return parsed;
+}
+
+function productionBinding(config, label) {
+  const bindings = config?.env?.production?.hyperdrive;
+  if (!Array.isArray(bindings) || bindings.length !== 1) {
+    fail(`${label}_production_binding_ambiguous`);
+  }
+  const binding = bindings[0];
+  if (!binding || typeof binding !== "object" || Array.isArray(binding)) {
+    fail(`${label}_production_binding_invalid`);
+  }
+  if (
+    Object.keys(binding).sort().join(",") !== "binding,id" ||
+    binding.binding !== "HYPERDRIVE" ||
+    typeof binding.id !== "string" ||
+    !HEX_32.test(binding.id)
+  ) {
+    fail(`${label}_production_binding_invalid`);
+  }
+  return binding;
+}
+
+function normalizePostgresScheme(value) {
+  return value === "postgres" || value === "postgresql" ? "postgresql" : value;
+}
+
+export function validateProductionHyperdriveAuthority(input) {
+  const response = input.response;
+  const result = response?.result;
+  if (
+    response?.success !== true ||
+    !result ||
+    typeof result !== "object" ||
+    Array.isArray(result) ||
+    result.id !== input.expectedConfigId
+  ) {
+    fail("hyperdrive_response_invalid");
+  }
+  const origin = result.origin;
+  if (!origin || typeof origin !== "object" || Array.isArray(origin)) {
+    fail("hyperdrive_origin_invalid");
+  }
+
+  let database;
+  try {
+    database = new URL(input.databaseUrl);
+  } catch {
+    fail("database_url_invalid");
+  }
+  const databaseName = decodeURIComponent(database.pathname.replace(/^\//, ""));
+  const databaseUser = decodeURIComponent(database.username);
+  const databasePort = Number(database.port || "5432");
+  const databaseScheme = normalizePostgresScheme(
+    database.protocol.replace(/:$/, ""),
+  );
+  const originScheme = normalizePostgresScheme(origin.scheme);
+  if (
+    typeof origin.host !== "string" ||
+    origin.host !== database.hostname ||
+    !Number.isSafeInteger(origin.port) ||
+    origin.port !== databasePort ||
+    typeof origin.database !== "string" ||
+    origin.database !== databaseName ||
+    typeof origin.user !== "string" ||
+    origin.user !== databaseUser ||
+    originScheme !== databaseScheme ||
+    databaseScheme !== "postgresql"
+  ) {
+    fail("hyperdrive_authority_mismatch");
+  }
+  const authorityReceipt = createHash("sha256")
+    .update(
+      [origin.host, String(origin.port), origin.database, origin.user].join(
+        "\u0000",
+      ),
+    )
+    .digest("hex");
+  return { schemaVersion: 1, verdict: "pass", authorityReceipt };
+}
+
+export function validateProductionHyperdriveBindingDelta(input) {
+  if (input.force === true) fail("force_forbidden");
+  if (!Array.isArray(input.changes) || input.changes.length === 0) {
+    fail("changes_missing");
+  }
+
+  let wranglerChanges = 0;
+  const seenPaths = new Set();
+  for (const change of input.changes) {
+    if (
+      !change ||
+      typeof change.path !== "string" ||
+      typeof change.status !== "string"
+    ) {
+      fail("change_invalid");
+    }
+    if (seenPaths.has(change.path)) fail("change_ambiguous");
+    seenPaths.add(change.path);
+    if (change.path === WRANGLER_PATH) {
+      if (change.status !== "M") fail("wrangler_status_invalid");
+      wranglerChanges += 1;
+      continue;
+    }
+    const statuses = ALLOWED_NON_RUNTIME_CHANGES.get(change.path);
+    if (!statuses?.has(change.status)) fail("path_not_allowlisted");
+  }
+  if (wranglerChanges !== 1) fail("wrangler_change_ambiguous");
+
+  const base = parseConfig(input.baseWranglerSource, "base");
+  const candidate = parseConfig(input.candidateWranglerSource, "candidate");
+  const baseBinding = productionBinding(base, "base");
+  const candidateBinding = productionBinding(candidate, "candidate");
+  if (baseBinding.id === candidateBinding.id) fail("binding_unchanged");
+
+  // Structural equality is necessary but not sufficient because TOML comments
+  // and whitespace do not survive parsing. Require byte equality after one
+  // and only one exact id-token substitution so no textual Wrangler drift can
+  // hide beside the admitted binding update.
+  if (input.candidateWranglerSource.split(candidateBinding.id).length !== 2) {
+    fail("candidate_binding_token_ambiguous");
+  }
+  if (
+    input.candidateWranglerSource.replace(
+      candidateBinding.id,
+      baseBinding.id,
+    ) !== input.baseWranglerSource
+  ) {
+    fail("wrangler_text_delta_not_bounded");
+  }
+
+  // Mask only the candidate production id. Deep equality after this point
+  // rejects every other Wrangler mutation, including staging, vars, routes,
+  // migrations, extra bindings, and parse-shape ambiguity.
+  candidateBinding.id = baseBinding.id;
+  if (!isDeepStrictEqual(candidate, base)) fail("wrangler_delta_not_bounded");
+
+  return {
+    schemaVersion: 1,
+    verdict: "pass",
+    changedPathCount: input.changes.length,
+  };
+}
+
+function requireSha(value, label) {
+  if (typeof value !== "string" || !SHA_40.test(value))
+    fail(`${label}_invalid`);
+  return value;
+}
+
+function git(root, args) {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trimEnd();
+}
+
+function readChanges(root, baseSha, candidateSha) {
+  const output = git(root, [
+    "diff",
+    "--name-status",
+    "--no-renames",
+    `${baseSha}..${candidateSha}`,
+  ]);
+  if (!output) return [];
+  return output.split("\n").map((line) => {
+    const [status, path, extra] = line.split("\t");
+    if (extra !== undefined || !status || !path) fail("change_invalid");
+    return { status, path };
+  });
+}
+
+export function validateTrustedPolicyIdentityFromGit(input) {
+  const policySha = requireSha(input.policySha, "policy_sha");
+  const candidateSha = requireSha(input.candidateSha, "candidate_sha");
+  for (const path of TRUSTED_POLICY_PATHS) {
+    let policyBlob;
+    let candidateBlob;
+    try {
+      policyBlob = git(input.repoRoot, ["rev-parse", `${policySha}:${path}`]);
+      candidateBlob = git(input.repoRoot, [
+        "rev-parse",
+        `${candidateSha}:${path}`,
+      ]);
+    } catch {
+      fail("trusted_policy_path_missing");
+    }
+    if (policyBlob !== candidateBlob) fail("trusted_policy_identity_mismatch");
+  }
+  return {
+    schemaVersion: 1,
+    verdict: "pass",
+    policyPathCount: TRUSTED_POLICY_PATHS.length,
+  };
+}
+
+export function admitProductionHyperdriveBindingFromGit(input) {
+  const baseSha = requireSha(input.baseSha, "base_sha");
+  const candidateSha = requireSha(input.candidateSha, "candidate_sha");
+  if (input.force === true) fail("force_forbidden");
+  try {
+    git(input.repoRoot, ["merge-base", "--is-ancestor", baseSha, candidateSha]);
+  } catch {
+    fail("base_not_ancestor");
+  }
+  const baseWranglerSource = git(input.repoRoot, [
+    "show",
+    `${baseSha}:${WRANGLER_PATH}`,
+  ]);
+  const candidateWranglerSource = git(input.repoRoot, [
+    "show",
+    `${candidateSha}:${WRANGLER_PATH}`,
+  ]);
+  const changes = readChanges(input.repoRoot, baseSha, candidateSha);
+  for (const [path, expected] of PINNED_EXISTING_MAIN_TRANSITIONS) {
+    if (!changes.some((change) => change.path === path)) continue;
+    const observed = [
+      git(input.repoRoot, ["rev-parse", `${baseSha}:${path}`]),
+      git(input.repoRoot, ["rev-parse", `${candidateSha}:${path}`]),
+    ];
+    if (!isDeepStrictEqual(observed, expected)) {
+      fail("existing_main_transition_mismatch");
+    }
+  }
+  return validateProductionHyperdriveBindingDelta({
+    baseWranglerSource,
+    candidateWranglerSource,
+    changes,
+    force: input.force,
+  });
+}
+
+async function main() {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    strict: true,
+    options: {
+      "repo-root": { type: "string" },
+      "base-sha": { type: "string" },
+      "candidate-sha": { type: "string" },
+      "policy-sha": { type: "string" },
+      force: { type: "boolean", default: false },
+      "hyperdrive-json": { type: "string" },
+    },
+  });
+  if (values["hyperdrive-json"]) {
+    if (
+      values.force ||
+      values["base-sha"] ||
+      values["candidate-sha"] ||
+      values["policy-sha"]
+    ) {
+      fail("authority_mode_ambiguous");
+    }
+    const config = parseConfig(
+      readFileSync(
+        `${values["repo-root"] || process.cwd()}/${WRANGLER_PATH}`,
+        "utf8",
+      ),
+      "candidate",
+    );
+    const expectedConfigId = productionBinding(config, "candidate").id;
+    const result = validateProductionHyperdriveAuthority({
+      response: JSON.parse(readFileSync(values["hyperdrive-json"], "utf8")),
+      // biome-ignore lint/suspicious/noUndeclaredEnvVars: protected GitHub environment injects this standalone admission input outside Turbo caching.
+      databaseUrl: process.env.DATABASE_URL,
+      expectedConfigId,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  validateTrustedPolicyIdentityFromGit({
+    repoRoot: values["repo-root"] || process.cwd(),
+    policySha: values["policy-sha"],
+    candidateSha: values["candidate-sha"],
+  });
+  const result = admitProductionHyperdriveBindingFromGit({
+    repoRoot: values["repo-root"] || process.cwd(),
+    baseSha: values["base-sha"],
+    candidateSha: values["candidate-sha"],
+    force: values.force,
+  });
+  // Config ids are not emitted. The workflow publishes only bounded verdicts.
+  process.stdout.write(
+    `${JSON.stringify({ schemaVersion: result.schemaVersion, verdict: result.verdict, changedPathCount: result.changedPathCount })}\n`,
+  );
+}
+
+if (import.meta.main) {
+  main().catch(() => {
+    process.stderr.write("production Hyperdrive binding admission rejected\n");
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/scripts/production-hyperdrive-binding-admission.test.mjs
+++ b/packages/cloud/scripts/production-hyperdrive-binding-admission.test.mjs
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+import {
+  ALLOWED_NON_RUNTIME_CHANGES,
+  admitProductionHyperdriveBindingFromGit,
+  PINNED_EXISTING_MAIN_TRANSITIONS,
+  TRUSTED_POLICY_PATHS,
+  validateProductionHyperdriveAuthority,
+  validateProductionHyperdriveBindingDelta,
+  validateTrustedPolicyIdentityFromGit,
+  WRANGLER_PATH,
+} from "./production-hyperdrive-binding-admission.mjs";
+
+const oldId = "1".repeat(32);
+const newId = "2".repeat(32);
+const repoRoot = resolve(import.meta.dirname, "../../..");
+const policyFixtureSha = execFileSync(
+  "git",
+  ["-C", repoRoot, "rev-parse", "HEAD"],
+  {
+    encoding: "utf8",
+  },
+).trim();
+const prePolicyFixtureSha = execFileSync(
+  "git",
+  ["-C", repoRoot, "rev-parse", "HEAD^"],
+  { encoding: "utf8" },
+).trim();
+
+function config(id = oldId, extra = "") {
+  return `name = "cloud"\n${extra}\n[env.production]\nname = "cloud-production"\n[[env.production.hyperdrive]]\nbinding = "HYPERDRIVE"\nid = "${id}"\n\n[env.staging]\nname = "cloud-staging"\n[[env.staging.hyperdrive]]\nbinding = "HYPERDRIVE"\nid = "${"3".repeat(32)}"\n`;
+}
+
+function valid(overrides = {}) {
+  return {
+    baseWranglerSource: config(oldId),
+    candidateWranglerSource: config(newId),
+    changes: [{ status: "M", path: WRANGLER_PATH }],
+    force: false,
+    ...overrides,
+  };
+}
+
+describe("production Hyperdrive binding-only admission", () => {
+  test("accepts exactly one production binding id replacement", () => {
+    expect(validateProductionHyperdriveBindingDelta(valid())).toMatchObject({
+      schemaVersion: 1,
+      verdict: "pass",
+      changedPathCount: 1,
+    });
+  });
+
+  test("accepts only the explicitly classified non-runtime policy files", () => {
+    const changes = [
+      { status: "M", path: WRANGLER_PATH },
+      ...[...ALLOWED_NON_RUNTIME_CHANGES].map(([path, statuses]) => ({
+        path,
+        status: statuses.has("A") ? "A" : "M",
+      })),
+    ];
+    expect(
+      validateProductionHyperdriveBindingDelta(valid({ changes })),
+    ).toMatchObject({ verdict: "pass", changedPathCount: changes.length });
+  });
+
+  test("pins the two unrelated workflow/test transitions already reviewed on main", () => {
+    expect([...PINNED_EXISTING_MAIN_TRANSITIONS]).toEqual([
+      [
+        ".github/workflows/deploy-eliza-provisioning-worker.yml",
+        [
+          "ca21ddcc79058357594872fc60cbf4bc64adbd3a",
+          "9e8ecb1f91fdb6db79b8e6c6a5588509804c12c5",
+        ],
+      ],
+      [
+        "packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts",
+        [
+          "2cfd3cf834dae09bb285b9292928f906602181fc",
+          "f0f54a609f8e918a59b9adfbcc24c6e2cebd18e7",
+        ],
+      ],
+    ]);
+  });
+
+  test("admits the reviewed production binding commit from its served base", () => {
+    expect(
+      admitProductionHyperdriveBindingFromGit({
+        repoRoot,
+        baseSha: "c0a8de04019f62a96c5f6bf21ee7c15ee554cafe",
+        candidateSha: "579d546d2d23c954c0aef9775356781e674cb689",
+        force: false,
+      }),
+    ).toMatchObject({ verdict: "pass", changedPathCount: 3 });
+  });
+
+  test("requires all production policy blobs to equal the trusted develop policy", () => {
+    expect(
+      validateTrustedPolicyIdentityFromGit({
+        repoRoot,
+        policySha: policyFixtureSha,
+        candidateSha: policyFixtureSha,
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      verdict: "pass",
+      policyPathCount: TRUSTED_POLICY_PATHS.length,
+    });
+  });
+
+  test("rejects a candidate missing the trusted policy blobs", () => {
+    expect(() =>
+      validateTrustedPolicyIdentityFromGit({
+        repoRoot,
+        policySha: policyFixtureSha,
+        candidateSha: prePolicyFixtureSha,
+      }),
+    ).toThrow(/production_hyperdrive_binding_admission/);
+  });
+
+  test.each([
+    ["force", { force: true }],
+    ["missing changes", { changes: [] }],
+    [
+      "duplicate path",
+      {
+        changes: [
+          { status: "M", path: WRANGLER_PATH },
+          { status: "M", path: WRANGLER_PATH },
+        ],
+      },
+    ],
+    [
+      "code path",
+      { changes: [{ status: "M", path: "packages/cloud/api/src/index.ts" }] },
+    ],
+    [
+      "migration",
+      {
+        changes: [
+          {
+            status: "A",
+            path: "packages/cloud/shared/src/db/migrations/9999.sql",
+          },
+        ],
+      },
+    ],
+    ["deleted Wrangler", { changes: [{ status: "D", path: WRANGLER_PATH }] }],
+    ["unchanged id", { candidateWranglerSource: config(oldId) }],
+    [
+      "staging mutation",
+      {
+        candidateWranglerSource: config(newId).replace(
+          "3".repeat(32),
+          "4".repeat(32),
+        ),
+      },
+    ],
+    [
+      "general Wrangler mutation",
+      {
+        candidateWranglerSource: config(
+          newId,
+          'compatibility_date = "2099-01-01"',
+        ),
+      },
+    ],
+    [
+      "comment-only Wrangler mutation",
+      {
+        candidateWranglerSource: `${config(newId)}# forbidden textual drift\n`,
+      },
+    ],
+    [
+      "duplicate candidate id token",
+      {
+        candidateWranglerSource: `${config(newId)}# ${newId}\n`,
+      },
+    ],
+    ["malformed TOML", { candidateWranglerSource: "[env.production" }],
+    [
+      "multiple bindings",
+      {
+        candidateWranglerSource: `${config(newId)}\n[[env.production.hyperdrive]]\nbinding = "SECOND"\nid = "${"5".repeat(32)}"\n`,
+      },
+    ],
+    [
+      "extra binding field",
+      {
+        candidateWranglerSource: config(newId).replace(
+          `id = "${newId}"`,
+          `id = "${newId}"\nlocalConnectionString = "forbidden"`,
+        ),
+      },
+    ],
+    ["uppercase id", { candidateWranglerSource: config("A".repeat(32)) }],
+  ])("rejects %s", (_label, overrides) => {
+    expect(() =>
+      validateProductionHyperdriveBindingDelta(valid(overrides)),
+    ).toThrow(/production_hyperdrive_binding_admission/);
+  });
+});
+
+describe("production Hyperdrive authority", () => {
+  const expectedConfigId = "2".repeat(32);
+  const response = {
+    success: true,
+    result: {
+      id: expectedConfigId,
+      origin: {
+        host: "db.example.invalid",
+        port: 36497,
+        database: "railway",
+        user: "postgres",
+        scheme: "postgresql",
+      },
+    },
+  };
+
+  test("accepts exact protected URL and Hyperdrive origin equality", () => {
+    expect(
+      validateProductionHyperdriveAuthority({
+        response,
+        expectedConfigId,
+        databaseUrl:
+          "postgresql://postgres:secret@db.example.invalid:36497/railway?sslmode=require",
+      }),
+    ).toMatchObject({
+      schemaVersion: 1,
+      verdict: "pass",
+      authorityReceipt: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+  });
+
+  test.each([
+    ["response failure", { response: { ...response, success: false } }],
+    ["wrong config", { expectedConfigId: "4".repeat(32) }],
+    [
+      "wrong host",
+      {
+        databaseUrl: "postgresql://postgres:secret@other.invalid:36497/railway",
+      },
+    ],
+    [
+      "wrong port",
+      {
+        databaseUrl:
+          "postgresql://postgres:secret@db.example.invalid:5432/railway",
+      },
+    ],
+    [
+      "wrong database",
+      {
+        databaseUrl:
+          "postgresql://postgres:secret@db.example.invalid:36497/other",
+      },
+    ],
+    [
+      "wrong user",
+      {
+        databaseUrl:
+          "postgresql://other:secret@db.example.invalid:36497/railway",
+      },
+    ],
+    [
+      "wrong scheme",
+      {
+        databaseUrl: "https://postgres:secret@db.example.invalid:36497/railway",
+      },
+    ],
+  ])("rejects %s", (_label, overrides) => {
+    expect(() =>
+      validateProductionHyperdriveAuthority({
+        response,
+        expectedConfigId,
+        databaseUrl:
+          "postgresql://postgres:secret@db.example.invalid:36497/railway",
+        ...overrides,
+      }),
+    ).toThrow(/production_hyperdrive_binding_admission/);
+  });
+});

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -25,6 +25,10 @@ import {
 const repoRoot = resolve(import.meta.dirname, "../../..");
 const workflowPath = resolve(repoRoot, CERTIFICATION_WORKFLOW);
 const workflow = readFileSync(workflowPath, "utf8").replaceAll("\r\n", "\n");
+const releaseWorkflow = readFileSync(
+  resolve(repoRoot, ".github/workflows/cloud-cf-release.yml"),
+  "utf8",
+).replaceAll("\r\n", "\n");
 const sourceSha = "a".repeat(40);
 const treeSha = "b".repeat(40);
 const workflowSha256 = "c".repeat(64);
@@ -315,7 +319,7 @@ describe("Cloud CF workflow staging certification gate", () => {
     expect(validate).not.toContain("environment: production");
     expect(validate).toContain("ref: $" + "{{ github.sha }}");
     expect(validate).toContain("persist-credentials: false");
-    expect(validate).toContain("git rev-parse 'HEAD^{tree}'");
+    expect(validate).toContain(`git rev-parse "\${certified_base_sha}^{tree}"`);
     expect(validate).toContain(
       '(.event == "push" or .event == "workflow_dispatch")',
     );
@@ -333,7 +337,7 @@ describe("Cloud CF workflow staging certification gate", () => {
     );
     expect(validate).toContain("digest-mismatch: error");
     expect(validate).toContain("staging-release-certification.mjs verify");
-    expect(validate).not.toContain("inputs.force");
+    expect(validate).toContain("inputs.force == true");
     expect(authorize).toContain("validate-staging-certification");
     expect(authorize).toContain(
       "needs.validate-staging-certification.result == 'success'",
@@ -342,6 +346,109 @@ describe("Cloud CF workflow staging certification gate", () => {
     expect(release).toContain(
       "needs.validate-staging-certification.result == 'success'",
     );
+  });
+
+  test("admits only a certified currently served binding-only recovery", () => {
+    const source = jobBlock(workflow, "validate-deploy-source");
+    const validate = jobBlock(workflow, "validate-staging-certification");
+    expect(workflow).toContain("production_binding_only_recovery:");
+    expect(workflow).toContain("certified_production_base_sha:");
+    expect(workflow).toContain("certified_recovery_policy_sha:");
+    expect(source).toContain(
+      "Production binding-only recovery may target only production",
+    );
+    expect(source).toContain("Production binding-only recovery forbids force");
+    expect(validate).toContain("fetch-depth: 0");
+    expect(validate).toContain("https://api.eliza.app/api/health");
+    expect(validate).toContain(".commit == $base");
+    expect(validate).toContain('.environment == "production"');
+    expect(validate).toContain("git merge-base --is-ancestor");
+    expect(validate).toContain("production-hyperdrive-binding-admission.mjs");
+    expect(validate).toContain('certification_mode="binding_only"');
+    expect(validate).toContain(
+      `git show "\${CERTIFIED_BASE_SHA}:.github/workflows/cloud-cf-deploy.yml"`,
+    );
+    expect(validate).toContain('--workflow-file "$workflow_file"');
+    expect(validate).toContain(
+      "Resolve immutable successful recovery-policy artifact",
+    );
+    expect(validate).toContain("recovery-policy-certification");
+    expect(validate).toContain(
+      `git show "\${POLICY_SHA}:packages/cloud/scripts/production-hyperdrive-binding-admission.mjs"`,
+    );
+    expect(validate).toContain('--policy-sha "$POLICY_SHA"');
+    expect(validate).toContain("Certified develop policy bytes admitted");
+  });
+
+  test("rechecks the trusted policy and all authorities inside the mutation job", () => {
+    const caller = jobBlock(workflow, "release");
+    const migrate = jobBlock(releaseWorkflow, "migrate-db");
+    expect(caller).toContain("production_binding_only_recovery:");
+    expect(caller).toContain("certified_production_base_sha:");
+    expect(caller).toContain("certified_recovery_policy_sha:");
+    expect(migrate).toContain(
+      "Re-admit bounded Hyperdrive recovery immediately before mutation",
+    );
+    expect(migrate).toContain('--policy-sha "$POLICY_SHA"');
+    expect(migrate).toContain(`hyperdrive/configs/\${candidate_id}`);
+    expect(migrate).toContain("preflight-database-identity.ts");
+    expect(migrate).toContain("loadCanonicalMigrations");
+    expect(migrate).toContain("validateAppliedMigrationLedger");
+    expect(migrate).toContain(
+      "Production migration ledger matches exact current main",
+    );
+    expect(migrate).not.toContain("railway variable list");
+    expect(migrate).toContain("wrangler deploy --env production --dry-run");
+    expect(migrate).toContain("Served production base drifted before mutation");
+    expect(migrate).toContain("--canonical-ref refs/heads/main");
+    expect(
+      migrate.indexOf("Re-admit bounded Hyperdrive recovery"),
+    ).toBeLessThan(migrate.indexOf("- name: Run migrations"));
+  });
+
+  test("fails closed before mutation when trusted policy or authority evidence drifts", () => {
+    const migrate = jobBlock(releaseWorkflow, "migrate-db");
+    expect(migrate).toContain(
+      "Certified recovery policy is no longer contained in develop",
+    );
+    expect(migrate).toContain(
+      "Protected audit and migration database authorities differ",
+    );
+    expect(migrate).toContain(
+      "Protected recovery authority settings are incomplete",
+    );
+    expect(migrate).toContain("trap cleanup EXIT");
+    expect(migrate).toContain("production_migration_ledger_not_current");
+    expect(migrate).toContain('DATABASE_IDENTITY_GATE_MODE" = "enforce');
+  });
+
+  test("re-audits database authority and exact production Worker before approval", () => {
+    const authorize = jobBlock(workflow, "authorize-production");
+    const release = jobBlock(workflow, "release");
+    expect(authorize).toContain("environment: production");
+    expect(authorize).toContain("secrets.DATABASE_URL");
+    expect(authorize).toContain("secrets.RAILWAY_TOKEN");
+    expect(authorize).toContain("secrets.CLOUDFLARE_API_TOKEN");
+    expect(authorize).toContain("secrets.CLOUDFLARE_ACCOUNT_ID");
+    expect(authorize).toContain(`hyperdrive/configs/\${candidate_id}`);
+    expect(authorize).toContain('--hyperdrive-json "$response"');
+    expect(authorize).toContain("develop:refs/remotes/origin/develop");
+    expect(authorize).toContain(
+      'git merge-base --is-ancestor "$POLICY_SHA" refs/remotes/origin/develop',
+    );
+    expect(authorize).toContain(
+      "audit-production-railway-database-authority.ts",
+    );
+    expect(authorize).toContain("--canonical-ref refs/heads/main");
+    expect(authorize).toContain("bun run build:core");
+    expect(authorize).toContain("wrangler deploy --env production --dry-run");
+    expect(authorize.match(/--canonical-ref refs\/heads\/main/g)).toHaveLength(
+      2,
+    );
+    expect(authorize).toContain("Destroy private bounded-recovery evidence");
+    expect(release).toContain("environment == 'production'");
+    expect(release).toContain("group: cloud-cf-release-v6-");
+    expect(release).toContain("cancel-in-progress: false");
   });
 
   test("fails closed on absent, expired, digestless, or noncanonical artifacts", () => {


### PR DESCRIPTION
## Summary

- add a strict production-only Hyperdrive binding recovery gate anchored to a separately certified immutable develop policy and the immutable staging certificate for the currently served production base
- execute the admission verifier from the certified policy Git object and require exact policy blob identity across the develop policy and production candidate
- structurally and byte-for-byte permit only one production Hyperdrive id replacement plus explicitly classified non-Cloud-runtime workflow/test transitions already present on main
- re-prove served-base identity, Hyperdrive origin equality, protected database identity, exact-current main migration ledger, canonical main freshness, and exact production Worker build/dry-run both before authorization and again inside the protected mutation job immediately before migrations

Closes #29510

## Independent-review fixes

- Self-authorization: the candidate does not execute its own verifier bytes; it extracts the verifier from the exact certified develop policy SHA, then that trusted verifier requires exact Git blob identity for both Cloud workflows and all policy scripts/tests.
- TOCTOU: the protected release mutation job repeats policy/base admission, cache-bypassed served-base proof, Hyperdrive-to-protected-DATABASE_URL equality, protected identity enforcement, exact-current main migration-ledger proof, Worker dry-run, and final canonical-main guard immediately before the existing migration step.

## Fail-closed policy

Rejects force, non-production use, missing/stale/unserved base or policy certification, non-ancestor candidates, trusted-policy byte drift, code or migration changes, general/comment/format-only Wrangler changes, duplicate/multiple bindings or id tokens, ambiguous parsing, drift in the two already-reviewed main workflow/test transitions, Hyperdrive/database authority mismatch, non-current main source or migrations, and failed Worker dry-run. Protected production approval and release concurrency remain unchanged.

## Exact source

- base: cd2bb056ae27cb46d124e9e288a4e51f7127b141
- head: e2d5a803f39387307bb818f6d551e8a92f0f4e0b
- tree: 27217839c226abfc415ccaaa0ea69e3bda871145
- mechanical range-diff from the pre-rebase candidate: exact `=`

## Verification

- focused policy/certification + exact-current provisioning-worker authority: 128/128 PASS
- actionlint: PASS
- YAML parse: PASS
- Biome changed scripts/tests: PASS
- canonical environment/source guard suites: PASS
- GitHub action pinning: PASS
- diff check and clean worktree: PASS
- broader current-tree baseline caveats: one obsolete admission assertion still expects removed `build-pages`; one provisioning concurrency assertion predates the already-merged unique runner lease. Neither overlaps this five-file patch.

No Cloudflare binding, database row, tenant, worker, billing, job, compute, or adoption mutation is included.