### PR TITLE
fix(android): keep native allowlist artifact-aware

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -25,6 +25,7 @@ import {
   applyAndroidCloudSplashTheme,
   applyAndroidGeneratedBuildTargetProperties,
   applyAndroidPlayManifestHardening,
+  assertAndroidCloudNativeLibraryAllowlist,
   createAndroidPlayManifestPolicy,
   findAndroidCloudPackagedRuntimeOffenders,
   findAndroidPlayIndexHtmlFindings,
@@ -339,10 +340,10 @@ describe("Android Play manifest policy", () => {
       expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).toContain(permission);
     }
     expect(ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES).toEqual([
-      "base/lib/arm64-v8a/libdatastore_shared_counter.so",
-      "base/lib/armeabi-v7a/libdatastore_shared_counter.so",
-      "base/lib/x86/libdatastore_shared_counter.so",
-      "base/lib/x86_64/libdatastore_shared_counter.so",
+      "lib/arm64-v8a/libdatastore_shared_counter.so",
+      "lib/armeabi-v7a/libdatastore_shared_counter.so",
+      "lib/x86/libdatastore_shared_counter.so",
+      "lib/x86_64/libdatastore_shared_counter.so",
     ]);
     expect(ANDROID_PLAY_ALLOWED_PERMISSIONS).toContain(
       "android.permission.MODIFY_AUDIO_SETTINGS",
@@ -437,6 +438,67 @@ describe("Android Play manifest policy", () => {
         "eliza_ime_permission_needed",
       ]),
     });
+  });
+
+  it("accepts only the exact DataStore JNI paths in a Cloud debug APK", () => {
+    expect(
+      assertAndroidCloudNativeLibraryAllowlist({
+        artifact: "/artifacts/app-debug.apk",
+        entries: [...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES],
+        env: {},
+      }),
+    ).toEqual([...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES]);
+  });
+
+  it("rejects extra native code in a Cloud debug APK", () => {
+    expect(() =>
+      assertAndroidCloudNativeLibraryAllowlist({
+        artifact: "/artifacts/app-debug.apk",
+        entries: [
+          ...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES,
+          "lib/arm64-v8a/libunexpected.so",
+        ],
+        env: {},
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
+        message: expect.stringContaining("lib/arm64-v8a/libunexpected.so"),
+      }),
+    );
+  });
+
+  it("accepts only the exact module-rooted DataStore JNI paths in a Cloud AAB", () => {
+    const aabNativeLibraries = ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES.map(
+      (entry) => `base/${entry}`,
+    );
+    expect(
+      assertAndroidCloudNativeLibraryAllowlist({
+        artifact: "/artifacts/app-release.aab",
+        entries: aabNativeLibraries,
+        env: {},
+      }),
+    ).toEqual(aabNativeLibraries);
+  });
+
+  it("rejects extra native code in a Cloud AAB", () => {
+    expect(() =>
+      assertAndroidCloudNativeLibraryAllowlist({
+        artifact: "/artifacts/app-release.aab",
+        entries: [
+          ...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES.map(
+            (entry) => `base/${entry}`,
+          ),
+          "base/lib/arm64-v8a/libunexpected.so",
+        ],
+        env: {},
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
+        message: expect.stringContaining("base/lib/arm64-v8a/libunexpected.so"),
+      }),
+    );
   });
 
   it("targets API 36 and excludes background-worker dependencies in Cloud", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6200,16 +6200,46 @@ export const ANDROID_PLAY_ALLOWED_QUERY_ACTIONS = Object.freeze([
 // cross-process shared-counter JNI helper. Keep an exact ABI allowlist so a
 // local-agent or inference library still cannot leak into the Cloud client.
 export const ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES = Object.freeze([
-  "base/lib/arm64-v8a/libdatastore_shared_counter.so",
-  "base/lib/armeabi-v7a/libdatastore_shared_counter.so",
-  "base/lib/x86/libdatastore_shared_counter.so",
-  "base/lib/x86_64/libdatastore_shared_counter.so",
+  "lib/arm64-v8a/libdatastore_shared_counter.so",
+  "lib/armeabi-v7a/libdatastore_shared_counter.so",
+  "lib/x86/libdatastore_shared_counter.so",
+  "lib/x86_64/libdatastore_shared_counter.so",
 ]);
 
 export function resolveAndroidCloudAllowedNativeLibraries(env = process.env) {
   return isAndroidFirebaseIndependentRemoteBuild(env)
     ? []
     : [...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES];
+}
+
+/** Enforce the exact Play JNI set at each archive format's native-library root. */
+export function assertAndroidCloudNativeLibraryAllowlist({
+  artifact,
+  entries,
+  env = process.env,
+} = {}) {
+  const artifactKind = resolveAndroidArtifactKind(artifact);
+  const artifactRoot = artifactKind === "aab" ? "base/" : "";
+  const expectedNativeLibraries = resolveAndroidCloudAllowedNativeLibraries(env)
+    .map((entry) => `${artifactRoot}${entry}`)
+    .sort();
+  const nativeLibraries = entries
+    .filter((entry) => /(?:^|\/)lib\/[^/]+\/[^/]+\.so$/i.test(entry))
+    .sort();
+  if (
+    JSON.stringify(nativeLibraries) !== JSON.stringify(expectedNativeLibraries)
+  ) {
+    throw mobileBuildError(
+      `[mobile-build] android-cloud native libraries differ from the Play allowlist:\n${nativeLibraries
+        .map((entry) => `  - ${entry}`)
+        .join("\n")}`,
+      {
+        code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
+        context: { artifact, artifactKind, nativeLibraries },
+      },
+    );
+  }
+  return nativeLibraries;
 }
 
 export const ANDROID_PLAY_DATA_EXTRACTION_RULES = `<?xml version="1.0" encoding="utf-8"?>
@@ -10048,23 +10078,7 @@ export function auditAndroidCloudArtifact(
     );
   }
   if (!lp3ColorPolicyEnabled) {
-    const nativeLibraries = entries
-      .filter((entry) => /(?:^|\/)lib\/[^/]+\/[^/]+\.so$/i.test(entry))
-      .sort();
-    if (
-      JSON.stringify(nativeLibraries) !==
-      JSON.stringify(resolveAndroidCloudAllowedNativeLibraries(env).sort())
-    ) {
-      throw mobileBuildError(
-        `[mobile-build] android-cloud native libraries differ from the Play allowlist:\n${nativeLibraries
-          .map((entry) => `  - ${entry}`)
-          .join("\n")}`,
-        {
-          code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
-          context: { artifact, nativeLibraries },
-        },
-      );
-    }
+    assertAndroidCloudNativeLibraryAllowlist({ artifact, entries, env });
     const textAssetEntries = entries.filter(
       (entry) =>
         /(?:^|\/)assets\//.test(entry) &&


### PR DESCRIPTION
## Summary
- keep one canonical exact DataStore JNI allowlist
- derive the archive root from the artifact kind: `lib/...` for APK and `base/lib/...` for AAB
- add explicit APK and AAB accept/reject-extra regressions

This repairs the Android Cloud debug regression introduced by #29552 without widening the Play native-code policy.

## Verification
- 167 passed, 8 intentional real-AAB fixture skips, 0 failed across Android Play/AAB/LP3 and mobile renderer/artifact guard suites
- Biome clean on both changed files
- canonical Android Cloud debug build and final artifact audit in progress