### PR TITLE
fix(core): restore triage adapter route-cache FIFO bound

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/triage-service.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/triage-service.test.ts
@@ -135,22 +135,26 @@ describe("TriageService registry and routing", () => {
 	it("bounds the message-to-adapter route cache at production capacity", async () => {
 		const store = new MessageRefStore();
 		const service = new TriageService(store);
-		const refs = Array.from({ length: 5_001 }, (_, index) =>
-			message(`route-${index}`, "gmail", { receivedAtMs: index }),
-		);
-		service.register(
-			adapter("gmail", {
-				listMessages: async () => refs,
-			}),
-		);
+		const gmail = adapter("gmail", {
+			listMessages: async () =>
+				Array.from({ length: 5_001 }, (_, index) =>
+					message(`route-${index}`, "gmail", { receivedAtMs: index }),
+				),
+		});
+		service.register(gmail);
 
 		await service.triage(runtime(), { sources: ["gmail"], nowMs: 10_000 });
 
-		expect(service.getAdapterForMessage("route-0")).toBeUndefined();
-		expect(service.getAdapterForMessage("route-5000")).toBe(
-			service.getAdapter("gmail"),
+		// Cache is a 5000-entry FIFO. Store retains every triaged ref (#28112).
+		expect(service.__adapterRouteCacheSizeForTests()).toBe(5_000);
+		expect(service.__hasAdapterRouteCacheEntryForTests("route-0")).toBe(false);
+		expect(service.__hasAdapterRouteCacheEntryForTests("route-5000")).toBe(
+			true,
 		);
-		expect(store.listMessages()).toHaveLength(5_000);
+		expect(store.listMessages()).toHaveLength(5_001);
+		// Evicted cache entries still route through the authoritative store.
+		expect(service.getAdapterForMessage("route-0")).toBe(gmail);
+		expect(service.getAdapterForMessage("route-5000")).toBe(gmail);
 	});
 
 	it("keeps one lazy singleton until it is explicitly reset", () => {

--- a/packages/core/src/features/messaging/triage/triage-service.ts
+++ b/packages/core/src/features/messaging/triage/triage-service.ts
@@ -99,6 +99,13 @@ export class TriageService {
 		return this.store;
 	}
 
+	// adapterByMessageId grows one entry per message routed through triage(). Cap
+	// it (FIFO eviction by Map insertion order) so a long-running agent doesn't
+	// retain a routing entry for every message it has ever seen. Evicted entries
+	// fall back to the store-based lookup in getAdapterForMessage(). This is a
+	// process-memory bound on a fast-path cache, not a content cap.
+	private static readonly MAX_ADAPTER_ROUTES = 5000;
+
 	private trackAdapterForMessage(
 		source: MessageSource,
 		messageId: string,
@@ -106,6 +113,24 @@ export class TriageService {
 		const adapter = this.adapters.get(source);
 		if (!adapter) return;
 		this.adapterByMessageId.set(`${source}:${messageId}`, adapter);
+		while (this.adapterByMessageId.size > TriageService.MAX_ADAPTER_ROUTES) {
+			const oldest = this.adapterByMessageId.keys().next().value;
+			if (oldest === undefined) break;
+			this.adapterByMessageId.delete(oldest);
+		}
+	}
+
+	/** Test-only: size of the fast-path adapter route cache. */
+	__adapterRouteCacheSizeForTests(): number {
+		return this.adapterByMessageId.size;
+	}
+
+	/** Test-only: whether messageId is in the fast-path cache (not the store). */
+	__hasAdapterRouteCacheEntryForTests(messageId: string): boolean {
+		for (const key of this.adapterByMessageId.keys()) {
+			if (key.endsWith(`:${messageId}`)) return true;
+		}
+		return false;
 	}
 
 	getAdapterForMessage(messageId: string): MessageAdapter | undefined {


### PR DESCRIPTION
Fixes #29629

# Relates to

- #29629
- Collateral from #28112 (complete-retention sweep). This restores a process-memory cache bound, not a content cap.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fast-path Map only. `getAdapterForMessage` still falls back to `MessageRefStore` for evicted ids, so routing is unchanged. MessageRefStore complete-retention is untouched.

# Background

## What does this PR do?

`#28112` deleted `MAX_ADAPTER_ROUTES` and the FIFO eviction loop from `TriageService.trackAdapterForMessage`. `adapterByMessageId` then grew one entry per triaged message for the process lifetime. That loop was a memory bound on a cache whose fallback store is authoritative, not a silent content cap.

The leftover test still expected `getAdapterForMessage("route-0")` to be `undefined` and `store.listMessages()` length `5000`. Those assertions were only true when the store also capped at 5000. Under complete retention, an evicted cache entry correctly resolves via the store.

This PR:

- Restores `MAX_ADAPTER_ROUTES = 5000` and FIFO eviction by Map insertion order.
- Rewrites the bound test to assert cache size/membership, store length `5001`, and that evicted ids still route through the store.

## What kind of change is this?

Bug fix (non-breaking). Process-memory bound on a fast-path cache.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/messaging/triage/__tests__/triage-service.test.ts`

## Detailed testing steps

```
bun run --cwd packages/core test src/features/messaging/triage/__tests__/triage-service.test.ts
bun run --cwd packages/core test src/features/messaging/triage/__tests__/message-ref-store.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/core lint:check
```

Exact-head results at `dccdaf6dc5ac4e9dc7c30cc4b3c85679b8ac3bef` (rebased onto `elizaOS/develop@f7a4fbec264f81ff87801fdde65b7533a3d94fd4`; range-diff identity `b5391784d8 = dccdaf6dc5`, same patch-id):

- `triage-service.test.ts` 24/24 pass.
- `message-ref-store.test.ts`: 10/10 pass (complete retention unchanged).
- Combined: 2 files / 34 tests pass.
- `typecheck`: pass (post-rebase).
- `lint:check`: pass (warnings only, pre-existing `noExplicitAny` outside this diff).

Hosted Source / Billing / Windows gates rerun from this synchronize. Do not merge the stale `b5391784` / `027ccfa2` head.

# Evidence Gate

<!-- evidence-head:dccdaf6dc5ac4e9dc7c30cc4b3c85679b8ac3bef -->

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

# Evidence Details

## Real LLM-call trajectory

N/A - no model call.

# Known gaps / failures

`bun run verify` was run on this head after rebase onto `elizaOS/develop@f7a4fbec26`. It does not pass end-to-end on Windows because develop is already red before this diff. Exact unrelated blocker:

- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck lint:check --concurrency=8`: 138 successful / 146 total. Failed at `@elizaos/electrobun#lint:check`. The package script is `bunx @biomejs/biome check $(find src -type f \( -name '*.ts' -o -name '*.tsx' \) ! -name '*.d.ts' -print)`; on Windows this invokes `FIND.exe` and prints `File not found - *.tsx`. That package is not in this two-file diff. `@elizaos/core#lint:check` is green.

Remaining verify stages after that turbo stop did not run (`&&` chain): `audit:build-model`, `audit:turbo-build-deps`, `audit:tee-secret-leak`, `audit:hetzner-fleet-routing`, `audit:workflow-triggers`, `audit:scripts`, `audit:scripts:inventory`, `audit:test-lane-membership`, `audit:view-bundle-inventory`, `audit:plugin-view-inventory`, `audit:focused-tests`.

Earlier verify stages passed: `check:agents-claude`, `check:biome-version`, `check:i18n` (en keys OK; other-locale gaps are warnings), `ci-bun-version-contract`, `ci-turbo-cache-contract`, `fix-deps:check`, `ensure-plugin-test-conventions:check`, `audit:alias-read-guard`, `audit:tsconfig-workspace-resolution`, `audit:publish-graph`.

# Sync with develop

- [x] Rebased onto current `elizaOS/develop` `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`.
- [x] Exact head `dccdaf6dc5ac4e9dc7c30cc4b3c85679b8ac3bef`.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI; core triage cache bound only.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI; core triage cache bound only.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI; core triage cache bound only.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend request path; in-process Map eviction only.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, memory, wallet, or generated artifact.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@f7a4fbec264f81ff87801fdde65b7533a3d94fd4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-29629-triage-route-cache-bound]

