### PR TITLE
fix(cloud): retire completed rate-limit cutover hot path

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -469,6 +469,47 @@ describe("Miniflare Durable Object integration", () => {
     expect(body.cutoverAt - Date.now()).toBeLessThanOrEqual(60_000);
   }, 120_000);
 
+  test("the active v2 rate-limit identity answers while the obsolete cutover coordinator is blocked", async () => {
+    expect(
+      (await post("/test-block-ledger", {}, "rate-limit:v2:cutover")).status,
+    ).toBe(202);
+
+    const blockedCutover = post(
+      "/rate-limit-v2-cutover",
+      { windowMs: 60_000 },
+      "rate-limit:v2:cutover",
+    );
+    const cutoverAnsweredEarly = await Promise.race([
+      blockedCutover.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 300)),
+    ]);
+    expect(cutoverAnsweredEarly).toBe(false);
+
+    const isolated = await Promise.race([
+      post(
+        "/rate-limit",
+        {
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 1,
+          windowStartedAt: Math.floor(Date.now() / 60_000) * 60_000,
+        },
+        "rate-limit:v2:org-miniflare-cutover-blocked",
+      ),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () =>
+            reject(
+              new Error("v2 rate limit waited behind cutover coordinator"),
+            ),
+          500,
+        );
+      }),
+    ]);
+    expect(isolated.status).toBe(200);
+    expect((await blockedCutover).status).toBe(200);
+  }, 120_000);
+
   test("clearing one subject denial cannot clear an independent denial", async () => {
     const credential = {
       organizationId: "org-miniflare-independent-fences",

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -500,6 +500,8 @@ describe("InferenceAdmissionGate", () => {
       expect(network.rateStorage.read("ledger")).toBeUndefined();
       expect(network.rateStorage.read("rate-limits")).toBeUndefined();
       expect(network.requestedNames).toContain("rate-limit:v2:org-a");
+      expect(network.requestedNames).not.toContain("rate-limit:v2:cutover");
+      expect(network.requestedNames).not.toContain("org-a");
       expect(
         network.requestedNames.filter((name) => name === "rate-limit:v2:org-a"),
       ).toHaveLength(1);
@@ -514,7 +516,7 @@ describe("InferenceAdmissionGate", () => {
     });
   });
 
-  test("cuts over only after the entire legacy fixed window has expired", async () => {
+  test("advances fixed windows entirely on the isolated rate-limit identity", async () => {
     const network = createRateLimitGateNetwork();
     const clock = spyOn(Date, "now").mockReturnValue(61_234);
     const body = {
@@ -545,8 +547,10 @@ describe("InferenceAdmissionGate", () => {
           }),
         ).toMatchObject({ allowed: true, remaining: 0 });
       });
-      expect(network.legacyStorage.read("rate-limits")).toBeDefined();
+      expect(network.legacyStorage.read("rate-limits")).toBeUndefined();
       expect(network.rateStorage.read("rate-limits")).toBeDefined();
+      expect(network.requestedNames).not.toContain("rate-limit:v2:cutover");
+      expect(network.requestedNames).not.toContain("org-a");
     } finally {
       clock.mockRestore();
     }

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -3,9 +3,9 @@
  *
  * Cloudflare KV is eventually consistent and cannot safely decrement a cached
  * counter or balance under concurrency. Billing leases retain one Durable
- * Object per organization, while endpoint limits move to rate-only identities
- * at the next complete fixed-window boundary. This preserves quota without
- * letting slow ledger storage block the rate-limit input gate.
+ * Object per organization, while endpoint limits use independent rate-only
+ * identities. This preserves quota without letting slow ledger storage block
+ * the rate-limit input gate.
  */
 
 import { sql } from "drizzle-orm";
@@ -24,7 +24,6 @@ import type { EndpointType } from "./org-rate-limits";
 const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
 const RATE_LIMIT_GATE_PREFIX = "rate-limit:v2:";
-const RATE_LIMIT_CUTOVER_GATE = "rate-limit:v2:cutover";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
@@ -56,10 +55,6 @@ interface HydrateResponse {
 
 interface RateLimitWarmResponse {
   warmed: boolean;
-}
-
-interface RateLimitCutoverResponse {
-  cutoverAt: number;
 }
 
 export interface InferenceRateLimitDecision {
@@ -154,16 +149,6 @@ function rateLimitGateStub(organizationId: string): RuntimeDurableObjectStub {
     );
   }
   return namespace.getByName(`${RATE_LIMIT_GATE_PREFIX}${organizationId}`);
-}
-
-function rateLimitCutoverStub(): RuntimeDurableObjectStub {
-  const namespace = getCloudBinding<RuntimeDurableObjectNamespace>(GATE_BINDING);
-  if (!namespace) {
-    throw new InferenceAdmissionGateUnavailableError(
-      "Inference admission Durable Object binding is missing",
-    );
-  }
-  return namespace.getByName(RATE_LIMIT_CUTOVER_GATE);
 }
 
 async function gateFetch(
@@ -307,33 +292,6 @@ async function parseRateLimitWarmResponse(response: Response): Promise<RateLimit
   }
 }
 
-async function parseRateLimitCutoverResponse(
-  response: Response,
-  windowMs: number,
-): Promise<RateLimitCutoverResponse> {
-  try {
-    const value = await response.json();
-    const cutoverAt =
-      value && typeof value === "object" ? (value as Record<string, unknown>).cutoverAt : undefined;
-    if (
-      !Number.isSafeInteger(cutoverAt) ||
-      (cutoverAt as number) <= 0 ||
-      (cutoverAt as number) % windowMs !== 0
-    ) {
-      throw new TypeError("response does not match the rate-limit cutover schema");
-    }
-    return { cutoverAt: cutoverAt as number };
-  } catch (error) {
-    // error-policy:J3 malformed cutover state never selects a second quota lane.
-    throw new InferenceAdmissionGateUnavailableError(
-      `Inference admission gate returned invalid rate-limit cutover JSON: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-      { cause: error },
-    );
-  }
-}
-
 async function parseRateLimitResponse(response: Response): Promise<InferenceRateLimitDecision> {
   try {
     const value = await response.json();
@@ -431,50 +389,21 @@ export async function warmInferenceAdmissionGate(organizationId: string): Promis
   await hydrateInferenceAdmissionGate(organizationId, gateStub(organizationId));
 }
 
-const rateLimitCutovers = new Map<number, Promise<number>>();
 const rateLimitWarms = new Map<string, { expiresAt: number; promise: Promise<void> }>();
 
-function rateLimitCutoverAt(windowMs: number): Promise<number> {
-  const existing = rateLimitCutovers.get(windowMs);
-  if (existing) return existing;
-  const cutover = gateFetch(
-    RATE_LIMIT_CUTOVER_GATE,
-    "/rate-limit-v2-cutover",
-    { windowMs },
-    rateLimitCutoverStub(),
-    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
-  )
-    .then(async (response) => {
-      if (!response.ok) {
-        throw new InferenceAdmissionGateUnavailableError(
-          `Inference rate-limit cutover failed with status ${response.status}`,
-        );
-      }
-      return (await parseRateLimitCutoverResponse(response, windowMs)).cutoverAt;
-    })
-    .catch((error) => {
-      rateLimitCutovers.delete(windowMs);
-      throw error;
-    });
-  rateLimitCutovers.set(windowMs, cutover);
-  return cutover;
-}
-
-async function activeRateLimitGate(
+function activeRateLimitGate(
   organizationId: string,
   windowMs: number,
-): Promise<{
+): {
   stub: RuntimeDurableObjectStub;
   windowStartedAt: number;
-}> {
-  const cutoverAt = await rateLimitCutoverAt(windowMs);
-  // Capture the fixed-window identity together with the lane decision. A
-  // legacy request can otherwise enter just before cutover, wait behind a
-  // ledger input gate, and start a second copy of the new window after v2 has
-  // already begun accepting traffic.
+} {
+  // Capture the fixed-window identity before the request can wait behind the
+  // Durable Object input gate. This keeps delayed arrivals charged to the
+  // window in which the Worker admitted them.
   const now = Date.now();
   return {
-    stub: now >= cutoverAt ? rateLimitGateStub(organizationId) : gateStub(organizationId),
+    stub: rateLimitGateStub(organizationId),
     windowStartedAt: Math.floor(now / windowMs) * windowMs,
   };
 }
@@ -496,7 +425,6 @@ export async function warmInferenceRateLimitGate(
     if (oldest !== undefined) rateLimitWarms.delete(oldest);
   }
   const warm = (async () => {
-    await rateLimitCutoverAt(windowMs);
     const response = await gateFetch(
       organizationId,
       "/rate-limit-warm",
@@ -560,7 +488,7 @@ export async function consumeInferenceRateLimit(params: {
     );
   }
 
-  const activeGate = await activeRateLimitGate(params.organizationId, params.windowMs);
+  const activeGate = activeRateLimitGate(params.organizationId, params.windowMs);
   const response = await gateFetch(
     params.organizationId,
     "/rate-limit",


### PR DESCRIPTION
# Relates to

Fixes #29686.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`44b4e2ffcea333184c7521343dc5807fc8f043da`).
- [x] `bun install --frozen-lockfile` was run after sync; the exact unrelated full-verification blocker is recorded below.
- [x] A reviewer can confirm the change from the focused unit and real Miniflare Durable Object regression tests below.

# Sync with develop

- [x] Fetched and based on the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes; the exact unrelated package typecheck blocker is documented in **Known gaps / failures**.

# Risks

Low. This removes an obsolete global coordinator lookup from the Worker client hot path after cutover has completed. Requests continue to fail closed and use the same existing `rate-limit:v2:<organization>` fixed-window Durable Object state. The server cutover endpoint and persisted state remain unchanged for compatibility and rollback.

# Background

## What does this PR do?

Inference admission currently waits up to 1.5 seconds on the singleton `rate-limit:v2:cutover` Durable Object before calling the active per-organization v2 rate-only identity. If that obsolete coordinator is unavailable, otherwise healthy inference requests fail closed as `rate_limit_unavailable`.

This PR always selects the already-authoritative per-organization v2 identity for consume and prewarm. It keeps the fixed-window timestamp captured before any Durable Object queue wait, so delayed requests cannot open a duplicate window or roll durable state backward.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; this retires completed internal migration coordination while preserving its server endpoint.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/services/inference-admission-gate.ts`, then the blocked-coordinator regression in `packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts`.

## Detailed testing steps

- `bun --config=bunfig.live.toml test packages/cloud/api/__tests__/inference-admission-gate.test.ts` — 38 pass, 0 fail.
- `bun test packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts` — 15 pass, 0 fail.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/inference-admission-gate.ts packages/cloud/api/__tests__/inference-admission-gate.test.ts packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts` — clean.
- `bun run --cwd packages/cloud/shared typecheck` — clean.

# Evidence Gate

<!-- evidence-head:59e12c3a7b1ece03d7b77f6c0b3b90bc0eb9d97d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Durable Object routing change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Durable Object routing change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change; the real Miniflare regression is the executable walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A - production incident tail contains tenant context; the focused Miniflare test reproduces the blocked coordinator and proves the per-org identity remains responsive.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database schema, rows, generated artifacts, or on-chain state changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, prompt, provider, or model behavior changed.

## Backend + frontend logs

N/A - sensitive live incident logs are not copied into the public PR. The Miniflare suite blocks the exact coordinator identity and verifies that the active per-organization identity responds independently.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

`bun run --cwd packages/cloud/api typecheck` reaches an unrelated workspace-resolution failure in unchanged `packages/cloud/shared/src/lib/eliza/runtime/initializer.ts`: TypeScript cannot resolve `@elizaos/plugin-doordash`. The changed shared client passes its package typecheck, both focused suites compile and pass, and Biome is clean. Full `bun run verify` was not run because it would encounter the same unrelated workspace dependency gap during this incident fix.

An initial concurrent Miniflare run contended with the repository-wide Bun coverage collector and tripped an older 500 ms test timeout; the complete Miniflare file passed 15/15 when rerun alone. The normal coverage-enabled unit command completed every assertion, then Bun reported an internal coverage `WriteFailed`; the same file passed 38/38 with the repository-provided no-coverage config.

## Maintainer CI exception record

N/A - no exception requested.

