### PR TITLE
fix(inbox): sanitize non-finite policy amounts

### DIFF
--- a/plugins/plugin-inbox/src/inbox/email-curation.ts
+++ b/plugins/plugin-inbox/src/inbox/email-curation.ts
@@ -1382,7 +1382,9 @@ export function calibrateEmailCurationConfidence(
   }
   for (const effect of input.policyEffects) {
     if (effect.kind === "lower_confidence") {
-      confidence -= effect.amount ?? 0.1;
+      const requestedAmount = effect.amount ?? 0.1;
+      const amount = Number.isFinite(requestedAmount) ? requestedAmount : 0.1;
+      confidence -= amount;
     }
   }
   if (hasUncitedStrongSemanticEvidence(input.evidence)) {

--- a/plugins/plugin-inbox/test/inbox-curation.test.ts
+++ b/plugins/plugin-inbox/test/inbox-curation.test.ts
@@ -28,6 +28,7 @@ import type {
   EmailCurationPolicyHook,
 } from "../src/inbox/email-curation.ts";
 import {
+  calibrateEmailCurationConfidence,
   compareCurationDecisions,
   curateEmailCandidates,
 } from "../src/inbox/email-curation.ts";
@@ -204,65 +205,129 @@ describe("InboxService.triageWithCuration", () => {
   });
 });
 
