### PR TITLE
perf(cloud): keep inference rate limits on sync SQLite

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -146,7 +146,9 @@ describe("Miniflare Durable Object integration", () => {
       throw new Error("Admission test Worker bundle was not emitted");
 
     miniflare = new Miniflare({
-      compatibilityDate: "2026-06-01",
+      // Match the deployed API Worker so synchronous SQLite KV is exercised
+      // under the exact production compatibility contract.
+      compatibilityDate: "2026-04-01",
       compatibilityFlags: ["nodejs_compat"],
       modules: true,
       script: await output.text(),
@@ -508,6 +510,50 @@ describe("Miniflare Durable Object integration", () => {
     ]);
     expect(isolated.status).toBe(200);
     expect((await blockedCutover).status).toBe(200);
+  }, 120_000);
+
+  test("synchronous SQLite KV continues the exact async-KV quota window", async () => {
+    const gateName = "rate-limit:v2:org-miniflare-sync-kv-compat";
+    const windowMs = 60_000;
+    const windowStartedAt = Math.floor(Date.now() / windowMs) * windowMs;
+    expect(
+      (
+        await post(
+          "/test-seed-legacy-rate-limits",
+          {
+            completions: {
+              windowStartedAt,
+              windowMs,
+              maxRequests: 1,
+              count: 1,
+            },
+          },
+          gateName,
+        )
+      ).status,
+    ).toBe(204);
+
+    const denied = await post(
+      "/rate-limit",
+      {
+        endpointType: "completions",
+        windowMs,
+        maxRequests: 1,
+        windowStartedAt,
+      },
+      gateName,
+    );
+    expect(denied.status).toBe(429);
+
+    const persisted = await post("/test-read-legacy-rate-limits", {}, gateName);
+    expect(JSON.parse(await persisted.text())).toEqual({
+      completions: {
+        windowStartedAt,
+        windowMs,
+        maxRequests: 1,
+        count: 2,
+      },
+    });
   }, 120_000);
 
   test("clearing one subject denial cannot clear an independent denial", async () => {

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -34,6 +34,40 @@ class TestStorage {
   failNextPut = false;
   failNextSetAlarm = false;
   failNextTransactionCommit = false;
+  rejectAsyncRateLimitStorage = false;
+
+  readonly kv = {
+    get: <T = unknown>(key: string): T | undefined => {
+      const value = this.values.get(key);
+      return value === undefined ? undefined : (structuredClone(value) as T);
+    },
+    put: <T>(key: string, value: T): void => {
+      if (this.failNextPut) {
+        this.failNextPut = false;
+        throw new Error("injected storage failure");
+      }
+      this.values.set(key, structuredClone(value));
+    },
+    delete: (key: string): boolean => this.values.delete(key),
+    list: <T = unknown>(options: { prefix?: string; limit?: number } = {}) =>
+      this.syncEntries<T>(options),
+  };
+
+  private syncEntries<T>(options: {
+    prefix?: string;
+    limit?: number;
+  }): Array<[string, T]> {
+    const entries = [...this.values.entries()]
+      .filter(
+        ([key]) =>
+          options.prefix === undefined || key.startsWith(options.prefix),
+      )
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]): [string, T] => [key, structuredClone(value) as T]);
+    return options.limit === undefined
+      ? entries
+      : entries.slice(0, options.limit);
+  }
 
   async get<T>(key: string): Promise<T | undefined>;
   async get<T>(keys: string[]): Promise<Map<string, T>>;
@@ -41,6 +75,13 @@ class TestStorage {
     keyOrKeys: string | string[],
   ): Promise<T | undefined | Map<string, T>> {
     await Promise.resolve();
+    if (
+      this.rejectAsyncRateLimitStorage &&
+      (keyOrKeys === "rate-limits" ||
+        (Array.isArray(keyOrKeys) && keyOrKeys.includes("rate-limits")))
+    ) {
+      throw new Error("async rate-limit storage path must not be used");
+    }
     if (Array.isArray(keyOrKeys)) {
       return new Map(
         keyOrKeys.flatMap((key) => {
@@ -74,6 +115,9 @@ class TestStorage {
 
   async put(key: string, value: unknown): Promise<void> {
     await Promise.resolve();
+    if (this.rejectAsyncRateLimitStorage && key === "rate-limits") {
+      throw new Error("async rate-limit storage path must not be used");
+    }
     if (this.failNextPut) {
       this.failNextPut = false;
       throw new Error("injected storage failure");
@@ -489,6 +533,46 @@ describe("InferenceAdmissionGate", () => {
         maxRequests: 1,
       }),
     ).rejects.toBeInstanceOf(InferenceAdmissionGateUnavailableError);
+  });
+
+  test("rate-only requests use synchronous SQLite KV and preserve the legacy key", async () => {
+    const storage = new TestStorage();
+    storage.rejectAsyncRateLimitStorage = true;
+    const gate = createGate(storage);
+    const windowStartedAt = 60_000;
+    const clock = spyOn(Date, "now").mockReturnValue(windowStartedAt + 1);
+    try {
+      expect(
+        (
+          await post(gate, "/rate-limit", {
+            endpointType: "completions",
+            windowMs: 60_000,
+            maxRequests: 1,
+            windowStartedAt,
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        (
+          await post(gate, "/rate-limit", {
+            endpointType: "completions",
+            windowMs: 60_000,
+            maxRequests: 1,
+            windowStartedAt,
+          })
+        ).status,
+      ).toBe(429);
+      expect(storage.read<Record<string, unknown>>("rate-limits")).toEqual({
+        completions: {
+          count: 2,
+          maxRequests: 1,
+          windowMs: 60_000,
+          windowStartedAt,
+        },
+      });
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   test("rate-limit prewarm loads its isolated window without consuming a request", async () => {

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -627,15 +627,24 @@ export class InferenceAdmissionGate {
     this.ledger = snapshot;
   }
 
-  private async loadRateLimitWindows(): Promise<RateLimitWindows> {
+  private loadRateLimitWindows(): RateLimitWindows {
+    // This namespace is SQLite-backed in every deployed environment. Its
+    // synchronous KV facade reads the same hidden __cf_kv table as the legacy
+    // async API, but does not yield the object input gate for a local counter
+    // read. The async read/write pair previously made this tiny rate-only
+    // object vulnerable to storage-tail latency and caller aborts even though
+    // it performs no network or database I/O.
     this.rateLimitWindows ??=
-      (await this.state.storage.get<RateLimitWindows>(RATE_LIMITS_KEY)) ?? {};
+      this.state.storage.kv.get<RateLimitWindows>(RATE_LIMITS_KEY) ?? {};
     return this.rateLimitWindows;
   }
 
-  private async saveRateLimitWindows(windows: RateLimitWindows): Promise<void> {
+  private saveRateLimitWindows(windows: RateLimitWindows): void {
     const snapshot = cloneRateLimitWindows(windows);
-    await this.state.storage.put(RATE_LIMITS_KEY, snapshot);
+    // Synchronous SQLite storage remains strongly consistent and durable. It
+    // also preserves the exact legacy key, so an immediate Worker rollback
+    // observes the current counter instead of opening a duplicate quota lane.
+    this.state.storage.kv.put(RATE_LIMITS_KEY, snapshot);
     this.rateLimitWindows = snapshot;
   }
 
@@ -1024,7 +1033,7 @@ export class InferenceAdmissionGate {
     }
 
     const windowStartedAt = request.windowStartedAt ?? currentWindowStartedAt;
-    const windows = cloneRateLimitWindows(await this.loadRateLimitWindows());
+    const windows = cloneRateLimitWindows(this.loadRateLimitWindows());
     const existing = windows[request.endpointType];
     if (existing && existing.windowStartedAt > windowStartedAt) {
       const resetAt = existing.windowStartedAt + existing.windowMs;
@@ -1051,7 +1060,7 @@ export class InferenceAdmissionGate {
           };
     current.count = Math.min(current.count + 1, Number.MAX_SAFE_INTEGER);
     windows[request.endpointType] = current;
-    await this.saveRateLimitWindows(windows);
+    this.saveRateLimitWindows(windows);
 
     const allowed = current.count <= request.maxRequests;
     const resetAt = windowStartedAt + request.windowMs;
@@ -1226,7 +1235,7 @@ export class InferenceAdmissionGate {
   }
 
   private async warmRateLimit(): Promise<Response> {
-    await this.loadRateLimitWindows();
+    this.loadRateLimitWindows();
     return Response.json({ warmed: true });
   }
 

--- a/packages/cloud/api/test/fixtures/inference-admission-gate-worker.ts
+++ b/packages/cloud/api/test/fixtures/inference-admission-gate-worker.ts
@@ -16,6 +16,15 @@ export class TestInferenceAdmissionGate extends InferenceAdmissionGate {
 
   override async fetch(request: Request): Promise<Response> {
     const path = new URL(request.url).pathname;
+    if (path === "/test-seed-legacy-rate-limits") {
+      const body = (await request.json()) as Record<string, unknown>;
+      await this.testState.storage.put("rate-limits", body);
+      return new Response(null, { status: 204 });
+    }
+    if (path === "/test-read-legacy-rate-limits") {
+      const value = await this.testState.storage.get("rate-limits");
+      return Response.json(value ?? null);
+    }
     if (path === "/test-block-billing-queue") {
       let entered: () => void = () => undefined;
       const started = new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- keep rate-only `InferenceAdmissionGate` reads and writes on SQLite synchronous KV
- preserve the exact legacy `rate-limits` key for live quota and rollback continuity
- exercise async-to-sync storage compatibility in real Miniflare under the deployed compatibility date

## Root cause
Read-only staging Durable Object analytics for the exact per-org rate object show a low normal median but a heavy tail with client disconnects crossing the caller's 1.5 second abort. This object performs no database, network, or Redis work; the rate-only path was yielding on asynchronous SQLite storage reads and writes inside the API Worker isolate. A tail event therefore becomes `rate_limit_unavailable`, after which client retry/failover can inflate the full chat turn.

This change removes those storage yields. It does not raise the timeout, fail open, change rate-limit identity, or reset/double quota.

## Safety
- the bound Durable Object namespace is SQLite-backed and Wrangler declares `storage = "sqlite"`
- synchronous KV and asynchronous KV address the same hidden SQLite KV table and exact key
- an immediate rollback to the old asynchronous handler sees counts written by this handler
- writes remain strongly consistent and durable before the response

## Verification
- focused unit and real-Miniflare suites: **55 pass / 0 fail**
- exact deployed-compatibility-date Miniflare suite: **16 pass / 0 fail**
- Cloud API TypeScript check
- Worker bundle/build dry run
- Biome and `git diff --check`

Live effectiveness still requires staging deploy plus repeated latency/error probes before promotion.
