### PR TITLE
fix(ui): catalog learnedskills empty-state i18n keys

### DIFF
--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.sso.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.sso.test.tsx
@@ -38,6 +38,7 @@ function signIn(): void {
 }
 
 function clearAuthedCookie(): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom must clear the synchronous SSO cookie the bridge reads.
   document.cookie =
     "steward-authed=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
 }
@@ -115,6 +116,7 @@ afterEach(() => {
 
 describe("AppModeEntryRoute — SSO auto-bridge (managed app origin)", () => {
   it("signed out + domain session marker → full-page bounce to the eliza.app mint leg with a stored state nonce + PKCE challenge", async () => {
+    // biome-ignore lint/suspicious/noDocumentCookie: jsdom must seed the synchronous SSO cookie the bridge reads.
     document.cookie = "steward-authed=1; path=/";
     renderEntry("/chat?x=1");
 
@@ -153,6 +155,7 @@ describe("AppModeEntryRoute — SSO auto-bridge (managed app origin)", () => {
   });
 
   it("logout-then-visit does NOT re-bridge: the explicit logged-out marker wins over a live eliza.app session", async () => {
+    // biome-ignore lint/suspicious/noDocumentCookie: jsdom must seed the synchronous SSO cookie the bridge reads.
     document.cookie = "steward-authed=1; path=/";
     localStorage.setItem(SSO_LOGGED_OUT_KEY, "1");
     renderEntry("/");
@@ -161,6 +164,7 @@ describe("AppModeEntryRoute — SSO auto-bridge (managed app origin)", () => {
   });
 
   it("a fresh failed attempt (loop guard) falls through to login instead of bouncing again", async () => {
+    // biome-ignore lint/suspicious/noDocumentCookie: jsdom must seed the synchronous SSO cookie the bridge reads.
     document.cookie = "steward-authed=1; path=/";
     sessionStorage.setItem(SSO_ATTEMPT_KEY, String(Date.now()));
     renderEntry("/");

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -77,6 +77,7 @@ function clearCookies(): void {
   for (const part of document.cookie.split(";")) {
     const name = part.split("=")[0]?.trim();
     if (name)
+      // biome-ignore lint/suspicious/noDocumentCookie: jsdom must clear the synchronous cookie jar the bridge reads.
       document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
   }
 }

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -6422,6 +6422,8 @@
   "learnedskills.activeSkills": "Active learned skills",
   "learnedskills.disabled": "Disabled",
   "learnedskills.empty": "I haven’t picked up any abilities yet. Browse the catalog or add one by example, and I’ll start using it.",
+  "learnedskills.emptyTitle": "No learned skills yet",
+  "learnedskills.startLearning": "Learn a skill",
   "learnedskills.refinements": "{{count}} refinements",
   "learnedskills.score": "{{score}} score",
   "learnedskills.derivedFrom": "Derived from trajectory:",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Standing `develop` CI regressions from the merge wave that introduced the
Vault/SSO UI, reproduced at the current `develop` head
(`80c22d42a0e1e2e41a58e034877b22b63ad5ebf5`):

1. **Required gate (`All Tests Passed`)**: the i18n source-catalog check
   (`packages/app-core/scripts/check-i18n.mjs`) fails because two literal `t()`
   keys used in `CharacterLearnedSkillsSection.tsx` are missing from the
   `en.json` source catalog. This fails the `changes` and `quality` jobs and,
   via the cascade, the whole `ci-ok` / `All Tests Passed` gate on every
   develop push (verified in run `33070776705`: `canonical / Quality` and
   `tests / Classify changed paths` both failed on `en.json missing 2 key(s)`).
2. **Quality gate (lint)**: `quality / Develop Gate (lint)` fails on
   `lint/suspicious/noDocumentCookie` in the new SSO test files.

No issue exists for these; they are directly observable CI failures reproduced
at the exact develop head.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun run verify` was run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (`80c22d42a0e…`); zero conflicts.
- [x] The affected checks pass post-sync at the PR head: `check-i18n.mjs` and
      `biome check` on the touched files (full `bun run verify` is a
      heavyweight repo-wide gate run on CI).

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Two JSON catalog keys added to the source locale only (no production code,
rendering, or other locale files change) and five biome-ignore annotations on
intentional `document.cookie` seeding/clearing in tests, matching the
repository's established suppression pattern.

# Background

## What does this PR do?

1. Adds `learnedskills.emptyTitle` ("No learned skills yet") and
   `learnedskills.startLearning` ("Learn a skill") to
   `packages/ui/src/i18n/locales/en.json`, exactly matching the `defaultValue`
   strings the component already renders, so the source catalog satisfies the
   i18n source-catalog contract.
2. Adds `biome-ignore lint/suspicious/noDocumentCookie` annotations to the
   intentional cookie seeding/clearing in the new SSO test files
   (`AppModeEntryRoute.sso.test.tsx`, `sso-bridge.test.ts`), using the same
   justification pattern as the existing CSRF cookie tests.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`CharacterLearnedSkillsSection.tsx` calls
`t("learnedskills.emptyTitle", { defaultValue: "No learned skills yet" })` and
`t("learnedskills.startLearning", { defaultValue: "Learn a skill" })`. The i18n
contract requires every literal `t("key")` to exist in `en.json`; these two do
not, so `check-i18n.mjs` exits 1 on every develop push, failing the required
`All Tests Passed` merge gate. `#17605` documents the drift class this gate
exists to prevent.

The same merge wave introduced SSO tests that seed the synchronous cookie jar
via `document.cookie` without the suppression the rest of the suite uses
(failing `quality / Develop Gate (lint)`).

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Reproduce the red state, then the green state at the PR head:

```bash
# Red (before this PR, at the failing develop head 80c22d42a0e…):
git show 80c22d42a0e1e2e41a58e034877b22b63ad5ebf5:packages/ui/src/i18n/locales/en.json \
  > /tmp/en-red.json
node packages/app-core/scripts/check-i18n.mjs   # exits 1: en.json missing 2 key(s)

# Green (with this PR):
node packages/app-core/scripts/check-i18n.mjs   # exits 0: "[i18n] OK"
bunx @biomejs/biome check packages/ui/src/cloud/app-mode/AppModeEntryRoute.sso.test.tsx \
  packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
```

## Detailed testing steps

- [x] `node packages/app-core/scripts/check-i18n.mjs` at the PR head exits `0`
      with `[i18n] OK — 4452 literal keys …`.
- [x] `biome check` passes on the two touched test files (no errors, no unused
      suppression comments).
- [x] The exact CI failures are reproduced at the failing develop head:
      `en.json missing 2 key(s)` in `canonical / Quality` and
      `tests / Classify changed paths` (run `33070776705`); the
      `noDocumentCookie` lint errors in `quality / Develop Gate (lint)`
      (run `33070776705`).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6993c692718f3635cd0f06f1e73e74bde84d874c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes; catalog + test-only edit
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow changes; strings byte-identical to defaultValue fallbacks
<!-- evidence-row:backend-logs -->
- [ ] N/A - non-runtime catalog edit; no server code path affected
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no client runtime behavior changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model code changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts; shared i18n data verified unchanged
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes.`

## Backend + frontend logs

`N/A - non-runtime catalog edit.` The observable "log" is the CI gate itself:
on the current develop head (`80c22d42a0e…`, run `33070776705`), `tests / Classify changed paths`
(`https://github.com/elizaOS/eliza/actions/runs/33070776705/job/98512540257`)
and `canonical / Quality`
(`https://github.com/elizaOS/eliza/actions/runs/33070776705/job/98512540115`)
fail with `en.json missing 2 key(s) used in source`, and
`quality / Develop Gate (lint)`
(`https://github.com/elizaOS/eliza/actions/runs/33070776705/job/98512540561`)
fails on `noDocumentCookie`. All pass with this PR at the head commit.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface changes.`