### PR TITLE
fix(orchestrator): bulk hydrate task collections

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -2152,6 +2152,20 @@ describe("OrchestratorTaskService — usage telemetry", () => {
 });
 
 describe("OrchestratorTaskService — aggregation and bulk controls", () => {
+  it("hydrates collection views without issuing per-task point reads", async () => {
+    const { service, store } = makeServiceWithStore();
+    await service.createTask(createInput({ title: "first" }));
+    await service.createTask(createInput({ title: "second" }));
+    const pointRead = vi.spyOn(store, "getTask");
+
+    expect(await service.listTasks()).toHaveLength(2);
+    expect(await service.listTaskDetails()).toHaveLength(2);
+    expect((await service.getStatus()).taskCount).toBe(2);
+    expect((await service.getAccountOverview()).assignments).toEqual([]);
+    expect((await service.getRoomRoster()).rooms).toEqual([]);
+    expect(pointRead).not.toHaveBeenCalled();
+  });
+
   it("reports an empty status with no tasks", async () => {
     const status = await makeService().getStatus();
     expect(status.taskCount).toBe(0);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -2376,6 +2376,50 @@ describe("OrchestratorTaskService — aggregation and bulk controls", () => {
   });
 });
 
+describe("OrchestratorTaskService — stuck-task reaping", () => {
+  it("preserves a task when a live session attaches after candidate discovery", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp, {
+      ELIZA_ORCHESTRATOR_STUCK_TASK_REAP_MS: "1",
+    });
+    const task = await service.createTask(createInput({ title: "race-safe" }));
+    const staleSessionId = await addStoredSession(
+      store,
+      task.id,
+      "stale-session",
+    );
+    await store.updateSession(staleSessionId, { lastActivityAt: 1 });
+    await store.updateTask(task.id, { lastActivityAt: 1 });
+
+    const listTaskDocuments = store.listTaskDocuments.bind(store);
+    vi.spyOn(store, "listTaskDocuments").mockImplementationOnce(
+      async (filter = {}) => {
+        const snapshot = await listTaskDocuments(filter);
+        const liveSessionId = await addStoredSession(
+          store,
+          task.id,
+          "new-live-session",
+        );
+        acp.liveSessions.set(liveSessionId, {
+          id: liveSessionId,
+          status: "ready",
+        });
+        return snapshot;
+      },
+    );
+
+    expect(await service.reapStuckTasks(Date.now() + 60_000)).toEqual([]);
+    const detail = must(await service.getTask(task.id), "task detail");
+    expect(detail.status).toBe("active");
+    expect(detail.sessions.map((session) => session.sessionId)).toContain(
+      "new-live-session",
+    );
+    expect(
+      detail.events.some((event) => event.eventType === "task_stalled_reaped"),
+    ).toBe(false);
+  });
+});
+
 describe("OrchestratorTaskService — store degradation resilience (#11641)", () => {
   /** Runtime that hands back the same logger it wires in, so a test can assert
    * on warn calls. */

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -2377,6 +2377,39 @@ describe("OrchestratorTaskService — aggregation and bulk controls", () => {
 });
 
 describe("OrchestratorTaskService — stuck-task reaping", () => {
+  it("repairs and interrupts a genuinely stuck task exactly once", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp, {
+      ELIZA_ORCHESTRATOR_STUCK_TASK_REAP_MS: "1",
+    });
+    const task = await service.createTask(createInput({ title: "stuck" }));
+    const staleSessionId = await addStoredSession(
+      store,
+      task.id,
+      "stale-session",
+    );
+    await store.updateSession(staleSessionId, { lastActivityAt: 1 });
+    await store.updateTask(task.id, { status: "active", lastActivityAt: 1 });
+    const nowMs = Date.now() + 60_000;
+
+    expect(await service.reapStuckTasks(nowMs)).toEqual([task.id]);
+    const detail = must(await service.getTask(task.id), "task detail");
+    expect(detail.status).toBe("interrupted");
+    expect(detail.sessions).toEqual([
+      expect.objectContaining({
+        sessionId: staleSessionId,
+        status: "stopped",
+        stoppedAt: nowMs,
+      }),
+    ]);
+    expect(
+      detail.events.filter(
+        (event) => event.eventType === "task_stalled_reaped",
+      ),
+    ).toHaveLength(1);
+    expect(await service.reapStuckTasks(nowMs + 60_000)).toEqual([]);
+  });
+
   it("preserves a task when a live session attaches after candidate discovery", async () => {
     const acp = new FakeAcp();
     const { service, store } = makeServiceWithStore(acp, {
@@ -2407,6 +2440,48 @@ describe("OrchestratorTaskService — stuck-task reaping", () => {
         return snapshot;
       },
     );
+
+    expect(await service.reapStuckTasks(Date.now() + 60_000)).toEqual([]);
+    const detail = must(await service.getTask(task.id), "task detail");
+    expect(detail.status).toBe("active");
+    expect(detail.sessions.map((session) => session.sessionId)).toContain(
+      "new-live-session",
+    );
+    expect(
+      detail.events.some((event) => event.eventType === "task_stalled_reaped"),
+    ).toBe(false);
+  });
+
+  it("preserves a task when a live session attaches during the ACP liveness probe", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp, {
+      ELIZA_ORCHESTRATOR_STUCK_TASK_REAP_MS: "1",
+    });
+    const task = await service.createTask(
+      createInput({ title: "post-refresh-race-safe" }),
+    );
+    const staleSessionId = await addStoredSession(
+      store,
+      task.id,
+      "stale-session",
+    );
+    await store.updateSession(staleSessionId, { lastActivityAt: 1 });
+    await store.updateTask(task.id, { lastActivityAt: 1 });
+
+    const getSession = acp.getSession.bind(acp);
+    vi.spyOn(acp, "getSession").mockImplementationOnce(async (sessionId) => {
+      const result = await getSession(sessionId);
+      const liveSessionId = await addStoredSession(
+        store,
+        task.id,
+        "new-live-session",
+      );
+      acp.liveSessions.set(liveSessionId, {
+        id: liveSessionId,
+        status: "ready",
+      });
+      return result;
+    });
 
     expect(await service.reapStuckTasks(Date.now() + 60_000)).toEqual([]);
     const detail = must(await service.getTask(task.id), "task detail");

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -663,6 +663,39 @@ class PgliteBareScanRejectingAdapter extends FakeSqlAdapter {
 }
 
 describe("RuntimeDbTaskStore", () => {
+  it("hydrates a filtered task collection with one SQL query instead of one point read per task", async () => {
+    const seenSql: string[] = [];
+    const adapter = new FakeSqlAdapter();
+    const capturing = {
+      execute: (sql: string, params?: unknown[]) =>
+        adapter.execute(sql, params),
+      all: (sql: string, params?: unknown[]) => {
+        seenSql.push(sql);
+        return adapter.all(sql, params);
+      },
+    };
+    const store = new RuntimeDbTaskStore(capturing);
+    const first = await store.createTask(
+      createInput({ title: "first", projectId: "project-a" }),
+    );
+    const second = await store.createTask(
+      createInput({ title: "second", projectId: "project-a" }),
+    );
+    await store.createTask(
+      createInput({ title: "other", projectId: "project-b" }),
+    );
+
+    seenSql.length = 0;
+    const docs = await store.listTaskDocuments({ projectId: "project-a" });
+
+    expect(new Set(docs.map((doc) => doc.task.id))).toEqual(
+      new Set([first.task.id, second.task.id]),
+    );
+    expect(seenSql).toHaveLength(1);
+    expect(seenSql[0]).toContain("project_id = ?");
+    expect(seenSql[0]).not.toContain("WHERE id = ?");
+  });
+
   it("resolves a session without a `document LIKE` query so pglite/postgres do not fail (#11641)", async () => {
     // On pglite the old `SELECT document FROM orchestrator_tasks WHERE document
     // LIKE ?` threw, spamming a failed-query warn on every session event and

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -17,6 +17,7 @@ import {
 import type {
   CreateTaskInput,
   OrchestratorTaskDocument,
+  OrchestratorTaskEvent,
   OrchestratorTaskPlanRevision,
   OrchestratorTaskSession,
 } from "../../src/services/orchestrator-task-types.js";
@@ -39,6 +40,11 @@ function createInput(
   overrides: Partial<CreateTaskInput> = {},
 ): CreateTaskInput {
   return { title: "Ship feature", goal: "Implement and verify", ...overrides };
+}
+
+function must<T>(value: T | null | undefined, label: string): T {
+  if (value == null) throw new Error(`Missing ${label}`);
+  return value;
 }
 
 function sessionFor(
@@ -74,6 +80,30 @@ function sessionFor(
     createdAt: now,
     updatedAt: now,
     ...overrides,
+  };
+}
+
+function stuckReapInput(doc: OrchestratorTaskDocument) {
+  const event: OrchestratorTaskEvent = {
+    id: "reap-event",
+    taskId: doc.task.id,
+    eventType: "task_stalled_reaped",
+    summary: "stuck task",
+    data: {},
+    timestamp: 2,
+    createdAt: new Date("2026-05-20T12:01:00.000Z").toISOString(),
+  };
+  return {
+    taskId: doc.task.id,
+    expectedTaskUpdatedAt: doc.task.updatedAt,
+    expectedSessions: doc.sessions.map((session) => ({
+      sessionId: session.sessionId,
+      status: session.status,
+      updatedAt: session.updatedAt,
+    })),
+    deadSessionIds: doc.sessions.map((session) => session.sessionId),
+    event,
+    nowMs: 2,
   };
 }
 
@@ -502,6 +532,45 @@ describe("InMemoryTaskStore", () => {
 });
 
 describe("FileTaskStore", () => {
+  it("persists one atomic stuck-task reap and rejects a stale snapshot", async () => {
+    const file = await tempFile();
+    const store = new FileTaskStore(file);
+    const { task } = await store.createTask(
+      createInput({ title: "file reap" }),
+    );
+    await store.updateTask(task.id, { status: "active", lastActivityAt: 1 });
+    await store.addSession(sessionFor(task.id));
+    const snapshot = await store.getTask(task.id);
+    expect(snapshot).not.toBeNull();
+
+    await store.addSession(
+      sessionFor(task.id, { id: "row-2", sessionId: "late-session" }),
+    );
+    expect(
+      await store.interruptStuckTaskIfUnchanged(
+        stuckReapInput(must(snapshot, "file task snapshot")),
+      ),
+    ).toBe(false);
+    const current = await store.getTask(task.id);
+    expect(current).not.toBeNull();
+    const input = stuckReapInput(must(current, "current file task"));
+    input.deadSessionIds = ["session-1", "late-session"];
+    expect(await store.interruptStuckTaskIfUnchanged(input)).toBe(true);
+
+    const reopened = new FileTaskStore(file);
+    const persisted = await reopened.getTask(task.id);
+    expect(persisted?.task.status).toBe("interrupted");
+    expect(persisted?.sessions.map((session) => session.status)).toEqual([
+      "stopped",
+      "stopped",
+    ]);
+    expect(
+      persisted?.events.filter(
+        (event) => event.eventType === "task_stalled_reaped",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("serializes first-touch loads so concurrent operations cannot hydrate over each other", async () => {
     const file = await tempFile();
     const seed = new FileTaskStore(file);
@@ -663,6 +732,36 @@ class PgliteBareScanRejectingAdapter extends FakeSqlAdapter {
 }
 
 describe("RuntimeDbTaskStore", () => {
+  it("persists an atomic stuck-task reap through the runtime DB backend", async () => {
+    const adapter = new FakeSqlAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(
+      createInput({ title: "runtime DB reap" }),
+    );
+    await store.updateTask(task.id, { status: "active", lastActivityAt: 1 });
+    await store.addSession(sessionFor(task.id));
+    const snapshot = await store.getTask(task.id);
+    expect(snapshot).not.toBeNull();
+    expect(
+      await store.interruptStuckTaskIfUnchanged(
+        stuckReapInput(must(snapshot, "runtime DB task snapshot")),
+      ),
+    ).toBe(true);
+
+    const reopened = new RuntimeDbTaskStore(adapter);
+    const persisted = await reopened.getTask(task.id);
+    expect(persisted?.task.status).toBe("interrupted");
+    expect(persisted?.sessions[0]).toMatchObject({
+      status: "stopped",
+      stoppedAt: 2,
+    });
+    expect(
+      persisted?.events.filter(
+        (event) => event.eventType === "task_stalled_reaped",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("hydrates a filtered task collection with one SQL query instead of one point read per task", async () => {
     const seenSql: string[] = [];
     const adapter = new FakeSqlAdapter();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -132,6 +132,7 @@ function planRevisionFor(
  */
 class FakeSqlAdapter {
   readonly rows = new Map<string, Record<string, unknown>>();
+  beforeConditionalUpdate?: () => Promise<void> | void;
   private projectColumn = false;
 
   async execute(sql: string, params: unknown[] = []): Promise<void> {
@@ -159,6 +160,39 @@ class FakeSqlAdapter {
         lastActivityAt,
         document,
       ] = params;
+      this.rows.set(id as string, {
+        id,
+        status,
+        archived,
+        priority,
+        title,
+        project_id: projectId,
+        search_text: searchText,
+        updated_at: updatedAt,
+        last_activity_at: lastActivityAt,
+        document,
+      });
+      return;
+    }
+    if (head === "UPDATE") {
+      const beforeConditionalUpdate = this.beforeConditionalUpdate;
+      this.beforeConditionalUpdate = undefined;
+      await beforeConditionalUpdate?.();
+      const [
+        status,
+        archived,
+        priority,
+        title,
+        projectId,
+        searchText,
+        updatedAt,
+        lastActivityAt,
+        document,
+        id,
+        expectedDocument,
+      ] = params;
+      const current = this.rows.get(id as string);
+      if (!current || current.document !== expectedDocument) return;
       this.rows.set(id as string, {
         id,
         status,
@@ -534,28 +568,37 @@ describe("InMemoryTaskStore", () => {
 describe("FileTaskStore", () => {
   it("persists one atomic stuck-task reap and rejects a stale snapshot", async () => {
     const file = await tempFile();
-    const store = new FileTaskStore(file);
-    const { task } = await store.createTask(
+    const staleWriter = new FileTaskStore(file);
+    const { task } = await staleWriter.createTask(
       createInput({ title: "file reap" }),
     );
-    await store.updateTask(task.id, { status: "active", lastActivityAt: 1 });
-    await store.addSession(sessionFor(task.id));
-    const snapshot = await store.getTask(task.id);
+    await staleWriter.updateTask(task.id, {
+      status: "active",
+      lastActivityAt: 1,
+    });
+    await staleWriter.addSession(sessionFor(task.id));
+    const snapshot = await staleWriter.getTask(task.id);
     expect(snapshot).not.toBeNull();
 
-    await store.addSession(
+    const liveWriter = new FileTaskStore(file);
+    await liveWriter.addSession(
       sessionFor(task.id, { id: "row-2", sessionId: "late-session" }),
     );
     expect(
-      await store.interruptStuckTaskIfUnchanged(
+      await staleWriter.interruptStuckTaskIfUnchanged(
         stuckReapInput(must(snapshot, "file task snapshot")),
       ),
     ).toBe(false);
-    const current = await store.getTask(task.id);
+    const current = await staleWriter.getTask(task.id);
     expect(current).not.toBeNull();
+    expect(current?.sessions.map((session) => session.sessionId)).toContain(
+      "late-session",
+    );
+    expect(current?.task.status).toBe("active");
+    expect(current?.events).toHaveLength(0);
     const input = stuckReapInput(must(current, "current file task"));
     input.deadSessionIds = ["session-1", "late-session"];
-    expect(await store.interruptStuckTaskIfUnchanged(input)).toBe(true);
+    expect(await staleWriter.interruptStuckTaskIfUnchanged(input)).toBe(true);
 
     const reopened = new FileTaskStore(file);
     const persisted = await reopened.getTask(task.id);
@@ -734,19 +777,38 @@ class PgliteBareScanRejectingAdapter extends FakeSqlAdapter {
 describe("RuntimeDbTaskStore", () => {
   it("persists an atomic stuck-task reap through the runtime DB backend", async () => {
     const adapter = new FakeSqlAdapter();
-    const store = new RuntimeDbTaskStore(adapter);
-    const { task } = await store.createTask(
+    const staleWriter = new RuntimeDbTaskStore(adapter);
+    const { task } = await staleWriter.createTask(
       createInput({ title: "runtime DB reap" }),
     );
-    await store.updateTask(task.id, { status: "active", lastActivityAt: 1 });
-    await store.addSession(sessionFor(task.id));
-    const snapshot = await store.getTask(task.id);
+    await staleWriter.updateTask(task.id, {
+      status: "active",
+      lastActivityAt: 1,
+    });
+    await staleWriter.addSession(sessionFor(task.id));
+    const snapshot = await staleWriter.getTask(task.id);
     expect(snapshot).not.toBeNull();
+
+    const liveWriter = new RuntimeDbTaskStore(adapter);
+    adapter.beforeConditionalUpdate = () =>
+      liveWriter.addSession(
+        sessionFor(task.id, { id: "row-2", sessionId: "late-session" }),
+      );
     expect(
-      await store.interruptStuckTaskIfUnchanged(
+      await staleWriter.interruptStuckTaskIfUnchanged(
         stuckReapInput(must(snapshot, "runtime DB task snapshot")),
       ),
-    ).toBe(true);
+    ).toBe(false);
+
+    const current = await staleWriter.getTask(task.id);
+    expect(current?.sessions.map((session) => session.sessionId)).toContain(
+      "late-session",
+    );
+    expect(current?.task.status).toBe("active");
+    expect(current?.events).toHaveLength(0);
+    const input = stuckReapInput(must(current, "current runtime DB task"));
+    input.deadSessionIds = ["session-1", "late-session"];
+    expect(await staleWriter.interruptStuckTaskIfUnchanged(input)).toBe(true);
 
     const reopened = new RuntimeDbTaskStore(adapter);
     const persisted = await reopened.getTask(task.id);
@@ -757,6 +819,42 @@ describe("RuntimeDbTaskStore", () => {
     });
     expect(
       persisted?.events.filter(
+        (event) => event.eventType === "task_stalled_reaped",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("compares against the exact legacy runtime DB document serialization", async () => {
+    const adapter = new FakeSqlAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(
+      createInput({ title: "legacy runtime DB reap" }),
+    );
+    await store.updateTask(task.id, {
+      status: "active",
+      lastActivityAt: 1,
+    });
+    await store.addSession(sessionFor(task.id));
+
+    const row = must(adapter.rows.get(task.id), "runtime DB row");
+    const legacyDocument = JSON.parse(String(row.document)) as Record<
+      string,
+      unknown
+    >;
+    delete legacyDocument.planRevisions;
+    row.document = JSON.stringify(legacyDocument);
+
+    const snapshot = must(await store.getTask(task.id), "legacy task snapshot");
+    expect(snapshot.planRevisions).toEqual([]);
+    expect(
+      await store.interruptStuckTaskIfUnchanged(stuckReapInput(snapshot)),
+    ).toBe(true);
+
+    const persisted = must(await store.getTask(task.id), "reaped legacy task");
+    expect(persisted.task.status).toBe("interrupted");
+    expect(persisted.planRevisions).toEqual([]);
+    expect(
+      persisted.events.filter(
         (event) => event.eventType === "task_stalled_reaped",
       ),
     ).toHaveLength(1);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1295,12 +1295,12 @@ export class OrchestratorTaskService extends Service {
 
   /** Retry persisted coordinator-review deliveries after a runtime restart. */
   async recoverCompletionBarriers(): Promise<number> {
-    const tasks = await this.store.listTasks();
+    const taskDocs = await this.store.listTaskDocuments();
     let recovered = 0;
-    for (const task of tasks) {
+    for (const doc of taskDocs) {
+      const task = doc.task;
       if (!task.completionCoordinatorSessionId) continue;
-      const doc = await this.store.getTask(task.id);
-      const coordinator = doc?.sessions.find(
+      const coordinator = doc.sessions.find(
         (session) => session.sessionId === task.completionCoordinatorSessionId,
       );
       if (!coordinator?.aggregateCompletionRequestedAt) continue;
@@ -1338,13 +1338,10 @@ export class OrchestratorTaskService extends Service {
     const acp = acpOverride ?? this.acp();
     if (!acp) throw new Error("ACP service unavailable for Smithers recovery");
 
-    const [acpSessions, taskRecords] = await Promise.all([
+    const [acpSessions, taskDocs] = await Promise.all([
       acp.listSessions(),
-      this.store.listTasks({}),
+      this.store.listTaskDocuments({}),
     ]);
-    const taskDocs = (
-      await Promise.all(taskRecords.map((task) => this.store.getTask(task.id)))
-    ).filter((doc): doc is OrchestratorTaskDocument => doc !== null);
     const acpById = new Map(
       acpSessions.map((session) => [session.id, session]),
     );
@@ -3609,13 +3606,28 @@ export class OrchestratorTaskService extends Service {
   }
 
   async listTasks(filter: TaskListFilter = {}): Promise<TaskThreadDto[]> {
-    const records = await this.store.listTasks(filter);
-    const docs = await Promise.all(
-      records.map((record) => this.store.getTask(record.id)),
+    return (await this.store.listTaskDocuments(filter)).map(toTaskThread);
+  }
+
+  async listTaskDetails(
+    filter: TaskListFilter = {},
+  ): Promise<TaskThreadDetailDto[]> {
+    const docs = await this.store.listTaskDocuments(filter);
+    for (const doc of docs) assertProjectIdRegistered(doc.task.projectId);
+    const details = docs.map(toTaskThreadDetail);
+    if (!details.some((detail) => detail.admission)) return details;
+    const { queuedTaskIds } = await this.getAdmissionSnapshot();
+    const positions = new Map(
+      queuedTaskIds.map((taskId, index) => [taskId, index + 1]),
     );
-    return docs
-      .filter((doc): doc is OrchestratorTaskDocument => doc !== null)
-      .map(toTaskThread);
+    return details.map((detail) => {
+      if (!detail.admission) return detail;
+      detail.admission = {
+        ...detail.admission,
+        position: positions.get(detail.id) ?? 0,
+      };
+      return detail;
+    });
   }
 
   async getTask(taskId: string): Promise<TaskThreadDetailDto | null> {
@@ -6507,10 +6519,7 @@ export class OrchestratorTaskService extends Service {
   // ---- aggregate ---------------------------------------------------------
 
   async getStatus(): Promise<OrchestratorStatus> {
-    const records = await this.store.listTasks({ includeArchived: false });
-    const docs = (
-      await Promise.all(records.map((record) => this.store.getTask(record.id)))
-    ).filter((doc): doc is OrchestratorTaskDocument => doc !== null);
+    const docs = await this.store.listTaskDocuments({ includeArchived: false });
 
     const byStatus = {
       open: 0,
@@ -6551,10 +6560,7 @@ export class OrchestratorTaskService extends Service {
   }
 
   async getAccountOverview(): Promise<OrchestratorAccountOverview> {
-    const records = await this.store.listTasks({ includeArchived: false });
-    const docs = (
-      await Promise.all(records.map((record) => this.store.getTask(record.id)))
-    ).filter((doc): doc is OrchestratorTaskDocument => doc !== null);
+    const docs = await this.store.listTaskDocuments({ includeArchived: false });
 
     const assignments: OrchestratorAccountAssignment[] = [];
     for (const doc of docs) {
@@ -6621,10 +6627,7 @@ export class OrchestratorTaskService extends Service {
    * one sub-agent session are included (an empty room has no roster to show).
    */
   async getRoomRoster(): Promise<OrchestratorRoomRosterOverview> {
-    const records = await this.store.listTasks({ includeArchived: false });
-    const docs = (
-      await Promise.all(records.map((record) => this.store.getTask(record.id)))
-    ).filter((doc): doc is OrchestratorTaskDocument => doc !== null);
+    const docs = await this.store.listTaskDocuments({ includeArchived: false });
 
     const orchestratorLabel = this.runtime.character?.name ?? "Orchestrator";
     const rooms: OrchestratorRoomRoster[] = [];
@@ -6815,11 +6818,12 @@ export class OrchestratorTaskService extends Service {
     try {
       const thresholdMs = this.stuckTaskReapThresholdMs();
       const acp = this.acp();
-      const records = await this.store.listTasks({ includeArchived: false });
-      for (const record of records) {
-        if (record.status !== "active" || record.paused) continue;
-        const doc = await this.store.getTask(record.id);
-        if (doc?.task.status !== "active" || doc.task.paused) continue;
+      const docs = await this.store.listTaskDocuments({
+        includeArchived: false,
+        status: "active",
+      });
+      for (const doc of docs) {
+        if (doc.task.status !== "active" || doc.task.paused) continue;
 
         const liveRows = doc.sessions.filter(
           (s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status),
@@ -6863,7 +6867,7 @@ export class OrchestratorTaskService extends Service {
         }
         await this.store.addEvent({
           id: randomUUID(),
-          taskId: record.id,
+          taskId: doc.task.id,
           eventType: "task_stalled_reaped",
           summary: `No live sub-agent session and no activity for ${Math.round(
             idleMs / 60_000,
@@ -6876,13 +6880,13 @@ export class OrchestratorTaskService extends Service {
           timestamp: nowMs,
           createdAt: nowIso(),
         });
-        await this.advanceTaskStatus(record.id, "interrupted");
-        this.emitChange(record.id);
+        await this.advanceTaskStatus(doc.task.id, "interrupted");
+        this.emitChange(doc.task.id);
         this.log("info", "stuck task reaped to interrupted", {
-          taskId: record.id,
+          taskId: doc.task.id,
           idleMs,
         });
-        reaped.push(record.id);
+        reaped.push(doc.task.id);
       }
     } catch (err) {
       // error-policy:J7 background reconcile tick — a store/ACP hiccup is

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -6822,7 +6822,12 @@ export class OrchestratorTaskService extends Service {
         includeArchived: false,
         status: "active",
       });
-      for (const doc of docs) {
+      for (const candidate of docs) {
+        // The bulk snapshot is candidate discovery only. A session may attach
+        // while the scan is in flight, so the destructive decision must use a
+        // fresh document read immediately before evaluating liveness/idleness.
+        const doc = await this.store.getTask(candidate.task.id);
+        if (!doc) continue;
         if (doc.task.status !== "active" || doc.task.paused) continue;
 
         const liveRows = doc.sessions.filter(

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -164,6 +164,7 @@ import {
   type OrchestratorRoomRoster,
   type OrchestratorRoomRosterOverview,
   type OrchestratorTaskDocument,
+  type OrchestratorTaskEvent,
   type OrchestratorTaskPriority,
   type OrchestratorTaskRecord,
   type OrchestratorTaskSession,
@@ -6862,15 +6863,7 @@ export class OrchestratorTaskService extends Service {
         const idleMs = nowMs - latestActivityMs;
         if (idleMs < thresholdMs) continue;
 
-        // Repair rows the bridge never saw go terminal, so DTOs stop counting
-        // phantom "active" sessions for the interrupted task.
-        for (const row of deadRows) {
-          await this.store.updateSession(row.sessionId, {
-            status: "stopped",
-            stoppedAt: nowMs,
-          });
-        }
-        await this.store.addEvent({
+        const event = {
           id: randomUUID(),
           taskId: doc.task.id,
           eventType: "task_stalled_reaped",
@@ -6884,8 +6877,20 @@ export class OrchestratorTaskService extends Service {
           },
           timestamp: nowMs,
           createdAt: nowIso(),
+        } satisfies OrchestratorTaskEvent;
+        const interrupted = await this.store.interruptStuckTaskIfUnchanged({
+          taskId: doc.task.id,
+          expectedTaskUpdatedAt: doc.task.updatedAt,
+          expectedSessions: doc.sessions.map((session) => ({
+            sessionId: session.sessionId,
+            status: session.status,
+            updatedAt: session.updatedAt,
+          })),
+          deadSessionIds: deadRows.map((row) => row.sessionId),
+          event,
+          nowMs,
         });
-        await this.advanceTaskStatus(doc.task.id, "interrupted");
+        if (!interrupted) continue;
         this.emitChange(doc.task.id);
         this.log("info", "stuck task reaped to interrupted", {
           taskId: doc.task.id,
@@ -6899,6 +6904,7 @@ export class OrchestratorTaskService extends Service {
       this.log("warn", "stuck-task reap pass failed", {
         error: err instanceof Error ? err.message : String(err),
       });
+      this.runtime.reportError("OrchestratorTask.reapStuckTasks", err);
     } finally {
       this.stuckTaskReapInFlight = false;
     }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -424,15 +424,20 @@ export class InMemoryTaskStore {
   async listTasks(
     filter: TaskListFilter = {},
   ): Promise<OrchestratorTaskRecord[]> {
+    return (await this.listTaskDocuments(filter)).map((doc) => doc.task);
+  }
+
+  async listTaskDocuments(
+    filter: TaskListFilter = {},
+  ): Promise<OrchestratorTaskDocument[]> {
     const matches = [...this.docs.values()]
       .filter((doc) => matchesFilter(doc.task, filter, buildSearchText(doc)))
-      .map((doc) => doc.task)
-      .sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+      .sort((a, b) => b.task.lastActivityAt - a.task.lastActivityAt);
     const limited =
       filter.limit && filter.limit > 0
         ? matches.slice(0, filter.limit)
         : matches;
-    return limited.map((t) => structuredClone(t));
+    return limited.map(cloneDocument);
   }
 
   async updateTask(
@@ -698,6 +703,10 @@ export class FileTaskStore extends InMemoryTaskStore {
   override async listTasks(filter?: TaskListFilter) {
     await this.ensureLoaded();
     return super.listTasks(filter);
+  }
+  override async listTaskDocuments(filter?: TaskListFilter) {
+    await this.ensureLoaded();
+    return super.listTaskDocuments(filter);
   }
   override async updateTask(
     id: string,
@@ -1068,6 +1077,12 @@ export class RuntimeDbTaskStore {
   async listTasks(
     filter: TaskListFilter = {},
   ): Promise<OrchestratorTaskRecord[]> {
+    return (await this.listTaskDocuments(filter)).map((doc) => doc.task);
+  }
+
+  async listTaskDocuments(
+    filter: TaskListFilter = {},
+  ): Promise<OrchestratorTaskDocument[]> {
     await this.ensureInitialized();
     const clauses: string[] = [];
     const params: unknown[] = [];
@@ -1106,8 +1121,8 @@ export class RuntimeDbTaskStore {
       params,
     );
     return rows
-      .map((row) => this.parseDoc(row)?.task)
-      .filter((t): t is OrchestratorTaskRecord => Boolean(t));
+      .map((row) => this.parseDoc(row))
+      .filter((doc): doc is OrchestratorTaskDocument => doc !== null);
   }
 
   /** Run a mutation against the freshest stored document, then persist it. */
@@ -1331,6 +1346,9 @@ export class OrchestratorTaskStore {
   }
   listTasks(filter?: TaskListFilter) {
     return this.delegate.listTasks(filter);
+  }
+  listTaskDocuments(filter?: TaskListFilter) {
+    return this.delegate.listTaskDocuments(filter);
   }
   updateTask(id: string, patch: Partial<OrchestratorTaskRecord>) {
     return this.delegate.updateTask(id, patch);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -402,6 +402,57 @@ function matchesFilter(
   return true;
 }
 
+function applyStuckTaskInterrupt(
+  doc: OrchestratorTaskDocument,
+  input: InterruptStuckTaskInput,
+): boolean {
+  if (doc.task.status !== "active" || doc.task.paused) return false;
+  if (doc.task.updatedAt !== input.expectedTaskUpdatedAt) return false;
+
+  const expectedSessions = input.expectedSessions
+    .map(
+      (session) =>
+        `${session.sessionId}\u0000${session.status}\u0000${session.updatedAt}`,
+    )
+    .sort();
+  const currentSessions = doc.sessions
+    .map(
+      (session) =>
+        `${session.sessionId}\u0000${session.status}\u0000${session.updatedAt}`,
+    )
+    .sort();
+  if (
+    expectedSessions.length !== currentSessions.length ||
+    expectedSessions.some(
+      (session, index) => session !== currentSessions[index],
+    )
+  ) {
+    return false;
+  }
+
+  const deadSessionIds = new Set(input.deadSessionIds);
+  const liveSessionIds = doc.sessions
+    .filter((session) => !TERMINAL_TASK_SESSION_STATUSES.has(session.status))
+    .map((session) => session.sessionId);
+  if (liveSessionIds.some((sessionId) => !deadSessionIds.has(sessionId))) {
+    return false;
+  }
+
+  const nextStatus = nextTaskStatus(doc.task.status, "interrupted");
+  const updatedAt = nowIso();
+  for (const session of doc.sessions) {
+    if (!deadSessionIds.has(session.sessionId)) continue;
+    session.status = "stopped";
+    session.stoppedAt = input.nowMs;
+    session.updatedAt = updatedAt;
+  }
+  doc.events.push(structuredClone(input.event));
+  doc.task.status = nextStatus;
+  doc.task.updatedAt = updatedAt;
+  doc.task.lastActivityAt = Date.now();
+  return true;
+}
+
 /**
  * In-memory backend. The file backend extends this with JSON persistence; the
  * SQL backend reimplements the same surface against a runtime adapter.
@@ -548,52 +599,7 @@ export class InMemoryTaskStore {
   ): Promise<boolean> {
     return this.enqueue(async () => {
       const doc = this.docs.get(input.taskId);
-      if (doc?.task.status !== "active" || doc.task.paused) return false;
-      if (doc.task.updatedAt !== input.expectedTaskUpdatedAt) return false;
-
-      const expectedSessions = input.expectedSessions
-        .map(
-          (session) =>
-            `${session.sessionId}\u0000${session.status}\u0000${session.updatedAt}`,
-        )
-        .sort();
-      const currentSessions = doc.sessions
-        .map(
-          (session) =>
-            `${session.sessionId}\u0000${session.status}\u0000${session.updatedAt}`,
-        )
-        .sort();
-      if (
-        expectedSessions.length !== currentSessions.length ||
-        expectedSessions.some(
-          (session, index) => session !== currentSessions[index],
-        )
-      ) {
-        return false;
-      }
-
-      const deadSessionIds = new Set(input.deadSessionIds);
-      const liveSessionIds = doc.sessions
-        .filter(
-          (session) => !TERMINAL_TASK_SESSION_STATUSES.has(session.status),
-        )
-        .map((session) => session.sessionId);
-      if (liveSessionIds.some((sessionId) => !deadSessionIds.has(sessionId))) {
-        return false;
-      }
-
-      const nextStatus = nextTaskStatus(doc.task.status, "interrupted");
-      const updatedAt = nowIso();
-      for (const session of doc.sessions) {
-        if (!deadSessionIds.has(session.sessionId)) continue;
-        session.status = "stopped";
-        session.stoppedAt = input.nowMs;
-        session.updatedAt = updatedAt;
-      }
-      doc.events.push(structuredClone(input.event));
-      doc.task.status = nextStatus;
-      doc.task.updatedAt = updatedAt;
-      doc.task.lastActivityAt = Date.now();
+      if (!doc || !applyStuckTaskInterrupt(doc, input)) return false;
       this.noteMutated(input.taskId);
       await this.afterWrite();
       return true;
@@ -810,7 +816,46 @@ export class FileTaskStore extends InMemoryTaskStore {
   }
   override async interruptStuckTaskIfUnchanged(input: InterruptStuckTaskInput) {
     await this.ensureLoaded();
-    return super.interruptStuckTaskIfUnchanged(input);
+    return this.enqueue(async () =>
+      this.withLock(async () => {
+        let contents: string;
+        try {
+          contents = await readFile(this.filePath, "utf8");
+        } catch (error) {
+          const code =
+            isRecord(error) && typeof error.code === "string" ? error.code : "";
+          if (code === "ENOENT") return false;
+          throw error;
+        }
+        const parsed = JSON.parse(contents) as unknown;
+        if (!Array.isArray(parsed)) {
+          throw new Error(
+            "orchestrator-task-store: state file is not a task-document array",
+          );
+        }
+        const documents = parsed.map(normalizeTaskDocument);
+        if (documents.some((doc) => doc === null)) {
+          throw new Error(
+            "orchestrator-task-store: state file contains an invalid task document",
+          );
+        }
+        const validDocuments = documents as OrchestratorTaskDocument[];
+        const doc = validDocuments.find(
+          (candidate) => candidate.task.id === input.taskId,
+        );
+        if (!doc || !applyStuckTaskInterrupt(doc, input)) {
+          this.hydrate(validDocuments);
+          return false;
+        }
+
+        const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+        const payload = JSON.stringify(validDocuments, null, 2);
+        await writeFile(tempPath, `${payload}\n`, "utf8");
+        await rename(tempPath, this.filePath);
+        this.hydrate(validDocuments);
+        return true;
+      }),
+    );
   }
   override async findSession(sessionId: string, taskId?: string) {
     await this.ensureLoaded();
@@ -1133,12 +1178,54 @@ export class RuntimeDbTaskStore {
     );
   }
 
+  private async persistIfDocumentMatches(
+    doc: OrchestratorTaskDocument,
+    expectedDocument: string,
+  ): Promise<void> {
+    const searchText = buildSearchText(doc);
+    await this.exec().run(
+      `UPDATE orchestrator_tasks SET
+         status = ?,
+         archived = ?,
+         priority = ?,
+         title = ?,
+         project_id = ?,
+         search_text = ?,
+         updated_at = ?,
+         last_activity_at = ?,
+         document = ?
+       WHERE id = ? AND document = ?`,
+      [
+        doc.task.status,
+        doc.task.archived ? 1 : 0,
+        doc.task.priority,
+        doc.task.title,
+        doc.task.projectId ?? null,
+        searchText,
+        doc.task.updatedAt,
+        doc.task.lastActivityAt,
+        JSON.stringify(doc),
+        doc.task.id,
+        expectedDocument,
+      ],
+    );
+  }
+
   private async loadOne(id: string): Promise<OrchestratorTaskDocument | null> {
+    return (await this.loadOneWithRawDocument(id))?.doc ?? null;
+  }
+
+  private async loadOneWithRawDocument(
+    id: string,
+  ): Promise<{ doc: OrchestratorTaskDocument; rawDocument: string } | null> {
     const rows = await this.exec().all(
       "SELECT document FROM orchestrator_tasks WHERE id = ?",
       [id],
     );
-    return rows.length > 0 ? this.parseDoc(rows[0]) : null;
+    const row = rows[0];
+    if (!isRecord(row) || typeof row.document !== "string") return null;
+    const doc = this.parseDoc(row);
+    return doc ? { doc, rawDocument: row.document } : null;
   }
 
   async createTask(input: CreateTaskInput): Promise<OrchestratorTaskDocument> {
@@ -1265,9 +1352,19 @@ export class RuntimeDbTaskStore {
   }
 
   async interruptStuckTaskIfUnchanged(input: InterruptStuckTaskInput) {
-    return this.mutate(input.taskId, (cache) =>
-      cache.interruptStuckTaskIfUnchanged(input),
-    );
+    return this.enqueue(async () => {
+      await this.ensureInitialized();
+      const loaded = await this.loadOneWithRawDocument(input.taskId);
+      if (!loaded) return false;
+      const next = cloneDocument(loaded.doc);
+      if (!applyStuckTaskInterrupt(next, input)) return false;
+      await this.persistIfDocumentMatches(next, loaded.rawDocument);
+      const persisted = await this.loadOne(input.taskId);
+      return (
+        persisted?.task.status === "interrupted" &&
+        persisted.events.some((event) => event.id === input.event.id)
+      );
+    });
   }
 
   async findSession(sessionId: string, taskId?: string) {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -22,21 +22,34 @@ import {
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import type {
-  CreateTaskInput,
-  OrchestratorTaskArtifact,
-  OrchestratorTaskDecision,
-  OrchestratorTaskDocument,
-  OrchestratorTaskEvent,
-  OrchestratorTaskMessage,
-  OrchestratorTaskPlanRevision,
-  OrchestratorTaskRecord,
-  OrchestratorTaskSession,
-  OrchestratorTaskUsage,
-  TaskListFilter,
+import {
+  type CreateTaskInput,
+  nextTaskStatus,
+  type OrchestratorTaskArtifact,
+  type OrchestratorTaskDecision,
+  type OrchestratorTaskDocument,
+  type OrchestratorTaskEvent,
+  type OrchestratorTaskMessage,
+  type OrchestratorTaskPlanRevision,
+  type OrchestratorTaskRecord,
+  type OrchestratorTaskSession,
+  type OrchestratorTaskUsage,
+  type TaskListFilter,
+  TERMINAL_TASK_SESSION_STATUSES,
 } from "./orchestrator-task-types.js";
 
 export type TaskStoreBackend = "runtime-db" | "file" | "memory";
+
+export interface InterruptStuckTaskInput {
+  taskId: string;
+  expectedTaskUpdatedAt: string;
+  expectedSessions: Array<
+    Pick<OrchestratorTaskSession, "sessionId" | "status" | "updatedAt">
+  >;
+  deadSessionIds: string[];
+  event: OrchestratorTaskEvent;
+  nowMs: number;
+}
 
 interface Logger {
   warn?: (message: string, ...args: unknown[]) => void;
@@ -523,6 +536,70 @@ export class InMemoryTaskStore {
     });
   }
 
+  /**
+   * Interrupt a stuck task only when the document is still the exact snapshot
+   * whose external session liveness was checked by the caller. Session repair,
+   * audit event, and task transition share one queued write so a concurrent
+   * attach cannot land between those mutations and be overwritten by a stale
+   * reap decision.
+   */
+  async interruptStuckTaskIfUnchanged(
+    input: InterruptStuckTaskInput,
+  ): Promise<boolean> {
+    return this.enqueue(async () => {
+      const doc = this.docs.get(input.taskId);
+      if (doc?.task.status !== "active" || doc.task.paused) return false;
+      if (doc.task.updatedAt !== input.expectedTaskUpdatedAt) return false;
+
+      const expectedSessions = input.expectedSessions
+        .map(
+          (session) =>
+            `${session.sessionId}\u0000${session.status}\u0000${session.updatedAt}`,
+        )
+        .sort();
+      const currentSessions = doc.sessions
+        .map(
+          (session) =>
+            `${session.sessionId}\u0000${session.status}\u0000${session.updatedAt}`,
+        )
+        .sort();
+      if (
+        expectedSessions.length !== currentSessions.length ||
+        expectedSessions.some(
+          (session, index) => session !== currentSessions[index],
+        )
+      ) {
+        return false;
+      }
+
+      const deadSessionIds = new Set(input.deadSessionIds);
+      const liveSessionIds = doc.sessions
+        .filter(
+          (session) => !TERMINAL_TASK_SESSION_STATUSES.has(session.status),
+        )
+        .map((session) => session.sessionId);
+      if (liveSessionIds.some((sessionId) => !deadSessionIds.has(sessionId))) {
+        return false;
+      }
+
+      const nextStatus = nextTaskStatus(doc.task.status, "interrupted");
+      const updatedAt = nowIso();
+      for (const session of doc.sessions) {
+        if (!deadSessionIds.has(session.sessionId)) continue;
+        session.status = "stopped";
+        session.stoppedAt = input.nowMs;
+        session.updatedAt = updatedAt;
+      }
+      doc.events.push(structuredClone(input.event));
+      doc.task.status = nextStatus;
+      doc.task.updatedAt = updatedAt;
+      doc.task.lastActivityAt = Date.now();
+      this.noteMutated(input.taskId);
+      await this.afterWrite();
+      return true;
+    });
+  }
+
   async findSession(
     sessionId: string,
     taskId?: string,
@@ -730,6 +807,10 @@ export class FileTaskStore extends InMemoryTaskStore {
   ) {
     await this.ensureLoaded();
     return super.updateSession(sessionId, patch, taskId);
+  }
+  override async interruptStuckTaskIfUnchanged(input: InterruptStuckTaskInput) {
+    await this.ensureLoaded();
+    return super.interruptStuckTaskIfUnchanged(input);
   }
   override async findSession(sessionId: string, taskId?: string) {
     await this.ensureLoaded();
@@ -1183,6 +1264,12 @@ export class RuntimeDbTaskStore {
     });
   }
 
+  async interruptStuckTaskIfUnchanged(input: InterruptStuckTaskInput) {
+    return this.mutate(input.taskId, (cache) =>
+      cache.interruptStuckTaskIfUnchanged(input),
+    );
+  }
+
   async findSession(sessionId: string, taskId?: string) {
     await this.ensureInitialized();
     if (taskId) {
@@ -1365,6 +1452,9 @@ export class OrchestratorTaskStore {
     taskId?: string,
   ) {
     return this.delegate.updateSession(sessionId, patch, taskId);
+  }
+  interruptStuckTaskIfUnchanged(input: InterruptStuckTaskInput) {
+    return this.delegate.interruptStuckTaskIfUnchanged(input);
   }
   findSession(sessionId: string, taskId?: string) {
     return this.delegate.findSession(sessionId, taskId);

--- a/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
@@ -367,6 +367,7 @@ class RuntimeGitHubPullRequestSource implements OpenPullRequestSource {
 
 interface TaskServiceLike {
   listTasks(): Promise<Array<{ id: string }>>;
+  listTaskDetails?(): Promise<TaskThreadDetailDto[]>;
   getTask(taskId: string): Promise<TaskThreadDetailDto | null>;
   createTask(input: CreateTaskInput): Promise<TaskThreadDetailDto>;
   updateTask(
@@ -825,10 +826,14 @@ export class WaveSupervisor extends Service {
   private async loadWaveTasks(): Promise<TaskThreadDetailDto[]> {
     const service = this.taskService();
     if (!service) return [];
+    if (service.listTaskDetails) {
+      return (await service.listTaskDetails()).filter((task) =>
+        Boolean(readWaveId(task.metadata)),
+      );
+    }
     const summaries = await service.listTasks();
-    const details = await Promise.all(
-      summaries.map((task) => service.getTask(task.id)),
-    );
+    const details: Array<TaskThreadDetailDto | null> = [];
+    for (const task of summaries) details.push(await service.getTask(task.id));
     return details.filter(
       (task): task is TaskThreadDetailDto =>
         task !== null && Boolean(readWaveId(task.metadata)),


### PR DESCRIPTION
Closes #29683

## What changed
- add a filtered bulk-document read to every orchestrator task-store backend
- replace collection-wide `listTasks()` + per-task `getTask()` fan-out in status, roster, recovery, and wave supervision
- treat the bulk reaper scan as candidate discovery and require a durable compare-and-swap before interruption
- make FileTaskStore revalidate under its cross-instance lock and RuntimeDbTaskStore use an exact raw-document conditional update

## Why
Collection refreshes could issue one list query followed by an unbounded point query for every durable task. Large histories amplified periodic supervisor and UI refreshes into database bursts. Reaping also needs cross-process atomicity: a fresh session written by another store instance must never be overwritten by a stale interrupted snapshot.

## Exact-current provenance
- base: `82b233336658690bd162c394bcbcfb155bba883b`
- head: `26ca9bdc09c3fe7430539d3fbab4c1af577fd29f`
- tree: `f291005b0932f3606f6494f394f19e624489ac67`
- durable-CAS diff SHA-256: `e8fc57207d1bb1f644da2249d2c1f15be0d96f8f859a33f200780dfecb58897c`

## Evidence
- Runtime DB collection regression proves one filtered SQL query and zero point reads
- service regression proves list/status/account/room collection views issue zero point reads
- two-instance FileTaskStore regression proves a stale writer preserves a newly attached live session
- two-instance RuntimeDbTaskStore regression injects a live write after stale validation and proves the conditional update fails closed
- legacy Runtime DB regression proves exact raw stored serialization remains reappable
- package focused Vitest: **164/164 PASS**
- plugin + live-harness typechecks: **PASS**
- Biome + `git diff --check`: **PASS**
- independent exact local diff review: **P0/P1/P2/P3 = 0/0/0/0**
- hosted run: https://github.com/elizaOS/eliza/actions/runs/33135581922

## Scope boundaries
- no timer-policy change
- no live VPS, device, pairing, gateway, or deployment mutation
- no UI change; screenshot/video evidence N/A
