### PR TITLE
fix(lifeops): stop Shared retries and recover Dedicated activity capture

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -51,6 +51,9 @@ const h = vi.hoisted(() => {
     // imports of the capture) install methods onto ElizaClient.prototype at
     // module scope; give the mock a real class so those installs land.
     ElizaClient: class ElizaClient {},
+    apiBase: "https://shared.example.test",
+    authorityRevision: 0,
+    authoritySubscribers: new Set<() => void>(),
     getStatus: vi.fn(async () => ({ state: "running" })),
     captureLifeOpsActivitySignal: vi.fn(async () => ({
       signal: { id: "sig-1" },
@@ -112,6 +115,12 @@ vi.mock("@elizaos/ui/api", () => ({
     return () => h.authSubscribers.delete(listener);
   },
   client: {
+    getBaseUrl: () => h.apiBase,
+    getAuthorityRevision: () => h.authorityRevision,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -128,6 +137,12 @@ vi.mock("@elizaos/ui/bridge", () => ({
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
   client: {
+    getBaseUrl: () => h.apiBase,
+    getAuthorityRevision: () => h.authorityRevision,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -147,6 +162,12 @@ vi.mock("@elizaos/ui/events", () => ({
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
   client: {
+    getBaseUrl: () => h.apiBase,
+    getAuthorityRevision: () => h.authorityRevision,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -177,6 +198,12 @@ vi.mock("@elizaos/ui/browser", () => ({
     return () => h.authSubscribers.delete(listener);
   },
   client: {
+    getBaseUrl: () => h.apiBase,
+    getAuthorityRevision: () => h.authorityRevision,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -315,6 +342,9 @@ describe("startLifeOpsActivitySignalCapture", () => {
     h.loadDesktopWorkspaceSnapshot.mockResolvedValue({ supported: false });
     h.authState = { phase: "authenticated", access: { role: "OWNER" } };
     h.authSubscribers.clear();
+    h.authoritySubscribers.clear();
+    h.apiBase = "https://shared.example.test";
+    h.authorityRevision = 0;
     h.capacitorGetPlatform.mockReturnValue("web");
     h.capacitorIsNative.mockReturnValue(false);
     h.capacitorIsPluginAvailable.mockReturnValue(true);
@@ -1121,7 +1151,7 @@ describe("startLifeOpsActivitySignalCapture", () => {
     expect(sources).toContain("page_visibility");
   });
 
-  it("latches off for the document after a typed dedicated-runtime-unavailable 503", async () => {
+  it("stands down on the same authority after a typed dedicated-runtime-unavailable 503", async () => {
     vi.useFakeTimers();
     const consoleError = vi
       .spyOn(console, "error")
@@ -1145,7 +1175,8 @@ describe("startLifeOpsActivitySignalCapture", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     window.dispatchEvent(new Event("focus"));
     document.dispatchEvent(new Event("eliza:app-resume"));
-    await vi.advanceTimersByTimeAsync(65_000);
+    for (const listener of h.authoritySubscribers) listener();
+    await vi.advanceTimersByTimeAsync(300_000);
     document.dispatchEvent(new Event("visibilitychange"));
     await vi.advanceTimersByTimeAsync(0);
 
@@ -1155,6 +1186,93 @@ describe("startLifeOpsActivitySignalCapture", () => {
     );
     expect(consoleError).not.toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+
+  it.each(["dedicated handoff", "same-host account change"])(
+    "recovers activity capture after %s without reloading the document",
+    async (transition) => {
+      vi.useFakeTimers();
+      h.isApiError.mockImplementation(
+        (error) =>
+          typeof error === "object" && error !== null && "kind" in error,
+      );
+      h.captureLifeOpsActivitySignal.mockRejectedValue(
+        typedLifeOpsUnavailableError(),
+      );
+      stop = startLifeOpsActivitySignalCapture(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(h.captureLifeOpsActivitySignal).toHaveBeenCalledTimes(1);
+
+      h.captureLifeOpsActivitySignal.mockClear();
+      h.captureLifeOpsActivitySignal.mockResolvedValue({
+        signal: { id: "new-runtime" },
+      });
+      if (transition === "dedicated handoff") {
+        h.apiBase = "https://dedicated.example.test";
+      } else {
+        h.authorityRevision += 1;
+      }
+      for (const listener of h.authoritySubscribers) listener();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(capturedSources()).toContain("app_lifecycle");
+      expect(capturedSources()).toContain("page_visibility");
+      const resumed = h.captureLifeOpsActivitySignal.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(65_000);
+      expect(h.captureLifeOpsActivitySignal.mock.calls.length).toBeGreaterThan(
+        resumed,
+      );
+      expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: "capture_error" }),
+      );
+    },
+  );
+
+  it("does not carry queued signals or a late unsupported response into the next authority", async () => {
+    vi.useFakeTimers();
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    let rejectOld: (error: unknown) => void = () => {
+      throw new Error("Old request has not started");
+    };
+    h.captureLifeOpsActivitySignal.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectOld = reject;
+        }),
+    );
+    stop = startLifeOpsActivitySignalCapture(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalledTimes(1);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    h.apiBase = "https://dedicated.example.test";
+    for (const listener of h.authoritySubscribers) listener();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(h.captureLifeOpsActivitySignal.mock.calls.length).toBeGreaterThan(1);
+    rejectOld(typedLifeOpsUnavailableError());
+    await vi.advanceTimersByTimeAsync(0);
+    const resumed = h.captureLifeOpsActivitySignal.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(65_000);
+    expect(h.captureLifeOpsActivitySignal.mock.calls.length).toBeGreaterThan(
+      resumed,
+    );
+    expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: "hidden" }),
+    );
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
   });
 
   it("removes every listener and interval on stop", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -273,6 +273,34 @@ function publishAuthStatus(phase: string): void {
   }
 }
 
+function typedLifeOpsUnavailableError(): {
+  kind: "http";
+  status: number;
+  path: string;
+  code: string;
+  data: {
+    success: false;
+    code: string;
+    capability: string;
+    requiredExecutionTier: "dedicated-always";
+    upgradeRequired: true;
+  };
+} {
+  return {
+    kind: "http",
+    status: 503,
+    path: "/api/lifeops/activity-signals",
+    code: "lifeops_runtime_unavailable",
+    data: {
+      success: false,
+      code: "lifeops_runtime_unavailable",
+      capability: "lifeops-activity-signals",
+      requiredExecutionTier: "dedicated-always",
+      upgradeRequired: true,
+    },
+  };
+}
+
 describe("startLifeOpsActivitySignalCapture", () => {
   let stop: (() => void) | undefined;
 
@@ -1057,6 +1085,76 @@ describe("startLifeOpsActivitySignalCapture", () => {
     expect(h.dispatchStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ status: "capture_error" }),
     );
+  });
+
+  it("serializes one capability probe at the ready boundary before lifecycle/page-state fan-out", async () => {
+    vi.useFakeTimers();
+    let resolveCapture:
+      | ((value: { signal: { id: string } }) => void)
+      | undefined;
+    h.captureLifeOpsActivitySignal.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalledTimes(1);
+    expect(capturedSources()).toEqual(["app_lifecycle"]);
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("eliza:app-resume"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalledTimes(1);
+
+    h.captureLifeOpsActivitySignal.mockResolvedValue({
+      signal: { id: "sig-ok" },
+    });
+    resolveCapture?.({ signal: { id: "sig-ok" } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const sources = capturedSources();
+    expect(sources[0]).toBe("app_lifecycle");
+    expect(sources).toContain("page_visibility");
+  });
+
+  it("latches off for the document after a typed dedicated-runtime-unavailable 503", async () => {
+    vi.useFakeTimers();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    h.captureLifeOpsActivitySignal.mockRejectedValue(
+      typedLifeOpsUnavailableError(),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalledTimes(1);
+    expect(capturedSources()).toEqual(["app_lifecycle"]);
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
+
+    h.captureLifeOpsActivitySignal.mockClear();
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("eliza:app-resume"));
+    await vi.advanceTimersByTimeAsync(65_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalled();
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it("removes every listener and interval on stop", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -1268,7 +1268,10 @@ describe("startLifeOpsActivitySignalCapture", () => {
       resumed,
     );
     expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalledWith(
-      expect.objectContaining({ state: "hidden" }),
+      expect.objectContaining({
+        source: "page_visibility",
+        metadata: expect.objectContaining({ visibilityState: "hidden" }),
+      }),
     );
     expect(h.dispatchStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ status: "capture_error" }),

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -54,8 +54,14 @@
  * Expected unavailability (runtime not yet running, transient network/timeout,
  * endpoint 503, a stale binding whose deleted agent answers with the structural
  * agent-gone 404) quietly stands the capture down.
- * Capability-specific 503s use a bounded retry interval because the global
- * runtime status cannot prove that this optional plugin route is active.
+ * A typed dedicated-runtime-unavailable gate (`lifeops_runtime_unavailable`,
+ * requiredExecutionTier dedicated-always) latches every activity-signal source
+ * off for this document: Shared will not grow a LifeOps ingest path later in
+ * the same renderer, so retrying page/visibility POSTs only fans out 503s.
+ * Generic capability 503s still use a bounded retry interval because a
+ * Dedicated plugin may come up after boot, and the global runtime status
+ * cannot prove that this optional route is active. Sends are serialized so a
+ * retry boundary cannot emit lifecycle + page-state before the probe settles.
  * Anything else is surfaced observably: a `capture_error` status event plus a
  * prefixed console.error — but only while still mounted; a failure that lands
  * after stop is discarded rather than published. Teardown's own failures are
@@ -282,6 +288,8 @@ export function startLifeOpsActivitySignalCapture(
   let runtimeReadinessGeneration = 0;
   let runtimePoller: number | null = null;
   let activitySignalsRetryAtMs = 0;
+  let activitySignalsUnsupported = false;
+  let sendChain: Promise<void> = Promise.resolve();
   let mounted = true;
 
   const stopRuntimeReadiness = (): void => {
@@ -298,12 +306,6 @@ export function startLifeOpsActivitySignalCapture(
     stopRuntimeReadiness();
   };
 
-  const standDownActivitySignals = (): void => {
-    runtimeReady = false;
-    activitySignalsRetryAtMs =
-      Date.now() + ACTIVITY_SIGNALS_CAPABILITY_RETRY_MS;
-  };
-
   const isRuntimeUnavailableError = (error: unknown): boolean =>
     isApiError(error) &&
     error.kind === "http" &&
@@ -312,6 +314,41 @@ export function startLifeOpsActivitySignalCapture(
 
   const isRateLimitedError = (error: unknown): boolean =>
     isApiError(error) && error.kind === "http" && error.status === 429;
+
+  const isTypedDedicatedRuntimeUnavailable = (error: unknown): boolean => {
+    if (!isRuntimeUnavailableError(error) || !isApiError(error)) {
+      return false;
+    }
+    if (error.code === "lifeops_runtime_unavailable") {
+      return true;
+    }
+    const data = error.data;
+    if (!data || typeof data !== "object") {
+      return false;
+    }
+    const body = data as {
+      code?: unknown;
+      capability?: unknown;
+      requiredExecutionTier?: unknown;
+    };
+    return (
+      body.code === "lifeops_runtime_unavailable" ||
+      (body.capability === "lifeops-activity-signals" &&
+        body.requiredExecutionTier === "dedicated-always")
+    );
+  };
+
+  const standDownActivitySignals = (error: unknown): void => {
+    runtimeReady = false;
+    if (isTypedDedicatedRuntimeUnavailable(error)) {
+      // Shared (and any other dedicated-always wall) will not start ingesting
+      // later in this document. Bounded retry is only for generic 503s.
+      activitySignalsUnsupported = true;
+      return;
+    }
+    activitySignalsRetryAtMs =
+      Date.now() + ACTIVITY_SIGNALS_CAPABILITY_RETRY_MS;
+  };
 
   const isExpectedTransientError = (error: unknown): boolean =>
     isApiError(error) && (error.kind === "network" || error.kind === "timeout");
@@ -347,11 +384,11 @@ export function startLifeOpsActivitySignalCapture(
       return;
     }
     if (isRuntimeUnavailableError(error)) {
-      standDownActivitySignals();
+      standDownActivitySignals(error);
       return;
     }
     if (isRateLimitedError(error)) {
-      standDownActivitySignals();
+      standDownActivitySignals(error);
       return;
     }
     if (isExpectedTransientError(error) || isCloudAgentGoneError(error)) {
@@ -398,7 +435,9 @@ export function startLifeOpsActivitySignalCapture(
         return false;
       }
       const ready =
-        status.state === "running" && Date.now() >= activitySignalsRetryAtMs;
+        !activitySignalsUnsupported &&
+        status.state === "running" &&
+        Date.now() >= activitySignalsRetryAtMs;
       runtimeReady = ready;
       return ready;
     } catch (error) {
@@ -424,45 +463,53 @@ export function startLifeOpsActivitySignalCapture(
   const sendSignal = async (
     signal: CaptureLifeOpsActivitySignalRequest,
   ): Promise<LifeOpsActivitySignal | null> => {
-    if (!mounted || !runtimeReady) {
-      return null;
-    }
-    const normalized: CaptureLifeOpsActivitySignalRequest = {
-      ...signal,
-      platform: signal.platform ?? platform,
+    const run = async (): Promise<LifeOpsActivitySignal | null> => {
+      if (!mounted || !runtimeReady || activitySignalsUnsupported) {
+        return null;
+      }
+      const normalized: CaptureLifeOpsActivitySignalRequest = {
+        ...signal,
+        platform: signal.platform ?? platform,
+      };
+      const fingerprint = fingerprintSignal(normalized);
+      const dedupeKey = `${normalized.source}:${normalized.platform ?? ""}`;
+      const previous = lastSent.get(dedupeKey);
+      const nowMs = Date.now();
+      if (
+        previous &&
+        previous.fingerprint === fingerprint &&
+        nowMs - previous.sentAtMs < APP_SIGNAL_DEDUP_WINDOW_MS
+      ) {
+        return null;
+      }
+      lastSent.set(dedupeKey, { fingerprint, sentAtMs: nowMs });
+      try {
+        const { signal: persisted } =
+          await client.captureLifeOpsActivitySignal(normalized);
+        return persisted;
+      } catch (error) {
+        lastSent.delete(dedupeKey);
+        if (isSessionUnavailableError(error)) {
+          suspendForUnavailableSession();
+          return null;
+        }
+        if (isRuntimeUnavailableError(error)) {
+          standDownActivitySignals(error);
+          return null;
+        }
+        if (isRateLimitedError(error)) {
+          standDownActivitySignals(error);
+          return null;
+        }
+        throw error;
+      }
     };
-    const fingerprint = fingerprintSignal(normalized);
-    const dedupeKey = `${normalized.source}:${normalized.platform ?? ""}`;
-    const previous = lastSent.get(dedupeKey);
-    const nowMs = Date.now();
-    if (
-      previous &&
-      previous.fingerprint === fingerprint &&
-      nowMs - previous.sentAtMs < APP_SIGNAL_DEDUP_WINDOW_MS
-    ) {
-      return null;
-    }
-    lastSent.set(dedupeKey, { fingerprint, sentAtMs: nowMs });
-    try {
-      const { signal: persisted } =
-        await client.captureLifeOpsActivitySignal(normalized);
-      return persisted;
-    } catch (error) {
-      lastSent.delete(dedupeKey);
-      if (isSessionUnavailableError(error)) {
-        suspendForUnavailableSession();
-        return null;
-      }
-      if (isRuntimeUnavailableError(error)) {
-        standDownActivitySignals();
-        return null;
-      }
-      if (isRateLimitedError(error)) {
-        standDownActivitySignals();
-        return null;
-      }
-      throw error;
-    }
+    const pending = sendChain.then(run, run);
+    sendChain = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
   };
 
   const sendSnapshotResult = async (result: {
@@ -478,6 +525,9 @@ export function startLifeOpsActivitySignalCapture(
   };
 
   const fireAndForget = (signal: CaptureLifeOpsActivitySignalRequest): void => {
+    if (!mounted || !runtimeReady || activitySignalsUnsupported) {
+      return;
+    }
     void sendSignal(signal).catch(reportCaptureError);
   };
 
@@ -749,10 +799,19 @@ export function startLifeOpsActivitySignalCapture(
   };
 
   const emitCurrentState = (reason: string): void => {
-    emitLifecycleState("active");
-    emitPageState(reason);
-    void emitDesktopSnapshot(reason);
-    void refreshMobileHealthSnapshot(reason).catch(reportCaptureError);
+    void (async () => {
+      await sendSignal({
+        source: "app_lifecycle",
+        state: "active",
+        metadata: { reason: "resume" },
+      });
+      if (!mounted || !runtimeReady || activitySignalsUnsupported) {
+        return;
+      }
+      emitPageState(reason);
+      void emitDesktopSnapshot(reason);
+      void refreshMobileHealthSnapshot(reason).catch(reportCaptureError);
+    })().catch(reportCaptureError);
   };
 
   document.addEventListener("visibilitychange", handleVisibilityChange);

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -1,72 +1,13 @@
 /**
- * Imperative renderer-side controller that captures presence/health/screen-time
- * activity signals and posts them to the LifeOps activity-signals endpoint:
- * browser lifecycle listeners on every platform, the Capacitor MobileSignals
- * plugin on native mobile, and the Electrobun power/workspace bridge on
- * desktop. Signals are deduped by per-source fingerprint and re-captured on app
- * resume.
+ * Captures owner-consented presence, health and screen-time signals in the
+ * renderer service host. One instance owns browser listeners, mobile monitoring
+ * and desktop polling; stop awaits native teardown before replacement starts.
  *
- * The renderer-service host starts this via `../register.ts`
- * (`registerRendererService`), passing its per-instance context through, scoped
- * to main app windows only — never popouts, detached shells, the phone
- * companion, app windows, or the model tester. The controller upholds four
- * hard guarantees (#16504, #17110):
- *
- * - **Idempotent start.** One capture per renderer: a second start while one
- *   is active returns the active capture's stop function instead of installing
- *   duplicate listeners/pollers. Stop fully releases the singleton so a later
- *   start re-initializes cleanly (host replacement, HMR).
- * - **Race-safe stop.** Native startup awaits (permission check, listener
- *   registration, monitor start) re-check the stop flag after every await:
- *   stopping mid-start removes the late listener handle, stops monitoring if
- *   it already engaged, and never installs a late poller interval.
- * - **No capture before consent.** Native monitoring starts only when the OS
- *   permission status is already "granted". This background service never
- *   prompts — requesting permission is the settings UI's job — and a denial
- *   is surfaced as a `permission_unavailable` status event, then re-checked on
- *   each app resume so a grant made in Settings activates without a restart.
- * - **Commit-after-success teardown.** `stop()` is async-capable: it removes
- *   the native listener, stops monitoring, cancels any scheduled background
- *   refresh, and awaits all of it before resolving, so the renderer-service
- *   registry can serialize a successor's start behind it (defect #2 of
- *   #17110 — a stale generation's in-flight `stopMonitoring()` can no longer
- *   land after the replacement's `startMonitoring()`). Symmetrically, native
- *   monitoring only *commits* its listener handle once `startMonitoring()`
- *   resolves `{ enabled: true }`; a rejection or `enabled: false` rolls the
- *   listener back instead of wedging the retry guard forever. The optional
- *   `context` (the registry's per-instance shell/signal) is accepted so this
- *   module's `start()` matches the renderer-service contract, but `signal` is
- *   deliberately not independently observed via an `abort` listener: the
- *   registry always calls this returned `stop` as the instance's cleanup in
- *   the same synchronous tick as aborting the signal, and a second listener
- *   racing that call would see `mounted` already false and hand back an
- *   already-resolved promise — silently orphaning the real, still in-flight
- *   teardown and defeating the serialization this fix exists to provide.
- *   `mounted` alone is the race-free source of truth every async
- *   continuation re-checks after its await, so a late completion (a
- *   resolved/rejected in-flight request, a delayed native event) discards
- *   itself instead of publishing after stop.
- *
- * Canonical auth state gates runtime readiness: a signed-out renderer makes no
- * protected status requests, and the capture arms immediately when the app's
- * existing auth probe publishes a valid session. A defensive 401/403 from an
- * already-armed request suspends the poller until auth publishes again.
- * Expected unavailability (runtime not yet running, transient network/timeout,
- * endpoint 503, a stale binding whose deleted agent answers with the structural
- * agent-gone 404) quietly stands the capture down.
- * A typed dedicated-runtime-unavailable gate (`lifeops_runtime_unavailable`,
- * requiredExecutionTier dedicated-always) latches every activity-signal source
- * off for this document: Shared will not grow a LifeOps ingest path later in
- * the same renderer, so retrying page/visibility POSTs only fans out 503s.
- * Generic capability 503s still use a bounded retry interval because a
- * Dedicated plugin may come up after boot, and the global runtime status
- * cannot prove that this optional route is active. Sends are serialized so a
- * retry boundary cannot emit lifecycle + page-state before the probe settles.
- * Anything else is surfaced observably: a `capture_error` status event plus a
- * prefixed console.error — but only while still mounted; a failure that lands
- * after stop is discarded rather than published. Teardown's own failures are
- * the exception: they always report (J6), since they are this instance's own
- * teardown, not a stale generation's late noise.
+ * Signal requests serialize within an API authority. An unsupported LifeOps
+ * route stands down until that authority changes; generic transient failures
+ * retain bounded recovery. Queued requests and late responses cannot cross
+ * authority or session generations. Authentication and existing native consent
+ * gate capture, and unexpected failures remain observable through status events.
  */
 import { Capacitor } from "@capacitor/core";
 import {
@@ -291,6 +232,8 @@ export function startLifeOpsActivitySignalCapture(
   let activitySignalsUnsupported = false;
   let sendChain: Promise<void> = Promise.resolve();
   let mounted = true;
+  let authorityBase = client.getBaseUrl();
+  let authorityRevision = client.getAuthorityRevision();
 
   const stopRuntimeReadiness = (): void => {
     runtimeReadinessGeneration += 1;
@@ -326,23 +269,20 @@ export function startLifeOpsActivitySignalCapture(
     if (!data || typeof data !== "object") {
       return false;
     }
-    const body = data as {
-      code?: unknown;
-      capability?: unknown;
-      requiredExecutionTier?: unknown;
-    };
     return (
-      body.code === "lifeops_runtime_unavailable" ||
-      (body.capability === "lifeops-activity-signals" &&
-        body.requiredExecutionTier === "dedicated-always")
+      ("code" in data && data.code === "lifeops_runtime_unavailable") ||
+      ("capability" in data &&
+        data.capability === "lifeops-activity-signals" &&
+        "requiredExecutionTier" in data &&
+        data.requiredExecutionTier === "dedicated-always")
     );
   };
 
   const standDownActivitySignals = (error: unknown): void => {
     runtimeReady = false;
     if (isTypedDedicatedRuntimeUnavailable(error)) {
-      // Shared (and any other dedicated-always wall) will not start ingesting
-      // later in this document. Bounded retry is only for generic 503s.
+      // A Shared authority cannot ingest this capability. Dedicated handoff
+      // or account replacement resets this state through onAuthorityChange.
       activitySignalsUnsupported = true;
       return;
     }
@@ -463,8 +403,14 @@ export function startLifeOpsActivitySignalCapture(
   const sendSignal = async (
     signal: CaptureLifeOpsActivitySignalRequest,
   ): Promise<LifeOpsActivitySignal | null> => {
+    const generation = runtimeReadinessGeneration;
     const run = async (): Promise<LifeOpsActivitySignal | null> => {
-      if (!mounted || !runtimeReady || activitySignalsUnsupported) {
+      if (
+        !mounted ||
+        !runtimeReady ||
+        activitySignalsUnsupported ||
+        generation !== runtimeReadinessGeneration
+      ) {
         return null;
       }
       const normalized: CaptureLifeOpsActivitySignalRequest = {
@@ -486,8 +432,12 @@ export function startLifeOpsActivitySignalCapture(
       try {
         const { signal: persisted } =
           await client.captureLifeOpsActivitySignal(normalized);
+        if (!mounted || generation !== runtimeReadinessGeneration) return null;
         return persisted;
       } catch (error) {
+        // error-policy:J4 stale responses belong to a retired capture authority;
+        // current transport failures stand down or propagate to the boundary.
+        if (!mounted || generation !== runtimeReadinessGeneration) return null;
         lastSent.delete(dedupeKey);
         if (isSessionUnavailableError(error)) {
           suspendForUnavailableSession();
@@ -505,6 +455,7 @@ export function startLifeOpsActivitySignalCapture(
       }
     };
     const pending = sendChain.then(run, run);
+    // error-policy:J5 the caller observes pending; the queue must remain usable.
     sendChain = pending.then(
       () => undefined,
       () => undefined,
@@ -799,13 +750,19 @@ export function startLifeOpsActivitySignalCapture(
   };
 
   const emitCurrentState = (reason: string): void => {
+    const generation = runtimeReadinessGeneration;
     void (async () => {
       await sendSignal({
         source: "app_lifecycle",
         state: "active",
         metadata: { reason: "resume" },
       });
-      if (!mounted || !runtimeReady || activitySignalsUnsupported) {
+      if (
+        !mounted ||
+        !runtimeReady ||
+        activitySignalsUnsupported ||
+        generation !== runtimeReadinessGeneration
+      ) {
         return;
       }
       emitPageState(reason);
@@ -871,6 +828,25 @@ export function startLifeOpsActivitySignalCapture(
   // Subscribe before reading the snapshot so an auth publication racing this
   // startup cannot be missed. A duplicate authenticated publication is a no-op.
   const unsubscribeAuthStatus = subscribeAuthStatus(handleAuthStatus);
+  const unsubscribeAuthority = client.onAuthorityChange(() => {
+    const nextBase = client.getBaseUrl();
+    const nextRevision = client.getAuthorityRevision();
+    if (
+      !mounted ||
+      (nextBase === authorityBase && nextRevision === authorityRevision)
+    )
+      return;
+    authorityBase = nextBase;
+    authorityRevision = nextRevision;
+    stopRuntimeReadiness();
+    activitySignalsUnsupported = false;
+    activitySignalsRetryAtMs = 0;
+    lastSent.clear();
+    // A slow request to the previous host must not block the new owner. Its
+    // queued work and completion are invalidated by the readiness generation.
+    sendChain = Promise.resolve();
+    startRuntimeReadiness("runtime-authority-changed");
+  });
   const initialAuth = getAuthStatusSnapshot();
   if (
     isAuthenticatedNow() &&
@@ -905,6 +881,7 @@ export function startLifeOpsActivitySignalCapture(
       activeCaptureStop = null;
     }
     unsubscribeAuthStatus();
+    unsubscribeAuthority();
     sessionAllowsReadiness = false;
     stopRuntimeReadiness();
     document.removeEventListener("visibilitychange", handleVisibilityChange);

--- a/plugins/plugin-personal-assistant/src/register.test.ts
+++ b/plugins/plugin-personal-assistant/src/register.test.ts
@@ -16,6 +16,7 @@ const h = vi.hoisted(() => ({
   // imports of the capture) install methods onto ElizaClient.prototype at
   // module scope; give the mock a real class so those installs land.
   ElizaClient: class ElizaClient {},
+  authoritySubscribers: new Set<() => void>(),
   getStatus: vi.fn(async () => ({ state: "running" })),
   captureLifeOpsActivitySignal: vi.fn(async () => ({
     signal: { id: "sig-1" },
@@ -73,6 +74,12 @@ vi.mock("@elizaos/ui/api", () => ({
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
   client: {
+    getBaseUrl: () => "http://fixture.local",
+    getAuthorityRevision: () => 0,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -81,6 +88,12 @@ vi.mock("@elizaos/ui/bridge", () => ({
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
   client: {
+    getBaseUrl: () => "http://fixture.local",
+    getAuthorityRevision: () => 0,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -95,6 +108,12 @@ vi.mock("@elizaos/ui/events", () => ({
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
   client: {
+    getBaseUrl: () => "http://fixture.local",
+    getAuthorityRevision: () => 0,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -115,6 +134,12 @@ vi.mock("@elizaos/ui/browser", () => ({
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
   client: {
+    getBaseUrl: () => "http://fixture.local",
+    getAuthorityRevision: () => 0,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -125,6 +150,12 @@ vi.mock("@elizaos/ui/auth-status", () => ({
   APP_RESUME_EVENT: "eliza:app-resume",
   ElizaClient: h.ElizaClient,
   client: {
+    getBaseUrl: () => "http://fixture.local",
+    getAuthorityRevision: () => 0,
+    onAuthorityChange: (listener: () => void) => {
+      h.authoritySubscribers.add(listener);
+      return () => h.authoritySubscribers.delete(listener);
+    },
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
   },
@@ -200,6 +231,7 @@ describe("personal-assistant renderer registration entry", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    h.authoritySubscribers.clear();
     h.getStatus.mockResolvedValue({ state: "running" });
     h.capacitorGetPlatform.mockReturnValue("web");
     h.capacitorIsPluginAvailable.mockReturnValue(true);


### PR DESCRIPTION
Shared renderers now make one serialized LifeOps capability probe and stop sending activity signals after the typed unsupported response. When the same page hands off to Dedicated, or its account changes, capture resumes under the new API authority. Old queued payloads and late responses cannot affect that authority. Generic 503 and 429 failures retain bounded recovery.

The original PR's document-wide unsupported flag prevented recovery after Dedicated provisioning completed. This revision preserves its serialization fix and scopes the flag, deduplication state and queue to the real API client's authority notifications.

# Relates to

Addresses #27898. Deployed Shared and real native-device acceptance remain tracked there; this PR does not automatically close that rollout requirement.

# Sync with develop

Candidate `a0d4f59cf4179678bd4515e52c4e3fffe7e293cd`, rebased on `f1bed247dee05c54a3a11a7af9c35167c82f1e6b`. Original contribution authorship is retained. Normal installation passed with Bun 1.3.14 and Node 24.15.0, including the existing fused-inference installation check.

Final repository verification passes all 373 tasks and final audits.

# Risks

This changes renderer background activity capture and its handoff timing. Authentication, native consent and teardown still gate capture. The regression suite covers session recovery, host replacement, duplicate notifications, stale queues, late responses and existing native monitoring lifecycles.

# Background

## What does this PR do?

The lifecycle request completes before visibility, desktop and mobile fan-out. Unsupported capability state survives duplicate notifications for the same authority, but a real host or bearer change invalidates the previous generation and starts a fresh readiness probe.

## What kind of change is this?

Bug fix; no route, DTO, UI layout or public API change.

# Documentation changes needed?

None. The controller header documents its authority and lifecycle guarantees.

# Testing

- Final candidate: 57 capture and renderer-registration tests pass.
- Complete personal-assistant suite on `377b44535cdab91a8c9c5cbd8c892e3473d1a1ed`: 301 files pass; 2,608 tests pass and six skip. The only difference to the final candidate is the newly merged native iMessage regression test file. All five tests in that incoming file pass on the final candidate after root verification.
- Six existing real API-client authority tests pass on the unchanged client source.
- Chromium runs the production capture controller, API client and authentication probe against controlled HTTP endpoints. A five-minute Shared observation emits one failed capability request. The real `repointBaseUrl` method then restores Dedicated lifecycle and visibility requests in the same page. No browser exception occurs; the only console error is the expected initial Shared 503.
- The original PR implementation fails the same browser handoff with zero Dedicated requests. Separately removing only the queue-generation guard makes the stale visibility payload regression fail. Both negative results are retained.

## Where should a reviewer start?

Read the request/response report and watch the handoff recording. The original implementation's recording and failure report provide the before comparison. The page is an explicit diagnostic fixture; it is not presented as the deployed product.

## Detailed testing steps

The evidence archive includes the reproducible Bun/Playwright harness and its fixture. Production modules resolve from the checked-out source; native-only browser shims use the app's existing configuration. The local Dedicated endpoint accepts activity signals and an idle WebSocket connection for the real client reconnect. No external account, provider or VPS is mutated by this harness.

# Evidence Gate

<!-- evidence-head:a0d4f59cf4179678bd4515e52c4e3fffe7e293cd -->

<!-- evidence-row:before-screenshots -->
- [x] Diagnostic fixture before: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-ee379-lifeops-before-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-ee379-lifeops-before-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] Diagnostic fixture after: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-after-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-after-mobile.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-desktop-10fps.mp4
<!-- evidence-row:backend-logs -->
- [x] [29607-a0d4-lifeops-package-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-package-tests.log)
<!-- evidence-row:frontend-logs -->
- [x] [29607-a0d4-lifeops-http.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-http.json)
<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, action or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [29607-a0d4-lifeops-provenance.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-provenance.json)
<!-- evidence-row:ocr-review -->
N/A - background controller change with no rendered product UI change; the diagnostic fixture captures are manually inspected.

# Evidence Details

## Real LLM-call trajectory

N/A - background activity transport only; no inference behavior changes.

## Backend + frontend logs

[Complete logs and reports](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-evidence.zip). The post-verification desktop report records exactly one Shared POST/503 over 300,000 ms, followed by two Dedicated POST/200 responses after `repointBaseUrl`. Browser exceptions: zero. The only console error is the expected initial Shared 503. The mobile-width report has the same statuses with a 1,500 ms Shared observation; it is not a second five-minute claim.

## Screenshots (before / after) + video walkthrough

These are manually inspected diagnostic fixture captures. The background controller has no rendered product view; network reports establish the behavior.

### Before

![Desktop diagnostic before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-ee379-lifeops-before-desktop.jpg)
![Mobile diagnostic before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-ee379-lifeops-before-mobile.jpg)

### After

![Desktop diagnostic after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-after-desktop.jpg)
![Mobile diagnostic after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-after-mobile.jpg)

### Walkthrough video

[Final desktop recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-desktop.mp4), [final mobile recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-a0d4-lifeops-mobile.mp4), [original implementation failure](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/29607-ee379-lifeops-before.mp4).

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

The full package proof predates only the incoming iMessage test additions; the final replay is recorded separately. The browser proof uses real production client/controller code with controlled endpoints. It does not claim a deployed Shared staging run, native hardware ingestion or a VPS release. Those rollout checks remain in #27898. No app UI or native bridge implementation changes, so a full app visual redesign audit and live-model trajectory do not apply. Negative-control failures are intentional and are distinguished from passing candidate runs.

## Maintainer CI exception record

N/A - no exception requested. Exact-head hosted checks must pass before merge.

