### PR TITLE
feat(scenario-runner): add deterministic embeddings for semantic recall

### DIFF
--- a/packages/core/src/testing/deterministic-model-plugin.test.ts
+++ b/packages/core/src/testing/deterministic-model-plugin.test.ts
@@ -210,5 +210,150 @@ describe("createDeterministicModelPlugin", () => {
 	it("registers only text-generation models", () => {
 		const plugin = createDeterministicModelPlugin();
 		expect(plugin.models?.[ModelType.TEXT_EMBEDDING]).toBeUndefined();
+		expect(plugin.models?.[ModelType.TEXT_EMBEDDING_BATCH]).toBeUndefined();
+	});
+});
+
+function embeddingHandler(
+	plugin: ReturnType<typeof createDeterministicModelPlugin>,
+	type:
+		| typeof ModelType.TEXT_EMBEDDING
+		| typeof ModelType.TEXT_EMBEDDING_BATCH = ModelType.TEXT_EMBEDDING,
+) {
+	const handler = plugin.models?.[type];
+	if (!handler) throw new Error(`missing deterministic handler for ${type}`);
+	return handler;
+}
+
+function bytesOf(vector: number[]): Buffer {
+	return Buffer.from(new Float64Array(vector).buffer);
+}
+
+describe("createDeterministicModelPlugin embeddings", () => {
+	it("registers a fixed-dimension TEXT_EMBEDDING contract when enabled", () => {
+		const plugin = createDeterministicModelPlugin({ embeddings: true });
+		expect(plugin.models?.[ModelType.TEXT_EMBEDDING]).toEqual(
+			expect.any(Function),
+		);
+		expect(plugin.models?.[ModelType.TEXT_EMBEDDING_BATCH]).toEqual(
+			expect.any(Function),
+		);
+	});
+
+	it("returns identical vectors for identical normalized inputs across reset", async () => {
+		const plugin = createDeterministicModelPlugin({ embeddings: true });
+		const first = await embeddingHandler(plugin)(runtime, {
+			text: "  Solar  Panel  Yield  ",
+		});
+		plugin.fixtures.resetConsumption();
+		const second = await embeddingHandler(plugin)(runtime, {
+			text: "solar panel yield",
+		});
+		const third = await embeddingHandler(plugin)(runtime, "solar panel yield");
+
+		expect(Array.isArray(first)).toBe(true);
+		expect(first).toHaveLength(384);
+		expect(first.every((value) => Number.isFinite(value))).toBe(true);
+		expect(second).toEqual(first);
+		expect(third).toEqual(first);
+		expect(bytesOf(second).equals(bytesOf(first))).toBe(true);
+		expect(bytesOf(third).equals(bytesOf(first))).toBe(true);
+	});
+
+	it("maps distinct inputs to distinct vectors and honors purpose-built fixtures", async () => {
+		const purposeBuilt = new Array(384).fill(0);
+		purposeBuilt[0] = 1;
+		const plugin = createDeterministicModelPlugin({
+			embeddings: true,
+			fixtures: [
+				{
+					name: "arid-solar",
+					match: {
+						modelType: ModelType.TEXT_EMBEDDING,
+						input: "photovoltaic yield under arid conditions",
+					},
+					response: purposeBuilt,
+					times: "any",
+				},
+			],
+		});
+
+		const mapped = await embeddingHandler(plugin)(runtime, {
+			text: "photovoltaic yield under arid conditions",
+		});
+		const hashed = await embeddingHandler(plugin)(runtime, {
+			text: "weekly grocery list milk eggs bread",
+		});
+
+		expect(mapped).toEqual(purposeBuilt);
+		expect(hashed).not.toEqual(purposeBuilt);
+		expect(hashed).toHaveLength(384);
+	});
+
+	it("answers the null dimension probe with a zero vector of the declared width", async () => {
+		const plugin = createDeterministicModelPlugin({
+			embeddings: { dimension: 8 },
+		});
+		await expect(embeddingHandler(plugin)(runtime, null)).resolves.toEqual(
+			new Array(8).fill(0),
+		);
+		expect(plugin.getFixtureDiagnostics().calls).toEqual([]);
+	});
+
+	it("fails visibly for unmatched strict fixtures and invalid vectors", async () => {
+		const strict = createDeterministicModelPlugin({
+			embeddings: { strict: true, dimension: 4 },
+		});
+		await expect(
+			embeddingHandler(strict)(runtime, { text: "unregistered" }),
+		).rejects.toThrow("no fixture matched");
+
+		const invalid = createDeterministicModelPlugin({
+			embeddings: { dimension: 4 },
+			fixtures: [
+				{
+					name: "wrong-width",
+					match: { modelType: ModelType.TEXT_EMBEDDING, input: "bad" },
+					response: [1, 2],
+				},
+			],
+		});
+		await expect(
+			embeddingHandler(invalid)(runtime, { text: "bad" }),
+		).rejects.toThrow("invalid embedding vector");
+
+		const nonFinite = createDeterministicModelPlugin({
+			embeddings: { dimension: 2 },
+			fixtures: [
+				{
+					name: "nan-vector",
+					match: { modelType: ModelType.TEXT_EMBEDDING, input: "nan" },
+					response: [Number.NaN, 1],
+				},
+			],
+		});
+		await expect(
+			embeddingHandler(nonFinite)(runtime, { text: "nan" }),
+		).rejects.toThrow("invalid embedding vector");
+	});
+
+	it("embeds a batch with the same per-text contract", async () => {
+		const plugin = createDeterministicModelPlugin({
+			embeddings: { dimension: 8 },
+		});
+		const [first] = (await embeddingHandler(
+			plugin,
+			ModelType.TEXT_EMBEDDING_BATCH,
+		)(runtime, { texts: ["alpha"] })) as number[][];
+		plugin.fixtures.resetConsumption();
+		const [again, other] = (await embeddingHandler(
+			plugin,
+			ModelType.TEXT_EMBEDDING_BATCH,
+		)(runtime, { texts: ["alpha", "beta"] })) as number[][];
+
+		expect(again).toEqual(first);
+		expect(other).not.toEqual(first);
+		expect(again).toHaveLength(8);
+		expect(other).toHaveLength(8);
 	});
 });

