### PR TITLE
fix(cloud): fail closed on X identity verification

### DIFF
--- a/packages/cloud/api/v1/twitter/status/route.connection-role.test.ts
+++ b/packages/cloud/api/v1/twitter/status/route.connection-role.test.ts
@@ -1,11 +1,14 @@
-/** Exercises Twitter status role validation before connection lookup. */
+/** Exercises Twitter status role validation and fail-closed connection projection with mocks. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import type { TwitterConnectionStatus } from "@/lib/services/twitter-automation";
 
-const getConnectionStatus = mock(async () => ({
-  connected: true,
-  username: "owner-acct",
-}));
+const getConnectionStatus = mock(
+  async (): Promise<TwitterConnectionStatus> => ({
+    connected: true,
+    username: "owner-acct",
+  }),
+);
 const isConfigured = mock(() => true);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -48,6 +51,36 @@ describe("GET /api/v1/twitter/status connectionRole identity", () => {
     expect(body.connectionRole).toBe(role);
     expect(getConnectionStatus).toHaveBeenCalledTimes(1);
     expect(getConnectionStatus).toHaveBeenCalledWith("org-1", role);
+  });
+
+  test("returns no active connectionId for an unverified provider identity", async () => {
+    getConnectionStatus.mockResolvedValueOnce({
+      connected: false,
+      storedIdentity: {
+        verified: false,
+        username: "stored-handle",
+        userId: "stored-user",
+      },
+      errorCode: "provider_identity_verification_failed",
+      error: "X identity could not be verified. Try reconnecting.",
+    });
+
+    const response = await getStatus("?connectionRole=owner");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      connected: boolean;
+      connectionId: string | null;
+      storedIdentity: { verified: false; username: string; userId: string };
+      errorCode: string;
+    };
+    expect(body.connected).toBe(false);
+    expect(body.connectionId).toBeNull();
+    expect(body.storedIdentity).toEqual({
+      verified: false,
+      username: "stored-handle",
+      userId: "stored-user",
+    });
+    expect(body.errorCode).toBe("provider_identity_verification_failed");
   });
 
   test.each(["AGENT", "Owner", "foo", "1e2", "agent ", "owner\n"])(

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
@@ -1,15 +1,12 @@
-// Pins the fail-closed error policy of TwitterAutomationService: an internal platform/API failure
-// propagates or surfaces as a distinct error field, and is never conflated with a designed-empty
-// ("not connected", "identity absent") result. Deterministic — twitter-api-v2, the oauth2 token
-// client, and the secrets store are stubbed via mock.module; no real network.
+/**
+ * Pins TwitterAutomationService's fail-closed provider error policy with deterministic module
+ * stubs. Internal API failures remain distinct from designed-empty results, and the harness
+ * rejects any real network call.
+ */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-interface MeResult {
-  data: { username: string; id: string; profile_image_url?: string };
-}
-
 // Per-test behavior for the stubbed twitter-api-v2 client and oauth2 token endpoint.
