### PR TITLE
fix(ui): define browser env in permission priming fixture

### DIFF
--- a/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
+++ b/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
@@ -133,7 +133,14 @@ const result = await build({
   platform: "browser",
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
-  define: { "process.env.NODE_ENV": '"production"' },
+  // This is a browser-only fixture. The modal graph can reach shared styling
+  // helpers that probe Node environment variables at module initialization;
+  // keep those probes deterministic instead of leaving a missing `process`
+  // global that prevents React from mounting.
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    "process.env": "{}",
+  },
   plugins: [stubClient, stubCore, shimNodeBuiltins],
   write: false,
 });


### PR DESCRIPTION
Closes #29630.

## Summary

The permission-priming e2e bundle reaches a shared terminal-theme module that evaluates `process.env` at module initialization. In Chromium that missing Node global aborts before React mounts, so the first microphone-card selector waits until timeout.

This change defines an empty browser environment only for this fixture bundle while retaining the explicit production React mode.

## Exact provenance

- base: `027ccfa2fce52f9b442076ad6d3549a3f86e809e`
- head: `c18c15383fbbab62ea8d00c755c6c28d30096fb0`
- tree: `ea0d47906b676a70bd53fff7104a470620219ce7`
- scope: one fixture runner file, `+8/-1`

## Verification

- real desktop and mobile headless flows PASS
- microphone grant -> location denial/recovery -> notifications -> completion
- eight screenshots and one mobile video generated
- zero page errors
- `packages/ui` typecheck PASS
- `node --check` PASS
- `git diff --check` PASS
- Biome intentionally excludes `src/**/__e2e__`; candidate lines match surrounding style

Independent exact-head review: P0/P1/P2/P3 = 0/0/0/0.

No production runtime, deployment, device, browser session, billing, or live service state was touched.