### PR TITLE
fix(plugin-inbox): honor RFC 8058 one-click when List-Unsubscribe carries both mailto and https

### DIFF
--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -116,12 +116,20 @@ function unsubscribeMethod(args: {
   listUnsubscribePost: string | null;
 }): EmailSubscriptionSender["unsubscribeMethod"] {
   const options = listUnsubscribeOptions(args.listUnsubscribe);
-  if (options.mailto) return "mailto";
-  if (!options.httpUrl) return "manual_only";
-  if (/one-click/i.test(args.listUnsubscribePost ?? "")) {
-    return "http_one_click";
+  // Classification must mirror the executor's HTTP-first preference in
+  // `unsubscribeEmailSender` (it dispatches `unsubscribeHttpUrl` before
+  // `unsubscribeMailto`). RFC 8058 §2 recommends senders publish BOTH a
+  // mailto and an https target with `List-Unsubscribe-Post:
+  // List-Unsubscribe=One-Click`; classifying that common case as "mailto"
+  // desynced the summary and the recorded method from the request actually
+  // sent, firing an HTTP GET instead of the required one-click POST.
+  if (options.httpUrl) {
+    return /one-click/i.test(args.listUnsubscribePost ?? "")
+      ? "http_one_click"
+      : "http_get";
   }
-  return "http_get";
+  if (options.mailto) return "mailto";
+  return "manual_only";
 }
 
 function parseMailtoUnsubscribe(value: string): {

--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -117,6 +117,22 @@ function listUnsubscribeOptions(value: string | null): {
   return { httpUrl: httpsUrl ?? httpUrl, mailto };
 }
 
+function isOneClickPost(value: string | null): boolean {
+  if (!value) return false;
+  // RFC 8058 §2 fixes the `List-Unsubscribe-Post` header field to the single
+  // key/value pair `List-Unsubscribe=One-Click`. Parse the normalized value as
+  // that exact pair instead of substring-matching `one-click`, so a malformed
+  // marker such as `List-Unsubscribe=Not-One-Click` (or any header that merely
+  // contains the token) cannot promote an untrusted sender to a state-changing
+  // POST with a fabricated one-click body.
+  const pair = value.trim();
+  const eq = pair.indexOf("=");
+  if (eq < 0) return false;
+  const key = pair.slice(0, eq).trim();
+  const val = pair.slice(eq + 1).trim();
+  return /^List-Unsubscribe$/i.test(key) && /^One-Click$/i.test(val);
+}
+
 function unsubscribeMethod(args: {
   listUnsubscribe: string | null;
   listUnsubscribePost: string | null;
@@ -135,7 +151,7 @@ function unsubscribeMethod(args: {
     // RFC 8058 §2 mandates an https URI for one-click. A cleartext http target
     // is downgraded to an HTTP GET so unsubscribe credentials are never POSTed
     // over an unencrypted transport.
-    return /one-click/i.test(args.listUnsubscribePost ?? "") &&
+    return isOneClickPost(args.listUnsubscribePost) &&
       /^https:\/\//i.test(options.httpUrl)
       ? "http_one_click"
       : "http_get";

--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -98,17 +98,23 @@ function listUnsubscribeOptions(value: string | null): {
   httpUrl: string | null;
   mailto: string | null;
 } {
+  let httpsUrl: string | null = null;
   let httpUrl: string | null = null;
   let mailto: string | null = null;
   for (const entry of listUnsubscribeEntries(value)) {
-    if (!httpUrl && /^https?:\/\//i.test(entry)) {
+    if (!httpsUrl && /^https:\/\//i.test(entry)) {
+      httpsUrl = entry;
+    } else if (!httpUrl && /^http:\/\//i.test(entry)) {
       httpUrl = entry;
     }
     if (!mailto && /^mailto:/i.test(entry)) {
       mailto = entry;
     }
   }
-  return { httpUrl, mailto };
+  // RFC 8058 §2 requires an https target for the one-click POST, so prefer a
+  // compliant https entry over a cleartext http one when a sender publishes
+  // both; the executor then dispatches to the secure URL.
+  return { httpUrl: httpsUrl ?? httpUrl, mailto };
 }
 
 function unsubscribeMethod(args: {
@@ -122,9 +128,15 @@ function unsubscribeMethod(args: {
   // mailto and an https target with `List-Unsubscribe-Post:
   // List-Unsubscribe=One-Click`; classifying that common case as "mailto"
   // desynced the summary and the recorded method from the request actually
-  // sent, firing an HTTP GET instead of the required one-click POST.
+  // sent, firing an HTTP GET instead of the required one-click POST. Any http
+  // target (including cleartext) still routes through an HTTP method so the
+  // summary never disagrees with the executor's URL-first dispatch.
   if (options.httpUrl) {
-    return /one-click/i.test(args.listUnsubscribePost ?? "")
+    // RFC 8058 §2 mandates an https URI for one-click. A cleartext http target
+    // is downgraded to an HTTP GET so unsubscribe credentials are never POSTed
+    // over an unencrypted transport.
+    return /one-click/i.test(args.listUnsubscribePost ?? "") &&
+      /^https:\/\//i.test(options.httpUrl)
       ? "http_one_click"
       : "http_get";
   }

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -357,6 +357,35 @@ describe("InboxUnsubscribeService", () => {
       expect(result.summary.mailtoOnlyCount).toBe(0);
     });
 
+    it("downgrades a malformed one-click marker to http_get (RFC 8058 exact key/value)", async () => {
+      // RFC 8058 §2 fixes `List-Unsubscribe-Post` to the exact pair
+      // `List-Unsubscribe=One-Click`. A substring match on `one-click` would
+      // promote a sender whose header only CONTAINS the token — e.g.
+      // `List-Unsubscribe=Not-One-Click` — to a state-changing one-click POST
+      // with a fabricated canonical body. The classifier must reject the
+      // malformed marker and stay an HTTP GET.
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <https://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=Not-One-Click",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+      expect(brand?.unsubscribeMethod).toBe("http_get");
+      expect(result.summary.oneClickEligibleCount).toBe(0);
+    });
+
     it("falls back to manual_only when no List-Unsubscribe header is present", async () => {
       const gateway = makeGateway({
         messages: [gmailMessage({ id: "m1", fromEmail: "x@y.com" })],
@@ -543,6 +572,45 @@ describe("InboxUnsubscribeService", () => {
       expect(record.status).toBe("succeeded");
       expect(record.httpStatusCode).toBe(200);
       expect(records).toHaveLength(1);
+    });
+
+    it("fires an HTTP GET (not POST) for a malformed one-click marker", async () => {
+      // Executor-level regression for the malformed-marker finding: a header
+      // that merely contains `one-click` (here `List-Unsubscribe=Not-One-Click`)
+      // must not reach the state-changing POST branch. The wire request stays a
+      // GET with no fabricated one-click body, and the record reflects that.
+      const tracked = trackedResponse(200);
+      let observedMethod: string | undefined;
+      let observedBody: string | undefined;
+      fetchSpy.mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          observedMethod = init?.method;
+          observedBody = typeof init?.body === "string" ? init.body : undefined;
+          return tracked.response;
+        },
+      );
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <https://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=Not-One-Click",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "news@brand.com",
+        userAuthorization: true,
+      });
+
+      expect(observedMethod).toBe("GET");
+      expect(observedBody).toBeUndefined();
+      expect(record.method).toBe("http_get");
+      expect(record.status).toBe("succeeded");
     });
 
     it("fires an HTTP GET for a mailto+https sender without a one-click post", async () => {

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -277,6 +277,63 @@ describe("InboxUnsubscribeService", () => {
       expect(result.summary.mailtoOnlyCount).toBe(0);
     });
 
+    it("downgrades a mailto+cleartext-http one-click sender to http_get (RFC 8058 https-only)", async () => {
+      // RFC 8058 §2 mandates an https URI for the one-click POST. A cleartext
+      // http target with a one-click post header must NOT be classified
+      // http_one_click; it stays an HTTP GET so unsubscribe credentials are
+      // never POSTed over an unencrypted transport, while still agreeing with
+      // the executor's URL-first dispatch (never "mailto").
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <http://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+      expect(brand?.unsubscribeMethod).toBe("http_get");
+      expect(brand?.unsubscribeHttpUrl).toBe("http://brand.com/unsub");
+      expect(result.summary.oneClickEligibleCount).toBe(0);
+      expect(result.summary.mailtoOnlyCount).toBe(0);
+    });
+
+    it("prefers the https target over a cleartext http one for one-click", async () => {
+      // When a sender lists both an http and an https unsubscribe URL, the
+      // https entry must win so the one-click POST goes to the compliant
+      // secure target regardless of header order.
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<http://brand.com/unsub>, <https://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+      expect(brand?.unsubscribeMethod).toBe("http_one_click");
+      expect(brand?.unsubscribeHttpUrl).toBe("https://brand.com/unsub");
+      expect(result.summary.oneClickEligibleCount).toBe(1);
+    });
+
     it("classifies a mailto+https sender WITHOUT a one-click post as http_get", async () => {
       const gateway = makeGateway({
         messages: [

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -247,6 +247,59 @@ describe("InboxUnsubscribeService", () => {
       expect(shop?.unsubscribeMailto).toBe("mailto:unsub@shop.com");
     });
 
+    it("classifies a mailto+https+one-click sender as http_one_click (RFC 8058 §2)", async () => {
+      // RFC 8058 §2 recommends senders publish BOTH a mailto and an https URI
+      // alongside `List-Unsubscribe-Post`. The classifier must agree with the
+      // executor's HTTP-first preference, not label this common case "mailto".
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            from: "Brand News",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <https://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+      expect(brand?.unsubscribeMethod).toBe("http_one_click");
+      expect(brand?.unsubscribeHttpUrl).toBe("https://brand.com/unsub");
+      expect(brand?.unsubscribeMailto).toBe("mailto:unsub@brand.com");
+      expect(result.summary.oneClickEligibleCount).toBe(1);
+      expect(result.summary.mailtoOnlyCount).toBe(0);
+    });
+
+    it("classifies a mailto+https sender WITHOUT a one-click post as http_get", async () => {
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <https://brand.com/unsub>",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+      expect(brand?.unsubscribeMethod).toBe("http_get");
+      expect(result.summary.oneClickEligibleCount).toBe(0);
+      expect(result.summary.mailtoOnlyCount).toBe(0);
+    });
+
     it("falls back to manual_only when no List-Unsubscribe header is present", async () => {
       const gateway = makeGateway({
         messages: [gmailMessage({ id: "m1", fromEmail: "x@y.com" })],
@@ -389,6 +442,81 @@ describe("InboxUnsubscribeService", () => {
       expect(record.status).toBe("succeeded");
       expect(record.httpStatusCode).toBe(200);
       expect(tracked.cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires an RFC 8058 one-click POST for a mailto+https+one-click sender", async () => {
+      // Regression for #29677: the header carries both a mailto and an https
+      // target plus `List-Unsubscribe-Post: List-Unsubscribe=One-Click`. Before
+      // the fix the classifier returned "mailto", so the executor issued an
+      // HTTP GET (a no-op on POST-only mailer platforms) and recorded
+      // `http_get`. It must now POST with the one-click body and record
+      // `http_one_click`.
+      const tracked = trackedResponse(200);
+      let observedMethod: string | undefined;
+      let observedBody: string | undefined;
+      fetchSpy.mockImplementation(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          expect(String(input)).toBe("https://brand.com/unsub");
+          observedMethod = init?.method;
+          observedBody = typeof init?.body === "string" ? init.body : undefined;
+          return tracked.response;
+        },
+      );
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <https://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service, records } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "news@brand.com",
+        userAuthorization: true,
+      });
+
+      expect(observedMethod).toBe("POST");
+      expect(observedBody).toBe("List-Unsubscribe=One-Click");
+      expect(record.method).toBe("http_one_click");
+      expect(record.status).toBe("succeeded");
+      expect(record.httpStatusCode).toBe(200);
+      expect(records).toHaveLength(1);
+    });
+
+    it("fires an HTTP GET for a mailto+https sender without a one-click post", async () => {
+      const tracked = trackedResponse(200);
+      let observedMethod: string | undefined;
+      fetchSpy.mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          observedMethod = init?.method;
+          return tracked.response;
+        },
+      );
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe:
+              "<mailto:unsub@brand.com>, <https://brand.com/unsub>",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "news@brand.com",
+        userAuthorization: true,
+      });
+
+      expect(observedMethod).toBe("GET");
+      expect(record.method).toBe("http_get");
+      expect(record.status).toBe("succeeded");
     });
 
     it("sends a mailto unsubscribe through the Gmail gateway", async () => {


### PR DESCRIPTION
# Relates to

Closes #29677

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates run (see evidence). Root `bun run verify` not run to completion on this machine — see **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the before/after test evidence below.

# Sync with develop

- [x] Branched from and rebased onto the latest `origin/develop` (`6fcead95d0`); zero conflicts.
- [ ] `bun run verify` — not completed on this machine; owning-package typecheck, lint, and focused tests pass. See **Known gaps / failures**.

# Risks

Low. The change is confined to the `List-Unsubscribe` classifier
(`unsubscribeMethod` / `listUnsubscribeOptions` / `isOneClickPost`) in one
plugin. It re-orders classification to match what the executor already does,
requires an exact RFC 8058 `List-Unsubscribe=One-Click` marker and an `https`
target before a one-click POST, and prefers an `https` target over a cleartext
`http` one. That last preference is the one dispatch-behavior change: when a
sender publishes both a cleartext and an `https` URL, the executor now fetches
the `https` target regardless of header order (previously whichever appeared
first won) — a security improvement, not a re-route of an otherwise-reachable
sender. No schema, route, public type, or export changes. The two
previously-covered paths (mailto-only, https-only) are unchanged and remain
green.

# Background

## What does this PR do?

Fixes a classifier/executor disagreement in `InboxUnsubscribeService`
(`plugins/plugin-inbox/src/inbox/unsubscribe-service.ts`).

`unsubscribeMethod()` classified a sender as `"mailto"` whenever the
`List-Unsubscribe` header contained a `mailto:` entry — **even when the same
header also carried an `https://` URL and `List-Unsubscribe-Post:
List-Unsubscribe=One-Click`**. [RFC 8058 §2](https://www.rfc-editor.org/rfc/rfc8058#section-2)
explicitly recommends senders provide BOTH a mailto and an https URI, so this
is the common, correct-sender case.

Two contract breaks followed:

1. **Scan summary undercounted one-click eligibility** and mislabeled the method
   shown to the user as `mailto` (`oneClickEligibleCount` was 0, `mailtoOnlyCount`
   incremented).
2. **At execution `unsubscribeEmailSender` actually prefers the HTTP URL**
   (`if (sender.unsubscribeHttpUrl)` runs first) but derived `oneClick` from the
   mislabeled method, so it fired an HTTP **GET** rather than the RFC 8058
   one-click **POST** with body `List-Unsubscribe=One-Click`. Many mailer
   platforms only honor the POST, so the user is told they unsubscribed while
   the request may be a silent no-op.

The fix reorders `unsubscribeMethod()` to mirror the executor's HTTP-first
preference: when an https target is present, classify `http_one_click` (when
`List-Unsubscribe-Post` indicates one-click) else `http_get`; fall back to
`mailto` only when no https target exists; else `manual_only`. Now the summary,
the recorded `record.method`, and the request actually sent all agree.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

### Classifier/executor agreement — four header combinations

| # | `List-Unsubscribe` | `List-Unsubscribe-Post` | Classified (after) | Executor request | `record.method` |
|---|--------------------|-------------------------|--------------------|------------------|-----------------|
| a | `<mailto:unsub@brand.com>, <https://brand.com/unsub>` | `List-Unsubscribe=One-Click` | `http_one_click` | **POST** body `List-Unsubscribe=One-Click` | `http_one_click` |
| b | `<mailto:unsub@brand.com>, <https://brand.com/unsub>` | (absent) | `http_get` | GET | `http_get` |
| c | `<mailto:unsub@shop.com>` | (absent) | `mailto` | `sendMailtoUnsubscribeEmail` | `mailto` |
| d | `<https://brand.com/unsub>` | `List-Unsubscribe=One-Click` | `http_one_click` | **POST** body `List-Unsubscribe=One-Click` | `http_one_click` |

Before the fix, row (a) classified `mailto` → executor issued a **GET** (the
reported bug). Rows (c) and (d) are unchanged regression guards.

# Documentation changes needed?

No. Behavior now matches the RFC 8058 contract the package already intended; no
public API or documented behavior changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-inbox/test/unsubscribe-service.test.ts` — four added tests cover
combinations (a)–(d) at both the classifier (`scanEmailSubscriptions`) and the
executor (`unsubscribeEmailSender`) boundary, using the existing deterministic
mock `InboxGmailGateway` and the **real** SSRF-guarded transport with an
injected `fetchImpl` (the guard policy still runs).

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-inbox typecheck   # tsc --noEmit — passes
bun run --cwd plugins/plugin-inbox lint        # biome — passes
cd plugins/plugin-inbox && bunx vitest run --config ./vitest.config.ts test/unsubscribe-service.test.ts
```

# Evidence Gate

<!-- evidence-head:09b486d8fbdab56897c7d6b6b0dc8183ae71a068 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only classifier logic; no rendered UI surface changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only classifier logic; no rendered UI surface changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the changed path is a header classifier verified by unit tests.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - complete failing-BEFORE (6 failed / 17 passed, source reverted to parent `6fcead95d0`) and passing-AFTER (23 passed) `vitest` runs at head `09b486d8fb` are inline below in **Backend + frontend logs**, with per-assertion `Expected/Received` and file:line. No hosted-file attachment: `agent-cortex` has `push:false` on `elizaOS/eliza` (verified) so the `pr-evidence` release path 404s, and the only fork-contributor host the evidence gate trusts (`/user-attachments/files/…`) is mintable only through GitHub's interactive web uploader, which this headless CLI cannot drive. `check-pr-evidence.mjs` documents this fork limitation. Per repo policy evidence is inline, not committed.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a pure header-classification fix with no model call.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - a runtime capture of the persisted `EmailUnsubscribeRecord.method`, the actual dispatched HTTP verb/URL/body, and the scan-classified method for all six `List-Unsubscribe` header shapes is inline below in **Domain artifact — runtime unsubscribe classification/dispatch capture**, generated by exercising the real `InboxUnsubscribeService` against the deterministic mock gateway and the real SSRF-guarded transport at head `09b486d8fb`. Same hosting constraint as backend-logs (`agent-cortex` `push:false`; no headless route to a gate-trusted GitHub attachment host); the artifact is inlined rather than attached, per repo evidence-inline policy.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; the fix is a deterministic header classifier.`

## Backend + frontend logs

Frontend: `N/A - no frontend surface.`

Backend — failing BEFORE the fix. This run reverts **only**
`plugins/plugin-inbox/src/inbox/unsubscribe-service.ts` to its parent-commit
state (`6fcead95d0`) while keeping every committed PR test, then reruns the
identical command at head `09b486d8fb`. All six RFC 8058 cases fail exactly
where one-click / https / exact-marker classification is expected:

```bash
bunx vitest run --config ./vitest.config.ts test/unsubscribe-service.test.ts --reporter=verbose
```

<details>
<summary>vitest — before (unsubscribe-service.ts reverted to parent): 6 failed / 17 passed (23)</summary>

```
 × scanEmailSubscriptions > classifies a mailto+https+one-click sender as http_one_click (RFC 8058 §2)
   AssertionError: expected 'mailto' to be 'http_one_click'   ❯ test/unsubscribe-service.test.ts:273:40
 × scanEmailSubscriptions > classifies a mailto+https sender WITHOUT a one-click post as http_get
   AssertionError: expected 'mailto' to be 'http_get'         ❯ test/unsubscribe-service.test.ts:304:40
 × scanEmailSubscriptions > prefers the https target over a cleartext http one for one-click
   AssertionError: expected 'http://brand.com/unsub' to be 'https://brand.com/unsub'  ❯ test/unsubscribe-service.test.ts:333:41
 × scanEmailSubscriptions > downgrades a mailto+cleartext-http one-click sender to http_get (RFC 8058 https-only)
   AssertionError: expected 'mailto' to be 'http_get'         ❯ test/unsubscribe-service.test.ts:355:40
 × scanEmailSubscriptions > downgrades a malformed one-click marker to http_get (RFC 8058 exact key/value)
   AssertionError: expected 'mailto' to be 'http_get'         ❯ test/unsubscribe-service.test.ts:385:40
 × unsubscribeEmailSender execution > fires an RFC 8058 one-click POST for a mailto+https+one-click sender
   AssertionError: expected 'GET' to be 'POST'                ❯ test/unsubscribe-service.test.ts:569:30
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
 Test Files  1 failed (1)
      Tests  6 failed | 17 passed (23)
```
</details>

Backend — passing AFTER the fix. A follow-up commit (review Finding 1) also
tightens the classifier so RFC 8058 one-click requires an **https** target: a
cleartext `http://` URL with a one-click post header downgrades to an HTTP GET
instead of POSTing unsubscribe credentials in the clear, and an `https` entry is
preferred over an `http` one. A further commit (review of `39d52da`) closes the
malformed-marker finding: `List-Unsubscribe-Post` is now parsed as the **exact**
`List-Unsubscribe=One-Click` key/value pair instead of a substring match, so a
malformed value such as `List-Unsubscribe=Not-One-Click` can no longer promote a
sender to a state-changing one-click POST — it stays an HTTP GET. Two more tests
pin that behaviour (now 23 passed):

<details>
<summary>vitest — after (fixed classifier): 23 passed</summary>

```
 ✓ ...scanEmailSubscriptions > classifies a mailto+https+one-click sender as http_one_click (RFC 8058 §2) 2ms
 ✓ ...scanEmailSubscriptions > classifies a mailto+https sender WITHOUT a one-click post as http_get 1ms
 ✓ ...scanEmailSubscriptions > downgrades a mailto+cleartext-http one-click sender to http_get (RFC 8058 https-only) 1ms
 ✓ ...scanEmailSubscriptions > prefers the https target over a cleartext http one for one-click 1ms
 ✓ ...scanEmailSubscriptions > downgrades a malformed one-click marker to http_get (RFC 8058 exact key/value) 1ms
 ✓ ...unsubscribeEmailSender execution > fires an RFC 8058 one-click POST for a mailto+https+one-click sender 2ms
 ✓ ...unsubscribeEmailSender execution > fires an HTTP GET for a mailto+https sender without a one-click post 2ms
 ✓ ...unsubscribeEmailSender execution > fires an HTTP GET (not POST) for a malformed one-click marker 1ms
 ✓ ...unsubscribeEmailSender execution > sends a mailto unsubscribe through the Gmail gateway 2ms
 Test Files  1 passed (1)
      Tests  23 passed (23)
```
</details>

Typecheck + lint (owning package, exact head `09b486d8fb`):

<details>
<summary>typecheck + biome</summary>

```
$ bun run --cwd plugins/plugin-inbox typecheck
$ tsc --noEmit -p tsconfig.json      # exit 0, no output = clean
$ bunx @biomejs/biome check plugins/plugin-inbox/src/inbox/unsubscribe-service.ts plugins/plugin-inbox/test/unsubscribe-service.test.ts
Checked 2 files in 67ms. No fixes applied.   # exit 0
```
</details>

## Domain artifact — runtime unsubscribe classification/dispatch capture

Generated at head `09b486d8fb` by exercising the **real** `InboxUnsubscribeService`
(`plugins/plugin-inbox/src/inbox/unsubscribe-service.ts`) against the
deterministic mock `InboxGmailGateway` and the real SSRF-guarded transport with
an injected `fetchImpl`, across every `List-Unsubscribe` header shape. For each
shape the capture records the scan-classified method shown to the user
(`scanClassifiedMethod`), the **actual** wire request the executor dispatched
(`dispatchedHttpVerb`/`dispatchedHttpUrl`/`dispatchedHttpBody`), and the
persisted `EmailUnsubscribeRecord.method`/`recordStatus`. The three agree on
every row — the invariant this PR restores.

<details>
<summary>unsubscribe-domain-artifacts.json — 6 header shapes, classifier ↔ wire ↔ record agreement</summary>

| header shape | scanClassifiedMethod | dispatched verb | dispatched body | record.method | status |
| --- | --- | --- | --- | --- | --- |
| mailto + https + one-click post | `http_one_click` | **POST** `https://brand.com/unsub` | `List-Unsubscribe=One-Click` | `http_one_click` | succeeded |
| mailto + https, no post header | `http_get` | GET `https://brand.com/unsub` | — | `http_get` | succeeded |
| mailto + cleartext http + one-click post | `http_get` | GET `http://brand.com/unsub` | — | `http_get` | succeeded |
| mailto + https + MALFORMED post (`Not-One-Click`) | `http_get` | GET `https://brand.com/unsub` | — | `http_get` | succeeded |
| mailto only | `mailto` | — (mailto dispatched) | — | `mailto` | succeeded |
| no List-Unsubscribe header | `manual_only` | — | — | `manual_only` | blocked_no_mechanism |

```json
{
  "generatedBy": "real InboxUnsubscribeService + deterministic mock gateway + real SSRF-guarded transport (injected fetchImpl)",
  "prNumber": 29679,
  "evidenceHead": "09b486d8fbdab56897c7d6b6b0dc8183ae71a068",
  "rows": [
    { "headerShape": "mailto + https + one-click post", "scanClassifiedMethod": "http_one_click", "dispatchedHttpVerb": "POST", "dispatchedHttpUrl": "https://brand.com/unsub", "dispatchedHttpBody": "List-Unsubscribe=One-Click", "recordMethod": "http_one_click", "recordStatus": "succeeded" },
    { "headerShape": "mailto + https, no post header", "scanClassifiedMethod": "http_get", "dispatchedHttpVerb": "GET", "dispatchedHttpUrl": "https://brand.com/unsub", "dispatchedHttpBody": null, "recordMethod": "http_get", "recordStatus": "succeeded" },
    { "headerShape": "mailto + cleartext http + one-click post", "scanClassifiedMethod": "http_get", "dispatchedHttpVerb": "GET", "dispatchedHttpUrl": "http://brand.com/unsub", "dispatchedHttpBody": null, "recordMethod": "http_get", "recordStatus": "succeeded" },
    { "headerShape": "mailto + https + MALFORMED post (Not-One-Click)", "scanClassifiedMethod": "http_get", "dispatchedHttpVerb": "GET", "dispatchedHttpUrl": "https://brand.com/unsub", "dispatchedHttpBody": null, "recordMethod": "http_get", "recordStatus": "succeeded" },
    { "headerShape": "mailto only", "scanClassifiedMethod": "mailto", "dispatchedHttpVerb": null, "mailtoDispatched": true, "recordMethod": "mailto", "recordStatus": "succeeded" },
    { "headerShape": "no List-Unsubscribe header", "scanClassifiedMethod": "manual_only", "dispatchedHttpVerb": null, "recordMethod": "manual_only", "recordStatus": "blocked_no_mechanism" }
  ]
}
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - backend-only classifier fix; no rendered visual surface.`

### Before

`N/A - no UI.`

### After

`N/A - no UI.`

### Walkthrough video

`N/A - no UI flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface in this change.`

## Known gaps / failures

- Root `bun run verify` was not run to completion on this machine (long-running
  repo-wide gate). The owning package's `typecheck`, `lint`, and focused
  `unsubscribe-service.test.ts` all pass.
- The full `plugin-inbox` `test` lane has two pre-existing failures unrelated to
  this change — `src/inbox/reflection.test.ts` (emoji/surrogate handling) and
  `src/inbox/aggregate.xdm-unread.test.ts` (NaN-timestamp ordering) — that also
  fail on a clean `origin/develop` checkout (`2 failed | 236 passed` before my
  change; my change only adds passing tests). They are environment/runtime
  artifacts in unrelated files, not regressions from this PR.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@09b486d8fbdab56897c7d6b6b0dc8183ae71a068:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@09b486d8fbdab56897c7d6b6b0dc8183ae71a068:packages/skills/skills/contribute-to-eliza"} -->


