### PR TITLE
fix(android): keep chat and Calendar clear of system UI

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -95,7 +95,12 @@ import {
   OS_INTENT_COMPOSER_PREFILL_EVENT,
   type OsIntentComposerPrefillDetail,
 } from "../../os-intent/host";
-import { isIOS, isNative, isStandalonePwa } from "../../platform/init";
+import {
+  isAndroid,
+  isIOS,
+  isNative,
+  isStandalonePwa,
+} from "../../platform/init";
 import {
   getPhysicalScreenVerticalExtent,
   KEYBOARD_INTRUSION_THRESHOLD_PX,
@@ -179,6 +184,7 @@ import {
 import {
   isShortLandscapeViewport,
   measureSafeAreaInsetTop,
+  resolveChatKeyboardHiddenViewportBaseline,
   resolveChatNativeKeyboardLift,
   resolveChatPanelHalfDetentHeight,
   resolveChatPanelLayout,
@@ -2978,16 +2984,24 @@ export function ChatOverlay({
       for (const handle of handles) handle.remove();
     };
   }, []);
-  // Track the layout-viewport height with the keyboard DOWN. On Android the
-  // WebView window shrinks (adjustResize) when the keyboard opens, so the fixed
-  // overlay's `bottom: 0` already rises with it; on iOS (`resize: "body"`) the
-  // layout height is unchanged and the fixed composer stays behind the keyboard.
-  const baseInnerHeightRef = React.useRef(viewport.innerHeight);
+  // Preserve the last trustworthy keyboard-hidden viewport. Some Android
+  // windows resize before keyboardWillShow, while the Light Phone III keyboard
+  // overlays the WebView without resizing it at all. A same-orientation height
+  // drop is therefore provisional until the native event resolves; a width
+  // change resets the baseline for rotation or a new window class.
+  const keyboardHiddenViewportRef = React.useRef({
+    innerHeight: viewport.innerHeight,
+    innerWidth: viewport.innerWidth,
+  });
   React.useEffect(() => {
-    if (nativeKeyboardHeight === 0) {
-      baseInnerHeightRef.current = viewport.innerHeight;
-    }
-  }, [nativeKeyboardHeight, viewport.innerHeight]);
+    keyboardHiddenViewportRef.current =
+      resolveChatKeyboardHiddenViewportBaseline({
+        previous: keyboardHiddenViewportRef.current,
+        currentInnerHeight: viewport.innerHeight,
+        currentInnerWidth: viewport.innerWidth,
+        nativeKeyboardVisible: nativeKeyboardHeight > 0,
+      });
+  }, [nativeKeyboardHeight, viewport.innerHeight, viewport.innerWidth]);
 
   // Lift the composer above the keyboard by ONLY the part the layout didn't
   // already absorb. On Android the window shrank by ~the keyboard height
