### PR TITLE
fix(cloud): fail blocked Headscale joins

### DIFF
--- a/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh
+++ b/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh
@@ -5,13 +5,23 @@ set -eu
 # the full rationale on reconnect-first + distinct auth-expired signaling). The
 # only delta is the final privilege drop to CLOUD_AGENT_RUN_AS_USER via gosu.
 TS_AUTHKEY_EXPIRED_EXIT_CODE=78
+TS_UP_TIMEOUT_SECONDS="${TS_UP_TIMEOUT_SECONDS:-120}"
+
+ts_interactive_auth_required() {
+  case "$1" in
+    *'"authurl": "http'*|*'"authurl":"http'*|*"authurl=true"*|*"authurl is http"*) return 0 ;;
+    *"needslogin"*|*"needsmachineauth"*) return 0 ;;
+    *"machineauthorized=false"*|*'"machineauthorized":false'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 ts_authkey_permanent_failure() {
   case "$1" in
     *"authkey expired"*|*"auth key expired"*|*"key expired"*) return 0 ;;
     *"authkey already used"*|*"auth key already used"*) return 0 ;;
     *"invalid key"*|*"invalid authkey"*|*"invalid auth key"*) return 0 ;;
-    *) return 1 ;;
+    *) ts_interactive_auth_required "$1" ;;
   esac
 }
 
@@ -40,11 +50,60 @@ ts_try_fetch_fresh_authkey() {
 }
 
 ts_up() {
-  ts_up_output="$(
-    # shellcheck disable=SC2086
-    tailscale --socket="$ts_socket" up "$@" 2>&1
-  )" && ts_up_rc=0 || ts_up_rc=$?
-  [ -n "$ts_up_output" ] && printf '%s\n' "$ts_up_output" >&2
+  ts_up_output_file="/tmp/tailscale-up.$$.log"
+  : > "$ts_up_output_file"
+  chmod 600 "$ts_up_output_file"
+  ts_daemon_log_start_line=$(( $(wc -l < /tmp/tailscaled.log 2>/dev/null || printf '0') + 1 ))
+
+  # JSON exposes interactive state when the CLI prints it. With --auth-key the
+  # CLI suppresses that URL, so also inspect tailscaled's private log for the
+  # RegisterReq machineAuthorized=false / authURL=true response. Never copy the
+  # raw authorization URL to container logs; --timeout bounds silent stalls.
+  # shellcheck disable=SC2086
+  tailscale --socket="$ts_socket" up \
+    --json \
+    --timeout="${TS_UP_TIMEOUT_SECONDS}s" \
+    "$@" \
+    >"$ts_up_output_file" 2>&1 &
+  ts_up_pid=$!
+  ts_up_auth_required=0
+  ts_up_interactive_auth=0
+
+  while kill -0 "$ts_up_pid" 2>/dev/null; do
+    ts_up_snapshot="$(cat "$ts_up_output_file" 2>/dev/null || true)"
+    ts_daemon_snapshot="$(tail -n +"$ts_daemon_log_start_line" /tmp/tailscaled.log 2>/dev/null || true)"
+    ts_up_snapshot_lower="$(printf '%s\n%s' "$ts_up_snapshot" "$ts_daemon_snapshot" | tr '[:upper:]' '[:lower:]')"
+    if [ -n "$ts_up_snapshot_lower" ] && ts_authkey_permanent_failure "$ts_up_snapshot_lower"; then
+      ts_up_auth_required=1
+      if ts_interactive_auth_required "$ts_up_snapshot_lower"; then
+        ts_up_interactive_auth=1
+      fi
+      kill "$ts_up_pid" 2>/dev/null || true
+      break
+    fi
+    sleep 0.1
+  done
+
+  if wait "$ts_up_pid"; then
+    ts_up_rc=0
+  else
+    ts_up_rc=$?
+  fi
+  ts_up_output="$(cat "$ts_up_output_file" 2>/dev/null || true)"
+  rm -f "$ts_up_output_file"
+  ts_daemon_snapshot="$(tail -n +"$ts_daemon_log_start_line" /tmp/tailscaled.log 2>/dev/null || true)"
+  ts_up_output_lower="$(printf '%s\n%s' "$ts_up_output" "$ts_daemon_snapshot" | tr '[:upper:]' '[:lower:]')"
+  if [ -n "$ts_up_output_lower" ] && ts_authkey_permanent_failure "$ts_up_output_lower"; then
+    ts_up_auth_required=1
+    if ts_interactive_auth_required "$ts_up_output_lower"; then
+      ts_up_interactive_auth=1
+    fi
+  fi
+  if [ "$ts_up_auth_required" -eq 1 ]; then
+    ts_up_rc=1
+  else
+    [ -n "$ts_up_output" ] && printf '%s\n' "$ts_up_output" >&2
+  fi
   return 0
 }
 
@@ -62,6 +121,13 @@ start_tailscale_if_configured() {
     echo "[cloud-agent-entrypoint] TS_AUTHKEY is set but tailscale/tailscaled is not installed" >&2
     exit 1
   fi
+
+  case "$TS_UP_TIMEOUT_SECONDS" in
+    ''|*[!0-9]*|0)
+      echo "[cloud-agent-entrypoint] TS_UP_TIMEOUT_SECONDS must be a positive integer" >&2
+      exit 1
+      ;;
+  esac
 
   ts_state_dir="${TS_STATE_DIR:-/var/lib/tailscale}"
   ts_socket="${TS_SOCKET:-/tmp/tailscaled.sock}"
