### PR TITLE
fix(logger): load Node builtins in native ESM

### DIFF
--- a/packages/logger/src/logger.native-esm.test.ts
+++ b/packages/logger/src/logger.native-esm.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Exercises the logger through real native-ESM Node subprocesses so Vitest's
+ * module transform cannot supply CommonJS globals. The source run asserts its
+ * TypeScript loader preserves that boundary; a built package is also checked
+ * through plain Node when `dist` is present.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function verifyNativeEsmTarget({
+  name,
+  url,
+  loaderArgs = [],
+}: {
+  name: string;
+  url: string;
+  loaderArgs?: string[];
+}): void {
+  const directory = mkdtempSync(join(tmpdir(), "eliza-logger-native-esm-"));
+  temporaryDirectories.push(directory);
+
+  const outputMarker = `native-esm-${name}-output`;
+  const promptMarker = `native-esm-${name}-prompt`;
+  const chatMarker = `native-esm-${name}-chat`;
+  const successMarker = `native-esm-${name}-ok`;
+  const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+  const outputPath = join(directory, "output.log");
+  const childScript = `
+      if (typeof require !== "undefined") {
+        throw new Error("native ESM harness unexpectedly exposed require");
+      }
+      const loggerModule = await import(${JSON.stringify(url)});
+      loggerModule.logger.info(${JSON.stringify(outputMarker)});
+      loggerModule.logPrompt("text", ${JSON.stringify(promptMarker)}, {
+        agentName: "native-esm",
+      });
+      loggerModule.logChatIn({
+        agentName: "native-esm",
+        agentId: "agent-native-esm",
+        roomId: "room-native-esm",
+        messageId: "message-native-esm",
+        text: ${JSON.stringify(chatMarker)},
+      });
+      if (!loggerModule.recentLogs().includes(${JSON.stringify(outputMarker)})) {
+        throw new Error("native ESM log entry did not reach recentLogs");
+      }
+      console.log(${JSON.stringify(successMarker)});
+    `;
+
+  const result = spawnSync(
+    process.execPath,
+    [...loaderArgs, "--input-type=module", "--eval", childScript],
+    {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        LOG_FILE: outputPath,
+        LOG_JSON_FORMAT: "true",
+        LOG_LEVEL: "info",
+        NO_COLOR: "1",
+      },
+    },
+  );
+
+  const childOutput = [result.error?.message, result.stdout, result.stderr]
+    .filter(Boolean)
+    .join("\n");
+  expect(result.status, childOutput).toBe(0);
+  expect(result.stdout).toContain(successMarker);
+  expect(readFileSync(outputPath, "utf8")).toContain(outputMarker);
+  expect(readFileSync(join(directory, "prompts.log"), "utf8")).toContain(
+    promptMarker,
+  );
+  expect(readFileSync(join(directory, "chat.log"), "utf8")).toContain(
+    chatMarker,
+  );
+}
+
+describe("native Node ESM", () => {
+  const sourceUrl = new URL("./logger.ts", import.meta.url).href;
+  const distUrl = new URL("../dist/index.js", import.meta.url).href;
+
+  it("initializes source JSON mode and writes every file sink", () => {
+    verifyNativeEsmTarget({
+      name: "source",
+      url: sourceUrl,
+      loaderArgs: ["--import", "tsx"],
+    });
+  });
+
+  it.skipIf(!existsSync(fileURLToPath(distUrl)))(
+    "initializes the built package through plain Node ESM",
+    () => {
+      verifyNativeEsmTarget({ name: "dist", url: distUrl });
+    },
+  );
+});

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -799,17 +799,27 @@ let _promptLogFd: number | null = null;
 let _chatLogFd: number | null = null;
 let _promptLogCounter = 0;
 
