### PR TITLE
fix(ci): enforce staging Telegram Environment authority

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -357,16 +357,21 @@ tokens so staging automation cannot mutate production zones.
 
 The Cloud release resolves the public Telegram bot ID and username before
 database migration or API deployment. Staging consumes the complete
-repository-scoped `VITE_TELEGRAM_BOT_ID` / `VITE_TELEGRAM_BOT_USERNAME` pair
-and requires both components to differ from production. Production ignores
-that repository pair and derives its exact canonical identity from the checked
-out `packages/homepage/src/lib/contact.ts`. Missing, partial, malformed,
-out-of-range, or cross-environment staging values stop the release without
-printing either value. Do not expect same-named GitHub Environment variables
-to override the repository pair: GitHub makes Environment variables available
-after values in the `vars` context have already been resolved. Implicit Vite
-fallback use remains local/direct-only; protected production explicitly selects
-and validates the canonical source constants. Pull requests are validated by
+`VITE_TELEGRAM_BOT_ID` / `VITE_TELEGRAM_BOT_USERNAME` pair only from the
+protected `staging` GitHub Environment and requires both components to differ
+from production. Before the reusable release enters any Environment,
+`cloud-cf-deploy.yml` evaluates both names at organization/repository scope and
+passes a required provenance flag. The Environment-scoped preflight first
+rejects either component at either outer scope as conflicting authority, then
+validates the pair exposed by its job Environment; all of this precedes any
+mutation.
+Missing, partial, malformed, out-of-range, duplicate-scope, or
+cross-environment staging configuration stops the release without printing
+either value. Production continues to ignore every GitHub Telegram input and
+derives its exact canonical identity from the checked out
+`packages/homepage/src/lib/contact.ts`. Implicit Vite fallback use remains
+local/direct-only; protected production explicitly selects and validates the
+canonical source constants. Pull requests are validated by
 `pr-static-smoke.yml`; there is no credentialed or artifact-only Pages preview
 path in `cloud-cf-deploy.yml`.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -361,10 +361,14 @@ database migration or API deployment. Staging consumes the complete
 protected `staging` GitHub Environment and requires both components to differ
 from production. Before the reusable release enters any Environment,
 `cloud-cf-deploy.yml` evaluates both names at organization/repository scope and
-passes a required provenance flag. The Environment-scoped preflight first
-rejects either component at either outer scope as conflicting authority, then
-validates the pair exposed by its job Environment; all of this precedes any
-mutation.
+passes a required provenance flag plus the workflow attempt that produced it.
+The Environment-scoped preflight rejects a stale attempt receipt before it
+validates or emits Environment values, then rejects either component at either
+outer scope as conflicting authority and validates the pair exposed by its job
+Environment. Because GitHub preserves successful job outputs during failed-job
+reruns, the migration, API deploy, Pages build, and Pages deploy jobs each
+repeat the attempt check as their first step; a partial rerun must be replaced
+with a full rerun before any stale receipt can reach a release mutation.
 Missing, partial, malformed, out-of-range, duplicate-scope, or
 cross-environment staging configuration stops the release without printing
 either value. Production continues to ignore every GitHub Telegram input and

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -357,21 +357,23 @@ tokens so staging automation cannot mutate production zones.
 
 The Cloud release resolves the public Telegram bot ID and username before
 database migration or API deployment. Staging consumes the complete
-`VITE_TELEGRAM_BOT_ID` / `VITE_TELEGRAM_BOT_USERNAME` pair only from the
-protected `staging` GitHub Environment and requires both components to differ
-from production. Before the reusable release enters any Environment,
-`cloud-cf-deploy.yml` evaluates both names at organization/repository scope and
-passes a required provenance flag plus the workflow attempt that produced it.
-The Environment-scoped preflight rejects a stale attempt receipt before it
-validates or emits Environment values, then rejects either component at either
-outer scope as conflicting authority and validates the pair exposed by its job
-Environment. Because GitHub preserves successful job outputs during failed-job
-reruns, the migration, API deploy, Pages build, and Pages deploy jobs each
-repeat the attempt check as their first step; a partial rerun must be replaced
-with a full rerun before any stale receipt can reach a release mutation.
-Missing, partial, malformed, out-of-range, duplicate-scope, or
-cross-environment staging configuration stops the release without printing
-either value. Production continues to ignore every GitHub Telegram input and
+`VITE_TELEGRAM_BOT_ID` / `VITE_TELEGRAM_BOT_USERNAME` configuration-variable
+pair only when it matches the protected `staging` GitHub Environment secret
+`TELEGRAM_IDENTITY_AUTHORITY_SHA256`, and requires both components to differ
+from production. The receipt is the lowercase SHA-256 of the framed bytes
+`elizaOS/eliza\0staging\0telegram-public-identity\0v1\0<ID>\0<lowercase-username>\n`.
+The reusable release uses an exact caller-secret allowlist that deliberately
+does not forward that receipt, so a repository or organization secret cannot
+substitute for the Environment authority. A repository/organization variable
+may resolve the same committed public pair, but cannot select a different pair.
+Because GitHub preserves successful job outputs during failed-job reruns, the
+migration, API deploy, Pages build, and Pages deploy jobs each repeat the bound
+attempt check as their first step; a partial rerun must be replaced with a full
+rerun before stale admitted values can reach a release mutation. Cancel and
+fully rerun any in-flight release when rotating the pair or receipt. Missing,
+partial, malformed, out-of-range, receipt-mismatched, or cross-environment
+staging configuration stops the release without printing either value or the
+receipt. Production continues to ignore every GitHub Telegram input and
 derives its exact canonical identity from the checked out
 `packages/homepage/src/lib/contact.ts`. Implicit Vite fallback use remains
 local/direct-only; protected production explicitly selects and validates the

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -103,6 +103,28 @@ permissions:
   actions: read
 
 jobs:
+  resolve-telegram-configuration-authority:
+    name: Resolve Telegram configuration authority
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      repo_or_org_configured: ${{ steps.scope.outputs.configured }}
+    steps:
+      - name: Detect Telegram variables outside a GitHub Environment
+        id: scope
+        env:
+          TELEGRAM_REPO_OR_ORG_CONFIGURED: ${{ vars.VITE_TELEGRAM_BOT_ID != '' || vars.VITE_TELEGRAM_BOT_USERNAME != '' }}
+        run: |
+          set -euo pipefail
+          case "$TELEGRAM_REPO_OR_ORG_CONFIGURED" in
+            true|false) ;;
+            *)
+              echo "::error::Unable to resolve Telegram configuration scope"
+              exit 1
+              ;;
+          esac
+          printf 'configured=%s\n' "$TELEGRAM_REPO_OR_ORG_CONFIGURED" >> "$GITHUB_OUTPUT"
+
   validate-deploy-source:
     name: Validate Canonical Deploy Source
     # A manual dispatch can select an invalid ref, so reject it before any
@@ -828,8 +850,8 @@ jobs:
 
   release:
     name: Mutate and verify Cloud CF release
-    needs: [validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
-    if: ${{ always() && github.event_name != 'pull_request' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
+    needs: [resolve-telegram-configuration-authority, validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
+    if: ${{ always() && github.event_name != 'pull_request' && needs.resolve-telegram-configuration-authority.result == 'success' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
     # One critical section for migrate + API + Pages + routing proof.
     # `queue: max` is GitHub's production-deploy contract: up to 100 approved
     # releases wait instead of the default one-pending eviction. FIFO is by
@@ -843,6 +865,7 @@ jobs:
     secrets: inherit
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
+      telegram_repo_or_org_configured: ${{ needs.resolve-telegram-configuration-authority.outputs.repo_or_org_configured == 'true' }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
       # Resolve the proof request at the entry workflow boundary. A live-ready
       # automatic release is a Develop effect reconciliation with a bound

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -109,13 +109,19 @@ jobs:
     timeout-minutes: 2
     outputs:
       repo_or_org_configured: ${{ steps.scope.outputs.configured }}
+      run_attempt: ${{ steps.scope.outputs.run_attempt }}
     steps:
       - name: Detect Telegram variables outside a GitHub Environment
         id: scope
         env:
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ github.run_attempt }}
           TELEGRAM_REPO_OR_ORG_CONFIGURED: ${{ vars.VITE_TELEGRAM_BOT_ID != '' || vars.VITE_TELEGRAM_BOT_USERNAME != '' }}
         run: |
           set -euo pipefail
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Unable to resolve Telegram configuration authority run attempt"
+            exit 1
+          }
           case "$TELEGRAM_REPO_OR_ORG_CONFIGURED" in
             true|false) ;;
             *)
@@ -124,6 +130,7 @@ jobs:
               ;;
           esac
           printf 'configured=%s\n' "$TELEGRAM_REPO_OR_ORG_CONFIGURED" >> "$GITHUB_OUTPUT"
+          printf 'run_attempt=%s\n' "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
   validate-deploy-source:
     name: Validate Canonical Deploy Source
@@ -865,6 +872,7 @@ jobs:
     secrets: inherit
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
+      telegram_authority_run_attempt: ${{ needs.resolve-telegram-configuration-authority.outputs.run_attempt }}
       telegram_repo_or_org_configured: ${{ needs.resolve-telegram-configuration-authority.outputs.repo_or_org_configured == 'true' }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
       # Resolve the proof request at the entry workflow boundary. A live-ready

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -103,33 +103,23 @@ permissions:
   actions: read
 
 jobs:
-  resolve-telegram-configuration-authority:
-    name: Resolve Telegram configuration authority
+  bind-telegram-release-attempt:
+    name: Bind Telegram release attempt
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      repo_or_org_configured: ${{ steps.scope.outputs.configured }}
-      run_attempt: ${{ steps.scope.outputs.run_attempt }}
+      run_attempt: ${{ steps.attempt.outputs.run_attempt }}
     steps:
-      - name: Detect Telegram variables outside a GitHub Environment
-        id: scope
+      - name: Bind Telegram release attempt
+        id: attempt
         env:
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ github.run_attempt }}
-          TELEGRAM_REPO_OR_ORG_CONFIGURED: ${{ vars.VITE_TELEGRAM_BOT_ID != '' || vars.VITE_TELEGRAM_BOT_USERNAME != '' }}
         run: |
           set -euo pipefail
           [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
             echo "::error::Unable to resolve Telegram configuration authority run attempt"
             exit 1
           }
-          case "$TELEGRAM_REPO_OR_ORG_CONFIGURED" in
-            true|false) ;;
-            *)
-              echo "::error::Unable to resolve Telegram configuration scope"
-              exit 1
-              ;;
-          esac
-          printf 'configured=%s\n' "$TELEGRAM_REPO_OR_ORG_CONFIGURED" >> "$GITHUB_OUTPUT"
           printf 'run_attempt=%s\n' "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
   validate-deploy-source:
@@ -857,8 +847,8 @@ jobs:
 
   release:
     name: Mutate and verify Cloud CF release