-describe("email curation safe sort (NaN + tiebreak)", () => {
-  it("orders via curateEmailCandidates with NaN confidence tiebreak by candidateId", () => {
-    const baseCandidates: EmailCurationCandidate[] = [
-      {
-        id: "c-1",
+describe("email curation confidence boundary and safe sort", () => {
+  it.each([
+    ["NaN", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["negative infinity", Number.NEGATIVE_INFINITY],
+  ] as const)("treats %s policy amount like an omitted amount", (_, amount) => {
+    const baseInput = {
+      action: "archive" as const,
+      scores: { save: 0, archive: 2, delete: 0, review: 0 },
+      evidence: [],
+      degraded: false,
+      blockedDelete: false,
+      threadConflict: false,
+    };
+    const omitted = calibrateEmailCurationConfidence({
+      ...baseInput,
+      policyEffects: [
+        {
+          kind: "lower_confidence",
+          code: "test_default_penalty",
+          message: "Use the default confidence penalty.",
+        },
+      ],
+    });
+
+    const actual = calibrateEmailCurationConfidence({
+      ...baseInput,
+      policyEffects: [
+        {
+          kind: "lower_confidence",
+          amount,
+          code: "test_non_finite_penalty",
+          message: "Supply an invalid confidence penalty.",
+        },
+      ],
+    });
+
+    expect(actual).toBe(omitted);
+  });
+
+  it("preserves finite policy amounts and accumulates multiple effects", () => {
+    const baseInput = {
+      action: "review" as const,
+      scores: { save: 0, archive: 0, delete: 0, review: 1 },
+      evidence: [],
+      degraded: false,
+      blockedDelete: false,
+      threadConflict: false,
+    };
+    const calibrateWithAmounts = (...amounts: number[]) =>
+      calibrateEmailCurationConfidence({
+        ...baseInput,
+        policyEffects: amounts.map((amount, index) => ({
+          kind: "lower_confidence" as const,
+          amount,
+          code: `test_finite_penalty_${index}`,
+          message: "Apply a finite confidence penalty.",
+        })),
+      });
+    const omitted = calibrateEmailCurationConfidence({
+      ...baseInput,
+      policyEffects: [
+        {
+          kind: "lower_confidence",
+          code: "test_default_penalty",
+          message: "Use the default confidence penalty.",
+        },
+      ],
+    });
+    const lowered = calibrateWithAmounts(0.2);
+    const raised = calibrateWithAmounts(-0.05);
+    const combined = calibrateWithAmounts(0.2, -0.05);
+
+    expect(lowered).toBeLessThan(omitted);
+    expect(raised).toBeGreaterThan(omitted);
+    expect(combined).toBeGreaterThan(lowered);
+    expect(combined).toBeLessThan(omitted);
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["negative infinity", Number.NEGATIVE_INFINITY],
+  ] as const)(
+    "keeps decision confidence and review rationale finite for %s policy amount",
+    (_, amount) => {
+      const candidate: EmailCurationCandidate = {
+        id: "policy-probe",
         threadId: null,
         subject: "Hello",
         snippet: "hi",
-        body: { text: "Hello world", contentType: "text/plain" as const },
+        body: { text: "Hello world", contentType: "text/plain" },
         from: "Alice Example <alice@example.com>",
         fromEmail: "alice@example.com",
         to: [],
         cc: [],
         labels: [],
         headers: {},
-      },
-      {
-        id: "c-nan",
-        threadId: null,
-        subject: "Hello",
-        snippet: "hi",
-        body: { text: "Hello world", contentType: "text/plain" as const },
-        from: "Bob Example <bob@example.com>",
-        fromEmail: "bob@example.com",
-        to: [],
-        cc: [],
-        labels: [],
-        headers: {},
-      },
-    ];
-    const policyHook: EmailCurationPolicyHook = (ctx) => {
-      if (ctx.candidate.id === "c-nan") {
-        return [
-          {
-            kind: "lower_confidence" as const,
-            amount: Number.NaN,
-            code: "test_nan",
-            message: "force NaN",
-          },
-        ];
+      };
+      const effect = {
+        kind: "lower_confidence" as const,
+        code: "test_confidence_penalty",
+        message: "Lower confidence for the test policy.",
+      };
+      const omittedDecision = curateEmailCandidates({
+        candidates: [candidate],
+        policyHook: () => [effect],
+      }).decisions[0];
+      const decision = curateEmailCandidates({
+        candidates: [candidate],
+        policyHook: () => [{ ...effect, amount }],
+      }).decisions[0];
+      if (!omittedDecision || !decision) {
+        throw new Error("expected one curation decision");
       }
-      return [];
-    };
-    const out = curateEmailCandidates({
-      candidates: baseCandidates,
-      now: "2026-08-23T00:00:00.000Z",
-      policyHook,
-    });
-    // c-nan confidence becomes NaN -> sort score NaN -> coerced to 0, so it sorts last; tiebreak by candidateId if scores tie
-    const order = out.decisions.map((d) => d.candidateId);
-    // ensure both present and ranking is deterministic
-    expect(order).toContain("c-nan");
-    expect(order).toContain("c-1");
-    // c-1 should rank before c-nan because NaN -> 0 is smallest
-    expect(out.decisions[0]?.candidateId).toBe("c-1");
-    expect(out.decisions[0]?.rank).toBe(1);
-    expect(out.decisions[1]?.candidateId).toBe("c-nan");
-    expect(out.decisions[1]?.rank).toBe(2);
-  });
+
+      expect(Number.isFinite(decision.confidence)).toBe(true);
+      expect(decision.confidence).toBeGreaterThanOrEqual(0);
+      expect(decision.confidence).toBeLessThanOrEqual(1);
+      expect(decision.confidence).toBe(omittedDecision.confidence);
+      expect(decision.bulkReview.rationale).not.toMatch(/NaN|Infinity/);
+    },
+  );
 
   it("tiebreaks equal scores by candidateId via compareCurationDecisions", () => {
     const a = {


### PR DESCRIPTION
## Summary

- normalize non-finite `lower_confidence` policy amounts to the existing omitted-amount default before calibration arithmetic
- preserve finite positive, finite negative, and accumulated policy-effect semantics
- replace the stale NaN-ranking expectation with direct calibration and full decision-boundary regressions

Fixes #29309

## Behavior

Before this change, the exact issue input produced `NaN` confidence, while `+Infinity` and `-Infinity` silently forced confidence to `0` and `1`. All three now produce the same confidence as an omitted amount:

```text
input              calibration   decision confidence   rationale
NaN                0.86          0.34                  review candidate at 0.34 confidence...
+Infinity          0.86          0.34                  review candidate at 0.34 confidence...
-Infinity          0.86          0.34                  review candidate at 0.34 confidence...
omitted amount     0.86          0.34                  review candidate at 0.34 confidence...
```

Finite amounts remain verbatim policy inputs. Tests cover positive values, negative values, and multiple accumulated effects.

## Verification

- RED exact-source probe on base `367a1fec7fa482c76afbe0de9bacf9ce4d14e5ed`: `NaN`, `0`, and `1` decision confidence; exit 1
- GREEN exact-source probe on this head: all three inputs match omitted baselines (`0.86` calibration, `0.34` decision); exit 0
- targeted committed suite: 1 file / 17 tests passed
- package lint check: 67 files checked, no fixes
- strict TypeScript: changed production module passed
- strict TypeScript: changed test and its transitive inbox modules passed with only broad runtime types isolated by the local harness
- committed diff check passed

The full package `tsc -p tsconfig.json` was attempted but is not claimed as a local pass: the deliberately disk-bounded harness does not install the monorepo dependency closure, so it reports missing unrelated core/UI/connector packages. Hosted CI owns that complete installed-workspace check.

## Evidence

| Evidence surface | Result |
| --- | --- |
| Domain output | Inline RED/GREEN confidence and rationale table above, manually reviewed on the exact source |
| UI screenshots / video | N/A - no rendered UI changes |
| Frontend / backend logs | N/A - pure deterministic domain function; exact runtime probe output is above |
| Live-model trajectory | N/A - no model, prompt, provider, or action behavior changed |
| Native / device capture | N/A - no native or device surface changed |

## Coordination

PR #28975 is semantically adjacent but changes a different test path and no production file. This PR intentionally leaves its file untouched. If #28975 lands afterward, its comments describing NaN reaching the comparator should be refreshed; the defensive comparator regression remains covered here.

<!-- evidence-head:ec79ee0db8fbcf04d511b25468728e7464b35df0 -->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->