### PR TITLE
fix(ui): repair Story Gate accessibility baseline

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-conversation-item.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.test.tsx
@@ -92,6 +92,14 @@ describe("ChatConversationItem", () => {
     expect(onRequestDeleteConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the active game-modal title readable on its dark surface", () => {
+    renderItem({ variant: "game-modal", isActive: true });
+
+    const title = screen.getByText("Planning the launch");
+    expect(title.classList.contains("text-white")).toBe(true);
+    expect(title.classList.contains("text-bg")).toBe(false);
+  });
+
   it("renders the delete-confirm prompt and wires Yes/No while confirming", () => {
     const onConfirmDelete = vi.fn();
     const onCancelDelete = vi.fn();

--- a/packages/ui/src/components/composites/chat/chat-conversation-item.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.test.tsx
@@ -92,14 +92,6 @@ describe("ChatConversationItem", () => {
     expect(onRequestDeleteConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the active game-modal title readable on its dark surface", () => {
-    renderItem({ variant: "game-modal", isActive: true });
-
-    const title = screen.getByText("Planning the launch");
-    expect(title.classList.contains("text-white")).toBe(true);
-    expect(title.classList.contains("text-bg")).toBe(false);
-  });
-
   it("renders the delete-confirm prompt and wires Yes/No while confirming", () => {
     const onConfirmDelete = vi.fn();
     const onCancelDelete = vi.fn();

--- a/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
@@ -66,7 +66,7 @@ function TruncatingConversationTitle({
       className={
         variant === "game-modal"
           ? `block w-full min-w-0 max-w-full truncate text-left text-sm font-medium leading-tight transition-colors ${
-              isActive ? "text-bg" : "text-white/90 group-hover:text-white"
+              isActive ? "text-white" : "text-white/90 group-hover:text-white"
             }`
           : `block min-w-0 max-w-full flex-1 truncate text-left text-sm font-normal leading-snug transition-colors ${
               isActive

--- a/packages/ui/src/components/composites/trajectories/trajectory-a11y-structure.test.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-a11y-structure.test.tsx
@@ -1,0 +1,51 @@
+/** Verifies the semantic structures used by trajectory Storybook surfaces. */
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TrajectoryCacheStats } from "./trajectory-cache-stats";
+import { TrajectoryCodeBlock } from "./trajectory-code-block";
+
+describe("trajectory accessibility structure", () => {
+  afterEach(cleanup);
+
+  it("keeps every definition-list group limited to terms and details", () => {
+    const { container } = render(
+      <TrajectoryCacheStats
+        heading="Cache"
+        metrics={[
+          {
+            id: "hits",
+            label: "Hits",
+            value: "4",
+            meta: "Across two requests",
+          },
+        ]}
+      />,
+    );
+
+    const group = container.querySelector("dl > div");
+    expect(group).not.toBeNull();
+    expect(
+      Array.from(group?.children ?? []).map((node) => node.tagName),
+    ).toEqual(["DT", "DD", "DD"]);
+  });
+
+  it("gives a labelled code attachment an explicit region role", () => {
+    const { container } = render(
+      <TrajectoryCodeBlock
+        collapseLabel="Collapse"
+        content=""
+        copyLabel="Copy"
+        expandLabel="Expand"
+        label="Response"
+        linesLabel="0 lines"
+        onCopy={vi.fn()}
+      />,
+    );
+
+    const code = container.querySelector("pre");
+    expect(code?.getAttribute("role")).toBe("region");
+    expect(code?.getAttribute("aria-label")).toBe("Response");
+  });
+});

--- a/packages/ui/src/components/composites/trajectories/trajectory-cache-stats.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-cache-stats.tsx
@@ -49,9 +49,9 @@ export function TrajectoryCacheStats({
                 {metric.value}
               </dd>
               {metric.meta ? (
-                <div className="mt-1 text-xs text-[color:var(--settings-muted)]">
+                <dd className="mt-1 text-xs text-[color:var(--settings-muted)]">
                   {metric.meta}
-                </div>
+                </dd>
               ) : null}
             </PagePanel.SummaryCard>
           ))}

--- a/packages/ui/src/components/composites/trajectories/trajectory-code-block.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-code-block.tsx
@@ -70,6 +70,7 @@ export function TrajectoryCodeBlock({
       <CodeBlock
         value={displayContent}
         presentation="attachment"
+        role="region"
         wrap
         tabIndex={0}
         aria-label={typeof label === "string" ? label : "Trajectory content"}

--- a/packages/ui/src/components/workspace/AppWorkspaceContent.test.tsx
+++ b/packages/ui/src/components/workspace/AppWorkspaceContent.test.tsx
@@ -61,7 +61,22 @@ describe("AppWorkspaceContent", () => {
     expect(scrollRegion?.contains(screen.getByTestId("workspace-body"))).toBe(
       true,
     );
+    expect(scrollRegion?.tabIndex).toBe(0);
     expect(chatClearanceOwners(container)).toEqual([scrollRegion]);
+  });
+
+  it("keeps the headerless router-owned scroller keyboard focusable", () => {
+    const { container } = render(
+      <AppWorkspaceContent layout="scroll">
+        <div data-testid="workspace-body">Body</div>
+      </AppWorkspaceContent>,
+    );
+
+    const scrollRegion = container.querySelector<HTMLElement>(
+      '[data-shell-scroll-region="true"]',
+    );
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion?.tabIndex).toBe(0);
   });
 
   it("lets fullscreen surfaces opt out of floating-chat clearance", () => {

--- a/packages/ui/src/components/workspace/AppWorkspaceContent.test.tsx
+++ b/packages/ui/src/components/workspace/AppWorkspaceContent.test.tsx
@@ -61,8 +61,11 @@ describe("AppWorkspaceContent", () => {
     expect(scrollRegion?.contains(screen.getByTestId("workspace-body"))).toBe(
       true,
     );
-    expect(scrollRegion?.tabIndex).toBe(0);
-    expect(chatClearanceOwners(container)).toEqual([scrollRegion]);
+    const viewport = scrollRegion?.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    expect(viewport?.tabIndex).toBe(0);
+    expect(chatClearanceOwners(container)).toEqual([viewport]);
   });
 
   it("keeps the headerless router-owned scroller keyboard focusable", () => {
@@ -76,7 +79,11 @@ describe("AppWorkspaceContent", () => {
       '[data-shell-scroll-region="true"]',
     );
     expect(scrollRegion).not.toBeNull();
-    expect(scrollRegion?.tabIndex).toBe(0);
+    expect(
+      scrollRegion?.querySelector<HTMLElement>(
+        '[data-slot="scroll-area-viewport"]',
+      )?.tabIndex,
+    ).toBe(0);
   });
 
   it("lets fullscreen surfaces opt out of floating-chat clearance", () => {

--- a/packages/ui/src/components/workspace/AppWorkspaceContent.tsx
+++ b/packages/ui/src/components/workspace/AppWorkspaceContent.tsx
@@ -11,6 +11,7 @@ import type React from "react";
 import type { ReactNode } from "react";
 import { PageFrame } from "../../layouts/page-frame";
 import { cn } from "../../lib/utils";
+import { ScrollArea } from "../ui/scroll-area";
 import { AppWorkspaceChrome } from "./AppWorkspaceChrome";
 
 const CHAT_CLEARANCE_CLASS =
@@ -100,32 +101,30 @@ export function AppWorkspaceContent({
     header ? (
       <div className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden">
         {header}
-        <div
+        <ScrollArea
           data-shell-scroll-region="true"
-          // biome-ignore lint/a11y/noNoninteractiveTabindex: the overflow container must be keyboard reachable.
-          tabIndex={0}
-          className={cn(
-            "eliza-chat-scroll min-h-0 min-w-0 w-full flex-1 overflow-y-auto",
+          className="min-h-0 min-w-0 w-full flex-1"
+          viewportClassName={cn(
+            "eliza-chat-scroll overflow-y-auto",
             clearanceClass,
             className,
           )}
         >
           {children}
-        </div>
+        </ScrollArea>
       </div>
     ) : (
-      <div
+      <ScrollArea
         data-shell-scroll-region="true"
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: the overflow container must be keyboard reachable.
-        tabIndex={0}
-        className={cn(
-          "eliza-chat-scroll min-h-0 min-w-0 w-full flex-1 overflow-y-auto",
+        className="min-h-0 min-w-0 w-full flex-1"
+        viewportClassName={cn(
+          "eliza-chat-scroll overflow-y-auto",
           clearanceClass,
           className,
         )}
       >
         {children}
-      </div>
+      </ScrollArea>
     )
   ) : (
     <div

--- a/packages/ui/src/components/workspace/AppWorkspaceContent.tsx
+++ b/packages/ui/src/components/workspace/AppWorkspaceContent.tsx
@@ -102,6 +102,8 @@ export function AppWorkspaceContent({
         {header}
         <div
           data-shell-scroll-region="true"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: the overflow container must be keyboard reachable.
+          tabIndex={0}
           className={cn(
             "eliza-chat-scroll min-h-0 min-w-0 w-full flex-1 overflow-y-auto",
             clearanceClass,
@@ -114,6 +116,8 @@ export function AppWorkspaceContent({
     ) : (
       <div
         data-shell-scroll-region="true"
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: the overflow container must be keyboard reachable.
+        tabIndex={0}
         className={cn(
           "eliza-chat-scroll min-h-0 min-w-0 w-full flex-1 overflow-y-auto",
           clearanceClass,


### PR DESCRIPTION
Closes #29641

## Scope
- delegate legacy router-owned workspace scrolling/focusability to canonical `ScrollArea` while retaining chat clearance and shell/no-drag markers
- keep trajectory definition-list children semantically valid and label empty code attachments through an explicit region
- restore active game-modal conversation-title contrast
- rely on rendered Storybook + axe for contrast rather than brittle class-string assertions

## Exact source
- base: `027ccfa2fce52f9b442076ad6d3549a3f86e809e`
- head: `2c830bf6d81d03298608831c44ce3428deee46e1`
- tree: `af4da150f88ad288bac2bcf09d07cbc386ac5a2b`
- five-commit mechanical rebase range-diff: `=`

## Verification
- focused Vitest: 15/15 PASS
- UI typecheck: PASS
- changed-file Biome + diff-check: PASS
- tight design-system baseline: zero findings
- tight design-contract graph: zero findings/debt
- real Storybook + axe: repaired workspace, trajectory, and game-modal stories have zero relevant violations
- independent final review P0/P1/P2/P3 = 0/0/0/0
- zero path overlap with #29621/#29628/#29631/#29638/#29640

No Cloud/Dedicated runtime, deployment, device, browser-auth, live-service, billing, adoption, or paid-state changes.