### PR TITLE
fix(ui): align Vault and Character route contracts

### DIFF
--- a/packages/app/test/ui-smoke/vault-tabs-accessibility.spec.ts
+++ b/packages/app/test/ui-smoke/vault-tabs-accessibility.spec.ts
@@ -90,6 +90,28 @@ test.describe("Vault tab accessibility", () => {
     expect(headerDirection).toBe("row");
   });
 
+  test("uses the full available page width on every Vault tab", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    for (const tab of ["Overview", "Secrets", "Logins", "Routing"]) {
+      await page.getByRole("tab", { name: tab }).click();
+      const panel = page.getByRole("tabpanel", {
+        name: `${tab} Vault section`,
+      });
+      await expect(panel).toBeVisible();
+      const panelBox = await panel.boundingBox();
+      const contentBox = await panel
+        .locator(":scope > *")
+        .first()
+        .boundingBox();
+
+      expect(contentBox?.x).toBe(panelBox?.x);
+      expect(contentBox?.width).toBe(panelBox?.width);
+    }
+  });
+
   test("shares route gutters with the Character family", async ({ page }) => {
     for (const viewport of [
       { width: 390, height: 844 },

--- a/packages/app/test/ui-smoke/vault-tabs-accessibility.spec.ts
+++ b/packages/app/test/ui-smoke/vault-tabs-accessibility.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Verifies the Vault section switcher as a real keyboard-operated tab set
+ * against the deterministic UI-smoke app and API stub.
+ */
+
+import { expect, test } from "@playwright/test";
+import { openAppPath, seedAppStorage } from "./helpers";
+
+test.describe("Vault tab accessibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/cloud/login", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          sessionId: "vault-tabs-login",
+          browserUrl: "https://example.invalid/auth",
+        }),
+      });
+    });
+    await page.route("**/api/cloud/login/status**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "authenticated",
+          token: "vault-tabs-test-token",
+          organizationId: "vault-tabs-org",
+          userId: "vault-tabs-user",
+        }),
+      });
+    });
+    await page.route("**/api/cloud/login/persist", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    });
+    await seedAppStorage(page, {
+      "app-workspace-chrome:chat-collapsed": "true",
+    });
+    await openAppPath(page, "/vault");
+    await expect(page.getByTestId("section-nav-vault")).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+
+  test("exposes tab semantics and supports roving keyboard focus", async ({
+    page,
+  }) => {
+    const tabList = page.getByRole("tablist", { name: "Vault sections" });
+    const overview = page.getByRole("tab", { name: "Overview" });
+    const secrets = page.getByRole("tab", { name: "Secrets" });
+    const logins = page.getByRole("tab", { name: "Logins" });
+    const routing = page.getByRole("tab", { name: "Routing" });
+
+    await expect(tabList).toBeVisible();
+    await expect(overview).toHaveAttribute("aria-selected", "true");
+    await expect(overview).toHaveAttribute("aria-controls", /.+/);
+    await expect(secrets).toHaveAttribute("tabindex", "-1");
+
+    await overview.focus();
+    await page.keyboard.press("ArrowRight");
+    await expect(secrets).toBeFocused();
+    await expect(secrets).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByTestId("vault-tab-secrets-content")).toBeVisible();
+
+    await page.keyboard.press("End");
+    await expect(routing).toBeFocused();
+    await expect(routing).toHaveAttribute("aria-selected", "true");
+
+    await page.keyboard.press("Home");
+    await expect(overview).toBeFocused();
+    await expect(overview).toHaveAttribute("aria-selected", "true");
+    await expect(logins).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("uses the desktop section-header layout at a desktop viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const refresh = page.getByRole("button", { name: "Re-detect backends" });
+    await expect(refresh).toBeVisible();
+    const headerDirection = await refresh.evaluate(
+      (element) =>
+        getComputedStyle(element.parentElement as HTMLElement).flexDirection,
+    );
+    expect(headerDirection).toBe("row");
+  });
+});

--- a/packages/app/test/ui-smoke/vault-tabs-accessibility.spec.ts
+++ b/packages/app/test/ui-smoke/vault-tabs-accessibility.spec.ts
@@ -89,4 +89,49 @@ test.describe("Vault tab accessibility", () => {
     );
     expect(headerDirection).toBe("row");
   });
+
+  test("shares route gutters with the Character family", async ({ page }) => {
+    for (const viewport of [
+      { width: 390, height: 844 },
+      { width: 820, height: 1180 },
+      { width: 1440, height: 900 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await openAppPath(page, "/vault");
+      await expect(page.getByTestId("section-nav-vault")).toBeVisible();
+      const vaultBody = await page
+        .locator("[data-framed-page-body]")
+        .boundingBox();
+      const vaultTab = await page
+        .getByTestId("vault-tab-overview")
+        .boundingBox();
+
+      for (const characterRoute of [
+        "/character",
+        "/character/skills",
+        "/character/experience",
+      ]) {
+        await openAppPath(page, characterRoute);
+        await expect(page.getByTestId("section-nav-character")).toBeVisible();
+        const characterBody = await page
+          .locator("[data-framed-page-body]")
+          .boundingBox();
+        const characterTab = await page
+          .getByRole("button", { name: "Personality" })
+          .boundingBox();
+
+        expect(characterBody?.x).toBe(vaultBody?.x);
+        expect(characterBody?.width).toBe(vaultBody?.width);
+        expect(characterTab?.x).toBe(vaultTab?.x);
+      }
+
+      await openAppPath(page, "/character/select");
+      await expect(page.locator("[data-framed-page-body]")).toBeVisible();
+      const characterSelectBody = await page
+        .locator("[data-framed-page-body]")
+        .boundingBox();
+      expect(characterSelectBody?.x).toBe(vaultBody?.x);
+      expect(characterSelectBody?.width).toBe(vaultBody?.width);
+    }
+  });
 });

