### PR TITLE
test(app): stabilize browser interaction fixtures

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -871,12 +871,12 @@ test.describe("assistant home app flow", () => {
 
     await openAppPath(page, "/wallet");
     await expect(
-      page.getByTestId("wallets-sidebar").getByRole("button", {
-        name: /^Tokens$/,
-      }),
+      page
+        .getByRole("tablist", { name: "Wallet asset type" })
+        .getByRole("tab", { name: "Tokens", selected: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "RPC settings", exact: true }),
+      page.getByRole("button", { name: "Network settings", exact: true }),
     ).toBeVisible();
     await screenshot(page, "07-wallet-view-with-pill");
   });

--- a/packages/app/test/ui-smoke/perf-interaction-kpi.spec.ts
+++ b/packages/app/test/ui-smoke/perf-interaction-kpi.spec.ts
@@ -211,6 +211,9 @@ async function installStreamingFetch(page: Page): Promise<void> {
 
 test.describe("dashboard shell interaction framerate", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Reflect.set(window, "__ELIZA_APP_API_BASE__", window.location.origin);
+    });
     await seedAppStorage(page);
     await page.route("**/api/conversations", async (route) => {
       if (route.request().method() !== "GET") {


### PR DESCRIPTION
Closes #29639

## Scope
- assert the actual selected `Tokens` tab under the `Wallet asset type` tablist and the current `Network settings` accessible name
- seed the performance fixture to its same-origin mocked API before storage/bootstrap
- preserve the real streaming parser and frame-KPI assertions
- exclude the separately diagnosed Vite HMR transport defect

## Exact source
- base: `027ccfa2fce52f9b442076ad6d3549a3f86e809e`
- head: `820ea0f775cd156345faa5b11497e05c94603b3f`
- tree: `d829090ac0b00a57f9c04b01ce692e038191d625`
- mechanical rebase range-diff: `=`

## Verification
- assistant focused Chromium: 1/1 PASS
- interaction perf Chromium: 1/1 PASS; observed buckets 98/119/118/120/57 fps
- changed-file Biome and diff-check: PASS
- independent review P0/P1/P2/P3 = 0/0/0/0; semantic assertions are stronger, same-origin seed is test-only, no open-PR path overlap

No product/runtime/device/live-service/deploy/paid changes.