### PR TITLE
fix(ui): hide placeholder Security rows behind one notice

### DIFF
--- a/packages/ui/src/cloud/account-security/SecuritySurface.test.tsx
+++ b/packages/ui/src/cloud/account-security/SecuritySurface.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Launch-quality Security IA: working controls stay live; unavailable
+ * Sessions/MFA/audit/export capabilities must not appear as four peer-level
+ * operational rows. jsdom only — no live account mutation.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const apiFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../cloud-ui", () => ({
+  DashboardPageContainer: ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  useSetPageHeader: () => undefined,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("../lib/api-client", () => ({
+  api: apiMock,
+  apiFetch: apiFetchMock,
+}));
+
+vi.mock("./data/audit-client", () => ({
+  emitAuditEvent: vi.fn(),
+}));
+
+vi.mock("./data/consent-store", () => ({
+  getTrajectoryLoggingEnabled: vi.fn(() => false),
+  getVisionEnabled: vi.fn(() => false),
+  setTrajectoryLoggingEnabled: vi.fn(),
+  setVisionEnabled: vi.fn(),
+}));
+
+vi.mock("./data/account-deletion-client", () => ({
+  submitAccountDeletion: vi.fn(),
+  endLocalSessionAfterDeletion: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { SecuritySurface } from "./SecuritySurface";
+
+const ALL_AVAILABLE = {
+  sessions: true,
+  mfa: true,
+  auditLog: true,
+  dataExport: true,
+} as const;
+
+describe("SecuritySurface launch IA", () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    apiFetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hides four peer-level unavailable rows behind one non-interactive notice", () => {
+    render(<SecuritySurface />);
+
+    const notice = screen.getByTestId("cloud-unavailable-account-security");
+    expect(notice).toBeTruthy();
+    expect(notice.getAttribute("role")).toBe("status");
+    expect(notice.querySelector("button")).toBeNull();
+    expect(notice.querySelector("a")).toBeNull();
+    expect(notice.querySelector('[role="switch"]')).toBeNull();
+    expect(notice.textContent).toMatch(/session inventory/i);
+    expect(notice.textContent).toMatch(/two-factor authentication/i);
+    expect(notice.textContent).toMatch(/audit-log reading/i);
+    expect(notice.textContent).toMatch(/data export/i);
+
+    expect(screen.queryByTestId("cloud-active-sessions")).toBeNull();
+    expect(screen.queryByTestId("cloud-mfa-panel")).toBeNull();
+    expect(screen.queryByTestId("cloud-recent-audit-events")).toBeNull();
+    expect(screen.queryByText("Export unavailable")).toBeNull();
+    expect(screen.queryByText("Download my data")).toBeNull();
+    expect(screen.queryByText("Active sessions")).toBeNull();
+    expect(screen.queryByText("Two-factor authentication")).toBeNull();
+    expect(screen.queryByText("Recent security events")).toBeNull();
+
+    expect(screen.getByTestId("cloud-privacy-panel")).toBeTruthy();
+    expect(screen.getByTestId("vision-toggle")).toBeTruthy();
+    expect(screen.getByTestId("trajectory-toggle")).toBeTruthy();
+    expect(screen.getByTestId("delete-account-trigger")).toBeTruthy();
+    expect(screen.getByTestId("cloud-plugin-permissions-link")).toBeTruthy();
+    expect(screen.getByTestId("cloud-api-keys-link")).toBeTruthy();
+    expect(screen.getByTestId("cloud-incident-report")).toBeTruthy();
+
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("mounts functional sessions, MFA, and audit panels when those capabilities are available", async () => {
+    apiMock.mockImplementation((path: string) => {
+      if (path === "/api/v1/sessions") {
+        return Promise.resolve({ sessions: [] });
+      }
+      if (path === "/api/v1/me/mfa") {
+        return Promise.resolve({ enrolled: false, method: null });
+      }
+      return Promise.reject(new Error(`unexpected ${path}`));
+    });
+
+    render(<SecuritySurface capabilities={ALL_AVAILABLE} />);
+
+    expect(await screen.findByTestId("cloud-active-sessions")).toBeTruthy();
+    expect(screen.getByTestId("cloud-mfa-panel")).toBeTruthy();
+    expect(screen.getByTestId("cloud-recent-audit-events")).toBeTruthy();
+    expect(
+      screen.queryByTestId("cloud-unavailable-account-security"),
+    ).toBeNull();
+    expect(screen.getByTestId("vision-toggle")).toBeTruthy();
+    expect(screen.getByTestId("delete-account-trigger")).toBeTruthy();
+    expect(screen.queryByText("Export unavailable")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/account-security/SecuritySurface.tsx
+++ b/packages/ui/src/cloud/account-security/SecuritySurface.tsx
@@ -1,12 +1,19 @@
 /**
- * Security surface — the SOC2 user-facing overview: sessions / API-keys link /
- * MFA / privacy / audit / incident panels. Mounted by the `cloud-security`
- * Settings section (`/settings#cloud-security`).
+ * Security surface — SOC2 user-facing overview. Working controls (plugin
+ * grants, API keys, privacy switches, account deletion, incident report) stay
+ * live. Sessions / MFA / audit-log reading / data export stay behind one
+ * honest availability notice until #22873 ships them. Mounted by the
+ * `cloud-security` Settings section (`/settings#cloud-security`).
  */
 
 import { DashboardPageContainer, useSetPageHeader } from "../../cloud-ui";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
+import {
+  type AccountSecurityCapabilities,
+  DEFAULT_ACCOUNT_SECURITY_CAPABILITIES,
+  listUnavailableAccountSecurityCapabilities,
+} from "./account-security-capabilities";
 import { ActiveSessionsPanel } from "./components/active-sessions-panel";
 import { ApiKeysLink } from "./components/api-keys-link";
 import { IncidentReportPanel } from "./components/incident-report-panel";
@@ -14,28 +21,38 @@ import { MfaPanel } from "./components/mfa-panel";
 import { PluginPermissionsLink } from "./components/plugin-permissions-link";
 import { PrivacyPanel } from "./components/privacy-panel";
 import { RecentAuditEvents } from "./components/recent-audit-events";
+import { UnavailableAccountSecurityNotice } from "./components/unavailable-account-security-notice";
 
 /** The security surface. Assumes a `PageHeaderProvider` ancestor. */
-export function SecuritySurface() {
+export function SecuritySurface({
+  capabilities = DEFAULT_ACCOUNT_SECURITY_CAPABILITIES,
+}: {
+  capabilities?: AccountSecurityCapabilities;
+} = {}) {
   const t = useCloudT();
   useSetPageHeader({
     title: "Security",
     description:
-      "Sessions, keys, MFA, privacy controls, and audit visibility for your account.",
+      "Privacy controls, account deletion, and related security settings for your account.",
   });
   useDocumentTitle(
     t("cloud.security.metaTitle", { defaultValue: "Security · Eliza Cloud" }),
   );
 
+  const unavailable = listUnavailableAccountSecurityCapabilities(capabilities);
+
   return (
     <DashboardPageContainer>
       <div className="space-y-6">
         <PluginPermissionsLink />
-        <ActiveSessionsPanel />
+        {capabilities.sessions ? <ActiveSessionsPanel /> : null}
         <ApiKeysLink />
-        <MfaPanel />
+        {capabilities.mfa ? <MfaPanel /> : null}
         <PrivacyPanel />
-        <RecentAuditEvents />
+        {capabilities.auditLog ? <RecentAuditEvents /> : null}
+        {unavailable.length > 0 ? (
+          <UnavailableAccountSecurityNotice unavailable={unavailable} />
+        ) : null}
         <IncidentReportPanel />
       </div>
     </DashboardPageContainer>

--- a/packages/ui/src/cloud/account-security/account-security-capabilities.test.ts
+++ b/packages/ui/src/cloud/account-security/account-security-capabilities.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pins the launch-default unavailable set and the one-notice capability list.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ACCOUNT_SECURITY_CAPABILITIES,
+  formatCapabilityList,
+  listUnavailableAccountSecurityCapabilities,
+} from "./account-security-capabilities";
+
+describe("account-security capabilities", () => {
+  it("defaults all four launch capabilities to unavailable", () => {
+    expect(DEFAULT_ACCOUNT_SECURITY_CAPABILITIES).toEqual({
+      sessions: false,
+      mfa: false,
+      auditLog: false,
+      dataExport: false,
+    });
+    expect(
+      listUnavailableAccountSecurityCapabilities(
+        DEFAULT_ACCOUNT_SECURITY_CAPABILITIES,
+      ),
+    ).toEqual(["sessions", "mfa", "auditLog", "dataExport"]);
+  });
+
+  it("omits live capabilities from the unavailable list", () => {
+    expect(
+      listUnavailableAccountSecurityCapabilities({
+        sessions: true,
+        mfa: false,
+        auditLog: false,
+        dataExport: true,
+      }),
+    ).toEqual(["mfa", "auditLog"]);
+  });
+
+  it("formats the availability notice as a single English conjunction", () => {
+    expect(formatCapabilityList(["session inventory"])).toBe(
+      "session inventory",
+    );
+    expect(formatCapabilityList(["session inventory", "data export"])).toBe(
+      "session inventory and data export",
+    );
+    expect(
+      formatCapabilityList([
+        "session inventory",
+        "two-factor authentication",
+        "audit-log reading",
+        "data export",
+      ]),
+    ).toBe(
+      "session inventory, two-factor authentication, audit-log reading, and data export",
+    );
+  });
+});

--- a/packages/ui/src/cloud/account-security/account-security-capabilities.ts
+++ b/packages/ui/src/cloud/account-security/account-security-capabilities.ts
@@ -1,0 +1,52 @@
+/**
+ * Launch-time availability of account-security capabilities that still belong
+ * to production MFA/session/audit/export work (#22873). Until those ship, the
+ * Security route must not present them as peer-level operational rows.
+ */
+
+export const ACCOUNT_SECURITY_CAPABILITY_KEYS = [
+  "sessions",
+  "mfa",
+  "auditLog",
+  "dataExport",
+] as const;
+
+export type AccountSecurityCapability =
+  (typeof ACCOUNT_SECURITY_CAPABILITY_KEYS)[number];
+
+export type AccountSecurityCapabilities = Record<
+  AccountSecurityCapability,
+  boolean
+>;
+
+/** Default launch state: none of the four roadmap capabilities are live. */
+export const DEFAULT_ACCOUNT_SECURITY_CAPABILITIES: AccountSecurityCapabilities =
+  {
+    sessions: false,
+    mfa: false,
+    auditLog: false,
+    dataExport: false,
+  };
+
+export const ACCOUNT_SECURITY_CAPABILITY_LABELS: Record<
+  AccountSecurityCapability,
+  string
+> = {
+  sessions: "session inventory",
+  mfa: "two-factor authentication",
+  auditLog: "audit-log reading",
+  dataExport: "data export",
+};
+
+export function listUnavailableAccountSecurityCapabilities(
+  capabilities: AccountSecurityCapabilities,
+): AccountSecurityCapability[] {
+  return ACCOUNT_SECURITY_CAPABILITY_KEYS.filter((key) => !capabilities[key]);
+}
+
+export function formatCapabilityList(items: readonly string[]): string {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}

--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -230,12 +230,12 @@ describe("account-security panels", () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  it("keeps export unavailable while wiring the real account-deletion endpoint", () => {
+  it("keeps export off the privacy panel while wiring the real account-deletion endpoint", () => {
     const source = readFileSync(PRIVACY_PANEL_SOURCE, "utf8");
     const deletionDialog = readFileSync(ACCOUNT_DELETION_DIALOG_SOURCE, "utf8");
     const deletionPage = readFileSync(ACCOUNT_DELETION_PAGE_SOURCE, "utf8");
 
-    expect(source).toContain("Export unavailable");
+    expect(source).not.toContain("Export unavailable");
     expect(source).toContain("<AccountDeletionDialog />");
     expect(source).not.toContain("Deletion unavailable");
     expect(deletionDialog).toContain('data-testid="delete-account-trigger"');

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.test.tsx
@@ -68,12 +68,12 @@ describe("PrivacyPanel", () => {
     expect(consentMock.setVisionEnabled).toHaveBeenCalledWith(true);
   });
 
-  it("routes DSR export and delete through labelled SettingsRows", () => {
+  it("keeps account deletion live without a peer-level export row", () => {
     render(<PrivacyPanel />);
-    expect(screen.getByText("Download my data")).toBeTruthy();
     const del = screen.getByText("Delete account") as HTMLButtonElement;
     expect(screen.getByTestId("delete-account-trigger")).toBe(del);
     expect(del.disabled).toBe(false);
-    expect(screen.getByText("Export unavailable")).toBeTruthy();
+    expect(screen.queryByText("Download my data")).toBeNull();
+    expect(screen.queryByText("Export unavailable")).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -4,10 +4,11 @@
  *   - trajectory logging toggle (local consent store)
  *
  * Account deletion renders the Worker's read-only lifecycle admission state.
- * Data export remains visible but unavailable until its export job ships.
+ * Data export is not shown as a peer-level row while the export job is
+ * unavailable; SecuritySurface consolidates it into one availability notice.
  */
 
-import { Camera, Download, ScrollText, Trash2 } from "lucide-react";
+import { Camera, ScrollText, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { SettingsSwitchRow } from "../../../components/settings/settings-agent-rows";
 import {
@@ -15,7 +16,6 @@ import {
   SettingsRow,
   SettingsStack,
 } from "../../../components/settings/settings-layout";
-import { Button } from "../../../components/ui/button";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { emitAuditEvent } from "../data/audit-client";
 import {
@@ -88,31 +88,6 @@ export function PrivacyPanel() {
           })}
           checked={trajectory}
           onCheckedChange={onTrajectoryChange}
-        />
-        <SettingsRow
-          icon={Download}
-          label={t("cloud.privacyPanel.downloadTitle", {
-            defaultValue: "Download my data",
-          })}
-          description={t("cloud.privacyPanel.downloadDescription", {
-            defaultValue:
-              "Bundle your conversations, agents, and connector data into a portable archive (GDPR / CCPA right-to-export).",
-          })}
-          control={
-            <Button
-              size="sm"
-              variant="outline"
-              disabled
-              title={t("cloud.privacyPanel.exportComingSoon", {
-                defaultValue:
-                  "Data export is coming soon — not yet available on this server.",
-              })}
-            >
-              {t("cloud.privacyPanel.exportUnavailable", {
-                defaultValue: "Export unavailable",
-              })}
-            </Button>
-          }
         />
         <SettingsRow
           icon={Trash2}

--- a/packages/ui/src/cloud/account-security/components/unavailable-account-security-notice.tsx
+++ b/packages/ui/src/cloud/account-security/components/unavailable-account-security-notice.tsx
@@ -1,0 +1,62 @@
+/**
+ * Single non-interactive availability notice for roadmap account-security
+ * capabilities that are not live yet. Replaces four peer-level dead rows.
+ */
+
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
+import { useCloudT } from "../../shell/CloudI18nProvider";
+import {
+  ACCOUNT_SECURITY_CAPABILITY_LABELS,
+  type AccountSecurityCapability,
+  formatCapabilityList,
+} from "../account-security-capabilities";
+
+export function UnavailableAccountSecurityNotice({
+  unavailable,
+}: {
+  unavailable: readonly AccountSecurityCapability[];
+}) {
+  const t = useCloudT();
+  if (unavailable.length === 0) return null;
+
+  const names = unavailable.map((key) =>
+    t(`cloud.security.unavailable.capability.${key}`, {
+      defaultValue: ACCOUNT_SECURITY_CAPABILITY_LABELS[key],
+    }),
+  );
+  const listed = formatCapabilityList(names);
+  const summary = `${listed.charAt(0).toUpperCase()}${listed.slice(1)} ${
+    unavailable.length === 1 ? "is" : "are"
+  } not available on this server.`;
+
+  return (
+    <SettingsStack
+      data-testid="cloud-unavailable-account-security"
+      role="status"
+    >
+      <SettingsGroup
+        title={t("cloud.security.unavailable.title", {
+          defaultValue: "Not available yet",
+        })}
+        description={t("cloud.security.unavailable.description", {
+          defaultValue:
+            "These capabilities will appear here when they ship. They are not mixed with working controls.",
+        })}
+      >
+        <SettingsRow
+          label={t("cloud.security.unavailable.summary", {
+            defaultValue: summary,
+          })}
+          description={t("cloud.security.unavailable.liveControls", {
+            defaultValue:
+              "Privacy switches and account deletion on this page are the live controls.",
+          })}
+        />
+      </SettingsGroup>
+    </SettingsStack>
+  );
+}


### PR DESCRIPTION
## Summary
- Stop presenting Sessions, MFA, audit-log reading, and data export as four peer-level operational Security rows while those capabilities remain unavailable.
- Keep live privacy switches and account deletion usable, and consolidate the roadmap capabilities into one non-interactive availability notice.
- Functional sessions/MFA/audit panels still mount when those capabilities are marked available so #22873 can turn them on without a second IA pass.

Fixes #29200

## Test plan
- [x] Focused UI tests fail on unpatched `develop` (four dead rows still mounted; `Export unavailable` still shown).
- [x] Same tests pass after the fix: one `role="status"` notice, no sessions/MFA/audit/export rows, privacy toggles and delete remain.
- [x] Capability-available presentation still mounts sessions, MFA, and audit panels.
- [x] `bunx @biomejs/biome check` on touched files.