### PR TITLE
test(cloud): follow reusable Pages build admission

### DIFF
--- a/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
+++ b/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
@@ -227,14 +227,22 @@ describe("committed Cloud CF workflow matches the policy", () => {
     expect(cloudCfRelease).not.toContain("cloud-cf-deploy-app-");
   });
 
-  test("PR Pages previews remain pinned to staging inputs", () => {
-    const buildPages = jobBlock(cloudCf, "build-pages");
-    expect(buildPages).not.toContain("inputs.target_environment");
-    expect(buildPages).toContain("VITE_API_URL: https://api-staging.eliza.app");
-    expect(buildPages).toContain(
-      "NEXT_PUBLIC_APP_URL: https://cloud-staging.eliza.app",
+  test("Pages builds remain bound to the admitted release environment", () => {
+    const release = jobBlock(cloudCf, "release");
+    const buildPages = jobBlock(cloudCfRelease, "build-pages");
+    expect(release).toContain("github.event_name != 'pull_request'");
+    expect(release).toContain(
+      `target_environment: \${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}`,
     );
-    expect(buildPages).toContain("VITE_ENVIRONMENT: staging");
+    expect(buildPages).toContain(
+      `VITE_API_URL: \${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}`,
+    );
+    expect(buildPages).toContain(
+      `NEXT_PUBLIC_APP_URL: \${{ (inputs.target_environment == 'production') && 'https://cloud.eliza.app' || 'https://cloud-staging.eliza.app' }}`,
+    );
+    expect(buildPages).toContain(
+      `VITE_ENVIRONMENT: \${{ inputs.target_environment }}`,
+    );
   });
 });
 


### PR DESCRIPTION
# Relates to

- Follow-up release-test blocker found while reviewing #29664.

# Risks

Low. This changes one static workflow contract test and no workflow, runtime,
deployment, database, or production behavior. The protected contract remains
fail-closed: pull requests cannot enter the release job, and Pages build inputs
must match the admitted staging or production environment.

# Background

`build-pages` moved from `.github/workflows/cloud-cf-deploy.yml` into the
reusable `.github/workflows/cloud-cf-release.yml`, but the admission-lock test
still searched the wrapper workflow. The deterministic result was
`missing job build-pages`, blocking Script Tests even though the release
topology itself was correct.

This PR reads `build-pages` from its current owner and replaces the obsolete
fixed-staging preview assertions with the current authority contract:

- the wrapper's release job rejects `pull_request` execution;
- the wrapper maps the admitted production condition to `production` and all
  other admitted releases to `staging`;
- the reusable Pages build derives API URL, app URL, and `VITE_ENVIRONMENT`
  from that target.

# Exact source

- implementation base: `993927774621a524c6dd4a2cc2de9711feec2678`
- rebased `origin/develop`: `94634a2dca3453681c4c157a94e841f375a97c47`
- head: `4cc8d3256f912bd897d0531ec81bac6caa2aa68d`
- scope: `packages/cloud/scripts/production-deploy-admission-lock.test.mjs` only

# Testing

- red control on the implementation base: 15 pass / 1 fail (`missing job build-pages`)
- exact-head admission-lock test: 16 pass / 0 fail
- exact-head Cloud CF focused suite: 56 pass / 0 fail / 755 assertions
- `bun install --frozen-lockfile --ignore-scripts`: pass
- Biome on the changed file: pass, no warnings
- `git diff --check`: pass
- exact changed-file scope: pass

The full dynamically inventoried `bun run test:scripts` lane completed and the
changed admission-lock test passed. The aggregate still exited 1 on unrelated
base failures: the real Git HTTP boundary exceeded its 5-second test timeout,
the unchanged PostgreSQL-resilience workflow test rejects an existing Railway
command in the workflow, and the plugin-conventions subprocess exceeded its
30-second test timeout. An additional broader selected suite reproduced an
unchanged provisioning-worker concurrency assertion. None of those tests or
their owned files are changed here.

# Evidence Gate

<!-- evidence-head:4cc8d3256f912bd897d0531ec81bac6caa2aa68d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, or provider change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain-state change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Maintainer CI exception record

N/A - no exception requested.
