### PR TITLE
fix(cloud): unblock personal Dedicated cutover on lifecycle history

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -83,6 +83,12 @@ const currentUser = {
 const realAuthSnapshot = { ...realAuth };
 
 let cutoverHistory = [
+  {
+    id: "lifecycle-1",
+    role: "system" as const,
+    content: "The signed-in mobile session started.",
+    createdAt: 5,
+  },
   { id: "u1", role: "user" as const, content: "hello", createdAt: 10 },
   {
     id: "a1",
@@ -1320,8 +1326,8 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       importFetch.mockImplementation(async () =>
         Response.json({
           complete: true,
-          sourceMessageCount: cutoverHistory.length,
-          inserted: cutoverHistory.length,
+          sourceMessageCount: 2,
+          inserted: 2,
           skipped: 0,
           sourceScheduledTaskCount: 2,
           importedScheduledTasks: 2,
@@ -1646,7 +1652,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       ).toMatchObject({
         sourceAgentId: PERSONAL_C,
         cutoverToken: `personal-cutover:${PERSONAL_C}:${CUTOVER_TARGET}`,
-        sharedMessageCount: cutoverHistory.length,
+        sharedMessageCount: 2,
         sharedScheduledTaskCount: 2,
         sharedTodoCount: 1,
         sharedTodoMutationCount: 1,
@@ -1697,6 +1703,12 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       };
       currentUser.telegram_id = null;
       cutoverHistory = [
+        {
+          id: "lifecycle-1",
+          role: "system",
+          content: "The signed-in mobile session started.",
+          createdAt: 5,
+        },
         { id: "u1", role: "user", content: "hello", createdAt: 10 },
         {
           id: "a1",

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -488,7 +488,15 @@ app.post("/", async (c) => {
     let markerCommitted = false;
     let remindersReserved = false;
     try {
-      if (history.some((message) => !message.id)) {
+      // Lifecycle system turns remain in Shared's model history, but they are
+      // not authored chat messages and the Dedicated import boundary rejects
+      // caller-supplied system authority. Count and transfer only the same
+      // user/assistant transcript that the Dedicated receipt can attest.
+      const transferableHistory = history.filter(
+        (message): message is typeof message & { role: "user" | "assistant" } =>
+          message.role === "user" || message.role === "assistant",
+      );
+      if (transferableHistory.some((message) => !message.id)) {
         return json(
           {
             success: false,
@@ -527,7 +535,7 @@ app.post("/", async (c) => {
       }
       const importUrl = `${base}/api/conversations/${encodeURIComponent(sourceAgentId)}/import`;
       let todoSnapshot = await readTodoCutoverSnapshot(sourceAgentId, user.id);
-      const importedMessages = history.map((message) => ({
+      const importedMessages = transferableHistory.map((message) => ({
         sourceId: message.id,
         role: message.role,
         text: message.content,
@@ -561,7 +569,7 @@ app.post("/", async (c) => {
         if (
           !confirmsPersonalImport(
             receipt,
-            history.length,
+            importedMessages.length,
             scheduledTasks.length,
             todoSnapshot,
             false,
@@ -614,7 +622,7 @@ app.post("/", async (c) => {
         sourceAgentId,
         dedicatedAgentId: target.id,
         cutoverToken: sealToken,
-        sharedMessageCount: history.length,
+        sharedMessageCount: importedMessages.length,
         sharedScheduledTaskCount: scheduledTasks.length,
         sharedTodoCount: todoSnapshot.todos.length,
         sharedTodoMutationCount: todoSnapshot.mutations.length,
@@ -643,7 +651,7 @@ app.post("/", async (c) => {
         !activation.response.ok ||
         !confirmsPersonalImport(
           activation.receipt,
-          history.length,
+          importedMessages.length,
           scheduledTasks.length,
           todoSnapshot,
           true,
@@ -678,7 +686,7 @@ app.post("/", async (c) => {
               c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
               new URL(c.req.url).origin,
             ) ?? base,
-          importedMessages: history.length,
+          importedMessages: importedMessages.length,
           importedScheduledTasks: scheduledTasks.length,
           importedTodos: todoSnapshot.todos.length,
           importedTodoMutations: todoSnapshot.mutations.length,


### PR DESCRIPTION
## Incident

Production realtime voice consent and WebSocket service are healthy, but the canonical Personal conversation cannot mint because its Shared-to-Dedicated authority receipt never finalized. The cutover importer receives lifecycle system rows that the Dedicated import boundary correctly excludes, while the coordinator compares the receipt against the unfiltered count.

## Scope

- Exact cherry-pick of the reviewed fix already merged to develop in #29654.
- Transfer and attest only authored user/assistant messages.
- Preserve the full Shared seal and all existing ownership, schema, reminder, Todo, and rollback gates.
- No other develop commits or production configuration changes.

The stable patch-id matches the reviewed source commit exactly: 54392d13904975dedae75fa8282e6da7427a8eb7.

## Verification

- Focused upgrade/cutover suite: 17 passed, 0 failed, 171 assertions.
- Biome: clean on both changed files.
- Cloud API TypeScript check: clean with the repository source custom condition.
- git diff --check: clean.

After deploy, retry the supported cutover endpoint for the existing Dedicated target, then verify Personal voice mint and the live WebSocket ready event.