### PR TITLE
fix(ui): apply HIG hierarchy across Character tabs

### DIFF
--- a/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
@@ -10,6 +10,19 @@ import { memo, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { Input } from "../ui/input";
 import { StatusDot } from "../ui/status-badge";
 import { Textarea } from "../ui/textarea";
@@ -556,13 +569,6 @@ const ExperienceQueueRow = memo(function ExperienceQueueRow({
   onSelect: (experienceId: string) => void;
 }) {
   const title = experience.learning || experience.result || experience.context;
-  const reviewReasons = [
-    clampScore(experience.importance) >= 0.75 ? "high importance" : null,
-    clampScore(experience.confidence) < 0.65 ? "low confidence" : null,
-    experience.previousBelief || experience.correctedBelief
-      ? "belief changed"
-      : null,
-  ].filter(Boolean);
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: `experience-row-${experience.id}`,
     role: "list-item",
@@ -581,31 +587,42 @@ const ExperienceQueueRow = memo(function ExperienceQueueRow({
       data-state={isSelected ? "on" : "off"}
       aria-pressed={isSelected}
       data-testid={`experience-row-${experience.id}`}
-      className="w-full min-w-0"
+      className="w-full min-w-0 rounded-none border-b border-border/40 px-0 py-3 last:border-b-0"
       onClick={() => onSelect(experience.id)}
       {...agentProps}
     >
-      <div className="flex min-w-0 items-start gap-2">
+      <div className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-2">
         <OutcomeDot
           outcome={experience.outcome}
           review={needsReview(experience)}
         />
-        <h4 className="line-clamp-2 text-sm font-semibold text-txt">{title}</h4>
-      </div>
-      <div className="grid w-full grid-cols-2 gap-2 text-xs text-muted">
-        <span>Importance {formatPercent(experience.importance)}</span>
-        <span>Confidence {formatPercent(experience.confidence)}</span>
-      </div>
-      <p className="line-clamp-2 text-sm text-muted-strong">
-        {experience.context}
-      </p>
-      <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted">
-        <span>{experience.type}</span>
-        {experience.domain ? <span>· {experience.domain}</span> : null}
-        <span>· {formatTimestamp(experience.createdAt)}</span>
-        {reviewReasons.length > 0 ? (
-          <span>· {reviewReasons.join(", ")}</span>
-        ) : null}
+        <div className="min-w-0 space-y-1.5">
+          <h4 className="line-clamp-2 text-sm font-semibold text-txt">
+            {title}
+          </h4>
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            <span className="text-muted">
+              Importance{" "}
+              <strong className="font-medium text-muted-strong">
+                {formatPercent(experience.importance)}
+              </strong>
+            </span>
+            <span className="text-muted">
+              Confidence{" "}
+              <strong className="font-medium text-muted-strong">
+                {formatPercent(experience.confidence)}
+              </strong>
+            </span>
+          </div>
+          <p className="line-clamp-1 text-sm text-muted-strong md:line-clamp-2">
+            {experience.context}
+          </p>
+          <div className="line-clamp-1 text-xs text-muted">
+            {experience.type}
+            {experience.domain ? ` · ${experience.domain}` : ""}
+            {` · ${formatTimestamp(experience.createdAt)}`}
+          </div>
+        </div>
       </div>
     </Button>
   );
@@ -669,6 +686,7 @@ export function CharacterExperienceWorkspace({
 }) {
   const { t } = useTranslation();
   const [reviewFilter, setReviewFilter] = useState<ReviewFilter>("all");
+  const [graphOpen, setGraphOpen] = useState(false);
 
   const selectedExperience = useMemo(
     () => selectedOrFirst(experiences, selectedExperienceId),
@@ -754,7 +772,7 @@ export function CharacterExperienceWorkspace({
   );
 
   const { ref: reviewRef, agentProps: reviewAgentProps } =
-    useAgentElement<HTMLDivElement>({
+    useAgentElement<HTMLButtonElement>({
       id: "experience-filter-review",
       role: "select",
       label: t("character.reviewFilter"),
@@ -856,6 +874,10 @@ export function CharacterExperienceWorkspace({
     );
   }
 
+  const selectedReviewLabel =
+    REVIEW_FILTERS.find((option) => option.value === reviewFilter)?.label ??
+    "All";
+
   return (
     /* Flat — no card/border. The shell owns the page's horizontal padding. */
     <section className="flex min-w-0 flex-col gap-4">
@@ -892,34 +914,50 @@ export function CharacterExperienceWorkspace({
           />
         </div>
 
-        <div
-          ref={reviewRef}
-          className="mt-4 flex flex-wrap gap-1"
-          {...reviewAgentProps}
-        >
-          {REVIEW_FILTERS.map((option) => (
-            <Button
-              key={option.value}
-              variant="selection"
-              size="pillDense"
-              data-state={reviewFilter === option.value ? "on" : "off"}
-              aria-pressed={reviewFilter === option.value}
-              onClick={() => setReviewFilter(option.value)}
-            >
-              {option.label}
-            </Button>
-          ))}
+        <div className="mt-4 flex min-w-0 items-center justify-between gap-3">
+          <span className="text-sm text-muted">Review status</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                ref={reviewRef}
+                type="button"
+                size="dense"
+                variant="ghostMuted"
+                className="min-w-36 justify-between"
+                aria-label={`Filter review status, ${selectedReviewLabel} selected`}
+                {...reviewAgentProps}
+              >
+                <span>{selectedReviewLabel}</span>
+                <span aria-hidden="true">▾</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-48">
+              <DropdownMenuLabel>Review status</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={reviewFilter}
+                onValueChange={(value) => {
+                  const option = REVIEW_FILTERS.find(
+                    (candidate) => candidate.value === value,
+                  );
+                  if (option) setReviewFilter(option.value);
+                }}
+              >
+                {REVIEW_FILTERS.map((option) => (
+                  <DropdownMenuRadioItem
+                    key={option.value}
+                    value={option.value}
+                  >
+                    {option.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 
-      <ExperienceGraphPanel
-        experiences={filteredExperiences}
-        selectedExperienceId={visibleSelectedExperience?.id ?? null}
-        onSelectExperience={onSelectExperience}
-      />
-
       <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(19rem,25rem)_minmax(0,1fr)]">
-        <div className="flex min-h-[28rem] min-w-0 flex-col overflow-hidden">
+        <div className="flex min-h-[28rem] min-w-0 flex-col overflow-hidden xl:border-r xl:border-border/40 xl:pr-4">
           <div className="px-4 py-3">
             <div className="text-sm font-semibold text-txt">Review queue</div>
           </div>
@@ -942,21 +980,21 @@ export function CharacterExperienceWorkspace({
         </div>
 
         {visibleSelectedExperience ? (
-          <div className="flex min-w-0 flex-col gap-4 p-4">
-            <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 items-start gap-2">
-                  <OutcomeDot
-                    outcome={visibleSelectedExperience.outcome}
-                    review={needsReview(visibleSelectedExperience)}
-                  />
-                  <h4 className="text-lg font-semibold leading-snug text-txt">
-                    {visibleSelectedExperience.learning ||
-                      visibleSelectedExperience.result ||
-                      visibleSelectedExperience.context}
-                  </h4>
-                </div>
-                <p className="mt-1 text-xs text-muted">
+          <div className="flex min-w-0 flex-col gap-4 py-4 xl:pl-4">
+            <div className="min-w-0 space-y-3">
+              <div className="flex min-w-0 items-start gap-2">
+                <OutcomeDot
+                  outcome={visibleSelectedExperience.outcome}
+                  review={needsReview(visibleSelectedExperience)}
+                />
+                <h4 className="text-lg font-semibold leading-snug text-txt">
+                  {visibleSelectedExperience.learning ||
+                    visibleSelectedExperience.result ||
+                    visibleSelectedExperience.context}
+                </h4>
+              </div>
+              <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="min-w-0 text-xs text-muted">
                   {visibleSelectedExperience.type}
                   {visibleSelectedExperience.domain
                     ? ` · ${visibleSelectedExperience.domain}`
@@ -966,49 +1004,49 @@ export function CharacterExperienceWorkspace({
                     ? ` · Updated ${formatTimestamp(visibleSelectedExperience.updatedAt)}`
                     : ""}
                 </p>
-              </div>
-              <div className="flex items-center gap-2">
-                {onDeleteExperience ? (
-                  <Button
-                    ref={deleteRef}
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={
-                      deletingExperienceId === visibleSelectedExperience.id
-                    }
-                    onClick={() =>
-                      onDeleteExperience(visibleSelectedExperience)
-                    }
-                    {...deleteAgentProps}
-                  >
-                    {deletingExperienceId === visibleSelectedExperience.id
-                      ? "Deleting…"
-                      : "Delete"}
-                  </Button>
-                ) : null}
-                {onSaveExperience ? (
-                  <Button
-                    ref={saveRef}
-                    type="button"
-                    size="sm"
-                    disabled={
-                      savingExperienceId === visibleSelectedExperience.id
-                    }
-                    onClick={() =>
-                      onSaveExperience(visibleSelectedExperience, draft)
-                    }
-                    {...saveAgentProps}
-                  >
-                    {savingExperienceId === visibleSelectedExperience.id
-                      ? "Saving…"
-                      : "Save review"}
-                  </Button>
-                ) : null}
+                <div className="flex shrink-0 items-center gap-2">
+                  {onDeleteExperience ? (
+                    <Button
+                      ref={deleteRef}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={
+                        deletingExperienceId === visibleSelectedExperience.id
+                      }
+                      onClick={() =>
+                        onDeleteExperience(visibleSelectedExperience)
+                      }
+                      {...deleteAgentProps}
+                    >
+                      {deletingExperienceId === visibleSelectedExperience.id
+                        ? "Deleting…"
+                        : "Delete"}
+                    </Button>
+                  ) : null}
+                  {onSaveExperience ? (
+                    <Button
+                      ref={saveRef}
+                      type="button"
+                      size="sm"
+                      disabled={
+                        savingExperienceId === visibleSelectedExperience.id
+                      }
+                      onClick={() =>
+                        onSaveExperience(visibleSelectedExperience, draft)
+                      }
+                      {...saveAgentProps}
+                    >
+                      {savingExperienceId === visibleSelectedExperience.id
+                        ? "Saving…"
+                        : "Save review"}
+                    </Button>
+                  ) : null}
+                </div>
               </div>
             </div>
 
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(16rem,0.8fr)]">
+            <div className="grid gap-4 2xl:grid-cols-[minmax(0,1.2fr)_minmax(16rem,0.8fr)]">
               <div className="space-y-4">
                 <div className="min-w-0">
                   <div className="text-xs text-muted">Learned takeaway</div>
@@ -1016,7 +1054,7 @@ export function CharacterExperienceWorkspace({
                     {visibleSelectedExperience.learning || "Not recorded."}
                   </p>
                 </div>
-                <div className="grid gap-3 md:grid-cols-3">
+                <div className="grid gap-3 2xl:grid-cols-3">
                   <EvidencePanel
                     title="Context"
                     body={visibleSelectedExperience.context}
@@ -1221,6 +1259,34 @@ export function CharacterExperienceWorkspace({
           </div>
         ) : null}
       </div>
+
+      <Collapsible
+        open={graphOpen}
+        onOpenChange={setGraphOpen}
+        className="border-t border-border/40 pt-4"
+      >
+        <div className="flex min-w-0 items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-txt">Experience map</h3>
+            <p className="mt-1 text-xs text-muted">
+              Explore connections among the {filteredExperiences.length} shown
+              experiences.
+            </p>
+          </div>
+          <CollapsibleTrigger asChild>
+            <Button type="button" variant="outline" size="sm">
+              {graphOpen ? "Hide map" : "Show map"}
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+        <CollapsibleContent className="pt-2">
+          <ExperienceGraphPanel
+            experiences={filteredExperiences}
+            selectedExperienceId={visibleSelectedExperience?.id ?? null}
+            onSelectExperience={onSelectExperience}
+          />
+        </CollapsibleContent>
+      </Collapsible>
     </section>
   );
 }

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -230,18 +230,19 @@ export function CharacterHubView({
       <FramedPageBody
         scroll="page"
         padded={false}
-        className="[@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
+        className="[@media(min-width:768px)_and_(min-height:600px)]:px-10 lg:px-8"
         data-testid="character-editor-view"
       >
         <div className="flex min-w-0 flex-col pt-1">
           <WidgetHost slot="character" className="mb-4" />
-          <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
+          <div className="flex min-w-0 flex-col gap-4 sm:gap-6 md:gap-8">
             {characterSaveError ? (
               <span className="rounded-sm border border-status-danger/20 bg-status-danger-bg px-2 py-1 text-2xs font-medium text-status-danger">
                 {characterSaveError}
               </span>
             ) : null}
-            <section>
+            <section className="space-y-4 border-b border-border/40 pb-6">
+              <h2 className="text-sm font-semibold text-txt">Identity</h2>
               <CharacterIdentityPanel
                 nameText={typeof d.name === "string" ? d.name : ""}
                 systemText={typeof d.system === "string" ? d.system : ""}
@@ -251,20 +252,24 @@ export function CharacterHubView({
               />
             </section>
 
-            <CharacterStylePanel
-              d={d}
-              pendingStyleEntries={pendingStyleEntries}
-              styleEntryDrafts={styleEntryDrafts}
-              handlePendingStyleEntryChange={handlePendingStyleEntryChange}
-              handleAddStyleEntry={handleAutoAddStyleEntry}
-              handleRemoveStyleEntry={handleAutoRemoveStyleEntry}
-              handleStyleEntryDraftChange={handleStyleEntryDraftChange}
-              handleCommitStyleEntry={handleAutoCommitStyleEntry}
-              handleReorderStyleEntries={handleAutoReorderStyleEntries}
-              t={t}
-            />
+            <section className="space-y-4 border-b border-border/40 pb-6">
+              <h2 className="text-sm font-semibold text-txt">Voice</h2>
+              <CharacterStylePanel
+                d={d}
+                pendingStyleEntries={pendingStyleEntries}
+                styleEntryDrafts={styleEntryDrafts}
+                handlePendingStyleEntryChange={handlePendingStyleEntryChange}
+                handleAddStyleEntry={handleAutoAddStyleEntry}
+                handleRemoveStyleEntry={handleAutoRemoveStyleEntry}
+                handleStyleEntryDraftChange={handleStyleEntryDraftChange}
+                handleCommitStyleEntry={handleAutoCommitStyleEntry}
+                handleReorderStyleEntries={handleAutoReorderStyleEntries}
+                t={t}
+              />
+            </section>
 
-            <section>
+            <section className="space-y-4 pb-6">
+              <h2 className="text-sm font-semibold text-txt">Examples</h2>
               <CharacterExamplesPanel
                 d={d}
                 normalizedMessageExamples={normalizedMessageExamples}

--- a/packages/ui/src/components/character/CharacterLearnedSkillsSection.tsx
+++ b/packages/ui/src/components/character/CharacterLearnedSkillsSection.tsx
@@ -177,11 +177,33 @@ export function CharacterLearnedSkillsSection({
         ) : null}
 
         {isEmpty ? (
-          <div className="py-3 text-xs-tight leading-5 text-muted">
-            {t("learnedskills.empty", {
-              defaultValue:
-                "I haven’t picked up any abilities yet. Browse the catalog or add one by example, and I’ll start using it.",
-            })}
+          <div className="flex max-w-lg flex-col items-start gap-3 py-6 md:mx-auto md:min-h-[50vh] md:items-center md:justify-center md:text-center">
+            <div>
+              <h2 className="text-base font-semibold text-txt">
+                {t("learnedskills.emptyTitle", {
+                  defaultValue: "No learned skills yet",
+                })}
+              </h2>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                {t("learnedskills.empty", {
+                  defaultValue:
+                    "Ask Eliza to practice a capability. Skills that are ready for review will appear here.",
+                })}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() =>
+                client.sendChatMessage(
+                  "Help me learn a new skill. Ask what capability I want to practice.",
+                )
+              }
+            >
+              {t("learnedskills.startLearning", {
+                defaultValue: "Learn a skill",
+              })}
+            </Button>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
Closes #29536

## What changed

Applies one Apple HIG-inspired information hierarchy across the Character family while preserving the canonical Personality / Relationships / Skills / Experience navigation introduced by #29528.

- **Personality:** groups the editor into Identity, Voice, and Examples sections using spacing and lightweight dividers, without nested surfaces.
- **Skills:** replaces the dead empty canvas with a concise explanation and a primary Learn a skill action.
- **Experience:** puts the review queue before the graph, replaces status chips with a compact menu, keeps detail text readable, and progressively discloses the Experience map.
- **Relationships:** unchanged in this follow-up; it retains the canonical list-first hierarchy and compact Type menu from #29528.

## Visual comparison

### Personality

| Mobile before | Mobile after |
| --- | --- |
| ![Personality mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-personality-mobile-before.png) | ![Personality mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-personality-mobile-after-v3.png) |

| Desktop before | Desktop after |
| --- | --- |
| ![Personality desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-personality-desktop-before.png) | ![Personality desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-personality-desktop-after-v3.png) |

### Skills

| Mobile before | Mobile after |
| --- | --- |
| ![Skills mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-skills-mobile-before.png) | ![Skills mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-skills-mobile-after-v3.png) |

| Desktop before | Desktop after |
| --- | --- |
| ![Skills desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-skills-desktop-before.png) | ![Skills desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-skills-desktop-after-v3.png) |

### Experience

| Mobile before | Mobile after |
| --- | --- |
| ![Experience mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-mobile-before.png) | ![Experience mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-mobile-after-v5.png) |

| Desktop before | Desktop after |
| --- | --- |
| ![Experience desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-desktop-before.png) | ![Experience desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-desktop-after-v7.png) |

## Verification

- Character family aesthetic audit: 16/16 passed; 0 broken, 0 needs-work, 0 metric-budget failures.
- Packaged OCR: 16/16 verified; 0 broken, 0 needs-eyeball.
- UI package typecheck passed.
- CharacterHubView focused tests: 6/6 passed.
- Biome and design-system contract checks passed.

Walkthrough: [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-character-walkthrough.mp4)

<!-- evidence-head:5a98647cbabf9ea6539adc3a8b344b01c7e004f8 -->

## Evidence checklist

| Evidence | Artifact |
| --- | --- |
| Before screenshots | Personality, Skills, and Experience mobile/desktop comparisons above |
| After screenshots | Personality, Skills, and Experience mobile/desktop comparisons above |
| Video | [Character tab walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-character-walkthrough.mp4) |
| Frontend log | [Audit log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-character-frontend-v2.log) |
| OCR | [Packaged OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-character-ocr.json) |
| Backend logs | N/A — client-only layout and interaction hierarchy change |
| Live-model trajectory | N/A — no agent behavior or inference change |
| Domain artifact | N/A — no persisted domain contract change |

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29537-hig-character-before-contact-sheet.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29537-hig-character-after-contact-sheet-v5.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29537-hig-character-walkthrough-faststart.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only layout and interaction hierarchy change

<!-- evidence-row:frontend-logs -->
- [x] [hig-character-frontend-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-character-frontend-v2.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior or inference change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain contract change

<!-- evidence-row:ocr-review -->
- [x] [hig-experience-ocr-v7.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-ocr-v7.json)