--- a/packages/ui/src/components/character/CharacterExperienceView.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceView.tsx
@@ -103,10 +103,7 @@ export function CharacterExperienceView({
     <ShellViewAgentSurface viewId="experience">
       <FramedPage>
         {pageChrome}
-        <FramedPageBody
-          padded={false}
-          className="gap-4 pt-1 [@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
-        >
+        <FramedPageBody className="gap-4 pt-1">
           {error ? (
             <div className="rounded-sm border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
               {error}

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -227,12 +227,7 @@ export function CharacterHubView({
   return (
     <FramedPage>
       {pageChrome}
-      <FramedPageBody
-        scroll="page"
-        padded={false}
-        className="[@media(min-width:768px)_and_(min-height:600px)]:px-10 lg:px-8"
-        data-testid="character-editor-view"
-      >
+      <FramedPageBody scroll="page" data-testid="character-editor-view">
         <div className="flex min-w-0 flex-col pt-1">
           <WidgetHost slot="character" className="mb-4" />
           <div className="flex min-w-0 flex-col gap-4 sm:gap-6 md:gap-8">

--- a/packages/ui/src/components/character/CharacterSectionNav.tsx
+++ b/packages/ui/src/components/character/CharacterSectionNav.tsx
@@ -83,10 +83,7 @@ export function CharacterSectionNav({
   return (
     <>
       <FramedPageHeader title="Character" />
-      <FramedPageNavigation
-        padded={false}
-        className="overflow-x-auto [@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
-      >
+      <FramedPageNavigation className="overflow-x-auto">
         <SectionTabStrip
           entries={CHARACTER_SECTION_TABS}
           activeId={activeCharacterTabId(activePath)}

--- a/packages/ui/src/components/character/CharacterSkillsView.tsx
+++ b/packages/ui/src/components/character/CharacterSkillsView.tsx
@@ -19,10 +19,7 @@ export function CharacterSkillsView({
     <ShellViewAgentSurface viewId="character-skills">
       <FramedPage>
         {pageChrome}
-        <FramedPageBody
-          padded={false}
-          className="gap-4 pt-1 [@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
-        >
+        <FramedPageBody className="gap-4 pt-1">
           <CharacterLearnedSkillsSection showTitle={false} />
         </FramedPageBody>
       </FramedPage>

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -99,7 +99,7 @@ function VaultTabTrigger({
       value={id}
       data-state={isActive ? "active" : "inactive"}
       data-testid={testId}
-      className="shrink-0 bg-transparent px-3 py-1.5 text-txt-strong hover:bg-accent-subtle data-[state=active]:bg-accent-subtle data-[state=active]:text-txt-strong max-[420px]:px-2 max-[360px]:px-1"
+      className="h-9 shrink-0 bg-transparent px-3 py-1.5 text-xs text-txt-strong hover:bg-accent-subtle data-[state=active]:bg-accent-subtle data-[state=active]:text-txt-strong pointer-coarse:min-h-touch pointer-coarse:min-w-touch max-[420px]:px-2 max-[360px]:px-1"
     >
       {label}
     </TabsTrigger>

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -16,6 +16,7 @@
 
 import { KeyRound, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAgentElement } from "../../agent-surface";
 // All requests go through the shared client (never bare `fetch`) so they hit
 // the configured apiBase and carry the injected auth token — a bare relative
 // fetch targets the page origin unauthenticated, which breaks remote/token-
@@ -28,7 +29,6 @@ import {
   type VaultTab,
 } from "../../hooks/useSecretsManagerModal";
 import { getShortcutLabel } from "../../hooks/useSecretsManagerShortcut";
-import { SectionTabStrip } from "../shared/SectionNav";
 import { Badge } from "../ui/badge";
 import { Banner } from "../ui/banner";
 import {
@@ -39,7 +39,7 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import { Separator } from "../ui/separator";
-import { Tabs, TabsContent } from "../ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { SettingsActionButton } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 import { LoginsTab } from "./vault-tabs/LoginsTab";
@@ -68,6 +68,43 @@ const VAULT_SECTION_TABS = [
   { id: "logins", label: "Logins", testId: "vault-tab-logins" },
   { id: "routing", label: "Routing", testId: "vault-tab-routing" },
 ] as const;
+
+function VaultTabTrigger({
+  id,
+  label,
+  testId,
+  activeTab,
+  onSelect,
+}: {
+  id: VaultTab;
+  label: string;
+  testId: string;
+  activeTab: VaultTab;
+  onSelect: (tab: VaultTab) => void;
+}): React.JSX.Element {
+  const isActive = activeTab === id;
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: `vault-tab-${id}`,
+    role: "tab",
+    label: `${label} Vault section`,
+    group: "vault-tabs",
+    status: isActive ? "active" : "inactive",
+    onActivate: () => onSelect(id),
+  });
+
+  return (
+    <TabsTrigger
+      ref={ref}
+      {...agentProps}
+      value={id}
+      data-state={isActive ? "active" : "inactive"}
+      data-testid={testId}
+      className="shrink-0 bg-transparent px-3 py-1.5 text-txt-strong hover:bg-accent-subtle data-[state=active]:bg-accent-subtle data-[state=active]:text-txt-strong max-[420px]:px-2 max-[360px]:px-1"
+    >
+      {label}
+    </TabsTrigger>
+  );
+}
 
 function readHashTab(): VaultTab | null {
   if (typeof window === "undefined") return null;
@@ -608,16 +645,20 @@ export function VaultWorkspace({
               onValueChange={onTabChange}
               className="flex min-h-0 flex-1 flex-col"
             >
-              <SectionTabStrip
-                entries={VAULT_SECTION_TABS}
-                activeId={activeTab}
-                onSelect={onTabChange}
-                testId="section-nav-vault"
-                ariaLabel="Vault sections"
-                agentIdPrefix="vault-tab"
-                className="self-start px-0 py-0"
-                tabClassName="max-[360px]:px-2"
-              />
+              <TabsList
+                aria-label="Vault sections"
+                data-testid="section-nav-vault"
+                className="h-auto max-w-full self-start justify-start gap-1 overflow-x-auto rounded-none bg-transparent p-0"
+              >
+                {VAULT_SECTION_TABS.map((tab) => (
+                  <VaultTabTrigger
+                    key={tab.id}
+                    {...tab}
+                    activeTab={activeTab}
+                    onSelect={onTabChange}
+                  />
+                ))}
+              </TabsList>
 
               <div className="mt-2 min-h-0 flex-1 overflow-y-auto pr-1">
                 <TabsContent

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -28,6 +28,7 @@ import {
   type VaultTab,
 } from "../../hooks/useSecretsManagerModal";
 import { getShortcutLabel } from "../../hooks/useSecretsManagerShortcut";
+import { SectionTabStrip } from "../shared/SectionNav";
 import { Badge } from "../ui/badge";
 import { Banner } from "../ui/banner";
 import {
@@ -38,7 +39,7 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import { Separator } from "../ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { Tabs, TabsContent } from "../ui/tabs";
 import { SettingsActionButton } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 import { LoginsTab } from "./vault-tabs/LoginsTab";
@@ -60,6 +61,13 @@ import type {
 } from "./vault-tabs/types";
 
 const HASH_PREFIX = "vault";
+
+const VAULT_SECTION_TABS = [
+  { id: "overview", label: "Overview", testId: "vault-tab-overview" },
+  { id: "secrets", label: "Secrets", testId: "vault-tab-secrets" },
+  { id: "logins", label: "Logins", testId: "vault-tab-logins" },
+  { id: "routing", label: "Routing", testId: "vault-tab-routing" },
+] as const;
 
 function readHashTab(): VaultTab | null {
   if (typeof window === "undefined") return null;
@@ -600,20 +608,16 @@ export function VaultWorkspace({
               onValueChange={onTabChange}
               className="flex min-h-0 flex-1 flex-col"
             >
-              <TabsList className="h-9 shrink-0 self-start">
-                <TabsTrigger value="overview" data-testid="vault-tab-overview">
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger value="secrets" data-testid="vault-tab-secrets">
-                  Secrets
-                </TabsTrigger>
-                <TabsTrigger value="logins" data-testid="vault-tab-logins">
-                  Logins
-                </TabsTrigger>
-                <TabsTrigger value="routing" data-testid="vault-tab-routing">
-                  Routing
-                </TabsTrigger>
-              </TabsList>
+              <SectionTabStrip
+                entries={VAULT_SECTION_TABS}
+                activeId={activeTab}
+                onSelect={onTabChange}
+                testId="section-nav-vault"
+                ariaLabel="Vault sections"
+                agentIdPrefix="vault-tab"
+                className="self-start px-0 py-0"
+                tabClassName="max-[360px]:px-2"
+              />
 
               <div className="mt-2 min-h-0 flex-1 overflow-y-auto pr-1">
                 <TabsContent

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -264,7 +264,7 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
   }, [entries]);
 
   return (
-    <section data-testid="vault-inventory-panel" className="space-y-2 pt-1">
+    <section data-testid="vault-inventory-panel" className="space-y-4">
       {findingsAvailable ? null : (
         <Card
           data-testid="vault-security-findings-unavailable"
@@ -314,18 +314,23 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
           </ul>
         </Card>
       ) : null}
-      <div className="flex items-center justify-between gap-2">
-        <p className="min-w-0 text-sm font-medium text-txt">
-          {t("vaultinventory.storedSecrets", {
-            defaultValue: "Stored secrets",
-          })}
-        </p>
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
+        <div className="min-w-0 space-y-1">
+          <h2 className="text-sm font-semibold text-txt">
+            {t("vaultinventory.storedSecrets", {
+              defaultValue: "Stored secrets",
+            })}
+          </h2>
+          <p className="text-xs text-muted">
+            Encrypted credentials and references available to this agent.
+          </p>
+        </div>
         <Button
           ref={addSecretRef}
           {...addSecretAgentProps}
           variant="outline"
           size="sm"
-          className="shrink-0"
+          className="self-start"
           onClick={() => setShowAdd((v) => !v)}
           aria-label={t("vaultinventory.addSecret", {
             defaultValue: "Add secret",
@@ -361,12 +366,13 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
           <Loader2 className="size-3.5 animate-spin" aria-hidden /> Loading…
         </div>
       ) : entries.length === 0 ? (
-        <p
+        <div
           data-testid="vault-inventory-empty"
-          className="p-3 text-center text-xs text-muted"
+          className="flex min-h-40 max-w-sm items-center text-xs text-muted sm:justify-center sm:text-center"
         >
-          No secrets yet.
-        </p>
+          No secrets yet. Add one when this agent needs a credential or secure
+          reference.
+        </div>
       ) : (
         <div className="space-y-3">
           {CATEGORY_ORDER.map((cat) => {

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -314,15 +314,15 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
           </ul>
         </Card>
       ) : null}
-      <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
-        <div className="min-w-0 space-y-1">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-[min(100%,30rem)] flex-1 space-y-1">
           <h2 className="text-sm font-semibold text-txt">
             {t("vaultinventory.storedSecrets", {
               defaultValue: "Stored secrets",
             })}
           </h2>
           <p className="text-xs text-muted">
-            Encrypted credentials and references available to this agent.
+            Manage secret values without exposing their contents.
           </p>
         </div>
         <Button
@@ -368,10 +368,12 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
       ) : entries.length === 0 ? (
         <div
           data-testid="vault-inventory-empty"
-          className="flex min-h-40 max-w-sm items-center text-xs text-muted sm:justify-center sm:text-center"
+          className="flex min-h-40 w-full items-center text-xs text-muted sm:justify-center sm:text-center"
         >
-          No secrets yet. Add one when this agent needs a credential or secure
-          reference.
+          <p className="max-w-sm">
+            No secrets yet. Add one when this agent needs a credential or secure
+            reference.
+          </p>
         </div>
       ) : (
         <div className="space-y-3">

--- a/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
@@ -294,8 +294,8 @@ export function LoginsTab() {
 
   return (
     <section data-testid="saved-logins-panel" className="max-w-3xl space-y-4">
-      <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
-        <div className="min-w-0 space-y-1">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-[min(100%,30rem)] flex-1 space-y-1">
           <h2 className="text-sm font-semibold text-txt">
             {t("logins.title", { defaultValue: "Saved logins" })}
           </h2>
@@ -472,22 +472,26 @@ export function LoginsTab() {
       ) : logins.length === 0 ? (
         <div
           data-testid="saved-logins-empty"
-          className="flex min-h-40 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+          className="flex min-h-40 w-full items-center text-xs text-muted sm:justify-center sm:text-center"
         >
-          {t("logins.empty", {
-            defaultValue:
-              "No saved logins. Add one, or sign in to 1Password / Bitwarden on Overview.",
-          })}
+          <p className="max-w-md">
+            {t("logins.empty", {
+              defaultValue:
+                "No saved logins. Add one, or sign in to 1Password / Bitwarden on Overview.",
+            })}
+          </p>
         </div>
       ) : filtered.length === 0 ? (
         <div
           data-testid="saved-logins-no-match"
-          className="flex min-h-32 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+          className="flex min-h-32 w-full items-center text-xs text-muted sm:justify-center sm:text-center"
         >
-          {t("logins.noMatch", {
-            filter,
-            defaultValue: 'No logins match "{{filter}}".',
-          })}
+          <p className="max-w-md">
+            {t("logins.noMatch", {
+              filter,
+              defaultValue: 'No logins match "{{filter}}".',
+            })}
+          </p>
         </div>
       ) : (
         <div className="overflow-hidden rounded-lg border border-line-subtle bg-bg-card">

--- a/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
@@ -293,13 +293,13 @@ export function LoginsTab() {
   });
 
   return (
-    <section data-testid="saved-logins-panel" className="space-y-2">
-      <div className="flex items-center justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-txt">
+    <section data-testid="saved-logins-panel" className="max-w-3xl space-y-4">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
+        <div className="min-w-0 space-y-1">
+          <h2 className="text-sm font-semibold text-txt">
             {t("logins.title", { defaultValue: "Saved logins" })}
-          </p>
-          <p className="text-2xs text-muted">
+          </h2>
+          <p className="text-xs text-muted">
             {t("logins.description", {
               defaultValue:
                 "Browser autofill from local vault, 1Password, and Bitwarden.",
@@ -311,7 +311,7 @@ export function LoginsTab() {
           {...addLoginAgentProps}
           variant="outline"
           size="sm"
-          className="shrink-0"
+          className="self-start"
           onClick={() => setShowAdd((v) => !v)}
         >
           <Plus className="size-3.5" aria-hidden />
@@ -470,82 +470,78 @@ export function LoginsTab() {
           {t("logins.loading", { defaultValue: "Loading…" })}
         </div>
       ) : logins.length === 0 ? (
-        <Card asChild variant="vaultEmpty" data-testid="saved-logins-empty">
-          <div>
-            {t("logins.empty", {
-              defaultValue:
-                "No saved logins. Add one, or sign in to 1Password / Bitwarden on Overview.",
-            })}
-          </div>
-        </Card>
-      ) : filtered.length === 0 ? (
-        <Card asChild variant="vaultEmpty" data-testid="saved-logins-no-match">
-          <div>
-            {t("logins.noMatch", {
-              filter,
-              defaultValue: 'No logins match "{{filter}}".',
-            })}
-          </div>
-        </Card>
-      ) : (
-        <Card
-          asChild
-          variant="transparent"
-          surface="card"
-          border="subtle"
-          className="space-y-1 p-1"
+        <div
+          data-testid="saved-logins-empty"
+          className="flex min-h-40 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
         >
-          <ul data-testid="saved-logins-list">
+          {t("logins.empty", {
+            defaultValue:
+              "No saved logins. Add one, or sign in to 1Password / Bitwarden on Overview.",
+          })}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div
+          data-testid="saved-logins-no-match"
+          className="flex min-h-32 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+        >
+          {t("logins.noMatch", {
+            filter,
+            defaultValue: 'No logins match "{{filter}}".',
+          })}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-line-subtle bg-bg-card">
+          <ul
+            data-testid="saved-logins-list"
+            className="divide-y divide-line-subtle"
+          >
             {filtered.map((login) => (
-              <Card
-                asChild
+              <li
                 key={`${login.source}:${login.identifier}`}
-                variant="vaultListRow"
+                className="flex items-center gap-2 p-3 sm:px-4"
               >
-                <li className="flex items-center gap-2">
-                  <Badge
-                    variant={SOURCE_PILL_VARIANT[login.source]}
-                    size="micro"
-                    className="shrink-0"
-                  >
-                    {sourceLabel(login.source)}
-                  </Badge>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-xs font-medium text-txt">
-                      {login.title}
-                      {login.domain && login.domain !== login.title ? (
-                        <span className="ml-1.5 text-muted">
-                          ({login.domain})
-                        </span>
-                      ) : null}
-                    </p>
-                    <p className="truncate text-2xs text-muted">
-                      {login.username || "—"} · {relativeAge(login.updatedAt)}
-                    </p>
-                  </div>
-                  {login.domain ? (
-                    <AgentAutoallowToggle
-                      domain={login.domain}
-                      allowed={autoallowMap[login.domain] === true}
-                      onChange={(next) =>
-                        void onToggleAutoallow(login.domain ?? "", next)
-                      }
-                    />
-                  ) : null}
-                  {login.source === "in-house" ? (
-                    <DeleteLoginButton
-                      identifier={login.identifier}
-                      target={login.domain ?? login.username}
-                      onDelete={() => void onDelete(login)}
-                    />
-                  ) : (
-                    <ExternalRowAction login={login} />
-                  )}
-                </li>
-              </Card>
+                <Badge
+                  variant={SOURCE_PILL_VARIANT[login.source]}
+                  size="micro"
+                  className="shrink-0"
+                >
+                  {sourceLabel(login.source)}
+                </Badge>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium text-txt">
+                    {login.title}
+                    {login.domain && login.domain !== login.title ? (
+                      <span className="ml-1.5 text-muted">
+                        ({login.domain})
+                      </span>
+                    ) : null}
+                  </p>
+                  <p className="truncate text-2xs text-muted">
+                    {login.username || "—"} · {relativeAge(login.updatedAt)}
+                  </p>
+                </div>
+                {login.domain ? (
+                  <AgentAutoallowToggle
+                    domain={login.domain}
+                    allowed={autoallowMap[login.domain] === true}
+                    onChange={(next) =>
+                      void onToggleAutoallow(login.domain ?? "", next)
+                    }
+                  />
+                ) : null}
+                {login.source === "in-house" ? (
+                  <DeleteLoginButton
+                    identifier={login.identifier}
+                    target={login.domain ?? login.username}
+                    onDelete={() => void onDelete(login)}
+                  />
+                ) : (
+                  <ExternalRowAction login={login} />
+                )}
+              </li>
             ))}
           </ul>
-        </Card>
+        </div>
       )}
     </section>
   );

--- a/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
@@ -293,7 +293,7 @@ export function LoginsTab() {
   });
 
   return (
-    <section data-testid="saved-logins-panel" className="max-w-3xl space-y-4">
+    <section data-testid="saved-logins-panel" className="w-full space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-[min(100%,30rem)] flex-1 space-y-1">
           <h2 className="text-sm font-semibold text-txt">

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -166,7 +166,7 @@ export function OverviewTab(props: OverviewTabProps) {
   );
 
   return (
-    <div className="max-w-3xl space-y-4">
+    <div className="w-full space-y-4">
       <p
         role="status"
         aria-live="polite"
@@ -196,68 +196,23 @@ export function OverviewTab(props: OverviewTabProps) {
               })}
             </p>
           </div>
-          <Button
-            ref={redetectRef}
-            {...redetectAgentProps}
-            variant="ghost"
-            size="sm"
-            onClick={onReload}
-            aria-label={t("vault.overview.redetect", {
-              defaultValue: "Re-detect backends",
-            })}
-            title={t("vault.overview.redetect", {
-              defaultValue: "Re-detect backends",
-            })}
-          >
-            <RefreshCw className="size-3.5" aria-hidden />
-            Refresh
-          </Button>
-        </div>
-
-        <div className="overflow-hidden rounded-lg border border-line-subtle bg-bg-card">
-          <div className="divide-y divide-line-subtle">
-            {orderedBackends(backends, preferences).map((backend) => (
-              <BackendRow
-                key={backend.id}
-                backend={backend}
-                enabled={isEnabled(backend.id)}
-                isPrimary={preferences.enabled[0] === backend.id}
-                position={preferences.enabled.indexOf(backend.id)}
-                totalEnabled={preferences.enabled.length}
-                methods={
-                  backend.id === "in-house"
-                    ? []
-                    : (installMethods[backend.id as InstallableBackendId] ?? [])
-                }
-                installSheetOpen={installSheet === backend.id}
-                signinSheetOpen={signinSheet === backend.id}
-                onToggle={(on) => setEnabled(backend.id, on)}
-                onMoveUp={() => moveUp(backend.id)}
-                onMoveDown={() => moveDown(backend.id)}
-                onOpenInstallSheet={() =>
-                  setInstallSheet(backend.id as InstallableBackendId)
-                }
-                onOpenSigninSheet={() =>
-                  setSigninSheet(backend.id as InstallableBackendId)
-                }
-                onCloseSheets={() => {
-                  setInstallSheet(null);
-                  setSigninSheet(null);
-                }}
-                onInstallComplete={() => {
-                  setInstallSheet(null);
-                  onInstallComplete();
-                }}
-                onSigninComplete={() => {
-                  setSigninSheet(null);
-                  onSigninComplete();
-                }}
-                onSignout={() => onSignout(backend.id as InstallableBackendId)}
-              />
-            ))}
-          </div>
-
-          <div className="flex items-center justify-end border-t border-line-subtle px-3 py-2.5 sm:px-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              ref={redetectRef}
+              {...redetectAgentProps}
+              variant="ghost"
+              size="sm"
+              onClick={onReload}
+              aria-label={t("vault.overview.redetect", {
+                defaultValue: "Re-detect backends",
+              })}
+              title={t("vault.overview.redetect", {
+                defaultValue: "Re-detect backends",
+              })}
+            >
+              <RefreshCw className="size-3.5" aria-hidden />
+              Refresh
+            </Button>
             <Button
               ref={saveRef}
               {...saveAgentProps}
@@ -275,6 +230,48 @@ export function OverviewTab(props: OverviewTabProps) {
                     })}
             </Button>
           </div>
+        </div>
+
+        <div className="divide-y divide-line-subtle border-y border-line-subtle">
+          {orderedBackends(backends, preferences).map((backend) => (
+            <BackendRow
+              key={backend.id}
+              backend={backend}
+              enabled={isEnabled(backend.id)}
+              isPrimary={preferences.enabled[0] === backend.id}
+              position={preferences.enabled.indexOf(backend.id)}
+              totalEnabled={preferences.enabled.length}
+              methods={
+                backend.id === "in-house"
+                  ? []
+                  : (installMethods[backend.id as InstallableBackendId] ?? [])
+              }
+              installSheetOpen={installSheet === backend.id}
+              signinSheetOpen={signinSheet === backend.id}
+              onToggle={(on) => setEnabled(backend.id, on)}
+              onMoveUp={() => moveUp(backend.id)}
+              onMoveDown={() => moveDown(backend.id)}
+              onOpenInstallSheet={() =>
+                setInstallSheet(backend.id as InstallableBackendId)
+              }
+              onOpenSigninSheet={() =>
+                setSigninSheet(backend.id as InstallableBackendId)
+              }
+              onCloseSheets={() => {
+                setInstallSheet(null);
+                setSigninSheet(null);
+              }}
+              onInstallComplete={() => {
+                setInstallSheet(null);
+                onInstallComplete();
+              }}
+              onSigninComplete={() => {
+                setSigninSheet(null);
+                onSigninComplete();
+              }}
+              onSignout={() => onSignout(backend.id as InstallableBackendId)}
+            />
+          ))}
         </div>
       </section>
     </div>

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -169,7 +169,7 @@ export function OverviewTab(props: OverviewTabProps) {
     <div className="max-w-3xl space-y-4">
       {protection ? <ProtectionCard protection={protection} /> : null}
       <section aria-labelledby="vault-backends-heading">
-        <div className="flex items-start justify-between gap-4 pb-3">
+        <div className="flex flex-col items-start gap-3 pb-3 sm:flex-row sm:justify-between sm:gap-4">
           <div className="min-w-0 space-y-1">
             <h2
               id="vault-backends-heading"
@@ -799,6 +799,7 @@ export function InstallSheet({
           {...closeAgentProps}
           variant="ghost"
           size="sm"
+          className="self-start"
           onClick={close}
           disabled={running}
         >

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -166,95 +166,105 @@ export function OverviewTab(props: OverviewTabProps) {
   );
 
   return (
-    <div className="space-y-3">
+    <div className="max-w-3xl space-y-4">
       {protection ? <ProtectionCard protection={protection} /> : null}
-      <div className="flex items-center justify-between pb-1">
-        <p className="text-2xs text-muted">
-          {t("vault.overview.routeHint", {
-            defaultValue:
-              "Sensitive values route to the first enabled backend.",
-          })}
-        </p>
-        <Button
-          ref={redetectRef}
-          {...redetectAgentProps}
-          variant="ghost"
-          size="icon-sm"
-          onClick={onReload}
-          aria-label={t("vault.overview.redetect", {
-            defaultValue: "Re-detect backends",
-          })}
-          title={t("vault.overview.redetect", {
-            defaultValue: "Re-detect backends",
-          })}
-        >
-          <RefreshCw className="size-3.5" aria-hidden />
-        </Button>
-      </div>
+      <section aria-labelledby="vault-backends-heading">
+        <div className="flex items-start justify-between gap-4 pb-3">
+          <div className="min-w-0 space-y-1">
+            <h2
+              id="vault-backends-heading"
+              className="text-sm font-semibold text-txt"
+            >
+              Secret backends
+            </h2>
+            <p className="text-xs text-muted">
+              {t("vault.overview.routeHint", {
+                defaultValue:
+                  "Sensitive values route to the first enabled backend.",
+              })}
+            </p>
+          </div>
+          <Button
+            ref={redetectRef}
+            {...redetectAgentProps}
+            variant="ghost"
+            size="sm"
+            onClick={onReload}
+            aria-label={t("vault.overview.redetect", {
+              defaultValue: "Re-detect backends",
+            })}
+            title={t("vault.overview.redetect", {
+              defaultValue: "Re-detect backends",
+            })}
+          >
+            <RefreshCw className="size-3.5" aria-hidden />
+            Refresh
+          </Button>
+        </div>
 
-      <div className="space-y-1.5">
-        {orderedBackends(backends, preferences).map((backend) => (
-          <BackendRow
-            key={backend.id}
-            backend={backend}
-            enabled={isEnabled(backend.id)}
-            isPrimary={preferences.enabled[0] === backend.id}
-            position={preferences.enabled.indexOf(backend.id)}
-            totalEnabled={preferences.enabled.length}
-            methods={
-              backend.id === "in-house"
-                ? []
-                : (installMethods[backend.id as InstallableBackendId] ?? [])
-            }
-            installSheetOpen={installSheet === backend.id}
-            signinSheetOpen={signinSheet === backend.id}
-            onToggle={(on) => setEnabled(backend.id, on)}
-            onMoveUp={() => moveUp(backend.id)}
-            onMoveDown={() => moveDown(backend.id)}
-            onOpenInstallSheet={() =>
-              setInstallSheet(backend.id as InstallableBackendId)
-            }
-            onOpenSigninSheet={() =>
-              setSigninSheet(backend.id as InstallableBackendId)
-            }
-            onCloseSheets={() => {
-              setInstallSheet(null);
-              setSigninSheet(null);
-            }}
-            onInstallComplete={() => {
-              setInstallSheet(null);
-              onInstallComplete();
-            }}
-            onSigninComplete={() => {
-              setSigninSheet(null);
-              onSigninComplete();
-            }}
-            onSignout={() => onSignout(backend.id as InstallableBackendId)}
-          />
-        ))}
-      </div>
+        <div className="overflow-hidden rounded-lg border border-line-subtle bg-bg-card">
+          <div className="divide-y divide-line-subtle">
+            {orderedBackends(backends, preferences).map((backend) => (
+              <BackendRow
+                key={backend.id}
+                backend={backend}
+                enabled={isEnabled(backend.id)}
+                isPrimary={preferences.enabled[0] === backend.id}
+                position={preferences.enabled.indexOf(backend.id)}
+                totalEnabled={preferences.enabled.length}
+                methods={
+                  backend.id === "in-house"
+                    ? []
+                    : (installMethods[backend.id as InstallableBackendId] ?? [])
+                }
+                installSheetOpen={installSheet === backend.id}
+                signinSheetOpen={signinSheet === backend.id}
+                onToggle={(on) => setEnabled(backend.id, on)}
+                onMoveUp={() => moveUp(backend.id)}
+                onMoveDown={() => moveDown(backend.id)}
+                onOpenInstallSheet={() =>
+                  setInstallSheet(backend.id as InstallableBackendId)
+                }
+                onOpenSigninSheet={() =>
+                  setSigninSheet(backend.id as InstallableBackendId)
+                }
+                onCloseSheets={() => {
+                  setInstallSheet(null);
+                  setSigninSheet(null);
+                }}
+                onInstallComplete={() => {
+                  setInstallSheet(null);
+                  onInstallComplete();
+                }}
+                onSigninComplete={() => {
+                  setSigninSheet(null);
+                  onSigninComplete();
+                }}
+                onSignout={() => onSignout(backend.id as InstallableBackendId)}
+              />
+            ))}
+          </div>
 
-      <Card
-        variant="topDivider"
-        className="flex items-center justify-end gap-2 pt-2"
-      >
-        <Button
-          ref={saveRef}
-          {...saveAgentProps}
-          variant="default"
-          size="sm"
-          onClick={onSave}
-          disabled={saving}
-        >
-          {saving
-            ? t("vault.overview.saving", { defaultValue: "Saving…" })
-            : savedAt !== null
-              ? t("vault.overview.saved", { defaultValue: "Saved" })
-              : t("vault.overview.savePreferences", {
-                  defaultValue: "Save preferences",
-                })}
-        </Button>
-      </Card>
+          <div className="flex items-center justify-end border-t border-line-subtle px-3 py-2.5 sm:px-4">
+            <Button
+              ref={saveRef}
+              {...saveAgentProps}
+              variant="default"
+              size="sm"
+              onClick={onSave}
+              disabled={saving}
+            >
+              {saving
+                ? t("vault.overview.saving", { defaultValue: "Saving…" })
+                : savedAt !== null
+                  ? t("vault.overview.saved", { defaultValue: "Saved" })
+                  : t("vault.overview.savePreferences", {
+                      defaultValue: "Save preferences",
+                    })}
+            </Button>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }
@@ -439,14 +449,8 @@ export function BackendRow(props: BackendRowProps) {
   const installableId = backend.id as InstallableBackendId;
 
   return (
-    <Card
-      variant="transparent"
-      surface="card"
-      border={enabled ? "standard" : "subtle"}
-      padding="compact"
-      className={enabled ? "py-2.5" : "py-2.5 opacity-70"}
-    >
-      <div className="flex items-center gap-3">
+    <div className={enabled ? "p-3 sm:p-4" : "p-3 opacity-70 sm:p-4"}>
+      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-x-3 gap-y-2">
         <Checkbox
           ref={enableRef}
           {...enableAgentProps}
@@ -459,9 +463,9 @@ export function BackendRow(props: BackendRowProps) {
           })}
         />
 
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium text-txt">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-sm font-medium text-txt">
               {backend.label}
             </span>
             <StatusPill tone={tone} text={status} />
@@ -541,40 +545,43 @@ export function BackendRow(props: BackendRowProps) {
               {t("vault.backend.signOut", { defaultValue: "Sign out" })}
             </Button>
           )}
-          {enabled && backend.available && backend.signedIn !== false && (
-            <>
-              <Button
-                ref={moveUpRef}
-                {...moveUpAgentProps}
-                variant="ghost"
-                size="icon-sm"
-                onClick={onMoveUp}
-                disabled={position <= 0}
-                title={t("vault.backend.moveUp", { defaultValue: "Move up" })}
-                aria-label={t("vault.backend.moveUp", {
-                  defaultValue: "Move up",
-                })}
-              >
-                <ChevronUp className="size-3.5" aria-hidden />
-              </Button>
-              <Button
-                ref={moveDownRef}
-                {...moveDownAgentProps}
-                variant="ghost"
-                size="icon-sm"
-                onClick={onMoveDown}
-                disabled={position < 0 || position >= totalEnabled - 1}
-                title={t("vault.backend.moveDown", {
-                  defaultValue: "Move down",
-                })}
-                aria-label={t("vault.backend.moveDown", {
-                  defaultValue: "Move down",
-                })}
-              >
-                <ChevronDown className="size-3.5" aria-hidden />
-              </Button>
-            </>
-          )}
+          {enabled &&
+            backend.available &&
+            backend.signedIn !== false &&
+            totalEnabled > 1 && (
+              <>
+                <Button
+                  ref={moveUpRef}
+                  {...moveUpAgentProps}
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onMoveUp}
+                  disabled={position <= 0}
+                  title={t("vault.backend.moveUp", { defaultValue: "Move up" })}
+                  aria-label={t("vault.backend.moveUp", {
+                    defaultValue: "Move up",
+                  })}
+                >
+                  <ChevronUp className="size-3.5" aria-hidden />
+                </Button>
+                <Button
+                  ref={moveDownRef}
+                  {...moveDownAgentProps}
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onMoveDown}
+                  disabled={position < 0 || position >= totalEnabled - 1}
+                  title={t("vault.backend.moveDown", {
+                    defaultValue: "Move down",
+                  })}
+                  aria-label={t("vault.backend.moveDown", {
+                    defaultValue: "Move down",
+                  })}
+                >
+                  <ChevronDown className="size-3.5" aria-hidden />
+                </Button>
+              </>
+            )}
         </div>
       </div>
 
@@ -595,7 +602,7 @@ export function BackendRow(props: BackendRowProps) {
           onComplete={onSigninComplete}
         />
       )}
-    </Card>
+    </div>
   );
 }
 

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -167,10 +167,22 @@ export function OverviewTab(props: OverviewTabProps) {
 
   return (
     <div className="max-w-3xl space-y-4">
+      <p
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {saving
+          ? "Saving Vault preferences."
+          : savedAt !== null
+            ? "Vault preferences saved."
+            : ""}
+      </p>
       {protection ? <ProtectionCard protection={protection} /> : null}
       <section aria-labelledby="vault-backends-heading">
-        <div className="flex flex-col items-start gap-3 pb-3 sm:flex-row sm:justify-between sm:gap-4">
-          <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-start justify-between gap-3 pb-3">
+          <div className="min-w-[min(100%,30rem)] flex-1 space-y-1">
             <h2
               id="vault-backends-heading"
               className="text-sm font-semibold text-txt"

--- a/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
@@ -78,6 +78,7 @@ export function RoutingTab(props: RoutingTabProps) {
 
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState("");
   const [showAdd, setShowAdd] = useState(false);
   const [keyPattern, setKeyPattern] = useState("");
   const [scopeKind, setScopeKind] = useState<RoutingScopeKind>("agent");
@@ -227,6 +228,7 @@ export function RoutingTab(props: RoutingTabProps) {
   const saveConfig = useCallback(
     async (next: RoutingConfig) => {
       setSaving(true);
+      setSaveStatus("");
       setError(null);
       try {
         const body = await client.fetch<{ config: RoutingConfig }>(
@@ -238,6 +240,7 @@ export function RoutingTab(props: RoutingTabProps) {
           },
         );
         onConfigChange(body.config);
+        setSaveStatus("Routing preferences saved.");
       } catch (err) {
         setError(
           err instanceof Error
@@ -338,6 +341,14 @@ export function RoutingTab(props: RoutingTabProps) {
 
   return (
     <div data-testid="routing-tab" className="max-w-3xl space-y-6">
+      <p
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {saveStatus}
+      </p>
       <section className="space-y-3">
         <div className="space-y-1">
           <h2 className="text-sm font-semibold text-txt">
@@ -378,8 +389,8 @@ export function RoutingTab(props: RoutingTabProps) {
 
       {/* Rules table */}
       <section className="space-y-4">
-        <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
-          <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-[min(100%,30rem)] flex-1 space-y-1">
             <h2 className="text-sm font-semibold text-txt">
               {t("routing.rules.title", { defaultValue: "Routing rules" })}
             </h2>
@@ -612,22 +623,26 @@ export function RoutingTab(props: RoutingTabProps) {
         {config.rules.length === 0 ? (
           <div
             data-testid="routing-rules-empty"
-            className="flex min-h-32 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+            className="flex min-h-32 w-full items-center text-xs text-muted sm:justify-center sm:text-center"
           >
-            {t("routing.empty", {
-              defaultValue:
-                "No routing rules. The default profile applies for every caller.",
-            })}
+            <p className="max-w-md">
+              {t("routing.empty", {
+                defaultValue:
+                  "No routing rules. The default profile applies for every caller.",
+              })}
+            </p>
           </div>
         ) : visibleRules.length === 0 ? (
           <div
             data-testid="routing-rules-no-match"
-            className="flex min-h-32 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+            className="flex min-h-32 w-full items-center text-xs text-muted sm:justify-center sm:text-center"
           >
-            {t("routing.noMatch", {
-              filter: rulesFilter,
-              defaultValue: 'No rules match "{{filter}}".',
-            })}
+            <p className="max-w-md">
+              {t("routing.noMatch", {
+                filter: rulesFilter,
+                defaultValue: 'No rules match "{{filter}}".',
+              })}
+            </p>
           </div>
         ) : (
           <div className="overflow-x-auto rounded-lg border border-line-subtle">

--- a/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
@@ -41,7 +41,6 @@ import {
   TableHeader,
   TableRow,
 } from "../../ui/table";
-import { SettingsSelectRow } from "../settings-agent-rows";
 import type {
   AgentSummary,
   InstalledApp,
@@ -314,6 +313,17 @@ export function RoutingTab(props: RoutingTabProps) {
     [config, saveConfig],
   );
 
+  const { ref: defaultProfileRef, agentProps: defaultProfileAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "routing-default-profile",
+      role: "select",
+      label: "Default routing profile",
+      group: "routing",
+      options: allProfileIds,
+      getValue: () => config.defaultProfile ?? "default",
+      onFill: (value) => void onDefaultProfileChange(value),
+    });
+
   const visibleRules = useMemo(() => {
     if (!rulesFilter.trim()) return config.rules;
     const needle = rulesFilter.trim().toLowerCase();
@@ -327,33 +337,53 @@ export function RoutingTab(props: RoutingTabProps) {
   }, [config.rules, rulesFilter]);
 
   return (
-    <div data-testid="routing-tab" className="space-y-4">
-      <SettingsSelectRow
-        agentId="routing-default-profile"
-        agentLabel="Default routing profile"
-        group="routing"
-        label={t("routing.defaultProfile.title", {
-          defaultValue: "Default profile",
-        })}
-        description={t("routing.defaultProfile.description", {
-          defaultValue:
-            'Applied when no rule matches. Falls back to "default".',
-        })}
-        value={config.defaultProfile ?? "default"}
-        onValueChange={(value) => void onDefaultProfileChange(value)}
-        disabled={saving}
-        testId="routing-default-profile"
-        options={allProfileIds.map((id) => ({ value: id, label: id }))}
-      />
+    <div data-testid="routing-tab" className="max-w-3xl space-y-6">
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold text-txt">
+            {t("routing.defaultProfile.title", {
+              defaultValue: "Default profile",
+            })}
+          </h2>
+          <p className="text-xs text-muted">
+            {t("routing.defaultProfile.description", {
+              defaultValue:
+                'Applied when no rule matches. Falls back to "default".',
+            })}
+          </p>
+        </div>
+        <Select
+          value={config.defaultProfile ?? "default"}
+          onValueChange={(value) => void onDefaultProfileChange(value)}
+          disabled={saving}
+        >
+          <SettingsSelectTrigger
+            ref={defaultProfileRef}
+            {...defaultProfileAgentProps}
+            variant="touch"
+            className="w-full"
+            data-testid="routing-default-profile"
+          >
+            <SelectValue />
+          </SettingsSelectTrigger>
+          <SelectContent>
+            {allProfileIds.map((id) => (
+              <SelectItem key={id} value={id}>
+                {id}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </section>
 
       {/* Rules table */}
-      <section className="space-y-2">
-        <div className="flex items-center justify-between gap-2">
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-txt">
+      <section className="space-y-4">
+        <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
+          <div className="min-w-0 space-y-1">
+            <h2 className="text-sm font-semibold text-txt">
               {t("routing.rules.title", { defaultValue: "Routing rules" })}
-            </p>
-            <p className="text-2xs text-muted">
+            </h2>
+            <p className="text-xs text-muted">
               {t("routing.rules.description", {
                 defaultValue:
                   "Per-context overrides. Match keys exactly (e.g. OPENROUTER_API_KEY) or use wildcards (e.g. OPENROUTER_*).",
@@ -365,7 +395,7 @@ export function RoutingTab(props: RoutingTabProps) {
             {...addRuleToggleAgentProps}
             variant="outline"
             size="sm"
-            className="shrink-0"
+            className="self-start"
             onClick={() => setShowAdd((v) => !v)}
             disabled={saving}
             aria-label={t("routing.addRule", {
@@ -580,79 +610,89 @@ export function RoutingTab(props: RoutingTabProps) {
         )}
 
         {config.rules.length === 0 ? (
-          <Card variant="vaultEmpty" data-testid="routing-rules-empty">
+          <div
+            data-testid="routing-rules-empty"
+            className="flex min-h-32 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+          >
             {t("routing.empty", {
               defaultValue:
                 "No routing rules. The default profile applies for every caller.",
             })}
-          </Card>
+          </div>
         ) : visibleRules.length === 0 ? (
-          <Card variant="vaultEmpty" data-testid="routing-rules-no-match">
+          <div
+            data-testid="routing-rules-no-match"
+            className="flex min-h-32 max-w-md items-center text-xs text-muted sm:justify-center sm:text-center"
+          >
             {t("routing.noMatch", {
               filter: rulesFilter,
               defaultValue: 'No rules match "{{filter}}".',
             })}
-          </Card>
+          </div>
         ) : (
-          <Table
-            data-testid="routing-rules-table"
-            density="compact"
-            layout="fixed"
-          >
-            <TableHeader>
-              <TableRow className="text-left text-muted">
-                <TableHead className="px-2 py-1 font-medium">
-                  {t("routing.table.key", { defaultValue: "Key" })}
-                </TableHead>
-                <TableHead className="px-2 py-1 font-medium">
-                  {t("routing.table.scope", { defaultValue: "Scope" })}
-                </TableHead>
-                <TableHead className="px-2 py-1 font-medium">
-                  {t("routing.table.profile", { defaultValue: "Profile" })}
-                </TableHead>
-                <TableHead className="w-16 px-2 py-1 font-medium text-right">
-                  {t("routing.table.actions", { defaultValue: "Actions" })}
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {visibleRules.map((rule, idx) => {
-                const targetId =
-                  rule.scope.agentId ??
-                  rule.scope.appName ??
-                  rule.scope.skillId ??
-                  "—";
-                const targetLabel =
-                  rule.scope.kind === "agent"
-                    ? (agentNameById.get(rule.scope.agentId ?? "") ?? targetId)
-                    : rule.scope.kind === "app"
-                      ? (appLabelByName.get(rule.scope.appName ?? "") ??
+          <div className="overflow-x-auto rounded-lg border border-line-subtle">
+            <Table
+              data-testid="routing-rules-table"
+              density="compact"
+              layout="fixed"
+              className="min-w-[36rem]"
+            >
+              <TableHeader>
+                <TableRow className="text-left text-muted">
+                  <TableHead className="px-2 py-1 font-medium">
+                    {t("routing.table.key", { defaultValue: "Key" })}
+                  </TableHead>
+                  <TableHead className="px-2 py-1 font-medium">
+                    {t("routing.table.scope", { defaultValue: "Scope" })}
+                  </TableHead>
+                  <TableHead className="px-2 py-1 font-medium">
+                    {t("routing.table.profile", { defaultValue: "Profile" })}
+                  </TableHead>
+                  <TableHead className="w-16 px-2 py-1 font-medium text-right">
+                    {t("routing.table.actions", { defaultValue: "Actions" })}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {visibleRules.map((rule, idx) => {
+                  const targetId =
+                    rule.scope.agentId ??
+                    rule.scope.appName ??
+                    rule.scope.skillId ??
+                    "—";
+                  const targetLabel =
+                    rule.scope.kind === "agent"
+                      ? (agentNameById.get(rule.scope.agentId ?? "") ??
                         targetId)
-                      : targetId;
-                const ruleKey = `${rule.keyPattern}:${rule.scope.kind}:${targetId}:${rule.profileId}:${idx}`;
-                const keyExists = allKeys.includes(rule.keyPattern);
-                return (
-                  <RoutingRuleRow
-                    key={ruleKey}
-                    ruleKey={ruleKey}
-                    keyPattern={rule.keyPattern}
-                    scopeKind={rule.scope.kind}
-                    targetLabel={targetLabel}
-                    profileId={rule.profileId}
-                    keyExists={keyExists}
-                    onOpenInSecrets={() =>
-                      navigate({
-                        tab: "secrets",
-                        focusKey: rule.keyPattern,
-                        focusProfileId: rule.profileId,
-                      })
-                    }
-                    onDelete={() => void onDeleteRule(rule)}
-                  />
-                );
-              })}
-            </TableBody>
-          </Table>
+                      : rule.scope.kind === "app"
+                        ? (appLabelByName.get(rule.scope.appName ?? "") ??
+                          targetId)
+                        : targetId;
+                  const ruleKey = `${rule.keyPattern}:${rule.scope.kind}:${targetId}:${rule.profileId}:${idx}`;
+                  const keyExists = allKeys.includes(rule.keyPattern);
+                  return (
+                    <RoutingRuleRow
+                      key={ruleKey}
+                      ruleKey={ruleKey}
+                      keyPattern={rule.keyPattern}
+                      scopeKind={rule.scope.kind}
+                      targetLabel={targetLabel}
+                      profileId={rule.profileId}
+                      keyExists={keyExists}
+                      onOpenInSecrets={() =>
+                        navigate({
+                          tab: "secrets",
+                          focusKey: rule.keyPattern,
+                          focusProfileId: rule.profileId,
+                        })
+                      }
+                      onDelete={() => void onDeleteRule(rule)}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
         )}
 
         {saving && (

--- a/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
@@ -340,7 +340,7 @@ export function RoutingTab(props: RoutingTabProps) {
   }, [config.rules, rulesFilter]);
 
   return (
-    <div data-testid="routing-tab" className="max-w-3xl space-y-6">
+    <div data-testid="routing-tab" className="w-full space-y-6">
       <p
         role="status"
         aria-live="polite"

--- a/packages/ui/src/components/settings/vault-tabs/SecretsTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/SecretsTab.tsx
@@ -37,7 +37,7 @@ export function SecretsTab({
     [navigate],
   );
   return (
-    <div className="max-w-3xl">
+    <div className="w-full">
       <VaultInventoryPanel
         entries={entries}
         securityFindings={securityFindings}

--- a/packages/ui/src/components/settings/vault-tabs/SecretsTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/SecretsTab.tsx
@@ -37,14 +37,16 @@ export function SecretsTab({
     [navigate],
   );
   return (
-    <VaultInventoryPanel
-      entries={entries}
-      securityFindings={securityFindings}
-      onChanged={onChanged}
-      onJumpToRouting={onJumpToRouting}
-      focusKey={focusKey}
-      focusProfileId={focusProfileId}
-      onFocusApplied={onFocusApplied}
-    />
+    <div className="max-w-3xl">
+      <VaultInventoryPanel
+        entries={entries}
+        securityFindings={securityFindings}
+        onChanged={onChanged}
+        onJumpToRouting={onJumpToRouting}
+        focusKey={focusKey}
+        focusProfileId={focusProfileId}
+        onFocusApplied={onFocusApplied}
+      />
+    </div>
   );
 }

--- a/packages/ui/src/components/shared/SectionNav.tsx
+++ b/packages/ui/src/components/shared/SectionNav.tsx
@@ -152,6 +152,7 @@ export function SectionNavTab({
   agentLabel,
   agentGroup,
   className,
+  testId,
 }: {
   label: React.ReactNode;
   isActive: boolean;
@@ -160,6 +161,7 @@ export function SectionNavTab({
   agentLabel?: string;
   agentGroup?: string;
   className?: string;
+  testId?: string;
 }): React.JSX.Element {
   if (agentId && agentLabel) {
     return (
@@ -171,6 +173,7 @@ export function SectionNavTab({
         agentLabel={agentLabel}
         agentGroup={agentGroup}
         className={className}
+        testId={testId}
       />
     );
   }
@@ -180,6 +183,7 @@ export function SectionNavTab({
       isActive={isActive}
       onSelect={onSelect}
       className={className}
+      testId={testId}
     />
   );
 }
@@ -191,6 +195,7 @@ function SectionNavTabButton({
   agentRef,
   agentProps,
   className,
+  testId,
 }: {
   label: React.ReactNode;
   isActive: boolean;
@@ -198,6 +203,7 @@ function SectionNavTabButton({
   agentRef?: React.Ref<HTMLButtonElement>;
   agentProps?: Record<string, string>;
   className?: string;
+  testId?: string;
 }): React.JSX.Element {
   return (
     <Button
@@ -211,6 +217,7 @@ function SectionNavTabButton({
       size="compact"
       data-state={isActive ? "on" : "off"}
       className={cn("shrink-0", className)}
+      data-testid={testId}
       {...agentProps}
     >
       {label}
@@ -226,6 +233,7 @@ function AgentSectionNavTab({
   agentLabel,
   agentGroup,
   className,
+  testId,
 }: {
   label: React.ReactNode;
   isActive: boolean;
@@ -234,6 +242,7 @@ function AgentSectionNavTab({
   agentLabel: string;
   agentGroup?: string;
   className?: string;
+  testId?: string;
 }): React.JSX.Element {
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: agentId,
@@ -253,6 +262,7 @@ function AgentSectionNavTab({
       agentRef={ref}
       agentProps={agentProps}
       className={className}
+      testId={testId}
     />
   );
 }
@@ -282,6 +292,7 @@ export function SectionTabStrip({
     id: string;
     label: React.ReactNode;
     agentLabel?: string;
+    testId?: string;
   }[];
   activeId: string;
   onSelect: (id: string) => void;
@@ -316,6 +327,7 @@ export function SectionTabStrip({
           agentLabel={entry.agentLabel}
           agentGroup={agentIdPrefix}
           className={tabClassName}
+          testId={entry.testId}
         />
       ))}
     </nav>

--- a/packages/ui/src/navigation/builtin-route-descriptors.ts
+++ b/packages/ui/src/navigation/builtin-route-descriptors.ts
@@ -92,6 +92,14 @@ const WORKSPACE_LAYOUT: PageLayoutManifest = Object.freeze({
   gutter: "standard",
 });
 
+/** Routes whose rendered view owns its canonical FramedPage width and gutter. */
+const FRAMED_PAGE_LAYOUT: PageLayoutManifest = Object.freeze({
+  kind: "content",
+  width: "wide",
+  scroll: "view",
+  gutter: "none",
+});
+
 const FULL_WORKSPACE_LAYOUT: PageLayoutManifest = Object.freeze({
   kind: "workspace",
   width: "full",
@@ -150,10 +158,10 @@ export const BUILTIN_ROUTE_DESCRIPTORS = defineBuiltinRoutes({
     layout: IMMERSIVE_LAYOUT,
     surface: { shared: (path) => path === "/views" },
   },
-  character: { path: "/character", layout: WORKSPACE_LAYOUT },
+  character: { path: "/character", layout: FRAMED_PAGE_LAYOUT },
   "character-select": {
     path: "/character/select",
-    layout: WORKSPACE_LAYOUT,
+    layout: FRAMED_PAGE_LAYOUT,
   },
   automations: { path: "/automations", layout: WORKSPACE_LAYOUT },
   triggers: { aliasOf: "automations" },
@@ -169,10 +177,10 @@ export const BUILTIN_ROUTE_DESCRIPTORS = defineBuiltinRoutes({
   trajectories: { path: "/apps/trajectories", layout: WORKSPACE_LAYOUT },
   transcripts: { path: "/apps/transcripts", layout: CONTENT_LAYOUT },
   relationships: { path: "/apps/relationships", layout: WORKSPACE_LAYOUT },
-  experience: { path: "/character/experience", layout: CONTENT_LAYOUT },
+  experience: { path: "/character/experience", layout: FRAMED_PAGE_LAYOUT },
   "character-skills": {
     path: "/character/skills",
-    layout: CONTENT_LAYOUT,
+    layout: FRAMED_PAGE_LAYOUT,
   },
   memories: { path: "/apps/memories", layout: WORKSPACE_LAYOUT },
   rolodex: { path: "/rolodex", layout: CONTENT_LAYOUT },
@@ -180,7 +188,7 @@ export const BUILTIN_ROUTE_DESCRIPTORS = defineBuiltinRoutes({
   database: { path: "/apps/database", layout: WORKSPACE_LAYOUT },
   desktop: { path: "/desktop", layout: FULL_WORKSPACE_LAYOUT },
   settings: { path: "/settings", layout: FULL_WORKSPACE_LAYOUT },
-  vault: { path: "/vault", layout: CONTENT_LAYOUT },
+  vault: { path: "/vault", layout: FRAMED_PAGE_LAYOUT },
   logs: { path: "/apps/logs", layout: CONTENT_LAYOUT },
   background: {
     path: "/background",

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsPage.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsPage.tsx
@@ -16,10 +16,7 @@ export function RelationshipsPage({
   return (
     <FramedPage reserveComposer={false}>
       {pageChrome}
-      <FramedPageBody
-        padded={false}
-        className="[@media(min-width:768px)_and_(min-height:600px)]:px-6 lg:px-8"
-      >
+      <FramedPageBody>
         <RelationshipsView />
       </FramedPageBody>
     </FramedPage>


### PR DESCRIPTION
## Summary

- preserve true Radix tab semantics across Vault Overview, Secrets, Logins, and Routing, including arrow-key roving focus and tab-panel association
- give every Vault tab one HIG-informed hierarchy, content measure, alignment grid, responsive action pattern, and touch-safe tab geometry
- use the same single FramedPage gutter across Vault and the Character family instead of stacking route-shell and page padding
- standardize Personality, Character Select, Relationships, Skills, and Experience on the canonical 16 px mobile, 24 px tablet, and 32 px desktop gutter
- let every Vault tab fill that canonical width and render backends as a continuous settings list, with Refresh and Save in the section action area instead of an empty boxed footer

Closes #29553

## Visual evidence

The original sheet is retained as the baseline. The exact-head after sheets show Vault Overview, Secrets, Logins, and Routing followed by Character Personality, Skills, and Experience. Pages in each row use the same visible content edge.

### Before

![Before: Vault tabs before canonicalization](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-before-all-all-tabs.jpg)

### After — desktop

![After: Vault and Character routes at desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-after-desktop-cb6e9704.jpg)

### After — mobile

![After: Vault and Character routes at mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-after-mobile-cb6e9704.jpg)

### Vault tabs — individual exact-head captures

| Tab | Desktop | Mobile |
| --- | --- | --- |
| Overview | ![Vault Overview desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-overview-desktop-cb6e9704.png) | ![Vault Overview mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-overview-mobile-cb6e9704.png) |
| Secrets | ![Vault Secrets desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-secrets-desktop-cb6e9704.png) | ![Vault Secrets mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-secrets-mobile-cb6e9704.png) |
| Logins | ![Vault Logins desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-logins-desktop-cb6e9704.png) | ![Vault Logins mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-logins-mobile-cb6e9704.png) |
| Routing | ![Vault Routing desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-routing-desktop-cb6e9704.png) | ![Vault Routing mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-vault-routing-mobile-cb6e9704.png) |

## Validation

- rebased cleanly onto `origin/develop` at `74ac678832`
- `bun run --cwd packages/ui typecheck`
- 74 focused UI Vitest assertions passed across Vault, Character, routing manifests, and shared navigation
- 9 Relationships view assertions passed
- focused Chromium route test passed: true tab semantics, keyboard navigation, responsive header layout, full-width content on every Vault tab, and equal Vault/Character body + tab coordinates at 390, 820, and 1440 px
- exact-head visual capture passed for 14 mobile/desktop route states
- `audit:app` was attempted; its unrelated built-in-chat bootstrap fails before route audit because `home-screen` never becomes visible
- the broader Relationships package lane currently reaches an unrelated workspace-resolution baseline failure (`@elizaos/plugin-openai/endpoint-config`); the focused Relationships view suite passes

<!-- evidence-head:cb6e970434a00f1f1531a5ea88e1a6d3cab4fa27 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-before-all-all-tabs.jpg)

<!-- evidence-row:after-screenshots -->
- [x] [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-after-desktop-cb6e9704.jpg) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-after-mobile-cb6e9704.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-walkthrough-cb6e9704.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend path changed or fired

<!-- evidence-row:frontend-logs -->
- [x] [frontend console and network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-frontend-console-network-211f3574.log) — deterministic smoke stubs intentionally return unsupported-route 404/501 responses; the route assertions and captures pass

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - layout-only UI change with no domain mutation

<!-- evidence-row:ocr-review -->
- [x] [OCR review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29556-ocr-cb6e9704.txt)
