### PR TITLE
test(app): bound Cloud runtime-choice proof action

### DIFF
--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -168,6 +168,7 @@ describe("forbidden Cloud agent mutations", () => {
       "https://api.test/api/v1/eliza/agents/private/api/conversations/private/messages";
     audit.observeRequest("GET", history);
     audit.observeResponse("GET", history, 200);
+    audit.observeRequest("GET", "/api/v1/eliza/personal");
     audit.observeResponse("GET", "/api/v1/eliza/personal", 200);
     const firstLogicalTurn = JSON.stringify({
       text: "private prompt",
@@ -205,7 +206,13 @@ describe("forbidden Cloud agent mutations", () => {
       clientErrorChatSendResponseCount: 1,
       serverErrorChatSendResponseCount: 1,
       otherChatSendResponseCount: 1,
+      personalIdentityGetRequestCount: 1,
       successfulPersonalIdentityGetCount: 1,
+      clientErrorPersonalIdentityGetResponseCount: 0,
+      serverErrorPersonalIdentityGetResponseCount: 0,
+      otherPersonalIdentityGetResponseCount: 0,
+      failedPersonalIdentityGetRequestCount: 0,
+      pendingPersonalIdentityGetRequestCount: 0,
       historyGetRequestCount: 1,
       successfulHistoryGetCount: 1,
       clientErrorHistoryGetResponseCount: 0,
@@ -222,6 +229,30 @@ describe("forbidden Cloud agent mutations", () => {
     expect(JSON.stringify(snapshot)).not.toMatch(
       /api\.test|private|idempotency|prompt/,
     );
+  });
+
+  it("reduces pre-identity request outcomes to closed counters", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const personal = "https://api.test/api/v1/eliza/personal";
+    for (const status of [200, 404, 503, 302]) {
+      audit.observeRequest("GET", personal);
+      audit.observeResponse("GET", personal, status);
+    }
+    audit.observeRequest("GET", personal);
+    audit.observeRequestFailure("GET", personal, "private timeout detail");
+    audit.observeRequest("GET", personal);
+
+    const snapshot = await audit.snapshot();
+    expect(snapshot).toMatchObject({
+      personalIdentityGetRequestCount: 6,
+      successfulPersonalIdentityGetCount: 1,
+      clientErrorPersonalIdentityGetResponseCount: 1,
+      serverErrorPersonalIdentityGetResponseCount: 1,
+      otherPersonalIdentityGetResponseCount: 1,
+      failedPersonalIdentityGetRequestCount: 1,
+      pendingPersonalIdentityGetRequestCount: 1,
+    });
+    expect(JSON.stringify(snapshot)).not.toMatch(/api\.test|private|timeout/);
   });
 
   it("reduces timed-out history proof traffic to privacy-safe counters", async () => {

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -60,7 +60,13 @@ export interface CloudLiveNetworkAuditSnapshot {
   clientErrorChatSendResponseCount: number;
   serverErrorChatSendResponseCount: number;
   otherChatSendResponseCount: number;
+  personalIdentityGetRequestCount: number;
   successfulPersonalIdentityGetCount: number;
+  clientErrorPersonalIdentityGetResponseCount: number;
+  serverErrorPersonalIdentityGetResponseCount: number;
+  otherPersonalIdentityGetResponseCount: number;
+  failedPersonalIdentityGetRequestCount: number;
+  pendingPersonalIdentityGetRequestCount: number;
   historyGetRequestCount: number;
   successfulHistoryGetCount: number;
   clientErrorHistoryGetResponseCount: number;
@@ -702,7 +708,12 @@ export function createCloudLiveNetworkAudit(): {
   let clientErrorChatSendResponseCount = 0;
   let serverErrorChatSendResponseCount = 0;
   let otherChatSendResponseCount = 0;
+  let personalIdentityGetRequestCount = 0;
   let successfulPersonalIdentityGetCount = 0;
+  let clientErrorPersonalIdentityGetResponseCount = 0;
+  let serverErrorPersonalIdentityGetResponseCount = 0;
+  let otherPersonalIdentityGetResponseCount = 0;
+  let failedPersonalIdentityGetRequestCount = 0;
   let historyGetRequestCount = 0;
   let successfulHistoryGetCount = 0;
   let clientErrorHistoryGetResponseCount = 0;
@@ -755,6 +766,9 @@ export function createCloudLiveNetworkAudit(): {
         } else unidentifiedChatSendAttemptCount += 1;
       }
       if (isHistoryGet(method, rawUrl)) historyGetRequestCount += 1;
+      if (isPersonalIdentityGet(method, rawUrl)) {
+        personalIdentityGetRequestCount += 1;
+      }
     },
     observeResponse(method, rawUrl, status, responseBody) {
       const chatScope = chatSendScope(method, rawUrl);
@@ -806,15 +820,22 @@ export function createCloudLiveNetworkAudit(): {
           otherHistoryGetResponseCount += 1;
         }
       }
-      if (
-        status >= 200 &&
-        status < 300 &&
-        isPersonalIdentityGet(method, rawUrl)
-      ) {
-        successfulPersonalIdentityGetCount += 1;
+      if (isPersonalIdentityGet(method, rawUrl)) {
+        if (status >= 200 && status < 300) {
+          successfulPersonalIdentityGetCount += 1;
+        } else if (status >= 400 && status < 500) {
+          clientErrorPersonalIdentityGetResponseCount += 1;
+        } else if (status >= 500 && status < 600) {
+          serverErrorPersonalIdentityGetResponseCount += 1;
+        } else {
+          otherPersonalIdentityGetResponseCount += 1;
+        }
       }
     },
     observeRequestFailure(method, rawUrl, errorText = "") {
+      if (isPersonalIdentityGet(method, rawUrl)) {
+        failedPersonalIdentityGetRequestCount += 1;
+      }
       if (!isHistoryGet(method, rawUrl)) return;
       failedHistoryGetRequestCount += 1;
       if (/tim(?:e|ed)[ _-]?out/i.test(errorText)) {
@@ -832,6 +853,12 @@ export function createCloudLiveNetworkAudit(): {
         serverErrorHistoryGetResponseCount +
         otherHistoryGetResponseCount +
         failedHistoryGetRequestCount;
+      const terminalPersonalIdentityGetCount =
+        successfulPersonalIdentityGetCount +
+        clientErrorPersonalIdentityGetResponseCount +
+        serverErrorPersonalIdentityGetResponseCount +
+        otherPersonalIdentityGetResponseCount +
+        failedPersonalIdentityGetRequestCount;
       return {
         forbiddenAgentMutationCount,
         chatSendAttemptCount,
@@ -842,7 +869,16 @@ export function createCloudLiveNetworkAudit(): {
         clientErrorChatSendResponseCount,
         serverErrorChatSendResponseCount,
         otherChatSendResponseCount,
+        personalIdentityGetRequestCount,
         successfulPersonalIdentityGetCount,
+        clientErrorPersonalIdentityGetResponseCount,
+        serverErrorPersonalIdentityGetResponseCount,
+        otherPersonalIdentityGetResponseCount,
+        failedPersonalIdentityGetRequestCount,
+        pendingPersonalIdentityGetRequestCount: Math.max(
+          0,
+          personalIdentityGetRequestCount - terminalPersonalIdentityGetCount,
+        ),
         historyGetRequestCount,
         successfulHistoryGetCount,
         clientErrorHistoryGetResponseCount,

--- a/packages/app/test/cloud-live-optional-action.ts
+++ b/packages/app/test/cloud-live-optional-action.ts
@@ -1,0 +1,74 @@
+/** Bounds optional Cloud onboarding actions without retaining DOM or account data. */
+
+import type { Locator } from "@playwright/test";
+
+export type CloudLiveOptionalActionPhase =
+  | "pre-identity-runtime-choice"
+  | "pre-identity-oauth-choice"
+  | "post-identity-tutorial-skip";
+
+export type CloudLiveOptionalActionName =
+  | "runtime-cloud"
+  | "oauth-start"
+  | "tutorial-skip";
+
+export class CloudLiveOptionalActionDeadlineError extends Error {
+  readonly code = "CLOUD_LIVE_OPTIONAL_ACTION_DEADLINE";
+
+  constructor(
+    readonly phase: CloudLiveOptionalActionPhase,
+    readonly action: CloudLiveOptionalActionName,
+  ) {
+    super(`[cloud-live] ${phase} action deadline exceeded`);
+    this.name = "CloudLiveOptionalActionDeadlineError";
+  }
+}
+
+interface ClickCloudLiveOptionalActionOptions {
+  phase: CloudLiveOptionalActionPhase;
+  action: CloudLiveOptionalActionName;
+  offerTimeoutMs: number;
+  actionTimeoutMs: number;
+}
+
+/**
+ * Resolve the locator again while Playwright retries a detached/replaced node,
+ * but never inherit the enclosing trajectory's multi-minute timeout. Absence is
+ * an expected optional state; a continuously unstable offered action is a
+ * closed, typed failure with no selector, text, URL, or DOM content attached.
+ */
+export async function clickCloudLiveOptionalAction(
+  locator: Locator,
+  options: ClickCloudLiveOptionalActionOptions,
+): Promise<boolean> {
+  const target = locator.first();
+  const offered = await target
+    .waitFor({ state: "visible", timeout: options.offerTimeoutMs })
+    .then(
+      () => true,
+      // error-policy:J4 absence is the one expected optional-action failure.
+      // Strict selector and browser failures remain fatal.
+      (error: unknown) => {
+        if (error instanceof Error && error.name === "TimeoutError") {
+          return false;
+        }
+        throw error;
+      },
+    );
+  if (!offered) return false;
+
+  try {
+    await target.click({ timeout: options.actionTimeoutMs });
+  } catch (error) {
+    // error-policy:J3 Playwright's timeout may contain private DOM/selector
+    // context. Replace it with the closed phase/action classification only.
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new CloudLiveOptionalActionDeadlineError(
+        options.phase,
+        options.action,
+      );
+    }
+    throw error;
+  }
+  return true;
+}

--- a/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
@@ -41,6 +41,71 @@ describe("Cloud live trajectory diagnostic", () => {
     ).toThrow("trajectory elapsed time must be non-negative");
   });
 
+  it("records only closed pre-identity action and request counters", () => {
+    const diagnostic = createCloudLiveTrajectoryDiagnostic(
+      "pre-identity-runtime-choice",
+      456,
+      {
+        runtimeCloudActionAttemptCount: 1,
+        runtimeCloudActionSuccessCount: 0,
+        runtimeCloudActionTimeoutCount: 1,
+        personalIdentityGetRequestCount: 0,
+        successfulPersonalIdentityGetResponseCount: 0,
+        clientErrorPersonalIdentityGetResponseCount: 0,
+        serverErrorPersonalIdentityGetResponseCount: 0,
+        otherPersonalIdentityGetResponseCount: 0,
+        failedPersonalIdentityGetRequestCount: 0,
+        pendingPersonalIdentityGetRequestCount: 0,
+        token: "private-token",
+        selector: "private-selector",
+      } as Parameters<typeof createCloudLiveTrajectoryDiagnostic>[2],
+    );
+
+    expect(diagnostic).toEqual({
+      schema: CLOUD_LIVE_TRAJECTORY_DIAGNOSTIC_SCHEMA,
+      phase: "pre-identity-runtime-choice",
+      elapsedMs: 456,
+      preIdentity: {
+        runtimeCloudActionAttemptCount: 1,
+        runtimeCloudActionSuccessCount: 0,
+        runtimeCloudActionTimeoutCount: 1,
+        personalIdentityGetRequestCount: 0,
+        successfulPersonalIdentityGetResponseCount: 0,
+        clientErrorPersonalIdentityGetResponseCount: 0,
+        serverErrorPersonalIdentityGetResponseCount: 0,
+        otherPersonalIdentityGetResponseCount: 0,
+        failedPersonalIdentityGetRequestCount: 0,
+        pendingPersonalIdentityGetRequestCount: 0,
+      },
+    });
+    expect(JSON.stringify(diagnostic)).not.toMatch(
+      /selector|locator|https?:|token|transcript/i,
+    );
+  });
+
+  it("rejects invalid pre-identity counters", () => {
+    const counters = {
+      runtimeCloudActionAttemptCount: 1,
+      runtimeCloudActionSuccessCount: 0,
+      runtimeCloudActionTimeoutCount: 0,
+      personalIdentityGetRequestCount: 0,
+      successfulPersonalIdentityGetResponseCount: 0,
+      clientErrorPersonalIdentityGetResponseCount: 0,
+      serverErrorPersonalIdentityGetResponseCount: 0,
+      otherPersonalIdentityGetResponseCount: 0,
+      failedPersonalIdentityGetRequestCount: 0,
+      pendingPersonalIdentityGetRequestCount: -1,
+    };
+
+    expect(() =>
+      createCloudLiveTrajectoryDiagnostic(
+        "pre-identity-runtime-choice",
+        456,
+        counters,
+      ),
+    ).toThrow("pre-identity counters must be non-negative integers");
+  });
+
   it("overwrites one private receipt with restrictive permissions", async () => {
     const mkdirFn = vi.fn(async () => undefined);
     let written = "";

--- a/packages/app/test/cloud-live-trajectory-diagnostic.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.ts
@@ -10,6 +10,7 @@ export const CLOUD_LIVE_TRAJECTORY_DIAGNOSTIC_SCHEMA =
 
 export const CLOUD_LIVE_TRAJECTORY_PHASES = [
   "protected-cloud-boot",
+  "pre-identity-runtime-choice",
   "personal-identity",
   "live-chat",
   "post-reload-navigation",
@@ -28,12 +29,40 @@ export interface CloudLiveTrajectoryDiagnostic {
   schema: typeof CLOUD_LIVE_TRAJECTORY_DIAGNOSTIC_SCHEMA;
   phase: CloudLiveTrajectoryPhase;
   elapsedMs: number;
+  preIdentity?: CloudLivePreIdentityDiagnostic;
 }
+
+export interface CloudLivePreIdentityDiagnostic {
+  runtimeCloudActionAttemptCount: number;
+  runtimeCloudActionSuccessCount: number;
+  runtimeCloudActionTimeoutCount: number;
+  personalIdentityGetRequestCount: number;
+  successfulPersonalIdentityGetResponseCount: number;
+  clientErrorPersonalIdentityGetResponseCount: number;
+  serverErrorPersonalIdentityGetResponseCount: number;
+  otherPersonalIdentityGetResponseCount: number;
+  failedPersonalIdentityGetRequestCount: number;
+  pendingPersonalIdentityGetRequestCount: number;
+}
+
+const CLOUD_LIVE_PRE_IDENTITY_DIAGNOSTIC_KEYS = [
+  "runtimeCloudActionAttemptCount",
+  "runtimeCloudActionSuccessCount",
+  "runtimeCloudActionTimeoutCount",
+  "personalIdentityGetRequestCount",
+  "successfulPersonalIdentityGetResponseCount",
+  "clientErrorPersonalIdentityGetResponseCount",
+  "serverErrorPersonalIdentityGetResponseCount",
+  "otherPersonalIdentityGetResponseCount",
+  "failedPersonalIdentityGetRequestCount",
+  "pendingPersonalIdentityGetRequestCount",
+] as const satisfies readonly (keyof CloudLivePreIdentityDiagnostic)[];
 
 interface WriteCloudLiveTrajectoryDiagnosticOptions {
   diagnosticPath: string;
   phase: CloudLiveTrajectoryPhase;
   elapsedMs: number;
+  preIdentity?: CloudLivePreIdentityDiagnostic;
   mkdirFn?: typeof mkdir;
   writeFileFn?: typeof writeFile;
 }
@@ -41,6 +70,7 @@ interface WriteCloudLiveTrajectoryDiagnosticOptions {
 export function createCloudLiveTrajectoryDiagnostic(
   phase: CloudLiveTrajectoryPhase,
   elapsedMs: number,
+  preIdentity?: CloudLivePreIdentityDiagnostic,
 ): CloudLiveTrajectoryDiagnostic {
   if (!CLOUD_LIVE_TRAJECTORY_PHASES.includes(phase)) {
     throw new Error("[cloud-live] unsupported trajectory phase");
@@ -50,11 +80,25 @@ export function createCloudLiveTrajectoryDiagnostic(
       "[cloud-live] trajectory elapsed time must be non-negative",
     );
   }
-  return {
+  const diagnostic: CloudLiveTrajectoryDiagnostic = {
     schema: CLOUD_LIVE_TRAJECTORY_DIAGNOSTIC_SCHEMA,
     phase,
     elapsedMs,
   };
+  if (preIdentity) {
+    const closedCounters = {} as CloudLivePreIdentityDiagnostic;
+    for (const key of CLOUD_LIVE_PRE_IDENTITY_DIAGNOSTIC_KEYS) {
+      const value = preIdentity[key];
+      if (!Number.isSafeInteger(value) || value < 0) {
+        throw new Error(
+          "[cloud-live] pre-identity counters must be non-negative integers",
+        );
+      }
+      closedCounters[key] = value;
+    }
+    diagnostic.preIdentity = closedCounters;
+  }
+  return diagnostic;
 }
 
 /**
@@ -66,10 +110,15 @@ export async function writeCloudLiveTrajectoryDiagnostic({
   diagnosticPath,
   phase,
   elapsedMs,
+  preIdentity,
   mkdirFn = mkdir,
   writeFileFn = writeFile,
 }: WriteCloudLiveTrajectoryDiagnosticOptions): Promise<void> {
-  const diagnostic = createCloudLiveTrajectoryDiagnostic(phase, elapsedMs);
+  const diagnostic = createCloudLiveTrajectoryDiagnostic(
+    phase,
+    elapsedMs,
+    preIdentity,
+  );
   await mkdirFn(dirname(diagnosticPath), { recursive: true, mode: 0o700 });
   await writeFileFn(
     diagnosticPath,

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -1,0 +1,89 @@
+/** Real-browser regression coverage for bounded optional Cloud actions. */
+
+import { expect, test } from "@playwright/test";
+import {
+  CloudLiveOptionalActionDeadlineError,
+  clickCloudLiveOptionalAction,
+} from "../cloud-live-optional-action";
+
+test.describe("Cloud live optional action boundary", () => {
+  test.use({ serviceWorkers: "block" });
+
+  test("clicks a stable offered action", async ({ page }) => {
+    await page.setContent(`
+      <button data-testid="runtime-cloud">Sign in</button>
+      <output data-testid="click-count">0</output>
+      <script>
+        document.addEventListener("click", (event) => {
+          if (!(event.target instanceof HTMLElement)) return;
+          if (event.target.dataset.testid !== "runtime-cloud") return;
+          const output = document.querySelector('[data-testid="click-count"]');
+          output.textContent = String(Number(output.textContent) + 1);
+        });
+      </script>
+    `);
+
+    await expect(
+      clickCloudLiveOptionalAction(page.getByTestId("runtime-cloud"), {
+        phase: "pre-identity-runtime-choice",
+        action: "runtime-cloud",
+        offerTimeoutMs: 500,
+        actionTimeoutMs: 500,
+      }),
+    ).resolves.toBe(true);
+    await expect(page.getByTestId("click-count")).toHaveText("1");
+  });
+
+  test("fails closed when an offered action is continuously replaced", async ({
+    page,
+  }) => {
+    await page.setContent(`
+      <button data-testid="runtime-cloud">Sign in</button>
+      <script>
+        let replacing = true;
+        let offset = false;
+        const replace = () => {
+          if (!replacing) return;
+          const current = document.querySelector('[data-testid="runtime-cloud"]');
+          const replacement = current.cloneNode(true);
+          offset = !offset;
+          replacement.style.transform = "translateX(" + (offset ? 12 : 0) + "px)";
+          current.replaceWith(replacement);
+          requestAnimationFrame(replace);
+        };
+        requestAnimationFrame(replace);
+      </script>
+    `);
+    await page.evaluate(
+      () =>
+        new Promise((resolve) => requestAnimationFrame(() => resolve(null))),
+    );
+
+    const startedAt = Date.now();
+    const result = await clickCloudLiveOptionalAction(
+      page.getByTestId("runtime-cloud"),
+      {
+        phase: "pre-identity-runtime-choice",
+        action: "runtime-cloud",
+        offerTimeoutMs: 500,
+        actionTimeoutMs: 250,
+      },
+    ).then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok)
+      throw new Error("continuous replacement unexpectedly clicked");
+    expect(result.error).toBeInstanceOf(CloudLiveOptionalActionDeadlineError);
+    expect(result.error).toMatchObject({
+      name: "CloudLiveOptionalActionDeadlineError",
+      code: "CLOUD_LIVE_OPTIONAL_ACTION_DEADLINE",
+      phase: "pre-identity-runtime-choice",
+      action: "runtime-cloud",
+    });
+    expect(String(result.error)).not.toMatch(/data-testid|Sign in|locator/);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+});

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -35,10 +35,15 @@ import {
   installCloudLiveAnchoredRetryChipObserver,
   writeCloudLiveContinuityEvidence,
 } from "../cloud-live-continuity-contract";
+import {
+  CloudLiveOptionalActionDeadlineError,
+  clickCloudLiveOptionalAction,
+} from "../cloud-live-optional-action";
 import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
 import { waitForRendererCloudApiOrigin } from "../cloud-live-renderer-api-readiness";
 import {
   CLOUD_LIVE_TRAJECTORY_TIMEOUT_MS,
+  type CloudLivePreIdentityDiagnostic,
   type CloudLiveTrajectoryPhase,
   writeCloudLiveTrajectoryDiagnostic,
 } from "../cloud-live-trajectory-diagnostic";
@@ -80,44 +85,53 @@ test.use({
   serviceWorkers: "block",
 });
 
-// Click an optional onboarding affordance. Absence is a legitimate product
-// state: the runtime chooser and the OAuth authorize block only render under
-// some first-run configurations, so a visibility timeout is reported as an
-// explicit "not offered". A click that fails on a control that IS visible is a
-// real defect and must fail the lane rather than be swallowed.
 async function clickIfVisible(
   locator: Locator,
   timeout = 10_000,
 ): Promise<boolean> {
-  const target = locator.first();
-  const offered = await target.waitFor({ state: "visible", timeout }).then(
-    () => true,
-    // error-policy:J4 a timeout is the one expected failure — the optional
-    // affordance never appeared — and becomes a distinct absent state. Anything
-    // else is rethrown: a strict-mode violation (two elements matched the
-    // locator) would otherwise be reported as "not offered", quietly turning a
-    // broken selector into a passing skip.
-    (error: unknown) => {
-      if (error instanceof Error && error.name === "TimeoutError") return false;
-      throw error;
-    },
-  );
-  if (!offered) return false;
-  await target.click();
-  return true;
+  return await clickCloudLiveOptionalAction(locator, {
+    phase: "post-identity-tutorial-skip",
+    action: "tutorial-skip",
+    offerTimeoutMs: timeout,
+    actionTimeoutMs: timeout,
+  });
 }
 
 // Drive the cloud entry point of first-run: the transcript's Eliza Cloud option,
 // then the SensitiveRequestBlock "Connect Eliza Cloud" OAuth authorize
 // affordance if shown.
-async function chooseCloudRuntime(page: Page): Promise<void> {
-  await clickIfVisible(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-    30_000,
-  );
-  await clickIfVisible(
+async function chooseCloudRuntime(
+  page: Page,
+  onRuntimeChoiceState?: (
+    state: "attempt" | "success" | "timeout",
+  ) => Promise<void>,
+): Promise<void> {
+  await onRuntimeChoiceState?.("attempt");
+  try {
+    const clicked = await clickCloudLiveOptionalAction(
+      page.getByTestId("choice-__first_run__:runtime:cloud"),
+      {
+        phase: "pre-identity-runtime-choice",
+        action: "runtime-cloud",
+        offerTimeoutMs: 30_000,
+        actionTimeoutMs: 30_000,
+      },
+    );
+    if (clicked) await onRuntimeChoiceState?.("success");
+  } catch (error) {
+    if (error instanceof CloudLiveOptionalActionDeadlineError) {
+      await onRuntimeChoiceState?.("timeout");
+    }
+    throw error;
+  }
+  await clickCloudLiveOptionalAction(
     page.getByTestId("sensitive-request-oauth-start"),
-    5_000,
+    {
+      phase: "pre-identity-oauth-choice",
+      action: "oauth-start",
+      offerTimeoutMs: 5_000,
+      actionTimeoutMs: 5_000,
+    },
   );
 }
 
@@ -524,11 +538,12 @@ async function proveAnchoredTurnHistory(
 
 async function resolvePersonalIdentity(
   page: Page,
+  chooseRuntime = true,
 ): Promise<CloudLiveRuntimeBinding> {
   await expect(page.getByTestId("chat-overlay")).toBeVisible({
     timeout: 60_000,
   });
-  await chooseCloudRuntime(page);
+  if (chooseRuntime) await chooseCloudRuntime(page);
   for (let attempt = 1; attempt <= PERSONAL_IDENTITY_ATTEMPTS; attempt += 1) {
     let binding: CloudLiveRuntimeBinding | null = null;
     await expect
@@ -589,11 +604,13 @@ test.describe("real cloud login + personal identity + chat", () => {
       .outputPath("privacy-safe-trajectory-history-network-diagnostics.json");
     const enterTrajectoryPhase = async (
       phase: CloudLiveTrajectoryPhase,
+      preIdentity?: CloudLivePreIdentityDiagnostic,
     ): Promise<void> => {
       await writeCloudLiveTrajectoryDiagnostic({
         diagnosticPath: trajectoryDiagnosticPath,
         phase,
         elapsedMs: Date.now() - trajectoryStartedAt,
+        preIdentity,
       });
     };
     await enterTrajectoryPhase("protected-cloud-boot");
@@ -676,11 +693,47 @@ test.describe("real cloud login + personal identity + chat", () => {
       description: rendererApiOrigin,
     });
 
+    const runtimeChoiceCounters = {
+      runtimeCloudActionAttemptCount: 0,
+      runtimeCloudActionSuccessCount: 0,
+      runtimeCloudActionTimeoutCount: 0,
+    };
+    const writePreIdentityDiagnostic = async (): Promise<void> => {
+      const audit = await primaryAudit.snapshot();
+      await enterTrajectoryPhase("pre-identity-runtime-choice", {
+        ...runtimeChoiceCounters,
+        personalIdentityGetRequestCount: audit.personalIdentityGetRequestCount,
+        successfulPersonalIdentityGetResponseCount:
+          audit.successfulPersonalIdentityGetCount,
+        clientErrorPersonalIdentityGetResponseCount:
+          audit.clientErrorPersonalIdentityGetResponseCount,
+        serverErrorPersonalIdentityGetResponseCount:
+          audit.serverErrorPersonalIdentityGetResponseCount,
+        otherPersonalIdentityGetResponseCount:
+          audit.otherPersonalIdentityGetResponseCount,
+        failedPersonalIdentityGetRequestCount:
+          audit.failedPersonalIdentityGetRequestCount,
+        pendingPersonalIdentityGetRequestCount:
+          audit.pendingPersonalIdentityGetRequestCount,
+      });
+    };
+    await writePreIdentityDiagnostic();
+    await chooseCloudRuntime(page, async (state) => {
+      if (state === "attempt") {
+        runtimeChoiceCounters.runtimeCloudActionAttemptCount += 1;
+      } else if (state === "success") {
+        runtimeChoiceCounters.runtimeCloudActionSuccessCount += 1;
+      } else {
+        runtimeChoiceCounters.runtimeCloudActionTimeoutCount += 1;
+      }
+      await writePreIdentityDiagnostic();
+    });
+
     // The current Cloud join flow resolves the account-derived Personal Eliza
     // identity through the read-only Personal endpoint. It persists the
     // account-owned binding without creating dedicated compute.
     await enterTrajectoryPhase("personal-identity");
-    const referenceBinding = await resolvePersonalIdentity(page);
+    const referenceBinding = await resolvePersonalIdentity(page, false);
     const identityAudit = await primaryAudit.snapshot();
     expect(
       identityAudit.successfulPersonalIdentityGetCount,


### PR DESCRIPTION
Closes #29534

## Summary

- bound optional Cloud onboarding visibility and click/action deadlines so a detached/re-rendering first-run runtime choice cannot inherit the 35-minute trajectory budget
- classify an offered-but-continuously-unstable control as `CLOUD_LIVE_OPTIONAL_ACTION_DEADLINE` with a closed `pre-identity-runtime-choice` phase
- retain only allowlisted numeric runtime-choice and Personal identity request/response counters in the privacy-safe trajectory artifact
- keep `PERSONAL_IDENTITY_ATTEMPT_TIMEOUT_MS = 180_000` and its predicate unchanged
- add real Chromium coverage for a stable click and a continuously replaced action

## Incident provenance

- terminal staging run: `33049523461`
- deployed source: `a4e5933f15d3b4831336c02fc306498a869b7074`
- API Worker, Pages, and routing passed; the protected browser proof timed out before its first Personal identity request while the runtime-cloud action was continuously replaced

## Exact source

- base: `c467a61b01a0f10c517508e4abf57136f713cb58`
- head: `82889ae04094549521930381494b7347ab7627be`
- tree: `42a1ff1c35072f9bbf9cbe0947b417bc611305db`

## Verification

- 41/41 focused Vitest unit tests
- 2/2 focused real-Chromium Playwright tests
- app typecheck dependency graph: 69/69 tasks
- exact touched-file Biome: pass
- diff check: pass
- current `develop` includes the plugin-pty shared-workspace dependency repair (`6d53ff9edb977e7b19a7c49c61ff7057ef9a4729`)
- repository-wide `bun run verify` reached 144/146 tasks, then hit an unrelated parallel generated-file race in UI design-system inventory (`packages/core/src/features/index.d.ts` disappeared while being read); touched-scope lint/typecheck/tests all pass

## Safety

Proof harness and test diagnostics only. No product UI behavior, production deployment, billing, Dedicated row, provisioning, cutover, browser profile, or phone mutation occurred.

@lalalune please review the bounded proof phase and privacy-safe counter contract.
