### PR TITLE
fix(cloud): fence stale container cleanup

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -849,6 +849,15 @@ jobs:
             append_environment_setting \
               "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
               PROVISIONING_JOB_LANES agent
+            # The legacy orphan reconciler classifies rowless/wrong-node
+            # containers from mutable database observations and can issue a
+            # direct `docker rm -f`. Until its authority includes the live
+            # generation's immutable container id + attempt, deploys must
+            # actively disarm it. This constant overwrites stale hand-edited
+            # host state instead of preserving ORPHAN_RECONCILER_ENABLED=1.
+            append_environment_setting \
+              "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
+              ORPHAN_RECONCILER_ENABLED 0
             # Headscale is the required dedicated-agent ingress. Bridge-host
             # fallback was a legacy escape hatch; if it remains hand-set on the
             # box, docker-sandbox-provider deliberately disables VPN injection
@@ -1168,6 +1177,12 @@ jobs:
               exit 1
             fi
             echo "Verified required provisioning-host setting names; values were not printed."
+
+            if ! require_environment_setting_equals \
+              "$ENV_FILE" ORPHAN_RECONCILER_ENABLED 0; then
+              echo "::error::Provisioning host orphan reconciler must remain disarmed"
+              exit 1
+            fi
 
             case "$WARM_POOL_ENABLED" in
               true|false) ;;
@@ -1492,6 +1507,13 @@ jobs:
                   "$NODE_BIN" "$ENV_SERIALIZER" equals \
                   "$ENV_FILE" WARM_POOL_ENABLED; then
               echo "::error::Provisioning host warm-pool drift. Values were not printed."
+              exit 1
+            fi
+            if ! printf '%s' 0 \
+              | sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+                  "$NODE_BIN" "$ENV_SERIALIZER" equals \
+                  "$ENV_FILE" ORPHAN_RECONCILER_ENABLED; then
+              echo "::error::Provisioning host orphan reconciler is not disarmed."
               exit 1
             fi
             # The worker logs to journald via systemd's stdout/stderr capture.

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -36,6 +36,7 @@ const FIELD_ENCRYPTION_KEY = "SECRETS_MASTER_KEY";
 const BRIDGE_FALLBACK_KEY = "AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK";
 const AGENT_BASE_DOMAIN_KEY = "ELIZA_CLOUD_AGENT_BASE_DOMAIN";
 const CONTAINERS_SSH_KEY = "CONTAINERS_SSH_KEY";