+/** Load a Node builtin synchronously without breaking browser source imports. */
+function getNodeBuiltin<T>(id: string): T | null {
+  if (
+    typeof process === "undefined" ||
+    typeof process.getBuiltinModule !== "function"
+  ) {
+    return null;
+  }
+  try {
+    return (process.getBuiltinModule(id) as T | undefined) ?? null;
+  } catch {
+    // error-policy:J7 optional Node diagnostics must not prevent logger startup.
+    return null;
+  }
+}
+
 let _fs: typeof import("node:fs") | null = null;
 function getFs(): typeof import("node:fs") | null {
   if (_fs) return _fs;
-  try {
-    _fs = require("node:fs");
-    return _fs;
-  } catch {
-    // error-policy:J7 logger is a leaf and cannot report through itself; no
-    // node:fs (browser build) legitimately means "no file sink", not a failure.
-    return null;
-  }
+  _fs = getNodeBuiltin<typeof import("node:fs")>("node:fs");
+  return _fs;
 }
 
 /**
@@ -872,7 +882,8 @@ function ensureFileLog(): boolean {
 
     const fs = getFs();
     if (!fs) return false;
-    const pathMod = require("node:path");
+    const pathMod = getNodeBuiltin<typeof import("node:path")>("node:path");
+    if (!pathMod) return false;
     const isBooleanFlag = ["true", "1", "yes", "on"].includes(
       logFileEnv.trim().toLowerCase(),
     );
@@ -1394,8 +1405,8 @@ function sealAdze(base: Record<string, unknown>): ReturnType<typeof adze.seal> {
     let hostname = "unknown";
     if (typeof process !== "undefined" && process.platform) {
       // Node.js environment
-      const os = require("node:os");
-      hostname = os.hostname();
+      const os = getNodeBuiltin<typeof import("node:os")>("node:os");
+      if (os) hostname = os.hostname();
     } else {
       // Browser environment
       const browserLocation = (


### PR DESCRIPTION
# Relates to

Closes #29543.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto live upstream `develop` commit `a0f057c5111287996e979825f76a02aecb556894` with zero conflicts.
- [ ] `bun install` and the full root `bun run verify` were not run locally; the exact reason and focused replacement checks are recorded below.
- [x] A reviewer can confirm the native-ESM behavior from the fresh-process regression and compatibility checks below.

# Sync with develop

- [x] Rebased onto live upstream `develop` commit `a0f057c5111287996e979825f76a02aecb556894`; zero conflicts.
- [ ] Full root `bun run verify` was not run locally; focused exact-head checks pass and hosted CI owns the full monorepo closure.

# Risks

Low. Node builtins now load synchronously through the Node 24 `process.getBuiltinModule` API. Environments without that API retain the existing safe fallback: optional file sinks stay disabled and JSON metadata uses the `unknown` hostname. No static `node:*` import was added to the browser-source-imported logger leaf.

# Background

## What does this PR do?

- Replaces the logger's three CommonJS `require("node:*")` calls with one guarded native-ESM-compatible builtin loader.
- Restores JSON logger initialization and the `output.log`, `prompts.log`, and `chat.log` sinks under native Node ESM.
- Adds a fresh-process regression that proves `require` is absent, exercises the TypeScript source through `tsx`, and exercises built `dist/index.js` through plain Node when the build artifact exists.

## What kind of change is this?

Bug fix (non-breaking logger runtime correction).

# Documentation changes needed?

No project documentation change is needed. The public logger APIs and environment variables are unchanged.

# Testing

## Where should a reviewer start?

Start with `getNodeBuiltin` in `packages/logger/src/logger.ts`, then the native subprocess harness in `packages/logger/src/logger.native-esm.test.ts`.

## Detailed testing steps

- RED on live develop `d453dde92c9d3a51e1174befe27b20deea4d287b` (the logger source blob is unchanged in this PR's live base): native Node ESM with `LOG_JSON_FORMAT=true` failed at `logger.ts:1397` with `ReferenceError: require is not defined in ES module scope`; file logging silently created no sinks.
- Node 24.19.0 focused regression: `vitest run packages/logger/src/logger.native-esm.test.ts` — 2/2 passed, covering source plus rebuilt dist.
- Node 24.19.0 logger suite: 3 files passed; 61 tests passed and one pre-existing Windows-only file-permission test skipped (62 total).
- `tsc --noEmit -p packages/logger/tsconfig.json` — passed.
- Bun 1.3.14 `bun run build` in `packages/logger` — passed (`tsc6` build plus package-dist preparation).
- Repository Biome helper over `packages/logger/src` — all 6 files passed with no fixes.
- Bun 1.3.14 source smoke with JSON mode — `recentLogs` plus real `output.log`, `prompts.log`, and `chat.log` markers passed.
- Bun 1.3.14 browser-target bundle — 42 modules, 84,960 bytes, and no static `node:*` load.
- `git diff a0f057c5111287996e979825f76a02aecb556894...HEAD --check` — passed.

# Evidence Gate

Evidence matches exact commit `a505a4514c76c6f51eb84a3612b4514c5d1395ef`.
<!-- evidence-head:a505a4514c76c6f51eb84a3612b4514c5d1395ef -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - Node logger module-runtime correction with no rendered visual surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - Node logger module-runtime correction with no rendered visual surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive user flow or rendered visual surface changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - package-level regression tests create and inspect real temporary logger sinks; exact results are under Testing`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request path or rendered client behavior changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model path changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - generated logs are temporary test outputs verified by content assertions; no persisted application domain state changed`.
<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - this runtime correction renders no pixels`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changed.

## Backend + frontend logs

The native subprocess and Bun smokes created real `output.log`, `prompts.log`, and `chat.log` files and asserted unique markers in each; exact pass counts and commands are listed under Testing. N/A for attached production logs because this is an isolated package-runtime correction, not a deployed backend or frontend request path.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- A full dependency install and root `bun run verify` were intentionally not run locally because recreating the multi-gigabyte monorepo dependency tree would conflict with the requested disk cleanup. A disposable exact-package harness supplied the logger's declared dependency/tool closure; hosted CI provides the full monorepo closure.
- Local Node was 24.19.0 rather than the repository's pinned 24.15.x minor; both satisfy the package's Node `>=24.0.0` contract, and hosted CI supplies the pinned runtime.
- The logger suite's one skipped test is the existing `file sink permissions` case, which is explicitly skipped on Windows. No new or failing test was skipped.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated upstream `develop` SHA: `a0f057c5111287996e979825f76a02aecb556894`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->
