### PR TITLE
fix(plugin-pty): declare shared workspace dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2979,6 +2979,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",

--- a/plugins/plugin-pty/package.json
+++ b/plugins/plugin-pty/package.json
@@ -41,7 +41,8 @@
   "author": "elizaOS",
   "license": "MIT",
   "dependencies": {
-    "@elizaos/core": "workspace:*"
+    "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*"
   },
   "optionalDependencies": {
     "@lydell/node-pty": "^1.1.0"


### PR DESCRIPTION
## Summary

- declares the `@elizaos/shared` workspace dependency already imported by `plugin-pty`
- updates the lockfile so CI creates the workspace link and Turbo orders the shared build before PTY
- fixes the deterministic Cloud Worker and Pages build failure from staging run `33044136360`

## Exact source

- base: `e43b933906fa5324e9f7b337aac53d5ca5f6a340`
- head: `6d53ff9edb977e7b19a7c49c61ff7057ef9a4729`
- tree: `7a1ee905c12d2d96338898f404424e5caea0fd77`

## Verification

- exact previously failing `bun run build:core`: 60/60 tasks passed
- plugin unit tests: 113/113 passed
- plugin typecheck passed
- frozen lock install passed
- Biome and `git diff --check` passed

## Safety

The failed staging run completed database identity/migration checks but failed before Worker or Pages deployment. This PR changes no runtime behavior beyond restoring the declared build dependency and performs no production, billing, row, or adoption mutation.