### PR TITLE
fix(ui): unify Character family tabs

### DIFF
--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -69,6 +69,7 @@ const FRAMED_PAGE_SLUGS = new Set([
   "builtin-memories",
   "builtin-tasks",
   "builtin-vault",
+  "plugin-relationships-gui",
 ]);
 const FRAMED_PAGE_MAX_WIDTH_PX = 1024;
 const FRAMED_PAGE_GEOMETRY_TOLERANCE_PX = 2;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -477,18 +477,21 @@ function ViewSurfaceFrame({
   children,
   declaration,
   nav,
+  suppressHeader = false,
   title,
 }: {
   children: ReactNode;
   declaration: SurfaceManifestBearer | null | undefined;
   nav?: ReactNode;
+  suppressHeader?: boolean;
   title: string;
 }) {
   const manifest = resolveRoutedSurfaceManifest(declaration);
   if (manifest.layout.topology === "ambient") {
     return <>{children}</>;
   }
-  const showHeader = manifest.header === "normal" && nav === undefined;
+  const showHeader =
+    manifest.header === "normal" && nav === undefined && !suppressHeader;
   return (
     <AppWorkspaceContent
       nav={nav}
@@ -610,8 +613,10 @@ const APP_SHELL_VIEW_PROPS = {
 
 function RegisteredAppShellPage({
   registration,
+  viewProps,
 }: {
   registration: AppShellPageRegistration;
+  viewProps?: Record<string, unknown>;
 }) {
   const bridge = requireRegisteredAgentSurface(
     appShellAgentSurfaceDescriptor(registration),
@@ -619,13 +624,13 @@ function RegisteredAppShellPage({
   let content: ReactNode;
   if (registration.Component) {
     const Component = registration.Component;
-    content = <Component />;
+    content = <Component {...viewProps} />;
   } else if (registration.loader) {
     content = (
       <RetainedLazyComponent
         loader={registration.loader}
         cacheKey={registration.id}
-        componentProps={APP_SHELL_VIEW_PROPS}
+        componentProps={{ ...APP_SHELL_VIEW_PROPS, ...viewProps }}
         fallback={
           <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center text-sm text-muted">
             Loading {registration.label}…
@@ -1153,10 +1158,19 @@ function findRemoteViewForRoute(
   );
 }
 
-function renderRemoteView(view: ViewRegistryEntry, nav?: ReactNode): ReactNode {
+function renderRemoteView(
+  view: ViewRegistryEntry,
+  nav?: ReactNode,
+  viewProps?: Record<string, unknown>,
+): ReactNode {
   if (!view.bundleUrl && !view.frameUrl) return null;
   return (
-    <ViewSurfaceFrame declaration={view} nav={nav} title={view.label}>
+    <ViewSurfaceFrame
+      declaration={view}
+      nav={nav}
+      suppressHeader={Boolean(viewProps?.pageChrome)}
+      title={view.label}
+    >
       <DynamicViewLoader
         bundleUrl={view.bundleUrl}
         frameUrl={view.frameUrl}
@@ -1165,6 +1179,7 @@ function renderRemoteView(view: ViewRegistryEntry, nav?: ReactNode): ReactNode {
         viewType={view.viewType}
         reserveChatClearance={false}
         surface={view.surface}
+        viewProps={viewProps}
       />
     </ViewSurfaceFrame>
   );
@@ -1470,17 +1485,13 @@ function buildStaticTabRenderers(): Record<
       <ViewUnavailableFallback viewId="documents" pageLayout={pageLayout} />
     ),
     experience: ({ characterNav, pageLayout }) => (
-      <AppWorkspaceContent nav={characterNav} pageLayout={pageLayout}>
-        <LazyCharacterExperienceView />
+      <AppWorkspaceContent pageLayout={pageLayout} reserveChatClearance={false}>
+        <LazyCharacterExperienceView pageChrome={characterNav} />
       </AppWorkspaceContent>
     ),
     "character-skills": ({ characterNav, pageLayout }) => (
-      <AppWorkspaceContent
-        nav={characterNav}
-        pageLayout={pageLayout}
-        reserveChatClearance={false}
-      >
-        <LazyCharacterSkillsView />
+      <AppWorkspaceContent pageLayout={pageLayout} reserveChatClearance={false}>
+        <LazyCharacterSkillsView pageChrome={characterNav} />
       </AppWorkspaceContent>
     ),
     memories: wrapOverlayAware(<LazyMemoryViewerView />),
@@ -1644,6 +1655,17 @@ function renderViewRouterContent({
   const walletNav = isWalletSectionPath(navigationPath) ? (
     <WalletSectionNav activePath={navigationPath} />
   ) : undefined;
+  const characterFamilyPath = isCharacterSectionPath(navigationPath);
+  const characterRelationshipsTab =
+    resolveBuiltinTabId(tab) === "relationships";
+  const characterNav =
+    characterFamilyPath || characterRelationshipsTab ? (
+      <CharacterSectionNav
+        activePath={
+          characterFamilyPath ? navigationPath : "/apps/relationships"
+        }
+      />
+    ) : undefined;
   // Native-OS feature surfaces are plugin-owned. Prefer the plugin's bundled
   // registration when it is present; retain the legacy renderer only as a
   // compatibility fallback while older builds finish migrating their plugin.
@@ -1681,15 +1703,30 @@ function renderViewRouterContent({
     enabledKinds,
     managedCloudRuntime,
   );
-  const renderAppShellPage = (registration: AppShellPageRegistration) => (
-    <ViewSurfaceFrame
-      declaration={registration}
-      nav={walletNav}
-      title={registration.label}
-    >
-      <RegisteredAppShellPage registration={registration} />
-    </ViewSurfaceFrame>
-  );
+  const renderAppShellPage = (registration: AppShellPageRegistration) => {
+    const registrationCharacterNav =
+      characterNav ??
+      (registration.id === "relationships" ? (
+        <CharacterSectionNav activePath="/apps/relationships" />
+      ) : undefined);
+    return (
+      <ViewSurfaceFrame
+        declaration={registration}
+        nav={registrationCharacterNav ? undefined : walletNav}
+        suppressHeader={Boolean(registrationCharacterNav)}
+        title={registration.label}
+      >
+        <RegisteredAppShellPage
+          registration={registration}
+          viewProps={
+            registrationCharacterNav
+              ? { pageChrome: registrationCharacterNav }
+              : undefined
+          }
+        />
+      </ViewSurfaceFrame>
+    );
+  };
 
   if (
     visibleAppShellPage &&
@@ -1715,7 +1752,16 @@ function renderViewRouterContent({
     appSlug,
   );
   if (remoteView?.bundleUrl || remoteView?.frameUrl) {
-    return renderRemoteView(remoteView, walletNav);
+    const remoteCharacterNav =
+      characterNav ??
+      (remoteView.id === "relationships" ? (
+        <CharacterSectionNav activePath="/apps/relationships" />
+      ) : undefined);
+    return renderRemoteView(
+      remoteView,
+      remoteCharacterNav ? undefined : walletNav,
+      remoteCharacterNav ? { pageChrome: remoteCharacterNav } : undefined,
+    );
   }
   if (visibleAppShellPage) {
     return renderAppShellPage(visibleAppShellPage);
@@ -1741,13 +1787,6 @@ function renderViewRouterContent({
       </ViewSurfaceFrame>
     );
   }
-
-  // Character-family routes (Personality/Relationships/Skills/Experience) share
-  // one "Character" header + section strip in the same nav slot (#13591). Unlike
-  // Wallet, the members are a fixed host-owned set, so the strip is static.
-  const characterNav = isCharacterSectionPath(navigationPath) ? (
-    <CharacterSectionNav activePath={navigationPath} />
-  ) : undefined;
 
   return renderStaticViewRouterTab({
     tab,

--- a/packages/ui/src/components/character/CharacterExperienceView.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceView.tsx
@@ -2,7 +2,7 @@
  * Renders the character experience page for inspecting and editing agent
  * persona-facing fields.
  */
-import { useCallback, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { client } from "../../api/client";
 import type { ExperienceRecord } from "../../api/client-types";
 import { useFetchData } from "../../hooks/useFetchData";
@@ -14,11 +14,14 @@ import { mapExperienceRecordToHubRecord } from "./character-hub-helpers";
 /**
  * The Experience section of the Character family (#13591): the agent's learned
  * experiences, editable/deletable. Owns just the experiences fetch (not the
- * hub's other reads), so opening it never pulls data it doesn't render. Renders
- * a headerless body — the shared `CharacterSectionNav` supplies the "Character"
- * header + section strip in the shell nav slot.
+ * hub's other reads), so opening it never pulls data it doesn't render. The
+ * host supplies Character-family chrome as part of this view's framed page.
  */
-export function CharacterExperienceView() {
+export function CharacterExperienceView({
+  pageChrome,
+}: {
+  pageChrome?: ReactNode;
+}) {
   const fetchState = useFetchData<ExperienceRecord[]>(async () => {
     const response = await client.listExperiences({ limit: 100 });
     return response.experiences;
@@ -99,7 +102,11 @@ export function CharacterExperienceView() {
   return (
     <ShellViewAgentSurface viewId="experience">
       <FramedPage>
-        <FramedPageBody className="gap-4 pt-1">
+        {pageChrome}
+        <FramedPageBody
+          padded={false}
+          className="gap-4 pt-1 [@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
+        >
           {error ? (
             <div className="rounded-sm border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
               {error}

--- a/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
@@ -869,7 +869,7 @@ export function CharacterExperienceWorkspace({
           </div>
         </div>
 
-        <div className="mt-4 grid gap-3 md:grid-cols-4">
+        <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 lg:grid-cols-4">
           <StatTile
             label="Captured"
             value={String(stats.total)}

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -230,7 +230,7 @@ export function CharacterHubView({
       <FramedPageBody
         scroll="page"
         padded={false}
-        className="sm:px-6 lg:px-8"
+        className="[@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
         data-testid="character-editor-view"
       >
         <div className="flex min-w-0 flex-col pt-1">

--- a/packages/ui/src/components/character/CharacterSectionNav.tsx
+++ b/packages/ui/src/components/character/CharacterSectionNav.tsx
@@ -44,7 +44,7 @@ const CHARACTER_SECTION_TABS: readonly SectionTab[] = [
     id: "relationships",
     label: "Relationships",
     path: "/apps/relationships",
-    aliases: ["/character/relationships"],
+    aliases: ["/character/relationships", "/relationships"],
   },
   { id: "character-skills", label: "Skills", path: "/character/skills" },
   { id: "experience", label: "Experience", path: "/character/experience" },
@@ -83,7 +83,10 @@ export function CharacterSectionNav({
   return (
     <>
       <FramedPageHeader title="Character" />
-      <FramedPageNavigation padded={false} className="sm:px-6 lg:px-8">
+      <FramedPageNavigation
+        padded={false}
+        className="overflow-x-auto [@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
+      >
         <SectionTabStrip
           entries={CHARACTER_SECTION_TABS}
           activeId={activeCharacterTabId(activePath)}

--- a/packages/ui/src/components/character/CharacterSkillsView.tsx
+++ b/packages/ui/src/components/character/CharacterSkillsView.tsx
@@ -1,20 +1,28 @@
 /**
  * The Skills section of the Character family (#13591): the agent's learned/
  * curated skills, distinct from developer-managed Agent Skills (the developer
- * "Skills" tool at /apps/skills). Renders a headerless body — the shared
- * `CharacterSectionNav` supplies the "Character" header + section strip in the
- * shell nav slot, so this view never renders its own top bar.
+ * "Skills" tool at /apps/skills). The host supplies Character-family chrome as
+ * part of this view's framed page, so this view never renders a second top bar.
  */
 
+import type { ReactNode } from "react";
 import { FramedPage, FramedPageBody } from "../../layouts/framed-page";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { CharacterLearnedSkillsSection } from "./CharacterLearnedSkillsSection";
 
-export function CharacterSkillsView() {
+export function CharacterSkillsView({
+  pageChrome,
+}: {
+  pageChrome?: ReactNode;
+}) {
   return (
     <ShellViewAgentSurface viewId="character-skills">
       <FramedPage>
-        <FramedPageBody className="gap-4 pt-1">
+        {pageChrome}
+        <FramedPageBody
+          padded={false}
+          className="gap-4 pt-1 [@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
+        >
           <CharacterLearnedSkillsSection showTitle={false} />
         </FramedPageBody>
       </FramedPage>

--- a/packages/ui/src/layouts/framed-page/framed-page.tsx
+++ b/packages/ui/src/layouts/framed-page/framed-page.tsx
@@ -87,7 +87,7 @@ export function FramedPageNavigation({
   return (
     <div
       className={cn(
-        "mx-auto w-full max-w-5xl shrink-0 pb-2",
+        "mx-auto w-full max-w-5xl min-w-0 shrink-0 pb-2",
         padded && "px-4 sm:px-6 lg:px-8",
         className,
       )}

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsPage.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsPage.tsx
@@ -1,20 +1,27 @@
 /**
- * Composes the plugin-owned Relationships view with the shared shell navigation
- * primitive. The plugin owns its route chrome; the app shell only mounts the
- * registered plugin surface.
+ * Exposes the plugin-owned Relationships body to its registered app-shell
+ * surface. The host owns Character-family page chrome so local and remote
+ * renderers share one header and tab contract.
  */
 
-import { ViewHeader } from "@elizaos/ui/components";
-import type { JSX } from "react";
+import { FramedPage, FramedPageBody } from "@elizaos/ui/layouts";
+import type { JSX, ReactNode } from "react";
 import { RelationshipsView } from "./RelationshipsView.tsx";
 
-export function RelationshipsPage(): JSX.Element {
+export function RelationshipsPage({
+  pageChrome,
+}: {
+  pageChrome?: ReactNode;
+}): JSX.Element {
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-      <ViewHeader title="Relationships" />
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+    <FramedPage reserveComposer={false}>
+      {pageChrome}
+      <FramedPageBody
+        padded={false}
+        className="[@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
+      >
         <RelationshipsView />
-      </div>
-    </div>
+      </FramedPageBody>
+    </FramedPage>
   );
 }

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
@@ -1,32 +1,28 @@
 /**
  * RelationshipsSpatialView — the entity / relationship knowledge-graph viewer
- * authored once with the spatial vocabulary, so it renders correctly wherever it
- * is displayed:
- *
- *   - GUI today through `<SpatialSurface>` (DOM).
- *   - Future adapters can reuse the same snapshot contract behind the retained modality types.
- *
- * It is purely presentational (a snapshot + an action callback in, primitives
- * out) and imports only the cross-modality primitives, so it is safe to render
- * without pulling browser-only runtime imports into the presentational layer.
+ * projected into the canonical web component vocabulary used by the Character
+ * family. It is purely presentational: a snapshot and action callback enter;
+ * accessible filters and entity rows leave.
  *
  * The two graph payloads (entities + their outbound edges) are joined and
  * projected to {@link EntityNode}s in the data wrapper ({@link ./RelationshipsView.tsx});
  * this component never fetches or computes the graph — it displays the snapshot
  * and dispatches actions. The entity-kind filter is the one piece of interactive
- * state it owns locally (via {@link useSpatialState}); filtering the already-built
- * node list is presentation-only and works on every surface.
+ * state it owns locally; filtering the already-built node list is
+ * presentation-only.
  */
 
 import {
   Button,
   Card,
-  HStack,
-  List,
-  Text,
-  useSpatialState,
-  VStack,
-} from "@elizaos/ui/spatial";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@elizaos/ui";
+import { useState } from "react";
 
 /** A typed edge shown under its source entity, already projected for display. */
 export interface RelationshipEdge {
@@ -96,11 +92,11 @@ export function RelationshipsSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={1} padding={1} shrink={0} width="100%">
+    <Card variant="transparentSquare" className="w-full min-w-0">
       {snapshot.state === "loading" ? (
-        <Text tone="muted" align="center" style="caption">
+        <div className="py-8 text-center text-sm text-muted">
           Loading relationships
-        </Text>
+        </div>
       ) : snapshot.state === "error" ? (
         <RelationshipsErrorBody snapshot={snapshot} dispatch={dispatch} />
       ) : snapshot.state === "empty" ? (
@@ -121,15 +117,20 @@ function RelationshipsErrorBody({
 }) {
   return (
     <>
-      <Text bold>Could not load relationships</Text>
-      <Text tone="danger" style="caption">
+      <h2 className="text-sm font-semibold text-txt">
+        Could not load relationships
+      </h2>
+      <p className="mt-1 text-sm text-danger">
         {snapshot.error ?? "Could not load relationships."}
-      </Text>
-      <HStack gap={1}>
-        <Button agent="retry" onPress={dispatch("retry")}>
-          Retry
-        </Button>
-      </HStack>
+      </p>
+      <Button
+        className="mt-3"
+        size="sm"
+        data-agent-id="retry"
+        onClick={dispatch("retry")}
+      >
+        Retry
+      </Button>
     </>
   );
 }
@@ -140,14 +141,20 @@ function RelationshipsEmptyBody({
   dispatch: (action: string) => () => void;
 }) {
   return (
-    <>
-      <Text bold>None</Text>
-      <HStack gap={1}>
-        <Button agent="add" onPress={dispatch("add")}>
-          Add someone
-        </Button>
-      </HStack>
-    </>
+    <div className="py-8 text-center">
+      <h2 className="text-sm font-semibold text-txt">No relationships yet</h2>
+      <p className="mt-1 text-sm text-muted">
+        Add a person to start building the relationship graph.
+      </p>
+      <Button
+        className="mt-3"
+        size="sm"
+        data-agent-id="add"
+        onClick={dispatch("add")}
+      >
+        Add someone
+      </Button>
+    </div>
   );
 }
 
@@ -161,7 +168,7 @@ function RelationshipsReadyBody({
   // The active kind filter is the one piece of interactive local state. Empty
   // string = "all kinds". A single selection keeps the chips and the rendered
   // cards in agreement on every surface.
-  const [activeKind, setActiveKind] = useSpatialState<string>("");
+  const [activeKind, setActiveKind] = useState("");
 
   const visible =
     activeKind === ""
@@ -177,19 +184,19 @@ function RelationshipsReadyBody({
           onSelect={setActiveKind}
         />
       ) : null}
-      <Text style="caption" tone="muted">
-        Graph ({visible.length})
-      </Text>
+      <div className="mt-4 text-xs font-medium text-muted">
+        {visible.length} {visible.length === 1 ? "entity" : "entities"}
+      </div>
       {visible.length === 0 ? (
-        <Text tone="muted" style="caption">
-          None
-        </Text>
+        <div className="py-8 text-sm text-muted">
+          No matching relationships.
+        </div>
       ) : (
-        <List gap={1}>
+        <div className="mt-2 divide-y divide-border/45 border-y border-border/45">
           {visible.map((node) => (
             <EntityNodeBlock key={node.id} node={node} onAction={onAction} />
           ))}
-        </List>
+        </div>
       )}
     </>
   );
@@ -204,26 +211,54 @@ function KindFilters({
   active: string;
   onSelect: (kind: string) => void;
 }) {
+  const allKindsValue = "__all__";
+  const selectedLabel =
+    filters.find((filter) => filter.kind === active)?.label ?? "All";
+
   return (
-    <HStack gap={1} wrap align="center">
-      <Button
-        agent="relationships-kind-all"
-        variant={active === "" ? "solid" : "ghost"}
-        onPress={() => onSelect("")}
-      >
-        All
-      </Button>
-      {filters.map((filter) => (
-        <Button
-          key={filter.kind}
-          agent={`relationships-kind-${filter.kind}`}
-          variant={active === filter.kind ? "solid" : "ghost"}
-          onPress={() => onSelect(active === filter.kind ? "" : filter.kind)}
-        >
-          {filter.label}
-        </Button>
-      ))}
-    </HStack>
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <span className="text-sm text-muted">Type</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            size="dense"
+            variant="ghostMuted"
+            className="min-w-32 justify-between"
+            data-agent-id="relationships-kind-filter"
+            aria-label={`Filter relationship type, ${selectedLabel} selected`}
+          >
+            <span>{selectedLabel}</span>
+            <span aria-hidden="true">▾</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-48">
+          <DropdownMenuLabel>Filter by type</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={active || allKindsValue}
+            onValueChange={(value) =>
+              onSelect(value === allKindsValue ? "" : value)
+            }
+          >
+            <DropdownMenuRadioItem
+              value={allKindsValue}
+              data-agent-id="relationships-kind-all"
+            >
+              All
+            </DropdownMenuRadioItem>
+            {filters.map((filter) => (
+              <DropdownMenuRadioItem
+                key={filter.kind}
+                value={filter.kind}
+                data-agent-id={`relationships-kind-${filter.kind}`}
+              >
+                {filter.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
@@ -235,43 +270,45 @@ function EntityNodeBlock({
   onAction?: (action: string) => void;
 }) {
   return (
-    <VStack gap={0} agent={`rel-${node.id}`}>
-      <HStack gap={1} align="center">
-        <VStack gap={0} grow={1}>
-          <Text bold wrap={false}>
+    <div className="min-w-0 py-3" data-agent-id={`rel-${node.id}`}>
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold text-txt">
             {node.name}
-          </Text>
-        </VStack>
-        <Text style="caption" tone="primary" wrap={false}>
-          {node.kindLabel}
-        </Text>
+          </div>
+          {node.identityLine ? (
+            <div className="mt-0.5 truncate text-xs text-muted">
+              {node.identityLine}
+            </div>
+          ) : null}
+        </div>
+        <span className="shrink-0 text-xs text-muted">{node.kindLabel}</span>
         <Button
-          agent={`open-${node.id}`}
-          onPress={() => onAction?.(`open:${node.id}`)}
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`Open ${node.name}`}
+          data-agent-id={`open-${node.id}`}
+          onClick={() => onAction?.(`open:${node.id}`)}
         >
           ›
         </Button>
-      </HStack>
-      {node.identityLine ? (
-        <Text style="caption" tone="muted" wrap={false}>
-          {node.identityLine}
-        </Text>
-      ) : null}
+      </div>
       {node.edges.length > 0
         ? node.edges.map((edge) => (
-            <HStack key={edge.id} gap={1} align="center">
-              <Text tone="muted" wrap={false}>
-                ›
-              </Text>
-              <VStack gap={0} grow={1}>
-                <Text wrap={false}>{edge.toName}</Text>
-              </VStack>
-              <Text style="caption" tone="muted" wrap={false}>
-                {edge.meta}
-              </Text>
-            </HStack>
+            <div
+              key={edge.id}
+              className="mt-2 grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-2 pl-1 text-xs"
+            >
+              <span aria-hidden="true" className="text-muted">
+                ↳
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-muted-strong">{edge.toName}</div>
+                <div className="truncate text-muted">{edge.meta}</div>
+              </div>
+            </div>
           ))
         : null}
-    </VStack>
+    </div>
   );
 }

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
@@ -188,7 +188,7 @@ describe("RelationshipsView — states", () => {
         })}
       />,
     );
-    await screen.findByText("None");
+    await screen.findByRole("heading", { name: "No relationships yet" });
     expect(screen.queryByText("Pat Doe")).toBeNull();
   });
 
@@ -201,7 +201,7 @@ describe("RelationshipsView — states", () => {
         })}
       />,
     );
-    await screen.findByText("None");
+    await screen.findByRole("heading", { name: "No relationships yet" });
     fireEvent.click(agent("add"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
@@ -251,7 +251,7 @@ describe("RelationshipsView — states", () => {
 });
 
 describe("RelationshipsView — filtering + freshness", () => {
-  it("narrows the visible entity nodes when a kind filter chip is toggled", async () => {
+  it("narrows the visible entity nodes when a type menu option is selected", async () => {
     render(
       <RelationshipsView
         fetchers={makeFetchers({
@@ -275,8 +275,14 @@ describe("RelationshipsView — filtering + freshness", () => {
     await screen.findByText("Pat Doe");
     expect(screen.getByText("Acme Corp")).toBeTruthy();
 
-    // Toggle the Organizations filter: only the org node should remain.
-    fireEvent.click(agent("relationships-kind-organization"));
+    // Select Organizations from the type menu: only the org node should remain.
+    fireEvent.pointerDown(agent("relationships-kind-filter"), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "Organizations" }),
+    );
     await waitFor(() => expect(screen.queryByText("Pat Doe")).toBeNull());
     expect(screen.getByText("Acme Corp")).toBeTruthy();
   });


### PR DESCRIPTION
Closes #29526

## Summary

- Give Personality, Relationships, Skills, and Experience one Character header and section-tab contract.
- Replace the Relationships spatial-control presentation with canonical web atoms and compact entity rows.
- Present relationship type as a single-choice `Type / All` menu instead of a second tab or chip layer.
- Remove duplicate Relationships chrome and double floating-composer clearance.
- Use a two-column Experience metrics grid on narrow screens while retaining four columns on desktop.
- Add Relationships to the canonical framed-page visual audit.

## Verification

- `packages/ui` typecheck passed.
- Focused UI Vitest: 52/52 passed.
- Relationships Vitest: 15/15 passed, including opening the type menu and filtering by Organizations.
- Design-system tight baseline passed.
- Molecular inventory and design-contract graph passed with zero findings and zero debt.
- Character-family visual audit: 16/16 viewports passed, zero broken, zero needs-work.
- Exact final Relationships menu audit: 4/4 viewports passed, all `good`.
- Packaged OCR: final Relationships menu 4/4 verified, zero broken, zero needs-eyeball.

The single `needs-eyeball` result in the broader 16-view run is the existing mobile touch-viewport hover probe for Personality's offscreen Add Post control; it has no render-state, geometry, overflow, token, or semantic failure.

## Visual comparison

### Relationships — mobile

| Before | After |
| --- | --- |
| ![Relationships mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-before-relationships-mobile.png) | ![Relationships mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-after-relationships-mobile-menu.png) |

### Relationships — desktop

| Before | After |
| --- | --- |
| ![Relationships desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-before-relationships-desktop.png) | ![Relationships desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-after-relationships-desktop-menu.png) |

### Experience metrics — mobile portrait

| Before | After |
| --- | --- |
| ![Experience mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-before-experience-mobile.png) | ![Experience mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-after-experience-mobile.png) |

### Experience metrics — mobile landscape

| Before | After |
| --- | --- |
| ![Experience landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-before-experience-landscape.png) | ![Experience landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-after-experience-landscape.png) |

## Evidence

Evidence artifacts correspond to the exact pushed head.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-before-relationships-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-after-relationships-mobile-menu.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-character-family-menu-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - UI-only layout and presentation change; no backend behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] [29528-character-family-frontend-audit-v3.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-character-family-frontend-audit-v3.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, protocol, native, or model-domain artifact changed.

<!-- evidence-row:ocr-review -->
- [x] [29528-relationship-menu-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29528-relationship-menu-ocr-triage.json)

<!-- evidence-head:ec8858eeb00bbc4492f3fe55f5d47222e64329cf -->