-const twitterApiBehavior: { me: () => Promise<MeResult> } = {
+const twitterApiBehavior: { me: () => Promise<unknown> } = {
   me: async () => ({ data: { username: "alice", id: "42" } }),
 };
 const oauth2Behavior: {
@@ -24,6 +21,7 @@ const oauth2Behavior: {
 };
 const secretStore: Record<string, string | null> = {};
 const secretWriteOrder: string[] = [];
+const warningLogs: Array<{ message: string; context?: Record<string, unknown> }> = [];
 let failSecretNames = new Set<string>();
 
 class MockTwitterApi {
@@ -32,6 +30,17 @@ class MockTwitterApi {
 }
 
 mock.module("twitter-api-v2", () => ({ TwitterApi: MockTwitterApi }));
+
+mock.module("../../utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: (message: string, context?: Record<string, unknown>) => {
+      warningLogs.push({ message, context });
+    },
+  },
+}));
 
 mock.module("./oauth2-client", () => ({
   requestTwitterOAuth2Token: () => oauth2Behavior.requestToken(),
@@ -87,6 +96,7 @@ describe("TwitterAutomationService error policy", () => {
   beforeEach(() => {
     for (const key of Object.keys(secretStore)) delete secretStore[key];
     secretWriteOrder.length = 0;
+    warningLogs.length = 0;
     failSecretNames = new Set();
     twitterApiBehavior.me = async () => ({ data: { username: "alice", id: "42" } });
     oauth2Behavior.requestToken = async () => ({
@@ -154,28 +164,83 @@ describe("TwitterAutomationService error policy", () => {
       expect(status.error).toBeUndefined();
     });
 
-    test("internal validation failure is disconnected WITH an error field — distinct from empty", async () => {
+    test("internal validation failure is disconnected with a safe classified error", async () => {
       secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
       twitterApiBehavior.me = async () => {
-        throw Object.assign(new Error("upstream 500 boom"), { code: 500 });
+        throw Object.assign(new Error("upstream private diagnostic"), { code: 500 });
       };
       const service = await loadService();
       const status = await service.getConnectionStatus("org-1", "owner");
       expect(status.connected).toBe(false);
-      expect(typeof status.error).toBe("string");
-      expect(status.error).toContain("reconnecting");
+      expect(status.errorCode).toBe("provider_identity_verification_failed");
+      expect(status.error).toBe("X identity could not be verified. Try reconnecting.");
+      expect(JSON.stringify({ status, warningLogs })).not.toContain("private diagnostic");
     });
 
-    test("the OAuth2 403 quirk stays connected but still carries an explicit error, never silent", async () => {
+    test("HTTP 403 fails closed and preserves stored identity only as unverified metadata", async () => {
       secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      secretStore.TWITTER_OWNER_USERNAME = "stored-handle";
+      secretStore.TWITTER_OWNER_USER_ID = "stored-user";
       twitterApiBehavior.me = async () => {
-        throw Object.assign(new Error("profile forbidden"), { code: 403 });
+        throw Object.assign(new Error("provider private detail"), { code: 403 });
       };
       const service = await loadService();
       const status = await service.getConnectionStatus("org-1", "owner");
-      expect(status.connected).toBe(true);
-      expect(typeof status.error).toBe("string");
-      expect(status.error).toContain("OAuth2 credentials are stored");
+      expect(status).toEqual({
+        connected: false,
+        storedIdentity: {
+          verified: false,
+          username: "stored-handle",
+          userId: "stored-user",
+        },
+        errorCode: "provider_identity_verification_failed",
+        error: "X identity could not be verified. Try reconnecting.",
+      });
+      expect(status.username).toBeUndefined();
+      expect(status.userId).toBeUndefined();
+      expect(JSON.stringify({ status, warningLogs })).not.toContain("provider private detail");
+      expect(warningLogs).toContainEqual({
+        message: "[TwitterAutomation] Provider identity verification failed",
+        context: {
+          organizationId: "org-1",
+          connectionRole: "owner",
+          errorCode: "provider_identity_verification_failed",
+          status: 403,
+        },
+      });
+    });
+
+    test.each([
+      ["missing id", { data: { username: "provider-handle" } }],
+      ["empty id", { data: { id: "", username: "provider-handle" } }],
+      ["blank id", { data: { id: "   ", username: "provider-handle" } }],
+      ["non-string id", { data: { id: 42, username: "provider-handle" } }],
+      ["missing username", { data: { id: "42" } }],
+      ["empty username", { data: { id: "42", username: "" } }],
+      ["blank username", { data: { id: "42", username: "   " } }],
+      ["non-string username", { data: { id: "42", username: ["private-handle"] } }],
+    ])("a 200 response with %s fails closed", async (_case, providerResponse) => {
+      secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      secretStore.TWITTER_OWNER_USERNAME = "stored-handle";
+      secretStore.TWITTER_OWNER_USER_ID = "stored-user";
+      twitterApiBehavior.me = async () => providerResponse;
+
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+
+      expect(status).toEqual({
+        connected: false,
+        storedIdentity: {
+          verified: false,
+          username: "stored-handle",
+          userId: "stored-user",
+        },
+        errorCode: "provider_identity_verification_failed",
+        error: "X identity could not be verified. Try reconnecting.",
+      });
+      expect(status.username).toBeUndefined();
+      expect(status.userId).toBeUndefined();
+      expect(JSON.stringify({ status, warningLogs })).not.toContain("private-handle");
     });
 
     test("a valid token reports connected with no error", async () => {
@@ -184,6 +249,7 @@ describe("TwitterAutomationService error policy", () => {
       const status = await service.getConnectionStatus("org-1", "owner");
       expect(status.connected).toBe(true);
       expect(status.username).toBe("alice");
+      expect(status.userId).toBe("42");
       expect(status.error).toBeUndefined();
     });
   });

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
@@ -252,6 +252,52 @@ describe("TwitterAutomationService error policy", () => {
       expect(status.userId).toBe("42");
       expect(status.error).toBeUndefined();
     });
+
+    test.each([
+      ["an empty", ""],
+      ["a blank", "   "],
+      ["a null", null],
+      ["a non-string", 42],
+    ])("ignores %s optional avatar after verifying username and id", async (_case, avatarUrl) => {
+      secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      twitterApiBehavior.me = async () => ({
+        data: {
+          username: "alice",
+          id: "42",
+          profile_image_url: avatarUrl,
+        },
+      });
+
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+
+      expect(status).toEqual({
+        connected: true,
+        username: "alice",
+        userId: "42",
+      });
+    });
+
+    test("normalizes a valid optional avatar after verifying username and id", async () => {
+      secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      twitterApiBehavior.me = async () => ({
+        data: {
+          username: "alice",
+          id: "42",
+          profile_image_url: "  https://cdn.example/avatar.png  ",
+        },
+      });
+
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+
+      expect(status).toEqual({
+        connected: true,
+        username: "alice",
+        userId: "42",
+        avatarUrl: "https://cdn.example/avatar.png",
+      });
+    });
   });
 
   describe("getBrokerCredentials (OAuth2 refresh/rotate contract)", () => {

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
@@ -127,6 +127,41 @@ function normalizeOptionalCredentialValue(value: string | undefined): string | n
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+interface VerifiedTwitterIdentity {
+  username: string;
+  userId: string;
+  avatarUrl?: string;
+}
+
+/** Treat the provider response as untrusted runtime data before reporting readiness. */
+function parseVerifiedTwitterIdentity(value: unknown): VerifiedTwitterIdentity | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const data = Reflect.get(value, "data");
+  if (data === null || typeof data !== "object" || Array.isArray(data)) return null;
+
+  const username = Reflect.get(data, "username");
+  const userId = Reflect.get(data, "id");
+  if (
+    typeof username !== "string" ||
+    username.trim().length === 0 ||
+    typeof userId !== "string" ||
+    userId.trim().length === 0
+  ) {
+    return null;
+  }
+
+  const avatarUrl = Reflect.get(data, "profile_image_url");
+  if (avatarUrl !== undefined && (typeof avatarUrl !== "string" || avatarUrl.trim().length === 0)) {
+    return null;
+  }
+
+  return {
+    username: username.trim(),
+    userId: userId.trim(),
+    ...(typeof avatarUrl === "string" ? { avatarUrl: avatarUrl.trim() } : {}),
+  };
+}
+
 function addTwitterApiErrorPart(parts: string[], value: unknown): void {
   if (typeof value === "string" && value.trim().length > 0) {
     parts.push(value.trim());
@@ -300,6 +335,14 @@ export interface TwitterConnectionStatus {
   username?: string;
   userId?: string;
   avatarUrl?: string;
+  /** Stored fallback metadata; `verified: false` means it cannot prove connection readiness. */
+  storedIdentity?: {
+    verified: false;
+    username?: string;
+    userId?: string;
+  };
+  /** Stable, redacted classification for provider identity verification failures. */
+  errorCode?: "provider_identity_verification_failed";
   error?: string;
 }
 
@@ -776,38 +819,45 @@ class TwitterAutomationService {
         "user.fields": ["profile_image_url"],
       });
 
-      return {
-        connected: true,
-        username: me.data.username,
-        userId: me.data.id,
-        avatarUrl: me.data.profile_image_url,
-      };
-    } catch (error) {
-      // error-policy:J4 token-validation failure degrades to a distinguishable connection status
-      // carrying an explicit error field — never a silent healthy/empty state. A missing-credentials
-      // case returns { connected:false } with no error above; this branch always sets error.
-      const errorMessage = formatTwitterApiError(error, "Token validation failed");
-      logger.warn("[TwitterAutomation] Token validation failed", {
-        organizationId,
-        connectionRole: role,
-        error: errorMessage,
-        status: getTwitterApiErrorStatus(error),
-      });
-
-      if (oauth2AccessToken && getTwitterApiErrorStatus(error) === 403) {
-        return {
-          connected: true,
-          username: username ?? undefined,
-          userId: twitterUserId ?? undefined,
-          error: `X rejected profile validation, but OAuth2 credentials are stored: ${errorMessage}`,
-        };
+      const identity = parseVerifiedTwitterIdentity(me);
+      if (!identity) {
+        throw new Error("X returned an invalid identity response");
       }
 
       return {
+        connected: true,
+        username: identity.username,
+        userId: identity.userId,
+        ...(identity.avatarUrl ? { avatarUrl: identity.avatarUrl } : {}),
+      };
+    } catch (error) {
+      // error-policy:J4 token/provider-identity validation failure degrades to a distinguishable
+      // connection status carrying an explicit error field — never a silent healthy/empty state. A
+      // missing-credentials case returns { connected:false } with no error above; this branch always
+      // sets error.
+      const errorCode = "provider_identity_verification_failed" as const;
+      const status = getTwitterApiErrorStatus(error);
+      logger.warn("[TwitterAutomation] Provider identity verification failed", {
+        organizationId,
+        connectionRole: role,
+        errorCode,
+        status,
+      });
+
+      const storedIdentity =
+        username || twitterUserId
+          ? {
+              verified: false as const,
+              username: username ?? undefined,
+              userId: twitterUserId ?? undefined,
+            }
+          : undefined;
+
+      return {
         connected: false,
-        username: username ?? undefined,
-        userId: twitterUserId ?? undefined,
-        error: "Token may be expired. Try reconnecting.",
+        ...(storedIdentity ? { storedIdentity } : {}),
+        errorCode,
+        error: "X identity could not be verified. Try reconnecting.",
       };
     }
   }

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
@@ -151,14 +151,13 @@ function parseVerifiedTwitterIdentity(value: unknown): VerifiedTwitterIdentity |
   }
 
   const avatarUrl = Reflect.get(data, "profile_image_url");
-  if (avatarUrl !== undefined && (typeof avatarUrl !== "string" || avatarUrl.trim().length === 0)) {
-    return null;
-  }
+  const normalizedAvatarUrl =
+    typeof avatarUrl === "string" && avatarUrl.trim().length > 0 ? avatarUrl.trim() : undefined;
 
   return {
     username: username.trim(),
     userId: userId.trim(),
-    ...(typeof avatarUrl === "string" ? { avatarUrl: avatarUrl.trim() } : {}),
+    ...(normalizedAvatarUrl ? { avatarUrl: normalizedAvatarUrl } : {}),
   };
 }
 


### PR DESCRIPTION
# Relates to

Closes #29591.

Related but explicitly out of scope: #29593 owns the OAuth callback success projection and the generic Twitter connection-adapter/catalog readiness contract.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [ ] This PR targets `develop` but must be rebased onto current `origin/develop` before merge. Its exact tested head was based on `01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`; current `develop` is `027ccfa2fce52f9b442076ad6d3549a3f86e809e`.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync;
      the unrelated baseline-only i18n failure is recorded below.
- [x] A reviewer can confirm the changed contract from the deterministic service
      and route tests listed below, without contacting the real provider.

# Sync with develop

- [x] Historical exact-head tests were run after rebasing onto `origin/develop@01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`; zero conflicts at that time. This is not a current-sync claim.
- [x] `bun run verify` was run post-sync. Its exact unrelated baseline blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change only makes X status reporting more conservative when provider
identity verification fails or returns malformed required identity data. A complete provider
identity remains connected. Stored username/user-id metadata remains available
under `storedIdentity.verified: false`, but can no longer create an active
`connectionId`. No OAuth grant, callback, adapter/catalog, secret, message, or
provider configuration is changed.

# Background

## What does this PR do?

- Fails closed for HTTP 403 and all other X identity-verification failures.
- Runtime-validates `/2/users/me` before returning `connected: true`; `data.id`
  and `data.username` must both be non-empty strings, while malformed optional
  avatar data is omitted.
- Returns a stable redacted `provider_identity_verification_failed` error and
  retains stored identity only as explicitly unverified metadata.
- Ensures the public status projection returns `connectionId: null` whenever
  identity verification did not succeed.
- Adds deterministic tests for missing, empty, blank, and non-string id/username
  responses with a hard guard against real network calls.

## What kind of change is this?

Bug fix (non-breaking status-contract correction).

# Documentation changes needed?

No documentation change is needed. The existing public status shape is extended
with an explicit safe error classification and unverified metadata projection;
the behavior is pinned by service and route contract tests.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/twitter-automation/index.ts`
2. `packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts`
3. `packages/cloud/api/v1/twitter/status/route.connection-role.test.ts`

## Detailed testing steps

Exact tested head: `dd0319fa6e718f0c0d11bd32fcae2afe71a99845`

- `bun test packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts`
  - PASS: 28 tests, 0 failures.
- `bun test packages/cloud/api/v1/twitter/status/route.connection-role.test.ts`
  - PASS: 15 tests, 0 failures; unverified status projects `connectionId: null`.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/twitter-automation/index.ts packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts packages/cloud/api/v1/twitter/status/route.connection-role.test.ts`
  - PASS: 3 files checked, no fixes applied.
- `bun run typecheck` in `packages/cloud/shared`
  - PASS: generated keyword artifacts unchanged; `tsc --noEmit` succeeded.
- `bun run typecheck` in `packages/cloud/api`
  - PASS: `tsc --noEmit` and the nested Wrangler production dry-run succeeded.
- `bun install --frozen-lockfile`
  - PASS: 3,721 installs checked, no changes.
- Original fail-closed patch identity after rebase:
  - Approved pre-rebase commit: `33da877c68ffa85f23c4cde5c5e8ed9f54b4fa99`.
  - Rebased commit: `7f1ce10a0500f58bd5c2b6fb48d85a4c509de649`.
  - Stable patch-id is identical: `1474438d7b371c6e44488096119b1f332e36cd56`.
  - `git range-diff` reports `=` and all three parent/result blobs are identical.
- Review follow-up:
  - `dd0319fa6e718f0c0d11bd32fcae2afe71a99845` omits malformed optional avatar data while keeping `data.id` and `data.username` fail-closed.

# Evidence Gate

Evidence matches the exact tested commit.
<!-- evidence-head:dd0319fa6e718f0c0d11bd32fcae2afe71a99845 -->

This diff has no rendered UI surface. The issue also explicitly prohibits a
real provider call or external provider mutation, so the deterministic service
and route contract tests above are the applicable acceptance evidence.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only status-contract change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only status-contract change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI interaction changed; live provider interaction is outside the authorized scope.
<!-- evidence-row:backend-logs -->
- [x] N/A - acceptance forbids a real provider call; deterministic tests exercise success, 403, network/error, and malformed-response branches without external mutation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, model, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB row, credential, grant, message, or provider artifact is created or mutated.
<!-- evidence-row:ocr-review -->
- [x] N/A - the diff has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM or agent behavior changed.

## Backend + frontend logs

N/A - no live provider call is permitted by #29591. The deterministic test
harness rejects any unexpected network request and verifies that provider
diagnostics and private fixture identifiers do not reach the returned status or
warning logs. No frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only status-contract change with no rendered UI.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered UI interaction; real provider interaction is prohibited.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun run verify` exits 1 at the pre-existing `check:i18n` gate before later
  monorepo checks. It reports that `en.json` lacks
  `learnedskills.emptyTitle` and `learnedskills.startLearning`, plus the existing
  translation backlog in es/ja/ko/pt/tl/vi/zh-CN.
- Baseline proof: in this same clean worktree detached at exact
  `origin/develop` `01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`, the exact command
  `bun run check:i18n` exits 1 with the same missing keys and counts. None of the
  three changed files is an i18n source or locale file.
- No live X provider call was made because #29591 explicitly requires
  deterministic tests and forbids provider/grant/credential/message/environment
  mutation.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

— [cloud-agent]