### PR TITLE
fix(ui): compose Character Personality as one framed page

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1552,21 +1552,13 @@ function buildStaticTabRenderers(): Record<
       </PageFrame>
     ),
     character: ({ characterNav, pageLayout }) => (
-      <AppWorkspaceContent
-        nav={characterNav}
-        pageLayout={pageLayout}
-        reserveChatClearance={false}
-      >
-        <LazyCharacterEditor />
+      <AppWorkspaceContent pageLayout={pageLayout} reserveChatClearance={false}>
+        <LazyCharacterEditor pageChrome={characterNav} />
       </AppWorkspaceContent>
     ),
     "character-select": ({ characterNav, pageLayout }) => (
-      <AppWorkspaceContent
-        nav={characterNav}
-        pageLayout={pageLayout}
-        reserveChatClearance={false}
-      >
-        <LazyCharacterEditor />
+      <AppWorkspaceContent pageLayout={pageLayout} reserveChatClearance={false}>
+        <LazyCharacterEditor pageChrome={characterNav} />
       </AppWorkspaceContent>
     ),
     inventory: ({ walletNav, pageLayout }) => (

--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../events/index";
 import { useChatAvatarVoiceBridge, useVoiceChat } from "../../hooks";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
+import { FramedPage, FramedPageBody } from "../../layouts/framed-page";
 import { useAppSelectorShallow } from "../../state";
 import { normalizeCharacterMessageExamples } from "../../utils/character-message-examples";
 import {
@@ -259,11 +260,13 @@ export function CharacterEditor({
   sceneOverlay = false,
   inModal: _inModal = false,
   onHeaderActionsChange,
+  pageChrome,
 }: {
   initialPage?: CharacterEditorPage;
   sceneOverlay?: boolean;
   inModal?: boolean;
   onHeaderActionsChange?: (actions: ReactNode | null) => void;
+  pageChrome?: ReactNode;
 } = {}) {
   useRenderGuard("CharacterEditor");
   const {
@@ -1275,7 +1278,7 @@ export function CharacterEditor({
 
   /* ── Loading state ──────────────────────────────────────────────── */
   if (characterLoading && !characterData) {
-    return (
+    const loadingState = (
       <div
         className={
           sceneOverlay
@@ -1292,6 +1295,14 @@ export function CharacterEditor({
           })}
         </div>
       </div>
+    );
+    return sceneOverlay ? (
+      loadingState
+    ) : (
+      <FramedPage>
+        {pageChrome}
+        <FramedPageBody scroll="page">{loadingState}</FramedPageBody>
+      </FramedPage>
     );
   }
 
@@ -1476,6 +1487,7 @@ export function CharacterEditor({
           {/* ── Standalone page: the Personality section (Character family) */}
           {!sceneOverlay && (
             <CharacterHubView
+              pageChrome={pageChrome}
               d={d}
               bioText={bioText}
               normalizedMessageExamples={normalizedMessageExamples}

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -14,7 +14,7 @@
  * only.
  */
 import type { MessageExampleGroup } from "@elizaos/core";
-import { useCallback, useEffect, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { client } from "../../api/client";
 import type { CharacterData } from "../../api/client-types";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
@@ -43,6 +43,7 @@ function mergeCharacterPatch(
 }
 
 export function CharacterHubView({
+  pageChrome,
   d,
   bioText,
   normalizedMessageExamples,
@@ -54,6 +55,7 @@ export function CharacterHubView({
   handleStyleEntryDraftChange,
   characterSaveError,
 }: {
+  pageChrome?: ReactNode;
   d: CharacterData;
   bioText: string;
   normalizedMessageExamples: MessageExampleGroup[];
@@ -224,7 +226,13 @@ export function CharacterHubView({
 
   return (
     <FramedPage>
-      <FramedPageBody scroll="page" data-testid="character-editor-view">
+      {pageChrome}
+      <FramedPageBody
+        scroll="page"
+        padded={false}
+        className="sm:px-6 lg:px-8"
+        data-testid="character-editor-view"
+      >
         <div className="flex min-w-0 flex-col pt-1">
           <WidgetHost slot="character" className="mb-4" />
           <div className="flex min-w-0 flex-col gap-4 sm:gap-6">

--- a/packages/ui/src/components/character/CharacterSectionNav.tsx
+++ b/packages/ui/src/components/character/CharacterSectionNav.tsx
@@ -81,9 +81,9 @@ export function CharacterSectionNav({
   activePath: string;
 }): React.JSX.Element {
   return (
-    <div className="flex shrink-0 flex-col">
+    <>
       <FramedPageHeader title="Character" />
-      <FramedPageNavigation>
+      <FramedPageNavigation padded={false} className="sm:px-6 lg:px-8">
         <SectionTabStrip
           entries={CHARACTER_SECTION_TABS}
           activeId={activeCharacterTabId(activePath)}
@@ -95,10 +95,11 @@ export function CharacterSectionNav({
           }}
           testId={`section-nav-${CHARACTER_SECTION_GROUP}`}
           ariaLabel="Character sections"
-          className="py-0"
+          className="px-0 py-0"
+          tabClassName="max-[420px]:px-2 max-[360px]:px-1"
         />
       </FramedPageNavigation>
       <Separator tone="subtle45" />
-    </div>
+    </>
   );
 }

--- a/packages/ui/src/components/shared/SectionNav.tsx
+++ b/packages/ui/src/components/shared/SectionNav.tsx
@@ -151,6 +151,7 @@ export function SectionNavTab({
   agentId,
   agentLabel,
   agentGroup,
+  className,
 }: {
   label: React.ReactNode;
   isActive: boolean;
@@ -158,6 +159,7 @@ export function SectionNavTab({
   agentId?: string;
   agentLabel?: string;
   agentGroup?: string;
+  className?: string;
 }): React.JSX.Element {
   if (agentId && agentLabel) {
     return (
@@ -168,6 +170,7 @@ export function SectionNavTab({
         agentId={agentId}
         agentLabel={agentLabel}
         agentGroup={agentGroup}
+        className={className}
       />
     );
   }
@@ -176,6 +179,7 @@ export function SectionNavTab({
       label={label}
       isActive={isActive}
       onSelect={onSelect}
+      className={className}
     />
   );
 }
@@ -186,12 +190,14 @@ function SectionNavTabButton({
   onSelect,
   agentRef,
   agentProps,
+  className,
 }: {
   label: React.ReactNode;
   isActive: boolean;
   onSelect: () => void;
   agentRef?: React.Ref<HTMLButtonElement>;
   agentProps?: Record<string, string>;
+  className?: string;
 }): React.JSX.Element {
   return (
     <Button
@@ -204,7 +210,7 @@ function SectionNavTabButton({
       variant="selection"
       size="compact"
       data-state={isActive ? "on" : "off"}
-      className="shrink-0"
+      className={cn("shrink-0", className)}
       {...agentProps}
     >
       {label}
@@ -219,6 +225,7 @@ function AgentSectionNavTab({
   agentId,
   agentLabel,
   agentGroup,
+  className,
 }: {
   label: React.ReactNode;
   isActive: boolean;
@@ -226,6 +233,7 @@ function AgentSectionNavTab({
   agentId: string;
   agentLabel: string;
   agentGroup?: string;
+  className?: string;
 }): React.JSX.Element {
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: agentId,
@@ -244,6 +252,7 @@ function AgentSectionNavTab({
       onSelect={onSelect}
       agentRef={ref}
       agentProps={agentProps}
+      className={className}
     />
   );
 }
@@ -267,6 +276,7 @@ export function SectionTabStrip({
   ariaLabel,
   className,
   agentIdPrefix,
+  tabClassName,
 }: {
   entries: readonly {
     id: string;
@@ -282,6 +292,8 @@ export function SectionTabStrip({
   className?: string;
   /** Prefix that opts each tab into the enclosing view's agent surface. */
   agentIdPrefix?: string;
+  /** Optional responsive sizing shared by every tab in this strip. */
+  tabClassName?: string;
 }): React.JSX.Element | null {
   // A single-entry section is just its header; no secondary nav to render.
   if (entries.length < 2) return null;
@@ -303,6 +315,7 @@ export function SectionTabStrip({
           agentId={agentIdPrefix ? `${agentIdPrefix}-${entry.id}` : undefined}
           agentLabel={entry.agentLabel}
           agentGroup={agentIdPrefix}
+          className={tabClassName}
         />
       ))}
     </nav>


### PR DESCRIPTION
Closes #29514

Stacked on #29303 so this PR contains only the Character page change. It will be retargeted to `develop` after the parent lands.

## Summary

- Compose the Character header, section tabs, and Personality editor inside one canonical `FramedPage`.
- Keep all four Character tabs visible on narrow mobile screens.
- Remove the duplicated mobile page inset while preserving tablet and desktop gutters.
- Preserve autosave and existing Character section navigation behavior.

## Verification

- Biome passed.
- `packages/ui` typecheck passed.
- Focused Vitest: 62/62 passed.
- Real Character audit: 4/4 viewports passed, zero broken, zero needs-work, zero horizontal overflow.
- Packaged OCR: 4/4 views verified, zero broken, zero needs-eyeball.

The mobile portrait audit is marked `needs-eyeball` only because its desktop-style hover probe cannot hover the offscreen Add Post control on a touch viewport. It has no render-state, geometry, overflow, token, or semantic failure.

## Visual comparison

| Mobile before | Mobile after |
| --- | --- |
| ![Character mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-before-mobile-character.png) | ![Character mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-after-mobile-character.png) |

| Desktop before | Desktop after |
| --- | --- |
| ![Character desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-before-desktop-character.png) | ![Character desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-after-desktop-character.png) |

## Evidence

Evidence artifacts correspond to the exact pushed head.

<!-- evidence-head:eabac4f1404670f776fbff8c26a6e92215253bf9 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-before-mobile-character.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-after-mobile-character.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-eliza-character-personality-mobile-padding-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - UI-only page composition; no backend behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] [29522-frontend-audit.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-frontend-audit.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, protocol, native, or model-domain artifact changed.

<!-- evidence-row:ocr-review -->
- [x] [29522-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29522-ocr-triage.json)
