### PR TITLE
fix(android): match DataStore JNI AAB paths

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
@@ -286,8 +286,28 @@ function writeSyntheticCloudAab(
       "clean synthetic DEX io/ionic/android_js_engine/NativeWebAPI",
       "utf8",
     ),
+    "base/lib/arm64-v8a/libdatastore_shared_counter.so": Buffer.from(
+      "synthetic AndroidX DataStore JNI arm64-v8a",
+      "utf8",
+    ),
+    "base/lib/armeabi-v7a/libdatastore_shared_counter.so": Buffer.from(
+      "synthetic AndroidX DataStore JNI armeabi-v7a",
+      "utf8",
+    ),
+    "base/lib/x86/libdatastore_shared_counter.so": Buffer.from(
+      "synthetic AndroidX DataStore JNI x86",
+      "utf8",
+    ),
+    "base/lib/x86_64/libdatastore_shared_counter.so": Buffer.from(
+      "synthetic AndroidX DataStore JNI x86_64",
+      "utf8",
+    ),
     "base/manifest/AndroidManifest.xml": Buffer.from(
       "compiled manifest placeholder",
+      "utf8",
+    ),
+    "base/res/drawable-nodpi-v4/eliza_cloud_splash_mark.png": Buffer.from(
+      "synthetic transparent splash mark",
       "utf8",
     ),
     "base/assets/capacitor.config.json": Buffer.from("{}", "utf8"),
@@ -1452,7 +1472,7 @@ describe("Android Cloud outer audit boundary", () => {
     }
   });
 
-  it("keeps the Play AAB native-free when Background Runner is stripped", () => {
+  it("accepts the exact packaged DataStore JNI set after Background Runner is stripped", () => {
     const temporaryDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "eliza-outer-aab-no-background-runner-jni-"),
     );
@@ -1475,6 +1495,40 @@ describe("Android Cloud outer audit boundary", () => {
       expect(log.mock.calls.at(-1)?.[0]).toContain(
         "android-cloud artifact audit passed",
       );
+    } finally {
+      fs.rmSync(temporaryDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects native code beyond the exact packaged DataStore JNI set", () => {
+    const temporaryDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-outer-aab-extra-jni-"),
+    );
+    const log = vi.fn();
+    try {
+      const artifact = writeSyntheticCloudAab(temporaryDir, {
+        extraEntries: {
+          "base/lib/arm64-v8a/libunexpected.so": Buffer.from(
+            "unexpected JNI payload",
+            "utf8",
+          ),
+        },
+      });
+
+      expect(() =>
+        auditAndroidCloudArtifact(
+          { artifact, env: {}, javaHome: JAVA_HOME },
+          { inspectAndroidAppBundleImpl: () => syntheticAabEvidence(), log },
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
+          message: expect.stringContaining(
+            "base/lib/arm64-v8a/libunexpected.so",
+          ),
+        }),
+      );
+      expect(log).not.toHaveBeenCalled();
     } finally {
       fs.rmSync(temporaryDir, { force: true, recursive: true });
     }

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -339,10 +339,10 @@ describe("Android Play manifest policy", () => {
       expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).toContain(permission);
     }
     expect(ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES).toEqual([
-      "lib/arm64-v8a/libdatastore_shared_counter.so",
-      "lib/armeabi-v7a/libdatastore_shared_counter.so",
-      "lib/x86/libdatastore_shared_counter.so",
-      "lib/x86_64/libdatastore_shared_counter.so",
+      "base/lib/arm64-v8a/libdatastore_shared_counter.so",
+      "base/lib/armeabi-v7a/libdatastore_shared_counter.so",
+      "base/lib/x86/libdatastore_shared_counter.so",
+      "base/lib/x86_64/libdatastore_shared_counter.so",
     ]);
     expect(ANDROID_PLAY_ALLOWED_PERMISSIONS).toContain(
       "android.permission.MODIFY_AUDIO_SETTINGS",

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6200,10 +6200,10 @@ export const ANDROID_PLAY_ALLOWED_QUERY_ACTIONS = Object.freeze([
 // cross-process shared-counter JNI helper. Keep an exact ABI allowlist so a
 // local-agent or inference library still cannot leak into the Cloud client.
 export const ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES = Object.freeze([
-  "lib/arm64-v8a/libdatastore_shared_counter.so",
-  "lib/armeabi-v7a/libdatastore_shared_counter.so",
-  "lib/x86/libdatastore_shared_counter.so",
-  "lib/x86_64/libdatastore_shared_counter.so",
+  "base/lib/arm64-v8a/libdatastore_shared_counter.so",
+  "base/lib/armeabi-v7a/libdatastore_shared_counter.so",
+  "base/lib/x86/libdatastore_shared_counter.so",
+  "base/lib/x86_64/libdatastore_shared_counter.so",
 ]);
 
 export function resolveAndroidCloudAllowedNativeLibraries(env = process.env) {


### PR DESCRIPTION
Closes #29541.

## Summary

- matches the exact `base/lib/<abi>/libdatastore_shared_counter.so` paths emitted by Bundletool
- upgrades the synthetic Cloud AAB fixture to contain the real DataStore JNI entry shape and system splash resource
- proves the outer artifact audit accepts exactly those four ABIs and still rejects any extra native library

## Verification

- `bun x vitest run --root packages/app-core scripts/run-mobile-build-android-play-policy.test.mjs scripts/run-mobile-build-android-aab-audit.test.mjs` — 111 passed, 7 skipped
- `bun x @biomejs/biome check` on all three changed files
- `bun run --cwd packages/app build:android:cloud` — Gradle 507 tasks successful; Cloud AAB audit and post-Gradle audit passed
- local release AAB SHA-256: `2b560c7181349ea18ede2842a3e2c69bda95aea3b1f9ff0b59d2a51d8ea3f316`