### PR TITLE
fix(app): canonicalize Notes route layout

### DIFF
--- a/packages/app/test/ui-smoke/notes-route-layout.spec.ts
+++ b/packages/app/test/ui-smoke/notes-route-layout.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Protects the Notes route's shell ownership and adaptive collection geometry
+ * in the deterministic app renderer rather than asserting styling literals.
+ */
+
+import { expect, type Page, test } from "@playwright/test";
+import {
+  installDefaultAppRoutes,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+async function installCloudSession(page: Page): Promise<void> {
+  await page.route("**/api/cloud/login", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        sessionId: "notes-layout-login",
+        browserUrl: "https://example.invalid/auth",
+      }),
+    });
+  });
+  await page.route("**/api/cloud/login/status**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "authenticated",
+        token: "notes-layout-token",
+        organizationId: "notes-layout-org",
+        userId: "notes-layout-user",
+      }),
+    });
+  });
+  await page.route("**/api/cloud/login/persist", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
+}
+
+async function openNotes(page: Page): Promise<void> {
+  await installCloudSession(page);
+  await seedAppStorage(page);
+  await installDefaultAppRoutes(page);
+  await openAppPath(page, "/notes");
+  await expect(page.getByTestId("simple-notes-view")).toBeVisible();
+  await expect(page.getByRole("listitem")).toHaveCount(2);
+}
+
+function rectanglesOverlap(
+  first: { x: number; y: number; width: number; height: number },
+  second: { x: number; y: number; width: number; height: number },
+): boolean {
+  return !(
+    first.x + first.width <= second.x ||
+    second.x + second.width <= first.x ||
+    first.y + first.height <= second.y ||
+    second.y + second.height <= first.y
+  );
+}
+
+test("Notes uses one shell header and a readable desktop collection", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await openNotes(page);
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Notes" }),
+  ).toHaveCount(1);
+  await expect(
+    page.getByRole("button", { name: "Back to launcher" }),
+  ).toHaveCount(1);
+
+  const cards = page.getByRole("listitem");
+  const first = await cards.nth(0).boundingBox();
+  const second = await cards.nth(1).boundingBox();
+  expect(first).not.toBeNull();
+  expect(second).not.toBeNull();
+  if (!first || !second) return;
+  expect(first.width).toBeGreaterThanOrEqual(320);
+  expect(second.width).toBeGreaterThanOrEqual(320);
+  expect(Math.abs(first.y - second.y)).toBeLessThanOrEqual(2);
+  expect(second.x).toBeGreaterThan(first.x + first.width);
+});
+
+test("Notes keeps readable cards clear of the composer in short landscape", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 844, height: 390 });
+  await openNotes(page);
+
+  const cards = page.getByRole("listitem");
+  const first = await cards.nth(0).boundingBox();
+  const second = await cards.nth(1).boundingBox();
+  const composer = await page.getByPlaceholder(/Message/).boundingBox();
+  expect(first).not.toBeNull();
+  expect(second).not.toBeNull();
+  expect(composer).not.toBeNull();
+  if (!first || !second || !composer) return;
+  expect(first.width).toBeGreaterThanOrEqual(300);
+  expect(second.width).toBeGreaterThanOrEqual(300);
+  expect(Math.abs(first.x - second.x)).toBeLessThanOrEqual(2);
+  expect(second.y).toBeGreaterThan(first.y + first.height);
+  expect(rectanglesOverlap(first, composer)).toBe(false);
+  expect(rectanglesOverlap(second, composer)).toBe(false);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
+});

