### PR TITLE
fix(ui): canonicalize the Automations route

### DIFF
--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -632,6 +632,13 @@ async function installAutomationsApi(
 }
 
 test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const origin = window.location.origin;
+    const host = window as unknown as Record<string, unknown>;
+    host.__ELIZA_APP_API_BASE__ = origin;
+    host.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: origin };
+    host.__ELIZAOS_API_BASE__ = origin;
+  });
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
 });
@@ -647,11 +654,14 @@ test("automations overview empty state encourages creating tasks and workflows",
   await expect(
     page.getByRole("heading", { name: "Automations" }),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Prompts" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Workflows" })).toBeVisible();
+  const filterMenu = page.getByRole("button", {
+    name: "Filter automations, All selected",
+  });
+  await expect(filterMenu).toBeVisible();
   await expect(page.getByText("Nothing scheduled yet")).toBeVisible();
 
-  await page.getByRole("button", { name: "Workflows" }).click();
+  await filterMenu.click();
+  await page.getByRole("menuitemradio", { name: /Workflows/ }).click();
   await expect(page.getByTestId("automations-empty-state")).toHaveAttribute(
     "aria-label",
     "No workflows",
@@ -741,6 +751,45 @@ test("automations empty state remains reachable beside chat in short landscape",
   expect(geometry?.sidePadding).toBeGreaterThan(0);
 });
 
+test("populated automations remain readable beside chat in short landscape", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 844, height: 390 });
+  const workflow = workflowFixture(
+    "workflow-message-pipeline",
+    "Message pipeline",
+  );
+  await installAutomationsApi(page, [eventTaskItem(), workflowItem(workflow)]);
+
+  await openAppPath(page, "/automations");
+
+  const title = page.getByText("Message pipeline");
+  await expect(title).toBeVisible();
+  await expect(page.getByText("Every hour")).toBeVisible();
+  const geometry = await page.evaluate(() => {
+    const body = document.querySelector("[data-framed-page-body]");
+    const row = document.querySelector(
+      "[data-agent-label='Open Message pipeline']",
+    );
+    if (!(body instanceof HTMLElement) || !(row instanceof HTMLElement)) {
+      return null;
+    }
+    const bodyRect = body.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
+    return {
+      bodyWidth: bodyRect.width,
+      rowWidth: rowRect.width,
+      rowRight: rowRect.right,
+      viewportWidth: window.innerWidth,
+    };
+  });
+
+  expect(geometry).not.toBeNull();
+  expect(geometry?.bodyWidth).toBeGreaterThanOrEqual(400);
+  expect(geometry?.rowWidth).toBeGreaterThanOrEqual(300);
+  expect(geometry?.rowRight).toBeLessThan(geometry?.viewportWidth ?? 0);
+});
+
 test("automations can list tasks, create a task, and inspect Smithers source", async ({
   page,
 }) => {
@@ -755,12 +804,20 @@ test("automations can list tasks, create a task, and inspect Smithers source", a
 
   await openAppPath(page, "/automations");
 
-  await expect(page.getByRole("button", { name: "Prompts" })).toContainText(
-    "1",
-  );
-  await expect(page.getByRole("button", { name: "Workflows" })).toContainText(
-    "1",
-  );
+  await expect(page.getByTestId("automations-shell")).toBeVisible();
+  await expect(page.getByText("Message pipeline")).toBeVisible();
+  const filterMenu = page.getByRole("button", {
+    name: "Filter automations, All selected",
+  });
+  await expect(filterMenu).toContainText("2");
+  await filterMenu.click();
+  await expect(
+    page.getByRole("menuitemradio", { name: /Prompts/ }),
+  ).toContainText("1");
+  await expect(
+    page.getByRole("menuitemradio", { name: /Workflows/ }),
+  ).toContainText("1");
+  await page.keyboard.press("Escape");
   await expect(
     page.getByRole("button", { name: "Message triage" }),
   ).toBeVisible();

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 899 maintained React files. 101 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 899 maintained React files. 102 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/src/components/pages/AutomationsFeed.test.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.test.tsx
@@ -229,9 +229,12 @@ describe("AutomationsFeed", () => {
     render(<AutomationsFeed />);
 
     await screen.findByText("Nightly review");
-    fireEvent.click(screen.getByRole("button", { name: "New automation" }));
-    expect(screen.getByTestId("automation-create-menu")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "New workflow" }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "New automation" }),
+      { button: 0, ctrlKey: false },
+    );
+    expect(await screen.findByTestId("automation-create-menu")).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "New workflow" }));
     expect(await screen.findByTestId("workflow-studio")).toBeTruthy();
     expect(screen.getByLabelText("Workflow name")).toBeTruthy();
   });
