### PR TITLE
fix(app): enable local self-hosted realtime voice

### DIFF
--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -89,9 +89,10 @@ describe("devViewStudioPlugin", () => {
 });
 
 describe("local realtime voice defaults", () => {
-  test("enables the realtime client without force-arming unresolved agents", () => {
+  test("enables realtime and health-probed self-hosted eligibility without force-arming", () => {
     expect(resolveLocalRealtimeVoiceDefines("serve", 31_338, {})).toEqual({
       "import.meta.env.VITE_VOICE_REALTIME_WS": JSON.stringify("1"),
+      "import.meta.env.VITE_VOICE_REALTIME_SELF_HOSTED": JSON.stringify("1"),
     });
   });
 
@@ -99,14 +100,33 @@ describe("local realtime voice defaults", () => {
     expect(
       resolveLocalRealtimeVoiceDefines("serve", 31_338, {
         VITE_VOICE_REALTIME_WS: "0",
+        VITE_VOICE_REALTIME_SELF_HOSTED: "false",
         VITE_VOICE_REALTIME_FORCE: "false",
       }),
     ).toEqual({});
     expect(
       resolveLocalRealtimeVoiceDefines("serve", 31_338, {
         VITE_VOICE_REALTIME_WS: "1",
+        VITE_VOICE_REALTIME_SELF_HOSTED: "1",
       }),
     ).toEqual({});
+  });
+
+  test("defaults only a missing flag when the other has an explicit opt-out", () => {
+    expect(
+      resolveLocalRealtimeVoiceDefines("serve", 31_338, {
+        VITE_VOICE_REALTIME_WS: "0",
+      }),
+    ).toEqual({
+      "import.meta.env.VITE_VOICE_REALTIME_SELF_HOSTED": JSON.stringify("1"),
+    });
+    expect(
+      resolveLocalRealtimeVoiceDefines("serve", 31_338, {
+        VITE_VOICE_REALTIME_SELF_HOSTED: "0",
+      }),
+    ).toEqual({
+      "import.meta.env.VITE_VOICE_REALTIME_WS": JSON.stringify("1"),
+    });
   });
 
   test("does not change builds or dev servers without a gateway", () => {
@@ -117,14 +137,16 @@ describe("local realtime voice defaults", () => {
   test("preserves explicit opt-outs loaded from .env.local", () => {
     const envDir = mkdtempSync(path.join(os.tmpdir(), "eliza-voice-env-"));
     const previousWs = process.env.VITE_VOICE_REALTIME_WS;
+    const previousSelfHosted = process.env.VITE_VOICE_REALTIME_SELF_HOSTED;
     const previousForce = process.env.VITE_VOICE_REALTIME_FORCE;
     delete process.env.VITE_VOICE_REALTIME_WS;
+    delete process.env.VITE_VOICE_REALTIME_SELF_HOSTED;
     delete process.env.VITE_VOICE_REALTIME_FORCE;
 
     try {
       writeFileSync(
         path.join(envDir, ".env.local"),
-        "VITE_VOICE_REALTIME_WS=0\nVITE_VOICE_REALTIME_FORCE=false\n",
+        "VITE_VOICE_REALTIME_WS=0\nVITE_VOICE_REALTIME_SELF_HOSTED=false\nVITE_VOICE_REALTIME_FORCE=false\n",
       );
       expect(
         resolveLocalRealtimeVoiceDefinesFromEnv(
@@ -139,6 +161,11 @@ describe("local realtime voice defaults", () => {
         delete process.env.VITE_VOICE_REALTIME_WS;
       } else {
         process.env.VITE_VOICE_REALTIME_WS = previousWs;
+      }
+      if (previousSelfHosted === undefined) {
+        delete process.env.VITE_VOICE_REALTIME_SELF_HOSTED;
+      } else {
+        process.env.VITE_VOICE_REALTIME_SELF_HOSTED = previousSelfHosted;
       }
       if (previousForce === undefined) {
         delete process.env.VITE_VOICE_REALTIME_FORCE;

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1756,9 +1756,10 @@ function resolveOptionalLocalVoiceGatewayPort(
  * A configured loopback voice gateway is an explicit local-development opt-in
  * to the realtime voice stack. Keep deployed builds staged behind their
  * existing flags, while making the supported local gateway command sufficient
- * to enable the staged realtime client without an easy-to-miss Vite flag.
- * The force flag stays an explicit diagnostic bypass, so a missing agent id or
- * failed capability resolution remains visible. Explicit client flag values
+ * to enable both the staged realtime client and its self-hosted eligibility
+ * path. The eligibility path still requires a paired remote runtime and a live
+ * same-origin health probe. The force flag stays an explicit diagnostic bypass,
+ * so a failed capability check remains visible. Explicit client flag values
  * always win, including an explicit opt-out.
  */
 export function resolveLocalRealtimeVoiceDefines(
@@ -1771,6 +1772,10 @@ export function resolveLocalRealtimeVoiceDefines(
   const defines: Record<string, string> = {};
   if (env.VITE_VOICE_REALTIME_WS === undefined) {
     defines["import.meta.env.VITE_VOICE_REALTIME_WS"] = JSON.stringify("1");
+  }
+  if (env.VITE_VOICE_REALTIME_SELF_HOSTED === undefined) {
+    defines["import.meta.env.VITE_VOICE_REALTIME_SELF_HOSTED"] =
+      JSON.stringify("1");
   }
   return defines;
 }

--- a/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
+++ b/packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md
@@ -74,10 +74,12 @@ loopback gateway; all other `/api` traffic remains on `31337`. The provider
 loop is Cartesia Ink 2 STT → local runtime/model route → Cartesia Sonic 3.5 TTS.
 The Cartesia key remains in the gateway process and is never exposed to Vite or
 the browser. In dev-server mode, configuring `ELIZA_LOCAL_VOICE_GATEWAY_PORT`
-also defaults the staged realtime client flag on. An explicit
-`VITE_VOICE_REALTIME_WS` value still wins, the diagnostic
-`VITE_VOICE_REALTIME_FORCE` bypass remains explicit-only, and
-production/mobile builds keep their existing staged defaults.
+defaults both the staged realtime client and self-hosted capability flags on.
+The self-hosted path still requires a paired remote runtime and a successful
+same-origin health probe. Explicit `VITE_VOICE_REALTIME_WS` and
+`VITE_VOICE_REALTIME_SELF_HOSTED` values still win, the diagnostic
+`VITE_VOICE_REALTIME_FORCE` bypass remains explicit-only, and production/mobile
+builds keep their existing staged defaults.
 
 ## Flag retirement
 


### PR DESCRIPTION
## Summary

- default the self-hosted realtime capability alongside the realtime WebSocket client when Vite serves with `ELIZA_LOCAL_VOICE_GATEWAY_PORT`
- preserve every explicit shell or `.env.local` value independently
- keep `VITE_VOICE_REALTIME_FORCE` explicit-only and keep build/mobile output unchanged
- document the paired-runtime plus live health-probe requirement

Fixes #29632.

## Exact source

- base/current develop: `d15781f893f9696c09d3d30b63a6f6ee9cd0732a`
- head: `621b20fba371e423864f60f07477d7ce9bc1c0b8`
- tree: `28783d763db653e9961c6ad407d5a49288ccb280`
- range-diff versus the previously reviewed patch: unchanged (`=`)
- changed paths: `packages/app/vite.config.ts`, `packages/app/vite.config.test.ts`, `packages/ui/src/voice/REALTIME_VOICE_UI_WIRING.md`

## Why the prior attempt was superseded

#29387 read only `process.env` during Vite config evaluation, so it could overwrite explicit `.env.local` opt-outs, and it initially defaulted the debug-only FORCE bypass. Merged #29453 fixed Vite `loadEnv` precedence and limited the default to WS. This PR extends that exact safe resolver with the supported health-probed self-hosted stamp; it does not revive FORCE.

## Verification

- focused Vite behavior: 21/21 PASS on this exact rebased head
- exact Biome on both source/test files: PASS
- `git diff --check`: PASS
- rebase range-diff: unchanged (`=`)
- prior identical patch: `packages/app` typecheck PASS and repository verify build/typecheck/lint graph 375/375 tasks PASS
- current exact-head hosted Source/Billing/Windows gates: pending after guarded repin

## Evidence applicability

- Screenshots/video: N/A - Vite capability resolution and reference documentation only; no rendered layout or component changes.
- Live browser/device/audio: pending post-merge runtime acceptance; this source checkpoint does not mutate the browser, phones, gateway, or live VPS. Runtime eligibility still requires the existing paired remote and same-origin health probe.
- Provider secrets: unchanged; provider credentials remain gateway-side and no credential is defined into the renderer.

