### PR TITLE
fix(cloud): retire premature backup admission protocol guard

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts
@@ -85,6 +85,7 @@ const activePersonalTargetLookups: Array<{
 mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
   findActivePersonalDedicatedTarget: async (
     organizationId: string,
+    _userId: string,
     sourceAgentId: string,
   ) => {
     activePersonalTargetLookups.push({ organizationId, sourceAgentId });

--- a/packages/cloud/shared/src/db/agent-backup-admission-cursors-migration.pglite.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-admission-cursors-migration.pglite.test.ts
@@ -26,8 +26,12 @@ const UNIQUE_NODE_INCARNATION = "40000000-0000-4000-8000-000000000002";
 const FIRST_HISTORY_ID = "50000000-0000-4000-8000-000000000001";
 const ABA_HISTORY_ID = "50000000-0000-4000-8000-000000000002";
 const UNIQUE_HISTORY_ID = "50000000-0000-4000-8000-000000000003";
-const migration = readFileSync(
+const admissionMigration = readFileSync(
   new URL("./migrations/0341_agent_backup_admission_cursors.sql", import.meta.url),
+  "utf8",
+);
+const guardRetirementMigration = readFileSync(
+  new URL("./migrations/0342_retire_agent_backup_admission_protocol_guard.sql", import.meta.url),
   "utf8",
 );
 
@@ -44,9 +48,9 @@ async function publicTables(): Promise<string[]> {
   return result.rows.map(({ table_name }) => table_name);
 }
 
-async function applyMigration(target = database): Promise<void> {
+async function applyMigration(source: string, target = database): Promise<void> {
   await target.transaction(async (transaction) => {
-    for (const statement of migration.split("--> statement-breakpoint")) {
+    for (const statement of source.split("--> statement-breakpoint")) {
       if (statement.trim()) await transaction.exec(statement);
     }
   });
@@ -155,15 +159,15 @@ beforeAll(async () => {
   `);
   tablesBeforeMigration = await publicTables();
 
-  await applyMigration();
-  await applyMigration();
+  await applyMigration(admissionMigration);
+  await applyMigration(admissionMigration);
 }, 60_000);
 
 afterAll(async () => {
   await database.close();
 });
 
-describe("0334 backup admission authority migration", () => {
+describe("0341-0342 backup admission authority migrations", () => {
   test("never guesses an append-only occurrence for legacy rows", async () => {
     const backups = await database.query<{ id: string; source_node_history_id: string | null }>(`
       SELECT id, source_node_history_id
@@ -516,6 +520,123 @@ describe("0334 backup admission authority migration", () => {
     expect(secondLane.rows).toEqual([]);
   });
 
+  test("retires only the protocol guard and remains idempotent", async () => {
+    await applyMigration(guardRetirementMigration);
+    await applyMigration(guardRetirementMigration);
+
+    const guards = await database.query<{
+      function_count: number;
+      trigger_count: number;
+    }>(`
+      SELECT
+        (
+          SELECT count(*)::integer
+          FROM pg_trigger
+          WHERE tgrelid = 'agent_sandbox_backups'::regclass
+            AND tgname = 'agent_sandbox_backups_require_admission_protocol'
+            AND NOT tgisinternal
+        ) AS trigger_count,
+        (
+          SELECT count(*)::integer
+          FROM pg_proc
+          JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
+          WHERE pg_namespace.nspname = 'public'
+            AND pg_proc.proname = 'require_agent_backup_admission_protocol'
+        ) AS function_count
+    `);
+    expect(guards.rows).toEqual([{ function_count: 0, trigger_count: 0 }]);
+
+    const preservedTriggers = await database.query<{ tgname: string }>(`
+      SELECT tgname
+      FROM pg_trigger
+      WHERE tgrelid = 'agent_sandbox_backups'::regclass
+        AND tgname IN (
+          'agent_sandbox_backups_bind_admission_authorities',
+          'agent_sandbox_backups_preserve_admission_identity'
+        )
+        AND NOT tgisinternal
+      ORDER BY tgname
+    `);
+    expect(preservedTriggers.rows).toEqual([
+      { tgname: "agent_sandbox_backups_bind_admission_authorities" },
+      { tgname: "agent_sandbox_backups_preserve_admission_identity" },
+    ]);
+
+    const preservedConstraints = await database.query<{ conname: string }>(`
+      SELECT conname
+      FROM pg_constraint
+      WHERE conrelid = 'agent_sandbox_backups'::regclass
+        AND conname IN (
+          'agent_sandbox_backups_capture_source_occurrence_check',
+          'agent_sandbox_backups_source_node_occurrence_fkey'
+        )
+      ORDER BY conname
+    `);
+    expect(preservedConstraints.rows).toEqual([
+      { conname: "agent_sandbox_backups_capture_source_occurrence_check" },
+      { conname: "agent_sandbox_backups_source_node_occurrence_fkey" },
+    ]);
+
+    const ownerId = "backup-worker-forward-migration";
+    const generation = "60000000-0000-4000-8000-000000000002";
+    await database.exec(`
+      UPDATE agent_sandbox_backups
+      SET catalog_lease_owner = '${ownerId}',
+        catalog_lease_generation = '${generation}',
+        catalog_lease_expires_at = clock_timestamp() + interval '1 hour'
+      WHERE id = '${PROTOCOL_BACKUP_ID}';
+      UPDATE agent_sandbox_backups
+      SET catalog_lease_expires_at = catalog_lease_expires_at + interval '1 hour'
+      WHERE id = '${PROTOCOL_BACKUP_ID}';
+    `);
+    const lease = await database.query<{
+      catalog_lease_generation: string | null;
+      catalog_lease_owner: string | null;
+      lease_is_live: boolean;
+    }>(`
+      SELECT catalog_lease_owner, catalog_lease_generation,
+        catalog_lease_expires_at > clock_timestamp() AS lease_is_live
+      FROM agent_sandbox_backups
+      WHERE id = '${PROTOCOL_BACKUP_ID}'
+    `);
+    expect(lease.rows).toEqual([
+      {
+        catalog_lease_generation: generation,
+        catalog_lease_owner: ownerId,
+        lease_is_live: true,
+      },
+    ]);
+
+    await expect(
+      database.exec(`
+        UPDATE agent_sandbox_backups
+        SET source_node_id = 'different-node'
+        WHERE id = '${IMMUTABLE_BACKUP_ID}'
+      `),
+    ).rejects.toThrow(/admission identity is immutable/i);
+    await expect(
+      database.exec(`
+        INSERT INTO agent_sandbox_backups (
+          id, catalog_version, catalog_state, catalog_organization_id,
+          source_node_history_id, source_node_record_id, source_node_incarnation,
+          created_at
+        ) VALUES (
+          '${FOREIGN_KEY_BACKUP_ID}', 1, 'legacy_unmigrated', '${ORGANIZATION_ID}',
+          '${UNIQUE_HISTORY_ID}', '30000000-0000-4000-8000-000000000099',
+          '${UNIQUE_NODE_INCARNATION}', '2026-08-26T13:00:00Z'
+        )
+      `),
+    ).rejects.toThrow(/source_node_occurrence|foreign key/i);
+
+    await database.exec(`
+      UPDATE agent_sandbox_backups
+      SET catalog_lease_owner = NULL,
+        catalog_lease_generation = NULL,
+        catalog_lease_expires_at = NULL
+      WHERE id = '${PROTOCOL_BACKUP_ID}'
+    `);
+  });
+
   test("aborts cutover instead of silently stranding a legacy capture", async () => {
     const blockedDatabase = new PGlite();
     try {
@@ -532,7 +653,7 @@ describe("0334 backup admission authority migration", () => {
           '20000000-0000-4000-8000-000000000099', 2, 'failed_retryable', 'capturing'
         );
       `);
-      await expect(applyMigration(blockedDatabase)).rejects.toThrow(
+      await expect(applyMigration(admissionMigration, blockedDatabase)).rejects.toThrow(
         /explicit source occurrence reconciliation/i,
       );
       const columns = await blockedDatabase.query<{ column_name: string }>(`
@@ -588,7 +709,9 @@ describe("0334 backup admission authority migration", () => {
             catalog_organization_id, source_node_history_id, catalog_lease_expires_at
           ) VALUES ${fixture.rows};
         `);
-        await expect(applyMigration(blockedDatabase)).rejects.toThrow(fixture.expected);
+        await expect(applyMigration(admissionMigration, blockedDatabase)).rejects.toThrow(
+          fixture.expected,
+        );
       } finally {
         await blockedDatabase.close();
       }

--- a/packages/cloud/shared/src/db/migration-journal-registration.test.ts
+++ b/packages/cloud/shared/src/db/migration-journal-registration.test.ts
@@ -107,7 +107,7 @@ describe("migrations/meta/_journal.json registration", () => {
     expect(new Set(entries.map((e) => e.tag)).size).toBe(entries.length);
   });
 
-  test("keeps the deployed 0320-0340 stack and appends backup admission", () => {
+  test("keeps the deployed 0320-0340 stack and appends backup admission migrations", () => {
     const entries = journalEntries();
     const sharedConsent = entries.find(
       ({ tag }) => tag === "0320_personal_shared_multi_principal_consent",
@@ -121,11 +121,18 @@ describe("migrations/meta/_journal.json registration", () => {
     const backupAdmissionCursors = entries.find(
       ({ tag }) => tag === "0341_agent_backup_admission_cursors",
     );
+    const backupAdmissionGuardRetirement = entries.find(
+      ({ tag }) => tag === "0342_retire_agent_backup_admission_protocol_guard",
+    );
 
     expect(sharedConsent).toMatchObject({ idx: 303, when: 1794254400011 });
     expect(replacementTail).toMatchObject({ idx: 311, when: 1794254400019 });
     expect(dedicatedAdoption).toMatchObject({ idx: 312, when: 1794254400020 });
     expect(backupAdmissionCursors).toMatchObject({ idx: 324, when: 1794254400032 });
+    expect(backupAdmissionGuardRetirement).toMatchObject({
+      idx: 325,
+      when: 1794254400033,
+    });
   });
 
   test("the catalogue, capture, and restore stack is registered in strict deployment order", () => {

--- a/packages/cloud/shared/src/db/migrations/0342_retire_agent_backup_admission_protocol_guard.sql
+++ b/packages/cloud/shared/src/db/migrations/0342_retire_agent_backup_admission_protocol_guard.sql
@@ -1,0 +1,6 @@
+-- Retires the writer fence until backup admission consumes the dedicated cursor authorities.
+
+DROP TRIGGER IF EXISTS "agent_sandbox_backups_require_admission_protocol"
+  ON "public"."agent_sandbox_backups";
+--> statement-breakpoint
+DROP FUNCTION IF EXISTS "public"."require_agent_backup_admission_protocol"();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2276,6 +2276,13 @@
       "when": 1794254400032,
       "tag": "0341_agent_backup_admission_cursors",
       "breakpoints": true
+    },
+    {
+      "idx": 325,
+      "version": "7",
+      "when": 1794254400033,
+      "tag": "0342_retire_agent_backup_admission_protocol_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { pushSchema } from "drizzle-kit/api";
 import { asc, eq, sql } from "drizzle-orm";
 import { Client } from "pg";
@@ -13,11 +14,14 @@ import {
   acquireEphemeralPostgres,
   type EphemeralPostgres,
 } from "../../../lib/services/tenant-db/__tests__/ephemeral-postgres";
+import { sqlRows } from "../../execute-helpers";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import {
   agentBackupCatalogAuthorities,
   agentSandboxBackups,
   agentSandboxes,
 } from "../../schemas/agent-sandboxes";
+import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
@@ -42,7 +46,9 @@ interface TenantFixture {
   readonly organizationId: string;
   readonly userId: string;
   readonly agentId: string;
+  readonly nodeHistoryId: string;
   readonly nodeRecordId: string;
+  readonly nodeId: string;
   readonly nodeIncarnation: string;
 }
 
@@ -50,14 +56,18 @@ const TENANT_A = {
   organizationId: "10000000-0000-4000-8000-000000000201",
   userId: "20000000-0000-4000-8000-000000000201",
   agentId: "30000000-0000-4000-8000-000000000201",
+  nodeHistoryId: "41000000-0000-4000-8000-000000000201",
   nodeRecordId: "40000000-0000-4000-8000-000000000201",
+  nodeId: "backup-catalogue-tenant-a-node",
   nodeIncarnation: "50000000-0000-4000-8000-000000000201",
 } as const satisfies TenantFixture;
 const TENANT_B = {
   organizationId: "10000000-0000-4000-8000-000000000202",
   userId: "20000000-0000-4000-8000-000000000202",
   agentId: "30000000-0000-4000-8000-000000000202",
+  nodeHistoryId: "41000000-0000-4000-8000-000000000202",
   nodeRecordId: "40000000-0000-4000-8000-000000000202",
+  nodeId: "backup-catalogue-tenant-b-node",
   nodeIncarnation: "50000000-0000-4000-8000-000000000202",
 } as const satisfies TenantFixture;
 const OPERATION_A1 = "60000000-0000-4000-8000-000000000201";
@@ -67,6 +77,10 @@ const OWNER_A = "backup-catalogue-postgres-worker-a";
 const OWNER_B = "backup-catalogue-postgres-worker-b";
 const PAYLOAD_DIGEST = "a".repeat(64);
 const CONTAINER_ID = "b".repeat(64);
+const BACKUP_ADMISSION_MIGRATIONS = [
+  "0341_agent_backup_admission_cursors",
+  "0342_retire_agent_backup_admission_protocol_guard",
+] as const;
 
 type ClientModule = typeof import("../../client");
 type CatalogRepository = typeof import("../agent-backup-catalog");
@@ -82,6 +96,26 @@ let catalogRepository: CatalogRepository | undefined;
 function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined): void {
   if (value === undefined) delete process.env[name];
   else process.env[name] = value;
+}
+
+async function expectPostgresFailure(operation: Promise<unknown>, expected: RegExp): Promise<void> {
+  let failure: unknown;
+  try {
+    await operation;
+  } catch (error) {
+    failure = error;
+  }
+
+  const details: string[] = [];
+  let current = failure;
+  for (let depth = 0; current && depth < 8; depth += 1) {
+    if (current instanceof Error) details.push(current.message);
+    if (typeof current !== "object") break;
+    const record = current as { cause?: unknown; constraint?: unknown };
+    if (typeof record.constraint === "string") details.push(record.constraint);
+    current = record.cause;
+  }
+  expect(details.join("\n")).toMatch(expected);
 }
 
 async function createIsolatedDatabase(baseDsn: string): Promise<{
@@ -182,6 +216,18 @@ async function initializeHarness(): Promise<void> {
   dbWrite = client.dbWrite;
   closeDatabaseConnectionsForTests = client.closeDatabaseConnectionsForTests;
   catalogRepository = repository;
+}
+
+async function applyBackupAdmissionMigrations(): Promise<void> {
+  if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+  for (const tag of BACKUP_ADMISSION_MIGRATIONS) {
+    const source = readFileSync(new URL(`../../migrations/${tag}.sql`, import.meta.url), "utf8");
+    await dbWrite.transaction(async (transaction) => {
+      for (const statement of source.split("--> statement-breakpoint")) {
+        if (statement.trim()) await transaction.execute(sql.raw(statement));
+      }
+    });
+  }
 }
 
 async function waitForRepositoryLockWaiters(
@@ -289,6 +335,33 @@ async function settleTeardown(
   }
 }
 
+async function seedSourceAuthority(tenant: TenantFixture): Promise<void> {
+  if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+  const hostKeyFingerprint = `sha256:${tenant.nodeId}`;
+  await dbWrite.insert(agentNodeIncarnationHistories).values({
+    id: tenant.nodeHistoryId,
+    docker_node_record_id: tenant.nodeRecordId,
+    node_id: tenant.nodeId,
+    node_incarnation: tenant.nodeIncarnation,
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    host_key_fingerprint: hostKeyFingerprint,
+  });
+  await dbWrite.insert(dockerNodes).values({
+    id: tenant.nodeRecordId,
+    node_id: tenant.nodeId,
+    hostname: tenant.nodeId,
+    status: "healthy",
+    host_key_fingerprint: hostKeyFingerprint,
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    node_incarnation: tenant.nodeIncarnation,
+    current_node_history_id: tenant.nodeHistoryId,
+  });
+}
+
 async function seedTenant(tenant: TenantFixture, suffix: string): Promise<void> {
   if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
   await dbWrite.insert(organizations).values({
@@ -343,7 +416,7 @@ async function seedBackup(params: {
     lifecycle_revision: 0n,
     source_provider: "operator-onboarded",
     source_node_record_id: params.tenant.nodeRecordId,
-    source_node_id: `backup-catalogue-${params.suffix}-node`,
+    source_node_id: params.tenant.nodeId,
     source_node_incarnation: params.tenant.nodeIncarnation,
     source_provider_server_id: null,
     source_provider_handle: `backup-catalogue-${params.suffix}-container`,
@@ -407,6 +480,8 @@ realPostgres("canonical backup catalogue contention", () => {
         organizations,
         users,
         userCharacters,
+        agentNodeIncarnationHistories,
+        dockerNodes,
         agentSandboxes,
         agentSandboxBackups,
         agentBackupCatalogAuthorities,
@@ -414,6 +489,9 @@ realPostgres("canonical backup catalogue contention", () => {
       dbWrite as never,
     );
     await apply();
+    await seedSourceAuthority(TENANT_A);
+    await seedSourceAuthority(TENANT_B);
+    await applyBackupAdmissionMigrations();
     await installBackupMutationGuardForTests();
   }, 60_000);
 
@@ -427,6 +505,173 @@ realPostgres("canonical backup catalogue contention", () => {
     await dbWrite.delete(organizations);
     await seedTenant(TENANT_A, "tenant-a");
     await seedTenant(TENANT_B, "tenant-b");
+  });
+
+  test("retires only the protocol guard after the admission migration", async () => {
+    if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+    const [migrationState] = await sqlRows<{
+      bind_trigger_exists: boolean;
+      capture_check_exists: boolean;
+      node_cursor_exists: boolean;
+      occurrence_fk_exists: boolean;
+      organization_cursor_exists: boolean;
+      preserve_trigger_exists: boolean;
+      protocol_function_exists: boolean;
+      protocol_trigger_exists: boolean;
+    }>(
+      dbWrite,
+      sql`
+        SELECT
+          EXISTS (
+            SELECT 1 FROM pg_trigger
+            WHERE tgrelid = 'agent_sandbox_backups'::regclass
+              AND tgname = 'agent_sandbox_backups_require_admission_protocol'
+              AND NOT tgisinternal
+          ) AS protocol_trigger_exists,
+          to_regprocedure('public.require_agent_backup_admission_protocol()') IS NOT NULL
+            AS protocol_function_exists,
+          EXISTS (
+            SELECT 1 FROM pg_trigger
+            WHERE tgrelid = 'agent_sandbox_backups'::regclass
+              AND tgname = 'agent_sandbox_backups_bind_admission_authorities'
+              AND NOT tgisinternal
+          ) AS bind_trigger_exists,
+          EXISTS (
+            SELECT 1 FROM pg_trigger
+            WHERE tgrelid = 'agent_sandbox_backups'::regclass
+              AND tgname = 'agent_sandbox_backups_preserve_admission_identity'
+              AND NOT tgisinternal
+          ) AS preserve_trigger_exists,
+          EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conrelid = 'agent_sandbox_backups'::regclass
+              AND conname = 'agent_sandbox_backups_source_node_occurrence_fkey'
+          ) AS occurrence_fk_exists,
+          EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conrelid = 'agent_sandbox_backups'::regclass
+              AND conname = 'agent_sandbox_backups_capture_source_occurrence_check'
+          ) AS capture_check_exists,
+          to_regclass('public.agent_backup_organization_admission_cursors') IS NOT NULL
+            AS organization_cursor_exists,
+          to_regclass('public.agent_backup_node_admission_cursors') IS NOT NULL
+            AS node_cursor_exists
+      `,
+    );
+    expect(migrationState).toEqual({
+      bind_trigger_exists: true,
+      capture_check_exists: true,
+      node_cursor_exists: true,
+      occurrence_fk_exists: true,
+      organization_cursor_exists: true,
+      preserve_trigger_exists: true,
+      protocol_function_exists: false,
+      protocol_trigger_exists: false,
+    });
+
+    const backupId = await seedBackup({
+      tenant: TENANT_A,
+      suffix: "preserved-authorities",
+      operationId: OPERATION_A1,
+      dueAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const [bound] = await dbWrite
+      .select({
+        sourceNodeHistoryId: agentSandboxBackups.source_node_history_id,
+        sourceNodeId: agentSandboxBackups.source_node_id,
+      })
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, backupId));
+    expect(bound).toEqual({
+      sourceNodeHistoryId: TENANT_A.nodeHistoryId,
+      sourceNodeId: TENANT_A.nodeId,
+    });
+
+    await expectPostgresFailure(
+      dbWrite
+        .update(agentSandboxBackups)
+        .set({ source_node_id: TENANT_B.nodeId })
+        .where(eq(agentSandboxBackups.id, backupId))
+        .execute(),
+      /admission identity is immutable/i,
+    );
+    const [preserved] = await dbWrite
+      .select({ sourceNodeId: agentSandboxBackups.source_node_id })
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, backupId));
+    expect(preserved?.sourceNodeId).toBe(TENANT_A.nodeId);
+    await expectPostgresFailure(
+      dbWrite
+        .insert(agentSandboxBackups)
+        .values({
+          id: randomUUID(),
+          sandbox_record_id: TENANT_A.agentId,
+          snapshot_type: "auto",
+          state_data: { memories: [], config: {}, workspaceFiles: {} },
+          state_data_storage: "inline",
+          size_bytes: 0,
+          backup_kind: "full",
+          source_node_history_id: TENANT_B.nodeHistoryId,
+          source_node_record_id: TENANT_A.nodeRecordId,
+          source_node_incarnation: TENANT_A.nodeIncarnation,
+        })
+        .execute(),
+      /source_node_occurrence|foreign key/i,
+    );
+  });
+
+  test("claims, heartbeats, and releases without the protocol GUC", async () => {
+    if (!dbWrite || !catalogRepository) {
+      throw new Error("Real PostgreSQL harness was not initialized");
+    }
+    const [session] = await sqlRows<{ protocol: string | null }>(
+      dbWrite,
+      sql`SELECT current_setting('eliza.agent_backup_admission_protocol', true) AS protocol`,
+    );
+    expect(session?.protocol).not.toBe("2");
+
+    const backupId = await seedBackup({
+      tenant: TENANT_A,
+      suffix: "no-protocol-guc",
+      operationId: OPERATION_A1,
+      dueAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const [claim] = await catalogRepository.claimDueAgentBackupOperations({
+      ownerId: OWNER_A,
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim?.backup.lifecycle_generation) {
+      throw new Error("Expected a claimed backup with lifecycle authority");
+    }
+    const heartbeat = await catalogRepository.heartbeatAgentBackupOperation({
+      organizationId: TENANT_A.organizationId,
+      backupId,
+      execution: { ownerId: claim.ownerId, generation: claim.generation },
+      leaseMs: 60_000,
+    });
+    expect(heartbeat).toMatchObject({
+      id: backupId,
+      catalog_lease_owner: claim.ownerId,
+      catalog_lease_generation: claim.generation,
+    });
+
+    const released = await catalogRepository.failAgentBackupOperation({
+      organizationId: TENANT_A.organizationId,
+      backupId,
+      operationId: OPERATION_A1,
+      lifecycleGeneration: claim.backup.lifecycle_generation,
+      expectedState: "scheduled",
+      terminal: true,
+      error: { code: "CAPTURE_TERMINAL", message: "forward migration release proof" },
+      execution: { ownerId: claim.ownerId, generation: claim.generation },
+    });
+    expect(released).toMatchObject({
+      catalog_state: "failed_terminal",
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+    });
   });
 
   test("serves another tenant while preserving one-operation-per-tenant admission", async () => {


### PR DESCRIPTION
## Summary

- append a forward `0342` migration that retires the premature backup-admission protocol trigger/function
- preserve the 0341 cursor tables, exact source-occurrence FK/check, authority binding, and immutable admission identity
- update the voice mint test mock to the production three-argument ownership lookup signature

## Why

Migration 0341 installs the rollout fence for a later durable organization/node cursor consumer. That reader/writer is not in the current tree, so marking the existing DISTINCT-ON claimant as protocol 2 would be unsafe. With the fence armed, today's production claim and heartbeat paths reject every v2 lease activation/renewal. This forward migration restores the pre-fence runtime behavior without rewriting already-applied migration history or weakening the new source-occurrence authorities.

## Verification

- PostgreSQL 18.4 actual 0341→0342 integration: 6/6
- focused migration/journal/repository tests: 48/48
- isolated voice mint test: 12/12
- cloud shared typecheck
- full cloud shared lint
- migration journal/schema check
- Biome and `git diff --check`

Exact reviewed head: `c541de3de04badc4101288db01c07702a0b0aed8`.

Production promotion remains held until this exact change is merged into develop and the resulting tree completes a fresh staging certification.