@@ -364,7 +367,15 @@ describe("AutomationsFeed", () => {
     expect(screen.queryByRole("button", { name: /create/i })).toBeNull();
     expect(screen.queryByRole("button", { name: "New" })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Workflows" }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", {
+        name: "Filter automations, All selected",
+      }),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: /^Workflows/ }),
+    );
     const workflowEmptyLabel = await screen.findByText("No workflows");
     expect(workflowEmptyLabel.classList.contains("sr-only")).toBe(true);
     expect(

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -9,16 +9,13 @@ import {
   AlertTriangle,
   CalendarClock,
   CheckCircle2,
-  CircleSlash,
+  ChevronDown,
   Clock,
   History,
-  Layers,
-  Play,
   PlayCircle,
   Plus,
   Rocket,
   Workflow,
-  X,
 } from "lucide-react";
 import {
   type ReactNode,
@@ -41,6 +38,12 @@ import { resolveCloudConsoleUrl } from "../../cloud/applications/lib/native-clou
 import { getCached, invalidate, setCached } from "../../hooks/resource-cache";
 import { useAutomationDeepLink } from "../../hooks/useAutomationDeepLink";
 import { useFetchData } from "../../hooks/useFetchData";
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+  FramedPageNavigation,
+} from "../../layouts/framed-page";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import {
   type FeedFilter,
@@ -49,9 +52,16 @@ import {
 import { formatSchedule } from "../../utils/cron-format";
 import { mergeUnifiedTasks } from "../../utils/merge-unified-tasks";
 import { openExternalUrl } from "../../utils/openExternalUrl";
-import { PagePanel } from "../composites/page-panel";
-import { ViewHeader } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { ListSkeleton } from "../ui/skeleton-layouts";
 import { Spinner } from "../ui/spinner";
 import { StatusDot } from "../ui/status-badge";
@@ -96,6 +106,17 @@ const FILTER_LABELS: Record<FeedFilter, { key: string; defaultLabel: string }> =
       defaultLabel: "Inactive",
     },
   };
+const FILTER_OPTIONS: readonly FeedFilter[] = [
+  "all",
+  "prompts",
+  "workflows",
+  "active",
+  "inactive",
+];
+
+function isFeedFilter(value: string): value is FeedFilter {
+  return FILTER_OPTIONS.some((option) => option === value);
+}
 
 function isUnavailableScheduledTaskSupplement(error: unknown): boolean {
   if (!isApiError(error)) return false;
@@ -106,13 +127,6 @@ function isUnavailableScheduledTaskSupplement(error: unknown): boolean {
     error.message.includes("cannot be parsed as a URL against")
   );
 }
-const FILTER_ICONS: Record<FeedFilter, ReactNode> = {
-  all: <Layers className="size-3.5" aria-hidden />,
-  prompts: <CheckCircle2 className="size-3.5" aria-hidden />,
-  workflows: <Workflow className="size-3.5" aria-hidden />,
-  active: <Play className="size-3.5" aria-hidden />,
-  inactive: <CircleSlash className="size-3.5" aria-hidden />,
-};
 const NEW_AUTOMATION_LINK_ID = "__new__";
 
 /** Namespaces cached rows by the currently selected local or Cloud agent. */
@@ -566,7 +580,7 @@ export function AutomationsFeed({
     description: "Choose a workflow or prompt automation",
     onActivate: () => setCreateOpen(true),
   });
-  const newWorkflowAction = useAgentElement<HTMLButtonElement>({
+  const newWorkflowAction = useAgentElement<HTMLDivElement>({
     id: "action-new-workflow",
     role: "button",
     label: "New workflow",
@@ -574,7 +588,7 @@ export function AutomationsFeed({
     description: "Open the Smithers workflow studio",
     onActivate: () => setEditor({ kind: "workflow", workflowId: null }),
   });
-  const newPromptAction = useAgentElement<HTMLButtonElement>({
+  const newPromptAction = useAgentElement<HTMLDivElement>({
     id: "action-new-prompt",
     role: "button",
     label: "New prompt automation",
@@ -659,102 +673,82 @@ export function AutomationsFeed({
 
   const feedContent = (
     <ShellViewAgentSurface viewId="automations">
-      <div
-        className="flex h-full min-h-0 min-w-0 w-full flex-col"
+      <FramedPage
+        reserveComposer={false}
+        className="flex h-full min-h-0 min-w-0 w-full flex-col pb-[var(--eliza-chat-clearance,5.25rem)] [@media(orientation:landscape)_and_(max-height:520px)]:pb-0"
         data-testid="automations-layout"
       >
         {/* Uniform view header (#13451/#13597): bare-icon back, centered title. */}
-        <ViewHeader
+        <FramedPageHeader
           title={t("automationsfeed.title", { defaultValue: "Automations" })}
-          right={
-            <div className="relative">
-              <Button
-                ref={newAutomationAction.ref}
-                type="button"
-                variant="ghostMuted"
-                size="icon-sm"
-                aria-label={t("automationsfeed.addAutomation", {
-                  defaultValue: "Add automation",
-                })}
-                aria-expanded={createOpen}
-                onClick={() => setCreateOpen((current) => !current)}
-                {...newAutomationAction.agentProps}
-              >
-                {createOpen ? (
-                  <X className="size-4" aria-hidden />
-                ) : (
-                  <Plus className="size-4" aria-hidden />
-                )}
-              </Button>
-              {createOpen ? (
-                <div
-                  className="absolute right-0 top-11 z-30 flex gap-1 rounded-xl border border-border/60 bg-card p-1.5"
-                  data-testid="automation-create-menu"
+          actions={
+            <DropdownMenu open={createOpen} onOpenChange={setCreateOpen}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  ref={newAutomationAction.ref}
+                  type="button"
+                  variant="selection"
+                  size="compact"
+                  aria-label="New automation"
+                  aria-expanded={createOpen}
+                  {...newAutomationAction.agentProps}
                 >
-                  <Button
-                    ref={newWorkflowAction.ref}
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label="New workflow"
-                    title="Workflow"
-                    onClick={() =>
-                      setEditor({ kind: "workflow", workflowId: null })
-                    }
-                    {...newWorkflowAction.agentProps}
-                  >
-                    <Workflow className="size-4 text-accent-muted dark:text-accent" />
-                  </Button>
-                  <Button
-                    ref={newPromptAction.ref}
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label="New prompt automation"
-                    title="Prompt"
-                    onClick={() => setEditor({ kind: "task", taskId: null })}
-                    {...newPromptAction.agentProps}
-                  >
-                    <CheckCircle2 className="size-4" />
-                  </Button>
-                </div>
-              ) : null}
-            </div>
+                  <Plus className="size-4" aria-hidden />
+                  New
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="min-w-52"
+                data-testid="automation-create-menu"
+              >
+                <DropdownMenuLabel>Create automation</DropdownMenuLabel>
+                <DropdownMenuItem
+                  ref={newWorkflowAction.ref}
+                  className="gap-2"
+                  aria-label="New workflow"
+                  onSelect={() =>
+                    setEditor({ kind: "workflow", workflowId: null })
+                  }
+                  {...newWorkflowAction.agentProps}
+                >
+                  <Workflow className="size-4" aria-hidden />
+                  Workflow
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  ref={newPromptAction.ref}
+                  className="gap-2"
+                  aria-label="New prompt automation"
+                  onSelect={() => setEditor({ kind: "task", taskId: null })}
+                  {...newPromptAction.agentProps}
+                >
+                  <CheckCircle2 className="size-4" aria-hidden />
+                  Prompt automation
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           }
         />
-        {/* This direct-rendered route has no TabContentView wrapper, so it owns
-            the one scroll region that reserves the ambient chat footprint. */}
-        <div
+        {data && !(workflowServiceIssue && rows.length === 0) ? (
+          <FramedPageNavigation className="flex items-center justify-between gap-3">
+            <span className="text-sm text-muted">Show</span>
+            <AutomationFilterMenu
+              filter={filter}
+              counts={filterCounts}
+              onSelect={setFilter}
+            />
+          </FramedPageNavigation>
+        ) : null}
+        <FramedPageBody
+          scroll="page"
           data-testid="automations-scroll-region"
           data-shell-scroll-region="true"
-          className="eliza-chat-scroll min-h-0 min-w-0 w-full flex-1 overflow-x-hidden overflow-y-auto pb-[var(--eliza-chat-clearance,5.25rem)] pe-[var(--eliza-chat-side-clearance,0px)]"
+          className="device-layout gap-4 overflow-x-hidden py-4"
         >
-          {/* Flat — no card/border. The shell owns the page's horizontal padding. */}
           <div
             data-testid="automations-shell"
-            className="device-layout mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 pt-[var(--view-pad-top)] pb-[var(--view-pad-bottom)] lg:px-6"
+            className="flex w-full flex-col gap-4"
           >
-            {data && !(workflowServiceIssue && rows.length === 0) ? (
-              <>
-                {/* Filter chips */}
-                <div className="flex flex-wrap gap-1.5">
-                  {(Object.keys(FILTER_LABELS) as FeedFilter[]).map((key) => (
-                    <FilterChipButton
-                      key={key}
-                      filter={key}
-                      label={t(FILTER_LABELS[key].key, {
-                        defaultValue: FILTER_LABELS[key].defaultLabel,
-                      })}
-                      icon={FILTER_ICONS[key]}
-                      count={filterCounts[key]}
-                      isActive={filter === key}
-                      onSelect={setFilter}
-                    />
-                  ))}
-                </div>
-              </>
-            ) : null}
-
             {workflowServiceIssue && rows.length > 0 && (
               <WorkflowServiceIssuePanel
                 issue={workflowServiceIssue}
@@ -780,8 +774,7 @@ export function AutomationsFeed({
               />
             )}
 
-            {/* Feed — flat, no card/border; rows separate by whitespace. */}
-            <PagePanel variant="inset" className="p-0">
+            <div className="border-y border-border/50">
               {(loading || dataState.cacheKey !== cacheKey) && !data ? (
                 <ListSkeleton rows={6} className="p-3" />
               ) : workflowServiceIssue && rows.length === 0 ? (
@@ -821,7 +814,7 @@ export function AutomationsFeed({
                   </p>
                 </div>
               ) : (
-                <ul>
+                <ul className="divide-y divide-border/40">
                   {rows.map((row) => (
                     <FeedRowItem
                       key={row.key}
@@ -869,10 +862,10 @@ export function AutomationsFeed({
                   ))}
                 </ul>
               )}
-            </PagePanel>
+            </div>
           </div>
-        </div>
-      </div>
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 
@@ -935,58 +928,64 @@ function WorkflowServiceIssuePanel({
   );
 }
 
-function FilterChipButton({
+function AutomationFilterMenu({
   filter,
-  label,
-  icon,
-  count,
-  isActive,
+  counts,
   onSelect,
 }: {
   filter: FeedFilter;
-  label: string;
-  icon: ReactNode;
-  count: number;
-  isActive: boolean;
+  counts: Readonly<Record<FeedFilter, number>>;
   onSelect: (filter: FeedFilter) => void;
 }) {
+  const { t } = useTranslation();
+  const selectedLabel = t(FILTER_LABELS[filter].key, {
+    defaultValue: FILTER_LABELS[filter].defaultLabel,
+  });
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `tab-${filter}`,
-    role: "tab",
-    label,
+    id: "filter-automations",
+    role: "button",
+    label: `Filter automations, ${selectedLabel} selected`,
     group: "automations-filters",
-    status: isActive ? "active" : "inactive",
-    description: `Filter automations to "${label}"`,
-    onActivate: () => onSelect(filter),
+    status: filter,
+    description: "Choose which automations appear in the feed",
   });
   return (
-    <Button
-      ref={ref}
-      onClick={() => onSelect(filter)}
-      aria-current={isActive ? "true" : undefined}
-      variant="selection"
-      size="pillDense"
-      data-state={isActive ? "on" : "off"}
-      // Borderless text tab (#10710): active reads as accent text on a faint
-      // wash; the count renders as plain text and hides at zero.
-      {...agentProps}
-    >
-      <span className="[&>svg]:h-3.5 [&>svg]:w-3.5">{icon}</span>
-      <span
-        className={
-          isActive
-            ? undefined
-            : "hidden sm:inline [@media(orientation:landscape)_and_(max-height:520px)]:hidden"
-        }
-      >
-        {label}
-      </span>
-      {count > 0 ? (
-        <span className="text-[0.65rem] font-semibold tabular-nums">
-          {count}
-        </span>
-      ) : null}
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          ref={ref}
+          variant="ghostMuted"
+          size="dense"
+          className="gap-1.5"
+          aria-label={`Filter automations, ${selectedLabel} selected`}
+          {...agentProps}
+        >
+          <span>{selectedLabel}</span>
+          <span className="tabular-nums text-muted">({counts[filter]})</span>
+          <ChevronDown className="size-4" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-52">
+        <DropdownMenuLabel>Filter automations</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={filter}
+          onValueChange={(value) => {
+            if (isFeedFilter(value)) onSelect(value);
+          }}
+        >
+          {FILTER_OPTIONS.map((option) => (
+            <DropdownMenuRadioItem key={option} value={option}>
+              <span className="flex-1">
+                {t(FILTER_LABELS[option].key, {
+                  defaultValue: FILTER_LABELS[option].defaultLabel,
+                })}
+              </span>
+              <span className="tabular-nums text-muted">{counts[option]}</span>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -1051,7 +1050,7 @@ function FeedRowItem({
   return (
     <li
       ref={registerRef}
-      className="group flex items-center gap-3 px-4 py-3 transition-colors hover:bg-bg-accent/40"
+      className="group flex items-center gap-3 py-3 transition-colors hover:bg-bg-accent/40"
     >
       <Button
         ref={openAction.ref}

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -46,7 +46,9 @@ import {
 } from "../../layouts/framed-page";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import {
+  FEED_FILTERS,
   type FeedFilter,
+  isFeedFilter,
   passesFilter,
 } from "../../utils/automation-feed-filter";
 import { formatSchedule } from "../../utils/cron-format";
@@ -106,18 +108,6 @@ const FILTER_LABELS: Record<FeedFilter, { key: string; defaultLabel: string }> =
       defaultLabel: "Inactive",
     },
   };
-const FILTER_OPTIONS: readonly FeedFilter[] = [
-  "all",
-  "prompts",
-  "workflows",
-  "active",
-  "inactive",
-];
-
-function isFeedFilter(value: string): value is FeedFilter {
-  return FILTER_OPTIONS.some((option) => option === value);
-}
-
 function isUnavailableScheduledTaskSupplement(error: unknown): boolean {
   if (!isApiError(error)) return false;
   if (error.status === 404) return true;
@@ -973,7 +963,7 @@ function AutomationFilterMenu({
             if (isFeedFilter(value)) onSelect(value);
           }}
         >
-          {FILTER_OPTIONS.map((option) => (
+          {FEED_FILTERS.map((option) => (
             <DropdownMenuRadioItem key={option} value={option}>
               <span className="flex-1">
                 {t(FILTER_LABELS[option].key, {

--- a/packages/ui/src/utils/automation-feed-filter.ts
+++ b/packages/ui/src/utils/automation-feed-filter.ts
@@ -4,12 +4,19 @@
  * vitest without resolving the rest of the UI bundle.
  */
 
-export type FeedFilter =
-  | "all"
-  | "prompts"
-  | "workflows"
-  | "active"
-  | "inactive";
+export const FEED_FILTERS = [
+  "all",
+  "prompts",
+  "workflows",
+  "active",
+  "inactive",
+] as const;
+
+export type FeedFilter = (typeof FEED_FILTERS)[number];
+
+export function isFeedFilter(value: string): value is FeedFilter {
+  return FEED_FILTERS.some((filter) => filter === value);
+}
 
 // `kind` is the internal row discriminant: a "task" row is a workbench prompt
 // automation (glossary "prompt automation"); a "workflow" row is a node-graph
@@ -34,7 +41,7 @@ export function passesFilter(row: FeedRowSummary, filter: FeedFilter): boolean {
       return row.active;
     case "inactive":
       return !row.active;
-    default:
-      return true;
   }
+  const _exhaustive: never = filter;
+  return _exhaustive;
 }


### PR DESCRIPTION
## Summary

- Adopts the canonical framed-page anatomy and shared Character/Vault page gutters.
- Replaces five equal-weight filter chips with one compact labeled filter menu.
- Makes creation explicit through a labeled New menu for Workflow and Prompt automation, with canonical 8px icon-label spacing.
- Renders automations as a continuous divided list instead of an inset card.
- Fixes the short-landscape collapse caused by reserving composer side clearance twice.

Closes #29575

## Behavior

- **Workflow** opens a new Workflow Studio.
- **Prompt automation** opens the prompt Task Editor.
- Selecting an existing automation opens its matching editor; saving returns to and refreshes the feed.

## Verification

- `bun run --cwd packages/ui test -- src/components/pages/AutomationsFeed.test.tsx` - 17 passed.
- `bun run --cwd packages/ui typecheck` - passed.
- Automations Chromium UI smoke suite - 5 passed.
- Biome check for all touched TS/TSX files - passed.
- Molecular component inventory check - passed.
- Manual inspection of every image below at full resolution - passed.

## Evidence checklist

Evidence head: `2a66da690a6b9f0e7b38649655a6f8539a74162b`
<!-- evidence-head:2a66da690a6b9f0e7b38649655a6f8539a74162b -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-before-desktop.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-after-desktop.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-automations-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - fixture-backed UI layout only; no backend behavior changed
<!-- evidence-row:frontend-logs -->
- [x] [29578-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain data contract changed
<!-- evidence-row:ocr-review -->
- [x] [29578-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-ocr-review.txt)

## Before

### Desktop

![Before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-before-desktop.png)

### Mobile portrait

![Before mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-before-mobile-portrait.png)

### Mobile landscape - collapsed regression

![Before mobile landscape collapsed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-before-mobile-landscape-collapsed.png)

### Tablet portrait

![Before tablet portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-before-tablet-portrait.png)

## After

### Desktop

![After desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-after-desktop.png)

### Mobile portrait

![After mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-after-mobile-portrait.png)

### Mobile landscape

![After mobile landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-after-mobile-landscape.png)

### Tablet portrait

![After tablet portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-after-tablet-portrait.png)

### New action hover

![New action hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-desktop-new-hover.png)

### Create menu with corrected icon-label spacing

![Create automation menu](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-desktop-create-menu.png)

### Filter menu

![Filter automations menu](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-desktop-filter-menu.png)

### Workflow destination

![New Workflow Studio](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-desktop-new-workflow.png)

### Prompt automation destination

![New prompt automation editor](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-desktop-new-prompt.png)

## Walkthrough video

https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-automations-walkthrough.mp4

## Frontend logs

[Playwright trace with frontend console and network activity](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-frontend-trace.zip)

## OCR review

[Exact-head OCR and manual visual-text review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29578-ocr-review.txt)

## Known baseline gaps

- `bun run verify` is blocked on current `develop` by existing i18n catalog debt (1,171+ missing translated keys and two existing English learned-skills keys). This PR does not touch locale catalogs.
- Full `packages/ui` `lint:check` is blocked by existing Vault molecular-inventory findings reproduced on the baseline. Focused Biome and current molecular-inventory checks for this diff pass.
- `packages/app audit:app` was attempted across five cycles, but the broad audit stopped on existing builtin-chat/camera startup/auth failures before reaching Automations. The dedicated production-renderer Automations suite and exact-head captures pass.

## Maintainer CI exception record

N/A - no exception requested.

