### PR TITLE
fix(ci): repair canonical script baseline

### DIFF
--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -314,6 +314,7 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
       .filter(Boolean);
     expect(uploadedPaths).toEqual([
       "artifacts/app-live-e2e/cloud-staging-receipt.json",
+      "packages/app/test-results/**/privacy-safe-trajectory-history-network-diagnostics.json",
       "packages/app/test-results/**/privacy-safe-post-reload-history-network-diagnostics.json",
       "packages/app/test-results/**/privacy-safe-fresh-context-history-network-diagnostics.json",
     ]);

--- a/packages/scripts/__tests__/audit-scripts-inventory.test.ts
+++ b/packages/scripts/__tests__/audit-scripts-inventory.test.ts
@@ -174,9 +174,18 @@ describe("script inventory: packages/app surface (issue #10200)", () => {
   test("documented standalone scripts are tracked separately from true orphans", () => {
     const byFile = (name: string) => inv.files.find((f) => f.file === name);
 
+    // The live-smoke workflow now invokes this operator entrypoint directly,
+    // so CI is the strongest reachability color while the named root command
+    // remains recorded as an operator caller.
     expect(byFile("run-scenarios-isolated.mjs")?.category).toBe(
-      "reachable-from-operator-script",
+      "reachable-from-ci-workflow",
     );
+    expect(
+      byFile("run-scenarios-isolated.mjs")?.operatorScriptCallers,
+    ).toContainEqual({
+      packageJson: "package.json",
+      script: "test:scenarios:isolated",
+    });
     expect(inv.summary.filesByCategory.orphan).toBe(0);
     expect(inv.summary.orphanFiles).toBe(0);
     expect(inv.summary.documentationFileReferences).toBeGreaterThan(0);

--- a/packages/scripts/__tests__/live-information-workflow.test.ts
+++ b/packages/scripts/__tests__/live-information-workflow.test.ts
@@ -1,4 +1,4 @@
-/** Verifies the manual live-information workflow fails before setup when exact planner or independent-judge credentials are absent. */
+/** Verifies independently judged scenario workflows fail before setup when exact acting-model or judge credentials are absent. */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { spawnSync } from "../lib/spawn-sync-captured.mjs";
@@ -23,10 +23,13 @@ function credentialStep() {
   const steps = workflow.jobs?.smoke?.steps ?? [];
   const step = steps.find(
     (candidate) =>
-      candidate.name === "Require exact live information credentials",
+      candidate.name ===
+      "Require exact independently judged scenario credentials",
   );
   if (!step?.run)
-    throw new Error("Missing live-information credential preflight");
+    throw new Error(
+      "Missing independently judged scenario credential preflight",
+    );
   return { step, steps };
 }
 
@@ -49,7 +52,7 @@ function runPreflight(
   });
 }
 
-describe("Live Smoke live-information credential boundary", () => {
+describe("Live Smoke independently judged scenario credential boundary", () => {
   test("runs before workspace setup", () => {
     const { step, steps } = credentialStep();
     const preflightIndex = steps.indexOf(step);
@@ -75,7 +78,7 @@ describe("Live Smoke live-information credential boundary", () => {
         const rejected = runPreflight(provider, { [key]: value });
         expect(rejected.status).toBe(1);
         expect(rejected.stdout).toContain(
-          "selected live-information planner credential is missing or blank",
+          "selected acting model credential is missing or blank",
         );
       }
 

--- a/packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts
+++ b/packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts
@@ -1,6 +1,6 @@
 /**
- * Proves the merge-queue Biome workflow checks GitHub's synthesized candidate
- * SHA and that the repository-pinned formatter rejects a planted bad file.
+ * Proves the manual full-tree Biome diagnostic checks the dispatched SHA with
+ * repository-pinned commands and rejects a planted bad file.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -22,11 +22,14 @@ const WORKFLOW_PATH = path.join(
 );
 
 describe("merge candidate Biome workflow", () => {
-  test("checks the exact merge-group candidate with pinned repository commands", () => {
+  test("checks the exact dispatched candidate with pinned repository commands", () => {
     const workflow = parse(readFileSync(WORKFLOW_PATH, "utf8"));
 
-    expect(workflow.on).toEqual({
-      merge_group: { types: ["checks_requested"] },
+    expect(workflow.on).toEqual({ workflow_dispatch: null });
+    expect(workflow.concurrency).toEqual({
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: this is the literal GitHub Actions expression the workflow must use.
+      group: "merge-candidate-biome-${{ github.run_id }}",
+      "cancel-in-progress": false,
     });
     const job = workflow.jobs["candidate-tree"];
     const checkout = job.steps.find(

--- a/packages/scripts/test-console/lib/connections.mjs
+++ b/packages/scripts/test-console/lib/connections.mjs
@@ -35,6 +35,10 @@ export const OPT_IN_GATES = [
     label: "Orchestrator multi-account",
   },
   {
+    key: "ORCHESTRATOR_LIVE",
+    label: "Orchestrator task-agent sessions",
+  },
+  {
     key: "RUN_LIVE_SMITHERS_SUBSCRIPTION",
     label: "Smithers Codex subscription tests",
   },

--- a/plugins/plugin-computeruse/assets/hero.svg
+++ b/plugins/plugin-computeruse/assets/hero.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="Computer Use">
+  <defs>
+    <linearGradient id="bg-computer-use" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#281d15"/>
+      <stop offset="1" stop-color="#19140b"/>
+    </linearGradient>
+    <radialGradient id="blobA-computer-use" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#da732f" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#da732f" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-computer-use" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#c3ae28" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#c3ae28" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-computer-use" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-computer-use" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-computer-use" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-computer-use" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#ed8845" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" fill="url(#bg-computer-use)"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-computer-use)" filter="url(#soft-computer-use)"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-computer-use)" filter="url(#soft-computer-use)"/>
+  </g>
+
+  <g stroke="#eadfd7" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="1024" y2="256"/>
+    <line x1="0" y1="512" x2="1024" y2="512"/>
+    <line x1="0" y1="768" x2="1024" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="1024"/>
+    <line x1="512" y1="0" x2="512" y2="1024"/>
+    <line x1="768" y1="0" x2="768" y2="1024"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="#ed8845" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(512 432)" filter="url(#iglow-computer-use)"
+     color="#eadfd7" stroke="#eadfd7" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="-110" y="-110" width="220" height="220" rx="28"/>
+    <rect x="-58" y="-58" width="116" height="116" rx="14"/>
+    <line x1="-110" y1="-66" x2="-150" y2="-66"/>
+    <line x1="-110" y1="0" x2="-150" y2="0"/>
+    <line x1="-110" y1="66" x2="-150" y2="66"/>
+    <line x1="110" y1="-66" x2="150" y2="-66"/>
+    <line x1="110" y1="0" x2="150" y2="0"/>
+    <line x1="110" y1="66" x2="150" y2="66"/>
+    <line x1="-66" y1="-110" x2="-66" y2="-150"/>
+    <line x1="0" y1="-110" x2="0" y2="-150"/>
+    <line x1="66" y1="-110" x2="66" y2="-150"/>
+    <line x1="-66" y1="110" x2="-66" y2="150"/>
+    <line x1="0" y1="110" x2="0" y2="150"/>
+    <line x1="66" y1="110" x2="66" y2="150"/>
+    <circle cx="0" cy="0" r="14" stroke-width="0" fill="currentColor"/>
+  </g>
+
+  <rect x="0" y="784" width="1024" height="240" fill="url(#label-computer-use)"/>
+  <text x="512" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="#eadfd7">Computer Use</text>
+  <rect x="460" y="924" width="104" height="6" rx="3" fill="#ed8845"/>
+
+  <rect width="1024" height="1024" fill="url(#vig-computer-use)"/>
+</svg>

--- a/plugins/plugin-linear/assets/hero.svg
+++ b/plugins/plugin-linear/assets/hero.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="Linear">
+  <defs>
+    <linearGradient id="bg-linear" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#282015"/>
+      <stop offset="1" stop-color="#19160b"/>
+    </linearGradient>
+    <radialGradient id="blobA-linear" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#da902f" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#da902f" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-linear" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#bec328" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#bec328" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-linear" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-linear" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-linear" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-linear" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#eda445" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" fill="url(#bg-linear)"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-linear)" filter="url(#soft-linear)"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-linear)" filter="url(#soft-linear)"/>
+  </g>
+
+  <g stroke="#eae2d7" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="1024" y2="256"/>
+    <line x1="0" y1="512" x2="1024" y2="512"/>
+    <line x1="0" y1="768" x2="1024" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="1024"/>
+    <line x1="512" y1="0" x2="512" y2="1024"/>
+    <line x1="768" y1="0" x2="768" y2="1024"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="#eda445" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(512 432)" filter="url(#iglow-linear)"
+     color="#eae2d7" stroke="#eae2d7" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="-150" y="-150" width="300" height="300" rx="36"/>
+    <polyline points="-92,-6 -36,52 92,-78" fill="none"/>
+  </g>
+
+  <rect x="0" y="784" width="1024" height="240" fill="url(#label-linear)"/>
+  <text x="512" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="#eae2d7">Linear</text>
+  <rect x="460" y="924" width="104" height="6" rx="3" fill="#eda445"/>
+
+  <rect width="1024" height="1024" fill="url(#vig-linear)"/>
+</svg>

--- a/scripts/generate-view-heroes.mjs
+++ b/scripts/generate-view-heroes.mjs
@@ -138,6 +138,13 @@ export const views = [
     icon: VIEW_HERO_ICONS.calendar,
   },
   {
+    out: "plugins/plugin-computeruse/assets/hero.svg",
+    id: "computer-use",
+    label: "Computer Use",
+    hue: 24,
+    icon: VIEW_HERO_ICONS.modelTester,
+  },
+  {
     out: "plugins/plugin-documents/assets/hero.svg",
     id: "documents",
     label: "Documents",
@@ -178,6 +185,13 @@ export const views = [
     label: "Inbox",
     hue: 168,
     icon: VIEW_HERO_ICONS.inbox,
+  },
+  {
+    out: "plugins/plugin-linear/assets/hero.svg",
+    id: "linear",
+    label: "Linear",
+    hue: 34,
+    icon: VIEW_HERO_ICONS.todos,
   },
   {
     out: "plugins/plugin-messages/assets/hero.svg",


### PR DESCRIPTION
Closes #29637

## Scope
- refresh four stale canonical workflow/script contract tests against current authoritative files
- cover the existing guarded ORCHESTRATOR_LIVE console toggle
- register and deterministically generate the missing Computer Use and Linear app hero SVGs
- no Cloud/Dedicated runtime, deployment, billing, quote, adoption, device, live-service, or paid-state changes

## Exact source
- base: `027ccfa2fce52f9b442076ad6d3549a3f86e809e`
- head: `c1993b7a061b4cb96822ab5735de09615325721a`
- tree: `13b0866ea0ea7709c992a65c843adee53d035c1b`

## Verification
- owned focused matrix: 43/43
- independent targeted review: 52/52; P0/P1/P2/P3 = 0/0/0/0
- repo typecheck: 232/232 tasks
- hero manifest: 20/20; generator `--check`; SVG byte comparison and XML validation
- workflow/security suites: 22/22; workflow trigger audit: 63 workflows
- UI lint/design graph, Biome, diff check: PASS

Independent review verified all eight files, exact generated output, zero overlap with #29621, and no weakened fail-closed gates.