-    needs: [resolve-telegram-configuration-authority, validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
-    if: ${{ always() && github.event_name != 'pull_request' && needs.resolve-telegram-configuration-authority.result == 'success' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
+    needs: [bind-telegram-release-attempt, validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
+    if: ${{ always() && github.event_name != 'pull_request' && needs.bind-telegram-release-attempt.result == 'success' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
     # One critical section for migrate + API + Pages + routing proof.
     # `queue: max` is GitHub's production-deploy contract: up to 100 approved
     # releases wait instead of the default one-pending eviction. FIFO is by
@@ -869,11 +859,66 @@ jobs:
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
-    secrets: inherit
+    # Explicitly forward every caller-scope secret consumed by the reusable
+    # release except TELEGRAM_IDENTITY_AUTHORITY_SHA256. That receipt must come
+    # only from the protected job Environment in the called workflow; `inherit`
+    # would also admit a repository/organization secret with the same name.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CONTAINERS_SSH_KEY: ${{ secrets.CONTAINERS_SSH_KEY }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
+      ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+      ELIZACLOUD_API_KEY: ${{ secrets.ELIZACLOUD_API_KEY }}
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+      ELIZA_APNS_KEY: ${{ secrets.ELIZA_APNS_KEY }}
+      ELIZA_APNS_KEY_ID: ${{ secrets.ELIZA_APNS_KEY_ID }}
+      ELIZA_APNS_TEAM_ID: ${{ secrets.ELIZA_APNS_TEAM_ID }}
+      ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
+      ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
+      ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+      ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
+      ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
+      ELIZA_SERVICE_JWT_SECRET: ${{ secrets.ELIZA_SERVICE_JWT_SECRET }}
+      ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64 }}
+      ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 }}
+      FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
+      FAL_KEY: ${{ secrets.FAL_KEY }}
+      FISH_AUDIO_API_KEY: ${{ secrets.FISH_AUDIO_API_KEY }}
+      FISH_AUDIO_REFERENCE_ID: ${{ secrets.FISH_AUDIO_REFERENCE_ID }}
+      GATEWAY_INTERNAL_SECRET: ${{ secrets.GATEWAY_INTERNAL_SECRET }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
+      INFERENCE_AUTH_PROBE_TOKEN: ${{ secrets.INFERENCE_AUTH_PROBE_TOKEN }}
+      LOCAL_EMBEDDINGS_API_KEY: ${{ secrets.LOCAL_EMBEDDINGS_API_KEY }}
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+      OIDC_CLIENTS: ${{ secrets.OIDC_CLIENTS }}
+      OIDC_SIGNING_JWKS: ${{ secrets.OIDC_SIGNING_JWKS }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      RAILWAY_DATABASE_URL: ${{ secrets.RAILWAY_DATABASE_URL }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
+      STAGING_SESSION_EXCHANGE_SIGNING_SECRET: ${{ secrets.STAGING_SESSION_EXCHANGE_SIGNING_SECRET }}
+      STEWARD_API_URL: ${{ secrets.STEWARD_API_URL }}
+      STEWARD_JWT_SECRET: ${{ secrets.STEWARD_JWT_SECRET }}
+      STEWARD_PLATFORM_KEYS: ${{ secrets.STEWARD_PLATFORM_KEYS }}
+      STEWARD_REQUEST_SIGNING_SECRET: ${{ secrets.STEWARD_REQUEST_SIGNING_SECRET }}
+      STEWARD_SESSION_SECRET: ${{ secrets.STEWARD_SESSION_SECRET }}
+      STEWARD_TENANT_API_KEY: ${{ secrets.STEWARD_TENANT_API_KEY }}
+      TUNNEL_HOSTNAME_SIGNING_SECRET: ${{ secrets.TUNNEL_HOSTNAME_SIGNING_SECRET }}
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      VAST_BASE_URL: ${{ secrets.VAST_BASE_URL }}
+      VOICE_REALTIME_ELIZA_AUTHORIZATION: ${{ secrets.VOICE_REALTIME_ELIZA_AUTHORIZATION }}
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
-      telegram_authority_run_attempt: ${{ needs.resolve-telegram-configuration-authority.outputs.run_attempt }}
-      telegram_repo_or_org_configured: ${{ needs.resolve-telegram-configuration-authority.outputs.repo_or_org_configured == 'true' }}
+      telegram_authority_run_attempt: ${{ needs.bind-telegram-release-attempt.outputs.run_attempt }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
       # Resolve the proof request at the entry workflow boundary. A live-ready
       # automatic release is a Develop effect reconciliation with a bound

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -11,6 +11,10 @@ on:
         description: staging or production
         required: true
         type: string
+      telegram_repo_or_org_configured:
+        description: Whether either Telegram public identity variable resolves outside a GitHub Environment
+        required: true
+        type: boolean
       force:
         description: Bypass the deploy freshness guard
         required: false
@@ -69,11 +73,11 @@ jobs:
         id: telegram
         env:
           TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
-          # GitHub Environment variables cannot overwrite values already
-          # resolved through the vars context. Treat this repository pair as
-          # staging-only input; production ignores it and uses source truth.
-          STAGING_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
-          STAGING_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          TELEGRAM_REPO_OR_ORG_CONFIGURED: ${{ inputs.telegram_repo_or_org_configured }}
+          # The caller proves the same names are absent at repository and
+          # organization scope before staging may trust this job Environment.
+          ENVIRONMENT_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          ENVIRONMENT_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
         run: |
           set -euo pipefail
 
@@ -108,23 +112,26 @@ jobs:
             resolved_bot_id="$canonical_bot_id"
             resolved_bot_username="$canonical_bot_username"
           else
-            if [ -z "$STAGING_TELEGRAM_BOT_ID" ] || \
-              [ -z "$STAGING_TELEGRAM_BOT_USERNAME" ]; then
-              fail "Repository VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must configure the complete staging pair"
+            if [ "$TELEGRAM_REPO_OR_ORG_CONFIGURED" = "true" ]; then
+              fail "Staging Telegram public identity must be configured only on the staging GitHub Environment"
             fi
-            valid_bot_id "$STAGING_TELEGRAM_BOT_ID" || \
-              fail "Repository VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
-            [[ "$STAGING_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
-              fail "Repository VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
-            staging_bot_username_key="$(printf '%s' "$STAGING_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+            if [ -z "$ENVIRONMENT_TELEGRAM_BOT_ID" ] || \
+              [ -z "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" ]; then
+              fail "The staging GitHub Environment must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
+            fi
+            valid_bot_id "$ENVIRONMENT_TELEGRAM_BOT_ID" || \
+              fail "The staging GitHub Environment VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
+            [[ "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+              fail "The staging GitHub Environment VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
+            staging_bot_username_key="$(printf '%s' "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
             [[ "$staging_bot_username_key" == *bot ]] || \
-              fail "Repository VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
-            if [ "$STAGING_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
+              fail "The staging GitHub Environment VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
+            if [ "$ENVIRONMENT_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
               [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
               fail "Staging Telegram configuration must use an identity fully distinct from production"
             fi
-            resolved_bot_id="$STAGING_TELEGRAM_BOT_ID"
-            resolved_bot_username="$STAGING_TELEGRAM_BOT_USERNAME"
+            resolved_bot_id="$ENVIRONMENT_TELEGRAM_BOT_ID"
+            resolved_bot_username="$ENVIRONMENT_TELEGRAM_BOT_USERNAME"
           fi
 
           printf 'bot_id=%s\n' "$resolved_bot_id" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -352,8 +352,11 @@ jobs:
             echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
+          admitted_telegram_bot_username_key="$(
+            printf '%s' "$ADMITTED_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]'
+          )"
           [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
-            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            [[ "$admitted_telegram_bot_username_key" == *bot ]] || {
             echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
@@ -902,8 +905,11 @@ jobs:
             echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
+          admitted_telegram_bot_username_key="$(
+            printf '%s' "$ADMITTED_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]'
+          )"
           [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
-            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            [[ "$admitted_telegram_bot_username_key" == *bot ]] || {
             echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
@@ -2405,8 +2411,11 @@ jobs:
             echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
+          admitted_telegram_bot_username_key="$(
+            printf '%s' "$ADMITTED_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]'
+          )"
           [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
-            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            [[ "$admitted_telegram_bot_username_key" == *bot ]] || {
             echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
@@ -2538,8 +2547,11 @@ jobs:
             echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
+          admitted_telegram_bot_username_key="$(
+            printf '%s' "$ADMITTED_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]'
+          )"
           [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
-            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            [[ "$admitted_telegram_bot_username_key" == *bot ]] || {
             echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -11,6 +11,10 @@ on:
         description: staging or production
         required: true
         type: string
+      telegram_authority_run_attempt:
+        description: Workflow attempt that resolved Telegram configuration outside a GitHub Environment
+        required: true
+        type: string
       telegram_repo_or_org_configured:
         description: Whether either Telegram public identity variable resolves outside a GitHub Environment
         required: true
@@ -72,7 +76,9 @@ jobs:
       - name: Validate Telegram public identity preflight
         id: telegram
         env:
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
           TELEGRAM_REPO_OR_ORG_CONFIGURED: ${{ inputs.telegram_repo_or_org_configured }}
           # The caller proves the same names are absent at repository and
           # organization scope before staging may trust this job Environment.
@@ -91,6 +97,13 @@ jobs:
             [[ "$candidate" =~ ^[1-9][0-9]{0,15}$ ]] || return 1
             (( 10#$candidate <= 4503599627370495 ))
           }
+
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || \
+            fail "Telegram configuration authority run attempt is missing or invalid"
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || \
+            fail "Cloud release run attempt is missing or invalid"
+          [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || \
+            fail "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs"
 
           case "$TARGET_ENVIRONMENT" in
             staging|production) ;;
@@ -197,6 +210,25 @@ jobs:
       # and the caller's certification job gate on it.
       superseded: ${{ steps.source_guard.outputs.superseded }}
     steps:
+      - name: Reject stale Telegram configuration authority
+        env:
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Telegram configuration authority run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Cloud release run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
+            echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
@@ -716,6 +748,25 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
+      - name: Reject stale Telegram configuration authority
+        env:
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Telegram configuration authority run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Cloud release run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
+            echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+
       - name: Reclaim disk from leaked checkouts of prior runs
         continue-on-error: true
         run: |
@@ -2190,6 +2241,25 @@ jobs:
       telegram_bot_username: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
       whatsapp_phone_number: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
     steps:
+      - name: Reject stale Telegram configuration authority
+        env:
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Telegram configuration authority run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Cloud release run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
+            echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Bind Pages artifacts to this producer attempt
@@ -2292,6 +2362,25 @@ jobs:
       # github.run_attempt.
       pages_authority_artifact: pages-deployment-authority-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
+      - name: Reject stale Telegram configuration authority
+        env:
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Telegram configuration authority run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Cloud release run attempt is missing or invalid" >&2
+            exit 1
+          }
+          [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
+            echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+
       - name: Reclaim disk from leaked checkouts of prior runs
         continue-on-error: true
         run: |

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -12,13 +12,9 @@ on:
         required: true
         type: string
       telegram_authority_run_attempt:
-        description: Workflow attempt that resolved Telegram configuration outside a GitHub Environment
+        description: Workflow attempt bound before the protected Telegram configuration is resolved
         required: true
         type: string
-      telegram_repo_or_org_configured:
-        description: Whether either Telegram public identity variable resolves outside a GitHub Environment
-        required: true
-        type: boolean
       force:
         description: Bypass the deploy freshness guard
         required: false
@@ -44,6 +40,117 @@ on:
         required: false
         type: string
         default: ""
+    # Keep caller-scope secrets explicit. The Telegram authority receipt is
+    # declared for the reusable-workflow type contract but intentionally not
+    # forwarded by the caller, so jobs below may resolve it only from their
+    # protected GitHub Environment.
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: false
+      CARTESIA_API_KEY:
+        required: false
+      CEREBRAS_API_KEY:
+        required: false
+      CLOUDFLARE_ACCOUNT_ID:
+        required: false
+      CLOUDFLARE_API_TOKEN:
+        required: false
+      CONTAINERS_SSH_KEY:
+        required: false
+      DATABASE_URL:
+        required: false
+      DEEPGRAM_API_KEY:
+        required: false
+      ELEVENLABS_API_KEY:
+        required: false
+      ELIZACLOUD_API_KEY:
+        required: false
+      ELIZAOS_CLOUD_API_KEY:
+        required: false
+      ELIZA_APNS_KEY:
+        required: false
+      ELIZA_APNS_KEY_ID:
+        required: false
+      ELIZA_APNS_TEAM_ID:
+        required: false
+      ELIZA_APP_BLOOIO_API_KEY:
+        required: false
+      ELIZA_APP_BLOOIO_PHONE_NUMBER:
+        required: false
+      ELIZA_APP_BLOOIO_WEBHOOK_SECRET:
+        required: false
+      ELIZA_APP_TELEGRAM_BOT_TOKEN:
+        required: false
+      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
+        required: false
+      ELIZA_APP_WEBHOOK_GATEWAY_SECRET:
+        required: false
+      ELIZA_MOBILE_APP_AUTH_APP_ID:
+        required: false
+      ELIZA_SERVICE_JWT_SECRET:
+        required: false
+      ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64:
+        required: false
+      ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64:
+        required: false
+      FAL_API_KEY:
+        required: false
+      FAL_KEY:
+        required: false
+      FISH_AUDIO_API_KEY:
+        required: false
+      FISH_AUDIO_REFERENCE_ID:
+        required: false
+      GATEWAY_INTERNAL_SECRET:
+        required: false
+      GROQ_API_KEY:
+        required: false
+      HEADSCALE_API_KEY:
+        required: false
+      INFERENCE_AUTH_PROBE_TOKEN:
+        required: false
+      LOCAL_EMBEDDINGS_API_KEY:
+        required: false
+      NEON_DATABASE_URL:
+        required: false
+      OIDC_CLIENTS:
+        required: false
+      OIDC_SIGNING_JWKS:
+        required: false
+      OPENAI_API_KEY:
+        required: false
+      OPENROUTER_API_KEY:
+        required: false
+      RAILWAY_DATABASE_URL:
+        required: false
+      RAILWAY_TOKEN:
+        required: false
+      SECRETS_MASTER_KEY:
+        required: false
+      STAGING_SESSION_EXCHANGE_SIGNING_SECRET:
+        required: false
+      STEWARD_API_URL:
+        required: false
+      STEWARD_JWT_SECRET:
+        required: false
+      STEWARD_PLATFORM_KEYS:
+        required: false
+      STEWARD_REQUEST_SIGNING_SECRET:
+        required: false
+      STEWARD_SESSION_SECRET:
+        required: false
+      STEWARD_TENANT_API_KEY:
+        required: false
+      TELEGRAM_IDENTITY_AUTHORITY_SHA256:
+        required: false
+      TUNNEL_HOSTNAME_SIGNING_SECRET:
+        required: false
+      VAST_API_KEY:
+        required: false
+      VAST_BASE_URL:
+        required: false
+      VOICE_REALTIME_ELIZA_AUTHORIZATION:
+        required: false
     outputs:
       superseded:
         description: >-
@@ -64,6 +171,8 @@ jobs:
     # GitHub cannot create or enter an arbitrary environment before the shell
     # rejects it. The target value itself is never normalized.
     environment: ${{ inputs.target_environment == 'production' && 'production' || 'staging' }}
+    # These outputs contain only the accepted public identity. The protected
+    # authority digest is never emitted or passed to another job.
     outputs:
       telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
       telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
@@ -79,11 +188,13 @@ jobs:
           RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
-          TELEGRAM_REPO_OR_ORG_CONFIGURED: ${{ inputs.telegram_repo_or_org_configured }}
-          # The caller proves the same names are absent at repository and
-          # organization scope before staging may trust this job Environment.
+          # Configuration variables carry only public values. A protected
+          # Environment secret binds the accepted pair; that secret is
+          # deliberately absent from the caller's forwarding map, so a
+          # repository/organization secret cannot substitute for it.
           ENVIRONMENT_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
           ENVIRONMENT_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          TELEGRAM_IDENTITY_AUTHORITY_SHA256: ${{ secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256 }}
         run: |
           set -euo pipefail
 
@@ -125,24 +236,30 @@ jobs:
             resolved_bot_id="$canonical_bot_id"
             resolved_bot_username="$canonical_bot_username"
           else
-            if [ "$TELEGRAM_REPO_OR_ORG_CONFIGURED" = "true" ]; then
-              fail "Staging Telegram public identity must be configured only on the staging GitHub Environment"
-            fi
             if [ -z "$ENVIRONMENT_TELEGRAM_BOT_ID" ] || \
               [ -z "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" ]; then
-              fail "The staging GitHub Environment must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
+              fail "The protected staging Telegram identity must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
             fi
             valid_bot_id "$ENVIRONMENT_TELEGRAM_BOT_ID" || \
-              fail "The staging GitHub Environment VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
+              fail "The protected staging VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
             [[ "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
-              fail "The staging GitHub Environment VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
+              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
             staging_bot_username_key="$(printf '%s' "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
             [[ "$staging_bot_username_key" == *bot ]] || \
-              fail "The staging GitHub Environment VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
+              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
             if [ "$ENVIRONMENT_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
               [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
               fail "Staging Telegram configuration must use an identity fully distinct from production"
             fi
+            [[ "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" =~ ^[0-9a-f]{64}$ ]] || \
+              fail "The staging GitHub Environment must provide a valid TELEGRAM_IDENTITY_AUTHORITY_SHA256 receipt"
+            computed_identity_sha256="$(
+              printf 'elizaOS/eliza\0staging\0telegram-public-identity\0v1\0%s\0%s\n' \
+                "$ENVIRONMENT_TELEGRAM_BOT_ID" "$staging_bot_username_key" \
+                | sha256sum | cut -d ' ' -f 1
+            )"
+            [ "$computed_identity_sha256" = "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" ] || \
+              fail "The staging Telegram identity does not match its protected Environment authority receipt"
             resolved_bot_id="$ENVIRONMENT_TELEGRAM_BOT_ID"
             resolved_bot_username="$ENVIRONMENT_TELEGRAM_BOT_USERNAME"
           fi
@@ -212,6 +329,8 @@ jobs:
     steps:
       - name: Reject stale Telegram configuration authority
         env:
+          ADMITTED_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
+          ADMITTED_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
         run: |
@@ -226,6 +345,16 @@ jobs:
           }
           [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
             echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_ID" =~ ^[1-9][0-9]{0,15}$ ]] && \
+            (( 10#$ADMITTED_TELEGRAM_BOT_ID <= 4503599627370495 )) || {
+            echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
+            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
 
@@ -750,6 +879,8 @@ jobs:
     steps:
       - name: Reject stale Telegram configuration authority
         env:
+          ADMITTED_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
+          ADMITTED_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
         run: |
@@ -764,6 +895,16 @@ jobs:
           }
           [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
             echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_ID" =~ ^[1-9][0-9]{0,15}$ ]] && \
+            (( 10#$ADMITTED_TELEGRAM_BOT_ID <= 4503599627370495 )) || {
+            echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
+            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
 
@@ -2237,12 +2378,12 @@ jobs:
       artifact_run_id: ${{ steps.pages-artifact.outputs.run_id }}
       artifact_run_attempt: ${{ steps.pages-artifact.outputs.run_attempt }}
       artifact_source_sha: ${{ steps.pages-artifact.outputs.source_sha }}
-      telegram_bot_id: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
-      telegram_bot_username: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
       whatsapp_phone_number: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
     steps:
       - name: Reject stale Telegram configuration authority
         env:
+          ADMITTED_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
+          ADMITTED_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
         run: |
@@ -2257,6 +2398,16 @@ jobs:
           }
           [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
             echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_ID" =~ ^[1-9][0-9]{0,15}$ ]] && \
+            (( 10#$ADMITTED_TELEGRAM_BOT_ID <= 4503599627370495 )) || {
+            echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
+            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
 
@@ -2349,8 +2500,8 @@ jobs:
     timeout-minutes: 75
     # Release gate (#11208/#18088): canonical Pages aliases wait for the matching
     # API deployment and the artifact built by this protected release.
-    needs: [deploy-api, build-pages]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.build-pages.result == 'success' }}
+    needs: [resolve-pages-environment-config, deploy-api, build-pages]
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.resolve-pages-environment-config.result == 'success' && needs.deploy-api.result == 'success' && needs.build-pages.result == 'success' }}
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
@@ -2364,6 +2515,8 @@ jobs:
     steps:
       - name: Reject stale Telegram configuration authority
         env:
+          ADMITTED_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
+          ADMITTED_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
         run: |
@@ -2378,6 +2531,16 @@ jobs:
           }
           [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || {
             echo "::error::Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_ID" =~ ^[1-9][0-9]{0,15}$ ]] && \
+            (( 10#$ADMITTED_TELEGRAM_BOT_ID <= 4503599627370495 )) || {
+            echo "::error::Admitted Telegram bot ID output is missing or invalid; re-run all jobs" >&2
+            exit 1
+          }
+          [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] && \
+            [[ "${ADMITTED_TELEGRAM_BOT_USERNAME,,}" == *bot ]] || {
+            echo "::error::Admitted Telegram username output is missing or invalid; re-run all jobs" >&2
             exit 1
           }
 
@@ -2593,8 +2756,8 @@ jobs:
         working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/app build:web
         env:
-          VITE_TELEGRAM_BOT_ID: ${{ needs.build-pages.outputs.telegram_bot_id }}
-          VITE_TELEGRAM_BOT_USERNAME: ${{ needs.build-pages.outputs.telegram_bot_username }}
+          VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.build-pages.outputs.whatsapp_phone_number }}
           VITE_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -52,12 +52,12 @@ VITE_ELIZA_IOS_API_TOKEN=
 VITE_ELIZA_DEVICE_BRIDGE_URL=
 VITE_ELIZA_DEVICE_BRIDGE_TOKEN=
 
-# Implicit Telegram source fallback use is local/direct-only. At repository
-# scope, this pair is the explicit staging release authority so the homepage
-# CTA and Steward Login Widget cannot resolve different identities. Protected
-# production releases ignore it and explicitly select the canonical constants
-# from contact.ts. A same-named GitHub Environment pair does not override the
-# repository pair.
+# Implicit Telegram source fallback use is local/direct-only. Protected staging
+# reads this pair only from the staging GitHub Environment so the homepage CTA
+# and Steward Login Widget cannot resolve different identities. Do not define
+# either name as a GitHub organization or repository variable: the release
+# caller detects that conflicting scope and fails before mutation. Protected
+# production explicitly selects the canonical constants from contact.ts.
 VITE_TELEGRAM_BOT_ID=
 VITE_TELEGRAM_BOT_USERNAME=
 

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -53,11 +53,11 @@ VITE_ELIZA_DEVICE_BRIDGE_URL=
 VITE_ELIZA_DEVICE_BRIDGE_TOKEN=
 
 # Implicit Telegram source fallback use is local/direct-only. Protected staging
-# reads this pair only from the staging GitHub Environment so the homepage CTA
-# and Steward Login Widget cannot resolve different identities. Do not define
-# either name as a GitHub organization or repository variable: the release
-# caller detects that conflicting scope and fails before mutation. Protected
-# production explicitly selects the canonical constants from contact.ts.
+# accepts this public pair only when it matches the staging GitHub Environment
+# secret TELEGRAM_IDENTITY_AUTHORITY_SHA256, so the homepage CTA and Steward
+# Login Widget cannot resolve different identities. Configuration variables
+# carry values but are not protected-release authority. Production explicitly
+# selects the canonical constants from contact.ts.
 VITE_TELEGRAM_BOT_ID=
 VITE_TELEGRAM_BOT_USERNAME=
 

--- a/packages/homepage/.env.example
+++ b/packages/homepage/.env.example
@@ -12,10 +12,11 @@
 
 VITE_ELIZACLOUD_API_URL=https://api.eliza.app
 
-# Local/direct builds may use the source defaults. At repository scope, this ID
-# and the username below form the protected staging release pair and are
-# required before any release mutation starts. Protected production releases
-# ignore them and derive the canonical pair from contact.ts.
+# Local/direct builds may use the source defaults. Protected staging reads this
+# ID and the username below only from its GitHub Environment. Either name at
+# GitHub organization or repository scope blocks the release before mutation.
+# Protected production ignores them and derives the canonical pair from
+# contact.ts.
 # Bot numeric ID (first part of bot token before the colon)
 # Example: If token is 8202935775:AAGL9Dhf..., use 8202935775
 VITE_TELEGRAM_BOT_ID=

--- a/packages/homepage/.env.example
+++ b/packages/homepage/.env.example
@@ -13,10 +13,10 @@
 VITE_ELIZACLOUD_API_URL=https://api.eliza.app
 
 # Local/direct builds may use the source defaults. Protected staging reads this
-# ID and the username below only from its GitHub Environment. Either name at
-# GitHub organization or repository scope blocks the release before mutation.
-# Protected production ignores them and derives the canonical pair from
-# contact.ts.
+# public ID and the username below only after the pair matches the staging
+# GitHub Environment secret TELEGRAM_IDENTITY_AUTHORITY_SHA256; configuration
+# variables are not protected-release authority. Protected production ignores
+# them and derives the canonical pair from contact.ts.
 # Bot numeric ID (first part of bot token before the colon)
 # Example: If token is 8202935775:AAGL9Dhf..., use 8202935775
 VITE_TELEGRAM_BOT_ID=

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -122,8 +122,8 @@ isolated visual harness.
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
-| `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Local/direct-build Telegram username fallback; with the ID, the repository-scoped staging release authority |
-| `VITE_TELEGRAM_BOT_ID` | `8931353359` | Local/direct-build numeric Telegram ID fallback; with the username, the repository-scoped staging release authority |
+| `VITE_TELEGRAM_BOT_USERNAME` | source constant | Local/direct-build Telegram username fallback; protected staging reads the pair only from its GitHub Environment |
+| `VITE_TELEGRAM_BOT_ID` | source constant | Local/direct-build numeric Telegram ID fallback; protected staging reads the pair only from its GitHub Environment |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
@@ -131,12 +131,13 @@ isolated visual harness.
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 
 The Telegram defaults above do not authorize a protected staging Pages
-artifact. The Cloud release preflight requires the explicit, valid repository
-pair before staging migrations or API deployment, and neither component may
-match production. Production ignores the repository pair and derives its exact
-identity from `src/lib/contact.ts` at the checked-out release SHA. Do not treat
-same-named GitHub Environment variables as overrides: they arrive after the
-repository `vars` context has already been resolved.
+artifact. The Cloud release preflight requires the explicit, valid pair on the
+protected `staging` GitHub Environment before migrations or API deployment,
+and neither component may match production. Before entering that Environment,
+the caller records whether either name resolves at organization or repository
+scope. The Environment-scoped preflight rejects a conflicting scope before any
+mutation. Production ignores all GitHub Telegram inputs and derives its exact
+identity from `src/lib/contact.ts` at the checked-out release SHA.
 
 ## How to extend
 

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -122,8 +122,8 @@ isolated visual harness.
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
-| `VITE_TELEGRAM_BOT_USERNAME` | source constant | Local/direct-build Telegram username fallback; protected staging reads the pair only from its GitHub Environment |
-| `VITE_TELEGRAM_BOT_ID` | source constant | Local/direct-build numeric Telegram ID fallback; protected staging reads the pair only from its GitHub Environment |
+| `VITE_TELEGRAM_BOT_USERNAME` | source constant | Local/direct-build Telegram username fallback; protected staging accepts the pair only with its Environment authority receipt |
+| `VITE_TELEGRAM_BOT_ID` | source constant | Local/direct-build numeric Telegram ID fallback; protected staging accepts the pair only with its Environment authority receipt |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
@@ -131,13 +131,16 @@ isolated visual harness.
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 
 The Telegram defaults above do not authorize a protected staging Pages
-artifact. The Cloud release preflight requires the explicit, valid pair on the
-protected `staging` GitHub Environment before migrations or API deployment,
-and neither component may match production. Before entering that Environment,
-the caller records whether either name resolves at organization or repository
-scope. The Environment-scoped preflight rejects a conflicting scope before any
-mutation. Production ignores all GitHub Telegram inputs and derives its exact
-identity from `src/lib/contact.ts` at the checked-out release SHA.
+artifact. The Cloud release preflight requires the explicit, valid pair as
+configuration variables before migrations or API deployment, and neither
+component may match production. It accepts the pair only when the protected
+`staging` GitHub Environment secret `TELEGRAM_IDENTITY_AUTHORITY_SHA256` matches
+the framed ID plus lowercase username. The reusable release explicitly does
+not forward that secret from repository or organization scope; configuration
+variables carry public values but are not release authority. Cancel and fully
+rerun an in-flight release after rotating the pair or receipt. Production
+ignores all GitHub Telegram inputs and derives its exact identity from
+`src/lib/contact.ts` at the checked-out release SHA.
 
 ## How to extend
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -122,8 +122,8 @@ isolated visual harness.
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
-| `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Local/direct-build Telegram username fallback; with the ID, the repository-scoped staging release authority |
-| `VITE_TELEGRAM_BOT_ID` | `8931353359` | Local/direct-build numeric Telegram ID fallback; with the username, the repository-scoped staging release authority |
+| `VITE_TELEGRAM_BOT_USERNAME` | source constant | Local/direct-build Telegram username fallback; protected staging reads the pair only from its GitHub Environment |
+| `VITE_TELEGRAM_BOT_ID` | source constant | Local/direct-build numeric Telegram ID fallback; protected staging reads the pair only from its GitHub Environment |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
@@ -131,12 +131,13 @@ isolated visual harness.
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 
 The Telegram defaults above do not authorize a protected staging Pages
-artifact. The Cloud release preflight requires the explicit, valid repository
-pair before staging migrations or API deployment, and neither component may
-match production. Production ignores the repository pair and derives its exact
-identity from `src/lib/contact.ts` at the checked-out release SHA. Do not treat
-same-named GitHub Environment variables as overrides: they arrive after the
-repository `vars` context has already been resolved.
+artifact. The Cloud release preflight requires the explicit, valid pair on the
+protected `staging` GitHub Environment before migrations or API deployment,
+and neither component may match production. Before entering that Environment,
+the caller records whether either name resolves at organization or repository
+scope. The Environment-scoped preflight rejects a conflicting scope before any
+mutation. Production ignores all GitHub Telegram inputs and derives its exact
+identity from `src/lib/contact.ts` at the checked-out release SHA.
 
 ## How to extend
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -122,8 +122,8 @@ isolated visual harness.
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
-| `VITE_TELEGRAM_BOT_USERNAME` | source constant | Local/direct-build Telegram username fallback; protected staging reads the pair only from its GitHub Environment |
-| `VITE_TELEGRAM_BOT_ID` | source constant | Local/direct-build numeric Telegram ID fallback; protected staging reads the pair only from its GitHub Environment |
+| `VITE_TELEGRAM_BOT_USERNAME` | source constant | Local/direct-build Telegram username fallback; protected staging accepts the pair only with its Environment authority receipt |
+| `VITE_TELEGRAM_BOT_ID` | source constant | Local/direct-build numeric Telegram ID fallback; protected staging accepts the pair only with its Environment authority receipt |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
@@ -131,13 +131,16 @@ isolated visual harness.
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 
 The Telegram defaults above do not authorize a protected staging Pages
-artifact. The Cloud release preflight requires the explicit, valid pair on the
-protected `staging` GitHub Environment before migrations or API deployment,
-and neither component may match production. Before entering that Environment,
-the caller records whether either name resolves at organization or repository
-scope. The Environment-scoped preflight rejects a conflicting scope before any
-mutation. Production ignores all GitHub Telegram inputs and derives its exact
-identity from `src/lib/contact.ts` at the checked-out release SHA.
+artifact. The Cloud release preflight requires the explicit, valid pair as
+configuration variables before migrations or API deployment, and neither
+component may match production. It accepts the pair only when the protected
+`staging` GitHub Environment secret `TELEGRAM_IDENTITY_AUTHORITY_SHA256` matches
+the framed ID plus lowercase username. The reusable release explicitly does
+not forward that secret from repository or organization scope; configuration
+variables carry public values but are not release authority. Cancel and fully
+rerun an in-flight release after rotating the pair or receipt. Production
+ignores all GitHub Telegram inputs and derives its exact identity from
+`src/lib/contact.ts` at the checked-out release SHA.
 
 ## How to extend
 

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -21,8 +21,8 @@ cp .env.example .env.local
 | Variable | Description |
 |---|---|
 | `VITE_ELIZACLOUD_API_URL` | Eliza Cloud backend URL (defaults to `https://api.eliza.app`) |
-| `VITE_TELEGRAM_BOT_USERNAME` | Local/direct-build Telegram username fallback (default `ElizaIsNotABot`); with the ID, the repository-scoped staging release authority |
-| `VITE_TELEGRAM_BOT_ID` | Local/direct-build numeric Telegram ID fallback (default `8931353359`); with the username, the repository-scoped staging release authority |
+| `VITE_TELEGRAM_BOT_USERNAME` | Local/direct-build Telegram username fallback; protected staging reads the pair only from its GitHub Environment |
+| `VITE_TELEGRAM_BOT_ID` | Local/direct-build numeric Telegram ID fallback; protected staging reads the pair only from its GitHub Environment |
 | `VITE_DISCORD_CLIENT_ID` | Optional Discord Application ID override (default `1468649258654630063`) |
 | `WHATSAPP_PUBLIC_ENABLED` | Deployment switch that must be true before the public WhatsApp CTA is built |
 | `VITE_WHATSAPP_PHONE_NUMBER` | Admitted Blooio WhatsApp sender in E.164 format; set to the shared `+18087881821` number |
@@ -31,14 +31,14 @@ OAuth provider callback configuration belongs to the unified Cloud auth routes
 and API deployment. Do not register a callback against this source package or
 its optional test-harness port.
 
-Protected staging releases require the complete repository-scoped pair before
-migrations or API deployment, and neither component may match the canonical
-production identity. Protected production releases ignore that pair and derive
-their exact identity from `src/lib/contact.ts` at the checked-out release SHA.
-Same-named GitHub Environment variables are not an override mechanism because
-GitHub resolves the repository `vars` context before Environment variables
-arrive on the runner. Pull requests have static build checks but no Pages
-preview release path.
+Protected staging releases require the complete pair on the protected
+`staging` GitHub Environment before migrations or API deployment, and neither
+component may match the canonical production identity. The caller checks both
+names before entering any Environment; either organization- or
+repository-scoped component is conflicting authority and fails the staging
+release. Protected production releases ignore all GitHub Telegram inputs and
+derive their exact identity from `src/lib/contact.ts` at the checked-out release
+SHA. Pull requests have static build checks but no Pages preview release path.
 
 ### WhatsApp production activation
 

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -21,8 +21,8 @@ cp .env.example .env.local
 | Variable | Description |
 |---|---|
 | `VITE_ELIZACLOUD_API_URL` | Eliza Cloud backend URL (defaults to `https://api.eliza.app`) |
-| `VITE_TELEGRAM_BOT_USERNAME` | Local/direct-build Telegram username fallback; protected staging reads the pair only from its GitHub Environment |
-| `VITE_TELEGRAM_BOT_ID` | Local/direct-build numeric Telegram ID fallback; protected staging reads the pair only from its GitHub Environment |
+| `VITE_TELEGRAM_BOT_USERNAME` | Local/direct-build Telegram username fallback; protected staging accepts the pair only with its Environment authority receipt |
+| `VITE_TELEGRAM_BOT_ID` | Local/direct-build numeric Telegram ID fallback; protected staging accepts the pair only with its Environment authority receipt |
 | `VITE_DISCORD_CLIENT_ID` | Optional Discord Application ID override (default `1468649258654630063`) |
 | `WHATSAPP_PUBLIC_ENABLED` | Deployment switch that must be true before the public WhatsApp CTA is built |
 | `VITE_WHATSAPP_PHONE_NUMBER` | Admitted Blooio WhatsApp sender in E.164 format; set to the shared `+18087881821` number |
@@ -31,14 +31,17 @@ OAuth provider callback configuration belongs to the unified Cloud auth routes
 and API deployment. Do not register a callback against this source package or
 its optional test-harness port.
 
-Protected staging releases require the complete pair on the protected
-`staging` GitHub Environment before migrations or API deployment, and neither
-component may match the canonical production identity. The caller checks both
-names before entering any Environment; either organization- or
-repository-scoped component is conflicting authority and fails the staging
-release. Protected production releases ignore all GitHub Telegram inputs and
-derive their exact identity from `src/lib/contact.ts` at the checked-out release
-SHA. Pull requests have static build checks but no Pages preview release path.
+Protected staging releases require the complete configuration-variable pair
+before migrations or API deployment, and neither component may match the
+canonical production identity. The pair is accepted only when the protected
+`staging` GitHub Environment secret `TELEGRAM_IDENTITY_AUTHORITY_SHA256` matches
+the framed ID plus lowercase username. That receipt is not forwarded from
+repository or organization scope, so configuration variables carry public
+values but do not establish release authority. Cancel and fully rerun an
+in-flight release after rotating the pair or receipt. Protected production
+releases ignore all GitHub Telegram inputs and derive their exact identity from
+`src/lib/contact.ts` at the checked-out release SHA. Pull requests have static
+build checks but no Pages preview release path.
 
 ### WhatsApp production activation
 

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -40,9 +40,19 @@ interface WorkflowJob {
   with?: Record<string, string | boolean>;
 }
 
+interface WorkflowCallInput {
+  required?: boolean;
+  type?: string;
+}
+
 interface WorkflowFile {
   jobs?: Record<string, WorkflowJob>;
-  on?: Record<string, unknown>;
+  on?: {
+    workflow_call?: {
+      inputs?: Record<string, WorkflowCallInput>;
+    };
+    [event: string]: unknown;
+  };
 }
 
 interface TelegramExecution {
@@ -95,6 +105,7 @@ function runTelegramPreflight(
   overrides: Partial<{
     botId: string;
     botUsername: string;
+    repoOrOrgConfigured: boolean;
     targetEnvironment: string;
   }> = {},
 ): TelegramExecution {
@@ -116,8 +127,11 @@ function runTelegramPreflight(
         GITHUB_OUTPUT: githubOutputPath,
         GITHUB_STEP_SUMMARY: summaryPath,
         TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
-        STAGING_TELEGRAM_BOT_ID: overrides.botId ?? stagingTelegram.botId,
-        STAGING_TELEGRAM_BOT_USERNAME:
+        TELEGRAM_REPO_OR_ORG_CONFIGURED: String(
+          overrides.repoOrOrgConfigured ?? false,
+        ),
+        ENVIRONMENT_TELEGRAM_BOT_ID: overrides.botId ?? stagingTelegram.botId,
+        ENVIRONMENT_TELEGRAM_BOT_USERNAME:
           overrides.botUsername ?? stagingTelegram.botUsername,
       },
       stderr: "pipe",
@@ -217,6 +231,45 @@ describe("homepage deployment workflow", () => {
     expect(release?.with?.target_environment).toContain("production");
   });
 
+  it("requires caller-scope Telegram provenance before entering a GitHub Environment", () => {
+    const authorityResolver =
+      parsedWorkflow.jobs?.["resolve-telegram-configuration-authority"];
+    const authorityStep = namedStep(
+      authorityResolver,
+      "Detect Telegram variables outside a GitHub Environment",
+    );
+    const release = parsedWorkflow.jobs?.release;
+    const provenanceInput =
+      parsedReleaseWorkflow.on?.workflow_call?.inputs
+        ?.telegram_repo_or_org_configured;
+
+    expect(authorityResolver?.environment).toBeUndefined();
+    expect(authorityResolver?.outputs?.repo_or_org_configured).toBe(
+      githubExpression("steps.scope.outputs.configured"),
+    );
+    expect(authorityStep.env).toEqual({
+      TELEGRAM_REPO_OR_ORG_CONFIGURED: githubExpression(
+        "vars.VITE_TELEGRAM_BOT_ID != '' || vars.VITE_TELEGRAM_BOT_USERNAME != ''",
+      ),
+    });
+    expect(release?.environment).toBeUndefined();
+    expect(jobNeeds(release)).toContain(
+      "resolve-telegram-configuration-authority",
+    );
+    expect(release?.if).toContain(
+      "needs.resolve-telegram-configuration-authority.result == 'success'",
+    );
+    expect(release?.with?.telegram_repo_or_org_configured).toBe(
+      githubExpression(
+        "needs.resolve-telegram-configuration-authority.outputs.repo_or_org_configured == 'true'",
+      ),
+    );
+    expect(provenanceInput).toMatchObject({
+      required: true,
+      type: "boolean",
+    });
+  });
+
   it("runs the Telegram resolver before every release mutation", () => {
     const jobs = parsedReleaseWorkflow.jobs ?? {};
     const jobNames = Object.keys(jobs);
@@ -236,8 +289,13 @@ describe("homepage deployment workflow", () => {
     expect(resolver?.steps?.[0]?.uses).toContain("actions/checkout@");
     expect(telegramValidation?.env).toEqual({
       TARGET_ENVIRONMENT: githubExpression("inputs.target_environment"),
-      STAGING_TELEGRAM_BOT_ID: githubExpression("vars.VITE_TELEGRAM_BOT_ID"),
-      STAGING_TELEGRAM_BOT_USERNAME: githubExpression(
+      TELEGRAM_REPO_OR_ORG_CONFIGURED: githubExpression(
+        "inputs.telegram_repo_or_org_configured",
+      ),
+      ENVIRONMENT_TELEGRAM_BOT_ID: githubExpression(
+        "vars.VITE_TELEGRAM_BOT_ID",
+      ),
+      ENVIRONMENT_TELEGRAM_BOT_USERNAME: githubExpression(
         "vars.VITE_TELEGRAM_BOT_USERNAME",
       ),
     });
@@ -262,7 +320,7 @@ describe("homepage deployment workflow", () => {
     );
   });
 
-  it("accepts valid repository-scoped staging Telegram identities", () => {
+  it("accepts valid staging-Environment Telegram identities", () => {
     for (const valid of [
       { target: "staging", ...stagingTelegram },
       {
@@ -287,11 +345,39 @@ describe("homepage deployment workflow", () => {
     }
   });
 
-  it("derives production Telegram identity from source and ignores repository staging input", () => {
+  it("rejects outer-scope Telegram configuration before validating or leaking Environment values", () => {
+    const conflictingTelegram = {
+      botId: "outer-scope-id-fixture",
+      botUsername: "outer-scope-username-fixture",
+    };
+    const execution = runTelegramPreflight({
+      ...conflictingTelegram,
+      repoOrOrgConfigured: true,
+      targetEnvironment: "staging",
+    });
+
+    expect(execution.exitCode).toBe(1);
+    expect(execution.githubOutput).toBe("");
+    expect(execution.summary).toBe("");
+    expect(execution.stderr).toContain(
+      "Staging Telegram public identity must be configured only on the staging GitHub Environment",
+    );
+    expect(execution.stderr).not.toContain("must match the Telegram");
+    assertNoPublicSurfaceLeak(execution, [
+      conflictingTelegram.botId,
+      conflictingTelegram.botUsername,
+    ]);
+  });
+
+  it("derives production Telegram identity from source and ignores all staging inputs", () => {
     for (const configuredStagingPair of [
-      { botId: "", botUsername: "" },
-      stagingTelegram,
-      { botId: "not-a-number", botUsername: "not-a-valid-name!" },
+      { botId: "", botUsername: "", repoOrOrgConfigured: false },
+      { ...stagingTelegram, repoOrOrgConfigured: true },
+      {
+        botId: "not-a-number",
+        botUsername: "not-a-valid-name!",
+        repoOrOrgConfigured: true,
+      },
     ]) {
       const execution = runTelegramPreflight({
         ...configuredStagingPair,

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -69,6 +69,14 @@ const qualityWorkflow = readFileSync(qualityWorkflowPath, "utf8");
 const contactSource = readFileSync(contactPath, "utf8");
 const parsedWorkflow = Bun.YAML.parse(workflow) as WorkflowFile;
 const parsedReleaseWorkflow = Bun.YAML.parse(releaseWorkflow) as WorkflowFile;
+const telegramAuthorityGuardName =
+  "Reject stale Telegram configuration authority";
+const guardedReleaseJobNames = [
+  "migrate-db",
+  "deploy-api",
+  "build-pages",
+  "deploy-app",
+] as const;
 
 const resolver =
   parsedReleaseWorkflow.jobs?.["resolve-pages-environment-config"];
@@ -105,6 +113,8 @@ function runTelegramPreflight(
   overrides: Partial<{
     botId: string;
     botUsername: string;
+    authorityRunAttempt: string;
+    releaseRunAttempt: string;
     repoOrOrgConfigured: boolean;
     targetEnvironment: string;
   }> = {},
@@ -126,7 +136,9 @@ function runTelegramPreflight(
         ...process.env,
         GITHUB_OUTPUT: githubOutputPath,
         GITHUB_STEP_SUMMARY: summaryPath,
+        RELEASE_RUN_ATTEMPT: overrides.releaseRunAttempt ?? "1",
         TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
+        TELEGRAM_AUTHORITY_RUN_ATTEMPT: overrides.authorityRunAttempt ?? "1",
         TELEGRAM_REPO_OR_ORG_CONFIGURED: String(
           overrides.repoOrOrgConfigured ?? false,
         ),
@@ -173,6 +185,49 @@ function namedStep(job: WorkflowJob | undefined, name: string): WorkflowStep {
   const found = job?.steps?.find((candidate) => candidate.name === name);
   if (!found) throw new Error(`Missing workflow step: ${name}`);
   return found;
+}
+
+function runTelegramAuthorityGuard(
+  jobName: (typeof guardedReleaseJobNames)[number],
+  authorityRunAttempt: string,
+  releaseRunAttempt: string,
+): TelegramExecution {
+  const guard = namedStep(
+    parsedReleaseWorkflow.jobs?.[jobName],
+    telegramAuthorityGuardName,
+  );
+  if (!guard.run) throw new Error(`Missing executable guard in ${jobName}`);
+
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), "homepage-telegram-authority-guard-"),
+  );
+  const githubOutputPath = path.join(fixtureRoot, "github-output.txt");
+  const summaryPath = path.join(fixtureRoot, "step-summary.md");
+
+  try {
+    const result = Bun.spawnSync(["bash", "-c", guard.run], {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: githubOutputPath,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        RELEASE_RUN_ATTEMPT: releaseRunAttempt,
+        TELEGRAM_AUTHORITY_RUN_ATTEMPT: authorityRunAttempt,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    return {
+      exitCode: result.exitCode,
+      githubOutput: readOptionalFile(githubOutputPath),
+      stderr: result.stderr.toString(),
+      stdout: result.stdout.toString(),
+      summary: readOptionalFile(summaryPath),
+    };
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
 }
 
 describe("homepage deployment workflow", () => {
@@ -242,12 +297,19 @@ describe("homepage deployment workflow", () => {
     const provenanceInput =
       parsedReleaseWorkflow.on?.workflow_call?.inputs
         ?.telegram_repo_or_org_configured;
+    const attemptInput =
+      parsedReleaseWorkflow.on?.workflow_call?.inputs
+        ?.telegram_authority_run_attempt;
 
     expect(authorityResolver?.environment).toBeUndefined();
     expect(authorityResolver?.outputs?.repo_or_org_configured).toBe(
       githubExpression("steps.scope.outputs.configured"),
     );
+    expect(authorityResolver?.outputs?.run_attempt).toBe(
+      githubExpression("steps.scope.outputs.run_attempt"),
+    );
     expect(authorityStep.env).toEqual({
+      TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression("github.run_attempt"),
       TELEGRAM_REPO_OR_ORG_CONFIGURED: githubExpression(
         "vars.VITE_TELEGRAM_BOT_ID != '' || vars.VITE_TELEGRAM_BOT_USERNAME != ''",
       ),
@@ -264,9 +326,18 @@ describe("homepage deployment workflow", () => {
         "needs.resolve-telegram-configuration-authority.outputs.repo_or_org_configured == 'true'",
       ),
     );
+    expect(release?.with?.telegram_authority_run_attempt).toBe(
+      githubExpression(
+        "needs.resolve-telegram-configuration-authority.outputs.run_attempt",
+      ),
+    );
     expect(provenanceInput).toMatchObject({
       required: true,
       type: "boolean",
+    });
+    expect(attemptInput).toMatchObject({
+      required: true,
+      type: "string",
     });
   });
 
@@ -288,7 +359,11 @@ describe("homepage deployment workflow", () => {
     );
     expect(resolver?.steps?.[0]?.uses).toContain("actions/checkout@");
     expect(telegramValidation?.env).toEqual({
+      RELEASE_RUN_ATTEMPT: githubExpression("github.run_attempt"),
       TARGET_ENVIRONMENT: githubExpression("inputs.target_environment"),
+      TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
+        "inputs.telegram_authority_run_attempt",
+      ),
       TELEGRAM_REPO_OR_ORG_CONFIGURED: githubExpression(
         "inputs.telegram_repo_or_org_configured",
       ),
@@ -318,6 +393,43 @@ describe("homepage deployment workflow", () => {
     expect(pagesBuild?.if).toContain(
       "needs.resolve-pages-environment-config.result == 'success'",
     );
+  });
+
+  it("guards the first selected job for every partial-rerun mutation path", () => {
+    const guardScripts: string[] = [];
+
+    for (const jobName of guardedReleaseJobNames) {
+      const job = parsedReleaseWorkflow.jobs?.[jobName];
+      const guard = namedStep(job, telegramAuthorityGuardName);
+
+      expect(job?.steps?.[0]?.name, jobName).toBe(telegramAuthorityGuardName);
+      expect(guard.env, jobName).toEqual({
+        RELEASE_RUN_ATTEMPT: githubExpression("github.run_attempt"),
+        TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
+          "inputs.telegram_authority_run_attempt",
+        ),
+      });
+      expect(guard.run, jobName).toBeTruthy();
+      guardScripts.push(guard.run ?? "");
+
+      const initialAttempt = runTelegramAuthorityGuard(jobName, "1", "1");
+      expect(initialAttempt.exitCode, `${jobName} attempt 1`).toBe(0);
+      expect(initialAttempt.githubOutput, `${jobName} attempt 1`).toBe("");
+      expect(initialAttempt.stdout, `${jobName} attempt 1`).toBe("");
+      expect(initialAttempt.stderr, `${jobName} attempt 1`).toBe("");
+      expect(initialAttempt.summary, `${jobName} attempt 1`).toBe("");
+
+      const partialRerun = runTelegramAuthorityGuard(jobName, "1", "2");
+      expect(partialRerun.exitCode, `${jobName} partial rerun`).toBe(1);
+      expect(partialRerun.githubOutput, `${jobName} partial rerun`).toBe("");
+      expect(partialRerun.stdout, `${jobName} partial rerun`).toBe("");
+      expect(partialRerun.summary, `${jobName} partial rerun`).toBe("");
+      expect(partialRerun.stderr, `${jobName} partial rerun`).toContain(
+        "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs",
+      );
+    }
+
+    expect(new Set(guardScripts).size).toBe(1);
   });
 
   it("accepts valid staging-Environment Telegram identities", () => {
@@ -366,6 +478,31 @@ describe("homepage deployment workflow", () => {
     assertNoPublicSurfaceLeak(execution, [
       conflictingTelegram.botId,
       conflictingTelegram.botUsername,
+    ]);
+  });
+
+  it("rejects a stale Telegram authority receipt reused by a partial rerun", () => {
+    const environmentTelegram = {
+      botId: "partial-rerun-environment-id-fixture",
+      botUsername: "partial-rerun-environment-username-fixture",
+    };
+    const execution = runTelegramPreflight({
+      ...environmentTelegram,
+      authorityRunAttempt: "1",
+      releaseRunAttempt: "2",
+      targetEnvironment: "staging",
+    });
+
+    expect(execution.exitCode).toBe(1);
+    expect(execution.githubOutput).toBe("");
+    expect(execution.summary).toBe("");
+    expect(execution.stderr).toContain(
+      "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs",
+    );
+    expect(execution.stderr).not.toContain("must match the Telegram");
+    assertNoPublicSurfaceLeak(execution, [
+      environmentTelegram.botId,
+      environmentTelegram.botUsername,
     ]);
   });
 

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -3,6 +3,7 @@
  * public messaging identity preflight that must succeed before release
  * mutations can begin.
  */
+import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -35,6 +36,7 @@ interface WorkflowJob {
   if?: string;
   needs?: string | string[];
   outputs?: Record<string, string>;
+  secrets?: "inherit" | Record<string, string>;
   steps?: WorkflowStep[];
   uses?: string;
   with?: Record<string, string | boolean>;
@@ -50,6 +52,7 @@ interface WorkflowFile {
   on?: {
     workflow_call?: {
       inputs?: Record<string, WorkflowCallInput>;
+      secrets?: Record<string, { required?: boolean }>;
     };
     [event: string]: unknown;
   };
@@ -105,6 +108,21 @@ const stagingTelegram = {
   botUsername: "ElizaStage29206Bot",
 };
 
+function telegramIdentityAuthoritySha256(
+  botId: string,
+  botUsername: string,
+): string {
+  const framed = [
+    "elizaOS/eliza",
+    "staging",
+    "telegram-public-identity",
+    "v1",
+    botId,
+    botUsername.toLowerCase(),
+  ].join("\0");
+  return createHash("sha256").update(`${framed}\n`).digest("hex");
+}
+
 function readOptionalFile(filePath: string): string {
   return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
 }
@@ -114,11 +132,14 @@ function runTelegramPreflight(
     botId: string;
     botUsername: string;
     authorityRunAttempt: string;
+    authoritySha256: string;
     releaseRunAttempt: string;
-    repoOrOrgConfigured: boolean;
     targetEnvironment: string;
   }> = {},
 ): TelegramExecution {
+  // This executes the checked-in shell contract locally. Environment-secret
+  // provenance is enforced separately by the structural caller-allowlist test;
+  // a local GITHUB_OUTPUT file cannot model hosted runner scope or filtering.
   if (!telegramValidation?.run) {
     throw new Error("Missing executable Telegram public identity preflight");
   }
@@ -130,6 +151,8 @@ function runTelegramPreflight(
   const summaryPath = path.join(fixtureRoot, "step-summary.md");
 
   try {
+    const botId = overrides.botId ?? stagingTelegram.botId;
+    const botUsername = overrides.botUsername ?? stagingTelegram.botUsername;
     const result = Bun.spawnSync(["bash", "-c", telegramValidation.run], {
       cwd: repositoryRoot,
       env: {
@@ -139,12 +162,11 @@ function runTelegramPreflight(
         RELEASE_RUN_ATTEMPT: overrides.releaseRunAttempt ?? "1",
         TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
         TELEGRAM_AUTHORITY_RUN_ATTEMPT: overrides.authorityRunAttempt ?? "1",
-        TELEGRAM_REPO_OR_ORG_CONFIGURED: String(
-          overrides.repoOrOrgConfigured ?? false,
-        ),
-        ENVIRONMENT_TELEGRAM_BOT_ID: overrides.botId ?? stagingTelegram.botId,
-        ENVIRONMENT_TELEGRAM_BOT_USERNAME:
-          overrides.botUsername ?? stagingTelegram.botUsername,
+        ENVIRONMENT_TELEGRAM_BOT_ID: botId,
+        ENVIRONMENT_TELEGRAM_BOT_USERNAME: botUsername,
+        TELEGRAM_IDENTITY_AUTHORITY_SHA256:
+          overrides.authoritySha256 ??
+          telegramIdentityAuthoritySha256(botId, botUsername),
       },
       stderr: "pipe",
       stdout: "pipe",
@@ -191,6 +213,8 @@ function runTelegramAuthorityGuard(
   jobName: (typeof guardedReleaseJobNames)[number],
   authorityRunAttempt: string,
   releaseRunAttempt: string,
+  botId = stagingTelegram.botId,
+  botUsername = stagingTelegram.botUsername,
 ): TelegramExecution {
   const guard = namedStep(
     parsedReleaseWorkflow.jobs?.[jobName],
@@ -211,6 +235,8 @@ function runTelegramAuthorityGuard(
         ...process.env,
         GITHUB_OUTPUT: githubOutputPath,
         GITHUB_STEP_SUMMARY: summaryPath,
+        ADMITTED_TELEGRAM_BOT_ID: botId,
+        ADMITTED_TELEGRAM_BOT_USERNAME: botUsername,
         RELEASE_RUN_ATTEMPT: releaseRunAttempt,
         TELEGRAM_AUTHORITY_RUN_ATTEMPT: authorityRunAttempt,
       },
@@ -286,59 +312,91 @@ describe("homepage deployment workflow", () => {
     expect(release?.with?.target_environment).toContain("production");
   });
 
-  it("requires caller-scope Telegram provenance before entering a GitHub Environment", () => {
-    const authorityResolver =
-      parsedWorkflow.jobs?.["resolve-telegram-configuration-authority"];
-    const authorityStep = namedStep(
-      authorityResolver,
-      "Detect Telegram variables outside a GitHub Environment",
+  it("binds the release attempt before entering a GitHub Environment", () => {
+    const attemptBinder =
+      parsedWorkflow.jobs?.["bind-telegram-release-attempt"];
+    const attemptStep = namedStep(
+      attemptBinder,
+      "Bind Telegram release attempt",
     );
     const release = parsedWorkflow.jobs?.release;
-    const provenanceInput =
-      parsedReleaseWorkflow.on?.workflow_call?.inputs
-        ?.telegram_repo_or_org_configured;
     const attemptInput =
       parsedReleaseWorkflow.on?.workflow_call?.inputs
         ?.telegram_authority_run_attempt;
 
-    expect(authorityResolver?.environment).toBeUndefined();
-    expect(authorityResolver?.outputs?.repo_or_org_configured).toBe(
-      githubExpression("steps.scope.outputs.configured"),
+    expect(attemptBinder?.environment).toBeUndefined();
+    expect(attemptBinder?.outputs?.run_attempt).toBe(
+      githubExpression("steps.attempt.outputs.run_attempt"),
     );
-    expect(authorityResolver?.outputs?.run_attempt).toBe(
-      githubExpression("steps.scope.outputs.run_attempt"),
-    );
-    expect(authorityStep.env).toEqual({
+    expect(attemptStep.env).toEqual({
       TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression("github.run_attempt"),
-      TELEGRAM_REPO_OR_ORG_CONFIGURED: githubExpression(
-        "vars.VITE_TELEGRAM_BOT_ID != '' || vars.VITE_TELEGRAM_BOT_USERNAME != ''",
-      ),
     });
     expect(release?.environment).toBeUndefined();
-    expect(jobNeeds(release)).toContain(
-      "resolve-telegram-configuration-authority",
-    );
+    expect(jobNeeds(release)).toContain("bind-telegram-release-attempt");
     expect(release?.if).toContain(
-      "needs.resolve-telegram-configuration-authority.result == 'success'",
-    );
-    expect(release?.with?.telegram_repo_or_org_configured).toBe(
-      githubExpression(
-        "needs.resolve-telegram-configuration-authority.outputs.repo_or_org_configured == 'true'",
-      ),
+      "needs.bind-telegram-release-attempt.result == 'success'",
     );
     expect(release?.with?.telegram_authority_run_attempt).toBe(
       githubExpression(
-        "needs.resolve-telegram-configuration-authority.outputs.run_attempt",
+        "needs.bind-telegram-release-attempt.outputs.run_attempt",
       ),
     );
-    expect(provenanceInput).toMatchObject({
-      required: true,
-      type: "boolean",
-    });
+    expect(
+      parsedReleaseWorkflow.on?.workflow_call?.inputs
+        ?.telegram_repo_or_org_configured,
+    ).toBeUndefined();
     expect(attemptInput).toMatchObject({
       required: true,
       type: "string",
     });
+  });
+
+  it("forwards an exact caller-secret allowlist without the Environment authority receipt", () => {
+    const release = parsedWorkflow.jobs?.release;
+    const callerSecrets = release?.secrets;
+    const environmentOnlySecrets = [
+      "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+    ] as const;
+    const referencedSecrets = [
+      ...releaseWorkflow.matchAll(/\bsecrets\.([A-Z0-9_]+)/g),
+    ]
+      .map((match) => match[1])
+      .filter((name): name is string => Boolean(name));
+    const expectedCallerSecrets = [
+      ...new Set(
+        referencedSecrets.filter(
+          (name) =>
+            !environmentOnlySecrets.includes(
+              name as (typeof environmentOnlySecrets)[number],
+            ),
+        ),
+      ),
+    ].sort();
+
+    expect(callerSecrets).not.toBe("inherit");
+    expect(callerSecrets).toBeTypeOf("object");
+    const callerSecretMap = callerSecrets as Record<string, string>;
+    expect(Object.keys(callerSecretMap).sort()).toEqual(expectedCallerSecrets);
+    expect(
+      Object.keys(
+        parsedReleaseWorkflow.on?.workflow_call?.secrets ?? {},
+      ).sort(),
+    ).toEqual([...expectedCallerSecrets, ...environmentOnlySecrets].sort());
+    for (const name of expectedCallerSecrets) {
+      expect(callerSecretMap[name], name).toBe(
+        githubExpression(`secrets.${name}`),
+      );
+      expect(
+        parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name],
+        name,
+      ).toEqual({ required: false });
+    }
+    for (const name of environmentOnlySecrets) {
+      expect(callerSecretMap).not.toHaveProperty(name);
+      expect(parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name]).toEqual({
+        required: false,
+      });
+    }
   });
 
   it("runs the Telegram resolver before every release mutation", () => {
@@ -364,16 +422,18 @@ describe("homepage deployment workflow", () => {
       TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
         "inputs.telegram_authority_run_attempt",
       ),
-      TELEGRAM_REPO_OR_ORG_CONFIGURED: githubExpression(
-        "inputs.telegram_repo_or_org_configured",
-      ),
       ENVIRONMENT_TELEGRAM_BOT_ID: githubExpression(
         "vars.VITE_TELEGRAM_BOT_ID",
       ),
       ENVIRONMENT_TELEGRAM_BOT_USERNAME: githubExpression(
         "vars.VITE_TELEGRAM_BOT_USERNAME",
       ),
+      TELEGRAM_IDENTITY_AUTHORITY_SHA256: githubExpression(
+        "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+      ),
     });
+    expect(releaseWorkflow).not.toContain("secrets.VITE_TELEGRAM_BOT_ID");
+    expect(releaseWorkflow).not.toContain("secrets.VITE_TELEGRAM_BOT_USERNAME");
 
     expect(jobNeeds(migration)).toEqual(["resolve-pages-environment-config"]);
     expect(migration?.if).toContain(
@@ -404,6 +464,12 @@ describe("homepage deployment workflow", () => {
 
       expect(job?.steps?.[0]?.name, jobName).toBe(telegramAuthorityGuardName);
       expect(guard.env, jobName).toEqual({
+        ADMITTED_TELEGRAM_BOT_ID: githubExpression(
+          "needs.resolve-pages-environment-config.outputs.telegram_bot_id",
+        ),
+        ADMITTED_TELEGRAM_BOT_USERNAME: githubExpression(
+          "needs.resolve-pages-environment-config.outputs.telegram_bot_username",
+        ),
         RELEASE_RUN_ATTEMPT: githubExpression("github.run_attempt"),
         TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
           "inputs.telegram_authority_run_attempt",
@@ -427,6 +493,30 @@ describe("homepage deployment workflow", () => {
       expect(partialRerun.stderr, `${jobName} partial rerun`).toContain(
         "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs",
       );
+
+      for (const suppressed of [
+        { botId: "", botUsername: stagingTelegram.botUsername },
+        { botId: stagingTelegram.botId, botUsername: "" },
+        { botId: "4503599627370496", botUsername: stagingTelegram.botUsername },
+        { botId: stagingTelegram.botId, botUsername: "not-a-bot-name" },
+      ]) {
+        const missingOutput = runTelegramAuthorityGuard(
+          jobName,
+          "1",
+          "1",
+          suppressed.botId,
+          suppressed.botUsername,
+        );
+        expect(missingOutput.exitCode, `${jobName} suppressed output`).toBe(1);
+        expect(missingOutput.githubOutput).toBe("");
+        expect(missingOutput.stdout).toBe("");
+        expect(missingOutput.summary).toBe("");
+        expect(missingOutput.stderr).toContain("Admitted Telegram");
+        assertNoPublicSurfaceLeak(missingOutput, [
+          suppressed.botId,
+          suppressed.botUsername,
+        ]);
+      }
     }
 
     expect(new Set(guardScripts).size).toBe(1);
@@ -457,28 +547,66 @@ describe("homepage deployment workflow", () => {
     }
   });
 
-  it("rejects outer-scope Telegram configuration before validating or leaking Environment values", () => {
-    const conflictingTelegram = {
-      botId: "outer-scope-id-fixture",
-      botUsername: "outer-scope-username-fixture",
-    };
-    const execution = runTelegramPreflight({
-      ...conflictingTelegram,
-      repoOrOrgConfigured: true,
-      targetEnvironment: "staging",
-    });
-
-    expect(execution.exitCode).toBe(1);
-    expect(execution.githubOutput).toBe("");
-    expect(execution.summary).toBe("");
-    expect(execution.stderr).toContain(
-      "Staging Telegram public identity must be configured only on the staging GitHub Environment",
+  it("binds the accepted public pair to a framed protected authority receipt", () => {
+    const authoritySha256 = telegramIdentityAuthoritySha256(
+      stagingTelegram.botId,
+      stagingTelegram.botUsername,
     );
-    expect(execution.stderr).not.toContain("must match the Telegram");
-    assertNoPublicSurfaceLeak(execution, [
-      conflictingTelegram.botId,
-      conflictingTelegram.botUsername,
+    const equivalentCase = runTelegramPreflight({
+      authoritySha256,
+      botUsername: stagingTelegram.botUsername.toLowerCase(),
+    });
+    expect(equivalentCase.exitCode).toBe(0);
+    expect(equivalentCase.githubOutput).toContain(
+      `bot_username=${stagingTelegram.botUsername.toLowerCase()}\n`,
+    );
+    assertNoPublicSurfaceLeak(equivalentCase, [
+      stagingTelegram.botId,
+      stagingTelegram.botUsername,
+      authoritySha256,
     ]);
+
+    for (const invalid of [
+      { label: "missing receipt", authoritySha256: "" },
+      { label: "malformed receipt", authoritySha256: "not-a-sha256" },
+      {
+        label: "uppercase receipt",
+        authoritySha256: authoritySha256.toUpperCase(),
+      },
+      {
+        label: "receipt for another ID",
+        authoritySha256: telegramIdentityAuthoritySha256(
+          `${stagingTelegram.botId.slice(0, -1)}4`,
+          stagingTelegram.botUsername,
+        ),
+      },
+      {
+        label: "receipt for another username",
+        authoritySha256: telegramIdentityAuthoritySha256(
+          stagingTelegram.botId,
+          "AnotherStageBot",
+        ),
+      },
+    ]) {
+      const execution = runTelegramPreflight({
+        authoritySha256: invalid.authoritySha256,
+      });
+      expect(execution.exitCode, invalid.label).toBe(1);
+      expect(execution.githubOutput, invalid.label).toBe("");
+      expect(execution.summary, invalid.label).toBe("");
+      assertNoPublicSurfaceLeak(execution, [
+        stagingTelegram.botId,
+        stagingTelegram.botUsername,
+        invalid.authoritySha256,
+      ]);
+    }
+
+    expect(telegramIdentityAuthoritySha256("1", "2345Bot")).not.toBe(
+      telegramIdentityAuthoritySha256("12", "345Bot"),
+    );
+    expect(telegramValidation?.run).toContain(
+      "elizaOS/eliza\\0staging\\0telegram-public-identity\\0v1\\0%s\\0%s\\n",
+    );
   });
 
   it("rejects a stale Telegram authority receipt reused by a partial rerun", () => {
@@ -508,12 +636,11 @@ describe("homepage deployment workflow", () => {
 
   it("derives production Telegram identity from source and ignores all staging inputs", () => {
     for (const configuredStagingPair of [
-      { botId: "", botUsername: "", repoOrOrgConfigured: false },
-      { ...stagingTelegram, repoOrOrgConfigured: true },
+      { botId: "", botUsername: "" },
+      stagingTelegram,
       {
         botId: "not-a-number",
         botUsername: "not-a-valid-name!",
-        repoOrOrgConfigured: true,
       },
     ]) {
       const execution = runTelegramPreflight({
@@ -659,7 +786,7 @@ describe("homepage deployment workflow", () => {
     }
   });
 
-  it("preserves resolver outputs through the primary and legacy Pages builds", () => {
+  it("passes guarded resolver outputs directly to primary and legacy Pages builds", () => {
     const pagesBuild = parsedReleaseWorkflow.jobs?.["build-pages"];
     const appDeploy = parsedReleaseWorkflow.jobs?.["deploy-app"];
     const primaryBuild = namedStep(
@@ -671,16 +798,8 @@ describe("homepage deployment workflow", () => {
       "Legacy inline fallback - build app",
     );
 
-    expect(pagesBuild?.outputs?.telegram_bot_id).toBe(
-      githubExpression(
-        "needs.resolve-pages-environment-config.outputs.telegram_bot_id",
-      ),
-    );
-    expect(pagesBuild?.outputs?.telegram_bot_username).toBe(
-      githubExpression(
-        "needs.resolve-pages-environment-config.outputs.telegram_bot_username",
-      ),
-    );
+    expect(pagesBuild?.outputs).not.toHaveProperty("telegram_bot_id");
+    expect(pagesBuild?.outputs).not.toHaveProperty("telegram_bot_username");
     expect(primaryBuild.env?.VITE_TELEGRAM_BOT_ID).toBe(
       githubExpression(
         "needs.resolve-pages-environment-config.outputs.telegram_bot_id",
@@ -692,10 +811,17 @@ describe("homepage deployment workflow", () => {
       ),
     );
     expect(legacyBuild.env?.VITE_TELEGRAM_BOT_ID).toBe(
-      githubExpression("needs.build-pages.outputs.telegram_bot_id"),
+      githubExpression(
+        "needs.resolve-pages-environment-config.outputs.telegram_bot_id",
+      ),
     );
     expect(legacyBuild.env?.VITE_TELEGRAM_BOT_USERNAME).toBe(
-      githubExpression("needs.build-pages.outputs.telegram_bot_username"),
+      githubExpression(
+        "needs.resolve-pages-environment-config.outputs.telegram_bot_username",
+      ),
+    );
+    expect(jobNeeds(parsedReleaseWorkflow.jobs?.["deploy-app"])).toContain(
+      "resolve-pages-environment-config",
     );
     expect(releaseWorkflow).not.toContain("7684336618");
     expect(releaseWorkflow).not.toContain("Elizav2_Bot");


### PR DESCRIPTION
# Relates to

Relates to #29206 and staging account/provider-readiness epic #25025. This bounded workflow-policy candidate does not close either issue or make Telegram staging READY.

# Summary

This PR prevents repository/organization configuration from silently selecting the staging Telegram identity while keeping the public identity values usable by the build.

- `VITE_TELEGRAM_BOT_ID` and `VITE_TELEGRAM_BOT_USERNAME` remain public staging Environment variables.
- Protected staging Environment secret `TELEGRAM_IDENTITY_AUTHORITY_SHA256` binds that pair with a domain/version-separated, NUL-framed SHA-256 receipt.
- The reusable workflow declares the receipt for typing, while its caller uses an explicit secret allowlist and does not forward the receipt from repository or organization scope.
- The staging resolver validates the Environment-bound receipt without logging or emitting it; only the validated public ID and lowercase username become outputs.
- Migration, API deploy, Pages build, and Pages deploy fail closed before mutation when the authority output is missing, malformed, or belongs to another workflow attempt.
- Production ignores GitHub Telegram configuration and derives its public identity from checked-in canonical source.

# Current source

- Exact head: `b48d2a41768096ceff964a218091a89e46c27f05`.
- Exact base: `develop@3821d43f57655130c247637fb910fd4c87a22c75`.
- GitHub reports the branch mergeable, with zero unresolved review threads.
- The three-commit rebase is patch-equivalent to the previously reviewed branch; aggregate patch-id remains `00be98fd4dc0aa27812658254da9a2d1a5d21f77`.
- All nine changed files remain inside the bounded workflow/test/config-example/documentation lane.

# Testing

Exact head `b48d2a41768096ceff964a218091a89e46c27f05`:

- Focused Telegram workflow contract: **16/16 PASS, 511 assertions**.
- Related dependency closure: **286/286 PASS, 32,986 assertions**.
- Full repository `bun run verify`: **376/376 Turbo tasks PASS**, followed by every repository audit.
- Actionlint, Biome, workflow audit, Markdown links, and `git diff --check`: **PASS**.
- Independent current-head adversarial/security review: **PASS, zero P0-P3 findings**.
- Hosted exact-head CI: [run 33456541787](https://github.com/elizaOS/eliza/actions/runs/33456541787) — **4/4 PASS**, including `All Tests Passed`.
- Review-thread readback: **0 unresolved**.

A formal maintainer/admin approval on the current source is still required before merge.

# Evidence Gate

<!-- evidence-head:b48d2a41768096ceff964a218091a89e46c27f05 -->

This is a workflow-policy, test, environment-example, and documentation change. It changes no rendered UI or application runtime source.

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interactive or visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A — no backend runtime was deployed by this candidate.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, agent, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database row, fixture, provider identity, receipt, or configuration value was created.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual text exists for OCR review.

# Risks and remaining work

Names-only staging readback finds the public Telegram pair at both Environment and repository scope, while `TELEGRAM_IDENTITY_AUTHORITY_SHA256` is absent. Live staging therefore remains **BLOCKED** until an authorized owner reconciles scope, provisions the receipt, and captures separate provider-backed ownership and connect/reply evidence. This PR neither creates the receipt nor claims provider custody.

The repository currently has no effective `develop` ruleset or classic branch protection. The staging Environment's exact-branch policy does not protect updates to `develop`. Admission must be restored and semantically read back before merge under the #25025 policy.

# Deploy notes

Maintainers may approve and merge this source-only candidate once effective `develop` admission protection is restored/read back and the current-base, exact-head CI, independent-review, formal-approval, and resolved-thread gates still hold. A merge to `develop` may trigger standard repository automation; it does not provision the missing receipt or make any fixture row READY.

No provider/OAuth action, bot installation, message, database query or mutation, Cloudflare deployment, Environment configuration change, sandbox lifecycle action, or production mutation occurred while preparing or validating this candidate.
