### PR TITLE
fix(i18n): register dynamic view unavailable copy

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -5437,6 +5437,8 @@
   "dynamicviewloader.viewId": "View ID: {{viewId}}",
   "dynamicviewloader.restricted.title": "This view isn’t included here",
   "dynamicviewloader.restricted.body": "Open it from the desktop or web app, or install a mobile build that includes it.",
+  "dynamicviewloader.unavailable.title": "View unavailable",
+  "dynamicviewloader.unavailable.body": "This view is not available in the current runtime.",
   "dynamicviewloader.retry": "Retry",
   "vaultinventory.storedSecrets": "Stored secrets",
   "vaultinventory.storedSecrets.description": "Every secret stored locally, grouped by category. Add API keys, wallet keys, and plugin tokens here.",


### PR DESCRIPTION
# Relates to

Fixes #29487.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `develop` at `e43b933906fa5324e9f7b337aac53d5ca5f6a340`; subsequent compare audits found no overlap with the changed catalog file.
- [ ] `bun run verify` was not run. The exact failing verification subcommand, targeted formatting, and diff hygiene are recorded below.
- [x] The catalog entries exactly match the existing runtime fallback copy.

# Sync with develop

- [x] Based on `develop` at `e43b933906fa5324e9f7b337aac53d5ca5f6a340`; zero conflicts at the tested base. GitHub reported this head cleanly mergeable at the completed CI checkpoint; live `develop` has continued to advance since then.
- [x] Compare audits through the completed CI checkpoint did not touch `packages/ui/src/i18n/locales/en.json`.

# Risks

Minimal. This adds two English catalog entries and changes no component code. Both values match `ViewUnavailableState`'s existing `defaultValue` strings character-for-character, so rendered copy is unchanged.

# Background

## What does this PR do?

It registers:

- `dynamicviewloader.unavailable.title` → `View unavailable`
- `dynamicviewloader.unavailable.body` → `This view is not available in the current runtime.`

The source already uses these keys and fallbacks. Their absence made `check:i18n` fail the source/catalog integrity gate on `develop`.

## What kind of change is this?

Bug fix for the English i18n catalog and repository verification gate.

# Documentation changes needed?

No. There is no user-facing copy change.

# Testing

## Where should a reviewer start?

The two added lines in `packages/ui/src/i18n/locales/en.json`, compared with `ViewUnavailableState` in `packages/ui/src/components/views/ViewStatusStates.tsx`.

## Detailed testing steps

1. Deterministic RED on the unchanged base:

   ```text
   bun run check:i18n
   [i18n] en.json missing 2 key(s) used in source:
     - dynamicviewloader.unavailable.title
     - dynamicviewloader.unavailable.body
   exit 1
   ```

2. GREEN on exact head `7689c582d7517ebc8e728048d2e65ba2dfa9df39`:

   ```text
   bun run check:i18n
   [i18n] OK — 4425 literal keys, 6 wildcard prefixes, 69 dynamic sites,
   68 indirect-only keys; 8682 source keys × 8 locales
   exit 0
   ```

   Existing non-English translation gaps remain advisory warnings and fall back to English; they are unchanged except that these two newly canonical English keys now participate in that existing warning count.

3. Formatting and diff hygiene:

   ```text
   @biomejs/biome check packages/ui/src/i18n/locales/en.json
   Checked 1 file. No fixes applied.

   git diff HEAD^ HEAD --check
   exit 0
   ```

# Evidence Gate

<!-- evidence-head:7689c582d7517ebc8e728048d2e65ba2dfa9df39 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — rendered fallback copy already displayed these exact strings; the RED catalog-gate output is recorded above.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no visual or text change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no runtime code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head source/catalog integrity output is reproduced above.
<!-- evidence-row:ocr-review -->
- [x] N/A — rendered copy is byte-for-byte identical to the existing fallback.

# Evidence Details

## Known gaps / failures

- `bun run verify` was not run; `check:i18n`, the exact previously failing subcommand, is green.
- Non-English catalog gaps printed by `check:i18n` are pre-existing advisory warnings under the non-strict command.

## Maintainer CI exception record

N/A — no exception requested.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->

