### PR TITLE
fix(cloud): keep inference balance warm during settlement

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -10,6 +10,7 @@ import { creditsService } from "@/lib/services/credits";
 import {
   acquireInferenceAdmissionLease,
   consumeInferenceRateLimit,
+  createInferenceAdmissionBalanceFence,
   InferenceAdmissionGateUnavailableError,
   InferenceAdmissionLeaseRejectedError,
   markInferenceAdmissionLeaseDispatched,
@@ -968,6 +969,84 @@ describe("InferenceAdmissionGate", () => {
     ).toBe(402);
   });
 
+  test("a live DO fence rejects stale Workers and ignores a delayed older publication", async () => {
+    const gate = createGate();
+    await hydrateGate(gate, 1, "1");
+
+    await runWithCloudBindingsAsync(gateBindings(gate), async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "fenced-a",
+        balanceUsd: 1,
+        balanceRevision: "1",
+        estimatedCostUsd: 0.1,
+        recovery: organizationRecovery("fenced-a"),
+      });
+      await markInferenceAdmissionLeaseDispatched(lease);
+      const fence = createInferenceAdmissionBalanceFence(lease);
+
+      // The debit committed at $0.90, while another Worker still sees the old
+      // eventually-consistent $1/rev1 KV value. The direct DO update, not KV
+      // propagation, must close the remaining $0.90 before that Worker leases.
+      await fence.lowerCommittedBalance(0.1, "2");
+      // A delayed same-revision high projection cannot raise the committed
+      // lower ceiling before the first settler finishes.
+      expect(
+        (
+          await post(gate, "/hydrate", {
+            balanceUsd: 0.9,
+            balanceRevision: "2",
+          })
+        ).status,
+      ).toBe(200);
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "stale-worker-b",
+          balanceUsd: 1,
+          balanceRevision: "1",
+          estimatedCostUsd: 0.01,
+          recovery: organizationRecovery("stale-worker-b"),
+        }),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+
+      expect(
+        (
+          await post(gate, "/settle", {
+            requestId: "fenced-a",
+            balanceBackedUsd: 0.9,
+            gateConsumedUsd: 0.9,
+            balanceUsd: 0.1,
+            balanceRevision: "2",
+          })
+        ).status,
+      ).toBe(200);
+
+      // A second committed debit advanced the authority to rev3/$0.05. A
+      // delayed rev2/$0.10 cache publication can arrive afterward, but the
+      // revisioned DO fence must ignore it and reject a Worker carrying it.
+      expect(
+        (
+          await post(gate, "/hydrate", {
+            balanceUsd: 0.05,
+            balanceRevision: "3",
+          })
+        ).status,
+      ).toBe(200);
+      await fence.publishAuthoritativeBalance(0.1, "2");
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "delayed-publication-c",
+          balanceUsd: 0.1,
+          balanceRevision: "2",
+          estimatedCostUsd: 0.06,
+          recovery: organizationRecovery("delayed-publication-c"),
+        }),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+    });
+  });
+
   test("repeat hydration cannot double-count an active authoritative hold", async () => {
     const gate = createGate();
     await hydrateGate(gate, 100, "1");
@@ -1619,12 +1698,20 @@ describe("InferenceAdmissionGate", () => {
           })
         ).status,
       ).toBe(200);
-      recoverExpiredLease.mockResolvedValue({
-        balanceUsd: 2,
-        balanceRevision: "2",
-        collectedUsd: 8,
-        gateConsumedUsd: 8,
-      });
+      recoverExpiredLease.mockImplementation(
+        async (_context, _estimatedCostUsd, options) => {
+          const fence = options?.inferenceBalanceFence;
+          if (!fence) throw new Error("expected recovery balance fence");
+          await fence.lowerCommittedBalance(2, "2");
+          await fence.publishAuthoritativeBalance(2, "2");
+          return {
+            balanceUsd: 2,
+            balanceRevision: "2",
+            collectedUsd: 8,
+            gateConsumedUsd: 8,
+          };
+        },
+      );
 
       clock.mockReturnValue(1_300_000);
       await gate.alarm();

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -11,6 +11,7 @@ import {
   acquireInferenceAdmissionLease,
   consumeInferenceRateLimit,
   createInferenceAdmissionBalanceFence,
+  fenceInferenceAdmissionLeaseForSettlement,
   InferenceAdmissionGateUnavailableError,
   InferenceAdmissionLeaseRejectedError,
   markInferenceAdmissionLeaseDispatched,
@@ -248,6 +249,7 @@ function post(
     | "/hydrate"
     | "/lease"
     | "/dispatch"
+    | "/settlement-fence"
     | "/release"
     | "/settle"
     | "/rate-limit"
@@ -1047,6 +1049,104 @@ describe("InferenceAdmissionGate", () => {
     });
   });
 
