### PR TITLE
fix(cloud): soak revocation-fenced auth cache in staging

### DIFF
--- a/packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+describe("inference strong-revocation rollout", () => {
+  test("soaks revocation-fenced auth caching in staging without enabling production", async () => {
+    const config = Bun.TOML.parse(
+      await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
+    ) as {
+      env?: {
+        staging?: { vars?: Record<string, string> };
+        production?: { vars?: Record<string, string> };
+      };
+    };
+
+    expect(config.env?.staging?.vars?.INFERENCE_AUTH_CACHE_ENABLED).toBe(
+      "true",
+    );
+    expect(config.env?.staging?.vars?.INFERENCE_STRONG_REVOCATION_ENABLED).toBe(
+      "true",
+    );
+    expect(config.env?.production?.vars?.INFERENCE_AUTH_CACHE_ENABLED).toBe(
+      "true",
+    );
+    expect(
+      config.env?.production?.vars?.INFERENCE_STRONG_REVOCATION_ENABLED,
+    ).toBe("false");
+  });
+});

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -278,10 +278,11 @@ Staging and production inference require:
 - `INFERENCE_HOT_PATH_CACHES="true"`.
 
 `INFERENCE_AUTH_CACHE_ENABLED="true"` is inert unless
-`INFERENCE_STRONG_REVOCATION_ENABLED="true"`. The strong flag remains false in
-checked-in staging and production configuration until rollout evidence is
-approved, so authoritative authorization remains the default. The thin entry
-has its own `THIN_INFERENCE_ENTRY_ENABLED` rollout control.
+`INFERENCE_STRONG_REVOCATION_ENABLED="true"`. Staging enables the strong flag
+to soak the revocation-fenced positive cache; production keeps it false until
+the staged latency and revocation evidence is approved, so authoritative
+authorization remains the production default. The thin entry has its own
+`THIN_INFERENCE_ENTRY_ENABLED` rollout control.
 The thin entry lazily evaluates only the matched generative route module rather
 than the monolithic API router. Either flag remains an independent rollback
 control.

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -690,8 +690,11 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # One combined auth+org+moderation read; authoritative refresh runs only under
 # waitUntil and the 60s physical TTL bounds lost invalidation.
 INFERENCE_AUTH_CACHE_ENABLED = "true"
-# Default authoritative until the Durable Object revocation lane is soaked.
-INFERENCE_STRONG_REVOCATION_ENABLED = "false"
+# Staging soak: every positive auth-cache hit crosses the strongly consistent
+# organization Durable Object before provider dispatch. Production remains on
+# authoritative authorization until this lane passes the release latency and
+# revocation probes.
+INFERENCE_STRONG_REVOCATION_ENABLED = "true"
 # Pass-through streaming fast path (#15428): "true" pipes qualifying streamed
 # chat completions (OpenAI-compatible direct upstream, no tools/response_format/
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding


### PR DESCRIPTION
## Summary
- enable the existing revocation-fenced positive inference auth cache in staging only
- keep production on authoritative authorization until staging latency and revocation gates pass
- pin the staging/production rollout split with a config regression test

## Why
The positive auth cache was configured but inert because strong revocation was disabled. Live dedicated inference traces show authoritative authorization costs roughly 0.5–0.9 seconds per request. This staging-only soak validates the existing strongly consistent revocation lane before any production change.

## Validation
- `bun test ./packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts` (1/1)
- existing auth-cache/revocation/lifecycle/context suites passed before the final config commit (86/86 total)
- `bunx biome check packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts`
- `git diff --check`

## Rollout gates
Staging only. Before production: repeated inference soak, immediate revoke/disable denial, fresh credential rehydrate, and latency evidence. No fail-open behavior.