@@ -121,7 +187,7 @@ start_tailscale_if_configured() {
   fi
 
   ts_up_lower="$(printf '%s' "$ts_up_output" | tr '[:upper:]' '[:lower:]')"
-  if ts_authkey_permanent_failure "$ts_up_lower"; then
+  if [ "$ts_up_auth_required" -eq 1 ] || ts_authkey_permanent_failure "$ts_up_lower"; then
     # 3) SELF-HEAL via re-key hook (opt-in).
     fresh_key="$(ts_try_fetch_fresh_authkey "$ts_hostname")"
     if [ -n "$fresh_key" ]; then
@@ -134,6 +200,9 @@ start_tailscale_if_configured() {
     fi
 
     # 4) DISTINCT AUTH-EXPIRED SIGNAL.
+    if [ "$ts_up_interactive_auth" -eq 1 ]; then
+      echo "[cloud-agent-entrypoint] tailscale requires interactive authorization (AuthURL/NeedsLogin); unattended mesh join rejected" >&2
+    fi
     echo "[cloud-agent-entrypoint] FATAL: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying" >&2
     printf 'auth_expired hostname=%s\n' "$ts_hostname" > "$ts_authkey_expired_marker" 2>/dev/null || true
     exit "$TS_AUTHKEY_EXPIRED_EXIT_CODE"

--- a/packages/app-core/scripts/docker-entrypoint.sh
+++ b/packages/app-core/scripts/docker-entrypoint.sh
@@ -19,18 +19,34 @@ set -eu
 # re-key/recreate it instead of leaving it in an unbounded crash loop.
 TS_AUTHKEY_EXPIRED_EXIT_CODE=78
 
+# `tailscale up` defaults to waiting forever for Running. A rejected pre-auth
+# key can instead move the daemon to NeedsLogin with an interactive AuthURL,
+# which must never hold the mesh-first container boot indefinitely. Keep every
+# join attempt bounded; tests may lower this positive integer to exercise the
+# deadline without delaying the suite.
+TS_UP_TIMEOUT_SECONDS="${TS_UP_TIMEOUT_SECONDS:-120}"
+
 # Substrings that mean "this auth key will never work on retry" — a fresh key is
 # required, looping on the same one is pointless. Matched case-insensitively
 # against the `tailscale up` stderr. Kept broad on purpose: headscale/tailscale
 # phrase this as "authkey expired", "key expired", "authkey already used"
 # (single-use key consumed by a prior boot), or "invalid key".
+ts_interactive_auth_required() {
+  case "$1" in
+    *'"authurl": "http'*|*'"authurl":"http'*|*"authurl=true"*|*"authurl is http"*) return 0 ;;
+    *"needslogin"*|*"needsmachineauth"*) return 0 ;;
+    *"machineauthorized=false"*|*'"machineauthorized":false'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ts_authkey_permanent_failure() {
   # $1 = combined tailscale up output (lower-cased by caller)
   case "$1" in
     *"authkey expired"*|*"auth key expired"*|*"key expired"*) return 0 ;;
     *"authkey already used"*|*"auth key already used"*) return 0 ;;
     *"invalid key"*|*"invalid authkey"*|*"invalid auth key"*) return 0 ;;
-    *) return 1 ;;
+    *) ts_interactive_auth_required "$1" ;;
   esac
 }
 
@@ -73,14 +89,66 @@ ts_try_fetch_fresh_authkey() {
 }
 
 # Run `tailscale up`, capturing combined output so we can classify auth failures.
+# JSON mode exposes the daemon's otherwise-interactive AuthURL / NeedsLogin
+# state. Watch that output while the command is running so an unusable key fails
+# immediately; the CLI's own timeout remains the hard bound for silent stalls.
 # Args after the function name are passed through verbatim to `tailscale up`.
 ts_up() {
   # Globals: ts_socket, ts_up_output (set here), ts_up_rc (set here).
-  ts_up_output="$(
-    # shellcheck disable=SC2086
-    tailscale --socket="$ts_socket" up "$@" 2>&1
-  )" && ts_up_rc=0 || ts_up_rc=$?
-  [ -n "$ts_up_output" ] && printf '%s\n' "$ts_up_output" >&2
+  ts_up_output_file="/tmp/tailscale-up.$$.log"
+  : > "$ts_up_output_file"
+  chmod 600 "$ts_up_output_file"
+  ts_daemon_log_start_line=$(( $(wc -l < /tmp/tailscaled.log 2>/dev/null || printf '0') + 1 ))
+
+  # `up --json` intentionally suppresses its interactive URL when --auth-key
+  # is present, so also inspect tailscaled's private log for the RegisterReq
+  # machineAuthorized=false / authURL=true response. That evidence is never
+  # copied to container logs because the URL itself is an authorization secret.
+  # shellcheck disable=SC2086
+  tailscale --socket="$ts_socket" up \
+    --json \
+    --timeout="${TS_UP_TIMEOUT_SECONDS}s" \
+    "$@" \
+    >"$ts_up_output_file" 2>&1 &
+  ts_up_pid=$!
+  ts_up_auth_required=0
+  ts_up_interactive_auth=0
+
+  while kill -0 "$ts_up_pid" 2>/dev/null; do
+    ts_up_snapshot="$(cat "$ts_up_output_file" 2>/dev/null || true)"
+    ts_daemon_snapshot="$(tail -n +"$ts_daemon_log_start_line" /tmp/tailscaled.log 2>/dev/null || true)"
+    ts_up_snapshot_lower="$(printf '%s\n%s' "$ts_up_snapshot" "$ts_daemon_snapshot" | tr '[:upper:]' '[:lower:]')"
+    if [ -n "$ts_up_snapshot_lower" ] && ts_authkey_permanent_failure "$ts_up_snapshot_lower"; then
+      ts_up_auth_required=1
+      if ts_interactive_auth_required "$ts_up_snapshot_lower"; then
+        ts_up_interactive_auth=1
+      fi
+      kill "$ts_up_pid" 2>/dev/null || true
+      break
+    fi
+    sleep 0.1
+  done
+
+  if wait "$ts_up_pid"; then
+    ts_up_rc=0
+  else
+    ts_up_rc=$?
+  fi
+  ts_up_output="$(cat "$ts_up_output_file" 2>/dev/null || true)"
+  rm -f "$ts_up_output_file"
+  ts_daemon_snapshot="$(tail -n +"$ts_daemon_log_start_line" /tmp/tailscaled.log 2>/dev/null || true)"
+  ts_up_output_lower="$(printf '%s\n%s' "$ts_up_output" "$ts_daemon_snapshot" | tr '[:upper:]' '[:lower:]')"
+  if [ -n "$ts_up_output_lower" ] && ts_authkey_permanent_failure "$ts_up_output_lower"; then
+    ts_up_auth_required=1
+    if ts_interactive_auth_required "$ts_up_output_lower"; then
+      ts_up_interactive_auth=1
+    fi
+  fi
+  if [ "$ts_up_auth_required" -eq 1 ]; then
+    ts_up_rc=1
+  else
+    [ -n "$ts_up_output" ] && printf '%s\n' "$ts_up_output" >&2
+  fi
   return 0
 }
 
