### PR TITLE
fix(cloud): enable revocation-fenced auth cache in production

### DIFF
--- a/packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 describe("inference strong-revocation rollout", () => {
-  test("soaks revocation-fenced auth caching in staging without enabling production", async () => {
+  test("requires revocation-fenced auth caching in staging and production", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -22,6 +22,6 @@ describe("inference strong-revocation rollout", () => {
     );
     expect(
       config.env?.production?.vars?.INFERENCE_STRONG_REVOCATION_ENABLED,
-    ).toBe("false");
+    ).toBe("true");
   });
 });

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -278,10 +278,11 @@ Staging and production inference require:
 - `INFERENCE_HOT_PATH_CACHES="true"`.
 
 `INFERENCE_AUTH_CACHE_ENABLED="true"` is inert unless
-`INFERENCE_STRONG_REVOCATION_ENABLED="true"`. Staging enables the strong flag
-to soak the revocation-fenced positive cache; production keeps it false until
-the staged latency and revocation evidence is approved, so authoritative
-authorization remains the production default. The thin entry has its own
+`INFERENCE_STRONG_REVOCATION_ENABLED="true"`. Staging and production require
+the revocation-fenced positive cache. The release reconciler deploys and
+certifies the exact source in staging before the same commit can reach main or
+production, so a failed latency or revocation probe leaves production on its
+previous authoritative configuration. The thin entry has its own
 `THIN_INFERENCE_ENTRY_ENABLED` rollout control.
 The thin entry lazily evaluates only the matched generative route module rather
 than the monolithic API router. Either flag remains an independent rollback

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -280,8 +280,11 @@ Staging and production inference require:
 `INFERENCE_AUTH_CACHE_ENABLED="true"` is inert unless
 `INFERENCE_STRONG_REVOCATION_ENABLED="true"`. Staging and production require
 the revocation-fenced positive cache. The release reconciler deploys and
-certifies the exact source in staging before the same commit can reach main or
-production, so a failed latency or revocation probe leaves production on its
+certifies the exact source in staging before the same commit can reach main.
+That certificate proves release identity and generic staging health, but does
+not include the auth-latency or revocation probe results. The production
+workflow dispatch must remain operator-held until both probes pass on the
+certificate's exact source tree; a failed probe leaves production on its
 previous authoritative configuration. The thin entry has its own
 `THIN_INFERENCE_ENTRY_ENABLED` rollout control.
 The thin entry lazily evaluates only the matched generative route module rather

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -971,9 +971,10 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # waitUntil and the 60s physical TTL bounds lost invalidation.
 INFERENCE_AUTH_CACHE_ENABLED = "true"
 # Every positive cache hit crosses the per-organization Durable Object before
-# provider dispatch. The exact staging release certificate is the deployment
-# gate; production never receives this source unless that strong-revocation
-# lane and its latency/revocation probes pass first.
+# provider dispatch. The exact staging release certificate proves release
+# identity and generic staging health; it does not encode the auth-latency and
+# revocation probes. Operators must hold the production workflow dispatch until
+# those probes pass for the certificate's exact source tree.
 INFERENCE_STRONG_REVOCATION_ENABLED = "true"
 # Pass-through streaming fast path (#15428): "true" pipes qualifying streamed
 # chat completions (OpenAI-compatible direct upstream, no tools/response_format/

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -970,8 +970,11 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # One combined auth+org+moderation read; authoritative refresh runs only under
 # waitUntil and the 60s physical TTL bounds lost invalidation.
 INFERENCE_AUTH_CACHE_ENABLED = "true"
-# Default authoritative until the Durable Object revocation lane is soaked.
-INFERENCE_STRONG_REVOCATION_ENABLED = "false"
+# Every positive cache hit crosses the per-organization Durable Object before
+# provider dispatch. The exact staging release certificate is the deployment
+# gate; production never receives this source unless that strong-revocation
+# lane and its latency/revocation probes pass first.
+INFERENCE_STRONG_REVOCATION_ENABLED = "true"
 # Pass-through streaming fast path (#15428): "true" pipes qualifying streamed
 # chat completions (OpenAI-compatible direct upstream, no tools/response_format/
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding


### PR DESCRIPTION
## Summary
- enable the already-reviewed strong-revocation fence for production inference auth cache hits
- require both staging and production in the rollout regression
- document that exact-SHA staging certification gates main/production deployment

## Safety
This changes source configuration only. Production remains on its current build until the exact candidate passes Develop Full, staging effects, and latency/revocation probes. A failed staging certificate cannot reach main or production.

## Validation
- `bun test packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts`
- `bunx biome check packages/cloud/api/wrangler.toml packages/cloud/api/__tests__/inference-strong-revocation-rollout-wrangler.test.ts packages/cloud/api/docs/inference-hot-path.md`
- `git diff --check`

Depends on the staged revocation-fence rollout from #29692.