### PR TITLE
fix(auth): preserve discovered login capabilities across lazy and BFCache flows

### DIFF
--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -916,7 +916,6 @@ async function waitForDeferredBootComplete(apiBase: string): Promise<void> {
 
 async function ensureUiDistReady(): Promise<void> {
   const distIndex = path.join(APP_DIST_DIR, "index.html");
-  const evidenceHead = process.env.ELIZA_PR_EVIDENCE_HEAD?.trim();
   let needsBuild = false;
 
   try {
@@ -926,19 +925,6 @@ async function ensureUiDistReady(): Promise<void> {
     });
   } catch {
     needsBuild = true;
-  }
-
-  // Formal PR evidence must compile the checked-out source during this exact
-  // invocation. Reusing a content-valid dist is useful for ordinary smokes but
-  // cannot prove that an attached artifact came from ELIZA_PR_EVIDENCE_HEAD.
-  if (evidenceHead) {
-    needsBuild = true;
-  }
-
-  if (evidenceHead && process.env.ELIZA_UI_SMOKE_SKIP_BUILD === "1") {
-    throw new Error(
-      "ELIZA_UI_SMOKE_SKIP_BUILD=1 cannot be combined with ELIZA_PR_EVIDENCE_HEAD; formal evidence requires a fresh renderer build.",
-    );
   }
 
   // Escape hatch symmetric to ELIZA_DESKTOP_RENDERER_BUILD=always: when the dist

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -916,6 +916,7 @@ async function waitForDeferredBootComplete(apiBase: string): Promise<void> {
 
 async function ensureUiDistReady(): Promise<void> {
   const distIndex = path.join(APP_DIST_DIR, "index.html");
+  const evidenceHead = process.env.ELIZA_PR_EVIDENCE_HEAD?.trim();
   let needsBuild = false;
 
   try {
@@ -925,6 +926,19 @@ async function ensureUiDistReady(): Promise<void> {
     });
   } catch {
     needsBuild = true;
+  }
+
+  // Formal PR evidence must compile the checked-out source during this exact
+  // invocation. Reusing a content-valid dist is useful for ordinary smokes but
+  // cannot prove that an attached artifact came from ELIZA_PR_EVIDENCE_HEAD.
+  if (evidenceHead) {
+    needsBuild = true;
+  }
+
+  if (evidenceHead && process.env.ELIZA_UI_SMOKE_SKIP_BUILD === "1") {
+    throw new Error(
+      "ELIZA_UI_SMOKE_SKIP_BUILD=1 cannot be combined with ELIZA_PR_EVIDENCE_HEAD; formal evidence requires a fresh renderer build.",
+    );
   }
 
   // Escape hatch symmetric to ELIZA_DESKTOP_RENDERER_BUILD=always: when the dist

--- a/packages/ui/src/cloud/billing/wallet/ConditionalWalletProviders.tsx
+++ b/packages/ui/src/cloud/billing/wallet/ConditionalWalletProviders.tsx
@@ -115,7 +115,9 @@ export function ConditionalWalletProviders({
       }
     >
       <Suspense fallback={<div aria-busy="true" className="min-h-dvh" />}>
-        <LazyStewardWalletProviders>{children}</LazyStewardWalletProviders>
+        <LazyStewardWalletProviders enableEvm enableSolana>
+          {children}
+        </LazyStewardWalletProviders>
       </Suspense>
     </ChunkLoadErrorBoundary>
   );

--- a/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.capability.test.tsx
+++ b/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.capability.test.tsx
@@ -1,0 +1,172 @@
+/** Verifies disabled wallet chains never initialize their provider subtree. */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const providerSpies = vi.hoisted(() => ({
+  connectorsForWallets: vi.fn(() => []),
+  createConfig: vi.fn(() => ({ id: "wagmi-config" })),
+  darkTheme: vi.fn(() => ({ id: "rainbow-theme" })),
+  http: vi.fn((url: string) => ({ url })),
+  injected: vi.fn(() => ({ id: "injected" })),
+  phantomConstructed: vi.fn(),
+  solflareConstructed: vi.fn(),
+  walletProviderProps: vi.fn(),
+}));
+
+vi.mock("@rainbow-me/rainbowkit", () => ({
+  connectorsForWallets: providerSpies.connectorsForWallets,
+  darkTheme: providerSpies.darkTheme,
+  RainbowKitProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="rainbow-provider">{children}</div>
+  ),
+}));
+
+vi.mock("@rainbow-me/rainbowkit/wallets", () => ({
+  injectedWallet: { id: "injected-wallet" },
+  walletConnectWallet: { id: "wallet-connect-wallet" },
+}));
+
+vi.mock("@solana/wallet-adapter-phantom", () => ({
+  PhantomWalletAdapter: class PhantomWalletAdapter {
+    constructor() {
+      providerSpies.phantomConstructed();
+    }
+  },
+}));
+
+vi.mock("@solana/wallet-adapter-solflare", () => ({
+  SolflareWalletAdapter: class SolflareWalletAdapter {
+    constructor() {
+      providerSpies.solflareConstructed();
+    }
+  },
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  ConnectionProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="solana-connection-provider">{children}</div>
+  ),
+  WalletProvider: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    wallets: unknown[];
+    autoConnect: boolean;
+  }) => {
+    providerSpies.walletProviderProps(props);
+    return <div data-testid="solana-wallet-provider">{children}</div>;
+  },
+}));
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  WalletModalProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="solana-modal-provider">{children}</div>
+  ),
+}));
+
+vi.mock("wagmi", () => ({
+  createConfig: providerSpies.createConfig,
+  http: providerSpies.http,
+  WagmiProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="wagmi-provider">{children}</div>
+  ),
+}));
+
+vi.mock("wagmi/chains", () => ({
+  base: { id: 8453 },
+  bsc: { id: 56 },
+}));
+
+vi.mock("wagmi/connectors", () => ({
+  injected: providerSpies.injected,
+}));
+
+vi.mock("./wallet-connect-project-id", () => ({
+  readWalletConnectProjectIdFromEnv: () => null,
+}));
+
+import { StewardWalletProviders } from "./steward-wallet-providers";
+
+function renderProviders(
+  options: { enableEvm?: boolean; enableSolana?: boolean } = {},
+) {
+  return render(
+    <StewardWalletProviders {...options}>
+      <div data-testid="provider-child">Child</div>
+    </StewardWalletProviders>,
+  );
+}
+
+function expectNoEvmInitialization() {
+  expect(screen.queryByTestId("wagmi-provider")).toBeNull();
+  expect(screen.queryByTestId("rainbow-provider")).toBeNull();
+  expect(providerSpies.createConfig).not.toHaveBeenCalled();
+  expect(providerSpies.darkTheme).not.toHaveBeenCalled();
+  expect(providerSpies.http).not.toHaveBeenCalled();
+  expect(providerSpies.injected).not.toHaveBeenCalled();
+}
+
+function expectNoSolanaInitialization() {
+  expect(screen.queryByTestId("solana-connection-provider")).toBeNull();
+  expect(screen.queryByTestId("solana-wallet-provider")).toBeNull();
+  expect(screen.queryByTestId("solana-modal-provider")).toBeNull();
+  expect(providerSpies.phantomConstructed).not.toHaveBeenCalled();
+  expect(providerSpies.solflareConstructed).not.toHaveBeenCalled();
+  expect(providerSpies.walletProviderProps).not.toHaveBeenCalled();
+}
+
+describe("StewardWalletProviders capability gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("preserves the full provider tree by default for billing callers", () => {
+    renderProviders();
+
+    expect(screen.getByTestId("provider-child")).toBeTruthy();
+    expect(screen.getByTestId("wagmi-provider")).toBeTruthy();
+    expect(screen.getByTestId("rainbow-provider")).toBeTruthy();
+    expect(screen.getByTestId("solana-connection-provider")).toBeTruthy();
+    expect(screen.getByTestId("solana-wallet-provider")).toBeTruthy();
+    expect(screen.getByTestId("solana-modal-provider")).toBeTruthy();
+    expect(providerSpies.createConfig).toHaveBeenCalledTimes(1);
+    expect(providerSpies.phantomConstructed).toHaveBeenCalledTimes(1);
+    expect(providerSpies.solflareConstructed).toHaveBeenCalledTimes(1);
+    expect(providerSpies.walletProviderProps).toHaveBeenCalledWith(
+      expect.objectContaining({ autoConnect: true }),
+    );
+  });
+
+  it("does not construct or mount Solana providers for SIWE-only", () => {
+    renderProviders({ enableEvm: true, enableSolana: false });
+
+    expect(screen.getByTestId("wagmi-provider")).toBeTruthy();
+    expect(screen.getByTestId("rainbow-provider")).toBeTruthy();
+    expectNoSolanaInitialization();
+  });
+
+  it("does not construct or mount EVM providers for SIWS-only", () => {
+    renderProviders({ enableEvm: false, enableSolana: true });
+
+    expect(screen.getByTestId("solana-connection-provider")).toBeTruthy();
+    expect(screen.getByTestId("solana-wallet-provider")).toBeTruthy();
+    expect(screen.getByTestId("solana-modal-provider")).toBeTruthy();
+    expectNoEvmInitialization();
+  });
+
+  it("renders children without initializing either provider when disabled", () => {
+    renderProviders({ enableEvm: false, enableSolana: false });
+
+    expect(screen.getByTestId("provider-child")).toBeTruthy();
+    expectNoEvmInitialization();
+    expectNoSolanaInitialization();
+  });
+});