+  test("a settlement fence widens monotonically and rejects a stale second Worker before DB settlement", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 1, "1");
+
+    await runWithCloudBindingsAsync(gateBindings(gate), async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "resize-a",
+        balanceUsd: 1,
+        balanceRevision: "1",
+        estimatedCostUsd: 0.1,
+        recovery: organizationRecovery("resize-a"),
+      });
+      await markInferenceAdmissionLeaseDispatched(lease);
+
+      // Provider A reports a $0.90 actual cost. Its Postgres debit is paused;
+      // the durable transition must consume the delta before stale Worker B
+      // can lease against its old $1/rev1 projection.
+      await fenceInferenceAdmissionLeaseForSettlement(lease, 0.9);
+      expect(lease.estimatedCostUsd).toBe(0.9);
+      const fencedLedger = storage.read<{
+        availableUsd: number;
+        activeEstimateUsd: number;
+      }>("ledger");
+      expect(fencedLedger?.availableUsd).toBeCloseTo(0.1);
+      expect(fencedLedger?.activeEstimateUsd).toBeCloseTo(0.9);
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "stale-resize-b",
+          balanceUsd: 1,
+          balanceRevision: "1",
+          estimatedCostUsd: 0.2,
+          recovery: organizationRecovery("stale-resize-b"),
+        }),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+
+      // A lower replay is an acknowledged no-op and cannot shrink either the
+      // persisted or local lease.
+      await fenceInferenceAdmissionLeaseForSettlement(lease, 0.2);
+      expect(lease.estimatedCostUsd).toBe(0.9);
+      expect(
+        storage.read<{ estimatedCostUsd: number }>(storedLeaseKey("resize-a")),
+      ).toMatchObject({ estimatedCostUsd: 0.9 });
+    });
+  });
+
+  test("a lost settlement-fence acknowledgement replays before billing can continue", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10, "1");
+    let fenceAttempts = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            const response = await gate.fetch(incoming);
+            if (new URL(incoming.url).pathname === "/settlement-fence") {
+              fenceAttempts++;
+              if (fenceAttempts === 1) {
+                throw new Error("injected lost settlement-fence response");
+              }
+            }
+            return response;
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "resize-lost-ack",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 2,
+        recovery: organizationRecovery("resize-lost-ack"),
+      });
+      await markInferenceAdmissionLeaseDispatched(lease);
+      await fenceInferenceAdmissionLeaseForSettlement(lease, 8);
+      expect(lease.estimatedCostUsd).toBe(8);
+    });
+
+    expect(fenceAttempts).toBe(2);
+    expect(
+      storage.read<{ estimatedCostUsd: number }>(
+        storedLeaseKey("resize-lost-ack"),
+      ),
+    ).toMatchObject({ estimatedCostUsd: 8 });
+    expect(storage.read<{ activeEstimateUsd: number }>("ledger")).toMatchObject(
+      {
+        activeEstimateUsd: 8,
+      },
+    );
+  });
+
   test("repeat hydration cannot double-count an active authoritative hold", async () => {
     const gate = createGate();
     await hydrateGate(gate, 100, "1");
@@ -1609,6 +1709,63 @@ describe("InferenceAdmissionGate", () => {
       await gate.alarm();
       expect(storage.alarm).toBeUndefined();
       expect(recoverExpiredLease).not.toHaveBeenCalled();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("alarm recovery inherits a widened settlement fence after the live Worker crashes", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10, "1");
+      expect(
+        (
+          await post(gate, "/lease", {
+            requestId: "resize-crash-a",
+            balanceUsd: 10,
+            balanceRevision: "1",
+            estimatedCostUsd: 2,
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        (
+          await post(gate, "/dispatch", {
+            requestId: "resize-crash-a",
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        (
+          await post(gate, "/settlement-fence", {
+            requestId: "resize-crash-a",
+            estimatedCostUsd: 8,
+          })
+        ).status,
+      ).toBe(200);
+
+      // The live Worker disappears before Postgres. The alarm must recover
+      // the widened $8 exposure, not the original $2 estimate.
+      clock.mockReturnValue(1_300_000);
+      await expect(gate.alarm()).rejects.toThrow(
+        "Inference admission lease recovery failed",
+      );
+      expect(recoverExpiredLease).toHaveBeenCalledTimes(1);
+      expect(recoverExpiredLease.mock.calls[0]?.[1]).toBe(8);
+      expect(
+        storage.read<{
+          estimatedCostUsd: number;
+          phase: string;
+        }>(storedLeaseKey("resize-crash-a")),
+      ).toMatchObject({ estimatedCostUsd: 8, phase: "recovering" });
+      expect(
+        storage.read<{
+          activeEstimateUsd: number;
+          availableUsd: number;
+        }>("ledger"),
+      ).toMatchObject({ activeEstimateUsd: 8, availableUsd: 2 });
     } finally {
       clock.mockRestore();
     }

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -932,6 +932,42 @@ describe("InferenceAdmissionGate", () => {
     ).toBe(402);
   });
 
+  test("a committed overage lower-hint blocks a concurrent second admission before republish", async () => {
+    const gate = createGate();
+    await hydrateGate(gate, 1, "1");
+
+    // Request A reserved only $0.10, but its authoritative debit committed a
+    // $0.90 charge. While A still owns its lease, the settlement handoff lowers
+    // the cache projection to the committed $0.10 balance under the same
+    // revision before its newer snapshot is available.
+    expect(
+      (
+        await post(gate, "/lease", {
+          requestId: "overage-a",
+          balanceUsd: 1,
+          balanceAt: Date.now(),
+          balanceRevision: "1",
+          estimatedCostUsd: 0.1,
+        })
+      ).status,
+    ).toBe(200);
+
+    // Request B is concurrent with the paused authoritative republish. Applying
+    // the lower balance at the SAME revision must tighten the gate ceiling and
+    // reject B; the pre-fix preserved $1 projection admitted this request.
+    expect(
+      (
+        await post(gate, "/lease", {
+          requestId: "overage-b",
+          balanceUsd: 0.1,
+          balanceAt: Date.now(),
+          balanceRevision: "1",
+          estimatedCostUsd: 0.01,
+        })
+      ).status,
+    ).toBe(402);
+  });
+
   test("repeat hydration cannot double-count an active authoritative hold", async () => {
     const gate = createGate();
     await hydrateGate(gate, 100, "1");

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -11,6 +11,7 @@ import {
   acquireInferenceAdmissionLease,
   consumeInferenceRateLimit,
   createInferenceAdmissionBalanceFence,
+  fenceInferenceAdmissionLeaseForSettlement,
   InferenceAdmissionGateUnavailableError,
   InferenceAdmissionLeaseRejectedError,
   markInferenceAdmissionLeaseDispatched,
@@ -252,6 +253,7 @@ function post(
     | "/lease-dispatched"
     | "/lease-dispatched-authorized"
     | "/dispatch"
+    | "/settlement-fence"
     | "/release"
     | "/settle"
     | "/rate-limit"
@@ -1622,6 +1624,104 @@ describe("InferenceAdmissionGate", () => {
     });
   });
 
+  test("a settlement fence widens monotonically and rejects a stale second Worker before DB settlement", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 1, "1");
+
+    await runWithCloudBindingsAsync(gateBindings(gate), async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "resize-a",
+        balanceUsd: 1,
+        balanceRevision: "1",
+        estimatedCostUsd: 0.1,
+        recovery: organizationRecovery("resize-a"),
+      });
+      await markInferenceAdmissionLeaseDispatched(lease);
+
+      // Provider A reports a $0.90 actual cost. Its Postgres debit is paused;
+      // the durable transition must consume the delta before stale Worker B
+      // can lease against its old $1/rev1 projection.
+      await fenceInferenceAdmissionLeaseForSettlement(lease, 0.9);
+      expect(lease.estimatedCostUsd).toBe(0.9);
+      const fencedLedger = storage.read<{
+        availableUsd: number;
+        activeEstimateUsd: number;
+      }>("ledger");
+      expect(fencedLedger?.availableUsd).toBeCloseTo(0.1);
+      expect(fencedLedger?.activeEstimateUsd).toBeCloseTo(0.9);
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "stale-resize-b",
+          balanceUsd: 1,
+          balanceRevision: "1",
+          estimatedCostUsd: 0.2,
+          recovery: organizationRecovery("stale-resize-b"),
+        }),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+
+      // A lower replay is an acknowledged no-op and cannot shrink either the
+      // persisted or local lease.
+      await fenceInferenceAdmissionLeaseForSettlement(lease, 0.2);
+      expect(lease.estimatedCostUsd).toBe(0.9);
+      expect(
+        storage.read<{ estimatedCostUsd: number }>(storedLeaseKey("resize-a")),
+      ).toMatchObject({ estimatedCostUsd: 0.9 });
+    });
+  });
+
+  test("a lost settlement-fence acknowledgement replays before billing can continue", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10, "1");
+    let fenceAttempts = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            const response = await gate.fetch(incoming);
+            if (new URL(incoming.url).pathname === "/settlement-fence") {
+              fenceAttempts++;
+              if (fenceAttempts === 1) {
+                throw new Error("injected lost settlement-fence response");
+              }
+            }
+            return response;
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "resize-lost-ack",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 2,
+        recovery: organizationRecovery("resize-lost-ack"),
+      });
+      await markInferenceAdmissionLeaseDispatched(lease);
+      await fenceInferenceAdmissionLeaseForSettlement(lease, 8);
+      expect(lease.estimatedCostUsd).toBe(8);
+    });
+
+    expect(fenceAttempts).toBe(2);
+    expect(
+      storage.read<{ estimatedCostUsd: number }>(
+        storedLeaseKey("resize-lost-ack"),
+      ),
+    ).toMatchObject({ estimatedCostUsd: 8 });
+    expect(storage.read<{ activeEstimateUsd: number }>("ledger")).toMatchObject(
+      {
+        activeEstimateUsd: 8,
+      },
+    );
+  });
+
   test("repeat hydration cannot double-count an active authoritative hold", async () => {
     const gate = createGate();
     await hydrateGate(gate, 100, "1");
@@ -2644,6 +2744,63 @@ describe("InferenceAdmissionGate", () => {
       await gate.alarm();
       expect(storage.alarm).toBeUndefined();
       expect(recoverExpiredLease).not.toHaveBeenCalled();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("alarm recovery inherits a widened settlement fence after the live Worker crashes", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10, "1");
+      expect(
+        (
+          await post(gate, "/lease", {
+            requestId: "resize-crash-a",
+            balanceUsd: 10,
+            balanceRevision: "1",
+            estimatedCostUsd: 2,
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        (
+          await post(gate, "/dispatch", {
+            requestId: "resize-crash-a",
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        (
+          await post(gate, "/settlement-fence", {
+            requestId: "resize-crash-a",
+            estimatedCostUsd: 8,
+          })
+        ).status,
+      ).toBe(200);
+
+      // The live Worker disappears before Postgres. The alarm must recover
+      // the widened $8 exposure, not the original $2 estimate.
+      clock.mockReturnValue(1_300_000);
+      await expect(gate.alarm()).rejects.toThrow(
+        "Inference admission lease recovery failed",
+      );
+      expect(recoverExpiredLease).toHaveBeenCalledTimes(1);
+      expect(recoverExpiredLease.mock.calls[0]?.[1]).toBe(8);
+      expect(
+        storage.read<{
+          estimatedCostUsd: number;
+          phase: string;
+        }>(storedLeaseKey("resize-crash-a")),
+      ).toMatchObject({ estimatedCostUsd: 8, phase: "recovering" });
+      expect(
+        storage.read<{
+          activeEstimateUsd: number;
+          availableUsd: number;
+        }>("ledger"),
+      ).toMatchObject({ activeEstimateUsd: 8, availableUsd: 2 });
     } finally {
       clock.mockRestore();
     }

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -1507,6 +1507,42 @@ describe("InferenceAdmissionGate", () => {
     ).toBe(402);
   });
 
+  test("a committed overage lower-hint blocks a concurrent second admission before republish", async () => {
+    const gate = createGate();
+    await hydrateGate(gate, 1, "1");
+
+    // Request A reserved only $0.10, but its authoritative debit committed a
+    // $0.90 charge. While A still owns its lease, the settlement handoff lowers
+    // the cache projection to the committed $0.10 balance under the same
+    // revision before its newer snapshot is available.
+    expect(
+      (
+        await post(gate, "/lease", {
+          requestId: "overage-a",
+          balanceUsd: 1,
+          balanceAt: Date.now(),
+          balanceRevision: "1",
+          estimatedCostUsd: 0.1,
+        })
+      ).status,
+    ).toBe(200);
+
+    // Request B is concurrent with the paused authoritative republish. Applying
+    // the lower balance at the SAME revision must tighten the gate ceiling and
+    // reject B; the pre-fix preserved $1 projection admitted this request.
+    expect(
+      (
+        await post(gate, "/lease", {
+          requestId: "overage-b",
+          balanceUsd: 0.1,
+          balanceAt: Date.now(),
+          balanceRevision: "1",
+          estimatedCostUsd: 0.01,
+        })
+      ).status,
+    ).toBe(402);
+  });
+
   test("repeat hydration cannot double-count an active authoritative hold", async () => {
     const gate = createGate();
     await hydrateGate(gate, 100, "1");

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -10,6 +10,7 @@ import { creditsService } from "@/lib/services/credits";
 import {
   acquireInferenceAdmissionLease,
   consumeInferenceRateLimit,
+  createInferenceAdmissionBalanceFence,
   InferenceAdmissionGateUnavailableError,
   InferenceAdmissionLeaseRejectedError,
   markInferenceAdmissionLeaseDispatched,
@@ -1543,6 +1544,84 @@ describe("InferenceAdmissionGate", () => {
     ).toBe(402);
   });
 
+  test("a live DO fence rejects stale Workers and ignores a delayed older publication", async () => {
+    const gate = createGate();
+    await hydrateGate(gate, 1, "1");
+
+    await runWithCloudBindingsAsync(gateBindings(gate), async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "fenced-a",
+        balanceUsd: 1,
+        balanceRevision: "1",
+        estimatedCostUsd: 0.1,
+        recovery: organizationRecovery("fenced-a"),
+      });
+      await markInferenceAdmissionLeaseDispatched(lease);
+      const fence = createInferenceAdmissionBalanceFence(lease);
+
+      // The debit committed at $0.90, while another Worker still sees the old
+      // eventually-consistent $1/rev1 KV value. The direct DO update, not KV
+      // propagation, must close the remaining $0.90 before that Worker leases.
+      await fence.lowerCommittedBalance(0.1, "2");
+      // A delayed same-revision high projection cannot raise the committed
+      // lower ceiling before the first settler finishes.
+      expect(
+        (
+          await post(gate, "/hydrate", {
+            balanceUsd: 0.9,
+            balanceRevision: "2",
+          })
+        ).status,
+      ).toBe(200);
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "stale-worker-b",
+          balanceUsd: 1,
+          balanceRevision: "1",
+          estimatedCostUsd: 0.01,
+          recovery: organizationRecovery("stale-worker-b"),
+        }),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+
+      expect(
+        (
+          await post(gate, "/settle", {
+            requestId: "fenced-a",
+            balanceBackedUsd: 0.9,
+            gateConsumedUsd: 0.9,
+            balanceUsd: 0.1,
+            balanceRevision: "2",
+          })
+        ).status,
+      ).toBe(200);
+
+      // A second committed debit advanced the authority to rev3/$0.05. A
+      // delayed rev2/$0.10 cache publication can arrive afterward, but the
+      // revisioned DO fence must ignore it and reject a Worker carrying it.
+      expect(
+        (
+          await post(gate, "/hydrate", {
+            balanceUsd: 0.05,
+            balanceRevision: "3",
+          })
+        ).status,
+      ).toBe(200);
+      await fence.publishAuthoritativeBalance(0.1, "2");
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "delayed-publication-c",
+          balanceUsd: 0.1,
+          balanceRevision: "2",
+          estimatedCostUsd: 0.06,
+          recovery: organizationRecovery("delayed-publication-c"),
+        }),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+    });
+  });
+
   test("repeat hydration cannot double-count an active authoritative hold", async () => {
     const gate = createGate();
     await hydrateGate(gate, 100, "1");
@@ -2648,12 +2727,20 @@ describe("InferenceAdmissionGate", () => {
           })
         ).status,
       ).toBe(200);
-      recoverExpiredLease.mockResolvedValue({
-        balanceUsd: 2,
-        balanceRevision: "2",
-        collectedUsd: 8,
-        gateConsumedUsd: 8,
-      });
+      recoverExpiredLease.mockImplementation(
+        async (_context, _estimatedCostUsd, options) => {
+          const fence = options?.inferenceBalanceFence;
+          if (!fence) throw new Error("expected recovery balance fence");
+          await fence.lowerCommittedBalance(2, "2");
+          await fence.publishAuthoritativeBalance(2, "2");
+          return {
+            balanceUsd: 2,
+            balanceRevision: "2",
+            collectedUsd: 8,
+            gateConsumedUsd: 8,
+          };
+        },
+      );
 
       clock.mockReturnValue(1_300_000);
       await gate.alarm();

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -81,6 +81,11 @@ interface LeaseIdentityRequest {
   preProviderCancellationToken?: string;
 }
 
+interface SettlementFenceRequest {
+  requestId: string;
+  estimatedCostUsd: number;
+}
+
 interface RateLimitRequest {
   endpointType: string;
   windowMs: number;
@@ -964,6 +969,84 @@ export class InferenceAdmissionGate {
     return Response.json({ dispatched: true, duplicate: false });
   }
 
+  /**
+   * Widen a dispatched lease to the known post-provider cost before any money
+   * mutation starts. This transition never shrinks and never rejects for lack
+   * of available balance: the provider work already happened, so its job is to
+   * make every subsequent admission account for the full known exposure.
+   */
+  private async settlementFence(
+    request: SettlementFenceRequest,
+  ): Promise<Response> {
+    if (
+      !validRequestId(request.requestId) ||
+      !nonNegativeFinite(request.estimatedCostUsd) ||
+      request.estimatedCostUsd === 0
+    ) {
+      return jsonError("Invalid inference admission settlement fence", 400);
+    }
+    const existing = await this.load();
+    if (!existing) {
+      return jsonError("Inference admission ledger is unavailable", 503);
+    }
+    if (existing.settledRequestIds.includes(request.requestId)) {
+      return jsonError("Request ID was already settled", 409);
+    }
+    const ledger = cloneLedger(existing);
+    const lease = await this.loadLease(request.requestId);
+    if (!lease) {
+      return jsonError("Inference admission lease was not found", 409);
+    }
+    if (lease.phase !== "dispatched") {
+      return jsonError(
+        lease.phase === "recovering"
+          ? "Inference admission lease recovery is in progress"
+          : "Inference admission lease was not dispatched to a provider",
+        409,
+      );
+    }
+    if (
+      ledger.activeLeaseCount <= 0 ||
+      ledger.activeEstimateUsd + 0.0000001 < lease.estimatedCostUsd
+    ) {
+      throw new Error("Inference admission lease summary is inconsistent");
+    }
+
+    const fencedEstimateUsd = Math.max(
+      lease.estimatedCostUsd,
+      request.estimatedCostUsd,
+    );
+    if (fencedEstimateUsd === lease.estimatedCostUsd) {
+      return Response.json({
+        settlementFenced: true,
+        estimatedCostUsd: lease.estimatedCostUsd,
+        duplicate: true,
+      });
+    }
+    const activeEstimateUsd =
+      ledger.activeEstimateUsd + (fencedEstimateUsd - lease.estimatedCostUsd);
+    if (!nonNegativeFinite(activeEstimateUsd)) {
+      throw new Error(
+        "Inference admission settlement fence exceeds the ledger budget",
+      );
+    }
+    ledger.activeEstimateUsd = activeEstimateUsd;
+    recomputeAvailable(ledger);
+    const fencedLease: ActiveLease = {
+      ...lease,
+      estimatedCostUsd: fencedEstimateUsd,
+    };
+    await this.save(ledger, {
+      delete: [{ requestId: request.requestId, lease }],
+      put: [{ requestId: request.requestId, lease: fencedLease }],
+    });
+    return Response.json({
+      settlementFenced: true,
+      estimatedCostUsd: fencedEstimateUsd,
+      duplicate: false,
+    });
+  }
+
   private async release(request: LeaseIdentityRequest): Promise<Response> {
     if (
       !validRequestId(request.requestId) ||
@@ -1249,6 +1332,7 @@ export class InferenceAdmissionGate {
       | HydrateRequest
       | SettleRequest
       | LeaseIdentityRequest
+      | SettlementFenceRequest
       | RateLimitRequest
       | CredentialCheckRequest
       | CredentialRevokeRequest
@@ -1263,6 +1347,7 @@ export class InferenceAdmissionGate {
         | HydrateRequest
         | SettleRequest
         | LeaseIdentityRequest
+        | SettlementFenceRequest
         | RateLimitRequest
         | CredentialCheckRequest
         | CredentialRevokeRequest
@@ -1289,6 +1374,11 @@ export class InferenceAdmissionGate {
     if (path === "/dispatch") {
       return await this.serialize(() =>
         this.dispatch(body as LeaseIdentityRequest),
+      );
+    }
+    if (path === "/settlement-fence") {
+      return await this.serialize(() =>
+        this.settlementFence(body as SettlementFenceRequest),
       );
     }
     if (path === "/release") {

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -10,6 +10,7 @@
 import { runWithDbCacheAsync } from "@/db/client";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import { isAffiliateBillingAttribution } from "@/lib/services/affiliate-billing-attribution";
+import type { InferenceBalanceFence } from "@/lib/services/credits";
 import {
   type InferenceAdmissionRecoveryContext,
   type InferenceAdmissionRecoveryResult,
@@ -1498,11 +1499,67 @@ export class InferenceAdmissionGate {
     });
   }
 
+  /**
+   * Move the serialized balance authority before an alarm recovery publishes
+   * the same snapshot to eventually-consistent KV. The recovering lease stays
+   * active throughout this handoff.
+   */
+  private async fenceRecoveringLeaseBalance(
+    requestId: string,
+    expected: ActiveLease,
+    balanceUsd: number,
+    balanceRevision: string,
+  ): Promise<void> {
+    if (!nonNegativeFinite(balanceUsd)) {
+      throw new Error("Inference admission recovery balance fence is invalid");
+    }
+    const existing = await this.load();
+    if (!existing) {
+      throw new Error(
+        "Inference admission ledger disappeared during balance fencing",
+      );
+    }
+    const currentLease = await this.loadLease(requestId);
+    if (!currentLease && existing.settledRequestIds.includes(requestId)) {
+      return;
+    }
+    if (
+      !currentLease ||
+      currentLease.createdAt !== expected.createdAt ||
+      currentLease.estimatedCostUsd !== expected.estimatedCostUsd ||
+      currentLease.phase !== "recovering" ||
+      currentLease.recoveryStartedAt !== expected.recoveryStartedAt
+    ) {
+      throw new Error(
+        `Inference admission recovery fence lost lease ${requestId}`,
+      );
+    }
+    const ledger = cloneLedger(existing);
+    applyBalanceSnapshot(ledger, balanceUsd, balanceRevision);
+    await this.save(ledger);
+  }
+
   async alarm(): Promise<void> {
     const expired = await this.serialize(() => this.claimExpiredLeases());
     if (expired.length === 0) return;
     const results = await Promise.allSettled(
       expired.map(async ({ requestId, lease }) => {
+        const inferenceBalanceFence: InferenceBalanceFence = {
+          // Alarm recovery charges the exact active estimate, so the existing
+          // lease already fences this amount. The authoritative revision below
+          // is the first DO update needed; KV still receives its lower-only
+          // handoff before republication.
+          lowerCommittedBalance: async () => undefined,
+          publishAuthoritativeBalance: async (balanceUsd, balanceRevision) =>
+            this.serialize(() =>
+              this.fenceRecoveringLeaseBalance(
+                requestId,
+                lease,
+                balanceUsd,
+                balanceRevision,
+              ),
+            ),
+        };
         const recovered = await runWithCloudBindingsAsync(
           this.env as Record<string, unknown>,
           () =>
@@ -1510,6 +1567,7 @@ export class InferenceAdmissionGate {
               recoverExpiredInferenceAdmissionLease(
                 lease.recovery,
                 lease.estimatedCostUsd,
+                { inferenceBalanceFence },
               ),
             ),
         );

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -93,6 +93,11 @@ interface LeaseIdentityRequest {
   preProviderCancellationToken?: string;
 }
 
+interface SettlementFenceRequest {
+  requestId: string;
+  estimatedCostUsd: number;
+}
+
 interface RateLimitRequest {
   /** Stable across an internal transport retry so one arrival consumes once. */
   operationId?: string;
@@ -1068,6 +1073,84 @@ export class InferenceAdmissionGate {
     return Response.json({ dispatched: true, duplicate: false });
   }
 
+  /**
+   * Widen a dispatched lease to the known post-provider cost before any money
+   * mutation starts. This transition never shrinks and never rejects for lack
+   * of available balance: the provider work already happened, so its job is to
+   * make every subsequent admission account for the full known exposure.
+   */
+  private async settlementFence(
+    request: SettlementFenceRequest,
+  ): Promise<Response> {
+    if (
+      !validRequestId(request.requestId) ||
+      !nonNegativeFinite(request.estimatedCostUsd) ||
+      request.estimatedCostUsd === 0
+    ) {
+      return jsonError("Invalid inference admission settlement fence", 400);
+    }
+    const existing = await this.load();
+    if (!existing) {
+      return jsonError("Inference admission ledger is unavailable", 503);
+    }
+    if (existing.settledRequestIds.includes(request.requestId)) {
+      return jsonError("Request ID was already settled", 409);
+    }
+    const ledger = cloneLedger(existing);
+    const lease = await this.loadLease(request.requestId);
+    if (!lease) {
+      return jsonError("Inference admission lease was not found", 409);
+    }
+    if (lease.phase !== "dispatched") {
+      return jsonError(
+        lease.phase === "recovering"
+          ? "Inference admission lease recovery is in progress"
+          : "Inference admission lease was not dispatched to a provider",
+        409,
+      );
+    }
+    if (
+      ledger.activeLeaseCount <= 0 ||
+      ledger.activeEstimateUsd + 0.0000001 < lease.estimatedCostUsd
+    ) {
+      throw new Error("Inference admission lease summary is inconsistent");
+    }
+
+    const fencedEstimateUsd = Math.max(
+      lease.estimatedCostUsd,
+      request.estimatedCostUsd,
+    );
+    if (fencedEstimateUsd === lease.estimatedCostUsd) {
+      return Response.json({
+        settlementFenced: true,
+        estimatedCostUsd: lease.estimatedCostUsd,
+        duplicate: true,
+      });
+    }
+    const activeEstimateUsd =
+      ledger.activeEstimateUsd + (fencedEstimateUsd - lease.estimatedCostUsd);
+    if (!nonNegativeFinite(activeEstimateUsd)) {
+      throw new Error(
+        "Inference admission settlement fence exceeds the ledger budget",
+      );
+    }
+    ledger.activeEstimateUsd = activeEstimateUsd;
+    recomputeAvailable(ledger);
+    const fencedLease: ActiveLease = {
+      ...lease,
+      estimatedCostUsd: fencedEstimateUsd,
+    };
+    await this.save(ledger, {
+      delete: [{ requestId: request.requestId, lease }],
+      put: [{ requestId: request.requestId, lease: fencedLease }],
+    });
+    return Response.json({
+      settlementFenced: true,
+      estimatedCostUsd: fencedEstimateUsd,
+      duplicate: false,
+    });
+  }
+
   private async release(request: LeaseIdentityRequest): Promise<Response> {
     if (
       !validRequestId(request.requestId) ||
@@ -1435,6 +1518,7 @@ export class InferenceAdmissionGate {
       | HydrateRequest
       | SettleRequest
       | LeaseIdentityRequest
+      | SettlementFenceRequest
       | RateLimitRequest
       | CredentialCheckRequest
       | CredentialRevokeRequest
@@ -1452,6 +1536,7 @@ export class InferenceAdmissionGate {
         | HydrateRequest
         | SettleRequest
         | LeaseIdentityRequest
+        | SettlementFenceRequest
         | RateLimitRequest
         | CredentialCheckRequest
         | CredentialRevokeRequest
@@ -1511,6 +1596,11 @@ export class InferenceAdmissionGate {
     if (path === "/dispatch") {
       return await this.serialize(() =>
         this.dispatch(body as LeaseIdentityRequest),
+      );
+    }
+    if (path === "/settlement-fence") {
+      return await this.serialize(() =>
+        this.settlementFence(body as SettlementFenceRequest),
       );
     }
     if (path === "/release") {

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -10,6 +10,7 @@
 import { runWithDbCacheAsync } from "@/db/client";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import { isAffiliateBillingAttribution } from "@/lib/services/affiliate-billing-attribution";
+import type { InferenceBalanceFence } from "@/lib/services/credits";
 import {
   type InferenceAdmissionRecoveryContext,
   type InferenceAdmissionRecoveryResult,
@@ -1720,11 +1721,67 @@ export class InferenceAdmissionGate {
     });
   }
 
+  /**
+   * Move the serialized balance authority before an alarm recovery publishes
+   * the same snapshot to eventually-consistent KV. The recovering lease stays
+   * active throughout this handoff.
+   */
+  private async fenceRecoveringLeaseBalance(
+    requestId: string,
+    expected: ActiveLease,
+    balanceUsd: number,
+    balanceRevision: string,
+  ): Promise<void> {
+    if (!nonNegativeFinite(balanceUsd)) {
+      throw new Error("Inference admission recovery balance fence is invalid");
+    }
+    const existing = await this.load();
+    if (!existing) {
+      throw new Error(
+        "Inference admission ledger disappeared during balance fencing",
+      );
+    }
+    const currentLease = await this.loadLease(requestId);
+    if (!currentLease && existing.settledRequestIds.includes(requestId)) {
+      return;
+    }
+    if (
+      !currentLease ||
+      currentLease.createdAt !== expected.createdAt ||
+      currentLease.estimatedCostUsd !== expected.estimatedCostUsd ||
+      currentLease.phase !== "recovering" ||
+      currentLease.recoveryStartedAt !== expected.recoveryStartedAt
+    ) {
+      throw new Error(
+        `Inference admission recovery fence lost lease ${requestId}`,
+      );
+    }
+    const ledger = cloneLedger(existing);
+    applyBalanceSnapshot(ledger, balanceUsd, balanceRevision);
+    await this.save(ledger);
+  }
+
   async alarm(): Promise<void> {
     const expired = await this.serialize(() => this.claimExpiredLeases());
     if (expired.length === 0) return;
     const results = await Promise.allSettled(
       expired.map(async ({ requestId, lease }) => {
+        const inferenceBalanceFence: InferenceBalanceFence = {
+          // Alarm recovery charges the exact active estimate, so the existing
+          // lease already fences this amount. The authoritative revision below
+          // is the first DO update needed; KV still receives its lower-only
+          // handoff before republication.
+          lowerCommittedBalance: async () => undefined,
+          publishAuthoritativeBalance: async (balanceUsd, balanceRevision) =>
+            this.serialize(() =>
+              this.fenceRecoveringLeaseBalance(
+                requestId,
+                lease,
+                balanceUsd,
+                balanceRevision,
+              ),
+            ),
+        };
         const recovered = await runWithCloudBindingsAsync(
           this.env as Record<string, unknown>,
           () =>
@@ -1732,6 +1789,7 @@ export class InferenceAdmissionGate {
               recoverExpiredInferenceAdmissionLease(
                 lease.recovery,
                 lease.estimatedCostUsd,
+                { inferenceBalanceFence },
               ),
             ),
         );

--- a/packages/cloud/shared/src/lib/cache/invalidation-credit-hint.test.ts
+++ b/packages/cloud/shared/src/lib/cache/invalidation-credit-hint.test.ts
@@ -65,6 +65,20 @@ test("onCreditMutation drops the optimistic inference balance hint", async () =>
   expect(deleted).toContain(CacheKeys.eliza.orgBalance(organizationId));
 });
 
+test("inference settlement preserves only its handoff hint while invalidating every balance view", async () => {
+  const organizationId = "org-inference-settlement";
+
+  await CacheInvalidation.onCreditMutation(organizationId, {
+    preserveInferenceBalanceHint: true,
+  });
+
+  expect(deleted).not.toContain(CacheKeys.inference.orgBalance(organizationId));
+  expect(deleted).toContain(CacheKeys.org.credits(organizationId));
+  expect(deleted).toContain(CacheKeys.org.data(organizationId));
+  expect(deleted).toContain(CacheKeys.org.dashboard(organizationId));
+  expect(deleted).toContain(CacheKeys.eliza.orgBalance(organizationId));
+});
+
 test("each central invalidation method targets only its own cache scope", async () => {
   const organizationId = "org-invalidation-contract";
 

--- a/packages/cloud/shared/src/lib/cache/invalidation.ts
+++ b/packages/cloud/shared/src/lib/cache/invalidation.ts
@@ -18,20 +18,26 @@ export class CacheInvalidation {
    *
    * @param organizationId - Organization ID.
    */
-  static async onCreditMutation(organizationId: string): Promise<void> {
+  static async onCreditMutation(
+    organizationId: string,
+    options: { preserveInferenceBalanceHint?: boolean } = {},
+  ): Promise<void> {
     logger.debug(`[Cache Invalidation] Credit mutation for org=${organizationId}`);
 
-    await Promise.all([
+    const invalidations = [
       cache.del(CacheKeys.org.credits(organizationId)),
       cache.del(CacheKeys.org.data(organizationId)),
       cache.del(CacheKeys.org.dashboard(organizationId)),
       // Invalidate Eliza org balance cache on credit changes
       cache.del(CacheKeys.eliza.orgBalance(organizationId)),
+    ];
+    if (!options.preserveInferenceBalanceHint) {
       // Best-effort early eviction after a top-up, refund, or non-inference
       // debit. The admission hint's short TTL and safety margin remain the
       // correctness backstop when KV propagation or deletion is delayed.
-      cache.del(CacheKeys.inference.orgBalance(organizationId)),
-    ]);
+      invalidations.push(cache.del(CacheKeys.inference.orgBalance(organizationId)));
+    }
+    await Promise.all(invalidations);
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
@@ -4,7 +4,7 @@
  * acknowledgements, and global source-id replay protection without mocks.
  */
 
-import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
@@ -373,6 +373,10 @@ describe("affiliate payout outbox", () => {
         return await originalSnapshot(organizationId);
       },
     );
+    const inferenceBalanceFence = {
+      lowerCommittedBalance: mock(async () => undefined),
+      publishAuthoritativeBalance: mock(async () => undefined),
+    };
     const params = {
       organizationId: payerOrg.id,
       userId: payer.id,
@@ -383,11 +387,16 @@ describe("affiliate payout outbox", () => {
       actualCost: 0.9,
       reservationMetadata: reservationMetadata(uniq("affiliate-fenced-source"), attribution),
       preserveInferenceBalanceHint: true,
+      inferenceBalanceFence,
     };
 
     try {
       const settlement = creditsService.collectAffiliateInferenceFallback(params);
       await snapshotStarted.promise;
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(
+        0.1,
+        expect.stringMatching(/^(0|[1-9]\d*)$/),
+      );
 
       // The debit committed, but its revisioned snapshot is deliberately
       // paused. A concurrent admission sees the committed lower balance, not
@@ -407,6 +416,14 @@ describe("affiliate payout outbox", () => {
       const authoritative = await originalSnapshot(payerOrg.id);
       expect(published?.balanceUsd).toBeCloseTo(0.1, 6);
       expect(published?.balanceRevision).toBe(authoritative.revision);
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(
+        0.1,
+        authoritative.revision,
+      );
+      expect(inferenceBalanceFence.publishAuthoritativeBalance).toHaveBeenCalledWith(
+        authoritative.balanceUsd,
+        authoritative.revision,
+      );
     } finally {
       releaseSnapshot.resolve();
       snapshotSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
@@ -341,6 +341,83 @@ describe("affiliate payout outbox", () => {
     expect(await balance(attribution.affiliateUserId)).toBeCloseTo(0.05, 6);
   });
 
+  test("fenced affiliate settlement stays warm and lowers before its authoritative republish", async () => {
+    if (!pgliteReady) return;
+    const attribution = await seedAttribution();
+    const [payerOrg] = await dbWrite
+      .insert(organizations)
+      .values({
+        name: "Affiliate fenced handoff payer",
+        slug: uniq("affiliate-fenced-handoff"),
+        credit_balance: "1.000000",
+      })
+      .returning();
+    const [payer] = await dbWrite
+      .insert(users)
+      .values({
+        steward_user_id: uniq("affiliate-fenced-user"),
+        organization_id: payerOrg.id,
+      })
+      .returning();
+    const { readOrgBalanceHint, writeOrgBalanceHint } = await import("../inference-auth-cache");
+    const initial = await creditsService.getOrganizationBalanceSnapshot(payerOrg.id);
+    await writeOrgBalanceHint(payerOrg.id, initial.balanceUsd, Date.now(), initial.revision);
+
+    const snapshotStarted = Promise.withResolvers<void>();
+    const releaseSnapshot = Promise.withResolvers<void>();
+    const originalSnapshot = creditsService.getOrganizationBalanceSnapshot.bind(creditsService);
+    const snapshotSpy = spyOn(creditsService, "getOrganizationBalanceSnapshot").mockImplementation(
+      async (organizationId) => {
+        snapshotStarted.resolve();
+        await releaseSnapshot.promise;
+        return await originalSnapshot(organizationId);
+      },
+    );
+    const params = {
+      organizationId: payerOrg.id,
+      userId: payer.id,
+      requestId: uniq("affiliate-fenced-request"),
+      model: "openai/test-model",
+      provider: "openai",
+      billingSource: "cloud",
+      actualCost: 0.9,
+      reservationMetadata: reservationMetadata(uniq("affiliate-fenced-source"), attribution),
+      preserveInferenceBalanceHint: true,
+    };
+
+    try {
+      const settlement = creditsService.collectAffiliateInferenceFallback(params);
+      await snapshotStarted.promise;
+
+      // The debit committed, but its revisioned snapshot is deliberately
+      // paused. A concurrent admission sees the committed lower balance, not
+      // the old $1 projection and not an absent warming key.
+      expect(await readOrgBalanceHint(payerOrg.id)).toMatchObject({
+        balanceUsd: 0.1,
+        balanceRevision: initial.revision,
+      });
+
+      releaseSnapshot.resolve();
+      await expect(settlement).resolves.toMatchObject({
+        actualCost: 0.9,
+        collectedAmount: 0.9,
+        adjustmentType: "none",
+      });
+      const published = await readOrgBalanceHint(payerOrg.id);
+      const authoritative = await originalSnapshot(payerOrg.id);
+      expect(published?.balanceUsd).toBeCloseTo(0.1, 6);
+      expect(published?.balanceRevision).toBe(authoritative.revision);
+    } finally {
+      releaseSnapshot.resolve();
+      snapshotSpy.mockRestore();
+    }
+
+    // Alarm/live replay of the same identity retains a present authoritative
+    // hint instead of repeating the post-stream billing_cache_warming flap.
+    await creditsService.collectAffiliateInferenceFallback(params);
+    expect((await readOrgBalanceHint(payerOrg.id))?.balanceUsd).toBeCloseTo(0.1, 6);
+  });
+
   test("alarm and late-settlement races retain the first committed affiliate amount", async () => {
     if (!pgliteReady) return;
     const attribution = await seedAttribution();

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -19,7 +19,7 @@
  * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
@@ -137,6 +137,23 @@ beforeAll(async () => {
       // allowed by a standard UNIQUE index, so debit rows are unaffected.
       `CREATE UNIQUE INDEX IF NOT EXISTS credit_transactions_stripe_payment_intent_idx
         ON credit_transactions (stripe_payment_intent_id)`,
+      `CREATE SEQUENCE IF NOT EXISTS organization_balance_revision_seq AS bigint`,
+      `CREATE OR REPLACE FUNCTION advance_organization_balance_revision()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          IF NEW.credit_balance IS DISTINCT FROM OLD.credit_balance THEN
+            NEW.balance_revision := nextval('organization_balance_revision_seq');
+          END IF;
+          RETURN NEW;
+        END;
+        $$`,
+      `DROP TRIGGER IF EXISTS organizations_balance_revision_trigger ON organizations`,
+      `CREATE TRIGGER organizations_balance_revision_trigger
+        BEFORE UPDATE OF credit_balance ON organizations
+        FOR EACH ROW
+        EXECUTE FUNCTION advance_organization_balance_revision()`,
     ];
     for (const stmt of ddl) {
       await dbWrite.execute(stmt);
@@ -211,6 +228,137 @@ describe("reserveAndDeductCredits — atomic debit", () => {
       // The guard fails CLOSED — no money moved, no debit row written.
       expect(await readBalance()).toBeCloseTo(10, 6);
       expect(await listDebits()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a preserved inference debit lowers its durable fence immediately after commit and before cache work",
+    async () => {
+      if (!pgliteReady) return;
+      const { CacheInvalidation } = await import("../../cache/invalidation");
+      const events: string[] = [];
+      const invalidation = spyOn(CacheInvalidation, "onCreditMutation").mockImplementation(
+        async () => {
+          events.push("cache_invalidation");
+        },
+      );
+      let committedRevision = "";
+      const inferenceBalanceFence = {
+        lowerCommittedBalance: mock(async (balanceUsd: number, balanceRevision: string) => {
+          events.push("durable_fence");
+          expect(balanceUsd).toBeCloseTo(6.75, 6);
+          // A separate read observes the new value, proving this hook is after
+          // the owned transaction commits rather than inside it.
+          const committed = await dbWrite.execute(
+            `SELECT credit_balance, balance_revision FROM organizations WHERE id = '${ORG_ID}';`,
+          );
+          const row = committed.rows[0] as {
+            credit_balance: string;
+            balance_revision: string;
+          };
+          expect(Number(row.credit_balance)).toBeCloseTo(6.75, 6);
+          expect(Number(row.balance_revision)).toBeGreaterThan(0);
+          expect(balanceRevision).toBe(String(row.balance_revision));
+          committedRevision = balanceRevision;
+        }),
+        publishAuthoritativeBalance: mock(async () => undefined),
+      };
+
+      try {
+        const result = await creditsService.deductCredits({
+          organizationId: ORG_ID,
+          amount: 3.25,
+          description: "fenced inference charge",
+          metadata: { user_id: USER_ID },
+          preserveInferenceBalanceHint: true,
+          inferenceBalanceFence,
+        });
+        expect(result.success).toBe(true);
+      } finally {
+        invalidation.mockRestore();
+      }
+
+      expect(events).toEqual(["durable_fence", "cache_invalidation"]);
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledTimes(1);
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(
+        6.75,
+        committedRevision,
+      );
+      expect(inferenceBalanceFence.publishAuthoritativeBalance).not.toHaveBeenCalled();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a preserved inference hint without its durable fence fails before mutating money",
+    async () => {
+      if (!pgliteReady) return;
+
+      await expect(
+        creditsService.deductCredits({
+          organizationId: ORG_ID,
+          amount: 3.25,
+          description: "unfenced inference charge",
+          metadata: { user_id: USER_ID },
+          preserveInferenceBalanceHint: true,
+        }),
+      ).rejects.toThrow("Preserved inference debit requires an admission fence");
+
+      expect(await readBalance()).toBeCloseTo(10, 6);
+      expect(await listDebits()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a keyed replay repairs the durable fence with the latest committed balance revision",
+    async () => {
+      if (!pgliteReady) return;
+      const inferenceBalanceFence = {
+        lowerCommittedBalance: mock(async () => undefined),
+        publishAuthoritativeBalance: mock(async () => undefined),
+      };
+      const stripePaymentIntentId = `inference-debit:${ORG_ID}:fence-replay`;
+      const params = {
+        organizationId: ORG_ID,
+        amount: 3.25,
+        description: "replayed fenced inference charge",
+        metadata: { user_id: USER_ID },
+        stripePaymentIntentId,
+        preserveInferenceBalanceHint: true,
+        inferenceBalanceFence,
+      };
+
+      const first = await creditsService.deductCredits(params);
+      expect(first.success).toBe(true);
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledTimes(1);
+
+      // A later mutation advances the authoritative revision before a retry
+      // repairs a commit-then-ack-loss. Replay must fence that latest snapshot,
+      // not the revision captured by the original request.
+      await dbWrite.execute(
+        `UPDATE organizations SET credit_balance = credit_balance + 2 WHERE id = '${ORG_ID}';`,
+      );
+      const latest = await dbWrite.execute(
+        `SELECT credit_balance, balance_revision FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      const latestRow = latest.rows[0] as {
+        credit_balance: string;
+        balance_revision: string;
+      };
+      inferenceBalanceFence.lowerCommittedBalance.mockClear();
+
+      const replay = await creditsService.deductCredits(params);
+
+      expect(replay.success).toBe(true);
+      expect(replay.transaction?.id).toBe(first.transaction?.id);
+      expect(replay.newBalance).toBeCloseTo(Number(latestRow.credit_balance), 6);
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(
+        Number(latestRow.credit_balance),
+        String(latestRow.balance_revision),
+      );
+      expect(await listDebits()).toEqual([{ amount: -3.25, type: "debit" }]);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -385,6 +385,13 @@ export interface DeductCreditsParams {
    * Omit it (all existing callers) for the unchanged non-idempotent behavior.
    */
   stripePaymentIntentId?: string;
+  /**
+   * Internal inference-settlement handoff. Keep the last valid admission
+   * projection present while the caller reads and publishes the authoritative
+   * post-debit balance. This is safe only while a serialized admission lease
+   * fences provider dispatch; every other credit mutation must evict the hint.
+   */
+  preserveInferenceBalanceHint?: boolean;
 }
 
 export interface ReserveAndDeductParams extends DeductCreditsParams {
@@ -797,6 +804,7 @@ export class CreditsService {
       tokens_consumed,
       minimumBalanceRequired = 0,
       stripePaymentIntentId,
+      preserveInferenceBalanceHint = false,
       db,
       deferPostCommitEffects = false,
     } = params;
@@ -976,7 +984,9 @@ export class CreditsService {
           logger.error("[CreditsService] Failed to invalidate org cache:", error);
         });
         // Invalidate balance cache immediately after successful deduction
-        await CacheInvalidation.onCreditMutation(organizationId);
+        await CacheInvalidation.onCreditMutation(organizationId, {
+          preserveInferenceBalanceHint,
+        });
 
         // Track session usage if session_token is provided
         if (session_token) {

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -30,6 +30,12 @@ import type { PricingBillingSource } from "./ai-pricing-definitions";
 import { assertCreditRefundReservationPresent } from "./credit-reconciliation-invariants";
 import { resolveCostBuffer } from "./credits-config";
 import { emailService } from "./email";
+import { clearOrgAdmissionRefused, markOrgAdmissionRefused } from "./inference-admission-refusal";
+import {
+  invalidateOrgBalanceHint,
+  lowerOrgBalanceHint,
+  republishOrgBalanceHint,
+} from "./inference-auth-cache";
 import { organizationsService } from "./organizations";
 import { userSessionsService } from "./user-sessions";
 import {
@@ -336,6 +342,13 @@ export interface AffiliateInferenceFallbackParams {
   billingSource: string;
   actualCost: number;
   reservationMetadata: Record<string, unknown>;
+  /**
+   * Internal inference-settlement handoff. Keep and immediately lower the
+   * admission projection while a serialized admission lease remains active,
+   * then replace it with an authoritative balance revision. Alarm recovery
+   * owns the same still-active lease and must set this too.
+   */
+  preserveInferenceBalanceHint?: boolean;
 }
 
 /**
@@ -2048,8 +2061,46 @@ export class CreditsService {
       };
     });
 
+    if (params.preserveInferenceBalanceHint) {
+      try {
+        // The actual affiliate debit may exceed the estimate held by the
+        // Durable Object. Publish the committed lower ceiling before the
+        // authoritative read so a concurrent lease cannot spend that delta.
+        await lowerOrgBalanceHint(params.organizationId, outcome.newBalance, Date.now());
+        const balanceAt = Date.now();
+        const snapshot = await this.getOrganizationBalanceSnapshot(params.organizationId);
+        await republishOrgBalanceHint(
+          params.organizationId,
+          snapshot.balanceUsd,
+          balanceAt,
+          snapshot.revision,
+        );
+        clearOrgAdmissionRefused(params.organizationId);
+      } catch (cause) {
+        markOrgAdmissionRefused(params.organizationId);
+        try {
+          await invalidateOrgBalanceHint(params.organizationId);
+        } catch (invalidationError) {
+          logger.error(
+            "[CreditsService] Failed to invalidate affiliate balance handoff after publication failure",
+            {
+              organizationId: params.organizationId,
+              requestId: params.requestId,
+              error:
+                invalidationError instanceof Error
+                  ? invalidationError.message
+                  : String(invalidationError),
+            },
+          );
+        }
+        throw cause;
+      }
+    }
+
     if (outcome.inserted) {
-      await CacheInvalidation.onCreditMutation(params.organizationId);
+      await CacheInvalidation.onCreditMutation(params.organizationId, {
+        preserveInferenceBalanceHint: params.preserveInferenceBalanceHint,
+      });
       invalidateOrganizationCache(params.organizationId).catch((error) => {
         // error-policy:J7 the authoritative debit and shared invalidation have
         // committed; this legacy cache eviction is separately observable.

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -349,6 +349,19 @@ export interface AffiliateInferenceFallbackParams {
    * owns the same still-active lease and must set this too.
    */
   preserveInferenceBalanceHint?: boolean;
+  /**
+   * Synchronously lowers the serialized per-organization admission authority
+   * before the eventually-consistent cache projection is updated. Required
+   * whenever the preserved inference hint is used.
+   */
+  inferenceBalanceFence?: InferenceBalanceFence;
+}
+
+export interface InferenceBalanceFence {
+  /** Tighten the active gate immediately after the debit commits. */
+  lowerCommittedBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
+  /** Advance the gate revision before publishing the same snapshot to KV. */
+  publishAuthoritativeBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
 }
 
 /**
@@ -405,6 +418,12 @@ export interface DeductCreditsParams {
    * fences provider dispatch; every other credit mutation must evict the hint.
    */
   preserveInferenceBalanceHint?: boolean;
+  /**
+   * Synchronously lowers the serialized per-organization admission authority
+   * at the first post-commit boundary. Required whenever the preserved
+   * inference hint is used.
+   */
+  inferenceBalanceFence?: InferenceBalanceFence;
 }
 
 export interface ReserveAndDeductParams extends DeductCreditsParams {
@@ -419,7 +438,9 @@ export interface ReserveAndDeductParams extends DeductCreditsParams {
 interface CreditMutationRow {
   org_exists: boolean | string | number | null;
   current_balance: string | number | null;
+  current_balance_revision: string | number | null;
   new_balance: string | number | null;
+  new_balance_revision: string | number | null;
   id: string | null;
   organization_id: string | null;
   user_id: string | null;
@@ -448,6 +469,17 @@ function parseNumeric(value: string | number | null | undefined, fieldName: stri
     throw new Error(`[CreditsService] Invalid numeric ${fieldName}`);
   }
   return parsed;
+}
+
+function parseBalanceRevision(
+  value: string | number | null | undefined,
+  fieldName: string,
+): string {
+  const revision = String(value ?? "");
+  if (!/^(0|[1-9]\d*)$/.test(revision)) {
+    throw new Error(`[CreditsService] Invalid ${fieldName}`);
+  }
+  return revision;
 }
 
 function parseMetadata(value: CreditMutationRow["metadata"]): Record<string, unknown> {
@@ -818,9 +850,17 @@ export class CreditsService {
       minimumBalanceRequired = 0,
       stripePaymentIntentId,
       preserveInferenceBalanceHint = false,
+      inferenceBalanceFence,
       db,
       deferPostCommitEffects = false,
     } = params;
+
+    if (preserveInferenceBalanceHint && !inferenceBalanceFence) {
+      throw new Error("[CreditsService] Preserved inference debit requires an admission fence");
+    }
+    if (preserveInferenceBalanceHint && (db || deferPostCommitEffects)) {
+      throw new Error("[CreditsService] Preserved inference debit must own its post-commit fence");
+    }
 
     // Authoritative money-write guard: `<= 0` alone lets NaN through (the
     // comparison is false), after which `String(amount)::numeric` would reach
@@ -834,6 +874,7 @@ export class CreditsService {
     const committedKeyedDeduction = async (): Promise<{
       success: true;
       newBalance: number;
+      balanceRevision: string;
       transaction: CreditTransaction;
     } | null> => {
       if (!stripePaymentIntentId) return null;
@@ -845,11 +886,27 @@ export class CreditsService {
           "[CreditsService] Deduction idempotency key belongs to another organization",
         );
       }
+      const snapshot = await this.getOrganizationBalanceSnapshot(organizationId);
       return {
         success: true,
-        newBalance: await this.getOrganizationBalanceUsd(organizationId),
+        newBalance: snapshot.balanceUsd,
+        balanceRevision: snapshot.revision,
         transaction: existing,
       };
+    };
+
+    const lowerInferenceFenceAfterCommit = async (result: {
+      newBalance: number;
+      balanceRevision: string;
+    }): Promise<void> => {
+      if (!preserveInferenceBalanceHint) return;
+      // `writeTransaction` has committed at this point. Tighten the durable
+      // admission authority before any cache eviction, notification, or other
+      // awaited post-commit effect can let another Worker spend the difference
+      // between the lease estimate and the actual debit. The committed
+      // revision lets the DO ignore this lower only when it already holds a
+      // genuinely newer balance that necessarily incorporates this debit.
+      await inferenceBalanceFence?.lowerCommittedBalance(result.newBalance, result.balanceRevision);
     };
 
     // The unique insert is the first keyed decision. Avoiding an optimistic
@@ -863,7 +920,10 @@ export class CreditsService {
         tx,
         sql`
         WITH org AS (
-          SELECT id, credit_balance::numeric AS current_balance
+          SELECT
+            id,
+            credit_balance::numeric AS current_balance,
+            balance_revision AS current_balance_revision
           FROM organizations
           WHERE id = ${organizationId}
           FOR UPDATE
@@ -916,12 +976,16 @@ export class CreditsService {
           FROM eligible
           WHERE o.id = eligible.id
             AND EXISTS (SELECT 1 FROM inserted)
-          RETURNING eligible.new_balance
+          RETURNING
+            eligible.new_balance,
+            o.balance_revision AS new_balance_revision
         )
         SELECT
           EXISTS(SELECT 1 FROM org) AS org_exists,
           (SELECT current_balance FROM org) AS current_balance,
+          (SELECT current_balance_revision FROM org) AS current_balance_revision,
           (SELECT new_balance FROM updated) AS new_balance,
+          (SELECT new_balance_revision FROM updated) AS new_balance_revision,
           inserted.id,
           inserted.organization_id,
           inserted.user_id,
@@ -936,7 +1000,10 @@ export class CreditsService {
       `,
       );
       const mutation = mutationRows[0];
-      if (mutation?.id && mutation.new_balance === null) {
+      if (
+        mutation?.id &&
+        (mutation.new_balance === null || mutation.new_balance_revision === null)
+      ) {
         throw new Error("[CreditsService] Deduction claim committed without a balance mutation");
       }
       return mutationRows;
@@ -949,17 +1016,23 @@ export class CreditsService {
       // snapshot even though ON CONFLICT observed it. The next statement sees
       // the committed row and returns the same logical result.
       const replay = await committedKeyedDeduction();
-      if (replay) return replay;
+      if (replay) {
+        await lowerInferenceFenceAfterCommit(replay);
+        const { balanceRevision: _balanceRevision, ...publicReplay } = replay;
+        return publicReplay;
+      }
     }
     let result:
       | {
           success: true;
           newBalance: number;
+          balanceRevision: string;
           transaction: CreditTransaction;
         }
       | {
           success: false;
           newBalance: number;
+          balanceRevision: string;
           transaction: null;
           reason: "insufficient_balance" | "below_minimum" | "org_not_found";
         };
@@ -968,6 +1041,7 @@ export class CreditsService {
       result = {
         success: false,
         newBalance: 0,
+        balanceRevision: "0",
         transaction: null,
         reason: "org_not_found",
       };
@@ -976,6 +1050,10 @@ export class CreditsService {
       result = {
         success: false,
         newBalance: currentBalance,
+        balanceRevision: parseBalanceRevision(
+          row.current_balance_revision,
+          "current_balance_revision",
+        ),
         transaction: null,
         reason:
           minimumBalanceRequired > 0 && currentBalance < minimumBalanceRequired
@@ -986,11 +1064,15 @@ export class CreditsService {
       result = {
         success: true,
         newBalance: parseNumeric(row.new_balance, "new_balance"),
+        balanceRevision: parseBalanceRevision(row.new_balance_revision, "new_balance_revision"),
         transaction: toCreditTransaction(row),
       };
     }
 
     return await Promise.resolve(result).then(async (result) => {
+      if (result.success && preserveInferenceBalanceHint) {
+        await lowerInferenceFenceAfterCommit(result);
+      }
       // Invalidate organization cache if balance changed
       if (result.success && !deferPostCommitEffects) {
         invalidateOrganizationCache(organizationId).catch((error) => {
@@ -1017,7 +1099,8 @@ export class CreditsService {
 
         await this.notifyBalanceDecrease(organizationId, result.newBalance, metadata);
       }
-      return result;
+      const { balanceRevision: _balanceRevision, ...publicResult } = result;
+      return publicResult;
     });
   }
 
@@ -1883,6 +1966,9 @@ export class CreditsService {
   async collectAffiliateInferenceFallback(
     params: AffiliateInferenceFallbackParams,
   ): Promise<CreditReconciliationResult> {
+    if (params.preserveInferenceBalanceHint && !params.inferenceBalanceFence) {
+      throw new Error("[CreditsService] Fenced affiliate settlement requires an admission fence");
+    }
     const actual = new Decimal(params.actualCost);
     if (!actual.isFinite() || actual.isNegative()) {
       throw new Error("[CreditsService] Affiliate fallback actual cost is invalid");
@@ -1902,10 +1988,15 @@ export class CreditsService {
       params.reservationMetadata.affiliatePayout as { sourceId?: unknown } | undefined
     )?.sourceId;
     const outcome = await writeTransaction(async (tx) => {
-      const [org] = await sqlRows<{ current_balance: string | number }>(
+      const [org] = await sqlRows<{
+        current_balance: string | number;
+        balance_revision: string | number;
+      }>(
         tx,
         sql`
-          SELECT credit_balance::numeric AS current_balance
+          SELECT
+            credit_balance::numeric AS current_balance,
+            balance_revision
           FROM organizations
           WHERE id = ${params.organizationId}
           FOR UPDATE
@@ -1916,6 +2007,7 @@ export class CreditsService {
           collectedAmount: 0,
           actualCost,
           newBalance: 0,
+          balanceRevision: "0",
           transactionId: null,
           inserted: false,
         };
@@ -1979,6 +2071,7 @@ export class CreditsService {
           collectedAmount,
           actualCost: persistedActualCost,
           newBalance: parseNumeric(org.current_balance, "current_balance"),
+          balanceRevision: parseBalanceRevision(org.balance_revision, "balance_revision"),
           transactionId: existing.id,
           inserted: false,
         };
@@ -1994,6 +2087,7 @@ export class CreditsService {
           collectedAmount: 0,
           actualCost,
           newBalance: currentBalance.toNumber(),
+          balanceRevision: parseBalanceRevision(org.balance_revision, "balance_revision"),
           transactionId: null,
           inserted: false,
         };
@@ -2013,7 +2107,10 @@ export class CreditsService {
         collectedAmountUsd: collected.toFixed(6),
         affiliatePayoutSourceId: payoutSourceId,
       });
-      const [transaction] = await sqlRows<{ id: string }>(
+      const [transaction] = await sqlRows<{
+        id: string;
+        balance_revision: string | number;
+      }>(
         tx,
         sql`
           WITH updated AS (
@@ -2021,27 +2118,32 @@ export class CreditsService {
             SET credit_balance = ${newBalance.toFixed(6)}::numeric,
                 updated_at = NOW()
             WHERE id = ${params.organizationId}
+            RETURNING id, balance_revision
+          ),
+          inserted AS (
+            INSERT INTO credit_transactions (
+              organization_id,
+              amount,
+              type,
+              description,
+              metadata,
+              stripe_payment_intent_id,
+              created_at
+            )
+            SELECT
+              id,
+              ${collected.negated().toFixed(6)}::numeric,
+              'debit',
+              ${`Inference (deferred affiliate fallback): ${params.model}`},
+              ${transactionMetadata}::jsonb,
+              ${debitKey},
+              NOW()
+            FROM updated
             RETURNING id
           )
-          INSERT INTO credit_transactions (
-            organization_id,
-            amount,
-            type,
-            description,
-            metadata,
-            stripe_payment_intent_id,
-            created_at
-          )
-          SELECT
-            id,
-            ${collected.negated().toFixed(6)}::numeric,
-            'debit',
-            ${`Inference (deferred affiliate fallback): ${params.model}`},
-            ${transactionMetadata}::jsonb,
-            ${debitKey},
-            NOW()
-          FROM updated
-          RETURNING id
+          SELECT inserted.id, updated.balance_revision
+          FROM inserted
+          CROSS JOIN updated
         `,
       );
       if (!transaction) {
@@ -2056,6 +2158,7 @@ export class CreditsService {
         collectedAmount: collected.toNumber(),
         actualCost,
         newBalance: newBalance.toNumber(),
+        balanceRevision: parseBalanceRevision(transaction.balance_revision, "balance_revision"),
         transactionId: transaction.id,
         inserted: true,
       };
@@ -2066,9 +2169,17 @@ export class CreditsService {
         // The actual affiliate debit may exceed the estimate held by the
         // Durable Object. Publish the committed lower ceiling before the
         // authoritative read so a concurrent lease cannot spend that delta.
+        await params.inferenceBalanceFence?.lowerCommittedBalance(
+          outcome.newBalance,
+          outcome.balanceRevision,
+        );
         await lowerOrgBalanceHint(params.organizationId, outcome.newBalance, Date.now());
         const balanceAt = Date.now();
         const snapshot = await this.getOrganizationBalanceSnapshot(params.organizationId);
+        await params.inferenceBalanceFence?.publishAuthoritativeBalance(
+          snapshot.balanceUsd,
+          snapshot.revision,
+        );
         await republishOrgBalanceHint(
           params.organizationId,
           snapshot.balanceUsd,

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -385,6 +385,13 @@ export interface DeductCreditsParams {
    * Omit it (all existing callers) for the unchanged non-idempotent behavior.
    */
   stripePaymentIntentId?: string;
+  /**
+   * Internal inference-settlement handoff. Keep the last valid admission
+   * projection present while the caller reads and publishes the authoritative
+   * post-debit balance. This is safe only while a serialized admission lease
+   * fences provider dispatch; every other credit mutation must evict the hint.
+   */
+  preserveInferenceBalanceHint?: boolean;
 }
 
 export interface ReserveAndDeductParams extends DeductCreditsParams {
@@ -808,6 +815,7 @@ export class CreditsService {
       tokens_consumed,
       minimumBalanceRequired = 0,
       stripePaymentIntentId,
+      preserveInferenceBalanceHint = false,
       db,
       deferPostCommitEffects = false,
     } = params;
@@ -1001,7 +1009,9 @@ export class CreditsService {
           logger.error("[CreditsService] Failed to invalidate org cache:", error);
         });
         // Invalidate balance cache immediately after successful deduction
-        await CacheInvalidation.onCreditMutation(organizationId);
+        await CacheInvalidation.onCreditMutation(organizationId, {
+          preserveInferenceBalanceHint,
+        });
 
         // Track session usage if session_token is provided
         if (session_token) {

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -30,6 +30,12 @@ import type { PricingBillingSource } from "./ai-pricing-definitions";
 import { assertCreditRefundReservationPresent } from "./credit-reconciliation-invariants";
 import { resolveCostBuffer } from "./credits-config";
 import { emailService } from "./email";
+import { clearOrgAdmissionRefused, markOrgAdmissionRefused } from "./inference-admission-refusal";
+import {
+  invalidateOrgBalanceHint,
+  lowerOrgBalanceHint,
+  republishOrgBalanceHint,
+} from "./inference-auth-cache";
 import { organizationsService } from "./organizations";
 import { userSessionsService } from "./user-sessions";
 import {
@@ -336,6 +342,13 @@ export interface AffiliateInferenceFallbackParams {
   billingSource: string;
   actualCost: number;
   reservationMetadata: Record<string, unknown>;
+  /**
+   * Internal inference-settlement handoff. Keep and immediately lower the
+   * admission projection while a serialized admission lease remains active,
+   * then replace it with an authoritative balance revision. Alarm recovery
+   * owns the same still-active lease and must set this too.
+   */
+  preserveInferenceBalanceHint?: boolean;
 }
 
 /**
@@ -2073,8 +2086,46 @@ export class CreditsService {
       };
     });
 
+    if (params.preserveInferenceBalanceHint) {
+      try {
+        // The actual affiliate debit may exceed the estimate held by the
+        // Durable Object. Publish the committed lower ceiling before the
+        // authoritative read so a concurrent lease cannot spend that delta.
+        await lowerOrgBalanceHint(params.organizationId, outcome.newBalance, Date.now());
+        const balanceAt = Date.now();
+        const snapshot = await this.getOrganizationBalanceSnapshot(params.organizationId);
+        await republishOrgBalanceHint(
+          params.organizationId,
+          snapshot.balanceUsd,
+          balanceAt,
+          snapshot.revision,
+        );
+        clearOrgAdmissionRefused(params.organizationId);
+      } catch (cause) {
+        markOrgAdmissionRefused(params.organizationId);
+        try {
+          await invalidateOrgBalanceHint(params.organizationId);
+        } catch (invalidationError) {
+          logger.error(
+            "[CreditsService] Failed to invalidate affiliate balance handoff after publication failure",
+            {
+              organizationId: params.organizationId,
+              requestId: params.requestId,
+              error:
+                invalidationError instanceof Error
+                  ? invalidationError.message
+                  : String(invalidationError),
+            },
+          );
+        }
+        throw cause;
+      }
+    }
+
     if (outcome.inserted) {
-      await CacheInvalidation.onCreditMutation(params.organizationId);
+      await CacheInvalidation.onCreditMutation(params.organizationId, {
+        preserveInferenceBalanceHint: params.preserveInferenceBalanceHint,
+      });
       invalidateOrganizationCache(params.organizationId).catch((error) => {
         // error-policy:J7 the authoritative debit and shared invalidation have
         // committed; this legacy cache eviction is separately observable.

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -349,6 +349,19 @@ export interface AffiliateInferenceFallbackParams {
    * owns the same still-active lease and must set this too.
    */
   preserveInferenceBalanceHint?: boolean;
+  /**
+   * Synchronously lowers the serialized per-organization admission authority
+   * before the eventually-consistent cache projection is updated. Required
+   * whenever the preserved inference hint is used.
+   */
+  inferenceBalanceFence?: InferenceBalanceFence;
+}
+
+export interface InferenceBalanceFence {
+  /** Tighten the active gate immediately after the debit commits. */
+  lowerCommittedBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
+  /** Advance the gate revision before publishing the same snapshot to KV. */
+  publishAuthoritativeBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
 }
 
 /**
@@ -405,6 +418,12 @@ export interface DeductCreditsParams {
    * fences provider dispatch; every other credit mutation must evict the hint.
    */
   preserveInferenceBalanceHint?: boolean;
+  /**
+   * Synchronously lowers the serialized per-organization admission authority
+   * at the first post-commit boundary. Required whenever the preserved
+   * inference hint is used.
+   */
+  inferenceBalanceFence?: InferenceBalanceFence;
 }
 
 export interface ReserveAndDeductParams extends DeductCreditsParams {
@@ -419,8 +438,9 @@ export interface ReserveAndDeductParams extends DeductCreditsParams {
 interface CreditMutationRow {
   org_exists: boolean | string | number | null;
   current_balance: string | number | null;
+  current_balance_revision: string | number | null;
   new_balance: string | number | null;
-  balance_revision?: string | number | bigint | null;
+  new_balance_revision: string | number | null;
   id: string | null;
   organization_id: string | null;
   user_id: string | null;
@@ -451,10 +471,13 @@ function parseNumeric(value: string | number | null | undefined, fieldName: stri
   return parsed;
 }
 
-function parseBalanceRevision(value: string | number | bigint | null | undefined): string {
+function parseBalanceRevision(
+  value: string | number | bigint | null | undefined,
+  fieldName: string,
+): string {
   const revision = String(value ?? "");
   if (!/^(0|[1-9]\d*)$/.test(revision)) {
-    throw new Error("[CreditsService] Invalid organization balance revision");
+    throw new Error(`[CreditsService] Invalid ${fieldName}`);
   }
   return revision;
 }
@@ -829,9 +852,17 @@ export class CreditsService {
       minimumBalanceRequired = 0,
       stripePaymentIntentId,
       preserveInferenceBalanceHint = false,
+      inferenceBalanceFence,
       db,
       deferPostCommitEffects = false,
     } = params;
+
+    if (preserveInferenceBalanceHint && !inferenceBalanceFence) {
+      throw new Error("[CreditsService] Preserved inference debit requires an admission fence");
+    }
+    if (preserveInferenceBalanceHint && (db || deferPostCommitEffects)) {
+      throw new Error("[CreditsService] Preserved inference debit must own its post-commit fence");
+    }
 
     // Authoritative money-write guard: `<= 0` alone lets NaN through (the
     // comparison is false), after which `String(amount)::numeric` would reach
@@ -866,6 +897,20 @@ export class CreditsService {
       };
     };
 
+    const lowerInferenceFenceAfterCommit = async (result: {
+      newBalance: number;
+      balanceRevision: string;
+    }): Promise<void> => {
+      if (!preserveInferenceBalanceHint) return;
+      // `writeTransaction` has committed at this point. Tighten the durable
+      // admission authority before any cache eviction, notification, or other
+      // awaited post-commit effect can let another Worker spend the difference
+      // between the lease estimate and the actual debit. The committed
+      // revision lets the DO ignore this lower only when it already holds a
+      // genuinely newer balance that necessarily incorporates this debit.
+      await inferenceBalanceFence?.lowerCommittedBalance(result.newBalance, result.balanceRevision);
+    };
+
     // The unique insert is the first keyed decision. Avoiding an optimistic
     // pre-read both saves a query for new charges and prevents first-call races
     // from reaching the balance update before one winner owns the key. (#10846)
@@ -877,7 +922,10 @@ export class CreditsService {
         tx,
         sql`
         WITH org AS (
-          SELECT id, credit_balance::numeric AS current_balance, balance_revision
+          SELECT
+            id,
+            credit_balance::numeric AS current_balance,
+            balance_revision AS current_balance_revision
           FROM organizations
           WHERE id = ${organizationId}
           FOR UPDATE
@@ -930,16 +978,16 @@ export class CreditsService {
           FROM eligible
           WHERE o.id = eligible.id
             AND EXISTS (SELECT 1 FROM inserted)
-          RETURNING eligible.new_balance, o.balance_revision
+          RETURNING
+            eligible.new_balance,
+            o.balance_revision AS new_balance_revision
         )
         SELECT
           EXISTS(SELECT 1 FROM org) AS org_exists,
           (SELECT current_balance FROM org) AS current_balance,
+          (SELECT current_balance_revision FROM org) AS current_balance_revision,
           (SELECT new_balance FROM updated) AS new_balance,
-          COALESCE(
-            (SELECT balance_revision FROM updated),
-            (SELECT balance_revision FROM org)
-          ) AS balance_revision,
+          (SELECT new_balance_revision FROM updated) AS new_balance_revision,
           inserted.id,
           inserted.organization_id,
           inserted.user_id,
@@ -954,7 +1002,10 @@ export class CreditsService {
       `,
       );
       const mutation = mutationRows[0];
-      if (mutation?.id && mutation.new_balance === null) {
+      if (
+        mutation?.id &&
+        (mutation.new_balance === null || mutation.new_balance_revision === null)
+      ) {
         throw new Error("[CreditsService] Deduction claim committed without a balance mutation");
       }
       return mutationRows;
@@ -969,7 +1020,10 @@ export class CreditsService {
       // transaction already holds the organization lock and must not escape
       // to the global pool here (single-connection runtimes would deadlock).
       const replay = await committedKeyedDeduction();
-      if (replay) return replay;
+      if (replay) {
+        await lowerInferenceFenceAfterCommit(replay);
+        return replay;
+      }
     }
     let result:
       | {
@@ -999,7 +1053,10 @@ export class CreditsService {
       result = {
         success: false,
         newBalance: currentBalance,
-        balanceRevision: parseBalanceRevision(row.balance_revision),
+        balanceRevision: parseBalanceRevision(
+          row.current_balance_revision,
+          "current_balance_revision",
+        ),
         transaction: null,
         reason:
           minimumBalanceRequired > 0 && currentBalance < minimumBalanceRequired
@@ -1010,12 +1067,15 @@ export class CreditsService {
       result = {
         success: true,
         newBalance: parseNumeric(row.new_balance, "new_balance"),
-        balanceRevision: parseBalanceRevision(row.balance_revision),
+        balanceRevision: parseBalanceRevision(row.new_balance_revision, "new_balance_revision"),
         transaction: toCreditTransaction(row),
       };
     }
 
     return await Promise.resolve(result).then(async (result) => {
+      if (result.success && preserveInferenceBalanceHint) {
+        await lowerInferenceFenceAfterCommit(result);
+      }
       // Invalidate organization cache if balance changed
       if (result.success && !deferPostCommitEffects) {
         invalidateOrganizationCache(organizationId).catch((error) => {
@@ -1908,6 +1968,9 @@ export class CreditsService {
   async collectAffiliateInferenceFallback(
     params: AffiliateInferenceFallbackParams,
   ): Promise<CreditReconciliationResult> {
+    if (params.preserveInferenceBalanceHint && !params.inferenceBalanceFence) {
+      throw new Error("[CreditsService] Fenced affiliate settlement requires an admission fence");
+    }
     const actual = new Decimal(params.actualCost);
     if (!actual.isFinite() || actual.isNegative()) {
       throw new Error("[CreditsService] Affiliate fallback actual cost is invalid");
@@ -1927,10 +1990,15 @@ export class CreditsService {
       params.reservationMetadata.affiliatePayout as { sourceId?: unknown } | undefined
     )?.sourceId;
     const outcome = await writeTransaction(async (tx) => {
-      const [org] = await sqlRows<{ current_balance: string | number }>(
+      const [org] = await sqlRows<{
+        current_balance: string | number;
+        balance_revision: string | number;
+      }>(
         tx,
         sql`
-          SELECT credit_balance::numeric AS current_balance
+          SELECT
+            credit_balance::numeric AS current_balance,
+            balance_revision
           FROM organizations
           WHERE id = ${params.organizationId}
           FOR UPDATE
@@ -1941,6 +2009,7 @@ export class CreditsService {
           collectedAmount: 0,
           actualCost,
           newBalance: 0,
+          balanceRevision: "0",
           transactionId: null,
           inserted: false,
         };
@@ -2004,6 +2073,7 @@ export class CreditsService {
           collectedAmount,
           actualCost: persistedActualCost,
           newBalance: parseNumeric(org.current_balance, "current_balance"),
+          balanceRevision: parseBalanceRevision(org.balance_revision, "balance_revision"),
           transactionId: existing.id,
           inserted: false,
         };
@@ -2019,6 +2089,7 @@ export class CreditsService {
           collectedAmount: 0,
           actualCost,
           newBalance: currentBalance.toNumber(),
+          balanceRevision: parseBalanceRevision(org.balance_revision, "balance_revision"),
           transactionId: null,
           inserted: false,
         };
@@ -2038,7 +2109,10 @@ export class CreditsService {
         collectedAmountUsd: collected.toFixed(6),
         affiliatePayoutSourceId: payoutSourceId,
       });
-      const [transaction] = await sqlRows<{ id: string }>(
+      const [transaction] = await sqlRows<{
+        id: string;
+        balance_revision: string | number;
+      }>(
         tx,
         sql`
           WITH updated AS (
@@ -2046,27 +2120,32 @@ export class CreditsService {
             SET credit_balance = ${newBalance.toFixed(6)}::numeric,
                 updated_at = NOW()
             WHERE id = ${params.organizationId}
+            RETURNING id, balance_revision
+          ),
+          inserted AS (
+            INSERT INTO credit_transactions (
+              organization_id,
+              amount,
+              type,
+              description,
+              metadata,
+              stripe_payment_intent_id,
+              created_at
+            )
+            SELECT
+              id,
+              ${collected.negated().toFixed(6)}::numeric,
+              'debit',
+              ${`Inference (deferred affiliate fallback): ${params.model}`},
+              ${transactionMetadata}::jsonb,
+              ${debitKey},
+              NOW()
+            FROM updated
             RETURNING id
           )
-          INSERT INTO credit_transactions (
-            organization_id,
-            amount,
-            type,
-            description,
-            metadata,
-            stripe_payment_intent_id,
-            created_at
-          )
-          SELECT
-            id,
-            ${collected.negated().toFixed(6)}::numeric,
-            'debit',
-            ${`Inference (deferred affiliate fallback): ${params.model}`},
-            ${transactionMetadata}::jsonb,
-            ${debitKey},
-            NOW()
-          FROM updated
-          RETURNING id
+          SELECT inserted.id, updated.balance_revision
+          FROM inserted
+          CROSS JOIN updated
         `,
       );
       if (!transaction) {
@@ -2081,6 +2160,7 @@ export class CreditsService {
         collectedAmount: collected.toNumber(),
         actualCost,
         newBalance: newBalance.toNumber(),
+        balanceRevision: parseBalanceRevision(transaction.balance_revision, "balance_revision"),
         transactionId: transaction.id,
         inserted: true,
       };
@@ -2091,9 +2171,17 @@ export class CreditsService {
         // The actual affiliate debit may exceed the estimate held by the
         // Durable Object. Publish the committed lower ceiling before the
         // authoritative read so a concurrent lease cannot spend that delta.
+        await params.inferenceBalanceFence?.lowerCommittedBalance(
+          outcome.newBalance,
+          outcome.balanceRevision,
+        );
         await lowerOrgBalanceHint(params.organizationId, outcome.newBalance, Date.now());
         const balanceAt = Date.now();
         const snapshot = await this.getOrganizationBalanceSnapshot(params.organizationId);
+        await params.inferenceBalanceFence?.publishAuthoritativeBalance(
+          snapshot.balanceUsd,
+          snapshot.revision,
+        );
         await republishOrgBalanceHint(
           params.organizationId,
           snapshot.balanceUsd,

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -30,7 +30,6 @@ import type { PricingBillingSource } from "./ai-pricing-definitions";
 import { assertCreditRefundReservationPresent } from "./credit-reconciliation-invariants";
 import { resolveCostBuffer } from "./credits-config";
 import { emailService } from "./email";
-import { clearOrgAdmissionRefused, markOrgAdmissionRefused } from "./inference-admission-refusal";
 import {
   invalidateOrgBalanceHint,
   lowerOrgBalanceHint,
@@ -2188,9 +2187,7 @@ export class CreditsService {
           balanceAt,
           snapshot.revision,
         );
-        clearOrgAdmissionRefused(params.organizationId);
       } catch (cause) {
-        markOrgAdmissionRefused(params.organizationId);
         try {
           await invalidateOrgBalanceHint(params.organizationId);
         } catch (invalidationError) {

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -2188,9 +2188,11 @@ export class CreditsService {
           snapshot.revision,
         );
       } catch (cause) {
+        // error-policy:J2 preserve the failed publication after invalidating its cache projection.
         try {
           await invalidateOrgBalanceHint(params.organizationId);
         } catch (invalidationError) {
+          // error-policy:J6 failed-handoff cache cleanup is best-effort; the publication error is rethrown.
           logger.error(
             "[CreditsService] Failed to invalidate affiliate balance handoff after publication failure",
             {

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -17,7 +17,11 @@ import type {
 } from "../../types/cloud-worker-env";
 import { getCloudBinding } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
-import { type CreditReconciliationResult, creditsService } from "./credits";
+import {
+  type CreditReconciliationResult,
+  creditsService,
+  type InferenceBalanceFence,
+} from "./credits";
 import type { InferenceAdmissionRecoveryContext } from "./inference-admission-recovery";
 import type { EndpointType } from "./org-rate-limits";
 
@@ -584,6 +588,49 @@ export async function acquireInferenceAdmissionLease(params: {
     gate: stub,
     providerDispatched: false,
     preProviderCancellationToken: crypto.randomUUID(),
+  };
+}
+
+/**
+ * Keep the serialized admission authority ahead of the eventually-consistent
+ * KV projection during post-provider billing. Same-revision updates can only
+ * lower the ceiling; authoritative newer revisions advance it normally.
+ */
+async function publishInferenceAdmissionBalance(
+  lease: InferenceAdmissionLease,
+  balanceUsd: number,
+  balanceRevision: string,
+): Promise<void> {
+  const safeBalance = finiteNonNegative(balanceUsd, "balanceUsd");
+  if (!/^(0|[1-9]\d*)$/.test(balanceRevision)) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission balance fence revision is invalid",
+    );
+  }
+  const response = await gateFetch(
+    lease.organizationId,
+    "/hydrate",
+    { balanceUsd: safeBalance, balanceRevision },
+    lease.gate,
+    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+  );
+  if (!response.ok) {
+    throw new InferenceAdmissionGateUnavailableError(
+      `Inference admission balance fence failed with status ${response.status}`,
+    );
+  }
+  await parseHydrateResponse(response);
+}
+
+/** Build the two-stage live-settlement fence bound to one active lease. */
+export function createInferenceAdmissionBalanceFence(
+  lease: InferenceAdmissionLease,
+): InferenceBalanceFence {
+  return {
+    lowerCommittedBalance: async (balanceUsd, balanceRevision) =>
+      publishInferenceAdmissionBalance(lease, balanceUsd, balanceRevision),
+    publishAuthoritativeBalance: async (balanceUsd, balanceRevision) =>
+      publishInferenceAdmissionBalance(lease, balanceUsd, balanceRevision),
   };
 }
 

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -32,6 +32,8 @@ const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
+const SETTLEMENT_FENCE_GATE_TIMEOUT_MS = 1_500;
+const SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS = 3;
 const RATE_LIMIT_WARM_TTL_MS = 5 * 60_000;
 const RATE_LIMIT_WARM_MAX_ENTRIES = 4_096;
 
@@ -51,6 +53,11 @@ interface DispatchResponse {
 
 interface ReleaseResponse {
   released: boolean;
+}
+
+interface SettlementFenceResponse {
+  settlementFenced: boolean;
+  estimatedCostUsd: number;
 }
 
 interface HydrateResponse {
@@ -245,6 +252,31 @@ async function parseLeaseTransitionResponse<Field extends "dispatched" | "releas
     // error-policy:J3 malformed transition responses never advance a lease.
     throw new InferenceAdmissionGateUnavailableError(
       `Inference admission gate returned invalid ${field} JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+async function parseSettlementFenceResponse(response: Response): Promise<SettlementFenceResponse> {
+  try {
+    const value = await response.json();
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      (value as Record<string, unknown>).settlementFenced !== true ||
+      !Number.isFinite((value as Record<string, unknown>).estimatedCostUsd) ||
+      ((value as Record<string, unknown>).estimatedCostUsd as number) <= 0
+    ) {
+      throw new TypeError("response does not confirm the settlement fence");
+    }
+    return value as SettlementFenceResponse;
+  } catch (error) {
+    // A committed transition can lose its response. Treat malformed 2xx as
+    // acknowledgement ambiguity so the caller replays the monotonic request.
+    throw new InferenceAdmissionGateUnavailableError(
+      `Inference admission gate returned invalid settlement-fence JSON: ${
         error instanceof Error ? error.message : String(error)
       }`,
       { cause: error },
@@ -730,6 +762,74 @@ export async function markInferenceAdmissionLeaseDispatched(
   // the lease so a live error settlement can prove no provider was invoked.
   throw new InferenceAdmissionDispatchMarkError(
     `Inference admission gate dispatch acknowledgement remained ambiguous after ${DISPATCH_GATE_MAX_ATTEMPTS} attempts`,
+    { cause: lastAmbiguousError },
+  );
+}
+
+/**
+ * Before post-provider billing mutates money, widen the durable lease to the
+ * known actual cost. The DO transition is monotonic and idempotent, so an
+ * acknowledgement-ambiguous call is replayed and billing never starts until a
+ * valid acknowledgement confirms the durable exposure.
+ */
+export async function fenceInferenceAdmissionLeaseForSettlement(
+  lease: InferenceAdmissionLease,
+  knownActualCostUsd: number,
+): Promise<void> {
+  if (!lease.providerDispatched) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission settlement fence requires a dispatched lease",
+    );
+  }
+  const targetEstimateUsd = Math.max(
+    lease.estimatedCostUsd,
+    finiteNonNegative(knownActualCostUsd, "knownActualCostUsd"),
+  );
+  let lastAmbiguousError: unknown;
+  for (let attempt = 1; attempt <= SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS; attempt += 1) {
+    let response: Response;
+    try {
+      response = await gateFetch(
+        lease.organizationId,
+        "/settlement-fence",
+        {
+          requestId: lease.requestId,
+          estimatedCostUsd: targetEstimateUsd,
+        },
+        lease.gate,
+        AbortSignal.timeout(SETTLEMENT_FENCE_GATE_TIMEOUT_MS),
+      );
+    } catch (error) {
+      lastAmbiguousError = error;
+      if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
+    if (!response.ok) {
+      const error = new InferenceAdmissionGateUnavailableError(
+        `Inference admission settlement fence failed with status ${response.status}`,
+      );
+      if (response.status < 500) throw error;
+      lastAmbiguousError = error;
+      if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
+    try {
+      const payload = await parseSettlementFenceResponse(response);
+      if (payload.estimatedCostUsd + 0.0000001 < targetEstimateUsd) {
+        throw new InferenceAdmissionGateUnavailableError(
+          "Inference admission settlement fence acknowledged a lower estimate",
+        );
+      }
+      lease.estimatedCostUsd = Math.max(lease.estimatedCostUsd, payload.estimatedCostUsd);
+      return;
+    } catch (error) {
+      lastAmbiguousError = error;
+      if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
+  }
+  throw new InferenceAdmissionGateUnavailableError(
+    `Inference admission settlement-fence acknowledgement remained ambiguous after ${SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS} attempts`,
     { cause: lastAmbiguousError },
   );
 }

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -17,7 +17,11 @@ import type {
 } from "../../types/cloud-worker-env";
 import { getCloudBinding } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
-import { type CreditReconciliationResult, creditsService } from "./credits";
+import {
+  type CreditReconciliationResult,
+  creditsService,
+  type InferenceBalanceFence,
+} from "./credits";
 import type { InferenceAdmissionRecoveryContext } from "./inference-admission-recovery";
 import {
   type InferenceCredentialCheck,
@@ -692,6 +696,49 @@ export async function acquireInferenceAdmissionLease(params: {
     gate: stub,
     providerDispatched: false,
     preProviderCancellationToken,
+  };
+}
+
+/**
+ * Keep the serialized admission authority ahead of the eventually-consistent
+ * KV projection during post-provider billing. Same-revision updates can only
+ * lower the ceiling; authoritative newer revisions advance it normally.
+ */
+async function publishInferenceAdmissionBalance(
+  lease: InferenceAdmissionLease,
+  balanceUsd: number,
+  balanceRevision: string,
+): Promise<void> {
+  const safeBalance = finiteNonNegative(balanceUsd, "balanceUsd");
+  if (!/^(0|[1-9]\d*)$/.test(balanceRevision)) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission balance fence revision is invalid",
+    );
+  }
+  const response = await gateFetch(
+    lease.organizationId,
+    "/hydrate",
+    { balanceUsd: safeBalance, balanceRevision },
+    lease.gate,
+    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+  );
+  if (!response.ok) {
+    throw new InferenceAdmissionGateUnavailableError(
+      `Inference admission balance fence failed with status ${response.status}`,
+    );
+  }
+  await parseHydrateResponse(response);
+}
+
+/** Build the two-stage live-settlement fence bound to one active lease. */
+export function createInferenceAdmissionBalanceFence(
+  lease: InferenceAdmissionLease,
+): InferenceBalanceFence {
+  return {
+    lowerCommittedBalance: async (balanceUsd, balanceRevision) =>
+      publishInferenceAdmissionBalance(lease, balanceUsd, balanceRevision),
+    publishAuthoritativeBalance: async (balanceUsd, balanceRevision) =>
+      publishInferenceAdmissionBalance(lease, balanceUsd, balanceRevision),
   };
 }
 

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -302,6 +302,7 @@ async function parseSettlementFenceResponse(response: Response): Promise<Settlem
     }
     return value as SettlementFenceResponse;
   } catch (error) {
+    // error-policy:J2 preserve malformed acknowledgement details in the typed transport failure.
     // A committed transition can lose its response. Treat malformed 2xx as
     // acknowledgement ambiguity so the caller replays the monotonic request.
     throw new InferenceAdmissionGateUnavailableError(
@@ -957,6 +958,7 @@ export async function fenceInferenceAdmissionLeaseForSettlement(
         AbortSignal.timeout(SETTLEMENT_FENCE_GATE_TIMEOUT_MS),
       );
     } catch (error) {
+      // error-policy:J2 retry the idempotent fence, then rethrow with the last acknowledgement failure.
       lastAmbiguousError = error;
       if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
       break;
@@ -980,6 +982,7 @@ export async function fenceInferenceAdmissionLeaseForSettlement(
       lease.estimatedCostUsd = Math.max(lease.estimatedCostUsd, payload.estimatedCostUsd);
       return;
     } catch (error) {
+      // error-policy:J2 retry the idempotent fence, then rethrow with the last acknowledgement failure.
       lastAmbiguousError = error;
       if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
       break;

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -38,6 +38,8 @@ const RATE_LIMIT_GATE_MAX_ATTEMPTS = 2;
 const LEASE_GATE_MAX_ATTEMPTS = 2;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
+const SETTLEMENT_FENCE_GATE_TIMEOUT_MS = 1_500;
+const SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS = 3;
 const RATE_LIMIT_WARM_TTL_MS = 5 * 60_000;
 const RATE_LIMIT_WARM_MAX_ENTRIES = 4_096;
 
@@ -59,6 +61,11 @@ interface LeaseDispatchResponse extends LeaseResponse, DispatchResponse {}
 
 interface ReleaseResponse {
   released: boolean;
+}
+
+interface SettlementFenceResponse {
+  settlementFenced: boolean;
+  estimatedCostUsd: number;
 }
 
 interface HydrateResponse {
@@ -274,6 +281,31 @@ async function parseLeaseTransitionResponse<Field extends "dispatched" | "releas
     // error-policy:J3 malformed transition responses never advance a lease.
     throw new InferenceAdmissionGateUnavailableError(
       `Inference admission gate returned invalid ${field} JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+async function parseSettlementFenceResponse(response: Response): Promise<SettlementFenceResponse> {
+  try {
+    const value = await response.json();
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      (value as Record<string, unknown>).settlementFenced !== true ||
+      !Number.isFinite((value as Record<string, unknown>).estimatedCostUsd) ||
+      ((value as Record<string, unknown>).estimatedCostUsd as number) <= 0
+    ) {
+      throw new TypeError("response does not confirm the settlement fence");
+    }
+    return value as SettlementFenceResponse;
+  } catch (error) {
+    // A committed transition can lose its response. Treat malformed 2xx as
+    // acknowledgement ambiguity so the caller replays the monotonic request.
+    throw new InferenceAdmissionGateUnavailableError(
+      `Inference admission gate returned invalid settlement-fence JSON: ${
         error instanceof Error ? error.message : String(error)
       }`,
       { cause: error },
@@ -887,6 +919,74 @@ export async function markInferenceAdmissionLeaseDispatched(
   // the lease so a live error settlement can prove no provider was invoked.
   throw new InferenceAdmissionDispatchMarkError(
     `Inference admission gate dispatch acknowledgement remained ambiguous after ${DISPATCH_GATE_MAX_ATTEMPTS} attempts`,
+    { cause: lastAmbiguousError },
+  );
+}
+
+/**
+ * Before post-provider billing mutates money, widen the durable lease to the
+ * known actual cost. The DO transition is monotonic and idempotent, so an
+ * acknowledgement-ambiguous call is replayed and billing never starts until a
+ * valid acknowledgement confirms the durable exposure.
+ */
+export async function fenceInferenceAdmissionLeaseForSettlement(
+  lease: InferenceAdmissionLease,
+  knownActualCostUsd: number,
+): Promise<void> {
+  if (!lease.providerDispatched) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission settlement fence requires a dispatched lease",
+    );
+  }
+  const targetEstimateUsd = Math.max(
+    lease.estimatedCostUsd,
+    finiteNonNegative(knownActualCostUsd, "knownActualCostUsd"),
+  );
+  let lastAmbiguousError: unknown;
+  for (let attempt = 1; attempt <= SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS; attempt += 1) {
+    let response: Response;
+    try {
+      response = await gateFetch(
+        lease.organizationId,
+        "/settlement-fence",
+        {
+          requestId: lease.requestId,
+          estimatedCostUsd: targetEstimateUsd,
+        },
+        lease.gate,
+        AbortSignal.timeout(SETTLEMENT_FENCE_GATE_TIMEOUT_MS),
+      );
+    } catch (error) {
+      lastAmbiguousError = error;
+      if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
+    if (!response.ok) {
+      const error = new InferenceAdmissionGateUnavailableError(
+        `Inference admission settlement fence failed with status ${response.status}`,
+      );
+      if (response.status < 500) throw error;
+      lastAmbiguousError = error;
+      if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
+    try {
+      const payload = await parseSettlementFenceResponse(response);
+      if (payload.estimatedCostUsd + 0.0000001 < targetEstimateUsd) {
+        throw new InferenceAdmissionGateUnavailableError(
+          "Inference admission settlement fence acknowledged a lower estimate",
+        );
+      }
+      lease.estimatedCostUsd = Math.max(lease.estimatedCostUsd, payload.estimatedCostUsd);
+      return;
+    } catch (error) {
+      lastAmbiguousError = error;
+      if (attempt < SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
+  }
+  throw new InferenceAdmissionGateUnavailableError(
+    `Inference admission settlement-fence acknowledgement remained ambiguous after ${SETTLEMENT_FENCE_GATE_MAX_ATTEMPTS} attempts`,
     { cause: lastAmbiguousError },
   );
 }

--- a/packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
@@ -144,6 +144,7 @@ test("direct recovery replays one deterministic debit and returns the persisted 
     },
     0.3,
     "backstop",
+    { preserveBalanceHintDuringFencedHandoff: true },
   );
   expect(first).toEqual({
     balanceUsd: 9.5,

--- a/packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
@@ -35,7 +35,19 @@ mock.module("./inference-billing-fast-path", () => ({
   debitInferenceCost,
 }));
 
-const { recoverExpiredInferenceAdmissionLease } = await import("./inference-admission-recovery");
+const { recoverExpiredInferenceAdmissionLease: recoverExpiredInferenceAdmissionLeaseImpl } =
+  await import("./inference-admission-recovery");
+const inferenceBalanceFence = {
+  lowerCommittedBalance: mock(async () => undefined),
+  publishAuthoritativeBalance: mock(async () => undefined),
+};
+const recoverExpiredInferenceAdmissionLease = (
+  context: Parameters<typeof recoverExpiredInferenceAdmissionLeaseImpl>[0],
+  estimatedCostUsd: number,
+) =>
+  recoverExpiredInferenceAdmissionLeaseImpl(context, estimatedCostUsd, {
+    inferenceBalanceFence,
+  });
 
 const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000001";
 const USER_ID = "00000000-0000-4000-8000-000000000002";
@@ -108,6 +120,8 @@ beforeEach(() => {
   findAppById.mockReset();
   reserveInferenceCredits.mockReset();
   debitInferenceCost.mockReset();
+  inferenceBalanceFence.lowerCommittedBalance.mockClear();
+  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
 
   getOrganizationBalanceSnapshot.mockResolvedValue({
     balanceUsd: 9.5,
@@ -144,7 +158,10 @@ test("direct recovery replays one deterministic debit and returns the persisted 
     },
     0.3,
     "backstop",
-    { preserveBalanceHintDuringFencedHandoff: true },
+    {
+      preserveBalanceHintDuringFencedHandoff: true,
+      inferenceBalanceFence,
+    },
   );
   expect(first).toEqual({
     balanceUsd: 9.5,
@@ -196,6 +213,7 @@ test("affiliate recovery replays the atomic debit and payout identity", async ()
     billingSource: "gateway",
     actualCost: 0.3,
     preserveInferenceBalanceHint: true,
+    inferenceBalanceFence,
     reservationMetadata: {
       tenantTrace: "trace-1",
       affiliatePayout: {

--- a/packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
@@ -195,6 +195,7 @@ test("affiliate recovery replays the atomic debit and payout identity", async ()
     provider: "openai",
     billingSource: "gateway",
     actualCost: 0.3,
+    preserveInferenceBalanceHint: true,
     reservationMetadata: {
       tenantTrace: "trace-1",
       affiliatePayout: {

--- a/packages/cloud/shared/src/lib/services/inference-admission-recovery.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-recovery.ts
@@ -243,6 +243,11 @@ async function recoverOrganizationCharge(
     },
     estimatedCostUsd,
     "backstop",
+    {
+      // Recovery owns the still-active Durable Object lease and settles it only
+      // after this debit, preserving the same projection handoff as live turns.
+      preserveBalanceHintDuringFencedHandoff: true,
+    },
   );
   const collectedUsd = outcome.collectedAmountUsd;
   if (

--- a/packages/cloud/shared/src/lib/services/inference-admission-recovery.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-recovery.ts
@@ -160,6 +160,9 @@ async function recoverAffiliateDebit(
     provider: context.provider,
     billingSource: context.billingSource,
     actualCost: estimatedCostUsd,
+    // Alarm recovery owns the expired-but-still-active lease until it returns
+    // this authoritative accounting result to the Durable Object.
+    preserveInferenceBalanceHint: true,
     reservationMetadata: {
       ...(context.metadata ?? {}),
       affiliatePayout: {

--- a/packages/cloud/shared/src/lib/services/inference-admission-recovery.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-recovery.ts
@@ -14,7 +14,12 @@ import {
 } from "./affiliate-billing-attribution";
 import { AFFILIATE_PAYOUT_CONTRACT_VERSION } from "./affiliate-payout-outbox";
 import { type AppCreditReservationAccountingApp, appCreditsService } from "./app-credits";
-import { type CreditReconciliationResult, creditsService, MIN_RESERVATION } from "./credits";
+import {
+  type CreditReconciliationResult,
+  creditsService,
+  type InferenceBalanceFence,
+  MIN_RESERVATION,
+} from "./credits";
 import { debitInferenceCost } from "./inference-billing-fast-path";
 
 interface RecoveryBase {
@@ -141,6 +146,7 @@ async function recoverAffiliateDebit(
     OrganizationInferenceAdmissionRecovery["accounting"],
     { kind: "affiliate_debit" }
   >,
+  inferenceBalanceFence: InferenceBalanceFence,
 ): Promise<RecoveredCharge> {
   const attribution = accounting.attribution;
   const sourceId = accounting.payoutSourceId;
@@ -163,6 +169,7 @@ async function recoverAffiliateDebit(
     // Alarm recovery owns the expired-but-still-active lease until it returns
     // this authoritative accounting result to the Durable Object.
     preserveInferenceBalanceHint: true,
+    inferenceBalanceFence,
     reservationMetadata: {
       ...(context.metadata ?? {}),
       affiliatePayout: {
@@ -231,9 +238,15 @@ async function recoverAppReservation(
 async function recoverOrganizationCharge(
   context: OrganizationInferenceAdmissionRecovery,
   estimatedCostUsd: number,
+  inferenceBalanceFence: InferenceBalanceFence,
 ): Promise<RecoveredCharge> {
   if (context.accounting.kind === "affiliate_debit") {
-    return await recoverAffiliateDebit(context, estimatedCostUsd, context.accounting);
+    return await recoverAffiliateDebit(
+      context,
+      estimatedCostUsd,
+      context.accounting,
+      inferenceBalanceFence,
+    );
   }
   const outcome = await debitInferenceCost(
     {
@@ -250,6 +263,7 @@ async function recoverOrganizationCharge(
       // Recovery owns the still-active Durable Object lease and settles it only
       // after this debit, preserving the same projection handoff as live turns.
       preserveBalanceHintDuringFencedHandoff: true,
+      inferenceBalanceFence,
     },
   );
   const collectedUsd = outcome.collectedAmountUsd;
@@ -280,15 +294,19 @@ async function recoverOrganizationCharge(
 export async function recoverExpiredInferenceAdmissionLease(
   context: InferenceAdmissionRecoveryContext,
   estimatedCostUsd: number,
+  options: { inferenceBalanceFence?: InferenceBalanceFence } = {},
 ): Promise<InferenceAdmissionRecoveryResult> {
   if (!Number.isFinite(estimatedCostUsd) || estimatedCostUsd <= 0) {
     throw new Error("Inference admission recovery cost must be positive");
+  }
+  if (context.kind === "organization" && !options.inferenceBalanceFence) {
+    throw new Error("Organization inference recovery requires an admission balance fence");
   }
 
   const recovered =
     context.kind === "app"
       ? await recoverAppReservation(context, estimatedCostUsd)
-      : await recoverOrganizationCharge(context, estimatedCostUsd);
+      : await recoverOrganizationCharge(context, estimatedCostUsd, options.inferenceBalanceFence!);
 
   const snapshot = await creditsService.getOrganizationBalanceSnapshot(context.organizationId);
   return {

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -22,18 +22,17 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * Republish the gate hint with authoritative state after a committed inference
  * debit.
  *
- * A debit necessarily runs `CacheInvalidation.onCreditMutation`, which DELETES
- * `CacheKeys.inference.orgBalance`. That delete is correct for mutations whose
- * caller cannot know the resulting balance (top-ups, refunds, admin
- * adjustments), but the inference settler is the one mutation that both lowers
- * the balance and immediately knows the new value. Leaving the key absent made
- * the *next* turn a full miss, and on the Worker hot path a full miss is read
- * `cacheOnly` — a hard, user-visible 503 "Billing authorization is warming",
- * not a slow read. Every settled turn therefore armed a guaranteed failure for
- * the following turn (observed on staging as a strict 200/503 alternation).
+ * Credit mutations normally run `CacheInvalidation.onCreditMutation`, which
+ * deletes `CacheKeys.inference.orgBalance`. That delete is correct for callers
+ * that cannot know the resulting balance (top-ups, refunds, admin adjustments).
+ * A DO-fenced inference debit instead keeps the last valid projection present
+ * only through this authoritative overwrite; legacy inference settlers still
+ * delete then seed it here. Leaving the key absent until a later request made
+ * the *next* Worker turn a full `cacheOnly` miss — a hard, user-visible 503
+ * "Billing authorization is warming", not a slow read.
  *
- * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
- * entry exists, so after the delete it is always a no-op.
+ * `lowerOrgBalanceHint` cannot repair the delete path: it is lower-only and
+ * bails when no entry exists, so after eviction it is always a no-op.
  *
  * Republishing authoritatively (balance AND revision) costs nothing net: the
  * identical `getOrganizationBalanceSnapshot` read already happened moments

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -47,12 +47,21 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * is never allowed to dispatch from this projection. Older snapshots therefore
  * cannot reopen an active gate even if concurrent writers reach Redis out of order.
  */
-export async function republishOrgBalanceHintAfterDebit(organizationId: string): Promise<void> {
+export async function republishOrgBalanceHintAfterDebit(
+  organizationId: string,
+  options: {
+    publishAuthoritativeBalance?: (balanceUsd: number, balanceRevision: string) => Promise<void>;
+  } = {},
+): Promise<void> {
   // Captured BEFORE the authoritative read, matching `refreshOrgBalanceHint`:
   // the timestamp marks when the read started, so a delayed old query can never
   // masquerade as fresher than a debit that committed while it was in flight.
   const balanceAt = Date.now();
   const snapshot = await creditsService.getOrganizationBalanceSnapshot(organizationId);
+  // Advance the strongly consistent per-org authority before the same snapshot
+  // reaches eventually-consistent KV. A delayed older KV publication can then
+  // warm a Worker, but it cannot raise the Durable Object's revision/ceiling.
+  await options.publishAuthoritativeBalance?.(snapshot.balanceUsd, snapshot.revision);
   await republishOrgBalanceHint(organizationId, snapshot.balanceUsd, balanceAt, snapshot.revision);
   clearOrgAdmissionRefused(organizationId);
 }

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -45,7 +45,12 @@ export async function republishOrgBalanceHintAfterDebit(
   organizationId: string,
   balanceUsd: number,
   balanceRevision: string,
+  options: {
+    publishAuthoritativeBalance?: (balanceUsd: number, balanceRevision: string) => Promise<void>;
+  } = {},
 ): Promise<void> {
   const balanceAt = Date.now();
+  // Fence the committed revision before exposing its eventually consistent hint.
+  await options.publishAuthoritativeBalance?.(balanceUsd, balanceRevision);
   await republishOrgBalanceHint(organizationId, balanceUsd, balanceAt, balanceRevision);
 }

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -18,18 +18,17 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * Republish the gate hint with authoritative state after a committed inference
  * debit.
  *
- * A debit necessarily runs `CacheInvalidation.onCreditMutation`, which DELETES
- * `CacheKeys.inference.orgBalance`. That delete is correct for mutations whose
- * caller cannot know the resulting balance (top-ups, refunds, admin
- * adjustments), but the inference settler is the one mutation that both lowers
- * the balance and immediately knows the new value. Leaving the key absent made
- * the *next* turn a full miss, and on the Worker hot path a full miss is read
- * `cacheOnly` — a hard, user-visible 503 "Billing authorization is warming",
- * not a slow read. Every settled turn therefore armed a guaranteed failure for
- * the following turn (observed on staging as a strict 200/503 alternation).
+ * Credit mutations normally run `CacheInvalidation.onCreditMutation`, which
+ * deletes `CacheKeys.inference.orgBalance`. That delete is correct for callers
+ * that cannot know the resulting balance (top-ups, refunds, admin adjustments).
+ * A DO-fenced inference debit instead keeps the last valid projection present
+ * only through this authoritative overwrite; legacy inference settlers still
+ * delete then seed it here. Leaving the key absent until a later request made
+ * the *next* Worker turn a full `cacheOnly` miss — a hard, user-visible 503
+ * "Billing authorization is warming", not a slow read.
  *
- * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
- * entry exists, so after the delete it is always a no-op.
+ * `lowerOrgBalanceHint` cannot repair the delete path: it is lower-only and
+ * bails when no entry exists, so after eviction it is always a no-op.
  *
  * The debit statement returns both the committed balance and trigger-advanced
  * revision. Passing that atomic result here avoids a post-debit primary read

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -17,6 +17,7 @@ interface DeductCall {
   amount: number;
   source: unknown;
   idempotencyKey: string | undefined;
+  preserveInferenceBalanceHint: boolean | undefined;
 }
 let deductCalls: DeductCall[] = [];
 let deductResult:
@@ -39,6 +40,8 @@ let deductResult:
 let deductError: Error | null = null;
 let freshBalanceUsd: number;
 let freshBalanceCalls = 0;
+let freshBalanceGate: Promise<void> | null = null;
+let freshBalanceReadStarted: (() => void) | null = null;
 const invalidateUserCalls: string[] = [];
 let invalidateUserShouldReject = false;
 
@@ -49,20 +52,20 @@ mock.module("./credits", () => ({
       amount: number;
       metadata?: { source?: unknown; requestId?: string };
       stripePaymentIntentId?: string;
+      preserveInferenceBalanceHint?: boolean;
     }) => {
       deductCalls.push({
         organizationId: args.organizationId,
         amount: args.amount,
         source: args.metadata?.source,
         idempotencyKey: args.stripePaymentIntentId,
+        preserveInferenceBalanceHint: args.preserveInferenceBalanceHint,
       });
       if (deductError) throw deductError;
-      // Mirror production: a committed debit runs
-      // `CacheInvalidation.onCreditMutation`, which DELETES the org-balance
-      // gate hint before the settler's post-debit cache step runs. Modelling
-      // this is what makes the "next turn is warm" assertions real — without
-      // it the hint survives and the test cannot observe the 503 flap.
-      if (deductResult.success) {
+      // Mirror production credit invalidation. Inference settlement now opts
+      // into a fenced handoff: the prior hint stays present until the
+      // authoritative post-debit read below replaces it.
+      if (deductResult.success && !args.preserveInferenceBalanceHint) {
         const { CacheKeys: Keys } = await import("../cache/keys");
         const { cache: c } = await import("../cache/client");
         await c.del(Keys.inference.orgBalance(args.organizationId));
@@ -82,6 +85,8 @@ mock.module("./credits", () => ({
     },
     getOrganizationBalanceSnapshot: async () => {
       freshBalanceCalls++;
+      freshBalanceReadStarted?.();
+      if (freshBalanceGate) await freshBalanceGate;
       return { balanceUsd: freshBalanceUsd, revision: "2" };
     },
   },
@@ -107,6 +112,7 @@ const {
   getGateBalanceUsd,
   InferenceBalanceCacheWarmingError,
   writePendingInferenceCharge,
+  debitInferenceCost,
   createOptimisticDebitSettler,
   sweepStalePendingInferenceCharges,
 } = await import("./inference-billing-fast-path");
@@ -156,6 +162,8 @@ beforeEach(async () => {
   deductError = null;
   freshBalanceUsd = 50;
   freshBalanceCalls = 0;
+  freshBalanceGate = null;
+  freshBalanceReadStarted = null;
   invalidateUserCalls.length = 0;
   invalidateUserShouldReject = false;
   // Drop any pending entries left by a prior test.
@@ -388,11 +396,14 @@ describe("createOptimisticDebitSettler", () => {
     expect(deductCalls[0].idempotencyKey).toBe(
       `inference-debit:${input.organizationId}:${input.requestId}`,
     );
+    // Legacy non-Worker settlement has no active admission lease, so it keeps
+    // the normal delete-then-republish path.
+    expect(deductCalls[0].preserveInferenceBalanceHint).toBeUndefined();
     // Entry was claimed (deleted), so the sweep can never double-charge it.
     expect(await cache.get(CacheKeys.inference.pendingCharge(input.requestId))).toBeNull();
   });
 
-  test("on debit success republishes the org-balance hint the credit mutation evicted", async () => {
+  test("on debit success publishes the authoritative org-balance hint", async () => {
     const input = chargeInput();
     deductResult = { success: true, newBalance: 7.5, transaction: { id: "debit-2" } };
     // Authoritative post-debit balance the republish must pick up.
@@ -423,6 +434,42 @@ describe("createOptimisticDebitSettler", () => {
     // And the next turn's hot-path read must succeed instead of throwing the
     // cache-warming error the route surfaces as a 503.
     await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(4.25);
+  });
+
+  test("a 0ms next turn remains warm while the post-stream authoritative republish is paused", async () => {
+    const input = chargeInput();
+    deductResult = { success: true, newBalance: 4.25, transaction: { id: "debit-handoff" } };
+    freshBalanceUsd = 4.25;
+    await writeOrgBalanceHint(input.organizationId, 9, Date.now(), "1");
+    let releaseFreshBalance!: () => void;
+    freshBalanceGate = new Promise<void>((resolve) => {
+      releaseFreshBalance = resolve;
+    });
+    let markFreshBalanceReadStarted!: () => void;
+    const freshBalanceStarted = new Promise<void>((resolve) => {
+      markFreshBalanceReadStarted = resolve;
+    });
+    freshBalanceReadStarted = markFreshBalanceReadStarted;
+
+    // Model stream completion starts off-response settlement. Pause at the
+    // authoritative snapshot to model the exact 0-300ms interval after [DONE].
+    const settlement = debitInferenceCost(input, 0.02, "deferred", {
+      preserveBalanceHintDuringFencedHandoff: true,
+    });
+    await freshBalanceStarted;
+
+    expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
+
+    // The rapid next call must consume the last revisioned projection instead
+    // of observing a deletion and surfacing billing_cache_warming.
+    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(9);
+
+    releaseFreshBalance();
+    await settlement;
+    expect(await readOrgBalanceHint(input.organizationId)).toMatchObject({
+      balanceUsd: 4.25,
+      balanceRevision: "2",
+    });
   });
 
   // Opposite direction: the republish must not resurrect a hint for an org the
@@ -672,10 +719,10 @@ describe("#9899 hardening: backstop durability, lower-only hint, claim atomicity
 
   // The gate must never be raised above authoritative state by an out-of-order
   // debit (#9899 over-admit bound). The settler no longer trusts the debit's
-  // own `newBalance` for this at all: the committed debit's `onCreditMutation`
-  // evicts the hint, so the settler re-reads AUTHORITATIVE state and republishes
-  // that. A transaction reporting a stale-high balance therefore cannot raise
-  // the gate, because its reported number is never written.
+  // own `newBalance` for this at all: after normal eviction (or a DO-fenced
+  // preserved handoff), the settler re-reads AUTHORITATIVE state and republishes
+  // it. A transaction reporting a stale-high balance therefore cannot raise the
+  // gate, because its reported number is never written.
   test("a stale-high debit report never raises the gate; authoritative state wins", async () => {
     const input = chargeInput();
     await writeOrgBalanceHint(input.organizationId, 10, Date.now(), "1");

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -460,9 +460,11 @@ describe("createOptimisticDebitSettler", () => {
 
     expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
 
-    // The rapid next call must consume the last revisioned projection instead
-    // of observing a deletion and surfacing billing_cache_warming.
-    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(9);
+    // The rapid next call must consume the committed LOWER balance, not the
+    // pre-debit projection. The actual debit may exceed the active lease's
+    // estimate, so retaining 9 here would let a concurrent request over-admit
+    // before the revisioned snapshot returns.
+    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(4.25);
 
     releaseFreshBalance();
     await settlement;

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -18,6 +18,12 @@ interface DeductCall {
   source: unknown;
   idempotencyKey: string | undefined;
   preserveInferenceBalanceHint: boolean | undefined;
+  inferenceBalanceFence:
+    | {
+        lowerCommittedBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
+        publishAuthoritativeBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
+      }
+    | undefined;
 }
 let deductCalls: DeductCall[] = [];
 let deductResult:
@@ -38,6 +44,9 @@ let deductResult:
       reason: "insufficient_balance";
     };
 let deductError: Error | null = null;
+let deductBalanceRevision = "2";
+let deductPostCommitGate: Promise<void> | null = null;
+let deductFenceLowered: (() => void) | null = null;
 let freshBalanceUsd: number;
 let freshBalanceCalls = 0;
 let freshBalanceGate: Promise<void> | null = null;
@@ -53,6 +62,7 @@ mock.module("./credits", () => ({
       metadata?: { source?: unknown; requestId?: string };
       stripePaymentIntentId?: string;
       preserveInferenceBalanceHint?: boolean;
+      inferenceBalanceFence?: DeductCall["inferenceBalanceFence"];
     }) => {
       deductCalls.push({
         organizationId: args.organizationId,
@@ -60,8 +70,22 @@ mock.module("./credits", () => ({
         source: args.metadata?.source,
         idempotencyKey: args.stripePaymentIntentId,
         preserveInferenceBalanceHint: args.preserveInferenceBalanceHint,
+        inferenceBalanceFence: args.inferenceBalanceFence,
       });
       if (deductError) throw deductError;
+      if (deductResult.success && args.preserveInferenceBalanceHint) {
+        if (!args.inferenceBalanceFence) {
+          throw new Error("preserved inference debit requires a fence");
+        }
+        // Mirror the production debit boundary: the SQL commit is complete,
+        // then the DO is lowered before unrelated post-commit work finishes.
+        await args.inferenceBalanceFence.lowerCommittedBalance(
+          deductResult.newBalance,
+          deductBalanceRevision,
+        );
+        deductFenceLowered?.();
+        if (deductPostCommitGate) await deductPostCommitGate;
+      }
       // Mirror production credit invalidation. Inference settlement now opts
       // into a fenced handoff: the prior hint stays present until the
       // authoritative post-debit read below replaces it.
@@ -160,6 +184,9 @@ beforeEach(async () => {
   deductCalls = [];
   deductResult = { success: true, newBalance: 100, transaction: { id: "debit-1" } };
   deductError = null;
+  deductBalanceRevision = "2";
+  deductPostCommitGate = null;
+  deductFenceLowered = null;
   freshBalanceUsd = 50;
   freshBalanceCalls = 0;
   freshBalanceGate = null;
@@ -450,15 +477,38 @@ describe("createOptimisticDebitSettler", () => {
       markFreshBalanceReadStarted = resolve;
     });
     freshBalanceReadStarted = markFreshBalanceReadStarted;
+    let releaseDeductPostCommit!: () => void;
+    deductPostCommitGate = new Promise<void>((resolve) => {
+      releaseDeductPostCommit = resolve;
+    });
+    let markDeductFenceLowered!: () => void;
+    const deductFenceWasLowered = new Promise<void>((resolve) => {
+      markDeductFenceLowered = resolve;
+    });
+    deductFenceLowered = markDeductFenceLowered;
+    const inferenceBalanceFence = {
+      lowerCommittedBalance: mock(async () => undefined),
+      publishAuthoritativeBalance: mock(async () => undefined),
+    };
 
     // Model stream completion starts off-response settlement. Pause at the
     // authoritative snapshot to model the exact 0-300ms interval after [DONE].
     const settlement = debitInferenceCost(input, 0.02, "deferred", {
       preserveBalanceHintDuringFencedHandoff: true,
+      inferenceBalanceFence,
     });
+
+    // The committed debit lowers the DO before `deductCredits` completes its
+    // unrelated post-commit work, closing the actual-cost-over-estimate window.
+    await deductFenceWasLowered;
+    expect(freshBalanceCalls).toBe(0);
+    expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledTimes(1);
+    releaseDeductPostCommit();
     await freshBalanceStarted;
 
     expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
+    expect(deductCalls[0]?.inferenceBalanceFence).toBe(inferenceBalanceFence);
+    expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(4.25, "2");
 
     // The rapid next call must consume the committed LOWER balance, not the
     // pre-debit projection. The actual debit may exceed the active lease's
@@ -468,6 +518,7 @@ describe("createOptimisticDebitSettler", () => {
 
     releaseFreshBalance();
     await settlement;
+    expect(inferenceBalanceFence.publishAuthoritativeBalance).toHaveBeenCalledWith(4.25, "2");
     expect(await readOrgBalanceHint(input.organizationId)).toMatchObject({
       balanceUsd: 4.25,
       balanceRevision: "2",

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -463,15 +463,8 @@ describe("createOptimisticDebitSettler", () => {
     deductResult = { success: true, newBalance: 4.25, transaction: { id: "debit-handoff" } };
     freshBalanceUsd = 4.25;
     await writeOrgBalanceHint(input.organizationId, 9, Date.now(), "1");
-    let releaseFreshBalance!: () => void;
-    freshBalanceGate = new Promise<void>((resolve) => {
-      releaseFreshBalance = resolve;
-    });
-    let markFreshBalanceReadStarted!: () => void;
-    const freshBalanceStarted = new Promise<void>((resolve) => {
-      markFreshBalanceReadStarted = resolve;
-    });
-    freshBalanceReadStarted = markFreshBalanceReadStarted;
+    const publicationGate = Promise.withResolvers<void>();
+    const publicationStarted = Promise.withResolvers<void>();
     let releaseDeductPostCommit!: () => void;
     deductPostCommitGate = new Promise<void>((resolve) => {
       releaseDeductPostCommit = resolve;
@@ -483,11 +476,14 @@ describe("createOptimisticDebitSettler", () => {
     deductFenceLowered = markDeductFenceLowered;
     const inferenceBalanceFence = {
       lowerCommittedBalance: mock(async () => undefined),
-      publishAuthoritativeBalance: mock(async () => undefined),
+      publishAuthoritativeBalance: mock(async () => {
+        publicationStarted.resolve();
+        await publicationGate.promise;
+      }),
     };
 
     // Model stream completion starts off-response settlement. Pause at the
-    // authoritative snapshot to model the exact 0-300ms interval after [DONE].
+    // authoritative publication to model the exact 0-300ms interval after [DONE].
     const settlement = debitInferenceCost(input, 0.02, "deferred", {
       preserveBalanceHintDuringFencedHandoff: true,
       inferenceBalanceFence,
@@ -499,7 +495,7 @@ describe("createOptimisticDebitSettler", () => {
     expect(freshBalanceCalls).toBe(0);
     expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledTimes(1);
     releaseDeductPostCommit();
-    await freshBalanceStarted;
+    await publicationStarted.promise;
 
     expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
     expect(deductCalls[0]?.inferenceBalanceFence).toBe(inferenceBalanceFence);
@@ -508,10 +504,10 @@ describe("createOptimisticDebitSettler", () => {
     // The rapid next call must consume the committed LOWER balance, not the
     // pre-debit projection. The actual debit may exceed the active lease's
     // estimate, so retaining 9 here would let a concurrent request over-admit
-    // before the revisioned snapshot returns.
+    // before the revisioned publication completes.
     await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(4.25);
 
-    releaseFreshBalance();
+    publicationGate.resolve();
     await settlement;
     expect(inferenceBalanceFence.publishAuthoritativeBalance).toHaveBeenCalledWith(4.25, "2");
     expect(await readOrgBalanceHint(input.organizationId)).toMatchObject({

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -17,6 +17,7 @@ interface DeductCall {
   amount: number;
   source: unknown;
   idempotencyKey: string | undefined;
+  preserveInferenceBalanceHint: boolean | undefined;
 }
 let deductCalls: DeductCall[] = [];
 let deductResult:
@@ -39,6 +40,8 @@ let deductResult:
 let deductError: Error | null = null;
 let freshBalanceUsd: number;
 let freshBalanceCalls = 0;
+let freshBalanceGate: Promise<void> | null = null;
+let freshBalanceReadStarted: (() => void) | null = null;
 const invalidateUserCalls: string[] = [];
 let invalidateUserShouldReject = false;
 
@@ -49,20 +52,20 @@ mock.module("./credits", () => ({
       amount: number;
       metadata?: { source?: unknown; requestId?: string };
       stripePaymentIntentId?: string;
+      preserveInferenceBalanceHint?: boolean;
     }) => {
       deductCalls.push({
         organizationId: args.organizationId,
         amount: args.amount,
         source: args.metadata?.source,
         idempotencyKey: args.stripePaymentIntentId,
+        preserveInferenceBalanceHint: args.preserveInferenceBalanceHint,
       });
       if (deductError) throw deductError;
-      // Mirror production: a committed debit runs
-      // `CacheInvalidation.onCreditMutation`, which DELETES the org-balance
-      // gate hint before the settler's post-debit cache step runs. Modelling
-      // this is what makes the "next turn is warm" assertions real — without
-      // it the hint survives and the test cannot observe the 503 flap.
-      if (deductResult.success) {
+      // Mirror production credit invalidation. Inference settlement now opts
+      // into a fenced handoff: the prior hint stays present until the
+      // authoritative post-debit read below replaces it.
+      if (deductResult.success && !args.preserveInferenceBalanceHint) {
         const { CacheKeys: Keys } = await import("../cache/keys");
         const { cache: c } = await import("../cache/client");
         await c.del(Keys.inference.orgBalance(args.organizationId));
@@ -83,6 +86,8 @@ mock.module("./credits", () => ({
     },
     getOrganizationBalanceSnapshot: async () => {
       freshBalanceCalls++;
+      freshBalanceReadStarted?.();
+      if (freshBalanceGate) await freshBalanceGate;
       return { balanceUsd: freshBalanceUsd, revision: "2" };
     },
   },
@@ -109,6 +114,7 @@ const {
   getGateBalanceUsd,
   InferenceBalanceCacheWarmingError,
   writePendingInferenceCharge,
+  debitInferenceCost,
   createOptimisticDebitSettler,
   sweepStalePendingInferenceCharges,
 } = await import("./inference-billing-fast-path");
@@ -155,6 +161,8 @@ beforeEach(async () => {
   deductError = null;
   freshBalanceUsd = 50;
   freshBalanceCalls = 0;
+  freshBalanceGate = null;
+  freshBalanceReadStarted = null;
   invalidateUserCalls.length = 0;
   invalidateUserShouldReject = false;
   // Drop any pending entries left by a prior test.
@@ -385,11 +393,14 @@ describe("createOptimisticDebitSettler", () => {
     expect(deductCalls[0].idempotencyKey).toBe(
       `inference-debit:${input.organizationId}:${input.requestId}`,
     );
+    // Legacy non-Worker settlement has no active admission lease, so it keeps
+    // the normal delete-then-republish path.
+    expect(deductCalls[0].preserveInferenceBalanceHint).toBeUndefined();
     // Entry was claimed (deleted), so the sweep can never double-charge it.
     expect(await cache.get(CacheKeys.inference.pendingCharge(input.requestId))).toBeNull();
   });
 
-  test("on debit success republishes the org-balance hint the credit mutation evicted", async () => {
+  test("on debit success publishes the authoritative org-balance hint", async () => {
     const input = chargeInput();
     deductResult = { success: true, newBalance: 7.5, transaction: { id: "debit-2" } };
     await writeOrgBalanceHint(input.organizationId, 10, Date.now(), "1");
@@ -418,6 +429,42 @@ describe("createOptimisticDebitSettler", () => {
     // And the next turn's hot-path read must succeed instead of throwing the
     // cache-warming error the route surfaces as a 503.
     await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(4.25);
+  });
+
+  test("a 0ms next turn remains warm while the post-stream authoritative republish is paused", async () => {
+    const input = chargeInput();
+    deductResult = { success: true, newBalance: 4.25, transaction: { id: "debit-handoff" } };
+    freshBalanceUsd = 4.25;
+    await writeOrgBalanceHint(input.organizationId, 9, Date.now(), "1");
+    let releaseFreshBalance!: () => void;
+    freshBalanceGate = new Promise<void>((resolve) => {
+      releaseFreshBalance = resolve;
+    });
+    let markFreshBalanceReadStarted!: () => void;
+    const freshBalanceStarted = new Promise<void>((resolve) => {
+      markFreshBalanceReadStarted = resolve;
+    });
+    freshBalanceReadStarted = markFreshBalanceReadStarted;
+
+    // Model stream completion starts off-response settlement. Pause at the
+    // authoritative snapshot to model the exact 0-300ms interval after [DONE].
+    const settlement = debitInferenceCost(input, 0.02, "deferred", {
+      preserveBalanceHintDuringFencedHandoff: true,
+    });
+    await freshBalanceStarted;
+
+    expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
+
+    // The rapid next call must consume the last revisioned projection instead
+    // of observing a deletion and surfacing billing_cache_warming.
+    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(9);
+
+    releaseFreshBalance();
+    await settlement;
+    expect(await readOrgBalanceHint(input.organizationId)).toMatchObject({
+      balanceUsd: 4.25,
+      balanceRevision: "2",
+    });
   });
 
   // Opposite direction: the republish must not resurrect a hint for an org the

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -18,6 +18,12 @@ interface DeductCall {
   source: unknown;
   idempotencyKey: string | undefined;
   preserveInferenceBalanceHint: boolean | undefined;
+  inferenceBalanceFence:
+    | {
+        lowerCommittedBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
+        publishAuthoritativeBalance(balanceUsd: number, balanceRevision: string): Promise<void>;
+      }
+    | undefined;
 }
 let deductCalls: DeductCall[] = [];
 let deductResult:
@@ -38,6 +44,9 @@ let deductResult:
       reason: "insufficient_balance";
     };
 let deductError: Error | null = null;
+let deductBalanceRevision = "2";
+let deductPostCommitGate: Promise<void> | null = null;
+let deductFenceLowered: (() => void) | null = null;
 let freshBalanceUsd: number;
 let freshBalanceCalls = 0;
 let freshBalanceGate: Promise<void> | null = null;
@@ -53,6 +62,7 @@ mock.module("./credits", () => ({
       metadata?: { source?: unknown; requestId?: string };
       stripePaymentIntentId?: string;
       preserveInferenceBalanceHint?: boolean;
+      inferenceBalanceFence?: DeductCall["inferenceBalanceFence"];
     }) => {
       deductCalls.push({
         organizationId: args.organizationId,
@@ -60,8 +70,22 @@ mock.module("./credits", () => ({
         source: args.metadata?.source,
         idempotencyKey: args.stripePaymentIntentId,
         preserveInferenceBalanceHint: args.preserveInferenceBalanceHint,
+        inferenceBalanceFence: args.inferenceBalanceFence,
       });
       if (deductError) throw deductError;
+      if (deductResult.success && args.preserveInferenceBalanceHint) {
+        if (!args.inferenceBalanceFence) {
+          throw new Error("preserved inference debit requires a fence");
+        }
+        // Mirror the production debit boundary: the SQL commit is complete,
+        // then the DO is lowered before unrelated post-commit work finishes.
+        await args.inferenceBalanceFence.lowerCommittedBalance(
+          deductResult.newBalance,
+          deductBalanceRevision,
+        );
+        deductFenceLowered?.();
+        if (deductPostCommitGate) await deductPostCommitGate;
+      }
       // Mirror production credit invalidation. Inference settlement now opts
       // into a fenced handoff: the prior hint stays present until the
       // authoritative post-debit read below replaces it.
@@ -159,6 +183,9 @@ beforeEach(async () => {
   deductCalls = [];
   deductResult = { success: true, newBalance: 100, transaction: { id: "debit-1" } };
   deductError = null;
+  deductBalanceRevision = "2";
+  deductPostCommitGate = null;
+  deductFenceLowered = null;
   freshBalanceUsd = 50;
   freshBalanceCalls = 0;
   freshBalanceGate = null;
@@ -445,15 +472,38 @@ describe("createOptimisticDebitSettler", () => {
       markFreshBalanceReadStarted = resolve;
     });
     freshBalanceReadStarted = markFreshBalanceReadStarted;
+    let releaseDeductPostCommit!: () => void;
+    deductPostCommitGate = new Promise<void>((resolve) => {
+      releaseDeductPostCommit = resolve;
+    });
+    let markDeductFenceLowered!: () => void;
+    const deductFenceWasLowered = new Promise<void>((resolve) => {
+      markDeductFenceLowered = resolve;
+    });
+    deductFenceLowered = markDeductFenceLowered;
+    const inferenceBalanceFence = {
+      lowerCommittedBalance: mock(async () => undefined),
+      publishAuthoritativeBalance: mock(async () => undefined),
+    };
 
     // Model stream completion starts off-response settlement. Pause at the
     // authoritative snapshot to model the exact 0-300ms interval after [DONE].
     const settlement = debitInferenceCost(input, 0.02, "deferred", {
       preserveBalanceHintDuringFencedHandoff: true,
+      inferenceBalanceFence,
     });
+
+    // The committed debit lowers the DO before `deductCredits` completes its
+    // unrelated post-commit work, closing the actual-cost-over-estimate window.
+    await deductFenceWasLowered;
+    expect(freshBalanceCalls).toBe(0);
+    expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledTimes(1);
+    releaseDeductPostCommit();
     await freshBalanceStarted;
 
     expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
+    expect(deductCalls[0]?.inferenceBalanceFence).toBe(inferenceBalanceFence);
+    expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(4.25, "2");
 
     // The rapid next call must consume the committed LOWER balance, not the
     // pre-debit projection. The actual debit may exceed the active lease's
@@ -463,6 +513,7 @@ describe("createOptimisticDebitSettler", () => {
 
     releaseFreshBalance();
     await settlement;
+    expect(inferenceBalanceFence.publishAuthoritativeBalance).toHaveBeenCalledWith(4.25, "2");
     expect(await readOrgBalanceHint(input.organizationId)).toMatchObject({
       balanceUsd: 4.25,
       balanceRevision: "2",

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -455,9 +455,11 @@ describe("createOptimisticDebitSettler", () => {
 
     expect(deductCalls[0]?.preserveInferenceBalanceHint).toBe(true);
 
-    // The rapid next call must consume the last revisioned projection instead
-    // of observing a deletion and surfacing billing_cache_warming.
-    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(9);
+    // The rapid next call must consume the committed LOWER balance, not the
+    // pre-debit projection. The actual debit may exceed the active lease's
+    // estimate, so retaining 9 here would let a concurrent request over-admit
+    // before the revisioned snapshot returns.
+    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(4.25);
 
     releaseFreshBalance();
     await settlement;

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -350,6 +350,7 @@ export async function debitInferenceCost(
   ctx: DebitContext,
   amountUsd: number,
   source: "inline" | "backstop" | "deferred",
+  options: { preserveBalanceHintDuringFencedHandoff?: boolean } = {},
 ): Promise<InferenceDebitCollectionOutcome> {
   let result: Awaited<ReturnType<typeof creditsService.deductCredits>>;
   try {
@@ -361,6 +362,15 @@ export async function debitInferenceCost(
       // claimed by a backstop after an acknowledgement loss. One key across
       // sources makes the database row the exactly-once collection gate.
       stripePaymentIntentId: `inference-debit:${ctx.organizationId}:${ctx.requestId}`,
+      ...(options.preserveBalanceHintDuringFencedHandoff
+        ? {
+            // Keep the previous revisioned projection present until the
+            // authoritative post-debit snapshot below replaces it. This opt-in
+            // is valid only while the admission Durable Object still accounts
+            // the active lease; legacy non-Worker debits keep normal eviction.
+            preserveInferenceBalanceHint: true,
+          }
+        : {}),
       metadata: {
         user_id: ctx.userId,
         requestId: ctx.requestId,
@@ -437,9 +447,9 @@ export async function debitInferenceCost(
         persistedAmountUsd,
       });
     }
-    // The committed debit already evicted the gate hint via onCreditMutation.
-    // Republish authoritative balance + revision so the NEXT turn hits a warm
-    // entry instead of a fail-closed cache-warming 503. The revision-aware
+    // Replace the preserved handoff hint (DO-fenced Worker lane), or seed the
+    // entry normal invalidation evicted (legacy lane), with authoritative
+    // balance + revision so the NEXT turn stays warm. The revision-aware
     // Durable Object remains the Worker dispatch authority if concurrent cache
     // writers arrive out of order.
     try {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -13,7 +13,11 @@ import { CacheKeys, CacheTTL } from "../cache/keys";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
-import { type CreditReconciliationResult, creditsService } from "./credits";
+import {
+  type CreditReconciliationResult,
+  creditsService,
+  type InferenceBalanceFence,
+} from "./credits";
 import { clearOrgAdmissionRefused, markOrgAdmissionRefused } from "./inference-admission-refusal";
 import {
   INFERENCE_AUTH_CONTEXT_VERSION,
@@ -351,8 +355,18 @@ export async function debitInferenceCost(
   ctx: DebitContext,
   amountUsd: number,
   source: "inline" | "backstop" | "deferred",
-  options: { preserveBalanceHintDuringFencedHandoff?: boolean } = {},
+  options: {
+    preserveBalanceHintDuringFencedHandoff?: boolean;
+    inferenceBalanceFence?: InferenceBalanceFence;
+  } = {},
 ): Promise<InferenceDebitCollectionOutcome> {
+  if (options.preserveBalanceHintDuringFencedHandoff && !options.inferenceBalanceFence) {
+    throw new InferenceDebitInfrastructureError(
+      ctx.requestId,
+      ctx.organizationId,
+      new Error("Fenced inference debit requires an admission fence"),
+    );
+  }
   let result: Awaited<ReturnType<typeof creditsService.deductCredits>>;
   try {
     result = await creditsService.deductCredits({
@@ -370,6 +384,7 @@ export async function debitInferenceCost(
             // is valid only while the admission Durable Object still accounts
             // the active lease; legacy non-Worker debits keep normal eviction.
             preserveInferenceBalanceHint: true,
+            inferenceBalanceFence: options.inferenceBalanceFence,
           }
         : {}),
       metadata: {
@@ -449,10 +464,9 @@ export async function debitInferenceCost(
       });
     }
     try {
-      // A fenced debit can exceed its estimate. Lower the still-present hint
-      // to the committed balance BEFORE waiting on the authoritative snapshot,
-      // so a concurrent admission cannot dispatch from the pre-debit ceiling
-      // while the Durable Object still accounts only the original estimate.
+      // `deductCredits` lowers the Durable Object at its first post-commit
+      // boundary, including the keyed-replay path. Lower the eventually-
+      // consistent KV projection here before reading the authoritative state.
       if (options.preserveBalanceHintDuringFencedHandoff) {
         await lowerOrgBalanceHint(ctx.organizationId, result.newBalance, Date.now());
       }
@@ -461,7 +475,9 @@ export async function debitInferenceCost(
       // balance + revision so the NEXT turn stays warm. The revision-aware
       // Durable Object remains the Worker dispatch authority if concurrent
       // cache writers arrive out of order.
-      await republishOrgBalanceHintAfterDebit(ctx.organizationId);
+      await republishOrgBalanceHintAfterDebit(ctx.organizationId, {
+        publishAuthoritativeBalance: options.inferenceBalanceFence?.publishAuthoritativeBalance,
+      });
     } catch (cause) {
       markOrgAdmissionRefused(ctx.organizationId);
       try {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -18,6 +18,7 @@ import { clearOrgAdmissionRefused, markOrgAdmissionRefused } from "./inference-a
 import {
   INFERENCE_AUTH_CONTEXT_VERSION,
   invalidateOrgBalanceHint,
+  lowerOrgBalanceHint,
   readOrgBalanceHint,
   writeOrgBalanceHint,
 } from "./inference-auth-cache";
@@ -447,12 +448,19 @@ export async function debitInferenceCost(
         persistedAmountUsd,
       });
     }
-    // Replace the preserved handoff hint (DO-fenced Worker lane), or seed the
-    // entry normal invalidation evicted (legacy lane), with authoritative
-    // balance + revision so the NEXT turn stays warm. The revision-aware
-    // Durable Object remains the Worker dispatch authority if concurrent cache
-    // writers arrive out of order.
     try {
+      // A fenced debit can exceed its estimate. Lower the still-present hint
+      // to the committed balance BEFORE waiting on the authoritative snapshot,
+      // so a concurrent admission cannot dispatch from the pre-debit ceiling
+      // while the Durable Object still accounts only the original estimate.
+      if (options.preserveBalanceHintDuringFencedHandoff) {
+        await lowerOrgBalanceHint(ctx.organizationId, result.newBalance, Date.now());
+      }
+      // Replace the lowered handoff hint (DO-fenced Worker lane), or seed the
+      // entry normal invalidation evicted (legacy lane), with authoritative
+      // balance + revision so the NEXT turn stays warm. The revision-aware
+      // Durable Object remains the Worker dispatch authority if concurrent
+      // cache writers arrive out of order.
       await republishOrgBalanceHintAfterDebit(ctx.organizationId);
     } catch (cause) {
       markOrgAdmissionRefused(ctx.organizationId);

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -16,6 +16,7 @@ import { apiKeysService } from "./api-keys";
 import { type CreditReconciliationResult, creditsService } from "./credits";
 import {
   invalidateOrgBalanceHint,
+  lowerOrgBalanceHint,
   readOrgBalanceHint,
   writeOrgBalanceHint,
 } from "./inference-auth-cache";
@@ -446,11 +447,6 @@ export async function debitInferenceCost(
         persistedAmountUsd,
       });
     }
-    // Replace the preserved handoff hint (DO-fenced Worker lane), or seed the
-    // entry normal invalidation evicted (legacy lane), with authoritative
-    // balance + revision so the NEXT turn stays warm. The revision-aware
-    // Durable Object remains the Worker dispatch authority if concurrent cache
-    // writers arrive out of order.
     try {
       await republishOrgBalanceHintAfterDebit(
         ctx.organizationId,

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -350,6 +350,7 @@ export async function debitInferenceCost(
   ctx: DebitContext,
   amountUsd: number,
   source: "inline" | "backstop" | "deferred",
+  options: { preserveBalanceHintDuringFencedHandoff?: boolean } = {},
 ): Promise<InferenceDebitCollectionOutcome> {
   let result: Awaited<ReturnType<typeof creditsService.deductCredits>>;
   try {
@@ -361,6 +362,15 @@ export async function debitInferenceCost(
       // claimed by a backstop after an acknowledgement loss. One key across
       // sources makes the database row the exactly-once collection gate.
       stripePaymentIntentId: `inference-debit:${ctx.organizationId}:${ctx.requestId}`,
+      ...(options.preserveBalanceHintDuringFencedHandoff
+        ? {
+            // Keep the previous revisioned projection present until the
+            // authoritative post-debit snapshot below replaces it. This opt-in
+            // is valid only while the admission Durable Object still accounts
+            // the active lease; legacy non-Worker debits keep normal eviction.
+            preserveInferenceBalanceHint: true,
+          }
+        : {}),
       metadata: {
         user_id: ctx.userId,
         requestId: ctx.requestId,
@@ -436,9 +446,9 @@ export async function debitInferenceCost(
         persistedAmountUsd,
       });
     }
-    // The committed debit already evicted the gate hint via onCreditMutation.
-    // Republish authoritative balance + revision so the NEXT turn hits a warm
-    // entry instead of a fail-closed cache-warming 503. The revision-aware
+    // Replace the preserved handoff hint (DO-fenced Worker lane), or seed the
+    // entry normal invalidation evicted (legacy lane), with authoritative
+    // balance + revision so the NEXT turn stays warm. The revision-aware
     // Durable Object remains the Worker dispatch authority if concurrent cache
     // writers arrive out of order.
     try {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -13,7 +13,11 @@ import { CacheKeys, CacheTTL } from "../cache/keys";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
-import { type CreditReconciliationResult, creditsService } from "./credits";
+import {
+  type CreditReconciliationResult,
+  creditsService,
+  type InferenceBalanceFence,
+} from "./credits";
 import {
   invalidateOrgBalanceHint,
   lowerOrgBalanceHint,
@@ -351,8 +355,18 @@ export async function debitInferenceCost(
   ctx: DebitContext,
   amountUsd: number,
   source: "inline" | "backstop" | "deferred",
-  options: { preserveBalanceHintDuringFencedHandoff?: boolean } = {},
+  options: {
+    preserveBalanceHintDuringFencedHandoff?: boolean;
+    inferenceBalanceFence?: InferenceBalanceFence;
+  } = {},
 ): Promise<InferenceDebitCollectionOutcome> {
+  if (options.preserveBalanceHintDuringFencedHandoff && !options.inferenceBalanceFence) {
+    throw new InferenceDebitInfrastructureError(
+      ctx.requestId,
+      ctx.organizationId,
+      new Error("Fenced inference debit requires an admission fence"),
+    );
+  }
   let result: Awaited<ReturnType<typeof creditsService.deductCredits>>;
   try {
     result = await creditsService.deductCredits({
@@ -370,6 +384,7 @@ export async function debitInferenceCost(
             // is valid only while the admission Durable Object still accounts
             // the active lease; legacy non-Worker debits keep normal eviction.
             preserveInferenceBalanceHint: true,
+            inferenceBalanceFence: options.inferenceBalanceFence,
           }
         : {}),
       metadata: {
@@ -452,6 +467,7 @@ export async function debitInferenceCost(
         ctx.organizationId,
         result.newBalance,
         result.balanceRevision,
+        { publishAuthoritativeBalance: options.inferenceBalanceFence?.publishAuthoritativeBalance },
       );
     } catch (cause) {
       try {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -463,6 +463,9 @@ export async function debitInferenceCost(
       });
     }
     try {
+      if (options.preserveBalanceHintDuringFencedHandoff) {
+        await lowerOrgBalanceHint(ctx.organizationId, result.newBalance, Date.now());
+      }
       await republishOrgBalanceHintAfterDebit(
         ctx.organizationId,
         result.newBalance,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -814,6 +814,7 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
     provider: "cerebras",
     billingSource: "bitrouter",
     actualCost: 0.02,
+    preserveInferenceBalanceHint: true,
     reservationMetadata: {
       affiliatePayout: {
         sourceId: `ai_billing:affiliate:${leaseParams.requestId}`,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -175,11 +175,13 @@ const acquireInferenceAdmissionLease = mock(
   },
 );
 const settleInferenceAdmissionLease = mock(async () => undefined);
-const markInferenceAdmissionLeaseDispatched = mock(async (lease: { providerDispatched: boolean }) => {
-  if (lease.providerDispatched) return;
-  settlementEvents.push("dispatch");
-  lease.providerDispatched = true;
-});
+const markInferenceAdmissionLeaseDispatched = mock(
+  async (lease: { providerDispatched: boolean }) => {
+    if (lease.providerDispatched) return;
+    settlementEvents.push("dispatch");
+    lease.providerDispatched = true;
+  },
+);
 const fenceInferenceAdmissionLeaseForSettlement = mock(
   async (lease: { estimatedCostUsd: number }, knownActualCostUsd: number) => {
     settlementEvents.push("settlement_fence");
@@ -524,9 +526,9 @@ test("strong proof on and off each acquire exactly one Durable Object lease", as
 
   for (const strongProof of [credential, undefined]) {
     acquireInferenceAdmissionLease.mockClear();
-  createInferenceAdmissionBalanceFence.mockClear();
-  inferenceBalanceFence.lowerCommittedBalance.mockClear();
-  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
+    createInferenceAdmissionBalanceFence.mockClear();
+    inferenceBalanceFence.lowerCommittedBalance.mockClear();
+    inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
     await admitOrganizationInference({
       ...admissionParams(model, []),
       ...(strongProof ? { credential: strongProof } : {}),

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -465,6 +465,7 @@ test("warm Worker admission writes only the Durable Object lease before provider
     },
     0.01,
     "deferred",
+    { preserveBalanceHintDuringFencedHandoff: true },
   );
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.01);
@@ -556,6 +557,9 @@ test("unknown provider cost retains the admitted estimate and wins a later zero 
   expect(debitInferenceCost).toHaveBeenCalledTimes(1);
   expect(debitInferenceCost.mock.calls[0]?.[1]).toBe(leaseParams.estimatedCostUsd);
   expect(debitInferenceCost.mock.calls[0]?.[2]).toBe("deferred");
+  expect(debitInferenceCost.mock.calls[0]?.[3]).toEqual({
+    preserveBalanceHintDuringFencedHandoff: true,
+  });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBeCloseTo(
     leaseParams.estimatedCostUsd,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -150,6 +150,12 @@ let subscriptionFunded = false;
 let leaseFailure: Error | undefined;
 const isSubscriptionFundedOrganization = mock(async () => subscriptionFunded);
 const isOptimisticEligible = mock(() => eligible);
+const inferenceBalanceFence = {
+  lowerCommittedBalance: mock(async () => undefined),
+  publishAuthoritativeBalance: mock(async () => undefined),
+};
+const createInferenceAdmissionBalanceFence = mock(() => inferenceBalanceFence);
+
 const acquireInferenceAdmissionLease = mock(
   async (params: { organizationId: string; requestId: string; estimatedCostUsd: number }) => {
     if (leaseFailure) throw leaseFailure;
@@ -216,6 +222,7 @@ mock.module("./inference-billing-fast-path", () => ({
 }));
 mock.module("./inference-admission-gate", () => ({
   acquireInferenceAdmissionLease,
+  createInferenceAdmissionBalanceFence,
   inferenceSettlementAmounts: (_lease: unknown, actualCostUsd: number) => ({
     balanceBackedUsd: actualCostUsd,
     gateConsumedUsd: actualCostUsd,
@@ -279,6 +286,9 @@ async function hydratePricing(model: string): Promise<void> {
   expect(background).toHaveLength(1);
   await background[0];
   acquireInferenceAdmissionLease.mockClear();
+  createInferenceAdmissionBalanceFence.mockClear();
+  inferenceBalanceFence.lowerCommittedBalance.mockClear();
+  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
 }
 
 beforeEach(() => {
@@ -305,6 +315,9 @@ beforeEach(() => {
   admitInferenceChargeViaLedger.mockClear();
   optimisticSettle.mockClear();
   acquireInferenceAdmissionLease.mockClear();
+  createInferenceAdmissionBalanceFence.mockClear();
+  inferenceBalanceFence.lowerCommittedBalance.mockClear();
+  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
   settleInferenceAdmissionLease.mockClear();
   markInferenceAdmissionLeaseDispatched.mockClear();
   isOptimisticEligible.mockClear();
@@ -465,7 +478,7 @@ test("warm Worker admission writes only the Durable Object lease before provider
     },
     0.01,
     "deferred",
-    { preserveBalanceHintDuringFencedHandoff: true },
+    { preserveBalanceHintDuringFencedHandoff: true, inferenceBalanceFence },
   );
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.01);
@@ -482,6 +495,9 @@ test("strong proof on and off each acquire exactly one Durable Object lease", as
 
   for (const strongProof of [credential, undefined]) {
     acquireInferenceAdmissionLease.mockClear();
+  createInferenceAdmissionBalanceFence.mockClear();
+  inferenceBalanceFence.lowerCommittedBalance.mockClear();
+  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
     await admitOrganizationInference({
       ...admissionParams(model, []),
       ...(strongProof ? { credential: strongProof } : {}),
@@ -559,6 +575,7 @@ test("unknown provider cost retains the admitted estimate and wins a later zero 
   expect(debitInferenceCost.mock.calls[0]?.[2]).toBe("deferred");
   expect(debitInferenceCost.mock.calls[0]?.[3]).toEqual({
     preserveBalanceHintDuringFencedHandoff: true,
+    inferenceBalanceFence,
   });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBeCloseTo(
@@ -630,6 +647,9 @@ test("the exact Durable Object path admits when balance equals the estimate", as
   if (!quotedLease) throw new Error("expected quoted inference lease");
 
   acquireInferenceAdmissionLease.mockClear();
+  createInferenceAdmissionBalanceFence.mockClear();
+  inferenceBalanceFence.lowerCommittedBalance.mockClear();
+  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
   gateBalance = quotedLease.estimatedCostUsd;
   const background: Promise<unknown>[] = [];
   const request = admissionParams(model, background);
@@ -815,6 +835,7 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
     billingSource: "bitrouter",
     actualCost: 0.02,
     preserveInferenceBalanceHint: true,
+    inferenceBalanceFence,
     reservationMetadata: {
       affiliatePayout: {
         sourceId: `ai_billing:affiliate:${leaseParams.requestId}`,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -124,7 +124,10 @@ const reserveFlatUsageCredits = mock(async (context: { requestId?: string | null
   reconcile: reconcileReservation,
 }));
 let affiliateDebitError: Error | null = null;
+let settlementFenceError: Error | null = null;
+const settlementEvents: string[] = [];
 const collectAffiliateInferenceFallback = mock(async (params: { actualCost: number }) => {
+  settlementEvents.push("affiliate_db");
   if (affiliateDebitError) throw affiliateDebitError;
   return {
     reservedAmount: params.actualCost,
@@ -135,12 +138,15 @@ const collectAffiliateInferenceFallback = mock(async (params: { actualCost: numb
     adjustmentType: "none" as const,
   };
 });
-const debitInferenceCost = mock(async (_context: unknown, actualCostUsd: number) => ({
-  status: "collected" as const,
-  collectedAmountUsd: actualCostUsd,
-  balanceUsd: 50 - actualCostUsd,
-  transactionId: "inference-debit",
-}));
+const debitInferenceCost = mock(async (_context: unknown, actualCostUsd: number) => {
+  settlementEvents.push("direct_db");
+  return {
+    status: "collected" as const,
+    collectedAmountUsd: actualCostUsd,
+    balanceUsd: 50 - actualCostUsd,
+    transactionId: "inference-debit",
+  };
+});
 const writePendingInferenceCharge = mock(async () => true);
 const optimisticSettle = mock(async () => null);
 const admitInferenceChargeViaLedger = mock(async () => ({ admitted: true }));
@@ -169,7 +175,18 @@ const acquireInferenceAdmissionLease = mock(
   },
 );
 const settleInferenceAdmissionLease = mock(async () => undefined);
-const markInferenceAdmissionLeaseDispatched = mock(async () => undefined);
+const markInferenceAdmissionLeaseDispatched = mock(async (lease: { providerDispatched: boolean }) => {
+  if (lease.providerDispatched) return;
+  settlementEvents.push("dispatch");
+  lease.providerDispatched = true;
+});
+const fenceInferenceAdmissionLeaseForSettlement = mock(
+  async (lease: { estimatedCostUsd: number }, knownActualCostUsd: number) => {
+    settlementEvents.push("settlement_fence");
+    if (settlementFenceError) throw settlementFenceError;
+    lease.estimatedCostUsd = Math.max(lease.estimatedCostUsd, knownActualCostUsd);
+  },
+);
 
 class TestInferenceBalanceCacheWarmingError extends Error {}
 class TestInferenceAdmissionGateUnavailableError extends Error {}
@@ -223,6 +240,7 @@ mock.module("./inference-billing-fast-path", () => ({
 mock.module("./inference-admission-gate", () => ({
   acquireInferenceAdmissionLease,
   createInferenceAdmissionBalanceFence,
+  fenceInferenceAdmissionLeaseForSettlement,
   inferenceSettlementAmounts: (_lease: unknown, actualCostUsd: number) => ({
     balanceBackedUsd: actualCostUsd,
     gateConsumedUsd: actualCostUsd,
@@ -301,6 +319,8 @@ beforeEach(() => {
   repositoryBlock = null;
   affiliateRepositoryBlock = null;
   affiliateDebitError = null;
+  settlementFenceError = null;
+  settlementEvents.length = 0;
   pairReads = 0;
   fallbackReads = 0;
   catalogReads = 0;
@@ -316,6 +336,8 @@ beforeEach(() => {
   optimisticSettle.mockClear();
   acquireInferenceAdmissionLease.mockClear();
   createInferenceAdmissionBalanceFence.mockClear();
+  markInferenceAdmissionLeaseDispatched.mockClear();
+  fenceInferenceAdmissionLeaseForSettlement.mockClear();
   inferenceBalanceFence.lowerCommittedBalance.mockClear();
   inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
   settleInferenceAdmissionLease.mockClear();
@@ -427,6 +449,7 @@ test("warm Worker admission writes only the Durable Object lease before provider
   const leaseParams = acquireInferenceAdmissionLease.mock.calls.at(-1)?.[0] as
     | {
         requestId: string;
+        estimatedCostUsd: number;
         recovery: {
           version: number;
           kind: string;
@@ -466,6 +489,12 @@ test("warm Worker admission writes only the Durable Object lease before provider
     collectedAmount: 0.01,
   });
   await expect(replay).resolves.toMatchObject({ actualCost: 0.01 });
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence", "direct_db"]);
+  expect(fenceInferenceAdmissionLeaseForSettlement).toHaveBeenCalledTimes(1);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[1]).toBe(0.01);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[0].estimatedCostUsd).toBe(
+    Math.max(leaseParams.estimatedCostUsd, 0.01),
+  );
   expect(debitInferenceCost).toHaveBeenCalledTimes(1);
   expect(debitInferenceCost).toHaveBeenCalledWith(
     {
@@ -524,6 +553,21 @@ test("audited provider boundaries defer the lease commit until the required mark
   expect(markInferenceAdmissionLeaseDispatched).toHaveBeenCalledTimes(1);
 });
 
+test("a direct settlement fence failure prevents the database debit", async () => {
+  const model = nextModel();
+  await hydratePricing(model);
+  const admission = await admitOrganizationInference(admissionParams(model, []));
+  const error = new Error("settlement fence unavailable");
+  settlementFenceError = error;
+
+  await expect(admission.settle(1)).rejects.toBe(error);
+
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence"]);
+  expect(debitInferenceCost).not.toHaveBeenCalled();
+  expect(collectAffiliateInferenceFallback).not.toHaveBeenCalled();
+  expect(settleInferenceAdmissionLease).not.toHaveBeenCalled();
+});
+
 test("flat Worker admission leases the fixed catalog cost without token pricing reads", async () => {
   const background: Promise<unknown>[] = [];
   const flatCost = {
@@ -579,6 +623,10 @@ test("unknown provider cost retains the admitted estimate and wins a later zero 
   });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBeCloseTo(
+    leaseParams.estimatedCostUsd,
+  );
+  expect(fenceInferenceAdmissionLeaseForSettlement).toHaveBeenCalledWith(
+    expect.anything(),
     leaseParams.estimatedCostUsd,
   );
 });
@@ -776,6 +824,7 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
   const leaseParams = acquireInferenceAdmissionLease.mock.calls.at(-1)?.[0] as
     | {
         requestId: string;
+        estimatedCostUsd: number;
         recovery: {
           version: number;
           accounting: {
@@ -825,6 +874,12 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
   const replay = admission.reservation?.reconcile(99);
   await expect(first).resolves.toMatchObject({ actualCost: 0.02 });
   await expect(replay).resolves.toMatchObject({ actualCost: 0.02 });
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence", "affiliate_db"]);
+  expect(fenceInferenceAdmissionLeaseForSettlement).toHaveBeenCalledTimes(1);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[1]).toBe(0.02);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[0].estimatedCostUsd).toBe(
+    Math.max(leaseParams.estimatedCostUsd, 0.02),
+  );
   expect(collectAffiliateInferenceFallback).toHaveBeenCalledTimes(1);
   expect(collectAffiliateInferenceFallback.mock.calls[0]?.[0]).toMatchObject({
     organizationId: "org-1",
@@ -846,6 +901,28 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
   });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.02);
+});
+
+test("an affiliate settlement fence failure prevents the database debit", async () => {
+  const model = nextModel();
+  const affiliateCode = `PARTNER-${modelSequence}`;
+  const coldBackground: Promise<unknown>[] = [];
+  await admitOrganizationInference(admissionParams(model, coldBackground, { affiliateCode })).then(
+    () => null,
+    () => null,
+  );
+  await Promise.all(coldBackground);
+
+  const admission = await admitOrganizationInference(admissionParams(model, [], { affiliateCode }));
+  const error = new Error("settlement fence unavailable");
+  settlementFenceError = error;
+
+  await expect(admission.settle(1)).rejects.toBe(error);
+
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence"]);
+  expect(collectAffiliateInferenceFallback).not.toHaveBeenCalled();
+  expect(debitInferenceCost).not.toHaveBeenCalled();
+  expect(settleInferenceAdmissionLease).not.toHaveBeenCalled();
 });
 
 test("affiliate settlement retries the same post-provider amount after infrastructure failure", async () => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -418,6 +418,7 @@ test("warm Worker admission writes only the Durable Object lease before provider
     },
     0.01,
     "deferred",
+    { preserveBalanceHintDuringFencedHandoff: true },
   );
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.01);
@@ -472,6 +473,9 @@ test("unknown provider cost retains the admitted estimate and wins a later zero 
   expect(debitInferenceCost).toHaveBeenCalledTimes(1);
   expect(debitInferenceCost.mock.calls[0]?.[1]).toBe(leaseParams.estimatedCostUsd);
   expect(debitInferenceCost.mock.calls[0]?.[2]).toBe("deferred");
+  expect(debitInferenceCost.mock.calls[0]?.[3]).toEqual({
+    preserveBalanceHintDuringFencedHandoff: true,
+  });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBeCloseTo(
     leaseParams.estimatedCostUsd,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -123,7 +123,10 @@ const reserveFlatUsageCredits = mock(async (context: { requestId?: string | null
   reconcile: reconcileReservation,
 }));
 let affiliateDebitError: Error | null = null;
+let settlementFenceError: Error | null = null;
+const settlementEvents: string[] = [];
 const collectAffiliateInferenceFallback = mock(async (params: { actualCost: number }) => {
+  settlementEvents.push("affiliate_db");
   if (affiliateDebitError) throw affiliateDebitError;
   return {
     reservedAmount: params.actualCost,
@@ -134,12 +137,15 @@ const collectAffiliateInferenceFallback = mock(async (params: { actualCost: numb
     adjustmentType: "none" as const,
   };
 });
-const debitInferenceCost = mock(async (_context: unknown, actualCostUsd: number) => ({
-  status: "collected" as const,
-  collectedAmountUsd: actualCostUsd,
-  balanceUsd: 50 - actualCostUsd,
-  transactionId: "inference-debit",
-}));
+const debitInferenceCost = mock(async (_context: unknown, actualCostUsd: number) => {
+  settlementEvents.push("direct_db");
+  return {
+    status: "collected" as const,
+    collectedAmountUsd: actualCostUsd,
+    balanceUsd: 50 - actualCostUsd,
+    transactionId: "inference-debit",
+  };
+});
 const writePendingInferenceCharge = mock(async () => true);
 const optimisticSettle = mock(async () => null);
 const admitInferenceChargeViaLedger = mock(async () => ({ admitted: true }));
@@ -161,6 +167,20 @@ const inferenceBalanceFence = {
   publishAuthoritativeBalance: mock(async () => undefined),
 };
 const createInferenceAdmissionBalanceFence = mock(() => inferenceBalanceFence);
+const markInferenceAdmissionLeaseDispatched = mock(
+  async (lease: { providerDispatched: boolean }) => {
+    if (lease.providerDispatched) return;
+    settlementEvents.push("dispatch");
+    lease.providerDispatched = true;
+  },
+);
+const fenceInferenceAdmissionLeaseForSettlement = mock(
+  async (lease: { estimatedCostUsd: number }, knownActualCostUsd: number) => {
+    settlementEvents.push("settlement_fence");
+    if (settlementFenceError) throw settlementFenceError;
+    lease.estimatedCostUsd = Math.max(lease.estimatedCostUsd, knownActualCostUsd);
+  },
+);
 const settleInferenceAdmissionLease = mock(async () => undefined);
 
 mock.module("./ai-billing", () => ({
@@ -216,6 +236,7 @@ mock.module("./inference-billing-fast-path", () => ({
 mock.module("./inference-admission-gate", () => ({
   acquireInferenceAdmissionLease,
   createInferenceAdmissionBalanceFence,
+  fenceInferenceAdmissionLeaseForSettlement,
   inferenceSettlementAmounts: (_lease: unknown, actualCostUsd: number) => ({
     balanceBackedUsd: actualCostUsd,
     gateConsumedUsd: actualCostUsd,
@@ -225,7 +246,7 @@ mock.module("./inference-admission-gate", () => ({
     readonly requiredUsd = 1;
     readonly availableUsd = 0;
   },
-  markInferenceAdmissionLeaseDispatched: async () => undefined,
+  markInferenceAdmissionLeaseDispatched,
   settleInferenceAdmissionLease,
 }));
 mock.module("./inference-billing-ledger", () => ({
@@ -300,6 +321,8 @@ beforeEach(() => {
   repositoryBlock = null;
   affiliateRepositoryBlock = null;
   affiliateDebitError = null;
+  settlementFenceError = null;
+  settlementEvents.length = 0;
   pairReads = 0;
   fallbackReads = 0;
   catalogReads = 0;
@@ -315,6 +338,8 @@ beforeEach(() => {
   optimisticSettle.mockClear();
   acquireInferenceAdmissionLease.mockClear();
   createInferenceAdmissionBalanceFence.mockClear();
+  markInferenceAdmissionLeaseDispatched.mockClear();
+  fenceInferenceAdmissionLeaseForSettlement.mockClear();
   inferenceBalanceFence.lowerCommittedBalance.mockClear();
   inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
   settleInferenceAdmissionLease.mockClear();
@@ -376,6 +401,7 @@ test("warm Worker admission writes only the Durable Object lease before provider
   const leaseParams = acquireInferenceAdmissionLease.mock.calls.at(-1)?.[0] as
     | {
         requestId: string;
+        estimatedCostUsd: number;
         recovery: {
           version: number;
           kind: string;
@@ -415,6 +441,12 @@ test("warm Worker admission writes only the Durable Object lease before provider
     collectedAmount: 0.01,
   });
   await expect(replay).resolves.toMatchObject({ actualCost: 0.01 });
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence", "direct_db"]);
+  expect(fenceInferenceAdmissionLeaseForSettlement).toHaveBeenCalledTimes(1);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[1]).toBe(0.01);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[0].estimatedCostUsd).toBe(
+    Math.max(leaseParams.estimatedCostUsd, 0.01),
+  );
   expect(debitInferenceCost).toHaveBeenCalledTimes(1);
   expect(debitInferenceCost).toHaveBeenCalledWith(
     {
@@ -434,6 +466,21 @@ test("warm Worker admission writes only the Durable Object lease before provider
   );
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.01);
+});
+
+test("a direct settlement fence failure prevents the database debit", async () => {
+  const model = nextModel();
+  await hydratePricing(model);
+  const admission = await admitOrganizationInference(admissionParams(model, []));
+  const error = new Error("settlement fence unavailable");
+  settlementFenceError = error;
+
+  await expect(admission.settle(1)).rejects.toBe(error);
+
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence"]);
+  expect(debitInferenceCost).not.toHaveBeenCalled();
+  expect(collectAffiliateInferenceFallback).not.toHaveBeenCalled();
+  expect(settleInferenceAdmissionLease).not.toHaveBeenCalled();
 });
 
 test("flat Worker admission leases the fixed catalog cost without token pricing reads", async () => {
@@ -491,6 +538,10 @@ test("unknown provider cost retains the admitted estimate and wins a later zero 
   });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBeCloseTo(
+    leaseParams.estimatedCostUsd,
+  );
+  expect(fenceInferenceAdmissionLeaseForSettlement).toHaveBeenCalledWith(
+    expect.anything(),
     leaseParams.estimatedCostUsd,
   );
 });
@@ -656,6 +707,7 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
   const leaseParams = acquireInferenceAdmissionLease.mock.calls.at(-1)?.[0] as
     | {
         requestId: string;
+        estimatedCostUsd: number;
         recovery: {
           version: number;
           accounting: {
@@ -705,6 +757,12 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
   const replay = admission.reservation?.reconcile(99);
   await expect(first).resolves.toMatchObject({ actualCost: 0.02 });
   await expect(replay).resolves.toMatchObject({ actualCost: 0.02 });
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence", "affiliate_db"]);
+  expect(fenceInferenceAdmissionLeaseForSettlement).toHaveBeenCalledTimes(1);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[1]).toBe(0.02);
+  expect(fenceInferenceAdmissionLeaseForSettlement.mock.calls[0]?.[0].estimatedCostUsd).toBe(
+    Math.max(leaseParams.estimatedCostUsd, 0.02),
+  );
   expect(collectAffiliateInferenceFallback).toHaveBeenCalledTimes(1);
   expect(collectAffiliateInferenceFallback.mock.calls[0]?.[0]).toMatchObject({
     organizationId: "org-1",
@@ -726,6 +784,28 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
   });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.02);
+});
+
+test("an affiliate settlement fence failure prevents the database debit", async () => {
+  const model = nextModel();
+  const affiliateCode = `PARTNER-${modelSequence}`;
+  const coldBackground: Promise<unknown>[] = [];
+  await admitOrganizationInference(admissionParams(model, coldBackground, { affiliateCode })).then(
+    () => null,
+    () => null,
+  );
+  await Promise.all(coldBackground);
+
+  const admission = await admitOrganizationInference(admissionParams(model, [], { affiliateCode }));
+  const error = new Error("settlement fence unavailable");
+  settlementFenceError = error;
+
+  await expect(admission.settle(1)).rejects.toBe(error);
+
+  expect(settlementEvents).toEqual(["dispatch", "settlement_fence"]);
+  expect(collectAffiliateInferenceFallback).not.toHaveBeenCalled();
+  expect(debitInferenceCost).not.toHaveBeenCalled();
+  expect(settleInferenceAdmissionLease).not.toHaveBeenCalled();
 });
 
 test("affiliate settlement retries the same post-provider amount after infrastructure failure", async () => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -701,6 +701,7 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
     provider: "cerebras",
     billingSource: "bitrouter",
     actualCost: 0.02,
+    preserveInferenceBalanceHint: true,
     reservationMetadata: {
       affiliatePayout: {
         sourceId: `ai_billing:affiliate:${leaseParams.requestId}`,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -156,6 +156,11 @@ const acquireInferenceAdmissionLease = mock(
     providerDispatched: false,
   }),
 );
+const inferenceBalanceFence = {
+  lowerCommittedBalance: mock(async () => undefined),
+  publishAuthoritativeBalance: mock(async () => undefined),
+};
+const createInferenceAdmissionBalanceFence = mock(() => inferenceBalanceFence);
 const settleInferenceAdmissionLease = mock(async () => undefined);
 
 mock.module("./ai-billing", () => ({
@@ -210,6 +215,7 @@ mock.module("./inference-billing-fast-path", () => ({
 }));
 mock.module("./inference-admission-gate", () => ({
   acquireInferenceAdmissionLease,
+  createInferenceAdmissionBalanceFence,
   inferenceSettlementAmounts: (_lease: unknown, actualCostUsd: number) => ({
     balanceBackedUsd: actualCostUsd,
     gateConsumedUsd: actualCostUsd,
@@ -308,6 +314,9 @@ beforeEach(() => {
   admitInferenceChargeViaLedger.mockClear();
   optimisticSettle.mockClear();
   acquireInferenceAdmissionLease.mockClear();
+  createInferenceAdmissionBalanceFence.mockClear();
+  inferenceBalanceFence.lowerCommittedBalance.mockClear();
+  inferenceBalanceFence.publishAuthoritativeBalance.mockClear();
   settleInferenceAdmissionLease.mockClear();
   isOptimisticEligible.mockClear();
   listActiveEntriesForProviderModelPairs.mockClear();
@@ -418,7 +427,10 @@ test("warm Worker admission writes only the Durable Object lease before provider
     },
     0.01,
     "deferred",
-    { preserveBalanceHintDuringFencedHandoff: true },
+    {
+      preserveBalanceHintDuringFencedHandoff: true,
+      inferenceBalanceFence,
+    },
   );
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.01);
@@ -475,6 +487,7 @@ test("unknown provider cost retains the admitted estimate and wins a later zero 
   expect(debitInferenceCost.mock.calls[0]?.[2]).toBe("deferred");
   expect(debitInferenceCost.mock.calls[0]?.[3]).toEqual({
     preserveBalanceHintDuringFencedHandoff: true,
+    inferenceBalanceFence,
   });
   expect(settleInferenceAdmissionLease).toHaveBeenCalledTimes(1);
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBeCloseTo(
@@ -702,6 +715,7 @@ test("warm Worker affiliate admission has zero pre-dispatch repository calls", a
     billingSource: "bitrouter",
     actualCost: 0.02,
     preserveInferenceBalanceHint: true,
+    inferenceBalanceFence,
     reservationMetadata: {
       affiliatePayout: {
         sourceId: `ai_billing:affiliate:${leaseParams.requestId}`,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -470,7 +470,12 @@ export async function admitOrganizationInference(
           adjustmentType: "none",
         };
       }
-      const outcome = await debitInferenceCost(debit, actualCostUsd, "deferred");
+      const outcome = await debitInferenceCost(debit, actualCostUsd, "deferred", {
+        // The attached admission lease remains active until this authoritative
+        // debit and gate settlement finish, so the last valid projection can
+        // stay present during the post-stream republish handoff.
+        preserveBalanceHintDuringFencedHandoff: true,
+      });
       return {
         reservedAmount: outcome.collectedAmountUsd,
         actualCost: actualCostUsd,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -29,6 +29,7 @@ import {
 import {
   acquireInferenceAdmissionLease,
   createInferenceAdmissionBalanceFence,
+  fenceInferenceAdmissionLeaseForSettlement,
   InferenceAdmissionGateUnavailableError,
   type InferenceAdmissionLease,
   InferenceAdmissionLeaseRejectedError,
@@ -188,6 +189,10 @@ function attachInferenceAdmissionLease(
     const current = (async () => {
       if (selected.kind === "unknown" || selected.actualCostUsd > 0) {
         await markProviderDispatched();
+        await fenceInferenceAdmissionLeaseForSettlement(
+          lease,
+          selected.kind === "actual" ? selected.actualCostUsd : lease.estimatedCostUsd,
+        );
       }
       const reconciliation =
         selected.kind === "actual"

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -444,6 +444,10 @@ export async function admitOrganizationInference(
           billingSource: charge.billingSource,
           actualCost: actualCostUsd,
           reservationMetadata,
+          // The attached lease remains active until the affiliate debit,
+          // lower-only handoff, authoritative republish, and gate settlement
+          // all finish.
+          preserveInferenceBalanceHint: true,
         });
       const result: OrganizationInferenceAdmission = {
         mode: "durable_object_affiliate_debit",

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -28,6 +28,7 @@ import {
 } from "./credits";
 import {
   acquireInferenceAdmissionLease,
+  createInferenceAdmissionBalanceFence,
   InferenceAdmissionGateUnavailableError,
   type InferenceAdmissionLease,
   InferenceAdmissionLeaseRejectedError,
@@ -423,6 +424,7 @@ export async function admitOrganizationInference(
     if (!inferenceLease) {
       throw new InferenceAdmissionUnavailableError();
     }
+    const inferenceBalanceFence = createInferenceAdmissionBalanceFence(inferenceLease);
     if (affiliateAttribution) {
       const affiliatePayoutSourceId = getAffiliatePayoutSourceId(params.context);
       const reservationMetadata = {
@@ -448,6 +450,7 @@ export async function admitOrganizationInference(
           // lower-only handoff, authoritative republish, and gate settlement
           // all finish.
           preserveInferenceBalanceHint: true,
+          inferenceBalanceFence,
         });
       const result: OrganizationInferenceAdmission = {
         mode: "durable_object_affiliate_debit",
@@ -479,6 +482,7 @@ export async function admitOrganizationInference(
         // debit and gate settlement finish, so the last valid projection can
         // stay present during the post-stream republish handoff.
         preserveBalanceHintDuringFencedHandoff: true,
+        inferenceBalanceFence,
       });
       return {
         reservedAmount: outcome.collectedAmountUsd,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -34,6 +34,7 @@ import {
 import {
   acquireInferenceAdmissionLease,
   createInferenceAdmissionBalanceFence,
+  fenceInferenceAdmissionLeaseForSettlement,
   InferenceAdmissionGateUnavailableError,
   type InferenceAdmissionLease,
   InferenceAdmissionLeaseRejectedError,
@@ -267,6 +268,10 @@ function attachInferenceAdmissionLease(
       }
       if (selected.kind === "unknown" || selected.actualCostUsd > 0) {
         await markProviderDispatched();
+        await fenceInferenceAdmissionLeaseForSettlement(
+          lease,
+          selected.kind === "actual" ? selected.actualCostUsd : lease.estimatedCostUsd,
+        );
       }
       const reconciliation =
         selected.kind === "actual"

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -542,6 +542,10 @@ export async function admitOrganizationInference(
           billingSource: charge.billingSource,
           actualCost: actualCostUsd,
           reservationMetadata,
+          // The attached lease remains active until the affiliate debit,
+          // lower-only handoff, authoritative republish, and gate settlement
+          // all finish.
+          preserveInferenceBalanceHint: true,
         });
       const result: OrganizationInferenceAdmission = {
         mode: "durable_object_affiliate_debit",

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -33,6 +33,7 @@ import {
 } from "./credits";
 import {
   acquireInferenceAdmissionLease,
+  createInferenceAdmissionBalanceFence,
   InferenceAdmissionGateUnavailableError,
   type InferenceAdmissionLease,
   InferenceAdmissionLeaseRejectedError,
@@ -521,6 +522,7 @@ export async function admitOrganizationInference(
     if (!inferenceLease) {
       throw admissionUnavailable(params);
     }
+    const inferenceBalanceFence = createInferenceAdmissionBalanceFence(inferenceLease);
     if (affiliateAttribution) {
       const affiliatePayoutSourceId = getAffiliatePayoutSourceId(params.context);
       const reservationMetadata = {
@@ -546,6 +548,7 @@ export async function admitOrganizationInference(
           // lower-only handoff, authoritative republish, and gate settlement
           // all finish.
           preserveInferenceBalanceHint: true,
+          inferenceBalanceFence,
         });
       const result: OrganizationInferenceAdmission = {
         mode: "durable_object_affiliate_debit",
@@ -577,6 +580,7 @@ export async function admitOrganizationInference(
         // debit and gate settlement finish, so the last valid projection can
         // stay present during the post-stream republish handoff.
         preserveBalanceHintDuringFencedHandoff: true,
+        inferenceBalanceFence,
       });
       return {
         reservedAmount: outcome.collectedAmountUsd,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -568,7 +568,12 @@ export async function admitOrganizationInference(
           adjustmentType: "none",
         };
       }
-      const outcome = await debitInferenceCost(debit, actualCostUsd, "deferred");
+      const outcome = await debitInferenceCost(debit, actualCostUsd, "deferred", {
+        // The attached admission lease remains active until this authoritative
+        // debit and gate settlement finish, so the last valid projection can
+        // stay present during the post-stream republish handoff.
+        preserveBalanceHintDuringFencedHandoff: true,
+      });
       return {
         reservedAmount: outcome.collectedAmountUsd,
         actualCost: actualCostUsd,


### PR DESCRIPTION
## Current integration

This integrates the billing hint handoff with current `develop` without restoring the removed process-local refusal cache or the old post-debit primary read.

- Keep the admission hint present only while an active Durable Object lease fences settlement.
- Widen the lease to actual cost before the database debit, including retry-safe acknowledgement handling.
- Preserve the atomic committed balance/revision returned by the debit for both first execution and keyed replay.
- Lower the durable authority before publishing its cache projection; retain alarm recovery and affiliate settlement safeguards.
- Preserve the isolated organization-admission test wrapper and port the actual regressions into its subprocess fixture.
- Preserve the published PR history. The integration is a normal fast-forward update of the remote branch; no force push is needed.

## Validation

Validated head: `b3b04f7ab6d87c3093273aa0f337f76915cadcbf`; integrated develop through `032bdee3c4`.

- Final `bun install` and `bun run verify`: passed, all 377 workspace tasks and repository audits.
- Focused admission/cache/recovery suites: 125 passed.
- Real PGlite debit and affiliate-outbox suites: 35 passed.
- Complete Cloud shared sweep: 12,610 passed, including 348 isolated PGlite batches.
- Complete Cloud API runner: 6,482 passed across 598 files.
- The complete suites ran before the latest unrelated upstream A2A/provider changes. Those changes additionally pass all 14 focused tests; the billing implementation is unchanged from the complete-suite-tested revision.
- Cloud shared typecheck and lint: passed through repository verification.
- Earlier upstream shortcut UI lint failures were repaired in merged #30843; the final gate is green.
- Failure-handling comment-only token equality check passed.

All five hosted checks passed on the updated head in run 34065052653. The final merge candidate against develop `662d2060d9` additionally passed all 125 focused tests and 35 real-database tests after installation. Merged as `1b89a8bcd5a744e680e2a43a50a9605c713507dc`. Existing approvals target the older `c8e708264b833f946413aed0b65c14bc39aae6b1` revision, not this integration.

This is source/test validation, not evidence of a deployed latency improvement. Production currently serves a September 2 gateway revision. No production deployment or live monetary mutation was performed by this validation. Deployment must include the matching admission Durable Object implementation and callers for the new settlement fence; an older gate fails closed.

UI screenshots and native recordings are N/A for this backend billing change. Tests exercise admission fencing, replay, settlement recovery and real PGlite monetary state.