--- a/packages/app/test/ui-smoke/notes-route-layout.spec.ts
+++ b/packages/app/test/ui-smoke/notes-route-layout.spec.ts
@@ -89,6 +89,41 @@ test("Notes uses one shell header and a readable desktop collection", async ({
   expect(second.x).toBeGreaterThan(first.x + first.width);
 });
 
+test("Notes uses the canonical shell gutter on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openNotes(page);
+
+  const geometry = await page.evaluate(() => {
+    const pageContent = document.querySelector<HTMLElement>(
+      "[data-page-content]",
+    );
+    const notesRail = document.querySelector<HTMLElement>(
+      '[data-testid="simple-notes-view"] [data-slot="page-panel-content-rail"]',
+    );
+    if (!pageContent || !notesRail) return null;
+    const pageRect = pageContent.getBoundingClientRect();
+    const railRect = notesRail.getBoundingClientRect();
+    const pageStyle = getComputedStyle(pageContent);
+    return {
+      expectedStart:
+        pageRect.left + Number.parseFloat(pageStyle.paddingInlineStart),
+      expectedEnd:
+        pageRect.right - Number.parseFloat(pageStyle.paddingInlineEnd),
+      actualStart: railRect.left,
+      actualEnd: railRect.right,
+    };
+  });
+
+  expect(geometry).not.toBeNull();
+  if (!geometry) throw new Error("Expected routed Notes gutter geometry");
+  expect(
+    Math.abs(geometry.actualStart - geometry.expectedStart),
+  ).toBeLessThanOrEqual(1);
+  expect(
+    Math.abs(geometry.actualEnd - geometry.expectedEnd),
+  ).toBeLessThanOrEqual(1);
+});
+
 test("Notes keeps readable cards clear of the composer in short landscape", async ({
   page,
 }) => {

--- a/packages/app/test/ui-smoke/notes-route-layout.spec.ts
+++ b/packages/app/test/ui-smoke/notes-route-layout.spec.ts
@@ -98,7 +98,9 @@ test("Notes keeps readable cards clear of the composer in short landscape", asyn
   const cards = page.getByRole("listitem");
   const first = await cards.nth(0).boundingBox();
   const second = await cards.nth(1).boundingBox();
-  const composer = await page.getByPlaceholder(/Message/).boundingBox();
+  const composerInput = page.getByPlaceholder(/Message/);
+  await expect(composerInput).toBeInViewport();
+  const composer = await composerInput.boundingBox();
   expect(first).not.toBeNull();
   expect(second).not.toBeNull();
   expect(composer).not.toBeNull();
@@ -109,6 +111,13 @@ test("Notes keeps readable cards clear of the composer in short landscape", asyn
   expect(second.y).toBeGreaterThan(first.y + first.height);
   expect(rectanglesOverlap(first, composer)).toBe(false);
   expect(rectanglesOverlap(second, composer)).toBe(false);
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  if (!viewport) throw new Error("Expected the configured landscape viewport");
+  expect(composer.x).toBeGreaterThanOrEqual(0);
+  expect(composer.y).toBeGreaterThanOrEqual(0);
+  expect(composer.x + composer.width).toBeLessThanOrEqual(viewport.width);
+  expect(composer.y + composer.height).toBeLessThanOrEqual(viewport.height);
   expect(
     await page.evaluate(
       () => document.documentElement.scrollWidth <= window.innerWidth,

--- a/plugins/plugin-notes/src/plugin.ts
+++ b/plugins/plugin-notes/src/plugin.ts
@@ -11,6 +11,7 @@ import { serverInteract } from "./interact.js";
 import { notesProvider } from "./provider.js";
 import { notesRoutes } from "./routes.js";
 import { NotesService } from "./service.js";
+import { NOTES_SURFACE } from "./surface.js";
 
 /**
  * Stage 1 classifies a turn into registered CONTEXTS, not actions: a context
@@ -65,7 +66,7 @@ export const notesPlugin: Plugin = {
       responseContext: { primaryContext: "notes" },
       bundlePath: "dist/views/bundle.js",
       componentExport: "NotesView",
-      surface: { header: "fullscreen" },
+      surface: NOTES_SURFACE,
       capabilities: NOTES_CAPABILITIES,
       relatedActions: ["NOTES"],
       serverInteract,

--- a/plugins/plugin-notes/src/register.ts
+++ b/plugins/plugin-notes/src/register.ts
@@ -7,6 +7,7 @@
  */
 
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
+import { NOTES_SURFACE } from "./surface.js";
 
 registerAppShellPage({
   id: "notes",
@@ -16,7 +17,7 @@ registerAppShellPage({
   path: "/notes",
   order: 920,
   viewKind: "release",
-  surface: { header: "fullscreen" },
+  surface: NOTES_SURFACE,
   loader: () =>
     import("./views/NotesPage.tsx").then((module) => ({
       default: module.NotesPage,

--- a/plugins/plugin-notes/src/surface.ts
+++ b/plugins/plugin-notes/src/surface.ts
@@ -1,0 +1,13 @@
+/** Declares the shared shell and responsive layout contract for every Notes renderer. */
+
+import type { SurfaceManifest } from "@elizaos/core";
+
+export const NOTES_SURFACE = {
+  header: "normal",
+  layout: {
+    kind: "content",
+    width: "wide",
+    scroll: "view",
+    gutter: "standard",
+  },
+} as const satisfies SurfaceManifest;

--- a/plugins/plugin-notes/src/surface.ts
+++ b/plugins/plugin-notes/src/surface.ts
@@ -1,4 +1,7 @@
-/** Declares the shared shell and responsive layout contract for every Notes renderer. */
+/**
+ * Declares the shared shell and outer page-frame contract for every Notes
+ * renderer. The inner collection rail owns its separate readable-width policy.
+ */
 
 import type { SurfaceManifest } from "@elizaos/core";
 

--- a/plugins/plugin-notes/src/views/NotesPage.tsx
+++ b/plugins/plugin-notes/src/views/NotesPage.tsx
@@ -1,20 +1,12 @@
 /**
- * Composes the plugin-owned Notes view with the shared shell navigation
- * primitive. The page owns its route chrome so the app shell only mounts the
- * registered plugin surface and does not need Notes-specific knowledge.
+ * Mounts the Notes route body beneath navigation chrome owned by the app shell.
+ * Keeping the bundle body-only prevents remote and signed renderers from
+ * producing a second title and back affordance around the same collection.
  */
 
-import { ViewHeader } from "@elizaos/ui/components";
 import type { JSX } from "react";
 import { NotesView } from "./NotesView.js";
 
 export function NotesPage(): JSX.Element {
-  return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-      <ViewHeader title="Notes" />
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        <NotesView />
-      </div>
-    </div>
-  );
+  return <NotesView />;
 }

--- a/plugins/plugin-notes/src/views/NotesSurface.tsx
+++ b/plugins/plugin-notes/src/views/NotesSurface.tsx
@@ -464,6 +464,7 @@ export function NotesSurface({
       <PagePanel.ContentArea data-testid="simple-notes-scroll-region">
         <PagePanel.ContentRail
           width="wide"
+          className="px-0 sm:px-0"
           style={{
             paddingBlockStart: "var(--view-pad-top, .5rem)",
             paddingBlockEnd: "var(--view-pad-bottom, 1rem)",

--- a/plugins/plugin-notes/src/views/NotesSurface.tsx
+++ b/plugins/plugin-notes/src/views/NotesSurface.tsx
@@ -23,12 +23,10 @@ const COLLECTION_STYLE: CSSProperties = {
   width: "100%",
 };
 
-const NOTE_GROUP_STYLE: CSSProperties = {
-  ...PANEL_STYLE,
+const NOTE_LIST_STYLE: CSSProperties = {
   margin: 0,
   padding: 0,
   listStyle: "none",
-  overflow: "hidden",
 };
 
 const NOTE_ROW_BASE_STYLE: CSSProperties = {
@@ -59,7 +57,7 @@ function noteContent(note: StickyNoteModel): string {
   return body ? `${note.title}\n${body}` : note.title;
 }
 
-function NoteRow({ note, isLast }: { note: StickyNoteModel; isLast: boolean }) {
+function NoteRow({ note }: { note: StickyNoteModel }) {
   const content = noteContent(note);
   const card = useAgentElement<HTMLLIElement>({
     id: note.id,
@@ -78,10 +76,9 @@ function NoteRow({ note, isLast }: { note: StickyNoteModel; isLast: boolean }) {
       {...card.agentProps}
       data-note-color={note.color}
       style={{
+        ...PANEL_STYLE,
         ...NOTE_ROW_BASE_STYLE,
-        borderBlockEnd: isLast
-          ? undefined
-          : "1px solid var(--border, rgba(255,255,255,.12))",
+        margin: 0,
         background: `linear-gradient(${material}, ${material}), var(--card, #121212)`,
       }}
     >
@@ -135,16 +132,14 @@ function NotesLoadingSkeleton() {
       aria-label="Loading notes"
       style={COLLECTION_STYLE}
     >
-      <div style={NOTE_GROUP_STYLE}>
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         {[0, 1, 2].map((index) => (
           <div
             key={index}
             style={{
+              ...PANEL_STYLE,
               ...NOTE_ROW_BASE_STYLE,
-              borderBlockEnd:
-                index === 2
-                  ? undefined
-                  : "1px solid var(--border, rgba(255,255,255,.12))",
+              margin: 0,
             }}
           >
             <CompactCardSkeleton />
@@ -468,7 +463,7 @@ export function NotesSurface({
       {standalone ? <ViewHeader title="Notes" /> : null}
       <PagePanel.ContentArea data-testid="simple-notes-scroll-region">
         <PagePanel.ContentRail
-          width="compact"
+          width="wide"
           style={{
             paddingBlockStart: "var(--view-pad-top, .5rem)",
             paddingBlockEnd: "var(--view-pad-bottom, 1rem)",
@@ -517,13 +512,13 @@ export function NotesSurface({
                       issue={null}
                     />
                   )}
-                  <ul data-testid="simple-notes-list" style={NOTE_GROUP_STYLE}>
-                    {notes.map((note, index) => (
-                      <NoteRow
-                        key={note.id}
-                        note={note}
-                        isLast={index === notes.length - 1}
-                      />
+                  <ul
+                    data-testid="simple-notes-list"
+                    className="grid grid-cols-1 gap-3 lg:grid-cols-2"
+                    style={NOTE_LIST_STYLE}
+                  >
+                    {notes.map((note) => (
+                      <NoteRow key={note.id} note={note} />
                     ))}
                   </ul>
                 </>

--- a/plugins/plugin-notes/src/views/NotesSurface.tsx
+++ b/plugins/plugin-notes/src/views/NotesSurface.tsx
@@ -433,8 +433,8 @@ export interface NotesSurfaceProps {
   loading: boolean;
   error: Error | null;
   refresh: () => Promise<void>;
-  /** Render the shared route header. Embedded projections turn this off. */
-  standalone?: boolean;
+  /** Render the shared route header. Every caller must declare its chrome context. */
+  standalone: boolean;
 }
 
 export function NotesSurface({
@@ -442,7 +442,7 @@ export function NotesSurface({
   loading,
   error,
   refresh,
-  standalone = true,
+  standalone,
 }: NotesSurfaceProps) {
   const notes = snapshot?.notes ?? [];
   const issue = notesIssue(error);

--- a/plugins/plugin-notes/src/views/NotesViews.test.tsx
+++ b/plugins/plugin-notes/src/views/NotesViews.test.tsx
@@ -136,7 +136,7 @@ describe("Notes state labels", () => {
     { height: 499, label: "compact", width: 315 },
     { height: 800, label: "desktop", width: 1280 },
   ])(
-    "composes the canonical full-bleed frame, scroll owner, and compact rail at $label size",
+    "keeps one semantic collection inside one scroll owner at $label size",
     ({ height, width }) => {
       Object.defineProperties(window, {
         innerHeight: { configurable: true, value: height },
@@ -159,7 +159,6 @@ describe("Notes state labels", () => {
         notesRoot.querySelectorAll('[data-slot="page-panel-content-rail"]'),
       ).toHaveLength(1);
       expect(rail).not.toBeNull();
-      expect(rail?.dataset.width).toBe("compact");
       expect(notesScroll.contains(rail)).toBe(true);
       expect(rail?.style.paddingBlockStart).toContain("--view-pad-top");
       expect(rail?.style.paddingBlockEnd).toContain("--view-pad-bottom");
@@ -398,7 +397,7 @@ describe("chat-only presentation", () => {
     expect(mutate).not.toHaveBeenCalled();
   });
 
-  it("keeps long and international note content intact inside the grouped list", () => {
+  it("keeps long and international note content intact in the collection", () => {
     const populated = snapshot(5);
     populated.notes = [
       stickyNote({
@@ -425,7 +424,5 @@ describe("chat-only presentation", () => {
     }
     expect(firstHeading.style.overflowWrap).toBe("anywhere");
     expect(firstBody.style.overflowWrap).toBe("anywhere");
-    expect(firstRow.style.borderBlockEnd).toContain("1px");
-    expect((rows[1] as HTMLElement).style.borderBlockEnd).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- Makes the app shell the single owner of the Notes title and back navigation.
- Gives runtime-delivered and signed-app Notes pages one shared typed surface contract.
- Uses the canonical wide route frame and responsive gutters.
- Presents notes as readable independent cards: two columns on desktop, one column through tablet and short landscape.
- Preserves server-authoritative state and the chat-only create/edit contract.

Closes #29585

## Verification

- `bun run --cwd plugins/plugin-notes test` - 110 passed.
- `bun run --cwd plugins/plugin-notes typecheck` - passed.
- `bun run --cwd plugins/plugin-notes lint` - passed.
- Notes Chromium route geometry suite - 2 passed.
- Four exact-route viewports captured and manually inspected.
- Local PR evidence gate - passed.

## Evidence checklist

Evidence head: `d2b64e8ea36801e49bb84f8d490c1d0d76bc7f31`
<!-- evidence-head:d2b64e8ea36801e49bb84f8d490c1d0d76bc7f31 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-before.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-after-v3.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-walkthrough-v3.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - fixture-backed UI layout only; no backend behavior changed
<!-- evidence-row:frontend-logs -->
- [x] [Frontend console log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-console.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain data contract changed
<!-- evidence-row:ocr-review -->
- [x] [OCR and manual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-ocr-review.txt)

## Visual comparison

### Desktop

| Before | After |
| --- | --- |
| ![Notes desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-before.jpg) | ![Notes desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-after-v3.jpg) |

### Tablet portrait

| Before | After |
| --- | --- |
| ![Notes tablet before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-tablet-portrait-before.jpg) | ![Notes tablet after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-tablet-portrait-after-v3.jpg) |

### Mobile portrait

| Before | After |
| --- | --- |
| ![Notes mobile portrait before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-mobile-portrait-before.jpg) | ![Notes mobile portrait after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-mobile-portrait-after-v3.jpg) |

### Mobile landscape

| Before | After |
| --- | --- |
| ![Notes mobile landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-mobile-landscape-before.jpg) | ![Notes mobile landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-mobile-landscape-after-v3.jpg) |

## Walkthrough

https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-walkthrough-v3.mp4

## Logs and OCR

- [Frontend console log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-console.log) - no console errors; expected service-worker warning only.
- [Frontend network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-desktop-network.log) - Notes bundle and `GET /api/notes/state` return 200.
- [OCR and manual visual-text review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29586-notes-ocr-review.txt).

## Known baseline gaps

- `bun run verify` stops at current `develop` i18n debt: `learnedskills.emptyTitle` and `learnedskills.startLearning` are already missing from `en.json`. This PR does not touch locale catalogs.
- The broad app audit was attempted, but current Chat and Camera cases fail before Notes. A Notes-only audit timed out before assigning a verdict and reported zero findings. The exact-route four-viewport captures and geometry suite pass.

## Maintainer CI exception record

N/A - no exception requested.
