### PR TITLE
test(app): isolate canonical smoke host fixtures

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -81,11 +81,13 @@ async function installAssistantFlowRoutes(page: Page): Promise<{
     timestamp: number;
   }>;
   streamRequests: string[];
+  personalRequests: string[];
 }> {
   await installDefaultAppRoutes(page);
   let conversationCreated = false;
   let messageSequence = 0;
   const streamRequests: string[] = [];
+  const personalRequests: string[] = [];
   const messages: Array<{
     id: string;
     role: "user" | "assistant";
@@ -115,6 +117,43 @@ async function installAssistantFlowRoutes(page: Page): Promise<{
       sessionId: "assistant-flow-cloud-login",
       browserUrl:
         "https://www.elizacloud.ai/auth/cli-login?session=assistant-flow-cloud-login",
+    });
+  });
+  // Cloud onboarding resolves the authenticated Personal identity directly
+  // against the control-plane host. Keep that boundary deterministic and point
+  // its agent runtime back at this same-origin smoke stack; an unmocked request
+  // would escape to production and fail CORS instead of exercising the flow.
+  await page.route("**/api/v1/eliza/personal", async (route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = request.url();
+    personalRequests.push(`${method} ${url}`);
+    if (
+      method !== "GET" ||
+      url !== "https://api.eliza.app/api/v1/eliza/personal"
+    ) {
+      await route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "unexpected personal identity request" }),
+      });
+      return;
+    }
+    const pageUrl = page.url();
+    const origin = pageUrl.startsWith("http")
+      ? new URL(pageUrl).origin
+      : new URL(route.request().url()).origin;
+    await fulfillJson(route, {
+      success: true,
+      data: {
+        identity: {
+          id: "personal:00000000-0000-5000-8000-000000000001",
+          displayName: "Playwright Smoke",
+          runtime: "dedicated",
+          activeAgentId: "agent-assistant-flow",
+          apiBase: origin,
+        },
+      },
     });
   });
   await page.route("**/api/cloud/login/status**", async (route) => {
@@ -405,7 +444,7 @@ async function installAssistantFlowRoutes(page: Page): Promise<{
     },
   );
 
-  return { messages, streamRequests };
+  return { messages, streamRequests, personalRequests };
 }
 
 async function screenshot(page: Page, name: string): Promise<void> {
@@ -766,7 +805,7 @@ test.describe("assistant home app flow", () => {
     page,
   }) => {
     await rm(SCREENSHOT_DIR, { force: true, recursive: true });
-    await installAssistantFlowRoutes(page);
+    const initialAssistantApi = await installAssistantFlowRoutes(page);
 
     await page.addInitScript(() => {
       const clearKey = "eliza:ui-smoke:first-run-clear-done";
@@ -798,6 +837,12 @@ test.describe("assistant home app flow", () => {
       timeout: 20_000,
     });
     await screenshot(page, "01-first-run-clouds");
+    await page.getByTestId("choice-__first_run__:runtime:cloud").click();
+    await expect
+      .poll(() => initialAssistantApi.personalRequests.length, {
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(0);
 
     await page.unroute("**/api/first-run/status");
     await seedAssistantFlowStorage(page);
@@ -830,7 +875,7 @@ test.describe("assistant home app flow", () => {
       }
     });
     await installReadyDesktopStatusBridge(page);
-    await installAssistantFlowRoutes(page);
+    const readyAssistantApi = await installAssistantFlowRoutes(page);
 
     await openReadyChat(page);
     const rootChatInput = assistantComposer(page);
@@ -879,6 +924,17 @@ test.describe("assistant home app flow", () => {
       page.getByRole("button", { name: "Network settings", exact: true }),
     ).toBeVisible();
     await screenshot(page, "07-wallet-view-with-pill");
+    const personalRequests = [
+      ...initialAssistantApi.personalRequests,
+      ...readyAssistantApi.personalRequests,
+    ];
+    expect(personalRequests.length).toBeGreaterThan(0);
+    expect(
+      personalRequests.every(
+        (request) =>
+          request === "GET https://api.eliza.app/api/v1/eliza/personal",
+      ),
+    ).toBe(true);
   });
 
   test("drives the assistant home voice path with a scripted browser STT turn", async ({

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1529,6 +1529,18 @@ function smokeDatabaseQuery(sql: string) {
 
 /** Installs baseline API routes for smoke tests before flow-specific overrides. */
 export async function installDefaultAppRoutes(page: Page): Promise<void> {
+  // The UI-smoke server serves a production renderer from a same-origin
+  // backend proxy. Model the host's pre-React API-base injection so the bundle
+  // does not mistake that local stack for the hosted Cloud-only surface before
+  // any route fixture has a chance to answer. Keep this at document start: the
+  // app resolves branding while its entry module is evaluating.
+  await page.addInitScript(() => {
+    const host = window as typeof window & {
+      __ELIZA_APP_API_BASE__?: string;
+    };
+    host.__ELIZA_APP_API_BASE__ = window.location.origin;
+  });
+
   let notesRevision = 4;
   let smokeNotes: SmokeNote[] = [
     {

--- a/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
@@ -90,7 +90,7 @@ test.describe("confused-user onboarding", () => {
     await expectNoPageDiagnostics(page, testInfo.title);
   });
 
-  test("the sign-in-first composer is locked during onboarding — prefilled/typed text is ignored and never reaches the server, and tapping still completes", async ({
+  test("the onboarding composer stays enabled while external prefill is gated, and tapping still completes", async ({
     page,
   }) => {
     await injectFullCapabilityHost(page);
@@ -109,19 +109,13 @@ test.describe("confused-user onboarding", () => {
     });
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    // The onboarding surface is sign-in-first (#15339): the composer mounts
-    // LOCKED (disabled) with a "Sign in to start chatting" placeholder — the
-    // helper asserts that — so the confused user CANNOT type past setup, and the
-    // old #12178 "type free text → in-transcript reply" affordance is gone.
+    // The chat-native conductor keeps ordinary text input usable while its
+    // programmatic prefill seam remains gated. Tapping a structured choice is
+    // still a deterministic way to complete setup.
     await expectChatFirstOnboarding(page);
 
     const composer = page.getByTestId("chat-composer-textarea");
-    await expect(composer).toBeDisabled();
-
-    // The "just type at it" instinct — modeled by the same programmatic prefill
-    // path the app uses (CHAT_PREFILL_EVENT) — is IGNORED while onboarding is
-    // open: the draft is never set and nothing is sent. (The unit suite
-    // ChatOverlay.firstrun.test asserts the same behavior at the seam.)
+    await expect(composer).toBeEnabled();
     await page.evaluate(() => {
       window.dispatchEvent(
         new CustomEvent("eliza:chat:prefill", {
@@ -131,16 +125,16 @@ test.describe("confused-user onboarding", () => {
     });
     await page.waitForTimeout(500);
     await expect(composer).toHaveValue("");
-    await screenshot(page, "locked-composer-ignores-typing");
+    await screenshot(page, "composer-gates-external-prefill");
 
-    // Nothing was POSTed to /api/first-run, and no typed text leaked as a send.
+    // A gated external prefill must not POST setup or leak a chat send.
     expect(
       state.firstRunPosts.length,
-      "a locked onboarding composer must not trigger any first-run POST",
+      "a gated onboarding prefill must not trigger any first-run POST",
     ).toBe(0);
     expect(
       chatSends,
-      "prefilled/typed text must never reach the server before completion",
+      "a gated onboarding prefill must never reach the server",
     ).toEqual([]);
     expect(leaks).toEqual([]);
 
@@ -288,7 +282,8 @@ test.describe("confused-user onboarding", () => {
 
     // Nothing was persisted (no POST yet) → the conductor re-seeds a fresh
     // onboarding surface: the runtime CHOICE is unlocked (re-offered) while the
-    // composer stays sign-in-first locked, same contract as the first paint.
+    // text composer stays enabled and external prefill remains gated, matching
+    // the first paint.
     await expectChatFirstOnboarding(page);
     await screenshot(page, "after-reload-fresh-onboarding");
 

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -840,16 +840,16 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
   await expect(page.getByTestId(RUNTIME_CHOICE("remote"))).toBeVisible();
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
 
-  // Onboarding surface (#15339): first-run is sign-in-first, so the composer is
-  // LOCKED (disabled) with a "Sign in to start chatting" cue until the user
-  // signs in — typing into a not-yet-ready chat is prevented. The active
-  // onboarding sheet preserves the wallpaper without mounting a separate
-  // full-screen backdrop, and remains non-dismissable at its half detent.
+  // Onboarding surface (#12178): the composer stays enabled so a user can answer
+  // the in-chat conductor naturally. Attachments, voice, and ordinary agent
+  // sends remain gated by the first-run controller; the active sheet preserves
+  // the wallpaper and remains non-dismissable at its half detent.
   const composer = page.getByTestId("chat-composer-textarea");
-  await expect(composer).toBeDisabled();
+  await expect(composer).toBeEnabled();
+  await expect(composer).toHaveAttribute("placeholder", "Hey Eliza…");
   await expect(composer).toHaveAttribute(
-    "placeholder",
-    "Sign in to start chatting",
+    "aria-describedby",
+    "cc-first-run-hint",
   );
   await expect(page.getByTestId("chat-first-run-backdrop")).toHaveCount(0);
   await expect(chatOverlay).toHaveAttribute("data-open", "true");
@@ -1135,7 +1135,7 @@ export async function expectCloudOnlySignInOnboarding(
   await expect(composer).toBeDisabled();
   await expect(composer).toHaveAttribute(
     "placeholder",
-    "Sign in to start chatting",
+    "Sign in to get started",
   );
   await expect(page.getByTestId("chat-first-run-backdrop")).toHaveCount(0);
   await expect(chatOverlay).toHaveAttribute("data-open", "true");


### PR DESCRIPTION
## Purpose
Repair canonical app/browser smoke fixtures after the full production renderer exposed a local host boot-mode gap, a production Personal API escape, and stale first-run composer expectations.

## Exact source
- base/current develop: `3d5e516775b8c41c19e007c4871b201216844697`
- head: `4f28b0ae32ad0d6f679a4bb3f7ee6fd38f688817`
- tree: `4f94a064bebce23aaa62e80927cb6902f43474a4`
- scope: four app test-fixture files
- rebase range-diff: exact `=`

## Contract
- inject the same-origin app API base at document start so the local smoke renderer does not misclassify itself as hosted Cloud-only
- isolate Personal identity to the canonical `GET https://api.eliza.app/api/v1/eliza/personal`; record all matching requests, return 502 for wrong host/method, and assert every observed request is exact
- preserve the product's intentional enabled first-run text composer while proving external prefill is gated and no draft/send leaks
- preserve Cloud-only sign-in as disabled with current copy

## Verification
- exact assistant-home/Personal, launcher, Cloud-only, confused-user, and Local onboarding matrix: 8/8 PASS
- ChatOverlay first-run contract: 32/32 PASS
- branding policy: 12/12 PASS
- exact-file Biome and diff-check: PASS
- independent review P0/P1 = 0; its P2 host/method breadth and P3 stale-comment findings are corrected in this head

The separate Cloud tutorial sheet-collapse product defect remains deliberately unmodified and assigned to its own source lane. No runtime, device, browser-auth, Cloud, Dedicated, billing, or live-service state changed.