@@ -98,6 +166,13 @@ start_tailscale_if_configured() {
     echo "[docker-entrypoint] TS_AUTHKEY is set but tailscale/tailscaled is not installed" >&2
     exit 1
   fi
+
+  case "$TS_UP_TIMEOUT_SECONDS" in
+    ''|*[!0-9]*|0)
+      echo "[docker-entrypoint] TS_UP_TIMEOUT_SECONDS must be a positive integer" >&2
+      exit 1
+      ;;
+  esac
 
   ts_state_dir="${TS_STATE_DIR:-/var/lib/tailscale}"
   ts_socket="${TS_SOCKET:-/tmp/tailscaled.sock}"
@@ -167,7 +242,7 @@ start_tailscale_if_configured() {
   fi
 
   ts_up_lower="$(printf '%s' "$ts_up_output" | tr '[:upper:]' '[:lower:]')"
-  if ts_authkey_permanent_failure "$ts_up_lower"; then
+  if [ "$ts_up_auth_required" -eq 1 ] || ts_authkey_permanent_failure "$ts_up_lower"; then
     # 3) SELF-HEAL via re-key hook (opt-in). Ask the control plane for a fresh
     #    key and retry ONCE before giving up.
     fresh_key="$(ts_try_fetch_fresh_authkey "$ts_hostname")"
@@ -184,6 +259,9 @@ start_tailscale_if_configured() {
     # 4) DISTINCT AUTH-EXPIRED SIGNAL. Nothing worked and retrying is futile.
     #    Surface a machine-readable status the control plane can act on
     #    (re-key + recreate) instead of an unbounded restart loop on a dead key.
+    if [ "$ts_up_interactive_auth" -eq 1 ]; then
+      echo "[docker-entrypoint] tailscale requires interactive authorization (AuthURL/NeedsLogin); unattended mesh join rejected" >&2
+    fi
     echo "[docker-entrypoint] FATAL: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying" >&2
     printf 'auth_expired hostname=%s\n' "$ts_hostname" > "$ts_authkey_expired_marker" 2>/dev/null || true
     exit "$TS_AUTHKEY_EXPIRED_EXIT_CODE"

--- a/packages/app-core/scripts/docker-entrypoint.test.ts
+++ b/packages/app-core/scripts/docker-entrypoint.test.ts
@@ -113,6 +113,35 @@ sleep 5
 `;
 }
 
+// Tailscale 1.90 suppresses its BrowseToURL output when `up` has --auth-key,
+// even after Headscale returns an interactive URL. This fixture therefore stays
+// silent and blocked exactly like the CLI did in staging.
+const TAILSCALE_AUTH_URL_HANG_FIXTURE = `#!/bin/sh
+printf '%s\\n' "$@" > "$TAILSCALE_ARGS_LOG"
+exec sleep 30
+`;
+
+// The daemon still records the rejected RegisterReq in its private log. Include
+// the raw URL too so the test proves classification does not copy it into the
+// container's stderr logs.
+function tailscaledAuthUrlFixture(socketPath: string): string {
+  return `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    --socket=*) socket="\${arg#--socket=}" ;;
+  esac
+done
+: "\${socket:=${socketPath}}"
+mkdir -p "$(dirname "$socket")"
+: > "$socket"
+sleep 0.5
+printf '%s\\n' \\
+  'RegisterReq: got response; nodeKeyExpired=false, machineAuthorized=false; authURL=true' \\
+  'AuthURL is https://headscale.example.test/register/private-node-token'
+sleep 5
+`;
+}
+
 describeIfPosix("docker entrypoint", () => {
   test("preserves port normalization and starts without tailscale when no auth key is configured", () => {
     const result = runDockerEntrypoint(
@@ -217,7 +246,9 @@ printf '%s\\n' "$@" > "$TAILSCALE_ARGS_LOG"
   testIfLinux(
     "uses the auth key when tailscaled creates fresh state before its socket",
     async () => {
-      const root = await mkdtemp(path.join(tmpdir(), "docker-entrypoint-fresh-state-"));
+      const root = await mkdtemp(
+        path.join(tmpdir(), "docker-entrypoint-fresh-state-"),
+      );
       const binDir = path.join(root, "bin");
       const stateDir = path.join(root, "state");
       const socketPath = path.join(root, "tailscaled.sock");
@@ -406,7 +437,60 @@ exit 1
   );
 
   testIfLinux(
-    "re-key hook: fetches a fresh key and retries once when the baked key is rejected",
+    "fails an interactive Headscale AuthURL promptly without starting the agent",
+    async () => {
+      const root = await mkdtemp(
+        path.join(tmpdir(), "docker-entrypoint-authurl-"),
+      );
+      const binDir = path.join(root, "bin");
+      const stateDir = path.join(root, "state");
+      const socketPath = path.join(root, "tailscaled.sock");
+      const argsLog = path.join(root, "tailscale-args.log");
+      await mkdir(binDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeExecutable(path.join(binDir, "id"), ID_ROOT_FIXTURE);
+      await writeExecutable(
+        path.join(binDir, "tailscaled"),
+        tailscaledAuthUrlFixture(socketPath),
+      );
+      await writeExecutable(
+        path.join(binDir, "tailscale"),
+        TAILSCALE_AUTH_URL_HANG_FIXTURE,
+      );
+
+      const startedAt = Date.now();
+      const result = runDockerEntrypoint(
+        {
+          PATH: `${binDir}:/usr/bin:/bin`,
+          TS_AUTHKEY: KEY_LONG_EXPIRED,
+          TS_UP_TIMEOUT_SECONDS: "5",
+          SANDBOX_AGENT_ID: "agent-authurl",
+          TS_STATE_DIR: stateDir,
+          TS_SOCKET: socketPath,
+          HEADSCALE_URL: "https://headscale.example.test",
+          TAILSCALE_ARGS_LOG: argsLog,
+        },
+        ["/bin/sh", "-c", "printf should-not-start"],
+      );
+
+      expect(Date.now() - startedAt).toBeLessThan(3_000);
+      expect(result).toMatchObject({ code: 78, stdout: "" });
+      expect(result.stderr).toContain(
+        "interactive authorization (AuthURL/NeedsLogin)",
+      );
+      expect(result.stderr).not.toContain("private-node-token");
+      expect(result.stderr).toContain("node needs re-keying");
+      await expect(
+        readFile(path.join(stateDir, "authkey-expired"), "utf8"),
+      ).resolves.toContain("hostname=agent-authurl");
+      const args = await readFile(argsLog, "utf8");
+      expect(args).toContain("--json");
+      expect(args).toContain("--timeout=5s");
+    },
+  );
+
+  testIfLinux(
+    "re-key hook: retries a rejected AuthURL join without reusing stale daemon evidence",
     async () => {
       const root = await mkdtemp(
         path.join(tmpdir(), "docker-entrypoint-rekey-"),
@@ -421,10 +505,10 @@ exit 1
       await writeExecutable(path.join(binDir, "id"), ID_ROOT_FIXTURE);
       await writeExecutable(
         path.join(binDir, "tailscaled"),
-        tailscaledFixture(socketPath),
+        tailscaledAuthUrlFixture(socketPath),
       );
-      // First `up` (baked key) -> auth expired; second `up` (fresh key) -> ok.
-      // A counter file distinguishes the two invocations.
+      // First `up` (baked key) blocks while the daemon reports AuthURL; the
+      // second `up` (fresh key) succeeds. A counter distinguishes the calls.
       await writeExecutable(
         path.join(binDir, "tailscale"),
         `#!/bin/sh
@@ -435,8 +519,7 @@ n=0
 n=$((n + 1))
 printf '%s' "$n" > "$count_file"
 if [ "$n" -eq 1 ]; then
-  echo "Received error: authkey expired" >&2
-  exit 1
+  exec sleep 30
 fi
 exit 0
 `,
@@ -467,6 +550,7 @@ exit 0
 
       expect(result.code).toBe(0);
       expect(result.stdout).toBe("app-started");
+      expect(result.stderr).not.toContain("private-node-token");
       const args = await readFile(argsLog, "utf8");
       expect(args).toContain(`--auth-key=${KEY_LONG_EXPIRED}`);
       expect(args).toContain(`--auth-key=${KEY_FRESH_FROM_HOOK}`);
@@ -581,7 +665,9 @@ exec "$@"
   testIfLinux(
     "uses the auth key when tailscaled creates fresh state before its socket",
     async () => {
-      const root = await mkdtemp(path.join(tmpdir(), "cloud-entrypoint-fresh-state-"));
+      const root = await mkdtemp(
+        path.join(tmpdir(), "cloud-entrypoint-fresh-state-"),
+      );
       const binDir = path.join(root, "bin");
       const stateDir = path.join(root, "state");
       const socketPath = path.join(root, "tailscaled.sock");
@@ -624,6 +710,59 @@ exec "$@"
       const args = await readFile(argsLog, "utf8");
       expect(args.match(/^up$/gm)).toHaveLength(1);
       expect(args).toContain(`--auth-key=${KEY_CLOUD_TEST}`);
+    },
+  );
+
+  testIfLinux(
+    "fails an interactive Headscale AuthURL before privilege drop or app startup",
+    async () => {
+      const root = await mkdtemp(
+        path.join(tmpdir(), "cloud-entrypoint-authurl-"),
+      );
+      const binDir = path.join(root, "bin");
+      const stateDir = path.join(root, "state");
+      const socketPath = path.join(root, "tailscaled.sock");
+      const argsLog = path.join(root, "tailscale-args.log");
+      await mkdir(binDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeExecutable(path.join(binDir, "id"), ID_ROOT_FIXTURE);
+      await writeExecutable(
+        path.join(binDir, "tailscaled"),
+        tailscaledAuthUrlFixture(socketPath),
+      );
+      await writeExecutable(
+        path.join(binDir, "tailscale"),
+        TAILSCALE_AUTH_URL_HANG_FIXTURE,
+      );
+
+      const startedAt = Date.now();
+      const result = runEntrypoint(
+        {
+          PATH: `${binDir}:/usr/bin:/bin`,
+          TS_AUTHKEY: KEY_LONG_EXPIRED,
+          TS_UP_TIMEOUT_SECONDS: "5",
+          SANDBOX_AGENT_ID: "agent-cloud-authurl",
+          TS_STATE_DIR: stateDir,
+          TS_SOCKET: socketPath,
+          HEADSCALE_URL: "https://headscale.example.test",
+          TAILSCALE_ARGS_LOG: argsLog,
+        },
+        ["/bin/sh", "-c", "printf should-not-start"],
+      );
+
+      expect(Date.now() - startedAt).toBeLessThan(3_000);
+      expect(result).toMatchObject({ code: 78, stdout: "" });
+      expect(result.stderr).toContain(
+        "interactive authorization (AuthURL/NeedsLogin)",
+      );
+      expect(result.stderr).not.toContain("private-node-token");
+      expect(result.stderr).toContain("node needs re-keying");
+      await expect(
+        readFile(path.join(stateDir, "authkey-expired"), "utf8"),
+      ).resolves.toContain("hostname=agent-cloud-authurl");
+      const args = await readFile(argsLog, "utf8");
+      expect(args).toContain("--json");
+      expect(args).toContain("--timeout=5s");
     },
   );
 });

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts
@@ -1,0 +1,38 @@
+/** Exercises early Docker mesh-join classification with deterministic evidence. */
+import { describe, expect, test } from "bun:test";
+import { classifyDockerMeshJoinProbe } from "./docker-sandbox-provider";
+
+describe("classifyDockerMeshJoinProbe", () => {
+  test("terminates a running candidate that entered interactive Headscale auth", () => {
+    expect(
+      classifyDockerMeshJoinProbe(`state=running exit=0
+{
+  "AuthURL": "https://headscale.example.test/register/test-node",
+  "BackendState": "NeedsLogin"
+}`),
+    ).toEqual({
+      status: "terminal",
+      reason: "auth_required",
+      containerState: "running",
+      exitCode: 0,
+    });
+  });
+
+  test("keeps ordinary running and restarting candidates pending", () => {
+    expect(
+      classifyDockerMeshJoinProbe("state=running exit=0\ncontrol: waiting for network map"),
+    ).toEqual({ status: "pending" });
+    expect(
+      classifyDockerMeshJoinProbe("state=restarting exit=1\ncontrol: temporary dial timeout"),
+    ).toEqual({ status: "pending" });
+  });
+
+  test("terminates an exited candidate without requiring auth-specific logs", () => {
+    expect(classifyDockerMeshJoinProbe("state=exited exit=137\nOOMKilled")).toEqual({
+      status: "terminal",
+      reason: "container_exited",
+      containerState: "exited",
+      exitCode: 137,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts
@@ -3,20 +3,44 @@ import { describe, expect, test } from "bun:test";
 import { classifyDockerMeshJoinProbe } from "./docker-sandbox-provider";
 
 describe("classifyDockerMeshJoinProbe", () => {
-  test("terminates a running candidate that entered interactive Headscale auth", () => {
-    expect(
-      classifyDockerMeshJoinProbe(`state=running exit=0
-{
-  "AuthURL": "https://headscale.example.test/register/test-node",
-  "BackendState": "NeedsLogin"
-}`),
-    ).toEqual({
+  test.each([
+    "[docker-entrypoint] tailscale requires interactive authorization (AuthURL/NeedsLogin); unattended mesh join rejected",
+    "[cloud-agent-entrypoint] FATAL: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying",
+  ])("terminates a running candidate on its entrypoint-owned Headscale auth signal", (line) => {
+    expect(classifyDockerMeshJoinProbe(`state=running exit=0\n${line}`)).toEqual({
       status: "terminal",
       reason: "auth_required",
       containerState: "running",
       exitCode: 0,
     });
   });
+
+  test("terminates a running candidate on the entrypoint-owned marker", () => {
+    expect(classifyDockerMeshJoinProbe("state=running exit=0\nauthkey-marker=present")).toEqual({
+      status: "terminal",
+      reason: "auth_required",
+      containerState: "running",
+      exitCode: 0,
+    });
+  });
+
+  test("terminates a restarting candidate on the dedicated entrypoint exit code", () => {
+    expect(classifyDockerMeshJoinProbe("state=restarting exit=78")).toEqual({
+      status: "terminal",
+      reason: "auth_required",
+      containerState: "restarting",
+      exitCode: 78,
+    });
+  });
+
+  test.each(["plugin-openai: invalid key", "database: key expired", "interactive authorization"])(
+    "keeps a healthy running candidate pending when app logs contain %s",
+    (appLog) => {
+      expect(classifyDockerMeshJoinProbe(`state=running exit=0\n${appLog}`)).toEqual({
+        status: "pending",
+      });
+    },
+  );
 
   test("keeps ordinary running and restarting candidates pending", () => {
     expect(

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -965,6 +965,77 @@ export const PULL_TIMEOUT_MS = 300_000; // 5 min
 /** SSH command timeout for docker run / stop / rm. */
 const DOCKER_CMD_TIMEOUT_MS = 60_000;
 
+/** Bound each inline probe so transport loss cannot replace the 180s VPN budget. */
+const MESH_JOIN_PROBE_TIMEOUT_MS = 5_000;
+
+export type DockerMeshJoinProbeVerdict =
+  | { readonly status: "pending" }
+  | {
+      readonly status: "terminal";
+      readonly reason: "auth_required" | "container_exited";
+      readonly containerState: string | null;
+      readonly exitCode: number | null;
+    };
+
+/**
+ * Classify the bounded, secret-free Docker evidence collected while Headscale
+ * registration is pending. Only an explicit interactive/auth rejection or a
+ * terminal Docker state can abort the normal slow-join budget.
+ */
+export function classifyDockerMeshJoinProbe(output: string): DockerMeshJoinProbeVerdict {
+  const stateMatch = /^state=(\S+) exit=(-?\d+)$/m.exec(output);
+  const containerState = stateMatch?.[1] ?? null;
+  const exitCode = stateMatch ? Number.parseInt(stateMatch[2]!, 10) : null;
+  if (classifyMeshAuthStatus({ exitCode, logs: output }) === "auth_expired") {
+    return { status: "terminal", reason: "auth_required", containerState, exitCode };
+  }
+  if (containerState === "exited" || containerState === "dead") {
+    return { status: "terminal", reason: "container_exited", containerState, exitCode };
+  }
+  return { status: "pending" };
+}
+
+async function probeDockerMeshJoinTerminalFailure(
+  ssh: DockerSSHClient,
+  containerId: string,
+): Promise<Error | null> {
+  let output: string;
+  try {
+    output = await ssh.exec(
+      [
+        `docker inspect --format 'state={{.State.Status}} exit={{.State.ExitCode}}' ${shellQuote(containerId)} 2>/dev/null`,
+        `docker logs --tail 80 ${shellQuote(containerId)} 2>&1 || true`,
+      ].join("; "),
+      MESH_JOIN_PROBE_TIMEOUT_MS,
+    );
+  } catch (error) {
+    // error-policy:J1 This is an early transport observation, not the
+    // authoritative registration verdict. Preserve the normal Headscale
+    // budget unless Docker returned positive terminal evidence.
+    logger.debug(
+      "[docker-sandbox] Early mesh-join probe unavailable; registration remains pending",
+      {
+        containerId,
+        failureKind: classifyDockerSshProbeError(error),
+      },
+    );
+    return null;
+  }
+
+  const verdict = classifyDockerMeshJoinProbe(output);
+  if (verdict.status === "pending") return null;
+  return new ElizaError("Docker candidate cannot complete required Headscale registration", {
+    code: "SANDBOX_MESH_JOIN_TERMINAL",
+    context: {
+      containerId,
+      reason: verdict.reason,
+      containerState: verdict.containerState,
+      exitCode: verdict.exitCode,
+    },
+    severity: "ephemeral",
+  });
+}
+
 /**
  * Dedicated, tighter SSH timeout for the stop/rm calls on the delete path.
  * `docker stop` uses its own `-t 10` grace, so 25s caps the whole stop path
@@ -2724,6 +2795,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         // inferTailscaleHostname), NOT the bare agentId — Headscale only knows the
         // node by that hostname, so polling by agentId never matched and the node
         // "timed out" registering despite being online.
+        const meshJoinCandidateId = createdContainerId;
         let registration = await headscaleIntegration.waitForVPNRegistration(
           vpnEnvVars.TS_HOSTNAME ?? agentId,
           // 180s default (env-overridable via VPN_REGISTRATION_TIMEOUT_MS), not
@@ -2732,10 +2804,23 @@ export class DockerSandboxProvider implements SandboxProvider {
           // → 404 despite running. Single source of truth lives in
           // headscale-integration so the constant and this call agree.
           DEFAULT_REGISTRATION_TIMEOUT_MS,
-          // During a blue/green overlap the preserved live node shares this
-          // hostname — matching it would route the new sandbox to the OLD
-          // container, the race the reclaim-mode deletion used to guard (#16565).
-          previousVpnNodeId ? { excludeNodeId: previousVpnNodeId } : undefined,
+          {
+            // During a blue/green overlap the preserved live node shares this
+            // hostname — matching it would route the new sandbox to the OLD
+            // container, the race the reclaim-mode deletion used to guard (#16565).
+            ...(previousVpnNodeId ? { excludeNodeId: previousVpnNodeId } : {}),
+            // The entrypoint is mesh-first, so app readiness cannot make
+            // progress after an interactive AuthURL or terminal container exit.
+            // Await this probe inside the registration loop: exact-success
+            // cleanup can then retire the failed candidate and mint a new key
+            // without blindly burning the remaining 180s registration budget.
+            ...(meshJoinCandidateId
+              ? {
+                  probeTerminalCandidateFailure: () =>
+                    probeDockerMeshJoinTerminalFailure(ssh, meshJoinCandidateId),
+                }
+              : {}),
+          },
         );
         if (registration && remoteCompletionTracker) {
           try {

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -977,16 +977,38 @@ export type DockerMeshJoinProbeVerdict =
       readonly exitCode: number | null;
     };
 
+const ENTRYPOINT_MESH_AUTH_TERMINAL_PREFIXES: readonly string[] = [
+  "[docker-entrypoint] tailscale requires interactive authorization (authurl/needslogin);",
+  "[cloud-agent-entrypoint] tailscale requires interactive authorization (authurl/needslogin);",
+  "[docker-entrypoint] fatal: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying",
+  "[cloud-agent-entrypoint] fatal: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying",
+];
+
+function hasEntrypointMeshAuthTerminalEvidence(output: string): boolean {
+  return output
+    .toLowerCase()
+    .split(/\r?\n/)
+    .some((line) =>
+      ENTRYPOINT_MESH_AUTH_TERMINAL_PREFIXES.some((prefix) => line.startsWith(prefix)),
+    );
+}
+
 /**
  * Classify the bounded, secret-free Docker evidence collected while Headscale
- * registration is pending. Only an explicit interactive/auth rejection or a
- * terminal Docker state can abort the normal slow-join budget.
+ * registration is pending. Early admission deliberately accepts only the
+ * entrypoint-owned marker/prefix or exit 78 as auth evidence: once Tailscale is
+ * running, ordinary app/plugin logs share `docker logs` and may contain broad
+ * phrases such as "invalid key" that must not tear down a healthy candidate.
  */
 export function classifyDockerMeshJoinProbe(output: string): DockerMeshJoinProbeVerdict {
   const stateMatch = /^state=(\S+) exit=(-?\d+)$/m.exec(output);
   const containerState = stateMatch?.[1] ?? null;
   const exitCode = stateMatch ? Number.parseInt(stateMatch[2]!, 10) : null;
-  if (classifyMeshAuthStatus({ exitCode, logs: output }) === "auth_expired") {
+  if (
+    exitCode === TS_AUTHKEY_EXPIRED_EXIT_CODE ||
+    /^authkey-marker=present$/m.test(output) ||
+    hasEntrypointMeshAuthTerminalEvidence(output)
+  ) {
     return { status: "terminal", reason: "auth_required", containerState, exitCode };
   }
   if (containerState === "exited" || containerState === "dead") {
@@ -1004,6 +1026,7 @@ async function probeDockerMeshJoinTerminalFailure(
     output = await ssh.exec(
       [
         `docker inspect --format 'state={{.State.Status}} exit={{.State.ExitCode}}' ${shellQuote(containerId)} 2>/dev/null`,
+        `docker exec ${shellQuote(containerId)} sh -c 'test -f "\${TS_STATE_DIR:-/var/lib/tailscale}/${TS_AUTHKEY_EXPIRED_MARKER_BASENAME}" && echo authkey-marker=present || echo authkey-marker=absent' 2>/dev/null || echo authkey-marker=unknown`,
         `docker logs --tail 80 ${shellQuote(containerId)} 2>&1 || true`,
       ].join("; "),
       MESH_JOIN_PROBE_TIMEOUT_MS,

--- a/packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts
@@ -36,6 +36,9 @@ describe("classifyMeshAuthStatus", () => {
     "The last login error was: authkey expired",
     "authkey already used",
     "invalid key",
+    '{"AuthURL":"https://headscale.example/register/node","BackendState":"NeedsLogin"}',
+    '{"BackendState":"NeedsMachineAuth"}',
+    "RegisterReq: machineAuthorized=false; authURL=true",
     "FATAL: ... node needs re-keying",
   ])("flags auth-failure log phrasing: %s", (line) => {
     expect(classifyMeshAuthStatus({ logs: `boot\n${line}\nmore` })).toBe("auth_expired");
@@ -55,6 +58,12 @@ describe("classifyMeshAuthStatus", () => {
   it("does not treat a benign 'key' mention without a failure phrase as expired", () => {
     // Guards against over-broad matching: 'JWT_SECRET key loaded' must not trip.
     expect(classifyMeshAuthStatus({ logs: "loaded signing key ok" })).toBe("unknown");
+  });
+
+  it("does not treat an empty AuthURL in an ordinary status payload as interactive auth", () => {
+    expect(classifyMeshAuthStatus({ logs: '{"AuthURL":"","BackendState":"Starting"}' })).toBe(
+      "unknown",
+    );
   });
 
   it("prefers positive evidence: marker present wins even with exitCode 0", () => {

--- a/packages/cloud/shared/src/lib/services/headscale-auth-status.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-auth-status.ts
@@ -50,6 +50,19 @@ const AUTH_EXPIRED_LOG_PATTERNS: readonly string[] = [
   "invalid key",
   "invalid authkey",
   "invalid auth key",
+  // Tailscale 1.90 CLI JSON and daemon RegisterReq logs expose these when
+  // Headscale declines unattended pre-auth and requires interactive login.
+  '"authurl": "http',
+  '"authurl":"http',
+  "authurl=true",
+  "authurl is http",
+  '"backendstate": "needslogin"',
+  '"backendstate":"needslogin"',
+  '"backendstate": "needsmachineauth"',
+  '"backendstate":"needsmachineauth"',
+  "machineauthorized=false",
+  '"machineauthorized":false',
+  "interactive authorization",
   // The distinct FATAL line the entrypoint prints before exiting 78.
   "node needs re-keying",
 ];

--- a/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
@@ -257,6 +257,66 @@ describe("Headscale node lookup is keyed on the node name (not the agentId)", ()
     expect(nodeName).not.toBe("11111111-1111-4111-8111-111111111111");
   });
 
+  test("waitForVPNRegistration aborts immediately on a proven terminal candidate", async () => {
+    let lookups = 0;
+    let probes = 0;
+    const fake = {
+      getNodeByNameOrSuffixed: async () => {
+        lookups += 1;
+        return null;
+      },
+    } as unknown as HeadscaleClient;
+
+    await expect(
+      new HeadscaleIntegration(fake).waitForVPNRegistration(nodeName, 5_000, {
+        probeTerminalCandidateFailure: async () => {
+          probes += 1;
+          return new Error("candidate requires interactive Headscale authorization");
+        },
+      }),
+    ).rejects.toThrow("candidate requires interactive Headscale authorization");
+    expect(lookups).toBe(1);
+    expect(probes).toBe(1);
+  });
+
+  test("waitForVPNRegistration preserves the normal budget while the candidate is pending", async () => {
+    let probes = 0;
+    const fake = {
+      getNodeByNameOrSuffixed: async () => null,
+    } as unknown as HeadscaleClient;
+
+    await expect(
+      new HeadscaleIntegration(fake).waitForVPNRegistration(nodeName, 25, {
+        probeTerminalCandidateFailure: async () => {
+          probes += 1;
+          return null;
+        },
+      }),
+    ).resolves.toBeNull();
+    expect(probes).toBeGreaterThanOrEqual(1);
+  });
+
+  test("waitForVPNRegistration returns a routed IP before consulting the terminal probe", async () => {
+    let probes = 0;
+    const fake = {
+      getNodeByNameOrSuffixed: async (name: string) => ({
+        id: "73",
+        name,
+        ipAddresses: ["100.64.0.73"],
+      }),
+    } as unknown as HeadscaleClient;
+
+    await expect(
+      new HeadscaleIntegration(fake).waitForVPNRegistration(nodeName, 1_000, {
+        probeTerminalCandidateFailure: async () => {
+          probes += 1;
+          return new Error("must not override a successful registration");
+        },
+      }),
+    ).resolves.toMatchObject({ ip: "100.64.0.73", nodeId: "73" });
+    expect(probes).toBe(0);
+  });
+
   test("waitForVPNRegistration rejects malformed runtime node identity", async () => {
     for (const malformedNode of [
       { id: "", name: nodeName, ipAddresses: ["100.64.0.7"] },

--- a/packages/cloud/shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.ts
@@ -278,6 +278,13 @@ export class HeadscaleIntegration {
        *  accepting its IP would route the new sandbox to the old container —
        *  the exact race the reclaim-mode deletion used to guard against. */
       excludeNodeId?: string;
+      /**
+       * Inspect the exact Docker candidate after a Headscale miss. Returning
+       * an error proves that candidate cannot register and aborts immediately;
+       * `null` means it is still pending. The probe is awaited inline, so no
+       * detached poll can outlive a successful registration or its cleanup.
+       */
+      probeTerminalCandidateFailure?: () => Promise<Error | null>;
     },
   ): Promise<HeadscaleVpnRegistration | null> {
     logger.info(
@@ -355,6 +362,11 @@ export class HeadscaleIntegration {
         }
         // Transient errors (network, timeout) — keep polling
         logger.debug(`[headscale-integration] Poll error for ${nodeName}: ${msg}`);
+      }
+
+      const terminalCandidateFailure = await options?.probeTerminalCandidateFailure?.();
+      if (terminalCandidateFailure) {
+        throw terminalCandidateFailure;
       }
 
       // Exponential backoff with jitter to avoid thundering-herd on


### PR DESCRIPTION
# Relates to

Closes #29675.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated host-toolchain failure is recorded below.
- [x] Focused automated evidence below exercises the blocked join, pending join, and successful routed-IP paths.

# Sync with develop

- [x] Rebased onto `origin/develop` at `6fcead95d04740d71618e4eaf064f88adf66287e`; zero conflicts.
- [x] Focused affected-path checks pass. Full `bun run verify` reached 225/227 tasks and stopped only at the unrelated macOS Swift SDK/compiler mismatch documented below.

# Risks

Medium. This changes managed sandbox mesh admission and its provisioning-time observation. It remains fail-closed: the app still cannot start without a routed Tailscale IP. Terminal classification is limited to an explicit Headscale interactive-auth/NeedsLogin condition, the entrypoint's dedicated exit 78 marker, or a terminal container state. Generic slow/running joins remain pending for the existing registration budget.

# Background

## What does this PR do?

The pinned Tailscale CLI has an unbounded default timeout. When Headscale returns a non-authorized registration that requires interactive authorization, `tailscale up --auth-key` can stay blocked forever, leaving the mesh-first entrypoint alive while the app never starts. Because the provider previously polled only Headscale registration for the full budget, retry/cleanup could not reject that candidate promptly.

This patch:

- bounds the entrypoint join with a configurable 120-second default while watching current-attempt CLI and tailscaled evidence for explicit interactive-auth/NeedsLogin states;
- terminates that blocked join promptly, redacts authorization URLs, preserves the existing rekey hook, and exits with the existing fail-closed mesh marker instead of starting the app;
- adds a cancellation-safe provider-side probe after each Headscale miss so a terminal container or explicit mesh-auth failure rejects immediately, while transport failures and ordinary running state continue polling;
- preserves success precedence: a canonical routed IP still wins before the failure probe;
- leaves the existing reusable preauth-key policy unchanged.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed. The operational behavior and image/deployment path are documented below.

# Testing

## Where should a reviewer start?

Start with `packages/app-core/scripts/docker-entrypoint.test.ts` and `packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts`, then inspect the narrow callback added to `waitForVPNRegistration`.

## Detailed testing steps

- Forced-Linux entrypoint Vitest suite: **12 passed, 0 failed**. It proves a silent blocked CLI is bounded, a current-attempt `machineAuthorized=false; authURL=true` daemon response exits 78 in under three seconds without starting the app, authorization URLs are not emitted, and stale daemon evidence cannot poison a fresh-key retry.
- `bun --config=/dev/null test --reporter=dots packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts packages/cloud/shared/src/lib/services/headscale-integration.test.ts packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts`: **51 passed, 0 failed, 107 assertions**.
- `bun run typecheck` in `packages/cloud/shared`: **passed**.
- Biome checks for all seven touched TypeScript files: **passed**.
- `sh -n packages/app-core/scripts/docker-entrypoint.sh packages/app-core/deploy/cloud-agent-docker-entrypoint.sh`: **passed**.
- `git diff --check`: **passed**.

# Evidence Gate

<!-- evidence-head:55c114fce4d5cbadba5796f88e27ac884f6076e7 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend-only shell and provisioning-service change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend-only shell and provisioning-service change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive or rendered user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: sanitized staging evidence and deterministic exact-path test receipts are included below; no credentials, raw environment, or authorization URL is included.

<details><summary>Sanitized backend reproduction and focused receipt</summary>

```text
before: Headscale registration response reported machineAuthorized=false and interactive authorization required
before: container retained only entrypoint/tailscaled/tailscale processes; no app process and no routed mesh IP
after: forced-Linux entrypoint suite 12/12 passed; cloud mesh classifier/integration/probe suites 51/51 passed
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend request, response, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, action, provider, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no DB, memory, task, wallet, file-generation, audio, or other domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this is sandbox mesh admission and provisioning control flow only.

## Backend + frontend logs

Sanitized staging reproduction before the fix:

```text
Headscale registration response: machineAuthorized=false; authURL=true
Container process state: entrypoint + tailscaled + blocked tailscale up; no app process; no routed IP
```

The focused entrypoint test injects the same terminal daemon state and asserts sanitized exit 78, no app launch, and no authorization URL in output. The provider tests assert immediate rejection for explicit auth failure and terminal exit, continued polling for ordinary pending state, and successful routed-IP precedence.

Frontend logs: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change with no rendered UI.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- Full `bun run verify` on macOS completed **225 of 227 tasks** and then failed in untouched `@elizaos/plugin-computeruse#build`: the installed Apple Swift compiler and macOS SDK have different patch versions, causing `SwiftBridging` module redefinition/SDK compatibility errors. None of this PR's paths are in that package. All focused affected-path tests, cloud typecheck, TypeScript formatting/lint, shell syntax, and diff checks pass.
- `packages/app-core` tests require a Linux entrypoint environment; they were run through the forced-Linux Vitest harness described above and passed 12/12.

## Maintainer CI exception record

N/A - no exception requested.

# Deploy notes

No deployment or merge was performed. Production is untouched.

After merge, both halves must ship:

1. Run the canonical **Build Agent Image** workflow for the exact merged SHA. It builds `packages/app-core/deploy/Dockerfile.ci`, includes `packages/app-core/scripts/docker-entrypoint.sh`, runs the boot verification, and publishes the exact `ghcr.io/elizaos/eliza:sha-<short>` image plus digest/attestation.
2. Point staging's effective managed-sandbox image setting (`ELIZA_AGENT_IMAGE`/candidate pin) at that exact image digest or SHA tag; publishing alone does not replace an explicit staging pin.
3. Deploy the provisioning worker from the exact merged SHA so the provider-side early failure probe is active.

`Dockerfile.cloud-agent` remains behaviorally aligned for the subordinate cloud-agent image path, but the managed staging sandbox uses `Dockerfile.ci`.