--- a/packages/core/src/testing/deterministic-model-plugin.ts
+++ b/packages/core/src/testing/deterministic-model-plugin.ts
@@ -26,7 +26,9 @@ export interface DeterministicModelCall {
 export type DeterministicModelResponse =
 	| string
 	| GenerateTextResult
-	| Record<string, JsonValue>;
+	| Record<string, JsonValue>
+	| number[]
+	| number[][];
 
 export type DeterministicTextMatcher =
 	| string
@@ -137,6 +139,16 @@ export interface DeterministicModelPlugin extends Plugin {
 	getFixtureDiagnostics(): DeterministicModelDiagnostics;
 }
 
+export interface DeterministicEmbeddingOptions {
+	/** Fixed output width. Defaults to {@link DETERMINISTIC_EMBEDDING_DIMENSION}. */
+	dimension?: number;
+	/**
+	 * When true, unmatched embedding calls fail instead of hashing. Invalid
+	 * fixture vectors always fail.
+	 */
+	strict?: boolean;
+}
+
 export interface DeterministicModelPluginOptions {
 	fixtures?: DeterministicModelFixture[];
 	fixtureRegistry?: DeterministicModelFixtureRegistry;
@@ -149,6 +161,53 @@ export interface DeterministicModelPluginOptions {
 		intervalMs: number;
 		modelTypes?: ModelTypeName[];
 	};
+	/**
+	 * Opt-in deterministic TEXT_EMBEDDING / TEXT_EMBEDDING_BATCH handlers.
+	 * Default plugin construction stays text-only so keyword-only hosts remain
+	 * an explicit capability-unavailable mode.
+	 */
+	embeddings?: boolean | DeterministicEmbeddingOptions;
+}
+
+/** Fixed width used by scenario-owned deterministic embeddings. */
+export const DETERMINISTIC_EMBEDDING_DIMENSION = 384;
+
+export function normalizeDeterministicEmbeddingText(text: string): string {
+	return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+export function createDeterministicEmbedding(
+	text: string,
+	dimension: number = DETERMINISTIC_EMBEDDING_DIMENSION,
+): number[] {
+	if (!Number.isSafeInteger(dimension) || dimension <= 0) {
+		throw new Error(
+			"deterministic embedding dimension must be a positive integer",
+		);
+	}
+	const normalized = normalizeDeterministicEmbeddingText(text);
+	const values = new Float64Array(dimension);
+	let offset = 0;
+	let counter = 0;
+	while (offset < dimension) {
+		const digest = createHash("sha256")
+			.update(`${counter}\0${normalized}`)
+			.digest();
+		for (let i = 0; i + 3 < digest.length && offset < dimension; i += 4) {
+			const unsigned = digest.readUInt32BE(i);
+			values[offset++] = (unsigned + 0.5) / 4_294_967_296;
+		}
+		counter += 1;
+	}
+	let sumSquares = 0;
+	for (const value of values) sumSquares += value * value;
+	const norm = Math.sqrt(sumSquares);
+	if (norm === 0) {
+		values[0] = 1;
+	} else {
+		for (let i = 0; i < values.length; i++) values[i] /= norm;
+	}
+	return Array.from(values);
 }
 
 interface RegisteredFixture extends DeterministicModelFixture {
@@ -292,6 +351,29 @@ export function createDeterministicModelPlugin(
 		}) as never;
 	}
 
+	const embeddingConfig = resolveEmbeddingConfig(options.embeddings);
+	if (embeddingConfig) {
+		const embedOne = async (params: unknown) =>
+			resolveDeterministicEmbeddingVector({
+				fixtures,
+				fallback: options.resolve,
+				params,
+				dimension: embeddingConfig.dimension,
+				strict: embeddingConfig.strict,
+				signal: embeddingSignal(params),
+			});
+		models[ModelType.TEXT_EMBEDDING] = (async (_runtime, params) =>
+			embedOne(params)) as never;
+		models[ModelType.TEXT_EMBEDDING_BATCH] = (async (_runtime, params) => {
+			const texts = extractBatchEmbeddingTexts(params);
+			const vectors: number[][] = [];
+			for (const text of texts) {
+				vectors.push(await embedOne({ text }));
+			}
+			return vectors;
+		}) as never;
+	}
+
 	return {
 		name: "deterministic-model-provider",
 		description: "Fixture-driven model provider for real-runtime tests.",
@@ -415,13 +497,150 @@ function fixtureDiagnostic(
 	};
 }
 
+function resolveEmbeddingConfig(
+	embeddings: DeterministicModelPluginOptions["embeddings"],
+): { dimension: number; strict: boolean } | null {
+	if (!embeddings) return null;
+	const options = embeddings === true ? {} : embeddings;
+	const dimension = options.dimension ?? DETERMINISTIC_EMBEDDING_DIMENSION;
+	if (!Number.isSafeInteger(dimension) || dimension <= 0) {
+		throw new Error(
+			"deterministic embedding dimension must be a positive integer",
+		);
+	}
+	return { dimension, strict: options.strict === true };
+}
+
+function extractEmbeddingText(params: unknown): string | null {
+	if (params == null) return null;
+	if (typeof params === "string") return params;
+	if (typeof params === "object" && "text" in params) {
+		const text = (params as { text?: unknown }).text;
+		return typeof text === "string" ? text : null;
+	}
+	return null;
+}
+
+function extractBatchEmbeddingTexts(params: unknown): string[] {
+	if (params !== null && typeof params === "object" && "texts" in params) {
+		const texts = (params as { texts?: unknown }).texts;
+		if (
+			Array.isArray(texts) &&
+			texts.every((text) => typeof text === "string")
+		) {
+			return texts;
+		}
+	}
+	throw new Error(
+		"deterministic TEXT_EMBEDDING_BATCH requires params.texts: string[]",
+	);
+}
+
+function embeddingSignal(params: unknown): AbortSignal | undefined {
+	if (params !== null && typeof params === "object" && "signal" in params) {
+		const signal = (params as { signal?: unknown }).signal;
+		if (signal instanceof AbortSignal) return signal;
+	}
+	return undefined;
+}
+
+function parseEmbeddingResponse(response: DeterministicModelResponse): unknown {
+	if (Array.isArray(response)) return response;
+	if (typeof response === "string") {
+		try {
+			return JSON.parse(response);
+		} catch {
+			return response;
+		}
+	}
+	return response;
+}
+
+function assertEmbeddingVector(
+	value: unknown,
+	dimension: number,
+	label: string,
+): number[] {
+	if (
+		!Array.isArray(value) ||
+		value.length !== dimension ||
+		!value.every((entry) => typeof entry === "number" && Number.isFinite(entry))
+	) {
+		throw new Error(
+			`deterministic embedding fixture "${label}" returned an invalid embedding vector; expected ${dimension} finite numbers`,
+		);
+	}
+	return value;
+}
+
+async function resolveDeterministicEmbeddingVector(args: {
+	fixtures: DeterministicModelFixtureRegistry;
+	fallback?: DeterministicModelPluginOptions["resolve"];
+	params: unknown;
+	dimension: number;
+	strict: boolean;
+	signal?: AbortSignal;
+}): Promise<number[]> {
+	const text = extractEmbeddingText(args.params);
+	if (text === null) {
+		return new Array(args.dimension).fill(0);
+	}
+	const normalized = normalizeDeterministicEmbeddingText(text);
+	const call: DeterministicModelCall = {
+		modelType: ModelType.TEXT_EMBEDDING,
+		params: { prompt: normalized },
+		latestUserText: normalized,
+		toolNames: [],
+	};
+	let resolved: DeterministicModelFixtureResolution;
+	try {
+		resolved = args.fixtures.resolve(call);
+	} catch (error) {
+		if (
+			!(error instanceof DeterministicModelMatchError) ||
+			error.kind !== "unmatched"
+		) {
+			throw error;
+		}
+		if (args.fallback) {
+			const fallbackResponse = args.fallback(call);
+			if (fallbackResponse !== null && fallbackResponse !== undefined) {
+				registryUnmatchedRollbacks.get(args.fixtures)?.();
+				return assertEmbeddingVector(
+					parseEmbeddingResponse(fallbackResponse),
+					args.dimension,
+					"explicit-fallback-resolver",
+				);
+			}
+		}
+		if (args.strict) throw error;
+		registryUnmatchedRollbacks.get(args.fixtures)?.();
+		return createDeterministicEmbedding(normalized, args.dimension);
+	}
+	await applyDeterministicModelFixtureBehavior(resolved.behavior, args.signal);
+	return assertEmbeddingVector(
+		parseEmbeddingResponse(resolved.rawResponse),
+		args.dimension,
+		resolved.fixtureName,
+	);
+}
+
+function isEmbeddingModelType(modelType: ModelTypeName): boolean {
+	return (
+		modelType === ModelType.TEXT_EMBEDDING ||
+		modelType === ModelType.TEXT_EMBEDDING_BATCH
+	);
+}
+
 function matchesFixture(
 	fixture: RegisteredFixture,
 	call: DeterministicModelCall,
 ): boolean {
-	if (!fixture.match) return true;
 	if (typeof fixture.match === "function") return fixture.match(call);
+	const embeddingCall = isEmbeddingModelType(call.modelType);
+	if (!fixture.match) return !embeddingCall;
 	const match = fixture.match;
+	if (embeddingCall && !match.modelType) return false;
 	if (match.modelType) {
 		const expected = Array.isArray(match.modelType)
 			? match.modelType

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -49,8 +49,11 @@ export {
 } from "./deterministic-action-fixtures";
 export {
 	applyDeterministicModelFixtureBehavior,
+	createDeterministicEmbedding,
 	createDeterministicModelFixtureRegistry,
 	createDeterministicModelPlugin,
+	DETERMINISTIC_EMBEDDING_DIMENSION,
+	type DeterministicEmbeddingOptions,
 	type DeterministicModelCall,
 	type DeterministicModelCallDiagnostic,
 	type DeterministicModelDiagnostics,
@@ -66,6 +69,7 @@ export {
 	type DeterministicModelResponse,
 	type DeterministicSchemaMatcher,
 	type DeterministicTextMatcher,
+	normalizeDeterministicEmbeddingText,
 } from "./deterministic-model-plugin";
 // Package path resolution for monorepo tests
 export {

--- a/packages/scenario-runner/src/deterministic-embeddings.test.ts
+++ b/packages/scenario-runner/src/deterministic-embeddings.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Scenario-owned deterministic embedding surface for DocumentRecall.
+ *
+ * Simulated runtimes omit plugin-local-inference and default to keyword-only
+ * recall. This suite proves the opt-in deterministic TEXT_EMBEDDING lane can
+ * drive the real DocumentService vector/hybrid consumer with fixture-backed
+ * vectors, while the keyword-only lane stays silent (no DocumentRecall.embedding
+ * reports) when the canonical capability is disabled.
+ */
+import {
+  DocumentService,
+  type Memory,
+  MemoryType,
+  ModelType,
+  type UUID,
+} from "@elizaos/core";
+import { createDeterministicModelPlugin } from "@elizaos/core/testing";
+import { describe, expect, it, vi } from "vitest";
+import {
+  disableScenarioEmbeddingCapability,
+  enableScenarioDeterministicEmbeddingCapability,
+} from "./runtime-factory";
+
+const QUERY = "desert solar panel efficiency";
+const SEMANTIC_DOC = "photovoltaic yield under arid conditions";
+const KEYWORD_DOC = "weekly grocery list milk eggs bread";
+const DIMENSION = 8;
+
+function unitAxis(index: number, dimension = DIMENSION): number[] {
+  const vector = new Array(dimension).fill(0);
+  vector[index] = 1;
+  return vector;
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / Math.sqrt(normA * normB);
+}
+
+function makeFragment(id: string, text: string, embedding: number[]): Memory {
+  return {
+    id: id as UUID,
+    agentId: "agent-1" as UUID,
+    roomId: "room-1" as UUID,
+    entityId: "user-1" as UUID,
+    content: { text },
+    embedding,
+    metadata: {
+      type: MemoryType.FRAGMENT,
+      documentId: `${id}-doc` as UUID,
+      position: 0,
+      timestamp: Date.now(),
+    },
+    createdAt: Date.now(),
+  };
+}
+
+function makeMessage(text: string): Memory {
+  return {
+    id: "msg-1" as UUID,
+    agentId: "agent-1" as UUID,
+    roomId: "room-1" as UUID,
+    entityId: "user-1" as UUID,
+    content: { text },
+    createdAt: Date.now(),
+  };
+}
+
+function buildService(args: {
+  fragments: Memory[];
+  embeddingsEnabled: boolean;
+  plugin?: ReturnType<typeof createDeterministicModelPlugin>;
+}) {
+  const settings: Record<string, unknown> = {};
+  const runtimeSettings = {
+    setSetting: (key: string, value: unknown) => {
+      settings[key] = value;
+    },
+    getSetting: (key: string) => settings[key],
+  };
+  if (args.embeddingsEnabled) {
+    enableScenarioDeterministicEmbeddingCapability(runtimeSettings as never);
+  } else {
+    disableScenarioEmbeddingCapability(runtimeSettings as never);
+  }
+
+  const reportError = vi.fn();
+  const queryDocumentFragments = vi.fn(
+    async (params: {
+      embedding?: number[];
+      matchThreshold?: number;
+      limit: number;
+      offset?: number;
+    }) => {
+      const offset = params.offset ?? 0;
+      const ranked = args.fragments
+        .map((fragment) => {
+          const similarity =
+            params.embedding && fragment.embedding
+              ? cosine(params.embedding, fragment.embedding)
+              : 0;
+          return { ...fragment, similarity };
+        })
+        .filter((fragment) =>
+          params.embedding
+            ? fragment.similarity >= (params.matchThreshold ?? 0)
+            : true,
+        )
+        .sort((left, right) => right.similarity - left.similarity);
+      return ranked.slice(offset, offset + params.limit);
+    },
+  );
+
+  const runtime = {
+    agentId: "agent-1" as UUID,
+    adapter: { queryDocumentFragments },
+    getSetting: runtimeSettings.getSetting,
+    getModel: vi.fn((modelType: string) => {
+      if (!args.embeddingsEnabled) return undefined;
+      return args.plugin?.models?.[modelType];
+    }),
+    useModel: vi.fn(async (modelType: string, params: unknown) => {
+      const handler = args.plugin?.models?.[modelType];
+      if (!handler) {
+        throw new Error(
+          `no TEXT_EMBEDDING handler registered for ${modelType}`,
+        );
+      }
+      return handler({} as never, params as never);
+    }),
+    getCurrentRunId: () => "run-1",
+    reportError,
+    getRoomsForParticipants: vi.fn(async () => ["room-1" as UUID]),
+    getRoom: vi.fn(async () => ({
+      id: "room-1" as UUID,
+      agentId: "agent-1" as UUID,
+      worldId: "world-1" as UUID,
+    })),
+    getWorld: vi.fn(async () => ({
+      id: "world-1" as UUID,
+      agentId: "agent-1" as UUID,
+      metadata: {
+        roles: { "user-1": "USER" },
+        roleSources: { "user-1": "manual" },
+      },
+    })),
+  };
+
+  const service = new (
+    DocumentService as new (
+      runtime: unknown,
+    ) => DocumentService
+  )(runtime);
+  return { runtime, service, reportError, settings };
+}
+
+describe("scenario deterministic embeddings", () => {
+  it("lets DocumentRecall vector/hybrid select a semantic match keyword search cannot", async () => {
+    const semantic = unitAxis(0);
+    const distractor = unitAxis(1);
+    const query = unitAxis(0);
+    const plugin = createDeterministicModelPlugin({
+      embeddings: { dimension: DIMENSION, strict: true },
+      fixtures: [
+        {
+          name: "query",
+          match: { modelType: ModelType.TEXT_EMBEDDING, input: QUERY },
+          response: query,
+          times: "any",
+        },
+        {
+          name: "semantic-doc",
+          match: { modelType: ModelType.TEXT_EMBEDDING, input: SEMANTIC_DOC },
+          response: semantic,
+          times: "any",
+        },
+        {
+          name: "keyword-doc",
+          match: { modelType: ModelType.TEXT_EMBEDDING, input: KEYWORD_DOC },
+          response: distractor,
+          times: "any",
+        },
+      ],
+    });
+
+    const fragments = [
+      makeFragment("frag-semantic", SEMANTIC_DOC, semantic),
+      makeFragment("frag-keyword", KEYWORD_DOC, distractor),
+    ];
+    const { service, reportError, runtime } = buildService({
+      fragments,
+      embeddingsEnabled: true,
+      plugin,
+    });
+
+    const vectorHits = await service.searchDocuments(
+      makeMessage(QUERY),
+      undefined,
+      "vector",
+    );
+    const hybridHits = await service.searchDocuments(
+      makeMessage(QUERY),
+      undefined,
+      "hybrid",
+    );
+    const keywordHits = await service.searchDocuments(
+      makeMessage(QUERY),
+      undefined,
+      "keyword",
+    );
+
+    expect(vectorHits[0]?.id).toBe("frag-semantic");
+    expect(hybridHits[0]?.id).toBe("frag-semantic");
+    expect(keywordHits.map((hit) => hit.id)).not.toContain("frag-semantic");
+    expect(runtime.useModel).toHaveBeenCalledWith(
+      ModelType.TEXT_EMBEDDING,
+      expect.objectContaining({ text: QUERY }),
+    );
+    const diagnostics = plugin.getFixtureDiagnostics();
+    expect(
+      diagnostics.calls.some(
+        (call) =>
+          call.modelType === ModelType.TEXT_EMBEDDING &&
+          call.matchedFixtureName === "query",
+      ),
+    ).toBe(true);
+    expect(diagnostics.unexpectedCalls).toEqual([]);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("keeps keyword-only recall silent when the canonical capability is disabled", async () => {
+    const plugin = createDeterministicModelPlugin({
+      embeddings: { dimension: DIMENSION },
+    });
+    const fragments = [
+      makeFragment("frag-semantic", SEMANTIC_DOC, unitAxis(0)),
+      makeFragment(
+        "frag-keyword",
+        "desert solar panel efficiency notes",
+        unitAxis(1),
+      ),
+    ];
+    const { service, reportError, runtime, settings } = buildService({
+      fragments,
+      embeddingsEnabled: false,
+      plugin,
+    });
+
+    expect(settings.ELIZA_CANONICAL_EMBEDDINGS_ENABLED).toBe(false);
+    const hybridHits = await service.searchDocuments(
+      makeMessage(QUERY),
+      undefined,
+      "hybrid",
+    );
+
+    expect(hybridHits[0]?.id).toBe("frag-keyword");
+    expect(runtime.useModel).not.toHaveBeenCalled();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -20,12 +20,14 @@ import {
   deterministicScheduledDispatchRenderText,
   disableScenarioEmbeddingCapability,
   disposeScenarioProviderPlugin,
+  enableScenarioDeterministicEmbeddingCapability,
   isPostTurnEvaluationPrompt,
   isScheduledDispatchRenderPrompt,
   loadScenarioTestMocksForTests,
   resolveScenarioDeterministicModelCall,
   resolveScenarioProviderConfig,
   scenarioLiveProviderPreflightProblems,
+  shouldUseDeterministicEmbeddings,
   shouldUseDeterministicModel,
 } from "./runtime-factory";
 
@@ -197,6 +199,35 @@ describe("scenario embedding capability", () => {
       false,
       false,
     );
+  });
+
+  it("can enable the canonical embedding capability for deterministic embeddings", () => {
+    const setSetting = vi.fn();
+
+    enableScenarioDeterministicEmbeddingCapability({ setSetting } as never);
+
+    expect(setSetting).toHaveBeenCalledWith(
+      "ELIZA_CANONICAL_EMBEDDINGS_ENABLED",
+      true,
+      false,
+    );
+  });
+
+  it("keeps keyword-only as the default and opts into deterministic embeddings", () => {
+    expect(shouldUseDeterministicEmbeddings({}, {})).toBe(false);
+    expect(
+      shouldUseDeterministicEmbeddings(
+        { useDeterministicEmbeddings: true },
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    "SCENARIO_USE_DETERMINISTIC_EMBEDDINGS",
+    "ELIZA_SCENARIO_USE_DETERMINISTIC_EMBEDDINGS",
+  ])("can enable deterministic embeddings by %s", (name) => {
+    expect(shouldUseDeterministicEmbeddings({}, { [name]: "1" })).toBe(true);
   });
 });
 

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -21,6 +21,7 @@ import {
 } from "@elizaos/core";
 import {
   createDeterministicModelPlugin,
+  DETERMINISTIC_EMBEDDING_DIMENSION,
   type DeterministicModelDiagnostics,
   type DeterministicModelFixtureRegistry,
   type LiveProviderConfig,
@@ -176,6 +177,12 @@ export function disableScenarioEmbeddingCapability(
   runtime.setSetting(CANONICAL_EMBEDDING_CAPABILITY_SETTING, false, false);
 }
 
+export function enableScenarioDeterministicEmbeddingCapability(
+  runtime: Pick<AgentRuntime, "setSetting">,
+): void {
+  runtime.setSetting(CANONICAL_EMBEDDING_CAPABILITY_SETTING, true, false);
+}
+
 function isPlugin(value: unknown): value is Plugin {
   return (
     value !== null &&
@@ -250,6 +257,7 @@ export interface CreateScenarioRuntimeOptions {
   preferredProvider?: LiveProviderName;
   extraPlugins?: Plugin[];
   useDeterministicModel?: boolean;
+  useDeterministicEmbeddings?: boolean;
   executionProfile?: ScenarioExecutionProfile;
   requiredPlugins?: readonly string[];
   isolateFilesystemState?: boolean;
@@ -401,6 +409,20 @@ export function shouldUseDeterministicModel(
     options.useDeterministicModel === true ||
     envFlag(env.SCENARIO_USE_DETERMINISTIC_MODEL) ||
     envFlag(env.ELIZA_SCENARIO_USE_DETERMINISTIC_MODEL)
+  );
+}
+
+export function shouldUseDeterministicEmbeddings(
+  options: Pick<
+    CreateScenarioRuntimeOptions,
+    "useDeterministicEmbeddings"
+  > = {},
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    options.useDeterministicEmbeddings === true ||
+    envFlag(env.SCENARIO_USE_DETERMINISTIC_EMBEDDINGS) ||
+    envFlag(env.ELIZA_SCENARIO_USE_DETERMINISTIC_EMBEDDINGS)
   );
 }
 
@@ -980,17 +1002,28 @@ export async function createScenarioRuntime(
     createBasicCapabilitiesPlugin({ advancedCapabilities: true }),
   );
 
-  // Simulated scenarios omit embeddings because their assertions do not score
-  // semantic retrieval. AgentRuntime treats an absent embedding provider as an
-  // explicit disabled capability, avoiding both model downloads and fabricated
-  // vectors. Provider-qualified runs retain the production local provider.
+  // Simulated scenarios omit live embeddings because their assertions do not
+  // score semantic retrieval by default. AgentRuntime treats an absent embedding
+  // provider as an explicit disabled capability. Semantic-recall scenarios can
+  // opt into the deterministic TEXT_EMBEDDING surface instead of downloading a
+  // model. Provider-qualified runs retain the production local provider.
+  const useDeterministicEmbeddings =
+    providerConfig.name === DETERMINISTIC_MODEL_PROVIDER_NAME &&
+    shouldUseDeterministicEmbeddings(options);
   const skipEmbeddingPlugin =
     executionProfile === "simulated" &&
+    !useDeterministicEmbeddings &&
     (process.env.ELIZA_BENCH_SKIP_EMBEDDING ?? "1") !== "0";
   if (skipEmbeddingPlugin) {
     logger.info(
       "[scenario-runner] Embedding generation is disabled for the simulated profile; " +
-        "set ELIZA_BENCH_SKIP_EMBEDDING=0 to use @elizaos/plugin-local-inference.",
+        "set ELIZA_BENCH_SKIP_EMBEDDING=0 to use @elizaos/plugin-local-inference " +
+        "or SCENARIO_USE_DETERMINISTIC_EMBEDDINGS=1 for the fixture-backed surface.",
+    );
+  } else if (useDeterministicEmbeddings) {
+    logger.info(
+      "[scenario-runner] Using deterministic TEXT_EMBEDDING for the simulated profile; " +
+        "plugin-local-inference is not loaded.",
     );
   } else {
     const localEmbedding = (await import(
@@ -1004,6 +1037,8 @@ export async function createScenarioRuntime(
   applyRuntimeSettings(runtime, providerConfig.env);
   if (skipEmbeddingPlugin) {
     disableScenarioEmbeddingCapability(runtime);
+  } else if (useDeterministicEmbeddings) {
+    enableScenarioDeterministicEmbeddingCapability(runtime);
   }
   if (providerConfig.name === DETERMINISTIC_MODEL_PROVIDER_NAME) {
     if (!testMocks) {
@@ -1019,6 +1054,9 @@ export async function createScenarioRuntime(
         modelFixtureMode === "legacy-fallback"
           ? resolveScenarioDeterministicModelCall(call)
           : null,
+      embeddings: useDeterministicEmbeddings
+        ? { dimension: DETERMINISTIC_EMBEDDING_DIMENSION }
+        : undefined,
     });
     await runtime.registerPlugin(deterministicModelPlugin);
     const runtimeWithScenarioFixtures = runtime as AgentRuntime & {


### PR DESCRIPTION
## Summary

Simulated scenario runtimes omit `@elizaos/plugin-local-inference` and declare `ELIZA_CANONICAL_EMBEDDINGS_ENABLED=false`. That remains a valid keyword-only degradation. This PR adds an opt-in, scenario-owned deterministic `TEXT_EMBEDDING` surface so strict mock-model scenarios can exercise production DocumentRecall vector/hybrid retrieval without downloading a model or calling a network provider.

- Deterministic model plugin can register fixed-dimension `TEXT_EMBEDDING` / `TEXT_EMBEDDING_BATCH` handlers.
- Identical normalized inputs produce byte-equivalent vectors; distinct inputs can be hashed or mapped to purpose-built fixture vectors.
- Unmatched strict fixtures and invalid vectors fail visibly instead of fabricating success.
- Simulated keyword-only mode stays the default and still does not emit `DocumentRecall.embedding` / `RECALL_EMBEDDING_FAILED`.

Fixes #29066

## Test plan

- [x] New plugin tests fail on unpatched `develop` (`TEXT_EMBEDDING` handler missing).
- [x] After the fix, `packages/core/src/testing/deterministic-model-plugin.test.ts` is 15/15.
- [x] Scenario tests fail on unpatched `develop` (`shouldUseDeterministicEmbeddings` / `enableScenarioDeterministicEmbeddingCapability` missing).
- [x] After the fix, `deterministic-embeddings.test.ts` + embedding-focused `runtime-factory.test.ts` cases are 7/7.
- [x] Biome check clean on the six touched files.
- [ ] No live models or provider calls.

Unpatched baseline (`develop` `80c22d42a0`):

- core plugin suite: 6 failed / 9 passed
- scenario embedding suites: 5 failed / 38 passed

Patched head `ba04d306b4942540f445fe5a3fe97d0b983feef3`:

```
bunx vitest run src/testing/deterministic-model-plugin.test.ts
```

- 15 passed

```
bunx vitest run src/deterministic-embeddings.test.ts src/runtime-factory.test.ts -t embedding
```

- 7 passed / 36 skipped