### PR TITLE
fix(plugin-video): safely resolve subtitle/caption track URL to prevent TypeError on empty array (#29562)

### DIFF
--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -325,4 +325,24 @@ describe("VideoService deterministic behavior", () => {
       embedSubs: true,
     });
   });
+
+  it("degrades gracefully when subtitles/captions array is empty (#29562)", async () => {
+    const runtime = createRuntime();
+    const { service } = createServiceWithYtDlp([
+      {
+        title: "Music Video",
+        description: "Test",
+        categories: ["Music"],
+        subtitles: { en: [] },
+        automatic_captions: { en: [] },
+      },
+    ]);
+
+    const result = await service.processVideo(
+      "https://youtu.be/empty-subtitles-test",
+      runtime,
+    );
+
+    expect(result.text).toBe("No lyrics available.");
+  });
 });

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -576,19 +576,18 @@ export class VideoService extends IVideoService {
     elizaLogger.log("Getting transcript");
     try {
       // Check for manual subtitles
-      if (videoInfo.subtitles?.en) {
+      const manualSubUrl = videoInfo.subtitles?.en?.[0]?.url;
+      if (manualSubUrl) {
         elizaLogger.log("Manual subtitles found");
-        const srtContent = await this.downloadSRT(
-          videoInfo.subtitles.en[0].url,
-        );
+        const srtContent = await this.downloadSRT(manualSubUrl);
         return this.parseSRT(srtContent);
       }
 
       // Check for automatic captions
-      if (videoInfo.automatic_captions?.en) {
+      const autoCaptionUrl = videoInfo.automatic_captions?.en?.[0]?.url;
+      if (autoCaptionUrl) {
         elizaLogger.log("Automatic captions found");
-        const captionUrl = videoInfo.automatic_captions.en[0].url;
-        const captionContent = await this.downloadCaption(captionUrl);
+        const captionContent = await this.downloadCaption(autoCaptionUrl);
         return this.parseCaption(captionContent);
       }
 


### PR DESCRIPTION
## Summary

Fixes #29562.

When `yt-dlp` returns an empty array for `subtitles.en` (`{ subtitles: { en: [] } }`), `videoInfo.subtitles?.en` evaluated to truthy, causing `videoInfo.subtitles.en[0].url` to throw `TypeError: Cannot read properties of undefined (reading 'url')` and crash video processing instead of falling through to automatic captions / music degrade / audio transcription.

### Changes
- Safely extract track URL using optional chaining `videoInfo.subtitles?.en?.[0]?.url` and `videoInfo.automatic_captions?.en?.[0]?.url` before triggering download.
- Preserves documented fallback degrade path when subtitle/caption arrays are empty.