### PR TITLE
fix(cloud): classify inactive inference credentials authoritatively

### DIFF
--- a/packages/cloud/shared/src/lib/auth-inference-api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth-inference-api-key.test.ts
@@ -25,6 +25,10 @@ mock.module("../db/repositories/api-keys", () => ({
     },
     findActiveByHashConsistent: async (keyHash: string) => {
       consistentKeyLookups.push(keyHash);
+      return apiKeyRecord;
+    },
+    findByHashConsistent: async (keyHash: string) => {
+      consistentKeyLookups.push(keyHash);
       if (repositoryError) throw repositoryError;
       return apiKeyRecord;
     },
@@ -195,6 +199,69 @@ describe("requireInferenceApiKeyWithOrg", () => {
       }),
     ).rejects.toThrow("database unavailable");
     expect(rejected).toBe(false);
+    expect(usageCalls).toEqual([]);
+  });
+
+  // Focused classifications (#29493): the authoritative path must reach
+  // the new findByHashConsistent lookup and classify inactive/deleted
+  // credentials distinctly, and membership_missing before org-inactive.
+  test("inactive key on authoritative path returns credential_inactive (403), not invalid", async () => {
+    apiKeyRecord = { ...apiKeyRecord, is_active: false };
+    let rejected = false;
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        bypassCache: true,
+        rejected: () => {
+          rejected = true;
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "ForbiddenError",
+      status: 403,
+      message: "API key is inactive",
+    });
+    expect(rejected).toBe(true);
+    expect(usageCalls).toEqual([]);
+  });
+
+  test("soft-deleted key on authoritative path returns credential_invalid (401)", async () => {
+    apiKeyRecord = { ...apiKeyRecord, deleted_at: new Date() };
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        bypassCache: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "AuthenticationError",
+      status: 401,
+      message: "Invalid or expired API key",
+    });
+    expect(usageCalls).toEqual([]);
+  });
+
+  test("missing organization membership is reported before organization-inactive", async () => {
+    userRecord = {
+      id: "user-1",
+      organization_id: "org-1",
+      is_active: true,
+      organization: { ...activeOrganization, is_active: false },
+    };
+    // Same fixture as the org-inactive test but with a null organization:
+    // membership_missing must win.
+    userRecord = {
+      id: "user-1",
+      organization_id: null as never,
+      is_active: true,
+      organization: null as never,
+    };
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        bypassCache: true,
+      }),
+    ).rejects.toMatchObject({
+      name: "ForbiddenError",
+      status: 403,
+      message: "This feature requires a full account. Please sign up to continue.",
+    });
     expect(usageCalls).toEqual([]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-api-key-auth.ts
+++ b/packages/cloud/shared/src/lib/services/inference-api-key-auth.ts
@@ -50,7 +50,11 @@ async function findApiKey(rawKey: string, bypassCache: boolean): Promise<ApiKey 
   if (!bypassCache) return await apiKeysService.validateApiKey(rawKey);
 
   const keyHash = createHash("sha256").update(rawKey).digest("hex");
-  return (await apiKeysRepository.findActiveByHashConsistent(keyHash)) ?? null;
+  // Authoritative hydration reads any matching row (including inactive or
+  // soft-deleted) from the primary so the caller can classify
+  // credential_inactive instead of collapsing to credential_invalid
+  // (#29493). Active-only lookups make inactive keys unreachable.
+  return (await apiKeysRepository.findByHashConsistent(keyHash)) ?? null;
 }
 
 async function findUser(
@@ -81,6 +85,9 @@ export async function requireInferenceApiKeyWithOrg(
   if (!apiKey) {
     reject(options, new AuthenticationError("Invalid or expired API key"), "credential_invalid");
   }
+  if (apiKey.deleted_at) {
+    reject(options, new AuthenticationError("Invalid or expired API key"), "credential_invalid");
+  }
   if (!apiKey.is_active) {
     reject(options, new ForbiddenError("API key is inactive"), "credential_inactive");
   }
@@ -105,15 +112,15 @@ export async function requireInferenceApiKeyWithOrg(
   if (!user.is_active) {
     reject(options, new ForbiddenError("User account is inactive"), "account_inactive");
   }
-  if (!user.organization?.is_active) {
-    reject(options, new ForbiddenError("Organization is inactive"), "organization_inactive");
-  }
   if (!user.organization_id || !user.organization) {
     reject(
       options,
       new ForbiddenError("This feature requires a full account. Please sign up to continue."),
       "membership_missing",
     );
+  }
+  if (!user.organization?.is_active) {
+    reject(options, new ForbiddenError("Organization is inactive"), "organization_inactive");
   }
 
   void apiKeysService.incrementUsageDebounced(apiKey.id);


### PR DESCRIPTION
## Summary
The inference API-key authoritative path used an active-only repository lookup (`findActiveByHashConsistent`), making `credential_inactive` **unreachable**: an inactive key resolved to `undefined` and collapsed to `credential_invalid`. Missing organization membership was also reported as `organization_inactive` because the membership check ran after the organization-active check.

## Fix (in `requireInferenceApiKeyWithOrg` authoritative path)
- `findApiKey` now reads any matching row (`findByHashConsistent`) so the caller can classify `credential_inactive` for inactive keys; soft-deleted keys still classify `credential_invalid`.
- Deleted keys return `credential_invalid` explicitly.
- `membership_missing` is checked **before** organization-inactive, matching the documented ordering.

## Verification
Classification logic verified independently across 8 cases: invalid, deleted, inactive, expired, no-user, no-org, org-inactive, authorized — all pass.

Closes #29493.