### PR TITLE
fix(cloud): normalize phoneless legacy phone_verified NULL projections

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0343_normalize_legacy_null_phone_verified.sql
+++ b/packages/cloud/shared/src/db/migrations/0343_normalize_legacy_null_phone_verified.sql
@@ -1,0 +1,32 @@
+-- Append-only normalization for phoneless legacy projections: phone_verified NULL → false.
+-- Migration 0051 projected NULL when phone_number was absent. Do not touch rows that
+-- already have a phone number or a non-null verification flag. Publish only redacted
+-- aggregate before/after counts; never log user, provider, session, or phone identifiers.
+
+UPDATE "user_identities"
+SET
+  "phone_verified" = FALSE,
+  "updated_at" = NOW()
+WHERE "phone_number" IS NULL
+  AND "phone_verified" IS NULL;
+--> statement-breakpoint
+UPDATE "users"
+SET
+  "phone_verified" = FALSE,
+  "updated_at" = NOW()
+WHERE "phone_number" IS NULL
+  AND "phone_verified" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "user_identities"
+  DROP CONSTRAINT IF EXISTS "user_identities_phone_verified_requires_number";
+--> statement-breakpoint
+ALTER TABLE "user_identities"
+  ADD CONSTRAINT "user_identities_phone_verified_requires_number"
+  CHECK ("phone_verified" IS NOT TRUE OR "phone_number" IS NOT NULL);
+--> statement-breakpoint
+ALTER TABLE "users"
+  DROP CONSTRAINT IF EXISTS "users_phone_verified_requires_number";
+--> statement-breakpoint
+ALTER TABLE "users"
+  ADD CONSTRAINT "users_phone_verified_requires_number"
+  CHECK ("phone_verified" IS NOT TRUE OR "phone_number" IS NOT NULL);

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2283,6 +2283,13 @@
       "when": 1794254400033,
       "tag": "0342_retire_agent_backup_admission_protocol_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 326,
+      "version": "7",
+      "when": 1794254400034,
+      "tag": "0343_normalize_legacy_null_phone_verified",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
@@ -260,6 +260,25 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
     ).resolves.toEqual({ status: "identity_projection_conflict" });
   });
 
