### PR TITLE
test(cloud): cover Tier2ToolIndex search/discovery contract (#29650)

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/search/bm25-index.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/search/bm25-index.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Contract tests for Tier2ToolIndex — the BM25-backed discovery index behind
+ * the hosted agent's SEARCH_ACTIONS op (see actions/mcp.ts).
+ *
+ * The core BM25 primitive has its own suite; this file owns the wrapper's
+ * contract on top of it, exercised with real Tier2ToolIndex instances (no
+ * BM25 mocks):
+ *  - tag tokenization: buildTags splits tool names on _/- and combines them
+ *    with server name and platform, so a planner asking for "issues" surfaces
+ *    jira_search_issues-style tools without an exact-name query;
+ *  - platform filtering and pagination: search() filters case-insensitively
+ *    by platform and slices offset..offset+limit after relevance ranking (the
+ *    (offset + limit) * 2 over-fetch exists so filtering does not silently
+ *    shrink pages);
+ *  - lifecycle: build([]) resets the index to empty (no stale results from a
+ *    prior build) and getToolCount() reflects the current build.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+import { toActionName } from "../utils/action-naming";
+import type { Tier2ToolEntry } from "./bm25-index";
+import { Tier2ToolIndex } from "./bm25-index";
+
+/** Mirrors how service.ts builds Tier-2 entries from a server's MCP tools. */
+function makeEntry(serverName: string, toolName: string, description: string): Tier2ToolEntry {
+  const tool: Tool = { name: toolName, description, inputSchema: { type: "object" } };
+  return {
+    serverName,
+    toolName,
+    actionName: toActionName(serverName, toolName),
+    platform: serverName.toLowerCase(),
+    tool,
+  };
+}
+
+describe("Tier2ToolIndex tag tokenization & discovery", () => {
+  const jiraTools = [
+    makeEntry("jira", "jira_search_issues", "Search Jira issues by text"),
+    makeEntry("jira", "jira_get_issue", "Fetch a single Jira issue"),
+    makeEntry("jira", "jira_create_issue", "Create a new Jira issue"),
+    makeEntry("jira", "jira_get-comments", "List the comments on a Jira issue"),
+  ];
+
+  test("finds a tool by its full action name", () => {
+    const index = new Tier2ToolIndex();
+    index.build(jiraTools);
+
+    const results = index.search("JIRA_SEARCH_ISSUES");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].actionName).toBe("JIRA_SEARCH_ISSUES");
+  });
+
+  test("finds a tool by a fragment of its name, not just the exact name", () => {
+    const index = new Tier2ToolIndex();
+    index.build(jiraTools);
+
+    // "issues" is a token of jira_search_issues; the planner need not name
+    // the tool exactly to discover it.
+    const results = index.search("issues");
+
+    expect(results.map((r) => r.actionName)).toContain("JIRA_SEARCH_ISSUES");
+    expect(results[0].actionName).toBe("JIRA_SEARCH_ISSUES");
+  });
+
+  test("finds a tool by a hyphenated name fragment", () => {
+    const index = new Tier2ToolIndex();
+    index.build(jiraTools);
+
+    // buildTags splits toolName on "-", so "comments" surfaces
+    // jira_get-comments even though the action name never says "comments".
+    const results = index.search("comments");
+
+    expect(results.map((r) => r.actionName)).toContain("JIRA_GET_COMMENTS");
+    expect(results[0].actionName).toBe("JIRA_GET_COMMENTS");
+  });
+
+  test("finds tools by server and platform terms", () => {
+    const index = new Tier2ToolIndex();
+    index.build([
+      ...jiraTools,
+      makeEntry("github", "github_create_issue", "Open a GitHub issue"),
+      makeEntry("slack", "slack_post_message", "Post a message to Slack"),
+    ]);
+
+    const results = index.search("jira");
+
+    expect(results.length).toBe(4);
+    expect(results.every((r) => r.platform === "jira")).toBe(true);
+  });
+
+  test("tag tokens carry name fragments the action name drops", () => {
+    const index = new Tier2ToolIndex();
+    // Action names normalize away non-ASCII tokens, so the CJK fragment
+    // survives only in the tag field — tags are its sole carrier.
+    index.build([
+      makeEntry("jira", "jira_查询_问题", ""),
+      makeEntry("github", "github_create_issue", "Open a GitHub issue"),
+    ]);
+
+    const results = index.search("问题");
+
+    expect(results.map((r) => r.actionName)).toContain("JIRA_JIRA");
+  });
+
+  test("returns no results before any build", () => {
+    const index = new Tier2ToolIndex();
+
+    expect(index.search("issues")).toEqual([]);
+  });
+});
+
+describe("Tier2ToolIndex relevance ordering", () => {
+  test("a name match outranks description-only matches and unrelated entries", () => {
+    const index = new Tier2ToolIndex();
+    index.build([
+      makeEntry("crm", "crm_get_customer", "Look up account details and contacts"),
+      makeEntry("fin", "fin_summarize", "Customer churn summary report"),
+      makeEntry("sales", "sales_forecast", "Quarterly revenue forecast"),
+    ]);
+
+    const results = index.search("customer");
+
+    expect(results.map((r) => r.actionName)).toEqual(["CRM_GET_CUSTOMER", "FIN_SUMMARIZE"]);
+  });
+});
+
+describe("Tier2ToolIndex platform filtering & pagination", () => {
+  // Alternating GitHub/Jira docs with identical token counts, so every doc
+  // scores equally for the "issues" query and doc order decides placement.
+  function buildAlternating(githubCount: number, jiraCount: number): Tier2ToolEntry[] {
+    const entries: Tier2ToolEntry[] = [];
+    for (let i = 0; i < Math.max(githubCount, jiraCount); i++) {
+      if (i < githubCount)
+        entries.push(makeEntry("github", "github_create_issues", "Work with GitHub issues"));
+      if (i < jiraCount)
+        entries.push(makeEntry("jira", "jira_create_issues", "Work with Jira issues"));
+    }
+    return entries;
+  }
+
+  test("filters case-insensitively by platform and excludes other platforms", () => {
+    const index = new Tier2ToolIndex();
+    index.build(buildAlternating(0, 6));
+
+    const mixedCase = index.search("issues", "JIRA");
+    expect(mixedCase.length).toBe(6);
+    expect(mixedCase.every((r) => r.platform === "jira")).toBe(true);
+
+    expect(index.search("issues", "salesforce")).toEqual([]);
+    expect(index.search("issues", "GITHUB")).toEqual([]);
+  });
+
+  test("slices offset..offset+limit after filtering", () => {
+    const index = new Tier2ToolIndex();
+    index.build(buildAlternating(6, 6));
+
+    const allJira = index.search("issues", "jira", 10, 0);
+    expect(allJira).toHaveLength(6);
+
+    const pages = [0, 2, 4].map((offset) => index.search("issues", "jira", 2, offset));
+    expect(pages.map((p) => p.length)).toEqual([2, 2, 2]);
+    expect(pages.every((p) => p.every((r) => r.platform === "jira"))).toBe(true);
+    expect(pages.flat().map((r) => r.actionName)).toEqual(allJira.map((r) => r.actionName));
+  });
+
+  test("over-fetches past the platform filter so pages do not silently shrink", () => {
+    const index = new Tier2ToolIndex();
+    index.build(buildAlternating(10, 10));
+
+    // The first (offset + limit) raw results are half GitHub docs; without the
+    // (offset + limit) * 2 over-fetch the filtered page would come up short.
+    const results = index.search("issues", "jira", 3, 2);
+
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r.platform === "jira")).toBe(true);
+  });
+});
+
+describe("Tier2ToolIndex lifecycle", () => {
+  test("build() replaces the previous build completely", () => {
+    const index = new Tier2ToolIndex();
+    index.build([makeEntry("jira", "jira_search_issues", "Search Jira issues")]);
+    expect(index.search("issues")).toHaveLength(1);
+    expect(index.getToolCount()).toBe(1);
+
+    index.build([makeEntry("slack", "slack_post_message", "Post a message to Slack")]);
+
+    expect(index.search("issues")).toEqual([]);
+    expect(index.search("slack").map((r) => r.actionName)).toEqual(["SLACK_POST_MESSAGE"]);
+    expect(index.getToolCount()).toBe(1);
+  });
+
+  test("build([]) resets the index to empty", () => {
+    const index = new Tier2ToolIndex();
+    index.build([makeEntry("jira", "jira_search_issues", "Search Jira issues")]);
+    expect(index.search("issues")).toHaveLength(1);
+
+    index.build([]);
+
+    expect(index.search("issues")).toEqual([]);
+    expect(index.getToolCount()).toBe(0);
+  });
+
+  test("an empty build reports zero tools", () => {
+    const index = new Tier2ToolIndex();
+
+    expect(index.getToolCount()).toBe(0);
+    index.build([]);
+    expect(index.getToolCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes https://github.com/elizaOS/eliza/issues/29650

Definition of Done: full standard in [`CONTRIBUTING.md`](CONTRIBUTING.md).

- [x] This PR targets `develop` — rebased onto latest `origin/develop` (`82b2333366`) with zero conflicts.
- [x] `bun install` was run (fresh install, 3439 packages).
- [x] `bun run verify` passes on the PR head — see Testing below for the full gate result.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop` (`82b2333366`); zero conflicts.
- [x] `bun run verify` passes post-sync on head `ad86f8d5f` — full gate, exit 0.

# Risks

Low. Test-only change (`+214` lines, one new test file). No production code touched, so no runtime, security, or performance risk. Suite-cost increase: ~0.3 s per `cloud-shared` test run.

# Background

## What does this PR do?

Adds contract test coverage for `Tier2ToolIndex` — the BM25-backed discovery index for Tier-2 (discoverable) MCP tools in the cloud runtime — in `packages/cloud/shared/src/lib/eliza/plugin-mcp/search/bm25-index.test.ts`. Real `Tier2ToolIndex` instances throughout, no BM25 mocks. It owns the wrapper's contract on top of core's tested BM25 primitive (#26256):

- **Tag tokenization & discovery** — tools findable by full action name, by tool-name fragments (`"issues"` → `JIRA_SEARCH_ISSUES`; hyphenated `"comments"` → `JIRA_GET_COMMENTS`), and by server/platform terms. A CJK fixture (`jira_查询_问题`) whose action name normalizes away the non-ASCII tokens pins `buildTags` as the sole carrier of those fragments.
- **Relevance ordering** — a name match outranks description-only matches; unrelated entries are excluded.
- **Platform filtering & pagination** — case-insensitive platform filter; unknown platforms return `[]`; `offset..offset+limit` slices after filtering (pages tile the full filtered set); the `(offset + limit) * 2` over-fetch is asserted so filtering cannot silently shrink pages.
- **Lifecycle** — `build()` fully replaces the prior build; `build([])` resets `search` to `[]` and `getToolCount()` to `0`; a fresh index reports zero tools.

Note: the issue author's fork commit `7cec710` references this issue but is not in upstream `develop`; this PR is an independent implementation — happy to reconcile if their PR lands first.

## What kind of change is this?

Improvements (misc. changes to existing features) — fills a test gap; no behavior change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/eliza/plugin-mcp/search/bm25-index.test.ts` — each `describe` block maps to one acceptance-criteria bullet from #29650.

## Detailed testing steps

None: automated tests are acceptable.

- [x] `bun run verify` (full workspace gate) passes on the PR head: exit 0 in 221s — all audits (alias-read-guard, tsconfig-workspace-resolution, publish-graph, tee-secret-leak, workflow-triggers, test-lane-membership, focused-tests, etc.) plus monorepo-wide turbo `typecheck` and `lint:check` (8-way concurrency, 8 GB heap).
- [x] `bun test src/lib/eliza/plugin-mcp/search/bm25-index.test.ts` → **13 pass / 0 fail**
- [x] Full `plugin-mcp` subtree (`bun test src/lib/eliza/plugin-mcp/`) → **108 pass / 0 fail** (existing suites unaffected)
- [x] `tsc --noEmit -p packages/cloud/shared/tsconfig.json` → clean, 0 errors
- [x] Biome check on the new file → clean
- [x] Mutation-checked against the implementation (each mutation reverted; source untouched at head):
  - removing the `* 2` over-fetch → **2 test failures**
  - breaking case-insensitive platform matching → **1 failure**
  - `buildTags` dropping tool-name parts → **1 failure**

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ad86f8d5f2b0b1e53430f7996bac1937b5104c87 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A — test-only PR; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A — test-only PR; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user flow; automated tests are the walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A — no runtime code path changed; test runner output above is the equivalent evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent/action/provider/prompt/model change. The covered surface (`search_actions`) is exercised via unit tests, not a live LLM run.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no DB rows, memories, scheduled tasks, or generated artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; contract tests exercise search_actions' backing index directly.`

## Backend + frontend logs

`N/A - test-only change.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface.`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT changes.`

## Known gaps / failures

None. Full `bun run verify` passes on the exact PR head; all scoped checks (below) pass as well.

## Maintainer CI exception record

`N/A - no exception requested`.