### PR TITLE
test(cloud): restore compute-stop recovery fixture

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
@@ -233,7 +233,14 @@ beforeAll(async () => {
         created_at timestamp NOT NULL, updated_at timestamp NOT NULL
       );
       CREATE TABLE agent_sandboxes (
-        id uuid PRIMARY KEY, organization_id uuid NOT NULL
+        id uuid PRIMARY KEY, organization_id uuid NOT NULL, user_id uuid NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        lifecycle_revision bigint NOT NULL DEFAULT 0,
+        billing_status text NOT NULL DEFAULT 'active',
+        scheduled_shutdown_at timestamptz,
+        execution_tier text NOT NULL DEFAULT 'shared',
+        pool_status text, deletion_attempt_id uuid, deleted_at timestamptz,
+        replacement_cleanup_sandbox_id text
       );
       CREATE TABLE compute_billing_rate_segments (
         id uuid PRIMARY KEY DEFAULT gen_random_uuid(), organization_id uuid NOT NULL,
@@ -579,7 +586,9 @@ realPostgres("compute stop concurrency", () => {
           VALUES (${userId}, ${organizationId}, ${stewardUserId}, 'owner')`,
     );
     await dbWrite.execute(
-      sql`INSERT INTO agent_sandboxes(id, organization_id) VALUES (${agentId}, ${organizationId})`,
+      sql`INSERT INTO agent_sandboxes
+        (id, organization_id, user_id, status, lifecycle_revision, execution_tier)
+        VALUES (${agentId}, ${organizationId}, ${userId}, 'running', 5, 'dedicated-lazy')`,
     );
     const [seededJob] = await dbWrite
       .insert(jobsTable)
@@ -1129,10 +1138,21 @@ realPostgres("compute stop concurrency", () => {
       throw new Error("harness unavailable");
     }
     const organizationId = randomUUID();
+    const userId = randomUUID();
     const agentId = randomUUID();
+    const stewardUserId = `steward:${userId}`;
     await dbWrite.execute(
       sql`INSERT INTO organizations(id, credit_balance) VALUES (${organizationId}, 0)`,
     );
+    await dbWrite.execute(
+      sql`INSERT INTO users(id, organization_id, steward_user_id, role)
+          VALUES (${userId}, ${organizationId}, ${stewardUserId}, 'owner')`,
+    );
+    await dbWrite.execute(sql`INSERT INTO agent_sandboxes
+      (id, organization_id, user_id, status, lifecycle_revision, billing_status,
+       scheduled_shutdown_at, execution_tier)
+      VALUES (${agentId}, ${organizationId}, ${userId}, 'running', 5, 'shutdown_pending',
+        NOW() - interval '1 minute', 'dedicated-lazy')`);
     await dbWrite.execute(sql`INSERT INTO agent_compute_stop_intents
       (organization_id, agent_id, lifecycle_revision, status, attempts, next_attempt_at)
       VALUES (${organizationId}, ${agentId}, 5, 'terminal_attention', 3, NOW() - interval '1 minute')`);


### PR DESCRIPTION
# Relates to

Closes #29681

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were attempted after sync; the exact
      environment blocker is recorded below. Narrow static and real-PostgreSQL
      proof passed, and hosted CI owns the exact Bun acceptance run.
- [x] A reviewer can confirm the change works without reading the code, from the
      baseline and exact-head evidence below.

# Sync with develop

- [x] Merged the latest `origin/develop` at `44b4e2ffcea333184c7521343dc5807fc8f043da`; zero conflicts and no public-history rewrite.
- [x] Narrow post-sync checks pass. The exact unrelated local Bun runtime blocker
      is documented in **Known gaps / failures** below; the hosted real-PostgreSQL
      lane is the acceptance gate.

# Risks

Low. This changes one isolated integration-test fixture and its test seed; no
production schema, migration, query, or runtime path changes. The main risk is
future fixture drift, bounded by running the production recovery function against
the fixture in the hosted real-PostgreSQL lane.

# Background

## What does this PR do?

Restores the final durable-recovery case in the compute-stop concurrency suite.
The hand-built `agent_sandboxes` table had drifted behind the production recovery
query: it exposed only identity fields, so PostgreSQL failed the lifecycle join
with SQLSTATE `42703` before the test could evaluate recovery behavior.

The repair:

- mirrors the sandbox columns selected and filtered by
  `listRecoverableAgentComputeStopIntents`;
- seeds user/lifecycle state for the existing agent-billing concurrency case; and
- gives the terminal recovery case a matching live `dedicated-lazy` sandbox in
  due `shutdown_pending` state.

The regression is consumer-visible at the delivery boundary: it leaves
`cloud / e2e-tests` red on `develop` and removes hosted proof that terminal stop
authority remains recoverable after worker/job failure.

## What kind of change is this?

Bug fix (non-breaking, test-fixture repair).

# Documentation changes needed?

No documentation change is needed. Runtime behavior and public contracts are
unchanged; this brings the real-PostgreSQL fixture back into agreement with the
existing production contract.

# Testing

## Where should a reviewer start?

Start with the final test in
`packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts`,
then compare the fixture columns with the sandbox projection and predicates in
`listRecoverableAgentComputeStopIntents`.

## Detailed testing steps

1. Run the exact real-PostgreSQL suite:
   ```bash
   COMPUTE_STOP_CONCURRENCY_REQUIRED=1 \
   APPS_TENANT_DB_TEST_DSN=postgresql://postgres@127.0.0.1:5432/postgres \
   bun test --config=/dev/null --isolate \
     packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
   ```
2. Confirm all nine cases pass.
3. Confirm the final result includes the seeded `terminal_attention` intent with
   `attempts: 3`.
4. Run the formatter and parser checks:
   ```bash
   biome check packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
   tsc --ignoreConfig --noEmit --noCheck --target ESNext --module NodeNext \
     --moduleResolution NodeNext \
     packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
   git diff --check origin/develop...HEAD
   ```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:241c8a75a62178d938c1b5e2679dc7e02c4d5901 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only PostgreSQL fixture repair with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only PostgreSQL fixture repair with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visible user flow changes in this test-only patch.
<!-- evidence-row:backend-logs -->
- [x] Exact-head backend log: [fork Cloud Tests run 33130562186, `e2e-tests` job 98720437242](https://github.com/batmanscode/eliza/actions/runs/33130562186/job/98720437242) ran the production recovery function against real PostgreSQL on `241c8a75a62178d938c1b5e2679dc7e02c4d5901`.

  ```text
  COMPUTE_STOP_CONCURRENCY_REQUIRED=1; bun test v1.3.14
  (pass) terminal agent stop authority remains visible to the independent recovery scan
  9 pass; 0 fail; 31 expect() calls; Ran 9 tests across 1 file. [6.12s]
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, model, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] PostgreSQL 18.4 domain probe against the patched fixture/predicates returned one matching recovery row:
  ```json
  {
    "postgres": "18.4",
    "row_count": 1,
    "status": "terminal_attention",
    "attempts": 3,
    "billing_status": "shutdown_pending",
    "execution_tier": "dedicated-lazy"
  }
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or UI surface is changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

The baseline [Develop Full job](https://github.com/elizaOS/eliza/actions/runs/33126256588/job/98706980236)
recorded the fixture regression on `develop`:

```text
8 pass
1 fail
error: column agent_sandboxes.lifecycle_revision does not exist
code: "42703"
(fail) compute stop concurrency > terminal agent stop authority remains visible to the independent recovery scan
```

The exact-head [fork job](https://github.com/batmanscode/eliza/actions/runs/33130562186/job/98720437242)
then ran the same production Drizzle recovery path against real PostgreSQL:

```text
bun test v1.3.14 (0d9b296a)
(pass) compute stop concurrency > terminal agent stop authority remains visible to the independent recovery scan [8.44ms]
9 pass
0 fail
31 expect() calls
Ran 9 tests across 1 file. [6.12s]
```

Post-sync local checks on the exact file and diff passed:

```text
Biome 2.5.8: Checked 1 file. No fixes applied.
TypeScript 6.0.3 noCheck parse: exit 0
git diff --check: exit 0
PostgreSQL 18.4 predicate probe: 1 recoverable terminal_attention row
```

Frontend logs: N/A - no frontend path exists for this change.

## Screenshots (before / after) + video walkthrough

N/A - backend-only real-PostgreSQL integration fixture with no rendered surface.

## Known gaps / failures

- The cloud sandbox can execute Bun 1.3.14 metadata, but any JavaScript process
  aborts before user code even with repository config disabled:
  ```text
  bun --version
  1.3.14

  bun --config=/dev/null -e 'console.log("runtime-ok")'
  Aborted
  exit 134
  ```
  Therefore `bun install`, `bun run verify`, and the exact Bun suite cannot run
  in this local kernel. This is unrelated to the diff: it reproduces with a
  one-line program before repository code loads. The hosted `cloud / e2e-tests`
  job ran the pinned Bun version on Ubuntu with real PostgreSQL and passed the
  exact nine-case acceptance suite on this PR head.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@9e8d5cb3b87c555a6f6c9c152dfafacb893c7f40:skills/contribute-to-eliza
Attribution status: self-reported
— [batmanscode-codex]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@9e8d5cb3b87c555a6f6c9c152dfafacb893c7f40:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M12XTJM7QQ419EPB0GF2QEZK","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-28T00:55:25.575Z","completed_at":"2026-08-28T01:10:50.914Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T00:55:46.658Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2a92c6da9d84fff31f6879bb80f5b1a32ff46bb041e74cf473d2e56f49cc277c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c02181e7-eaeb-4b94-a8f1-95469f8e4ae2","object_id":"sha256:2a92c6da9d84fff31f6879bb80f5b1a32ff46bb041e74cf473d2e56f49cc277c","sha256":"2a92c6da9d84fff31f6879bb80f5b1a32ff46bb041e74cf473d2e56f49cc277c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAA1hVHSZSHwgSZ2pCSmi_xnkKhf6gZezbAVfaVoNhb7k","device_key_id":"081e163b7fae49bf82bcfed8e0ac4e42e61a374219bc0065cf61b0317b7a3ad5","device_signature":"EG_PHbp971vEDCKOBXvn_xv1KLwUMbcriNjJb1soJK1AYSMGYFqKCydATZlrJ7uw-Qj7iYFPLNEeCsTrZz67AA"}} -->