### PR TITLE
test(app): preserve post-choice identity polling

### DIFF
--- a/packages/app/test/cloud-live-optional-action.ts
+++ b/packages/app/test/cloud-live-optional-action.ts
@@ -33,6 +33,33 @@ interface ClickCloudLiveOptionalActionOptions {
   actionTimeoutMs: number;
 }
 
+interface PrepareCloudLivePersonalIdentityOptions {
+  chooseRuntime: boolean;
+  chatOverlay: Locator;
+  chatOverlayTimeoutMs: number;
+  chooseRuntimeAction: () => Promise<void>;
+}
+
+/**
+ * The chat overlay is a pre-choice gate, not a post-choice invariant: a valid
+ * Cloud choice may replace the first-run overlay while the account binding is
+ * still resolving. Callers that already chose the runtime must proceed directly
+ * to the bounded binding-or-retry predicate.
+ */
+export async function prepareCloudLivePersonalIdentity({
+  chooseRuntime,
+  chatOverlay,
+  chatOverlayTimeoutMs,
+  chooseRuntimeAction,
+}: PrepareCloudLivePersonalIdentityOptions): Promise<void> {
+  if (!chooseRuntime) return;
+  await chatOverlay.waitFor({
+    state: "visible",
+    timeout: chatOverlayTimeoutMs,
+  });
+  await chooseRuntimeAction();
+}
+
 /**
  * Resolve the locator again while Playwright retries a detached/replaced node,
  * but never inherit the enclosing trajectory's multi-minute timeout. Absence is

--- a/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
@@ -81,6 +81,19 @@ describe("Cloud live trajectory diagnostic", () => {
     expect(JSON.stringify(diagnostic)).not.toMatch(
       /selector|locator|https?:|token|transcript/i,
     );
+
+    expect(
+      createCloudLiveTrajectoryDiagnostic(
+        "personal-identity",
+        789,
+        diagnostic.preIdentity,
+      ),
+    ).toEqual({
+      schema: CLOUD_LIVE_TRAJECTORY_DIAGNOSTIC_SCHEMA,
+      phase: "personal-identity",
+      elapsedMs: 789,
+      preIdentity: diagnostic.preIdentity,
+    });
   });
 
   it("rejects invalid pre-identity counters", () => {

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "@playwright/test";
 import {
   CloudLiveOptionalActionDeadlineError,
   clickCloudLiveOptionalAction,
+  prepareCloudLivePersonalIdentity,
 } from "../cloud-live-optional-action";
 
 test.describe("Cloud live optional action boundary", () => {
@@ -59,14 +60,138 @@ test.describe("Cloud live optional action boundary", () => {
     await expect(page.getByTestId("retry-count")).toHaveText("1");
   });
 
+  test("allows post-choice overlay removal while the binding resolves", async ({
+    page,
+  }) => {
+    await page.setContent(`
+      <main data-testid="chat-overlay">
+        <button data-testid="runtime-cloud">Use Cloud</button>
+      </main>
+      <script>
+        document.addEventListener("click", (event) => {
+          if (!(event.target instanceof HTMLElement)) return;
+          if (event.target.dataset.testid !== "runtime-cloud") return;
+          document.querySelector('[data-testid="chat-overlay"]').remove();
+          setTimeout(() => { window.__testActiveBinding = "dedicated"; }, 25);
+        });
+      </script>
+    `);
+    await expect(page.getByTestId("chat-overlay")).toBeVisible();
+
+    await prepareCloudLivePersonalIdentity({
+      chooseRuntime: true,
+      chatOverlay: page.getByTestId("chat-overlay"),
+      chatOverlayTimeoutMs: 500,
+      chooseRuntimeAction: async () => {
+        await expect(
+          clickCloudLiveOptionalAction(page.getByTestId("runtime-cloud"), {
+            phase: "pre-identity-runtime-choice",
+            action: "runtime-cloud",
+            offerTimeoutMs: 500,
+            actionTimeoutMs: 500,
+          }),
+        ).resolves.toBe(true);
+      },
+    });
+    await expect(page.getByTestId("chat-overlay")).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as typeof window & { __testActiveBinding?: string })
+              .__testActiveBinding ?? null,
+        ),
+      )
+      .toBe("dedicated");
+  });
+
+  test("skips a detached post-choice overlay gate while a valid binding resolves", async ({
+    page,
+  }) => {
+    await page.setContent(`
+      <main data-testid="chat-overlay">Transitioning</main>
+      <script>
+        const churn = () => {
+          const current = document.querySelector('[data-testid="chat-overlay"]');
+          if (current) current.remove();
+          else document.body.insertAdjacentHTML("afterbegin", '<main data-testid="chat-overlay">Transitioning</main>');
+          requestAnimationFrame(churn);
+        };
+        requestAnimationFrame(churn);
+        setTimeout(() => { window.__testActiveBinding = "dedicated"; }, 25);
+      </script>
+    `);
+    let runtimeChoiceCalled = false;
+
+    await prepareCloudLivePersonalIdentity({
+      chooseRuntime: false,
+      chatOverlay: page.getByTestId("chat-overlay"),
+      chatOverlayTimeoutMs: 100,
+      chooseRuntimeAction: async () => {
+        runtimeChoiceCalled = true;
+      },
+    });
+    expect(runtimeChoiceCalled).toBe(false);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as typeof window & { __testActiveBinding?: string })
+              .__testActiveBinding ?? null,
+        ),
+      )
+      .toBe("dedicated");
+  });
+
+  test("fails closed when a post-choice binding and retry both remain absent", async ({
+    page,
+  }) => {
+    await page.setContent("<main>Transitioning</main>");
+    await prepareCloudLivePersonalIdentity({
+      chooseRuntime: false,
+      chatOverlay: page.getByTestId("chat-overlay"),
+      chatOverlayTimeoutMs: 100,
+      chooseRuntimeAction: async () => {
+        throw new Error("post-choice runtime action must not repeat");
+      },
+    });
+
+    const result = await expect
+      .poll(
+        async () =>
+          Boolean(
+            await page.evaluate(
+              () =>
+                (window as typeof window & { __testActiveBinding?: string })
+                  .__testActiveBinding,
+            ),
+          ) || (await page.getByTestId("identity-retry").isVisible()),
+        { timeout: 100 },
+      )
+      .toBe(true)
+      .then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+    expect(result.ok).toBe(false);
+  });
+
   test("fails closed when an offered action is continuously replaced", async ({
     page,
   }) => {
     await page.setContent(`
-      <button data-testid="runtime-cloud">Sign in</button>
+      <main data-testid="chat-overlay">
+        <button data-testid="runtime-cloud">Sign in</button>
+      </main>
       <script>
         let replacing = true;
         let offset = false;
+        document.addEventListener("click", (event) => {
+          if (!(event.target instanceof HTMLElement)) return;
+          if (event.target.dataset.testid !== "runtime-cloud") return;
+          document.querySelector('[data-testid="chat-overlay"]').remove();
+          window.__testActiveBinding = "dedicated";
+        });
         const replace = () => {
           if (!replacing) return;
           const current = document.querySelector('[data-testid="runtime-cloud"]');
@@ -110,6 +235,14 @@ test.describe("Cloud live optional action boundary", () => {
     });
     expect(String(result.error)).not.toMatch(/data-testid|Sign in|locator/);
     expect(Date.now() - startedAt).toBeLessThan(2_000);
+    await expect(page.getByTestId("chat-overlay")).toBeVisible();
+    expect(
+      await page.evaluate(
+        () =>
+          (window as typeof window & { __testActiveBinding?: string })
+            .__testActiveBinding ?? null,
+      ),
+    ).toBeNull();
   });
 
   test("fails closed when a Personal identity retry is continuously replaced", async ({

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -38,6 +38,7 @@ import {
 import {
   CloudLiveOptionalActionDeadlineError,
   clickCloudLiveOptionalAction,
+  prepareCloudLivePersonalIdentity,
 } from "../cloud-live-optional-action";
 import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
 import { waitForRendererCloudApiOrigin } from "../cloud-live-renderer-api-readiness";
@@ -540,10 +541,12 @@ async function resolvePersonalIdentity(
   page: Page,
   chooseRuntime = true,
 ): Promise<CloudLiveRuntimeBinding> {
-  await expect(page.getByTestId("chat-overlay")).toBeVisible({
-    timeout: 60_000,
+  await prepareCloudLivePersonalIdentity({
+    chooseRuntime,
+    chatOverlay: page.getByTestId("chat-overlay"),
+    chatOverlayTimeoutMs: 60_000,
+    chooseRuntimeAction: () => chooseCloudRuntime(page),
   });
-  if (chooseRuntime) await chooseCloudRuntime(page);
   for (let attempt = 1; attempt <= PERSONAL_IDENTITY_ATTEMPTS; attempt += 1) {
     let binding: CloudLiveRuntimeBinding | null = null;
     await expect
@@ -712,24 +715,32 @@ test.describe("real cloud login + personal identity + chat", () => {
       runtimeCloudActionSuccessCount: 0,
       runtimeCloudActionTimeoutCount: 0,
     };
+    const readPreIdentityDiagnostic =
+      async (): Promise<CloudLivePreIdentityDiagnostic> => {
+        const audit = await primaryAudit.snapshot();
+        return {
+          ...runtimeChoiceCounters,
+          personalIdentityGetRequestCount:
+            audit.personalIdentityGetRequestCount,
+          successfulPersonalIdentityGetResponseCount:
+            audit.successfulPersonalIdentityGetCount,
+          clientErrorPersonalIdentityGetResponseCount:
+            audit.clientErrorPersonalIdentityGetResponseCount,
+          serverErrorPersonalIdentityGetResponseCount:
+            audit.serverErrorPersonalIdentityGetResponseCount,
+          otherPersonalIdentityGetResponseCount:
+            audit.otherPersonalIdentityGetResponseCount,
+          failedPersonalIdentityGetRequestCount:
+            audit.failedPersonalIdentityGetRequestCount,
+          pendingPersonalIdentityGetRequestCount:
+            audit.pendingPersonalIdentityGetRequestCount,
+        };
+      };
     const writePreIdentityDiagnostic = async (): Promise<void> => {
-      const audit = await primaryAudit.snapshot();
-      await enterTrajectoryPhase("pre-identity-runtime-choice", {
-        ...runtimeChoiceCounters,
-        personalIdentityGetRequestCount: audit.personalIdentityGetRequestCount,
-        successfulPersonalIdentityGetResponseCount:
-          audit.successfulPersonalIdentityGetCount,
-        clientErrorPersonalIdentityGetResponseCount:
-          audit.clientErrorPersonalIdentityGetResponseCount,
-        serverErrorPersonalIdentityGetResponseCount:
-          audit.serverErrorPersonalIdentityGetResponseCount,
-        otherPersonalIdentityGetResponseCount:
-          audit.otherPersonalIdentityGetResponseCount,
-        failedPersonalIdentityGetRequestCount:
-          audit.failedPersonalIdentityGetRequestCount,
-        pendingPersonalIdentityGetRequestCount:
-          audit.pendingPersonalIdentityGetRequestCount,
-      });
+      await enterTrajectoryPhase(
+        "pre-identity-runtime-choice",
+        await readPreIdentityDiagnostic(),
+      );
     };
     await writePreIdentityDiagnostic();
     await chooseCloudRuntime(page, async (state) => {
@@ -746,7 +757,10 @@ test.describe("real cloud login + personal identity + chat", () => {
     // The current Cloud join flow resolves the account-derived Personal Eliza
     // identity through the read-only Personal endpoint. It persists the
     // account-owned binding without creating dedicated compute.
-    await enterTrajectoryPhase("personal-identity");
+    await enterTrajectoryPhase(
+      "personal-identity",
+      await readPreIdentityDiagnostic(),
+    );
     const referenceBinding = await resolvePersonalIdentity(page, false);
     const identityAudit = await primaryAudit.snapshot();
     expect(


### PR DESCRIPTION
Fixes the terminal deployed-renderer proof failure from staging run 33056825006.

The Cloud choice is allowed to replace/unmount the first-run chat overlay while the Personal binding is still resolving. `resolvePersonalIdentity(..., false)` now skips the stale post-choice overlay gate and proceeds directly to the existing binding-or-retry predicate. The default path still requires the overlay before choosing the runtime. The 180-second predicate, bounded retry action, and retry count are unchanged.

The privacy-safe `personal-identity` receipt now retains the latest pre-identity action/request counters instead of overwriting them at phase transition.

Exact provenance
- Base: `f55862ba19f8d65f356e56b9052318da74066243`
- Head: `1f5695b6b522a5eaab4db96167010d424ca423e3`
- Tree: `e0043fdad7e195c5d2ec92d3298b313644bebf06`
- Mechanical rebase from `fdb9f2d98b21ea4bcb249b7f5c90a07f7d8dbd01`: exact patch-id `8dadc434a194b2a42157649a5c73b4129087d8f8`; range-diff `=`
- Failed certificate: run `33056825006`, deployed source `d453dde92c9d3a51e1174befe27b20deea4d287b`, privacy artifact `9640625240` (`personal-identity`, elapsed 10371ms)

Focused gates on this exact rebased head
- 7/7 real Chromium cases passed: pre-choice gate/choice, post-choice overlay removal, detached overlay with async binding, absent binding+retry fail-closed, and both detached action boundaries
- 16/16 trajectory diagnostic tests passed
- `@elizaos/app` typecheck passed
- exact touched-file Biome passed
- `git diff --check` passed

Safety
- Staging deployment/routing at d453 succeeded, but immutable certification failed closed; no certificate exists.
- No production/main/quote/POST/cutover/billing/browser/device action occurred.
- No replacement staging run will dispatch until this exact replacement head is green, reviewed, and merged.

@lalalune review requested for the harness-only ordering repair.