### PR TITLE
chore(release): sync main production authority fixes into develop

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -331,6 +331,12 @@ jobs:
             echo "::error::Migration checkout resolved $actual_sha, expected $EXPECTED_DEPLOY_SHA"
             exit 1
           }
+          # Self-hosted runners can retain files created after checkout's own
+          # cleanup hook. Re-establish the exact immutable tree immediately
+          # before migrations; suppress removed paths so runner-local names do
+          # not enter deployment logs.
+          git reset --hard --quiet "$EXPECTED_DEPLOY_SHA"
+          git clean -ffdx -q
           [ -z "$(git status --porcelain)" ] || {
             echo "::error::Migration checkout is not clean"
             exit 1

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -1009,7 +1009,7 @@ bucket_name = "eliza-cloud-blob"
 # WebSocket driver in client.ts, which bypasses this binding).
 [[env.production.hyperdrive]]
 binding = "HYPERDRIVE"
-id = "9f59e4ec65f048f7b87e29e7b9c5d728"
+id = "486bdc36737a4ad1b526fc3c08627658"
 
 # KV is the Worker's cache backend (CacheClient). Workers can't reliably open raw
 # TCP to an external Redis (Railway's public proxy hangs under load), so the Worker

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -143,6 +143,23 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain(
       '[ "$actual_sha" = "$EXPECTED_DEPLOY_SHA" ] || {',
     );
+    const exactSourceCheck = workflow.indexOf(
+      '[ "$actual_sha" = "$EXPECTED_DEPLOY_SHA" ] || {',
+      verify,
+    );
+    const reset = workflow.indexOf(
+      'git reset --hard --quiet "$EXPECTED_DEPLOY_SHA"',
+      verify,
+    );
+    const clean = workflow.indexOf("git clean -ffdx -q", verify);
+    const cleanVerdict = workflow.indexOf(
+      '[ -z "$(git status --porcelain)" ] || {',
+      verify,
+    );
+    expect(reset).toBeGreaterThan(exactSourceCheck);
+    expect(clean).toBeGreaterThan(reset);
+    expect(cleanVerdict).toBeGreaterThan(clean);
+    expect(migration).toBeGreaterThan(cleanVerdict);
     expect(workflow).toContain("bun run db:cloud:migrate");
   });
 


### PR DESCRIPTION
Release-tree identity sync for the Cloud production promotion. This merges current main 579d546d2d23c954c0aef9775356781e674cb689 into develop dc6d42ca9341dfa8caa2bfb506aac53669c989d0 without conflict. Candidate commit: 9103972ba756870a30e17010b2f34e0994aba980. Candidate tree: 109da85a53c5af961a9b05def5f08405462ed3f9, exactly matching the current #29441 synthetic merge tree. After normal merge, staging must certify this exact tree before #29441 is promoted.