### PR TITLE
fix(plugin-x): a link-only/emoji-only recent tweet poisons isDuplicateTweet and halts posting

### DIFF
--- a/plugins/plugin-x/src/utils/memory.test.ts
+++ b/plugins/plugin-x/src/utils/memory.test.ts
@@ -142,4 +142,56 @@ describe("Twitter memory utilities", () => {
       isDuplicateTweet(runtime, "bot", "Dashboard shipped wallet", 0.6),
     ).resolves.toBe(true);
   });
+
+  // #29657: a recent tweet that normalizes to "" (URL-only or emoji-only) must
+  // not poison duplicate detection. Before the fix, `anyString.includes("")`
+  // was always true, so one such cached tweet flagged every future tweet as a
+  // duplicate and permanently halted autonomous posting.
+  it("does not treat a URL-only recent tweet as duplicate of unrelated text", async () => {
+    const runtime = runtimeWithStorage({
+      getCache: vi.fn(async () => ["https://t.co/abcd1234"]),
+    });
+
+    await expect(
+      isDuplicateTweet(
+        runtime,
+        "bot",
+        "Excited to announce our new roadmap for Q3!",
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("does not treat an emoji-only recent tweet as duplicate of unrelated text", async () => {
+    const runtime = runtimeWithStorage({
+      getCache: vi.fn(async () => ["🚀🚀🚀"]),
+    });
+
+    await expect(isDuplicateTweet(runtime, "bot", "gm everyone")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("does not treat two different empty-normalizing tweets as duplicates", async () => {
+    const runtime = runtimeWithStorage({
+      getCache: vi.fn(async () => ["https://t.co/abcd1234"]),
+    });
+
+    // A new URL-only tweet with a different raw URL normalizes to "" as well,
+    // but must not be flagged against the cached URL-only tweet.
+    await expect(
+      isDuplicateTweet(runtime, "bot", "https://t.co/wxyz9876"),
+    ).resolves.toBe(false);
+  });
+
+  it("still flags a byte-for-byte identical empty-normalizing tweet via the raw guard", async () => {
+    const runtime = runtimeWithStorage({
+      getCache: vi.fn(async () => ["https://t.co/abcd1234"]),
+    });
+
+    // The exact raw-text guard above the normalized loop still catches a
+    // genuinely identical repost even when it normalizes to "".
+    await expect(
+      isDuplicateTweet(runtime, "bot", "https://t.co/abcd1234"),
+    ).resolves.toBe(true);
+  });
 });

--- a/plugins/plugin-x/src/utils/memory.ts
+++ b/plugins/plugin-x/src/utils/memory.ts
@@ -312,6 +312,14 @@ export async function isDuplicateTweet(
   const normalizedNew = normalizeTweetForDuplicateCheck(tweetText);
   for (const recent of recentTweets) {
     const normalizedRecent = normalizeTweetForDuplicateCheck(recent);
+    // A tweet that normalizes to "" (URL-only or emoji-only) carries no
+    // comparable signal: `anyString.includes("")` is always true, so without
+    // this guard one such recent tweet flags every future tweet as a
+    // duplicate and permanently halts autonomous posting (#29657). The exact
+    // raw-text guard above still catches genuinely identical posts.
+    if (!normalizedRecent || !normalizedNew) {
+      continue;
+    }
     if (normalizedNew === normalizedRecent) {
       return true;
     }


### PR DESCRIPTION
# Relates to

Closes #29657

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; focused package checks (test, typecheck, lint) pass. Full `bun run verify` blocker noted under **Known gaps**.
- [x] A reviewer can confirm the change works from the before/after test evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`Current branch ... is up to date`).
- [x] Focused checks pass post-sync; full `bun run verify` blocker documented in **Known gaps** below.

# Risks

Low. The change is one guard clause inside `isDuplicateTweet` (plugins/plugin-x/src/utils/memory.ts). It only *narrows* when a tweet is flagged as a duplicate (it never newly flags something). The exact raw-text equality guard above the normalized loop is untouched, so byte-for-byte identical reposts are still caught.

# Background

## What does this PR do?

Fixes a liveness deadlock in the X (Twitter) autonomous posting loop.

`isDuplicateTweet` normalizes each recent tweet by stripping URLs and non-alphanumeric characters, then compares with `normalizedNew.includes(normalizedRecent) || normalizedRecent.includes(normalizedNew)`. When a previously posted tweet normalizes to the empty string — a URL-only tweet (`https://t.co/abcd`) or an emoji-only tweet (`🚀🚀🚀`) — `normalizedRecent` becomes `""`, and `anyString.includes("")` is **always true**. Every subsequently generated tweet is then reported as a duplicate.

The post callback (`utils/twitter-post-callback.ts`) treats a duplicate as a skip and returns `[]` without posting (log line `[Twitter] Skipping duplicate generated tweet`). Because no post succeeds, `addToRecentTweets` never runs, so the poisoned cache entry is never rotated out. Once the agent posts a single link-only or emoji-only tweet, its autonomous posting is silently and permanently deadlocked. Sharing bare links/emoji is common agent behavior, so this is a realistic liveness failure, not a theoretical edge.

**Fix:** skip the normalized comparisons when either normalized form is empty — an empty normalized form carries no comparable signal:

```ts
const normalizedRecent = normalizeTweetForDuplicateCheck(recent);
if (!normalizedRecent || !normalizedNew) {
  continue;
}
```

The exact-text `recentTweets.includes(tweetText)` guard above still catches genuinely identical raw posts. Scope is one function.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/utils/memory.test.ts` — four new regression cases in the "Twitter memory utilities" suite, plus the four pre-existing duplicate-detection cases (substring, token-similarity reorder, threshold) still green.

## Detailed testing steps

```bash
cd plugins/plugin-x
bunx vitest run src/utils/memory.test.ts   # 11 passed
bun run --cwd plugins/plugin-x typecheck    # clean
bun run --cwd plugins/plugin-x lint         # clean
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:c69ef34c1fcb9c8c234691e43d22ecb5b6a2eb02 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend string-dedup logic change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend string-dedup logic change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; the observable behavior is a server-side posting-loop deadlock proven by the failing→passing test below.
<!-- evidence-row:backend-logs -->
- [x] Backend run output for the exact `isDuplicateTweet` contract that gates the `[Twitter] Skipping duplicate generated tweet` code path in `twitter-post-callback.ts`. A live X posting loop needs real X API credentials unavailable in this environment, so the unit-level run of the gating contract stands in. Captured at head `c69ef34` in `plugins/plugin-x` (Bun 1.3.14, Vitest 4.1.10); the `Warn Failed to create memory` lines are the retry paths of unrelated cases in the same suite, printed by the structured logger.

<details><summary>backend run — bunx vitest run src/utils/memory.test.ts (after fix, 11 passed)</summary>

```text
# PR #29659 — isDuplicateTweet after-fix regression suite
# repo: elizaOS/eliza   head: c69ef34c1fcb9c8c234691e43d22ecb5b6a2eb02
# file: plugins/plugin-x/src/utils/memory.test.ts
# sha256(memory.test.ts): 1522c0e55a588a0157dc1ed55ad4fac358e78a808636e8c1daaf8f860cc861ce
# bun: 1.3.14   vitest: vitest/4.1.10 linux-arm64 node-v22.22.2
# command: bunx vitest run src/utils/memory.test.ts --reporter=verbose
# ---------------------------------------------------------------------


 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-29659/plugins/plugin-x

stderr | src/utils/memory.test.ts > Twitter memory utilities > treats duplicate memory writes as idempotent without retrying
 Warn       Failed to create memory (attempt 1/3): duplicate key constraint failed

stderr | src/utils/memory.test.ts > Twitter memory utilities > retries transient memory write failures and then succeeds
 Warn       Failed to create memory (attempt 1/2): database is busy

 ✓ src/utils/memory.test.ts > Twitter memory utilities > treats duplicate memory writes as idempotent without retrying 13ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > retries transient memory write failures and then succeeds 4ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > surfaces tweet lookup storage failures instead of permitting replay 2ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > stores the canonical entity UUID as the Twitter world owner 5ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > detects duplicate tweets after trimming case and punctuation-like spacing 3ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > uses token similarity for reordered near-duplicate tweets 2ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > honors the duplicate similarity threshold 1ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > does not treat a URL-only recent tweet as duplicate of unrelated text 1ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > does not treat an emoji-only recent tweet as duplicate of unrelated text 2ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > does not treat two different empty-normalizing tweets as duplicates 1ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > still flags a byte-for-byte identical empty-normalizing tweet via the raw guard 1ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  00:41:16
   Duration  13.11s (transform 10.58s, setup 0ms, import 12.87s, tests 37ms, environment 0ms)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/provider/model/action change; this is a pure string-comparison bug in a dedup helper.
<!-- evidence-row:domain-artifacts -->
- [x] Failure-sensitive domain artifact. Reverting only the production guard in `plugins/plugin-x/src/utils/memory.ts` while keeping the test file byte-identical (sha256 `1522c0e55a588a0157dc1ed55ad4fac358e78a808636e8c1daaf8f860cc861ce`) turns the three empty-normalizing cases red (`expected true to be false`) while the byte-identical-repost positive control stays green. This proves the added cases distinguish the poisoned normalized comparison from a validator that merely permits every empty-normalizing tweet, rather than passing vacuously.

<details><summary>before fix — production guard reverted, test file unchanged (3 failed | 8 passed)</summary>

```text
# PR #29659 — before-fix reproduction (production guard reverted; test file byte-identical)
# repo: elizaOS/eliza   head: c69ef34c1fcb9c8c234691e43d22ecb5b6a2eb02
# MUTANT: the fix in plugins/plugin-x/src/utils/memory.ts was reverted to reproduce #29657.
# test file UNCHANGED — sha256(memory.test.ts): 1522c0e55a588a0157dc1ed55ad4fac358e78a808636e8c1daaf8f860cc861ce
# command: bunx vitest run src/utils/memory.test.ts --reporter=verbose
# Expectation: the URL-only / emoji-only / two-empty cases FAIL (poisoned includes(""));
#              the byte-identical repost positive control still PASSES.
# ---------------------------------------------------------------------


 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-29659/plugins/plugin-x

stderr | src/utils/memory.test.ts > Twitter memory utilities > treats duplicate memory writes as idempotent without retrying
 Warn       Failed to create memory (attempt 1/3): duplicate key constraint failed

stderr | src/utils/memory.test.ts > Twitter memory utilities > retries transient memory write failures and then succeeds
 Warn       Failed to create memory (attempt 1/2): database is busy

 ✓ src/utils/memory.test.ts > Twitter memory utilities > treats duplicate memory writes as idempotent without retrying 11ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > retries transient memory write failures and then succeeds 5ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > surfaces tweet lookup storage failures instead of permitting replay 3ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > stores the canonical entity UUID as the Twitter world owner 7ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > detects duplicate tweets after trimming case and punctuation-like spacing 3ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > uses token similarity for reordered near-duplicate tweets 2ms
 ✓ src/utils/memory.test.ts > Twitter memory utilities > honors the duplicate similarity threshold 1ms
 × src/utils/memory.test.ts > Twitter memory utilities > does not treat a URL-only recent tweet as duplicate of unrelated text 9ms
   → expected true to be false // Object.is equality
 × src/utils/memory.test.ts > Twitter memory utilities > does not treat an emoji-only recent tweet as duplicate of unrelated text 3ms
   → expected true to be false // Object.is equality
 × src/utils/memory.test.ts > Twitter memory utilities > does not treat two different empty-normalizing tweets as duplicates 2ms
   → expected true to be false // Object.is equality
 ✓ src/utils/memory.test.ts > Twitter memory utilities > still flags a byte-for-byte identical empty-normalizing tweet via the raw guard 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/memory.test.ts > Twitter memory utilities > does not treat a URL-only recent tweet as duplicate of unrelated text
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/utils/memory.test.ts:161:5
    159|         "Excited to announce our new roadmap for Q3!",
    160|       ),
    161|     ).resolves.toBe(false);
       |     ^
    162|   });
    163|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  src/utils/memory.test.ts > Twitter memory utilities > does not treat an emoji-only recent tweet as duplicate of unrelated text
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/utils/memory.test.ts:169:65
    167|     });
    168|
    169|     await expect(isDuplicateTweet(runtime, "bot", "gm everyone")).reso…
       |                                                                 ^
    170|       false,
    171|     );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/utils/memory.test.ts > Twitter memory utilities > does not treat two different empty-normalizing tweets as duplicates
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/utils/memory.test.ts:183:5
    181|     await expect(
    182|       isDuplicateTweet(runtime, "bot", "https://t.co/wxyz9876"),
    183|     ).resolves.toBe(false);
       |     ^
    184|   });
    185|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 8 passed (11)
   Start at  00:41:42
   Duration  13.43s (transform 10.77s, setup 0ms, import 13.17s, tests 49ms, environment 0ms)
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - frontend. Backend: see the failing→passing reproduction below, which exercises the exact `isDuplicateTweet` contract that gates the `[Twitter] Skipping duplicate generated tweet` code path.

