### PR TITLE
fix(lifeops): decode module URL roots with fileURLToPath on Windows (#29569)

### DIFF
--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   appBase,
   CONNECTOR_PATH_ENV_NAMES,
@@ -54,7 +55,7 @@ function markdownCells(row) {
     .map((cell) => cell.replaceAll("__ESCAPED_PIPE__", "|").trim());
 }
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const IDENTITY_SLOT_CATALOG = resolve(
   ROOT,
   "docs/testing/hitl-identity-slots.md",

--- a/scripts/lifeops/env-layers.mjs
+++ b/scripts/lifeops/env-layers.mjs
@@ -39,7 +39,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 /** Home-layer file: shared across every checkout and worktree of this repo. */
 export const HOME_ENV_PATH = join(homedir(), ".eliza", ".env");

--- a/scripts/lifeops/env-layers.test.mjs
+++ b/scripts/lifeops/env-layers.test.mjs
@@ -24,7 +24,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   applyLayeredEnvToProcess,
   atomicWriteEnvFile,
@@ -38,7 +38,7 @@ import {
   writeSecret,
 } from "./env-layers.mjs";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 // realpath so git-canonicalized paths (macOS /var -> /private/var) compare equal.
 function tempDir(prefix) {

--- a/scripts/lifeops/hitl-credential-dashboard.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.mjs
@@ -79,7 +79,7 @@ import {
   recordOutcomes,
 } from "./hitl-ledger.mjs";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const REPO_ENV_PATH = join(ROOT, ".env");
 const PROBE_CACHE_PATH = join(
   ROOT,

--- a/scripts/lifeops/hitl-credential-dashboard.test.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.test.mjs
@@ -15,12 +15,13 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   dashboardErrorResponse,
   HttpError,
 } from "./hitl-credential-dashboard.mjs";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 test("credential dashboard does not serialize unexpected exception details", () => {
   const marker = "<script>internal/path/database.sql</script>";

--- a/scripts/lifeops/hitl-ledger.mjs
+++ b/scripts/lifeops/hitl-ledger.mjs
@@ -22,8 +22,9 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 export const LEDGER_PATH = join(ROOT, "docs/testing/hitl-ledger.json");
 


### PR DESCRIPTION
## Summary

Fixes #29569.

Uses `resolve(fileURLToPath(new URL("../..", import.meta.url)))` across LifeOps production modules and test helpers to avoid duplicate drive prefixes (`C:\\C:\\...`) on Windows.

### Changes
- `scripts/lifeops/env-layers.mjs`
- `scripts/lifeops/hitl-ledger.mjs`
- `scripts/lifeops/hitl-credential-dashboard.mjs`
- `scripts/lifeops/connector-paths.test.mjs`
- `scripts/lifeops/hitl-credential-dashboard.test.mjs`
- `scripts/lifeops/env-layers.test.mjs`