### PR TITLE
fix(ui-test): tolerate CSS side-effect imports

### DIFF
--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts
@@ -39,6 +39,26 @@ describe("fixture bundle", () => {
     expect(js).toContain("ready");
   });
 
+  it("drops incidental CSS side-effect imports from inline fixture bundles", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eliza-fixture-css-"));
+    const entry = join(root, "entry.ts");
+
+    await writeFile(
+      join(root, "side-effect.css"),
+      ".fixture-only { color: red; }",
+    );
+    await writeFile(
+      entry,
+      'import "./side-effect.css"; globalThis.__fixtureCssImport = "ready";',
+    );
+
+    const js = await bundleFixture({ entry });
+
+    expect(js).toContain("__fixtureCssImport");
+    expect(js).toContain("ready");
+    expect(js).not.toContain("fixture-only");
+  });
+
   it("bundles shared routing contracts before workspace dist exists", async () => {
     const root = await mkdtemp(join(tmpdir(), "eliza-fixture-contracts-"));
     const entry = join(root, "entry.ts");

--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
@@ -1,7 +1,8 @@
 /**
  * Bundle a shell fixture with esbuild and wrap it in a static HTML page for the
  * `__e2e__` runners to load over `file://` in headless Chromium. One esbuild
- * config (browser IIFE, tsx/ts loaders, NODE_ENV=production), one HTML skeleton
+ * config (browser IIFE, TypeScript loaders, incidental CSS discarded,
+ * NODE_ENV=production), one HTML skeleton
  * with the knobs the runners actually vary — Tailwind source (CDN vs a compiled
  * theme vs none), the `process` shim, `<html>` class, extra head markup, body
  * background — and an optional real-`@elizaos/ui` Tailwind v4 theme compile.
@@ -56,7 +57,7 @@ export async function bundleFixture({
     // export selection for packages with a dedicated renderer entrypoint.
     conditions: ["eliza-source", "browser"],
     jsx: "automatic",
-    loader: { ".tsx": "tsx", ".ts": "ts" },
+    loader: { ".tsx": "tsx", ".ts": "ts", ".css": "empty" },
     define: { "process.env.NODE_ENV": '"production"', ...define },
     plugins: [workspaceSourcePlugin, ...plugins],
     write: false,


### PR DESCRIPTION
# Relates to

Fixes #29507.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on live `develop` at `fd8464b41029e6410c989f6ca92e4f98074f165d`; a compare audit through `dc6d42ca9341dfa8caa2bfb506aac53669c989d0` found no overlap with either changed file.
- [ ] The full workspace `bun install` and `bun run verify` were not run. A pinned minimal harness, exact failing regression, targeted typecheck, formatting, and diff hygiene are recorded below; exact-head CI is required.
- [x] A reviewer can confirm the bundling contract from the real-esbuild RED/GREEN regression below without reading implementation internals.

# Sync with develop

- [x] Based on `develop` at `fd8464b41029e6410c989f6ca92e4f98074f165d`; zero conflicts.
- [x] Five subsequent live-`develop` commits through `dc6d42ca9341dfa8caa2bfb506aac53669c989d0` touched neither `fixture-bundle.ts` nor `fixture-bundle.test.ts`.
- [ ] `bun run verify` was not run; the exact narrower receipts and local integration gap are documented below.

# Risks

Low and fixture-only. Ordinary `.css` imports in shared inline browser fixtures are deliberately discarded. Fixture runners already supply visual styling explicitly through Tailwind compilation, CDN markup, or `headHtml`; production bundles are unchanged. A future fixture that needs imported CSS pixels must continue to inject or compile that CSS explicitly.

# Background

## What does this PR do?

It adds esbuild's `empty` loader for `.css` in the shared fixture bundler. This preserves the bundler's existing contract—one inline JavaScript IIFE with `write: false` and no output path—when a lazy UI dependency has an incidental CSS side-effect import.

A real-esbuild regression creates a temporary stylesheet, imports it from a fixture entry, and proves that the JavaScript payload remains while the CSS payload is absent.

## What kind of change is this?

Bug fix for shared UI browser-fixture infrastructure.

# Documentation changes needed?

No project documentation change. The bundler's maintained responsibility header now records that incidental fixture CSS is discarded.

# Testing

## Where should a reviewer start?

`packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts`, then the `.css` loader entry in `fixture-bundle.ts`.

## Detailed testing steps

1. RED on base behavior with the regression test added but without the loader:

   ```text
   Cannot import ".../side-effect.css" into a JavaScript file without an output path configured

   Test Files  1 failed (1)
        Tests  1 failed | 4 passed (5)
   exit 1
   ```

2. GREEN on exact head `53ae811937466cf0128588c28857b4bc0e343d62`:

   ```text
   node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts \
     src/testing/e2e-runner/fixture-bundle.test.ts

   Test Files  1 passed (1)
        Tests  5 passed (5)
   exit 0
   ```

3. Exact changed-file formatting:

   ```text
   @biomejs/biome check fixture-bundle.ts fixture-bundle.test.ts
   Checked 2 files in 14ms. No fixes applied.
   exit 0
   ```

4. Strict targeted TypeScript over both changed files with the package's ESNext/bundler settings:

   ```text
   tsc --ignoreConfig --noEmit --target ES2024 --module ESNext \
     --moduleResolution bundler --strict --skipLibCheck ...
   exit 0
   ```

5. Diff hygiene:

   ```text
   git diff HEAD^ HEAD --check
   exit 0
   ```

6. Exact offending-package integration through the committed `bundleFixture`:

   ```text
   import "@stwd/react/styles.css";
   {"cssMarker":".stwd-root","jsBytes":127,"cssDiscarded":true}
   exit 0
   ```

   The real package stylesheet resolved successfully, the JavaScript marker remained, and Steward's `.stwd-root` CSS payload was absent from the returned inline IIFE.

# Evidence Gate

<!-- evidence-head:53ae811937466cf0128588c28857b4bc0e343d62 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — fixture build infrastructure only; no rendered component or pixels change.
<!-- evidence-row:after-screenshots -->
- [x] N/A — fixture build infrastructure only; no rendered component or pixels change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user interaction changes.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A — the failure occurs before Chromium launches; the real-esbuild RED/GREEN output is the applicable log evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, action, or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head real-esbuild output is reproduced above: five tests pass and imported CSS content is absent from the returned IIFE.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A — no LLM path changes.

## Backend + frontend logs

N/A — fixture build infrastructure only. The deterministic esbuild diagnostics and exact-head test output are reproduced above.

## Screenshots (before / after) + video walkthrough

N/A — no rendered UI surface changes; this restores the pre-browser fixture build boundary.

## Audio / voice walkthrough

N/A — no audio, voice, transcript, TTS, or STT changes.

## Known gaps / failures

- `bun run verify` and full package typecheck were not run because the heavyweight monorepo install was deliberately pruned after the previous PRs. Strict targeted TypeScript, real-esbuild Vitest, Biome, and diff hygiene are green.
- `bun run --cwd packages/ui test:home-screen-e2e` was attempted. The original CSS/no-output-path error did not recur; the deliberately minimal harness then stopped before Chromium on 86 unrelated missing dependency/workspace resolutions (including `@capacitor/core`, `adze`, `motion/react`, and `zod`). Restoring the full monorepo install would undo the approved disk cleanup, so exact-head CI remains the integration authority.
- This fixes the CSS bundling failure observed in the `ui-core-fixture-e2e` and `chat-shell` paths. It does not claim to fix the independent permission-priming selector timeout previously observed in `ui-extended/fixture-e2e`.

## Maintainer CI exception record

N/A — no exception requested.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->