### PR TITLE
fix(evidence): detect plugin UI surfaces

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -48,13 +48,14 @@ export function hasMatchingEvidenceHead(body, headSha) {
  * A changed file forces surface artifacts when it is a rendered-UI source file
  * — labels are advisory and agents routinely omit them, so the gate cannot rely
  * on them alone. Detection is deliberately narrow: a visual EXTENSION (`.tsx`,
- * CSS family, `.svg`, `.html`, `.vue`) under a UI-bearing PACKAGE, excluding
+ * CSS family, `.svg`, `.html`, `.vue`) under a UI-bearing package or plugin,
+ * excluding
  * test/story/fixture files that render nothing a user sees. This is why editing
- * a real component in `packages/ui` or `packages/app` demands screenshots while
- * editing its `*.test.tsx` or `*.stories.tsx` does not.
+ * a real component in `packages/ui`, `packages/app`, or `plugins/*` demands
+ * screenshots while editing its `*.test.tsx` or `*.stories.tsx` does not.
  */
 const SURFACE_PATH_RE =
-  /(^|\/)(packages\/(app|ui|tui|homepage)|apps\/app|packages\/cloud\/frontend)\//i;
+  /(^|\/)(packages\/(app|ui|tui|homepage)|apps\/app|packages\/cloud\/frontend|plugins)\//i;
 const SURFACE_VISUAL_EXT_RE = /\.(tsx|jsx|css|scss|sass|less|svg|html|vue)$/i;
 const SURFACE_NON_VISUAL_RE =
   /(\.(test|spec|stories|story|bench)\.|\.d\.ts$|(^|\/)(__tests__|__e2e__|__mocks__|__fixtures__|test|tests|e2e|stories)\/)/i;

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -1130,11 +1130,19 @@ describe("check-pr-evidence row primitives", () => {
       requiresSurfaceArtifactsFromFiles([String.raw`apps\app\src\Panel.tsx`]),
       true,
     );
+    assert.equal(
+      requiresSurfaceArtifactsFromFiles([
+        "plugins/plugin-inbox/src/components/inbox/InboxView.tsx",
+      ]),
+      true,
+    );
     // Tests, stories, and server code render nothing a user sees.
     assert.equal(
       requiresSurfaceArtifactsFromFiles([
         "packages/ui/src/components/Foo.test.tsx",
         "packages/ui/src/components/Foo.stories.tsx",
+        "plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx",
+        "plugins/plugin-inbox/test/stubs/InboxView.tsx",
         "packages/app-core/src/services/thing.ts",
         "packages/app/README.md",
       ]),
@@ -1142,13 +1150,13 @@ describe("check-pr-evidence row primitives", () => {
     );
   });
 
-  it("forces surface artifacts from a UI diff even without labels", () => {
+  it("forces surface artifacts from a plugin UI diff even without labels", () => {
     const body = REQUIRED_EVIDENCE_ROWS.map(
       ({ id }) =>
         `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
     ).join("\n\n");
     const { ok, findings } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
-      changedFiles: ["packages/ui/src/components/NotificationRow.tsx"],
+      changedFiles: ["plugins/plugin-inbox/src/components/inbox/InboxView.tsx"],
     });
     assert.equal(ok, false);
     for (const id of SURFACE_ARTIFACT_ROW_IDS) {


### PR DESCRIPTION
# Relates to

Closes #29538.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto live upstream `develop` commit `3eafc190108161c0c368931bd31f71e0b9619cb8` with zero conflicts.
- [ ] `bun install` and the full `bun run verify` were not run locally; the exact reason and focused replacement checks are recorded below.
- [x] A reviewer can confirm the behavior from the focused regression suite and the real-consumer verification below.

# Sync with develop

- [x] Rebased onto live upstream `develop` commit `3eafc190108161c0c368931bd31f71e0b9619cb8`; zero conflicts.
- [ ] Full `bun run verify` was not run locally; focused exact-head checks pass and hosted CI owns the full monorepo closure.

# Risks

Low. Plugin files with rendered-UI extensions now receive the same evidence requirements as existing app/UI paths. Existing test, story, E2E, fixture, and stub exclusions remain in force, and nonvisual plugin files remain unaffected.

# Background

## What does this PR do?

- Extends rendered-surface detection to production visual files under `plugins/**`.
- Keeps plugin tests and test stubs excluded.
- Adds direct classifier coverage and an evaluator regression proving an all-`N/A` plugin UI PR now requires screenshots, a walkthrough, and OCR proof.

## What kind of change is this?

Bug fix (non-breaking CI/evidence enforcement correction).

# Documentation changes needed?

No project documentation change is needed. The detector's inline rationale now includes plugin UI.

# Testing

## Where should a reviewer start?

Start with `requiresSurfaceArtifactsFromFiles` in `scripts/check-pr-evidence.mjs` and the two plugin-path assertions in `scripts/check-pr-evidence.test.mjs`.

## Detailed testing steps

- RED on live develop: the two focused plugin regressions failed because the classifier returned `false` and the all-`N/A` body returned `ok: true`.
- `node --test scripts/check-pr-evidence.test.mjs` — 93/93 passed.
- `node scripts/check-pr-evidence.mjs --self-test` — 14-case self-test passed.
- `node --test scripts/check-pr-agent-attribution.test.mjs` — 21/21 passed, covering the shared-import consumer.
- `bun x @biomejs/biome@2.5.8 check scripts/check-pr-evidence.test.mjs` — passed.
- `git diff refs/codex/live-29538...HEAD --check` — passed.
- `node scripts/pr-evidence.mjs verify 29055` with this fix — correctly fails the real plugin-only UI PR for `before-screenshots: artifact-required`, `walkthrough-video: artifact-required`, and `ocr-review: ocr-required`.

# Evidence Gate

Evidence matches exact commit `2ff37dbc91bed495e83ee162dcb2c34da294c41d`.
<!-- evidence-head:2ff37dbc91bed495e83ee162dcb2c34da294c41d -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - deterministic CI checker change with no rendered visual surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - deterministic CI checker change with no rendered visual surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive user flow or rendered visual surface changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path changed; validation is the deterministic Node test output above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend runtime code or request path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model path changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no database, memory, task, wallet, file-generation, or audio state changed`.
<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - this changes evidence classification only and renders no pixels`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changed.

## Backend + frontend logs

N/A - deterministic repository checker; exact command results are listed under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- A full dependency install and `bun run verify` were intentionally not run locally because this isolated worktree has no dependency closure and recreating the multi-gigabyte monorepo install would conflict with the requested disk cleanup. Hosted CI provides the full closure.
- Whole-file Biome checking of `scripts/check-pr-evidence.mjs` still reports two pre-existing formatting findings around its self-test at lines 2449 and 2473; neither line is in this diff. The edited test file passes the repository-pinned Biome 2.5.8 check.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated upstream `develop` SHA: `3eafc190108161c0c368931bd31f71e0b9619cb8`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->