@@ -2996,17 +3010,14 @@ export function ChatOverlay({
   // iOS the layout doesn't shrink (layoutShrink = 0), so the full native height
   // lifts the fixed composer above the keyboard. Web (no native plugin) keeps
   // the visualViewport-derived inset.
-  // The shipped Android window uses adjustResize, so the native bridge height
-  // must never be applied as an additional fixed-overlay bottom offset. In the
-  // observed race the WebView resized 919→520 before keyboardWillShow; the
-  // effect above then captured 520 as its baseline and a later 398px bridge
-  // event lifted the composer a second time, all the way to the status bar.
-  // iOS keeps the explicit bridge lift because its native window is configured
-  // not to resize around the keyboard.
+  // Pixel's adjustResize path consumes the bridge height and therefore returns
+  // zero. The Light Phone III's keyboard leaves the WebView at full height, so
+  // its unabsorbed bridge height becomes the fixed-overlay lift. iOS keeps the
+  // same explicit bridge path for its resize:"body" window.
   const nativeLift = resolveChatNativeKeyboardLift({
-    platformNeedsNativeLift: isIOS,
+    platformNeedsNativeLift: isIOS || isAndroid,
     nativeKeyboardHeight,
-    keyboardDownInnerHeight: baseInnerHeightRef.current,
+    keyboardHiddenInnerHeight: keyboardHiddenViewportRef.current.innerHeight,
     currentInnerHeight: viewport.innerHeight,
   });
   const effectiveKeyboardInset = Math.max(keyboardInset, nativeLift);
@@ -3187,7 +3198,7 @@ export function ChatOverlay({
   const openH = panelMaxH;
   // The nominal half detent can exceed the entire visible panel when a native
   // keyboard lifts the overlay without shrinking Chromium's layout viewport
-  // (the LP3 WebView reports 414px while Gboard consumes 223px). A resting
+  // (the LP3 WebView reports 414px while its keyboard consumes 223px). A resting
   // detent may never outrun its current panel ceiling: panelCapH intentionally
   // follows threadHeight during a live over-pull, so an oversized HALF target
   // otherwise re-expands the cap and clips the grabber above the screen.

--- a/packages/ui/src/components/shell/chat-panel-layout.test.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   type ChatPanelLayoutInput,
   isShortLandscapeViewport,
+  resolveChatKeyboardHiddenViewportBaseline,
   resolveChatNativeKeyboardLift,
   resolveChatPanelHalfDetentHeight,
   resolveChatPanelLayout,
@@ -36,14 +37,39 @@ describe("resolveChatNativeKeyboardLift", () => {
   it("never double-lifts Android when adjustResize wins the event race", () => {
     // Exact Pixel 11 Pro failure: the WebView had already shrunk 919→520, then
     // keyboardWillShow delivered 398px. Because the resize arrived first, the
-    // component briefly observed 520 as its keyboard-down baseline. Android's
-    // platform contract must win over that stale baseline and keep bottom: 0.
+    // component briefly observed 520 before the native event. The stable
+    // keyboard-hidden baseline still proves that adjustResize consumed all of
+    // the native inset, so the fixed overlay stays at bottom: 0.
+    expect(
+      resolveChatNativeKeyboardLift({
+        platformNeedsNativeLift: true,
+        nativeKeyboardHeight: 398,
+        keyboardHiddenInnerHeight: 919,
+        currentInnerHeight: 520,
+      }),
+    ).toBe(0);
+  });
+
+  it("lifts above the Light Phone III keyboard when its WebView does not resize", () => {
+    // Physical LP3 evidence: its native keyboard bridge reported 223 CSS px
+    // while innerHeight and visualViewport.height both remained 414 CSS px.
+    expect(
+      resolveChatNativeKeyboardLift({
+        platformNeedsNativeLift: true,
+        nativeKeyboardHeight: 223,
+        keyboardHiddenInnerHeight: 414,
+        currentInnerHeight: 414,
+      }),
+    ).toBe(223);
+  });
+
+  it("keeps web surfaces independent from native keyboard bridge values", () => {
     expect(
       resolveChatNativeKeyboardLift({
         platformNeedsNativeLift: false,
-        nativeKeyboardHeight: 398,
-        keyboardDownInnerHeight: 520,
-        currentInnerHeight: 520,
+        nativeKeyboardHeight: 200,
+        keyboardHiddenInnerHeight: 414,
+        currentInnerHeight: 414,
       }),
     ).toBe(0);
   });
@@ -53,7 +79,7 @@ describe("resolveChatNativeKeyboardLift", () => {
       resolveChatNativeKeyboardLift({
         platformNeedsNativeLift: true,
         nativeKeyboardHeight: 336,
-        keyboardDownInnerHeight: 852,
+        keyboardHiddenInnerHeight: 852,
         currentInnerHeight: 852,
       }),
     ).toBe(336);
@@ -61,10 +87,45 @@ describe("resolveChatNativeKeyboardLift", () => {
       resolveChatNativeKeyboardLift({
         platformNeedsNativeLift: true,
         nativeKeyboardHeight: 336,
-        keyboardDownInnerHeight: 852,
+        keyboardHiddenInnerHeight: 852,
         currentInnerHeight: 700,
       }),
     ).toBe(184);
+  });
+});
+
+describe("resolveChatKeyboardHiddenViewportBaseline", () => {
+  it("does not let Pixel's resize-before-event race overwrite the resting height", () => {
+    expect(
+      resolveChatKeyboardHiddenViewportBaseline({
+        previous: { innerHeight: 919, innerWidth: 412 },
+        currentInnerHeight: 520,
+        currentInnerWidth: 412,
+        nativeKeyboardVisible: false,
+      }),
+    ).toEqual({ innerHeight: 919, innerWidth: 412 });
+  });
+
+  it("resets the baseline across a real orientation or window-class change", () => {
+    expect(
+      resolveChatKeyboardHiddenViewportBaseline({
+        previous: { innerHeight: 919, innerWidth: 412 },
+        currentInnerHeight: 412,
+        currentInnerWidth: 919,
+        nativeKeyboardVisible: false,
+      }),
+    ).toEqual({ innerHeight: 412, innerWidth: 919 });
+  });
+
+  it("holds the baseline while a native keyboard is visible", () => {
+    expect(
+      resolveChatKeyboardHiddenViewportBaseline({
+        previous: { innerHeight: 414, innerWidth: 360 },
+        currentInnerHeight: 414,
+        currentInnerWidth: 360,
+        nativeKeyboardVisible: true,
+      }),
+    ).toEqual({ innerHeight: 414, innerWidth: 360 });
   });
 });
 
@@ -250,9 +311,9 @@ describe("resolveChatPanelLayout", () => {
     );
   });
 
-  it("keeps the complete grab target visible above LP3 Gboard", () => {
+  it("keeps the complete grab target visible above the LP3 keyboard", () => {
     // Physical LP3 capture: the WebView kept its 414px layout viewport while
-    // Gboard reported a 223px native lift. The keyboard gap is 12px. A 22px
+    // the native keyboard reported a 223px lift. The keyboard gap is 12px. A 22px
     // reserve seats the grabber's 44px hit zone fully on-screen even though the
     // preferred 200px panel no longer fits above the keyboard.
     const input: ChatPanelLayoutInput = {
@@ -340,9 +401,9 @@ describe("resolveChatPanelLayout", () => {
 });
 
 describe("resolveChatPanelHalfDetentHeight", () => {
-  it("clamps the LP3 half detent to the Gboard-constrained panel ceiling", () => {
+  it("clamps the LP3 half detent to the keyboard-constrained panel ceiling", () => {
     // 46% of the unchanged 414px WebView is 190px, but physical LP3 proof
-    // leaves only a 157px panel above Gboard once its full grab target is
+    // leaves only a 157px panel above the keyboard once its full grab target is
     // reserved. The resting motion target must not expand past that ceiling.
     expect(resolveChatPanelHalfDetentHeight(414, 157)).toBe(157);
   });

--- a/packages/ui/src/components/shell/chat-panel-layout.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.ts
@@ -68,28 +68,70 @@ export interface ChatPanelLayout {
 
 export interface ChatNativeKeyboardLiftInput {
   /**
-   * True only when the native window does not resize around the keyboard.
-   * The shipped iOS shell needs an explicit fixed-overlay lift; Android's
-   * adjustResize window already moves fixed content above the IME.
+   * True when a native shell may report keyboard pixels that its layout
+   * viewport did not absorb. The returned lift still subtracts any resize the
+   * viewport already performed, so an adjustResize Android window gets zero.
    */
   platformNeedsNativeLift: boolean;
   /** Keyboard height reported by the native Keyboard bridge. */
   nativeKeyboardHeight: number;
-  /** Layout viewport height captured while the keyboard was down. */
-  keyboardDownInnerHeight: number;
+  /** Stable layout viewport height captured while the keyboard was hidden. */
+  keyboardHiddenInnerHeight: number;
   /** Current layout viewport height. */
   currentInnerHeight: number;
+}
+
+export interface ChatKeyboardHiddenViewportBaseline {
+  innerHeight: number;
+  innerWidth: number;
+}
+
+export interface ChatKeyboardHiddenViewportBaselineInput {
+  previous: ChatKeyboardHiddenViewportBaseline;
+  currentInnerHeight: number;
+  currentInnerWidth: number;
+  nativeKeyboardVisible: boolean;
+}
+
+/**
+ * Preserve the last trustworthy keyboard-hidden layout viewport.
+ *
+ * Android can resize the WebView before its native keyboard event arrives.
+ * Keeping the larger same-orientation height prevents that transient resize
+ * from becoming the new baseline. A width change marks a real orientation or
+ * window-class transition and resets the baseline to the new geometry.
+ */
+export function resolveChatKeyboardHiddenViewportBaseline(
+  input: ChatKeyboardHiddenViewportBaselineInput,
+): ChatKeyboardHiddenViewportBaseline {
+  if (input.nativeKeyboardVisible) return input.previous;
+
+  const currentInnerHeight = Number.isFinite(input.currentInnerHeight)
+    ? Math.max(0, input.currentInnerHeight)
+    : 0;
+  const currentInnerWidth = Number.isFinite(input.currentInnerWidth)
+    ? Math.max(0, input.currentInnerWidth)
+    : 0;
+  const orientationOrWindowClassChanged =
+    Math.abs(currentInnerWidth - input.previous.innerWidth) > 1;
+
+  return {
+    innerHeight: orientationOrWindowClassChanged
+      ? currentInnerHeight
+      : Math.max(input.previous.innerHeight, currentInnerHeight),
+    innerWidth: currentInnerWidth,
+  };
 }
 
 /**
  * Return only the part of the native keyboard height that the layout viewport
  * has not already absorbed.
  *
- * Android can deliver its resize before `keyboardWillShow`. In that ordering,
- * a component may observe the shrunken height as both the keyboard-down and
- * current baseline. Platform-gating is therefore required in addition to the
- * height delta: the Android bridge height is a visibility signal, never an
- * instruction to lift a fixed overlay a second time.
+ * Android can deliver its resize before `keyboardWillShow`, so callers must
+ * preserve a stable keyboard-hidden baseline. This subtraction then handles
+ * both Android window behaviors: adjustResize consumes the bridge height and
+ * returns zero; overlay-style IMEs leave the viewport unchanged and return the
+ * full native lift.
  */
 export function resolveChatNativeKeyboardLift(
   input: ChatNativeKeyboardLiftInput,
@@ -99,15 +141,17 @@ export function resolveChatNativeKeyboardLift(
   const nativeKeyboardHeight = Number.isFinite(input.nativeKeyboardHeight)
     ? Math.max(0, input.nativeKeyboardHeight)
     : 0;
-  const keyboardDownInnerHeight = Number.isFinite(input.keyboardDownInnerHeight)
-    ? Math.max(0, input.keyboardDownInnerHeight)
+  const keyboardHiddenInnerHeight = Number.isFinite(
+    input.keyboardHiddenInnerHeight,
+  )
+    ? Math.max(0, input.keyboardHiddenInnerHeight)
     : 0;
   const currentInnerHeight = Number.isFinite(input.currentInnerHeight)
     ? Math.max(0, input.currentInnerHeight)
     : 0;
   const layoutShrink = Math.max(
     0,
-    keyboardDownInnerHeight - currentInnerHeight,
+    keyboardHiddenInnerHeight - currentInnerHeight,
   );
 
   return Math.max(0, nativeKeyboardHeight - layoutShrink);

--- a/packages/ui/src/widgets/HOME_CONTENT_TAXONOMY.md
+++ b/packages/ui/src/widgets/HOME_CONTENT_TAXONOMY.md
@@ -16,10 +16,10 @@ Clock + weather (`DefaultHomeWidgets`). Never ranked, never sunset; the calm
 backdrop a brand-new account still sees.
 
 ### Tier 2 - Live agent work (ongoing, self-hiding)
-Only work that needs the user's response belongs here:
-`needs-attention.pending`, plus setup-progress cards such as
-`model-download.status` and `agent-provisioning.status`. These rank by
-`approval`/`escalation`/setup signals and self-hide when idle. Continuous
+Only active setup work belongs here, such as `model-download.status` and
+`agent-provisioning.status`. Requests that need the user's response remain in
+the pinned notification center, where they can be grouped, opened, read, and
+dismissed without duplicating the same item as a resident card. Continuous
 activity streams, app-run lists, and running workflow lists stay in the
 launcher/sidebar/routed views.
 

--- a/packages/ui/src/widgets/home-priority-integration.test.ts
+++ b/packages/ui/src/widgets/home-priority-integration.test.ts
@@ -53,11 +53,7 @@ describe("home priority - real declarations + ranker scenario (#9143)", () => {
   it("registers only the kept home widgets with attention signalKinds", () => {
     const byKey = new Map(homeDeclarations().map((d) => [homeWidgetKey(d), d]));
     // Kept cards resolve on the home slot (spec §B target resident set)…
-    for (const key of [
-      "calendar/calendar.upcoming",
-      "needs-attention/needs-attention.pending",
-      "todo/todo.items",
-    ]) {
+    for (const key of ["calendar/calendar.upcoming", "todo/todo.items"]) {
       expect(byKey.has(key), `${key} should resolve on home`).toBe(true);
     }
     // …while the demoted/merged residents no longer hold a home declaration:
@@ -74,6 +70,7 @@ describe("home priority - real declarations + ranker scenario (#9143)", () => {
       "finances/finances.alerts",
       "relationships/relationships.attention",
       "inbox/inbox.unread",
+      "needs-attention/needs-attention.pending",
     ]) {
       expect(byKey.has(key), `${key} should not resolve on home`).toBe(false);
     }
@@ -99,11 +96,9 @@ describe("home priority - real declarations + ranker scenario (#9143)", () => {
     const order = rankedKeys(signals);
     const top3 = order.slice(0, 3);
 
-    // The two attention-worthy widgets occupy the front, ahead of every
-    // quiet widget (which rank by static base order only). Needs-attention
-    // floats via the urgent-notification derivation (urgent → escalation);
-    // the Today card rides its merged goal's self-published escalation signal.
-    expect(top3).toContain("needs-attention/needs-attention.pending");
+    // The Today card rides its merged goal's self-published escalation signal.
+    // Approval notifications stay in the pinned notification center instead
+    // of producing a second ranked Home card.
     expect(top3).toContain("todo/todo.items");
 
     // A quiet widget (calendar with no upcoming-event signal) ranks behind them.
@@ -156,11 +151,8 @@ describe("home priority - real declarations + ranker scenario (#9143)", () => {
     );
   });
 
-  it("with no live signals, ranks purely by base order (quiet home)", () => {
+  it("with no live signals, omits the duplicate needs-response resident", () => {
     const order = rankedKeys([]);
-    // needs-attention (order 60) outranks the per-plugin cards (order ≥ 110).
-    expect(
-      order.indexOf("needs-attention/needs-attention.pending"),
-    ).toBeLessThan(order.indexOf("calendar/calendar.upcoming"));
+    expect(order).not.toContain("needs-attention/needs-attention.pending");
   });
 });

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -31,7 +31,6 @@ export {
 import { MusicLibraryCharacterWidget } from "../components/character/MusicLibraryCharacterWidget";
 import { CALENDAR_HOME_WIDGET } from "../components/chat/widgets/calendar-upcoming";
 import { MODEL_DOWNLOAD_HOME_WIDGET } from "../components/chat/widgets/model-download";
-import { NEEDS_ATTENTION_HOME_WIDGET } from "../components/chat/widgets/needs-attention";
 import { TODO_PLUGIN_WIDGETS } from "../components/chat/widgets/todo";
 
 // The wallet / goals / sleep resident components are no longer registered
@@ -75,7 +74,7 @@ registerWidgetComponent(
 // snapshot. Goals + health left this set (spec §E items 4-5): the at-risk goal
 // is absorbed into the Today (todo) card and sleep moved to its routed dashboard,
 // so neither registers a home component here anymore.
-for (const w of [CALENDAR_HOME_WIDGET, NEEDS_ATTENTION_HOME_WIDGET]) {
+for (const w of [CALENDAR_HOME_WIDGET]) {
   registerWidgetComponent(w.pluginId, w.id, w.Component);
 }
 
@@ -140,23 +139,6 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   // Home keeps only essential, low-noise cards. Rich domain surfaces like inbox,
   // finances, relationships, workflow activity, feed activity, and orchestrator
   // app runs remain available through launcher/routed views, not resident cards.
-  // Needs response - the canonical "actions requiring your response" card
-  // (#9449). Backed by the core ApprovalService (GET /api/approvals), not a
-  // loadable plugin, so it is always-visible (declaration `visibility:
-  // "always"`) and self-hides when nothing is pending. Floats up at
-  // approval/escalation weight on its own data.
-  {
-    id: NEEDS_ATTENTION_HOME_WIDGET.id,
-    pluginId: NEEDS_ATTENTION_HOME_WIDGET.pluginId,
-    slot: "home",
-    label: "Needs response",
-    icon: "CircleHelp",
-    order: NEEDS_ATTENTION_HOME_WIDGET.order,
-    defaultEnabled: true,
-    // Backed by the core ApprovalService, not a loadable plugin (#9449).
-    visibility: "always",
-    signalKinds: NEEDS_ATTENTION_HOME_WIDGET.signalKinds,
-  },
   {
     id: CALENDAR_HOME_WIDGET.id,
     pluginId: CALENDAR_HOME_WIDGET.pluginId,

--- a/packages/ui/src/widgets/registry.visibility-drift.test.ts
+++ b/packages/ui/src/widgets/registry.visibility-drift.test.ts
@@ -54,12 +54,10 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
   });
 
   it("keeps always-visible core widgets on an empty snapshot but honors explicit disable", () => {
-    // Needs-attention is backed by the core ApprovalService, not a loadable
-    // plugin - the canonical `always` core surface with no snapshot entry.
     const emptyResolved = resolveWidgetsForSlot("home", []);
     expect(
       emptyResolved.find((r) => r.declaration.id === "needs-attention.pending"),
-    ).toBeTruthy();
+    ).toBeUndefined();
 
     // Calendar is `always` but IS backed by a real loadable plugin, so an
     // explicit present+disabled snapshot entry still hides it.

--- a/plugins/plugin-calendar/src/components/calendar/CalendarPage.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarPage.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Verifies that Calendar owns the native top inset required by its fullscreen route chrome.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CalendarPage } from "./CalendarPage.tsx";
+
+vi.mock("./SimpleCalendarView.tsx", () => ({
+  SimpleCalendarView: () => <div data-testid="calendar-body" />,
+}));
+
+describe("CalendarPage", () => {
+  it("keeps its fullscreen header below the native safe area", () => {
+    const { container } = render(<CalendarPage />);
+
+    expect(container.firstElementChild?.className).toContain(
+      "pt-[var(--safe-area-top,0px)]",
+    );
+  });
+});

--- a/plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx
@@ -10,7 +10,7 @@ import { SimpleCalendarView } from "./SimpleCalendarView.tsx";
 
 export function CalendarPage(): JSX.Element {
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden pt-[var(--safe-area-top,0px)]">
       <ViewHeader title="Calendar" />
       <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <SimpleCalendarView />

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.test.tsx
@@ -164,8 +164,7 @@ describe("SimpleCalendarView", () => {
     ).toBeNull();
   });
 
-  it("composes the shared source manager across the calendar grid", () => {
-    const refresh = vi.fn().mockResolvedValue(undefined);
+  it("keeps healthy calendar source controls out of the primary view", () => {
     const sources: LifeOpsCalendarSourceHealth[] = [
       {
         key: {
@@ -184,29 +183,16 @@ describe("SimpleCalendarView", () => {
       },
     ];
     fixtures.calendar.mockReturnValue(
-      calendarState({ sources, refresh, status: "ready" }),
+      calendarState({ sources, status: "ready" }),
     );
 
     render(<SimpleCalendarView />);
 
-    const scroll = screen.getByTestId("simple-calendar-scroll-region");
-    const managerSlot = screen.getByTestId("simple-calendar-source-manager");
-    const content = screen.getByTestId("simple-calendar-content");
-    expect(scroll.contains(managerSlot)).toBe(true);
-    expect(managerSlot.dataset.placement).toBe("secondary");
+    expect(screen.queryByTestId("simple-calendar-source-manager")).toBeNull();
     expect(
-      content.compareDocumentPosition(managerSlot) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).not.toBe(0);
-    expect(screen.getAllByTestId("calendar-source-manager")).toHaveLength(1);
-    expect(fixtures.sourceManager).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceHealth: sources }),
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Manage calendar sources" }),
-    );
-    expect(refresh).toHaveBeenCalledTimes(1);
+      screen.queryByRole("button", { name: "Manage calendar sources" }),
+    ).toBeNull();
+    expect(fixtures.sourceManager).not.toHaveBeenCalled();
   });
 
   it("renders canonical events with month navigation and selectable days", () => {

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
@@ -683,7 +683,7 @@ export function SimpleCalendarView({
     <div
       className="eliza-calendar-source-slot"
       data-testid="simple-calendar-source-manager"
-      data-placement={sourceNotice ? "promoted" : "secondary"}
+      data-placement="promoted"
     >
       <CalendarSourceManager
         sourceHealth={calendar.sources}
@@ -1051,8 +1051,6 @@ export function SimpleCalendarView({
               </PagePanel>
             ) : null}
           </div>
-
-          {sourceNotice ? null : sourceManager}
         </PagePanel.ContentRail>
       </PagePanel.ContentArea>
     </PagePanel.Frame>


### PR DESCRIPTION
Closes #29646

## What changed

- preserves a stable keyboard-hidden viewport baseline across Android IME event ordering
- applies only the native keyboard height not already absorbed by the layout viewport
- keeps Pixel `adjustResize` at zero extra lift while lifting above overlay-style LP3 keyboards
- resets the baseline on orientation/window-class changes

## Evidence

- `bun test packages/ui/src/components/shell/chat-panel-layout.test.ts` — 28/28 passed
- `bun run --cwd packages/ui typecheck` — passed
- Biome targeted check — passed
- `git diff --check` — passed
- Impeccable detector — no findings
- exact Pixel geometry: 919→520 layout with 398px native inset => 0px extra lift
- exact LP3 geometry: 414→414 layout with 223px native inset => 223px lift

## Physical evidence

Pending a data-preserving `install-r` when the LP3 returns. The current known-good APK, pairing, history, notifications, and rollback artifact remain untouched. No Pixel install is planned unless the shared-device matrix requires it.

## Visual evidence

- Before: captured physical LP3 keyboard overlay with composer hidden.
- After: pending exact combined APK physical capture.
- Video: pending exact combined APK physical typing/dismiss/relaunch walkthrough.

## N/A

- Backend logs: N/A — pure client layout geometry.
- Real-LLM trajectory: N/A — no agent/model behavior changed.
