### PR TITLE
fix(cloud): classify inactive inference credentials authoritatively

### DIFF
--- a/packages/cloud/shared/src/lib/auth-inference-api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth-inference-api-key.test.ts
@@ -1,30 +1,24 @@
 /**
- * Exercises the inference API-key boundary's exact 401/403 taxonomy and cache
- * bypass contract with deterministic service seams; no live credentials or DB.
+ * Exercises the inference API-key boundary's exact 401/403 taxonomy and direct
+ * authoritative-storage contract with deterministic seams; no live credentials or DB.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHash } from "node:crypto";
 
 let apiKeyRecord: Record<string, unknown> | null;
-let replicaApiKeyRecord: Record<string, unknown> | null;
 let userRecord: Record<string, unknown> | undefined;
 let repositoryError: Error | null;
 const validationCalls: string[] = [];
 const serviceUserLookups: string[] = [];
 const repositoryKeyLookups: string[] = [];
-const consistentKeyLookups: string[] = [];
 const repositoryUserLookups: string[] = [];
 const usageCalls: string[] = [];
 
 mock.module("../db/repositories/api-keys", () => ({
   apiKeysRepository: {
-    findActiveByHash: async (keyHash: string) => {
+    findByHashConsistent: async (keyHash: string) => {
       repositoryKeyLookups.push(keyHash);
-      return replicaApiKeyRecord;
-    },
-    findActiveByHashConsistent: async (keyHash: string) => {
-      consistentKeyLookups.push(keyHash);
       if (repositoryError) throw repositoryError;
       return apiKeyRecord;
     },
@@ -32,7 +26,7 @@ mock.module("../db/repositories/api-keys", () => ({
 }));
 mock.module("../db/repositories/users", () => ({
   usersRepository: {
-    findWithOrganization: async (userId: string) => {
+    findWithOrganizationForWrite: async (userId: string) => {
       repositoryUserLookups.push(userId);
       return userRecord;
     },
@@ -81,12 +75,10 @@ beforeEach(() => {
     is_active: true,
     organization: activeOrganization,
   };
-  replicaApiKeyRecord = apiKeyRecord;
   repositoryError = null;
   validationCalls.length = 0;
   serviceUserLookups.length = 0;
   repositoryKeyLookups.length = 0;
-  consistentKeyLookups.length = 0;
   repositoryUserLookups.length = 0;
   usageCalls.length = 0;
 });
@@ -94,12 +86,10 @@ beforeEach(() => {
 describe("requireInferenceApiKeyWithOrg", () => {
   test("invalid key remains the existing 401 authentication error", async () => {
     apiKeyRecord = null;
-    let rejected = false;
+    const rejected: string[] = [];
     await expect(
       requireInferenceApiKeyWithOrg("eliza_invalid", {
-        rejected: () => {
-          rejected = true;
-        },
+        rejected: (reason) => rejected.push(reason),
       }),
     ).rejects.toMatchObject({
       name: "AuthenticationError",
@@ -107,18 +97,16 @@ describe("requireInferenceApiKeyWithOrg", () => {
       code: "authentication_required",
       message: "Invalid or expired API key",
     });
-    expect(rejected).toBe(true);
+    expect(rejected).toEqual(["credential_invalid"]);
     expect(usageCalls).toEqual([]);
   });
 
   test("inactive user remains the existing 403 access error", async () => {
     userRecord = { ...userRecord, is_active: false };
-    let rejected = false;
+    const rejected: string[] = [];
     await expect(
       requireInferenceApiKeyWithOrg("eliza_valid", {
-        rejected: () => {
-          rejected = true;
-        },
+        rejected: (reason) => rejected.push(reason),
       }),
     ).rejects.toMatchObject({
       name: "ForbiddenError",
@@ -126,7 +114,7 @@ describe("requireInferenceApiKeyWithOrg", () => {
       code: "access_denied",
       message: "User account is inactive",
     });
-    expect(rejected).toBe(true);
+    expect(rejected).toEqual(["account_inactive"]);
     expect(usageCalls).toEqual([]);
   });
 
@@ -135,20 +123,25 @@ describe("requireInferenceApiKeyWithOrg", () => {
       ...userRecord,
       organization: { ...activeOrganization, is_active: false },
     };
-    await expect(requireInferenceApiKeyWithOrg("eliza_valid")).rejects.toMatchObject({
+    const rejected: string[] = [];
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        rejected: (reason) => rejected.push(reason),
+      }),
+    ).rejects.toMatchObject({
       name: "ForbiddenError",
       status: 403,
       code: "access_denied",
       message: "Organization is inactive",
     });
+    expect(rejected).toEqual(["organization_inactive"]);
     expect(usageCalls).toEqual([]);
   });
 
-  test("cache bypass reaches repositories without changing usage accounting", async () => {
+  test("authoritative inference auth skips secondary service caches", async () => {
     const keyTimings: number[] = [];
     const userTimings: number[] = [];
     const result = await requireInferenceApiKeyWithOrg("eliza_valid", {
-      bypassCache: true,
       timing: {
         keyLookup: (durationMs) => keyTimings.push(durationMs),
         userOrgLookup: (durationMs) => userTimings.push(durationMs),
@@ -160,26 +153,75 @@ describe("requireInferenceApiKeyWithOrg", () => {
     const keyHash = createHash("sha256").update("eliza_valid").digest("hex");
     expect(validationCalls).toEqual([]);
     expect(serviceUserLookups).toEqual([]);
-    expect(repositoryKeyLookups).toEqual([]);
-    expect(consistentKeyLookups).toEqual([keyHash]);
+    expect(repositoryKeyLookups).toEqual([keyHash]);
     expect(repositoryUserLookups).toEqual(["user-1"]);
     expect(keyTimings).toHaveLength(1);
     expect(userTimings).toHaveLength(1);
     expect(usageCalls).toEqual(["key-1"]);
   });
 
-  test("cache bypass never trusts a replica-only active key", async () => {
-    apiKeyRecord = null;
+  test("inactive API key returns the authoritative standing reason", async () => {
+    apiKeyRecord = { ...apiKeyRecord, is_active: false };
+    const rejected: string[] = [];
     await expect(
       requireInferenceApiKeyWithOrg("eliza_valid", {
-        bypassCache: true,
+        rejected: (reason) => rejected.push(reason),
       }),
-    ).rejects.toMatchObject({ status: 401 });
-    const keyHash = createHash("sha256").update("eliza_valid").digest("hex");
-
-    expect(repositoryKeyLookups).toEqual([]);
-    expect(consistentKeyLookups).toEqual([keyHash]);
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "API key is inactive",
+    });
+    expect(rejected).toEqual(["credential_inactive"]);
     expect(repositoryUserLookups).toEqual([]);
+    expect(usageCalls).toEqual([]);
+  });
+
+  test("expired API key remains invalid even when it is also inactive", async () => {
+    apiKeyRecord = {
+      ...apiKeyRecord,
+      is_active: false,
+      expires_at: new Date(Date.now() - 1_000),
+    };
+    const rejected: string[] = [];
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        rejected: (reason) => rejected.push(reason),
+      }),
+    ).rejects.toMatchObject({ status: 401, message: "API key has expired" });
+    expect(rejected).toEqual(["credential_invalid"]);
+    expect(repositoryUserLookups).toEqual([]);
+    expect(usageCalls).toEqual([]);
+  });
+
+  test("deleted API key remains invalid instead of exposing lifecycle state", async () => {
+    apiKeyRecord = {
+      ...apiKeyRecord,
+      is_active: false,
+      deleted_at: new Date(),
+    };
+    const rejected: string[] = [];
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        rejected: (reason) => rejected.push(reason),
+      }),
+    ).rejects.toMatchObject({ status: 401, message: "Invalid or expired API key" });
+    expect(rejected).toEqual(["credential_invalid"]);
+    expect(repositoryUserLookups).toEqual([]);
+    expect(usageCalls).toEqual([]);
+  });
+
+  test("missing organization membership is not mislabeled as organization inactivity", async () => {
+    userRecord = { ...userRecord, organization_id: null, organization: null };
+    const rejected: string[] = [];
+    await expect(
+      requireInferenceApiKeyWithOrg("eliza_valid", {
+        rejected: (reason) => rejected.push(reason),
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "This feature requires a full account. Please sign up to continue.",
+    });
+    expect(rejected).toEqual(["membership_missing"]);
     expect(usageCalls).toEqual([]);
   });
 
@@ -188,7 +230,6 @@ describe("requireInferenceApiKeyWithOrg", () => {
     let rejected = false;
     await expect(
       requireInferenceApiKeyWithOrg("eliza_valid", {
-        bypassCache: true,
         rejected: () => {
           rejected = true;
         },

--- a/packages/cloud/shared/src/lib/services/inference-api-key-auth.ts
+++ b/packages/cloud/shared/src/lib/services/inference-api-key-auth.ts
@@ -13,7 +13,6 @@ import type { Organization } from "../../db/schemas/organizations";
 import { AuthenticationError, ForbiddenError } from "../api/errors";
 import { apiKeysService } from "./api-keys";
 import type { InferenceAuthRejectionReason } from "./inference-auth-cache";
-import { usersService } from "./users";
 
 export interface InferenceApiKeyAuthTimingObserver {
   keyLookup(durationMs: number): void;
@@ -21,8 +20,6 @@ export interface InferenceApiKeyAuthTimingObserver {
 }
 
 export interface InferenceApiKeyAuthOptions {
-  /** Cache failures and authenticated probes must measure authoritative storage. */
-  bypassCache?: boolean;
   timing?: InferenceApiKeyAuthTimingObserver;
   /** Marks typed credential/account rejection without intercepting the throw. */
   rejected?(reason: InferenceAuthRejectionReason): void;
