### PR TITLE
fix(core): tolerate incomplete runtime model registries

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1448,8 +1448,10 @@ function withProviderOverflowText(state: State): State | null {
 function responseHandlerContextWindow(
 	runtime: IAgentRuntime,
 ): number | undefined {
-	return runtime
-		.getModelRegistrations()
+	const getModelRegistrations = runtime.getModelRegistrations;
+	if (typeof getModelRegistrations !== "function") return undefined;
+	return getModelRegistrations
+		.call(runtime)
 		.find(
 			(registration) =>
 				registration.modelType === ModelType.RESPONSE_HANDLER &&


### PR DESCRIPTION
## Summary

- Guard `runtime.getModelRegistrations` in `responseHandlerContextWindow` so incomplete runtime test doubles return no context window instead of throwing
- Preserve the runtime receiver when invoking the optional method

## Evidence

The current `develop` head `027ccfa2fce52f9b442076ad6d3549a3f86e809e` fails in hosted core macOS smoke run [33111421170](https://github.com/elizaOS/eliza/actions/runs/33111421170) with `TypeError: runtime.getModelRegistrations is not a function` in `packages/core/src/services/message.ts`. The failure reaches planner protocol and voice pipeline tests.

This restores the guarded lookup already used in the earlier implementation and keeps the change limited to the failing core path.

## Validation

- Biome direct check passed for `packages/core/src/services/message.ts`
- `git diff --check` passed
- The hosted exact-head failure above provides the regression reproduction

No unrelated files are changed.
