### PR TITLE
test(cloud): make release gates checkout-independent

### DIFF
--- a/packages/cloud/scripts/production-hyperdrive-binding-admission.test.mjs
+++ b/packages/cloud/scripts/production-hyperdrive-binding-admission.test.mjs
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
 import {
   ALLOWED_NON_RUNTIME_CHANGES,
@@ -23,14 +25,94 @@ const policyFixtureSha = execFileSync(
     encoding: "utf8",
   },
 ).trim();
-const prePolicyFixtureSha = execFileSync(
-  "git",
-  ["-C", repoRoot, "rev-parse", "HEAD^"],
-  { encoding: "utf8" },
-).trim();
+
+function fixtureGit(fixtureRoot, ...args) {
+  return execFileSync("git", ["-C", fixtureRoot, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_EMAIL: "policy-fixture@example.invalid",
+      GIT_AUTHOR_NAME: "Policy Fixture",
+      GIT_COMMITTER_EMAIL: "policy-fixture@example.invalid",
+      GIT_COMMITTER_NAME: "Policy Fixture",
+    },
+  }).trim();
+}
+
+function createGitFixture(label) {
+  const fixtureRoot = mkdtempSync(
+    join(tmpdir(), `hyperdrive-${label}-fixture-`),
+  );
+  try {
+    fixtureGit(fixtureRoot, "init", "--quiet", "--object-format=sha1");
+    return fixtureRoot;
+  } catch (error) {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+function commitGitFixture(fixtureRoot, message) {
+  fixtureGit(fixtureRoot, "add", "--all");
+  fixtureGit(
+    fixtureRoot,
+    "commit",
+    "--quiet",
+    "--no-verify",
+    "--no-gpg-sign",
+    "-m",
+    message,
+  );
+  return fixtureGit(fixtureRoot, "rev-parse", "HEAD");
+}
+
+function writeGitFixture(fixtureRoot, path, source) {
+  const fixturePath = join(fixtureRoot, path);
+  mkdirSync(dirname(fixturePath), { recursive: true });
+  writeFileSync(fixturePath, source, "utf8");
+}
+
+function createMissingTrustedPolicyFixture() {
+  const fixtureRoot = createGitFixture("policy");
+  try {
+    for (const path of TRUSTED_POLICY_PATHS) {
+      writeGitFixture(fixtureRoot, path, `${path}\n`);
+    }
+    const policySha = commitGitFixture(fixtureRoot, "trusted policy fixture");
+    const missingPath = TRUSTED_POLICY_PATHS.at(-1);
+    if (!missingPath)
+      throw new Error("Trusted policy fixture requires at least one path");
+    rmSync(join(fixtureRoot, missingPath));
+    const candidateSha = commitGitFixture(
+      fixtureRoot,
+      "missing trusted policy fixture",
+    );
+    return { candidateSha, fixtureRoot, policySha };
+  } catch (error) {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+    throw error;
+  }
+}
 
 function config(id = oldId, extra = "") {
   return `name = "cloud"\n${extra}\n[env.production]\nname = "cloud-production"\n[[env.production.hyperdrive]]\nbinding = "HYPERDRIVE"\nid = "${id}"\n\n[env.staging]\nname = "cloud-staging"\n[[env.staging.hyperdrive]]\nbinding = "HYPERDRIVE"\nid = "${"3".repeat(32)}"\n`;
+}
+
+function createProductionBindingFixture() {
+  const fixtureRoot = createGitFixture("binding");
+  try {
+    writeGitFixture(fixtureRoot, WRANGLER_PATH, config(oldId));
+    const baseSha = commitGitFixture(fixtureRoot, "served binding fixture");
+    writeGitFixture(fixtureRoot, WRANGLER_PATH, config(newId));
+    const candidateSha = commitGitFixture(
+      fixtureRoot,
+      "candidate binding fixture",
+    );
+    return { baseSha, candidateSha, fixtureRoot };
+  } catch (error) {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+    throw error;
+  }
 }
 
 function valid(overrides = {}) {
@@ -84,15 +166,20 @@ describe("production Hyperdrive binding-only admission", () => {
     ]);
   });
 
-  test("admits the reviewed production binding commit from its served base", () => {
-    expect(
-      admitProductionHyperdriveBindingFromGit({
-        repoRoot,
-        baseSha: "c0a8de04019f62a96c5f6bf21ee7c15ee554cafe",
-        candidateSha: "579d546d2d23c954c0aef9775356781e674cb689",
-        force: false,
-      }),
-    ).toMatchObject({ verdict: "pass", changedPathCount: 3 });
+  test("admits a production binding commit from its served base", () => {
+    const fixture = createProductionBindingFixture();
+    try {
+      expect(
+        admitProductionHyperdriveBindingFromGit({
+          repoRoot: fixture.fixtureRoot,
+          baseSha: fixture.baseSha,
+          candidateSha: fixture.candidateSha,
+          force: false,
+        }),
+      ).toMatchObject({ verdict: "pass", changedPathCount: 1 });
+    } finally {
+      rmSync(fixture.fixtureRoot, { force: true, recursive: true });
+    }
   });
 
   test("requires all production policy blobs to equal the trusted develop policy", () => {
@@ -110,13 +197,18 @@ describe("production Hyperdrive binding-only admission", () => {
   });
 
   test("rejects a candidate missing the trusted policy blobs", () => {
-    expect(() =>
-      validateTrustedPolicyIdentityFromGit({
-        repoRoot,
-        policySha: policyFixtureSha,
-        candidateSha: prePolicyFixtureSha,
-      }),
-    ).toThrow(/production_hyperdrive_binding_admission/);
+    const fixture = createMissingTrustedPolicyFixture();
+    try {
+      expect(() =>
+        validateTrustedPolicyIdentityFromGit({
+          repoRoot: fixture.fixtureRoot,
+          policySha: fixture.policySha,
+          candidateSha: fixture.candidateSha,
+        }),
+      ).toThrow(/production_hyperdrive_binding_admission/);
+    } finally {
+      rmSync(fixture.fixtureRoot, { force: true, recursive: true });
+    }
   });
 
   test.each([

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
@@ -14,6 +14,7 @@ import {
   acquireEphemeralPostgres,
   type EphemeralPostgres,
 } from "../../../lib/services/tenant-db/__tests__/ephemeral-postgres";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { sqlRows } from "../../execute-helpers";
 import {
   agentBackupNodeAdmissionCursors,
@@ -577,6 +578,9 @@ realPostgres("canonical backup catalogue contention", () => {
     await apply();
     await seedSourceAuthority(TENANT_A);
     await seedSourceAuthority(TENANT_B);
+    await installAgentNodeOccurrenceTriggerForTests((statement) =>
+      dbWrite.execute(sql.raw(statement)),
+    );
     await applyBackupAdmissionMigrations();
     await installBackupMutationGuardForTests();
   }, 60_000);
@@ -601,6 +605,8 @@ realPostgres("canonical backup catalogue contention", () => {
 
   test("retires only the protocol guard after the admission migration", async () => {
     if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+    const tenantAHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
+    const tenantBHistoryId = await requireCurrentNodeHistoryId(TENANT_B);
     const [migrationState] = await sqlRows<{
       bind_trigger_exists: boolean;
       capture_check_exists: boolean;
@@ -675,7 +681,7 @@ realPostgres("canonical backup catalogue contention", () => {
       .from(agentSandboxBackups)
       .where(eq(agentSandboxBackups.id, backupId));
     expect(bound).toEqual({
-      sourceNodeHistoryId: TENANT_A.nodeHistoryId,
+      sourceNodeHistoryId: tenantAHistoryId,
       sourceNodeId: TENANT_A.nodeId,
     });
 
@@ -703,7 +709,7 @@ realPostgres("canonical backup catalogue contention", () => {
           state_data_storage: "inline",
           size_bytes: 0,
           backup_kind: "full",
-          source_node_history_id: TENANT_B.nodeHistoryId,
+          source_node_history_id: tenantBHistoryId,
           source_node_record_id: TENANT_A.nodeRecordId,
           source_node_incarnation: TENANT_A.nodeIncarnation,
         })

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
@@ -561,7 +561,10 @@ const realPostgres = postgres ? describe : describe.skip;
 
 realPostgres("canonical backup catalogue contention", () => {
   beforeAll(async () => {
-    if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+    const initializedDbWrite = dbWrite;
+    if (!initializedDbWrite) {
+      throw new Error("Real PostgreSQL harness was not initialized");
+    }
     const { apply } = await pushSchema(
       {
         organizations,
@@ -573,13 +576,13 @@ realPostgres("canonical backup catalogue contention", () => {
         agentSandboxBackups,
         agentBackupCatalogAuthorities,
       } as never,
-      dbWrite as never,
+      initializedDbWrite as never,
     );
     await apply();
     await seedSourceAuthority(TENANT_A);
     await seedSourceAuthority(TENANT_B);
     await installAgentNodeOccurrenceTriggerForTests((statement) =>
-      dbWrite.execute(sql.raw(statement)),
+      initializedDbWrite.execute(sql.raw(statement)),
     );
     await applyBackupAdmissionMigrations();
     await installBackupMutationGuardForTests();


### PR DESCRIPTION
## Purpose

Clear the two remaining exact-tree release-test blockers found while reviewing #29664, without changing runtime, deployment, database, or production behavior.

## Changes

- replace Hyperdrive policy test dependencies on `HEAD^` and two historical commit objects with disposable two-commit SHA-1 Git fixtures
- keep the same positive binding-delta and missing-trusted-policy assertions while making them valid in the CI lane's depth-1 checkout
- install the live `0301_agent_node_occurrence_trigger` fixture before `0341`, matching production migration order
- assert against trigger-generated current occurrence IDs instead of deleted bootstrap IDs in the real-PostgreSQL backup-catalog test

## Exact source

- base develop: `993927774621a524c6dd4a2cc2de9711feec2678`
- head: `bc5706b9c0425c68524bce34248acee2b7258b7b`
- scope: two test files only

## Verification

- Hyperdrive admission: 29 pass / 0 fail
- true `git clone --no-local --depth=1` proof with the exact Hyperdrive test diff: 29 pass / 0 fail
- control proof: the smaller `HEAD:packages/core`-only repair still failed the historical binding case in depth 1 (28 pass / 1 fail), so both history dependencies are intentionally removed here
- disposable real PostgreSQL 16.10 with `REQUIRE_REAL_POSTGRES_BACKUP_CATALOG_TESTS=1`: 8 pass / 0 fail / 67 assertions
- Biome exact files: pass
- `git diff --check`: pass
- exact changed-file scope: pass

A broader local `build:core` reached and built the dependencies required by these tests, then failed in the unrelated unchanged `plugin-computeruse` macOS Swift SDK/toolchain path. The focused real-PostgreSQL and Git tests above passed after that build.

No Cloudflare, Railway, production, staging, tenant, billing, agent, or device mutation is included. The old promotion remains blocked until a corrected merged develop SHA receives a fresh immutable staging certificate.
