### PR TITLE
fix(app-core): recheck generation ownership after renderer URL resolution

### DIFF
--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.test.ts
@@ -144,4 +144,39 @@ describe("desktop session renderer readiness", () => {
 
     expect(window.webview.loadURL).toHaveBeenCalledTimes(2);
   });
+
+  it("does not let a superseded generation navigate after a newer generation completes", async () => {
+    const window = createWindow();
+    let releaseOldUrl: (() => void) | undefined;
+
+    const oldCall = reloadRendererAfterDesktopSessionPrime({
+      sessionPrimed: true,
+      backendGeneration: "31337:old",
+      window,
+      resolveRendererUrl: () =>
+        new Promise<string>((resolve) => {
+          releaseOldUrl = () => resolve("http://127.0.0.1:5174/old");
+        }),
+    });
+
+    // The newer generation reserves the window and completes first, while
+    // the older generation's URL lookup is still in flight.
+    await expect(
+      reloadRendererAfterDesktopSessionPrime({
+        sessionPrimed: true,
+        backendGeneration: "31337:new",
+        window,
+        resolveRendererUrl: async () => "http://127.0.0.1:5174/new",
+      }),
+    ).resolves.toBe(true);
+
+    releaseOldUrl?.();
+    await expect(oldCall).resolves.toBe(false);
+
+    expect(window.webview.loadURL).toHaveBeenCalledTimes(1);
+    expect(window.webview.loadURL).toHaveBeenCalledWith(
+      "http://127.0.0.1:5174/new",
+    );
+    expect(loggerState.info).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.ts
@@ -43,6 +43,13 @@ export async function reloadRendererAfterDesktopSessionPrime({
 
   try {
     const rendererUrl = await resolveRendererUrl();
+    // A newer generation may have reserved this window while the URL lookup
+    // above was in flight. Only the generation that still owns the
+    // reservation after the await may navigate or log success; a superseded
+    // generation must not clobber the newer generation's window state.
+    if (reloadedGenerationByWindow.get(window) !== backendGeneration) {
+      return false;
+    }
     window.webview.loadURL(rendererUrl);
     logger.info(
       "[Main] Reloaded desktop renderer after loopback session prime",


### PR DESCRIPTION
`reloadRendererAfterDesktopSessionPrime` reserves a backend generation before awaiting `resolveRendererUrl()`, but never rechecked ownership after that async boundary. A newer generation can reserve the same window while an older generation's URL lookup is still in flight; the older generation would then call `window.webview.loadURL(...)` and log success after the newer generation already took ownership, causing renderer flicker or state loss.

The catch path already rechecks ownership before cleanup; the success path now performs the same recheck before navigating, returning `false` without logging when superseded.

Added a regression test reproducing the exact race: an older generation's deferred URL lookup resolves after a newer generation has already completed, and must not navigate or log success.

Fixes #29270