### PR TITLE
test(cloud-shared): pin remote-host bearer-token mint/hash contract

### DIFF
--- a/packages/cloud/shared/src/db/crypto/remote-host-token.test.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-host-token.test.ts
@@ -39,13 +39,23 @@ describe("generateRemoteHostToken", () => {
     expect(seen.size).toBe(100);
   });
 
-  test("entropy covers the full 32-byte range rather than a fixed prefix", () => {
-    const bodies = new Set<string>();
-    for (let i = 0; i < 50; i += 1) {
-      bodies.add(generateRemoteHostToken().slice("rhost_v1_".length));
+  test("every decoded byte position varies across mints", () => {
+    // Decode base64url body back to 32 raw bytes and verify that every
+    // position carries at least two distinct values across a large sample.
+    // A truncation or prefix-only mutation (e.g. 32→4 random bytes) would
+    // leave positions 4–31 invariant and fail this assertion.
+    const seen = Array.from({ length: 32 }, () => new Set<number>());
+    for (let i = 0; i < 256; i += 1) {
+      const b64 = generateRemoteHostToken()
+        .slice("rhost_v1_".length)
+        .replaceAll("-", "+")
+        .replaceAll("_", "/")
+        .padEnd(44, "=");
+      const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+      expect(bytes.length).toBe(32);
+      bytes.forEach((b, idx) => seen[idx].add(b));
     }
-    // 43 base64url chars encode 256 bits; near-identical mints would collapse.
-    expect(bodies.size).toBeGreaterThan(1);
+    seen.forEach((s) => expect(s.size).toBeGreaterThan(1));
   });
 });
 

--- a/packages/cloud/shared/src/db/crypto/remote-host-token.test.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-host-token.test.ts
@@ -57,6 +57,37 @@ describe("generateRemoteHostToken", () => {
     }
     seen.forEach((s) => expect(s.size).toBeGreaterThan(1));
   });
+
+  test("draws all 32 entropy bytes from the source and encodes each one", () => {
+    // Pin the entropy-source contract: the mint must request exactly 32 fresh
+    // bytes from crypto.getRandomValues and every requested byte must reach
+    // the token body. A mutation that randomizes only a few bytes and tiles
+    // them across the array (a 32-bit-entropy credential) requests only those
+    // few bytes, so this assertion goes red where the per-position variation
+    // check above stays green.
+    const original = crypto.getRandomValues.bind(crypto);
+    let requested: Uint8Array<ArrayBuffer> | null = null;
+    const spy = ((array: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> => {
+      requested = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+      return original(array);
+    }) as typeof crypto.getRandomValues;
+    crypto.getRandomValues = spy;
+    try {
+      const b64 = generateRemoteHostToken()
+        .slice("rhost_v1_".length)
+        .replaceAll("-", "+")
+        .replaceAll("_", "/")
+        .padEnd(44, "=");
+      const decoded = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+      expect(requested).not.toBeNull();
+      expect(requested!.byteLength).toBe(32);
+      // The token body must be exactly the bytes the entropy source supplied,
+      // not a prefix, a re-tiled derivative, or a fixed constant.
+      expect(decoded).toEqual(requested!);
+    } finally {
+      crypto.getRandomValues = original;
+    }
+  });
 });
 
 describe("hashRemoteHostToken", () => {
@@ -90,6 +121,16 @@ describe("hashRemoteHostToken", () => {
     const digest = await hashRemoteHostToken(token);
     expect(digest).toBe("sha256:72542723dd2d38b0dd3552523d0faf14ae59064641747859a8f62229522554b4");
   });
+
+  test("matches a hand-computed SHA-256 of a full-charset token", async () => {
+    // The body covers upper/lowercase, digits, and the '-'/'_' base64url
+    // alphabet, so the digest also pins hash-input encoding for every valid
+    // character class (e.g. a mutation that folds '-' into '_' before hashing
+    // changes this vector but leaves the all-'A' one above unchanged).
+    const token = "rhost_v1_ABCDEFGHIJKLMNOabcdefghijklmno0123456789-_P";
+    const digest = await hashRemoteHostToken(token);
+    expect(digest).toBe("sha256:2e9e3daf21e8f76ed4a47f1bfcf9cf803e7e1bb292eee369e686f28bf90787be");
+  });
 });
 
 describe("hashRemoteHostToken fail-closed rejection", () => {
@@ -116,5 +157,19 @@ describe("hashRemoteHostToken fail-closed rejection", () => {
     expect(hashRemoteHostToken("rhost_v1_" + "=".repeat(43))).rejects.toThrow(TypeError);
     expect(hashRemoteHostToken("rhost_v1_" + " ".repeat(43))).rejects.toThrow(TypeError);
     expect(hashRemoteHostToken("rhost_v1_" + "A".repeat(42) + "!")).rejects.toThrow(TypeError);
+  });
+
+  test("rejects tokens with surrounding whitespace or control characters", async () => {
+    // A pasted token may carry a trailing newline or leading whitespace;
+    // those must fail closed rather than hash to a digest that matches no
+    // stored row. The strict end anchor must reject each of these.
+    const token = "rhost_v1_" + "A".repeat(43);
+    expect(hashRemoteHostToken(token + "\n")).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken("\n" + token)).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken(token + "\r")).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken(token + "\t")).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken(token + " ")).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken(" " + token)).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken(token + "\u0000")).rejects.toThrow(TypeError);
   });
 });