### Before the fix — probe reproducing the deadlock (2 failed)

A probe test (`getCache` returns a prior URL-only / emoji-only post, then `isDuplicateTweet` on an unrelated new tweet) fails, confirming any recent tweet whose normalized form is `""` flags all future tweets as duplicates:

<details><summary>bunx vitest run src/utils/dup-probe.test.ts (before fix)</summary>

```
 ❯ src/utils/dup-probe.test.ts (2 tests | 2 failed) 20ms
     × URL-only recent tweet must not flag unrelated new tweet 14ms
     × emoji-only recent tweet must not flag gm everyone 3ms

 FAIL  src/utils/dup-probe.test.ts > #29657 probe > URL-only recent tweet must not flag unrelated new tweet
AssertionError: expected true to be false // Object.is equality
- Expected  false
+ Received  true

 FAIL  src/utils/dup-probe.test.ts > #29657 probe > emoji-only recent tweet must not flag gm everyone
AssertionError: expected true to be false // Object.is equality
- Expected  false
+ Received  true

 Test Files  1 failed (1)
      Tests  2 failed (2)
```
</details>

### After the fix — extended memory.test.ts (11 passed)

The probe is folded into permanent regression cases in `memory.test.ts`; the four pre-existing duplicate-detection tests remain green:

<details><summary>bunx vitest run src/utils/memory.test.ts (after fix)</summary>

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```
</details>

### Diff of `isDuplicateTweet`

<details><summary>git diff plugins/plugin-x/src/utils/memory.ts</summary>

```diff
   const normalizedNew = normalizeTweetForDuplicateCheck(tweetText);
   for (const recent of recentTweets) {
     const normalizedRecent = normalizeTweetForDuplicateCheck(recent);
+    // A tweet that normalizes to "" (URL-only or emoji-only) carries no
+    // comparable signal: `anyString.includes("")` is always true, so without
+    // this guard one such recent tweet flags every future tweet as a
+    // duplicate and permanently halts autonomous posting (#29657). The exact
+    // raw-text guard above still catches genuinely identical posts.
+    if (!normalizedRecent || !normalizedNew) {
+      continue;
+    }
     if (normalizedNew === normalizedRecent) {
       return true;
     }
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change (backend dedup helper in `plugins/plugin-x`).

### Before

N/A - no rendered surface.

### After

N/A - no rendered surface.

### Walkthrough video

N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- Full repo `bun run verify` was not run to completion on this Raspberry Pi worktree (it fans out Turbo across ~180 workspaces and is impractical here). Focused owning-package gates were run instead and pass: `bunx vitest run src/utils/memory.test.ts` (11 passed), `typecheck` (clean), `lint` (clean). The change is confined to one function in one file with no cross-package surface.
- Live X posting-loop backend logs require real X API credentials unavailable in this environment; the unit-level reproduction of the exact `isDuplicateTweet` contract stands in for that path.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c69ef34c1fcb9c8c234691e43d22ecb5b6a2eb02:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c69ef34c1fcb9c8c234691e43d22ecb5b6a2eb02:packages/skills/skills/contribute-to-eliza"} -->

