### PR TITLE
fix(ui): preserve /chat intent through the apex marketing handoff

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -4,8 +4,8 @@ import { canonicalCloudPathForLegacyDashboard } from "@elizaos/shared/elizacloud
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { savePersistedActiveServer } from "../../state/persistence";
 import { appModeNavigation } from "../app-mode/app-mode";
 import {
@@ -26,7 +26,8 @@ import {
  * /api/first-run/status probe throws the first-run onboarding chooser over the
  * console (the 2026-07-04 prod bug). The catch-all sends unauthenticated apex
  * visitors to /login and authenticated ones to the in-app /cloud view —
- * for EVERY path, not just the bare root — while all other hosts (per-agent
+ * except named app intents such as /chat, which hand off to the paired
+ * cloud-app origin preserving pathname + search. All other hosts (per-agent
  * subdomains, app.elizacloud.ai, localhost) fall through to the agent app
  * unchanged.
  */
@@ -50,18 +51,30 @@ function stewardToken(expSeconds: number): string {
 const FUTURE_EXP = Math.floor(Date.now() / 1000) + 3600;
 
 const realLocation = window.location;
+let locationReplace = vi.fn<(url: string) => void>();
+
 function setHostname(hostname: string): void {
+  locationReplace = vi.fn<(url: string) => void>();
   Object.defineProperty(window, "location", {
     configurable: true,
-    value: { ...realLocation, hostname },
+    value: {
+      ...realLocation,
+      hostname,
+      replace: locationReplace,
+    },
   });
+}
+
+function LoginPageProbe(): React.JSX.Element {
+  const location = useLocation();
+  return <div data-testid="login-page" data-search={location.search} />;
 }
 
 function renderCatchAll(initialPath = "/"): void {
   render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
-        <Route path="/login" element={<div data-testid="login-page" />} />
+        <Route path="/login" element={<LoginPageProbe />} />
         {/* The Cloud home target. The real app renders the management
             view here; the test just needs a marker to prove the apex
             catch-all redirected to it. */}
@@ -88,7 +101,7 @@ function renderCatchAllWithAppModeMarkers(initialPath = "/"): void {
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialPath]}>
         <Routes>
-          <Route path="/login" element={<div data-testid="login-page" />} />
+          <Route path="/login" element={<LoginPageProbe />} />
           <Route path="/cloud" element={<div data-testid="console-home" />} />
           <Route
             path="/cloud/agents"
@@ -181,6 +194,64 @@ describe("CloudRouterShell apex catch-all", () => {
     renderCatchAll("/settings");
     expect(screen.getByTestId("console-home")).toBeTruthy();
     expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+
+  it("sends an unauthenticated apex /chat visitor to login with returnTo=/chat", () => {
+    setHostname("staging.eliza.app");
+    renderCatchAll("/chat");
+    const login = screen.getByTestId("login-page");
+    expect(login).toBeTruthy();
+    expect(login.getAttribute("data-search")).toBe("?returnTo=%2Fchat");
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(screen.queryByTestId("console-home")).toBeNull();
+    expect(locationReplace).not.toHaveBeenCalled();
+  });
+
+  it("preserves query string on unauthenticated apex /chat login returnTo", () => {
+    setHostname("staging.eliza.app");
+    renderCatchAll("/chat?ref=nav");
+    expect(screen.getByTestId("login-page").getAttribute("data-search")).toBe(
+      "?returnTo=%2Fchat%3Fref%3Dnav",
+    );
+  });
+
+  it("hands an authenticated staging.eliza.app /chat visitor to the cloud app /chat, not /cloud", async () => {
+    setHostname("staging.eliza.app");
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAll("/chat");
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(screen.queryByTestId("console-home")).toBeNull();
+    expect(screen.queryByTestId("login-page")).toBeNull();
+    await waitFor(() => {
+      expect(locationReplace).toHaveBeenCalledWith(
+        "https://cloud-staging.eliza.app/chat",
+      );
+    });
+  });
+
+  it("preserves /chat search through the authenticated apex cloud-app handoff", async () => {
+    setHostname("staging.eliza.app");
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAll("/chat?ref=nav");
+    expect(screen.queryByTestId("console-home")).toBeNull();
+    await waitFor(() => {
+      expect(locationReplace).toHaveBeenCalledWith(
+        "https://cloud-staging.eliza.app/chat?ref=nav",
+      );
+    });
+  });
+
+  it("hands an authenticated legacy apex /chat visitor to the production cloud app /chat", async () => {
+    setHostname("elizacloud.ai");
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAll("/chat");
+    expect(screen.queryByTestId("console-home")).toBeNull();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    await waitFor(() => {
+      expect(locationReplace).toHaveBeenCalledWith(
+        "https://cloud.eliza.app/chat",
+      );
+    });
   });
 
   it("redirects any other authenticated apex deep app path to the console home", () => {

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -449,11 +449,27 @@ function MarketingDownloadsRoute({
 }
 
 /**
- * Where an authenticated visitor landing on a marketing host is sent. The
- * management-route boundary forwards this path to the canonical managed Cloud
- * app, where it renders inside the normal Eliza agent shell.
+ * Where an authenticated visitor landing on a marketing host is sent when
+ * they did not request a named app intent. The management-route boundary
+ * forwards this path to the canonical managed Cloud app, where it renders
+ * inside the normal Eliza agent shell.
  */
 const APEX_AUTHENTICATED_HOME = "/cloud";
+
+/**
+ * Authenticated marketing-host paths that must keep their named app intent
+ * through the Cloud-app handoff instead of collapsing to
+ * {@link APEX_AUTHENTICATED_HOME}. `/chat` is the launch front door.
+ */
+const APEX_PRESERVED_APP_INTENTS = new Set(["/chat"]);
+
+export function isApexPreservedAuthenticatedIntent(pathname: string): boolean {
+  const normalized =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+  return APEX_PRESERVED_APP_INTENTS.has(normalized);
+}
 
 /**
  * Catch-all element. Renders the agent app exactly as before, except on a
@@ -465,9 +481,11 @@ const APEX_AUTHENTICATED_HOME = "/cloud";
  * surfaces are registered routes and match before it — so:
  *
  *  - unauthenticated → the Steward `/login` page (`returnTo` preserved).
- *  - authenticated → the Cloud handoff ({@link APEX_AUTHENTICATED_HOME}),
- *    whatever the path: `/`, `/settings`, `/chat`, or any other app-only URL
- *    would otherwise boot the backendless app.
+ *  - authenticated named app intents (`/chat`) → the paired cloud-app origin,
+ *    preserving pathname + search + hash so `staging.eliza.app/chat` lands at
+ *    `cloud-staging.eliza.app/chat`.
+ *  - authenticated any other app-only URL (`/`, `/settings`, unknown deep
+ *    links) → {@link APEX_AUTHENTICATED_HOME} (`/cloud`).
  *  - auth state not yet readable → a blank fallback, never the app; rendering
  *    the app while auth resolves lets its tab system rewrite the URL and
  *    strand the visitor before the redirect can fire.
@@ -499,6 +517,9 @@ export function AppCatchAllRoute({
         `${location.pathname}${location.search}`,
       );
       return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
+    }
+    if (isApexPreservedAuthenticatedIntent(location.pathname)) {
+      return <CanonicalCloudAppRedirect />;
     }
     return <Navigate to={APEX_AUTHENTICATED_HOME} replace />;
   }
@@ -623,7 +644,8 @@ export function CloudRouterShell({
 
           {/* Catch-all: the existing tab/view app (chat is home) — except on
               apex control-plane hosts, where the agent app never boots:
-              unauthenticated → /login, authenticated → the console home.
+              unauthenticated → /login, authenticated /chat → cloud-app
+              origin /chat, other authenticated paths → the console home.
               See AppCatchAllRoute. */}
           <Route
             path="*"


### PR DESCRIPTION
## Summary

- Authenticated entry through `staging.eliza.app/chat` completed SSO then landed at `/cloud` because the marketing/apex catch-all rewrote every app path to `APEX_AUTHENTICATED_HOME`.
- Named authenticated app intents (currently `/chat`) now hand off to the paired cloud-app origin with pathname, search, and hash intact, matching the launch contract that a front-door `/chat` URL opens chat.
- Other authenticated apex paths (`/`, `/settings`, unknown deep links) still go to `/cloud`. The agent app still never boots on the marketing origin.
- Signed-out `/chat` already preserved `returnTo`; that pin is now explicit in the catch-all tests.

Fixes #28784

## Test plan

- [x] New `CloudRouterShell` tests fail on unpatched develop: authenticated apex `/chat` still landed on `/cloud`.
- [x] After the fix, `CloudRouterShell.test.tsx` is 24/24 green, including staging and legacy apex `/chat` handoff plus login `returnTo` pins.
- [x] Related shell suites (`CloudRouterShell.root-route.test.tsx`, `CloudRouterShell.private-registration.test.tsx`) remain green (29/29 combined).
- [x] Biome check clean on the two touched files; `packages/ui` typecheck clean.