@@ -46,20 +43,13 @@ function reject(
   throw error;
 }
 
-async function findApiKey(rawKey: string, bypassCache: boolean): Promise<ApiKey | null> {
-  if (!bypassCache) return await apiKeysService.validateApiKey(rawKey);
-
+async function findApiKey(rawKey: string): Promise<ApiKey | null> {
   const keyHash = createHash("sha256").update(rawKey).digest("hex");
-  return (await apiKeysRepository.findActiveByHashConsistent(keyHash)) ?? null;
+  return (await apiKeysRepository.findByHashConsistent(keyHash)) ?? null;
 }
 
-async function findUser(
-  userId: string,
-  bypassCache: boolean,
-): Promise<UserWithOrganization | undefined> {
-  return bypassCache
-    ? await usersRepository.findWithOrganization(userId)
-    : await usersService.getWithOrganization(userId);
+async function findUser(userId: string): Promise<UserWithOrganization | undefined> {
+  return await usersRepository.findWithOrganizationForWrite(userId);
 }
 
 /**
@@ -70,28 +60,30 @@ export async function requireInferenceApiKeyWithOrg(
   rawKey: string,
   options: InferenceApiKeyAuthOptions = {},
 ): Promise<InferenceApiKeyAuthResult> {
-  const bypassCache = options.bypassCache === true;
   const keyStartedAt = performance.now();
   let apiKey: ApiKey | null;
   try {
-    apiKey = await findApiKey(rawKey, bypassCache);
+    apiKey = await findApiKey(rawKey);
   } finally {
     options.timing?.keyLookup(performance.now() - keyStartedAt);
   }
   if (!apiKey) {
     reject(options, new AuthenticationError("Invalid or expired API key"), "credential_invalid");
   }
-  if (!apiKey.is_active) {
-    reject(options, new ForbiddenError("API key is inactive"), "credential_inactive");
+  if (apiKey.deleted_at) {
+    reject(options, new AuthenticationError("Invalid or expired API key"), "credential_invalid");
   }
   if (apiKey.expires_at && new Date(apiKey.expires_at) < new Date()) {
     reject(options, new AuthenticationError("API key has expired"), "credential_invalid");
+  }
+  if (!apiKey.is_active) {
+    reject(options, new ForbiddenError("API key is inactive"), "credential_inactive");
   }
 
   const userStartedAt = performance.now();
   let user: UserWithOrganization | undefined;
   try {
-    user = await findUser(apiKey.user_id, bypassCache);
+    user = await findUser(apiKey.user_id);
   } finally {
     options.timing?.userOrgLookup(performance.now() - userStartedAt);
   }
@@ -105,15 +97,15 @@ export async function requireInferenceApiKeyWithOrg(
   if (!user.is_active) {
     reject(options, new ForbiddenError("User account is inactive"), "account_inactive");
   }
-  if (!user.organization?.is_active) {
-    reject(options, new ForbiddenError("Organization is inactive"), "organization_inactive");
-  }
   if (!user.organization_id || !user.organization) {
     reject(
       options,
       new ForbiddenError("This feature requires a full account. Please sign up to continue."),
       "membership_missing",
     );
+  }
+  if (!user.organization.is_active) {
+    reject(options, new ForbiddenError("Organization is inactive"), "organization_inactive");
   }
 
   void apiKeysService.incrementUsageDebounced(apiKey.id);

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -26,7 +26,7 @@ let assertCredentialActive: (
   credential: { kind: string; credentialId?: string; userId: string },
 ) => Promise<void>;
 const incrementUsageCalls: string[] = [];
-const bypassCacheCalls: boolean[] = [];
+const authBoundaryCalls: string[] = [];
 const moderationBypassCacheCalls: boolean[] = [];
 const ADMISSION = {
   balance: { balanceUsd: 100, balanceAt: 1, balanceRevision: "1" },
@@ -40,16 +40,15 @@ const ADMISSION = {
 
 mock.module("./inference-api-key-auth", () => ({
   requireInferenceApiKeyWithOrg: async (
-    _rawKey: string,
+    rawKey: string,
     options: {
-      bypassCache?: boolean;
       timing?: {
         keyLookup(durationMs: number): void;
         userOrgLookup(durationMs: number): void;
       };
     } = {},
   ) => {
-    bypassCacheCalls.push(options.bypassCache === true);
+    authBoundaryCalls.push(rawKey);
     options.timing?.keyLookup(1);
     options.timing?.userOrgLookup(2);
     return await authImpl();
@@ -140,7 +139,7 @@ beforeEach(async () => {
   shouldBlock = async () => false;
   assertCredentialActive = async () => undefined;
   incrementUsageCalls.length = 0;
-  bypassCacheCalls.length = 0;
+  authBoundaryCalls.length = 0;
   moderationBypassCacheCalls.length = 0;
   __clearInferenceApiKeyHydrations();
   // Clear any cached entry from a prior test.
@@ -254,7 +253,7 @@ describe("resolveInferenceAuthContext", () => {
         kind: "slow_path",
         reason: "mobile_api_key",
       });
-      expect(bypassCacheCalls).toEqual([]);
+      expect(authBoundaryCalls).toEqual([]);
       expect(incrementUsageCalls).toEqual([]);
       expect(availability).not.toHaveBeenCalled();
       expect(cacheRead).not.toHaveBeenCalled();
@@ -543,10 +542,10 @@ describe("resolveInferenceAuthContext", () => {
     }
   });
 
-  test("authenticated probe bypasses lower caches only after an actual IAC miss", async () => {
+  test("authenticated probe bypasses the combined cache only after an actual IAC miss", async () => {
     const warm = await resolveInferenceAuthContext(reqWithApiKey());
     expect(warm.kind).toBe("authorized");
-    bypassCacheCalls.length = 0;
+    authBoundaryCalls.length = 0;
     moderationBypassCacheCalls.length = 0;
     process.env.INFERENCE_AUTH_PROBE_TOKEN = "unit-probe-token";
     const request = reqWithApiKey();
@@ -560,7 +559,7 @@ describe("resolveInferenceAuthContext", () => {
     });
     expect(controlled.kind).toBe("authorized");
     if (controlled.kind === "authorized") expect(controlled.source).toBe("origin");
-    expect(bypassCacheCalls).toEqual([true]);
+    expect(authBoundaryCalls).toEqual([KEY]);
     expect(moderationBypassCacheCalls).toEqual([true]);
     expect(telemetry?.cacheRead).toBe("miss");
     expect(telemetry?.controlledProbe).toBe("on");
@@ -570,7 +569,7 @@ describe("resolveInferenceAuthContext", () => {
 
   test("oversized probe control is ignored and cannot force the authoritative path", async () => {
     await resolveInferenceAuthContext(reqWithApiKey());
-    bypassCacheCalls.length = 0;
+    authBoundaryCalls.length = 0;
     process.env.INFERENCE_AUTH_PROBE_TOKEN = "unit-probe-token";
     const request = reqWithApiKey();
     request.headers.set("X-Eliza-Auth-Probe", `unit-probe-token:${"a".repeat(600)}`);
@@ -583,7 +582,7 @@ describe("resolveInferenceAuthContext", () => {
       });
       expect(result.kind).toBe("authorized");
       if (result.kind === "authorized") expect(result.source).toBe("cache");
-      expect(bypassCacheCalls).toEqual([]);
+      expect(authBoundaryCalls).toEqual([]);
       expect(telemetry?.controlledProbe).toBe("off");
     } finally {
       delete process.env.INFERENCE_AUTH_PROBE_TOKEN;
@@ -606,7 +605,7 @@ describe("resolveInferenceAuthContext", () => {
 
       expect(result.kind).toBe("authorized");
       if (result.kind === "authorized") expect(result.source).toBe("origin");
-      expect(bypassCacheCalls).toEqual([true]);
+      expect(authBoundaryCalls).toEqual([KEY]);
       expect(moderationBypassCacheCalls).toEqual([true]);
       expect(telemetry?.cacheAvailability).toBe("unavailable");
       expect(telemetry?.cacheRead).toBe("unavailable");
@@ -656,7 +655,7 @@ describe("resolveInferenceAuthContext", () => {
       await expect(resolveInferenceAuthContext(reqWithApiKey())).rejects.toThrow(
         "Invalid or expired API key",
       );
-      expect(bypassCacheCalls).toEqual([true]);
+      expect(authBoundaryCalls).toEqual([KEY]);
       expect(writeSpy).not.toHaveBeenCalled();
     } finally {
       availabilitySpy.mockRestore();
@@ -694,7 +693,7 @@ describe("resolveInferenceAuthContext", () => {
 
     expect(result.kind).toBe("authorized");
     if (result.kind === "authorized") expect(result.source).toBe("origin");
-    expect(bypassCacheCalls).toEqual([true]);
+    expect(authBoundaryCalls).toEqual([KEY]);
     expect(moderationBypassCacheCalls).toEqual([true]);
     expect(telemetry?.cacheRead).toBe("invalid");
     expect((await readInferenceAuthContext(keyHash))?.userId).toBe("user-1");

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -675,7 +675,6 @@ export async function resolveInferenceAuthContext(
       trace.cacheRead === "unavailable" ||
       trace.cacheRead === "error";
     const { user, apiKey } = await requireInferenceApiKeyWithOrg(credential.rawKey, {
-      bypassCache: bypassAuthoritativeCaches,
       timing: {
         keyLookup: (durationMs) => {
           trace.timings.keyLookupMs = Math.round(durationMs * 100) / 100;

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -139,14 +139,17 @@ afterAll(() => {
 });
 
 describe("inference hot-path benchmark", () => {
-  test("cold miss pays the authoritative chain exactly once, then caches", async () => {
+  test("cold miss performs one combined cache read before authoritative hydration", async () => {
+    const getSpy = spyOn(cache, "getWithOutcome");
     const cold = await resolveInferenceAuthContext(req());
     expect(cold.kind).toBe("authorized");
+    expect(getSpy).toHaveBeenCalledTimes(1);
     expect(authChainCalls).toBe(1); // one auth chain
     expect(moderationCalls).toBe(1); // one moderation read
     expect(admissionLoadCalls).toBe(1); // one admission projection load (IAC v2)
     expect(appScopeCalls).toBe(1); // one app-key scope load (IAC v2)
     expect(revocationBoundaryCalls).toBe(1);
+    getSpy.mockRestore();
   });
 
   test("WARM hit = exactly 1 cache read, 0 writes, 0 auth, 0 moderation", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #29340 / #29385. The inference API-key helper still used an active-only repository lookup and, on a healthy combined-auth-cache miss, fell through `apiKeysService` / `usersService` caches. That made `credential_inactive` unreachable, extra Redis reads beyond the one-read admission contract, and missing organization membership report as `organization_inactive`.

- After the single combined inference-auth cache read, authoritative hydration reads primary repositories (`findByHashConsistent`, `findWithOrganizationForWrite`) instead of secondary service caches.
- Inactive credentials return `credential_inactive`.
- Deleted or expired credentials remain `credential_invalid` (expiry is classified before inactivity).
- Missing organization membership returns `membership_missing` before organization-active checks.

## Test plan

- [x] `bun test --isolate src/lib/auth-inference-api-key.test.ts` (9 pass; fail-then-pass on service-cache skip, expired+inactive, deleted, membership_missing, storage outage)
- [x] `bun test --isolate src/lib/services/inference-auth-context.test.ts src/lib/services/inference-hot-path-benchmark.test.ts` (49 pass)
- [x] biome check on changed files
- [x] `bun run typecheck` in `@elizaos/cloud-shared`

Fixes #29493