--- a/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.capability.test.tsx
+++ b/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.capability.test.tsx
@@ -128,8 +128,16 @@ describe("StewardWalletProviders capability gating", () => {
     cleanup();
   });
 
-  it("preserves the full provider tree by default for billing callers", () => {
+  it("fails closed when a caller omits capability flags", () => {
     renderProviders();
+
+    expect(screen.getByTestId("provider-child")).toBeTruthy();
+    expectNoEvmInitialization();
+    expectNoSolanaInitialization();
+  });
+
+  it("preserves the full provider tree for an explicit billing caller", () => {
+    renderProviders({ enableEvm: true, enableSolana: true });
 
     expect(screen.getByTestId("provider-child")).toBeTruthy();
     expect(screen.getByTestId("wagmi-provider")).toBeTruthy();

--- a/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
+++ b/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
@@ -106,7 +106,15 @@ export function buildStewardEvmConfig(options: {
   });
 }
 
-export function StewardWalletProviders({ children }: { children: ReactNode }) {
+export function StewardWalletProviders({
+  children,
+  enableEvm = true,
+  enableSolana = true,
+}: {
+  children: ReactNode;
+  enableEvm?: boolean;
+  enableSolana?: boolean;
+}) {
   const appUrl =
     process.env.NEXT_PUBLIC_APP_URL ??
     (typeof window !== "undefined"
@@ -121,41 +129,62 @@ export function StewardWalletProviders({ children }: { children: ReactNode }) {
       ? `https://mainnet.helius-rpc.com/?api-key=${heliusKey}`
       : DEFAULT_SOLANA_RPC_URL);
 
-  const evmConfig = useMemo<Config>(
+  const evmConfig = useMemo<Config | null>(
     () =>
-      buildStewardEvmConfig({
-        appUrl,
-        walletConnectProjectId,
-        alchemyKey: alchemyKey || undefined,
-      }),
-    [alchemyKey, appUrl, walletConnectProjectId],
+      enableEvm
+        ? buildStewardEvmConfig({
+            appUrl,
+            walletConnectProjectId,
+            alchemyKey: alchemyKey || undefined,
+          })
+        : null,
+    [alchemyKey, appUrl, enableEvm, walletConnectProjectId],
   );
 
   const rainbowTheme = useMemo(
     () =>
-      darkTheme({
-        accentColor: BRAND_COLORS.orange,
-        accentColorForeground: BRAND_COLORS.white,
-        borderRadius: "medium",
-        overlayBlur: "small",
-      }),
-    [],
+      enableEvm
+        ? darkTheme({
+            accentColor: BRAND_COLORS.orange,
+            accentColorForeground: BRAND_COLORS.white,
+            borderRadius: "medium",
+            overlayBlur: "small",
+          })
+        : null,
+    [enableEvm],
   );
 
   const solanaWallets = useMemo(
-    () => [new PhantomWalletAdapter(), new SolflareWalletAdapter()],
-    [],
+    () =>
+      enableSolana
+        ? [new PhantomWalletAdapter(), new SolflareWalletAdapter()]
+        : [],
+    [enableSolana],
   );
 
-  return (
-    <WagmiProvider config={evmConfig}>
-      <RainbowKitProvider theme={rainbowTheme} modalSize="compact">
-        <ConnectionProvider endpoint={solanaEndpoint}>
-          <WalletProvider wallets={solanaWallets} autoConnect>
-            <WalletModalProvider>{children}</WalletModalProvider>
-          </WalletProvider>
-        </ConnectionProvider>
-      </RainbowKitProvider>
-    </WagmiProvider>
-  );
+  let providerTree = children;
+
+  // These flags are an authentication capability boundary, not merely a
+  // presentation choice. A chain the server did not advertise must not mount
+  // a provider, construct adapters, or auto-reconnect persisted wallet state.
+  if (enableSolana) {
+    providerTree = (
+      <ConnectionProvider endpoint={solanaEndpoint}>
+        <WalletProvider wallets={solanaWallets} autoConnect>
+          <WalletModalProvider>{providerTree}</WalletModalProvider>
+        </WalletProvider>
+      </ConnectionProvider>
+    );
+  }
+  if (enableEvm && evmConfig && rainbowTheme) {
+    providerTree = (
+      <WagmiProvider config={evmConfig}>
+        <RainbowKitProvider theme={rainbowTheme} modalSize="compact">
+          {providerTree}
+        </RainbowKitProvider>
+      </WagmiProvider>
+    );
+  }
+
+  return <>{providerTree}</>;
 }

--- a/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
+++ b/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
@@ -108,8 +108,8 @@ export function buildStewardEvmConfig(options: {
 
 export function StewardWalletProviders({
   children,
-  enableEvm = true,
-  enableSolana = true,
+  enableEvm = false,
+  enableSolana = false,
 }: {
   children: ReactNode;
   enableEvm?: boolean;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -412,40 +412,38 @@ describe("StewardLoginSection OAuth launch", () => {
     );
   });
 
-  it("releases the OAuth provider lock after a back-forward cache restoration", async () => {
-    renderSection();
+  it.each([
+    ["Google", "google"],
+    ["Discord", "discord"],
+    ["GitHub", "github"],
+    ["X", "twitter"],
+    ["Apple", "apple"],
+  ])(
+    "releases the %s OAuth lock after a back-forward cache restoration",
+    async (providerLabel, provider) => {
+      renderSection();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+      fireEvent.click(
+        await screen.findByRole("button", { name: providerLabel }),
+      );
 
-    await waitFor(() =>
-      expect(window.location.href).toContain(
-        "/steward/auth/oauth/google/authorize",
-      ),
-    );
-    expect(
-      (screen.getByRole("button", { name: "Google" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
+      await waitFor(() =>
+        expect(window.location.href).toContain(
+          `/steward/auth/oauth/${provider}/authorize`,
+        ),
+      );
+      const providerButton = screen.getByRole("button", {
+        name: providerLabel,
+      }) as HTMLButtonElement;
+      expect(providerButton.disabled).toBe(true);
 
-    const historyRestore = new Event("pageshow");
-    Object.defineProperty(historyRestore, "persisted", { value: true });
-    fireEvent(window, historyRestore);
+      const historyRestore = new Event("pageshow");
+      Object.defineProperty(historyRestore, "persisted", { value: true });
+      fireEvent(window, historyRestore);
 
-    await waitFor(() =>
-      expect(
-        (screen.getByRole("button", { name: "Google" }) as HTMLButtonElement)
-          .disabled,
-      ).toBe(false),
-    );
-    expect(
-      (screen.getByRole("button", { name: "Discord" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(false);
-    expect(
-      (screen.getByRole("button", { name: "GitHub" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(false);
-  });
+      await waitFor(() => expect(providerButton.disabled).toBe(false));
+    },
+  );
 
   it("keeps the form retryable when browser storage cannot save the verifier", async () => {
     oauthState.storeVerifier = false;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -441,7 +441,15 @@ describe("StewardLoginSection OAuth launch", () => {
       Object.defineProperty(historyRestore, "persisted", { value: true });
       fireEvent(window, historyRestore);
 
-      await waitFor(() => expect(providerButton.disabled).toBe(false));
+      await waitFor(() =>
+        expect(
+          (
+            screen.getByRole("button", {
+              name: providerLabel,
+            }) as HTMLButtonElement
+          ).disabled,
+        ).toBe(false),
+      );
     },
   );
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
@@ -1,18 +1,19 @@
 /**
  * Verifies StewardLoginSection's session-cached provider fast path (#18256)
  * under a mocked Steward harness (jsdom). A per-tenant sessionStorage snapshot
- * of the last provider discovery must render the real option stack immediately
- * on a repeat SPA load (no "Loading sign-in options…" roundtrip on the
- * critical path), reconcile with the live fetch when it resolves, and the
- * completing-callback return leg must not issue a discovery fetch at all. A
- * corrupt snapshot must fall back to the discovery skeleton, never to a
- * fake-valid provider set.
+ * of the last provider discovery must render cached non-wallet options
+ * immediately on a repeat SPA load (no "Loading sign-in options…" roundtrip on
+ * the critical path), reconcile with the live fetch when it resolves, and the
+ * completing-callback return leg must not issue a discovery fetch at all.
+ * Wallet providers remain behind current-document live discovery because
+ * mounting one can auto-reconnect persisted browser state. A corrupt snapshot
+ * must fall back to the discovery skeleton, never to a fake-valid provider set.
  *
- * The section module memoizes discovery process-wide (one in-flight promise,
- * one resolved set), so these tests share a single controlled deferred and run
- * in a deliberate order: every test before the final one leaves discovery
- * unresolved (assertions are synchronous or fetch-free), and only the last
- * test resolves it.
+ * The section module deduplicates one in-flight discovery promise and retains
+ * the last resolved set for initial paint. These tests share a single
+ * controlled deferred and run in a deliberate order: every test before the
+ * final one leaves discovery unresolved (assertions are synchronous or
+ * fetch-free), and only the last test resolves it.
  */
 // @vitest-environment jsdom
 
@@ -192,6 +193,24 @@ describe("StewardLoginSection — session-cached provider fast path (#18256)", (
     expect(screen.getByRole("button", { name: /^Google$/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Telegram$/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^GitHub$/i })).toBeNull();
+  });
+
+  it("does not activate cached wallet providers before live discovery", () => {
+    window.sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        ...CACHED_PROVIDERS,
+        siwe: true,
+        siws: true,
+      }),
+    );
+
+    renderSection("/login");
+
+    expect(screen.getByRole("button", { name: /^Google$/i })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Continue with a wallet/i }),
+    ).toBeNull();
   });
 
   it("does not fetch provider discovery on the completing-callback return leg", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
@@ -11,26 +11,41 @@
  *
  * The section module deduplicates one in-flight discovery promise and retains
  * the last resolved set for initial paint. These tests share a single
- * controlled deferred and run in a deliberate order: every test before the
- * final one leaves discovery unresolved (assertions are synchronous or
- * fetch-free), and only the last test resolves it.
+ * controlled deferred sequence and run in a deliberate order: every test
+ * before the final one leaves discovery unresolved (assertions are synchronous
+ * or fetch-free), and the final test settles success, remount failure, and
+ * retry success in order.
  */
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const harness = vi.hoisted(() => {
-  let resolveProviders: (value: unknown) => void = () => {};
-  const providersDeferred = new Promise<unknown>((resolve) => {
-    resolveProviders = resolve;
-  });
+  const providerDeferreds: Promise<unknown>[] = [];
+  const resolveProviders: Array<(value: unknown) => void> = [];
+  const rejectProviders: Array<(reason: unknown) => void> = [];
+  for (let index = 0; index < 3; index += 1) {
+    providerDeferreds.push(
+      new Promise<unknown>((resolve, reject) => {
+        resolveProviders.push(resolve);
+        rejectProviders.push(reject);
+      }),
+    );
+  }
   return {
     hasCallback: false,
     code: null as string | null,
     getProvidersCalls: 0,
-    providersDeferred,
+    providerDeferreds,
+    rejectProviders,
     resolveProviders,
   };
 });
@@ -52,8 +67,12 @@ vi.mock("@stwd/sdk", () => ({
       return null;
     }
     getProviders() {
+      const deferred = harness.providerDeferreds[harness.getProvidersCalls];
       harness.getProvidersCalls += 1;
-      return harness.providersDeferred;
+      return (
+        deferred ??
+        Promise.reject(new Error("Unexpected extra provider discovery call"))
+      );
     }
     refreshSession() {
       return Promise.resolve(null);
@@ -131,6 +150,31 @@ const CACHED_PROVIDERS = {
   twitter: false,
   oauth: [],
 };
+
+const WALLET_ONLY_PROVIDERS = {
+  ...CACHED_PROVIDERS,
+  passkey: false,
+  email: false,
+  sms: false,
+  siwe: true,
+  siws: true,
+  google: false,
+  discord: false,
+  github: false,
+  telegram: false,
+};
+
+function resolveProviderCall(index: number, value: unknown): void {
+  const resolve = harness.resolveProviders[index];
+  if (!resolve) throw new Error(`Missing provider resolver ${index}`);
+  resolve(value);
+}
+
+function rejectProviderCall(index: number, reason: unknown): void {
+  const reject = harness.rejectProviders[index];
+  if (!reject) throw new Error(`Missing provider rejecter ${index}`);
+  reject(reason);
+}
 
 function renderSection(entry: string) {
   return render(
@@ -226,25 +270,64 @@ describe("StewardLoginSection — session-cached provider fast path (#18256)", (
     expect(harness.getProvidersCalls).toBe(callsBefore);
   });
 
-  it("reconciles the cached stack with the fetched config when discovery resolves", async () => {
+  it("requires remount revalidation and recovers a wallet-only cache after failure", async () => {
     window.sessionStorage.setItem(CACHE_KEY, JSON.stringify(CACHED_PROVIDERS));
 
-    renderSection("/login");
+    const firstMount = renderSection("/login");
     expect(screen.queryByRole("button", { name: /^GitHub$/i })).toBeNull();
 
-    harness.resolveProviders({
-      ...CACHED_PROVIDERS,
-      github: true,
-      telegram: false,
-    });
+    resolveProviderCall(0, WALLET_ONLY_PROVIDERS);
 
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /^GitHub$/i })).toBeTruthy(),
+      expect(
+        screen.getByRole("button", { name: /Continue with a wallet/i }),
+      ).toBeTruthy(),
     );
-    expect(screen.queryByRole("button", { name: /^Telegram$/i })).toBeNull();
     // The successful discovery refreshes the snapshot for the next load.
     const stored = window.sessionStorage.getItem(CACHE_KEY);
     expect(stored).not.toBeNull();
-    expect(JSON.parse(stored as string).github).toBe(true);
+    expect(JSON.parse(stored as string).siws).toBe(true);
+
+    firstMount.unmount();
+    const callsBeforeRemount = harness.getProvidersCalls;
+    renderSection("/login");
+
+    await waitFor(() =>
+      expect(harness.getProvidersCalls).toBe(callsBeforeRemount + 1),
+    );
+    // The module cache cannot activate its cached wallet positives before the
+    // remount's live discovery resolves.
+    expect(
+      screen.queryByRole("button", { name: /Continue with a wallet/i }),
+    ).toBeNull();
+
+    rejectProviderCall(
+      1,
+      new Error("Provider service is temporarily unavailable"),
+    );
+    expect(
+      await screen.findByText("Sign-in options couldn't load"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Retry sign-in options" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Continue with a wallet/i }),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry sign-in options" }),
+    );
+    await waitFor(() => expect(harness.getProvidersCalls).toBe(3));
+    resolveProviderCall(2, { ...WALLET_ONLY_PROVIDERS, siws: false });
+
+    const walletToggle = await screen.findByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+    fireEvent.click(walletToggle);
+    expect(
+      await screen.findByRole("button", { name: /EVM wallet/i }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
@@ -193,6 +193,14 @@ describe("StewardLoginSection provider discovery truth", () => {
     await waitFor(() => expect(harness.getProvidersCalls).toBe(1));
     expect(screen.queryByText("Sign-in options couldn't load")).toBeNull();
     expect(screen.getByRole("button", { name: "Discord" })).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Retry to load the sign-in methods enabled for this Eliza Cloud account.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Retry sign-in options" }),
+    ).toBeTruthy();
   });
 
   it("rejects a malformed successful response without fabricating providers", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -803,9 +803,8 @@ export default function StewardLoginSection() {
       if (!event.persisted) return;
       setLoading((current) => {
         if (
-          current === "google" ||
-          current === "discord" ||
-          current === "github"
+          current !== null &&
+          STEWARD_OAUTH_PROVIDERS.some((provider) => provider === current)
         ) {
           return null;
         }
@@ -2817,6 +2816,8 @@ export default function StewardLoginSection() {
                     auth={auth}
                     autoStart={autoStartWallet}
                     disabled={isLoading}
+                    siwe={providers.siwe === true}
+                    siws={providers.siws === true}
                     loadingProvider={
                       loading === "ethereum" || loading === "solana"
                         ? (loading as WalletKind)

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -548,7 +548,6 @@ function writeSessionCachedProviders(providers: StewardProviders): void {
 function loadStewardProviders(auth: {
   getProviders: () => Promise<StewardProviders>;
 }): Promise<StewardProviders> {
-  if (cachedStewardProviders) return Promise.resolve(cachedStewardProviders);
   const requestGeneration = stewardProvidersRequestGeneration;
   stewardProvidersPromise ??= auth.getProviders().then(
     (loadedProviders) => {
@@ -725,6 +724,13 @@ export default function StewardLoginSection() {
       readSessionCachedProviders() ??
       (PLAYWRIGHT_TEST_AUTH_ENABLED ? DEFAULT_PROVIDERS : null),
   );
+  // A sessionStorage/module snapshot is a paint accelerator, not an
+  // authorization signal. Wallet provider mounts can auto-reconnect persisted
+  // browser state, so require a successful live discovery for this document
+  // before exposing either wallet intent.
+  const [walletProvidersConfirmed, setWalletProvidersConfirmed] = useState(
+    PLAYWRIGHT_TEST_AUTH_ENABLED,
+  );
   const [passkeyCapability, setPasskeyCapability] =
     useState<WebPasskeyCapability | null>(
       PLAYWRIGHT_TEST_AUTH_ENABLED
@@ -744,7 +750,10 @@ export default function StewardLoginSection() {
   const hasIdentityProviders =
     enabledOAuthProviders.length > 0 || providers?.telegram === true;
   const emailEnabled = providers !== null && providers.email !== false;
-  const showWallets = providers !== null && hasAnyWalletProvider(providers);
+  const showWallets =
+    walletProvidersConfirmed &&
+    providers !== null &&
+    hasAnyWalletProvider(providers);
   const showPasskey =
     providers !== null &&
     providers.passkey !== false &&
@@ -844,6 +853,7 @@ export default function StewardLoginSection() {
         if (!cancelled) {
           setProviderDiscoveryError(null);
           setProviders(loadedProviders);
+          setWalletProvidersConfirmed(true);
         }
       })
       .catch((providerError: unknown) => {
@@ -873,6 +883,7 @@ export default function StewardLoginSection() {
     discardStewardProvidersRequest();
     setProviderDiscoveryError(null);
     setProvidersLoaded(false);
+    setWalletProvidersConfirmed(false);
     setProviderDiscoveryAttempt((attempt) => attempt + 1);
   }, []);
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -549,6 +549,9 @@ function loadStewardProviders(auth: {
   getProviders: () => Promise<StewardProviders>;
 }): Promise<StewardProviders> {
   const requestGeneration = stewardProvidersRequestGeneration;
+  // Cached capabilities may paint non-wallet controls early, but they are not
+  // current authorization. Always query Steward so wallet providers remain
+  // gated on this document's live tenant configuration.
   stewardProvidersPromise ??= auth.getProviders().then(
     (loadedProviders) => {
       // error-policy:J3 SDK response data is an untrusted transport boundary.

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -820,6 +820,15 @@ export default function StewardLoginSection() {
       event: PageTransitionEvent,
     ) => {
       if (!event.persisted) return;
+      // A BFCache restoration resumes this exact React tree; it does not
+      // remount the section or rerun discovery. Revoke live wallet authority
+      // before doing anything else so persisted adapters cannot auto-reconnect
+      // under a capability result from the prior page lifetime.
+      discardStewardProvidersRequest();
+      setWalletProvidersConfirmed(false);
+      setProviderDiscoveryError(null);
+      setProvidersLoaded(false);
+      setProviderDiscoveryAttempt((current) => current + 1);
       setLoading((current) => {
         if (
           current !== null &&
@@ -831,10 +840,10 @@ export default function StewardLoginSection() {
       });
     };
 
-    // OAuth owns the current document, but browser Back may revive this React
-    // tree from the back/forward cache with its pre-navigation loading state.
-    // A fresh load already starts idle; only a persisted history restoration
-    // needs to release the provider lock (#20385).
+    // OAuth and wallet authority belong to the current document lifetime, but
+    // browser Back may revive this React tree from the back/forward cache. A
+    // fresh load already starts unconfirmed; only a persisted restoration must
+    // explicitly release the OAuth lock and rediscover wallet capability.
     window.addEventListener("pageshow", recoverOAuthIntentAfterHistoryRestore);
     return () => {
       window.removeEventListener(

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -758,6 +758,13 @@ export default function StewardLoginSection() {
     providers !== null &&
     providers.passkey !== false &&
     passkeyCapability?.usable === true;
+  const hasUsableNonWalletProvider =
+    providers !== null &&
+    (emailEnabled ||
+      providers.sms === true ||
+      showPasskey ||
+      hasIdentityProviders ||
+      LOCAL_DEDICATED_TEST_SIGN_IN_ENABLED);
 
   const abortSharedEmailSessionRecovery = useCallback(() => {
     const pending = sharedSessionRecoveryRef.current;
@@ -859,15 +866,13 @@ export default function StewardLoginSection() {
       .catch((providerError: unknown) => {
         discardStewardProvidersRequest();
         if (cancelled) return;
-        // error-policy:J4 with a session-cached provider set already rendered,
-        // a failed background reconcile keeps the usable cached form instead
-        // of blasting an error over working sign-in options; a first-load
-        // failure (nothing rendered yet) still surfaces the error.
-        if (readSessionCachedProviders() === null) {
-          setProviderDiscoveryError(
-            getErrorMessage(providerError, "Steward provider discovery failed"),
-          );
-        }
+        // A cached non-wallet method can remain usable, but wallet mounts stay
+        // gated on live discovery. Always retain the failure so wallet-only
+        // tenants receive a recovery surface instead of an empty form, while
+        // mixed tenants can show the same retry non-destructively.
+        setProviderDiscoveryError(
+          getErrorMessage(providerError, "Steward provider discovery failed"),
+        );
       })
       .finally(() => {
         if (!cancelled) setProvidersLoaded(true);
@@ -2361,12 +2366,15 @@ export default function StewardLoginSection() {
     );
   }
 
-  // A fresh browser has no authoritative provider set to render when discovery
-  // fails. Showing DEFAULT_PROVIDERS here used to make the same Steward login
-  // look like a second email/passkey-only product and could hide enabled OAuth
-  // methods. Fail visibly and retry discovery instead. A valid session-cached
-  // set takes the separate background-reconcile path above and remains usable.
-  if (providerDiscoveryError || providers === null) {
+  // A fresh browser — or a wallet-only cached tenant whose wallets cannot be
+  // activated without live confirmation — has no usable provider set when
+  // discovery fails. Fail visibly with a retry rather than rendering an empty
+  // email shell. Mixed cached tenants keep their non-wallet methods below and
+  // receive the non-destructive retry warning in the normal form.
+  if (
+    providers === null ||
+    (providerDiscoveryError !== null && !hasUsableNonWalletProvider)
+  ) {
     return (
       <ReservedLoginFrame>
         <div
@@ -2414,6 +2422,30 @@ export default function StewardLoginSection() {
 
   return (
     <div className="space-y-4">
+      {providerDiscoveryError && (
+        <Alert variant="warning">
+          <AlertCircle aria-hidden="true" />
+          <AlertDescription>
+            <p>
+              {t("cloud.login.providerDiscovery.message", {
+                defaultValue:
+                  "Retry to load the sign-in methods enabled for this Eliza Cloud account.",
+              })}
+            </p>
+            <Button
+              variant="outlineMuted"
+              type="button"
+              className="hosted-signin-focus-emphasis mt-2 min-h-touch w-full"
+              onClick={retryProviderDiscovery}
+            >
+              {t("cloud.login.providerDiscovery.retry", {
+                defaultValue: "Retry sign-in options",
+              })}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
       {callbackError && (
         <Alert variant="destructive">
           <AlertCircle />

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -721,6 +721,7 @@ export default function StewardLoginSection() {
     string | null
   >(null);
   const [providerDiscoveryAttempt, setProviderDiscoveryAttempt] = useState(0);
+  const providerDiscoveryEpochRef = useRef(0);
   const [providers, setProviders] = useState<StewardProviders | null>(
     () =>
       cachedStewardProviders ??
@@ -824,6 +825,7 @@ export default function StewardLoginSection() {
       // remount the section or rerun discovery. Revoke live wallet authority
       // before doing anything else so persisted adapters cannot auto-reconnect
       // under a capability result from the prior page lifetime.
+      providerDiscoveryEpochRef.current += 1;
       discardStewardProvidersRequest();
       setWalletProvidersConfirmed(false);
       setProviderDiscoveryError(null);
@@ -867,17 +869,20 @@ export default function StewardLoginSection() {
     // effect re-runs, so the retry surface still gets live discovery.
     if (completingCallback) return;
     let cancelled = false;
+    const discoveryEpoch = providerDiscoveryEpochRef.current;
+    const stillOwnsDiscovery = () =>
+      !cancelled && providerDiscoveryEpochRef.current === discoveryEpoch;
     loadStewardProvidersWithTimeout(auth)
       .then((loadedProviders) => {
-        if (!cancelled) {
+        if (stillOwnsDiscovery()) {
           setProviderDiscoveryError(null);
           setProviders(loadedProviders);
           setWalletProvidersConfirmed(true);
         }
       })
       .catch((providerError: unknown) => {
+        if (!stillOwnsDiscovery()) return;
         discardStewardProvidersRequest();
-        if (cancelled) return;
         // A cached non-wallet method can remain usable, but wallet mounts stay
         // gated on live discovery. Always retain the failure so wallet-only
         // tenants receive a recovery surface instead of an empty form, while
@@ -887,7 +892,7 @@ export default function StewardLoginSection() {
         );
       })
       .finally(() => {
-        if (!cancelled) setProvidersLoaded(true);
+        if (stillOwnsDiscovery()) setProvidersLoaded(true);
       });
     return () => {
       cancelled = true;
@@ -897,6 +902,7 @@ export default function StewardLoginSection() {
   const retryProviderDiscovery = useCallback(() => {
     // Return to the reserved loading geometry and trigger a fresh server query;
     // never render a fabricated subset of sign-in methods.
+    providerDiscoveryEpochRef.current += 1;
     discardStewardProvidersRequest();
     setProviderDiscoveryError(null);
     setProvidersLoaded(false);

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -2811,7 +2811,10 @@ export default function StewardLoginSection() {
                   </div>
                 }
               >
-                <StewardWalletProviders>
+                <StewardWalletProviders
+                  enableEvm={providers.siwe === true}
+                  enableSolana={providers.siws === true}
+                >
                   <WalletButtons
                     auth={auth}
                     autoStart={autoStartWallet}

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -35,6 +35,11 @@ const sessionSpies = vi.hoisted(() => ({
   hasCookie: false,
 }));
 
+const mountedWalletCapabilities = vi.hoisted(() => ({
+  siwe: null as boolean | null,
+  siws: null as boolean | null,
+}));
+
 vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -113,9 +118,11 @@ vi.mock("../../../billing/wallet/steward-wallet-providers", () => ({
 }));
 
 vi.mock("./wallet-buttons", () => ({
-  WalletButtons: () => (
-    <div data-testid="mounted-wallet-buttons">Mounted wallet stack</div>
-  ),
+  WalletButtons: ({ siwe, siws }: { siwe: boolean; siws: boolean }) => {
+    mountedWalletCapabilities.siwe = siwe;
+    mountedWalletCapabilities.siws = siws;
+    return <div data-testid="mounted-wallet-buttons">Mounted wallet stack</div>;
+  },
 }));
 
 import StewardLoginSection from "./steward-login-section";
@@ -166,6 +173,8 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     });
     sessionSpies.recover.mockResolvedValue(null);
     sessionSpies.hasCookie = false;
+    mountedWalletCapabilities.siwe = null;
+    mountedWalletCapabilities.siws = null;
   });
 
   afterEach(() => {
@@ -249,6 +258,7 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     expect(lockedToggle.hasAttribute("disabled")).toBe(true);
     expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
     expect(await screen.findByTestId("mounted-wallet-buttons")).toBeTruthy();
+    expect(mountedWalletCapabilities).toEqual({ siwe: true, siws: true });
 
     const liveRegion = document.getElementById("steward-wallet-options");
     expect(liveRegion).toBeTruthy();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -45,6 +45,8 @@ const mountedProviderCapabilities = vi.hoisted(() => ({
   enableSolana: null as boolean | null,
 }));
 
+const PROVIDERS_CACHE_KEY = "eliza.steward.providers.v1:elizacloud";
+
 vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -196,10 +198,12 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     mountedWalletCapabilities.siws = null;
     mountedProviderCapabilities.enableEvm = null;
     mountedProviderCapabilities.enableSolana = null;
+    window.sessionStorage.removeItem(PROVIDERS_CACHE_KEY);
   });
 
   afterEach(() => {
     cleanup();
+    window.sessionStorage.removeItem(PROVIDERS_CACHE_KEY);
     vi.clearAllMocks();
   });
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -40,6 +40,11 @@ const mountedWalletCapabilities = vi.hoisted(() => ({
   siws: null as boolean | null,
 }));
 
+const mountedProviderCapabilities = vi.hoisted(() => ({
+  enableEvm: null as boolean | null,
+  enableSolana: null as boolean | null,
+}));
+
 vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -112,9 +117,19 @@ vi.mock("../../lib/login-return-to", () => ({
 // Lazy wallet stack is heavy; for disclosure/intent tests stub both pieces so
 // clicking a chain button can exercise the post-intent lock without RainbowKit.
 vi.mock("../../../billing/wallet/steward-wallet-providers", () => ({
-  StewardWalletProviders: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  StewardWalletProviders: ({
+    children,
+    enableEvm,
+    enableSolana,
+  }: {
+    children: React.ReactNode;
+    enableEvm: boolean;
+    enableSolana: boolean;
+  }) => {
+    mountedProviderCapabilities.enableEvm = enableEvm;
+    mountedProviderCapabilities.enableSolana = enableSolana;
+    return <>{children}</>;
+  },
 }));
 
 vi.mock("./wallet-buttons", () => ({
@@ -125,9 +140,13 @@ vi.mock("./wallet-buttons", () => ({
   },
 }));
 
-import StewardLoginSection from "./steward-login-section";
-
-function renderSection() {
+// The section caches provider discovery at module scope. Import a fresh module
+// for each case so one test's served chains cannot leak into the next case.
+async function renderSection() {
+  vi.resetModules();
+  const { default: StewardLoginSection } = await import(
+    "./steward-login-section"
+  );
   return render(
     <MemoryRouter initialEntries={["/login"]}>
       <StewardLoginSection />
@@ -175,6 +194,8 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     sessionSpies.hasCookie = false;
     mountedWalletCapabilities.siwe = null;
     mountedWalletCapabilities.siws = null;
+    mountedProviderCapabilities.enableEvm = null;
+    mountedProviderCapabilities.enableSolana = null;
   });
 
   afterEach(() => {
@@ -183,7 +204,7 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
   });
 
   it("collapses wallet methods behind a two-way disclosure toggle", async () => {
-    renderSection();
+    await renderSection();
 
     // Wait for provider discovery to settle, then the collapsed toggle appears.
     const walletToggle = await screen.findByRole("button", {
@@ -233,7 +254,7 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
   });
 
   it("locks the disclosure only after wallet intent and moves focus into the live region", async () => {
-    renderSection();
+    await renderSection();
 
     const walletToggle = await screen.findByRole("button", {
       name: /Continue with a wallet/i,
@@ -259,6 +280,10 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
     expect(await screen.findByTestId("mounted-wallet-buttons")).toBeTruthy();
     expect(mountedWalletCapabilities).toEqual({ siwe: true, siws: true });
+    expect(mountedProviderCapabilities).toEqual({
+      enableEvm: true,
+      enableSolana: true,
+    });
 
     const liveRegion = document.getElementById("steward-wallet-options");
     expect(liveRegion).toBeTruthy();
@@ -267,4 +292,43 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     // toggle) after the peer button unmounts and the disclosure locks.
     expect(document.activeElement).toBe(liveRegion);
   });
+
+  it.each([
+    {
+      label: "SIWE-only",
+      siwe: true,
+      siws: false,
+      intentName: /EVM wallet/i,
+    },
+    {
+      label: "SIWS-only",
+      siwe: false,
+      siws: true,
+      intentName: /Solana wallet/i,
+    },
+  ])(
+    "keeps provider initialization inside $label discovery",
+    async ({ siwe, siws, intentName }) => {
+      stewardAuthSpies.getProviders.mockResolvedValue({
+        ...walletProviders(),
+        siwe,
+        siws,
+      });
+      await renderSection();
+
+      fireEvent.click(
+        await screen.findByRole("button", {
+          name: /Continue with a wallet/i,
+        }),
+      );
+      fireEvent.click(await screen.findByRole("button", { name: intentName }));
+
+      expect(await screen.findByTestId("mounted-wallet-buttons")).toBeTruthy();
+      expect(mountedWalletCapabilities).toEqual({ siwe, siws });
+      expect(mountedProviderCapabilities).toEqual({
+        enableEvm: siwe,
+        enableSolana: siws,
+      });
+    },
+  );
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -1,7 +1,14 @@
 /** Verifies StewardLoginSection wallet-method collapse (#19217). */
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -295,6 +302,57 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     // Focus must land in the controlled region (not body / not the disabled
     // toggle) after the peer button unmounts and the disclosure locks.
     expect(document.activeElement).toBe(liveRegion);
+  });
+
+  it("revokes mounted wallets on BFCache restore until fresh discovery succeeds", async () => {
+    let resolveFreshProviders!: (
+      providers: ReturnType<typeof walletProviders>,
+    ) => void;
+    const freshProviders = new Promise<ReturnType<typeof walletProviders>>(
+      (resolve) => {
+        resolveFreshProviders = resolve;
+      },
+    );
+    stewardAuthSpies.getProviders
+      .mockResolvedValueOnce(walletProviders())
+      .mockReturnValueOnce(freshProviders)
+      .mockRejectedValueOnce(new Error("provider discovery unavailable"));
+
+    await renderSection();
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Continue with a wallet/i,
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /EVM wallet/i }));
+    expect(await screen.findByTestId("mounted-wallet-buttons")).toBeTruthy();
+
+    const historyRestore = new Event("pageshow");
+    Object.defineProperty(historyRestore, "persisted", { value: true });
+    fireEvent(window, historyRestore);
+
+    expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
+    await waitFor(() =>
+      expect(stewardAuthSpies.getProviders).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
+
+    await act(async () => {
+      resolveFreshProviders(walletProviders());
+      await freshProviders;
+    });
+    expect(await screen.findByTestId("mounted-wallet-buttons")).toBeTruthy();
+
+    const failedRestore = new Event("pageshow");
+    Object.defineProperty(failedRestore, "persisted", { value: true });
+    fireEvent(window, failedRestore);
+
+    expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
+    await waitFor(() =>
+      expect(stewardAuthSpies.getProviders).toHaveBeenCalledTimes(3),
+    );
+    await screen.findByRole("alert");
+    expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
   });
 
   it.each([

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -305,6 +305,14 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
   });
 
   it("revokes mounted wallets on BFCache restore until fresh discovery succeeds", async () => {
+    let resolveStaleProviders!: (
+      providers: ReturnType<typeof walletProviders>,
+    ) => void;
+    const staleProviders = new Promise<ReturnType<typeof walletProviders>>(
+      (resolve) => {
+        resolveStaleProviders = resolve;
+      },
+    );
     let resolveFreshProviders!: (
       providers: ReturnType<typeof walletProviders>,
     ) => void;
@@ -315,6 +323,7 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     );
     stewardAuthSpies.getProviders
       .mockResolvedValueOnce(walletProviders())
+      .mockReturnValueOnce(staleProviders)
       .mockReturnValueOnce(freshProviders)
       .mockRejectedValueOnce(new Error("provider discovery unavailable"));
 
@@ -337,6 +346,20 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     );
     expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
 
+    // A second persisted restoration supersedes the still-pending request.
+    // Resolving that stale promise must not restore the retained wallet intent.
+    const secondRestore = new Event("pageshow");
+    Object.defineProperty(secondRestore, "persisted", { value: true });
+    fireEvent(window, secondRestore);
+    await waitFor(() =>
+      expect(stewardAuthSpies.getProviders).toHaveBeenCalledTimes(3),
+    );
+    await act(async () => {
+      resolveStaleProviders(walletProviders());
+      await staleProviders;
+    });
+    expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
+
     await act(async () => {
       resolveFreshProviders(walletProviders());
       await freshProviders;
@@ -349,7 +372,7 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
 
     expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();
     await waitFor(() =>
-      expect(stewardAuthSpies.getProviders).toHaveBeenCalledTimes(3),
+      expect(stewardAuthSpies.getProviders).toHaveBeenCalledTimes(4),
     );
     await screen.findByRole("alert");
     expect(screen.queryByTestId("mounted-wallet-buttons")).toBeNull();

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.capability.test.tsx
@@ -1,0 +1,90 @@
+/** Verifies wallet-chain capability gating with deterministic vendor hook doubles. */
+// @vitest-environment jsdom
+
+import type { StewardAuth } from "@stwd/sdk";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const walletHooks = vi.hoisted(() => ({
+  connectAsync: vi.fn(),
+  openConnectModal: vi.fn(),
+  setSolanaModalVisible: vi.fn(),
+  signMessageAsync: vi.fn(),
+}));
+
+vi.mock("@rainbow-me/rainbowkit", () => ({
+  useConnectModal: () => ({
+    openConnectModal: walletHooks.openConnectModal,
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    connected: false,
+    publicKey: null,
+    signMessage: undefined,
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({
+    setVisible: walletHooks.setSolanaModalVisible,
+  }),
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: undefined, isConnected: false }),
+  useConnect: () => ({
+    connectAsync: walletHooks.connectAsync,
+    connectors: [],
+  }),
+  useSignMessage: () => ({
+    signMessageAsync: walletHooks.signMessageAsync,
+  }),
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+import { WalletButtons } from "./wallet-buttons";
+
+const auth = {} as StewardAuth;
+
+describe("WalletButtons capability gating", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { siwe: true, siws: false },
+    { siwe: false, siws: true },
+    { siwe: true, siws: true },
+  ])(
+    "renders only announced chains for siwe=$siwe and siws=$siws",
+    ({ siwe, siws }) => {
+      render(
+        <WalletButtons
+          auth={auth}
+          autoStart={null}
+          disabled={false}
+          siwe={siwe}
+          siws={siws}
+          loadingProvider={null}
+          onLoadingChange={vi.fn()}
+          onSuccess={vi.fn()}
+          onError={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /EVM wallet/i }) !== null,
+      ).toBe(siwe);
+      expect(
+        screen.queryByRole("button", { name: /Solana wallet/i }) !== null,
+      ).toBe(siws);
+    },
+  );
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.capability.test.tsx
@@ -58,6 +58,23 @@ describe("WalletButtons capability gating", () => {
     vi.clearAllMocks();
   });
 
+  it("fails closed when wallet capabilities are omitted", () => {
+    render(
+      <WalletButtons
+        auth={auth}
+        autoStart={null}
+        disabled={false}
+        loadingProvider={null}
+        onLoadingChange={vi.fn()}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
+  });
+
   it.each([
     { siwe: true, siws: false },
     { siwe: false, siws: true },

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
@@ -164,8 +164,8 @@ export function WalletButtons({
   autoStart,
   auth,
   disabled,
-  siwe,
-  siws,
+  siwe = false,
+  siws = false,
   onAutoStartHandled,
   onSuccess,
   onError,
@@ -175,8 +175,8 @@ export function WalletButtons({
   autoStart?: "ethereum" | "solana" | null;
   auth: StewardAuth;
   disabled: boolean;
-  siwe: boolean;
-  siws: boolean;
+  siwe?: boolean;
+  siws?: boolean;
   onAutoStartHandled?: () => void;
   onSuccess: (result: StewardAuthResult) => void | Promise<void>;
   onError: (error: Error, kind: "ethereum" | "solana") => void;

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
@@ -13,6 +13,9 @@
  *   2. Once connected, auto-trigger the SIWE/SIWS signature.
  *   3. Call onSuccess(result) or onError(err).
  *
+ * The discovered SIWE/SIWS capabilities remain authoritative after this lazy
+ * stack mounts, so an unannounced chain never renders a sign-in control.
+ *
  * Must render inside `StewardWalletProviders` (wagmi + RainbowKit + Solana
  * adapter contexts — shared with the billing crypto top-up).
  */
@@ -161,6 +164,8 @@ export function WalletButtons({
   autoStart,
   auth,
   disabled,
+  siwe,
+  siws,
   onAutoStartHandled,
   onSuccess,
   onError,
@@ -170,6 +175,8 @@ export function WalletButtons({
   autoStart?: "ethereum" | "solana" | null;
   auth: StewardAuth;
   disabled: boolean;
+  siwe: boolean;
+  siws: boolean;
   onAutoStartHandled?: () => void;
   onSuccess: (result: StewardAuthResult) => void | Promise<void>;
   onError: (error: Error, kind: "ethereum" | "solana") => void;
@@ -178,26 +185,30 @@ export function WalletButtons({
 }) {
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-      <EthereumButton
-        autoStart={autoStart === "ethereum"}
-        auth={auth}
-        disabled={disabled}
-        onAutoStartHandled={onAutoStartHandled}
-        loading={loadingProvider === "ethereum"}
-        onSuccess={onSuccess}
-        onError={(err) => onError(err, "ethereum")}
-        onLoadingChange={(l) => onLoadingChange(l ? "ethereum" : null)}
-      />
-      <SolanaButton
-        autoStart={autoStart === "solana"}
-        auth={auth}
-        disabled={disabled}
-        onAutoStartHandled={onAutoStartHandled}
-        loading={loadingProvider === "solana"}
-        onSuccess={onSuccess}
-        onError={(err) => onError(err, "solana")}
-        onLoadingChange={(l) => onLoadingChange(l ? "solana" : null)}
-      />
+      {siwe && (
+        <EthereumButton
+          autoStart={autoStart === "ethereum"}
+          auth={auth}
+          disabled={disabled}
+          onAutoStartHandled={onAutoStartHandled}
+          loading={loadingProvider === "ethereum"}
+          onSuccess={onSuccess}
+          onError={(err) => onError(err, "ethereum")}
+          onLoadingChange={(l) => onLoadingChange(l ? "ethereum" : null)}
+        />
+      )}
+      {siws && (
+        <SolanaButton
+          autoStart={autoStart === "solana"}
+          auth={auth}
+          disabled={disabled}
+          onAutoStartHandled={onAutoStartHandled}
+          loading={loadingProvider === "solana"}
+          onSuccess={onSuccess}
+          onError={(err) => onError(err, "solana")}
+          onLoadingChange={(l) => onLoadingChange(l ? "solana" : null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# Relates to

Relates to #27888 and #27887. Parent readiness issue: #25025.

- Candidate: `120d99a3036440cc112ac7352c0ba5005b47c4a6`
- Base: `develop@6e7c46c9c03`
- Status: Draft pending exact-head independent review and hosted CI.

# What changed

- Live Steward discovery remains the authority for the current document; cached capability data may accelerate paint but cannot authorize wallet provider mounting.
- Cached non-wallet methods remain usable during a visibly reported discovery failure, while wallet-only or empty configurations fail closed with retry.
- A persisted BFCache restoration immediately revokes wallet confirmation, invalidates stale discovery, unmounts any auto-connecting provider tree, and requires a fresh affirmative response before wallets return.
- OAuth loading state is released after BFCache restoration for every supported OAuth provider.
- SIWE and SIWS provider trees mount only when their exact live-discovered capability is enabled.
- The reusable wallet provider wrapper defaults both capability flags off; the billing boundary explicitly opts into both supported chains.

# Scope and risk

UI-only: 10 files under `packages/ui`. No Cloud API, session storage, native bridge, workflow, migration, evidence-runner, or deployment change. The prior broad head was replaced because it contained unrelated auth/session work and self-attesting evidence machinery.

# Testing

- Focused Vitest matrix: 6 files, 43/43 passed. The BFCache authority regression also passed directly in isolation.
- The BFCache regression proves mounted wallets disappear immediately, remain absent while fresh discovery is pending, return only after an affirmative response, and remain absent after a rejection.
- `packages/ui` typecheck passed on the repaired tree.
- Targeted Biome passed on all 10 changed files; `git diff --check` passed.
- `packages/app audit:app` reached 199/219 passing captures before it was intentionally stopped because the reviewed SHA was superseded. The final delta changes only provider unmount/loading behavior, not layout or styling; focused DOM behavior is covered above.
- Hosted CI: pending for this exact candidate.

No real OAuth grant, passkey operation, wallet connection, signature, or account mutation was performed.
