### PR TITLE
docs(cloud): align SandboxRegistry docs and diagnostics with the atomic generation-fenced route trio

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -6432,12 +6432,16 @@ export async function startEliza(
 
     // Cloud sandbox self-registration (Path A). When this runtime is the
     // entrypoint of a Hetzner-provisioned container, the provisioner injects
-    // the SANDBOX_REGISTRY_* env vars. Writing the `agent:<id>:server` +
-    // `server:<name>:url` keys to the shared Upstash Redis lets the
-    // multi-tenant gateways resolve this container as the inference target
-    // and forward inbound platform messages here. Returns null for every
-    // non-provisioned runtime, so this is inert outside the cloud
-    // container. See packages/shared/src/sandbox-registry.ts.
+    // the SANDBOX_REGISTRY_* env vars. Writing the public
+    // `agent:<id>:server` + `server:<name>:url` pair and the private
+    // `server:<name>:registration` generation fence atomically to shared Redis
+    // lets the multi-tenant gateways resolve this container as the inference
+    // target and forward inbound platform messages here. Owned heartbeat
+    // refresh cannot recreate a missing trio
+    // (`SANDBOX_REGISTRY_OWNERSHIP_LOST`); durable recovery after complete
+    // expiry is #24767. Returns null for every non-provisioned runtime, so
+    // this is inert outside the cloud container. See
+    // packages/shared/src/sandbox-registry.ts.
     const { buildSandboxRegistryFromEnv } = await import(
       "@elizaos/shared/sandbox-registry"
     );
@@ -6447,7 +6451,7 @@ export async function startEliza(
         await sandboxRegistry.register();
       } catch (err) {
         logger.error(
-          `[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here until the next hb_signal succeeds): ${formatError(err)}`,
+          `[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here; heartbeat cannot recreate a missing trio and fails closed with SANDBOX_REGISTRY_OWNERSHIP_LOST): ${formatError(err)}`,
         );
       }
       sandboxRegistry.startHeartbeat(

--- a/packages/app-core/src/runtime/startup/server-only-host.test.ts
+++ b/packages/app-core/src/runtime/startup/server-only-host.test.ts
@@ -718,7 +718,7 @@ describe("sandbox registry", () => {
     });
 
     expect(errorSpy).toHaveBeenCalledWith(
-      "[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here until the next heartbeat succeeds): redis down",
+      "[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here; heartbeat cannot recreate a missing trio and fails closed with SANDBOX_REGISTRY_OWNERSHIP_LOST): redis down",
     );
     expect(reportError).toHaveBeenCalledExactlyOnceWith(
       "eliza.sandboxRegistry",

--- a/packages/app-core/src/runtime/startup/server-only-host.ts
+++ b/packages/app-core/src/runtime/startup/server-only-host.ts
@@ -298,10 +298,12 @@ export async function startServerOnlyHost({
     try {
       await sandboxRegistry.register();
     } catch (err) {
-      // error-policy:J7 registry heartbeat can recover after an initial
-      // registration failure; surface the degraded routing path to the agent.
+      // error-policy:J7 initial registration failure is fail-closed: heartbeat
+      // refresh requires the already-written trio and reports
+      // SANDBOX_REGISTRY_OWNERSHIP_LOST instead of recreating missing keys.
+      // Durable recovery after complete expiry is tracked in #24767.
       logger.error(
-        `[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here until the next heartbeat succeeds): ${formatError(err)}`,
+        `[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here; heartbeat cannot recreate a missing trio and fails closed with SANDBOX_REGISTRY_OWNERSHIP_LOST): ${formatError(err)}`,
       );
       currentRuntime?.reportError("eliza.sandboxRegistry", err, {
         phase: "register",

--- a/packages/cloud/infra/STAGING_AUTHORITY.md
+++ b/packages/cloud/infra/STAGING_AUTHORITY.md
@@ -26,7 +26,7 @@ empty log query for the other runtime proves nothing.
 | Console (`cloud-staging.eliza.app`) | Same artifact as App Pages | Same Pages deployment, independently proved on the Console hostname | Not containerized | No direct DB; inherit the API row |
 | Telegram ingress (Worker edge or `gateway-webhook-stg`) | Exact API Worker source and served `personalSharedTelegramEdge.enabled` beacon; when disabled, also the protected `Deploy Gateway Webhook` run SHA | `enabled=true`: exact Worker deployment plus positive Worker-edge, delivery-ledger, and provider receipt; `enabled=false`: published exact Railway receipt and currently active deployment ID | Worker edge is not containerized; the Railway digest is not emitted by the current receipt and remains unresolved unless provider metadata supplies it | Inherit the compatible API row; the Railway fallback has no direct SQL access |
 | Discord gateway | Unresolved after deployment; the operator checkout is not attested | Railway deployment ID and `/health` + `/ready`; current repository automation does not bind them to a source SHA | Not attested by the current deploy script | No direct SQL access; inherit the compatible API row |
-| Connector `SandboxRegistry` route | Attested agent-image source SHA plus the provisioning-worker SHA that injected the registry and route identity | Same Redis authority as the gateway; privacy-safe paired-key/TTL readback; deployed resolver returns `ready` | Running container digest must match the agent-image attestation | Control-plane sandbox row and compatible API migration authority |
+| Connector `SandboxRegistry` route | Attested agent-image source SHA plus the provisioning-worker SHA that injected the registry and route identity | Same Redis authority as the gateway; privacy-safe trio evidence (public pair in memory; private generation-key presence/TTL without name expansion or value); deployed resolver returns `ready` | Running container digest must match the agent-image attestation | Control-plane sandbox row and compatible API migration authority |
 | Provisioning worker | `Deploy Eliza Provisioning Worker` `deployment_sha` | `/opt/eliza` HEAD plus the running systemd process identity and post-restart stability evidence | Daemon is not containerized; separately resolve the managed-agent image to a registry digest | Exact-SHA migration plus activation preflight in the same workflow |
 | Agent router | Same SHA and checkout as the provisioning worker | Running systemd process plus local and canonical `/healthz` and `/readyz` | Not containerized | Same database and exact-SHA migration authority as the provisioning worker |
 
@@ -249,13 +249,27 @@ deploy receipt is required before accepting Discord staging E2E evidence.
 
 ### Connector SandboxRegistry route
 
-Dedicated containers self-register the current platform route through two
-short-lived Redis keys: `agent:<id>:server` points to a server name and
-`server:<name>:url` points to its resolver address. The current
-`SandboxRegistry` pipelines both writes with a 90-second TTL and refreshes them
-every 30 seconds. The pipeline is not a Redis transaction, so a failed partial
-write remains possible; the Telegram and Discord resolvers read the two keys in
-order and the evidence contract fails closed unless both are present.
+Dedicated containers self-register the current platform route as one
+TTL-backed trio written atomically by `SandboxRegistry` through a single Redis
+`EVAL` (REST and TCP):
+
+- public resolver pair: `agent:<id>:server` (server-name pointer) and
+  `server:<name>:url` (resolver address)
+- private runtime-generation fence: `server:<name>:registration`
+
+Telegram and Discord resolvers read only the public pair, in that order, and
+fail closed unless both are present. That two-key resolver view is not the
+full lifecycle contract: registration, owned refresh, and generation-gated
+cleanup always update all three keys together. Current `SandboxRegistry`
+writers apply a 90-second TTL to the whole trio and refresh on a 30-second
+heartbeat. Those lifetimes are writer-specific; legacy/operator entries and
+other registry writers do not share this contract.
+
+Owned refresh fails closed with `SANDBOX_REGISTRY_OWNERSHIP_LOST` when the
+trio is missing, expired, or owned by another generation. A heartbeat cannot
+recreate an absent trio after initial registration failure or complete expiry.
+Durable recovery after complete expiry is a separate design concern under
+#24767.
 
 1. Resolve the exact gateway deployment, provisioning-worker checkout, sandbox
    row, running container, and agent-image digest before reading the registry.
@@ -267,14 +281,19 @@ order and the evidence contract fails closed unless both are present.
    token, hostname, service ID, or connection fingerprint.
 3. Starting from the exact route agent ID already bound to the sandbox row, use
    a least-privilege read-only Redis operation restricted to
-   `GET`/`EXISTS`/`PTTL` on its two known keys. Do not discover candidates with
+   `GET`/`EXISTS`/`PTTL` on the known public pair plus a presence/TTL check
+   for the private generation key. Read the two public keys only in memory.
+   For the private generation key, verify presence and a positive TTL without
+   publishing its expanded name or value. Do not discover candidates with
    `SCAN`. An older readback derived from `SCAN` is insufficient for this
    known-keys contract: it discovers candidates instead of proving the exact
-   pair already bound to the reviewed route and sandbox. Retain only closed
-   fields such as `pairFound`, `bothTtlsPositive`,
+   trio already bound to the reviewed route and sandbox. Retain only closed
+   fields such as `publicPairFound`, `bothPublicTtlsPositive`,
+   `generationKeyPresent`, `generationTtlPositive`,
    `ttlDeltaWithinBound`, and the UTC sample time. Successive samples spanning a
-   heartbeat should remain coherent; key names and values stay in memory only.
-4. Run the deployed resolver contract against that same pair and require
+   heartbeat should remain coherent; public key names and values stay in
+   memory only, and the private generation key is never expanded or dumped.
+4. Run the deployed resolver contract against the public pair and require
    `kind=ready`. Preserve only the normalized result; a server name or URL is
    sensitive operational data and does not belong in the public receipt.
 5. Prove HTTP reachability separately from the gateway network, then prove one
@@ -282,10 +301,13 @@ order and the evidence contract fails closed unless both are present.
    `ready` resolution alone do not prove that the container accepts traffic or
    that Telegram/Discord delivered a reply.
 
-Fail closed if only one key exists, either TTL is absent/expired, the two
-authorities differ, the pair cannot be bound to the exact sandbox/image, or a
-legacy long-lived pointer is substituted for a current heartbeat. Never scan
-or publish raw agent IDs, server names, URLs, Redis values, or provider content.
+Fail closed if the public pair is incomplete, the private generation key is
+absent or has no positive TTL, any trio TTL is absent/expired, the two
+authorities differ, the trio cannot be bound to the exact sandbox/image, or a
+legacy long-lived pointer is substituted for a current `SandboxRegistry`
+heartbeat. Never scan or publish raw agent IDs, server names, URLs, Redis
+values, expanded private route names, the generation token, or provider
+content.
 
 ### Provisioning worker
 
@@ -389,7 +411,7 @@ Before starting a probe, mark every row `proved`, `not applicable`, or
   unavailable for exact-source staging evidence while its deployment identity
   gap remains open.
 - A connector routing claim additionally requires a live, coherent
-  `SandboxRegistry` pair from the gateway's own Redis authority, `ready`
+  `SandboxRegistry` trio from the gateway's own Redis authority, `ready`
   resolution, the exact container image digest, gateway-to-container HTTP
   reachability, and a positive forward/ACK. No single one of these substitutes
   for the others.

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -235,12 +235,18 @@ export async function resolveIdentity(
 /**
  * Why an agent could not be routed to, which is not one condition but two.
  *
- * `agent:<id>:server` is written by a booted container and lives 30 days, while
- * `server:<name>:url` is refreshed by the pod's heartbeat and expires after two
- * minutes. So a missing routing key means the agent has never come up, and a
- * present routing key with no URL means an established agent whose pod is down
- * or scaled to zero. Callers that treat "no route" as "not provisioned yet" —
- * and answer with onboarding — must only do so for `unregistered`.
+ * This resolver reads the public pair only: `agent:<id>:server` then
+ * `server:<name>:url`. That two-key resolver view is distinct from the
+ * `SandboxRegistry` lifecycle contract, which also maintains a private
+ * `server:<name>:registration` generation fence and writes the full trio
+ * atomically through one Redis EVAL. TTLs are writer-specific: current
+ * `SandboxRegistry` entries use a 90-second trio TTL refreshed every 30
+ * seconds, while legacy/operator writers may still use different lifetimes.
+ * A missing routing pointer means this resolver cannot name a server
+ * (`unregistered`). A present pointer with no URL means a named server that
+ * is not currently resolvable (`unreachable`). Callers that treat "no route"
+ * as "not provisioned yet" — and answer with onboarding — must only do so
+ * for `unregistered`.
  */
 export type AgentServerLookup =
   | ({ kind: "ready" } & ServerRoute)

--- a/packages/shared/src/sandbox-registry.docs.test.ts
+++ b/packages/shared/src/sandbox-registry.docs.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Source/docs drift guard for the SandboxRegistry route trio. Reads the
+ * current-contract surfaces named by #28734 and fails if comments, the
+ * staging authority, or startup diagnostics still describe a non-atomic
+ * two-write pipeline, incompatible 30-day/two-minute TTLs, or heartbeat
+ * recovery after SANDBOX_REGISTRY_OWNERSHIP_LOST.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+function collapsed(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+const SURFACES = {
+  stagingAuthority: "packages/cloud/infra/STAGING_AUTHORITY.md",
+  registry: "packages/shared/src/sandbox-registry.ts",
+  webhookRouter: "packages/cloud/services/gateway-webhook/src/server-router.ts",
+  agentRuntime: "packages/agent/src/runtime/eliza.ts",
+  serverOnlyHost: "packages/app-core/src/runtime/startup/server-only-host.ts",
+} as const;
+
+const STALE_CLAIMS = [
+  "writes two Redis keys",
+  "pipelines both writes",
+  "pipeline is not a Redis transaction",
+  "TTL for both Redis keys",
+  "only writes twice per heartbeat",
+  "lives 30 days",
+  "expires after two minutes",
+  "heartbeat can recover after an initial",
+  "until the next heartbeat succeeds",
+  "until the next hb_signal succeeds",
+  "privacy-safe paired-key",
+] as const;
+
+describe("SandboxRegistry trio docs and diagnostics", () => {
+  const files = Object.fromEntries(
+    Object.entries(SURFACES).map(([name, path]) => [
+      name,
+      collapsed(readRepoFile(path)),
+    ]),
+  ) as Record<keyof typeof SURFACES, string>;
+
+  it("does not describe a non-atomic two-write pipeline, incompatible TTLs, or heartbeat recovery", () => {
+    for (const [name, source] of Object.entries(files)) {
+      for (const claim of STALE_CLAIMS) {
+        expect(source, `${name} still claims: ${claim}`).not.toContain(claim);
+      }
+    }
+  });
+
+  it("distinguishes the public resolver pair from the private generation-fenced trio", () => {
+    expect(files.registry).toContain("server:<serverName>:registration");
+    expect(files.registry).toContain("SANDBOX_REGISTRY_OWNERSHIP_LOST");
+    expect(files.registry).toContain("#24767");
+    expect(files.registry).toContain("writer-specific");
+
+    expect(files.stagingAuthority).toContain("EVAL");
+    expect(files.stagingAuthority).toContain("90-second");
+    expect(files.stagingAuthority).toContain("30-second");
+    expect(files.stagingAuthority).toContain("writer-specific");
+    expect(files.stagingAuthority).toContain("SANDBOX_REGISTRY_OWNERSHIP_LOST");
+    expect(files.stagingAuthority).toContain("#24767");
+    expect(files.stagingAuthority).toContain("publicPairFound");
+    expect(files.stagingAuthority).toContain("generationKeyPresent");
+    expect(files.stagingAuthority).toContain(
+      "without publishing its expanded name or value",
+    );
+
+    expect(files.webhookRouter).toContain("two-key resolver view");
+    expect(files.webhookRouter).toContain("server:<name>:registration");
+    expect(files.webhookRouter).toContain("writer-specific");
+    expect(files.webhookRouter).toContain("90-second trio TTL");
+
+    expect(files.agentRuntime).toContain("server:<name>:registration");
+    expect(files.serverOnlyHost).toContain("#24767");
+  });
+
+  it("startup diagnostics no longer promise heartbeat recreation after register failure", () => {
+    const diagnostic =
+      "heartbeat cannot recreate a missing trio and fails closed with SANDBOX_REGISTRY_OWNERSHIP_LOST";
+    expect(files.agentRuntime).toContain(diagnostic);
+    expect(files.serverOnlyHost).toContain(diagnostic);
+    expect(files.agentRuntime).not.toMatch(
+      /until the next (heartbeat|hb_signal) succeeds/,
+    );
+    expect(files.serverOnlyHost).not.toMatch(
+      /until the next (heartbeat|hb_signal) succeeds/,
+    );
+  });
+});

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -4,13 +4,22 @@
  * resolve `agent_id -> server URL` and forward inbound platform messages to
  * THIS container.
  *
- * It writes two Redis keys with a short TTL; a periodic heartbeat refreshes the
- * TTL while the container is alive, and `unregister()` deletes them on graceful
- * shutdown if they still point at this container. If the container crashes, the
- * keys expire naturally and the gateways stop routing to a dead address.
+ * It writes one TTL-backed route trio atomically through a single Redis EVAL
+ * for both REST and TCP. A periodic heartbeat refreshes the TTL while this
+ * generation still owns the trio, and `unregister()` deletes the keys on
+ * graceful shutdown if they still belong to this generation. If the container
+ * crashes, the keys expire naturally and the gateways stop routing to a dead
+ * address. Refresh fails closed with `SANDBOX_REGISTRY_OWNERSHIP_LOST` when
+ * the trio is missing, expired, or owned by another generation — a heartbeat
+ * cannot recreate an absent trio. Durable recovery after complete expiry is
+ * tracked in #24767.
  *
- *   server:<serverName>:url = <serverUrl>   (resolver address)
- *   agent:<agentId>:server  = <serverName>  (agent -> server pointer)
+ *   server:<serverName>:url            = <serverUrl>   (public resolver address)
+ *   agent:<agentId>:server             = <serverName>  (public agent -> server pointer)
+ *   server:<serverName>:registration   = <generation>  (private runtime-generation fence)
+ *
+ * Gateways read only the public pair. The generation fence is a lifecycle
+ * key, not part of the resolver view.
  *
  * Two transports are supported, selected by the URL scheme so the same registry
  * works before and after the managed Redis is migrated off Upstash:
@@ -79,8 +88,10 @@ export interface SandboxRegistryConfig {
   serverName: string;
   serverUrl: string;
   /**
-   * TTL for both Redis keys in seconds. Keep this at least 3x the heartbeat
-   * interval so one missed tick does not expire a healthy container.
+   * TTL for the three Redis keys in seconds. Keep this at least 3x the
+   * heartbeat interval so one missed tick does not expire a healthy
+   * container. This lifetime is writer-specific to `SandboxRegistry`; other
+   * registry writers do not share it.
    */
   ttlSeconds: number;
 }
@@ -307,8 +318,9 @@ export class SandboxRegistry {
    * Execute one or more commands over a native RESP/TCP connection and return
    * the per-command replies (AUTH/SELECT preamble replies are stripped). One
    * short-lived connection per call keeps the lifecycle trivial — the registry
-   * only writes twice per heartbeat (every 30s), so connection churn is
-   * negligible and there is no socket to leak if the container is killed.
+   * only writes the trio once per heartbeat (every 30s) via one EVAL, so
+   * connection churn is negligible and there is no socket to leak if the
+   * container is killed.
    */
   private async tcpExec(commands: string[][]): Promise<unknown[]> {
     const url = new URL(this.config.redisUrl);


### PR DESCRIPTION
Fixes #28734

## Summary
- Aligns `STAGING_AUTHORITY.md`, `SandboxRegistry` comments, gateway resolver notes, and startup diagnostics with the current atomic three-key contract (`agent:server`, `server:url`, private `server:registration`) written through one Redis `EVAL`.
- Distinguishes the two-key public resolver view from the full trio lifecycle, documents writer-specific 90s TTL / 30s heartbeat for `SandboxRegistry` only, and replaces heartbeat-recreate language with fail-closed `SANDBOX_REGISTRY_OWNERSHIP_LOST` (durable recovery remains #24767).
- Staging evidence now requires privacy-safe trio checks: public pair in memory, private generation-key presence/TTL without publishing name expansion or value.

## Test plan
- [x] `packages/shared` vitest: `src/sandbox-registry.docs.test.ts` (docs/diagnostic drift guard)
- [x] `packages/shared` vitest: `src/sandbox-registry.test.ts` + `src/sandbox-registry.encoding.test.ts`
- [x] `server-only-host.test.ts` diagnostic assertion updated; full app-core file not re-run here due to incomplete local node_modules
- [ ] CI shared + app-core lanes on this PR