### PR TITLE
fix(cloud): remove dedicated chat ingress reconnects

### DIFF
--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -14,6 +14,7 @@ import {
   test,
 } from "bun:test";
 import { runInNewContext } from "node:vm";
+import { hasDbCacheContext } from "@/db/client";
 import * as agentSandboxesActual from "@/db/repositories/agent-sandboxes";
 import { AuthenticationError, ForbiddenError } from "@/lib/api/errors";
 import * as authActual from "@/lib/auth";
@@ -52,6 +53,8 @@ const browserClaimCalls: Array<{
   binding: { agentId: string; expectedOrigin: string };
 }> = [];
 const authRequests: Request[] = [];
+const authDbCacheContexts: boolean[] = [];
+const sandboxDbCacheContexts: boolean[] = [];
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
   ...cloudBindingsActual,
@@ -61,6 +64,7 @@ mock.module("@/lib/auth", () => ({
   ...authActual,
   requireAuthOrApiKeyWithOrg: async (request: Request) => {
     authRequests.push(request);
+    authDbCacheContexts.push(hasDbCacheContext());
     if (authResult === "throw") throw new AuthenticationError("unauthorized");
     if (authResult === "forbidden") throw new ForbiddenError("forbidden");
     if (authResult === "unexpected") throw new Error("auth dependency failed");
@@ -71,7 +75,10 @@ mock.module("@/db/repositories/agent-sandboxes", () => ({
   ...agentSandboxesActual,
   agentSandboxesRepository: {
     ...agentSandboxesActual.agentSandboxesRepository,
-    findByIdAndOrg: async () => sandboxResult,
+    findByIdAndOrg: async () => {
+      sandboxDbCacheContexts.push(hasDbCacheContext());
+      return sandboxResult;
+    },
   },
 }));
 mock.module("@/lib/services/provisioning-jobs", () => ({
@@ -245,6 +252,8 @@ beforeEach(() => {
   browserClaimError = null;
   browserClaimCalls.length = 0;
   authRequests.length = 0;
+  authDbCacheContexts.length = 0;
+  sandboxDbCacheContexts.length = 0;
   rateLimitResult = { success: true };
   rateLimitError = null;
   rateLimitKeys.length = 0;
@@ -900,6 +909,8 @@ describe("dedicated-agent-proxy — unified auth", () => {
 
     expect(res.status).toBe(200);
     expect(authRequests).toHaveLength(1);
+    expect(authDbCacheContexts).toEqual([true]);
+    expect(sandboxDbCacheContexts).toEqual([true]);
     expect(authRequests[0]?.headers.get("cookie")).toBeNull();
     expect(captured).not.toBeNull();
     // The container gets the agent's own token, NOT the cloud token.
@@ -1320,6 +1331,8 @@ describe("dedicated-agent-proxy — CORS + unroutable short-circuit (#15347)", (
     expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
     expect(res.headers.get("access-control-allow-credentials")).toBeNull();
     expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-max-age")).toBe("600");
+    expect(res.headers.get("cache-control")).toBe("no-store");
     expect(captured).toBeNull(); // preflight is answered at the edge
   });
 
@@ -1350,6 +1363,7 @@ describe("dedicated-agent-proxy — CORS + unroutable short-circuit (#15347)", (
     expect(
       deniedPreflight.headers.get("access-control-allow-origin"),
     ).toBeNull();
+    expect(deniedPreflight.headers.get("access-control-max-age")).toBeNull();
 
     const request = makeRequest("victim-cloud-token", attackerOrigin, {
       cookie: "steward-token=victim-session",

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -784,6 +784,12 @@ function dedicatedProxyPreflight(request: Request, url: URL): Response {
   if (!applyDedicatedProxyCors(request, url, headers)) {
     return new Response(null, { status: 403, headers });
   }
+  // The browser's CORS-preflight cache is separate from its HTTP cache, so
+  // `Cache-Control: no-store` still protects the response while this bounded
+  // grant avoids another full Worker/auth-router round trip on every chat
+  // turn. The cache is keyed by origin, URL, method, credentials mode, and
+  // requested headers; the Worker revalidates the real bearer on every POST.
+  headers.set("access-control-max-age", "600");
   return new Response(null, { status: 204, headers });
 }
 
@@ -976,7 +982,15 @@ export function handleDedicatedAgentProxy(
     if (request.method === "OPTIONS") {
       return dedicatedProxyPreflight(request, url);
     }
-    const response = await proxyDedicatedAgent(request, env, url, agentId);
+    // UUID-subdomain requests bypass bootstrap-app.ts, including its
+    // request-scoped DB cache middleware. Enter the same boundary here so the
+    // auth/JIT lookup and sandbox ownership lookup reuse one Hyperdrive
+    // connection within this request instead of reconnecting for every query.
+    // The cache is connection-scoped only: credentials and ownership are still
+    // revalidated on every request and no I/O object crosses Worker requests.
+    const response = await runWithDbCacheAsync(() =>
+      proxyDedicatedAgent(request, env, url, agentId),
+    );
     return withDedicatedProxyBrowserPolicy(request, url, response);
   });
 }


### PR DESCRIPTION
Root cause: UUID agent-subdomain requests bypass bootstrap middleware, so Cloud auth and sandbox ownership queries did not share the request-scoped Hyperdrive connection. On the live Pixel trace this sat inside a 4.20s ingress segment. This change enters the existing request-scoped DB boundary without caching credentials or ownership across requests. It also adds a bounded 600s successful CORS preflight grant while retaining Cache-Control: no-store and omitting the grant for denied origins.\n\nLive evidence before fix: 1.772s OPTIONS preflight; multiple serial auth/routing lookups before the container.\n\nValidation:\n- dedicated-agent-proxy focused suite: 50/50 pass\n- explicit regression proves auth and sandbox ownership run with request DB cache context\n- Biome clean\n- git diff check clean\n\nNo auth, ownership, rate-limit, or credential-swap gate is relaxed.