### PR TITLE
fix(ui): align Experience detail content

### DIFF
--- a/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
@@ -993,56 +993,54 @@ export function CharacterExperienceWorkspace({
                     visibleSelectedExperience.context}
                 </h4>
               </div>
-              <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <p className="min-w-0 text-xs text-muted">
-                  {visibleSelectedExperience.type}
-                  {visibleSelectedExperience.domain
-                    ? ` · ${visibleSelectedExperience.domain}`
-                    : ""}
-                  {` · Created ${formatTimestamp(visibleSelectedExperience.createdAt)}`}
-                  {visibleSelectedExperience.updatedAt
-                    ? ` · Updated ${formatTimestamp(visibleSelectedExperience.updatedAt)}`
-                    : ""}
-                </p>
-                <div className="flex shrink-0 items-center gap-2">
-                  {onDeleteExperience ? (
-                    <Button
-                      ref={deleteRef}
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={
-                        deletingExperienceId === visibleSelectedExperience.id
-                      }
-                      onClick={() =>
-                        onDeleteExperience(visibleSelectedExperience)
-                      }
-                      {...deleteAgentProps}
-                    >
-                      {deletingExperienceId === visibleSelectedExperience.id
-                        ? "Deleting…"
-                        : "Delete"}
-                    </Button>
-                  ) : null}
-                  {onSaveExperience ? (
-                    <Button
-                      ref={saveRef}
-                      type="button"
-                      size="sm"
-                      disabled={
-                        savingExperienceId === visibleSelectedExperience.id
-                      }
-                      onClick={() =>
-                        onSaveExperience(visibleSelectedExperience, draft)
-                      }
-                      {...saveAgentProps}
-                    >
-                      {savingExperienceId === visibleSelectedExperience.id
-                        ? "Saving…"
-                        : "Save review"}
-                    </Button>
-                  ) : null}
-                </div>
+              <p className="text-xs text-muted">
+                {visibleSelectedExperience.type}
+                {visibleSelectedExperience.domain
+                  ? ` · ${visibleSelectedExperience.domain}`
+                  : ""}
+                {` · Created ${formatTimestamp(visibleSelectedExperience.createdAt)}`}
+                {visibleSelectedExperience.updatedAt
+                  ? ` · Updated ${formatTimestamp(visibleSelectedExperience.updatedAt)}`
+                  : ""}
+              </p>
+              <div className="flex items-center justify-end gap-2">
+                {onDeleteExperience ? (
+                  <Button
+                    ref={deleteRef}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={
+                      deletingExperienceId === visibleSelectedExperience.id
+                    }
+                    onClick={() =>
+                      onDeleteExperience(visibleSelectedExperience)
+                    }
+                    {...deleteAgentProps}
+                  >
+                    {deletingExperienceId === visibleSelectedExperience.id
+                      ? "Deleting…"
+                      : "Delete"}
+                  </Button>
+                ) : null}
+                {onSaveExperience ? (
+                  <Button
+                    ref={saveRef}
+                    type="button"
+                    size="sm"
+                    disabled={
+                      savingExperienceId === visibleSelectedExperience.id
+                    }
+                    onClick={() =>
+                      onSaveExperience(visibleSelectedExperience, draft)
+                    }
+                    {...saveAgentProps}
+                  >
+                    {savingExperienceId === visibleSelectedExperience.id
+                      ? "Saving…"
+                      : "Save review"}
+                  </Button>
+                ) : null}
               </div>
             </div>
 
@@ -1070,7 +1068,7 @@ export function CharacterExperienceWorkspace({
                 </div>
               </div>
 
-              <div className="space-y-4 lg:pl-4">
+              <div className="space-y-4 2xl:pl-4">
                 <ScoreBar
                   label="Importance"
                   value={visibleSelectedExperience.importance}


### PR DESCRIPTION
Closes #29547

## What changed

- Gives Delete and Save review a dedicated trailing action row beneath the selected experience metadata.
- Keeps the title, metadata, evidence fields, and score bars on one content edge.
- Applies score-column padding only at the breakpoint where the score region actually becomes a second column.

## Visual comparison

| Before | After |
| --- | --- |
| ![Before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-desktop-after-v7.png) | ![After](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-desktop-after-v8.png) |

## Verification

- Desktop Experience aesthetic audit passed with 0 broken, 0 needs-work, and 0 metric-budget failures.
- Packaged OCR verified the desktop capture.
- UI package typecheck passed.
- Biome passed.

<!-- evidence-head:06b5d2ae2adc7d2f6c5c8a5337314d89417beafd -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29548-hig-experience-desktop-after-v7.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29548-hig-experience-desktop-after-v8.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29548-hig-experience-detail-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only layout correction

<!-- evidence-row:frontend-logs -->
- [x] [hig-experience-detail-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-detail-frontend.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior or inference change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain contract change

<!-- evidence-row:ocr-review -->
- [x] [hig-experience-ocr-v8.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/hig-experience-ocr-v8.json)
