### PR TITLE
fix(app): skip unused landing-hero preloads on /login

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -316,8 +316,12 @@
 
       // These are the only above-the-fold image requests in the desktop
       // static hero. Start them from the HTML parse instead of waiting for
-      // the entry -> public shell -> landing-page module chain.
-      if (window.matchMedia("(min-width: 641px)").matches) {
+      // the entry -> public shell -> landing-page module chain. Skip every
+      // other public route (including signed-out /login): those surfaces do
+      // not render these marks, so a host-wide preload becomes an unused
+      // high-priority fetch.
+      const pathname = (location.pathname || "/").replace(/\/+$/, "") || "/";
+      if (pathname === "/" && window.matchMedia("(min-width: 641px)").matches) {
         for (const href of [
           "/brand/logos/logo_white_orangebg.svg",
           "/brand/logos/eliza_text_black.svg",

--- a/packages/app/test/index-html-landing-hero-preload.test.ts
+++ b/packages/app/test/index-html-landing-hero-preload.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Route-aware contract for landing-hero image preloads injected by index.html.
+ * Marketing desktop `/` starts the above-the-fold marks during HTML parse.
+ * Signed-out `/login` must not high-priority-fetch those unused SVGs.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it } from "vitest";
+
+const appRoot = join(import.meta.dirname, "..");
+const indexHtml = readFileSync(join(appRoot, "index.html"), "utf8");
+
+const LANDING_HERO_MARKS = [
+  "/brand/logos/logo_white_orangebg.svg",
+  "/brand/logos/eliza_text_black.svg",
+] as const;
+
+const MARKETING_ORIGIN = "https://staging.eliza.app";
+
+const openDocuments: JSDOM[] = [];
+
+afterEach(() => {
+  while (openDocuments.length > 0) {
+    openDocuments.pop()?.window.close();
+  }
+});
+
+function parseSurface(url: string, options?: { desktop?: boolean }): JSDOM {
+  const desktop = options?.desktop ?? true;
+  const dom = new JSDOM(indexHtml, {
+    pretendToBeVisual: true,
+    runScripts: "dangerously",
+    url,
+    beforeParse(window) {
+      window.matchMedia = (query: string): MediaQueryList =>
+        ({
+          matches: desktop && /min-width:\s*641px/.test(query),
+          media: query,
+          onchange: null,
+          addListener() {},
+          removeListener() {},
+          addEventListener() {},
+          removeEventListener() {},
+          dispatchEvent() {
+            return false;
+          },
+        }) as MediaQueryList;
+    },
+  });
+  openDocuments.push(dom);
+  return dom;
+}
+
+function landingHeroPreloads(document: Document): HTMLLinkElement[] {
+  const allowed = new Set<string>(LANDING_HERO_MARKS);
+  return [...document.querySelectorAll("link")].filter((link) => {
+    const href = link.getAttribute("href") ?? "";
+    const asImage =
+      link.getAttribute("as") === "image" ||
+      (link as HTMLLinkElement).as === "image";
+    return link.rel === "preload" && asImage && allowed.has(href);
+  });
+}
+
+describe("index.html landing-hero image preloads", () => {
+  it("preloads both desktop landing marks on the marketing root", () => {
+    const { document } = parseSurface(`${MARKETING_ORIGIN}/`).window;
+    const preloads = landingHeroPreloads(document);
+
+    expect(preloads.map((link) => link.getAttribute("href"))).toEqual([
+      ...LANDING_HERO_MARKS,
+    ]);
+    for (const preload of preloads) {
+      expect(preload.getAttribute("fetchpriority")).toBe("high");
+    }
+  });
+
+  it.each(["/login", "/login/", "/login?returnTo=%2Fchat"])(
+    "does not high-priority-preload unused landing marks on %s",
+    (pathnameAndSearch) => {
+      const { document } = parseSurface(
+        `${MARKETING_ORIGIN}${pathnameAndSearch}`,
+      ).window;
+
+      expect(landingHeroPreloads(document)).toEqual([]);
+    },
+  );
+
+  it("does not preload landing marks on other public marketing routes", () => {
+    const { document } = parseSurface(`${MARKETING_ORIGIN}/downloads`).window;
+
+    expect(landingHeroPreloads(document)).toEqual([]);
+  });
+
+  it("does not preload landing marks on a narrow marketing root", () => {
+    const { document } = parseSurface(`${MARKETING_ORIGIN}/`, {
+      desktop: false,
+    }).window;
+
+    expect(landingHeroPreloads(document)).toEqual([]);
+  });
+
+  it("does not preload landing marks on a non-marketing desktop host", () => {
+    const { document } = parseSurface("https://localhost/").window;
+
+    expect(landingHeroPreloads(document)).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #27892.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install --frozen-lockfile` was run after sync. `bun run verify` was
      not re-run end-to-end; focused Vitest and Biome results are recorded
      below.
- [x] A reviewer can confirm the route-aware preload contract from the
      JSDOM tests listed below, without a live staging login.

# Sync with develop

- [x] Branched from `elizaOS/eliza` `develop` at
      `01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`; zero conflicts.
- [x] Focused tests and Biome were run post-sync.

# Risks

Low. Parser-time image preloads for the desktop marketing hero are gated to
the landing pathname. Signed-out `/login` no longer high-priority-fetches
those unused SVGs. The landing route still injects the same `rel=preload`
`as=image` `fetchpriority=high` marks. Login methods, providers, callbacks,
and authentication behavior are untouched.

# Background

## What does this PR do?

- The hosted app shell classified the whole marketing hostname and then
  injected high-priority preloads for `/brand/logos/logo_white_orangebg.svg`
  and `/brand/logos/eliza_text_black.svg` on every desktop route, including
  signed-out `/login`.
- Those marks are above-the-fold only on the desktop landing hero. Login
  renders a different lockup and never consumes the preloaded SVGs, which
  produced unused-preload console warnings.
- The inline bootstrap now normalizes `location.pathname` and injects the
  landing-hero preloads only on `/`. Other public marketing routes, including
  `/login` and `/downloads`, skip them. Narrow viewports still skip them.

## What kind of change is this?

Bug fix (non-breaking launch-path resource-hint correction).

# Documentation changes needed?

No documentation change is needed. This is a parser-time preload gate; the
rendered landing and login surfaces are unchanged.

# Testing

## Where should a reviewer start?

1. `packages/app/index.html` (marketing bootstrap preload gate)
2. `packages/app/test/index-html-landing-hero-preload.test.ts`

## Detailed testing steps

Exact tested head: `51fd68d67c2b2587b116371a902d93aa45c9dc36`

Unpatched baseline (tests written first, `origin/develop`
`01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda`):

```
bunx vitest run --config vitest.config.ts test/index-html-landing-hero-preload.test.ts
```

- 4 failed / 3 passed
- `/login`, `/login/`, `/login?returnTo=%2Fchat`, and `/downloads` still
  injected the unused high-priority landing marks
- marketing `/`, narrow `/`, and non-marketing `localhost/` already matched
  the intended contract

Patched head:

```
bunx vitest run --config vitest.config.ts test/index-html-landing-hero-preload.test.ts test/index-html-desktop-preboot.test.ts
```

- 2 files / 12 tests passed
- desktop marketing `/` still preloads both hero marks at `fetchpriority=high`
- `/login` variants and `/downloads` inject none
- existing desktop preboot surfaces still classify correctly

Biome on the new test file: `Checked 1 file in 22ms. No fixes applied.`

No live staging login was performed.

# Evidence Gate

<!-- evidence-head:51fd68d67c2b2587b116371a902d93aa45c9dc36 -->

- [x] Before full-page screenshots: `N/A - parser-time resource-hint gate only;
      no rendered visual surface change; issue forbids live staging login.`
- [x] After full-page screenshots: `N/A - same reason.`
- [x] Video walkthrough: `N/A - same reason.`
- [x] Backend logs: `N/A - no backend path.`
- [x] Frontend console/network logs: `N/A - deterministic JSDOM executes the
      committed index.html bootstrap; unpatched fail / patched pass recorded
      above.`
- [x] Real-LLM trajectory: `N/A - no agent/model change.`
- [x] Domain artifacts: `N/A - no DB/wallet/file artifacts.`
- [x] OCR visual-text review: `N/A - no rendered visual surface change.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no backend path. Frontend contract is the JSDOM suite above, which
executes the committed `index.html` bootstrap against marketing `/` and
`/login`.

## Screenshots (before / after) + video walkthrough

N/A - resource-hint only; tests-only acceptance; no live staging login.

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

`bun run verify` was not re-run end-to-end. Focused Vitest covering the
touched HTML bootstrap plus the existing desktop preboot suite, and Biome
on the new test file, were run on this head.

## Maintainer CI exception record

N/A - no exception requested