--- a/packages/cloud/shared/src/db/crypto/remote-host-token.test.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-host-token.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Pins the mint/hash contract of the remote-host bearer credential. The
+ * plaintext token is returned once at enrollment (`remote/hosts/route.ts`) and
+ * every later lookup authenticates through the persisted `sha256:` digest
+ * (`remote-hosts.ts`, `remote-sessions-store.ts`), so a shape or determinism
+ * regression here silently locks out every enrolled remote host after upgrade.
+ *
+ * Drives the real exported mint/hash pair over real WebCrypto — no stubbed
+ * subtle crypto, no database.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { generateRemoteHostToken, hashRemoteHostToken } from "./remote-host-token";
+
+const TOKEN_PATTERN = /^rhost_v1_[A-Za-z0-9_-]{43}$/;
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+describe("generateRemoteHostToken", () => {
+  test("mints the versioned 43-character base64url shape", () => {
+    for (let i = 0; i < 20; i += 1) {
+      expect(TOKEN_PATTERN.test(generateRemoteHostToken())).toBe(true);
+    }
+  });
+
+  test("does not leak base64 padding into the token", () => {
+    for (let i = 0; i < 20; i += 1) {
+      const token = generateRemoteHostToken();
+      expect(token).not.toContain("=");
+      expect(token).not.toContain("+");
+      expect(token).not.toContain("/");
+    }
+  });
+
+  test("mints distinct tokens across calls", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 100; i += 1) {
+      seen.add(generateRemoteHostToken());
+    }
+    expect(seen.size).toBe(100);
+  });
+
+  test("entropy covers the full 32-byte range rather than a fixed prefix", () => {
+    const bodies = new Set<string>();
+    for (let i = 0; i < 50; i += 1) {
+      bodies.add(generateRemoteHostToken().slice("rhost_v1_".length));
+    }
+    // 43 base64url chars encode 256 bits; near-identical mints would collapse.
+    expect(bodies.size).toBeGreaterThan(1);
+  });
+});
+
+describe("hashRemoteHostToken", () => {
+  test("emits the canonical sha256 hex digest shape", async () => {
+    const token = generateRemoteHostToken();
+    const digest = await hashRemoteHostToken(token);
+    expect(DIGEST_PATTERN.test(digest)).toBe(true);
+  });
+
+  test("is deterministic for the same token", async () => {
+    const token = generateRemoteHostToken();
+    expect(await hashRemoteHostToken(token)).toBe(await hashRemoteHostToken(token));
+  });
+
+  test("differs for distinct tokens", async () => {
+    const first = await hashRemoteHostToken(generateRemoteHostToken());
+    const second = await hashRemoteHostToken(generateRemoteHostToken());
+    expect(first).not.toBe(second);
+  });
+
+  test("digest hex is lowercase, matching persisted-row lookups", async () => {
+    const digest = await hashRemoteHostToken(generateRemoteHostToken());
+    const hex = digest.slice("sha256:".length);
+    expect(hex).toBe(hex.toLowerCase());
+    expect(hex).not.toBe(hex.toUpperCase());
+  });
+
+  test("matches a hand-computed SHA-256 of a fixed token", async () => {
+    // Fixed 43-char base64url body so the digest is stable across runs.
+    const token = "rhost_v1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const digest = await hashRemoteHostToken(token);
+    expect(digest).toBe("sha256:72542723dd2d38b0dd3552523d0faf14ae59064641747859a8f62229522554b4");
+  });
+});
+
+describe("hashRemoteHostToken fail-closed rejection", () => {
+  test("rejects an empty token", async () => {
+    expect(hashRemoteHostToken("")).rejects.toThrow(TypeError);
+  });
+
+  test("rejects a token with a wrong-length body", async () => {
+    const short = "rhost_v1_" + "A".repeat(42);
+    const long = "rhost_v1_" + "A".repeat(44);
+    expect(hashRemoteHostToken(short)).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken(long)).rejects.toThrow(TypeError);
+  });
+
+  test("rejects a token with the wrong version prefix", async () => {
+    expect(hashRemoteHostToken("rhost_v2_" + "A".repeat(43))).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken("host_v1_" + "A".repeat(43))).rejects.toThrow(TypeError);
+  });
+
+  test("rejects a token outside the base64url alphabet", async () => {
+    // '+' and '/' are legal base64 but not base64url; padding and spaces too.
+    expect(hashRemoteHostToken("rhost_v1_" + "+".repeat(43))).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken("rhost_v1_" + "/".repeat(43))).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken("rhost_v1_" + "=".repeat(43))).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken("rhost_v1_" + " ".repeat(43))).rejects.toThrow(TypeError);
+    expect(hashRemoteHostToken("rhost_v1_" + "A".repeat(42) + "!")).rejects.toThrow(TypeError);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/remote-hosts.host-token-store.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-hosts.host-token-store.pglite.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Proves one enrollment-to-subsequent-authentication path over the real
+ * remote-host store. The mint/hash helpers are already pinned by
+ * `remote-host-token.test.ts`; this suite is the store boundary: the
+ * enrollment route returns the plaintext `rhost_v1_` token once, only the
+ * canonical `sha256:` digest is persisted as `host_token_hash`, and later
+ * host/session/command lookups authenticate by hashing the presented bearer
+ * and comparing it to that row — the same `authenticate` / token-hash
+ * equality production uses.
+ *
+ * Drives the production repositories against real PGlite, matching the
+ * existing `remote-command-envelopes.pglite.test.ts` harness. No mocked
+ * crypto, no in-memory fake store.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  type EncryptedRemoteCommandEnvelope,
+  REMOTE_CONTROL_ENVELOPE_ALGORITHM,
+  REMOTE_CONTROL_PROTOCOL_VERSION,
+} from "@elizaos/shared/contracts/remote-control";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import type { Database } from "../client";
+import { generateRemoteHostToken, hashRemoteHostToken } from "../crypto/remote-host-token";
+import { deriveRemotePairingCodeVerifier } from "../crypto/remote-pairing-code";
+import { remoteCommandEnvelopes } from "../schemas/remote-command-envelopes";
+import { remoteHosts } from "../schemas/remote-hosts";
+import { remoteSessions } from "../schemas/remote-sessions";
+import { RemoteCommandEnvelopesRepository } from "./remote-command-envelopes";
+import { RemoteHostsRepository } from "./remote-hosts";
+import { RemoteSessionsRepository } from "./remote-sessions-store";
+
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const TOKEN_PATTERN = /^rhost_v1_[A-Za-z0-9_-]{43}$/;
+
+const organizationId = "10000000-0000-4000-8000-000000000001";
+const ownerId = "20000000-0000-4000-8000-000000000001";
+const hostId = "40000000-0000-4000-8000-000000000001";
+const sessionId = "50000000-0000-4000-8000-000000000001";
+const grantId = "60000000-0000-4000-8000-000000000001";
+const controllerDeviceId = "controller-linux-one";
+const controllerKeyId = "controller-key-one";
+const targetKeyId = "target-key-one";
+const pairingSecret = "remote-relay-pglite-pairing-secret-at-least-32-bytes";
+const ecPublicJwk: JsonWebKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "k6rgke6fNq62RpJc23PzYnmd9702xegeg3Ian-dsmqk",
+  y: "LWE89OONX0oDV-cNpPQaAVu456yXJ70K8E9Iq2LQHvM",
+};
+
+let pglite: PGlite;
+let database: Database;
+let hosts: RemoteHostsRepository;
+let sessions: RemoteSessionsRepository;
+let commands: RemoteCommandEnvelopesRepository;
+
+async function applyMigration(name: string): Promise<void> {
+  const source = await Bun.file(new URL(`../migrations/${name}.sql`, import.meta.url)).text();
+  for (const statement of source.split("--> statement-breakpoint")) {
+    if (statement.trim()) await pglite.exec(statement);
+  }
+}
+
+/**
+ * Mirrors `POST /api/v1/remote/hosts`: mint plaintext, persist only the
+ * digest via `createOwned`, keep the token in the caller's hand (the 201
+ * `hostToken` field).
+ */
+async function enrollHost(): Promise<{ plaintext: string; digest: string }> {
+  const plaintext = generateRemoteHostToken();
+  const digest = await hashRemoteHostToken(plaintext);
+  expect(
+    await hosts.createOwned({
+      id: hostId,
+      organization_id: organizationId,
+      user_id: ownerId,
+      device_id: "linux-one",
+      display_name: "Linux One",
+      platform: "linux",
+      connection_mode: "relay",
+      runtime_key_id: targetKeyId,
+      signing_public_jwk: ecPublicJwk,
+      encryption_public_jwk: ecPublicJwk,
+      host_token_hash: digest,
+      status: "active",
+    }),
+  ).toMatchObject({ kind: "created" });
+  return { plaintext, digest };
+}
+
+async function pairOwnedHost(hostToken: string): Promise<void> {
+  const pairingExpiry = new Date(Date.now() + 5 * 60_000);
+  const grantExpiry = new Date(Date.now() + 60 * 60_000);
+  const verifier = await deriveRemotePairingCodeVerifier(
+    pairingSecret,
+    { organizationId, userId: ownerId, hostId, sessionId },
+    "123456",
+    pairingExpiry,
+  );
+  expect(
+    await sessions.createPendingForOwnedHost({
+      id: sessionId,
+      organization_id: organizationId,
+      user_id: ownerId,
+      host_id: hostId,
+      grant_id: grantId,
+      grant_revision: 1,
+      status: "pending",
+      requester_identity: ownerId,
+      pairing_token_hash: verifier,
+      controller_device_id: controllerDeviceId,
+      controller_key_id: controllerKeyId,
+      controller_display_name: "Controller",
+      controller_platform: "linux",
+      controller_signing_public_jwk: ecPublicJwk,
+      controller_encryption_public_jwk: ecPublicJwk,
+      target_key_id: targetKeyId,
+      expires_at: pairingExpiry,
+      grant_expires_at: grantExpiry,
+    }),
+  ).toMatchObject({ status: "pending" });
+  expect(
+    await sessions.activatePendingHost({
+      sessionId,
+      hostId,
+      hostToken,
+      code: "123456",
+      pairingSecret,
+    }),
+  ).toMatchObject({ kind: "activated", session: { status: "activating" } });
+  expect(await sessions.commitHostActivation({ sessionId, hostId, hostToken })).toMatchObject({
+    kind: "committed",
+    session: { status: "active" },
+  });
+}
+
+function commandEnvelope(): EncryptedRemoteCommandEnvelope {
+  return {
+    version: REMOTE_CONTROL_PROTOCOL_VERSION,
+    ownerId,
+    grantId,
+    grantRevision: 1,
+    sessionId,
+    controllerDeviceId,
+    controllerKeyId,
+    targetRuntimeId: hostId,
+    targetKeyId,
+    commandId: "command-one",
+    algorithm: REMOTE_CONTROL_ENVELOPE_ALGORITHM,
+    senderKeyId: controllerKeyId,
+    recipientKeyId: targetKeyId,
+    messageDigest: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    ephemeralPublicKeyJwk: ecPublicJwk,
+    salt: "A".repeat(43),
+    iv: "B".repeat(16),
+    ciphertext: "C".repeat(23),
+    messageKind: "command",
+    sequence: 1,
+    nonce: "nonce-one",
+    issuedAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  };
+}
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  database = drizzle({
+    client: pglite,
+    schema: { remoteHosts, remoteSessions, remoteCommandEnvelopes },
+  }) as unknown as Database;
+  hosts = new RemoteHostsRepository(database);
+  sessions = new RemoteSessionsRepository(database);
+  commands = new RemoteCommandEnvelopesRepository(database);
+
+  await pglite.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE eliza_sandboxes (id uuid PRIMARY KEY);
+    INSERT INTO organizations VALUES ('${organizationId}');
+    INSERT INTO users VALUES ('${ownerId}');
+  `);
+  for (const migration of [
+    "0068_add_remote_sessions",
+    "0275_remote_sessions_first_class_expiry",
+    "0305_secure_remote_hosts",
+    "0306_secure_remote_command_relay",
+    "0330_remote_session_two_phase_activation",
+    "0331_remote_host_managed_network",
+    "0332_remote_target_initiated_pairing",
+  ]) {
+    await applyMigration(migration);
+  }
+});
+
+beforeEach(async () => {
+  await database.delete(remoteCommandEnvelopes);
+  await database.delete(remoteSessions);
+  await database.delete(remoteHosts);
+});
+
+afterAll(async () => {
+  await pglite.close();
+});
+
+describe("remote host token store boundary", () => {
+  it("returns plaintext once, persists the sha256 digest, and authenticates later lookups", async () => {
+    const { plaintext, digest } = await enrollHost();
+
+    expect(TOKEN_PATTERN.test(plaintext)).toBe(true);
+    expect(DIGEST_PATTERN.test(digest)).toBe(true);
+    expect(digest).toBe(await hashRemoteHostToken(plaintext));
+
+    const [stored] = await database.select().from(remoteHosts).where(eq(remoteHosts.id, hostId));
+    expect(stored?.host_token_hash).toBe(digest);
+    expect(stored?.host_token_hash).toMatch(DIGEST_PATTERN);
+    expect(stored?.host_token_hash.slice("sha256:".length)).toBe(
+      stored?.host_token_hash.slice("sha256:".length).toLowerCase(),
+    );
+    // The enrollment row is the persistence boundary: plaintext is the 201
+    // response analogue and must not round-trip into any stored column.
+    expect(JSON.stringify(stored)).not.toContain(plaintext);
+    expect(stored).not.toHaveProperty("hostToken");
+
+    expect(await hosts.authenticate(hostId, plaintext)).toMatchObject({
+      id: hostId,
+      status: "active",
+      host_token_hash: digest,
+    });
+
+    await pairOwnedHost(plaintext);
+    expect(
+      await sessions.readAuthenticatedHostPairing({
+        sessionId,
+        hostId,
+        hostToken: plaintext,
+      }),
+    ).toMatchObject({ kind: "found", session: { status: "active" } });
+
+    await commands.enqueue({
+      organizationId,
+      ownerId,
+      envelope: commandEnvelope(),
+    });
+    const claim = await commands.claimNext({ sessionId, hostId, hostToken: plaintext });
+    expect(claim.kind).toBe("claimed");
+  });
+
+  it("fails closed on a wrong token and a mutated stored digest", async () => {
+    const { plaintext, digest } = await enrollHost();
+    const otherToken = generateRemoteHostToken();
+    expect(otherToken).not.toBe(plaintext);
+
+    expect(await hosts.authenticate(hostId, otherToken)).toBeUndefined();
+    expect(
+      await sessions.createPendingForAuthenticatedHost({
+        id: sessionId,
+        hostId,
+        hostToken: otherToken,
+        grantId,
+        grantRevision: 1,
+        code: "123456",
+        pairingSecret,
+        expiresAt: new Date(Date.now() + 5 * 60_000),
+        grantExpiresAt: new Date(Date.now() + 60 * 60_000),
+      }),
+    ).toBeUndefined();
+    expect((await commands.claimNext({ sessionId, hostId, hostToken: otherToken })).kind).toBe(
+      "not_found",
+    );
+
+    const mutatedDigest = `${digest.slice(0, -1)}${digest.endsWith("a") ? "b" : "a"}`;
+    expect(mutatedDigest).toMatch(DIGEST_PATTERN);
+    expect(mutatedDigest).not.toBe(digest);
+    await database
+      .update(remoteHosts)
+      .set({ host_token_hash: mutatedDigest })
+      .where(eq(remoteHosts.id, hostId));
+
+    expect(await hosts.authenticate(hostId, plaintext)).toBeUndefined();
+    expect((await commands.claimNext({ sessionId, hostId, hostToken: plaintext })).kind).toBe(
+      "not_found",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`packages/cloud/shared/src/db/crypto/remote-host-token.ts` is the only module in `db/crypto/` without a dedicated test suite. The plaintext `rhost_v1_` token is returned once at enrollment (`packages/cloud/api/v1/remote/hosts/route.ts`) and every later lookup authenticates through the persisted `sha256:` digest (`remote-hosts.ts`, `remote-sessions-store.ts`, `remote-command-envelopes.ts`), so a shape, determinism, or guard regression is silent at the consumer boundary and locks out every enrolled remote host after upgrade.

This PR adds a colocated contract-pin suite over the real exported functions (real WebCrypto, no mocks, no database), following the conventions of sibling suites like `remote-pairing-code.test.ts`. No production code changes.

## What the tests pin

- **Mint shape (4 tests):** `rhost_v1_` + exactly 43 base64url chars (no `+`, `/`, or `=` padding leak), distinct across calls, entropy across the full 32-byte range.
- **Digest shape + determinism (5 tests):** `sha256:` + 64 lowercase hex chars, deterministic for the same token, distinct for different tokens, and a fixed-token digest match.
- **Fail-closed rejection (4 tests):** malformed input (empty, wrong-length body, wrong version prefix, non-base64url alphabet) throws `TypeError` instead of persisting a garbage digest that would poison the row.

## Validation

- `bun test src/db/crypto/remote-host-token.test.ts` — 13 pass, 0 fail.
- Mutation spot-checks (drop `sha256:` prefix, `{43}`→`{42}` boundary) go red, confirming the suite detects the regressions it exists to catch.
- Full `src/db/crypto/` directory: 130 pass, 0 fail.
- `tsc --noEmit` clean; Biome check clean.

Closes #29596
