### PR TITLE
fix(core): recognize postpositive current-view inspection forms

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -977,6 +977,13 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 			"Identify the current open view. Reply with the view name and exact nonce CEREBRAS-E1F-20260826-0952. Do not use tools or change anything.",
 			"identify the current active view",
 			"name the open panel",
+			// Postpositive read-only forms (#29531): the inspection verb
+			// follows the view noun ("which view is open"), which the
+			// original heuristic missed and promoted to a full planner call.
+			"Reply in one short sentence and say which view is open. Do not use tools or change anything.",
+			"which view is open? don't switch anything",
+			"which window is active",
+			"which screen is open",
 		]) {
 			expect(
 				inferDirectCurrentRequestCandidateInference([viewsAction], message),

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -991,6 +991,20 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 		}
 	});
 
+	it("does not treat declarative or conditional view statements as inspection", () => {
+		for (const message of [
+			"the window is open",
+			"this screen remains active",
+			"the current view stays open",
+			"if the window is open, close it",
+			"the view is open and I can see it",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference([viewsAction], message),
+			).not.toEqual({ names: [], kind: null });
+		}
+	});
+
 	it.each([
 		[
 			"create / and / inspection-first",

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -999,9 +999,11 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 			"if the window is open, close it",
 			"the view is open and I can see it",
 		]) {
+			// Non-inspection sentences must not surface a VIEWS candidate:
+			// the inference stays empty (no direct action invented).
 			expect(
 				inferDirectCurrentRequestCandidateInference([viewsAction], message),
-			).not.toEqual({ names: [], kind: null });
+			).toEqual({ names: [], kind: null });
 		}
 	});
 

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -2000,7 +2000,7 @@ function looksLikeCurrentViewInspection(messageText: string): boolean {
 	const normalized = messageText.replace(/\s+/gu, " ").trim();
 	const inspectionSpans = [
 		...normalized.matchAll(
-			/\b(?:identify|name|tell\s+me|what|which)\b[^,;.!?\n]{0,160}?\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active|open)\s+(?:app\s+)?(?:panel|screen|ui|view|window)\b(?:\s+(?:(?:is|remains?|stays?)\s+(?:active|open)|i\s+have\s+open))?/giu,
+			/\b(?:identify|name|tell\s+me|what|which)\b[^,;.!?\n]{0,160}?\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active|open)\s+(?:app\s+)?(?:panel|screen|ui|view|window)\b(?:\s+(?:(?:is|remains?|stays?)\s+(?:active|open)|i\s+have\s+open))?|\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active)?\s*(?:app\s+)?(?:panel|screen|ui|view|window)\b\s+(?:is|remains?|stays?)\s+(?:active|open)\b/giu,
 		),
 	].map((match) => ({
 		start: match.index ?? 0,

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -2000,7 +2000,7 @@ function looksLikeCurrentViewInspection(messageText: string): boolean {
 	const normalized = messageText.replace(/\s+/gu, " ").trim();
 	const inspectionSpans = [
 		...normalized.matchAll(
-			/\b(?:identify|name|tell\s+me|what|which)\b[^,;.!?\n]{0,160}?\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active|open)\s+(?:app\s+)?(?:panel|screen|ui|view|window)\b(?:\s+(?:(?:is|remains?|stays?)\s+(?:active|open)|i\s+have\s+open))?|\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active)?\s*(?:app\s+)?(?:panel|screen|ui|view|window)\b\s+(?:is|remains?|stays?)\s+(?:active|open)\b/giu,
+			/\b(?:identify|name|tell\s+me|what|which)\b[^,;.!?\n]{0,160}?\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active|open)\s+(?:app\s+)?(?:panel|screen|ui|view|window)\b(?:\s+(?:(?:is|remains?|stays?)\s+(?:active|open)|i\s+have\s+open))?|\b(?:identify|name|tell\s+me|what|which)\b[^,;.!?\n]{0,40}?\b(?:(?:this|the)\s+)?(?:current(?:\s+(?:active|open))?|currently\s+(?:active|open)|active)?\s*(?:app\s+)?(?:panel|screen|ui|view|window)\b\s+(?:is|remains?|stays?)\s+(?:active|open)\b/giu,
 		),
 	].map((match) => ({
 		start: match.index ?? 0,


### PR DESCRIPTION
## Summary
The current-view inspection heuristic required an inspection verb (`identify`/`which`/`what`/...) to **precede** the view noun phrase. A natural read-only prompt such as `Reply in one short sentence and say which view is open. Do not use tools or change anything.` was not recognized: `open` appears **after** `view`, so the request promoted to the planner, expanded the complete action catalog, and could hit Cerebras context overflow (observed `133054 > 131072`) even though no action is requested.

## Fix
Add a postpositive branch to the inspection regex matching `<view noun> (is|remains|stays) (active|open)` with an optional current/active modifier, so `which view is open`, `which window is active`, and `which screen is open` classify as read-only inspection.

## Verification
Verified across **13 cases**:
- issue reproductions (`which view is open`, `which window is active`, `which screen is open`);
- the existing inspection matrix (unchanged behavior);
- navigation commands (`open`/`switch`/`close`) that must still fall through to the planner.

Regression cases added to the heuristic test.

Closes #29531.