+const ORPHAN_RECONCILER_KEY = "ORPHAN_RECONCILER_ENABLED";
 const DELETION_AUTHORITY_SECRET_NAMES = [
   "AGENT_BACKUP_R2_ACCESS_KEY_ID",
   "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
@@ -390,6 +391,12 @@ describe("provisioning deployment EnvironmentFile wiring", () => {
     expect(workflow).toContain(
       'DATABASE_SSL_NO_VERIFY="$DATABASE_SSL_NO_VERIFY"',
     );
+    expect(workflow).toContain(
+      "Provisioning host orphan reconciler must remain disarmed",
+    );
+    expect(workflow).toContain(
+      "Provisioning host orphan reconciler is not disarmed.",
+    );
   });
 
   it("pins privileged helper execution to an exact-SHA root-owned copy", () => {
@@ -598,10 +605,11 @@ describe("atomic workflow block (executed verbatim)", () => {
     );
   });
 
-  it("removes bridge fallback, pins the lane, and strips backup authority from the shared file", () => {
+  it("removes bridge fallback, pins safe daemon gates, and strips backup authority from the shared file", () => {
     const result = runAtomicReconcile({
       seedHostFile:
         `${BRIDGE_FALLBACK_KEY}=1\nOTHER=keep\n` +
+        `${ORPHAN_RECONCILER_KEY}=1\n` +
         "AGENT_BACKUP_R2_SECRET_ACCESS_KEY=must-disappear\n" +
         "AGENT_BACKUP_OPERATION_LEASE_MS=must-disappear\n",
       seedBackupFile:
@@ -612,6 +620,12 @@ describe("atomic workflow block (executed verbatim)", () => {
     expect(
       lookupSystemdEnvironmentValue(result.host, "PROVISIONING_JOB_LANES"),
     ).toBe("agent");
+    expect(
+      lookupSystemdEnvironmentValue(result.host, ORPHAN_RECONCILER_KEY),
+    ).toBe("0");
+    expect(
+      result.host.match(new RegExp(`^${ORPHAN_RECONCILER_KEY}=`, "gm")),
+    ).toHaveLength(1);
     expect(result.host).toContain("OTHER=keep\n");
     expect(result.host).not.toContain("AGENT_BACKUP_R2_SECRET_ACCESS_KEY");
     expect(result.host).not.toContain("AGENT_BACKUP_OPERATION_LEASE_MS");

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
@@ -2445,6 +2445,33 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(deleteVpn).toHaveBeenCalledWith("1447");
   });
 
+  test("a stale immutable id cannot resolve or delete its same-name successor", async () => {
+    const legacyLookup = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(NODE);
+    const { commands } = stubSsh(async (command) => {
+      if (command.startsWith("docker inspect")) {
+        throw new Error(
+          `[docker-ssh] Command exited with code 1 on ${NODE.hostname}: [stderr] Error: No such object: ${CONTAINER_ID}`,
+        );
+      }
+      return "";
+    });
+
+    await expect(
+      replacementProvider().stopOnSpecificNodeForReplacement(
+        NODE.node_id,
+        CONTAINER_NAME,
+        null,
+        legacyReplacementIdentity({ vpnNodeName: null, previousVpnNodeId: null }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(legacyLookup).toHaveBeenCalledWith(NODE.node_id);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain(CONTAINER_ID);
+    expect(commands[0]).not.toContain(`docker stop`);
+    expect(commands[0]).not.toContain(`docker rm`);
+  });
+
   test("keeps an exact id-less fence unresolved when Docker reports absence", async () => {
     stubNodeLookup();
     const { commands } = stubSsh(async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -190,6 +190,13 @@ type ReplacementLifecycleHarnessService = {
     expectedEnvironmentRevision: number,
     updateData: Partial<AgentSandbox>,
   ): Promise<AgentSandbox>;
+  persistAdoptedFailedProvisionCleanupFence(
+    agentId: string,
+    orgId: string,
+    adopted: AgentSandbox,
+    handle: SandboxHandle,
+    failureMessage: string,
+  ): Promise<void>;
   retirePersistedReplacementCleanup(agentId: string, orgId: string): Promise<boolean>;
   getReplacementCleanupLocator(rec: AgentSandbox): TestReplacementLocator | null;
   getProvider(): Promise<SandboxProvider>;
@@ -197,6 +204,9 @@ type ReplacementLifecycleHarnessService = {
 
 const replacementLifecycleHarnessState = new WeakMap<object, ReplacementLifecycleHarnessState>();
 let restoreReplacementLifecycleHarness: (() => void) | null = null;
+let realPersistAdoptedFailedProvisionCleanupFence:
+  | ReplacementLifecycleHarnessService["persistAdoptedFailedProvisionCleanupFence"]
+  | null = null;
 const replacementAwareProviderMarker = Symbol("replacement-aware-provider");
 let replacementAttemptSequence = 0;
 
@@ -377,9 +387,12 @@ beforeAll(async () => {
   const originals = {
     persistReplacementCleanupStage: prototype.persistReplacementCleanupStage,
     transferReplacementToPrimary: prototype.transferReplacementToPrimary,
+    persistAdoptedFailedProvisionCleanupFence: prototype.persistAdoptedFailedProvisionCleanupFence,
     retirePersistedReplacementCleanup: prototype.retirePersistedReplacementCleanup,
     getReplacementCleanupLocator: prototype.getReplacementCleanupLocator,
   };
+  realPersistAdoptedFailedProvisionCleanupFence =
+    originals.persistAdoptedFailedProvisionCleanupFence;
 
   prototype.persistReplacementCleanupStage = async function (
     _agentId,
@@ -480,6 +493,57 @@ beforeAll(async () => {
     return replacementLifecycleHarnessState.get(this)?.candidate ?? null;
   };
 
+  prototype.persistAdoptedFailedProvisionCleanupFence = async function (
+    agentId,
+    _orgId,
+    adopted,
+    handle,
+    failureMessage,
+  ): Promise<void> {
+    const locator = replacementLocatorFromTestHandle(handle);
+    if (
+      adopted.id !== agentId ||
+      adopted.sandbox_id !== locator.sandboxId ||
+      adopted.node_id !== locator.nodeId ||
+      adopted.container_name !== locator.containerName ||
+      adopted.bridge_url !== handle.bridgeUrl ||
+      adopted.health_url !== handle.healthUrl ||
+      !locator.replacementAttemptId ||
+      !locator.containerId ||
+      !locator.allocationCounted
+    ) {
+      throw new Error("Failed provision fixture cannot fence a different runtime generation");
+    }
+    const state = replacementLifecycleHarnessState.get(this) ?? {
+      candidate: null,
+      expected: null,
+    };
+    if (state.candidate) expectSameReplacement(state.candidate, locator);
+    state.candidate = locator;
+    state.expected = {
+      status: adopted.status,
+      environmentRevision: adopted.environment_revision,
+      sandboxId: adopted.sandbox_id,
+      nodeId: adopted.node_id,
+      containerName: adopted.container_name,
+    };
+    replacementLifecycleHarnessState.set(this, state);
+    await agentSandboxesRepository.update(agentId, {
+      status: "error",
+      error_message: `Provisioning cleanup pending: ${failureMessage}`,
+      sandbox_id: null,
+      bridge_url: null,
+      health_url: null,
+      last_heartbeat_at: null,
+      node_id: null,
+      container_name: null,
+      bridge_port: null,
+      web_ui_port: null,
+      headscale_ip: null,
+      pool_ready_at: null,
+    });
+  };
+
   prototype.retirePersistedReplacementCleanup = async function (): Promise<boolean> {
     const state = replacementLifecycleHarnessState.get(this);
     if (!state?.candidate) return false;
@@ -534,6 +598,8 @@ beforeAll(async () => {
   restoreReplacementLifecycleHarness = () => {
     prototype.persistReplacementCleanupStage = originals.persistReplacementCleanupStage;
     prototype.transferReplacementToPrimary = originals.transferReplacementToPrimary;
+    prototype.persistAdoptedFailedProvisionCleanupFence =
+      originals.persistAdoptedFailedProvisionCleanupFence;
     prototype.retirePersistedReplacementCleanup = originals.retirePersistedReplacementCleanup;
     prototype.getReplacementCleanupLocator = originals.getReplacementCleanupLocator;
   };
@@ -8099,8 +8165,24 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(runningWrites).toBe(1);
       expect(markErrorSpy).toHaveBeenCalledTimes(1);
       // The row already adopted and cleared its temporary cleanup fence before
-      // restore failed. The catch must retain the returned immutable handle;
-      // resolving the deterministic name here could kill a healthy retry.
+      // restore failed. Before remote retirement, the catch moves that exact
+      // handle back into durable cleanup ownership and removes every serving
+      // locator so a partial provider failure cannot advertise/reuse it.
+      expect(updateSpy).toHaveBeenCalledWith(
+        AGENT,
+        expect.objectContaining({
+          status: "error",
+          sandbox_id: null,
+          bridge_url: null,
+          health_url: null,
+          node_id: null,
+          container_name: null,
+          bridge_port: null,
+          web_ui_port: null,
+          headscale_ip: null,
+        }),
+      );
+      // Resolving the deterministic name here could kill a healthy retry.
       expect(stopForReplacement).not.toHaveBeenCalled();
       expect(stopOnSpecificNodeForReplacement).toHaveBeenCalledWith(
         "node-2",
@@ -8128,6 +8210,304 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       ensureStartedSpy.mockRestore();
       pushStateSpy.mockRestore();
       getProviderSpy.mockRestore();
+    }
+  });
+
+  test("(9a) adopted failure CAS moves the existing slot into cleanup without capacity mutation", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    if (!realPersistAdoptedFailedProvisionCleanupFence) {
+      throw new Error("real failed-provision fence implementation was not captured");
+    }
+    const handle = exactFailedProvisionHandle();
+    const adopted: AgentSandbox = {
+      ...provisioningReadyRow(),
+      execution_tier: "dedicated-lazy",
+      status: "running",
+      sandbox_id: handle.sandboxId,
+      bridge_url: handle.bridgeUrl,
+      health_url: handle.healthUrl,
+      node_id: "node-2",
+      container_name: `agent-${AGENT}`,
+      bridge_port: 21070,
+      web_ui_port: 23900,
+      headscale_ip: null,
+      lifecycle_revision: 41,
+    };
+    let setValues: Record<string, unknown> | undefined;
+    let whereClause: SQL | undefined;
+    const returning = mock(async () => [{ id: AGENT }]);
+    const where = mock((clause: SQL) => {
+      whereClause = clause;
+      return { returning };
+    });
+    const set = mock((values: Record<string, unknown>) => {
+      setValues = values;
+      return { where };
+    });
+    const update = mock(() => ({ set }));
+    const execute = mock(async () => ({ rows: [] as Array<{ id: string }> }));
+    upgradeTransactionImpl = async (fn) => fn({ update, execute } as unknown as UpgradeTx);
+    const svc = new ElizaSandboxService();
+    const lockSpy = spyOn(
+      svc as unknown as { lockLifecycle: (...args: unknown[]) => Promise<void> },
+      "lockLifecycle",
+    ).mockResolvedValue(undefined);
+    const readSpy = spyOn(
+      svc as unknown as {
+        getAgentForLifecycleMutation: (...args: unknown[]) => Promise<AgentSandbox | undefined>;
+      },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue({
+      ...adopted,
+      // A heartbeat is allowed to advance the whole-row revision after
+      // adoption. The locked runtime tuple is unchanged, so cleanup must use
+      // this fresh revision instead of stranding the exact generation.
+      lifecycle_revision: 42,
+      last_heartbeat_at: new Date("2026-08-27T00:00:30.000Z"),
+    });
+
+    try {
+      await realPersistAdoptedFailedProvisionCleanupFence.call(
+        svc as unknown as ReplacementLifecycleHarnessService,
+        AGENT,
+        ORG,
+        adopted,
+        handle,
+        "State restore failed: HTTP 500",
+      );
+      expect(setValues).toMatchObject({
+        status: "error",
+        sandbox_id: null,
+        bridge_url: null,
+        health_url: null,
+        last_heartbeat_at: null,
+        node_id: null,
+        container_name: null,
+        bridge_port: null,
+        web_ui_port: null,
+        headscale_ip: null,
+        pool_ready_at: null,
+        replacement_cleanup_sandbox_id: `agent-${AGENT}`,
+        replacement_cleanup_node_id: "node-2",
+        replacement_cleanup_container_name: `agent-${AGENT}`,
+        replacement_cleanup_attempt_id: "55555555-5555-4555-8555-555555555555",
+        replacement_cleanup_container_id: "b".repeat(64),
+        replacement_cleanup_allocation_counted: true,
+      });
+      expect(update).toHaveBeenCalledTimes(1);
+      // This ownership transfer represents the already-counted primary slot;
+      // it must not update docker_nodes. The persisted cleanup convergence owns
+      // the single decrement after exact remote absence is proven.
+      expect(execute).not.toHaveBeenCalled();
+      expect(returning).toHaveBeenCalledTimes(1);
+      if (!whereClause) throw new Error("failed-provision fence built no CAS predicate");
+      const query = new PgDialect().sqlToQuery(whereClause);
+      expect(query.sql).toContain("lifecycle_revision");
+      expect(query.params).toContain(42);
+      expect(query.params).toContain(`agent-${AGENT}`);
+      expect(query.params).toContain("node-2");
+    } finally {
+      upgradeTransactionImpl = null;
+      lockSpy.mockRestore();
+      readSpy.mockRestore();
+    }
+  });
+
+  test("(9b) Docker-removed/VPN-failed cleanup stays fenced and a retry cannot reuse the dead bridge", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    let current: AgentSandbox = {
+      ...provisioningReadyRow(),
+      execution_tier: "dedicated-lazy",
+    };
+    const backup: AgentSandboxBackup = {
+      id: "49494949-4949-4949-8949-494949494949",
+      sandbox_record_id: current.id,
+      snapshot_type: "pre-shutdown",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      state_data_key: null,
+      size_bytes: 2,
+      backup_kind: "full",
+      parent_backup_id: null,
+      content_hash: null,
+      created_at: new Date("2026-08-27T00:00:00.000Z"),
+    };
+    const failedHandle: SandboxHandle = {
+      ...exactFailedProvisionHandle(),
+      metadata: {
+        ...exactFailedProvisionHandle().metadata,
+        vpnNodeId: "vpn-failed-generation",
+        vpnNodeName: `agent-${AGENT}`,
+        vpnRegistrationStartedAt: "2026-08-27T00:00:00.000Z",
+      },
+    };
+    const successorHandle: SandboxHandle = {
+      ...failedHandle,
+      bridgeUrl: "https://runtime-successor.example",
+      healthUrl: "https://runtime-successor.example/health",
+      metadata: {
+        ...failedHandle.metadata,
+        bridgePort: 21071,
+        webUiPort: 23901,
+        headscaleIp: "100.64.0.202",
+        vpnNodeId: "vpn-successor-generation",
+        replacementAttemptId: "66666666-6666-4666-8666-666666666666",
+        containerId: "c".repeat(64),
+      },
+    };
+
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
+      async () => current,
+    );
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockImplementation(
+      async () => current,
+    );
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockImplementation(
+      async () => {
+        current = {
+          ...current,
+          status: "provisioning",
+          error_message: null,
+          lifecycle_revision: current.lifecycle_revision + 1,
+        };
+        return current;
+      },
+    );
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup")
+      .mockResolvedValueOnce(backup)
+      .mockResolvedValue(undefined);
+    const reconstructedSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => {
+        current = {
+          ...current,
+          ...data,
+          lifecycle_revision: current.lifecycle_revision + 1,
+          updated_at: new Date(),
+        } as AgentSandbox;
+        return current;
+      },
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const create = mock().mockResolvedValueOnce(failedHandle).mockResolvedValue(successorHandle);
+    let exactCleanupCalls = 0;
+    let failedDockerPresent = true;
+    let failedVpnPresent = true;
+    const stopOnSpecificNodeForReplacement = mock(async () => {
+      exactCleanupCalls += 1;
+      // The first provider call removes Docker, then Headscale deletion fails.
+      // The second call proves Docker already absent and finishes the same VPN.
+      failedDockerPresent = false;
+      if (exactCleanupCalls === 1) {
+        throw new Error("Headscale delete failed after Docker absence");
+      }
+      failedVpnPresent = false;
+    });
+    const stopForReplacement = mock(async () => {});
+    const provider: SandboxProvider = {
+      create,
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement,
+      stopOnSpecificNodeForReplacement,
+      checkHealth: async () => true,
+    };
+    const svc = new ElizaSandboxService(provider);
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const pushStateSpy = spyOn(svc as unknown as { pushState: () => Promise<unknown> }, "pushState")
+      .mockRejectedValueOnce(new Error("State restore failed: HTTP 500"))
+      .mockResolvedValue(undefined);
+    const markErrorSpy = spyOn(
+      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      "markError",
+    ).mockImplementation(async (_rec, msg) => {
+      current = { ...current, status: "error", error_message: msg };
+    });
+
+    try {
+      const first = await svc.provision(AGENT, ORG);
+      expect(first.success).toBe(false);
+      expect(first.retryable).toBe(true);
+      expect(first.error).toContain("Headscale delete failed after Docker absence");
+      expect(failedDockerPresent).toBe(false);
+      expect(failedVpnPresent).toBe(true);
+      expect(current).toMatchObject({
+        status: "error",
+        sandbox_id: null,
+        bridge_url: null,
+        health_url: null,
+        node_id: null,
+        container_name: null,
+        bridge_port: null,
+        web_ui_port: null,
+        headscale_ip: null,
+      });
+      const retained = (
+        svc as unknown as ReplacementLifecycleHarnessService
+      ).getReplacementCleanupLocator(current);
+      expect(retained).toMatchObject({
+        sandboxId: `agent-${AGENT}`,
+        nodeId: "node-2",
+        containerName: `agent-${AGENT}`,
+        replacementAttemptId: "55555555-5555-4555-8555-555555555555",
+        containerId: "b".repeat(64),
+        vpnNodeId: "vpn-failed-generation",
+        allocationCounted: true,
+      });
+      expect(markErrorSpy).not.toHaveBeenCalled();
+
+      const retry = await svc.provision(AGENT, ORG);
+      expect(retry.success).toBe(true);
+      expect(failedVpnPresent).toBe(false);
+      expect(create).toHaveBeenCalledTimes(2);
+      expect(current).toMatchObject({
+        status: "running",
+        sandbox_id: `agent-${AGENT}`,
+        bridge_url: successorHandle.bridgeUrl,
+        health_url: successorHandle.healthUrl,
+        node_id: "node-2",
+        bridge_port: 21071,
+        headscale_ip: "100.64.0.202",
+      });
+      expect(
+        (svc as unknown as ReplacementLifecycleHarnessService).getReplacementCleanupLocator(
+          current,
+        ),
+      ).toBeNull();
+      expect(stopForReplacement).not.toHaveBeenCalled();
+      expect(stopOnSpecificNodeForReplacement).toHaveBeenCalledTimes(2);
+      for (const call of stopOnSpecificNodeForReplacement.mock.calls) {
+        expect(call).toEqual([
+          "node-2",
+          `agent-${AGENT}`,
+          "vpn-failed-generation",
+          expect.objectContaining({
+            replacementAttemptId: "55555555-5555-4555-8555-555555555555",
+            containerId: "b".repeat(64),
+            allocationCounted: true,
+          }),
+        ]);
+      }
+    } finally {
+      findSpy.mockRestore();
+      findByIdSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      reconstructedSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      pushStateSpy.mockRestore();
+      markErrorSpy.mockRestore();
     }
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -2229,9 +2229,9 @@ describe("ElizaSandboxService sleep", () => {
 // backed sandbox to `running` when the provider handle carries no durable
 // node_id (metadata shape drift, or an empty-string nodeId). Such a row would be
 // an unattributable orphan the node recount undercounts (#15378) and the orphan
-// reconciler provably cannot reap (allHaveNodeAndStamp skips live null-node
-// rows). The guard must fail LOUD + NON-retryable, and the container must be
-// torn down per the standard post-create-failure convention.
+// reconciler cannot safely reap without immutable generation authority. The
+// guard must fail LOUD and leave an incomplete Docker handle non-destructive:
+// resolving its mutable name could remove a healthy successor.
 describe("ElizaSandboxService provision — node attribution guard (C1b)", () => {
   function dedicatedProvisionTarget(): AgentSandbox {
     // A dedicated agent mid-provision: DB already ready (so provision() skips
@@ -2330,7 +2330,7 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
   }
 
   test.skipIf(process.platform === "win32")(
-    "docker-backed handle with EMPTY nodeId: no running+null row, non-retryable, container stopped",
+    "docker-backed handle with EMPTY nodeId: no running+null row and no mutable-name teardown",
     async () => {
       const { result, create, stop, updateSpy } = await runProvisionWithMetadata({
         // Docker-backed by provider tag, but the strict guard fails (empty
@@ -2345,31 +2345,28 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
 
       // Provision fails (not a fabricated success).
       expect(result.success).toBe(false);
+      expect(result.retryable).toBe(true);
+      expect(result.error).toContain("Replacement cleanup is still pending");
 
       // NEVER minted a running row.
       for (const call of updateSpy.mock.calls) {
         expect((call[1] as { status?: string }).status).not.toBe("running");
       }
 
-      // markError ran with the distinguishable, non-retryable prefix.
+      // Incomplete cleanup identity remains retryable and never marks the row
+      // terminal: doing so would discard the only chance to reconcile safely.
       const errorUpdate = updateSpy.mock.calls.find(
         (c) => (c[1] as { status?: string }).status === "error",
       );
-      expect(errorUpdate).toBeDefined();
-      if (!errorUpdate) {
-        throw new Error("Expected the empty-node attribution error update");
-      }
-      expect((errorUpdate[1] as { error_message?: string }).error_message).toContain(
-        "provision attribution guard:",
-      );
+      expect(errorUpdate).toBeUndefined();
 
-      // Non-retryable: the guard message matches none of the port-collision
-      // retry patterns, so create() ran exactly once (no retry loop).
+      // This invocation does not create again. The returned retryable result is
+      // for later cleanup reconciliation with better identity, not an in-loop
+      // attempt that could collide on the deterministic name.
       expect(create).toHaveBeenCalledTimes(1);
 
-      // Container torn down per the post-create-failure convention (not leaked,
-      // not left invisible-but-alive).
-      expect(stop).toHaveBeenCalledTimes(1);
+      // Fail closed: this legacy method resolves a reusable Docker name.
+      expect(stop).not.toHaveBeenCalled();
     },
   );
 
@@ -2384,21 +2381,17 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
       });
 
       expect(result.success).toBe(false);
+      expect(result.retryable).toBe(true);
+      expect(result.error).toContain("Replacement cleanup is still pending");
       for (const call of updateSpy.mock.calls) {
         expect((call[1] as { status?: string }).status).not.toBe("running");
       }
       const errorUpdate = updateSpy.mock.calls.find(
         (c) => (c[1] as { status?: string }).status === "error",
       );
-      expect(errorUpdate).toBeDefined();
-      if (!errorUpdate) {
-        throw new Error("Expected the incomplete-metadata attribution error update");
-      }
-      expect((errorUpdate[1] as { error_message?: string }).error_message).toContain(
-        "provision attribution guard:",
-      );
+      expect(errorUpdate).toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
-      expect(stop).toHaveBeenCalledTimes(1);
+      expect(stop).not.toHaveBeenCalled();
     },
   );
 
@@ -7318,6 +7311,22 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     };
   }
 
+  function exactFailedProvisionHandle(): SandboxHandle {
+    const containerName = `agent-${AGENT}`;
+    return {
+      ...providerHandle(),
+      sandboxId: containerName,
+      metadata: {
+        ...providerHandle().metadata,
+        containerName,
+        volumePath: `/var/lib/eliza/${containerName}`,
+        replacementAttemptId: "55555555-5555-4555-8555-555555555555",
+        containerId: "b".repeat(64),
+        allocationCounted: true,
+      },
+    };
+  }
+
   test("(1) lock lost but row already running+reachable → reuse, provider.create NEVER called", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const runningRow: AgentSandbox = {
@@ -8008,7 +8017,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  test("(9) restore failure after the early running-write still ends in markError", async () => {
+  test("(9) post-adoption failure retires the exact Docker generation, never its reusable name", async () => {
     // 'running' must never stick on a failed provision: a restore failure takes
     // the same catch as before (ghost cleanup → markError), so the early
     // reachability flip cannot leave a broken agent advertised as running.
@@ -8070,13 +8079,17 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       svc as unknown as { pushState: () => Promise<unknown> },
       "pushState",
     ).mockRejectedValue(new Error("State restore failed: HTTP 500"));
-    const stop = mock(async () => {});
+    const stopForReplacement = mock(async () => {});
+    const stopOnSpecificNodeForReplacement = mock(async () => {});
+    const failedHandle = exactFailedProvisionHandle();
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
     ).mockResolvedValue({
-      create: mock(async () => providerHandle()),
-      stop,
+      create: mock(async () => failedHandle),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement,
+      stopOnSpecificNodeForReplacement,
       checkHealth: async () => true,
     } as SandboxProvider);
     try {
@@ -8085,8 +8098,20 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(res.error).toBe("State restore failed: HTTP 500");
       expect(runningWrites).toBe(1);
       expect(markErrorSpy).toHaveBeenCalledTimes(1);
-      // Ghost cleanup still stops the container whose restore failed.
-      expect(stop).toHaveBeenCalledWith("sandbox-blue-1");
+      // The row already adopted and cleared its temporary cleanup fence before
+      // restore failed. The catch must retain the returned immutable handle;
+      // resolving the deterministic name here could kill a healthy retry.
+      expect(stopForReplacement).not.toHaveBeenCalled();
+      expect(stopOnSpecificNodeForReplacement).toHaveBeenCalledWith(
+        "node-2",
+        `agent-${AGENT}`,
+        null,
+        expect.objectContaining({
+          replacementAttemptId: "55555555-5555-4555-8555-555555555555",
+          containerId: "b".repeat(64),
+          allocationCounted: true,
+        }),
+      );
       // A transient 5xx must NOT be classified as unrecoverable: the snapshot
       // chain stays intact for the retry that may restore it.
       expect(pruneSpy).not.toHaveBeenCalled();
@@ -8304,12 +8329,20 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
       "ensureRuntimeAgentStarted",
     ).mockResolvedValue(null);
-    const create = mock(async () => providerHandle());
-    const stop = mock(async () => {});
+    const failedHandle = exactFailedProvisionHandle();
+    const create = mock(async () => failedHandle);
+    const stopForReplacement = mock(async () => {});
+    const stopOnSpecificNodeForReplacement = mock(async () => {});
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement,
+      stopOnSpecificNodeForReplacement,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       // A transient failure fails the provision (the resume job retries), rather
@@ -8321,8 +8354,17 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(pruneSpy).not.toHaveBeenCalled();
       const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(logged).not.toContain("Unrecoverable snapshot");
-      // Ghost cleanup still stops the just-created container.
-      expect(stop).toHaveBeenCalledTimes(1);
+      // Cleanup retains the exact generation and never resolves its reusable name.
+      expect(stopForReplacement).not.toHaveBeenCalled();
+      expect(stopOnSpecificNodeForReplacement).toHaveBeenCalledWith(
+        "node-2",
+        `agent-${AGENT}`,
+        null,
+        expect.objectContaining({
+          replacementAttemptId: "55555555-5555-4555-8555-555555555555",
+          containerId: "b".repeat(64),
+        }),
+      );
     } finally {
       findSpy.mockRestore();
       findByIdSpy.mockRestore();
@@ -8729,8 +8771,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(false);
-      expect((res as { retryable?: boolean }).retryable).not.toBe(true);
-      expect(stop).toHaveBeenCalledTimes(1);
+      expect((res as { retryable?: boolean }).retryable).toBe(true);
+      expect(res.error).toContain("Replacement cleanup is still pending");
+      expect(stop).not.toHaveBeenCalled();
       expect(
         updateSpy.mock.calls.some(
           ([, data]) => (data as { sandbox_id?: string }).sandbox_id === "sandbox-blue-1",
@@ -8739,13 +8782,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       const errorWrite = updateSpy.mock.calls.find(
         ([, data]) => (data as { status?: string }).status === "error",
       );
-      expect(errorWrite).toBeDefined();
-      if (!errorWrite) {
-        throw new Error("Expected the failed-provision error write");
-      }
-      expect(String((errorWrite[1] as { error_message?: string }).error_message)).toContain(
-        "provision attribution guard:",
-      );
+      expect(errorWrite).toBeUndefined();
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();
@@ -8884,8 +8921,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       const res = await svc.provision(AGENT, ORG);
 
       expect(res.success).toBe(false);
+      expect((res as { retryable?: boolean }).retryable).toBe(true);
+      expect(res.error).toContain("Replacement cleanup is still pending");
       expect(create).not.toHaveBeenCalled();
-      expect(stop).toHaveBeenCalledTimes(1);
+      expect(stop).not.toHaveBeenCalled();
       expect(healthInputs).toEqual([
         {
           sandboxId: "sandbox-blue-1",
@@ -8906,13 +8945,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       const errorWrite = updateSpy.mock.calls.find(
         ([, data]) => (data as { status?: string }).status === "error",
       );
-      expect(errorWrite).toBeDefined();
-      if (!errorWrite) {
-        throw new Error("Expected the invalid-adoption error write");
-      }
-      expect(String((errorWrite[1] as { error_message?: string }).error_message)).toContain(
-        "provision attribution guard:",
-      );
+      expect(errorWrite).toBeUndefined();
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -93,7 +93,7 @@ import type { CreditReconciliationResult, CreditReservation } from "./credits";
 import { withDefaultAgentCharacter } from "./default-agent-character";
 import { holdsCountedNodeSlot, isDeletionContinuation } from "./docker-node-workload-queries";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
-import { shellQuote } from "./docker-sandbox-utils";
+import { getContainerName, shellQuote } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
 import {
   AGENT_PERSONAL_CUTOVER_KEY,
@@ -133,6 +133,7 @@ import {
   type SandboxProvider,
 } from "./sandbox-provider";
 import {
+  assertSandboxReplacementAttemptId,
   isContainerBackedExecutionTier,
   type SandboxDeletionStopOutcome,
   SandboxReplacementCleanupUnresolvedError,
@@ -4445,10 +4446,7 @@ export class ElizaSandboxService {
             await this.retirePersistedReplacementCleanup(rec.id, rec.organization_id);
           } else {
             const provider = await this.getProvider();
-            if (!provider.stopForReplacement) {
-              throw new Error("Sandbox provider cannot prove failed provision absent");
-            }
-            await provider.stopForReplacement(handle.sandboxId);
+            await this.retireFailedProvisionHandle(provider, handle, rec.id);
           }
         } catch (stopErr) {
           // error-policy:J1 provisioning boundary translation — failed ghost
@@ -12058,6 +12056,90 @@ export class ElizaSandboxService {
       vpnRegistrationStartedAt,
       allocationCounted: metadata.allocationCounted,
     };
+  }
+
+  /**
+   * Retire the exact container returned by a failed provision tail.
+   *
+   * Docker container names are deterministic per agent and therefore mutable
+   * across attempts. A delayed cleanup must never resolve that name again: a
+   * healthy successor may already own it. Preserve the returned immutable
+   * Docker id + attempt label all the way into the provider's inspect-before-
+   * stop fence. Non-Docker providers retain their historical sandbox-id path.
+   */
+  private async retireFailedProvisionHandle(
+    provider: SandboxProvider,
+    handle: SandboxHandle,
+    expectedAgentId: string,
+  ): Promise<void> {
+    if (!isDockerBackedMetadata(handle.metadata)) {
+      if (!provider.stopForReplacement) {
+        throw new Error("Sandbox provider cannot prove failed provision absent");
+      }
+      await provider.stopForReplacement(handle.sandboxId);
+      return;
+    }
+
+    const metadata = isDockerSandboxMetadata(handle.metadata) ? handle.metadata : undefined;
+    if (!metadata) {
+      throw new Error("Failed Docker provision has incomplete placement metadata");
+    }
+    const locator = this.replacementLocatorFromHandle(handle);
+    if (
+      metadata.agentId !== expectedAgentId ||
+      locator.sandboxId !== locator.containerName ||
+      locator.containerName !== getContainerName(expectedAgentId)
+    ) {
+      throw new Error("Failed Docker provision cleanup identity does not match its agent");
+    }
+    assertSandboxReplacementAttemptId(locator.replacementAttemptId);
+    if (!locator.containerId || !/^[a-f0-9]{12,64}$/.test(locator.containerId)) {
+      throw new Error("Failed Docker provision cleanup has no immutable container id");
+    }
+    if (!provider.stopOnSpecificNodeForReplacement) {
+      throw new Error("Sandbox provider cannot retire an exact failed Docker provision");
+    }
+
+    // Legacy replacement callbacks freeze the immutable container/attempt but
+    // may carry only part of the newer node-record authority tuple. Supplying a
+    // partial tuple would correctly fail the provider's exact-authority gate,
+    // so omit it unless the handle explicitly declares the v1 cleanup protocol.
+    const exactNodeAuthority =
+      metadata.replacementSecretCleanupVersion === 1
+        ? {
+            nodeRecordId: metadata.nodeRecordId,
+            nodeHostname: metadata.hostname,
+            nodeSshPort: metadata.nodeSshPort,
+            nodeSshUser: metadata.nodeSshUser,
+            nodeHostKeyFingerprint: metadata.nodeHostKeyFingerprint,
+            replacementSecretCleanupVersion: 1 as const,
+          }
+        : {};
+    if (
+      metadata.replacementSecretCleanupVersion === 1 &&
+      (!metadata.nodeRecordId ||
+        !metadata.hostname ||
+        typeof metadata.nodeSshPort !== "number" ||
+        !metadata.nodeSshUser ||
+        !metadata.nodeHostKeyFingerprint)
+    ) {
+      throw new Error("Failed Docker provision cleanup has incomplete exact node authority");
+    }
+
+    await provider.stopOnSpecificNodeForReplacement(
+      locator.nodeId,
+      locator.containerName,
+      locator.vpnNodeId,
+      {
+        ...exactNodeAuthority,
+        replacementAttemptId: locator.replacementAttemptId,
+        containerId: locator.containerId,
+        vpnNodeName: locator.vpnNodeName,
+        previousVpnNodeId: locator.previousVpnNodeId,
+        vpnRegistrationStartedAt: locator.vpnRegistrationStartedAt?.toISOString() ?? null,
+        allocationCounted: locator.allocationCounted,
+      },
+    );
   }
 
   private replacementLocatorFromCleanupError(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3929,6 +3929,11 @@ export class ElizaSandboxService {
     for (let attempt = 1; attempt <= MAX_PROVISION_ATTEMPTS; attempt++) {
       attemptsMade = attempt;
       let handle;
+      // Once the temporary replacement fence is transferred to the primary
+      // row, retain the exact returned generation. A later restore/billing
+      // tail failure must CAS this same generation back into durable cleanup
+      // ownership before any remote resource can be removed.
+      let adoptedGeneration: AgentSandbox | null = null;
 
       try {
         const retryHandle =
@@ -4165,15 +4170,7 @@ export class ElizaSandboxService {
           rec.environment_revision,
           updateData,
         );
-
-        // Re-enter the billable set on every successful provision. A
-        // credit-suspended agent (billing_status='suspended') that a user tops
-        // up and resumes/wakes via the user-facing routes would otherwise run
-        // (status='running') permanently EXCLUDED from listBillableSandboxes =
-        // free dedicated compute forever. The service-key resume/restart routes
-        // already reactivate; do it here so ALL provision paths re-enter billing.
-        // Idempotent + exempt-guarded (ne billing_status 'exempt').
-        await agentBillingRepository.reactivateSandboxBillingAfterFunding(rec.id, new Date());
+        adoptedGeneration = updated;
 
         // 5. Restore from backup (reconstructs incrementals back to a full).
         //
@@ -4391,7 +4388,16 @@ export class ElizaSandboxService {
             });
           }
           completed = ready;
+          adoptedGeneration = ready;
         }
+
+        // Re-enter the billable set only after the complete provision tail is
+        // successful. Keeping this after restore/readiness also leaves the
+        // adopted lifecycle_revision unchanged while a failed tail is fenced
+        // back into durable cleanup ownership. A credit-suspended agent that a
+        // user funds and resumes would otherwise run outside the billable set;
+        // the update remains idempotent and exempt-guarded.
+        await agentBillingRepository.reactivateSandboxBillingAfterFunding(rec.id, new Date());
 
         logger.info("[agent-sandbox] Provisioned", {
           agentId: rec.id,
@@ -4446,7 +4452,23 @@ export class ElizaSandboxService {
             await this.retirePersistedReplacementCleanup(rec.id, rec.organization_id);
           } else {
             const provider = await this.getProvider();
-            await this.retireFailedProvisionHandle(provider, handle, rec.id);
+            if (isDockerBackedMetadata(handle.metadata)) {
+              if (!adoptedGeneration) {
+                throw new Error(
+                  "Failed Docker provision has no durable cleanup fence or adopted generation",
+                );
+              }
+              await this.persistAdoptedFailedProvisionCleanupFence(
+                rec.id,
+                rec.organization_id,
+                adoptedGeneration,
+                handle,
+                msg,
+              );
+              await this.retirePersistedReplacementCleanup(rec.id, rec.organization_id);
+            } else {
+              await this.retireFailedNonDockerProvisionHandle(provider, handle);
+            }
           }
         } catch (stopErr) {
           // error-policy:J1 provisioning boundary translation — failed ghost
@@ -12058,28 +12080,13 @@ export class ElizaSandboxService {
     };
   }
 
-  /**
-   * Retire the exact container returned by a failed provision tail.
-   *
-   * Docker container names are deterministic per agent and therefore mutable
-   * across attempts. A delayed cleanup must never resolve that name again: a
-   * healthy successor may already own it. Preserve the returned immutable
-   * Docker id + attempt label all the way into the provider's inspect-before-
-   * stop fence. Non-Docker providers retain their historical sandbox-id path.
-   */
-  private async retireFailedProvisionHandle(
-    provider: SandboxProvider,
+  private exactFailedDockerProvisionLocator(
     handle: SandboxHandle,
     expectedAgentId: string,
-  ): Promise<void> {
-    if (!isDockerBackedMetadata(handle.metadata)) {
-      if (!provider.stopForReplacement) {
-        throw new Error("Sandbox provider cannot prove failed provision absent");
-      }
-      await provider.stopForReplacement(handle.sandboxId);
-      return;
-    }
-
+  ): {
+    metadata: DockerSandboxMetadata;
+    locator: Omit<ReplacementCleanupLocator, "createdAt">;
+  } {
     const metadata = isDockerSandboxMetadata(handle.metadata) ? handle.metadata : undefined;
     if (!metadata) {
       throw new Error("Failed Docker provision has incomplete placement metadata");
@@ -12096,25 +12103,6 @@ export class ElizaSandboxService {
     if (!locator.containerId || !/^[a-f0-9]{12,64}$/.test(locator.containerId)) {
       throw new Error("Failed Docker provision cleanup has no immutable container id");
     }
-    if (!provider.stopOnSpecificNodeForReplacement) {
-      throw new Error("Sandbox provider cannot retire an exact failed Docker provision");
-    }
-
-    // Legacy replacement callbacks freeze the immutable container/attempt but
-    // may carry only part of the newer node-record authority tuple. Supplying a
-    // partial tuple would correctly fail the provider's exact-authority gate,
-    // so omit it unless the handle explicitly declares the v1 cleanup protocol.
-    const exactNodeAuthority =
-      metadata.replacementSecretCleanupVersion === 1
-        ? {
-            nodeRecordId: metadata.nodeRecordId,
-            nodeHostname: metadata.hostname,
-            nodeSshPort: metadata.nodeSshPort,
-            nodeSshUser: metadata.nodeSshUser,
-            nodeHostKeyFingerprint: metadata.nodeHostKeyFingerprint,
-            replacementSecretCleanupVersion: 1 as const,
-          }
-        : {};
     if (
       metadata.replacementSecretCleanupVersion === 1 &&
       (!metadata.nodeRecordId ||
@@ -12125,21 +12113,170 @@ export class ElizaSandboxService {
     ) {
       throw new Error("Failed Docker provision cleanup has incomplete exact node authority");
     }
+    return { metadata, locator };
+  }
 
-    await provider.stopOnSpecificNodeForReplacement(
-      locator.nodeId,
-      locator.containerName,
-      locator.vpnNodeId,
-      {
-        ...exactNodeAuthority,
-        replacementAttemptId: locator.replacementAttemptId,
-        containerId: locator.containerId,
-        vpnNodeName: locator.vpnNodeName,
-        previousVpnNodeId: locator.previousVpnNodeId,
-        vpnRegistrationStartedAt: locator.vpnRegistrationStartedAt?.toISOString() ?? null,
-        allocationCounted: locator.allocationCounted,
-      },
-    );
+  /**
+   * Move an already-adopted Docker generation back into durable cleanup
+   * ownership before any remote side effect.
+   *
+   * `transferReplacementToPrimary` deliberately clears the temporary cleanup
+   * locator when the container becomes the primary runtime. A later restore or
+   * readiness-tail failure must reverse that ownership transfer atomically:
+   * make the row non-serving, clear every primary runtime locator, and preserve
+   * the exact immutable Docker/VPN identity plus its EXISTING capacity slot.
+   * The locked runtime tuple proves that the primary row is still the exact
+   * generation returned by adoption. The CAS uses the freshly locked revision
+   * so benign heartbeat/billing writes after adoption do not strand cleanup.
+   * No capacity increment/decrement occurs here;
+   * `retirePersistedReplacementCleanup` releases the same slot exactly once
+   * after remote absence is proven.
+   */
+  private async persistAdoptedFailedProvisionCleanupFence(
+    agentId: string,
+    orgId: string,
+    adopted: AgentSandbox,
+    handle: SandboxHandle,
+    failureMessage: string,
+  ): Promise<void> {
+    const { metadata, locator } = this.exactFailedDockerProvisionLocator(handle, agentId);
+    if (!locator.allocationCounted) {
+      throw new Error("Adopted Docker provision has no owned capacity slot to transfer");
+    }
+    if (
+      adopted.id !== agentId ||
+      adopted.organization_id !== orgId ||
+      (adopted.status !== "running" && adopted.status !== "provisioning") ||
+      adopted.sandbox_id !== locator.sandboxId ||
+      adopted.node_id !== locator.nodeId ||
+      adopted.container_name !== locator.containerName ||
+      adopted.bridge_url !== handle.bridgeUrl ||
+      adopted.health_url !== handle.healthUrl ||
+      adopted.bridge_port !== metadata.bridgePort ||
+      adopted.web_ui_port !== metadata.webUiPort ||
+      (metadata.headscaleIp !== undefined && adopted.headscale_ip !== metadata.headscaleIp)
+    ) {
+      throw new Error("Adopted Docker cleanup handle does not match its primary runtime");
+    }
+
+    await dbWrite.transaction(async (tx) => {
+      await this.lockLifecycle(tx, agentId, orgId);
+      const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
+      if (!current) throw new Error("Agent disappeared before failed provision cleanup fencing");
+      const tierRejection = containerBackedServiceRejection(current, "replacement");
+      if (tierRejection) throw new Error(tierRejection);
+
+      const existing = this.getReplacementCleanupLocator(current);
+      if (existing) {
+        this.assertSameReplacementIdentity(existing, locator);
+        if (
+          existing.containerId !== locator.containerId ||
+          existing.vpnNodeId !== locator.vpnNodeId ||
+          current.status === "running" ||
+          current.sandbox_id !== null ||
+          current.bridge_url !== null ||
+          current.health_url !== null ||
+          current.node_id !== null ||
+          current.container_name !== null
+        ) {
+          throw new Error("Failed provision cleanup fence conflicts with the current generation");
+        }
+        return;
+      }
+
+      if (
+        current.deletion_attempt_id !== null ||
+        current.status !== adopted.status ||
+        current.environment_revision !== adopted.environment_revision ||
+        current.lifecycle_job_id !== adopted.lifecycle_job_id ||
+        current.lifecycle_execution_generation !== adopted.lifecycle_execution_generation ||
+        current.sandbox_id !== adopted.sandbox_id ||
+        current.node_id !== adopted.node_id ||
+        current.container_name !== adopted.container_name ||
+        current.bridge_url !== adopted.bridge_url ||
+        current.health_url !== adopted.health_url ||
+        current.bridge_port !== adopted.bridge_port ||
+        current.web_ui_port !== adopted.web_ui_port ||
+        current.headscale_ip !== adopted.headscale_ip ||
+        current.docker_image !== adopted.docker_image ||
+        current.image_digest !== adopted.image_digest
+      ) {
+        throw new Error(
+          "Primary runtime generation changed before failed provision cleanup fencing",
+        );
+      }
+
+      const fencedAt = new Date();
+      const [fenced] = await tx
+        .update(agentSandboxes)
+        .set({
+          status: "error",
+          error_message: `Provisioning cleanup pending: ${failureMessage}`,
+          sandbox_id: null,
+          bridge_url: null,
+          health_url: null,
+          last_heartbeat_at: null,
+          node_id: null,
+          container_name: null,
+          bridge_port: null,
+          web_ui_port: null,
+          headscale_ip: null,
+          pool_ready_at: null,
+          replacement_cleanup_sandbox_id: locator.sandboxId,
+          replacement_cleanup_node_id: locator.nodeId,
+          replacement_cleanup_container_name: locator.containerName,
+          replacement_cleanup_attempt_id: locator.replacementAttemptId,
+          replacement_cleanup_container_id: locator.containerId,
+          replacement_cleanup_vpn_node_id: locator.vpnNodeId,
+          replacement_cleanup_vpn_node_name: locator.vpnNodeName,
+          replacement_cleanup_preserved_vpn_node_id: locator.previousVpnNodeId,
+          replacement_cleanup_vpn_registration_started_at: locator.vpnRegistrationStartedAt,
+          replacement_cleanup_allocation_counted: true,
+          replacement_cleanup_created_at: fencedAt,
+          updated_at: fencedAt,
+        })
+        .where(
+          and(
+            eq(agentSandboxes.id, agentId),
+            eq(agentSandboxes.organization_id, orgId),
+            inArray(agentSandboxes.execution_tier, [...CONTAINER_BACKED_EXECUTION_TIERS]),
+            eq(agentSandboxes.status, current.status),
+            eq(agentSandboxes.environment_revision, current.environment_revision),
+            eq(agentSandboxes.lifecycle_revision, current.lifecycle_revision),
+            sql`${agentSandboxes.lifecycle_job_id} IS NOT DISTINCT FROM ${current.lifecycle_job_id}`,
+            sql`${agentSandboxes.lifecycle_execution_generation} IS NOT DISTINCT FROM ${current.lifecycle_execution_generation}`,
+            sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${current.sandbox_id}`,
+            sql`${agentSandboxes.node_id} IS NOT DISTINCT FROM ${current.node_id}`,
+            sql`${agentSandboxes.container_name} IS NOT DISTINCT FROM ${current.container_name}`,
+            sql`${agentSandboxes.bridge_url} IS NOT DISTINCT FROM ${current.bridge_url}`,
+            sql`${agentSandboxes.health_url} IS NOT DISTINCT FROM ${current.health_url}`,
+            sql`${agentSandboxes.bridge_port} IS NOT DISTINCT FROM ${current.bridge_port}`,
+            sql`${agentSandboxes.web_ui_port} IS NOT DISTINCT FROM ${current.web_ui_port}`,
+            sql`${agentSandboxes.headscale_ip} IS NOT DISTINCT FROM ${current.headscale_ip}`,
+            sql`${agentSandboxes.docker_image} IS NOT DISTINCT FROM ${current.docker_image}`,
+            sql`${agentSandboxes.image_digest} IS NOT DISTINCT FROM ${current.image_digest}`,
+            sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
+            sql`${agentSandboxes.replacement_cleanup_sandbox_id} IS NULL`,
+          ),
+        )
+        .returning({ id: agentSandboxes.id });
+      if (!fenced) {
+        throw new Error("Failed provision cleanup ownership CAS failed");
+      }
+    });
+  }
+
+  private async retireFailedNonDockerProvisionHandle(
+    provider: SandboxProvider,
+    handle: SandboxHandle,
+  ): Promise<void> {
+    if (isDockerBackedMetadata(handle.metadata)) {
+      throw new Error("Docker cleanup requires durable failed-provision ownership");
+    }
+    if (!provider.stopForReplacement) {
+      throw new Error("Sandbox provider cannot prove failed provision absent");
+    }
+    await provider.stopForReplacement(handle.sandboxId);
   }
 
   private replacementLocatorFromCleanupError(


### PR DESCRIPTION
# Relates to

Closes #29678.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`44b4e2ffcea333184c7521343dc5807fc8f043da`).
- [ ] `bun install` and the monorepo-wide `bun run verify` were not rerun; the exact affected tests, package typecheck, Biome, and diff validation are green and the broader gap is recorded below.
- [x] A reviewer can confirm the change from the automated regression evidence below without reading the implementation.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Monorepo-wide `bun run verify` was not run; exact affected-path validation is documented in **Known gaps / failures**.

# Risks

**Medium.** This changes failed-provision container retirement and provisioning-worker deployment configuration. Docker cleanup now fails closed when immutable identity is incomplete, which can temporarily retain a failed container for reconciliation instead of risking deletion of a healthy successor. Non-Docker cleanup keeps its existing behavior. The orphan reaper remains disabled until it has durable live-generation authority.

# Background

## What does this PR do?

This contains two narrow protections:

1. The deployment workflow now owns `ORPHAN_RECONCILER_ENABLED=0`, overwrites any stale host `=1`, and verifies the value both before service restart and in the health gate. This contains the observed staging killer while its read-authority mismatch is investigated.
2. Post-adoption Docker tail failures first CAS-transfer the unchanged primary generation into the durable cleanup locator, clear every serving/runtime field, and preserve its exact container ID, replacement attempt, VPN identity, and existing capacity ownership. Only persisted cleanup may then perform remote retirement; partial provider failure remains non-serving and retryable. Mutable sandbox-ID cleanup remains available only for non-Docker providers.

There are no database or schema changes.

## What kind of change is this?

Bug fix (non-breaking lifecycle-safety and deployment-configuration change).

# Documentation changes needed?

No project-documentation change is required. The workflow is the authoritative deployment configuration, and comments explain why destructive orphan reconciliation stays disabled.

# Testing

## Where should a reviewer start?

- `.github/workflows/deploy-eliza-provisioning-worker.yml`
- `packages/cloud/shared/src/lib/services/eliza-sandbox.ts`
- `packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts`
- `packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts`
- `packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts`

## Detailed testing steps

All results are from exact head `24ebcad76d3c0da62af7dd885547e6b726c191ec` after rebasing onto `44b4e2ffcea333184c7521343dc5807fc8f043da`.

1. Run the combined service/provider regression suite:
   `bun --config=.codex-bunfig-no-coverage.toml test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts --timeout 30000 --reporter=dots`
   Result: **336 pass, 0 fail, 2,161 assertions**. The temporary config only disabled coverage-file output and was not committed.
2. Run the workflow/environment tests:
   `bun test packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts`
   Result: **37 pass, 0 fail, 591 assertions**.
3. Run the environment-reconciliation test alone after the final health-gate assertions.
   Result: **12 pass, 0 fail, 176 assertions**.
4. Run `bun run --cwd packages/cloud/shared typecheck`.
   Result: pass.
5. Run Biome on all four changed TypeScript files.
   Result: pass.
6. Run `git diff --check origin/develop...HEAD`.
   Result: pass.

# Evidence Gate

<!-- evidence-head:24ebcad76d3c0da62af7dd885547e6b726c191ec -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend lifecycle and deployment configuration only.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no branch deployment was performed; exact lifecycle/provider regressions and the sanitized pre-fix Docker-event receipt are included inline below
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or console behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database rows, memories, wallet output, generated files, or other domain artifacts are mutated by this PR.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM or agent-behavior change.

## Backend + frontend logs

Sanitized incident receipt for one deterministic staging sandbox name:

| Generation | Immutable Docker ID prefix | Started (UTC) | Direct SIGKILL (UTC) | Destroyed (UTC) | Healthy/live evidence |
|---|---|---:|---:|---:|---|
| 1 | `4cca1111` | 23:21:48 | 23:28:43 | 23:28:45 | Healthy before removal; elapsed about 6m55s |
| 2 | `5986f285` | 23:33:13 | 23:38:35 | 23:38:48 | Healthy before removal; elapsed about 5m22s |
| 3 | `0dffafe3` | 23:46:12 | 23:53:57 | 23:53:59 | Recovery completed 23:46:33; fresh heartbeat 23:53:43 |
| 4 | `be3cf286` | 23:57:14 | 00:04:07 | 00:04:08 | Serving row updated 00:03:51; node-health sweep 00:03:13 |

Each generation had a distinct replacement-attempt label. Each removal was a direct signal 9 followed by destroy, with no preceding stop/SIGTERM and no active destructive lifecycle job. Generation 4 was killed about 412 seconds after start, 15 seconds after a fresh serving-row update, and 54 seconds after the node-health sweep. Generation 3 had the same sweep-plus-54-seconds shape. This timing and event shape attribute the observed incident to the stale-enabled orphan phase. The underlying authority mismatch that caused a live row to be classified as orphaned remains unresolved, so this PR explicitly disarms destructive reaping instead of claiming to repair that authority.

Frontend logs: N/A - no frontend code path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio change.

## Known gaps / failures

- The monorepo-wide `bun run verify` was not run locally. The affected package typecheck, 373 focused tests, Biome, and diff checks are green; required hosted checks remain authoritative before merge.
- This PR does not resolve why orphan-reconciler read authority missed a fresh live row. It force-disarms the destructive sweep on deploy until generation/attempt/container-ID ownership is durable.
- No deployment was performed from this branch. After merge, the normal provisioning-worker deployment must run to overwrite any stale host `ORPHAN_RECONCILER_ENABLED=1`.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

## Database changes

None. No schema, migration, or database data changes.

## Deployment instructions

After merge, use the normal provisioning-worker deployment workflow. Its environment reconciliation must report exactly one `ORPHAN_RECONCILER_ENABLED=0` before restart, and the post-restart health gate must confirm the same value. Do not re-enable the orphan reconciler until its authority is fenced by durable generation/attempt/container-ID ownership.


