### PR TITLE
fix(connectors): isolate google oauth grants by role

### DIFF
--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -13,6 +13,7 @@ const coreMocks = vi.hoisted(() => {
   type TestAccount = {
     id: string;
     provider: string;
+    accountKey?: string;
     label?: string;
     role?: string;
     purpose?: string[];
@@ -937,7 +938,7 @@ describe("connector account routes", () => {
   });
 
   it("strips client-controlled policy metadata and owner-binding fields", async () => {
-    const { ctx, captured } = createConnectorAccountHarness({
+    const { ctx, captured, storage } = createConnectorAccountHarness({
       method: "POST",
       pathname: "/api/connectors/google/accounts",
       body: {
@@ -946,6 +947,7 @@ describe("connector account routes", () => {
         accessGate: "owner_binding",
         ownerBindingId: "client-binding",
         ownerIdentityId: "client-identity",
+        accountKey: "client-controlled-account-key",
         metadata: {
           safe: "visible",
           privacy: "public",
@@ -979,6 +981,9 @@ describe("connector account routes", () => {
       ownerBindingId: "client-binding",
       ownerIdentityId: "client-identity",
     });
+    await expect(
+      storage.getAccount("google", "acct_policy"),
+    ).resolves.not.toHaveProperty("accountKey");
     expect(JSON.stringify(captured.body)).not.toContain("refresh-secret");
     expect(JSON.stringify(captured.body)).not.toContain("credentialRefs");
   });

--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -143,6 +143,46 @@ describe("ConnectorAccountManager", () => {
 		expect(accounts[0]?.metadata).toEqual({ provider: true, stored: true });
 	});
 
+	it("rejects an ambiguous external alias while resolving an exact account key", async () => {
+		const manager = getConnectorAccountManager(makeRuntime());
+		const shared = {
+			provider: "google",
+			purpose: ["automation" as const],
+			accessGate: "open" as const,
+			status: "connected" as const,
+			externalId: "shared-google-subject",
+			createdAt: 1,
+			updatedAt: 1,
+		};
+		manager.registerProvider({
+			provider: "google",
+			listAccounts: () => [
+				{
+					...shared,
+					id: "owner-account",
+					accountKey: "owner-key",
+					role: "OWNER",
+				},
+				{
+					...shared,
+					id: "agent-account",
+					accountKey: "agent-key",
+					role: "AGENT",
+				},
+			],
+		});
+
+		await expect(
+			manager.getAccount("google", "agent-key"),
+		).resolves.toMatchObject({
+			id: "agent-account",
+			role: "AGENT",
+		});
+		await expect(
+			manager.getAccount("google", "shared-google-subject"),
+		).resolves.toBeNull();
+	});
+
 	it("resolves provider-synthesized accounts by id even before persistence", async () => {
 		const runtime = makeRuntime();
 		const manager = getConnectorAccountManager(runtime);
@@ -207,6 +247,150 @@ describe("ConnectorAccountManager", () => {
 				code: "code-2",
 			}),
 		).rejects.toThrow(/already used|unknown|expired/i);
+	});
+
+	it("serializes concurrent OAuth callbacks through final account persistence", async () => {
+		const storage = new InMemoryConnectorAccountStorage();
+		const persistAccount = storage.upsertAccount.bind(storage);
+		let signalFirstWrite!: () => void;
+		let releaseFirstWrite!: () => void;
+		const firstWriteEntered = new Promise<void>((resolve) => {
+			signalFirstWrite = resolve;
+		});
+		const firstWriteRelease = new Promise<void>((resolve) => {
+			releaseFirstWrite = resolve;
+		});
+		let writeCount = 0;
+		storage.upsertAccount = async (account) => {
+			writeCount += 1;
+			if (writeCount === 1) {
+				signalFirstWrite();
+				await firstWriteRelease;
+			}
+			return persistAccount(account);
+		};
+
+		const firstRuntime = makeRuntime();
+		const secondRuntime = makeRuntime();
+		(firstRuntime as unknown as { agentId: string }).agentId = "shared-agent";
+		(secondRuntime as unknown as { agentId: string }).agentId = "shared-agent";
+		const firstManager = getConnectorAccountManager(firstRuntime);
+		const secondManager = getConnectorAccountManager(secondRuntime);
+		firstManager.setStorage(storage);
+		secondManager.setStorage(storage);
+		const callbackCodes: string[] = [];
+		const provider = {
+			provider: "oauth-serialized-success",
+			startOAuth: () => ({ authUrl: "https://auth.example/start" }),
+			completeOAuth: (request) => {
+				callbackCodes.push(request.code ?? "");
+				return {
+					account: {
+						id: "shared-oauth-account",
+						provider: "oauth-serialized-success",
+						role: "OWNER",
+						purpose: ["messaging"],
+						accessGate: "open",
+						status: "connected",
+						createdAt: 1,
+						updatedAt: 1,
+					},
+				};
+			},
+		};
+		firstManager.registerProvider(provider);
+		secondManager.registerProvider(provider);
+		const firstFlow = await firstManager.startOAuth("oauth-serialized-success");
+		const secondFlow = await secondManager.startOAuth(
+			"oauth-serialized-success",
+		);
+
+		const first = firstManager.completeOAuth("oauth-serialized-success", {
+			state: firstFlow.state,
+			code: "code-1",
+		});
+		await firstWriteEntered;
+		const second = secondManager.completeOAuth("oauth-serialized-success", {
+			state: secondFlow.state,
+			code: "code-2",
+		});
+		await Promise.resolve();
+
+		expect(callbackCodes).toEqual(["code-1"]);
+		releaseFirstWrite();
+		await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+		expect(callbackCodes).toEqual(["code-1", "code-2"]);
+		await expect(
+			firstManager.listAccounts("oauth-serialized-success"),
+		).resolves.toHaveLength(1);
+	});
+
+	it("keeps a committed OAuth account when the queued callback fails", async () => {
+		const storage = new InMemoryConnectorAccountStorage();
+		const persistAccount = storage.upsertAccount.bind(storage);
+		let signalFirstWrite!: () => void;
+		let releaseFirstWrite!: () => void;
+		const firstWriteEntered = new Promise<void>((resolve) => {
+			signalFirstWrite = resolve;
+		});
+		const firstWriteRelease = new Promise<void>((resolve) => {
+			releaseFirstWrite = resolve;
+		});
+		storage.upsertAccount = async (account) => {
+			signalFirstWrite();
+			await firstWriteRelease;
+			storage.upsertAccount = persistAccount;
+			return persistAccount(account);
+		};
+
+		const manager = getConnectorAccountManager(makeRuntime());
+		manager.setStorage(storage);
+		const callbackCodes: string[] = [];
+		manager.registerProvider({
+			provider: "oauth-serialized-failure",
+			startOAuth: () => ({ authUrl: "https://auth.example/start" }),
+			completeOAuth: (request) => {
+				callbackCodes.push(request.code ?? "");
+				if (request.code === "code-2")
+					throw new Error("second callback rejected");
+				return {
+					account: {
+						id: "committed-oauth-account",
+						provider: "oauth-serialized-failure",
+						role: "OWNER",
+						purpose: ["messaging"],
+						accessGate: "open",
+						status: "connected",
+						createdAt: 1,
+						updatedAt: 1,
+					},
+				};
+			},
+		});
+		const firstFlow = await manager.startOAuth("oauth-serialized-failure");
+		const secondFlow = await manager.startOAuth("oauth-serialized-failure");
+
+		const first = manager.completeOAuth("oauth-serialized-failure", {
+			state: firstFlow.state,
+			code: "code-1",
+		});
+		await firstWriteEntered;
+		const second = manager.completeOAuth("oauth-serialized-failure", {
+			state: secondFlow.state,
+			code: "code-2",
+		});
+		await Promise.resolve();
+
+		expect(callbackCodes).toEqual(["code-1"]);
+		releaseFirstWrite();
+		await expect(first).resolves.toMatchObject({
+			account: { id: "committed-oauth-account" },
+		});
+		await expect(second).rejects.toThrow(/completion failed/i);
+		expect(callbackCodes).toEqual(["code-1", "code-2"]);
+		await expect(
+			manager.getAccount("oauth-serialized-failure", "committed-oauth-account"),
+		).resolves.toMatchObject({ status: "connected" });
 	});
 
 	it("preserves PKCE code verifier through database-backed OAuth flow storage", async () => {
@@ -405,6 +589,53 @@ describe("durable storage binding", () => {
 			provider: "google",
 			externalId: "user@example.com",
 			status: "connected",
+		});
+	});
+
+	it("round-trips a provider-owned account key separately from the external identity", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const manager = getConnectorAccountManager(makeRuntime(adapter));
+		const stableKey = "acct_google_role_bound_key";
+
+		const account = await manager.upsertAccount("google", {
+			...GOOGLE_ACCOUNT,
+			id: stableKey,
+			accountKey: stableKey,
+			externalId: "shared-google-subject",
+		});
+
+		expect(account.accountKey).toBe(stableKey);
+		await expect(
+			adapter.getConnectorAccount({
+				provider: "google",
+				accountKey: stableKey,
+			}),
+		).resolves.toMatchObject({
+			accountKey: stableKey,
+			externalId: "shared-google-subject",
+		});
+	});
+
+	it("preserves stored identity fields when a provider returns a partial patch", async () => {
+		const manager = getConnectorAccountManager(makeRuntime());
+		await manager.upsertAccount("google", {
+			...GOOGLE_ACCOUNT,
+			accountKey: "acct_google_owner_key",
+			externalId: "google-owner-subject",
+		});
+		manager.registerProvider({
+			provider: "google",
+			patchAccount: async () => ({ status: "disabled" }),
+		});
+
+		await expect(
+			manager.patchAccount("google", GOOGLE_ACCOUNT.id, { status: "disabled" }),
+		).resolves.toMatchObject({
+			accountKey: "acct_google_owner_key",
+			externalId: "google-owner-subject",
+			role: "OWNER",
+			status: "disabled",
 		});
 	});
 

--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -379,6 +379,8 @@ describe("ConnectorAccountManager", () => {
 			state: secondFlow.state,
 			code: "code-2",
 		});
+		const secondRejection =
+			expect(second).rejects.toThrow(/completion failed/i);
 		await Promise.resolve();
 
 		expect(callbackCodes).toEqual(["code-1"]);
@@ -386,7 +388,7 @@ describe("ConnectorAccountManager", () => {
 		await expect(first).resolves.toMatchObject({
 			account: { id: "committed-oauth-account" },
 		});
-		await expect(second).rejects.toThrow(/completion failed/i);
+		await secondRejection;
 		expect(callbackCodes).toEqual(["code-1", "code-2"]);
 		await expect(
 			manager.getAccount("oauth-serialized-failure", "committed-oauth-account"),

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -59,6 +59,8 @@ export type ConnectorOAuthFlowStatus =
 export interface ConnectorAccount {
 	id: string;
 	provider: string;
+	/** Provider-owned durable identity; never accepted from public HTTP bodies. */
+	accountKey?: string;
 	label?: string;
 	role: ConnectorAccountRole;
 	purpose: ConnectorAccountPurpose[];
@@ -74,6 +76,8 @@ export interface ConnectorAccount {
 }
 
 export interface ConnectorAccountPatch {
+	/** Provider-owned durable identity; never accepted from public HTTP bodies. */
+	accountKey?: string;
 	label?: string;
 	role?: ConnectorAccountRole;
 	purpose?: ConnectorAccountPurpose | ConnectorAccountPurpose[];
@@ -378,6 +382,7 @@ type ActionWithConnectorAccountPolicy = Action & {
 const runtimeManagers = new WeakMap<IAgentRuntime, ConnectorAccountManager>();
 let standaloneManager: ConnectorAccountManager | null = null;
 const oauthCodeVerifierSecrets = new Map<string, string>();
+const oauthCompletionQueues = new Map<string, Promise<void>>();
 
 function nowMs(): number {
 	return Date.now();
@@ -452,6 +457,7 @@ function mergeStoredAndProviderAccount(
 		...providerAccount,
 		id: stored.id,
 		provider: stored.provider,
+		accountKey: stored.accountKey ?? providerAccount.accountKey,
 		label: stored.label ?? providerAccount.label,
 		role: stored.role,
 		purpose: [...stored.purpose],
@@ -495,6 +501,10 @@ function normalizeAccount(
 	return {
 		id,
 		provider: normalizedProvider,
+		accountKey:
+			typeof full.accountKey === "string" && full.accountKey.trim()
+				? full.accountKey.trim()
+				: undefined,
 		label: typeof full.label === "string" ? full.label : undefined,
 		role: normalizeConnectorAccountRole(full.role),
 		purpose: normalizeStringArray(full.purpose),
@@ -532,6 +542,7 @@ function mergeAccountPatch(
 			...patch,
 			provider: account.provider,
 			id: account.id,
+			accountKey: patch.accountKey ?? account.accountKey,
 			purpose:
 				patch.purpose !== undefined
 					? normalizeStringArray(patch.purpose)
@@ -611,7 +622,14 @@ export class InMemoryConnectorAccountStorage
 		provider: string,
 		accountId: string,
 	): Promise<ConnectorAccount | null> {
-		const account = this.accounts.get(accountKey(provider, accountId));
+		const normalizedProvider = normalizeProvider(provider);
+		const account =
+			this.accounts.get(accountKey(normalizedProvider, accountId)) ??
+			Array.from(this.accounts.values()).find(
+				(candidate) =>
+					candidate.provider === normalizedProvider &&
+					candidate.accountKey === accountId,
+			);
 		return account ? cloneAccount(account) : null;
 	}
 
@@ -625,7 +643,10 @@ export class InMemoryConnectorAccountStorage
 	}
 
 	async deleteAccount(provider: string, accountId: string): Promise<boolean> {
-		return this.accounts.delete(accountKey(provider, accountId));
+		const account = await this.getAccount(provider, accountId);
+		return account
+			? this.accounts.delete(accountKey(account.provider, account.id))
+			: false;
 	}
 
 	async createOAuthFlow(flow: ConnectorOAuthFlow): Promise<ConnectorOAuthFlow> {
@@ -800,7 +821,7 @@ class DatabaseConnectorAccountStorage implements ConnectorAccountStorage {
 		const record = await this.adapter.upsertConnectorAccount({
 			...(looksLikeUuid(account.id) ? { id: account.id } : {}),
 			provider: normalizeProvider(account.provider),
-			accountKey: account.externalId ?? account.id,
+			accountKey: account.accountKey ?? account.externalId ?? account.id,
 			externalId: account.externalId ?? null,
 			displayName: account.label ?? null,
 			username: account.displayHandle ?? null,
@@ -1110,6 +1131,7 @@ function databaseRecordToAccount(
 	return {
 		id: record.id,
 		provider: normalizeProvider(record.provider),
+		accountKey: record.accountKey,
 		label:
 			record.displayName ??
 			record.email ??
@@ -1513,13 +1535,15 @@ export class ConnectorAccountManager extends Service {
 		const providerAccounts = (await registered.listAccounts(this)).map(
 			cloneAccount,
 		);
-		const providerAccount = providerAccounts.find(
-			(account) =>
-				account.id === accountId ||
-				account.externalId === accountId ||
-				account.displayHandle === accountId,
+		const exactAccount = providerAccounts.find(
+			(account) => account.id === accountId || account.accountKey === accountId,
 		);
-		return providerAccount ?? null;
+		if (exactAccount) return exactAccount;
+		const aliases = providerAccounts.filter(
+			(account) =>
+				account.externalId === accountId || account.displayHandle === accountId,
+		);
+		return aliases.length === 1 ? aliases[0] : null;
 	}
 
 	async upsertAccount(
@@ -1567,8 +1591,13 @@ export class ConnectorAccountManager extends Service {
 		const providerId = normalizeProvider(provider);
 		const registered = this.providers.get(providerId);
 		if (registered?.patchAccount) {
+			const existing = await this.storage.getAccount(providerId, accountId);
 			const patched = await registered.patchAccount(accountId, patch, this);
-			return this.upsertAccount(providerId, patched, accountId);
+			return this.upsertAccount(
+				providerId,
+				existing ? mergeAccountPatch(existing, patched) : patched,
+				accountId,
+			);
 		}
 		const existing = await this.storage.getAccount(providerId, accountId);
 		if (!existing) return null;
@@ -1691,6 +1720,52 @@ export class ConnectorAccountManager extends Service {
 		redirectUrl?: string;
 	}> {
 		const providerId = normalizeProvider(provider);
+		return this.runSerializedOAuthCompletion(providerId, () =>
+			this.completeOAuthUnserialized(providerId, input),
+		);
+	}
+
+	private runSerializedOAuthCompletion<T>(
+		providerId: string,
+		operation: () => Promise<T>,
+	): Promise<T> {
+		// Completion spans provider verification, account/credential writes,
+		// compensation, and terminal flow persistence. Keep that whole sequence
+		// single-filed for every manager serving the same agent in this process.
+		// This intentionally makes no cross-process active-active claim: that would
+		// require a distributed lease with fencing across DB, vault, and provider
+		// side effects, which the connector provider contract does not expose.
+		const agentId = this.runtime?.agentId ?? "standalone";
+		const queueKey = `${agentId}\u0000${providerId}`;
+		const previous = oauthCompletionQueues.get(queueKey) ?? Promise.resolve();
+		const next = previous.catch(() => undefined).then(operation);
+		const tail = next.then(
+			() => undefined,
+			() => undefined,
+		);
+		oauthCompletionQueues.set(queueKey, tail);
+		return next.finally(() => {
+			if (oauthCompletionQueues.get(queueKey) === tail) {
+				oauthCompletionQueues.delete(queueKey);
+			}
+		});
+	}
+
+	private async completeOAuthUnserialized(
+		providerId: string,
+		input: {
+			state: string;
+			code?: string;
+			error?: string;
+			errorDescription?: string;
+			query?: Record<string, string>;
+			body?: Record<string, unknown>;
+		},
+	): Promise<{
+		flow: ConnectorOAuthFlow;
+		account?: ConnectorAccount;
+		redirectUrl?: string;
+	}> {
 		const flow = await this.storage.consumeOAuthFlow(
 			providerId,
 			input.state,

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -1144,7 +1144,7 @@ function databaseRecordToAccount(
 		),
 		accessGate: (record.accessGate ?? "open") as ConnectorAccountAccessGate,
 		status,
-		externalId: record.externalId ?? record.accountKey,
+		externalId: record.externalId ?? undefined,
 		displayHandle: record.username ?? record.email ?? undefined,
 		ownerBindingId: record.ownerBindingId ?? undefined,
 		ownerIdentityId: record.ownerIdentityId ?? undefined,

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -2660,14 +2660,66 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			provider: params.provider,
 			accountKey: params.accountKey,
 		});
-		const existingId = params.id
-			? String(params.id)
-			: this.connectorAccountIdsByKey.get(lookupKey);
+		const requestedRole = params.role ?? "OWNER";
+		const existingByExternalRole =
+			params.externalId != null
+				? Array.from(this.connectorAccountsById.values()).find(
+						(account) =>
+							account.agentId === agentId &&
+							account.provider === params.provider &&
+							account.externalId === params.externalId &&
+							account.role === requestedRole &&
+							account.deletedAt == null,
+					)
+				: undefined;
+		const existingByAccountKeyId = this.connectorAccountIdsByKey.get(lookupKey);
+		const requestedId = params.id ? String(params.id) : undefined;
+		const existingByRequestedId = requestedId
+			? this.connectorAccountsById.get(requestedId)
+			: undefined;
+		if (existingByRequestedId?.deletedAt != null) {
+			throw new Error(
+				"Connector account id already belongs to a deleted account",
+			);
+		}
+
+		let existingId: string | undefined;
+		if (existingByRequestedId) {
+			if (
+				existingByAccountKeyId &&
+				existingByAccountKeyId !== existingByRequestedId.id
+			) {
+				throw new Error(
+					"Connector account id and account key resolve to different accounts",
+				);
+			}
+			if (
+				existingByExternalRole &&
+				existingByExternalRole.id !== existingByRequestedId.id
+			) {
+				throw new Error(
+					"Connector account id and external identity resolve to different accounts",
+				);
+			}
+			existingId = existingByRequestedId.id;
+		} else if (params.externalId != null) {
+			if (
+				existingByAccountKeyId &&
+				existingByAccountKeyId !== existingByExternalRole?.id
+			) {
+				throw new Error(
+					"Connector account key and external identity resolve to different accounts",
+				);
+			}
+			existingId = existingByExternalRole?.id;
+		} else {
+			existingId = existingByAccountKeyId;
+		}
 		const existing = existingId
 			? this.connectorAccountsById.get(existingId)
 			: undefined;
 		const now = Date.now();
-		const id = params.id ?? existing?.id ?? randomUuid();
+		const id = existing?.id ?? params.id ?? randomUuid();
 		const profile = cloneConnectorJsonObject(
 			params.profile !== undefined ? params.profile : existing?.profile,
 		);

--- a/packages/core/src/database/inMemoryConnectorAccountStorage.test.ts
+++ b/packages/core/src/database/inMemoryConnectorAccountStorage.test.ts
@@ -14,6 +14,71 @@ import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
 const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
 
 describe("InMemoryDatabaseAdapter connector account storage", () => {
+	it("keeps external identities role-scoped and rejects split identity keys", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const subject = "shared-google-subject";
+		const ownerKey = "acct_google_owner_key";
+		const agentKey = "acct_google_agent_key";
+		const legacyOwner = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "google",
+			accountKey: subject,
+			externalId: subject,
+			role: "OWNER",
+		});
+
+		const owner = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "google",
+			accountKey: ownerKey,
+			externalId: subject,
+			role: "OWNER",
+		});
+		const agent = await adapter.upsertConnectorAccount({
+			agentId,
+			provider: "google",
+			accountKey: agentKey,
+			externalId: subject,
+			role: "AGENT",
+		});
+
+		expect(owner.id).toBe(legacyOwner.id);
+		expect(agent.id).not.toBe(owner.id);
+		await expect(
+			adapter.upsertConnectorAccount({
+				agentId,
+				provider: "google",
+				accountKey: agentKey,
+				externalId: subject,
+				role: "OWNER",
+			}),
+		).rejects.toThrow(/different accounts/);
+		await expect(
+			adapter.upsertConnectorAccount({
+				id: "00000000-0000-0000-0000-000000000099" as UUID,
+				agentId,
+				provider: "google",
+				accountKey: ownerKey,
+				externalId: "different-google-subject",
+				role: "OWNER",
+			}),
+		).rejects.toThrow(/different accounts/);
+		await expect(
+			adapter.upsertConnectorAccount({
+				agentId,
+				provider: "google",
+				accountKey: ownerKey,
+				externalId: "another-google-subject",
+				role: "OWNER",
+			}),
+		).rejects.toThrow(/different accounts/);
+		expect(await adapter.getConnectorAccount({ id: owner.id })).toMatchObject({
+			accountKey: ownerKey,
+			externalId: subject,
+		});
+	});
+
 	it("returns every account when pagination was not requested", async () => {
 		const adapter = new InMemoryDatabaseAdapter();
 		await adapter.initialize();

--- a/plugins/plugin-google-workspace/src/connector-account-provider.disconnect.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.disconnect.test.ts
@@ -14,11 +14,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createGoogleConnectorAccountProvider,
   revokeGoogleOAuthGrantWithFetch,
+  stableGoogleConnectorAccountId,
 } from "./connector-account-provider.js";
 
 const AGENT_ID = "00000000-0000-4000-8000-00000000e19a" as UUID;
 const ACCOUNT_ID = "10000000-0000-4000-8000-000000000001" as UUID;
 const VAULT_REF = `connector.${AGENT_ID}.google.${ACCOUNT_ID}.oauth_tokens`;
+const SIBLING_ACCOUNT_ID = "10000000-0000-4000-8000-000000000002" as UUID;
+const SIBLING_VAULT_REF = `connector.${AGENT_ID}.google.${SIBLING_ACCOUNT_ID}.oauth_tokens`;
 
 function runtimeHarness() {
   const adapter = new InMemoryDatabaseAdapter();
@@ -75,6 +78,8 @@ async function connectedManager(harness: ReturnType<typeof runtimeHarness>) {
       purpose: ["messaging"],
       accessGate: "owner_binding",
       status: "connected",
+      externalId: "google-shared-subject",
+      accountKey: stableGoogleConnectorAccountId("google-shared-subject", "OWNER"),
       createdAt: Date.now(),
       updatedAt: Date.now(),
       metadata: {},
@@ -150,6 +155,49 @@ describe("Google connector disconnect", () => {
     await expect(harness.adapter.getConnectorAccount({ id: ACCOUNT_ID })).resolves.toBeNull();
   });
 
+  it("removes one role locally without revoking a Google grant still used by a sibling role", async () => {
+    const harness = runtimeHarness();
+    const manager = await connectedManager(harness);
+    harness.vault.set(
+      SIBLING_VAULT_REF,
+      JSON.stringify({ access_token: "agent-access", refresh_token: "agent-refresh" })
+    );
+    await manager.upsertAccount(
+      "google",
+      {
+        id: SIBLING_ACCOUNT_ID,
+        provider: "google",
+        role: "AGENT",
+        purpose: ["messaging"],
+        accessGate: "owner_binding",
+        status: "connected",
+        externalId: "google-shared-subject",
+        accountKey: stableGoogleConnectorAccountId("google-shared-subject", "AGENT"),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      SIBLING_ACCOUNT_ID
+    );
+    await harness.adapter.setConnectorAccountCredentialRef({
+      accountId: SIBLING_ACCOUNT_ID,
+      credentialType: "oauth.tokens",
+      vaultRef: SIBLING_VAULT_REF,
+    });
+
+    await expect(manager.deleteAccount("google", SIBLING_ACCOUNT_ID)).resolves.toBe(true);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(harness.vault.has(SIBLING_VAULT_REF)).toBe(false);
+    expect(harness.vault.has(VAULT_REF)).toBe(true);
+    await expect(manager.getAccount("google", ACCOUNT_ID)).resolves.toMatchObject({
+      status: "connected",
+      role: "OWNER",
+    });
+    await expect(
+      harness.adapter.listConnectorAccountCredentialRefs({ accountId: ACCOUNT_ID })
+    ).resolves.toHaveLength(1);
+  });
+
   it("keeps the connected account and credentials when Google cannot confirm revocation", async () => {
     const harness = runtimeHarness();
     const manager = await connectedManager(harness);
@@ -170,6 +218,51 @@ describe("Google connector disconnect", () => {
     });
     await expect(
       harness.adapter.listConnectorAccountCredentialRefs({ accountId: ACCOUNT_ID })
+    ).resolves.toHaveLength(1);
+  });
+
+  it("rejects a connected account with no stable identity before revoking its grant", async () => {
+    const harness = runtimeHarness();
+    await harness.adapter.initialize();
+    const manager = getConnectorAccountManager(harness.runtime);
+    manager.registerProvider(createGoogleConnectorAccountProvider(harness.runtime));
+    const account = await manager.upsertAccount(
+      "google",
+      {
+        id: ACCOUNT_ID,
+        provider: "google",
+        role: "OWNER",
+        purpose: ["messaging"],
+        accessGate: "owner_binding",
+        status: "connected",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        metadata: {},
+      },
+      ACCOUNT_ID
+    );
+    await harness.adapter.setConnectorAccountCredentialRef({
+      accountId: account.id as UUID,
+      credentialType: "oauth.tokens",
+      vaultRef: VAULT_REF,
+    });
+
+    await expect(manager.deleteAccount("google", account.id)).rejects.toMatchObject({
+      code: "GOOGLE_OAUTH_EXTERNAL_ID_MISSING",
+    });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(harness.revokeWatches).not.toHaveBeenCalled();
+    expect(harness.remove).not.toHaveBeenCalled();
+    expect(harness.vault.has(VAULT_REF)).toBe(true);
+    await expect(
+      harness.adapter.getConnectorAccount({ id: account.id as UUID })
+    ).resolves.toMatchObject({
+      status: "connected",
+      deletedAt: null,
+    });
+    await expect(
+      harness.adapter.listConnectorAccountCredentialRefs({ accountId: account.id as UUID })
     ).resolves.toHaveLength(1);
   });
 
@@ -196,7 +289,9 @@ describe("Google connector disconnect", () => {
     const manager = await connectedManager(harness);
     harness.remove.mockRejectedValueOnce(new Error("vault unavailable"));
 
-    await expect(manager.deleteAccount("google", ACCOUNT_ID)).rejects.toThrow(/vault unavailable/);
+    await expect(manager.deleteAccount("google", ACCOUNT_ID)).rejects.toThrow(
+      /sibling degradation/i
+    );
     const fetchStub = vi.mocked(globalThis.fetch);
     expect(fetchStub).toHaveBeenCalledTimes(1);
     await expect(harness.adapter.getConnectorAccount({ id: ACCOUNT_ID })).resolves.toMatchObject({

--- a/plugins/plugin-google-workspace/src/connector-account-provider.identity-binding.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.identity-binding.test.ts
@@ -40,35 +40,47 @@ function stubIdTokenVerification(payload: Record<string, unknown>) {
   } as never);
 }
 
-function runtime() {
+function createRuntimeHarness(options?: {
+  credentialRefs?: Array<Record<string, unknown>>;
+  failVaultSet?: boolean;
+  vaultEntries?: Record<string, string>;
+}) {
   const vault = new Map<string, string>();
-  return {
+  for (const [key, value] of Object.entries(options?.vaultEntries ?? {})) {
+    vault.set(key, value);
+  }
+  const adapter = {
+    listConnectorAccountCredentialRefs: vi.fn(async () => options?.credentialRefs ?? []),
+    deleteConnectorAccountCredentialRefs: vi.fn(async () => 0),
+    setConnectorAccountCredentialRef: vi.fn(async () => undefined),
+  };
+  const vaultService = {
+    set: vi.fn(async (key: string, value: string) => {
+      if (options?.failVaultSet) throw new Error("vault write rejected");
+      vault.set(key, value);
+    }),
+    get: vi.fn(async (key: string) => vault.get(key) ?? null),
+    has: vi.fn(async (key: string) => vault.has(key)),
+    remove: vi.fn(async (key: string) => {
+      vault.delete(key);
+    }),
+  };
+  const value = {
     agentId: "agent-1",
-    adapter: {
-      listConnectorAccountCredentialRefs: vi.fn(async () => []),
-      deleteConnectorAccountCredentialRefs: vi.fn(async () => 0),
-      setConnectorAccountCredentialRef: vi.fn(async () => undefined),
-    },
+    adapter,
     getSetting: (key: string) =>
       ({
         GOOGLE_CLIENT_ID: "client-id",
         GOOGLE_CLIENT_SECRET: "client-secret",
         GOOGLE_REDIRECT_URI: "http://127.0.0.1:31437/api/connectors/google/oauth/callback",
       })[key],
-    getService: (serviceType: string) =>
-      serviceType === "vault"
-        ? {
-            set: vi.fn(async (key: string, value: string) => {
-              vault.set(key, value);
-            }),
-            get: vi.fn(async (key: string) => vault.get(key) ?? null),
-            has: vi.fn(async (key: string) => vault.has(key)),
-            remove: vi.fn(async (key: string) => {
-              vault.delete(key);
-            }),
-          }
-        : null,
+    getService: (serviceType: string) => (serviceType === "vault" ? vaultService : null),
   } as never;
+  return { value, adapter, vault, vaultService };
+}
+
+function runtime() {
+  return createRuntimeHarness().value;
 }
 
 function manager(existing: ConnectorAccount | null = null) {
@@ -76,6 +88,7 @@ function manager(existing: ConnectorAccount | null = null) {
   const restoreAccount = vi.fn(async (account: ConnectorAccount) => account);
   const deleteAccount = vi.fn(async () => true);
   const getAccount = vi.fn(async () => existing);
+  const listAccounts = vi.fn(async () => (existing ? [existing] : []));
   const upsertAccount = vi.fn(
     async (
       provider: string,
@@ -86,6 +99,7 @@ function manager(existing: ConnectorAccount | null = null) {
       return {
         id: accountId,
         provider,
+        accountKey: input.accountKey,
         role: input.role ?? "OWNER",
         purpose: Array.isArray(input.purpose)
           ? input.purpose
@@ -104,6 +118,7 @@ function manager(existing: ConnectorAccount | null = null) {
   return {
     value: {
       getAccount,
+      listAccounts,
       upsertAccount,
       getStorage: () => ({
         setConnectorAccountCredentialRef,
@@ -112,6 +127,9 @@ function manager(existing: ConnectorAccount | null = null) {
       }),
     } as unknown as ConnectorAccountManager,
     getAccount,
+    listAccounts,
+    restoreAccount,
+    deleteAccount,
     upsertAccount,
   };
 }
@@ -219,9 +237,10 @@ describe("Google OAuth connector-account identity binding", () => {
 
     const expected = stableGoogleConnectorAccountId("subject-1", "OWNER");
     expect(result?.account?.id).toBe(expected);
+    expect(result?.account?.accountKey).toBe(expected);
     expect(harness.upsertAccount).toHaveBeenCalledWith(
       "google",
-      expect.objectContaining({ externalId: "subject-1" }),
+      expect.objectContaining({ accountKey: expected, externalId: "subject-1" }),
       expected
     );
   });
@@ -300,9 +319,125 @@ describe("Google OAuth connector-account identity binding", () => {
     expect(result?.account?.role).toBe("AGENT");
     expect(harness.upsertAccount).toHaveBeenCalledWith(
       "google",
-      expect.objectContaining({ role: "AGENT" }),
+      expect.objectContaining({
+        accountKey: stableGoogleConnectorAccountId("original-subject", "AGENT"),
+        role: "AGENT",
+      }),
       "existing-account"
     );
+  });
+
+  it("lazy-upgrades a role-matched legacy account and removes its prior credential", async () => {
+    stubToken("legacy-subject", "expected-nonce");
+    const priorVaultRef = "connector.agent-1.google.legacy-account.oauth.tokens";
+    const runtimeHarness = createRuntimeHarness({
+      credentialRefs: [
+        {
+          accountId: "00000000-0000-0000-0000-000000000042",
+          credentialType: "oauth.tokens",
+          vaultRef: priorVaultRef,
+        },
+      ],
+      vaultEntries: { [priorVaultRef]: "old-token-set" },
+    });
+    const provider = createGoogleConnectorAccountProvider(runtimeHarness.value);
+    const legacyAccount: ConnectorAccount = {
+      id: "00000000-0000-0000-0000-000000000042",
+      provider: "google",
+      accountKey: "legacy-subject",
+      role: "OWNER",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "legacy-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const harness = manager(legacyAccount);
+
+    const result = await provider.completeOAuth?.(callback(), harness.value);
+
+    expect(result?.account?.id).toBe(legacyAccount.id);
+    expect(result?.account?.accountKey).toBe(
+      stableGoogleConnectorAccountId("legacy-subject", "OWNER")
+    );
+    expect(runtimeHarness.adapter.listConnectorAccountCredentialRefs).toHaveBeenCalledWith({
+      accountId: legacyAccount.id,
+    });
+    expect(runtimeHarness.vault.has(priorVaultRef)).toBe(false);
+    expect(harness.upsertAccount).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({
+        accountKey: stableGoogleConnectorAccountId("legacy-subject", "OWNER"),
+      }),
+      legacyAccount.id
+    );
+  });
+
+  it("loads reauthorization credential refs by the resolved canonical account id", async () => {
+    stubToken("original-subject", "expected-nonce");
+    const runtimeHarness = createRuntimeHarness();
+    const provider = createGoogleConnectorAccountProvider(runtimeHarness.value);
+    const existing: ConnectorAccount = {
+      id: "00000000-0000-0000-0000-000000000043",
+      provider: "google",
+      accountKey: stableGoogleConnectorAccountId("original-subject", "OWNER"),
+      role: "OWNER",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "original-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const harness = manager(existing);
+
+    await provider.completeOAuth?.(callback(existing.accountKey), harness.value);
+
+    expect(runtimeHarness.adapter.listConnectorAccountCredentialRefs).toHaveBeenCalledWith({
+      accountId: existing.id,
+    });
+    expect(harness.upsertAccount).toHaveBeenCalledWith("google", expect.any(Object), existing.id);
+  });
+
+  it("does not delete a lazy-matched legacy account when credential persistence fails", async () => {
+    stubToken("legacy-subject", "expected-nonce");
+    const priorVaultRef = "connector.agent-1.google.legacy-account.oauth.tokens";
+    const runtimeHarness = createRuntimeHarness({
+      credentialRefs: [
+        {
+          accountId: "00000000-0000-0000-0000-000000000044",
+          credentialType: "oauth.tokens",
+          vaultRef: priorVaultRef,
+        },
+      ],
+      failVaultSet: true,
+      vaultEntries: { [priorVaultRef]: "old-token-set" },
+    });
+    const provider = createGoogleConnectorAccountProvider(runtimeHarness.value);
+    const legacyAccount: ConnectorAccount = {
+      id: "00000000-0000-0000-0000-000000000044",
+      provider: "google",
+      accountKey: "legacy-subject",
+      role: "OWNER",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "legacy-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const harness = manager(legacyAccount);
+
+    await expect(provider.completeOAuth?.(callback(), harness.value)).rejects.toThrow(
+      "vault write rejected"
+    );
+
+    expect(harness.deleteAccount).not.toHaveBeenCalled();
+    expect(harness.restoreAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ id: legacyAccount.id, status: "error" })
+    );
+    expect(runtimeHarness.vault.has(priorVaultRef)).toBe(false);
   });
 
   it("rejects a reauthorization flow for an account that was deleted", async () => {

--- a/plugins/plugin-google-workspace/src/connector-account-provider.identity-binding.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.identity-binding.test.ts
@@ -51,7 +51,7 @@ function createRuntimeHarness(options?: {
   }
   const adapter = {
     listConnectorAccountCredentialRefs: vi.fn(async () => options?.credentialRefs ?? []),
-    deleteConnectorAccountCredentialRefs: vi.fn(async () => 0),
+    deleteConnectorAccountCredentialRefs: vi.fn(async () => options?.credentialRefs?.length ?? 0),
     setConnectorAccountCredentialRef: vi.fn(async () => undefined),
   };
   const vaultService = {

--- a/plugins/plugin-google-workspace/src/connector-account-provider.role.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.role.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { createGoogleConnectorAccountProvider } from "./connector-account-provider.js";
+import {
+  createGoogleConnectorAccountProvider,
+  stableGoogleConnectorAccountId,
+} from "./connector-account-provider.js";
 
 const provider = createGoogleConnectorAccountProvider({
   getSetting: () => undefined,
@@ -24,8 +27,132 @@ describe("Google connector account role admission", () => {
 
   it("preserves an explicit canonical role", async () => {
     await expect(
-      provider.createAccount?.({ role: "AGENT" } as never, {} as never)
-    ).resolves.toMatchObject({ provider: "google", role: "AGENT" });
+      provider.createAccount?.(
+        { role: "AGENT", externalId: "shared-subject" } as never,
+        {} as never
+      )
+    ).resolves.toMatchObject({
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "AGENT"),
+      externalId: "shared-subject",
+      provider: "google",
+      role: "AGENT",
+    });
+  });
+
+  it("rekeys an existing account when its role changes", async () => {
+    const existing = {
+      id: "account-1",
+      provider: "google",
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "OWNER"),
+      role: "OWNER",
+      purpose: ["automation"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "shared-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const getAccount = vi.fn(async () => existing);
+
+    await expect(
+      provider.patchAccount?.("account-1", { role: "AGENT" }, { getAccount } as never)
+    ).resolves.toMatchObject({
+      id: "account-1",
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "AGENT"),
+      externalId: "shared-subject",
+      role: "AGENT",
+    });
+  });
+
+  it.each([
+    ["replace", "different-subject"],
+    ["clear", null],
+  ])("rejects an external identity %s without OAuth", async (_label, externalId) => {
+    const existing = {
+      id: "account-1",
+      provider: "google",
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "OWNER"),
+      role: "OWNER",
+      purpose: ["automation"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "shared-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const getAccount = vi.fn(async () => existing);
+
+    await expect(
+      provider.patchAccount?.("account-1", { externalId }, { getAccount } as never)
+    ).rejects.toMatchObject({ code: "GOOGLE_CONNECTOR_EXTERNAL_ID_IMMUTABLE" });
+  });
+
+  it("validates a role patch before revoking calendar watches", async () => {
+    const revokeGoogleCalendarWatchesByAccount = vi.fn(async () => undefined);
+    const guardedProvider = createGoogleConnectorAccountProvider({
+      getSetting: () => undefined,
+      getService: (serviceType: string) =>
+        serviceType === "calendar" ? { revokeGoogleCalendarWatchesByAccount } : null,
+    } as never);
+    const existing = {
+      id: "account-1",
+      provider: "google",
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "OWNER"),
+      role: "OWNER",
+      purpose: ["automation"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "shared-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const getAccount = vi.fn(async () => existing);
+
+    await expect(
+      guardedProvider.patchAccount?.(
+        "account-1",
+        { role: "administrator" as never, status: "disabled" },
+        { getAccount } as never
+      )
+    ).rejects.toMatchObject({ code: "GOOGLE_CONNECTOR_ROLE_INVALID" });
+    expect(revokeGoogleCalendarWatchesByAccount).not.toHaveBeenCalled();
+  });
+
+  it("detects a role identity collision before revoking calendar watches", async () => {
+    const revokeGoogleCalendarWatchesByAccount = vi.fn(async () => undefined);
+    const guardedProvider = createGoogleConnectorAccountProvider({
+      getSetting: () => undefined,
+      getService: (serviceType: string) =>
+        serviceType === "calendar" ? { revokeGoogleCalendarWatchesByAccount } : null,
+    } as never);
+    const owner = {
+      id: "owner-account",
+      provider: "google",
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "OWNER"),
+      role: "OWNER",
+      purpose: ["automation"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "shared-subject",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const agent = {
+      ...owner,
+      id: "agent-account",
+      accountKey: stableGoogleConnectorAccountId("shared-subject", "AGENT"),
+      role: "AGENT",
+    };
+    const getAccount = vi.fn(async (_provider: string, accountRef: string) =>
+      accountRef === owner.id ? owner : agent
+    );
+
+    await expect(
+      guardedProvider.patchAccount?.(owner.id, { role: "AGENT", status: "disabled" }, {
+        getAccount,
+      } as never)
+    ).rejects.toMatchObject({ code: "GOOGLE_CONNECTOR_ROLE_ACCOUNT_CONFLICT" });
+    expect(revokeGoogleCalendarWatchesByAccount).not.toHaveBeenCalled();
   });
 
   it("returns a role-bound consent URL for a valid new grant", async () => {

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -21,7 +21,6 @@ import {
   type ConnectorAccountPatch,
   type ConnectorAccountProvider,
   type ConnectorAccountPurpose,
-  type ConnectorAccountRole,
   type ConnectorOAuthCallbackRequest,
   type ConnectorOAuthCallbackResult,
   type ConnectorOAuthStartRequest,
@@ -53,6 +52,7 @@ import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 const GOOGLE_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo";
 const GOOGLE_OAUTH_REVOKED_AT_METADATA_KEY = "oauthRevokedAt";
+type GoogleConnectorRole = "OWNER" | "AGENT" | "TEAM";
 
 /** Maximum time allowed for one Google OAuth or userinfo request. */
 export const GOOGLE_OAUTH_FETCH_TIMEOUT_MS = 15_000;
@@ -119,10 +119,7 @@ function createOidcNonce(): string {
  * the role keeps an owner grant distinct from an intentionally separate agent
  * grant for the same Google account.
  */
-export function stableGoogleConnectorAccountId(
-  subject: string,
-  role: ConnectorAccountRole
-): string {
+export function stableGoogleConnectorAccountId(subject: string, role: GoogleConnectorRole): string {
   const digest = createHash("sha256").update(`${role}\u0000${subject}`).digest("hex").slice(0, 32);
   return `acct_google_${digest}`;
 }
@@ -640,7 +637,7 @@ function requestedScopesFromMetadata(metadata: unknown): string[] {
   return scopes;
 }
 
-function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
+function roleFromMetadata(metadata: unknown): GoogleConnectorRole {
   const record =
     metadata && typeof metadata === "object" && !Array.isArray(metadata)
       ? (metadata as Record<string, unknown>)
@@ -681,7 +678,7 @@ function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
 async function resolveOAuthRoleAtStart(
   request: ConnectorOAuthStartRequest,
   manager: ConnectorAccountManager
-): Promise<ConnectorAccountRole> {
+): Promise<GoogleConnectorRole> {
   const accountId = nonEmptyString(request.accountId);
   if (!accountId) {
     return roleFromMetadata(request.metadata);
@@ -916,10 +913,13 @@ export function createGoogleConnectorAccountProvider(
       // Persistence is owned by the manager; this adapter just normalizes the
       // patch into a Google-shaped account so role/purpose/status defaults are
       // sensible when an upstream caller creates the row before OAuth runs.
+      const role = roleFromMetadata({ role: input.role });
+      const externalId = nonEmptyString(input.externalId);
       return {
         ...input,
         provider: GOOGLE_SERVICE_NAME,
-        role: roleFromMetadata({ role: input.role }),
+        ...(externalId ? { accountKey: stableGoogleConnectorAccountId(externalId, role) } : {}),
+        role,
         purpose: input.purpose ?? ["messaging", "calendar", "drive", "meet"],
         accessGate: input.accessGate ?? "open",
         status: input.status ?? "pending",
@@ -929,15 +929,56 @@ export function createGoogleConnectorAccountProvider(
     patchAccount: async (
       accountId: string,
       patch: ConnectorAccountPatch,
-      _manager: ConnectorAccountManager
+      manager: ConnectorAccountManager
     ) => {
+      const existing = await manager.getAccount(GOOGLE_SERVICE_NAME, accountId);
+      if (!existing) {
+        return { ...patch, provider: GOOGLE_SERVICE_NAME };
+      }
+
+      const existingExternalId = nonEmptyString(existing.externalId);
+      if (
+        patch.externalId !== undefined &&
+        nonEmptyString(patch.externalId) !== existingExternalId
+      ) {
+        throw new ElizaError("Google connector external identity can only be changed by OAuth.", {
+          code: "GOOGLE_CONNECTOR_EXTERNAL_ID_IMMUTABLE",
+          context: { accountId },
+          severity: "fatal",
+        });
+      }
+      const role = roleFromMetadata({ role: patch.role ?? existing.role });
+      const nextAccountKey = existingExternalId
+        ? stableGoogleConnectorAccountId(existingExternalId, role)
+        : nonEmptyString(existing.accountKey);
+      if (nextAccountKey && nextAccountKey !== existing.accountKey) {
+        const conflictingAccount = await manager.getAccount(GOOGLE_SERVICE_NAME, nextAccountKey);
+        if (conflictingAccount && conflictingAccount.id !== existing.id) {
+          throw new ElizaError("A Google connector account already owns this subject and role.", {
+            code: "GOOGLE_CONNECTOR_ROLE_ACCOUNT_CONFLICT",
+            context: { accountId, conflictingAccountId: conflictingAccount.id, role },
+            severity: "fatal",
+          });
+        }
+      }
       if (patch.status === "revoked" || patch.status === "disabled") {
         const calendarService = runtime.getService("calendar");
         if (isGoogleCalendarWatchRevocationService(calendarService)) {
           await calendarService.revokeGoogleCalendarWatchesByAccount(accountId);
         }
       }
-      return { ...patch, provider: GOOGLE_SERVICE_NAME };
+      return {
+        ...existing,
+        ...patch,
+        provider: GOOGLE_SERVICE_NAME,
+        ...(existingExternalId && nextAccountKey
+          ? {
+              accountKey: nextAccountKey,
+              externalId: existingExternalId,
+            }
+          : {}),
+        role,
+      };
     },
 
     deleteAccount: async (accountId: string, manager: ConnectorAccountManager): Promise<void> => {
@@ -1105,7 +1146,7 @@ export function createGoogleConnectorAccountProvider(
         config.redirectUri;
 
       const requestedAccountId = nonEmptyString(request.flow.accountId);
-      const existingAccount = requestedAccountId
+      let existingAccount = requestedAccountId
         ? await manager.getAccount(GOOGLE_SERVICE_NAME, requestedAccountId)
         : null;
       if (requestedAccountId && !existingAccount) {
@@ -1118,9 +1159,9 @@ export function createGoogleConnectorAccountProvider(
           }
         );
       }
-      const priorCredentialRefs: OAuthCredentialRefSnapshot[] = requestedAccountId
+      let priorCredentialRefs: OAuthCredentialRefSnapshot[] = existingAccount
         ? await runtime.adapter.listConnectorAccountCredentialRefs({
-            accountId: requestedAccountId as UUID,
+            accountId: existingAccount.id as UUID,
           })
         : [];
 
@@ -1234,8 +1275,31 @@ export function createGoogleConnectorAccountProvider(
             }
           );
         }
-        const accountId =
-          requestedAccountId ?? stableGoogleConnectorAccountId(externalId, requestedRole);
+        const providerAccountKey = stableGoogleConnectorAccountId(externalId, requestedRole);
+        if (!existingAccount) {
+          const identityMatches = (await manager.listAccounts(GOOGLE_SERVICE_NAME)).filter(
+            (account) =>
+              nonEmptyString(account.externalId) === externalId &&
+              roleFromMetadata({ role: account.role }) === requestedRole
+          );
+          if (identityMatches.length > 1) {
+            throw new ElizaError(
+              "Google OAuth found multiple connector accounts for the same subject and role.",
+              {
+                code: "GOOGLE_OAUTH_ACCOUNT_IDENTITY_AMBIGUOUS",
+                context: { externalId, role: requestedRole },
+                severity: "fatal",
+              }
+            );
+          }
+          existingAccount = identityMatches[0] ?? null;
+          if (existingAccount) {
+            priorCredentialRefs = await runtime.adapter.listConnectorAccountCredentialRefs({
+              accountId: existingAccount.id as UUID,
+            });
+          }
+        }
+        const accountId = existingAccount?.id ?? providerAccountKey;
         const expiresAt = Date.now() + tokens.expires_in * 1000;
         const oauthCredentialVersion = String(Date.now());
         const accountMetadata = {
@@ -1264,6 +1328,7 @@ export function createGoogleConnectorAccountProvider(
           {
             ...(existingAccount ?? {}),
             provider: GOOGLE_SERVICE_NAME,
+            accountKey: providerAccountKey,
             role: existingAccount?.role ?? requestedRole,
             purpose: purposes,
             accessGate: "open",

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -184,6 +184,101 @@ async function removeCredentialIfPresent(runtime: IAgentRuntime, vaultRef: strin
   }
 }
 
+async function clearGoogleAccountCredentials(
+  runtime: IAgentRuntime,
+  account: ConnectorAccount
+): Promise<void> {
+  const refs = await runtime.adapter.listConnectorAccountCredentialRefs({
+    accountId: account.id as UUID,
+  });
+  const failures: unknown[] = [];
+  for (const ref of refs) {
+    try {
+      await removeCredentialIfPresent(runtime, ref.vaultRef);
+    } catch (error) {
+      // error-policy:J2 A shared-grant revocation invalidates every sibling;
+      // retain each local cleanup failure while continuing the bounded sweep.
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `Google vault cleanup failed for ${account.id}`);
+  }
+  try {
+    const deleted = await credentialAdapter(runtime).deleteConnectorAccountCredentialRefs({
+      accountId: account.id as UUID,
+    });
+    if (deleted !== refs.length) {
+      failures.push(
+        new Error(
+          `Deleted ${deleted} of ${refs.length} Google connector credential refs for ${account.id}`
+        )
+      );
+    }
+  } catch (error) {
+    // error-policy:J2 Durable-ref cleanup is part of the same shared-grant
+    // invalidation and must remain visible with any vault cleanup failures.
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `Google credential cleanup failed for ${account.id}`);
+  }
+}
+
+async function degradeGoogleAccountsAfterRevocation(args: {
+  runtime: IAgentRuntime;
+  manager: ConnectorAccountManager;
+  externalId?: string;
+  reason: string;
+}): Promise<void> {
+  const accounts = (await args.manager.listAccounts(GOOGLE_SERVICE_NAME)).filter(
+    (account) => !args.externalId || nonEmptyString(account.externalId) === args.externalId
+  );
+  const failures: unknown[] = [];
+  const revokedAt = new Date().toISOString();
+  const calendarService = args.runtime.getService("calendar");
+  for (const account of accounts) {
+    if (isGoogleCalendarWatchRevocationService(calendarService)) {
+      try {
+        await calendarService.revokeGoogleCalendarWatchesByAccount(account.id);
+      } catch (error) {
+        // error-policy:J2 A project-wide Google revocation invalidates every
+        // sibling role; retain watch cleanup failures while degrading all rows.
+        failures.push(error);
+      }
+    }
+    const metadata = isRecord(account.metadata) ? { ...account.metadata } : {};
+    delete metadata.credentialRefs;
+    delete metadata.oauthCredentialRefs;
+    try {
+      await args.manager.getStorage().upsertAccount({
+        ...account,
+        status: "error",
+        metadata: {
+          ...metadata,
+          [GOOGLE_OAUTH_REVOKED_AT_METADATA_KEY]: revokedAt,
+          oauthUnavailableReason: args.reason,
+        },
+        updatedAt: Date.now(),
+      });
+    } catch (error) {
+      // error-policy:J2 Row degradation and credential cleanup are independent
+      // fail-closed obligations; preserve a failed row write and continue.
+      failures.push(error);
+    }
+    try {
+      await clearGoogleAccountCredentials(args.runtime, account);
+    } catch (error) {
+      // error-policy:J2 Continue the sibling sweep and report every incomplete
+      // cleanup on one terminal error.
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Google shared-grant sibling degradation was incomplete");
+  }
+}
+
 async function compensateOAuthCompletion(args: {
   runtime: IAgentRuntime;
   manager: ConnectorAccountManager;
@@ -191,6 +286,7 @@ async function compensateOAuthCompletion(args: {
   originalError: unknown;
   existingAccount: ConnectorAccount | null;
   priorCredentialRefs: OAuthCredentialRefSnapshot[];
+  externalId?: string;
   pendingAccountId?: string;
   attemptedVaultRef?: string;
 }): Promise<never> {
@@ -220,39 +316,43 @@ async function compensateOAuthCompletion(args: {
   }
 
   const rollbackAccountId = args.pendingAccountId ?? args.existingAccount?.id;
-  if (rollbackAccountId) {
+  if (revocationAttempted) {
     try {
-      if (revocationAttempted) {
-        for (const priorRef of args.priorCredentialRefs) {
-          try {
-            await removeCredentialIfPresent(args.runtime, priorRef.vaultRef);
-          } catch (error) {
-            // error-policy:J2 A revoked combined Google authorization makes
-            // every prior token unusable; retain cleanup failures while still
-            // marking the account unavailable and clearing durable refs.
-            compensationErrors.push(error);
-          }
-        }
-        await restoreCredentialRefs(args.runtime, rollbackAccountId, []);
-        if (args.existingAccount) {
-          const metadata = isRecord(args.existingAccount.metadata)
-            ? { ...args.existingAccount.metadata }
-            : {};
-          delete metadata.credentialRefs;
-          delete metadata.oauthCredentialRefs;
-          await args.manager.getStorage().upsertAccount({
-            ...args.existingAccount,
-            status: "error",
-            metadata: {
-              ...metadata,
-              [GOOGLE_OAUTH_REVOKED_AT_METADATA_KEY]: new Date().toISOString(),
-              oauthUnavailableReason: "reauthorization_compensation_revoked_combined_grant",
-            },
-          });
-        } else {
-          await args.manager.getStorage().deleteAccount(GOOGLE_SERVICE_NAME, rollbackAccountId);
-        }
-      } else if (args.existingAccount) {
+      if (args.existingAccount) {
+        await args.manager.getStorage().upsertAccount(args.existingAccount);
+      }
+      const externalId =
+        nonEmptyString(args.existingAccount?.externalId) ??
+        args.externalId ??
+        (rollbackAccountId
+          ? nonEmptyString(
+              (await args.manager.getAccount(GOOGLE_SERVICE_NAME, rollbackAccountId))?.externalId
+            )
+          : undefined);
+      // A token exchange can succeed before the ID token is authenticated. If
+      // revocation then occurs without a trusted subject, every local Google
+      // account is conservatively unavailable because any one may share the
+      // project-wide grant that Google invalidated.
+      await degradeGoogleAccountsAfterRevocation({
+        runtime: args.runtime,
+        manager: args.manager,
+        externalId,
+        reason: externalId
+          ? "reauthorization_compensation_revoked_combined_grant"
+          : "unattributed_compensation_revoked_google_grant",
+      });
+      if (rollbackAccountId && !args.existingAccount) {
+        await args.manager.getStorage().deleteAccount(GOOGLE_SERVICE_NAME, rollbackAccountId);
+      }
+    } catch (error) {
+      // error-policy:J2 Account/ref restoration failure is retained; callers
+      // must see that compensation was incomplete rather than the initial
+      // validation or writer failure alone.
+      compensationErrors.push(error);
+    }
+  } else if (rollbackAccountId) {
+    try {
+      if (args.existingAccount) {
         await restoreCredentialRefs(args.runtime, rollbackAccountId, args.priorCredentialRefs);
         await args.manager.getStorage().upsertAccount(args.existingAccount);
       } else {
@@ -986,10 +1086,6 @@ export function createGoogleConnectorAccountProvider(
       if (!account) {
         return;
       }
-      const calendarService = runtime.getService("calendar");
-      if (isGoogleCalendarWatchRevocationService(calendarService)) {
-        await calendarService.revokeGoogleCalendarWatchesByAccount(accountId);
-      }
       const metadata = isRecord(account.metadata) ? account.metadata : {};
       const alreadyRevoked = Boolean(
         nonEmptyString(metadata[GOOGLE_OAUTH_REVOKED_AT_METADATA_KEY])
@@ -998,6 +1094,35 @@ export function createGoogleConnectorAccountProvider(
         accountId: account.id as UUID,
       });
       const hasOAuthTokenRef = refs.some((ref) => ref.credentialType === "oauth.tokens");
+      const externalId = nonEmptyString(account.externalId);
+      const siblingAccounts = externalId
+        ? (await manager.listAccounts(GOOGLE_SERVICE_NAME)).filter(
+            (candidate) =>
+              candidate.id !== account.id && nonEmptyString(candidate.externalId) === externalId
+          )
+        : [];
+      const siblingRefSets = await Promise.all(
+        siblingAccounts.map(async (candidate) => ({
+          account: candidate,
+          refs: await runtime.adapter.listConnectorAccountCredentialRefs({
+            accountId: candidate.id as UUID,
+          }),
+        }))
+      );
+      const sharedGrantStillInUse = siblingRefSets.some(({ refs: siblingRefs }) =>
+        siblingRefs.some((ref) => ref.credentialType === "oauth.tokens")
+      );
+      if (!alreadyRevoked && !externalId) {
+        throw new ElizaError("Connected Google account has no stable external identity.", {
+          code: "GOOGLE_OAUTH_EXTERNAL_ID_MISSING",
+          context: { accountId },
+          severity: "fatal",
+        });
+      }
+      const calendarService = runtime.getService("calendar");
+      if (isGoogleCalendarWatchRevocationService(calendarService)) {
+        await calendarService.revokeGoogleCalendarWatchesByAccount(accountId);
+      }
       if (!alreadyRevoked && hasOAuthTokenRef) {
         const resolved = await Promise.all(
           refs.map(async (ref) => ({
@@ -1013,18 +1138,16 @@ export function createGoogleConnectorAccountProvider(
             severity: "fatal",
           });
         }
-        await revokeGoogleOAuthGrantWithFetch(revocationTokenFromSecret(oauth.stored.secret));
-        await manager.getStorage().upsertAccount({
-          ...account,
-          status: "error",
-          metadata: {
-            ...metadata,
-            [GOOGLE_OAUTH_REVOKED_AT_METADATA_KEY]: new Date().toISOString(),
-          },
-          updatedAt: Date.now(),
-        });
-        for (const { stored } of resolved) {
-          await stored.remove();
+        if (sharedGrantStillInUse) {
+          await clearGoogleAccountCredentials(runtime, account);
+        } else {
+          await revokeGoogleOAuthGrantWithFetch(revocationTokenFromSecret(oauth.stored.secret));
+          await degradeGoogleAccountsAfterRevocation({
+            runtime,
+            manager,
+            externalId,
+            reason: "last_role_disconnect_revoked_shared_grant",
+          });
         }
       } else if (account.status === "connected" && !alreadyRevoked) {
         throw new ElizaError("Connected Google account has no persisted OAuth token set.", {
@@ -1053,13 +1176,16 @@ export function createGoogleConnectorAccountProvider(
           await stored.remove();
         }
       }
+      const remainingRefs = await runtime.adapter.listConnectorAccountCredentialRefs({
+        accountId: account.id as UUID,
+      });
       const deletedRefs = await credentialAdapter(runtime).deleteConnectorAccountCredentialRefs({
         accountId: account.id as UUID,
       });
-      if (deletedRefs !== refs.length) {
+      if (deletedRefs !== remainingRefs.length) {
         throw new ElizaError("Google connector credential refs were not deleted completely.", {
           code: "GOOGLE_OAUTH_CREDENTIAL_REF_CLEANUP_INCOMPLETE",
-          context: { accountId, expected: refs.length, deleted: deletedRefs },
+          context: { accountId, expected: remainingRefs.length, deleted: deletedRefs },
           severity: "fatal",
         });
       }
@@ -1072,7 +1198,35 @@ export function createGoogleConnectorAccountProvider(
         (result.account as Partial<ConnectorAccount> | undefined)?.id
       );
       if (!accountId) return;
-      await provider.deleteAccount?.(accountId, manager);
+      const account = await manager.getAccount(GOOGLE_SERVICE_NAME, accountId);
+      if (!account) return;
+      const externalId = nonEmptyString(account.externalId);
+      if (!externalId) {
+        throw new ElizaError("Google OAuth compensation has no stable external identity.", {
+          code: "GOOGLE_OAUTH_EXTERNAL_ID_MISSING",
+          context: { accountId },
+          severity: "fatal",
+        });
+      }
+      const refs = await runtime.adapter.listConnectorAccountCredentialRefs({
+        accountId: account.id as UUID,
+      });
+      const oauthRef = refs.find((ref) => ref.credentialType === "oauth.tokens");
+      if (!oauthRef) {
+        throw new ElizaError("Google OAuth compensation has no persisted token set.", {
+          code: "GOOGLE_OAUTH_CREDENTIAL_REF_MISSING",
+          context: { accountId },
+          severity: "fatal",
+        });
+      }
+      const stored = await resolveCredentialSecret(runtime, oauthRef.vaultRef);
+      await revokeGoogleOAuthGrantWithFetch(revocationTokenFromSecret(stored.secret));
+      await degradeGoogleAccountsAfterRevocation({
+        runtime,
+        manager,
+        externalId,
+        reason: "account_persistence_compensation_revoked_shared_grant",
+      });
       await manager.getStorage().deleteAccount(GOOGLE_SERVICE_NAME, accountId);
     },
 
@@ -1175,6 +1329,7 @@ export function createGoogleConnectorAccountProvider(
 
       let pendingAccountId: string | undefined;
       let attemptedVaultRef: string | undefined;
+      let verifiedExternalId: string | undefined;
       try {
         const grantedScopes = parseScopeString(tokens.scope);
         const normalizedGrant =
@@ -1261,6 +1416,7 @@ export function createGoogleConnectorAccountProvider(
             severity: "fatal",
           });
         }
+        verifiedExternalId = externalId;
         const requestedRole = existingAccount
           ? roleFromMetadata({ role: existingAccount.role })
           : roleFromMetadata(request.flow.metadata);
@@ -1430,6 +1586,7 @@ export function createGoogleConnectorAccountProvider(
           originalError: error,
           existingAccount,
           priorCredentialRefs,
+          externalId: verifiedExternalId,
           pendingAccountId,
           attemptedVaultRef,
         });

--- a/plugins/plugin-google-workspace/src/connector-account-provider.writer-reject.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.writer-reject.test.ts
@@ -17,7 +17,10 @@ import {
 } from "@elizaos/core";
 import { OAuth2Client } from "google-auth-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createGoogleConnectorAccountProvider } from "./connector-account-provider.js";
+import {
+  createGoogleConnectorAccountProvider,
+  stableGoogleConnectorAccountId,
+} from "./connector-account-provider.js";
 
 const REDIRECT_URI = "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
 const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
@@ -174,10 +177,15 @@ describe("google provider completion with a rejecting durable credential writer 
 
   it("revokes the combined grant and makes the prior account unavailable after a reauthorization writer failure", async () => {
     const priorVaultRef = "connector.prior.google.account.oauth_tokens";
+    const siblingVaultRef = "connector.prior.google.sibling.oauth_tokens";
     const vault = new Map([
       [
         priorVaultRef,
         JSON.stringify({ access_token: "prior-access", refresh_token: "prior-refresh" }),
+      ],
+      [
+        siblingVaultRef,
+        JSON.stringify({ access_token: "sibling-access", refresh_token: "sibling-refresh" }),
       ],
     ]);
     const putSecret = vi.fn(async () => {
@@ -220,6 +228,24 @@ describe("google provider completion with a rejecting durable credential writer 
       credentialType: "oauth.tokens",
       vaultRef: priorVaultRef,
     });
+    const sibling = await manager.upsertAccount(
+      "google",
+      {
+        provider: "google",
+        role: "AGENT",
+        purpose: ["messaging"],
+        accessGate: "owner_binding",
+        status: "connected",
+        externalId: "google-sub-writer-reject",
+        accountKey: stableGoogleConnectorAccountId("google-sub-writer-reject", "AGENT"),
+      },
+      "acct_google_sibling"
+    );
+    await adapter.setConnectorAccountCredentialRef({
+      accountId: sibling.id as never,
+      credentialType: "oauth.tokens",
+      vaultRef: siblingVaultRef,
+    });
     const flow = await manager.startOAuth("google", {
       accountId: account.id,
       scopes: ["gmail.read"],
@@ -244,10 +270,20 @@ describe("google provider completion with a rejecting durable credential writer 
         oauthUnavailableReason: "reauthorization_compensation_revoked_combined_grant",
       },
     });
+    await expect(manager.getAccount("google", sibling.id)).resolves.toMatchObject({
+      status: "error",
+      metadata: {
+        oauthUnavailableReason: "reauthorization_compensation_revoked_combined_grant",
+      },
+    });
     expect(vault.has(priorVaultRef)).toBe(false);
+    expect(vault.has(siblingVaultRef)).toBe(false);
     expect(remove).toHaveBeenCalledWith(priorVaultRef);
     await expect(
       adapter.listConnectorAccountCredentialRefs({ accountId: account.id as never })
+    ).resolves.toEqual([]);
+    await expect(
+      adapter.listConnectorAccountCredentialRefs({ accountId: sibling.id as never })
     ).resolves.toEqual([]);
   });
 
@@ -296,13 +332,48 @@ describe("google provider completion with a rejecting durable credential writer 
     });
   });
 
-  it("revokes the grant and creates no account when a new-account ID-token validation fails", async () => {
+  it("revokes the grant and degrades every existing account when a new-account ID token is untrusted", async () => {
     const putSecret = vi.fn(async () => "should-not-write");
+    const vault = new Map<string, string>();
+    const remove = vi.fn(async (key: string) => {
+      vault.delete(key);
+    });
     const adapter = new InMemoryDatabaseAdapter();
     await adapter.initialize();
-    const runtime = makeRuntime(putSecret, adapter);
+    const runtime = makeRuntime(putSecret, adapter, remove, {
+      get: async (key) => vault.get(key) ?? "",
+      has: async (key) => vault.has(key),
+    });
     const manager: ConnectorAccountManager = getConnectorAccountManager(runtime);
     manager.registerProvider(createGoogleConnectorAccountProvider(runtime));
+    const existingAccounts = await Promise.all(
+      [
+        ["acct_google_untrusted_owner", "known-owner-subject", "OWNER"],
+        ["acct_google_untrusted_agent", "other-agent-subject", "AGENT"],
+      ].map(async ([id, externalId, role]) => {
+        const account = await manager.upsertAccount(
+          "google",
+          {
+            provider: "google",
+            role: role as "OWNER" | "AGENT",
+            purpose: ["messaging"],
+            accessGate: "owner_binding",
+            status: "connected",
+            externalId,
+            accountKey: stableGoogleConnectorAccountId(externalId, role as "OWNER" | "AGENT"),
+          },
+          id
+        );
+        const vaultRef = `connector.existing.${id}.oauth_tokens`;
+        vault.set(vaultRef, JSON.stringify({ refresh_token: `refresh-${id}` }));
+        await adapter.setConnectorAccountCredentialRef({
+          accountId: account.id as never,
+          credentialType: "oauth.tokens",
+          vaultRef,
+        });
+        return account;
+      })
+    );
     const flow = await manager.startOAuth("google", {
       scopes: ["gmail.read"],
       metadata: { requestedRole: "OWNER" },
@@ -323,7 +394,18 @@ describe("google provider completion with a rejecting durable credential writer 
       REVOKE_ENDPOINT,
       expect.objectContaining({ body: "token=writer-reject-refresh-token" })
     );
-    await expect(manager.listAccounts("google")).resolves.toEqual([]);
+    for (const account of existingAccounts) {
+      await expect(manager.getAccount("google", account.id)).resolves.toMatchObject({
+        status: "error",
+        metadata: {
+          oauthUnavailableReason: "unattributed_compensation_revoked_google_grant",
+        },
+      });
+      await expect(
+        adapter.listConnectorAccountCredentialRefs({ accountId: account.id as never })
+      ).resolves.toEqual([]);
+    }
+    expect(remove).toHaveBeenCalledTimes(2);
   });
 
   it("removes a newly written secret, revokes the grant, and removes the provisional account when the ref writer rejects", async () => {

--- a/plugins/plugin-sql/drizzle/migrations/0005_connector_account_external_role.sql
+++ b/plugins/plugin-sql/drizzle/migrations/0005_connector_account_external_role.sql
@@ -1,0 +1,5 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "connector_accounts_agent_provider_external_role_uniq"
+	ON "connector_accounts" USING btree ("agent_id", "provider", "external_id", "role")
+	WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "connector_accounts_agent_provider_external_uniq";

--- a/plugins/plugin-sql/drizzle/migrations/meta/_journal.json
+++ b/plugins/plugin-sql/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785384000000,
       "tag": "0004_approval_request_idempotency",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787752800000,
+      "tag": "0005_connector_account_external_role",
+      "breakpoints": true
     }
   ]
 }

--- a/plugins/plugin-sql/drizzle/rollbacks/0005_connector_account_external_role.sql
+++ b/plugins/plugin-sql/drizzle/rollbacks/0005_connector_account_external_role.sql
@@ -1,0 +1,30 @@
+BEGIN;
+--> statement-breakpoint
+WITH ranked AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "agent_id", "provider", "external_id"
+      ORDER BY
+        CASE "role" WHEN 'OWNER' THEN 0 WHEN 'TEAM' THEN 1 ELSE 2 END,
+        "created_at",
+        "id"
+    ) AS sibling_rank
+  FROM "connector_accounts"
+  WHERE "deleted_at" IS NULL AND "external_id" IS NOT NULL
+)
+UPDATE "connector_accounts" AS account
+SET
+  "status" = 'disabled',
+  "deleted_at" = CURRENT_TIMESTAMP,
+  "updated_at" = CURRENT_TIMESTAMP
+FROM ranked
+WHERE account."id" = ranked."id" AND ranked.sibling_rank > 1;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "connector_accounts_agent_provider_external_role_uniq";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "connector_accounts_agent_provider_external_uniq"
+  ON "connector_accounts" USING btree ("agent_id", "provider", "external_id")
+  WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+COMMIT;

--- a/plugins/plugin-sql/drizzle/rollbacks/README.md
+++ b/plugins/plugin-sql/drizzle/rollbacks/README.md
@@ -1,0 +1,19 @@
+# Connector-account migration rollback
+
+Migration `0005_connector_account_external_role` is one-way during normal
+startup because it permits multiple active role rows for one provider subject.
+Do not start a pre-0005 binary against a database that has admitted those rows.
+
+To roll back deliberately:
+
+1. Stop every writer and take a restorable database and vault snapshot.
+2. Run `0005_connector_account_external_role.sql` in one database transaction.
+   It retains the oldest OWNER row when present (then TEAM, then AGENT),
+   soft-deletes role siblings, preserves their UUIDs and credential-reference
+   rows for audit/recovery, and restores the legacy partial unique index.
+3. Verify that each active `(agent_id, provider, external_id)` has one row and
+   that the legacy index exists before starting the older binary.
+
+Restoring a discarded role requires returning to the snapshot or upgrading
+again and explicitly reconnecting that role. Never hard-delete the archived
+rows or their vault material as part of an emergency binary rollback.

--- a/plugins/plugin-sql/src/__tests__/integration/connector-account-storage.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/connector-account-storage.real.test.ts
@@ -5,7 +5,10 @@
  * secrets), audit metadata is redacted before insert, and OAuth flow state is
  * single-use and expiry-aware.
  */
-import type { UUID } from "@elizaos/core";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getConnectorAccountManager, type IAgentRuntime, type UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DatabaseMigrationService } from "../../migration-service";
@@ -14,6 +17,21 @@ import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
 import * as schema from "../../schema";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
+
+const EXTERNAL_ROLE_MIGRATION_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../drizzle/migrations/0005_connector_account_external_role.sql"
+);
+
+async function applySqlMigrationFile(db: DrizzleDatabase, filePath: string): Promise<void> {
+  const migrationSql = fs.readFileSync(filePath, "utf8");
+  for (const statement of migrationSql.split(/-->\s*statement-breakpoint/)) {
+    const trimmed = statement.trim();
+    if (trimmed.length > 0) {
+      await db.execute(sql.raw(trimmed));
+    }
+  }
+}
 
 describe("Connector account storage", () => {
   let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
@@ -43,6 +61,21 @@ describe("Connector account storage", () => {
     await migrationService.runAllPluginMigrations();
     await migrationService.runAllPluginMigrations();
 
+    // Simulate an install created by 0001 before the role-scoped external
+    // identity migration, then prove the committed 0005 DDL is repeatable.
+    await db.execute(
+      sql.raw(`DROP INDEX IF EXISTS "connector_accounts_agent_provider_external_role_uniq"`)
+    );
+    await db.execute(
+      sql.raw(
+        `CREATE UNIQUE INDEX "connector_accounts_agent_provider_external_uniq" ` +
+          `ON "connector_accounts" USING btree ("agent_id", "provider", "external_id") ` +
+          `WHERE "deleted_at" IS NULL`
+      )
+    );
+    await applySqlMigrationFile(db, EXTERNAL_ROLE_MIGRATION_PATH);
+    await applySqlMigrationFile(db, EXTERNAL_ROLE_MIGRATION_PATH);
+
     const tables = await db.execute(sql`
       SELECT tablename FROM pg_tables
       WHERE schemaname = 'public'
@@ -62,6 +95,16 @@ describe("Connector account storage", () => {
     expect(tableNames).toContain("connector_account_audit_events");
     expect(tableNames).toContain("oauth_flows");
     expect(tableNames).not.toContain("life_connector_grants");
+
+    const accountIndexes = await db.execute(sql`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'connector_accounts'
+      ORDER BY indexname
+    `);
+    const indexNames = accountIndexes.rows.map((row) => String(row.indexname));
+    expect(indexNames).toContain("connector_accounts_agent_provider_external_role_uniq");
+    expect(indexNames).not.toContain("connector_accounts_agent_provider_external_uniq");
   });
 
   it("upserts account metadata and stores only credential refs", async () => {
@@ -117,6 +160,84 @@ describe("Connector account storage", () => {
     expect(columnNames).toContain("vault_ref");
     expect(columnNames).not.toContain("plaintext");
     expect(columnNames).not.toContain("ciphertext");
+  });
+
+  it("keeps role-scoped Google grants distinct and lazily upgrades a legacy account key", async () => {
+    const subject = "shared-google-subject";
+    const ownerKey = `acct_google_${"1".repeat(32)}`;
+    const agentKey = `acct_google_${"2".repeat(32)}`;
+    const legacyOwner = await adapter.upsertConnectorAccount({
+      provider: "google",
+      accountKey: subject,
+      externalId: subject,
+      role: "OWNER",
+    });
+    const credential = await adapter.setConnectorAccountCredentialRef({
+      accountId: legacyOwner.id,
+      credentialType: "oauth.tokens",
+      vaultRef: `connector.${testAgentId}.google.${legacyOwner.id}.oauth_tokens`,
+    });
+    const runtime = {
+      adapter,
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+    const manager = getConnectorAccountManager(runtime);
+    const accountShape = {
+      provider: "google",
+      purpose: ["automation" as const],
+      accessGate: "open" as const,
+      status: "connected" as const,
+      externalId: subject,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const owner = await manager.upsertAccount("google", {
+      ...accountShape,
+      id: ownerKey,
+      accountKey: ownerKey,
+      role: "OWNER",
+    });
+    const agent = await manager.upsertAccount("google", {
+      ...accountShape,
+      id: agentKey,
+      accountKey: agentKey,
+      role: "AGENT",
+    });
+
+    expect(owner.id).toBe(legacyOwner.id);
+    expect(agent.id).not.toBe(owner.id);
+    await expect(
+      adapter.getConnectorAccountCredentialRef({
+        accountId: owner.id as UUID,
+        credentialType: "oauth.tokens",
+      })
+    ).resolves.toMatchObject({ vaultRef: credential.vaultRef });
+
+    const ownerRetry = await manager.upsertAccount("google", {
+      ...accountShape,
+      id: ownerKey,
+      accountKey: ownerKey,
+      role: "OWNER",
+    });
+    expect(ownerRetry.id).toBe(owner.id);
+    await expect(
+      manager.upsertAccount("google", {
+        ...accountShape,
+        id: agentKey,
+        accountKey: agentKey,
+        role: "OWNER",
+      })
+    ).rejects.toThrow();
+
+    const listed = await adapter.listConnectorAccounts({ provider: "google" });
+    expect(listed).toHaveLength(2);
+    expect(listed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ accountKey: ownerKey, externalId: subject, role: "OWNER" }),
+        expect.objectContaining({ accountKey: agentKey, externalId: subject, role: "AGENT" }),
+      ])
+    );
   });
 
   it("redacts audit metadata before insert", async () => {

--- a/plugins/plugin-sql/src/__tests__/integration/connector-account-storage.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/connector-account-storage.real.test.ts
@@ -22,6 +22,10 @@ const EXTERNAL_ROLE_MIGRATION_PATH = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../../drizzle/migrations/0005_connector_account_external_role.sql"
 );
+const EXTERNAL_ROLE_ROLLBACK_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../drizzle/rollbacks/0005_connector_account_external_role.sql"
+);
 
 async function applySqlMigrationFile(db: DrizzleDatabase, filePath: string): Promise<void> {
   const migrationSql = fs.readFileSync(filePath, "utf8");
@@ -238,6 +242,57 @@ describe("Connector account storage", () => {
         expect.objectContaining({ accountKey: agentKey, externalId: subject, role: "AGENT" }),
       ])
     );
+  });
+
+  it("archives role siblings before restoring the legacy external-identity index", async () => {
+    const subject = "rollback-google-subject";
+    const owner = await adapter.upsertConnectorAccount({
+      provider: "google",
+      accountKey: "rollback-owner-key",
+      externalId: subject,
+      role: "OWNER",
+    });
+    const agent = await adapter.upsertConnectorAccount({
+      provider: "google",
+      accountKey: "rollback-agent-key",
+      externalId: subject,
+      role: "AGENT",
+    });
+    await adapter.setConnectorAccountCredentialRef({
+      accountId: agent.id,
+      credentialType: "oauth.tokens",
+      vaultRef: `connector.${testAgentId}.google.${agent.id}.oauth_tokens`,
+    });
+
+    await applySqlMigrationFile(db, EXTERNAL_ROLE_ROLLBACK_PATH);
+
+    const rows = await db.execute(sql`
+      SELECT "id", "role", "deleted_at"
+      FROM "connector_accounts"
+      WHERE "external_id" = ${subject}
+      ORDER BY "role"
+    `);
+    expect(rows.rows).toHaveLength(2);
+    expect(rows.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: owner.id, role: "OWNER", deleted_at: null }),
+        expect.objectContaining({ id: agent.id, role: "AGENT" }),
+      ])
+    );
+    expect(rows.rows.find((row) => row.id === agent.id)?.deleted_at).not.toBeNull();
+    const archivedCredential = await db.execute(sql`
+      SELECT "account_id" FROM "connector_account_credentials"
+      WHERE "account_id" = ${agent.id} AND "credential_type" = 'oauth.tokens'
+    `);
+    expect(archivedCredential.rows).toEqual([expect.objectContaining({ account_id: agent.id })]);
+
+    const indexes = await db.execute(sql`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = 'public' AND tablename = 'connector_accounts'
+    `);
+    const names = indexes.rows.map((row) => String(row.indexname));
+    expect(names).toContain("connector_accounts_agent_provider_external_uniq");
+    expect(names).not.toContain("connector_accounts_agent_provider_external_role_uniq");
   });
 
   it("redacts audit metadata before insert", async () => {

--- a/plugins/plugin-sql/src/__tests__/migration/partial-index-where.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/partial-index-where.real.test.ts
@@ -5,7 +5,7 @@
  * turn them into full unique indexes and diverge from the committed SQL
  * migrations. Covers the whole pipeline: snapshot capture, SQL generation
  * (including NULLS ordering), and a real-database check that RuntimeMigrator
- * and the committed drizzle/migrations/0003 file produce byte-identical
+ * and the committed drizzle/migrations/0004 file produce byte-identical
  * pg_get_indexdef output for the same declared index.
  */
 import fs from "node:fs";
@@ -25,9 +25,9 @@ import { createIsolatedTestDatabaseForMigration } from "../test-helpers";
 
 const INDEX_NAME = "approval_requests_agent_idempotency_uidx";
 
-const MIGRATION_0003_PATH = path.resolve(
+const MIGRATION_0004_PATH = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
-  "../../../drizzle/migrations/0003_approval_request_idempotency.sql"
+  "../../../drizzle/migrations/0004_approval_request_idempotency.sql"
 );
 
 async function getIndexDef(db: DrizzleDB, indexName: string): Promise<string> {
@@ -62,7 +62,7 @@ describe("Partial index WHERE clause preservation", () => {
       expect(connectorIndexes.connector_accounts_agent_provider_account_key_uniq.where).toBe(
         `"deleted_at" IS NULL`
       );
-      expect(connectorIndexes.connector_accounts_agent_provider_external_uniq.where).toBe(
+      expect(connectorIndexes.connector_accounts_agent_provider_external_role_uniq.where).toBe(
         `"deleted_at" IS NULL`
       );
 
@@ -130,9 +130,9 @@ describe("Partial index WHERE clause preservation", () => {
       }
     });
 
-    it("RuntimeMigrator and drizzle/migrations/0003 produce identical index DDL", async () => {
+    it("RuntimeMigrator and drizzle/migrations/0004 produce identical index DDL", async () => {
       // Path A: the committed SQL migration, applied verbatim from disk
-      // against a minimal pre-existing approval_requests table (0003 is an
+      // against a minimal pre-existing approval_requests table (0004 is an
       // ALTER + CREATE INDEX on an already-provisioned database).
       await db.execute(
         sql.raw(
@@ -140,7 +140,7 @@ describe("Partial index WHERE clause preservation", () => {
         )
       );
 
-      const migrationSql = fs.readFileSync(MIGRATION_0003_PATH, "utf8");
+      const migrationSql = fs.readFileSync(MIGRATION_0004_PATH, "utf8");
       for (const statement of migrationSql.split(/-->\s*statement-breakpoint/)) {
         const trimmed = statement.trim();
         if (trimmed.length > 0) {

--- a/plugins/plugin-sql/src/schema/connectorAccounts.ts
+++ b/plugins/plugin-sql/src/schema/connectorAccounts.ts
@@ -4,8 +4,9 @@
  *
  * - `connectorAccountsTable` — one row per connected external account,
  *   uniquely keyed on `(agentId, provider, accountKey)` and
- *   `(agentId, provider, externalId)` while `deletedAt` is null (soft-delete
- *   allows re-connecting the same account later).
+ *   `(agentId, provider, externalId, role)` while `deletedAt` is null. The
+ *   role-scoped external identity allows intentionally separate owner and
+ *   agent grants for the same provider subject; soft-delete allows reconnects.
  * - `connectorAccountCredentialsTable` — credentials for an account, stored
  *   only as a `vaultRef` pointer into `@elizaos/vault` or an external secret
  *   manager; never the raw secret. Unique per `(accountId, credentialType)`.
@@ -70,8 +71,8 @@ export const connectorAccountsTable = pgTable(
     uniqueIndex("connector_accounts_agent_provider_account_key_uniq")
       .on(table.agentId, table.provider, table.accountKey)
       .where(sql`${table.deletedAt} IS NULL`),
-    uniqueIndex("connector_accounts_agent_provider_external_uniq")
-      .on(table.agentId, table.provider, table.externalId)
+    uniqueIndex("connector_accounts_agent_provider_external_role_uniq")
+      .on(table.agentId, table.provider, table.externalId, table.role)
       .where(sql`${table.deletedAt} IS NULL`),
     index("connector_accounts_agent_provider_idx").on(table.agentId, table.provider),
     index("connector_accounts_status_idx").on(table.status),

--- a/plugins/plugin-sql/src/stores/connectorAccount.store.ts
+++ b/plugins/plugin-sql/src/stores/connectorAccount.store.ts
@@ -356,17 +356,30 @@ export class ConnectorAccountStore implements Store {
         }
       }
 
+      const hasExternalIdentity = params.externalId != null;
+      const conflictTarget = hasExternalIdentity
+        ? [
+            connectorAccountsTable.agentId,
+            connectorAccountsTable.provider,
+            connectorAccountsTable.externalId,
+            connectorAccountsTable.role,
+          ]
+        : [
+            connectorAccountsTable.agentId,
+            connectorAccountsTable.provider,
+            connectorAccountsTable.accountKey,
+          ];
+      const conflictUpdateSet = hasExternalIdentity
+        ? { ...updateSet, accountKey: params.accountKey }
+        : updateSet;
+
       const inserted = await this.db
         .insert(connectorAccountsTable)
         .values(insertValues)
         .onConflictDoUpdate({
-          target: [
-            connectorAccountsTable.agentId,
-            connectorAccountsTable.provider,
-            connectorAccountsTable.accountKey,
-          ],
+          target: conflictTarget,
           targetWhere: sql`${connectorAccountsTable.deletedAt} IS NULL`,
-          set: updateSet,
+          set: conflictUpdateSet,
         })
         .returning();
 


### PR DESCRIPTION
# Relates to

Follow-up to merged PR #26723. No issue is linked.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the
      deterministic connector tests and real PGlite migration/storage tests below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `88e1c0acee08faf8870ffdef64632c01e006ef22`; zero conflicts.
- [x] `bun run verify` was run post-sync. Its pre-existing `check:i18n` blocker is
      documented in **Known gaps / failures**; every subsequent verify stage passed.

# Risks

Medium. This changes connector-account identity resolution, OAuth compensation,
and a partial unique index. The migration creates the replacement role-scoped
index before dropping the old index, and real PGlite tests cover idempotency,
legacy-row upgrade, UUID preservation, and credential-reference preservation.

# Background

## What does this PR do?

- Keeps Google OWNER and AGENT grants for the same Google subject isolated with a
  provider-owned, role-scoped account key.
- Makes `(agent, provider, externalId, role)` the active SQL natural identity.
- Lazily upgrades legacy rows without changing their UUIDs or credential refs.
- Rejects ambiguous aliases, external identity mutation, and role collisions
  before provider side effects.
- Serializes OAuth completion for the same agent/provider within one process,
  including final writes and compensation.

## What kind of change is this?

Bug fix (non-breaking change).

## Why are we doing this? Any context or related work?

The Google role split introduced in #26723 computed role-bound logical IDs, but
the database bridge still persisted the raw external subject as `accountKey`.
That collapsed OWNER and AGENT grants back onto one connector account.

# Documentation changes needed?

No project documentation change is required. The provider/storage contract and
migration behavior are documented in code and regression tests.

# Testing

## Where should a reviewer start?

Start with `packages/core/src/connectors/account-manager.ts`, then
`plugins/plugin-google-workspace/src/connector-account-provider.ts`, and finally
`plugins/plugin-sql/drizzle/migrations/0005_connector_account_external_role.sql`.

## Detailed testing steps

Post-rebase results on exact head `f2c629189ee9226de38d8b93d5727c44f1392514`:

- `bun install --frozen-lockfile` — passed.
- Core, Google Workspace, and SQL typechecks — passed.
- `bun test packages/core/src/connectors/account-manager.test.ts` — 22/22 passed.
- New in-memory connector-account regression — 1 passed (15 unrelated tests skipped by filter).
- Google provider role and identity-binding tests — 22/22 passed.
- Real PGlite connector-account storage and migration suites — 13/13 passed.
- Targeted Biome checks and `git diff --check` — passed.
- The complete verify tail after `check:i18n` — passed, including 375/375 Turbo
  typecheck/lint tasks and all build, workflow, script, inventory, view, and
  anti-focused-test audits.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:f2c629189ee9226de38d8b93d5727c44f1392514 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend connector and database change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend connector and database change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no visual user flow or frontend behavior in this diff.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic provider tests and real PGlite tests exercise the changed path without live credentials.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, action-selection, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - assertions verify database rows, indexes, UUIDs, and credential refs without producing a user artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - this diff has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is deterministic connector, OAuth orchestration, and database logic.

## Backend + frontend logs

N/A - no live Google credentials were used. Mocked provider/vault tests cover
success, failure, compensation, role collision, and concurrent callbacks; real
PGlite tests exercise the SQL constraints and migration.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surfaces changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun run verify` stops at the repository-wide `check:i18n` baseline: translations
  are already missing on clean `origin/develop`, including
  `learnedskills.emptyTitle` and `learnedskills.startLearning` in `en.json`.
  The identical failure was reproduced in a clean detached worktree at
  `88e1c0acee08faf8870ffdef64632c01e006ef22`; that worktree was removed afterward.
  Every verify command after `check:i18n` passed on this PR head.
- OAuth completion serialization is deliberately process-local. A future
  active-active OAuth topology sharing one agent across processes needs a fenced
  distributed database/vault/provider lease; the current connector contract does
  not expose such a primitive and this PR does not claim a cross-process guarantee.
- No live Google account was used; automated tests use mocked provider/vault
  boundaries and a real in-process PGlite database.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
