### PR TITLE
fix(cloud): fail closed X callback and catalog when identity is unverified

### DIFF
--- a/packages/cloud/api/v1/twitter/callback/route.test.ts
+++ b/packages/cloud/api/v1/twitter/callback/route.test.ts
@@ -1,12 +1,34 @@
 /**
- * Exercises X OAuth callback identity binding with mocked transport/storage,
- * proving only a verified owner-role connection links personal DM identity.
+ * Exercises X OAuth callback identity binding and fail-closed success
+ * projection. Deterministic mocked transport/storage only; no real provider
+ * call, credential, or environment mutation.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
 let connectionRole: "owner" | "agent" = "owner";
 let callOrder: string[] = [];
+let tokenResult: {
+  accessToken: string;
+  refreshToken: string;
+  scope: string[];
+  expiresAt: number;
+  screenName?: string;
+  userId?: string;
+  identityLookupError?: string | null;
+} = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  scope: ["dm.read", "dm.write"],
+  expiresAt: 2_000_000_000,
+  screenName: "alice",
+  userId: "111",
+  identityLookupError: null,
+};
+let exchangeError: Error | null = null;
+let successLandingPath = false;
+const mintedProofs: unknown[] = [];
+
 const cacheGet = mock(async () => ({
   codeVerifier: "verifier",
   redirectUri: "https://api.example.test/api/v1/twitter/callback",
@@ -15,21 +37,21 @@ const cacheGet = mock(async () => ({
   connectionRole,
 }));
 const cacheDel = mock(async () => undefined);
-const exchangeOAuth2Token = mock(async () => ({
-  accessToken: "access-token",
-  refreshToken: "refresh-token",
-  scope: ["dm.read", "dm.write"],
-  expiresAt: 2_000_000_000,
-  screenName: "alice",
-  userId: "111",
-  identityLookupError: null,
-}));
+const exchangeOAuth2Token = mock(async () => {
+  if (exchangeError) throw exchangeError;
+  return tokenResult;
+});
 const storeCredentials = mock(async () => {
   callOrder.push("store");
 });
 const linkVerifiedXOwnerIdentity = mock(async () => {
   callOrder.push("link");
 });
+const mintOAuthSuccessProof = mock(async (args: unknown) => {
+  mintedProofs.push(args);
+  return "one-time-proof";
+});
+const isOAuthSuccessLandingPath = mock(() => successLandingPath);
 
 mock.module("@/lib/cache/client", () => ({
   cache: { get: cacheGet, del: cacheDel },
@@ -45,8 +67,8 @@ mock.module("@/lib/services/oauth/invalidation", () => ({
 }));
 mock.module("@/lib/services/oauth/success-proof", () => ({
   clearOAuthSuccessParams: mock(() => undefined),
-  isOAuthSuccessLandingPath: mock(() => false),
-  mintOAuthSuccessProof: mock(async () => null),
+  isOAuthSuccessLandingPath,
+  mintOAuthSuccessProof,
 }));
 mock.module("@/lib/security/redirect-validation", () => ({
   getDefaultPlatformRedirectOrigins: () => [],
@@ -64,12 +86,31 @@ const { default: route } = await import("./route");
 const app = new Hono();
 app.route("/api/v1/twitter/callback", route);
 
+function locationUrl(response: Response): URL {
+  const location = response.headers.get("location");
+  expect(location).toBeTruthy();
+  return new URL(location as string);
+}
+
 describe("GET /api/v1/twitter/callback", () => {
   beforeEach(() => {
     connectionRole = "owner";
     callOrder = [];
+    successLandingPath = false;
+    exchangeError = null;
+    mintedProofs.length = 0;
+    tokenResult = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      scope: ["dm.read", "dm.write"],
+      expiresAt: 2_000_000_000,
+      screenName: "alice",
+      userId: "111",
+      identityLookupError: null,
+    };
     linkVerifiedXOwnerIdentity.mockClear();
     storeCredentials.mockClear();
+    mintOAuthSuccessProof.mockClear();
   });
 
   test("links OAuth-verified owner X identity before storing credentials", async () => {
@@ -87,6 +128,10 @@ describe("GET /api/v1/twitter/callback", () => {
     });
     expect(storeCredentials).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["link", "store"]);
+    const url = locationUrl(response);
+    expect(url.searchParams.get("twitter_connected")).toBe("true");
+    expect(url.searchParams.get("twitter_username")).toBe("alice");
+    expect(url.searchParams.get("twitter_error")).toBeNull();
   });
 
   test("does not link an agent-role X identity to the authenticated user", async () => {
@@ -100,5 +145,96 @@ describe("GET /api/v1/twitter/callback", () => {
     expect(response.status).toBe(302);
     expect(linkVerifiedXOwnerIdentity).not.toHaveBeenCalled();
     expect(storeCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  test("mints a success proof for a verified identity on the success landing path", async () => {
+    successLandingPath = true;
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/twitter/callback?code=oauth-code&state=oauth-state",
+      ),
+    );
+    expect(response.status).toBe(302);
+    expect(mintOAuthSuccessProof).toHaveBeenCalledTimes(1);
+    expect(locationUrl(response).searchParams.get("proof")).toBe(
+      "one-time-proof",
+    );
+  });
+
+  test("does not emit connected success or a proof when identity lookup failed", async () => {
+    successLandingPath = true;
+    tokenResult = {
+      ...tokenResult,
+      screenName: undefined,
+      userId: undefined,
+      identityLookupError: "profile forbidden: secret-provider-detail-xyz",
+    };
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/twitter/callback?code=oauth-code&state=oauth-state",
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(storeCredentials).toHaveBeenCalledTimes(1);
+    expect(linkVerifiedXOwnerIdentity).not.toHaveBeenCalled();
+    expect(mintOAuthSuccessProof).not.toHaveBeenCalled();
+    const url = locationUrl(response);
+    expect(url.searchParams.get("twitter_connected")).toBeNull();
+    expect(url.searchParams.get("proof")).toBeNull();
+    expect(url.searchParams.get("twitter_warning")).toBeNull();
+    expect(url.searchParams.get("twitter_warning_detail")).toBeNull();
+    expect(url.searchParams.get("twitter_error_detail")).toBeNull();
+    expect(url.searchParams.get("twitter_error")).toBe(
+      "provider_identity_verification_failed",
+    );
+    expect(url.toString()).not.toContain("secret-provider-detail-xyz");
+    expect(url.toString()).not.toContain("forbidden");
+  });
+
+  test.each([
+    { screenName: undefined, userId: "111" },
+    { screenName: "alice", userId: undefined },
+    { screenName: "", userId: "111" },
+    { screenName: "alice", userId: "" },
+    { screenName: "   ", userId: "111" },
+    { screenName: "alice", userId: "   " },
+  ])(
+    "does not claim connected success for incomplete identity %j",
+    async (identity) => {
+      tokenResult = {
+        ...tokenResult,
+        ...identity,
+        identityLookupError: null,
+      };
+      const response = await app.fetch(
+        new Request(
+          "https://api.example.test/api/v1/twitter/callback?code=oauth-code&state=oauth-state",
+        ),
+      );
+      expect(storeCredentials).toHaveBeenCalledTimes(1);
+      const url = locationUrl(response);
+      expect(url.searchParams.get("twitter_connected")).toBeNull();
+      expect(url.searchParams.get("twitter_error")).toBe(
+        "provider_identity_verification_failed",
+      );
+      expect(url.searchParams.get("twitter_warning_detail")).toBeNull();
+    },
+  );
+
+  test("token exchange failures keep provider diagnostics out of the redirect URL", async () => {
+    exchangeError = new Error("invalid_grant: secret-provider-detail-xyz");
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/twitter/callback?code=oauth-code&state=oauth-state",
+      ),
+    );
+    expect(storeCredentials).not.toHaveBeenCalled();
+    const url = locationUrl(response);
+    expect(url.searchParams.get("twitter_error")).toBe("token_exchange_failed");
+    expect(url.searchParams.get("twitter_error_detail")).toBeNull();
+    expect(url.toString()).not.toContain("secret-provider-detail-xyz");
+    expect(url.toString()).not.toContain("invalid_grant");
   });
 });

--- a/packages/cloud/api/v1/twitter/callback/route.test.ts
+++ b/packages/cloud/api/v1/twitter/callback/route.test.ts
@@ -28,6 +28,7 @@ let tokenResult: {
 let exchangeError: Error | null = null;
 let successLandingPath = false;
 const mintedProofs: unknown[] = [];
+const logError = mock();
 
 const cacheGet = mock(async () => ({
   codeVerifier: "verifier",
@@ -79,7 +80,7 @@ mock.module("@/lib/security/redirect-validation", () => ({
   }),
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { error: mock(), warn: mock(), info: mock() },
+  logger: { error: logError, warn: mock(), info: mock() },
 }));
 
 const { default: route } = await import("./route");
@@ -98,6 +99,7 @@ describe("GET /api/v1/twitter/callback", () => {
     callOrder = [];
     successLandingPath = false;
     exchangeError = null;
+    logError.mockClear();
     mintedProofs.length = 0;
     tokenResult = {
       accessToken: "access-token",
@@ -236,5 +238,9 @@ describe("GET /api/v1/twitter/callback", () => {
     expect(url.searchParams.get("twitter_error_detail")).toBeNull();
     expect(url.toString()).not.toContain("secret-provider-detail-xyz");
     expect(url.toString()).not.toContain("invalid_grant");
+    expect(JSON.stringify(logError.mock.calls)).not.toContain(
+      "secret-provider-detail-xyz",
+    );
+    expect(JSON.stringify(logError.mock.calls)).not.toContain("invalid_grant");
   });
 });

--- a/packages/cloud/api/v1/twitter/callback/route.ts
+++ b/packages/cloud/api/v1/twitter/callback/route.ts
@@ -13,6 +13,10 @@ import {
   isOAuthSuccessLandingPath,
   mintOAuthSuccessProof,
 } from "@/lib/services/oauth/success-proof";
+import {
+  normalizeXProviderIdentity,
+  X_PROVIDER_IDENTITY_VERIFICATION_FAILED,
+} from "@/lib/services/oauth/x-identity";
 import { twitterAutomationService } from "@/lib/services/twitter-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -163,25 +167,28 @@ app.get("/", async (c) => {
         state.redirectUri,
       );
     } catch (error) {
-      const detail = redirectErrorDetail(error);
       logger.error("[Twitter Callback] Failed to exchange OAuth2 token", {
-        error: detail,
+        error: redirectErrorDetail(error),
         organizationId: state.organizationId,
       });
       return redirectTo(
         buildRedirectUrl(state.redirectUrl, {
           twitter_error: "token_exchange_failed",
-          twitter_error_detail: detail,
         }),
       );
     }
 
+    const verifiedIdentity = normalizeXProviderIdentity({
+      userId: tokens.userId,
+      username: tokens.screenName,
+    });
+
     try {
-      if (state.connectionRole === "owner" && tokens.userId) {
+      if (state.connectionRole === "owner" && verifiedIdentity) {
         await linkVerifiedXOwnerIdentity({
           organizationId: state.organizationId,
           userId: state.userId,
-          twitterUserId: tokens.userId,
+          twitterUserId: verifiedIdentity.userId,
         });
       }
       await twitterAutomationService.storeCredentials(
@@ -211,20 +218,25 @@ app.get("/", async (c) => {
     }
 
     await invalidateOAuthState(state.organizationId, "twitter", state.userId);
+
+    if (!verifiedIdentity || tokens.identityLookupError) {
+      logger.warn("[Twitter Callback] OAuth2 identity verification failed", {
+        organizationId: state.organizationId,
+        errorCode: X_PROVIDER_IDENTITY_VERIFICATION_FAILED,
+      });
+      return redirectTo(
+        buildRedirectUrl(state.redirectUrl, {
+          twitter_error: X_PROVIDER_IDENTITY_VERIFICATION_FAILED,
+        }),
+      );
+    }
+
     const successParams: Record<string, string> = {
       twitter_connected: "true",
       platform: "twitter",
       twitter_role: state.connectionRole ?? "owner",
+      twitter_username: verifiedIdentity.username,
     };
-    if (tokens.screenName) {
-      successParams.twitter_username = tokens.screenName;
-    }
-    if (tokens.identityLookupError) {
-      successParams.twitter_warning = "identity_lookup_failed";
-      successParams.twitter_warning_detail = redirectErrorDetail(
-        tokens.identityLookupError,
-      );
-    }
     const successTarget = buildRedirectUrl(state.redirectUrl, successParams);
     if (isOAuthSuccessLandingPath(successTarget.pathname)) {
       const proof = await mintOAuthSuccessProof({
@@ -321,15 +333,13 @@ app.get("/", async (c) => {
       oauthVerifier,
     );
   } catch (error) {
-    const detail = redirectErrorDetail(error);
     logger.error("[Twitter Callback] Failed to exchange token", {
-      error: detail,
+      error: redirectErrorDetail(error),
       organizationId: state.organizationId,
     });
     return redirectTo(
       buildRedirectUrl(redirectUrl, {
         twitter_error: "token_exchange_failed",
-        twitter_error_detail: detail,
       }),
     );
   }

--- a/packages/cloud/api/v1/twitter/callback/route.ts
+++ b/packages/cloud/api/v1/twitter/callback/route.ts
@@ -1,4 +1,4 @@
-// Handles v1 cloud API v1 twitter callback route traffic with route-local auth expectations.
+/** Completes X OAuth callbacks and projects only verified identities as connected. */
 import { Hono } from "hono";
 import { cache } from "@/lib/cache/client";
 import {
@@ -22,11 +22,6 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
-
-function redirectErrorDetail(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/\s+/g, " ").trim().slice(0, 240);
-}
 
 app.get("/", async (c) => {
   const oauthToken = c.req.query("oauth_token");
@@ -166,9 +161,10 @@ app.get("/", async (c) => {
         state.codeVerifier,
         state.redirectUri,
       );
-    } catch (error) {
+    } catch {
+      // error-policy:J1 translate provider failures without exposing response details.
       logger.error("[Twitter Callback] Failed to exchange OAuth2 token", {
-        error: redirectErrorDetail(error),
+        errorCode: "token_exchange_failed",
         organizationId: state.organizationId,
       });
       return redirectTo(
@@ -332,9 +328,10 @@ app.get("/", async (c) => {
       state.oauthTokenSecret,
       oauthVerifier,
     );
-  } catch (error) {
+  } catch {
+    // error-policy:J1 translate provider failures without exposing response details.
     logger.error("[Twitter Callback] Failed to exchange token", {
-      error: redirectErrorDetail(error),
+      errorCode: "token_exchange_failed",
       organizationId: state.organizationId,
     });
     return redirectTo(

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/twitter-adapter.identity.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/twitter-adapter.identity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Pins Twitter connection-adapter catalog readiness: stored X tokens without a
+ * complete provider identity are recoverable but must not project as active.
+ * Deterministic secrets doubles only; no real provider call or env mutation.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORG_ID = "org-1";
+const linkedAt = new Date("2024-01-02T00:00:00.000Z");
+
+let platformSecrets: Array<{ name: string; created_at: Date }> = [];
+const secretValues: Record<string, string | null> = {};
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+mock.module("../../secrets", () => ({
+  secretsService: {
+    get: async () => null,
+    delete: async () => undefined,
+  },
+}));
+mock.module("../provider-registry", () => ({
+  OAUTH_PROVIDERS: {
+    twitter: {
+      secretPatterns: {
+        accessToken: "TWITTER_ACCESS_TOKEN",
+        accessTokenSecret: "TWITTER_ACCESS_TOKEN_SECRET",
+        username: "TWITTER_USERNAME",
+        userId: "TWITTER_USER_ID",
+      },
+    },
+  },
+}));
+mock.module("./secrets-adapter-utils", () => ({
+  fetchPlatformSecrets: async () => platformSecrets,
+  getOptionalSecretValue: async (_org: string, name: string) => secretValues[name] ?? null,
+  getSecretValue: async (_org: string, name: string) => secretValues[name] ?? null,
+  getEarliestSecretDate: (records: Array<{ created_at: Date }>) =>
+    records[0]?.created_at ?? linkedAt,
+  updateSecretAccessTime: async () => undefined,
+  deletePlatformSecrets: async () => 0,
+}));
+
+const { twitterAdapter } = await import("./twitter-adapter");
+
+function resetSecrets() {
+  platformSecrets = [];
+  for (const key of Object.keys(secretValues)) delete secretValues[key];
+}
+
+function addSecret(name: string, value: string) {
+  platformSecrets.push({ name, created_at: linkedAt });
+  secretValues[name] = value;
+}
+
+describe("twitterAdapter listConnections identity contract", () => {
+  beforeEach(() => {
+    resetSecrets();
+  });
+
+  test("complete stored identity is catalogued as active", async () => {
+    addSecret("TWITTER_OWNER_OAUTH2_ACCESS_TOKEN", "oauth2-token");
+    addSecret("TWITTER_OWNER_USERNAME", "alice");
+    addSecret("TWITTER_OWNER_USER_ID", "111");
+
+    const connections = await twitterAdapter.listConnections(ORG_ID);
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.status).toBe("active");
+    expect(connections[0]?.platformUserId).toBe("111");
+    expect(connections[0]?.username).toBe("alice");
+    expect(connections[0]?.displayName).toBe("@alice");
+  });
+
+  test("stored token without identity is listed but not active and not unknown", async () => {
+    addSecret("TWITTER_OWNER_OAUTH2_ACCESS_TOKEN", "oauth2-token");
+
+    const connections = await twitterAdapter.listConnections(ORG_ID);
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.status).toBe("error");
+    expect(connections[0]?.status).not.toBe("active");
+    expect(connections[0]?.platformUserId).toBe("");
+    expect(connections[0]?.platformUserId).not.toBe("unknown");
+    expect(connections[0]?.username).toBeUndefined();
+    expect(connections[0]?.displayName).toBeUndefined();
+  });
+
+  test.each([
+    { username: "alice", userId: null },
+    { username: null, userId: "111" },
+    { username: "", userId: "111" },
+    { username: "alice", userId: "" },
+    { username: "   ", userId: "111" },
+    { username: "alice", userId: "   " },
+  ])("incomplete identity %j is not catalogued as active", async (identity) => {
+    addSecret("TWITTER_OWNER_OAUTH2_ACCESS_TOKEN", "oauth2-token");
+    if (identity.username != null) addSecret("TWITTER_OWNER_USERNAME", identity.username);
+    if (identity.userId != null) addSecret("TWITTER_OWNER_USER_ID", identity.userId);
+
+    const connections = await twitterAdapter.listConnections(ORG_ID);
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.status).not.toBe("active");
+    expect(connections[0]?.platformUserId).not.toBe("unknown");
+  });
+
+  test("legacy owner secrets without identity are not active", async () => {
+    addSecret("TWITTER_OAUTH_ACCESS_TOKEN", "legacy-token");
+
+    const connections = await twitterAdapter.listConnections(ORG_ID);
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.id).toBe("twitter:org-1:owner");
+    expect(connections[0]?.status).not.toBe("active");
+    expect(connections[0]?.platformUserId).not.toBe("unknown");
+  });
+
+  test("getToken still returns stored OAuth2 credentials when identity is unverified", async () => {
+    addSecret("TWITTER_OWNER_OAUTH2_ACCESS_TOKEN", "oauth2-token");
+    addSecret("TWITTER_OWNER_OAUTH2_SCOPE", "tweet.read users.read");
+
+    const token = await twitterAdapter.getToken(ORG_ID, "twitter:org-1:owner");
+    expect(token.accessToken).toBe("oauth2-token");
+    expect(token.scopes).toEqual(["tweet.read", "users.read"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/twitter-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/twitter-adapter.ts
@@ -11,6 +11,7 @@ import { Errors } from "../errors";
 import { OAUTH_PROVIDERS } from "../provider-registry";
 import type { OAuthConnection, OAuthStandardConnectionRole, TokenResult } from "../types";
 import { formatOAuthConnectionRole } from "../types";
+import { projectXCatalogIdentity } from "../x-identity";
 import {
   deletePlatformSecrets,
   fetchPlatformSecrets,
@@ -109,14 +110,15 @@ export const twitterAdapter: ConnectionAdapter = {
       const roleSecrets = platformSecrets.filter((secret) =>
         Object.values(names).includes(secret.name as (typeof names)[keyof typeof names]),
       );
+      const identity = projectXCatalogIdentity({ userId, username });
       connections.push({
         id: connectionId(organizationId, role),
         connectionRole: formatOAuthConnectionRole(role),
         platform: PLATFORM,
-        platformUserId: userId || "unknown",
-        username: username || undefined,
-        displayName: username ? `@${username}` : undefined,
-        status: "active",
+        platformUserId: identity.platformUserId,
+        username: identity.username,
+        displayName: identity.displayName,
+        status: identity.status,
         scopes: oauth2Scope ? oauth2Scope.split(/\s+/).filter(Boolean) : [],
         linkedAt: getEarliestSecretDate(roleSecrets.length > 0 ? roleSecrets : platformSecrets),
         tokenExpired: false,
@@ -144,14 +146,15 @@ export const twitterAdapter: ConnectionAdapter = {
         LEGACY_SECRET_NAMES.oauth2Scope,
         "twitter.legacy.oauth2Scope",
       );
+      const identity = projectXCatalogIdentity({ userId, username });
       connections.push({
         id: connectionId(organizationId, "OWNER"),
         connectionRole: "owner",
         platform: PLATFORM,
-        platformUserId: userId || "unknown",
-        username: username || undefined,
-        displayName: username ? `@${username}` : undefined,
-        status: "active",
+        platformUserId: identity.platformUserId,
+        username: identity.username,
+        displayName: identity.displayName,
+        status: identity.status,
         scopes: oauth2Scope ? oauth2Scope.split(/\s+/).filter(Boolean) : [],
         linkedAt: getEarliestSecretDate(platformSecrets),
         tokenExpired: false,

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.x-identity-projection.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.x-identity-projection.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pins generic OAuth connection catalog projection: unverified X credentials
+ * must not satisfy active/connected readiness. Uses the shared identity
+ * projector plus the real recency/preference helpers. No provider calls.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { OAuthConnection } from "./types";
+import { projectXCatalogIdentity } from "./x-identity";
+
+mock.module("../../../db/client", () => ({
+  dbRead: { select: () => ({ from: () => ({ where: async () => [] }) }) },
+  dbWrite: {},
+  db: {},
+}));
+mock.module("../../cache/client", () => ({
+  cache: { get: async () => null, set: async () => undefined, del: async () => undefined },
+}));
+mock.module("../../runtime/cloud-bindings", () => ({
+  getCloudAwareEnv: () => ({}),
+}));
+mock.module("../../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+mock.module("./connection-adapters", () => ({
+  getAdapter: () => null,
+  getAllAdapters: () => [],
+}));
+mock.module("./cache-version", () => ({
+  getOAuthVersion: async () => 1,
+  incrementOAuthVersion: async () => 1,
+}));
+mock.module("./provider-registry", () => ({
+  getProvider: () => undefined,
+  isProviderConfigured: () => false,
+  OAUTH_PROVIDERS: {},
+}));
+mock.module("./providers", () => ({
+  initiateOAuth2: async () => ({ authUrl: "https://example.test" }),
+}));
+mock.module("./token-cache", () => ({
+  tokenCache: { invalidateAll: async () => undefined },
+}));
+
+const { getMostRecentActiveConnection, getPreferredActiveConnection } = await import(
+  "./oauth-service"
+);
+
+function twitterConnection(
+  identity: { userId?: unknown; username?: unknown },
+  extras: Partial<Pick<OAuthConnection, "id" | "connectionRole" | "linkedAt">> = {},
+): OAuthConnection {
+  const projected = projectXCatalogIdentity(identity);
+  return {
+    id: extras.id ?? "twitter:org-1:owner",
+    connectionRole: extras.connectionRole ?? "owner",
+    platform: "twitter",
+    platformUserId: projected.platformUserId,
+    username: projected.username,
+    displayName: projected.displayName,
+    status: projected.status,
+    scopes: [],
+    linkedAt: extras.linkedAt ?? new Date("2024-01-01T00:00:00.000Z"),
+    tokenExpired: false,
+    source: "secrets",
+  };
+}
+
+describe("X connection catalog projection", () => {
+  test("unverified stored credentials do not satisfy active/connected readiness", () => {
+    const unverified = twitterConnection({});
+    expect(unverified.status).not.toBe("active");
+    expect(getMostRecentActiveConnection([unverified])).toBeNull();
+    expect(getPreferredActiveConnection([unverified])).toBeNull();
+    expect(getPreferredActiveConnection([unverified], undefined, "owner")).toBeNull();
+  });
+
+  test("verified identity remains the active catalog connection", () => {
+    const verified = twitterConnection({ userId: "111", username: "alice" });
+    expect(verified.status).toBe("active");
+    expect(getMostRecentActiveConnection([verified])?.id).toBe(verified.id);
+    expect(getPreferredActiveConnection([verified], undefined, "owner")?.id).toBe(verified.id);
+  });
+
+  test("mixed catalog prefers verified active X identity over stored-but-unverified", () => {
+    const unverified = twitterConnection(
+      {},
+      { id: "twitter:org-1:agent", connectionRole: "agent", linkedAt: new Date("2024-02-01") },
+    );
+    const verified = twitterConnection(
+      { userId: "111", username: "alice" },
+      { id: "twitter:org-1:owner", connectionRole: "owner", linkedAt: new Date("2024-01-01") },
+    );
+    expect(getMostRecentActiveConnection([unverified, verified])?.id).toBe(verified.id);
+    expect(getPreferredActiveConnection([unverified, verified], undefined, "agent")).toBeNull();
+    expect(getPreferredActiveConnection([unverified, verified], undefined, "owner")?.id).toBe(
+      verified.id,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/x-identity.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/x-identity.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the shared X identity verification contract used by OAuth2 callback
+ * success projection and generic connection-catalog readiness. Deterministic:
+ * no provider, secret, or environment mutation.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeXProviderIdentity,
+  projectXCatalogIdentity,
+  X_PROVIDER_IDENTITY_VERIFICATION_FAILED,
+} from "./x-identity";
+
+describe("X identity verification contract", () => {
+  test("accepts a complete trimmed user id and username", () => {
+    expect(normalizeXProviderIdentity({ userId: " 111 ", username: " alice " })).toEqual({
+      userId: "111",
+      username: "alice",
+    });
+  });
+
+  test.each([
+    { userId: undefined, username: "alice" },
+    { userId: "111", username: undefined },
+    { userId: "", username: "alice" },
+    { userId: "111", username: "" },
+    { userId: "   ", username: "alice" },
+    { userId: "111", username: "   " },
+    { userId: 111, username: "alice" },
+    { userId: "111", username: { handle: "alice" } },
+    { userId: null, username: null },
+  ])("rejects incomplete or malformed identity %j", (identity) => {
+    expect(normalizeXProviderIdentity(identity)).toBeNull();
+  });
+
+  test("verified identity projects as active catalog readiness", () => {
+    const projected = projectXCatalogIdentity({ userId: "111", username: "alice" });
+    expect(projected).toEqual({
+      verified: true,
+      status: "active",
+      platformUserId: "111",
+      username: "alice",
+      displayName: "@alice",
+    });
+  });
+
+  test("missing identity is not catalogued as active and does not use unknown", () => {
+    const projected = projectXCatalogIdentity({ userId: null, username: undefined });
+    expect(projected.verified).toBe(false);
+    expect(projected.status).toBe("error");
+    expect(projected.status).not.toBe("active");
+    expect(projected.platformUserId).toBe("");
+    expect(projected.platformUserId).not.toBe("unknown");
+    expect(projected.username).toBeUndefined();
+    expect(projected.displayName).toBeUndefined();
+  });
+
+  test("exports a stable redacted failure classification", () => {
+    expect(X_PROVIDER_IDENTITY_VERIFICATION_FAILED).toBe("provider_identity_verification_failed");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/x-identity.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/x-identity.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared X (Twitter) identity verification contract.
+ *
+ * Callback success projection, generic connection-catalog readiness, and
+ * OAuth2 token-exchange identity resolution must all use this same rule:
+ * a complete provider identity is a non-empty trimmed user id AND username.
+ * Stored tokens without that identity are recoverable but not verified.
+ */
+import type { OAuthConnectionStatus } from "./types";
+
+export const X_PROVIDER_IDENTITY_VERIFICATION_FAILED =
+  "provider_identity_verification_failed" as const;
+
+export type XProviderIdentityVerificationFailed = typeof X_PROVIDER_IDENTITY_VERIFICATION_FAILED;
+
+export interface CompleteXProviderIdentity {
+  userId: string;
+  username: string;
+}
+
+/** Normalize required X identity fields; returns null when unverified. */
+export function normalizeXProviderIdentity(identity: {
+  userId?: unknown;
+  username?: unknown;
+}): CompleteXProviderIdentity | null {
+  const userId = typeof identity.userId === "string" ? identity.userId.trim() : "";
+  const username = typeof identity.username === "string" ? identity.username.trim() : "";
+  if (userId.length === 0 || username.length === 0) {
+    return null;
+  }
+  return { userId, username };
+}
+
+/** Catalog projection: verified identity is active; stored-but-unverified is error. */
+export function projectXCatalogIdentity(identity: { userId?: unknown; username?: unknown }): {
+  verified: boolean;
+  status: Extract<OAuthConnectionStatus, "active" | "error">;
+  platformUserId: string;
+  username?: string;
+  displayName?: string;
+} {
+  const normalized = normalizeXProviderIdentity(identity);
+  if (!normalized) {
+    return {
+      verified: false,
+      status: "error",
+      platformUserId: "",
+    };
+  }
+  return {
+    verified: true,
+    status: "active",
+    platformUserId: normalized.userId,
+    username: normalized.username,
+    displayName: `@${normalized.username}`,
+  };
+}

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
@@ -134,7 +134,9 @@ describe("TwitterAutomationService error policy", () => {
 
     test("surfaces a failed identity lookup as a distinct field, not a fabricated identity", async () => {
       twitterApiBehavior.me = async () => {
-        throw Object.assign(new Error("profile forbidden"), { code: 403 });
+        throw Object.assign(new Error("profile forbidden: secret-provider-detail-xyz"), {
+          code: 403,
+        });
       };
       const service = await loadService();
       const result = await service.exchangeOAuth2Token("code", "verifier", "https://cb");
@@ -143,8 +145,31 @@ describe("TwitterAutomationService error policy", () => {
       expect(result.accessToken).toBe("access-tok");
       expect(result.screenName).toBeUndefined();
       expect(result.userId).toBeUndefined();
-      expect(typeof result.identityLookupError).toBe("string");
-      expect(result.identityLookupError).toContain("forbidden");
+      expect(result.identityLookupError).toBe("provider_identity_verification_failed");
+      expect(result.identityLookupError).not.toContain("forbidden");
+      expect(result.identityLookupError).not.toContain("secret-provider-detail-xyz");
+    });
+
+    test.each([
+      { data: { username: "", id: "42" } },
+      { data: { username: "alice", id: "" } },
+      { data: { username: "   ", id: "42" } },
+      { data: { username: "alice", id: "   " } },
+      { data: { username: "alice" } },
+      { data: { id: "42" } },
+      { data: { username: 1, id: "42" } },
+      { data: { username: "alice", id: 42 } },
+      { data: {} },
+      {},
+    ])("treats incomplete OAuth2 /2/users/me payload %j as unverified", async (payload) => {
+      twitterApiBehavior.me = async () => payload;
+      const service = await loadService();
+      const result = await service.exchangeOAuth2Token("code", "verifier", "https://cb");
+
+      expect(result.accessToken).toBe("access-tok");
+      expect(result.screenName).toBeUndefined();
+      expect(result.userId).toBeUndefined();
+      expect(result.identityLookupError).toBe("provider_identity_verification_failed");
     });
 
     test("a successful identity lookup leaves no lingering error signal", async () => {

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
@@ -160,6 +160,10 @@ describe("TwitterAutomationService error policy", () => {
       { data: { username: 1, id: "42" } },
       { data: { username: "alice", id: 42 } },
       { data: {} },
+      { data: [] },
+      { data: null },
+      [],
+      null,
       {},
     ])("treats incomplete OAuth2 /2/users/me payload %j as unverified", async (payload) => {
       twitterApiBehavior.me = async () => payload;

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
@@ -143,62 +143,26 @@ function parseVerifiedTwitterIdentity(value: unknown): VerifiedTwitterIdentity |
   const data = Reflect.get(value, "data");
   if (data === null || typeof data !== "object" || Array.isArray(data)) return null;
 
-  const username = Reflect.get(data, "username");
-  const userId = Reflect.get(data, "id");
-  if (
-    typeof username !== "string" ||
-    username.trim().length === 0 ||
-    typeof userId !== "string" ||
-    userId.trim().length === 0
-  ) {
-    return null;
-  }
+  const identity = normalizeXProviderIdentity({
+    username: Reflect.get(data, "username"),
+    userId: Reflect.get(data, "id"),
+  });
+  if (!identity) return null;
 
   const avatarUrl = Reflect.get(data, "profile_image_url");
   const normalizedAvatarUrl =
     typeof avatarUrl === "string" && avatarUrl.trim().length > 0 ? avatarUrl.trim() : undefined;
 
   return {
-    username: username.trim(),
-    userId: userId.trim(),
+    ...identity,
     ...(normalizedAvatarUrl ? { avatarUrl: normalizedAvatarUrl } : {}),
   };
-}
-
-function addTwitterApiErrorPart(parts: string[], value: unknown): void {
-  if (typeof value === "string" && value.trim().length > 0) {
-    parts.push(value.trim());
-  }
 }
 
 function getTwitterApiErrorStatus(error: unknown): number | null {
   if (!(error instanceof Error)) return null;
   const errorShape = error as TwitterApiErrorShape;
   return errorShape.data?.status ?? errorShape.code ?? null;
-}
-
-function formatTwitterApiError(error: unknown, fallback: string): string {
-  if (!(error instanceof Error)) return fallback;
-  const errorShape = error as TwitterApiErrorShape;
-  const parts = [error.message || fallback];
-
-  addTwitterApiErrorPart(parts, errorShape.data?.detail);
-  addTwitterApiErrorPart(parts, errorShape.data?.title);
-  addTwitterApiErrorPart(parts, errorShape.data?.error);
-
-  const errors = Array.isArray(errorShape.data?.errors) ? errorShape.data.errors : [];
-  for (const item of errors) {
-    addTwitterApiErrorPart(parts, item.detail);
-    addTwitterApiErrorPart(parts, item.message);
-    addTwitterApiErrorPart(parts, item.title);
-
-    const nestedErrors = Array.isArray(item.errors) ? item.errors : [];
-    for (const nested of nestedErrors) {
-      addTwitterApiErrorPart(parts, nested.message);
-    }
-  }
-
-  return [...new Set(parts)].join(" - ");
 }
 
 async function getRoleCredentials(
@@ -345,7 +309,7 @@ export interface TwitterConnectionStatus {
     userId?: string;
   };
   /** Stable, redacted classification for provider identity verification failures. */
-  errorCode?: "provider_identity_verification_failed";
+  errorCode?: typeof X_PROVIDER_IDENTITY_VERIFICATION_FAILED;
   error?: string;
 }
 
@@ -527,16 +491,7 @@ class TwitterAutomationService {
 
     try {
       const me = await client.v2.me();
-      const data =
-        me && typeof me === "object" && "data" in me ? (me as { data?: unknown }).data : undefined;
-      const dataRecord =
-        data !== null && typeof data === "object" && !Array.isArray(data)
-          ? (data as Record<string, unknown>)
-          : {};
-      const identity = normalizeXProviderIdentity({
-        userId: dataRecord.id,
-        username: dataRecord.username,
-      });
+      const identity = parseVerifiedTwitterIdentity(me);
       if (!identity) {
         // Token exchange succeeded; identity is incomplete so it cannot be treated as verified.
         identityLookupError = X_PROVIDER_IDENTITY_VERIFICATION_FAILED;
@@ -857,7 +812,7 @@ class TwitterAutomationService {
       // connection status carrying an explicit error field — never a silent healthy/empty state. A
       // missing-credentials case returns { connected:false } with no error above; this branch always
       // sets error.
-      const errorCode = "provider_identity_verification_failed" as const;
+      const errorCode = X_PROVIDER_IDENTITY_VERIFICATION_FAILED;
       const status = getTwitterApiErrorStatus(error);
       logger.warn("[TwitterAutomation] Provider identity verification failed", {
         organizationId,

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
@@ -9,6 +9,10 @@
 import { type TOAuth2Scope, TwitterApi } from "twitter-api-v2";
 import { logger } from "../../utils/logger";
 import type { OAuthConnectionRole } from "../oauth/types";
+import {
+  normalizeXProviderIdentity,
+  X_PROVIDER_IDENTITY_VERIFICATION_FAILED,
+} from "../oauth/x-identity";
 import { secretsService } from "../secrets";
 import {
   getTwitterOAuth2ClientAuthMode,
@@ -523,15 +527,34 @@ class TwitterAutomationService {
 
     try {
       const me = await client.v2.me();
-      screenName = me.data.username;
-      userId = me.data.id;
+      const data =
+        me && typeof me === "object" && "data" in me ? (me as { data?: unknown }).data : undefined;
+      const dataRecord =
+        data !== null && typeof data === "object" && !Array.isArray(data)
+          ? (data as Record<string, unknown>)
+          : {};
+      const identity = normalizeXProviderIdentity({
+        userId: dataRecord.id,
+        username: dataRecord.username,
+      });
+      if (!identity) {
+        // Token exchange succeeded; identity is incomplete so it cannot be treated as verified.
+        identityLookupError = X_PROVIDER_IDENTITY_VERIFICATION_FAILED;
+        logger.warn("[TwitterAutomation] OAuth2 profile lookup returned incomplete identity", {
+          errorCode: identityLookupError,
+          clientAuthMode: getTwitterOAuth2ClientAuthMode(),
+        });
+      } else {
+        screenName = identity.username;
+        userId = identity.userId;
+      }
     } catch (error) {
       // error-policy:J7 profile lookup is best-effort enrichment after a successful token
-      // exchange; the failure is surfaced to the caller via identityLookupError (never faked as a
-      // resolved identity) so the already-valid access token still flows through.
-      identityLookupError = formatTwitterApiError(error, "Failed to fetch X profile");
+      // exchange; the failure is a stable redacted classification (never a fabricated identity)
+      // so the already-valid access token still flows through for recovery.
+      identityLookupError = X_PROVIDER_IDENTITY_VERIFICATION_FAILED;
       logger.warn("[TwitterAutomation] OAuth2 profile lookup failed after token exchange", {
-        error: identityLookupError,
+        errorCode: identityLookupError,
         status: getTwitterApiErrorStatus(error),
         clientAuthMode: getTwitterOAuth2ClientAuthMode(),
       });


### PR DESCRIPTION
# Relates to

Fixes #29593. Supports #29919 without certifying the X provider lane. #29591/#29595 already own the merged fail-closed status behavior, which this integration preserves.

Definition of Done: full standard in CONTRIBUTING.md.

- [x] Targets develop, rebased without conflicts onto `357084b3092efb39f95807bcd459baadcc39f095`.
- [x] Frozen installation completed with Bun 1.3.14 / Node 24.15.0.
- [x] Full root `bun run verify` passed on the exact candidate content.
- [x] Renewed exact-head hosted CI passed.
- [ ] Current-head GitHub approval remains outstanding; prior approvals concern the old head.

# Sync with develop

Exact candidate: `71d03e46f722fe800a1981a895a75575cfe9c0c8`. Base: `357084b3092efb39f95807bcd459baadcc39f095`.

The original contribution is retained as a rebased commit. The integration reconciles the existing status parser with the shared identity rule, preserves envelope/array validation and optional avatar projection, and removes raw token-exchange diagnostics from callback logs. HTTP 403 remains disconnected with an explicit verification failure.

# Risks

The callback and catalog become conservative when credentials exist without a complete provider identity. Tokens remain recoverable. A complete identity still requires a non-empty trimmed user id and username; an optional malformed avatar cannot invalidate those fields. No provider or identity mutation is performed by the deterministic tests.

# Background

## What does this PR do?

An OAuth2 profile lookup failure previously allowed the callback to report connected success and the catalog to mark stored tokens active. The shared identity rule now gates callback success/proof and catalog readiness. Missing or malformed identity produces `provider_identity_verification_failed`, without raw provider diagnostic text in redirect URLs or token-exchange failure logs. Stored credentials remain available through `getToken`.

## What kind of change is this?

Bug fix for callback/catalog readiness and privacy of provider-error projection.

# Documentation changes needed?

No setup procedure changes. The callback and catalog contracts are covered by tests.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/oauth/x-identity.ts`, `packages/cloud/api/v1/twitter/callback/route.ts`, the Twitter catalog adapter, and `twitter-automation/index.ts`.

## Detailed testing steps

Run each file separately with `bun test --conditions=eliza-source`:

| File | Passed |
| --- | ---: |
| packages/cloud/shared/src/lib/services/oauth/x-identity.test.ts | 13 |
| packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts | 42 |
| packages/cloud/api/v1/twitter/callback/route.test.ts | 11 |
| packages/cloud/shared/src/lib/services/oauth/connection-adapters/twitter-adapter.identity.test.ts | 10 |
| packages/cloud/shared/src/lib/services/oauth/oauth-service.x-identity-projection.test.ts | 3 |
| packages/cloud/api/v1/twitter/status/route.connection-role.test.ts | 15 |

94 passed, zero failures, using deterministic provider/storage substitutes. The new negative control reproduced a private synthetic diagnostic in the token-exchange error log before the integration fix; the final callback suite rejects that leak. Both independent source reviews found no remaining actionable bug/security finding on the candidate content.

Frozen installation passed with native fused inference explicitly skipped as unrelated to cloud OAuth transport. Root `bun run verify` passed (exit 0), including owning workspace typecheck, lint, router contract and Worker bundle dry-run. Local evidence-row validation also passed.

# Evidence Gate

<!-- evidence-head:71d03e46f722fe800a1981a895a75575cfe9c0c8 -->

#29593 explicitly requires deterministic tests with no real provider calls or grant/credential/message/environment mutation. These tests establish the source contract only; live X onboarding certification remains separate under #29919/#25025.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend callback/catalog contract; no rendered application UI diff.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend callback/catalog contract; no rendered application UI diff.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI interaction changed; real provider calls are outside #29593 scope.
<!-- evidence-row:backend-logs -->
- [ ] N/A - #29593 explicitly limits acceptance to deterministic tests and forbids real provider calls. Source-test results above do not constitute live backend/provider logs.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - #29593 tests use deterministic storage substitutes and create no live identity, credential, grant or message.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

The detailed deterministic test results above cover source behavior. It is not a live X delivery or onboarding receipt. No frontend logs apply.

## Screenshots (before / after) + video walkthrough

N/A - no rendered application UI diff; provider-backed continuation remains outside this source PR.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

Full root verification passed. Hosted CI [run 34285597287](https://github.com/elizaOS/eliza/actions/runs/34285597287) passed on the exact head; historical approvals and checks do not approve this new head. No live X provider contact occurred. #29919 acceptance still needs authorized provider-backed evidence, custody and consent prerequisites. No merge, deployment or readiness promotion is requested.

## Maintainer CI exception record

N/A - no exception requested.
