### PR TITLE
fix(cloud): persist direct embedding ownership

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
@@ -178,6 +178,9 @@ describe("buildManagedElizaRuntimeConfig", () => {
       linkedAccounts: {
         elizacloud: { status: "linked", source: "api-key" },
       },
+      serviceRouting: {
+        embeddings: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
       cloud: {
         enabled: true,
         apiKey: "agent-api-key",
@@ -188,6 +191,48 @@ describe("buildManagedElizaRuntimeConfig", () => {
     expect(topology.runtime).toBe("cloud");
     expect(topology.services.inference).toBe(true);
     expect(topology.shouldLoadPlugin).toBe(true);
+  });
+
+  test("persists configured direct embedding ownership for managed containers", () => {
+    const config = buildManagedElizaRuntimeConfig({
+      ELIZAOS_CLOUD_API_KEY: "agent-api-key",
+      ELIZAOS_CLOUD_USE_EMBEDDINGS: "false",
+      EMBEDDING_BASE_URL: "http://eliza-embedding-sidecar:80/v1",
+    });
+
+    expect(config).toMatchObject({
+      serviceRouting: {
+        embeddings: { backend: "embeddings", transport: "direct" },
+      },
+    });
+  });
+
+  test("does not invent direct embedding ownership without a configured provider", () => {
+    const config = buildManagedElizaRuntimeConfig({
+      ELIZAOS_CLOUD_API_KEY: "agent-api-key",
+      ELIZAOS_CLOUD_USE_EMBEDDINGS: "false",
+    });
+
+    expect(config).toMatchObject({
+      serviceRouting: {
+        embeddings: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+    });
+  });
+
+  test("keeps explicit Cloud embedding opt-in on the canonical cloud-proxy route", () => {
+    const config = buildManagedElizaRuntimeConfig({
+      ELIZAOS_CLOUD_API_KEY: "agent-api-key",
+      ELIZAOS_CLOUD_USE_EMBEDDINGS: "true",
+      // A stale direct endpoint must not beat the explicit Cloud opt-in.
+      EMBEDDING_BASE_URL: "http://eliza-embedding-sidecar:80/v1",
+    });
+
+    expect(config).toMatchObject({
+      serviceRouting: {
+        embeddings: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+    });
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -563,6 +563,9 @@ export function buildManagedElizaRuntimeConfig(
 ): Record<string, unknown> {
   const apiKey = allEnv.ELIZAOS_CLOUD_API_KEY || "";
   const agentId = allEnv.ELIZA_CLOUD_AGENT_ID || allEnv.WAIFU_ELIZA_CLOUD_AGENT_ID;
+  const directEmbeddingProvider =
+    allEnv.ELIZAOS_CLOUD_USE_EMBEDDINGS?.trim().toLowerCase() === "false" &&
+    Boolean(allEnv.EMBEDDING_BASE_URL?.trim() || allEnv.EMBEDDING_API_KEY?.trim());
 
   return {
     logging: { level: "info" },
@@ -578,6 +581,14 @@ export function buildManagedElizaRuntimeConfig(
         }
       : {}),
     serviceRouting: buildDefaultElizaCloudServiceRouting({
+      // Canonical routing wins over process env during PID1 boot. Persist the
+      // same direct embedding ownership selected by managed provisioning;
+      // otherwise the default Eliza Cloud route below flips
+      // ELIZAOS_CLOUD_USE_EMBEDDINGS back to true. Legacy agents without a
+      // direct provider and explicit Cloud opt-ins keep cloud-proxy routing.
+      base: directEmbeddingProvider
+        ? { embeddings: { backend: "embeddings", transport: "direct" } }
+        : undefined,
       includeInference: true,
       nanoModel: allEnv.ELIZAOS_CLOUD_NANO_MODEL,
       smallModel: allEnv.ELIZAOS_CLOUD_SMALL_MODEL,


### PR DESCRIPTION
## Root cause

Managed agents can carry ELIZAOS_CLOUD_USE_EMBEDDINGS=false plus a direct embedding endpoint, but buildManagedElizaRuntimeConfig always persisted the default Eliza Cloud cloud-proxy route. Canonical eliza.json routing wins at PID1 boot, so that persisted route flipped Cloud embeddings back on and moved every recall call off the node.

## Fix

- Persist serviceRouting.embeddings as embeddings/direct only when Cloud embeddings are explicitly false and a direct endpoint or key is configured.
- Keep the historical elizacloud/cloud-proxy route for legacy agents with no direct provider.
- Keep explicit Cloud embedding opt-ins on cloud-proxy even if a stale direct endpoint remains.
- Do not include or imply the broader sidecar rollout.

## Validation

- bun --config=/dev/null test packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts (29 pass)
- bun run --cwd packages/cloud/shared typecheck
- bunx biome check packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
- git diff --check

A full local build:core also completed 55 of 56 tasks; its only failure was the host Swift SDK/compiler mismatch in unchanged plugin-computeruse native build code.