### PR TITLE
fix: bound cloud warming provider failover

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
   fetchWithSsrfGuard,
   getInferenceTimer,
   groupResponsePrecedencePolicy,
@@ -34,6 +35,9 @@ describe("elizaos-core Worker stub", () => {
     expect(DEFAULT_ELIZA_CLOUD_TEXT_MODEL).toBe(DEFAULT_CEREBRAS_TEXT_MODEL);
     expect(DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL).toBe(
       DEFAULT_CEREBRAS_TEXT_MODEL,
+    );
+    expect(ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED).toBe(
+      "ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED",
     );
   });
 

--- a/packages/cloud/api/src/stubs/elizaos-core.test.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.test.ts
@@ -106,11 +106,17 @@ describe("elizaos-core Worker stub", () => {
     expect(stubDefault.elizaLogger).toBe(stub.elizaLogger);
     expect(stubDefault.stringToUuid).toBe(stub.stringToUuid);
     expect(stubDefault.ContentType).toBe(stub.ContentType);
+    expect(stubDefault.ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED).toBe(
+      stub.ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
+    );
     expect(stubDefault.DEFAULT_CEREBRAS_TEXT_MODEL).toBe("gemma-4-31b");
   });
 
   test("model and media constants match the source literals", () => {
     expect(stub.DEFAULT_CEREBRAS_TEXT_MODEL).toBe("gemma-4-31b");
+    expect(stub.ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED).toBe(
+      "ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED",
+    );
     expect(stub.DEFAULT_ELIZA_CLOUD_TEXT_MODEL).toBe(
       stub.DEFAULT_CEREBRAS_TEXT_MODEL,
     );

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -10,6 +10,12 @@
 const NOT_AVAILABLE =
   "@elizaos/core runtime APIs are not available in the Cloudflare Workers API bundle. Route agent runtime work through the agent-server sidecar.";
 
+// Worker-safe mirror of the pure error-code literal consumed by
+// plugin-elizacloud while the Worker bundle aliases @elizaos/core to this
+// compatibility surface.
+export const ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED =
+  "ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED";
+
 // Worker-safe mirrors of the pure prompt fragments re-exported by core. The
 // cloud native-planner template interpolates them during bundle construction.
 export const groupResponsePrecedencePolicy = `response_precedence:
@@ -2005,6 +2011,7 @@ export type MediaGenerationResponse = Record<string, unknown>;
 export default {
   logger,
   elizaLogger,
+  ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
   DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,

--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { DefaultMessageService } from "../services/message";
+import { ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED } from "../services/message/fallback-reply";
 import type { Memory } from "../types/memory";
 import type { Content, UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
@@ -35,6 +36,16 @@ function creditError(): Error & { statusCode: number } {
 
 function authError(): Error & { statusCode: number } {
 	return Object.assign(new Error("account access denied"), { statusCode: 403 });
+}
+
+function cloudWarmingExhaustedError(): Error & {
+	code: string;
+	status: number;
+} {
+	return Object.assign(new Error("Cloud gateway warming budget exhausted"), {
+		code: ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
+		status: 503,
+	});
 }
 
 function makeRuntimeReturning(responses: unknown[]): IAgentRuntime {
@@ -70,6 +81,30 @@ type FailureReplyService = {
 };
 
 describe("DefaultMessageService structured failure replies", () => {
+	it("does not restart the Cloud warming budget across failure-reply model slots", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning([cloudWarmingExhaustedError()]);
+		const responseId = "00000000-0000-0000-0000-000000000002" as UUID;
+		const message = {
+			content: { text: "hello" },
+			roomId: "00000000-0000-0000-0000-000000000003" as UUID,
+		} as Memory;
+
+		const result = await service.buildStructuredFailureReply(
+			runtime,
+			message,
+			{ values: { recentMessages: "User: hello" } } as State,
+			responseId,
+			"test",
+		);
+
+		expect(result.responseContent?.text).toBe(
+			"Something went wrong on my end. Please try again.",
+		);
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+	});
+
 	it("preserves credit exhaustion when later fallback model slots fail generically", async () => {
 		const service = new DefaultMessageService() as unknown as {
 			generateFailureReplyText(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -158,6 +158,7 @@ import {
 import { DefaultMessageService } from "./services/message";
 import {
 	describeModelCallError,
+	isElizaCloudGatewayWarmingExhaustedError,
 	isModelProviderFallbackError,
 } from "./services/message/fallback-reply";
 import { sanitizeOutboundText } from "./services/message/outbound-sanitize";
@@ -7031,6 +7032,7 @@ export class AgentRuntime implements IAgentRuntime {
 
 		let lastModelError: unknown;
 		let providerAttemptStartedOutput = false;
+		const providersWithExhaustedWarmingBudget = new Set<string>();
 		for (
 			let resolvedIndex = 0;
 			resolvedIndex < resolvedModels.length;
@@ -7038,6 +7040,9 @@ export class AgentRuntime implements IAgentRuntime {
 		) {
 			const resolvedModel = resolvedModels[resolvedIndex];
 			if (!resolvedModel) {
+				continue;
+			}
+			if (providersWithExhaustedWarmingBudget.has(resolvedModel.provider)) {
 				continue;
 			}
 			const resolvedModelKey = resolvedModel.modelKey;
@@ -8206,7 +8211,16 @@ export class AgentRuntime implements IAgentRuntime {
 					});
 				}
 				lastModelError = error;
-				const nextModel = resolvedModels[resolvedIndex + 1];
+				if (isElizaCloudGatewayWarmingExhaustedError(error)) {
+					providersWithExhaustedWarmingBudget.add(resolvedModel.provider);
+				}
+				const nextModelIndex = resolvedModels.findIndex(
+					(candidate, candidateIndex) =>
+						candidateIndex > resolvedIndex &&
+						!providersWithExhaustedWarmingBudget.has(candidate.provider),
+				);
+				const nextModel =
+					nextModelIndex >= 0 ? resolvedModels[nextModelIndex] : undefined;
 				if (
 					requestedProvider !== undefined ||
 					!nextModel ||
@@ -8224,6 +8238,10 @@ export class AgentRuntime implements IAgentRuntime {
 					nextModel,
 					error,
 				});
+				// The loop increments after this catch. Jump over every registration
+				// backed by a provider whose one warming budget was already spent,
+				// while preserving an actually distinct provider as the next attempt.
+				resolvedIndex = nextModelIndex - 1;
 			}
 		}
 		this.rethrowModelFailoverError(

--- a/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
+++ b/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
@@ -8,7 +8,9 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { ElizaError } from "../../errors";
 import { AgentRuntime } from "../../runtime";
+import { ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED } from "../../services/message/fallback-reply";
 import { type Character, ModelType } from "../../types";
 
 function makeRuntime(settings: Record<string, string> = {}): AgentRuntime {
@@ -26,6 +28,13 @@ function makeRuntime(settings: Record<string, string> = {}): AgentRuntime {
 /** The exact subscription-limit error the cli-inference SDK session throws live. */
 const CLI_INFERENCE_LIMIT_ERROR =
 	"[cli-inference:sdk] subscription rate limit reached: You've hit your session limit · resets 9:30pm (UTC)";
+
+function cloudWarmingExhausted(): ElizaError {
+	return new ElizaError("cloud gateway warming budget exhausted", {
+		code: ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
+		severity: "ephemeral",
+	});
+}
 
 describe("AgentRuntime.useModel provider failover", () => {
 	it("tries the next registered provider when the preferred provider is exhausted", async () => {
@@ -220,6 +229,114 @@ describe("AgentRuntime.useModel provider failover", () => {
 		).resolves.toBe("direct response");
 		expect(unavailableLocalHandler).toHaveBeenCalledTimes(1);
 		expect(directHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("spends a warming budget once and skips later registrations from that provider", async () => {
+		const runtime = makeRuntime();
+		const exhaustedCloudHandler = vi.fn(async () => {
+			throw cloudWarmingExhausted();
+		});
+		const duplicateCloudHandler = vi.fn(async () => "duplicate cloud response");
+		const distinctProviderHandler = vi.fn(async () => "distinct response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			exhaustedCloudHandler,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_NANO,
+			duplicateCloudHandler,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_SMALL,
+			distinctProviderHandler,
+			"openai",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).resolves.toBe("distinct response");
+		expect(exhaustedCloudHandler).toHaveBeenCalledTimes(1);
+		expect(duplicateCloudHandler).not.toHaveBeenCalled();
+		expect(distinctProviderHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps ordinary 503 failover registration-scoped within the same provider", async () => {
+		const runtime = makeRuntime();
+		const ordinaryUnavailable = vi.fn(async () => {
+			throw Object.assign(new Error("ordinary upstream outage"), {
+				status: 503,
+			});
+		});
+		const sameProviderFallback = vi.fn(async () => "same provider recovered");
+		const distinctProviderFallback = vi.fn(async () => "distinct response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			ordinaryUnavailable,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_NANO,
+			sameProviderFallback,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_SMALL,
+			distinctProviderFallback,
+			"openai",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).resolves.toBe("same provider recovered");
+		expect(ordinaryUnavailable).toHaveBeenCalledTimes(1);
+		expect(sameProviderFallback).toHaveBeenCalledTimes(1);
+		expect(distinctProviderFallback).not.toHaveBeenCalled();
+	});
+
+	it("does not turn caller abort into provider failover", async () => {
+		const runtime = makeRuntime();
+		const abortReason = new DOMException("turn cancelled", "AbortError");
+		const abortedHandler = vi.fn(async () => {
+			throw abortReason;
+		});
+		const sameProviderFallback = vi.fn(async () => "same provider response");
+		const distinctProviderFallback = vi.fn(async () => "distinct response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			abortedHandler,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_NANO,
+			sameProviderFallback,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_SMALL,
+			distinctProviderFallback,
+			"openai",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).rejects.toBe(abortReason);
+		expect(abortedHandler).toHaveBeenCalledTimes(1);
+		expect(sameProviderFallback).not.toHaveBeenCalled();
+		expect(distinctProviderFallback).not.toHaveBeenCalled();
 	});
 
 	it("does not switch providers when a provider is explicitly requested", async () => {

--- a/packages/core/src/runtime/__tests__/use-model-trajectory-dedupe.test.ts
+++ b/packages/core/src/runtime/__tests__/use-model-trajectory-dedupe.test.ts
@@ -6,8 +6,10 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { ElizaError } from "../../errors";
 import { AgentRuntime } from "../../runtime";
 import { SECRET_SWAP_ENABLED_SETTING } from "../../security/secret-swap";
+import { ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED } from "../../services/message/fallback-reply";
 import {
 	getTrajectoryContext,
 	runWithTrajectoryContext,
@@ -277,6 +279,45 @@ describe("AgentRuntime.useModel trajectory accounting", () => {
 				response: "fallback-result",
 			}),
 		);
+	});
+
+	it("records no phantom trajectory for same-provider registrations skipped after warming", async () => {
+		const { runtime, trajectory } = await makeRuntime();
+		const exhaustedCloudHandler = vi.fn(async () => {
+			throw new ElizaError("cloud gateway warming budget exhausted", {
+				code: ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
+				severity: "ephemeral",
+			});
+		});
+		const skippedCloudHandler = vi.fn(async () => "must not run");
+		const distinctFallback = vi.fn(async () => "distinct fallback");
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			exhaustedCloudHandler,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_NANO,
+			skippedCloudHandler,
+			"elizaOSCloud",
+			100,
+		);
+		runtime.registerModel(ModelType.TEXT_SMALL, distinctFallback, "openai", 10);
+
+		await expect(
+			withStep("step-warming-exhausted", () =>
+				runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "warming" }),
+			),
+		).resolves.toBe("distinct fallback");
+		await vi.waitFor(() => expect(trajectory.calls).toHaveLength(2));
+		expect(exhaustedCloudHandler).toHaveBeenCalledTimes(1);
+		expect(skippedCloudHandler).not.toHaveBeenCalled();
+		expect(distinctFallback).toHaveBeenCalledTimes(1);
+		expect(trajectory.calls.map((call) => call.provider).sort()).toEqual([
+			"elizaOSCloud",
+			"openai",
+		]);
 	});
 
 	it("isolates mixed concurrent calls under one parent trajectory", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1815,8 +1815,10 @@ export function shouldSkipResponseMemoryPersistence(memory: Memory): boolean {
 export {
 	buildFailureReplyPrompt,
 	classifyStructuredFailureCause,
+	ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
 	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
+	isElizaCloudGatewayWarmingExhaustedError,
 	isInsufficientCreditsError,
 	isInsufficientCreditsMessage,
 	isModelProviderFallbackError,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -387,6 +387,7 @@ import {
 	classifyStructuredFailureCause,
 	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
+	isElizaCloudGatewayWarmingExhaustedError,
 	isInsufficientCreditsError,
 	isRateLimitError,
 	type StructuredFailureCause,
@@ -16349,6 +16350,27 @@ export class DefaultMessageService implements IMessageService {
 					error.name === "NoModelProviderConfiguredError"
 				) {
 					return { kind: "noProvider" };
+				}
+				// Eliza Cloud already spent its complete in-handler warming
+				// budget. Starting the next failure-reply model slot would create a
+				// fresh useModel dispatch and repay that same provider budget (up to
+				// four times) before falling back to the canned reply. Treat the
+				// typed exhaustion as terminal for this fallback loop while
+				// preserving any more actionable sticky failure seen earlier.
+				if (isElizaCloudGatewayWarmingExhaustedError(error)) {
+					runtime.logger.warn(
+						{
+							src: "service:message",
+							stage,
+							modelType,
+							error: error instanceof Error ? error.message : String(error),
+						},
+						"Structured failure reply stopped after Cloud warming exhaustion",
+					);
+					if (sawCreditsExhausted) return { kind: "creditsExhausted" };
+					if (sawAuthError) return { kind: "authFailed" };
+					if (sawRateLimit) return { kind: "rateLimited" };
+					return { kind: "text", value: "" };
 				}
 				// Credit exhaustion and account authorization are sticky across
 				// slots because no later model tier can heal the shared account.

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -29,6 +29,15 @@ type ErrorWithStatus = {
 	error?: unknown;
 };
 
+/**
+ * Stable provider error code emitted after Eliza Cloud spends its complete
+ * in-handler cache-warming retry budget. Runtime dispatch uses this typed
+ * signal to avoid spending that same budget again through another model
+ * registration backed by the same provider.
+ */
+export const ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED =
+	"ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED";
+
 function asErrorObject(error: unknown): ErrorWithStatus | null {
 	return typeof error === "object" && error !== null
 		? (error as ErrorWithStatus)
@@ -43,6 +52,16 @@ function unwrapRetryError(error: unknown): unknown {
 		return candidate.errors[candidate.errors.length - 1];
 	}
 	return error;
+}
+
+/** True only for Eliza Cloud's bounded cache-warming exhaustion signal. */
+export function isElizaCloudGatewayWarmingExhaustedError(
+	error: unknown,
+): boolean {
+	return (
+		asErrorObject(unwrapRetryError(error))?.code ===
+		ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED
+	);
 }
 
 function hasHttpStatus(error: unknown, statuses: readonly number[]): boolean {
@@ -271,6 +290,9 @@ export function isModelProviderFallbackError(
 		return false;
 	}
 	const unwrapped = unwrapRetryError(error);
+	if (isElizaCloudGatewayWarmingExhaustedError(unwrapped)) {
+		return true;
+	}
 	// Local inference can disappear after registration (model unload, device
 	// disconnect, or an unavailable native binding). Its typed capability error
 	// means another text provider may safely answer the same request.

--- a/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
@@ -11,12 +11,14 @@ import { ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED, type IAgentRuntime } from "@eliz
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  __resetNativeChatLimiterForTests,
   ElizaCloudGatewayWarmingExhaustedError,
   generateNativeChatCompletion,
   isWarmingUnavailableResponse,
   nextWarmingRetryDelayMs,
   requestNativeWithWarmingRetry,
   streamNativeChatCompletion,
+  withNativeChatLimit,
 } from "../../src/models/text";
 
 type RuntimeFixture = Pick<IAgentRuntime, "character" | "emitEvent" | "getSetting"> &
@@ -252,11 +254,15 @@ describe("buffered native chat completion", () => {
 describe("streaming native chat completion", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "1";
+    __resetNativeChatLimiterForTests();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+    __resetNativeChatLimiterForTests();
   });
 
   it("retries a warming 503 then streams the recovered response", async () => {
@@ -303,6 +309,47 @@ describe("streaming native chat completion", () => {
     controller.abort(abortReason);
     await expect(pending).rejects.toBe(abortReason);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the concurrency permit when a warming response body read aborts", async () => {
+    const controller = new AbortController();
+    const abortReason = new DOMException("turn cancelled", "AbortError");
+    const body = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller.signal.addEventListener(
+          "abort",
+          () => streamController.error(controller.signal.reason),
+          { once: true }
+        );
+      },
+    });
+    const fetchMock = mockFetchSequence([
+      () =>
+        new Response(body, {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    const pending = streamNativeChatCompletion(
+      runtime(),
+      "TEXT_SMALL",
+      { ...NATIVE_PARAMS, signal: controller.signal },
+      CONTEXT
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    controller.abort(abortReason);
+    await expect(pending).rejects.toBe(abortReason);
+
+    let followupEntered = false;
+    await expect(
+      withNativeChatLimit(async () => {
+        followupEntered = true;
+        return "released";
+      })
+    ).resolves.toBe("released");
+    expect(followupEntered).toBe(true);
   });
 
   it("preserves typed exhaustion when streaming spends its one retry budget", async () => {

--- a/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
@@ -1,15 +1,17 @@
 /**
  * Offline unit coverage for the cold-gateway warming retry: a 503 whose body
  * carries a structural `*_cache_warming` code (or the retryable
- * service_unavailable envelope) is retried in place with bounded backoff so
- * the runtime's useModel failover ladder is never consumed by a gateway that
- * recovers in ~3s, while every other failure still throws immediately. The
- * fetch is mocked; timers are faked to drive the backoff deterministically.
+ * service_unavailable envelope) is retried in place with bounded backoff so a
+ * gateway that recovers in ~3s stays within one registration. Persistent
+ * warming preserves a typed exhaustion signal for provider-aware fallback,
+ * while every other failure still throws immediately. The fetch is mocked;
+ * timers are faked to drive the backoff deterministically.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED, type IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ElizaCloudGatewayWarmingExhaustedError,
   generateNativeChatCompletion,
   isWarmingUnavailableResponse,
   nextWarmingRetryDelayMs,
@@ -19,6 +21,8 @@ import {
 
 type RuntimeFixture = Pick<IAgentRuntime, "character" | "emitEvent" | "getSetting"> &
   Partial<IAgentRuntime>;
+
+type ElizaErrorShape = Error & { code?: string; status?: number };
 
 function runtime(): IAgentRuntime {
   const settings: Record<string, string | undefined> = {
@@ -211,7 +215,7 @@ describe("buffered native chat completion", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("gives up after the bounded budget on persistent warming", async () => {
+  it("spends exactly one bounded retry budget and preserves typed exhaustion", async () => {
     const fetchMock = mockFetchSequence([warmingResponse]);
     const pending = generateNativeChatCompletion(
       runtime(),
@@ -221,6 +225,8 @@ describe("buffered native chat completion", () => {
     ).catch((error: Error & { status?: number }) => error);
     await vi.runAllTimersAsync();
     const error = await pending;
+    expect(error).toBeInstanceOf(ElizaCloudGatewayWarmingExhaustedError);
+    expect((error as ElizaErrorShape).code).toBe(ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED);
     expect((error as Error & { status?: number }).status).toBe(503);
     // 1 initial attempt + 4 bounded retries, then the normal error path.
     expect(fetchMock).toHaveBeenCalledTimes(5);
@@ -280,6 +286,38 @@ describe("streaming native chat completion", () => {
     expect((error as Error & { status?: number }).status).toBe(503);
     expect((error as Error).message).toBe("upstream provider exploded");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves caller abort during warming backoff without another request", async () => {
+    const fetchMock = mockFetchSequence([warmingResponse]);
+    const controller = new AbortController();
+    const abortReason = new DOMException("turn cancelled", "AbortError");
+    const pending = streamNativeChatCompletion(
+      runtime(),
+      "TEXT_SMALL",
+      { ...NATIVE_PARAMS, signal: controller.signal },
+      CONTEXT
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    controller.abort(abortReason);
+    await expect(pending).rejects.toBe(abortReason);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves typed exhaustion when streaming spends its one retry budget", async () => {
+    const fetchMock = mockFetchSequence([warmingResponse]);
+    const pending = streamNativeChatCompletion(
+      runtime(),
+      "TEXT_SMALL",
+      NATIVE_PARAMS,
+      CONTEXT
+    ).catch((error: Error) => error);
+    await vi.runAllTimersAsync();
+    const error = await pending;
+    expect(error).toBeInstanceOf(ElizaCloudGatewayWarmingExhaustedError);
+    expect((error as ElizaErrorShape).code).toBe(ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -1927,8 +1927,16 @@ export async function streamNativeChatCompletion(
       throw err;
     }
     if (response.status !== 503) break;
-    const warmingBodyText = await response.text();
-    releasePermit();
+    let warmingBodyText: string;
+    try {
+      warmingBodyText = await response.text();
+    } finally {
+      // The caller signal can abort while a 503 body is still streaming. The
+      // permit covers that read, so release it on both success and rejection;
+      // otherwise one cancelled response permanently consumes limiter
+      // capacity and eventually starves every later Cloud call.
+      releasePermit();
+    }
     const delayMs = nextWarmingRetryDelayMs(warmingRetryState, response, warmingBodyText);
     if (signal?.aborted) {
       throw signal.reason ?? new DOMException("Aborted", "AbortError");

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -15,6 +15,7 @@ import {
 	assertModelOutputComplete,
   buildCanonicalSystemPrompt,
   DEFAULT_CEREBRAS_TEXT_MODEL,
+  ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
   ElizaError,
   logger,
   ModelType,
@@ -480,8 +481,10 @@ function firstNumber(...values: unknown[]): number | undefined {
  * useModel failover ladder classifies any thrown 503 as fallback-class and
  * advances instantly, so one cold gateway spent the whole
  * RESPONSE_HANDLER→TEXT_NANO→TEXT_SMALL→TEXT_LARGE ladder in ~500ms and the
- * turn died. Retrying the SAME request here (inside the handler) keeps the
- * ladder intact for real provider failures. The gate is structural — HTTP
+ * turn died. Retrying the SAME request here (inside the handler) preserves
+ * one recovery budget. If that budget is exhausted, a typed error lets the
+ * runtime skip sibling registrations backed by this same provider while
+ * retaining failover to a distinct provider. The gate is structural — HTTP
  * status + typed body code/flag — never message prose, so a genuinely dead
  * provider (any other 503 body, or any non-503) still throws immediately.
  * The schedule is bounded and sums past the measured ~3s recovery; a
@@ -490,6 +493,20 @@ function firstNumber(...values: unknown[]): number | undefined {
  */
 const WARMING_RETRY_DELAYS_MS: readonly number[] = [250, 500, 1000, 1500];
 const WARMING_RETRY_MAX_WAIT_MS = 2_000;
+
+/** Persistent cache warming after the provider's complete bounded retry budget. */
+export class ElizaCloudGatewayWarmingExhaustedError extends ElizaError {
+  override readonly name = "ElizaCloudGatewayWarmingExhaustedError";
+  readonly status = 503;
+
+  constructor(label: string, attempts: number) {
+    super("elizaOS Cloud gateway remained unavailable after cache warming retries", {
+      code: ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED,
+      context: { attempts, provider: "elizaOSCloud", route: label, status: 503 },
+      severity: "ephemeral",
+    });
+  }
+}
 
 function parseJsonRecord(text: string): Record<string, unknown> | undefined {
   try {
@@ -552,8 +569,22 @@ export function nextWarmingRetryDelayMs(
   );
 }
 
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) {
+    return Promise.reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -561,8 +592,9 @@ function sleepMs(ms: number): Promise<void> {
  * retrying in place while the gateway reports the structural warming 503.
  * The permit is held only across each network attempt — body reads and
  * backoff sleeps run unguarded. Returns the final response with its body
- * already read so callers never double-consume it; non-warming failures and
- * an exhausted budget return immediately for the caller's normal error path.
+ * already read so callers never double-consume it. Non-warming failures return
+ * immediately for the caller's normal error path; persistent structural
+ * warming throws the typed exhaustion signal after this one complete budget.
  */
 export async function requestNativeWithWarmingRetry(
   doRequest: () => Promise<Response>,
@@ -578,7 +610,12 @@ export async function requestNativeWithWarmingRetry(
     recordGatewayResponseTelemetry(response, label);
     if (response.status !== 503) return { response, bodyText };
     const delayMs = nextWarmingRetryDelayMs(state, response, bodyText);
-    if (delayMs === undefined) return { response, bodyText };
+    if (delayMs === undefined) {
+      if (isWarmingUnavailableResponse(response.status, bodyText)) {
+        throw new ElizaCloudGatewayWarmingExhaustedError(label, state.attempt + 1);
+      }
+      return { response, bodyText };
+    }
     logger.warn(
       `[ELIZAOS_CLOUD] cloud gateway is warming (503) on ${label}; retrying in ${delayMs}ms (attempt ${state.attempt}/${WARMING_RETRY_DELAYS_MS.length})`
     );
@@ -1893,7 +1930,16 @@ export async function streamNativeChatCompletion(
     const warmingBodyText = await response.text();
     releasePermit();
     const delayMs = nextWarmingRetryDelayMs(warmingRetryState, response, warmingBodyText);
-    if (delayMs === undefined || signal?.aborted) {
+    if (signal?.aborted) {
+      throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+    if (delayMs === undefined) {
+      if (isWarmingUnavailableResponse(response.status, warmingBodyText)) {
+        throw new ElizaCloudGatewayWarmingExhaustedError(
+          "chat/completions:stream",
+          warmingRetryState.attempt + 1
+        );
+      }
       const errorBody = asRecord(parseJsonRecord(warmingBodyText)?.error);
       const message =
         firstString(errorBody.message) ?? `elizaOS Cloud error ${response.status}`;
@@ -1908,7 +1954,7 @@ export async function streamNativeChatCompletion(
     logger.warn(
       `[ELIZAOS_CLOUD] cloud gateway is warming (503) on chat/completions:stream; retrying in ${delayMs}ms (attempt ${warmingRetryState.attempt}/${WARMING_RETRY_DELAYS_MS.length})`
     );
-    await sleepMs(delayMs);
+    await sleepMs(delayMs, signal);
   }
   // Recorded before the ok-check so a failed forward still keeps its gateway
   // decomposition on the turn — errors are where attribution matters most.


### PR DESCRIPTION
Bounds one Eliza Cloud warming budget per provider per useModel dispatch. Persistent typed warming exhaustion skips sibling registrations backed by the same provider while preserving failover to a genuinely distinct provider; ordinary 503 behavior is unchanged and streaming backoff is abort-aware.

Validation: focused 33/33; adjacent core 61/61 and 139/139; plugin source 628/628; core/plugin typecheck, builds, package verifier, touched-file Biome, and diff check green.

Release context: removes the repeated RESPONSE_HANDLER -> TEXT_NANO -> TEXT_SMALL amplification responsible for ~10s cold-tail turns. It does not fail open and does not change the single bounded 3.25s recovery budget.