### PR TITLE
fix(cloud): filter lifecycle history at dedicated cutover

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -83,6 +83,12 @@ const currentUser = {
 const realAuthSnapshot = { ...realAuth };
 
 let cutoverHistory = [
+  {
+    id: "lifecycle-1",
+    role: "system" as const,
+    content: "The signed-in mobile session started.",
+    createdAt: 5,
+  },
   { id: "u1", role: "user" as const, content: "hello", createdAt: 10 },
   {
     id: "a1",
@@ -1320,8 +1326,8 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       importFetch.mockImplementation(async () =>
         Response.json({
           complete: true,
-          sourceMessageCount: cutoverHistory.length,
-          inserted: cutoverHistory.length,
+          sourceMessageCount: 2,
+          inserted: 2,
           skipped: 0,
           sourceScheduledTaskCount: 2,
           importedScheduledTasks: 2,
@@ -1646,7 +1652,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       ).toMatchObject({
         sourceAgentId: PERSONAL_C,
         cutoverToken: `personal-cutover:${PERSONAL_C}:${CUTOVER_TARGET}`,
-        sharedMessageCount: cutoverHistory.length,
+        sharedMessageCount: 2,
         sharedScheduledTaskCount: 2,
         sharedTodoCount: 1,
         sharedTodoMutationCount: 1,
@@ -1697,6 +1703,12 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       };
       currentUser.telegram_id = null;
       cutoverHistory = [
+        {
+          id: "lifecycle-1",
+          role: "system",
+          content: "The signed-in mobile session started.",
+          createdAt: 5,
+        },
         { id: "u1", role: "user", content: "hello", createdAt: 10 },
         {
           id: "a1",

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -488,7 +488,15 @@ app.post("/", async (c) => {
     let markerCommitted = false;
     let remindersReserved = false;
     try {
-      if (history.some((message) => !message.id)) {
+      // Lifecycle system turns remain in Shared's model history, but they are
+      // not authored chat messages and the Dedicated import boundary rejects
+      // caller-supplied system authority. Count and transfer only the same
+      // user/assistant transcript that the Dedicated receipt can attest.
+      const transferableHistory = history.filter(
+        (message): message is typeof message & { role: "user" | "assistant" } =>
+          message.role === "user" || message.role === "assistant",
+      );
+      if (transferableHistory.some((message) => !message.id)) {
         return json(
           {
             success: false,
@@ -527,7 +535,7 @@ app.post("/", async (c) => {
       }
       const importUrl = `${base}/api/conversations/${encodeURIComponent(sourceAgentId)}/import`;
       let todoSnapshot = await readTodoCutoverSnapshot(sourceAgentId, user.id);
-      const importedMessages = history.map((message) => ({
+      const importedMessages = transferableHistory.map((message) => ({
         sourceId: message.id,
         role: message.role,
         text: message.content,
@@ -561,7 +569,7 @@ app.post("/", async (c) => {
         if (
           !confirmsPersonalImport(
             receipt,
-            history.length,
+            importedMessages.length,
             scheduledTasks.length,
             todoSnapshot,
             false,
@@ -614,7 +622,7 @@ app.post("/", async (c) => {
         sourceAgentId,
         dedicatedAgentId: target.id,
         cutoverToken: sealToken,
-        sharedMessageCount: history.length,
+        sharedMessageCount: importedMessages.length,
         sharedScheduledTaskCount: scheduledTasks.length,
         sharedTodoCount: todoSnapshot.todos.length,
         sharedTodoMutationCount: todoSnapshot.mutations.length,
@@ -643,7 +651,7 @@ app.post("/", async (c) => {
         !activation.response.ok ||
         !confirmsPersonalImport(
           activation.receipt,
-          history.length,
+          importedMessages.length,
           scheduledTasks.length,
           todoSnapshot,
           true,
@@ -678,7 +686,7 @@ app.post("/", async (c) => {
               c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
               new URL(c.req.url).origin,
             ) ?? base,
-          importedMessages: history.length,
+          importedMessages: importedMessages.length,
           importedScheduledTasks: scheduledTasks.length,
           importedTodos: todoSnapshot.todos.length,
           importedTodoMutations: todoSnapshot.mutations.length,


### PR DESCRIPTION
# Relates to

Closes #29653

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Focused affected-surface tests, typecheck, lint, and diff checks pass; full hosted checks are requested below.
- [x] A reviewer can confirm the regression from the behavioral test and the exact receipt/count assertions.

# Sync with develop

- [x] Exact PR head `4bb2c241525fc8a2364bacdff933a26e49e1a74b` is based directly on `origin/develop` `027ccfa2fce52f9b442076ad6d3549a3f86e809e`; zero conflicts.
- [x] Affected-surface verification passes. The repository-wide Develop Full baseline is already red on the unchanged base; no exception is requested for this PR.

# Risks

Low and scoped to Personal Shared → Dedicated history transfer. The full Shared seal remains untouched. The transport now admits only the same authored roles already accepted by the Dedicated importer. A regression verifies receipt, marker, activation, response counts, and payload exclusion.

# Background

## What does this PR do?

Personal Shared history includes internal lifecycle `system` rows. The cutover route previously sent and counted every sealed row, while the Dedicated importer intentionally accepts only `user` and `assistant` rows. This caused `dedicated_history_receipt_invalid` after a healthy Dedicated runtime started.

This change preserves the complete authoritative Shared seal, derives an authored-only transfer transcript, validates IDs on transferred rows, and uses that exact transcript count at every receipt boundary.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change: this restores the existing security and cutover contract.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts`
- `packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts`

## Detailed testing steps

```bash
bun --config=/dev/null test packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts --timeout 120000
# 17 pass, 0 fail, 171 assertions

NODE_OPTIONS=--max-old-space-size=12288 bun run --cwd packages/cloud/api build
# exit 0 after building the local plugin-doordash workspace dependency

bunx @biomejs/biome check \
  packages/cloud/api/v1/eliza/agents/'[agentId]'/upgrade-tier/cutover/route.ts \
  packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
# Checked 2 files; no fixes applied

git diff --check
# exit 0
```

# Evidence Gate

<!-- evidence-head:4bb2c241525fc8a2364bacdff933a26e49e1a74b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only route correction; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only route correction; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI changed; live Pixel cutover is the post-deploy acceptance gate.
<!-- evidence-row:backend-logs -->
- [x] <details><summary>Sanitized production probe transcript</summary>

  ```text
  POST cutover coordinator -> HTTP 503 error=dedicated_history_receipt_invalid after the Dedicated runtime reported healthy.
  POST Dedicated authored-history import -> HTTP 200 complete=true sourceMessageCount=2 inserted=2 skipped=0.
  Sealed Shared history contained the same two authored turns plus one internal lifecycle system row; no credentials are included here.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed; the Pixel remained on setup solely after the typed backend cutover failure.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain schema or artifact changes; the transport receipt contract is exercised at the route boundary.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or agent-action change.

## Backend + frontend logs

Backend behavior: the production coordinator returned typed 503 `dedicated_history_receipt_invalid`; a direct authenticated import of the same two authored rows returned a complete 200 receipt with count 2. The added route regression proves the coordinator now sends and validates that same count while excluding the lifecycle row.

Frontend: N/A - no frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change. Live post-deploy Pixel cutover and first-turn verification remain required before declaring the incident resolved.

## Audio / voice walkthrough

N/A - no voice transport or audio behavior changed.

## Known gaps / failures

- The first plain Cloud API typecheck exhausted the default 4 GB Node heap. With `NODE_OPTIONS=--max-old-space-size=12288`, it exposed an unbuilt local `plugin-doordash/dist`; after building that existing workspace dependency, the unchanged canonical Cloud API build passed.
- The root `bunfig.toml` forces coverage and Bun's coverage writer failed after all assertions passed. Re-running the exact focused test with `--config=/dev/null` disabled that unrelated writer and passed cleanly.
- Live Pixel E2E is intentionally post-deploy acceptance evidence; production is not claimed fixed yet.

## Maintainer CI exception record

N/A - no exception requested. Do not merge until applicable exact-head checks and independent review pass.

# Deploy Notes

Deploy through the canonical Cloud pipeline: merge to `develop`, obtain staging certification, promote the certified tree to `main`, then production. After production reports the new source SHA, retry the existing authenticated Pixel cutover and verify Dedicated attachment plus the first chat turn.
