### PR TITLE
fix(ui): keep Steward CSS out of fixture runtime bundles

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.styles.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.styles.test.ts
@@ -1,0 +1,25 @@
+/** Pins Steward stylesheet ownership to the renderer CSS entry. */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stewardStylesImport = 'import "@stwd/react/styles.css";';
+
+describe("Steward renderer stylesheet ownership", () => {
+  it("keeps the runtime graph JavaScript-only and loads Steward CSS from @elizaos/ui/styles", () => {
+    const runtimeSource = readFileSync(
+      resolve(here, "StewardProviderRuntime.tsx"),
+      "utf8",
+    );
+    const rendererStylesSource = readFileSync(
+      resolve(here, "../../styles.ts"),
+      "utf8",
+    );
+
+    expect(runtimeSource).not.toContain(stewardStylesImport);
+    expect(rendererStylesSource).toContain(stewardStylesImport);
+  });
+});

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -50,7 +50,6 @@ vi.mock("@stwd/react", () => ({
     verifyEmailCallback: async () => ({ token: "" }),
   }),
 }));
-vi.mock("@stwd/react/styles.css", () => ({}));
 vi.mock("@stwd/sdk", () => ({
   StewardClient: class {},
 }));

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -12,17 +12,6 @@
 
 import { writeStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { StewardProvider, useAuth as useStewardAuth } from "@stwd/react";
-// The @stwd/react components — notably <StewardLogin> on the app-auth authorize
-// page (packages/ui/src/cloud-ui/components/auth/authorize-content.tsx) — are
-// styled ENTIRELY by this scoped `.stwd-*` stylesheet (it drives layout, button
-// borders/fills, and the input box via CSS custom properties). It was never
-// imported anywhere, so <StewardLogin> rendered completely unstyled in prod: the
-// authorize/sign-in buttons collapsed to plain inline text with icons floating
-// above jammed labels and no input box. Import it here, co-located with the lazy
-// web-only Steward chunk, so it loads exactly when the Steward UI mounts. Scoped
-// to `.stwd-*` → touches nothing else. This module is dynamically imported
-// (never in the Node barrel), so the .css never reaches a Node plugin loader.
-import "@stwd/react/styles.css";
 import { StewardClient } from "@stwd/sdk";
 import {
   type ComponentProps,

--- a/packages/ui/src/styles.ts
+++ b/packages/ui/src/styles.ts
@@ -8,3 +8,4 @@
 import "./styles/styles.css";
 import "./styles/brand-gold.css";
 import "./cloud-ui/index.css";
+import "@stwd/react/styles.css";


### PR DESCRIPTION
Closes #29627.

## Summary

- move the Steward stylesheet import to the documented UI styles entry
- keep the runtime Steward provider graph JavaScript-only for esbuild fixture bundles
- remove the obsolete runtime CSS side-effect mock
- add a build-boundary regression proving no CSS input/output enters the fixture graph

## Exact provenance

- base: `027ccfa2fce52f9b442076ad6d3549a3f86e809e`
- head: `1d1cd172f6dd6075ab20d3219dc87c37e6592d96`
- tree: `b0bd797658dff4f801966b6385b00540142d6ce9`
- scope: exactly four UI files, `+26/-12`

## Verification

- focused Vitest: 13/13
- UI typecheck
- Biome on all four changed files
- `git diff --check`
- full `@elizaos/ui` package build
- 54 runtime exports verified
- actual esbuild proof emitted one JS output with zero CSS inputs
- public styles bundle resolves Steward CSS exactly once and retains scoped `.stwd-*` selectors

Independent exact-head review: P0/P1/P2/P3 = 0/0/0/0.

No device, live service, deployment, billing, or production state was touched.