### PR TITLE
fix(ui): hide unowned rate-limit alerts on signed-out login

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -445,6 +445,25 @@ function describeEmailLoginError(error: unknown, fallback: string): string {
   return getErrorMessage(error, fallback);
 }
 
+/**
+ * Session restoration is a background reconcile of leftover browser
+ * credentials. A rate-limit from that unowned path must not blast a global
+ * "Too many requests" alert over the working signed-out form (#27712).
+ * User-initiated login actions keep their own catch blocks.
+ */
+function isUnownedSessionRestoreRateLimit(error: unknown): boolean {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status: unknown }).status === 429
+  ) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message.trim() : "";
+  return /^too many requests\b/i.test(message);
+}
+
 let cachedStewardProviders: StewardProviders | null = null;
 let stewardProvidersPromise: Promise<StewardProviders> | null = null;
 let stewardProvidersRequestGeneration = 0;
@@ -1042,7 +1061,9 @@ export default function StewardLoginSection() {
           return;
         }
       } catch (sessionError) {
-        if (!cancelled) {
+        // error-policy:J4 Unowned restore 429s stay off the signed-out form.
+        // Genuine restore failures (expired stored token) still surface.
+        if (!cancelled && !isUnownedSessionRestoreRateLimit(sessionError)) {
           setError(
             getErrorMessage(
               sessionError,

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.unowned-rate-limit.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.unowned-rate-limit.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Verifies the signed-out Steward login form does not render an unowned
+ * "Too many requests" alert from background session restoration (#27712).
+ * Deterministic SDK and session-boundary doubles; no real sessions.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => undefined;
+  Element.prototype.releasePointerCapture = () => undefined;
+  Element.prototype.scrollIntoView = () => undefined;
+});
+
+const authSpies = vi.hoisted(() => ({
+  getProviders: vi.fn(),
+  getSession: vi.fn(),
+  refreshSession: vi.fn(),
+  sendSmsOtp: vi.fn(),
+}));
+
+const sessionSpies = vi.hoisted(() => ({
+  storedToken: null as string | null,
+  hasAuthedCookie: vi.fn(),
+  recover: vi.fn(),
+  sync: vi.fn(),
+}));
+
+vi.mock("@elizaos/shared/steward-session-client", () => ({
+  hasStewardAuthedCookie: sessionSpies.hasAuthedCookie,
+  readStoredStewardToken: () => sessionSpies.storedToken,
+  writeStoredStewardToken: vi.fn(),
+  StewardSessionError: class StewardSessionError extends Error {
+    status: number;
+    code: string | null;
+    constructor(message: string, status: number, code: string | null = null) {
+      super(message);
+      this.name = "StewardSessionError";
+      this.status = status;
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getProviders = authSpies.getProviders;
+    getSession = authSpies.getSession;
+    refreshSession = authSpies.refreshSession;
+    sendSmsOtp = authSpies.sendSmsOtp;
+  },
+}));
+
+vi.mock("./passkey-capability", () => ({
+  resolveWebPasskeyCapability: () =>
+    Promise.resolve({ usable: false, reason: "native-without-bridge" }),
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test/steward",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/steward-email-login", () => ({
+  StewardEmailLoginError: class StewardEmailLoginError extends Error {},
+  startStewardEmailLogin: vi.fn(),
+  verifyStewardEmailSignInCode: vi.fn(),
+  pollStewardEmailSignInStatus: vi.fn(),
+}));
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => false,
+  consumeStewardCodeFromQuery: () => null,
+  stripLegacyTokenHashFromAddressBar: () => false,
+  exchangeStewardCodeViaApi: vi.fn(),
+  recoverStewardSessionViaCookie: sessionSpies.recover,
+  recoverStewardEmailSessionViaCookie: vi.fn(),
+  refreshStewardSessionViaCookie: vi.fn(),
+  syncStewardSessionCookie: sessionSpies.sync,
+}));
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/chat",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+import { StewardSessionError } from "@elizaos/shared/steward-session-client";
+import StewardLoginSection from "./steward-login-section";
+
+function renderSignedOutLogin() {
+  return render(
+    <MemoryRouter initialEntries={["/login?returnTo=%2Fchat"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+async function expectWorkingSignedOutForm() {
+  expect(await screen.findByLabelText("Phone number")).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Google" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Magic Link" })).toBeTruthy();
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(screen.queryByText("Too many requests")).toBeNull();
+}
+
+describe("StewardLoginSection unowned rate-limit alert (#27712)", () => {
+  beforeEach(() => {
+    authSpies.getProviders.mockResolvedValue({
+      passkey: false,
+      email: true,
+      sms: true,
+      siwe: false,
+      siws: false,
+      google: true,
+      discord: false,
+      github: false,
+      twitter: false,
+      oauth: ["google"],
+    });
+    authSpies.getSession.mockReturnValue(null);
+    authSpies.refreshSession.mockResolvedValue(null);
+    authSpies.sendSmsOtp.mockResolvedValue({
+      ok: true,
+      expiresAt: "2026-08-27T12:05:00.000Z",
+    });
+    window.localStorage.clear();
+    sessionSpies.storedToken = null;
+    sessionSpies.hasAuthedCookie.mockReturnValue(false);
+    sessionSpies.recover.mockResolvedValue(null);
+    sessionSpies.sync.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("does not alert Too many requests when cookie session restore is rate-limited", async () => {
+    sessionSpies.hasAuthedCookie.mockReturnValue(true);
+    sessionSpies.recover.mockRejectedValue(
+      new StewardSessionError("Too many requests", 429, "rate_limited"),
+    );
+
+    renderSignedOutLogin();
+
+    await expectWorkingSignedOutForm();
+    expect(sessionSpies.recover).toHaveBeenCalled();
+  });
+
+  it("does not alert Too many requests when stored-token cookie sync is rate-limited", async () => {
+    sessionSpies.storedToken = "stale-browser-token";
+    sessionSpies.hasAuthedCookie.mockReturnValue(false);
+    sessionSpies.sync.mockRejectedValue(new Error("Too many requests"));
+
+    renderSignedOutLogin();
+
+    await expectWorkingSignedOutForm();
+    expect(sessionSpies.sync).toHaveBeenCalledWith("stale-browser-token", null);
+  });
+
+  it("still surfaces an owned Too many requests alert after the user sends an SMS code", async () => {
+    authSpies.sendSmsOtp.mockRejectedValue(new Error("Too many requests"));
+
+    renderSignedOutLogin();
+
+    const phoneInput = await screen.findByLabelText("Phone number");
+    fireEvent.change(phoneInput, { target: { value: "+14155552671" } });
+    fireEvent.click(screen.getByRole("button", { name: "Text me a code" }));
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Too many requests")).toBeTruthy();
+    expect(screen.queryByText("Enter the text code")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Signed-out staging login rendered a global red `Too many requests` alert after the provider form loaded, with no `error`/`reason` query and no email/phone/OAuth/wallet/passkey/OTP submit. Background session restoration (cookie refresh or leftover stored-token cookie sync) wrote that 429 into the shared page-level error.

- Suppress only unowned restore rate-limits (`429` / `Too many requests`) so the working signed-out form stays clean.
- Genuine restore failures such as `Older session expired` still surface.
- Owned rate-limits after a user action (SMS send in this PR) still surface through their existing catch blocks.
- No auth, provider, or session mutation. Tight UI-only vs closed #27865 (that change swallowed every restore failure).

Fixes #27712

## Test plan

- [x] New login-form tests fail on unpatched `develop`: cookie restore 429 and stored-token sync 429 both render `role="alert"` `Too many requests`.
- [x] After the fix, `steward-login-section.unowned-rate-limit.test.tsx` is 3/3 green, including owned SMS 429 still alerting.
- [x] `steward-login-section.phone-login.test.tsx` remains green (12/12), including older-session-expired copy.
- [x] Related suites stay green: hash-token, email-login, provider-discovery-error (18/18).
- [x] Biome check clean on the two touched files.