### PR TITLE
test(app): bound Cloud identity retry action

### DIFF
--- a/packages/app/test/cloud-live-optional-action.ts
+++ b/packages/app/test/cloud-live-optional-action.ts
@@ -5,11 +5,13 @@ import type { Locator } from "@playwright/test";
 export type CloudLiveOptionalActionPhase =
   | "pre-identity-runtime-choice"
   | "pre-identity-oauth-choice"
+  | "personal-identity-retry"
   | "post-identity-tutorial-skip";
 
 export type CloudLiveOptionalActionName =
   | "runtime-cloud"
   | "oauth-start"
+  | "identity-retry"
   | "tutorial-skip";
 
 export class CloudLiveOptionalActionDeadlineError extends Error {

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -34,6 +34,31 @@ test.describe("Cloud live optional action boundary", () => {
     await expect(page.getByTestId("click-count")).toHaveText("1");
   });
 
+  test("clicks a stable Personal identity retry", async ({ page }) => {
+    await page.setContent(`
+      <button data-testid="identity-retry">Retry</button>
+      <output data-testid="retry-count">0</output>
+      <script>
+        document.addEventListener("click", (event) => {
+          if (!(event.target instanceof HTMLElement)) return;
+          if (event.target.dataset.testid !== "identity-retry") return;
+          const output = document.querySelector('[data-testid="retry-count"]');
+          output.textContent = String(Number(output.textContent) + 1);
+        });
+      </script>
+    `);
+
+    await expect(
+      clickCloudLiveOptionalAction(page.getByTestId("identity-retry"), {
+        phase: "personal-identity-retry",
+        action: "identity-retry",
+        offerTimeoutMs: 500,
+        actionTimeoutMs: 500,
+      }),
+    ).resolves.toBe(true);
+    await expect(page.getByTestId("retry-count")).toHaveText("1");
+  });
+
   test("fails closed when an offered action is continuously replaced", async ({
     page,
   }) => {
@@ -84,6 +109,56 @@ test.describe("Cloud live optional action boundary", () => {
       action: "runtime-cloud",
     });
     expect(String(result.error)).not.toMatch(/data-testid|Sign in|locator/);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  test("fails closed when a Personal identity retry is continuously replaced", async ({
+    page,
+  }) => {
+    await page.setContent(`
+      <button data-testid="identity-retry">Retry</button>
+      <script>
+        let offset = false;
+        const replace = () => {
+          const current = document.querySelector('[data-testid="identity-retry"]');
+          const replacement = current.cloneNode(true);
+          offset = !offset;
+          replacement.style.transform = "translateX(" + (offset ? 12 : 0) + "px)";
+          current.replaceWith(replacement);
+          requestAnimationFrame(replace);
+        };
+        requestAnimationFrame(replace);
+      </script>
+    `);
+    await page.evaluate(
+      () =>
+        new Promise((resolve) => requestAnimationFrame(() => resolve(null))),
+    );
+
+    const startedAt = Date.now();
+    const result = await clickCloudLiveOptionalAction(
+      page.getByTestId("identity-retry"),
+      {
+        phase: "personal-identity-retry",
+        action: "identity-retry",
+        offerTimeoutMs: 500,
+        actionTimeoutMs: 250,
+      },
+    ).then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unstable retry unexpectedly clicked");
+    expect(result.error).toBeInstanceOf(CloudLiveOptionalActionDeadlineError);
+    expect(result.error).toMatchObject({
+      name: "CloudLiveOptionalActionDeadlineError",
+      code: "CLOUD_LIVE_OPTIONAL_ACTION_DEADLINE",
+      phase: "personal-identity-retry",
+      action: "identity-retry",
+    });
+    expect(String(result.error)).not.toMatch(/data-testid|Retry|locator/);
     expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 });

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -570,7 +570,21 @@ async function resolvePersonalIdentity(
     if (attempt === PERSONAL_IDENTITY_ATTEMPTS) {
       throw new Error("Personal Eliza identity resolution exhausted its retry");
     }
-    await page.getByTestId("choice-__first_run__:error:retry").click();
+    const retryClicked = await clickCloudLiveOptionalAction(
+      page.getByTestId("choice-__first_run__:error:retry"),
+      {
+        phase: "personal-identity-retry",
+        action: "identity-retry",
+        offerTimeoutMs: 5_000,
+        actionTimeoutMs: 10_000,
+      },
+    );
+    if (!retryClicked) {
+      throw new CloudLiveOptionalActionDeadlineError(
+        "personal-identity-retry",
+        "identity-retry",
+      );
+    }
   }
   throw new Error("Personal Eliza identity resolution remained pending");
 }


### PR DESCRIPTION
Closes the remaining deployed Cloud proof hang seam after #29535.

The Personal identity retry action now uses the same typed bounded action helper as the first-run Cloud choice. A continuously detached/re-rendered retry fails closed as `CLOUD_LIVE_OPTIONAL_ACTION_DEADLINE` instead of inheriting the 35-minute trajectory timeout. The existing 180-second Personal identity predicate is unchanged.

Exact provenance
- Base: `3eafc190108161c0c368931bd31f71e0b9619cb8`
- Head: `5be5f34f2017f075bdabfb3410205b16377c53cc`
- Tree: `bf4c4b9f2dffc65a730403d852dac95921a3ab03`

Focused gates
- 4/4 real Chromium optional-action tests passed, including stable retry and continuous replacement
- `@elizaos/app` typecheck passed
- exact touched-file Biome passed
- `git diff --check` passed

Safety
- The prematurely dispatched staging run `33055730879` was cancelled before dependencies, config/authority checks, migrations, Worker deploy, or Pages deploy. No staging mutation occurred.
- No production, billing, adoption, quote, cutover, browser, or device action occurred.

After hosted checks pass, this follow-up is intended to merge to develop and anchor exactly one replacement staging certification.

@lalalune review requested for the fail-closed proof boundary.