+  test("phoneless telegram false/NULL projection remains eligible for phone convergence", async () => {
+    const pair = await createPair();
+    const proof = proofFor(pair);
+    const [telegramUser] = await dbWrite
+      .select()
+      .from(users)
+      .where(eq(users.id, pair.telegram.user.id));
+    expect(telegramUser.phone_number).toBeNull();
+    expect(telegramUser.phone_verified).toBe(false);
+
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+
+    const inspection = await usersRepository.inspectPhoneTelegramPersonalAccountConvergence(proof);
+    expect(inspection.status).toBe("eligible");
+  });
+
   test("converges exactly two $0 provisional accounts and retains an idempotent alias receipt", async () => {
     const pair = await createPair();
     const proof = proofFor(pair);

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-legacy-phone-verified-projection.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-legacy-phone-verified-projection.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Legacy phoneless user_identities.phone_verified NULL vs users.phone_verified
+ * false must not block otherwise coherent phone/Telegram convergence, and
+ * append-only repair must not restore healthy returning-login writes.
+ *
+ * Isolated PGlite only; no ambient Postgres and no live account mutation.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq, sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { organizationBalanceRevisionSequence, organizations } from "../../schemas/organizations";
+import { personalAccountConvergences } from "../../schemas/personal-account-convergences";
+import { personalDedicatedUpgradeAuthorities } from "../../schemas/personal-dedicated-upgrade-authorities";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../../schemas/personal-shared-groups";
+import { userCharacters } from "../../schemas/user-characters";
+import { userIdentities } from "../../schemas/user-identities";
+import { users } from "../../schemas/users";
+import { findReusablePersonalDelivery } from "../personal-shared-deliveries";
+import { usersRepository } from "../users";
+
+const PGLITE_TIMEOUT = 120_000;
+
+describe("legacy phoneless phone_verified projection (#28646)", () => {
+  let pgliteReady = true;
+  let sequence = 0;
+
+  const createPair = async () => {
+    sequence += 1;
+    const phoneNumber = `+14155554${String(sequence).padStart(4, "0")}`;
+    const telegramId = `30000${sequence}`;
+    const phone = await usersRepository.findOrCreatePhonePersonalAccount({
+      phoneNumber,
+      displayName: `Phone ${sequence}`,
+      organizationName: `Phone ${sequence}`,
+      organizationSlug: `phone-legacy-${sequence}`,
+    });
+    const telegram = await usersRepository.findOrCreateMessagingPersonalAccount({
+      platform: "telegram",
+      telegramId,
+      telegramUsername: `telegram_legacy_${sequence}`,
+      telegramFirstName: `Telegram ${sequence}`,
+      displayName: `Telegram ${sequence}`,
+      organizationName: `Telegram ${sequence}`,
+      organizationSlug: `telegram-legacy-${sequence}`,
+    });
+    return { phoneNumber, telegramId, phone, telegram };
+  };
+
+  const proofFor = (pair: Awaited<ReturnType<typeof createPair>>) => ({
+    phoneNumber: pair.phoneNumber,
+    telegramId: pair.telegramId,
+    stewardUserId: `steward-legacy-${sequence}`,
+    expectedTelegramUserId: pair.telegram.user.id,
+    expectedTelegramOrganizationId: pair.telegram.organization.id,
+  });
+
+  beforeAll(async () => {
+    if (!CAN_USE_ISOLATED_PGLITE) {
+      pgliteReady = false;
+      console.warn(
+        "[users-legacy-phone-verified-projection.test] isolated PGlite is required; refusing to mutate an ambient Postgres database.",
+      );
+      return;
+    }
+
+    try {
+      const { apply } = await pushSchema(
+        {
+          organizationBalanceRevisionSequence,
+          organizations,
+          users,
+          userIdentities,
+          personalAccountConvergences,
+          personalSharedGroupBindings,
+          personalSharedGroupParticipants,
+          personalSharedGroupJoinChallenges,
+          userCharacters,
+          agentSandboxes,
+          personalDedicatedUpgradeAuthorities,
+        } as never,
+        dbWrite as never,
+      );
+      await apply();
+      await dbWrite.execute(sql`
+        CREATE TABLE IF NOT EXISTS credit_transactions (
+          id uuid PRIMARY KEY,
+          organization_id uuid NOT NULL
+        )
+      `);
+      await dbWrite.execute(sql`
+        CREATE TABLE IF NOT EXISTS api_keys (
+          id uuid PRIMARY KEY,
+          organization_id uuid NOT NULL
+        )
+      `);
+      await dbWrite.execute(sql`
+        CREATE TABLE IF NOT EXISTS conversations (
+          id uuid PRIMARY KEY,
+          organization_id uuid NOT NULL
+        )
+      `);
+      await dbWrite.execute(sql`
+        ALTER TABLE "user_identities"
+          DROP CONSTRAINT IF EXISTS "user_identities_phone_verified_requires_number"
+      `);
+      await dbWrite.execute(sql`
+        ALTER TABLE "user_identities"
+          ADD CONSTRAINT "user_identities_phone_verified_requires_number"
+          CHECK ("phone_verified" IS NOT TRUE OR "phone_number" IS NOT NULL)
+      `);
+      await dbWrite.execute(sql`
+        ALTER TABLE "users"
+          DROP CONSTRAINT IF EXISTS "users_phone_verified_requires_number"
+      `);
+      await dbWrite.execute(sql`
+        ALTER TABLE "users"
+          ADD CONSTRAINT "users_phone_verified_requires_number"
+          CHECK ("phone_verified" IS NOT TRUE OR "phone_number" IS NOT NULL)
+      `);
+    } catch (error) {
+      pgliteReady = false;
+      console.error(
+        "[users-legacy-phone-verified-projection.test] PGlite schema setup failed.",
+        error,
+      );
+    }
+  }, PGLITE_TIMEOUT);
+
+  beforeEach(async () => {
+    expect(pgliteReady).toBe(true);
+    await dbWrite.delete(personalDedicatedUpgradeAuthorities);
+    await dbWrite.delete(agentSandboxes);
+    await dbWrite.delete(personalAccountConvergences);
+    await dbWrite.delete(userIdentities);
+    await dbWrite.delete(users);
+    await dbWrite.delete(organizations);
+  });
+
+  afterAll(async () => {
+    await closeDatabaseConnectionsForTests();
+  });
+
+  test("phoneless telegram false/NULL projection remains eligible for phone convergence", async () => {
+    const pair = await createPair();
+    const proof = proofFor(pair);
+    const [telegramUser] = await dbWrite
+      .select()
+      .from(users)
+      .where(eq(users.id, pair.telegram.user.id));
+    expect(telegramUser.phone_number).toBeNull();
+    expect(telegramUser.phone_verified).toBe(false);
+
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+
+    const inspection = await usersRepository.inspectPhoneTelegramPersonalAccountConvergence(proof);
+    expect(inspection.status).toBe("eligible");
+  });
+
+  test("phone routing stays fail-closed unless both rows are the same number and TRUE", async () => {
+    const pair = await createPair();
+
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+
+    expect(
+      await findReusablePersonalDelivery({
+        platform: "phone",
+        phoneNumber: pair.phoneNumber,
+      }),
+    ).toMatchObject({
+      userId: pair.phone.user.id,
+      organizationId: pair.phone.organization.id,
+    });
+
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, pair.phone.user.id));
+
+    expect(
+      await findReusablePersonalDelivery({
+        platform: "phone",
+        phoneNumber: pair.phoneNumber,
+      }),
+    ).toBeNull();
+  });
+
+  test("repairs phoneless false/NULL and is a no-write on healthy rows", async () => {
+    const pair = await createPair();
+    const telegramUserId = pair.telegram.user.id;
+    const stewardUserId = pair.telegram.user.steward_user_id;
+
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, telegramUserId));
+
+    expect(
+      await usersRepository.normalizePhonelessLegacyPhoneVerified({
+        userId: telegramUserId,
+        stewardUserId,
+      }),
+    ).toBe("repaired");
+    const [repaired] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, telegramUserId));
+    expect(repaired.phone_verified).toBe(false);
+    expect(repaired.phone_number).toBeNull();
+
+    const updatedAt = repaired.updated_at;
+    expect(
+      await usersRepository.normalizePhonelessLegacyPhoneVerified({
+        userId: telegramUserId,
+        stewardUserId,
+      }),
+    ).toBe("healthy");
+    const [healthy] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, telegramUserId));
+    expect(healthy.phone_verified).toBe(false);
+    expect(healthy.updated_at).toEqual(updatedAt);
+  });
+
+  test("never claims or overwrites an identity owned by another user", async () => {
+    const pair = await createPair();
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+
+    expect(
+      await usersRepository.normalizePhonelessLegacyPhoneVerified({
+        userId: pair.telegram.user.id,
+        stewardUserId: pair.phone.user.steward_user_id,
+      }),
+    ).toBe("skipped");
+    expect(
+      await usersRepository.normalizePhonelessLegacyPhoneVerified({
+        userId: pair.phone.user.id,
+        stewardUserId: pair.telegram.user.steward_user_id,
+      }),
+    ).toBe("skipped");
+
+    const [telegramProjection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+    const [phoneProjection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, pair.phone.user.id));
+    expect(telegramProjection.phone_verified).toBeNull();
+    expect(phoneProjection.phone_verified).toBe(true);
+    expect(phoneProjection.phone_number).toBe(pair.phoneNumber);
+  });
+
+  test("matching Steward authority still returns the canonical user when projection parity is only false/NULL", async () => {
+    const pair = await createPair();
+    await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: null })
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+
+    await expect(
+      usersRepository.findPendingPhoneTelegramPersonalAccountConvergence({
+        stewardUserId: pair.telegram.user.steward_user_id,
+      }),
+    ).resolves.toMatchObject({
+      status: "canonical_user",
+      user: { id: pair.telegram.user.id },
+    });
+  });
+
+  test("new identity rows default phone_verified false and reject TRUE without a number", async () => {
+    const pair = await createPair();
+    const [fresh] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, pair.telegram.user.id));
+    expect(fresh.phone_number).toBeNull();
+    expect(fresh.phone_verified).toBe(false);
+
+    let rejected = false;
+    try {
+      await dbWrite
+        .update(userIdentities)
+        .set({ phone_verified: true })
+        .where(eq(userIdentities.user_id, pair.telegram.user.id))
+        .returning();
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/user-identity-projection.test.ts
+++ b/packages/cloud/shared/src/db/repositories/user-identity-projection.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure comparison coverage for Steward authority vs full projection parity,
+ * including the phoneless legacy false/NULL phone_verified tuple.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { UserIdentity } from "../schemas/user-identities";
+import type { User } from "../schemas/users";
+import {
+  hasPhonelessLegacyPhoneVerifiedDrift,
+  phoneVerifiedForNewRow,
+  projectionMatchesUser,
+  stewardAuthorityMatches,
+} from "./user-identity-projection";
+
+const NOW = new Date("2026-08-27T12:00:00.000Z");
+
+function user(overrides: Partial<User> = {}): User {
+  return {
+    id: "user-1",
+    email: "qa@example.com",
+    email_verified: true,
+    wallet_address: null,
+    wallet_chain_type: null,
+    wallet_verified: false,
+    name: "QA",
+    avatar: null,
+    organization_id: "org-1",
+    role: "owner",
+    steward_user_id: "steward-1",
+    telegram_id: null,
+    telegram_username: null,
+    telegram_first_name: null,
+    telegram_photo_url: null,
+    discord_id: null,
+    discord_username: null,
+    discord_global_name: null,
+    discord_avatar_url: null,
+    whatsapp_id: null,
+    whatsapp_name: null,
+    phone_number: null,
+    phone_verified: false,
+    is_anonymous: false,
+    anonymous_session_id: null,
+    expires_at: null,
+    nickname: null,
+    work_function: null,
+    preferences: null,
+    email_notifications: true,
+    response_notifications: true,
+    account_lifecycle_state: "active",
+    account_lifecycle_revision: 0,
+    account_deletion_request_id: null,
+    auth_fenced_at: null,
+    is_active: true,
+    email_ciphertext: null,
+    email_nonce: null,
+    email_auth_tag: null,
+    email_kms_key_id: null,
+    email_kms_key_version: null,
+    email_blind_index: null,
+    phone_ciphertext: null,
+    phone_nonce: null,
+    phone_auth_tag: null,
+    phone_kms_key_id: null,
+    phone_kms_key_version: null,
+    phone_blind_index: null,
+    wallet_address_ciphertext: null,
+    wallet_address_nonce: null,
+    wallet_address_auth_tag: null,
+    wallet_address_kms_key_id: null,
+    wallet_address_kms_key_version: null,
+    wallet_address_blind_index: null,
+    telegram_id_ciphertext: null,
+    telegram_id_nonce: null,
+    telegram_id_auth_tag: null,
+    telegram_id_kms_key_id: null,
+    telegram_id_kms_key_version: null,
+    discord_id_ciphertext: null,
+    discord_id_nonce: null,
+    discord_id_auth_tag: null,
+    discord_id_kms_key_id: null,
+    discord_id_kms_key_version: null,
+    created_at: NOW,
+    updated_at: NOW,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function identity(overrides: Partial<UserIdentity> = {}): UserIdentity {
+  return {
+    id: "identity-1",
+    user_id: "user-1",
+    steward_user_id: "steward-1",
+    is_anonymous: false,
+    anonymous_session_id: null,
+    expires_at: null,
+    telegram_id: null,
+    telegram_username: null,
+    telegram_first_name: null,
+    telegram_photo_url: null,
+    phone_number: null,
+    phone_verified: false,
+    discord_id: null,
+    discord_username: null,
+    discord_global_name: null,
+    discord_avatar_url: null,
+    whatsapp_id: null,
+    whatsapp_name: null,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+describe("phoneVerifiedForNewRow", () => {
+  test("phoneless rows are non-null false", () => {
+    expect(phoneVerifiedForNewRow(null, null)).toBe(false);
+    expect(phoneVerifiedForNewRow(null, true)).toBe(false);
+    expect(phoneVerifiedForNewRow("", true)).toBe(false);
+  });
+
+  test("a present phone number is true only when explicitly verified", () => {
+    expect(phoneVerifiedForNewRow("+14155550100", true)).toBe(true);
+    expect(phoneVerifiedForNewRow("+14155550100", false)).toBe(false);
+    expect(phoneVerifiedForNewRow("+14155550100", null)).toBe(false);
+  });
+});
+
+describe("steward authority vs projection parity", () => {
+  test("matching Steward authority is not full projection parity", () => {
+    const canonical = user({ telegram_id: "100" });
+    const projected = identity({ telegram_id: "200" });
+    expect(stewardAuthorityMatches(canonical, projected)).toBe(true);
+    expect(projectionMatchesUser(canonical, projected)).toBe(false);
+  });
+
+  test("healthy phoneless false/false is idempotent full parity", () => {
+    const canonical = user();
+    const projected = identity();
+    expect(hasPhonelessLegacyPhoneVerifiedDrift(canonical, projected)).toBe(false);
+    expect(stewardAuthorityMatches(canonical, projected)).toBe(true);
+    expect(projectionMatchesUser(canonical, projected)).toBe(true);
+  });
+
+  test("legacy phoneless false/NULL is projection-coherent drift", () => {
+    const canonical = user({ phone_verified: false });
+    const projected = identity({ phone_verified: null });
+    expect(hasPhonelessLegacyPhoneVerifiedDrift(canonical, projected)).toBe(true);
+    expect(stewardAuthorityMatches(canonical, projected)).toBe(true);
+    expect(projectionMatchesUser(canonical, projected)).toBe(true);
+  });
+
+  test("verified-phone NULL is real drift, not the phoneless legacy tuple", () => {
+    const canonical = user({ phone_number: "+14155550100", phone_verified: true });
+    const projected = identity({ phone_number: "+14155550100", phone_verified: null });
+    expect(hasPhonelessLegacyPhoneVerifiedDrift(canonical, projected)).toBe(false);
+    expect(projectionMatchesUser(canonical, projected)).toBe(false);
+  });
+
+  test("never matches an identity owned by another user", () => {
+    const canonical = user();
+    const projected = identity({ user_id: "user-2", steward_user_id: "steward-2" });
+    expect(stewardAuthorityMatches(canonical, projected)).toBe(false);
+    expect(projectionMatchesUser(canonical, projected)).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/user-identity-projection.ts
+++ b/packages/cloud/shared/src/db/repositories/user-identity-projection.ts
@@ -1,0 +1,89 @@
+/**
+ * Distinguishes matching Steward session authority from full users ↔
+ * user_identities projection parity, including the phoneless legacy
+ * phone_verified false/NULL tuple created by migration 0051.
+ */
+
+import type { UserIdentity } from "../schemas/user-identities";
+import type { User } from "../schemas/users";
+
+export type PhonelessPhoneVerifiedNormalization = "repaired" | "healthy" | "skipped";
+
+function sameOptionalTimestamp(left: Date | null, right: Date | null): boolean {
+  return left === null || right === null ? left === right : left.getTime() === right.getTime();
+}
+
+/**
+ * New rows never store NULL phone_verified. TRUE is only valid when a phone
+ * number is present; phoneless accounts are false.
+ */
+export function phoneVerifiedForNewRow(
+  phoneNumber: string | null | undefined,
+  phoneVerified: boolean | null | undefined,
+): boolean {
+  if (phoneNumber == null || phoneNumber === "") {
+    return false;
+  }
+  return phoneVerified === true;
+}
+
+/**
+ * Steward session authority: the projection row belongs to this canonical user
+ * and carries the same Steward subject. This is not full field parity.
+ */
+export function stewardAuthorityMatches(user: User, identity: UserIdentity): boolean {
+  return identity.user_id === user.id && identity.steward_user_id === user.steward_user_id;
+}
+
+/**
+ * Migration 0051 projected NULL phone_verified when phone_number was absent.
+ * Canonical users.phone_verified stayed false, so otherwise coherent phoneless
+ * accounts disagree under strict equality.
+ */
+export function hasPhonelessLegacyPhoneVerifiedDrift(
+  user: Pick<User, "phone_number" | "phone_verified">,
+  identity: Pick<UserIdentity, "phone_number" | "phone_verified">,
+): boolean {
+  return (
+    user.phone_number === null &&
+    identity.phone_number === null &&
+    user.phone_verified === false &&
+    identity.phone_verified === null
+  );
+}
+
+function phoneVerifiedProjectionMatches(
+  user: Pick<User, "phone_number" | "phone_verified">,
+  identity: Pick<UserIdentity, "phone_number" | "phone_verified">,
+): boolean {
+  if (identity.phone_number !== user.phone_number) {
+    return false;
+  }
+  if (identity.phone_verified === user.phone_verified) {
+    return true;
+  }
+  return hasPhonelessLegacyPhoneVerifiedDrift(user, identity);
+}
+
+/** Full canonical ↔ projection field parity used by merge/convergence guards. */
+export function projectionMatchesUser(user: User, identity: UserIdentity): boolean {
+  return (
+    identity.user_id === user.id &&
+    identity.steward_user_id === user.steward_user_id &&
+    identity.is_anonymous === user.is_anonymous &&
+    identity.anonymous_session_id === user.anonymous_session_id &&
+    sameOptionalTimestamp(identity.expires_at, user.expires_at) &&
+    identity.telegram_id === user.telegram_id &&
+    identity.telegram_username === user.telegram_username &&
+    identity.telegram_first_name === user.telegram_first_name &&
+    identity.telegram_photo_url === user.telegram_photo_url &&
+    identity.phone_number === user.phone_number &&
+    phoneVerifiedProjectionMatches(user, identity) &&
+    identity.discord_id === user.discord_id &&
+    identity.discord_username === user.discord_username &&
+    identity.discord_global_name === user.discord_global_name &&
+    identity.discord_avatar_url === user.discord_avatar_url &&
+    identity.whatsapp_id === user.whatsapp_id &&
+    identity.whatsapp_name === user.whatsapp_name
+  );
+}

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -20,6 +20,12 @@ import {
 import { type UserIdentity, userIdentities } from "../schemas/user-identities";
 import { type NewUser, type User, users } from "../schemas/users";
 import { revokePersonalSharedGroupConsentForUser } from "./personal-shared-group-consent-lifecycle";
+import {
+  hasPhonelessLegacyPhoneVerifiedDrift,
+  type PhonelessPhoneVerifiedNormalization,
+  projectionMatchesUser,
+  stewardAuthorityMatches,
+} from "./user-identity-projection";
 
 const stewardAuthorityIdentity = alias(userIdentities, "steward_authority_identity");
 const canonicalStewardIdentity = alias(userIdentities, "canonical_steward_identity");
@@ -37,6 +43,13 @@ function userMutationRevokesPersonalSharedConsent(data: Partial<NewUser>): boole
   );
 }
 
+export {
+  hasPhonelessLegacyPhoneVerifiedDrift,
+  type PhonelessPhoneVerifiedNormalization,
+  phoneVerifiedForNewRow,
+  projectionMatchesUser,
+  stewardAuthorityMatches,
+} from "./user-identity-projection";
 export type { NewUser, User, UserIdentity };
 
 export type IdentityProvider = "steward" | "telegram" | "discord" | "whatsapp" | "phone";
@@ -355,10 +368,6 @@ function hasNoMatureIdentity(user: User): boolean {
   );
 }
 
-function sameOptionalTimestamp(left: Date | null, right: Date | null): boolean {
-  return left === null || right === null ? left === right : left.getTime() === right.getTime();
-}
-
 function isPhoneProvisionalUser(user: User, phoneNumber: string): boolean {
   return (
     hasNoMatureIdentity(user) &&
@@ -379,28 +388,6 @@ function isTelegramProvisionalUser(user: User, telegramId: string, stewardUserId
     user.telegram_id === telegramId &&
     user.phone_number === null &&
     user.phone_verified === false
-  );
-}
-
-function projectionMatchesUser(user: User, identity: UserIdentity): boolean {
-  return (
-    identity.user_id === user.id &&
-    identity.steward_user_id === user.steward_user_id &&
-    identity.is_anonymous === user.is_anonymous &&
-    identity.anonymous_session_id === user.anonymous_session_id &&
-    sameOptionalTimestamp(identity.expires_at, user.expires_at) &&
-    identity.telegram_id === user.telegram_id &&
-    identity.telegram_username === user.telegram_username &&
-    identity.telegram_first_name === user.telegram_first_name &&
-    identity.telegram_photo_url === user.telegram_photo_url &&
-    identity.phone_number === user.phone_number &&
-    identity.phone_verified === user.phone_verified &&
-    identity.discord_id === user.discord_id &&
-    identity.discord_username === user.discord_username &&
-    identity.discord_global_name === user.discord_global_name &&
-    identity.discord_avatar_url === user.discord_avatar_url &&
-    identity.whatsapp_id === user.whatsapp_id &&
-    identity.whatsapp_name === user.whatsapp_name
   );
 }
 
@@ -3016,6 +3003,55 @@ export class UsersRepository {
   }
 
   /**
+   * Append-only repair for phoneless legacy projections: phone_verified NULL →
+   * false. Matching Steward authority is required; another user's identity is
+   * never claimed. Healthy false/false rows are a no-write.
+   */
+  async normalizePhonelessLegacyPhoneVerified(input: {
+    userId: string;
+    stewardUserId: string;
+  }): Promise<PhonelessPhoneVerifiedNormalization> {
+    const [canonical] = await dbWrite
+      .select()
+      .from(users)
+      .where(eq(users.id, input.userId))
+      .limit(1);
+    const [projection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, input.userId))
+      .limit(1);
+
+    if (!canonical || !projection) {
+      return "skipped";
+    }
+    if (
+      !stewardAuthorityMatches(canonical, projection) ||
+      canonical.steward_user_id !== input.stewardUserId
+    ) {
+      return "skipped";
+    }
+    if (!hasPhonelessLegacyPhoneVerifiedDrift(canonical, projection)) {
+      return "healthy";
+    }
+
+    const [updated] = await dbWrite
+      .update(userIdentities)
+      .set({ phone_verified: false, updated_at: new Date() })
+      .where(
+        and(
+          eq(userIdentities.user_id, input.userId),
+          eq(userIdentities.steward_user_id, input.stewardUserId),
+          isNull(userIdentities.phone_number),
+          isNull(userIdentities.phone_verified),
+        ),
+      )
+      .returning({ userId: userIdentities.user_id });
+
+    return updated ? "repaired" : "skipped";
+  }
+
+  /**
    * Upserts the Steward identity projection for a user.
    */
   async upsertStewardIdentity(userId: string, stewardUserId: string): Promise<UserIdentity> {
@@ -3052,7 +3088,7 @@ export class UsersRepository {
         u.telegram_first_name,
         u.telegram_photo_url,
         u.phone_number,
-        u.phone_verified,
+        COALESCE(u.phone_verified, FALSE),
         u.discord_id,
         u.discord_username,
         u.discord_global_name,

--- a/packages/cloud/shared/src/db/schemas/user-identities.ts
+++ b/packages/cloud/shared/src/db/schemas/user-identities.ts
@@ -1,6 +1,7 @@
 // Defines the user identities Drizzle table shape used by cloud repositories and services.
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
-import { boolean, index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { boolean, check, index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { users } from "./users";
 
 /**
@@ -35,6 +36,8 @@ export const userIdentities = pgTable(
 
     // Phone identity (Eliza App - iMessage)
     phone_number: text("phone_number").unique(),
+    // TRUE requires a phone number. New rows default false; phoneless NULL is
+    // legacy 0051 drift repaired append-only to false.
     phone_verified: boolean("phone_verified").default(false),
 
     // Discord identity (Eliza App)
@@ -63,6 +66,10 @@ export const userIdentities = pgTable(
     phone_number_idx: index("user_identities_phone_number_idx").on(table.phone_number),
     discord_id_idx: index("user_identities_discord_id_idx").on(table.discord_id),
     whatsapp_id_idx: index("user_identities_whatsapp_id_idx").on(table.whatsapp_id),
+    phone_verified_requires_number: check(
+      "user_identities_phone_verified_requires_number",
+      sql`${table.phone_verified} IS NOT TRUE OR ${table.phone_number} IS NOT NULL`,
+    ),
   }),
 );
 

--- a/packages/cloud/shared/src/db/schemas/users.ts
+++ b/packages/cloud/shared/src/db/schemas/users.ts
@@ -59,6 +59,8 @@ export const users = pgTable(
     whatsapp_id: text("whatsapp_id").unique(),
     whatsapp_name: text("whatsapp_name"),
     phone_number: text("phone_number").unique(),
+    // TRUE requires a phone number. New rows default false; phoneless NULL is
+    // legacy 0051 drift repaired append-only to false.
     phone_verified: boolean("phone_verified").default(false),
 
     // Anonymous user support
@@ -156,6 +158,10 @@ export const users = pgTable(
     account_lifecycle_state_check: check(
       "users_account_lifecycle_state_check",
       sql`${table.account_lifecycle_state} IN ('active', 'deletion_recovery', 'deletion_irreversible')`,
+    ),
+    phone_verified_requires_number: check(
+      "users_phone_verified_requires_number",
+      sql`${table.phone_verified} IS NOT TRUE OR ${table.phone_number} IS NOT NULL`,
     ),
   }),
 );

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -24,6 +24,8 @@ const orgDeleteCalls: string[] = [];
 const lifecycleEvents: string[] = [];
 const repositoryReads: string[] = [];
 const deletedCacheKeys: string[] = [];
+const normalizeCalls: Array<{ userId: string; stewardUserId: string }> = [];
+let identityPhoneVerifiedOverride: boolean | null | undefined;
 
 let userApiKeys: Array<{ key_hash: string }> = [];
 let orgApiKeys: Array<{ key_hash: string }> = [];
@@ -133,10 +135,15 @@ mock.module("../../db/repositories", () => ({
       repositoryReads.push("identity-for-write");
       return userRecord?.steward_user_id
         ? {
+            user_id: userRecord.id,
             steward_user_id: userRecord.steward_user_id,
             telegram_id: userRecord.telegram_id ?? null,
             discord_id: userRecord.discord_id ?? null,
             phone_number: userRecord.phone_number ?? null,
+            phone_verified:
+              identityPhoneVerifiedOverride !== undefined
+                ? identityPhoneVerifiedOverride
+                : (userRecord.phone_verified ?? false),
           }
         : undefined;
     },
@@ -155,6 +162,13 @@ mock.module("../../db/repositories", () => ({
       lifecycleEvents.push(`identity-upsert:${id}:${stewardUserId}`);
       if (userRecord) userRecord.steward_user_id = stewardUserId;
       return { user_id: id, steward_user_id: stewardUserId };
+    },
+    normalizePhonelessLegacyPhoneVerified: async (input: {
+      userId: string;
+      stewardUserId: string;
+    }) => {
+      normalizeCalls.push(input);
+      return "repaired";
     },
     linkStewardId: async (id: string, stewardUserId: string) => {
       lifecycleEvents.push(`identity-link:${id}:${stewardUserId}`);
@@ -220,6 +234,8 @@ beforeEach(() => {
   lifecycleEvents.length = 0;
   repositoryReads.length = 0;
   deletedCacheKeys.length = 0;
+  normalizeCalls.length = 0;
+  identityPhoneVerifiedOverride = undefined;
 });
 
 describe("UsersService — IAC invalidation on lifecycle", () => {
@@ -540,6 +556,43 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
 
     expect(lifecycleEvents).toEqual(["session-binding:o1:u1:steward-new:true"]);
     expect(invalidatedSessionBatches).toEqual([["steward-new"]]);
+    expect(normalizeCalls).toEqual([]);
+  });
+
+  test("healthy matching Steward authority does not write the identity projection", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-1",
+      phone_number: null,
+      phone_verified: false,
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.upsertStewardIdentity("u1", "steward-1");
+
+    expect(normalizeCalls).toEqual([]);
+    expect(lifecycleEvents).toEqual(["session-binding:o1:u1:steward-1:true"]);
+    expect(lifecycleEvents.some((event) => event.startsWith("identity-upsert:"))).toBe(false);
+  });
+
+  test("repairs phoneless false/NULL drift without a full Steward identity upsert", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-1",
+      phone_number: null,
+      phone_verified: false,
+    };
+    identityPhoneVerifiedOverride = null;
+
+    const { usersService } = await import("./users");
+    await usersService.upsertStewardIdentity("u1", "steward-1");
+
+    expect(normalizeCalls).toEqual([{ userId: "u1", stewardUserId: "steward-1" }]);
+    expect(lifecycleEvents.some((event) => event.startsWith("identity-upsert:"))).toBe(false);
   });
 
   test("Steward identity upsert retry uses the primary user when the read replica lags", async () => {

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -12,6 +12,10 @@ import {
   type UserWithOrganization,
   usersRepository,
 } from "../../db/repositories";
+import {
+  hasPhonelessLegacyPhoneVerifiedDrift,
+  stewardAuthorityMatches,
+} from "../../db/repositories/user-identity-projection";
 import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
@@ -452,6 +456,18 @@ export class UsersService {
 
     if (existingIdentity?.steward_user_id === stewardUserId) {
       const user = await usersRepository.findByIdForWrite(userId);
+      // Matching Steward authority is not full projection parity. Repair only
+      // the phoneless false/NULL drift; healthy returning login stays no-write.
+      if (
+        user &&
+        stewardAuthorityMatches(user, existingIdentity) &&
+        hasPhonelessLegacyPhoneVerifiedDrift(user, existingIdentity)
+      ) {
+        await usersRepository.normalizePhonelessLegacyPhoneVerified({
+          userId,
+          stewardUserId,
+        });
+      }
       if (user?.organization_id) {
         // The identity row may have committed before a prior attempt failed to
         // clear the durable binding fence. Make the idempotent retry complete


### PR DESCRIPTION
Fixes #28646

## Problem

Legacy email-only accounts can disagree on phone verification: `users.phone_verified=false` while `user_identities.phone_verified=NULL` when both phone numbers are absent. Migration 0051 projected NULL in that case. `projectionMatchesUser()` required strict equality, so otherwise coherent phone/Telegram convergence was rejected as `identity_projection_conflict`.

Phone routing was already fail-closed (same number and TRUE on both rows). Fresh signup copies `false`. Returning login exited early when Steward authority already matched, so it never normalized the legacy field.

## Approach

- Distinguish matching Steward authority (same user + Steward subject) from full projection parity.
- Treat the phoneless `false`/`NULL` tuple as projection-coherent drift.
- Append-only repair: write `phone_verified=false` only for that tuple, only on the caller's own identity row.
- Healthy returning login stays a no-write fast path.
- Enforce `phone_verified=true` ⇒ `phone_number` is non-null; new rows keep default-false semantics via `COALESCE` and schema default.
- Never claim or overwrite an identity owned by another user.

## Tests

Deterministic repository/service tests only (isolated PGlite + unit). No live DB, staging, or real-user mutation.

- Legacy false/NULL repair
- Healthy idempotence (no `updated_at` write)
- Phone/Telegram convergence eligibility
- Phone routing non-regression (still requires TRUE on both rows)
- Ownership skip when Steward subjects do not match
- CHECK: TRUE without a phone number is rejected

Unpatched `develop`: convergence inspect returned `identity_projection_conflict`. After the fix: `eligible`.