### PR TITLE
fix(plugin-wallet): record approved-draft spend into RollingSpendCap (fail-open cap bypass)

### DIFF
--- a/plugins/plugin-wallet/src/sdk/policy/SpendingPolicy.test.ts
+++ b/plugins/plugin-wallet/src/sdk/policy/SpendingPolicy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression suite for SpendingPolicy's RollingSpendCap interaction with the
+ * DraftThenApprove path. Exercises the real exported class (no mocks): a
+ * payment at/above draftThreshold takes the draft branch and therefore never
+ * hits the auto-approval spend recording, so approveDraft() must accrue the
+ * approved amount into the rolling window exactly once. Without that, the
+ * largest payments — the ones the cap exists to govern — escaped the cap
+ * accounting entirely (fail-open guardrail hole, issue #29565).
+ */
+
+import { describe, expect, it } from "vitest";
+import { SpendingPolicy } from "./SpendingPolicy.ts";
+
+describe("SpendingPolicy — approved drafts and RollingSpendCap (#29565)", () => {
+  it("records an approved draft into the rolling window so a later payment over the cap is rejected", async () => {
+    const policy = new SpendingPolicy({
+      rollingCap: { maxAmount: 1000, windowMs: 86_400_000 },
+      draftThreshold: 400,
+    });
+
+    const drafted = await policy.check({ merchant: "m", amount: 400 });
+    expect(drafted.status).toBe("draft");
+    expect(drafted.draftId).toBeDefined();
+
+    expect(policy.approveDraft(drafted.draftId as string)).toBe(true);
+
+    // 700 alone fits under the 1000 cap, but 400 was already approved, so the
+    // cumulative 1100 must trip the cap. Pre-fix this returned "draft"/allowed
+    // because the approved draft contributed 0 to the window.
+    const next = await policy.check({ merchant: "m", amount: 700 });
+    expect(next.status).toBe("rejected");
+    expect(next.reason).toMatch(/spend cap exceeded/i);
+  });
+
+  it("regression: N drafted+approved payments over the cap block the next payment (repro: 5000 approved vs cap 1000)", async () => {
+    const policy = new SpendingPolicy({
+      rollingCap: { maxAmount: 1000, windowMs: 86_400_000 },
+      draftThreshold: 100,
+    });
+
+    let approvedTotal = 0;
+    for (let i = 0; i < 50; i++) {
+      const r = await policy.check({ merchant: "m", amount: 100 });
+      if (r.status === "draft" && r.draftId) {
+        policy.approveDraft(r.draftId);
+        approvedTotal += 100;
+      }
+    }
+
+    // With drafts counted, cumulative approval halts once it reaches the cap
+    // instead of climbing to the pre-fix 5000.
+    expect(approvedTotal).toBe(1000);
+
+    // A fresh below-threshold payment must now be rejected rather than
+    // auto-approved as if nothing had been spent.
+    const small = await policy.check({ merchant: "m", amount: 50 });
+    expect(small.status).toBe("rejected");
+
+    const large = await policy.check({ merchant: "m", amount: 1000 });
+    expect(large.status).toBe("rejected");
+  });
+
+  it("records spend only once when approveDraft is called repeatedly for the same draft", async () => {
+    const policy = new SpendingPolicy({
+      rollingCap: { maxAmount: 1000, windowMs: 86_400_000 },
+      draftThreshold: 600,
+    });
+
+    const drafted = await policy.check({ merchant: "m", amount: 600 });
+    expect(drafted.status).toBe("draft");
+    const draftId = drafted.draftId as string;
+
+    expect(policy.approveDraft(draftId)).toBe(true);
+    expect(policy.approveDraft(draftId)).toBe(true);
+
+    // Only 600 should be accrued. A subsequent 400 (below threshold, auto path)
+    // brings cumulative to exactly 1000 and is approved. Double-counting would
+    // have accrued 1200 and rejected this.
+    const fits = await policy.check({ merchant: "m", amount: 400 });
+    expect(fits.status).toBe("approved");
+
+    // But a fresh unit now pushes over the cap.
+    const over = await policy.check({ merchant: "m", amount: 1 });
+    expect(over.status).toBe("rejected");
+  });
+
+  it("rejectDraft never records spend, and a subsequently approved draft still fits", async () => {
+    const policy = new SpendingPolicy({
+      rollingCap: { maxAmount: 1000, windowMs: 86_400_000 },
+      draftThreshold: 500,
+    });
+
+    const first = await policy.check({ merchant: "m", amount: 900 });
+    expect(first.status).toBe("draft");
+    expect(policy.rejectDraft(first.draftId as string)).toBe(true);
+
+    // The rejected 900 must contribute nothing; a fresh 900 draft can be
+    // approved and fits within the 1000 cap.
+    const second = await policy.check({ merchant: "m", amount: 900 });
+    expect(second.status).toBe("draft");
+    expect(policy.approveDraft(second.draftId as string)).toBe(true);
+
+    // Now 900 is accrued; a further 200 exceeds the cap.
+    const over = await policy.check({ merchant: "m", amount: 200 });
+    expect(over.status).toBe("rejected");
+  });
+
+  it("approving an already-rejected draft is a no-op that records nothing", async () => {
+    const policy = new SpendingPolicy({
+      rollingCap: { maxAmount: 1000, windowMs: 86_400_000 },
+      draftThreshold: 500,
+    });
+
+    const drafted = await policy.check({ merchant: "m", amount: 800 });
+    const draftId = drafted.draftId as string;
+    expect(policy.rejectDraft(draftId)).toBe(true);
+    // Cannot resurrect a rejected draft; nothing is accrued.
+    expect(policy.approveDraft(draftId)).toBe(false);
+
+    const fresh = await policy.check({ merchant: "m", amount: 900 });
+    expect(fresh.status).toBe("draft");
+  });
+
+  it("approving a draft when rollingCap is undefined is a no-op and does not throw", async () => {
+    const policy = new SpendingPolicy({ draftThreshold: 100 });
+
+    const drafted = await policy.check({ merchant: "m", amount: 500 });
+    expect(drafted.status).toBe("draft");
+
+    expect(() => policy.approveDraft(drafted.draftId as string)).not.toThrow();
+    expect(policy.approveDraft(drafted.draftId as string)).toBe(true);
+  });
+
+  it("returns false when approving a draftId that does not exist", () => {
+    const policy = new SpendingPolicy({
+      rollingCap: { maxAmount: 1000, windowMs: 86_400_000 },
+      draftThreshold: 100,
+    });
+    expect(policy.approveDraft("draft-does-not-exist")).toBe(false);
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/policy/SpendingPolicy.ts
+++ b/plugins/plugin-wallet/src/sdk/policy/SpendingPolicy.ts
@@ -41,6 +41,13 @@ export interface DraftEntry {
   queuedAt: string; // ISO-8601
   approved: boolean;
   rejected: boolean;
+  /**
+   * True once this draft's amount has been recorded into the RollingSpendCap
+   * window. Guards against double-counting when approveDraft() is called more
+   * than once for the same draft. Approved-draft spend must accrue exactly once
+   * so the cap governs subsequent auto-approvals against the true balance.
+   */
+  counted: boolean;
 }
 
 /** Immutable record written to the audit log. */
@@ -160,11 +167,26 @@ export class SpendingPolicy {
 
   // ─── Draft queue management ─────────────────────────────────────────────────
 
-  /** Approve a queued draft by its draftId. Returns false if not found. */
+  /**
+   * Approve a queued draft by its draftId. Returns false if not found.
+   *
+   * A DraftThenApprove payment bypasses the auto-approval path in _check(), so
+   * its amount was never added to the RollingSpendCap window. Human approval is
+   * the point at which the spend becomes real, so record it here — exactly once
+   * and regardless of whether it now exceeds maxAmount (the human explicitly
+   * approved; the cap governs future auto-approvals, which must see the true
+   * accrued spend). Without this, the largest payments — the ones the cap is
+   * meant to govern — escape the rolling accounting entirely (fail-open).
+   */
   approveDraft(draftId: string): boolean {
     const draft = this.drafts.get(draftId);
     if (!draft) return false;
+    if (draft.rejected) return false;
     draft.approved = true;
+    if (this.config.rollingCap && !draft.counted) {
+      this.spendWindow.push({ amount: draft.payment.amount, ts: Date.now() });
+      draft.counted = true;
+    }
     return true;
   }
 
@@ -236,6 +258,7 @@ export class SpendingPolicy {
         queuedAt: payment.timestamp ?? new Date().toISOString(),
         approved: false,
         rejected: false,
+        counted: false,
       };
       this.drafts.set(draftId, draft);
 


### PR DESCRIPTION
# Relates to

Closes #29565

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package checks were run; the one unrelated pre-existing blocker is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below (red→green test + repro transcript).

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (branch was 0 commits behind at push time).
- [ ] `bun run verify` not run in full on this constrained host; focused package `test`/`typecheck`/`lint` pass. See **Known gaps / failures**.

# Risks

Low. The change is confined to `SpendingPolicy.approveDraft()` and the internal `DraftEntry` shape (a new `counted` boolean). It only *adds* spend accounting that was previously missing; it cannot approve a payment that the prior code rejected. The one behavioral tightening — `approveDraft()` on an already-`rejected` draft now returns `false` and records nothing instead of silently flipping `approved` — closes a resurrection path and has no in-repo callers.

# Background

## What does this PR do?

`SpendingPolicy` (exported from the `@elizaos/plugin-wallet` SDK) advertises a **RollingSpendCap**: "maximum cumulative spend in a rolling time window." But spend was only ever pushed into the rolling window on the *auto-approval* path inside `_check()`. Any payment whose `amount >= draftThreshold` takes the **DraftThenApprove** branch, returns `status: "draft"`, and was **never** recorded. `approveDraft()` only set `draft.approved = true` — it recorded nothing — and re-running `check()` on the same (still ≥ threshold) amount just re-drafted.

Consequently every payment at or above the draft threshold — i.e. the *largest* payments, exactly what the cap should govern — escaped the rolling-cap accounting entirely. The cap could be exceeded by an unbounded multiple, and a later below-threshold payment was approved as if nothing had been spent. This is a **fail-open** hole in a spending guardrail.

**Fix (~5 lines + a guard field):** `approveDraft()` now records the approved draft's amount into the rolling window **exactly once**, guarded by a new `DraftEntry.counted` flag so repeated approvals don't double-count. It also refuses to approve an already-`rejected` draft. The human explicitly approved, so spend is recorded regardless of whether it now exceeds `maxAmount` — the cap governs future *auto-approvals*, which must see the true accrued balance.

## What kind of change is this?

Bug fix (non-breaking; closes a fail-open guardrail hole).

# Documentation changes needed?

No. The class JSDoc already advertised the RollingSpendCap contract; this makes the implementation honor it. In-code header comments on `approveDraft()` and `DraftEntry.counted` explain the invariant.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/sdk/policy/SpendingPolicy.test.ts` — a new suite exercising the real exported class (no mocks).

## Detailed testing steps

```
cd plugins/plugin-wallet
node_modules/.bin/vitest run --config ./vitest.config.ts src/sdk/policy/SpendingPolicy.test.ts
```

Red-before / green-after was verified by stashing the source fix and re-running: 5 of 7 tests fail on the pre-fix implementation (the 2 that pass are the `rollingCap`-undefined no-op and the nonexistent-draftId guard, which don't depend on the fix), then all 7 pass with the fix applied.

# Evidence Gate

<!-- evidence-head:f4e131b25af198567543f187c7d4ab956b77152d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; SDK policy class change only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; SDK policy class change only.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; library function change verified by unit tests + repro transcript below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - full before/after reproduction transcript and structured test output are pasted inline under 'Backend + frontend logs'; the immutable-attachment channel is unavailable in this environment (fork account lacks pr-evidence release write access, HTTP 404, and the attachment uploader is unauthenticated). Deterministic library change with no server process.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; deterministic policy arithmetic.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the guardrail behavior itself, shown inline as the red (5 failed) vs green (7 passed) test transcript and the before(5000)/after(1000) repro output; no DB/on-chain/file artifact exists for this pure policy-arithmetic fix, and immutable upload is unavailable here (see backend-logs reason).
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic policy logic; no model call.`

## Backend + frontend logs

Reproduction using the real class (`plugins/plugin-wallet/src/sdk/policy/SpendingPolicy.ts`), no external deps:

```ts
const policy = new SpendingPolicy({ rollingCap: { maxAmount: 1000, windowMs: 86400000 }, draftThreshold: 100 });
let approved = 0;
for (let i=0;i<50;i++){ const r = await policy.check({merchant:"m",amount:100}); if(r.status==="draft"&&r.draftId){ policy.approveDraft(r.draftId); approved+=100; } }
// then probe a 50-unit and a 1000-unit payment
```

**Before fix (origin/develop fd05ebc6fe):**
```
Total approved spend via drafts: 5000 (rolling cap is 1000)
Subsequent 50-unit payment status: approved
After 5000 drafted+approved, a fresh 1000 payment status: draft/approved  (cap never trips against drafts)
```

**After fix:**
```
Total approved spend via drafts: 1000 (rolling cap is 1000)
Subsequent 50-unit payment status: rejected
After 5000 drafted+approved, a fresh 1000 payment status: rejected (EXPECT rejected if cap counted drafts)
```

Focused test output:
```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Red-before (pre-fix source, tests unchanged):
```
 ❯ src/sdk/policy/SpendingPolicy.test.ts (7 tests | 5 failed)
 Test Files  1 failed (1)
      Tests  5 failed | 2 passed (7)
```

Full `src/sdk` suite after fix (no regressions):
```
 Test Files  7 passed (7)
      Tests  43 passed (43)
```

## Screenshots (before / after) + video walkthrough

### Before
`N/A - no UI.`
### After
`N/A - no UI.`
### Walkthrough video
`N/A - no UI.`

## Audio / voice walkthrough

`N/A - no audio/voice surface.`

## Known gaps / failures

- `bun run typecheck` for `plugin-wallet` reports one pre-existing error unrelated to this change: `src/api/wallet-routes.ts(96,5): Cannot find module '@elizaos/plugin-elizacloud'` (resolves after building that workspace peer) and ~40 pre-existing `implicitly has an 'any' type` errors under `tsconfig.ui.json` in `src/ui/widgets/*.tsx`. Both reproduce on a clean `origin/develop` checkout (verified by `git stash`). The **server `tsconfig.json` project that includes my changed files passes cleanly (exit 0)**.
- Full repo `bun run verify` was not run on this constrained host (Raspberry Pi); focused `plugin-wallet` package `test`, server `typecheck`, and `lint` (`biome check`) all pass on the touched files.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Closes #29565

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@fd05ebc6fe474bbc061a1be2582315128cf13ae5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@fd05ebc6fe474bbc061a1be2582315128cf13ae5:packages/skills/skills/contribute-to-eliza"} -->

