### PR TITLE
fix(plugin-pty): externalize @elizaos/shared in the plugin bundle

### DIFF
--- a/plugins/plugin-pty/build.ts
+++ b/plugins/plugin-pty/build.ts
@@ -9,7 +9,7 @@ import { buildPlugin } from "../plugin-build";
 await buildPlugin({
   name: "@elizaos/plugin-pty",
   clean: true,
-  externals: ["@elizaos/core", "@lydell/node-pty"],
+  externals: ["@elizaos/core", "@elizaos/shared", "@lydell/node-pty"],
   targets: [
     {
       label: "Node",

--- a/plugins/plugin-pty/test/build-externals.test.ts
+++ b/plugins/plugin-pty/test/build-externals.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Pins the plugin-pty / @elizaos/shared published-package contract (#29490):
+ * shared is a workspace runtime dependency and a Bun.build external, so a
+ * clean checkout can bundle plugin-pty before packages/shared/dist exists.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { externalsFromPackageJson } from "../../plugin-build-externals.ts";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BUILD_TS = path.join(PACKAGE_ROOT, "build.ts");
+const PACKAGE_JSON = path.join(PACKAGE_ROOT, "package.json");
+const ENTRY = path.join(PACKAGE_ROOT, "lib", "eliza-code-spec.ts");
+
+function explicitBuildExternals(source: string): string[] {
+  const match = source.match(/externals:\s*\[([^\]]+)\]/);
+  if (!match) {
+    throw new Error("plugin-pty/build.ts has no explicit externals array");
+  }
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
+describe("plugin-pty shared build contract", () => {
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("declares @elizaos/shared as a workspace runtime dependency", async () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.dependencies?.["@elizaos/shared"]).toBe("workspace:*");
+    const fromManifest = await externalsFromPackageJson(PACKAGE_JSON);
+    expect(fromManifest).toContain("@elizaos/shared");
+  });
+
+  it("externalizes @elizaos/shared so the plugin bundle does not require shared dist", async () => {
+    const externals = explicitBuildExternals(readFileSync(BUILD_TS, "utf8"));
+    expect(externals).toEqual(
+      expect.arrayContaining([
+        "@elizaos/core",
+        "@elizaos/shared",
+        "@lydell/node-pty",
+      ]),
+    );
+
+    const outdir = mkdtempSync(path.join(tmpdir(), "plugin-pty-shared-ext-"));
+    tempDirs.push(outdir);
+    const bunArgs = [
+      "build",
+      ENTRY,
+      "--outdir",
+      outdir,
+      "--target",
+      "node",
+      "--format",
+      "esm",
+      ...externals.flatMap((name) => ["--external", name]),
+    ];
+    const built = spawnSync("bun", bunArgs, {
+      cwd: PACKAGE_ROOT,
+      encoding: "utf8",
+    });
+    expect(built.status, built.stderr || built.stdout).toBe(0);
+    const bundled = readFileSync(
+      path.join(outdir, "eliza-code-spec.js"),
+      "utf8",
+    );
+    expect(bundled).toMatch(/from\s*["']@elizaos\/shared["']/);
+    expect(bundled).not.toMatch(/packages\/shared\/src/);
+  });
+});


### PR DESCRIPTION
Fixes #29490

# Relates to

- #29490

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Build-config only. Runtime PTY spawn, routes, and credentials are unchanged. If `@elizaos/shared` were incorrectly externalized, the plugin would already fail today because it imports that specifier; this makes the bundle match the workspace dependency.

# Background

## What does this PR do?

`plugins/plugin-pty` already declares `@elizaos/shared` as a workspace dependency. Its Bun.build `externals` list still omitted it (`@elizaos/core` and `@lydell/node-pty` only), so a clean checkout can try to resolve/inline shared before `packages/shared/dist` exists.

This PR adds `@elizaos/shared` to the explicit externals list and pins the contract: manifest dependency, explicit externals array, and a Bun bundle of `lib/eliza-code-spec.ts` that keeps the `@elizaos/shared` import instead of inlining `packages/shared/src`.

## What kind of change is this?

Bug fix (non-breaking). Published-package / clean-build ordering.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-pty/test/build-externals.test.ts`

## Detailed testing steps

```
bun run --cwd plugins/plugin-pty test -- test/build-externals.test.ts
bun run --cwd plugins/plugin-pty test
bun run --cwd plugins/plugin-pty typecheck
bun run --cwd plugins/plugin-pty lint:check
bun run --cwd plugins/plugin-pty build
```

Exact-head results at `361a17090d975dac4f8a96de7a2525754190ff60`:

- focused `build-externals.test.ts`: 2/2 pass
- `typecheck`: pass
- `lint:check`: pass (22 files)
- `build`: pass
- full package `bun run test`: 114 passed / 1 failed — pre-existing Windows cwd assertion, not this diff (see Known gaps)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:361a17090d975dac4f8a96de7a2525754190ff60 -->

# Evidence Details

## Real LLM-call trajectory

N/A - no model call.

# Known gaps / failures

`bun run verify` was run on this work after rebase onto `elizaOS/develop@80c22d42a0`. It does not pass end-to-end on Windows because develop is already red before this diff. Exact unrelated blockers:

- `check:i18n` (`bun run check:i18n`): `en.json missing 2 key(s) used in source` — `learnedskills.emptyTitle` and `learnedskills.startLearning` in `packages/ui/src/components/character/CharacterLearnedSkillsSection.tsx`. Those keys exist on vanilla `elizaOS/develop`; this PR does not touch i18n or that file. Verify stops here because of `&&`.
- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck lint:check --concurrency=8`: failed at `@elizaos/shared#lint:check` (CRLF vs LF in `packages/shared/src/brand/brand.css` and `packages/shared/src/brand-classic/brand.css`) and `@elizaos/plugin-notes#lint:check` (CRLF in `plugins/plugin-notes/src/views/__e2e__/fixture.css`). Neither file is in this diff. Windows checkout CRLF; `@elizaos/plugin-pty#lint:check` is green.

Remaining verify stages after `check:i18n` were run on the pre-rebase head and passed: `check:agents-claude`, `check:biome-version`, `ci-bun-version-contract`, `ci-turbo-cache-contract`, `fix-deps:check`, `ensure-plugin-test-conventions:check`, `audit:alias-read-guard`, `audit:tsconfig-workspace-resolution`, `audit:publish-graph`, `audit:build-model`, `audit:turbo-build-deps`, `audit:tee-secret-leak`, `audit:hetzner-fleet-routing`, `audit:workflow-triggers`, `audit:scripts`, `audit:scripts:inventory`, `audit:test-lane-membership`, `audit:view-bundle-inventory`, `audit:plugin-view-inventory`, `audit:focused-tests`.

Package-local pre-existing: `plugins/plugin-pty` `test/pty-session-store.test.ts` `PtySessionStore.start > spawns with the spec's file/args and a minimal allowed env` expects cwd `/work/repo` and receives `C:\work\repo` on Windows. Not in this diff.

# Sync with develop

- [x] Rebased onto current `elizaOS/develop` `80c22d42a0e1e2e41a58e034877b22b63ad5ebf5`.
- [x] Exact head `361a17090d975dac4f8a96de7a2525754190ff60`.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@80c22d42a0e1e2e41a58e034877b22b63ad5ebf5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-29490-plugin-pty-shared-external]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI; plugin build externals only.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI; plugin build externals only.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI; plugin build externals only.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend request path; Bun.build contract only.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, memory, wallet, or generated artifact.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.


