### PR TITLE
fix(ui): keep managed Cloud routes behind pending private registration

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouterShell.private-registration.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.private-registration.test.tsx
@@ -8,11 +8,13 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getPrivateCloudRegistrationSnapshot,
   resetPrivateCloudRegistrationForTests,
   setPrivateCloudLoadForTests,
 } from "../private-cloud-registration";
 import { registerPublicCloudSurfaces } from "../register-public";
 import { CloudRouterShell } from "./CloudRouterShell";
+import { getCloudRoute, registerCloudRoute } from "./cloud-route-registry";
 
 vi.mock("./StewardProvider", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./StewardProvider")>();
@@ -133,5 +135,64 @@ describe("CloudRouterShell private Cloud registration UI", () => {
       expect(screen.getByTestId("app-probe")).toBeTruthy();
     });
     expect(attempts).toBe(2);
+  });
+
+  it("keeps a newly registered Billing route behind the pending private-registration barrier", async () => {
+    let publishBillingRoute!: () => void;
+    let completePrivateLoad!: () => void;
+    const billingRoutePublished = new Promise<void>((resolve) => {
+      publishBillingRoute = resolve;
+    });
+    const privateLoadCompleted = new Promise<void>((resolve) => {
+      completePrivateLoad = resolve;
+    });
+
+    window.history.replaceState({}, "", "/cloud/billing/payments/pay_cold");
+
+    setPrivateCloudLoadForTests(async () => {
+      await billingRoutePublished;
+      registerCloudRoute({
+        path: "cloud/billing/payments/:id",
+        group: "cloud",
+        element: function RegisteredBillingPaymentDetail() {
+          return <div data-testid="registered-billing-payment-detail" />;
+        },
+      });
+      await privateLoadCompleted;
+    });
+
+    render(<CloudRouterShell appElement={<div data-testid="app-probe" />} />);
+
+    expect(document.querySelector("[aria-busy='true']")).toBeTruthy();
+    expect(screen.queryByTestId("app-probe")).toBeNull();
+
+    await act(async () => {
+      publishBillingRoute();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getCloudRoute("cloud/billing/payments/:id")).toBeDefined();
+    expect(getPrivateCloudRegistrationSnapshot().status).toBe("pending");
+    expect(screen.queryByTestId("app-probe")).toBeNull();
+    expect(
+      screen.queryByTestId("registered-billing-payment-detail"),
+    ).toBeNull();
+    expect(document.querySelector("[aria-busy='true']")).toBeTruthy();
+    expect(window.location.pathname).toBe("/cloud/billing/payments/pay_cold");
+
+    await act(async () => {
+      completePrivateLoad();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("app-probe")).toBeTruthy();
+    });
+    expect(window.location.pathname).toBe("/cloud/billing/payments/pay_cold");
+    expect(
+      screen.queryByTestId("registered-billing-payment-detail"),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -402,13 +402,11 @@ function CloudRouteElement({
   }
   if (route.group && MANAGED_CLOUD_APP_GROUPS.has(route.group)) {
     if (isApexControlPlaneHost()) return <CanonicalCloudAppRedirect />;
-    return (
-      <StewardAuthProvider>
-        <CloudManagementSessionGate>
-          <AppCatchAllRoute appElement={appElement} />
-        </CloudManagementSessionGate>
-      </StewardAuthProvider>
-    );
+    // Individually registered cloud/admin routes must honor the same
+    // pending/error/retry/ready barrier as the `/cloud/*` wildcard. Publishing
+    // a domain route during private load must not mount the app shell early
+    // (#29283).
+    return <PrivateCloudAppRoute appElement={appElement} />;
   }
   const body = applyRouteGate(route.gate, renderRouteElement(route));
   return (


### PR DESCRIPTION
## Summary
- Individually registered managed Cloud routes (`group: "cloud"` / `"admin"`) now honor the same pending/error/retry/ready barrier as the `/cloud/*` wildcard bootstrap.
- Publishing a domain route during private registration no longer mounts the tab/view application before its owning page is available.
- Adds a deterministic `CloudRouterShell` regression with two explicit latches: publish `cloud/billing/payments/:id` during the private load, then complete that load separately.

Fixes #29283

## Test plan
- [x] New test fails on unpatched develop: registration remains `pending`, yet the application probe is mounted.
- [x] After the fix, `CloudRouterShell.private-registration.test.tsx` is 4/4 green, including the new Billing-route barrier case.
- [x] Related shell suites (`CloudRouterShell.test.tsx`, `CloudRouterShell.root-route.test.tsx`) remain green.
- [x] Biome check clean on the two touched files.