### PR TITLE
fix(reminders): restore Shared and Dedicated mutation parity

### DIFF
--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -29,6 +29,9 @@ export type SharedRuntimeReminderActionProvenance = {
   success: boolean;
   requiresConfirmation?: boolean;
   taskIds: string[];
+  /** Exact ordered choices from a failed ambiguity result; never inferred from prose. */
+  candidateTaskIds?: string[];
+  requiresSelection?: boolean;
   deliveryScope: string;
 };
 

--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -22,6 +22,16 @@ export type SharedRuntimePublicGrounding =
       observedAt: number;
     };
 
+/** Server-owned receipt retained only to authorize a scoped reminder follow-up. */
+export type SharedRuntimeReminderActionProvenance = {
+  actionName: "REMINDERS";
+  operation: "create" | "list" | "update" | "snooze" | "complete" | "delete" | "dismiss" | "clear";
+  success: boolean;
+  requiresConfirmation?: boolean;
+  taskIds: string[];
+  deliveryScope: string;
+};
+
 /** One persisted turn in a shared-runtime conversation. Mirrors `SharedTurnMessage`. */
 export type SharedRuntimeHistoryMessage = {
   /** Stable message id used to merge DO and Postgres writes without clobbering. */
@@ -34,6 +44,8 @@ export type SharedRuntimeHistoryMessage = {
   interrupted?: boolean;
   /** Successful public read attached to this reply; never mutation or private-account data. */
   grounding?: SharedRuntimePublicGrounding;
+  /** Authenticated reminder receipt; never projected as model/user content. */
+  reminderAction?: SharedRuntimeReminderActionProvenance;
 };
 
 /**

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -26,6 +26,8 @@ function groundedReminderAssistant(
     operation: SharedReminderOperation;
     success: boolean;
     taskIds?: string[];
+    candidateTaskIds?: string[];
+    requiresSelection?: boolean;
     requiresConfirmation?: boolean;
   },
 ) {
@@ -37,6 +39,8 @@ function groundedReminderAssistant(
       operation: receipt.operation,
       success: receipt.success,
       taskIds: receipt.taskIds ?? [],
+      ...(receipt.candidateTaskIds ? { candidateTaskIds: receipt.candidateTaskIds } : {}),
+      ...(receipt.requiresSelection ? { requiresSelection: true as const } : {}),
       deliveryScope: stableStringify(TEST_REMINDER_DELIVERY),
       ...(receipt.requiresConfirmation ? { requiresConfirmation: true as const } : {}),
     },
@@ -593,6 +597,8 @@ describe("Shared turn AgentRuntime boundary", () => {
     ["List my reminders", "list", undefined],
     ["Show me the reminders", "list", undefined],
     ["Remind me tomorrow to call mom", "create", undefined],
+    ["Will you remind me tomorrow to call mom", "create", undefined],
+    ["Remind me on August 30 to call mom", "create", undefined],
     ["Create a reminder to call mom", "create", undefined],
     ["Remove the reminder add something in my todo", "delete", "add something in my todo"],
     ["Could you please delete the reminder Stretch please", "delete", "stretch"],
@@ -602,6 +608,11 @@ describe("Shared turn AgentRuntime boundary", () => {
     ["Complete the reminder Stretch", "complete", "stretch"],
     ["Dismiss the reminder Stretch", "dismiss", "stretch"],
     ["Cancel the reminder Stretch", "dismiss", "stretch"],
+    ["Delete my Stretch reminder", "delete", "stretch"],
+    ["Update my Stretch reminder to 4pm", "update", "stretch"],
+    ["Complete my Stretch reminder", "complete", "stretch"],
+    ["Snooze my Stretch reminder for 5 minutes", "snooze", "stretch"],
+    ["Delete the reminder Stretch, then email Bob", "delete", "stretch"],
   ])(
     "derives trusted reminder operation intent for '%s'",
     async (message, expectedOperation, expectedTarget) => {
@@ -670,6 +681,7 @@ describe("Shared turn AgentRuntime boundary", () => {
     "Could you not update my reminder?",
     "I don't want you to update my reminder to 3pm",
     "Don’t update my reminder",
+    "Update the reminder Stretch to 4pm, actually don't",
   ])("does not require or trust a negated or discussed reminder mutation: %s", async (message) => {
     await runSharedAgentTurn({
       character: { name: "Eliza", system: "You are Eliza." },
@@ -740,6 +752,41 @@ describe("Shared turn AgentRuntime boundary", () => {
       );
     },
   );
+
+  test("preserves an ambiguous delete operation and exact candidates for an ordinal followup", async () => {
+    runtimeActionResults = [
+      {
+        success: false,
+        data: {
+          actionName: "REMINDERS",
+          operation: "delete",
+          requiresSelection: true,
+          candidateTaskIds: ["delete-candidate-a", "delete-candidate-b"],
+        },
+      },
+    ];
+    const ambiguous = await runSharedAgentTurn(reminderTurnInput("Delete the reminder Stretch"));
+    expect(ambiguous.history.at(-1)?.reminderAction).toMatchObject({
+      operation: "delete",
+      success: false,
+      taskIds: [],
+      requiresSelection: true,
+      candidateTaskIds: ["delete-candidate-a", "delete-candidate-b"],
+    });
+
+    runtimeActionResults = [
+      {
+        success: false,
+        data: { actionName: "REMINDERS", operation: "delete" },
+      },
+    ];
+    await runSharedAgentTurn(reminderTurnInput("the second one", ambiguous.history));
+
+    expect(runtimeInputs.at(-1)).toMatchObject({
+      reminderOperationIntent: "delete",
+      reminderTargetIntent: "delete-candidate-b",
+    });
+  });
 
   test("keeps a long explicit create request inside the trusted operation fence", async () => {
     runtimeActionResults = [

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -6,7 +6,69 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { ChannelType } from "@elizaos/core/edge";
+import { ChannelType, stableStringify } from "@elizaos/core/edge";
+import type {
+  RunSharedAgentTurnInput,
+  SharedReminderOperation,
+  SharedTurnMessage,
+} from "./run-shared-agent-turn";
+
+const TEST_REMINDER_DELIVERY = {
+  platform: "telegram" as const,
+  project: "eliza-app",
+  connectorAccountId: "bot:123456789",
+  chatId: "123456789",
+};
+
+function groundedReminderAssistant(
+  content: string,
+  receipt: {
+    operation: SharedReminderOperation;
+    success: boolean;
+    taskIds?: string[];
+    requiresConfirmation?: boolean;
+  },
+) {
+  return {
+    role: "assistant" as const,
+    content,
+    reminderAction: {
+      actionName: "REMINDERS" as const,
+      operation: receipt.operation,
+      success: receipt.success,
+      taskIds: receipt.taskIds ?? [],
+      deliveryScope: stableStringify(TEST_REMINDER_DELIVERY),
+      ...(receipt.requiresConfirmation ? { requiresConfirmation: true as const } : {}),
+    },
+  };
+}
+
+function assistantText(content: string): SharedTurnMessage {
+  return { role: "assistant", content };
+}
+
+function reminderTurnInput(
+  message: string,
+  history: SharedTurnMessage[] = [],
+  messageIds?: RunSharedAgentTurnInput["messageIds"],
+): RunSharedAgentTurnInput {
+  return {
+    character: { name: "Eliza", system: "You are Eliza." },
+    history,
+    message,
+    ...(messageIds ? { messageIds } : {}),
+    execution: {
+      agentKey: "personal:user-1",
+      roomKey: "personal:user-1",
+      authenticatedPersonalSharedUser: true,
+      channel: { type: ChannelType.DM, source: "telegram" },
+      reminders: {
+        delivery: TEST_REMINDER_DELIVERY,
+        runner: {} as never,
+      },
+    },
+  };
+}
 
 let providerConfigured = true;
 let runtimeFailure: Error | null = null;
@@ -28,8 +90,16 @@ mock.module("./shared-eliza-runtime", () => ({
       reply: "runtime reply",
       history: [
         ...history,
-        { role: "user", content: String(input.message) },
-        { role: "assistant", content: "runtime reply" },
+        {
+          id: (input.messageIds as { user?: string } | undefined)?.user,
+          role: "user",
+          content: String(input.message),
+        },
+        {
+          id: (input.messageIds as { assistant?: string } | undefined)?.assistant,
+          role: "assistant",
+          content: "runtime reply",
+        },
       ],
       model: String(input.model),
       degraded: false,
@@ -139,69 +209,175 @@ describe("Shared turn AgentRuntime boundary", () => {
     expect(result.reply).toBe("runtime reply");
   });
 
+  test("attaches exact server reminder provenance to the assistant history message", async () => {
+    runtimeActionResults = [
+      {
+        success: true,
+        data: {
+          actionName: "REMINDERS",
+          operation: "create",
+          task: { taskId: "created-reminder-1" },
+        },
+      },
+    ];
+    const result = await runSharedAgentTurn(
+      reminderTurnInput("Remind me tomorrow to stretch", [], {
+        user: "user-1",
+        assistant: "assistant-1",
+      }),
+    );
+
+    expect(result.history.at(-1)).toMatchObject({
+      id: "assistant-1",
+      role: "assistant",
+      reminderAction: {
+        actionName: "REMINDERS",
+        operation: "create",
+        success: true,
+        taskIds: ["created-reminder-1"],
+        deliveryScope: stableStringify(TEST_REMINDER_DELIVERY),
+      },
+    });
+
+    runtimeActionResults = [
+      {
+        success: true,
+        data: {
+          actionName: "REMINDERS",
+          operation: "update",
+          task: { taskId: "replacement-reminder" },
+        },
+        effectReceipts: [
+          {
+            resource: {
+              kind: "shared.reminder",
+              id: "superseded-reminder",
+            },
+          },
+        ],
+      },
+    ];
+    const updated = await runSharedAgentTurn(
+      reminderTurnInput("Update the reminder Stretch to 4pm"),
+    );
+    expect(updated.history.at(-1)?.reminderAction?.taskIds).toEqual(["replacement-reminder"]);
+  });
+
   test.each([
     {
       message: "Can you clear the list?",
       previous:
         "Your reminders:\n• add something to your todo — on Aug 28, 2026 at 3:06 AM Europe/Paris",
+      predecessor: { operation: "list" as const, success: true },
+      expectedOperation: "clear",
     },
     {
       message: "3 06 no 1:06",
       previous:
         "Got it — I'll remind you on Aug 28, 2026 at 3:06 AM Europe/Paris: add something to your todo",
+      predecessor: {
+        operation: "create" as const,
+        success: true,
+        taskIds: ["grounded-reminder-1"],
+      },
+      expectedOperation: "update",
     },
     {
       message: "Change the reminder to 3:06, not 1:06",
       previous:
         "Got it — I'll remind you on Aug 28, 2026 at 1:06 AM Europe/Paris: add something to your todo",
+      predecessor: {
+        operation: "create" as const,
+        success: true,
+        taskIds: ["grounded-reminder-1"],
+      },
+      expectedOperation: "update",
     },
     {
       message: "Could you please change the reminder to 3:06, not 1:06",
       previous:
         "Got it — I'll remind you on Aug 28, 2026 at 1:06 AM Europe/Paris: add something to your todo",
+      predecessor: {
+        operation: "create" as const,
+        success: true,
+        taskIds: ["grounded-reminder-1"],
+      },
+      expectedOperation: "update",
     },
     {
       message: "yes",
       previous:
         "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+      predecessor: {
+        operation: "clear" as const,
+        success: false,
+        requiresConfirmation: true,
+      },
+      expectedOperation: "clear",
     },
     {
       message: "Oui, je confirme, vas-y",
       previous:
         "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+      predecessor: {
+        operation: "clear" as const,
+        success: false,
+        requiresConfirmation: true,
+      },
+      expectedOperation: "clear",
     },
     {
       message: "Oui, je confirme, vas-y, efface tous mes rappels",
       previous:
         "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+      predecessor: {
+        operation: "clear" as const,
+        success: false,
+        requiresConfirmation: true,
+      },
+      expectedOperation: "clear",
     },
     {
       message: "Do it, clear all reminders",
       previous:
         "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+      predecessor: {
+        operation: "clear" as const,
+        success: false,
+        requiresConfirmation: true,
+      },
+      expectedOperation: "clear",
     },
     {
       message: "Remove the reminder Stretch",
       previous:
         "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+      predecessor: {
+        operation: "clear" as const,
+        success: false,
+        requiresConfirmation: true,
+      },
+      expectedOperation: "delete",
     },
     {
       message: "the 3:06 one",
       previous:
         "More than one reminder matches that. Which one do you mean?\n• Stretch — on Aug 28, 2026 at 3:06 AM Europe/Paris",
+      predecessor: { operation: "list" as const, success: true },
+      expectedOperation: "update",
     },
   ])(
     "keeps the contextual reminder follow-up '$message' on REMINDERS",
-    async ({ message, previous }) => {
+    async ({ message, previous, predecessor, expectedOperation }) => {
       runtimeActionResults = [
         {
           success: false,
-          data: { actionName: "REMINDERS", operation: "update" },
+          data: { actionName: "REMINDERS", operation: expectedOperation },
         },
       ];
       await runSharedAgentTurn({
         character: { name: "Eliza", system: "You are Eliza." },
-        history: [{ role: "assistant", content: previous }],
+        history: [groundedReminderAssistant(previous, predecessor)],
         message,
         execution: {
           agentKey: "personal:user-1",
@@ -209,12 +385,7 @@ describe("Shared turn AgentRuntime boundary", () => {
           authenticatedPersonalSharedUser: true,
           channel: { type: ChannelType.DM, source: "telegram" },
           reminders: {
-            delivery: {
-              platform: "telegram",
-              project: "eliza-app",
-              connectorAccountId: "bot:123456789",
-              chatId: "123456789",
-            },
+            delivery: TEST_REMINDER_DELIVERY,
             runner: {} as never,
           },
         },
@@ -230,6 +401,7 @@ describe("Shared turn AgentRuntime boundary", () => {
       ) {
         expect(prompt).toContain("call REMINDERS with operation=update, never operation=create");
         expect(runtimeInputs[0]?.reminderClockCorrection).toBe(true);
+        expect(runtimeInputs[0]?.reminderTargetIntent).toBe("grounded-reminder-1");
       }
       if (
         message === "Oui, je confirme, vas-y, efface tous mes rappels" ||
@@ -250,6 +422,36 @@ describe("Shared turn AgentRuntime boundary", () => {
       }
     },
   );
+
+  test("keeps a grounded contextual reminder mutation primary and communications blocked", async () => {
+    runtimeActionResults = [
+      {
+        success: true,
+        data: { actionName: "REMINDERS", operation: "delete" },
+      },
+    ];
+    const result = await runSharedAgentTurn(
+      reminderTurnInput("delete it, then email Bob", [
+        groundedReminderAssistant("Got it — I'll remind you tomorrow: Stretch", {
+          operation: "create",
+          success: true,
+          taskIds: ["stretch-reminder"],
+        }),
+      ]),
+    );
+
+    expect(runtimeInputs.at(-1)).toMatchObject({
+      reminderOperationIntent: "delete",
+      reminderTargetIntent: "stretch-reminder",
+    });
+    expect(JSON.stringify(runtimeInputs.at(-1))).toContain(
+      "Call REMINDERS before any terminal answer",
+    );
+    expect(result.capabilityWall).toBeUndefined();
+    expect(result.blockedSecondaryCapabilities).toEqual([
+      expect.objectContaining({ capability: "communications" }),
+    ]);
+  });
 
   test("classifies an initial clear-list request for the plugin confirmation fence", async () => {
     runtimeActionResults = [
@@ -332,6 +534,27 @@ describe("Shared turn AgentRuntime boundary", () => {
     expect(runtimeInputs.at(-1)?.reminderClearAllIntent).toBe(true);
   });
 
+  test.each(["Dismiss all reminders", "Cancel all my reminders"])(
+    "routes the destructive all-target synonym through the clear confirmation fence: %s",
+    async (message) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: {
+            actionName: "REMINDERS",
+            operation: "clear",
+            requiresConfirmation: true,
+          },
+        },
+      ];
+      await runSharedAgentTurn(reminderTurnInput(message));
+
+      expect(runtimeInputs.at(-1)?.reminderClearAllIntent).toBe(true);
+      expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBeUndefined();
+      expect(runtimeInputs.at(-1)?.reminderClearConfirmationChallenge).toBe(false);
+    },
+  );
+
   test.each(["Don't clear the list", "Explain how to clear all reminders"])(
     "does not treat negated or discussed clear text as a clear-all command: %s",
     async (message) => {
@@ -367,49 +590,25 @@ describe("Shared turn AgentRuntime boundary", () => {
   );
 
   test.each([
-    ["List my reminders", "list"],
-    ["Show me the reminders", "list"],
-    ["Remind me tomorrow to call mom", "create"],
-    ["Create a reminder to call mom", "create"],
-    ["Remove the reminder add something in my todo", "delete"],
-  ])("derives trusted reminder operation intent for '%s'", async (message, expectedOperation) => {
-    runtimeActionResults = [
-      {
-        success: false,
-        data: { actionName: "REMINDERS", operation: expectedOperation },
-      },
-    ];
-    await runSharedAgentTurn({
-      character: { name: "Eliza", system: "You are Eliza." },
-      history: [],
-      message,
-      execution: {
-        agentKey: "personal:user-1",
-        roomKey: "personal:user-1",
-        authenticatedPersonalSharedUser: true,
-        channel: { type: ChannelType.DM, source: "telegram" },
-        reminders: {
-          delivery: {
-            platform: "telegram",
-            project: "eliza-app",
-            connectorAccountId: "bot:123456789",
-            chatId: "123456789",
-          },
-          runner: {} as never,
-        },
-      },
-    });
-
-    expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBe(expectedOperation);
-  });
-
-  test.each(["Don't remind me at 3pm", "Can you explain how to remind me at 3pm?"])(
-    "does not trust negated or discussed create intent: %s",
-    async (message) => {
+    ["List my reminders", "list", undefined],
+    ["Show me the reminders", "list", undefined],
+    ["Remind me tomorrow to call mom", "create", undefined],
+    ["Create a reminder to call mom", "create", undefined],
+    ["Remove the reminder add something in my todo", "delete", "add something in my todo"],
+    ["Could you please delete the reminder Stretch please", "delete", "stretch"],
+    ["Update the reminder Stretch to 4pm", "update", "stretch"],
+    ["Reschedule the reminder Stretch to 4pm", "update", "stretch"],
+    ["Snooze my reminder Stretch for 5 minutes", "snooze", "stretch"],
+    ["Complete the reminder Stretch", "complete", "stretch"],
+    ["Dismiss the reminder Stretch", "dismiss", "stretch"],
+    ["Cancel the reminder Stretch", "dismiss", "stretch"],
+  ])(
+    "derives trusted reminder operation intent for '%s'",
+    async (message, expectedOperation, expectedTarget) => {
       runtimeActionResults = [
         {
           success: false,
-          data: { actionName: "REMINDERS", operation: "create" },
+          data: { actionName: "REMINDERS", operation: expectedOperation },
         },
       ];
       await runSharedAgentTurn({
@@ -433,7 +632,112 @@ describe("Shared turn AgentRuntime boundary", () => {
         },
       });
 
-      expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBeUndefined();
+      expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBe(expectedOperation);
+      expect(runtimeInputs.at(-1)?.reminderTargetIntent).toBe(expectedTarget);
+    },
+  );
+
+  test("rejects a mismatched reminder result for an explicit update before any terminal reply", async () => {
+    const input = reminderTurnInput("Update the reminder Stretch to 4pm");
+    runtimeActionResults = [
+      {
+        success: true,
+        data: { actionName: "REMINDERS", operation: "delete" },
+      },
+    ];
+
+    const error = await runSharedAgentTurn(input).catch((caught) => caught as Error);
+    expect((error.cause as Error).message).toContain("without an action result");
+    expect(runtimeInputs.at(-1)).toMatchObject({
+      reminderOperationIntent: "update",
+      reminderTargetIntent: "stretch",
+    });
+
+    runtimeActionResults = [
+      {
+        success: true,
+        data: { actionName: "REMINDERS", operation: "update" },
+      },
+    ];
+    await expect(runSharedAgentTurn(input)).resolves.toMatchObject({
+      reply: "runtime reply",
+    });
+  });
+
+  test.each([
+    "Don't remind me at 3pm",
+    "Can you explain how to remind me at 3pm?",
+    "Could you not update my reminder?",
+    "I don't want you to update my reminder to 3pm",
+    "Don’t update my reminder",
+  ])("does not require or trust a negated or discussed reminder mutation: %s", async (message) => {
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message,
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    });
+
+    expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBeUndefined();
+    expect(JSON.stringify(runtimeInputs.at(-1))).not.toContain(
+      "Call REMINDERS before any terminal answer",
+    );
+  });
+
+  test.each([
+    { operation: "create" as const, success: true, taskIds: ["created-reminder"] },
+    { operation: "list" as const, success: false, taskIds: [] },
+    { operation: "complete" as const, success: false, taskIds: ["failed-target"] },
+  ])("does not treat bare confirmation as contextual after $operation", async (receipt) => {
+    await runSharedAgentTurn(
+      reminderTurnInput("do it", [groundedReminderAssistant("Previous result", receipt)]),
+    );
+
+    expect(runtimeInputs.at(-1)?.reminderClearAllIntent).toBe(false);
+    expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBeUndefined();
+    expect(runtimeInputs.at(-1)?.reminderTargetIntent).toBeUndefined();
+    expect(JSON.stringify(runtimeInputs.at(-1))).not.toContain(
+      "Call REMINDERS before any terminal answer",
+    );
+  });
+
+  test.each([[], ["first-reminder", "second-reminder"]])(
+    "does not authorize contextual delete with an unbound receipt target",
+    async (taskIds) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: { actionName: "REMINDERS", operation: "delete" },
+        },
+      ];
+      await runSharedAgentTurn(
+        reminderTurnInput("delete it", [
+          groundedReminderAssistant("Previous reminder result", {
+            operation: "list",
+            success: true,
+            taskIds,
+          }),
+        ]),
+      );
+
+      expect(runtimeInputs.at(-1)?.reminderTargetIntent).toBeUndefined();
+      expect(JSON.stringify(runtimeInputs.at(-1))).not.toContain(
+        "Call REMINDERS before any terminal answer",
+      );
     },
   );
 
@@ -477,86 +781,114 @@ describe("Shared turn AgentRuntime boundary", () => {
       message: "Remind me at 3:06, not 1:06, to call mom",
       provenance: "reminderClockCorrection",
       history: [],
+      expectedOperation: "create",
     },
     {
       message: "Remind me at 3:06, not 1:06, to call mom",
       provenance: "reminderClockCorrection",
-      history: [
-        {
-          role: "assistant" as const,
-          content: "Got it — I'll remind you tomorrow: stretch",
-        },
-      ],
+      history: [assistantText("Got it — I'll remind you tomorrow: stretch")],
+      expectedOperation: "create",
+    },
+    {
+      message: "3:06, no 1:06",
+      provenance: "reminderClockCorrection",
+      history: [assistantText("Got it — I'll remind you tomorrow: Stretch")],
     },
     {
       message: "yes, clear all reminders",
       provenance: "reminderClearConfirmationChallenge",
       history: [],
+      expectedOperation: "clear",
     },
     {
       message: "yes, clear all reminders",
       provenance: "reminderClearConfirmationChallenge",
+      history: [assistantText("Got it — I'll remind you tomorrow: stretch")],
+      expectedOperation: "clear",
+    },
+    {
+      message: "yes, clear all reminders",
+      provenance: "reminderClearConfirmationChallenge",
+      history: [assistantText("Clearing removes every active reminder. Done.")],
+      expectedOperation: "clear",
+    },
+    {
+      message: "delete it",
+      provenance: "reminderClockCorrection",
+      history: [assistantText("Your reminders:\n• Stretch — tomorrow at 3:00 PM")],
+    },
+    {
+      message: "3:06, no 1:06",
+      provenance: "reminderClockCorrection",
       history: [
         {
-          role: "assistant" as const,
-          content: "Got it — I'll remind you tomorrow: stretch",
+          ...groundedReminderAssistant("Got it — I'll remind you tomorrow: Stretch", {
+            operation: "create",
+            success: true,
+            taskIds: ["interrupted-task"],
+          }),
+          interrupted: true,
         },
       ],
     },
     {
-      message: "yes, clear all reminders",
-      provenance: "reminderClearConfirmationChallenge",
+      message: "3:06, no 1:06",
+      provenance: "reminderClockCorrection",
       history: [
         {
           role: "assistant" as const,
-          content: "Clearing removes every active reminder. Done.",
+          content: "Got it — I'll remind you tomorrow: Stretch",
+          reminderAction: {
+            actionName: "REMINDERS" as const,
+            operation: "create" as const,
+            success: true,
+            taskIds: ["other-scope-task"],
+            deliveryScope: stableStringify({
+              ...TEST_REMINDER_DELIVERY,
+              chatId: "different-chat",
+            }),
+          },
         },
       ],
     },
   ])(
     "does not trust first-turn text as server mutation provenance: $message",
-    async ({ message, provenance, history }) => {
-      runtimeActionResults = [
-        {
-          success: false,
-          data: { actionName: "REMINDERS", operation: "update" },
-        },
-      ];
-      await runSharedAgentTurn({
-        character: { name: "Eliza", system: "You are Eliza." },
-        history,
-        message,
-        execution: {
-          agentKey: "personal:user-1",
-          roomKey: "personal:user-1",
-          authenticatedPersonalSharedUser: true,
-          channel: { type: ChannelType.DM, source: "telegram" },
-          reminders: {
-            delivery: {
-              platform: "telegram",
-              project: "eliza-app",
-              connectorAccountId: "bot:123456789",
-              chatId: "123456789",
+    async ({ message, provenance, history, expectedOperation }) => {
+      runtimeActionResults = expectedOperation
+        ? [
+            {
+              success: false,
+              data: {
+                actionName: "REMINDERS",
+                operation: expectedOperation,
+              },
             },
-            runner: {} as never,
-          },
-        },
-      });
+          ]
+        : undefined;
+      await runSharedAgentTurn(reminderTurnInput(message, history));
 
       expect(runtimeInputs.at(-1)?.[provenance]).toBe(false);
       expect(JSON.stringify(runtimeInputs.at(-1))).not.toContain(
         "operation=update, never operation=create",
       );
+      if (!expectedOperation) {
+        expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBeUndefined();
+        expect(runtimeInputs.at(-1)?.reminderTargetIntent).toBeUndefined();
+        expect(JSON.stringify(runtimeInputs.at(-1))).not.toContain(
+          "Call REMINDERS before any terminal answer",
+        );
+      }
     },
   );
 
   test.each(["Clean the reminder list please", "Remove the reminder add something in my todo"])(
     "routes the exact reminder phrase to REMINDERS when Todo is enabled too: %s",
     async (message) => {
+      const expectedOperation = message.startsWith("Clean") ? "clear" : "delete";
       runtimeActionResults = [
         {
           success: false,
-          data: { actionName: "REMINDERS", operation: "delete" },
+          data: { actionName: "REMINDERS", operation: expectedOperation },
         },
       ];
       await runSharedAgentTurn({
@@ -774,6 +1106,24 @@ describe("Shared turn AgentRuntime boundary", () => {
     expect(streamInputs).toHaveLength(1);
     expect(JSON.stringify(streamInputs[0])).toContain("trusted reminder delivery");
     expect(result.model).not.toBe("capability-wall");
+  });
+
+  test("preserves blocked secondary capability metadata on a buffered reminder stream", async () => {
+    runtimeActionResults = [
+      {
+        success: true,
+        data: { actionName: "REMINDERS", operation: "create" },
+      },
+    ];
+    const result = await runSharedAgentTurnStream(
+      reminderTurnInput("Remind me tomorrow to stretch, then email Bob now"),
+    );
+
+    expect(result.capabilityWall).toBeUndefined();
+    expect(result.blockedSecondaryCapabilities).toEqual([
+      expect.objectContaining({ capability: "communications" }),
+    ]);
+    expect(result.actionResults).toEqual(runtimeActionResults);
   });
 
   test("commits durable memory only after a runtime reply lands", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -139,6 +139,454 @@ describe("Shared turn AgentRuntime boundary", () => {
     expect(result.reply).toBe("runtime reply");
   });
 
+  test.each([
+    {
+      message: "Can you clear the list?",
+      previous:
+        "Your reminders:\n• add something to your todo — on Aug 28, 2026 at 3:06 AM Europe/Paris",
+    },
+    {
+      message: "3 06 no 1:06",
+      previous:
+        "Got it — I'll remind you on Aug 28, 2026 at 3:06 AM Europe/Paris: add something to your todo",
+    },
+    {
+      message: "Change the reminder to 3:06, not 1:06",
+      previous:
+        "Got it — I'll remind you on Aug 28, 2026 at 1:06 AM Europe/Paris: add something to your todo",
+    },
+    {
+      message: "Could you please change the reminder to 3:06, not 1:06",
+      previous:
+        "Got it — I'll remind you on Aug 28, 2026 at 1:06 AM Europe/Paris: add something to your todo",
+    },
+    {
+      message: "yes",
+      previous:
+        "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+    },
+    {
+      message: "Oui, je confirme, vas-y",
+      previous:
+        "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+    },
+    {
+      message: "Oui, je confirme, vas-y, efface tous mes rappels",
+      previous:
+        "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+    },
+    {
+      message: "Do it, clear all reminders",
+      previous:
+        "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+    },
+    {
+      message: "Remove the reminder Stretch",
+      previous:
+        "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+    },
+    {
+      message: "the 3:06 one",
+      previous:
+        "More than one reminder matches that. Which one do you mean?\n• Stretch — on Aug 28, 2026 at 3:06 AM Europe/Paris",
+    },
+  ])(
+    "keeps the contextual reminder follow-up '$message' on REMINDERS",
+    async ({ message, previous }) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: { actionName: "REMINDERS", operation: "update" },
+        },
+      ];
+      await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history: [{ role: "assistant", content: previous }],
+        message,
+        execution: {
+          agentKey: "personal:user-1",
+          roomKey: "personal:user-1",
+          authenticatedPersonalSharedUser: true,
+          channel: { type: ChannelType.DM, source: "telegram" },
+          reminders: {
+            delivery: {
+              platform: "telegram",
+              project: "eliza-app",
+              connectorAccountId: "bot:123456789",
+              chatId: "123456789",
+            },
+            runner: {} as never,
+          },
+        },
+      });
+
+      const prompt = JSON.stringify(runtimeInputs[0]);
+      expect(prompt).toContain("Call REMINDERS before any terminal answer");
+      expect(prompt).not.toContain("Call TODO before any terminal answer");
+      if (
+        message === "3 06 no 1:06" ||
+        message === "Change the reminder to 3:06, not 1:06" ||
+        message === "Could you please change the reminder to 3:06, not 1:06"
+      ) {
+        expect(prompt).toContain("call REMINDERS with operation=update, never operation=create");
+        expect(runtimeInputs[0]?.reminderClockCorrection).toBe(true);
+      }
+      if (
+        message === "Oui, je confirme, vas-y, efface tous mes rappels" ||
+        message === "Do it, clear all reminders"
+      ) {
+        expect(runtimeInputs[0]?.reminderClearConfirmationChallenge).toBe(true);
+      }
+      if (
+        message === "yes" ||
+        message.includes("efface tous mes rappels") ||
+        message === "Do it, clear all reminders"
+      ) {
+        expect(runtimeInputs[0]?.reminderClearAllIntent).toBe(true);
+      }
+      if (message === "Remove the reminder Stretch") {
+        expect(runtimeInputs[0]?.reminderClearAllIntent).toBe(false);
+        expect(runtimeInputs[0]?.reminderOperationIntent).toBe("delete");
+      }
+    },
+  );
+
+  test("classifies an initial clear-list request for the plugin confirmation fence", async () => {
+    runtimeActionResults = [
+      {
+        success: false,
+        data: { actionName: "REMINDERS", operation: "clear" },
+      },
+    ];
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "Can you clear the list?",
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    });
+
+    expect(runtimeInputs[0]?.reminderClearAllIntent).toBe(true);
+    expect(runtimeInputs[0]?.reminderClearConfirmationChallenge).toBe(false);
+
+    const longMessage = `Clear all my reminders because ${"I no longer need this scheduled item ".repeat(75)}`;
+    expect(longMessage.length).toBeGreaterThan(2_100);
+    expect(longMessage.length).toBeLessThanOrEqual(4_096);
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: longMessage,
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    });
+    expect(runtimeInputs.at(-1)?.reminderClearAllIntent).toBe(true);
+
+    const overTransportMessage = `Clear all my reminders because ${"this extra app context must not disable the mutation fence ".repeat(90)}`;
+    expect(overTransportMessage.length).toBeGreaterThan(4_096);
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: overTransportMessage,
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.DM, source: "client_chat" },
+        reminders: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    });
+    expect(runtimeInputs.at(-1)?.reminderClearAllIntent).toBe(true);
+  });
+
+  test.each(["Don't clear the list", "Explain how to clear all reminders"])(
+    "does not treat negated or discussed clear text as a clear-all command: %s",
+    async (message) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: { actionName: "REMINDERS", operation: "list" },
+        },
+      ];
+      await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history: [],
+        message,
+        execution: {
+          agentKey: "personal:user-1",
+          roomKey: "personal:user-1",
+          authenticatedPersonalSharedUser: true,
+          channel: { type: ChannelType.DM, source: "telegram" },
+          reminders: {
+            delivery: {
+              platform: "telegram",
+              project: "eliza-app",
+              connectorAccountId: "bot:123456789",
+              chatId: "123456789",
+            },
+            runner: {} as never,
+          },
+        },
+      });
+
+      expect(runtimeInputs.at(-1)?.reminderClearAllIntent).toBe(false);
+    },
+  );
+
+  test.each([
+    ["List my reminders", "list"],
+    ["Show me the reminders", "list"],
+    ["Remind me tomorrow to call mom", "create"],
+    ["Create a reminder to call mom", "create"],
+    ["Remove the reminder add something in my todo", "delete"],
+  ])("derives trusted reminder operation intent for '%s'", async (message, expectedOperation) => {
+    runtimeActionResults = [
+      {
+        success: false,
+        data: { actionName: "REMINDERS", operation: expectedOperation },
+      },
+    ];
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message,
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    });
+
+    expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBe(expectedOperation);
+  });
+
+  test.each(["Don't remind me at 3pm", "Can you explain how to remind me at 3pm?"])(
+    "does not trust negated or discussed create intent: %s",
+    async (message) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: { actionName: "REMINDERS", operation: "create" },
+        },
+      ];
+      await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history: [],
+        message,
+        execution: {
+          agentKey: "personal:user-1",
+          roomKey: "personal:user-1",
+          authenticatedPersonalSharedUser: true,
+          channel: { type: ChannelType.DM, source: "telegram" },
+          reminders: {
+            delivery: {
+              platform: "telegram",
+              project: "eliza-app",
+              connectorAccountId: "bot:123456789",
+              chatId: "123456789",
+            },
+            runner: {} as never,
+          },
+        },
+      });
+
+      expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBeUndefined();
+    },
+  );
+
+  test("keeps a long explicit create request inside the trusted operation fence", async () => {
+    runtimeActionResults = [
+      {
+        success: false,
+        data: { actionName: "REMINDERS", operation: "create" },
+      },
+    ];
+    const message = `Remind me tomorrow to ${"review the detailed checklist ".repeat(50)}`;
+    expect(message.length).toBeGreaterThan(120);
+    expect(message.length).toBeLessThan(2_000);
+
+    await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message,
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    });
+
+    expect(runtimeInputs.at(-1)?.reminderOperationIntent).toBe("create");
+  });
+
+  test.each([
+    {
+      message: "Remind me at 3:06, not 1:06, to call mom",
+      provenance: "reminderClockCorrection",
+      history: [],
+    },
+    {
+      message: "Remind me at 3:06, not 1:06, to call mom",
+      provenance: "reminderClockCorrection",
+      history: [
+        {
+          role: "assistant" as const,
+          content: "Got it — I'll remind you tomorrow: stretch",
+        },
+      ],
+    },
+    {
+      message: "yes, clear all reminders",
+      provenance: "reminderClearConfirmationChallenge",
+      history: [],
+    },
+    {
+      message: "yes, clear all reminders",
+      provenance: "reminderClearConfirmationChallenge",
+      history: [
+        {
+          role: "assistant" as const,
+          content: "Got it — I'll remind you tomorrow: stretch",
+        },
+      ],
+    },
+    {
+      message: "yes, clear all reminders",
+      provenance: "reminderClearConfirmationChallenge",
+      history: [
+        {
+          role: "assistant" as const,
+          content: "Clearing removes every active reminder. Done.",
+        },
+      ],
+    },
+  ])(
+    "does not trust first-turn text as server mutation provenance: $message",
+    async ({ message, provenance, history }) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: { actionName: "REMINDERS", operation: "update" },
+        },
+      ];
+      await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history,
+        message,
+        execution: {
+          agentKey: "personal:user-1",
+          roomKey: "personal:user-1",
+          authenticatedPersonalSharedUser: true,
+          channel: { type: ChannelType.DM, source: "telegram" },
+          reminders: {
+            delivery: {
+              platform: "telegram",
+              project: "eliza-app",
+              connectorAccountId: "bot:123456789",
+              chatId: "123456789",
+            },
+            runner: {} as never,
+          },
+        },
+      });
+
+      expect(runtimeInputs.at(-1)?.[provenance]).toBe(false);
+      expect(JSON.stringify(runtimeInputs.at(-1))).not.toContain(
+        "operation=update, never operation=create",
+      );
+    },
+  );
+
+  test.each(["Clean the reminder list please", "Remove the reminder add something in my todo"])(
+    "routes the exact reminder phrase to REMINDERS when Todo is enabled too: %s",
+    async (message) => {
+      runtimeActionResults = [
+        {
+          success: false,
+          data: { actionName: "REMINDERS", operation: "delete" },
+        },
+      ];
+      await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history: [],
+        message,
+        execution: {
+          agentKey: "personal:user-1",
+          roomKey: "personal:user-1",
+          authenticatedPersonalSharedUser: true,
+          channel: { type: ChannelType.DM, source: "telegram" },
+          todos: {} as never,
+          reminders: {
+            delivery: {
+              platform: "telegram",
+              project: "eliza-app",
+              connectorAccountId: "bot:123456789",
+              chatId: "123456789",
+            },
+            runner: {} as never,
+          },
+        },
+      });
+
+      const prompt = JSON.stringify(runtimeInputs[0]);
+      expect(prompt).toContain("Call REMINDERS before any terminal answer");
+      expect(prompt).not.toContain("Call TODO before any terminal answer");
+    },
+  );
+
   test("requires a grounded media action result instead of accepting a model-invented tool failure", async () => {
     const mediaInput = {
       character: { name: "Eliza", system: "You are Eliza." },
@@ -210,6 +658,60 @@ describe("Shared turn AgentRuntime boundary", () => {
     const parts = [];
     if (!result.parts) throw new Error("Expected buffered media parts");
     for await (const part of result.parts) parts.push(part);
+    expect(parts.at(-1)).toMatchObject({
+      type: "finish",
+      actionResults: runtimeActionResults,
+    });
+  });
+
+  test("buffers reminder streams and emits no delta without the required grounded action result", async () => {
+    const input = {
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [
+        {
+          role: "assistant" as const,
+          content:
+            "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+        },
+      ],
+      message: "yes, clear all reminders",
+      execution: {
+        agentKey: "personal:user-1",
+        roomKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true as const,
+        channel: { type: ChannelType.DM, source: "telegram" },
+        reminders: {
+          delivery: {
+            platform: "telegram" as const,
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+          runner: {} as never,
+        },
+      },
+    };
+    const observedParts: unknown[] = [];
+    const streamError = (await runSharedAgentTurnStream(input).catch(
+      (error) => error as Error,
+    )) as Error;
+    expect(streamError.message).toContain("AgentRuntime turn failed");
+    expect((streamError.cause as Error).message).toContain(
+      "executable REMINDERS request without an action result",
+    );
+    expect(observedParts).toHaveLength(0);
+    expect(streamInputs).toHaveLength(0);
+
+    runtimeActionResults = [
+      {
+        success: false,
+        data: { actionName: "REMINDERS", operation: "clear" },
+      },
+    ];
+    const grounded = await runSharedAgentTurnStream(input);
+    const parts = [];
+    if (!grounded.parts) throw new Error("Expected grounded reminder stream parts");
+    for await (const part of grounded.parts) parts.push(part);
     expect(parts.at(-1)).toMatchObject({
       type: "finish",
       actionResults: runtimeActionResults,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -51,6 +51,7 @@ import {
   sharedCapabilityTransportForSource,
 } from "./shared-capability-catalog";
 import {
+  hasTrailingSharedActionCancellation,
   resolveSharedCapabilityIntent,
   type SharedCapabilityResolution,
   type SharedCapabilityWall,
@@ -506,6 +507,18 @@ function reminderActionProvenance(
   if (Array.isArray(listedTasks)) {
     for (const task of listedTasks) addTaskId(task);
   }
+  const candidateTaskIds =
+    result.success === false &&
+    result.data?.requiresSelection === true &&
+    Array.isArray(result.data?.candidateTaskIds)
+      ? [
+          ...new Set(
+            result.data.candidateTaskIds.flatMap((taskId) =>
+              typeof taskId === "string" && taskId.trim() ? [taskId.trim()] : [],
+            ),
+          ),
+        ].slice(0, 100)
+      : [];
   // An update's dismissal receipt names the superseded row; only the
   // replacement in structured data may authorize a later correction.
   if (operation !== "update") {
@@ -521,7 +534,9 @@ function reminderActionProvenance(
     operation: operation as SharedReminderOperation,
     success: result.success === true,
     ...(result.data?.requiresConfirmation === true ? { requiresConfirmation: true } : {}),
+    ...(candidateTaskIds.length ? { requiresSelection: true } : {}),
     taskIds: [...taskIds],
+    ...(candidateTaskIds.length ? { candidateTaskIds } : {}),
     deliveryScope: reminderDeliveryScope(delivery),
   };
 }
@@ -724,10 +739,20 @@ function normalizedReminderOperationCommand(text: string): string | undefined {
   return normalized || undefined;
 }
 
-const POSITIVE_REMINDER_COMMAND_PREFIX = "(?:(?:can|could|would) you (?:please )?|please )?";
+const POSITIVE_REMINDER_COMMAND_PREFIX = "(?:(?:can|could|would|will) you (?:please )?|please )?";
+
+function primaryReminderCommandClause(text: string): string {
+  return (
+    text.split(
+      /\s*(?:[,;]\s*|\b(?:and\s+)?then\s+)(?=(?:email|call|text|message|dm|send|add|create|update|delete|remove|complete|show|list)\b)/iu,
+      1,
+    )[0] ?? text
+  );
+}
 
 function isExplicitReminderClearAllIntent(text: string): boolean {
-  const normalized = normalizedReminderOperationCommand(text);
+  if (hasTrailingSharedActionCancellation(text)) return false;
+  const normalized = normalizedReminderOperationCommand(primaryReminderCommandClause(text));
   if (!normalized) return false;
   const confirmation =
     "(?:yes|yep|oui|confirm|confirmed|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)";
@@ -750,7 +775,8 @@ function isShortReminderClearConfirmation(text: string): boolean {
 }
 
 function isExplicitReminderCreationIntent(text: string): boolean {
-  const normalized = normalizedReminderOperationCommand(text);
+  if (hasTrailingSharedActionCancellation(text)) return false;
+  const normalized = normalizedReminderOperationCommand(primaryReminderCommandClause(text));
   if (!normalized) return false;
   if (
     new RegExp(
@@ -761,13 +787,14 @@ function isExplicitReminderCreationIntent(text: string): boolean {
     return true;
   }
   const scheduleCue =
-    /\b(?:today|tomorrow|tonight|noon|midnight|next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|in (?:\d+|an?|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve) (?:minute|minutes|hour|hours|day|days|week|weeks)|at \d{1,2}(?: \d{2})?(?: am| pm)?|\d{1,2}(?: \d{2})? (?:am|pm)|every (?:day|weekday|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d+ (?:minute|minutes|hour|hours|day|days|week|weeks))|on (?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}(?: \d{1,2})?))\b/iu;
+    /\b(?:today|tomorrow|tonight|noon|midnight|next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|in (?:\d+|an?|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve) (?:minute|minutes|hour|hours|day|days|week|weeks)|at \d{1,2}(?: \d{2})?(?: am| pm)?|\d{1,2}(?: \d{2})? (?:am|pm)|every (?:day|weekday|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d+ (?:minute|minutes|hour|hours|day|days|week|weeks))|on (?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|(?:january|february|march|april|may|june|july|august|september|october|november|december) \d{1,2}(?: \d{4})?|\d{1,2}(?: \d{1,2})?))\b/iu;
   if (!scheduleCue.test(normalized)) return false;
   return new RegExp(`^${POSITIVE_REMINDER_COMMAND_PREFIX}remind me\\b.+$`, "iu").test(normalized);
 }
 
 function isExplicitReminderUpdateIntent(text: string): boolean {
-  const normalized = normalizedReminderOperationCommand(text);
+  if (hasTrailingSharedActionCancellation(text)) return false;
+  const normalized = normalizedReminderOperationCommand(primaryReminderCommandClause(text));
   return Boolean(
     normalized &&
       new RegExp(
@@ -795,6 +822,29 @@ function reminderTargetAfterCommandNoun(
   return match?.[1]?.trim() || undefined;
 }
 
+function reminderTargetBeforeCommandNoun(
+  normalized: string,
+  operations: string,
+): string | undefined {
+  const match = normalized.match(
+    new RegExp(
+      `^${POSITIVE_REMINDER_COMMAND_PREFIX}(?:${operations}) (?:the |my )?(.+?) reminder(?: (?:to|at|for|until) .+)?(?: please)?$`,
+      "iu",
+    ),
+  );
+  return match?.[1]?.trim() || undefined;
+}
+
+function reminderTargetAroundCommandNoun(
+  normalized: string,
+  operations: string,
+): string | undefined {
+  return (
+    reminderTargetAfterCommandNoun(normalized, operations) ??
+    reminderTargetBeforeCommandNoun(normalized, operations)
+  );
+}
+
 function updateTargetBeforeSchedule(value: string | undefined): string | undefined {
   if (!value) return undefined;
   const match = value.match(
@@ -812,7 +862,8 @@ function snoozeTargetBeforeDuration(value: string | undefined): string | undefin
 }
 
 function trustedReminderOperationIntent(text: string): TrustedReminderIntent | undefined {
-  const normalized = normalizedReminderOperationCommand(text);
+  if (hasTrailingSharedActionCancellation(text)) return undefined;
+  const normalized = normalizedReminderOperationCommand(primaryReminderCommandClause(text));
   if (!normalized || isExplicitReminderClearAllIntent(text)) return undefined;
   if (isExplicitReminderCreationIntent(text)) return { operation: "create" };
   if (
@@ -822,11 +873,11 @@ function trustedReminderOperationIntent(text: string): TrustedReminderIntent | u
   ) {
     return { operation: "list" };
   }
-  const deleteTarget = reminderTargetAfterCommandNoun(normalized, "remove|delete");
+  const deleteTarget = reminderTargetAroundCommandNoun(normalized, "remove|delete");
   if (deleteTarget) {
     return { operation: "delete", target: deleteTarget };
   }
-  const dismissTarget = reminderTargetAfterCommandNoun(normalized, "dismiss|cancel");
+  const dismissTarget = reminderTargetAroundCommandNoun(normalized, "dismiss|cancel");
   if (dismissTarget) {
     return { operation: "dismiss", target: dismissTarget };
   }
@@ -834,7 +885,7 @@ function trustedReminderOperationIntent(text: string): TrustedReminderIntent | u
     return {
       operation: "update",
       target: updateTargetBeforeSchedule(
-        reminderTargetAfterCommandNoun(normalized, "change|update|edit|reschedule"),
+        reminderTargetAroundCommandNoun(normalized, "change|update|edit|reschedule"),
       ),
     };
   }
@@ -847,7 +898,7 @@ function trustedReminderOperationIntent(text: string): TrustedReminderIntent | u
     | "dismiss"
     | undefined;
   if (operation) {
-    const target = reminderTargetAfterCommandNoun(normalized, operation);
+    const target = reminderTargetAroundCommandNoun(normalized, operation);
     return {
       operation,
       target: operation === "snooze" ? snoozeTargetBeforeDuration(target) : target,
@@ -868,13 +919,63 @@ function contextualReminderOperationIntent(
   if (
     /\b(?:update|change|edit|reschedule)\b/iu.test(normalized) ||
     isReminderClockCorrectionText(text) ||
-    /^(?:(?:the )?(?:\d{1,2}:\d{2}(?:\s*(?:am|pm))?|first|second|third|1st|2nd|3rd)(?: one)?)$/iu.test(
-      normalized,
-    )
+    /^(?:(?:the )?\d{1,2}:\d{2}(?:\s*(?:am|pm))?(?: one)?)$/iu.test(normalized)
   ) {
     return "update";
   }
   return undefined;
+}
+
+type ContextualReminderIntent = {
+  operation: Exclude<SharedReminderOperation, "create" | "list" | "clear">;
+  target?: string;
+};
+
+function reminderOrdinalSelectionIndex(text: string): number | undefined {
+  const normalized = normalizedShortReminderCommand(text);
+  if (!normalized) return undefined;
+  const match = normalized.match(/^(?:the )?(first|second|third|1st|2nd|3rd)(?: one)?$/iu);
+  switch (match?.[1]?.toLocaleLowerCase("en-US")) {
+    case "first":
+    case "1st":
+      return 0;
+    case "second":
+    case "2nd":
+      return 1;
+    case "third":
+    case "3rd":
+      return 2;
+    default:
+      return undefined;
+  }
+}
+
+function contextualReminderIntent(
+  text: string,
+  predecessor: SharedReminderActionProvenance | undefined,
+): ContextualReminderIntent | undefined {
+  if (!predecessor) return undefined;
+  const explicitOperation = contextualReminderOperationIntent(text);
+  if (explicitOperation) {
+    return {
+      operation: explicitOperation,
+      ...(predecessor.taskIds.length === 1 ? { target: predecessor.taskIds[0] } : {}),
+    };
+  }
+  const ordinalIndex = reminderOrdinalSelectionIndex(text);
+  const target =
+    ordinalIndex === undefined ? undefined : predecessor.candidateTaskIds?.[ordinalIndex];
+  if (
+    predecessor.success !== false ||
+    predecessor.requiresSelection !== true ||
+    !target ||
+    predecessor.operation === "create" ||
+    predecessor.operation === "list" ||
+    predecessor.operation === "clear"
+  ) {
+    return undefined;
+  }
+  return { operation: predecessor.operation, target };
 }
 
 function isContextualReminderFollowup(input: RunSharedAgentTurnInput): boolean {
@@ -886,7 +987,7 @@ function isContextualReminderFollowup(input: RunSharedAgentTurnInput): boolean {
     return false;
   }
   const text = (input.capabilityText ?? input.message).trim();
-  if (!text) return false;
+  if (!text || hasTrailingSharedActionCancellation(text)) return false;
   const normalizedConfirmation = text
     .normalize("NFKC")
     .toLocaleLowerCase("en-US")
@@ -1014,16 +1115,13 @@ export async function runSharedAgentTurn(
     input.history,
     input.execution?.reminders?.delivery,
   );
-  const contextualOperationIntent = isContextualReminderFollowup(input)
-    ? contextualReminderOperationIntent(reminderIntentText)
+  const contextualIntent = isContextualReminderFollowup(input)
+    ? contextualReminderIntent(reminderIntentText, trustedPredecessor)
     : undefined;
-  const reminderOperationIntent = trustedReminderIntent?.operation ?? contextualOperationIntent;
+  const reminderOperationIntent = trustedReminderIntent?.operation ?? contextualIntent?.operation;
   const reminderTargetIntent = reminderClockCorrection
     ? reminderScheduleProvenance?.taskIds[0]
-    : (trustedReminderIntent?.target ??
-      (contextualOperationIntent && trustedPredecessor?.taskIds.length === 1
-        ? trustedPredecessor.taskIds[0]
-        : undefined));
+    : (trustedReminderIntent?.target ?? contextualIntent?.target);
   const expectedReminderOperation = reminderClearAllIntent
     ? "clear"
     : reminderClockCorrection
@@ -1257,16 +1355,13 @@ export async function runSharedAgentTurnStream(
     input.history,
     input.execution?.reminders?.delivery,
   );
-  const contextualOperationIntent = isContextualReminderFollowup(input)
-    ? contextualReminderOperationIntent(reminderIntentText)
+  const contextualIntent = isContextualReminderFollowup(input)
+    ? contextualReminderIntent(reminderIntentText, trustedPredecessor)
     : undefined;
-  const reminderOperationIntent = trustedReminderIntent?.operation ?? contextualOperationIntent;
+  const reminderOperationIntent = trustedReminderIntent?.operation ?? contextualIntent?.operation;
   const reminderTargetIntent = reminderClockCorrection
     ? reminderScheduleProvenance?.taskIds[0]
-    : (trustedReminderIntent?.target ??
-      (contextualOperationIntent && trustedPredecessor?.taskIds.length === 1
-        ? trustedPredecessor.taskIds[0]
-        : undefined));
+    : (trustedReminderIntent?.target ?? contextualIntent?.target);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -327,6 +327,7 @@ function buildSharedRuntimeSystem(
   recallContext?: string,
   blockedCapabilities: SharedCapabilityWall[] = [],
   requiredAction?: RequiredSharedAction,
+  reminderClockCorrection = false,
   realtimeGrounding?: SharedRuntimePublicGrounding,
 ): string {
   const parts: string[] = [];
@@ -364,6 +365,9 @@ function buildSharedRuntimeSystem(
       "Current-turn execution requirement:\n" +
         `- The user's current message is an executable ${requestLabel} request, and ${requiredAction} is available for this verified account.\n` +
         `- Call ${requiredAction} before any terminal answer. ${ungroundedClaim}\n` +
+        (requiredAction === "REMINDERS" && reminderClockCorrection
+          ? "- This turn corrects an existing reminder clock time: call REMINDERS with operation=update, never operation=create.\n"
+          : "") +
         `- If the request is incomplete or cannot be applied, call ${requiredAction} anyway and use its grounded clarification or failure result; never invent success.`,
     );
   }
@@ -419,7 +423,14 @@ function hasRequiredActionResult(
   turn: RunSharedAgentTurnResult,
   actionName: RequiredSharedAction,
 ): boolean {
-  return Boolean(turn.actionResults?.some((result) => result.data?.actionName === actionName));
+  return hasNamedActionResult(turn.actionResults, actionName);
+}
+
+function hasNamedActionResult(
+  results: ActionResult[] | undefined,
+  actionName: RequiredSharedAction,
+): boolean {
+  return Boolean(results?.some((result) => result.data?.actionName === actionName));
 }
 
 function isWebSearchActionResult(result: ActionResult): boolean {
@@ -526,11 +537,182 @@ async function commitSharedTurnMemory(
   });
 }
 
+function hasGroundedReminderPredecessor(history: SharedTurnMessage[]): boolean {
+  const previous = history.at(-1);
+  if (previous?.role !== "assistant") return false;
+  return /^(?:Your reminders:|You have no (?:active )?reminders?\.|Got it — I'll remind|That reminder is already set|Reminder (?:snoozed|completed|dismissed|deleted)|Updated reminder:|Cleared \d+ reminders?\.|Clearing removes every active reminder\.|More than one reminder matches)/iu.test(
+    previous.content.trim(),
+  );
+}
+
+function hasGroundedReminderScheduleConfirmation(history: SharedTurnMessage[]): boolean {
+  const previous = history.at(-1);
+  return (
+    previous?.role === "assistant" &&
+    /^(?:Got it — I'll remind|That reminder is already set|Updated reminder:)/iu.test(
+      previous.content.trim(),
+    )
+  );
+}
+
+const REMINDER_CLEAR_CONFIRMATION_CHALLENGE =
+  "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.";
+
+function hasGroundedReminderClearChallenge(history: SharedTurnMessage[]): boolean {
+  const previous = history.at(-1);
+  return (
+    previous?.role === "assistant" &&
+    previous.content.trim() === REMINDER_CLEAR_CONFIRMATION_CHALLENGE
+  );
+}
+
+function isReminderClockCorrectionText(text: string): boolean {
+  return (
+    /\b\d{1,2}(?::\d{2}|\s+\d{2}|\s*(?:am|pm))\b/iu.test(text) &&
+    /\b(?:no|not|actually|instead|meant|change|make\s+that)\b/iu.test(text)
+  );
+}
+
+function normalizedShortReminderCommand(text: string): string | undefined {
+  const normalized = text
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .replace(/[\p{P}\p{S}]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return normalized && normalized.length <= 120 ? normalized : undefined;
+}
+
+function normalizedReminderOperationCommand(text: string): string | undefined {
+  const normalized = text
+    .slice(0, 4_096)
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .replace(/[\p{P}\p{S}]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return normalized || undefined;
+}
+
+const POSITIVE_REMINDER_COMMAND_PREFIX = "(?:(?:can|could|would) you (?:please )?|please )?";
+
+function isExplicitReminderClearAllIntent(text: string): boolean {
+  const normalized = normalizedReminderOperationCommand(text);
+  if (!normalized) return false;
+  const confirmation =
+    "(?:yes|yep|oui|confirm|confirmed|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)";
+  const clearCommand =
+    "(?:(?:clear|clean|delete|remove) (?:(?:all (?:(?:my|the) )?|my )reminders|the reminder list|the list)|(?:efface|supprime|vide) (?:tous mes rappels|la liste des rappels))";
+  return new RegExp(
+    `^(?:${confirmation} )*${POSITIVE_REMINDER_COMMAND_PREFIX}${clearCommand}\\b(?: .*)?$`,
+    "iu",
+  ).test(normalized);
+}
+
+function isShortReminderClearConfirmation(text: string): boolean {
+  const normalized = normalizedShortReminderCommand(text);
+  return Boolean(
+    normalized &&
+      /^(?:(?:yes|yep|oui|confirm(?:ed)?|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)(?: |$))+$/iu.test(
+        normalized,
+      ),
+  );
+}
+
+function isExplicitReminderCreationIntent(text: string): boolean {
+  const normalized = normalizedReminderOperationCommand(text);
+  if (!normalized) return false;
+  if (
+    new RegExp(
+      `^${POSITIVE_REMINDER_COMMAND_PREFIX}(?:set|create|add|schedule) (?:me )?(?:(?:a|an|new|another) )?reminder(?: .*)?$`,
+      "iu",
+    ).test(normalized)
+  ) {
+    return true;
+  }
+  const scheduleCue =
+    /\b(?:today|tomorrow|tonight|noon|midnight|next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|in \d+ (?:minute|minutes|hour|hours|day|days|week|weeks)|at \d{1,2}(?: \d{2})?(?: am| pm)?|\d{1,2}(?: \d{2})? (?:am|pm)|every (?:day|weekday|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d+ (?:minute|minutes|hour|hours|day|days|week|weeks))|on (?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}(?: \d{1,2})?))\b/iu;
+  if (!scheduleCue.test(normalized)) return false;
+  return new RegExp(`^${POSITIVE_REMINDER_COMMAND_PREFIX}remind me\\b.+$`, "iu").test(normalized);
+}
+
+function isExplicitReminderUpdateIntent(text: string): boolean {
+  const normalized = normalizedReminderOperationCommand(text);
+  return Boolean(
+    normalized &&
+      new RegExp(
+        `^${POSITIVE_REMINDER_COMMAND_PREFIX}(?:change|update|edit|reschedule) (?:the |my )?reminder\\b`,
+        "iu",
+      ).test(normalized),
+  );
+}
+
+function trustedReminderOperationIntent(text: string): "create" | "list" | "delete" | undefined {
+  const normalized = normalizedReminderOperationCommand(text);
+  if (!normalized || isExplicitReminderClearAllIntent(text)) return undefined;
+  if (isExplicitReminderCreationIntent(text)) return "create";
+  if (
+    /^(?:(?:can|could|would) you (?:please )?|please )?(?:(?:list|show)(?: me)?(?: all)?(?: (?:the|my))? reminders|what reminders do i have|do i have any reminders)(?: please)?$/iu.test(
+      normalized,
+    )
+  ) {
+    return "list";
+  }
+  if (
+    /^(?:(?:can|could|would) you (?:please )?|please )?(?:remove|delete|dismiss|cancel) (?:the )?reminder(?: (?:named|called))? .+(?: please)?$/iu.test(
+      normalized,
+    )
+  ) {
+    return "delete";
+  }
+  return undefined;
+}
+
+function isContextualReminderFollowup(input: RunSharedAgentTurnInput): boolean {
+  if (!hasGroundedReminderPredecessor(input.history)) return false;
+  const text = (input.capabilityText ?? input.message).trim();
+  if (!text) return false;
+  const normalizedConfirmation = text
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .replace(/[\p{P}\p{S}]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (
+    normalizedConfirmation.length <= 120 &&
+    /^(?:(?:yes|yep|oui|confirm(?:ed)?|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)(?: |$))+$/iu.test(
+      normalizedConfirmation,
+    )
+  ) {
+    return true;
+  }
+  if (
+    /^(?:(?:can|could|would)\s+you\s+|please\s+)?(?:clear|clean|remove|delete|dismiss|cancel|update|change|edit|reschedule|snooze|complete)\b[\s\S]{0,80}$/iu.test(
+      text,
+    )
+  ) {
+    return true;
+  }
+  if (/\b(?:efface|supprime|vide)\s+(?:tous mes rappels|la liste des rappels)\b/iu.test(text)) {
+    return true;
+  }
+  if (
+    /^(?:(?:the\s+)?(?:\d{1,2}:\d{2}(?:\s*(?:am|pm))?|first|second|third|1st|2nd|3rd)(?:\s+one)?)$/iu.test(
+      text,
+    )
+  ) {
+    return true;
+  }
+  return isReminderClockCorrectionText(text);
+}
+
 function capabilityResolution(
   input: RunSharedAgentTurnInput,
   capabilities: { reminders: boolean; todos: boolean },
+  explicit: SharedCapabilityResolution | null,
 ): SharedCapabilityResolution | null {
-  return resolveSharedCapabilityIntent(input.capabilityText ?? input.message, capabilities);
+  if (explicit || !isContextualReminderFollowup(input)) return explicit;
+  return resolveSharedCapabilityIntent("update reminder", capabilities);
 }
 
 function withCapabilityResolution(
@@ -576,8 +758,21 @@ export async function runSharedAgentTurn(
     reminders: remindersEnabled,
     todos: todosEnabled,
   };
-  const resolution = capabilityResolution(input, capabilities);
+  const reminderIntentText = input.capabilityText ?? input.message;
+  const explicitResolution = resolveSharedCapabilityIntent(reminderIntentText, capabilities);
+  const resolution = capabilityResolution(input, capabilities, explicitResolution);
   const requiredAction = requiredActionForTurn(input, resolution, actionsEnabled);
+  const reminderClockCorrection =
+    requiredAction === "REMINDERS" &&
+    hasGroundedReminderScheduleConfirmation(input.history) &&
+    isReminderClockCorrectionText(reminderIntentText) &&
+    (!explicitResolution || isExplicitReminderUpdateIntent(reminderIntentText)) &&
+    !isExplicitReminderCreationIntent(reminderIntentText);
+  const reminderClearConfirmationChallenge = hasGroundedReminderClearChallenge(input.history);
+  const reminderClearAllIntent =
+    isExplicitReminderClearAllIntent(reminderIntentText) ||
+    (reminderClearConfirmationChallenge && isShortReminderClearConfirmation(reminderIntentText));
+  const reminderOperationIntent = trustedReminderOperationIntent(reminderIntentText);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -656,12 +851,17 @@ export async function runSharedAgentTurn(
             input.recallContext,
             capabilityWall ? [capabilityWall] : blockedSecondary,
             requiredAction,
+            reminderClockCorrection,
             realtimeGrounding,
           ),
         },
         execution,
         agentKey: execution.agentKey,
         model: modelId,
+        reminderClockCorrection,
+        reminderClearConfirmationChallenge,
+        reminderClearAllIntent,
+        reminderOperationIntent,
         ...(realtimeGrounding ? { realtimeGrounding } : {}),
         ...(realtimeActionResults ? { preflightActionResults: realtimeActionResults } : {}),
       }),
@@ -766,8 +966,21 @@ export async function runSharedAgentTurnStream(
     reminders: remindersEnabled,
     todos: todosEnabled,
   };
-  const resolution = capabilityResolution(input, capabilities);
+  const reminderIntentText = input.capabilityText ?? input.message;
+  const explicitResolution = resolveSharedCapabilityIntent(reminderIntentText, capabilities);
+  const resolution = capabilityResolution(input, capabilities, explicitResolution);
   const requiredAction = requiredActionForTurn(input, resolution, actionsEnabled);
+  const reminderClockCorrection =
+    requiredAction === "REMINDERS" &&
+    hasGroundedReminderScheduleConfirmation(input.history) &&
+    isReminderClockCorrectionText(reminderIntentText) &&
+    (!explicitResolution || isExplicitReminderUpdateIntent(reminderIntentText)) &&
+    !isExplicitReminderCreationIntent(reminderIntentText);
+  const reminderClearConfirmationChallenge = hasGroundedReminderClearChallenge(input.history);
+  const reminderClearAllIntent =
+    isExplicitReminderClearAllIntent(reminderIntentText) ||
+    (reminderClearConfirmationChallenge && isShortReminderClearConfirmation(reminderIntentText));
+  const reminderOperationIntent = trustedReminderOperationIntent(reminderIntentText);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -786,7 +999,7 @@ export async function runSharedAgentTurnStream(
   // Current-data answers are buffered until their complete grounded reply has
   // passed validation; streaming an unverified numeric claim cannot be undone.
   if (
-    requiredAction === "GENERATE_MEDIA" ||
+    requiredAction ||
     (actionsEnabled &&
       ((publicSearchText && hasSharedRealtimeIntent(publicSearchText, input.history)) ||
         (!publicSearchText && hasSharedRealtimeIntent(message, input.history))))
@@ -817,37 +1030,39 @@ export async function runSharedAgentTurnStream(
   try {
     const execution = resolveRuntimeExecution(input);
     const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
-    return withStreamCapabilityResolution(
-      await runSharedElizaRuntimeTurnStream({
-        ...input,
-        character: {
-          ...input.character,
-          system: buildSharedRuntimeSystem(
-            input.character,
-            {
-              // A current-data request already took the buffered path above.
-              // Ordinary streamed turns must never expose a public-network tool.
-              webSearch: false,
-              reminders: remindersEnabled,
-              todos: todosEnabled,
-              media: actionsEnabled && Boolean(execution.media),
-              transport: sharedCapabilityTransportForSource(
-                execution.channel.source,
-                execution.channel.type,
-              ),
-            },
-            input.recallContext,
-            capabilityWall ? [capabilityWall] : blockedSecondary,
-            requiredAction,
-          ),
-        },
-        execution,
-        agentKey: execution.agentKey,
-        model: modelId,
-      }),
-      capabilityWall,
-      blockedSecondary,
-    );
+    const stream = await runSharedElizaRuntimeTurnStream({
+      ...input,
+      character: {
+        ...input.character,
+        system: buildSharedRuntimeSystem(
+          input.character,
+          {
+            // A current-data request already took the buffered path above.
+            // Ordinary streamed turns must never expose a public-network tool.
+            webSearch: false,
+            reminders: remindersEnabled,
+            todos: todosEnabled,
+            media: actionsEnabled && Boolean(execution.media),
+            transport: sharedCapabilityTransportForSource(
+              execution.channel.source,
+              execution.channel.type,
+            ),
+          },
+          input.recallContext,
+          capabilityWall ? [capabilityWall] : blockedSecondary,
+          requiredAction,
+          reminderClockCorrection,
+        ),
+      },
+      execution,
+      agentKey: execution.agentKey,
+      model: modelId,
+      reminderClockCorrection,
+      reminderClearConfirmationChallenge,
+      reminderClearAllIntent,
+      reminderOperationIntent,
+    });
+    return withStreamCapabilityResolution(stream, capabilityWall, blockedSecondary);
   } catch (error) {
     // error-policy:J2 no SSE bytes exist during setup, so retain the exact
     // runtime cause and add stable billing/diagnostic context for the caller.

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -26,12 +26,20 @@ import {
   type MediaGenerationResponse,
   type MessageExampleGroup,
   replaceNameTokens,
+  stableStringify,
   type UUID,
 } from "@elizaos/core/edge";
-import type { ScheduledTaskRunner, SharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
+import {
+  isSharedGroupReminderDelivery,
+  type ScheduledTaskRunner,
+  type SharedReminderDelivery,
+} from "@elizaos/plugin-scheduling/edge";
 import type { TodoStore } from "@elizaos/plugin-todos/edge";
 import { runWebSearchEdge } from "@elizaos/plugin-web-search/edge";
-import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-runtime-history";
+import type {
+  SharedRuntimePublicGrounding,
+  SharedRuntimeReminderActionProvenance,
+} from "../../../db/schemas/shared-runtime-history";
 import type { MobilePushMessage } from "../../mobile-push/types";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
 import { hasLanguageModelProviderConfigured } from "../../providers/language-model";
@@ -56,7 +64,10 @@ import {
   sharedRealtimePromptPolicy,
 } from "./shared-realtime-grounding";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
-import { sharedPublicWebGrounding } from "./shared-runtime-history-policy";
+import {
+  parseSharedReminderActionProvenance,
+  sharedPublicWebGrounding,
+} from "./shared-runtime-history-policy";
 import type {
   SharedProviderTimingReceipt,
   SharedRuntimeTimingReceipt,
@@ -82,7 +93,14 @@ export interface SharedTurnMessage {
   interrupted?: boolean;
   /** Bounded public-read authority retained for relevant follow-up turns. */
   grounding?: SharedRuntimePublicGrounding;
+  /** Server-authenticated reminder receipt used only for the next scoped follow-up. */
+  reminderAction?: SharedReminderActionProvenance;
 }
+
+export type SharedReminderOperation = SharedRuntimeReminderActionProvenance["operation"];
+
+/** Mutation provenance derived from a genuine REMINDERS result, never assistant prose. */
+export type SharedReminderActionProvenance = SharedRuntimeReminderActionProvenance;
 
 export interface SharedAgentCharacter {
   /** Display/agent name. */
@@ -422,15 +440,113 @@ function requiredActionForTurn(
 function hasRequiredActionResult(
   turn: RunSharedAgentTurnResult,
   actionName: RequiredSharedAction,
+  reminderOperation?: SharedReminderOperation,
 ): boolean {
-  return hasNamedActionResult(turn.actionResults, actionName);
+  return hasNamedActionResult(turn.actionResults, actionName, reminderOperation);
 }
 
 function hasNamedActionResult(
   results: ActionResult[] | undefined,
   actionName: RequiredSharedAction,
+  reminderOperation?: SharedReminderOperation,
 ): boolean {
-  return Boolean(results?.some((result) => result.data?.actionName === actionName));
+  return Boolean(
+    results?.some(
+      (result) =>
+        result.data?.actionName === actionName &&
+        (actionName !== "REMINDERS" ||
+          reminderOperation === undefined ||
+          result.data?.operation === reminderOperation),
+    ),
+  );
+}
+
+const SHARED_REMINDER_OPERATIONS = new Set<SharedReminderOperation>([
+  "create",
+  "list",
+  "update",
+  "snooze",
+  "complete",
+  "delete",
+  "dismiss",
+  "clear",
+]);
+
+function reminderDeliveryScope(delivery: SharedReminderDelivery): string {
+  if (isSharedGroupReminderDelivery(delivery)) {
+    const { ownerLabel: _ownerLabel, ...immutableAuthority } = delivery;
+    return stableStringify(immutableAuthority);
+  }
+  return stableStringify(delivery);
+}
+
+function reminderActionProvenance(
+  results: ActionResult[] | undefined,
+  delivery: SharedReminderDelivery | undefined,
+): SharedReminderActionProvenance | undefined {
+  if (!delivery) return undefined;
+  const result = results?.findLast((candidate) => candidate.data?.actionName === "REMINDERS");
+  const operation = result?.data?.operation;
+  if (
+    !result ||
+    typeof operation !== "string" ||
+    !SHARED_REMINDER_OPERATIONS.has(operation as SharedReminderOperation)
+  ) {
+    return undefined;
+  }
+  const taskIds = new Set<string>();
+  const addTaskId = (value: unknown) => {
+    if (!value || typeof value !== "object") return;
+    const taskId = (value as { taskId?: unknown }).taskId;
+    if (typeof taskId === "string" && taskId.trim()) taskIds.add(taskId.trim());
+  };
+  addTaskId(result.data?.task);
+  addTaskId(result.data?.replacement);
+  const listedTasks = result.data?.tasks;
+  if (Array.isArray(listedTasks)) {
+    for (const task of listedTasks) addTaskId(task);
+  }
+  // An update's dismissal receipt names the superseded row; only the
+  // replacement in structured data may authorize a later correction.
+  if (operation !== "update") {
+    for (const receipt of result.effectReceipts ?? []) {
+      if (receipt.resource?.kind === "shared.reminder") {
+        const id = receipt.resource.id;
+        if (typeof id === "string" && id.trim()) taskIds.add(id.trim());
+      }
+    }
+  }
+  return {
+    actionName: "REMINDERS",
+    operation: operation as SharedReminderOperation,
+    success: result.success === true,
+    ...(result.data?.requiresConfirmation === true ? { requiresConfirmation: true } : {}),
+    taskIds: [...taskIds],
+    deliveryScope: reminderDeliveryScope(delivery),
+  };
+}
+
+function withReminderActionProvenance(
+  turn: RunSharedAgentTurnResult,
+  input: RunSharedAgentTurnInput,
+): RunSharedAgentTurnResult {
+  const provenance = reminderActionProvenance(
+    turn.actionResults,
+    input.execution?.reminders?.delivery,
+  );
+  if (!provenance) return turn;
+  const history = [...turn.history];
+  const assistantIndex = input.messageIds?.assistant
+    ? history.findLastIndex(
+        (message) => message.role === "assistant" && message.id === input.messageIds?.assistant,
+      )
+    : history.findLastIndex((message) => message.role === "assistant");
+  if (assistantIndex < 0) return turn;
+  history[assistantIndex] = {
+    ...history[assistantIndex],
+    reminderAction: provenance,
+  };
+  return { ...turn, history };
 }
 
 function isWebSearchActionResult(result: ActionResult): boolean {
@@ -537,32 +653,46 @@ async function commitSharedTurnMemory(
   });
 }
 
-function hasGroundedReminderPredecessor(history: SharedTurnMessage[]): boolean {
+function trustedReminderPredecessor(
+  history: SharedTurnMessage[],
+  delivery: SharedReminderDelivery | undefined,
+): SharedReminderActionProvenance | undefined {
+  if (!delivery) return undefined;
   const previous = history.at(-1);
-  if (previous?.role !== "assistant") return false;
-  return /^(?:Your reminders:|You have no (?:active )?reminders?\.|Got it — I'll remind|That reminder is already set|Reminder (?:snoozed|completed|dismissed|deleted)|Updated reminder:|Cleared \d+ reminders?\.|Clearing removes every active reminder\.|More than one reminder matches)/iu.test(
-    previous.content.trim(),
-  );
+  const provenance = parseSharedReminderActionProvenance(previous?.reminderAction);
+  if (
+    previous?.role !== "assistant" ||
+    previous.interrupted === true ||
+    provenance?.deliveryScope !== reminderDeliveryScope(delivery)
+  ) {
+    return undefined;
+  }
+  const operation = provenance.operation;
+  if (!SHARED_REMINDER_OPERATIONS.has(operation)) return undefined;
+  return provenance;
 }
 
-function hasGroundedReminderScheduleConfirmation(history: SharedTurnMessage[]): boolean {
-  const previous = history.at(-1);
-  return (
-    previous?.role === "assistant" &&
-    /^(?:Got it — I'll remind|That reminder is already set|Updated reminder:)/iu.test(
-      previous.content.trim(),
-    )
-  );
+function groundedReminderSchedule(
+  history: SharedTurnMessage[],
+  delivery: SharedReminderDelivery | undefined,
+): SharedReminderActionProvenance | undefined {
+  const previous = trustedReminderPredecessor(history, delivery);
+  return previous?.success === true &&
+    (previous.operation === "create" || previous.operation === "update") &&
+    previous.taskIds.length === 1
+    ? previous
+    : undefined;
 }
 
-const REMINDER_CLEAR_CONFIRMATION_CHALLENGE =
-  "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.";
-
-function hasGroundedReminderClearChallenge(history: SharedTurnMessage[]): boolean {
-  const previous = history.at(-1);
-  return (
-    previous?.role === "assistant" &&
-    previous.content.trim() === REMINDER_CLEAR_CONFIRMATION_CHALLENGE
+function hasGroundedReminderClearChallenge(
+  history: SharedTurnMessage[],
+  delivery: SharedReminderDelivery | undefined,
+): boolean {
+  const previous = trustedReminderPredecessor(history, delivery);
+  return Boolean(
+    previous?.operation === "clear" &&
+      previous.success === false &&
+      previous.requiresConfirmation === true,
   );
 }
 
@@ -602,7 +732,7 @@ function isExplicitReminderClearAllIntent(text: string): boolean {
   const confirmation =
     "(?:yes|yep|oui|confirm|confirmed|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)";
   const clearCommand =
-    "(?:(?:clear|clean|delete|remove) (?:(?:all (?:(?:my|the) )?|my )reminders|the reminder list|the list)|(?:efface|supprime|vide) (?:tous mes rappels|la liste des rappels))";
+    "(?:(?:clear|clean|delete|remove|dismiss|cancel) (?:(?:all (?:(?:my|the) )?|my )reminders|the reminder list|the list)|(?:efface|supprime|vide) (?:tous mes rappels|la liste des rappels))";
   return new RegExp(
     `^(?:${confirmation} )*${POSITIVE_REMINDER_COMMAND_PREFIX}${clearCommand}\\b(?: .*)?$`,
     "iu",
@@ -631,7 +761,7 @@ function isExplicitReminderCreationIntent(text: string): boolean {
     return true;
   }
   const scheduleCue =
-    /\b(?:today|tomorrow|tonight|noon|midnight|next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|in \d+ (?:minute|minutes|hour|hours|day|days|week|weeks)|at \d{1,2}(?: \d{2})?(?: am| pm)?|\d{1,2}(?: \d{2})? (?:am|pm)|every (?:day|weekday|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d+ (?:minute|minutes|hour|hours|day|days|week|weeks))|on (?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}(?: \d{1,2})?))\b/iu;
+    /\b(?:today|tomorrow|tonight|noon|midnight|next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|in (?:\d+|an?|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve) (?:minute|minutes|hour|hours|day|days|week|weeks)|at \d{1,2}(?: \d{2})?(?: am| pm)?|\d{1,2}(?: \d{2})? (?:am|pm)|every (?:day|weekday|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d+ (?:minute|minutes|hour|hours|day|days|week|weeks))|on (?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}(?: \d{1,2})?))\b/iu;
   if (!scheduleCue.test(normalized)) return false;
   return new RegExp(`^${POSITIVE_REMINDER_COMMAND_PREFIX}remind me\\b.+$`, "iu").test(normalized);
 }
@@ -641,35 +771,120 @@ function isExplicitReminderUpdateIntent(text: string): boolean {
   return Boolean(
     normalized &&
       new RegExp(
-        `^${POSITIVE_REMINDER_COMMAND_PREFIX}(?:change|update|edit|reschedule) (?:the |my )?reminder\\b`,
+        `^${POSITIVE_REMINDER_COMMAND_PREFIX}(?:change|update|edit|reschedule)\\b[\\s\\S]{0,80}\\breminder\\b`,
         "iu",
       ).test(normalized),
   );
 }
 
-function trustedReminderOperationIntent(text: string): "create" | "list" | "delete" | undefined {
+type TrustedReminderIntent = {
+  operation: Exclude<SharedReminderOperation, "clear">;
+  target?: string;
+};
+
+function reminderTargetAfterCommandNoun(
+  normalized: string,
+  operations: string,
+): string | undefined {
+  const match = normalized.match(
+    new RegExp(
+      `^${POSITIVE_REMINDER_COMMAND_PREFIX}(?:${operations}) (?:the |my )?reminder(?: (?:named|called))?(?: (.+?))?(?: please)?$`,
+      "iu",
+    ),
+  );
+  return match?.[1]?.trim() || undefined;
+}
+
+function updateTargetBeforeSchedule(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const match = value.match(
+    /^(.+)\s+(?:to|at|for)\s+(?:(?:at|in)\s+)?(?:\d{1,2}(?:\s+\d{2})?\s*(?:am|pm)?|today|tomorrow|tonight|noon|midnight|next\b|every\b|on\b|in\b)[\s\S]*$/iu,
+  );
+  return match?.[1]?.trim() || value;
+}
+
+function snoozeTargetBeforeDuration(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const match = value.match(
+    /^(.+)\s+(?:for\s+(?:\d+|an?|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:minutes?|hours?|days?)|until\s+.+)$/iu,
+  );
+  return match?.[1]?.trim() || value;
+}
+
+function trustedReminderOperationIntent(text: string): TrustedReminderIntent | undefined {
   const normalized = normalizedReminderOperationCommand(text);
   if (!normalized || isExplicitReminderClearAllIntent(text)) return undefined;
-  if (isExplicitReminderCreationIntent(text)) return "create";
+  if (isExplicitReminderCreationIntent(text)) return { operation: "create" };
   if (
-    /^(?:(?:can|could|would) you (?:please )?|please )?(?:(?:list|show)(?: me)?(?: all)?(?: (?:the|my))? reminders|what reminders do i have|do i have any reminders)(?: please)?$/iu.test(
+    /^(?:(?:can|could|would) you (?:please )?|please )?(?:(?:list|show)(?: me)?(?: all)?(?: (?:the|my))? reminders?|what reminders do i have|do i have any reminders)(?: please)?$/iu.test(
       normalized,
     )
   ) {
-    return "list";
+    return { operation: "list" };
   }
+  const deleteTarget = reminderTargetAfterCommandNoun(normalized, "remove|delete");
+  if (deleteTarget) {
+    return { operation: "delete", target: deleteTarget };
+  }
+  const dismissTarget = reminderTargetAfterCommandNoun(normalized, "dismiss|cancel");
+  if (dismissTarget) {
+    return { operation: "dismiss", target: dismissTarget };
+  }
+  if (isExplicitReminderUpdateIntent(text)) {
+    return {
+      operation: "update",
+      target: updateTargetBeforeSchedule(
+        reminderTargetAfterCommandNoun(normalized, "change|update|edit|reschedule"),
+      ),
+    };
+  }
+  const targetedMutation = normalized.match(
+    /^(?:(?:can|could|would) you (?:please )?|please )?(snooze|complete|dismiss)\b[\s\S]*\breminder\b/iu,
+  );
+  const operation = targetedMutation?.[1]?.toLocaleLowerCase("en-US") as
+    | "snooze"
+    | "complete"
+    | "dismiss"
+    | undefined;
+  if (operation) {
+    const target = reminderTargetAfterCommandNoun(normalized, operation);
+    return {
+      operation,
+      target: operation === "snooze" ? snoozeTargetBeforeDuration(target) : target,
+    };
+  }
+  return undefined;
+}
+
+function contextualReminderOperationIntent(
+  text: string,
+): Exclude<SharedReminderOperation, "create" | "list" | "clear"> | undefined {
+  const normalized = normalizedReminderOperationCommand(text);
+  if (!normalized) return undefined;
+  if (/\b(?:remove|delete)\b/iu.test(normalized)) return "delete";
+  if (/\b(?:dismiss|cancel)\b/iu.test(normalized)) return "dismiss";
+  if (/\bsnooze\b/iu.test(normalized)) return "snooze";
+  if (/\bcomplete\b/iu.test(normalized)) return "complete";
   if (
-    /^(?:(?:can|could|would) you (?:please )?|please )?(?:remove|delete|dismiss|cancel) (?:the )?reminder(?: (?:named|called))? .+(?: please)?$/iu.test(
+    /\b(?:update|change|edit|reschedule)\b/iu.test(normalized) ||
+    isReminderClockCorrectionText(text) ||
+    /^(?:(?:the )?(?:\d{1,2}:\d{2}(?:\s*(?:am|pm))?|first|second|third|1st|2nd|3rd)(?: one)?)$/iu.test(
       normalized,
     )
   ) {
-    return "delete";
+    return "update";
   }
   return undefined;
 }
 
 function isContextualReminderFollowup(input: RunSharedAgentTurnInput): boolean {
-  if (!hasGroundedReminderPredecessor(input.history)) return false;
+  const predecessor = trustedReminderPredecessor(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
+  if (!predecessor) {
+    return false;
+  }
   const text = (input.capabilityText ?? input.message).trim();
   if (!text) return false;
   const normalizedConfirmation = text
@@ -684,7 +899,11 @@ function isContextualReminderFollowup(input: RunSharedAgentTurnInput): boolean {
       normalizedConfirmation,
     )
   ) {
-    return true;
+    return (
+      predecessor.operation === "clear" &&
+      predecessor.success === false &&
+      predecessor.requiresConfirmation === true
+    );
   }
   if (
     /^(?:(?:can|could|would)\s+you\s+|please\s+)?(?:clear|clean|remove|delete|dismiss|cancel|update|change|edit|reschedule|snooze|complete)\b[\s\S]{0,80}$/iu.test(
@@ -711,8 +930,19 @@ function capabilityResolution(
   capabilities: { reminders: boolean; todos: boolean },
   explicit: SharedCapabilityResolution | null,
 ): SharedCapabilityResolution | null {
-  if (explicit || !isContextualReminderFollowup(input)) return explicit;
-  return resolveSharedCapabilityIntent("update reminder", capabilities);
+  if (!isContextualReminderFollowup(input)) return explicit;
+  const contextual = resolveSharedCapabilityIntent("update reminder", capabilities);
+  if (
+    contextual?.kind === "enabled-primary" &&
+    explicit?.kind === "blocked-primary" &&
+    explicit.blocked.capability !== "reminders"
+  ) {
+    return {
+      ...contextual,
+      blockedSecondary: [explicit.blocked],
+    };
+  }
+  return explicit ?? contextual;
 }
 
 function withCapabilityResolution(
@@ -762,17 +992,43 @@ export async function runSharedAgentTurn(
   const explicitResolution = resolveSharedCapabilityIntent(reminderIntentText, capabilities);
   const resolution = capabilityResolution(input, capabilities, explicitResolution);
   const requiredAction = requiredActionForTurn(input, resolution, actionsEnabled);
+  const reminderScheduleProvenance = groundedReminderSchedule(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
   const reminderClockCorrection =
     requiredAction === "REMINDERS" &&
-    hasGroundedReminderScheduleConfirmation(input.history) &&
+    reminderScheduleProvenance !== undefined &&
     isReminderClockCorrectionText(reminderIntentText) &&
     (!explicitResolution || isExplicitReminderUpdateIntent(reminderIntentText)) &&
     !isExplicitReminderCreationIntent(reminderIntentText);
-  const reminderClearConfirmationChallenge = hasGroundedReminderClearChallenge(input.history);
+  const reminderClearConfirmationChallenge = hasGroundedReminderClearChallenge(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
   const reminderClearAllIntent =
     isExplicitReminderClearAllIntent(reminderIntentText) ||
     (reminderClearConfirmationChallenge && isShortReminderClearConfirmation(reminderIntentText));
-  const reminderOperationIntent = trustedReminderOperationIntent(reminderIntentText);
+  const trustedReminderIntent = trustedReminderOperationIntent(reminderIntentText);
+  const trustedPredecessor = trustedReminderPredecessor(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
+  const contextualOperationIntent = isContextualReminderFollowup(input)
+    ? contextualReminderOperationIntent(reminderIntentText)
+    : undefined;
+  const reminderOperationIntent = trustedReminderIntent?.operation ?? contextualOperationIntent;
+  const reminderTargetIntent = reminderClockCorrection
+    ? reminderScheduleProvenance?.taskIds[0]
+    : (trustedReminderIntent?.target ??
+      (contextualOperationIntent && trustedPredecessor?.taskIds.length === 1
+        ? trustedPredecessor.taskIds[0]
+        : undefined));
+  const expectedReminderOperation = reminderClearAllIntent
+    ? "clear"
+    : reminderClockCorrection
+      ? "update"
+      : reminderOperationIntent;
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -862,6 +1118,7 @@ export async function runSharedAgentTurn(
         reminderClearConfirmationChallenge,
         reminderClearAllIntent,
         reminderOperationIntent,
+        reminderTargetIntent,
         ...(realtimeGrounding ? { realtimeGrounding } : {}),
         ...(realtimeActionResults ? { preflightActionResults: realtimeActionResults } : {}),
       }),
@@ -874,7 +1131,14 @@ export async function runSharedAgentTurn(
       );
       turn = { ...turn, actionResults: [...realtimeActionResults, ...runtimeActionResults] };
     }
-    if (requiredAction && !hasRequiredActionResult(turn, requiredAction)) {
+    if (
+      requiredAction &&
+      !hasRequiredActionResult(
+        turn,
+        requiredAction,
+        requiredAction === "REMINDERS" ? expectedReminderOperation : undefined,
+      )
+    ) {
       throw new Error(
         `Eliza Shared runtime completed an executable ${requiredAction} request without an action result`,
       );
@@ -943,6 +1207,7 @@ export async function runSharedAgentTurn(
   // The durable memory commit runs OUTSIDE the provider try/catch: its failure
   // is a storage fault on an already-landed reply and must not be re-labeled
   // as a provider outcome for the caller's settlement classification.
+  turn = withReminderActionProvenance(turn, input);
   await commitSharedTurnMemory(input, turn.reply);
   return turn;
 }
@@ -970,17 +1235,38 @@ export async function runSharedAgentTurnStream(
   const explicitResolution = resolveSharedCapabilityIntent(reminderIntentText, capabilities);
   const resolution = capabilityResolution(input, capabilities, explicitResolution);
   const requiredAction = requiredActionForTurn(input, resolution, actionsEnabled);
+  const reminderScheduleProvenance = groundedReminderSchedule(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
   const reminderClockCorrection =
     requiredAction === "REMINDERS" &&
-    hasGroundedReminderScheduleConfirmation(input.history) &&
+    reminderScheduleProvenance !== undefined &&
     isReminderClockCorrectionText(reminderIntentText) &&
     (!explicitResolution || isExplicitReminderUpdateIntent(reminderIntentText)) &&
     !isExplicitReminderCreationIntent(reminderIntentText);
-  const reminderClearConfirmationChallenge = hasGroundedReminderClearChallenge(input.history);
+  const reminderClearConfirmationChallenge = hasGroundedReminderClearChallenge(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
   const reminderClearAllIntent =
     isExplicitReminderClearAllIntent(reminderIntentText) ||
     (reminderClearConfirmationChallenge && isShortReminderClearConfirmation(reminderIntentText));
-  const reminderOperationIntent = trustedReminderOperationIntent(reminderIntentText);
+  const trustedReminderIntent = trustedReminderOperationIntent(reminderIntentText);
+  const trustedPredecessor = trustedReminderPredecessor(
+    input.history,
+    input.execution?.reminders?.delivery,
+  );
+  const contextualOperationIntent = isContextualReminderFollowup(input)
+    ? contextualReminderOperationIntent(reminderIntentText)
+    : undefined;
+  const reminderOperationIntent = trustedReminderIntent?.operation ?? contextualOperationIntent;
+  const reminderTargetIntent = reminderClockCorrection
+    ? reminderScheduleProvenance?.taskIds[0]
+    : (trustedReminderIntent?.target ??
+      (contextualOperationIntent && trustedPredecessor?.taskIds.length === 1
+        ? trustedPredecessor.taskIds[0]
+        : undefined));
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -1023,6 +1309,12 @@ export async function runSharedAgentTurnStream(
       history: turn.history,
       ...(turn.actionResults?.length ? { actionResults: turn.actionResults } : {}),
       ...(turn.internalGrounding ? { internalGrounding: turn.internalGrounding } : {}),
+      ...(turn.capabilityWall ? { capabilityWall: turn.capabilityWall } : {}),
+      ...(turn.blockedSecondaryCapabilities?.length
+        ? {
+            blockedSecondaryCapabilities: turn.blockedSecondaryCapabilities,
+          }
+        : {}),
       parts,
     };
   }
@@ -1061,6 +1353,7 @@ export async function runSharedAgentTurnStream(
       reminderClearConfirmationChallenge,
       reminderClearAllIntent,
       reminderOperationIntent,
+      reminderTargetIntent,
     });
     return withStreamCapabilityResolution(stream, capabilityWall, blockedSecondary);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -10,6 +10,11 @@ import {
 describe("Shared capability wall", () => {
   test.each([
     ["remind me tomorrow at 9", "reminders"],
+    ["Clean the reminder list please", "reminders"],
+    ["Remove the reminder add something in my todo", "reminders"],
+    ["update my Stretch reminder", "reminders"],
+    ["clear all my reminders", "reminders"],
+    ["delete the Stretch reminder", "reminders"],
     ["add milk to my todo list", "todos"],
     ["add milk to my tasks", "todos"],
     ["show my checklist", "todos"],
@@ -58,6 +63,7 @@ describe("Shared capability wall", () => {
     "Give me two ideas for making a meeting shorter.",
     "Remember this code word for my next message: apricot-816.",
     "Make this message shorter.",
+    "Can you clear the list?",
   ])("keeps discussion and research in Shared: %s", (message) => {
     expect(resolveSharedCapabilityWall(message)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -13,7 +13,11 @@ describe("Shared capability wall", () => {
     ["Clean the reminder list please", "reminders"],
     ["Remove the reminder add something in my todo", "reminders"],
     ["update my Stretch reminder", "reminders"],
+    ["Snooze my reminder Stretch for 5 minutes", "reminders"],
+    ["Complete the reminder Stretch", "reminders"],
     ["clear all my reminders", "reminders"],
+    ["Dismiss all reminders", "reminders"],
+    ["Cancel all my reminders", "reminders"],
     ["delete the Stretch reminder", "reminders"],
     ["add milk to my todo list", "todos"],
     ["add milk to my tasks", "todos"],
@@ -64,6 +68,9 @@ describe("Shared capability wall", () => {
     "Remember this code word for my next message: apricot-816.",
     "Make this message shorter.",
     "Can you clear the list?",
+    "Could you not update my reminder?",
+    "I don't want you to update my reminder to 3pm",
+    "Don’t update my reminder",
   ])("keeps discussion and research in Shared: %s", (message) => {
     expect(resolveSharedCapabilityWall(message)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -71,6 +71,7 @@ describe("Shared capability wall", () => {
     "Could you not update my reminder?",
     "I don't want you to update my reminder to 3pm",
     "Don’t update my reminder",
+    "Update the reminder Stretch to 4pm, actually don't",
   ])("keeps discussion and research in Shared: %s", (message) => {
     expect(resolveSharedCapabilityWall(message)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -37,14 +37,14 @@ export type SharedCapabilityResolution =
     };
 
 const NON_EXECUTION_CONTEXT =
-  /^(?:please\s+)?(?:(?:can|could|would)\s+you\s+)?(?:do\s+not|don't|dont|never|explain|describe|define|translate|teach\s+me|tell\s+me\s+how|show\s+me\s+how|how\s+(?:do|would|can|to)|what\s+(?:is|are|would|happens?)|why\s+(?:do|would|can|is|are)|if\s+(?:i|we|you)|before\s+you)\b/i;
+  /^(?:please\s+)?(?:(?:(?:can|could|would)\s+you\s+(?:please\s+)?(?:not|avoid|refrain\s+from|explain|describe|define|translate|tell\s+me\s+how|show\s+me\s+how))|(?:i\s+)?(?:do\s+not|don['’]?t|dont)(?:\s+want\s+(?:you\s+)?to)?|never|explain|describe|define|translate|teach\s+me|tell\s+me\s+how|show\s+me\s+how|how\s+(?:do|would|can|to)|what\s+(?:is|are|would|happens?)|why\s+(?:do|would|can|is|are)|if\s+(?:i|we|you)|before\s+you)\b/i;
 
 const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
   {
     capability: "reminders",
     label: "Reminders",
     pattern:
-      /\b(?:remind\s+me|(?:set|create|add|schedule|cancel|delete|remove|dismiss|change|update|edit|reschedule|list|show|clear|clean)\b[\s\S]{0,48}\breminders?)\b/i,
+      /\b(?:remind\s+me|(?:set|create|add|schedule|cancel|delete|remove|dismiss|change|update|edit|reschedule|snooze|complete|list|show|clear|clean)\b[\s\S]{0,48}\breminders?)\b/i,
     constraint:
       "This transport has no trusted reminder delivery, so it cannot create, change, list, or deliver reminders.",
   },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -44,7 +44,7 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     capability: "reminders",
     label: "Reminders",
     pattern:
-      /\b(?:remind\s+me|(?:set|create|add|schedule|cancel|delete|change|list|show)\b[\s\S]{0,36}\breminders?)\b/i,
+      /\b(?:remind\s+me|(?:set|create|add|schedule|cancel|delete|remove|dismiss|change|update|edit|reschedule|list|show|clear|clean)\b[\s\S]{0,48}\breminders?)\b/i,
     constraint:
       "This transport has no trusted reminder delivery, so it cannot create, change, list, or deliver reminders.",
   },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -39,6 +39,17 @@ export type SharedCapabilityResolution =
 const NON_EXECUTION_CONTEXT =
   /^(?:please\s+)?(?:(?:(?:can|could|would)\s+you\s+(?:please\s+)?(?:not|avoid|refrain\s+from|explain|describe|define|translate|tell\s+me\s+how|show\s+me\s+how))|(?:i\s+)?(?:do\s+not|don['’]?t|dont)(?:\s+want\s+(?:you\s+)?to)?|never|explain|describe|define|translate|teach\s+me|tell\s+me\s+how|show\s+me\s+how|how\s+(?:do|would|can|to)|what\s+(?:is|are|would|happens?)|why\s+(?:do|would|can|is|are)|if\s+(?:i|we|you)|before\s+you)\b/i;
 
+/** A final explicit retraction cancels the executable clauses before it. */
+export function hasTrailingSharedActionCancellation(message: string | undefined): boolean {
+  const text = (message ?? "").trim();
+  return Boolean(
+    text &&
+      /(?:\b(?:actually|wait)[\s,]*(?:(?:do\s+not|don['’]?t|dont)(?:\s+(?:do\s+(?:that|it)|(?:update|change|delete|remove|dismiss|cancel|complete|snooze|set|create|schedule)\s+(?:that|it)))?|never\s+mind)|\b(?:never\s+mind|cancel\s+(?:that|it)|forget\s+(?:that|it)|scratch\s+that))\s*[.!?]*$/iu.test(
+        text,
+      ),
+  );
+}
+
 const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
   {
     capability: "reminders",
@@ -211,7 +222,7 @@ export function resolveSharedCapabilityIntent(
   capabilities: { reminders?: boolean; todos?: boolean } = {},
 ): SharedCapabilityResolution | null {
   const text = (message ?? "").trim();
-  if (!text) return null;
+  if (!text || hasTrailingSharedActionCancellation(text)) return null;
   const matches = RULES.flatMap((rule, priority) => matchesForRule(rule, priority, text)).sort(
     (left, right) => left.index - right.index || left.priority - right.priority,
   );

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -2370,6 +2370,7 @@ describe("Shared Eliza Workerd runtime", () => {
           delivery: {
             platform: "telegram",
             project: "eliza-app",
+            connectorAccountId: "bot:123456789",
             chatId: "123456789",
           },
         },
@@ -2389,6 +2390,7 @@ describe("Shared Eliza Workerd runtime", () => {
         delivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456789",
         },
       },
@@ -2418,11 +2420,13 @@ describe("Shared Eliza Workerd runtime", () => {
 
   test.each([
     {
+      scenario: "list success",
       operation: "list",
       parameters: { operation: "list" },
       expected: "Your reminders:\n• Stretch — on Aug 14, 2026 at 8:02 PM UTC",
     },
     {
+      scenario: "snooze success",
       operation: "snooze",
       parameters: {
         operation: "snooze",
@@ -2432,6 +2436,7 @@ describe("Shared Eliza Workerd runtime", () => {
       expected: "Reminder snoozed for 5 minutes: Stretch",
     },
     {
+      scenario: "complete success",
       operation: "complete",
       parameters: {
         operation: "complete",
@@ -2440,6 +2445,7 @@ describe("Shared Eliza Workerd runtime", () => {
       expected: "Reminder completed: Stretch",
     },
     {
+      scenario: "dismiss success",
       operation: "dismiss",
       parameters: {
         operation: "dismiss",
@@ -2447,9 +2453,20 @@ describe("Shared Eliza Workerd runtime", () => {
       },
       expected: "Reminder dismissed: Stretch",
     },
+    {
+      scenario: "dismiss durable failure",
+      operation: "dismiss",
+      parameters: {
+        operation: "dismiss",
+        taskId: "shared-reminder-sensitive-1",
+      },
+      expected:
+        "I couldn't verify that reminder change, so I won't claim it succeeded. Please list your reminders before retrying.",
+      failApply: true,
+    },
   ])(
-    "keeps the verified $operation result authoritative over a hostile evaluator",
-    async ({ operation, parameters, expected }) => {
+    "keeps the verified $scenario result authoritative over a hostile evaluator",
+    async ({ operation, parameters, expected, failApply = false }) => {
       const modelRequests: Array<Record<string, unknown>> = [];
       const task: ScheduledTask = {
         taskId: "shared-reminder-sensitive-1",
@@ -2471,7 +2488,14 @@ describe("Shared Eliza Workerd runtime", () => {
         source: "user_chat",
         createdBy: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
         ownerVisible: true,
-        metadata: {},
+        metadata: {
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            connectorAccountId: "bot:123456789",
+            chatId: "123456789",
+          },
+        },
         executionProfile: "notify-only",
         state: { status: "scheduled", followupCount: 0 },
       };
@@ -2498,6 +2522,9 @@ describe("Shared Eliza Workerd runtime", () => {
         async applyWithResult(taskId, verb, _payload, options) {
           expect(taskId).toBe("shared-reminder-sensitive-1");
           expect(verb).toBe(operation);
+          if (failApply) {
+            throw new Error("injected durable reminder mutation failure");
+          }
           const transition =
             verb === "snooze"
               ? ("snoozed" as const)
@@ -2654,6 +2681,7 @@ describe("Shared Eliza Workerd runtime", () => {
             delivery: {
               platform: "telegram",
               project: "eliza-app",
+              connectorAccountId: "bot:123456789",
               chatId: "123456789",
             },
           },
@@ -2664,11 +2692,21 @@ describe("Shared Eliza Workerd runtime", () => {
       expect(result.reply).not.toMatch(/shared-reminder-sensitive-1|scheduled|2026-08-14T/);
       expect(modelRequests).toHaveLength(2);
       expect(result.actionResults?.[0]).toMatchObject({
+        success: !failApply,
         verifiedUserFacing: true,
         userFacingText: expected,
         turnComplete: true,
       });
-      if (operation !== "list") {
+      if (failApply) {
+        expect(result.actionResults?.[0]).toMatchObject({
+          data: {
+            actionName: "REMINDERS",
+            operation: "dismiss",
+            failureCode: "REMINDER_MUTATION_UNVERIFIED",
+          },
+        });
+        expect(result.actionResults?.[0]?.effectReceipts).toBeUndefined();
+      } else if (operation !== "list") {
         expect(result.actionResults?.[0]).toMatchObject({
           effectReceipts: [
             {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -2511,7 +2511,15 @@ describe("Shared Eliza Workerd runtime", () => {
             expect(filter).toEqual({
               kind: "reminder",
               ownerVisibleOnly: true,
-              status: ["scheduled", "fired", "acknowledged"],
+              status: [
+                "scheduled",
+                "fired",
+                "acknowledged",
+                "completed",
+                "skipped",
+                "expired",
+                "failed",
+              ],
             });
           }
           return [task];
@@ -2667,7 +2675,10 @@ describe("Shared Eliza Workerd runtime", () => {
           model: "gemma-4-31b",
         },
         history: [],
-        message: `Please ${operation} my reminder`,
+        message:
+          operation === "list"
+            ? "Please list my reminders"
+            : `Please ${operation} my reminder Stretch`,
         messageIds: {
           user: "7d734b8f-1ac5-456a-8bf3-9cd61dd546ef",
           assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -109,6 +109,14 @@ type SharedElizaRuntimeTurnInput = Omit<RunSharedAgentTurnInput, "execution"> & 
   execution: NonNullable<RunSharedAgentTurnInput["execution"]>;
   agentKey: string;
   model: string;
+  /** Derived only from a grounded assistant predecessor at the server boundary. */
+  reminderClockCorrection?: boolean;
+  /** Derived only from the immediately preceding grounded clear-all warning. */
+  reminderClearConfirmationChallenge?: boolean;
+  /** Server-owned classification that the current request targets all reminders. */
+  reminderClearAllIntent?: boolean;
+  /** High-confidence server classification that dominates a confused planner. */
+  reminderOperationIntent?: "create" | "list" | "delete";
   /** Server-executed current-turn public read, never transport supplied. */
   realtimeGrounding?: SharedRuntimePublicGrounding;
   /** Traceable action receipt for the server-executed public read. */
@@ -770,6 +778,10 @@ async function executeMeasuredSharedElizaRuntimeTurn(
           runner: input.execution.reminders.runner,
           agentId: input.agentKey,
           delivery: input.execution.reminders.delivery,
+          clockCorrection: input.reminderClockCorrection === true,
+          clearConfirmationChallenge: input.reminderClearConfirmationChallenge === true,
+          clearAllIntent: input.reminderClearAllIntent === true,
+          operationIntent: input.reminderOperationIntent,
         })
       : undefined;
   const todoPlugin =

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -67,6 +67,7 @@ import type {
   SharedAgentTurnStreamPart,
   SharedAgentTurnUsage,
   SharedMediaGenerationPort,
+  SharedReminderOperation,
   SharedTurnMessage,
 } from "./run-shared-agent-turn";
 import { appendSharedInput, appendSharedTurn } from "./run-shared-agent-turn";
@@ -116,7 +117,9 @@ type SharedElizaRuntimeTurnInput = Omit<RunSharedAgentTurnInput, "execution"> & 
   /** Server-owned classification that the current request targets all reminders. */
   reminderClearAllIntent?: boolean;
   /** High-confidence server classification that dominates a confused planner. */
-  reminderOperationIntent?: "create" | "list" | "delete";
+  reminderOperationIntent?: Exclude<SharedReminderOperation, "clear">;
+  /** Server-authenticated visible title or exact prior receipt resource id. */
+  reminderTargetIntent?: string;
   /** Server-executed current-turn public read, never transport supplied. */
   realtimeGrounding?: SharedRuntimePublicGrounding;
   /** Traceable action receipt for the server-executed public read. */
@@ -778,10 +781,12 @@ async function executeMeasuredSharedElizaRuntimeTurn(
           runner: input.execution.reminders.runner,
           agentId: input.agentKey,
           delivery: input.execution.reminders.delivery,
+          operationIntentRequired: true,
           clockCorrection: input.reminderClockCorrection === true,
           clearConfirmationChallenge: input.reminderClearConfirmationChallenge === true,
           clearAllIntent: input.reminderClearAllIntent === true,
           operationIntent: input.reminderOperationIntent,
+          targetIntent: input.reminderTargetIntent,
         })
       : undefined;
   const todoPlugin =

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -218,6 +218,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
           delivery: {
             platform: "telegram",
             project: "eliza-app",
+            connectorAccountId: "bot:123456789",
             chatId: "123456789",
           },
         },
@@ -225,7 +226,10 @@ describe("Shared reminder relative-delay runtime authority", () => {
     });
 
     if (atIso === undefined) {
-      expect(modelCall).toBeGreaterThanOrEqual(3);
+      // The reminder action now returns a verified, terminal clarification for
+      // an invalid or cancelled delay, so the runtime must not spend a third
+      // model call evaluating a failure it already grounded.
+      expect(modelCall).toBe(2);
       expect(result.actionResults?.[0]?.success).toBe(false);
       expect(scheduledInputs).toHaveLength(0);
     } else {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -9,6 +9,7 @@ process.env.MOCK_REDIS = "1";
 
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { ChannelType, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
+import type { SharedReminderActionProvenance } from "./run-shared-agent-turn";
 
 let turn: Record<string, unknown>;
 let streamTurn: Record<string, unknown>;
@@ -433,6 +434,7 @@ type TestMessage = {
   content: string;
   createdAt?: number;
   interrupted?: boolean;
+  reminderAction?: SharedReminderActionProvenance;
   grounding?:
     | {
         kind: "web_search";
@@ -1340,6 +1342,45 @@ describe("SharedRuntimeChatService", () => {
     expect(memoryScopes[0]?.roomKey).not.toBe(agent.id);
     await Promise.all(h.background);
     expect(settleCalls).toEqual([0.004]);
+  });
+
+  test("persists validated reminder action provenance from a buffered terminal stream", async () => {
+    const reminderAction = {
+      actionName: "REMINDERS" as const,
+      operation: "create" as const,
+      success: true,
+      taskIds: ["created-reminder-1"],
+      deliveryScope: '{"chatId":"room-1","platform":"telegram"}',
+    };
+    streamTurn = {
+      degraded: false,
+      get history() {
+        const assistantId = (lastStreamTurnInput?.messageIds as { assistant?: string } | undefined)
+          ?.assistant;
+        return [
+          {
+            id: assistantId,
+            role: "assistant",
+            content: "hello back",
+            reminderAction,
+          },
+        ];
+      },
+      parts: (async function* () {
+        yield { type: "text-delta", text: "hello " };
+        yield { type: "finish", text: "hello back" };
+      })(),
+    };
+    const h = harness();
+
+    await (await new SharedRuntimeChatService().stream(agent, rpc, h)).text();
+
+    expect(h.history().at(-1)).toMatchObject({
+      role: "assistant",
+      content: "hello back",
+      interrupted: false,
+      reminderAction,
+    });
   });
 
   test("terminal done frame is not held open by a stalled long-term-memory mirror (#25689)", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -97,7 +97,10 @@ import {
 } from "./shared-recall";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
-import { sharedRuntimeModelHistoryMessages } from "./shared-runtime-history-policy";
+import {
+  parseSharedReminderActionProvenance,
+  sharedRuntimeModelHistoryMessages,
+} from "./shared-runtime-history-policy";
 import { normalizeSharedRuntimeRoom } from "./shared-runtime-room-identity";
 import {
   replayedSharedProviderTiming,
@@ -1802,6 +1805,11 @@ export class SharedRuntimeChatService {
     }
 
     const encoder = new TextEncoder();
+    const terminalReminderAction = parseSharedReminderActionProvenance(
+      turn.history?.findLast(
+        (message) => message.role === "assistant" && message.id === messageIds.assistant,
+      )?.reminderAction,
+    );
     const makeTurnMessages = (
       reply: string,
       interrupted: boolean,
@@ -1820,6 +1828,9 @@ export class SharedRuntimeChatService {
           createdAt: sentAt + 1,
           interrupted,
           ...(grounding ? { grounding } : {}),
+          ...(terminalReminderAction && !interrupted
+            ? { reminderAction: terminalReminderAction }
+            : {}),
         });
       }
       return messages;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
@@ -13,6 +13,7 @@ import {
   MAX_PUBLIC_WEB_GROUNDING_FUTURE_SKEW_MS,
   mergeSharedRuntimeHistoryMessages,
   parseSharedPublicWebGrounding,
+  parseSharedReminderActionProvenance,
   type SharedRuntimeHistoryMessageLike,
   selectSharedRuntimeContext,
   sharedPublicWebGrounding,
@@ -78,6 +79,67 @@ describe("shared runtime history merge policy", () => {
     expect(
       mergeSharedRuntimeHistoryMessages([grounded], [{ ...grounded, grounding: undefined }]),
     ).toEqual([grounded]);
+  });
+
+  test("a stale same-message snapshot cannot erase validated reminder action provenance", () => {
+    const reminderAction = {
+      actionName: "REMINDERS" as const,
+      operation: "update" as const,
+      success: true,
+      taskIds: ["task-1"],
+      deliveryScope: '{"chatId":"123"}',
+    };
+    const complete = {
+      id: "assistant-reminder-1",
+      role: "assistant" as const,
+      content: "Updated reminder: Stretch",
+      createdAt: 3,
+      reminderAction,
+    };
+
+    expect(
+      mergeSharedRuntimeHistoryMessages([complete], [{ ...complete, reminderAction: undefined }]),
+    ).toEqual([complete]);
+    expect(parseSharedReminderActionProvenance(reminderAction)).toEqual(reminderAction);
+  });
+
+  test("drops malformed or conflicting reminder action provenance", () => {
+    const base = {
+      id: "assistant-reminder-conflict",
+      role: "assistant" as const,
+      content: "Updated reminder: Stretch",
+      createdAt: 3,
+    };
+    const first = {
+      ...base,
+      reminderAction: {
+        actionName: "REMINDERS" as const,
+        operation: "update" as const,
+        success: true,
+        taskIds: ["task-1"],
+        deliveryScope: '{"chatId":"123"}',
+      },
+    };
+    const conflicting = {
+      ...base,
+      reminderAction: {
+        ...first.reminderAction,
+        taskIds: ["task-2"],
+      },
+    };
+    const malformed = {
+      ...base,
+      id: "assistant-reminder-malformed",
+      reminderAction: {
+        ...first.reminderAction,
+        deliveryScope: "",
+      },
+    };
+
+    expect(mergeSharedRuntimeHistoryMessages([first], [conflicting])).toEqual([base]);
+    expect(mergeSharedRuntimeHistoryMessages([], [malformed])).toEqual([
+      { ...base, id: "assistant-reminder-malformed" },
+    ]);
   });
 
   test("stale snapshots merge by id, reject invalid entries, and retain every turn", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
@@ -103,6 +103,41 @@ describe("shared runtime history merge policy", () => {
     expect(parseSharedReminderActionProvenance(reminderAction)).toEqual(reminderAction);
   });
 
+  test("bounds and authenticates ordered reminder ambiguity candidates", () => {
+    const ambiguity = {
+      actionName: "REMINDERS" as const,
+      operation: "delete" as const,
+      success: false,
+      requiresSelection: true as const,
+      taskIds: [],
+      candidateTaskIds: ["candidate-a", "candidate-a", "candidate-b"],
+      deliveryScope: '{"chatId":"123"}',
+    };
+
+    expect(parseSharedReminderActionProvenance(ambiguity)).toMatchObject({
+      requiresSelection: true,
+      candidateTaskIds: ["candidate-a", "candidate-b"],
+    });
+    expect(
+      parseSharedReminderActionProvenance({
+        ...ambiguity,
+        requiresSelection: undefined,
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderActionProvenance({
+        ...ambiguity,
+        success: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderActionProvenance({
+        ...ambiguity,
+        candidateTaskIds: Array.from({ length: 101 }, (_, index) => `candidate-${index}`),
+      }),
+    ).toBeUndefined();
+  });
+
   test("drops malformed or conflicting reminder action provenance", () => {
     const base = {
       id: "assistant-reminder-conflict",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -171,10 +171,18 @@ export function parseSharedReminderActionProvenance(
     ) ||
     typeof candidate.success !== "boolean" ||
     (candidate.requiresConfirmation !== undefined && candidate.requiresConfirmation !== true) ||
+    (candidate.requiresSelection !== undefined && candidate.requiresSelection !== true) ||
     typeof candidate.deliveryScope !== "string" ||
     !candidate.deliveryScope.trim() ||
     !Array.isArray(candidate.taskIds) ||
-    candidate.taskIds.some((taskId) => typeof taskId !== "string" || !taskId.trim())
+    candidate.taskIds.some((taskId) => typeof taskId !== "string" || !taskId.trim()) ||
+    (candidate.requiresSelection === true
+      ? candidate.success !== false ||
+        !Array.isArray(candidate.candidateTaskIds) ||
+        candidate.candidateTaskIds.length === 0 ||
+        candidate.candidateTaskIds.length > 100 ||
+        candidate.candidateTaskIds.some((taskId) => typeof taskId !== "string" || !taskId.trim())
+      : candidate.candidateTaskIds !== undefined)
   ) {
     return undefined;
   }
@@ -183,7 +191,13 @@ export function parseSharedReminderActionProvenance(
     operation: candidate.operation as SharedRuntimeReminderActionProvenance["operation"],
     success: candidate.success,
     ...(candidate.requiresConfirmation === true ? { requiresConfirmation: true } : {}),
+    ...(candidate.requiresSelection === true ? { requiresSelection: true } : {}),
     taskIds: [...new Set(candidate.taskIds.map((taskId) => taskId.trim()))],
+    ...(candidate.requiresSelection === true && Array.isArray(candidate.candidateTaskIds)
+      ? {
+          candidateTaskIds: [...new Set(candidate.candidateTaskIds.map((taskId) => taskId.trim()))],
+        }
+      : {}),
     deliveryScope: candidate.deliveryScope.trim(),
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -9,6 +9,7 @@ import type { ModelMessage } from "ai";
 import type {
   SharedRuntimeHistoryMessage,
   SharedRuntimePublicGrounding,
+  SharedRuntimeReminderActionProvenance,
 } from "../../../db/schemas/shared-runtime-history";
 import { logger } from "../../utils/logger";
 
@@ -142,6 +143,48 @@ export function parseSharedPublicWebGrounding(
     sourceUrls: sources.map((source) => source.url),
     sources,
     truncated: false,
+  };
+}
+
+const REMINDER_OPERATIONS = new Set<SharedRuntimeReminderActionProvenance["operation"]>([
+  "create",
+  "list",
+  "update",
+  "snooze",
+  "complete",
+  "delete",
+  "dismiss",
+  "clear",
+]);
+
+/** Validates persisted mutation provenance without trusting assistant text. */
+export function parseSharedReminderActionProvenance(
+  value: unknown,
+): SharedRuntimeReminderActionProvenance | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.actionName !== "REMINDERS" ||
+    typeof candidate.operation !== "string" ||
+    !REMINDER_OPERATIONS.has(
+      candidate.operation as SharedRuntimeReminderActionProvenance["operation"],
+    ) ||
+    typeof candidate.success !== "boolean" ||
+    (candidate.requiresConfirmation !== undefined && candidate.requiresConfirmation !== true) ||
+    typeof candidate.deliveryScope !== "string" ||
+    !candidate.deliveryScope.trim() ||
+    !Array.isArray(candidate.taskIds) ||
+    candidate.taskIds.some((taskId) => typeof taskId !== "string" || !taskId.trim())
+  ) {
+    return undefined;
+  }
+  return {
+    actionName: "REMINDERS",
+    operation: candidate.operation as SharedRuntimeReminderActionProvenance["operation"],
+    success: candidate.success,
+    ...(candidate.requiresConfirmation === true ? { requiresConfirmation: true } : {}),
+    taskIds: [...new Set(candidate.taskIds.map((taskId) => taskId.trim()))],
+    deliveryScope: candidate.deliveryScope.trim(),
   };
 }
 
@@ -512,7 +555,15 @@ function chooseMergedMessage<T extends SharedRuntimeHistoryMessageLike>(
   current: T | undefined,
   incoming: T,
 ): T {
-  if (!current) return incoming;
+  if (!current) {
+    if (incoming.role !== "assistant") return incoming;
+    const { reminderAction: _untrustedReminderAction, ...rest } = incoming;
+    const reminderAction = parseSharedReminderActionProvenance(incoming.reminderAction);
+    return {
+      ...rest,
+      ...(reminderAction ? { reminderAction } : {}),
+    } as T;
+  }
   if (
     current.role === "assistant" &&
     incoming.role === "assistant" &&
@@ -534,16 +585,29 @@ function chooseMergedMessage<T extends SharedRuntimeHistoryMessageLike>(
   if (current.role !== "assistant" || incoming.role !== "assistant") return chosen;
   const currentGrounding = parseSharedPublicWebGrounding(current.grounding);
   const incomingGrounding = parseSharedPublicWebGrounding(incoming.grounding);
-  if (!currentGrounding && !incomingGrounding) return chosen;
-  if (!currentGrounding) return { ...chosen, grounding: incomingGrounding };
-  if (!incomingGrounding) return { ...chosen, grounding: currentGrounding };
-  const grounding =
-    incomingGrounding.observedAt > currentGrounding.observedAt ||
-    (incomingGrounding.observedAt === currentGrounding.observedAt &&
-      JSON.stringify(incomingGrounding) > JSON.stringify(currentGrounding))
-      ? incomingGrounding
-      : currentGrounding;
-  return { ...chosen, grounding };
+  const grounding = !currentGrounding
+    ? incomingGrounding
+    : !incomingGrounding
+      ? currentGrounding
+      : incomingGrounding.observedAt > currentGrounding.observedAt ||
+          (incomingGrounding.observedAt === currentGrounding.observedAt &&
+            JSON.stringify(incomingGrounding) > JSON.stringify(currentGrounding))
+        ? incomingGrounding
+        : currentGrounding;
+  const currentReminderAction = parseSharedReminderActionProvenance(current.reminderAction);
+  const incomingReminderAction = parseSharedReminderActionProvenance(incoming.reminderAction);
+  const reminderAction =
+    currentReminderAction && incomingReminderAction
+      ? JSON.stringify(currentReminderAction) === JSON.stringify(incomingReminderAction)
+        ? currentReminderAction
+        : undefined
+      : (currentReminderAction ?? incomingReminderAction);
+  const { reminderAction: _untrustedReminderAction, ...chosenWithoutReminderAction } = chosen;
+  return {
+    ...chosenWithoutReminderAction,
+    ...(grounding ? { grounding } : {}),
+    ...(reminderAction ? { reminderAction } : {}),
+  } as T;
 }
 
 export function compareSharedRuntimeHistoryMessages(

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -388,7 +388,11 @@ describe("In-memory scheduled task store receipt commits", () => {
         followupCount: 0,
         lastDecisionLog: decision,
       },
-      metadata: { schedulingApplyReceipts: { [receiptKey]: true } },
+      metadata: {
+        schedulingApplyReceipts: {
+          [receiptKey]: { manifest: receiptKey },
+        },
+      },
     });
     const commit = (
       logId: string,
@@ -427,8 +431,8 @@ describe("In-memory scheduled task store receipt commits", () => {
     const stored = await store.get(original.taskId);
     if (!stored) throw new Error("expected committed in-memory task");
     expect(stored.metadata?.schedulingApplyReceipts).toEqual({
-      "receipt-a": true,
-      "receipt-b": true,
+      "receipt-a": { manifest: "receipt-a" },
+      "receipt-b": { manifest: "receipt-b" },
     });
     expect(stored.state.lastDecisionLog).toBe("second proposal");
 

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -451,6 +451,77 @@ describe("In-memory scheduled task store receipt commits", () => {
   });
 });
 
+describe("ScheduledTaskRunner — pre-effect intent reservations", () => {
+  it("keeps one immutable manifest without changing lifecycle state or logs", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(baseInput());
+    const beforeLogs = await h.logStore.list({
+      agentId: "test-agent",
+      taskId: task.taskId,
+    });
+    const options = {
+      idempotencyKey: "message-clear:manifest",
+      context: { taskIds: ["task-a"] },
+    };
+
+    const reserved = await h.runner.reserveApplyIntent(task.taskId, options);
+    const replayed = await h.runner.reserveApplyIntent(task.taskId, options);
+
+    expect(reserved.replayed).toBe(false);
+    expect(replayed.replayed).toBe(true);
+    expect(replayed.task.state).toEqual(task.state);
+    expect(
+      Object.values(replayed.task.metadata?.schedulingApplyIntents ?? {}),
+    ).toEqual([options.context]);
+    await expect(
+      h.runner.reserveApplyIntent(task.taskId, {
+        ...options,
+        context: { taskIds: ["task-a", "task-b"] },
+      }),
+    ).rejects.toThrow("conflicting context");
+    expect(
+      await h.logStore.list({ agentId: "test-agent", taskId: task.taskId }),
+    ).toEqual(beforeLogs);
+  });
+
+  it("converges concurrent conflicting reservations on one exact manifest", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(baseInput());
+    const idempotencyKey = "message-delete:manifest";
+    const contexts = [
+      { taskIds: ["task-a"] },
+      { taskIds: ["task-a", "task-b"] },
+    ];
+
+    const results = await Promise.allSettled(
+      contexts.map((context) =>
+        h.runner.reserveApplyIntent(task.taskId, {
+          idempotencyKey,
+          context,
+        }),
+      ),
+    );
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+    const winnerIndex = results.findIndex(
+      (result) => result.status === "fulfilled",
+    );
+    expect(winnerIndex).toBeGreaterThanOrEqual(0);
+    const stored = await h.runner.reserveApplyIntent(task.taskId, {
+      idempotencyKey,
+      context: contexts[winnerIndex] as Record<string, unknown>,
+    });
+    expect(
+      Object.values(stored.task.metadata?.schedulingApplyIntents ?? {}),
+    ).toEqual([contexts[winnerIndex]]);
+  });
+});
+
 describe("ScheduledTaskRunner — every verb", () => {
   it("snooze sets future fire time and resets the escalation cursor", async () => {
     const h = makeHarness("2026-05-09T12:00:00.000Z");

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -274,11 +274,18 @@ export function createInMemoryScheduledTaskStore(): ScheduledTaskStore {
       // mutation remains authoritative, but receipt identity is monotonic and
       // must merge from the current stored row just like the SQL adapter does.
       const committedTask = structuredClone(task);
+      const proposedReceipts = committedTask.metadata?.schedulingApplyReceipts;
+      const proposedReceiptValue =
+        proposedReceipts !== null &&
+        typeof proposedReceipts === "object" &&
+        !Array.isArray(proposedReceipts)
+          ? ((proposedReceipts as Record<string, unknown>)[receiptKey] ?? true)
+          : true;
       committedTask.metadata = {
         ...(committedTask.metadata ?? {}),
         schedulingApplyReceipts: {
           ...receiptMarkers,
-          [receiptKey]: true,
+          [receiptKey]: proposedReceiptValue,
         },
       };
       map.set(task.taskId, committedTask);
@@ -500,6 +507,51 @@ async function applyReceiptKey(
   return sha256Hex(`${verb}\0${idempotencyKey}`);
 }
 
+/**
+ * Returns whether this exact lifecycle request already committed on a task.
+ * Consumers use it only to recover a receipt after a response/claim crash;
+ * terminal rows without the exact marker remain invisible to fresh mutations.
+ */
+export async function hasScheduledTaskApplyReceipt(
+  task: ScheduledTask,
+  verb: ScheduledTaskReceiptVerb,
+  idempotencyKey: string,
+): Promise<boolean> {
+  const normalizedKey = normalizeApplyIdempotencyKey(idempotencyKey);
+  const receiptKey = await applyReceiptKey(verb, normalizedKey);
+  const receipts = task.metadata?.[APPLY_RECEIPTS_METADATA_KEY];
+  return (
+    receipts !== null &&
+    typeof receipts === "object" &&
+    !Array.isArray(receipts) &&
+    Object.hasOwn(receipts, receiptKey)
+  );
+}
+
+/** Read context committed atomically with one exact lifecycle receipt. */
+export async function scheduledTaskApplyReceiptContext(
+  task: ScheduledTask,
+  verb: ScheduledTaskReceiptVerb,
+  idempotencyKey: string,
+): Promise<Record<string, unknown> | undefined> {
+  const normalizedKey = normalizeApplyIdempotencyKey(idempotencyKey);
+  const receiptKey = await applyReceiptKey(verb, normalizedKey);
+  const receipts = task.metadata?.[APPLY_RECEIPTS_METADATA_KEY];
+  if (
+    receipts === null ||
+    typeof receipts !== "object" ||
+    Array.isArray(receipts)
+  ) {
+    return undefined;
+  }
+  const context = (receipts as Record<string, unknown>)[receiptKey];
+  return context !== null &&
+    typeof context === "object" &&
+    !Array.isArray(context)
+    ? (context as Record<string, unknown>)
+    : undefined;
+}
+
 async function applyReceiptLogId(args: {
   agentId: string;
   taskId: string;
@@ -514,6 +566,7 @@ async function applyReceiptLogId(args: {
 function writeApplyReceiptMarker(
   task: ScheduledTask,
   receiptKey: string,
+  context?: Record<string, unknown>,
 ): void {
   const existing = task.metadata?.[APPLY_RECEIPTS_METADATA_KEY];
   const receipts =
@@ -526,7 +579,7 @@ function writeApplyReceiptMarker(
     ...(task.metadata ?? {}),
     [APPLY_RECEIPTS_METADATA_KEY]: {
       ...receipts,
-      [receiptKey]: true,
+      [receiptKey]: context ? structuredClone(context) : true,
     },
   };
 }
@@ -548,6 +601,13 @@ function isRecurringTrigger(trigger: ScheduledTask["trigger"]): boolean {
     trigger.kind === "relative_to_anchor" ||
     trigger.kind === "during_window"
   );
+}
+
+/** Public consumer classifier for rows that retain a future scheduler occurrence. */
+export function isScheduledTaskRecurring(
+  task: Pick<ScheduledTask, "trigger">,
+): boolean {
+  return isRecurringTrigger(task.trigger);
 }
 
 function setEscalationCursor(
@@ -1574,7 +1634,10 @@ export function createScheduledTaskRunner(
     taskId: string,
     verb: ScheduledTaskReceiptVerb,
     payload: unknown,
-    options: { idempotencyKey: string },
+    options: {
+      idempotencyKey: string;
+      receiptContext?: Record<string, unknown>;
+    },
   ): Promise<ScheduledTaskApplyResult> {
     const idempotencyKey = normalizeApplyIdempotencyKey(options.idempotencyKey);
     const receiptKey = await applyReceiptKey(verb, idempotencyKey);
@@ -1594,7 +1657,11 @@ export function createScheduledTaskRunner(
         }
       : lifecycleMutation(structuredClone(existingTask), verb, payload);
     if (!replayCandidate) {
-      writeApplyReceiptMarker(mutation.task, receiptKey);
+      writeApplyReceiptMarker(
+        mutation.task,
+        receiptKey,
+        options.receiptContext,
+      );
     }
     const proposedCommit: ScheduledTaskLogEntry = {
       logId: await applyReceiptLogId({

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -51,6 +51,7 @@ import {
   type OwnerFactsView,
   SCHEDULED_TASK_EDIT_READONLY_KEYS,
   type ScheduledTask,
+  type ScheduledTaskApplyIntentResult,
   type ScheduledTaskApplyResult,
   type ScheduledTaskFilter,
   type ScheduledTaskLogEntry,
@@ -146,6 +147,10 @@ export type ScheduledTaskApplyCommitResult =
       commit: ScheduledTaskLogEntry;
     };
 
+export type ScheduledTaskApplyIntentCommitResult =
+  | { kind: "reserved"; task: ScheduledTask }
+  | { kind: "replayed"; task: ScheduledTask };
+
 export interface ScheduledTaskStore {
   upsert(
     task: ScheduledTask,
@@ -199,6 +204,11 @@ export interface ScheduledTaskStore {
     commit: ScheduledTaskLogEntry;
     nextFireAtIso: string | null;
   }): Promise<ScheduledTaskApplyCommitResult>;
+  /** Atomically reserve one non-mutating, idempotency-keyed apply intent. */
+  reserveApplyIntent(args: {
+    task: ScheduledTask;
+    intentKey: string;
+  }): Promise<ScheduledTaskApplyIntentCommitResult>;
   get(taskId: string): Promise<ScheduledTask | null>;
   findByIdempotencyKey(key: string): Promise<ScheduledTask | null>;
   list(filter?: ScheduledTaskFilter): Promise<ScheduledTask[]>;
@@ -295,6 +305,39 @@ export function createInMemoryScheduledTaskStore(): ScheduledTaskStore {
         task: structuredClone(committedTask),
         commit: structuredClone(commit),
       };
+    },
+    async reserveApplyIntent({ task, intentKey }) {
+      const existing = map.get(task.taskId);
+      if (!existing) {
+        throw new Error(`reserveApplyIntent: task ${task.taskId} not found`);
+      }
+      const storedIntents = existing.metadata?.schedulingApplyIntents;
+      const intentMarkers =
+        storedIntents !== null &&
+        typeof storedIntents === "object" &&
+        !Array.isArray(storedIntents)
+          ? (storedIntents as Record<string, unknown>)
+          : {};
+      if (Object.hasOwn(intentMarkers, intentKey)) {
+        return { kind: "replayed", task: structuredClone(existing) };
+      }
+      const proposedIntents = task.metadata?.schedulingApplyIntents;
+      const proposedValue =
+        proposedIntents !== null &&
+        typeof proposedIntents === "object" &&
+        !Array.isArray(proposedIntents)
+          ? ((proposedIntents as Record<string, unknown>)[intentKey] ?? true)
+          : true;
+      const committedTask = structuredClone(existing);
+      committedTask.metadata = {
+        ...(committedTask.metadata ?? {}),
+        schedulingApplyIntents: {
+          ...intentMarkers,
+          [intentKey]: structuredClone(proposedValue),
+        },
+      };
+      map.set(task.taskId, committedTask);
+      return { kind: "reserved", task: structuredClone(committedTask) };
     },
     async get(taskId) {
       const found = map.get(taskId);
@@ -450,6 +493,7 @@ function defaultTaskIdGenerator(): string {
 
 const CREATION_RECEIPT_METADATA_KEY = "schedulingCreationReceipt";
 const APPLY_RECEIPTS_METADATA_KEY = "schedulingApplyReceipts";
+const APPLY_INTENTS_METADATA_KEY = "schedulingApplyIntents";
 const APPLY_IDEMPOTENCY_KEY_MAX_LENGTH = 512;
 
 interface SchedulingCreationReceiptAnchor {
@@ -505,6 +549,54 @@ async function applyReceiptKey(
   idempotencyKey: string,
 ): Promise<string> {
   return sha256Hex(`${verb}\0${idempotencyKey}`);
+}
+
+async function applyIntentKey(idempotencyKey: string): Promise<string> {
+  return sha256Hex(`intent\0${idempotencyKey}`);
+}
+
+/** Read exact request context persisted before a multi-task lifecycle effect. */
+export async function scheduledTaskApplyIntentContext(
+  task: ScheduledTask,
+  idempotencyKey: string,
+): Promise<Record<string, unknown> | undefined> {
+  const normalizedKey = normalizeApplyIdempotencyKey(idempotencyKey);
+  const intentKey = await applyIntentKey(normalizedKey);
+  const intents = task.metadata?.[APPLY_INTENTS_METADATA_KEY];
+  if (
+    intents === null ||
+    typeof intents !== "object" ||
+    Array.isArray(intents)
+  ) {
+    return undefined;
+  }
+  const context = (intents as Record<string, unknown>)[intentKey];
+  return context !== null &&
+    typeof context === "object" &&
+    !Array.isArray(context)
+    ? (context as Record<string, unknown>)
+    : undefined;
+}
+
+function writeApplyIntentMarker(
+  task: ScheduledTask,
+  intentKey: string,
+  context: Record<string, unknown>,
+): void {
+  const existing = task.metadata?.[APPLY_INTENTS_METADATA_KEY];
+  const intents =
+    existing !== null &&
+    typeof existing === "object" &&
+    !Array.isArray(existing)
+      ? (existing as Record<string, unknown>)
+      : {};
+  task.metadata = {
+    ...(task.metadata ?? {}),
+    [APPLY_INTENTS_METADATA_KEY]: {
+      ...intents,
+      [intentKey]: structuredClone(context),
+    },
+  };
 }
 
 /**
@@ -898,7 +990,9 @@ export interface ScheduledTaskRunnerExtras {
 
 export interface ScheduledTaskRunnerHandle
   extends ScheduledTaskRunner,
-    ScheduledTaskRunnerExtras {}
+    ScheduledTaskRunnerExtras {
+  reserveApplyIntent: NonNullable<ScheduledTaskRunner["reserveApplyIntent"]>;
+}
 
 export function createScheduledTaskRunner(
   deps: ScheduledTaskRunnerDeps,
@@ -1713,6 +1807,44 @@ export function createScheduledTaskRunner(
     return {
       task: committed.task,
       commit,
+      idempotencyKey,
+      replayed: committed.kind === "replayed",
+    };
+  }
+
+  async function reserveApplyIntent(
+    taskId: string,
+    options: {
+      idempotencyKey: string;
+      context: Record<string, unknown>;
+    },
+  ): Promise<ScheduledTaskApplyIntentResult> {
+    const idempotencyKey = normalizeApplyIdempotencyKey(options.idempotencyKey);
+    const intentKey = await applyIntentKey(idempotencyKey);
+    const existingTask = await deps.store.get(taskId);
+    if (!existingTask) {
+      throw new Error(`reserveApplyIntent: task ${taskId} not found`);
+    }
+    const proposal = structuredClone(existingTask);
+    writeApplyIntentMarker(proposal, intentKey, options.context);
+    const committed = await deps.store.reserveApplyIntent({
+      task: proposal,
+      intentKey,
+    });
+    const committedContext = await scheduledTaskApplyIntentContext(
+      committed.task,
+      idempotencyKey,
+    );
+    if (
+      !committedContext ||
+      stableStringify(committedContext) !== stableStringify(options.context)
+    ) {
+      throw new Error(
+        `reserveApplyIntent: conflicting context for task ${taskId} and idempotency key`,
+      );
+    }
+    return {
+      task: committed.task,
       idempotencyKey,
       replayed: committed.kind === "replayed",
     };
@@ -2691,6 +2823,7 @@ export function createScheduledTaskRunner(
     remove,
     apply,
     applyWithResult,
+    reserveApplyIntent,
     pipeline,
     fire,
     fireWithResult,

--- a/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
@@ -360,8 +360,14 @@ describe("scheduling SQL persistence", () => {
         pipeline: { onComplete: [child as never] },
       });
       const requests = [
-        { idempotencyKey: "message-distinct-a:complete" },
-        { idempotencyKey: "message-distinct-b:complete" },
+        {
+          idempotencyKey: "message-distinct-a:complete",
+          receiptContext: { manifest: "manifest-a" },
+        },
+        {
+          idempotencyKey: "message-distinct-b:complete",
+          receiptContext: { manifest: "manifest-b" },
+        },
       ] as const;
 
       const applied = await Promise.all(
@@ -405,6 +411,12 @@ describe("scheduling SQL persistence", () => {
       if (!receiptMarkers)
         throw new Error("expected lifecycle receipt markers");
       expect(Object.keys(receiptMarkers)).toHaveLength(2);
+      expect(Object.values(receiptMarkers)).toEqual(
+        expect.arrayContaining([
+          { manifest: "manifest-a" },
+          { manifest: "manifest-b" },
+        ]),
+      );
 
       const replayed = await Promise.all(
         requests.map((options) =>

--- a/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
@@ -223,6 +223,65 @@ describe("scheduling SQL persistence", () => {
   );
 
   it(
+    "persists one immutable pre-effect intent without a lifecycle log",
+    async () => {
+      const harness = await createRuntimeHarness();
+      harnesses.push(harness);
+      const { runner } = await startSqlRunner(harness);
+      const created = await runner.scheduleWithResult(
+        receiptReminderInput("intent-reservation-task"),
+      );
+      const options = {
+        idempotencyKey: "clear-message:manifest",
+        context: { taskIds: [created.task.taskId] },
+      };
+
+      const reserved = await runner.reserveApplyIntent(
+        created.task.taskId,
+        options,
+      );
+      const replayed = await runner.reserveApplyIntent(
+        created.task.taskId,
+        options,
+      );
+
+      expect(reserved.replayed).toBe(false);
+      expect(replayed.replayed).toBe(true);
+      await expect(
+        runner.reserveApplyIntent(created.task.taskId, {
+          ...options,
+          context: { taskIds: [created.task.taskId, "later-task"] },
+        }),
+      ).rejects.toThrow("conflicting context");
+      const persisted = await harness.pg.query<{
+        status: string;
+        logs: number;
+        metadata_json: string;
+      }>(`
+        SELECT
+          state_json::jsonb ->> 'status' AS status,
+          (SELECT COUNT(*)::int
+             FROM app_scheduling.life_scheduled_task_log
+            WHERE agent_id = 'agent-sql-persist'
+              AND task_id = '${created.task.taskId}') AS logs,
+          metadata_json
+        FROM app_scheduling.life_scheduled_tasks
+        WHERE agent_id = 'agent-sql-persist'
+          AND id = '${created.task.taskId}'
+      `);
+      expect(persisted.rows[0]?.status).toBe("scheduled");
+      expect(persisted.rows[0]?.logs).toBe(1);
+      const metadata = JSON.parse(persisted.rows[0]?.metadata_json ?? "{}") as {
+        schedulingApplyIntents?: Record<string, unknown>;
+      };
+      expect(Object.values(metadata.schedulingApplyIntents ?? {})).toEqual([
+        options.context,
+      ]);
+    },
+    SQL_PERSISTENCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "replays one lifecycle receipt after the atomic commit outlives an observation failure",
     async () => {
       const harness = await createRuntimeHarness();

--- a/plugins/plugin-scheduling/src/scheduled-task/store.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/store.ts
@@ -534,6 +534,67 @@ export function createSchedulingSqlScheduledTaskStore(
         `commitApply: task ${task.taskId} could not commit receipt ${receiptKey}`,
       );
     },
+    async reserveApplyIntent({ task, intentKey }) {
+      const now = isoNow();
+      const proposedMetadataSql = `${sqlJson(task.metadata ?? {})}::jsonb`;
+      const proposedIntentValueSql = `COALESCE(
+        ${proposedMetadataSql} -> 'schedulingApplyIntents' -> ${sqlQuote(intentKey)},
+        'true'::jsonb
+      )`;
+      const rows = await executeSql(
+        `UPDATE ${TASK_TABLE}
+            SET metadata_json = jsonb_set(
+                                  metadata_json::jsonb,
+                                  '{schedulingApplyIntents}',
+                                  COALESCE(
+                                    metadata_json::jsonb -> 'schedulingApplyIntents',
+                                    '{}'::jsonb
+                                  ) || jsonb_build_object(
+                                    ${sqlQuote(intentKey)},
+                                    ${proposedIntentValueSql}
+                                  ),
+                                  true
+                                )::text,
+                updated_at = ${sqlQuote(now)},
+                version = version + 1
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND id = ${sqlQuote(task.taskId)}
+            AND transfer_status IS NULL
+            AND COALESCE(
+              metadata_json::jsonb #>> '{sharedCutoverImport,status}',
+              ''
+            ) <> 'reserved'
+            AND NOT (
+              COALESCE(
+                metadata_json::jsonb -> 'schedulingApplyIntents',
+                '{}'::jsonb
+              ) ? ${sqlQuote(intentKey)}
+            )
+          RETURNING *`,
+      );
+      const reserved = rows[0];
+      if (reserved) {
+        return { kind: "reserved", task: parseScheduledTaskRow(reserved) };
+      }
+      const replayRows = await executeSql(
+        `SELECT *
+           FROM ${TASK_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND id = ${sqlQuote(task.taskId)}
+            AND COALESCE(
+              metadata_json::jsonb -> 'schedulingApplyIntents',
+              '{}'::jsonb
+            ) ? ${sqlQuote(intentKey)}
+          LIMIT 1`,
+      );
+      const replayed = replayRows[0];
+      if (replayed) {
+        return { kind: "replayed", task: parseScheduledTaskRow(replayed) };
+      }
+      throw new Error(
+        `reserveApplyIntent: task ${task.taskId} could not reserve intent ${intentKey}`,
+      );
+    },
     async get(taskId: string) {
       const rows = await executeSql(
         `SELECT *

--- a/plugins/plugin-scheduling/src/scheduled-task/store.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/store.ts
@@ -439,13 +439,18 @@ export function createSchedulingSqlScheduledTaskStore(
       // authoritative for lifecycle changes, while the receipt map is merged
       // from that current row so distinct committed keys cannot erase one
       // another.
+      const proposedMetadataSql = `${sqlJson(task.metadata ?? {})}::jsonb`;
+      const proposedReceiptValueSql = `COALESCE(
+        ${proposedMetadataSql} -> 'schedulingApplyReceipts' -> ${sqlQuote(receiptKey)},
+        'true'::jsonb
+      )`;
       const mergedMetadataSql = `jsonb_set(
-        ${sqlJson(task.metadata ?? {})}::jsonb,
+        ${proposedMetadataSql},
         '{schedulingApplyReceipts}',
         COALESCE(
           metadata_json::jsonb -> 'schedulingApplyReceipts',
           '{}'::jsonb
-        ) || jsonb_build_object(${sqlQuote(receiptKey)}, TRUE),
+        ) || jsonb_build_object(${sqlQuote(receiptKey)}, ${proposedReceiptValueSql}),
         true
       )::text`;
       const rows = await executeSql(

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -401,7 +401,11 @@ export interface ScheduledTaskRunner {
     taskId: string,
     verb: ScheduledTaskReceiptVerb,
     payload: unknown,
-    options: { idempotencyKey: string },
+    options: {
+      idempotencyKey: string;
+      /** Internal durable context bound to this exact receipt-keyed effect. */
+      receiptContext?: Record<string, unknown>;
+    },
   ): Promise<ScheduledTaskApplyResult>;
   pipeline(taskId: string, outcome: TerminalState): Promise<ScheduledTask[]>;
 }

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -377,6 +377,13 @@ export interface ScheduledTaskApplyResult {
   replayed: boolean;
 }
 
+/** Durable, non-mutating intent marker used to fence a multi-task mutation. */
+export interface ScheduledTaskApplyIntentResult {
+  task: ScheduledTask;
+  idempotencyKey: string;
+  replayed: boolean;
+}
+
 export interface ScheduledTaskRunner {
   scheduleWithResult(
     task: Omit<ScheduledTask, "taskId" | "state">,
@@ -407,6 +414,17 @@ export interface ScheduledTaskRunner {
       receiptContext?: Record<string, unknown>;
     },
   ): Promise<ScheduledTaskApplyResult>;
+  /**
+   * Persist request context before any lifecycle effect. Implementations must
+   * never change task state or write a lifecycle log for this reservation.
+   */
+  reserveApplyIntent?(
+    taskId: string,
+    options: {
+      idempotencyKey: string;
+      context: Record<string, unknown>;
+    },
+  ): Promise<ScheduledTaskApplyIntentResult>;
   pipeline(taskId: string, outcome: TerminalState): Promise<ScheduledTask[]>;
 }
 

--- a/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
@@ -303,6 +303,73 @@ describe("Shared group reminder action", () => {
     });
   });
 
+  it("keeps immutable group authority in scope when the owner display label changes", async () => {
+    const currentDelivery = {
+      ...telegramGroupDelivery,
+      ownerLabel: "New display name",
+    };
+    const persistedDelivery = {
+      ...telegramGroupDelivery,
+      ownerLabel: "Old display name",
+    };
+    const { options, scheduleWithResult } = harness(currentDelivery);
+    const persisted = {
+      ...scheduledTask({
+        kind: "reminder",
+        promptInstructions: "Stand-up starts",
+        trigger: { kind: "once", atIso: "2026-08-14T20:05:00.000Z" },
+        priority: "medium",
+        escalation: {
+          steps: [{ delayMinutes: 0, channelKey: "current_dm" }],
+        },
+        output: {
+          destination: "channel",
+          target: "current_dm",
+          fallback: { body: "Stand-up starts" },
+        },
+        subject: { kind: "self", id: "personal:user-1" },
+        idempotencyKey: "persisted-group-semantic-key",
+        respectsGlobalPause: true,
+        source: "user_chat",
+        createdBy: "personal:user-1",
+        ownerVisible: true,
+        metadata: { delivery: persistedDelivery },
+        executionProfile: "notify-only",
+      }),
+      taskId: "persisted-group-reminder",
+    };
+    options.runner.list = vi.fn(async () => [persisted]);
+    scheduleWithResult.mockResolvedValue({
+      task: persisted,
+      commit: { logId: "persisted-group-log", occurredAtIso: NOW },
+      replayed: true,
+    });
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "group-label-update" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stand-up starts",
+          inMinutes: 5,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { deduplicated: true, replayed: true },
+    });
+    expect(scheduleWithResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: "persisted-group-semantic-key",
+      }),
+    );
+  });
+
   it("reserves the fire-time owner prefix inside the connector text budget", async () => {
     const budget = sharedReminderMaxBodyLength(telegramGroupDelivery);
     expect(budget).toBe(

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -14,6 +14,12 @@ import {
 } from "./shared-reminders.js";
 
 const NOW = "2026-08-14T20:00:00.000Z";
+const PRIVATE_DELIVERY = {
+  platform: "telegram" as const,
+  project: "eliza-app",
+  connectorAccountId: "bot:123456789",
+  chatId: "123456",
+};
 
 function scheduledTask(input: ScheduledTaskInput): ScheduledTask {
   return {
@@ -43,7 +49,7 @@ function reminderInput(
     source: "user_chat",
     createdBy: "personal:user-1",
     ownerVisible: true,
-    metadata: {},
+    metadata: { delivery: PRIVATE_DELIVERY },
     executionProfile: "notify-only",
   };
 }
@@ -66,7 +72,16 @@ function harness(): {
     },
     replayed: false,
   }));
-  const list = vi.fn(async () => [] as ScheduledTask[]);
+  const defaultTask = scheduledTask(
+    reminderInput("Stretch", {
+      kind: "once",
+      atIso: "2026-08-14T20:02:00.000Z",
+    }),
+  );
+  const list = vi.fn(
+    async (filter?: Parameters<ScheduledTaskRunner["list"]>[0]) =>
+      filter?.status ? [defaultTask] : ([] as ScheduledTask[]),
+  );
   const apply = vi.fn(async () => {
     throw new Error("not used");
   });
@@ -127,12 +142,7 @@ function harness(): {
     options: {
       runner,
       agentId: "personal:user-1",
-      delivery: {
-        platform: "telegram",
-        project: "eliza-app",
-        connectorAccountId: "bot:123456789",
-        chatId: "123456",
-      },
+      delivery: PRIVATE_DELIVERY,
       now: () => new Date(NOW),
     },
   };
@@ -407,7 +417,7 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result?.text).toBe(
-      "That reminder is already set on Aug 14, 2026 at 8:32:59.999 PM UTC: Persisted Stretch",
+      "That reminder is already set on Aug 14, 2026 at 1:32:59.999 PM America/Los_Angeles (Aug 14, 2026 at 8:32:59.999 PM UTC): Persisted Stretch",
     );
     expect(result?.text).not.toMatch(/every Monday|9:00 AM|2026-08-14T/);
   });
@@ -538,11 +548,45 @@ describe("Shared reminders edge plugin", () => {
     expect(result?.text).toBe(
       "Your reminders:\n" +
         "• Stretch — on Aug 14, 2026 at 8:32 PM UTC\n" +
-        "• Weekly planning — on Aug 14, 2026 at 8:45:59.999 PM UTC",
+        "• Weekly planning — on Aug 14, 2026 at 1:45:59.999 PM America/Los_Angeles (Aug 14, 2026 at 8:45:59.999 PM UTC)",
     );
     expect(result?.text).not.toMatch(
       /8:02 PM|every Monday|9:00 AM|2026-08-14T/,
     );
+  });
+
+  it("does not list or mutate a reminder pinned to another trusted destination", async () => {
+    const { options, list, applyWithResult } = harness();
+    const otherDestination = {
+      ...scheduledTask(
+        reminderInput("Private elsewhere", {
+          kind: "once",
+          atIso: "2026-08-14T20:02:00.000Z",
+        }),
+      ),
+      metadata: {
+        delivery: { ...PRIVATE_DELIVERY, chatId: "999999" },
+      },
+    };
+    list.mockResolvedValue([otherDestination]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const listed = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "list-other-destination" } as Memory,
+      undefined,
+      { parameters: { operation: "list" } },
+    );
+    const deleted = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "delete-other-destination" } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Private elsewhere" } },
+    );
+
+    expect(listed?.text).toBe("You have no reminders.");
+    expect(deleted?.text).toBe("You have no active reminders.");
+    expect(applyWithResult).not.toHaveBeenCalled();
   });
 
   it("keeps lifecycle acknowledgements user-facing while structured data retains the task id", async () => {
@@ -690,24 +734,1054 @@ describe("Shared reminders edge plugin", () => {
     ]);
   });
 
-  it("emits no acknowledgement when the durable lifecycle mutation fails", async () => {
-    const { options, applyWithResult } = harness();
-    applyWithResult.mockRejectedValueOnce(
-      new Error("injected durable apply failure"),
+  it("deduplicates the screenshot correction across distinct message ids and renders Paris time first", async () => {
+    const { options, list, scheduleWithResult } = harness();
+    let persisted: ScheduledTask | undefined;
+    let durableCreates = 0;
+    list.mockImplementation(async () => (persisted ? [persisted] : []));
+    scheduleWithResult.mockImplementation(async (input: ScheduledTaskInput) => {
+      const existing = persisted;
+      if (existing && existing.idempotencyKey === input.idempotencyKey) {
+        return {
+          task: existing,
+          commit: {
+            logId: "semantic-create-log",
+            taskId: existing.taskId,
+            agentId: "personal:user-1",
+            occurredAtIso: NOW,
+            transition: "scheduled" as const,
+            rolledUp: false,
+          },
+          replayed: true,
+        };
+      }
+      durableCreates += 1;
+      persisted = {
+        taskId: "semantic-reminder-1",
+        ...input,
+        state: { status: "scheduled", followupCount: 0 },
+      };
+      return {
+        task: persisted,
+        commit: {
+          logId: "semantic-create-log",
+          taskId: persisted.taskId,
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: false,
+      };
+    });
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const parameters = {
+      operation: "create",
+      reminderText: "add something to your todo",
+      atIso: "2026-08-28T01:06:00.000Z",
+      timezone: "Europe/Paris",
+    };
+
+    const first = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-message-create",
+        content: {
+          text: "Can you remind me at 3:06 am (French time) to add smth to my todo?",
+        },
+      } as Memory,
+      undefined,
+      { parameters: { ...parameters, timezone: "europe/paris" } },
     );
+    options.clockCorrection = true;
+    const correction = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-message-correction",
+        content: { text: "3 06 no 1:06" },
+      } as Memory,
+      undefined,
+      { parameters },
+    );
+
+    expect(durableCreates).toBe(1);
+    expect(scheduleWithResult).toHaveBeenCalledTimes(2);
+    expect(scheduleWithResult.mock.calls[0]?.[0]?.idempotencyKey).toBe(
+      scheduleWithResult.mock.calls[1]?.[0]?.idempotencyKey,
+    );
+    expect(first?.text).toBe(
+      "Got it — I'll remind you on Aug 28, 2026 at 3:06 AM Europe/Paris (Aug 28, 2026 at 1:06 AM UTC): add something to your todo",
+    );
+    expect(correction).toMatchObject({
+      success: true,
+      data: { operation: "update", replayed: true },
+      effectReceipts: [{ outcome: "noop" }],
+    });
+    expect(correction?.text).toContain(
+      "on Aug 28, 2026 at 3:06 AM Europe/Paris",
+    );
+  });
+
+  it("replays a pre-patch active row instead of duplicating it when create adds display timezone", async () => {
+    const { options, list, scheduleWithResult } = harness();
+    const legacy = {
+      ...scheduledTask(
+        reminderInput("add something to your todo", {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId: "legacy-active-reminder",
+      idempotencyKey: "shared-reminder:old-message:create",
+      metadata: { delivery: PRIVATE_DELIVERY },
+    };
+    list.mockResolvedValue([legacy]);
+    scheduleWithResult.mockResolvedValue({
+      task: legacy,
+      commit: {
+        logId: "legacy-create-log",
+        taskId: legacy.taskId,
+        agentId: "personal:user-1",
+        occurredAtIso: NOW,
+        transition: "scheduled" as const,
+        rolledUp: false,
+      },
+      replayed: true,
+    });
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "new-message-same-firing" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          target: "add something to your todo",
+          reminderText: "add something to your todo",
+          atIso: "2026-08-28T01:06:00.000Z",
+          timezone: "Europe/Paris",
+        },
+      },
+    );
+
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
+    expect(scheduleWithResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: "shared-reminder:old-message:create",
+      }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { deduplicated: true, replayed: true },
+      effectReceipts: [{ outcome: "noop" }],
+    });
+    expect(result?.text).toBe(
+      "That reminder is already set on Aug 28, 2026 at 1:06 AM UTC: add something to your todo",
+    );
+  });
+
+  it("coerces an adversarial planner operation into the trusted screenshot update", async () => {
+    const { options, list, scheduleWithResult, applyWithResult } = harness();
+    options.clockCorrection = true;
+    const original = {
+      ...scheduledTask(
+        reminderInput("add something to your todo", {
+          kind: "once" as const,
+          atIso: "2026-08-28T00:06:00.000Z",
+        }),
+      ),
+      taskId: "clock-correction-original",
+    };
+    list.mockResolvedValue([original]);
+    scheduleWithResult.mockImplementation(
+      async (input: ScheduledTaskInput) => ({
+        task: {
+          taskId: "clock-correction-replacement",
+          ...input,
+          state: { status: "scheduled" as const, followupCount: 0 },
+        },
+        commit: {
+          logId: "clock-correction-create-log",
+          taskId: "clock-correction-replacement",
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: false,
+      }),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-clock-correction",
+        content: { text: "3 06 no 1:06" },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "delete",
+          reminderText: "add something to your todo",
+          atIso: "2026-08-28T01:06:00.000Z",
+          timezone: "Europe/Paris",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { operation: "update" },
+    });
+    expect(result?.effectReceipts?.map((receipt) => receipt.operation)).toEqual(
+      ["shared.reminder.create", "shared.reminder.dismiss"],
+    );
+    expect(applyWithResult).toHaveBeenCalledWith(
+      "clock-correction-original",
+      "dismiss",
+      { reason: "replaced by reminder update" },
+      expect.any(Object),
+    );
+  });
+
+  it("does not overwrite an unrelated sole reminder from raw correction language", async () => {
+    const { options, list, scheduleWithResult, applyWithResult } = harness();
+    list.mockResolvedValue([
+      scheduledTask(
+        reminderInput("Take meds", {
+          kind: "once",
+          atIso: "2026-08-28T00:30:00.000Z",
+        }),
+      ),
+    ]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "initial-request-with-correction-words",
+        content: {
+          text: "Remind me at 3:06, not 1:06, to call mom",
+        },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Call mom",
+          atIso: "2026-08-28T01:06:00.000Z",
+          timezone: "Europe/Paris",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { operation: "create" },
+    });
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
+    expect(applyWithResult).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["list" as const, "List my reminders"],
+    ["create" as const, "Create a reminder to call mom"],
+  ])(
+    "prevents planner delete from overriding trusted %s intent",
+    async (operationIntent, text) => {
+      const { options, list, applyWithResult, scheduleWithResult } = harness();
+      options.operationIntent = operationIntent;
+      const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+      const result = await action?.handler(
+        {} as IAgentRuntime,
+        { id: `confused-${operationIntent}`, content: { text } } as Memory,
+        undefined,
+        { parameters: { operation: "delete" } },
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        verifiedUserFacing: true,
+        turnComplete: true,
+        data: {
+          operation: operationIntent,
+          failureCode: "REMINDER_OPERATION_MISMATCH",
+        },
+      });
+      expect(list).not.toHaveBeenCalled();
+      expect(applyWithResult).not.toHaveBeenCalled();
+      expect(scheduleWithResult).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects offset-less atIso values instead of guessing the Worker timezone", async () => {
+    const { options, scheduleWithResult } = harness();
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "offsetless-at-iso" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          atIso: "2026-08-28T03:06:00",
+          timezone: "Europe/Paris",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({ success: false, verifiedUserFacing: true });
+    expect(result?.text).toContain("explicit Z or ±HH:MM offset");
+    expect(scheduleWithResult).not.toHaveBeenCalled();
+  });
+
+  it("canonicalizes cron timezone casing before semantic deduplication", async () => {
+    const { options, list, scheduleWithResult } = harness();
+    let persisted: ScheduledTask | undefined;
+    let durableCreates = 0;
+    list.mockImplementation(async () => (persisted ? [persisted] : []));
+    scheduleWithResult.mockImplementation(async (input: ScheduledTaskInput) => {
+      const existing = persisted;
+      if (existing && existing.idempotencyKey === input.idempotencyKey) {
+        return {
+          task: existing,
+          commit: {
+            logId: "cron-semantic-log",
+            taskId: existing.taskId,
+            agentId: "personal:user-1",
+            occurredAtIso: NOW,
+            transition: "scheduled" as const,
+            rolledUp: false,
+          },
+          replayed: true,
+        };
+      }
+      durableCreates += 1;
+      persisted = {
+        taskId: "cron-semantic-reminder",
+        ...input,
+        state: { status: "scheduled", followupCount: 0 },
+      };
+      return {
+        task: persisted,
+        commit: {
+          logId: "cron-semantic-log",
+          taskId: persisted.taskId,
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: false,
+      };
+    });
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const invoke = (id: string, timezone: string) =>
+      action?.handler({} as IAgentRuntime, { id } as Memory, undefined, {
+        parameters: {
+          operation: "create",
+          reminderText: "Daily stretch",
+          cronExpression: "6 3 * * *",
+          timezone,
+        },
+      });
+
+    await invoke("cron-lowercase", "europe/paris");
+    const replay = await invoke("cron-canonical", "Europe/Paris");
+
+    expect(durableCreates).toBe(1);
+    expect(scheduleWithResult.mock.calls[0]?.[0]?.trigger).toEqual({
+      kind: "cron",
+      expression: "6 3 * * *",
+      tz: "Europe/Paris",
+    });
+    expect(scheduleWithResult.mock.calls[0]?.[0]?.idempotencyKey).toBe(
+      scheduleWithResult.mock.calls[1]?.[0]?.idempotencyKey,
+    );
+    expect(replay).toMatchObject({
+      success: true,
+      data: { deduplicated: true, replayed: true },
+    });
+  });
+
+  it("keeps relative scheduling idempotent across a delayed retry of the same message", async () => {
+    const { options, list, scheduleWithResult } = harness();
+    let currentTime = Date.parse(NOW);
+    options.now = () => new Date(currentTime);
+    let persisted: ScheduledTask | undefined;
+    let durableCreates = 0;
+    list.mockImplementation(async () => (persisted ? [persisted] : []));
+    scheduleWithResult.mockImplementation(async (input: ScheduledTaskInput) => {
+      const existing = persisted;
+      if (existing && existing.idempotencyKey === input.idempotencyKey) {
+        return {
+          task: existing,
+          commit: {
+            logId: "relative-retry-log",
+            taskId: existing.taskId,
+            agentId: "personal:user-1",
+            occurredAtIso: NOW,
+            transition: "scheduled" as const,
+            rolledUp: false,
+          },
+          replayed: true,
+        };
+      }
+      durableCreates += 1;
+      persisted = {
+        taskId: `relative-retry-${durableCreates}`,
+        ...input,
+        state: { status: "scheduled", followupCount: 0 },
+      };
+      return {
+        task: persisted,
+        commit: {
+          logId: `relative-retry-log-${durableCreates}`,
+          taskId: persisted.taskId,
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: false,
+      };
+    });
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const invoke = (id: string) =>
+      action?.handler(
+        {} as IAgentRuntime,
+        {
+          id,
+          content: { text: "Remind me in 2 minutes to stretch" },
+        } as Memory,
+        undefined,
+        {
+          parameters: {
+            operation: "create",
+            reminderText: "Stretch",
+            inMinutes: 2,
+          },
+        },
+      );
+
+    await invoke("same-relative-message");
+    currentTime += 5_000;
+    const replay = await invoke("same-relative-message");
+
+    expect(durableCreates).toBe(1);
+    expect(scheduleWithResult.mock.calls[0]?.[0]?.idempotencyKey).toBe(
+      "shared-reminder:same-relative-message:create",
+    );
+    expect(scheduleWithResult.mock.calls[1]?.[0]?.idempotencyKey).toBe(
+      "shared-reminder:same-relative-message:create",
+    );
+    expect(replay).toMatchObject({
+      success: true,
+      data: { deduplicated: true, replayed: true },
+    });
+
+    if (!persisted) throw new Error("Expected the first persisted reminder");
+    persisted.state = { status: "dismissed", followupCount: 0 };
+    currentTime += 5_000;
+    const terminalReplay = await invoke("same-relative-message");
+    expect(terminalReplay).toMatchObject({
+      success: false,
+      data: { replayedTerminalRequest: true },
+    });
+    expect(durableCreates).toBe(1);
+
+    await invoke("different-relative-message");
+    expect(durableCreates).toBe(2);
+  });
+
+  it("renders zoned sub-second instants with an explicit seconds field", async () => {
+    const { options } = harness();
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "zoned-sub-second" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          atIso: "2026-08-14T20:00:00.006Z",
+          timezone: "Europe/Paris",
+        },
+      },
+    );
+
+    expect(result?.text).toContain(
+      "10:00:00.006 PM Europe/Paris (Aug 14, 2026 at 8:00:00.006 PM UTC)",
+    );
+  });
+
+  it("deletes exact semantic duplicates by visible title and returns every durable receipt", async () => {
+    const { options, list, applyWithResult } = harness();
+    const tasks = ["duplicate-a", "duplicate-b"].map((taskId) => ({
+      ...scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId,
+      idempotencyKey: `semantic-${taskId}`,
+    }));
+    list.mockResolvedValue(tasks);
+    applyWithResult.mockImplementation(
+      async (taskId, _operation, _payload, input) => ({
+        task: {
+          ...(tasks.find((task) => task.taskId === taskId) ?? tasks[0]),
+          state: { status: "dismissed" as const, followupCount: 0 },
+        },
+        commit: {
+          logId: `dismiss-${taskId}`,
+          taskId,
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "dismissed" as const,
+          rolledUp: false,
+        },
+        idempotencyKey: input.idempotencyKey,
+        replayed: false,
+      }),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-delete-by-title",
+        content: { text: "Remove the reminder Stretch" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result?.text).toBe("Deleted 2 identical reminders: Stretch");
+    expect(result?.text).not.toMatch(/duplicate-[ab]/);
+    expect(result?.effectReceipts).toHaveLength(2);
+    expect(result?.userFacingEffectReceiptIds).toEqual([
+      "shared-reminder:dismiss:dismiss-duplicate-a",
+      "shared-reminder:dismiss:dismiss-duplicate-b",
+    ]);
+    expect(applyWithResult).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves the exact screenshot delete phrase to its visible reminder title", async () => {
+    const { options, list, applyWithResult } = harness();
+    options.operationIntent = "delete";
+    const task = {
+      ...scheduledTask(
+        reminderInput("add something to your todo", {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId: "screenshot-visible-title",
+    };
+    list.mockResolvedValue([task]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-full-delete-command",
+        content: {
+          text: "Remove the reminder add something in my todo",
+        },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "list",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { operation: "delete", affectedCount: 1 },
+    });
+    expect(applyWithResult).toHaveBeenCalledWith(
+      "screenshot-visible-title",
+      "dismiss",
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("clarifies instead of mutating when target-only todo wording matches two close titles", async () => {
+    const { options, list, applyWithResult } = harness();
+    list.mockResolvedValue(
+      ["add something to your todo", "add something in my todo"].map(
+        (title, index) => ({
+          ...scheduledTask(
+            reminderInput(title, {
+              kind: "once" as const,
+              atIso: "2026-08-28T01:06:00.000Z",
+            }),
+          ),
+          taskId: `close-todo-title-${index}`,
+        }),
+      ),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "ambiguous-screenshot-target" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "delete",
+          target: "Remove the reminder add something in my todo",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({ success: false, verifiedUserFacing: true });
+    expect(result?.text).toContain("More than one reminder matches");
+    expect(applyWithResult).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Pay $5", "Pay 5"],
+    ["Review C++", "Review C#"],
+  ])(
+    "keeps symbol-distinct reminder titles separate: %s vs %s",
+    async (selectedTitle, otherTitle) => {
+      const { options, list, applyWithResult } = harness();
+      const tasks = [selectedTitle, otherTitle].map((title, index) => ({
+        ...scheduledTask(
+          reminderInput(title, {
+            kind: "once" as const,
+            atIso: "2026-08-28T01:06:00.000Z",
+          }),
+        ),
+        taskId: `symbol-${index}`,
+      }));
+      list.mockResolvedValue(tasks);
+      const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+      await action?.handler(
+        {} as IAgentRuntime,
+        { id: `delete-symbol-${selectedTitle}` } as Memory,
+        undefined,
+        { parameters: { operation: "delete", target: selectedTitle } },
+      );
+
+      expect(applyWithResult).toHaveBeenCalledTimes(1);
+      expect(applyWithResult.mock.calls[0]?.[0]).toBe("symbol-0");
+    },
+  );
+
+  it("returns partial duplicate-delete receipts when one dismissal cannot be verified", async () => {
+    const { options, list, applyWithResult } = harness();
+    const durableFailure = new Error("injected second dismiss failure");
+    const reportError = vi.fn();
+    const tasks = ["partial-a", "partial-b"].map((taskId) => ({
+      ...scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId,
+    }));
+    list.mockResolvedValue(tasks);
+    applyWithResult
+      .mockResolvedValueOnce({
+        task: tasks[0],
+        commit: {
+          logId: "partial-dismiss-a",
+          taskId: "partial-a",
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "dismissed" as const,
+          rolledUp: false,
+        },
+        idempotencyKey: "partial-dismiss-a-key",
+        replayed: false,
+      })
+      .mockRejectedValueOnce(durableFailure);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      { reportError } as unknown as IAgentRuntime,
+      { id: "partial-delete" } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      data: { affectedCount: 1, failedCount: 1 },
+      effectReceipts: [
+        { receiptId: "shared-reminder:dismiss:partial-dismiss-a" },
+      ],
+    });
+    expect(result?.text).toContain("Deleted 1 reminder");
+    expect(result?.text).toContain("couldn't verify 1 other matching reminder");
+    expect(reportError).toHaveBeenCalledWith(
+      "SharedReminders.lifecycleMutation",
+      durableFailure,
+      { operation: "delete", phase: "dismiss", failedCount: 1 },
+    );
+  });
+
+  it("asks for schedule clarification when the same visible title is not an exact duplicate", async () => {
+    const { options, list, applyWithResult } = harness();
+    list.mockResolvedValue([
+      scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once",
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      {
+        ...scheduledTask(
+          reminderInput("Stretch", {
+            kind: "once",
+            atIso: "2026-08-28T02:06:00.000Z",
+          }),
+        ),
+        taskId: "reminder-2",
+      },
+    ]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "ambiguous-delete" } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      verifiedUserFacing: true,
+      turnComplete: true,
+    });
+    expect(result?.text).toContain("More than one reminder matches");
+    expect(result?.text).toContain("1:06 AM UTC");
+    expect(result?.text).toContain("2:06 AM UTC");
+    expect(result?.text).not.toMatch(/reminder-[12]/);
+    expect(applyWithResult).not.toHaveBeenCalled();
+  });
+
+  it("requires a second explicit confirmation before clearing and accepts French confirmation", async () => {
+    const { options, list, applyWithResult } = harness();
+    const tasks = ["clear-a", "clear-b"].map((taskId) => ({
+      ...scheduledTask(
+        reminderInput(`Reminder ${taskId}`, {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId,
+    }));
+    list.mockResolvedValue(tasks);
+    applyWithResult.mockImplementation(
+      async (taskId, _operation, _payload, input) => ({
+        task: {
+          ...(tasks.find((task) => task.taskId === taskId) ?? tasks[0]),
+          state: { status: "dismissed" as const, followupCount: 0 },
+        },
+        commit: {
+          logId: `clear-${taskId}`,
+          taskId,
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "dismissed" as const,
+          rolledUp: false,
+        },
+        idempotencyKey: input.idempotencyKey,
+        replayed: false,
+      }),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    options.clearAllIntent = true;
+
+    const initial = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-clear-initial",
+        content: { text: "Can you clear the list?" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete" } },
+    );
+    expect(initial).toMatchObject({
+      success: false,
+      data: { requiresConfirmation: true },
+    });
+    expect(applyWithResult).not.toHaveBeenCalled();
+
+    const longClearText = `Clear all my reminders because ${"I no longer need this scheduled item ".repeat(75)}`;
+    expect(longClearText.length).toBeGreaterThan(2_100);
+    expect(longClearText.length).toBeLessThanOrEqual(4_096);
+    const longInitial = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "long-clear-initial",
+        content: { text: longClearText },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete" } },
+    );
+    expect(longInitial).toMatchObject({
+      success: false,
+      data: { requiresConfirmation: true },
+    });
+    expect(applyWithResult).not.toHaveBeenCalled();
+
+    const unchallengedExplicitConfirmation = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "direct-clear-without-challenge",
+        content: { text: "yes, clear all reminders" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", confirmed: true } },
+    );
+    expect(unchallengedExplicitConfirmation).toMatchObject({
+      success: false,
+      data: { requiresConfirmation: true },
+    });
+    expect(applyWithResult).not.toHaveBeenCalled();
+
+    options.clearConfirmationChallenge = true;
+    const bareConfirmation = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-clear-confirmed",
+        content: { text: "Oui, je confirme, vas-y" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", confirmed: true } },
+    );
+    expect(bareConfirmation).toMatchObject({
+      success: false,
+      data: { requiresConfirmation: true },
+    });
+    expect(applyWithResult).not.toHaveBeenCalled();
+
+    const doItConfirmed = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "do-it-clear-confirmed",
+        content: { text: "Do it, clear all reminders" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", confirmed: true } },
+    );
+    expect(doItConfirmed).toMatchObject({
+      success: true,
+      text: "Cleared 2 reminders.",
+      data: { operation: "clear", dismissedCount: 2, failedCount: 0 },
+    });
+    expect(applyWithResult).toHaveBeenCalledTimes(2);
+    applyWithResult.mockClear();
+
+    const confirmed = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "screenshot-clear-explicit-confirmed",
+        content: {
+          text: "Oui, je confirme, vas-y, efface tous mes rappels",
+        },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", confirmed: true } },
+    );
+    expect(confirmed).toMatchObject({
+      success: true,
+      text: "Cleared 2 reminders.",
+      data: { dismissedCount: 2, failedCount: 0 },
+    });
+    expect(confirmed?.effectReceipts).toHaveLength(2);
+  });
+
+  it("keeps a targeted delete targeted even after a clear challenge", async () => {
+    const { options, applyWithResult } = harness();
+    options.clearConfirmationChallenge = true;
+    options.clearAllIntent = false;
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "targeted-delete-after-clear-challenge",
+        content: { text: "Remove the reminder Stretch" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { operation: "delete", affectedCount: 1 },
+    });
+    expect(applyWithResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists a timezone-only update as a receipt-backed replacement plus dismissal", async () => {
+    const { options, list, scheduleWithResult, applyWithResult } = harness();
+    const original = {
+      ...scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId: "update-original",
+      idempotencyKey: "update-original-key",
+      metadata: {
+        delivery: PRIVATE_DELIVERY,
+        pendingDispatch: { attempt: 2 },
+        escalationCursor: 1,
+        applyReceipts: { stale: true },
+      },
+    };
+    const duplicate = {
+      ...original,
+      taskId: "update-duplicate",
+      idempotencyKey: "update-duplicate-key",
+    };
+    list.mockResolvedValue([original, duplicate]);
+    scheduleWithResult.mockImplementation(
+      async (input: ScheduledTaskInput) => ({
+        task: {
+          taskId: "update-replacement",
+          ...input,
+          state: { status: "scheduled" as const, followupCount: 0 },
+        },
+        commit: {
+          logId: "update-create-log",
+          taskId: "update-replacement",
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: false,
+      }),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "update-by-title",
+        content: { text: "Actually use French time for the Stretch reminder" },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "update",
+          target: "Stretch",
+          timezone: "Europe/Paris",
+        },
+      },
+    );
+
+    expect(result?.text).toBe(
+      "Updated reminder: Stretch — on Aug 28, 2026 at 3:06 AM Europe/Paris (Aug 28, 2026 at 1:06 AM UTC)",
+    );
+    expect(scheduleWithResult.mock.calls[0]?.[0]?.metadata).toEqual({
+      delivery: PRIVATE_DELIVERY,
+      displayTimezone: "Europe/Paris",
+    });
+    expect(result?.effectReceipts).toHaveLength(3);
+    expect(result?.effectReceipts?.map((receipt) => receipt.operation)).toEqual(
+      [
+        "shared.reminder.create",
+        "shared.reminder.dismiss",
+        "shared.reminder.dismiss",
+      ],
+    );
+    expect(applyWithResult).toHaveBeenCalledWith(
+      "update-original",
+      "dismiss",
+      { reason: "replaced by reminder update" },
+      expect.objectContaining({
+        idempotencyKey:
+          "shared-reminder:update-by-title:update-dismiss:update-original",
+      }),
+    );
+    expect(applyWithResult).toHaveBeenCalledWith(
+      "update-duplicate",
+      "dismiss",
+      { reason: "replaced by reminder update" },
+      expect.objectContaining({
+        idempotencyKey:
+          "shared-reminder:update-by-title:update-dismiss:update-duplicate",
+      }),
+    );
+  });
+
+  it("returns a truthful visible failure when the durable lifecycle mutation fails", async () => {
+    const { options, applyWithResult } = harness();
+    const durableFailure = new Error("injected durable apply failure");
+    const reportError = vi.fn();
+    applyWithResult.mockRejectedValueOnce(durableFailure);
     const callback = vi.fn();
     const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
 
-    await expect(
-      action?.handler(
-        {} as IAgentRuntime,
-        { id: "message-dismiss-failure" } as Memory,
-        undefined,
-        { parameters: { operation: "dismiss", taskId: "reminder-1" } },
-        callback,
-      ),
-    ).rejects.toThrow("injected durable apply failure");
-    expect(callback).not.toHaveBeenCalled();
+    const result = await action?.handler(
+      { reportError } as unknown as IAgentRuntime,
+      { id: "message-dismiss-failure" } as Memory,
+      undefined,
+      { parameters: { operation: "dismiss", taskId: "reminder-1" } },
+      callback,
+    );
+    expect(result).toMatchObject({
+      success: false,
+      verifiedUserFacing: true,
+      turnComplete: true,
+      data: { failureCode: "REMINDER_MUTATION_UNVERIFIED" },
+    });
+    expect(result?.text).toContain("won't claim it succeeded");
+    expect(callback).toHaveBeenCalledWith({ text: result?.text });
+    expect(reportError).toHaveBeenCalledWith(
+      "SharedReminders.lifecycleMutation",
+      durableFailure,
+      { operation: "dismiss", phase: "dismiss", failedCount: 1 },
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "SharedReminders.handler",
+      durableFailure,
+      { operation: "dismiss", phase: "durable-operation" },
+    );
+  });
+
+  it("still returns the grounded failure when diagnostic reporting throws", async () => {
+    const { options, applyWithResult } = harness();
+    applyWithResult.mockRejectedValueOnce(new Error("durable failure"));
+    const callback = vi.fn();
+    const reportError = vi.fn(() => {
+      throw new Error("diagnostic reporter failure");
+    });
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      { reportError } as unknown as IAgentRuntime,
+      { id: "message-report-error-failure" } as Memory,
+      undefined,
+      { parameters: { operation: "dismiss", target: "Stretch" } },
+      callback,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      verifiedUserFacing: true,
+      turnComplete: true,
+    });
+    expect(callback).toHaveBeenCalledWith({ text: result?.text });
   });
 
   it("states exact millisecond delays and rejects sub-millisecond model durations", async () => {

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -2,6 +2,21 @@
 
 import type { IAgentRuntime, Memory } from "@elizaos/core/edge";
 import { describe, expect, it, vi } from "vitest";
+import {
+  createAnchorRegistry,
+  createCompletionCheckRegistry,
+  createConsolidationRegistry,
+  createEscalationLadderRegistry,
+  createInMemoryScheduledTaskLogStore,
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  createTaskGateRegistry,
+  registerBuiltInCompletionChecks,
+  registerBuiltInGates,
+  registerDefaultEscalationLadders,
+  type ScheduledTaskRunnerHandle,
+  TestNoopScheduledTaskDispatcher,
+} from "./scheduled-task/index.js";
 import type {
   ScheduledTask,
   ScheduledTaskInput,
@@ -146,6 +161,33 @@ function harness(): {
       now: () => new Date(NOW),
     },
   };
+}
+
+function durableRunner(): ScheduledTaskRunnerHandle {
+  const gates = createTaskGateRegistry();
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+  let taskCounter = 0;
+  return createScheduledTaskRunner({
+    agentId: "personal:user-1",
+    store: createInMemoryScheduledTaskStore(),
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: async () => ({ timezone: "UTC" }),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: TestNoopScheduledTaskDispatcher,
+    newTaskId: () => `durable-reminder-${++taskCounter}`,
+    now: () => new Date(NOW),
+  });
 }
 
 describe("Shared reminders edge plugin", () => {
@@ -485,7 +527,15 @@ describe("Shared reminders edge plugin", () => {
     expect(list).toHaveBeenCalledWith({
       kind: "reminder",
       ownerVisibleOnly: true,
-      status: ["scheduled", "fired", "acknowledged"],
+      status: [
+        "scheduled",
+        "fired",
+        "acknowledged",
+        "completed",
+        "skipped",
+        "expired",
+        "failed",
+      ],
     });
     expect(result).toMatchObject({
       verifiedUserFacing: true,
@@ -554,6 +604,60 @@ describe("Shared reminders edge plugin", () => {
       /8:02 PM|every Monday|9:00 AM|2026-08-14T/,
     );
   });
+
+  it.each(["completed", "skipped", "expired", "failed"] as const)(
+    "lists and clears a recurring reminder parked as %s",
+    async (status) => {
+      const { options, list, applyWithResult } = harness();
+      const recurring = {
+        ...scheduledTask(
+          reminderInput(`Recurring ${status}`, {
+            kind: "interval" as const,
+            everyMinutes: 30,
+          }),
+        ),
+        taskId: `recurring-${status}`,
+        state: { status, followupCount: 0 },
+      };
+      list.mockImplementation(async (filter) => {
+        const statuses = Array.isArray(filter?.status)
+          ? filter.status
+          : [filter?.status];
+        return statuses.includes(recurring.state.status) ? [recurring] : [];
+      });
+      const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+      const listed = await action?.handler(
+        {} as IAgentRuntime,
+        { id: `list-recurring-${status}` } as Memory,
+        undefined,
+        { parameters: { operation: "list" } },
+      );
+      expect(listed?.text).toContain(`Recurring ${status} — every 30 minutes`);
+
+      options.clearAllIntent = true;
+      options.clearConfirmationChallenge = true;
+      const cleared = await action?.handler(
+        {} as IAgentRuntime,
+        {
+          id: `clear-recurring-${status}`,
+          content: { text: "yes, clear all reminders" },
+        } as Memory,
+        undefined,
+        { parameters: { operation: "clear", confirmed: true } },
+      );
+      expect(cleared).toMatchObject({
+        success: true,
+        data: { dismissedCount: 1, failedCount: 0 },
+      });
+      expect(applyWithResult).toHaveBeenCalledWith(
+        recurring.taskId,
+        "dismiss",
+        { reason: "confirmed clear all reminders" },
+        expect.any(Object),
+      );
+    },
+  );
 
   it("does not list or mutate a reminder pinned to another trusted destination", async () => {
     const { options, list, applyWithResult } = harness();
@@ -734,6 +838,219 @@ describe("Shared reminders edge plugin", () => {
     ]);
   });
 
+  it.each(["complete", "dismiss"] as const)(
+    "recovers the original durable %s receipt after the row becomes terminal",
+    async (operation) => {
+      const runner = durableRunner();
+      const task = await runner.schedule(
+        reminderInput("Stretch", {
+          kind: "once",
+          atIso: "2026-08-14T20:02:00.000Z",
+        }),
+      );
+      const [action] =
+        createSharedRemindersEdgePlugin({
+          runner,
+          agentId: "personal:user-1",
+          delivery: PRIVATE_DELIVERY,
+          now: () => new Date(NOW),
+        }).actions ?? [];
+      const invoke = () =>
+        action?.handler(
+          {} as IAgentRuntime,
+          { id: `terminal-${operation}-retry` } as Memory,
+          undefined,
+          {
+            parameters: {
+              operation,
+              taskId: task.taskId,
+            },
+          },
+        );
+
+      const first = await invoke();
+      const replay = await invoke();
+
+      expect(first?.effectReceipts?.[0]).toMatchObject({
+        outcome: "applied",
+        operation: `shared.reminder.${operation}`,
+      });
+      expect(replay?.effectReceipts?.[0]).toMatchObject({
+        receiptId: first?.effectReceipts?.[0]?.receiptId,
+        outcome: "noop",
+        operation: `shared.reminder.${operation}`,
+        idempotency: { replayed: true },
+      });
+      expect(replay?.userFacingEffectReceiptIds).toEqual(
+        first?.userFacingEffectReceiptIds,
+      );
+    },
+  );
+
+  it("recovers every clear receipt when the terminal response is retried", async () => {
+    const runner = durableRunner();
+    await runner.schedule(
+      reminderInput("Stretch", {
+        kind: "once",
+        atIso: "2026-08-14T20:02:00.000Z",
+      }),
+    );
+    await runner.schedule(
+      reminderInput("Call mom", {
+        kind: "once",
+        atIso: "2026-08-14T20:03:00.000Z",
+      }),
+    );
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: PRIVATE_DELIVERY,
+        clearAllIntent: true,
+        clearConfirmationChallenge: true,
+        now: () => new Date(NOW),
+      }).actions ?? [];
+    const invoke = () =>
+      action?.handler(
+        {} as IAgentRuntime,
+        {
+          id: "terminal-clear-retry",
+          content: { text: "yes, clear all reminders" },
+        } as Memory,
+        undefined,
+        { parameters: { operation: "clear", confirmed: true } },
+      );
+
+    const first = await invoke();
+    const replay = await invoke();
+
+    expect(first).toMatchObject({
+      success: true,
+      data: { dismissedCount: 2, failedCount: 0 },
+    });
+    expect(replay).toMatchObject({
+      success: true,
+      data: { dismissedCount: 2, failedCount: 0 },
+      effectReceipts: [{ outcome: "noop" }, { outcome: "noop" }],
+    });
+    expect(replay?.userFacingEffectReceiptIds).toEqual(
+      first?.userFacingEffectReceiptIds,
+    );
+  });
+
+  it("replays the original clear target set without dismissing a later reminder", async () => {
+    const runner = durableRunner();
+    await runner.schedule(
+      reminderInput("Original reminder", {
+        kind: "once",
+        atIso: "2026-08-14T20:02:00.000Z",
+      }),
+    );
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: PRIVATE_DELIVERY,
+        clearAllIntent: true,
+        clearConfirmationChallenge: true,
+        now: () => new Date(NOW),
+      }).actions ?? [];
+    const invoke = () =>
+      action?.handler(
+        {} as IAgentRuntime,
+        {
+          id: "terminal-clear-stable-set",
+          content: { text: "yes, clear all reminders" },
+        } as Memory,
+        undefined,
+        { parameters: { operation: "clear", confirmed: true } },
+      );
+
+    const first = await invoke();
+    const later = await runner.schedule(
+      reminderInput("Later reminder", {
+        kind: "once",
+        atIso: "2026-08-14T20:03:00.000Z",
+      }),
+    );
+    const replay = await invoke();
+    const tasks = await runner.list({ kind: "reminder" });
+
+    expect(first).toMatchObject({
+      success: true,
+      data: { dismissedCount: 1, failedCount: 0 },
+    });
+    expect(replay).toMatchObject({
+      success: true,
+      data: { dismissedCount: 1, failedCount: 0 },
+      effectReceipts: [{ outcome: "noop" }],
+    });
+    expect(
+      tasks.find((task) => task.taskId === later.taskId)?.state.status,
+    ).toBe("scheduled");
+  });
+
+  it("keeps a completed recurring reminder live for list, deduplication, and delete", async () => {
+    const runner = durableRunner();
+    const task = await runner.schedule({
+      ...reminderInput("Daily stretch", {
+        kind: "cron",
+        expression: "0 9 * * *",
+        tz: "UTC",
+      }),
+      idempotencyKey: "daily-stretch-original",
+    });
+    await runner.applyWithResult(task.taskId, "complete", undefined, {
+      idempotencyKey: "complete-current-occurrence",
+    });
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: PRIVATE_DELIVERY,
+        now: () => new Date(NOW),
+      }).actions ?? [];
+
+    const listed = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "list-completed-recurring" } as Memory,
+      undefined,
+      { parameters: { operation: "list" } },
+    );
+    expect(listed?.text).toContain(
+      "Daily stretch — every day at 9:00 AM in UTC",
+    );
+
+    const recreated = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "recreate-completed-recurring" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Daily stretch",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+        },
+      },
+    );
+    expect(recreated).toMatchObject({
+      success: true,
+      data: { task: { taskId: task.taskId }, replayed: true },
+    });
+
+    const deleted = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "delete-completed-recurring" } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Daily stretch" } },
+    );
+    expect(deleted).toMatchObject({
+      success: true,
+      data: { task: { taskId: task.taskId }, affectedCount: 1 },
+    });
+  });
+
   it("deduplicates the screenshot correction across distinct message ids and renders Paris time first", async () => {
     const { options, list, scheduleWithResult } = harness();
     let persisted: ScheduledTask | undefined;
@@ -794,6 +1111,7 @@ describe("Shared reminders edge plugin", () => {
       { parameters: { ...parameters, timezone: "europe/paris" } },
     );
     options.clockCorrection = true;
+    options.targetIntent = "semantic-reminder-1";
     const correction = await action?.handler(
       {} as IAgentRuntime,
       {
@@ -801,7 +1119,7 @@ describe("Shared reminders edge plugin", () => {
         content: { text: "3 06 no 1:06" },
       } as Memory,
       undefined,
-      { parameters },
+      { parameters: { ...parameters, operation: "update" } },
     );
 
     expect(durableCreates).toBe(1);
@@ -881,9 +1199,10 @@ describe("Shared reminders edge plugin", () => {
     );
   });
 
-  it("coerces an adversarial planner operation into the trusted screenshot update", async () => {
+  it("refuses an adversarial planner delete during a receipt-bound correction", async () => {
     const { options, list, scheduleWithResult, applyWithResult } = harness();
     options.clockCorrection = true;
+    options.targetIntent = "clock-correction-original";
     const original = {
       ...scheduledTask(
         reminderInput("add something to your todo", {
@@ -932,18 +1251,14 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result).toMatchObject({
-      success: true,
-      data: { operation: "update" },
+      success: false,
+      data: {
+        operation: "update",
+        failureCode: "REMINDER_OPERATION_MISMATCH",
+      },
     });
-    expect(result?.effectReceipts?.map((receipt) => receipt.operation)).toEqual(
-      ["shared.reminder.create", "shared.reminder.dismiss"],
-    );
-    expect(applyWithResult).toHaveBeenCalledWith(
-      "clock-correction-original",
-      "dismiss",
-      { reason: "replaced by reminder update" },
-      expect.any(Object),
-    );
+    expect(scheduleWithResult).not.toHaveBeenCalled();
+    expect(applyWithResult).not.toHaveBeenCalled();
   });
 
   it("does not overwrite an unrelated sole reminder from raw correction language", async () => {
@@ -988,6 +1303,7 @@ describe("Shared reminders edge plugin", () => {
   it.each([
     ["list" as const, "List my reminders"],
     ["create" as const, "Create a reminder to call mom"],
+    ["update" as const, "Update the reminder Stretch to 4pm"],
   ])(
     "prevents planner delete from overriding trusted %s intent",
     async (operationIntent, text) => {
@@ -1012,6 +1328,153 @@ describe("Shared reminders edge plugin", () => {
         },
       });
       expect(list).not.toHaveBeenCalled();
+      expect(applyWithResult).not.toHaveBeenCalled();
+      expect(scheduleWithResult).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a planner mutation when the Shared boundary supplied no operation intent", async () => {
+    const { options, list, applyWithResult, scheduleWithResult } = harness();
+    options.operationIntentRequired = true;
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "negated-update-planner-call",
+        content: { text: "Could you not update my reminder?" },
+      } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      data: {
+        operation: "delete",
+        failureCode: "REMINDER_OPERATION_UNVERIFIED",
+      },
+    });
+    expect(list).not.toHaveBeenCalled();
+    expect(applyWithResult).not.toHaveBeenCalled();
+    expect(scheduleWithResult).not.toHaveBeenCalled();
+  });
+
+  it("rejects planner targeting when a trusted mutation has no exact server target", async () => {
+    const { options, list, applyWithResult } = harness();
+    options.operationIntentRequired = true;
+    options.operationIntent = "delete";
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "contextual-delete-without-target" } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      data: {
+        operation: "delete",
+        failureCode: "REMINDER_TARGET_UNVERIFIED",
+      },
+    });
+    expect(list).not.toHaveBeenCalled();
+    expect(applyWithResult).not.toHaveBeenCalled();
+  });
+
+  it("lets the trusted delete text override a planner-selected different reminder", async () => {
+    const { options, list, applyWithResult } = harness();
+    options.operationIntent = "delete";
+    options.targetIntent = "Remove the reminder Stretch";
+    const tasks = ["Stretch", "Take meds"].map((title, index) => ({
+      ...scheduledTask(
+        reminderInput(title, {
+          kind: "once" as const,
+          atIso: `2026-08-28T0${index + 1}:06:00.000Z`,
+        }),
+      ),
+      taskId: `trusted-target-${index}`,
+    }));
+    list.mockResolvedValue(tasks);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "trusted-delete-target",
+        content: { text: "Remove the reminder Stretch" },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "delete",
+          target: "Take meds",
+          taskId: "trusted-target-1",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { task: { taskId: "trusted-target-0" }, affectedCount: 1 },
+    });
+    expect(applyWithResult).toHaveBeenCalledTimes(1);
+    expect(applyWithResult.mock.calls[0]?.[0]).toBe("trusted-target-0");
+  });
+
+  it.each([
+    {
+      operation: "update" as const,
+      taskTitle: "4pm",
+      planner: {
+        operation: "update",
+        taskId: "wrong-target",
+        target: "4pm",
+        newReminderText: "Changed",
+        atIso: "2026-08-28T14:00:00.000Z",
+      },
+    },
+    {
+      operation: "delete" as const,
+      taskTitle: "Take meds",
+      planner: {
+        operation: "delete",
+        taskId: "wrong-target",
+        target: "Take meds",
+        newReminderText: "unused",
+        atIso: "2026-08-28T14:00:00.000Z",
+      },
+    },
+  ])(
+    "does not fuzzy-match a planner target for trusted $operation intent",
+    async ({ operation, taskTitle, planner }) => {
+      const { options, list, applyWithResult, scheduleWithResult } = harness();
+      options.operationIntent = operation;
+      options.targetIntent = "stretch";
+      list.mockResolvedValue([
+        {
+          ...scheduledTask(
+            reminderInput(taskTitle, {
+              kind: "once",
+              atIso: "2026-08-28T01:06:00.000Z",
+            }),
+          ),
+          taskId: "wrong-target",
+        },
+      ]);
+      const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+      const result = await action?.handler(
+        {} as IAgentRuntime,
+        { id: `exact-${operation}-target` } as Memory,
+        undefined,
+        { parameters: planner },
+      );
+
+      expect(result).toMatchObject({ success: false });
+      expect(result?.text).toContain("stretch");
       expect(applyWithResult).not.toHaveBeenCalled();
       expect(scheduleWithResult).not.toHaveBeenCalled();
     },
@@ -1274,7 +1737,7 @@ describe("Shared reminders edge plugin", () => {
     expect(applyWithResult).toHaveBeenCalledTimes(2);
   });
 
-  it("resolves the exact screenshot delete phrase to its visible reminder title", async () => {
+  it("refuses a planner list when trusted text requires a delete", async () => {
     const { options, list, applyWithResult } = harness();
     options.operationIntent = "delete";
     const task = {
@@ -1306,15 +1769,13 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result).toMatchObject({
-      success: true,
-      data: { operation: "delete", affectedCount: 1 },
+      success: false,
+      data: {
+        operation: "delete",
+        failureCode: "REMINDER_OPERATION_MISMATCH",
+      },
     });
-    expect(applyWithResult).toHaveBeenCalledWith(
-      "screenshot-visible-title",
-      "dismiss",
-      undefined,
-      expect.any(Object),
-    );
+    expect(applyWithResult).not.toHaveBeenCalled();
   });
 
   it("clarifies instead of mutating when target-only todo wording matches two close titles", async () => {

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -69,6 +69,16 @@ function reminderInput(
   };
 }
 
+async function applyIntentMetadataKey(idempotencyKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`intent\0${idempotencyKey}`),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
 function harness(): {
   options: SharedRemindersEdgePluginOptions;
   scheduleWithResult: ReturnType<typeof vi.fn>;
@@ -142,12 +152,33 @@ function harness(): {
       replayed: false,
     }),
   );
+  const reserveApplyIntent = vi.fn(
+    async (
+      taskId: string,
+      input: { idempotencyKey: string; context: Record<string, unknown> },
+    ) => {
+      const intentKey = await applyIntentMetadataKey(input.idempotencyKey);
+      return {
+        task: {
+          ...defaultTask,
+          taskId,
+          metadata: {
+            ...(defaultTask.metadata ?? {}),
+            schedulingApplyIntents: { [intentKey]: input.context },
+          },
+        },
+        idempotencyKey: input.idempotencyKey,
+        replayed: false,
+      };
+    },
+  );
   const runner: ScheduledTaskRunner = {
     scheduleWithResult,
     schedule: vi.fn(async (input: ScheduledTaskInput) => scheduledTask(input)),
     list,
     apply,
     applyWithResult,
+    reserveApplyIntent,
     pipeline: vi.fn(async () => []),
   };
   return {
@@ -984,6 +1015,115 @@ describe("Shared reminders edge plugin", () => {
       success: true,
       data: { dismissedCount: 1, failedCount: 0 },
       effectReceipts: [{ outcome: "noop" }],
+    });
+    expect(
+      tasks.find((task) => task.taskId === later.taskId)?.state.status,
+    ).toBe("scheduled");
+  });
+
+  it("retries a delete against only its reserved original target set", async () => {
+    const runner = durableRunner();
+    await runner.schedule({
+      ...reminderInput("Stretch", {
+        kind: "once",
+        atIso: "2026-08-14T20:02:00.000Z",
+      }),
+      idempotencyKey: "delete-original-a",
+    });
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: PRIVATE_DELIVERY,
+        now: () => new Date(NOW),
+      }).actions ?? [];
+    const invoke = () =>
+      action?.handler(
+        {} as IAgentRuntime,
+        { id: "terminal-delete-stable-set" } as Memory,
+        undefined,
+        { parameters: { operation: "delete", target: "Stretch" } },
+      );
+
+    const first = await invoke();
+    const later = await runner.schedule({
+      ...reminderInput("Stretch", {
+        kind: "once",
+        atIso: "2026-08-14T20:02:00.000Z",
+      }),
+      idempotencyKey: "delete-later-b",
+    });
+    const replay = await invoke();
+    const tasks = await runner.list({ kind: "reminder" });
+
+    expect(first).toMatchObject({
+      success: true,
+      data: { affectedCount: 1, failedCount: 0 },
+    });
+    expect(replay).toMatchObject({
+      success: true,
+      data: { affectedCount: 1, failedCount: 0 },
+      effectReceipts: [{ outcome: "noop" }],
+    });
+    expect(
+      tasks.find((task) => task.taskId === later.taskId)?.state.status,
+    ).toBe("scheduled");
+  });
+
+  it("reserves a clear target set before effects so an all-failed retry spares later tasks", async () => {
+    const durable = durableRunner();
+    await durable.schedule(
+      reminderInput("Original reminder", {
+        kind: "once",
+        atIso: "2026-08-14T20:02:00.000Z",
+      }),
+    );
+    let failDismissals = true;
+    const runner: ScheduledTaskRunner = {
+      ...durable,
+      applyWithResult: async (...args) => {
+        if (failDismissals) throw new Error("injected dismiss outage");
+        return durable.applyWithResult(...args);
+      },
+    };
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: PRIVATE_DELIVERY,
+        clearAllIntent: true,
+        clearConfirmationChallenge: true,
+        now: () => new Date(NOW),
+      }).actions ?? [];
+    const invoke = () =>
+      action?.handler(
+        {} as IAgentRuntime,
+        {
+          id: "terminal-clear-all-effects-failed",
+          content: { text: "yes, clear all reminders" },
+        } as Memory,
+        undefined,
+        { parameters: { operation: "clear", confirmed: true } },
+      );
+
+    const failed = await invoke();
+    const later = await durable.schedule(
+      reminderInput("Later reminder", {
+        kind: "once",
+        atIso: "2026-08-14T20:03:00.000Z",
+      }),
+    );
+    failDismissals = false;
+    const replay = await invoke();
+    const tasks = await durable.list({ kind: "reminder" });
+
+    expect(failed).toMatchObject({
+      success: false,
+      data: { dismissedCount: 0, failedCount: 1 },
+    });
+    expect(replay).toMatchObject({
+      success: true,
+      data: { dismissedCount: 1, failedCount: 0 },
     });
     expect(
       tasks.find((task) => task.taskId === later.taskId)?.state.status,
@@ -1927,6 +2067,11 @@ describe("Shared reminders edge plugin", () => {
       success: false,
       verifiedUserFacing: true,
       turnComplete: true,
+      data: {
+        operation: "delete",
+        requiresSelection: true,
+        candidateTaskIds: ["reminder-1", "reminder-2"],
+      },
     });
     expect(result?.text).toContain("More than one reminder matches");
     expect(result?.text).toContain("1:06 AM UTC");

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -2036,6 +2036,55 @@ describe("Shared reminders edge plugin", () => {
     );
   });
 
+  it("reports a partial replay when a durable delete manifest member is missing", async () => {
+    const { options, list, applyWithResult } = harness();
+    const requestId = "missing-member-delete";
+    const survivor = {
+      ...scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once" as const,
+          atIso: "2026-08-28T01:06:00.000Z",
+        }),
+      ),
+      taskId: "delete-survivor",
+    };
+    const manifest = {
+      kind: "shared_reminder_mutation_manifest",
+      requestId,
+      operation: "delete",
+      taskIds: ["delete-missing", survivor.taskId],
+    } as const;
+    const intentKey = await applyIntentMetadataKey(
+      `shared-reminder:${requestId}:delete:manifest`,
+    );
+    list.mockResolvedValue([
+      {
+        ...survivor,
+        metadata: {
+          ...(survivor.metadata ?? {}),
+          schedulingApplyIntents: { [intentKey]: manifest },
+        },
+      },
+    ]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: requestId } as Memory,
+      undefined,
+      { parameters: { operation: "delete", target: "Stretch" } },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      data: { affectedCount: 1, failedCount: 1 },
+    });
+    expect(result?.text).toContain("Deleted 1 reminder");
+    expect(result?.text).toContain("couldn't verify 1 other matching reminder");
+    expect(applyWithResult).toHaveBeenCalledTimes(1);
+    expect(applyWithResult.mock.calls[0]?.[0]).toBe(survivor.taskId);
+  });
+
   it("asks for schedule clarification when the same visible title is not an exact duplicate", async () => {
     const { options, list, applyWithResult } = harness();
     list.mockResolvedValue([

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -22,6 +22,7 @@ import { stableStringify } from "@elizaos/core/edge";
 import {
   hasScheduledTaskApplyReceipt,
   isScheduledTaskRecurring,
+  scheduledTaskApplyIntentContext,
   scheduledTaskApplyReceiptContext,
 } from "./scheduled-task/runner.js";
 import type {
@@ -40,6 +41,7 @@ export const SHARED_CUTOVER_GATEWAY_CHANNEL = "shared_gateway_dm";
 export const SHARED_REMINDER_MAX_TEXT_LENGTH = 2000;
 const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
 const CLEAR_RECEIPT_CONTEXT_KIND = "shared_reminder_clear_manifest";
+const MUTATION_INTENT_CONTEXT_KIND = "shared_reminder_mutation_manifest";
 
 type ClearReceiptManifest = {
   kind: typeof CLEAR_RECEIPT_CONTEXT_KIND;
@@ -47,8 +49,46 @@ type ClearReceiptManifest = {
   taskIds: string[];
 };
 
+type ReminderMutationManifest = {
+  kind: typeof MUTATION_INTENT_CONTEXT_KIND;
+  requestId: string;
+  operation: "clear" | "delete";
+  taskIds: string[];
+};
+
 function clearApplyIdempotencyKey(requestId: string, taskId: string): string {
   return `shared-reminder:${requestId}:clear:${taskId}`;
+}
+
+function mutationIntentIdempotencyKey(
+  requestId: string,
+  operation: ReminderMutationManifest["operation"],
+): string {
+  return `shared-reminder:${requestId}:${operation}:manifest`;
+}
+
+function parseReminderMutationManifest(
+  context: Record<string, unknown> | undefined,
+  requestId: string,
+  operation: ReminderMutationManifest["operation"],
+): ReminderMutationManifest | undefined {
+  if (
+    context?.kind !== MUTATION_INTENT_CONTEXT_KIND ||
+    context.requestId !== requestId ||
+    context.operation !== operation ||
+    !Array.isArray(context.taskIds) ||
+    context.taskIds.length === 0 ||
+    context.taskIds.length > 10_000 ||
+    !context.taskIds.every(
+      (taskId) => typeof taskId === "string" && taskId.length > 0,
+    )
+  ) {
+    return undefined;
+  }
+  const taskIds = [...new Set(context.taskIds as string[])].sort();
+  return taskIds.length === context.taskIds.length
+    ? { kind: MUTATION_INTENT_CONTEXT_KIND, requestId, operation, taskIds }
+    : undefined;
 }
 
 function parseClearReceiptManifest(
@@ -71,6 +111,122 @@ function parseClearReceiptManifest(
   return taskIds.length === context.taskIds.length
     ? { kind: CLEAR_RECEIPT_CONTEXT_KIND, requestId, taskIds }
     : undefined;
+}
+
+async function recoverReminderMutationManifest(args: {
+  tasks: ScheduledTask[];
+  requestId: string;
+  operation: ReminderMutationManifest["operation"];
+}): Promise<ReminderMutationManifest | undefined> {
+  const intentIdempotencyKey = mutationIntentIdempotencyKey(
+    args.requestId,
+    args.operation,
+  );
+  let recovered: ReminderMutationManifest | undefined;
+  const legacyReceiptTaskIds: string[] = [];
+  const accept = (manifest: ReminderMutationManifest | undefined) => {
+    if (!manifest) return;
+    if (
+      recovered &&
+      stableStringify(recovered.taskIds) !== stableStringify(manifest.taskIds)
+    ) {
+      throw new Error("Conflicting reminder mutation manifests");
+    }
+    recovered = manifest;
+  };
+  for (const task of args.tasks) {
+    accept(
+      parseReminderMutationManifest(
+        await scheduledTaskApplyIntentContext(task, intentIdempotencyKey),
+        args.requestId,
+        args.operation,
+      ),
+    );
+    const effectIdempotencyKey =
+      args.operation === "clear"
+        ? clearApplyIdempotencyKey(args.requestId, task.taskId)
+        : `shared-reminder:${args.requestId}:delete:${task.taskId}`;
+    if (
+      !(await hasScheduledTaskApplyReceipt(
+        task,
+        "dismiss",
+        effectIdempotencyKey,
+      ))
+    ) {
+      continue;
+    }
+    const receiptContext = await scheduledTaskApplyReceiptContext(
+      task,
+      "dismiss",
+      effectIdempotencyKey,
+    );
+    const mutationManifest = parseReminderMutationManifest(
+      receiptContext,
+      args.requestId,
+      args.operation,
+    );
+    if (mutationManifest) {
+      accept(mutationManifest);
+      continue;
+    }
+    if (args.operation === "clear") {
+      const clearManifest = parseClearReceiptManifest(
+        receiptContext,
+        args.requestId,
+      );
+      if (clearManifest) {
+        accept({
+          kind: MUTATION_INTENT_CONTEXT_KIND,
+          requestId: args.requestId,
+          operation: "clear",
+          taskIds: clearManifest.taskIds,
+        });
+        continue;
+      }
+    }
+    legacyReceiptTaskIds.push(task.taskId);
+  }
+  if (recovered) return recovered;
+  const taskIds = [...new Set(legacyReceiptTaskIds)].sort();
+  return taskIds.length > 0
+    ? {
+        kind: MUTATION_INTENT_CONTEXT_KIND,
+        requestId: args.requestId,
+        operation: args.operation,
+        taskIds,
+      }
+    : undefined;
+}
+
+async function reserveReminderMutationManifest(args: {
+  runner: ScheduledTaskRunner;
+  tasks: ScheduledTask[];
+  manifest: ReminderMutationManifest;
+}): Promise<ReminderMutationManifest> {
+  const manifestTaskIds = new Set(args.manifest.taskIds);
+  // list() is creation-ordered in both canonical stores. An additive later
+  // target therefore cannot change the shared oldest anchor chosen by two
+  // same-request reservations racing with different snapshots.
+  const anchor = args.tasks.find((task) => manifestTaskIds.has(task.taskId));
+  if (!anchor || !args.runner.reserveApplyIntent) {
+    throw new Error("Reminder mutation manifest storage is unavailable");
+  }
+  const idempotencyKey = mutationIntentIdempotencyKey(
+    args.manifest.requestId,
+    args.manifest.operation,
+  );
+  const reserved = await args.runner.reserveApplyIntent(anchor.taskId, {
+    idempotencyKey,
+    context: args.manifest,
+  });
+  const stored = parseReminderMutationManifest(
+    await scheduledTaskApplyIntentContext(reserved.task, idempotencyKey),
+    args.manifest.requestId,
+    args.manifest.operation,
+  );
+  if (!stored)
+    throw new Error("Reminder mutation manifest could not be verified");
+  return stored;
 }
 
 export const SHARED_REMINDERS_EDGE_COMPATIBILITY = {
@@ -1015,7 +1171,7 @@ function normalizedOperation(value: string | undefined): string | undefined {
 type ReminderTargetResolution =
   | { kind: "match"; task: ScheduledTask; semanticDuplicates: ScheduledTask[] }
   | { kind: "missing"; text: string }
-  | { kind: "ambiguous"; text: string };
+  | { kind: "ambiguous"; text: string; candidates: ScheduledTask[] };
 
 function ambiguityText(tasks: ScheduledTask[]): string {
   return (
@@ -1081,7 +1237,7 @@ async function resolveReminderTarget(args: {
     return args.coalesceExactSemanticDuplicates &&
       semanticDuplicates.length === tasks.length
       ? { kind: "match", task: first, semanticDuplicates }
-      : { kind: "ambiguous", text: ambiguityText(tasks) };
+      : { kind: "ambiguous", text: ambiguityText(tasks), candidates: tasks };
   }
 
   const idMatch = tasks.find((task) => task.taskId === reference);
@@ -1118,7 +1274,7 @@ async function resolveReminderTarget(args: {
     ) {
       return { kind: "match", task: first, semanticDuplicates };
     }
-    return { kind: "ambiguous", text: ambiguityText(exact) };
+    return { kind: "ambiguous", text: ambiguityText(exact), candidates: exact };
   }
 
   if (args.exactReference) {
@@ -1144,7 +1300,11 @@ async function resolveReminderTarget(args: {
     };
   }
   if (partial.length > 1) {
-    return { kind: "ambiguous", text: ambiguityText(partial) };
+    return {
+      kind: "ambiguous",
+      text: ambiguityText(partial),
+      candidates: partial,
+    };
   }
   return {
     kind: "missing",
@@ -1611,7 +1771,17 @@ export function createSharedRemindersEdgeAction(
             coalesceExactSemanticDuplicates: true,
           });
           if (target.kind !== "match") {
-            return await actionFailure(target.text, callback, { operation });
+            return await actionFailure(target.text, callback, {
+              operation,
+              ...(target.kind === "ambiguous"
+                ? {
+                    requiresSelection: true,
+                    candidateTaskIds: target.candidates
+                      .map((task) => task.taskId)
+                      .slice(0, 100),
+                  }
+                : {}),
+            });
           }
           const body =
             textParameter(
@@ -1830,61 +2000,46 @@ export function createSharedRemindersEdgeAction(
           const scopedById = new Map(
             scopedTasks.map((task) => [task.taskId, task]),
           );
-          const legacyReplayTasks: ScheduledTask[] = [];
-          let recoveredManifest: ClearReceiptManifest | undefined;
-          for (const task of scopedTasks) {
-            const idempotencyKey = clearApplyIdempotencyKey(
+          const recoveredManifest = await recoverReminderMutationManifest({
+            tasks: scopedTasks,
+            requestId,
+            operation: "clear",
+          });
+          const proposedManifest: ReminderMutationManifest =
+            recoveredManifest ?? {
+              kind: MUTATION_INTENT_CONTEXT_KIND,
               requestId,
-              task.taskId,
-            );
-            if (
-              !(await hasScheduledTaskApplyReceipt(
-                task,
-                "dismiss",
-                idempotencyKey,
-              ))
-            ) {
-              continue;
-            }
-            const manifest = parseClearReceiptManifest(
-              await scheduledTaskApplyReceiptContext(
-                task,
-                "dismiss",
-                idempotencyKey,
-              ),
-              requestId,
-            );
-            if (!manifest) {
-              legacyReplayTasks.push(task);
-              continue;
-            }
-            if (
-              recoveredManifest &&
-              stableStringify(recoveredManifest.taskIds) !==
-                stableStringify(manifest.taskIds)
-            ) {
-              return await actionFailure(
-                "I couldn't safely recover the original clear request, so I didn't clear any additional reminders. Please send a new clear request.",
-                callback,
-                {
-                  operation,
-                  failureCode: "REMINDER_CLEAR_MANIFEST_CONFLICT",
-                },
-              );
-            }
-            recoveredManifest = manifest;
+              operation: "clear",
+              taskIds: scopedTasks
+                .filter((task) => isActiveReminder(task))
+                .map((task) => task.taskId)
+                .sort(),
+            };
+          if (proposedManifest.taskIds.length === 0) {
+            const text = "You have no active reminders to clear.";
+            await callback?.({ text });
+            return {
+              success: true,
+              text,
+              data: {
+                actionName: "REMINDERS",
+                operation,
+                dismissedCount: 0,
+                failedCount: 0,
+              },
+              verifiedUserFacing: true,
+              userFacingText: text,
+              turnComplete: true,
+            };
           }
-          // Once any effect commits, its receipt atomically carries the full
-          // original target set. A retry must replay that set rather than
-          // re-listing reminders that may have been created afterward.
-          const manifestTaskIds = recoveredManifest
-            ? recoveredManifest.taskIds
-            : legacyReplayTasks.length > 0
-              ? legacyReplayTasks.map((task) => task.taskId).sort()
-              : scopedTasks
-                  .filter((task) => isActiveReminder(task))
-                  .map((task) => task.taskId)
-                  .sort();
+          // The exact target set is durable before the first dismiss attempt,
+          // including when every downstream effect fails.
+          const manifest = await reserveReminderMutationManifest({
+            runner: options.runner,
+            tasks: scopedTasks,
+            manifest: proposedManifest,
+          });
+          const manifestTaskIds = manifest.taskIds;
           const tasks = manifestTaskIds.flatMap((taskId) => {
             const task = scopedById.get(taskId);
             return task ? [task] : [];
@@ -1974,32 +2129,79 @@ export function createSharedRemindersEdgeAction(
           operation === "dismiss" ||
           operation === "delete"
         ) {
-          const target = await resolveReminderTarget({
-            runner: options.runner,
-            delivery,
-            exactReference: options.targetIntent !== undefined,
-            reference:
-              options.targetIntent ??
-              textParameter(
-                input,
-                "taskId",
-                "target",
-                "targetTitle",
-                "title",
-                "reminderText",
-              ),
-            coalesceExactSemanticDuplicates: operation === "delete",
-            replay: {
-              verb:
-                operation === "delete" || operation === "dismiss"
-                  ? "dismiss"
-                  : operation,
-              idempotencyKey: (task) =>
-                `shared-reminder:${String(message.id)}:${operation}:${task.taskId}`,
-            },
-          });
+          const requestId = String(message.id);
+          const deleteScopedTasks =
+            operation === "delete"
+              ? (
+                  await options.runner.list({
+                    kind: "reminder",
+                    ownerVisibleOnly: true,
+                    status: ALL_REMINDER_STATUSES,
+                  })
+                ).filter((task) => isReminderInDeliveryScope(task, delivery))
+              : undefined;
+          const recoveredDeleteManifest = deleteScopedTasks
+            ? await recoverReminderMutationManifest({
+                tasks: deleteScopedTasks,
+                requestId,
+                operation: "delete",
+              })
+            : undefined;
+          const recoveredDeleteTasks = recoveredDeleteManifest
+            ? recoveredDeleteManifest.taskIds.flatMap((taskId) => {
+                const task = deleteScopedTasks?.find(
+                  (candidate) => candidate.taskId === taskId,
+                );
+                return task ? [task] : [];
+              })
+            : [];
+          const target: ReminderTargetResolution = recoveredDeleteManifest
+            ? recoveredDeleteTasks.length > 0
+              ? {
+                  kind: "match",
+                  task: recoveredDeleteTasks[0],
+                  semanticDuplicates: recoveredDeleteTasks,
+                }
+              : {
+                  kind: "missing",
+                  text: "I couldn't safely recover the original delete request, so I didn't delete any additional reminders. Please send a new delete request.",
+                }
+            : await resolveReminderTarget({
+                runner: options.runner,
+                delivery,
+                exactReference: options.targetIntent !== undefined,
+                reference:
+                  options.targetIntent ??
+                  textParameter(
+                    input,
+                    "taskId",
+                    "target",
+                    "targetTitle",
+                    "title",
+                    "reminderText",
+                  ),
+                coalesceExactSemanticDuplicates: operation === "delete",
+                replay: {
+                  verb:
+                    operation === "delete" || operation === "dismiss"
+                      ? "dismiss"
+                      : operation,
+                  idempotencyKey: (task) =>
+                    `shared-reminder:${requestId}:${operation}:${task.taskId}`,
+                },
+              });
           if (target.kind !== "match") {
-            return await actionFailure(target.text, callback, { operation });
+            return await actionFailure(target.text, callback, {
+              operation,
+              ...(target.kind === "ambiguous"
+                ? {
+                    requiresSelection: true,
+                    candidateTaskIds: target.candidates
+                      .map((task) => task.taskId)
+                      .slice(0, 100),
+                  }
+                : {}),
+            });
           }
           const verb = operation === "delete" ? "dismiss" : operation;
           const minutes = positiveNumber(input, "snoozeMinutes", "minutes");
@@ -2021,8 +2223,39 @@ export function createSharedRemindersEdgeAction(
               { operation },
             );
           }
-          const mutationTargets =
+          let mutationTargets =
             operation === "delete" ? target.semanticDuplicates : [target.task];
+          let deleteManifest: ReminderMutationManifest | undefined;
+          if (operation === "delete") {
+            const proposedManifest: ReminderMutationManifest =
+              recoveredDeleteManifest ?? {
+                kind: MUTATION_INTENT_CONTEXT_KIND,
+                requestId,
+                operation: "delete",
+                taskIds: mutationTargets.map((task) => task.taskId).sort(),
+              };
+            deleteManifest = await reserveReminderMutationManifest({
+              runner: options.runner,
+              tasks: deleteScopedTasks ?? mutationTargets,
+              manifest: proposedManifest,
+            });
+            mutationTargets = deleteManifest.taskIds.flatMap((taskId) => {
+              const task = (deleteScopedTasks ?? mutationTargets).find(
+                (candidate) => candidate.taskId === taskId,
+              );
+              return task ? [task] : [];
+            });
+            if (mutationTargets.length === 0) {
+              return await actionFailure(
+                "I couldn't safely recover the original delete request, so I didn't delete any additional reminders. Please send a new delete request.",
+                callback,
+                {
+                  operation,
+                  failureCode: "REMINDER_DELETE_MANIFEST_UNRECOVERABLE",
+                },
+              );
+            }
+          }
           const appliedResults: ScheduledTaskApplyResult[] = [];
           let failedCount = 0;
           for (const task of mutationTargets) {
@@ -2034,6 +2267,9 @@ export function createSharedRemindersEdgeAction(
                   verb === "snooze" ? { minutes } : undefined,
                   {
                     idempotencyKey: `shared-reminder:${String(message.id)}:${operation}:${task.taskId}`,
+                    ...(deleteManifest
+                      ? { receiptContext: deleteManifest }
+                      : {}),
                   },
                 ),
               );

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -14,12 +14,15 @@ import type {
   ActionResult,
   EffectReceipt,
   HandlerCallback,
+  IAgentRuntime,
   Memory,
   Plugin,
 } from "@elizaos/core/edge";
+import { stableStringify } from "@elizaos/core/edge";
 import type {
   ScheduledTask,
   ScheduledTaskApplyResult,
+  ScheduledTaskInput,
   ScheduledTaskRunner,
   ScheduledTaskTrigger,
 } from "./scheduled-task/types.js";
@@ -272,6 +275,14 @@ export interface SharedRemindersEdgePluginOptions {
   runner: ScheduledTaskRunner;
   agentId: string;
   delivery: SharedReminderDelivery;
+  /** Server-owned provenance that the current turn corrects a grounded reminder. */
+  clockCorrection?: boolean;
+  /** Server-owned provenance for the immediately preceding clear-all warning. */
+  clearConfirmationChallenge?: boolean;
+  /** Server-owned classification that the current request targets all reminders. */
+  clearAllIntent?: boolean;
+  /** High-confidence server classification that dominates a confused planner. */
+  operationIntent?: "create" | "list" | "delete";
   now?: () => Date;
 }
 
@@ -309,14 +320,145 @@ function positiveNumber(
 async function actionFailure(
   text: string,
   callback?: HandlerCallback,
+  data: Record<string, unknown> = {},
 ): Promise<ActionResult> {
   await callback?.({ text });
   return {
     success: false,
     text,
     error: text,
-    data: { actionName: "REMINDERS" },
+    data: { actionName: "REMINDERS", ...data },
+    verifiedUserFacing: true,
+    userFacingText: text,
+    turnComplete: true,
   };
+}
+
+function reportReminderError(
+  runtime: Pick<IAgentRuntime, "reportError">,
+  scope: string,
+  error: unknown,
+  context: Record<string, unknown>,
+): void {
+  try {
+    runtime.reportError?.(scope, error, context);
+  } catch {
+    // Diagnostics are best-effort and must never hide the grounded result.
+  }
+}
+
+const ACTIVE_REMINDER_STATUSES = new Set([
+  "scheduled",
+  "fired",
+  "acknowledged",
+] as const);
+
+function isActiveReminder(task: ScheduledTask): boolean {
+  return ACTIVE_REMINDER_STATUSES.has(
+    task.state.status as "scheduled" | "fired" | "acknowledged",
+  );
+}
+
+function normalizeReminderText(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function normalizeReminderTargetTitle(value: string): string {
+  return normalizeReminderText(value).replace(
+    /\b(?:in|to) (?:my|your) todo(?: list)?\b/gu,
+    "to your todo",
+  );
+}
+
+function normalizeReminderTargetReference(value: string): string {
+  return normalizeReminderTargetTitle(value).replace(
+    /^(?:remove|delete|dismiss|cancel) (?:the )?reminder(?: (?:named|called))? /u,
+    "",
+  );
+}
+
+function deliveryScopeKey(delivery: SharedReminderDelivery): string {
+  if (isSharedGroupReminderDelivery(delivery)) {
+    const { ownerLabel: _ownerLabel, ...immutableAuthority } = delivery;
+    return stableStringify(immutableAuthority);
+  }
+  return stableStringify(delivery);
+}
+
+function taskDelivery(task: ScheduledTask): SharedReminderDelivery | undefined {
+  return parseSharedReminderDelivery(task.metadata?.delivery);
+}
+
+function isReminderInDeliveryScope(
+  task: ScheduledTask,
+  delivery: SharedReminderDelivery,
+): boolean {
+  const persistedDelivery = taskDelivery(task);
+  // Shared has always persisted a trusted destination. A malformed or absent
+  // destination is not legacy authority and must never become reachable from
+  // whichever transport happens to ask first.
+  return (
+    persistedDelivery !== undefined &&
+    deliveryScopeKey(persistedDelivery) === deliveryScopeKey(delivery)
+  );
+}
+
+function sameReminderSemantics(
+  task: ScheduledTask,
+  body: string,
+  trigger: ScheduledTaskTrigger,
+  delivery: SharedReminderDelivery,
+  timezone?: string,
+  includeTimezone = false,
+): boolean {
+  return (
+    isReminderInDeliveryScope(task, delivery) &&
+    normalizeReminderText(reminderText(task)) === normalizeReminderText(body) &&
+    stableStringify(task.trigger) === stableStringify(trigger) &&
+    (!includeTimezone || taskDisplayTimezone(task) === validTimeZone(timezone))
+  );
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+async function semanticCreateIdempotencyKey(args: {
+  agentId: string;
+  body: string;
+  trigger: ScheduledTaskTrigger;
+  delivery: SharedReminderDelivery;
+  timezone?: string;
+  includeTimezone?: boolean;
+  generation: number;
+}): Promise<string> {
+  const digest = await sha256Hex(
+    stableStringify({
+      agentId: args.agentId,
+      body: normalizeReminderText(args.body),
+      trigger: args.trigger,
+      deliveryScope: deliveryScopeKey(args.delivery),
+      ...(args.includeTimezone
+        ? { timezone: validTimeZone(args.timezone) ?? null }
+        : {}),
+    }),
+  );
+  return `shared-reminder:semantic:${digest}:${args.generation}`;
+}
+
+function scheduledTaskInput(task: ScheduledTask): ScheduledTaskInput {
+  const { taskId: _taskId, state: _state, ...input } = task;
+  return input;
 }
 
 function reminderTrigger(
@@ -345,7 +487,11 @@ function reminderTrigger(
     };
   }
   const atIso = textParameter(input, "atIso", "at");
-  if (atIso && Number.isFinite(Date.parse(atIso))) {
+  if (
+    atIso &&
+    /(?:Z|[+-]\d{2}:\d{2})$/iu.test(atIso) &&
+    Number.isFinite(Date.parse(atIso))
+  ) {
     return { kind: "once", atIso: new Date(atIso).toISOString() };
   }
   const everyMinutes = positiveNumber(input, "everyMinutes");
@@ -353,9 +499,14 @@ function reminderTrigger(
     return { kind: "interval", everyMinutes };
   }
   const expression = textParameter(input, "cronExpression", "cron");
-  const tz = textParameter(input, "timezone", "tz");
+  const tz = validTimeZone(textParameter(input, "timezone", "tz"));
   if (expression && tz) return { kind: "cron", expression, tz };
   return undefined;
+}
+
+function hasOffsetlessAtIso(input: Record<string, unknown>): boolean {
+  const atIso = textParameter(input, "atIso", "at");
+  return Boolean(atIso && !/(?:Z|[+-]\d{2}:\d{2})$/iu.test(atIso));
 }
 
 const UTC_MONTHS = [
@@ -387,6 +538,25 @@ function reminderText(task: ScheduledTask): string {
   return task.output?.fallback?.body ?? task.promptInstructions;
 }
 
+function validTimeZone(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: value,
+    }).resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+function taskDisplayTimezone(task: ScheduledTask): string | undefined {
+  const stored = task.metadata?.displayTimezone;
+  if (typeof stored === "string") return validTimeZone(stored);
+  return task.trigger.kind === "cron"
+    ? validTimeZone(task.trigger.tz)
+    : undefined;
+}
+
 function formatUtcInstant(atIso: string): string {
   const instant = new Date(atIso);
   if (!Number.isFinite(instant.getTime())) {
@@ -405,6 +575,37 @@ function formatUtcInstant(atIso: string): string {
         }`;
   const meridiem = hour < 12 ? "AM" : "PM";
   return `on ${UTC_MONTHS[instant.getUTCMonth()]} ${instant.getUTCDate()}, ${instant.getUTCFullYear()} at ${preciseTime} ${meridiem} UTC`;
+}
+
+function formatZonedInstant(atIso: string, timezone?: string): string {
+  const safeTimezone = validTimeZone(timezone);
+  if (!safeTimezone || safeTimezone === "UTC") return formatUtcInstant(atIso);
+  const instant = new Date(atIso);
+  if (!Number.isFinite(instant.getTime())) {
+    throw new Error("Shared reminder has an invalid one-off schedule");
+  }
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: safeTimezone,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second:
+      instant.getUTCSeconds() === 0 && instant.getUTCMilliseconds() === 0
+        ? undefined
+        : "2-digit",
+    hour12: true,
+  }).formatToParts(instant);
+  const part = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((candidate) => candidate.type === type)?.value ?? "";
+  const seconds = part("second");
+  const milliseconds = instant.getUTCMilliseconds();
+  const preciseTime = `${part("hour")}:${part("minute")}${
+    seconds ? `:${seconds}` : ""
+  }${milliseconds === 0 ? "" : `.${String(milliseconds).padStart(3, "0")}`}`;
+  const local = `on ${part("month")} ${part("day")}, ${part("year")} at ${preciseTime} ${part("dayPeriod")} ${safeTimezone}`;
+  return `${local} (${formatUtcInstant(atIso).slice(3)})`;
 }
 
 function formatDuration(milliseconds: number): string {
@@ -473,10 +674,13 @@ function cronScheduleDescription(expression: string, timezone: string): string {
   return `on its recurring schedule in ${timezone}`;
 }
 
-function scheduleDescription(trigger: ScheduledTaskTrigger): string {
+function scheduleDescription(
+  trigger: ScheduledTaskTrigger,
+  timezone?: string,
+): string {
   switch (trigger.kind) {
     case "once":
-      return formatUtcInstant(trigger.atIso);
+      return formatZonedInstant(trigger.atIso, timezone);
     case "interval":
       return `every ${trigger.everyMinutes} ${trigger.everyMinutes === 1 ? "minute" : "minutes"}`;
     case "cron":
@@ -506,7 +710,7 @@ function requestedScheduleDescription(
   const inMilliseconds =
     inMinutes === undefined ? undefined : minuteDurationMilliseconds(inMinutes);
   return inMilliseconds === undefined
-    ? scheduleDescription(trigger)
+    ? scheduleDescription(trigger, textParameter(input, "timezone", "tz"))
     : `in ${formatDuration(inMilliseconds)}`;
 }
 
@@ -516,9 +720,9 @@ function taskSummary(task: ScheduledTask): string {
 
 function taskScheduleDescription(task: ScheduledTask): string {
   if (task.state.status === "scheduled" && task.state.firedAt) {
-    return formatUtcInstant(task.state.firedAt);
+    return formatZonedInstant(task.state.firedAt, taskDisplayTimezone(task));
   }
-  return scheduleDescription(task.trigger);
+  return scheduleDescription(task.trigger, taskDisplayTimezone(task));
 }
 
 function creationReceipt(args: {
@@ -612,6 +816,327 @@ function lifecycleReceipt(
       };
 }
 
+type SemanticScheduleResult =
+  | {
+      kind: "persisted";
+      result: Awaited<ReturnType<ScheduledTaskRunner["scheduleWithResult"]>>;
+    }
+  | { kind: "legacy-existing"; task: ScheduledTask };
+
+async function scheduleSemanticReminder(args: {
+  runner: ScheduledTaskRunner;
+  agentId: string;
+  delivery: SharedReminderDelivery;
+  input: ScheduledTaskInput;
+  includeTimezoneInSemantics?: boolean;
+  requestIdempotencyKey?: string;
+}): Promise<SemanticScheduleResult> {
+  const displayTimezone =
+    typeof args.input.metadata?.displayTimezone === "string"
+      ? args.input.metadata.displayTimezone
+      : args.input.trigger.kind === "cron"
+        ? args.input.trigger.tz
+        : undefined;
+  const allTasks = (
+    await args.runner.list({ kind: "reminder", ownerVisibleOnly: true })
+  ).filter((task) => isReminderInDeliveryScope(task, args.delivery));
+  const semanticMatches = allTasks.filter((task) =>
+    sameReminderSemantics(
+      task,
+      args.input.promptInstructions,
+      args.input.trigger,
+      args.delivery,
+      displayTimezone,
+      args.includeTimezoneInSemantics,
+    ),
+  );
+  const { idempotencyKey: _idempotencyKey, ...input } = args.input;
+  const scheduleGeneration = async (
+    generation: number,
+  ): Promise<SemanticScheduleResult> => ({
+    kind: "persisted",
+    result: await args.runner.scheduleWithResult({
+      ...input,
+      idempotencyKey:
+        args.requestIdempotencyKey ??
+        (await semanticCreateIdempotencyKey({
+          agentId: args.agentId,
+          body: input.promptInstructions,
+          trigger: input.trigger,
+          delivery: args.delivery,
+          timezone: displayTimezone,
+          includeTimezone: args.includeTimezoneInSemantics,
+          generation,
+        })),
+    }),
+  });
+  const activeMatch = semanticMatches.find(isActiveReminder);
+  if (activeMatch) {
+    if (!activeMatch.idempotencyKey) {
+      return { kind: "legacy-existing", task: activeMatch };
+    }
+    const replayed = await args.runner.scheduleWithResult(
+      scheduledTaskInput(activeMatch),
+    );
+    if (isActiveReminder(replayed.task)) {
+      return { kind: "persisted", result: replayed };
+    }
+    // A lifecycle mutation may win between list() and idempotency replay.
+    // Retry once at the next semantic generation; the generation key makes a
+    // concurrent recreator converge on the same durable row.
+    const nextGeneration =
+      semanticMatches.filter((task) => !isActiveReminder(task)).length + 1;
+    return scheduleGeneration(nextGeneration);
+  }
+
+  const generation = semanticMatches.filter(
+    (task) => !isActiveReminder(task),
+  ).length;
+  return scheduleGeneration(generation);
+}
+
+function booleanParameter(
+  input: Record<string, unknown>,
+  ...names: string[]
+): boolean {
+  return names.some((name) => input[name] === true);
+}
+
+function normalizedOperation(value: string | undefined): string | undefined {
+  switch (
+    value
+      ?.trim()
+      .toLowerCase()
+      .replace(/[\s-]+/gu, "_")
+  ) {
+    case "set":
+    case "add":
+      return "create";
+    case "show":
+      return "list";
+    case "change":
+    case "edit":
+    case "reschedule":
+      return "update";
+    case "remove":
+    case "delete":
+    case "cancel":
+      return "delete";
+    case "clear":
+    case "clean":
+    case "clear_all":
+    case "clean_all":
+    case "delete_all":
+    case "remove_all":
+      return "clear";
+    case "create":
+    case "list":
+    case "update":
+    case "snooze":
+    case "complete":
+    case "dismiss":
+      return value
+        ?.trim()
+        .toLowerCase()
+        .replace(/[\s-]+/gu, "_");
+    default:
+      return undefined;
+  }
+}
+
+type ReminderTargetResolution =
+  | { kind: "match"; task: ScheduledTask; semanticDuplicates: ScheduledTask[] }
+  | { kind: "missing"; text: string }
+  | { kind: "ambiguous"; text: string };
+
+function ambiguityText(tasks: ScheduledTask[]): string {
+  return (
+    "More than one reminder matches that. Which one do you mean?\n" +
+    tasks.map((task) => `• ${taskSummary(task)}`).join("\n")
+  );
+}
+
+async function resolveReminderTarget(args: {
+  runner: ScheduledTaskRunner;
+  delivery: SharedReminderDelivery;
+  reference?: string;
+  coalesceExactSemanticDuplicates?: boolean;
+}): Promise<ReminderTargetResolution> {
+  const tasks = (
+    await args.runner.list({
+      kind: "reminder",
+      ownerVisibleOnly: true,
+      status: ["scheduled", "fired", "acknowledged"],
+    })
+  ).filter((task) => isReminderInDeliveryScope(task, args.delivery));
+  if (tasks.length === 0) {
+    return { kind: "missing", text: "You have no active reminders." };
+  }
+  const reference = args.reference?.trim();
+  if (!reference) {
+    if (tasks.length === 1) {
+      return { kind: "match", task: tasks[0], semanticDuplicates: [tasks[0]] };
+    }
+    const [first] = tasks;
+    const semanticDuplicates = tasks.filter((task) =>
+      sameReminderSemantics(
+        task,
+        reminderText(first),
+        first.trigger,
+        args.delivery,
+        taskDisplayTimezone(first),
+        true,
+      ),
+    );
+    return args.coalesceExactSemanticDuplicates &&
+      semanticDuplicates.length === tasks.length
+      ? { kind: "match", task: first, semanticDuplicates }
+      : { kind: "ambiguous", text: ambiguityText(tasks) };
+  }
+
+  const idMatch = tasks.find((task) => task.taskId === reference);
+  if (idMatch) {
+    return { kind: "match", task: idMatch, semanticDuplicates: [idMatch] };
+  }
+
+  const normalizedReference = normalizeReminderText(reference);
+  const normalizedTargetReference = normalizeReminderTargetReference(reference);
+  const exact = tasks.filter(
+    (task) =>
+      normalizeReminderTargetTitle(reminderText(task)) ===
+        normalizedTargetReference ||
+      normalizeReminderText(taskSummary(task)) === normalizedReference,
+  );
+  if (exact.length === 1) {
+    return { kind: "match", task: exact[0], semanticDuplicates: exact };
+  }
+  if (exact.length > 1) {
+    const [first] = exact;
+    const semanticDuplicates = exact.filter((task) =>
+      sameReminderSemantics(
+        task,
+        reminderText(first),
+        first.trigger,
+        args.delivery,
+        taskDisplayTimezone(first),
+        true,
+      ),
+    );
+    if (
+      args.coalesceExactSemanticDuplicates &&
+      semanticDuplicates.length === exact.length
+    ) {
+      return { kind: "match", task: first, semanticDuplicates };
+    }
+    return { kind: "ambiguous", text: ambiguityText(exact) };
+  }
+
+  const partial = tasks.filter((task) => {
+    const title = normalizeReminderTargetTitle(reminderText(task));
+    return (
+      title.length > 0 &&
+      (normalizedTargetReference.includes(title) ||
+        title.includes(normalizedTargetReference))
+    );
+  });
+  if (partial.length === 1) {
+    return {
+      kind: "match",
+      task: partial[0],
+      semanticDuplicates: partial,
+    };
+  }
+  if (partial.length > 1) {
+    return { kind: "ambiguous", text: ambiguityText(partial) };
+  }
+  return {
+    kind: "missing",
+    text: `I couldn't find an active reminder named “${reference}”.`,
+  };
+}
+
+function explicitClearConfirmation(
+  input: Record<string, unknown>,
+  message: Memory,
+  challengeActive: boolean,
+): boolean {
+  if (!challengeActive) return false;
+  if (!booleanParameter(input, "confirmed", "confirmClearAll")) return false;
+  const text = (message.content?.text?.trim() ?? "")
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .replace(/[\p{P}\p{S}]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (!text || text.length > 120) return false;
+  const confirmation =
+    "(?:yes|yep|oui|confirm|confirmed|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)";
+  const clearCommand =
+    "(?:(?:clear|clean|delete|remove) (?:all (?:my )?reminders|the reminder list|the list)|(?:efface|supprime|vide) (?:tous mes rappels|la liste des rappels))";
+  return new RegExp(
+    `^(?:${confirmation})(?: (?:${confirmation}))* ${clearCommand}$`,
+    "iu",
+  ).test(text);
+}
+
+function reminderScheduleInput(args: {
+  agentId: string;
+  body: string;
+  trigger: ScheduledTaskTrigger;
+  delivery: SharedReminderDelivery;
+  timezone?: string;
+}): ScheduledTaskInput {
+  return {
+    kind: "reminder",
+    promptInstructions: args.body,
+    trigger: args.trigger,
+    priority: "medium",
+    escalation: {
+      steps: [{ delayMinutes: 0, channelKey: "current_dm" }],
+    },
+    output: {
+      destination: "channel",
+      target: "current_dm",
+      fallback: { body: args.body },
+    },
+    subject: { kind: "self", id: args.agentId },
+    respectsGlobalPause: true,
+    source: "user_chat",
+    createdBy: args.agentId,
+    ownerVisible: true,
+    metadata: {
+      delivery: args.delivery,
+      ...(args.timezone ? { displayTimezone: args.timezone } : {}),
+    },
+    executionProfile: "notify-only",
+  };
+}
+
+function updatedReminderInput(args: {
+  task: ScheduledTask;
+  body: string;
+  trigger: ScheduledTaskTrigger;
+  delivery: SharedReminderDelivery;
+  timezone?: string;
+}): ScheduledTaskInput {
+  const existing = scheduledTaskInput(args.task);
+  return {
+    ...existing,
+    promptInstructions: args.body,
+    trigger: args.trigger,
+    output: {
+      ...existing.output,
+      destination: "channel",
+      target: "current_dm",
+      fallback: { ...existing.output?.fallback, body: args.body },
+    },
+    metadata: {
+      delivery: args.delivery,
+      ...(args.timezone ? { displayTimezone: args.timezone } : {}),
+    },
+  };
+}
+
 export function createSharedRemindersEdgeAction(
   options: SharedRemindersEdgePluginOptions,
 ): Action {
@@ -630,15 +1155,18 @@ export function createSharedRemindersEdgeAction(
       "REMIND_ME",
       "SET_REMINDER",
       "LIST_REMINDERS",
+      "UPDATE_REMINDER",
+      "DELETE_REMINDER",
       "SNOOZE_REMINDER",
       "DISMISS_REMINDER",
+      "CLEAR_REMINDERS",
     ],
     tags: ["resource:scheduled-item", "capability:read", "capability:write"],
     contexts: ["reminders", "general"],
     roleGate: { minRole: "GUEST" },
     description: groupDelivery
-      ? "Create, list, snooze, complete, or dismiss free reminders delivered only to this linked group chat. For create, supply reminderText and one schedule: inMinutes, atIso, everyMinutes, or cronExpression plus timezone."
-      : "Create, list, snooze, complete, or dismiss free reminders delivered only to this current verified private chat. For create, supply reminderText and one schedule: inMinutes, atIso, everyMinutes, or cronExpression plus timezone.",
+      ? "Create, list, update, snooze, complete, delete/dismiss, or confirmation-gated clear free reminders delivered only to this linked group chat. Resolve mutations by the visible reminder title; never ask the user for a task id. For create or update, supply reminderText and a schedule when it changes: inMinutes, atIso, everyMinutes, or cronExpression plus timezone."
+      : "Create, list, update, snooze, complete, delete/dismiss, or confirmation-gated clear free reminders delivered only to this current verified private chat. Resolve mutations by the visible reminder title; never ask the user for a task id. For create or update, supply reminderText and a schedule when it changes: inMinutes, atIso, everyMinutes, or cronExpression plus timezone.",
     parameters: [
       {
         name: "operation",
@@ -646,7 +1174,16 @@ export function createSharedRemindersEdgeAction(
         required: true,
         schema: {
           type: "string",
-          enum: ["create", "list", "snooze", "complete", "dismiss"],
+          enum: [
+            "create",
+            "list",
+            "update",
+            "snooze",
+            "complete",
+            "delete",
+            "dismiss",
+            "clear",
+          ],
         },
       },
       {
@@ -655,8 +1192,20 @@ export function createSharedRemindersEdgeAction(
         schema: { type: "string" },
       },
       {
+        name: "target",
+        description:
+          "Visible reminder title for update, snooze, complete, delete, or dismiss. Omit only when exactly one active reminder exists.",
+        schema: { type: "string" },
+      },
+      {
+        name: "newReminderText",
+        description: "Replacement reminder text when operation is update.",
+        schema: { type: "string" },
+      },
+      {
         name: "taskId",
-        description: "Reminder id for snooze, complete, or dismiss.",
+        description:
+          "Internal compatibility identifier for a reminder mutation. Never request or display it to the user; prefer target.",
         schema: { type: "string" },
       },
       {
@@ -666,7 +1215,8 @@ export function createSharedRemindersEdgeAction(
       },
       {
         name: "atIso",
-        description: "One-off absolute ISO-8601 timestamp.",
+        description:
+          "One-off absolute ISO-8601 timestamp with an explicit Z or ±HH:MM offset.",
         schema: { type: "string" },
       },
       {
@@ -681,7 +1231,8 @@ export function createSharedRemindersEdgeAction(
       },
       {
         name: "timezone",
-        description: "IANA timezone required with cronExpression.",
+        description:
+          "Canonical IANA timezone used to display one-off atIso times in local time; required with cronExpression.",
         schema: { type: "string" },
       },
       {
@@ -689,225 +1240,649 @@ export function createSharedRemindersEdgeAction(
         description: "Positive snooze duration in minutes.",
         schema: { type: "number" },
       },
+      {
+        name: "confirmed",
+        description:
+          "Set true for operation=clear only after the user explicitly confirms the immediately preceding clear-all warning. Never set it on the initial clear request.",
+        schema: { type: "boolean" },
+      },
     ],
     validate: async () => true,
     handler: async (
-      _runtime,
+      runtime,
       message: Memory,
       _state,
       rawOptions,
       callback?: HandlerCallback,
     ): Promise<ActionResult> => {
       const input = parameters(rawOptions);
-      const operation = textParameter(
-        input,
-        "operation",
-        "action",
-      )?.toLowerCase();
-      if (operation === "list") {
-        const tasks = await options.runner.list({
-          kind: "reminder",
-          ownerVisibleOnly: true,
-          status: ["scheduled", "fired", "acknowledged"],
-        });
-        const text =
-          tasks.length === 0
-            ? "You have no reminders."
-            : `Your reminders:\n${tasks.map((task) => `• ${taskSummary(task)}`).join("\n")}`;
-        await callback?.({ text });
-        return {
-          success: true,
-          text,
-          data: { actionName: "REMINDERS", operation, tasks },
-          verifiedUserFacing: true,
-          userFacingText: text,
-          turnComplete: true,
-        };
-      }
-
-      if (operation === "create") {
-        const body = textParameter(input, "reminderText", "text", "body");
-        if (!body)
-          return await actionFailure("Reminder text is required.", callback);
-        // Group sends reserve the fire-time owner prefix inside the limit.
-        const maxBodyLength = sharedReminderMaxBodyLength(delivery);
-        if (body.length > maxBodyLength) {
-          return await actionFailure(
-            `Reminder text must be ${maxBodyLength} characters or fewer.`,
-            callback,
-          );
-        }
-        const explicitDelay = resolveExplicitSharedReminderDelay(
-          message.content?.text,
-        );
-        if (explicitDelay.kind === "invalid") {
-          return await actionFailure(explicitDelay.reason, callback);
-        }
-        const inputMinutes = positiveNumber(
-          input,
-          "inMinutes",
-          "minutesFromNow",
-        );
-        if (
-          explicitDelay.kind === "absent" &&
-          inputMinutes !== undefined &&
-          minuteDurationMilliseconds(inputMinutes) === undefined
-        ) {
-          return await actionFailure(
-            "Reminder delay must resolve to a positive whole millisecond.",
-            callback,
-          );
-        }
-        const trigger = reminderTrigger(
-          input,
-          now(),
-          explicitDelay.kind === "resolved"
-            ? explicitDelay.milliseconds
-            : undefined,
-        );
-        if (!trigger) {
-          return await actionFailure(
-            "A reminder time is required: inMinutes, atIso, everyMinutes, or cronExpression with timezone.",
-            callback,
-          );
-        }
-        const scheduled = await options.runner.scheduleWithResult({
-          kind: "reminder",
-          promptInstructions: body,
-          trigger,
-          priority: "medium",
-          escalation: {
-            steps: [{ delayMinutes: 0, channelKey: "current_dm" }],
-          },
-          output: {
-            destination: "channel",
-            target: "current_dm",
-            fallback: { body },
-          },
-          subject: { kind: "self", id: options.agentId },
-          idempotencyKey: `shared-reminder:${String(message.id)}:create`,
-          respectsGlobalPause: true,
-          source: "user_chat",
-          createdBy: options.agentId,
-          ownerVisible: true,
-          metadata: { delivery },
-          executionProfile: "notify-only",
-        });
-        const schedule = scheduled.replayed
-          ? taskScheduleDescription(scheduled.task)
-          : requestedScheduleDescription(
-              input,
-              scheduled.task.trigger,
-              explicitDelay.kind === "resolved"
-                ? explicitDelay.milliseconds
-                : undefined,
-            );
-        const persistedBody = reminderText(scheduled.task);
-        const text = scheduled.replayed
-          ? `That reminder is already set ${schedule}: ${persistedBody}`
-          : `Got it — I'll remind ${groupDelivery ? "this group" : "you"} ${schedule}: ${persistedBody}`;
-        const receipt = creationReceipt(scheduled);
-        await callback?.({ text });
-        return {
-          success: true,
-          text,
-          data: {
-            actionName: "REMINDERS",
-            operation,
-            task: scheduled.task,
-            replayed: scheduled.replayed,
-          },
-          verifiedUserFacing: true,
-          userFacingText: text,
-          effectReceipts: [receipt],
-          userFacingEffectReceiptIds: [receipt.receiptId],
-          turnComplete: true,
-        };
-      }
-
-      if (operation === "snooze") {
-        const taskId = textParameter(input, "taskId");
-        const minutes = positiveNumber(input, "snoozeMinutes", "minutes");
-        if (!taskId || minutes === undefined) {
-          return await actionFailure(
-            "Snoozing requires taskId and snoozeMinutes.",
-            callback,
-          );
-        }
-        const snoozeMilliseconds = minuteDurationMilliseconds(minutes);
-        if (snoozeMilliseconds === undefined) {
-          return await actionFailure(
-            "Snooze duration must resolve to a positive whole millisecond.",
-            callback,
-          );
-        }
-        const applied = await options.runner.applyWithResult(
-          taskId,
-          "snooze",
-          { minutes },
-          {
-            idempotencyKey: `shared-reminder:${String(message.id)}:snooze:${taskId}`,
-          },
-        );
-        const text = `Reminder snoozed for ${formatDuration(snoozeMilliseconds)}: ${reminderText(applied.task)}`;
-        const receipt = lifecycleReceipt("snooze", applied);
-        await callback?.({ text });
-        return {
-          success: true,
-          text,
-          data: {
-            actionName: "REMINDERS",
-            operation,
-            task: applied.task,
-            replayed: applied.replayed,
-          },
-          verifiedUserFacing: true,
-          userFacingText: text,
-          effectReceipts: [receipt],
-          userFacingEffectReceiptIds: [receipt.receiptId],
-          turnComplete: true,
-        };
-      }
-
-      if (operation === "complete" || operation === "dismiss") {
-        const taskId = textParameter(input, "taskId");
-        if (!taskId)
-          return await actionFailure(
-            "A reminder taskId is required.",
-            callback,
-          );
-        const applied = await options.runner.applyWithResult(
-          taskId,
-          operation,
-          undefined,
-          {
-            idempotencyKey: `shared-reminder:${String(message.id)}:${operation}:${taskId}`,
-          },
-        );
-        const text = `Reminder ${operation === "complete" ? "completed" : "dismissed"}: ${reminderText(applied.task)}`;
-        const receipt = lifecycleReceipt(operation, applied);
-        await callback?.({ text });
-        return {
-          success: true,
-          text,
-          data: {
-            actionName: "REMINDERS",
-            operation,
-            task: applied.task,
-            replayed: applied.replayed,
-          },
-          verifiedUserFacing: true,
-          userFacingText: text,
-          effectReceipts: [receipt],
-          userFacingEffectReceiptIds: [receipt.receiptId],
-          turnComplete: true,
-        };
-      }
-
-      return await actionFailure(
-        "Choose create, list, snooze, complete, or dismiss.",
-        callback,
+      const requestedOperation = normalizedOperation(
+        textParameter(input, "operation", "action"),
       );
+      // Server-owned intent classifications dominate the planner's operation:
+      // otherwise delete-without-target could bypass clear confirmation or a
+      // grounded correction could delete the user's sole reminder.
+      const operation = options.clearAllIntent
+        ? "clear"
+        : options.clockCorrection
+          ? "update"
+          : (options.operationIntent ?? requestedOperation);
+      if (
+        (options.operationIntent === "create" ||
+          options.operationIntent === "list") &&
+        requestedOperation !== options.operationIntent
+      ) {
+        return await actionFailure(
+          "I couldn't safely verify that reminder operation, so I didn't run it. Please try again.",
+          callback,
+          {
+            operation: options.operationIntent,
+            failureCode: "REMINDER_OPERATION_MISMATCH",
+          },
+        );
+      }
+      try {
+        if (operation === "list") {
+          const tasks = (
+            await options.runner.list({
+              kind: "reminder",
+              ownerVisibleOnly: true,
+              status: ["scheduled", "fired", "acknowledged"],
+            })
+          ).filter((task) => isReminderInDeliveryScope(task, delivery));
+          const text =
+            tasks.length === 0
+              ? "You have no reminders."
+              : `Your reminders:\n${tasks.map((task) => `• ${taskSummary(task)}`).join("\n")}`;
+          await callback?.({ text });
+          return {
+            success: true,
+            text,
+            data: { actionName: "REMINDERS", operation, tasks },
+            verifiedUserFacing: true,
+            userFacingText: text,
+            turnComplete: true,
+          };
+        }
+
+        if (operation === "create") {
+          const body = textParameter(input, "reminderText", "text", "body");
+          if (!body) {
+            return await actionFailure("Reminder text is required.", callback, {
+              operation,
+            });
+          }
+          const maxBodyLength = sharedReminderMaxBodyLength(delivery);
+          if (body.length > maxBodyLength) {
+            return await actionFailure(
+              `Reminder text must be ${maxBodyLength} characters or fewer.`,
+              callback,
+              { operation },
+            );
+          }
+          const requestedTimezone = textParameter(input, "timezone", "tz");
+          const timezone = validTimeZone(requestedTimezone);
+          if (requestedTimezone && !timezone) {
+            return await actionFailure(
+              "Use a valid IANA timezone such as Europe/Paris.",
+              callback,
+              { operation },
+            );
+          }
+          if (hasOffsetlessAtIso(input)) {
+            return await actionFailure(
+              "Use an absolute atIso time with an explicit Z or ±HH:MM offset so I don't guess the timezone.",
+              callback,
+              { operation },
+            );
+          }
+          const explicitDelay = resolveExplicitSharedReminderDelay(
+            message.content?.text,
+          );
+          if (explicitDelay.kind === "invalid") {
+            return await actionFailure(explicitDelay.reason, callback, {
+              operation,
+            });
+          }
+          const inputMinutes = positiveNumber(
+            input,
+            "inMinutes",
+            "minutesFromNow",
+          );
+          if (
+            explicitDelay.kind === "absent" &&
+            inputMinutes !== undefined &&
+            minuteDurationMilliseconds(inputMinutes) === undefined
+          ) {
+            return await actionFailure(
+              "Reminder delay must resolve to a positive whole millisecond.",
+              callback,
+              { operation },
+            );
+          }
+          const trigger = reminderTrigger(
+            input,
+            now(),
+            explicitDelay.kind === "resolved"
+              ? explicitDelay.milliseconds
+              : undefined,
+          );
+          if (!trigger) {
+            return await actionFailure(
+              "A reminder time is required: inMinutes, atIso, everyMinutes, or cronExpression with timezone.",
+              callback,
+              { operation },
+            );
+          }
+          const outcome = await scheduleSemanticReminder({
+            runner: options.runner,
+            agentId: options.agentId,
+            delivery,
+            requestIdempotencyKey:
+              (explicitDelay.kind === "resolved" ||
+                inputMinutes !== undefined) &&
+              message.id
+                ? `shared-reminder:${String(message.id)}:create`
+                : undefined,
+            input: reminderScheduleInput({
+              agentId: options.agentId,
+              body,
+              trigger,
+              delivery,
+              timezone,
+            }),
+          });
+          if (outcome.kind === "legacy-existing") {
+            const text = `That reminder is already set ${taskScheduleDescription(outcome.task)}: ${reminderText(outcome.task)}`;
+            await callback?.({ text });
+            return {
+              success: true,
+              text,
+              data: {
+                actionName: "REMINDERS",
+                operation,
+                deduplicated: true,
+              },
+              verifiedUserFacing: true,
+              userFacingText: text,
+              turnComplete: true,
+            };
+          }
+          if (!isActiveReminder(outcome.result.task)) {
+            return await actionFailure(
+              "That retried reminder request is no longer active, so I didn't create another reminder.",
+              callback,
+              { operation, replayedTerminalRequest: true },
+            );
+          }
+          const scheduled = outcome.result;
+          const schedule = scheduled.replayed
+            ? taskScheduleDescription(scheduled.task)
+            : requestedScheduleDescription(
+                input,
+                scheduled.task.trigger,
+                explicitDelay.kind === "resolved"
+                  ? explicitDelay.milliseconds
+                  : undefined,
+              );
+          const persistedBody = reminderText(scheduled.task);
+          const text = scheduled.replayed
+            ? `That reminder is already set ${schedule}: ${persistedBody}`
+            : `Got it — I'll remind ${groupDelivery ? "this group" : "you"} ${schedule}: ${persistedBody}`;
+          const receipt = creationReceipt(scheduled);
+          await callback?.({ text });
+          return {
+            success: true,
+            text,
+            data: {
+              actionName: "REMINDERS",
+              operation,
+              task: scheduled.task,
+              replayed: scheduled.replayed,
+              deduplicated: scheduled.replayed,
+            },
+            verifiedUserFacing: true,
+            userFacingText: text,
+            effectReceipts: [receipt],
+            userFacingEffectReceiptIds: [receipt.receiptId],
+            turnComplete: true,
+          };
+        }
+
+        if (operation === "update") {
+          const target = await resolveReminderTarget({
+            runner: options.runner,
+            delivery,
+            reference: textParameter(
+              input,
+              "taskId",
+              "target",
+              "targetTitle",
+              "existingTitle",
+              "title",
+            ),
+            coalesceExactSemanticDuplicates: true,
+          });
+          if (target.kind !== "match") {
+            return await actionFailure(target.text, callback, { operation });
+          }
+          const body =
+            textParameter(
+              input,
+              "newReminderText",
+              "replacementText",
+              "reminderText",
+            ) ?? reminderText(target.task);
+          const maxBodyLength = sharedReminderMaxBodyLength(delivery);
+          if (body.length > maxBodyLength) {
+            return await actionFailure(
+              `Reminder text must be ${maxBodyLength} characters or fewer.`,
+              callback,
+              { operation },
+            );
+          }
+          const requestedTimezone = textParameter(input, "timezone", "tz");
+          const timezone = requestedTimezone
+            ? validTimeZone(requestedTimezone)
+            : taskDisplayTimezone(target.task);
+          if (requestedTimezone && !timezone) {
+            return await actionFailure(
+              "Use a valid IANA timezone such as Europe/Paris.",
+              callback,
+              { operation },
+            );
+          }
+          if (hasOffsetlessAtIso(input)) {
+            return await actionFailure(
+              "Use an absolute atIso time with an explicit Z or ±HH:MM offset so I don't guess the timezone. Nothing was changed.",
+              callback,
+              { operation },
+            );
+          }
+          const explicitDelay = resolveExplicitSharedReminderDelay(
+            message.content?.text,
+          );
+          if (explicitDelay.kind === "invalid") {
+            return await actionFailure(explicitDelay.reason, callback, {
+              operation,
+            });
+          }
+          const hasSchedulePatch =
+            explicitDelay.kind === "resolved" ||
+            [
+              "inMinutes",
+              "minutesFromNow",
+              "atIso",
+              "at",
+              "everyMinutes",
+              "cronExpression",
+              "cron",
+            ].some((name) => input[name] !== undefined);
+          const usesRelativeSchedule =
+            explicitDelay.kind === "resolved" ||
+            ["inMinutes", "minutesFromNow"].some(
+              (name) => input[name] !== undefined,
+            );
+          const trigger = hasSchedulePatch
+            ? reminderTrigger(
+                input,
+                now(),
+                explicitDelay.kind === "resolved"
+                  ? explicitDelay.milliseconds
+                  : undefined,
+              )
+            : requestedTimezone &&
+                timezone &&
+                target.task.trigger.kind === "cron"
+              ? { ...target.task.trigger, tz: timezone }
+              : target.task.trigger;
+          if (!trigger) {
+            return await actionFailure(
+              "I couldn't understand the replacement reminder time. Nothing was changed.",
+              callback,
+              { operation },
+            );
+          }
+          const outcome = await scheduleSemanticReminder({
+            runner: options.runner,
+            agentId: options.agentId,
+            delivery,
+            includeTimezoneInSemantics: true,
+            requestIdempotencyKey:
+              usesRelativeSchedule && message.id
+                ? `shared-reminder:${String(message.id)}:update-replacement`
+                : undefined,
+            input: updatedReminderInput({
+              task: target.task,
+              body,
+              trigger,
+              delivery,
+              timezone,
+            }),
+          });
+          if (
+            outcome.kind === "persisted" &&
+            !isActiveReminder(outcome.result.task)
+          ) {
+            return await actionFailure(
+              "That retried reminder update is no longer active, so I didn't create another reminder or dismiss anything else.",
+              callback,
+              { operation, replayedTerminalRequest: true },
+            );
+          }
+          const replacement =
+            outcome.kind === "persisted" ? outcome.result.task : outcome.task;
+          const receipts: EffectReceipt[] =
+            outcome.kind === "persisted"
+              ? [creationReceipt(outcome.result)]
+              : [];
+          const originalsToDismiss = target.semanticDuplicates.filter(
+            (task) => task.taskId !== replacement.taskId,
+          );
+          let failedDismissals = 0;
+          for (const original of originalsToDismiss) {
+            try {
+              const dismissed = await options.runner.applyWithResult(
+                original.taskId,
+                "dismiss",
+                { reason: "replaced by reminder update" },
+                {
+                  idempotencyKey: `shared-reminder:${String(message.id)}:update-dismiss:${original.taskId}`,
+                },
+              );
+              receipts.push(lifecycleReceipt("dismiss", dismissed));
+            } catch (error) {
+              failedDismissals += 1;
+              reportReminderError(
+                runtime,
+                "SharedReminders.updateDismiss",
+                error,
+                {
+                  operation,
+                  phase: "replacement-dismiss",
+                  failedCount: failedDismissals,
+                },
+              );
+            }
+          }
+          if (failedDismissals > 0) {
+            const removedCount = originalsToDismiss.length - failedDismissals;
+            const text = `I saved the replacement reminder and removed ${removedCount} ${removedCount === 1 ? "old copy" : "old copies"}, but couldn't verify removal of ${failedDismissals} ${failedDismissals === 1 ? "other copy" : "other copies"}. Please list your reminders before retrying.`;
+            await callback?.({ text });
+            return {
+              success: false,
+              text,
+              error: text,
+              data: {
+                actionName: "REMINDERS",
+                operation,
+                partial: true,
+                replacement,
+                removedCount,
+                failedCount: failedDismissals,
+              },
+              verifiedUserFacing: true,
+              userFacingText: text,
+              effectReceipts: receipts,
+              userFacingEffectReceiptIds: receipts.map(
+                (receipt) => receipt.receiptId,
+              ),
+              turnComplete: true,
+            };
+          }
+          const text =
+            replacement.taskId === target.task.taskId
+              ? `That reminder is already set ${taskScheduleDescription(replacement)}: ${reminderText(replacement)}`
+              : `Updated reminder: ${taskSummary(replacement)}`;
+          await callback?.({ text });
+          return {
+            success: true,
+            text,
+            data: {
+              actionName: "REMINDERS",
+              operation,
+              task: replacement,
+              replayed: outcome.kind === "persisted" && outcome.result.replayed,
+            },
+            verifiedUserFacing: true,
+            userFacingText: text,
+            ...(receipts.length
+              ? {
+                  effectReceipts: receipts,
+                  userFacingEffectReceiptIds: receipts.map(
+                    (receipt) => receipt.receiptId,
+                  ),
+                }
+              : {}),
+            turnComplete: true,
+          };
+        }
+
+        if (operation === "clear") {
+          if (
+            !explicitClearConfirmation(
+              input,
+              message,
+              options.clearConfirmationChallenge === true,
+            )
+          ) {
+            return await actionFailure(
+              "Clearing removes every active reminder. Please confirm by replying “yes, clear all reminders”.",
+              callback,
+              { operation, requiresConfirmation: true },
+            );
+          }
+          const tasks = (
+            await options.runner.list({
+              kind: "reminder",
+              ownerVisibleOnly: true,
+              status: ["scheduled", "fired", "acknowledged"],
+            })
+          ).filter((task) => isReminderInDeliveryScope(task, delivery));
+          if (tasks.length === 0) {
+            const text = "You have no active reminders to clear.";
+            await callback?.({ text });
+            return {
+              success: true,
+              text,
+              data: {
+                actionName: "REMINDERS",
+                operation,
+                dismissedCount: 0,
+                failedCount: 0,
+              },
+              verifiedUserFacing: true,
+              userFacingText: text,
+              turnComplete: true,
+            };
+          }
+          const receipts: EffectReceipt[] = [];
+          let failedCount = 0;
+          for (const task of tasks) {
+            try {
+              const applied = await options.runner.applyWithResult(
+                task.taskId,
+                "dismiss",
+                { reason: "confirmed clear all reminders" },
+                {
+                  idempotencyKey: `shared-reminder:${String(message.id)}:clear:${task.taskId}`,
+                },
+              );
+              receipts.push(lifecycleReceipt("dismiss", applied));
+            } catch (error) {
+              failedCount += 1;
+              reportReminderError(
+                runtime,
+                "SharedReminders.clearDismiss",
+                error,
+                {
+                  operation,
+                  phase: "confirmed-clear-dismiss",
+                  failedCount,
+                },
+              );
+            }
+          }
+          const dismissedCount = receipts.length;
+          const text =
+            failedCount === 0
+              ? `Cleared ${dismissedCount} ${dismissedCount === 1 ? "reminder" : "reminders"}.`
+              : `Cleared ${dismissedCount} ${dismissedCount === 1 ? "reminder" : "reminders"}, but couldn't verify ${failedCount} ${failedCount === 1 ? "other reminder" : "other reminders"}.`;
+          await callback?.({ text });
+          return {
+            success: failedCount === 0,
+            text,
+            ...(failedCount > 0 ? { error: text } : {}),
+            data: {
+              actionName: "REMINDERS",
+              operation,
+              dismissedCount,
+              failedCount,
+            },
+            verifiedUserFacing: true,
+            userFacingText: text,
+            effectReceipts: receipts,
+            userFacingEffectReceiptIds: receipts.map(
+              (receipt) => receipt.receiptId,
+            ),
+            turnComplete: true,
+          };
+        }
+
+        if (
+          operation === "snooze" ||
+          operation === "complete" ||
+          operation === "dismiss" ||
+          operation === "delete"
+        ) {
+          const target = await resolveReminderTarget({
+            runner: options.runner,
+            delivery,
+            reference:
+              textParameter(
+                input,
+                "taskId",
+                "target",
+                "targetTitle",
+                "title",
+                "reminderText",
+              ) ??
+              (options.operationIntent === "delete"
+                ? message.content?.text
+                : undefined),
+            coalesceExactSemanticDuplicates: operation === "delete",
+          });
+          if (target.kind !== "match") {
+            return await actionFailure(target.text, callback, { operation });
+          }
+          const verb = operation === "delete" ? "dismiss" : operation;
+          const minutes = positiveNumber(input, "snoozeMinutes", "minutes");
+          if (verb === "snooze" && minutes === undefined) {
+            return await actionFailure(
+              "Tell me how many minutes to snooze that reminder.",
+              callback,
+              { operation },
+            );
+          }
+          const snoozeMilliseconds =
+            verb === "snooze" && minutes !== undefined
+              ? minuteDurationMilliseconds(minutes)
+              : undefined;
+          if (verb === "snooze" && snoozeMilliseconds === undefined) {
+            return await actionFailure(
+              "Snooze duration must resolve to a positive whole millisecond.",
+              callback,
+              { operation },
+            );
+          }
+          const mutationTargets =
+            operation === "delete" ? target.semanticDuplicates : [target.task];
+          const appliedResults: ScheduledTaskApplyResult[] = [];
+          let failedCount = 0;
+          for (const task of mutationTargets) {
+            try {
+              appliedResults.push(
+                await options.runner.applyWithResult(
+                  task.taskId,
+                  verb,
+                  verb === "snooze" ? { minutes } : undefined,
+                  {
+                    idempotencyKey: `shared-reminder:${String(message.id)}:${operation}:${task.taskId}`,
+                  },
+                ),
+              );
+            } catch (error) {
+              reportReminderError(
+                runtime,
+                "SharedReminders.lifecycleMutation",
+                error,
+                {
+                  operation,
+                  phase: verb,
+                  failedCount: failedCount + 1,
+                },
+              );
+              if (operation !== "delete") throw error;
+              failedCount += 1;
+            }
+          }
+          const applied = appliedResults[0];
+          const appliedTask = applied?.task ?? target.task;
+          const text =
+            verb === "snooze"
+              ? `Reminder snoozed for ${formatDuration(snoozeMilliseconds as number)}: ${reminderText(appliedTask)}`
+              : operation === "delete"
+                ? failedCount > 0
+                  ? `Deleted ${appliedResults.length} ${appliedResults.length === 1 ? "reminder" : "reminders"}, but couldn't verify ${failedCount} ${failedCount === 1 ? "other matching reminder" : "other matching reminders"}: ${reminderText(appliedTask)}`
+                  : appliedResults.length === 1
+                    ? `Reminder deleted: ${reminderText(appliedTask)}`
+                    : `Deleted ${appliedResults.length} identical reminders: ${reminderText(appliedTask)}`
+                : `Reminder ${verb === "complete" ? "completed" : "dismissed"}: ${reminderText(appliedTask)}`;
+          const receipts = appliedResults.map((result) =>
+            lifecycleReceipt(verb, result),
+          );
+          await callback?.({ text });
+          return {
+            success: failedCount === 0,
+            text,
+            ...(failedCount > 0 ? { error: text } : {}),
+            data: {
+              actionName: "REMINDERS",
+              operation,
+              task: appliedTask,
+              replayed: applied?.replayed ?? false,
+              affectedCount: appliedResults.length,
+              failedCount,
+            },
+            verifiedUserFacing: true,
+            userFacingText: text,
+            effectReceipts: receipts,
+            userFacingEffectReceiptIds: receipts.map(
+              (receipt) => receipt.receiptId,
+            ),
+            turnComplete: true,
+          };
+        }
+
+        return await actionFailure(
+          "Choose create, list, update, snooze, complete, delete, dismiss, or clear.",
+          callback,
+          { operation: operation ?? "unknown" },
+        );
+      } catch (error) {
+        reportReminderError(runtime, "SharedReminders.handler", error, {
+          operation: operation ?? "unknown",
+          phase: "durable-operation",
+        });
+        return await actionFailure(
+          "I couldn't verify that reminder change, so I won't claim it succeeded. Please list your reminders before retrying.",
+          callback,
+          {
+            operation: operation ?? "unknown",
+            failureCode: "REMINDER_MUTATION_UNVERIFIED",
+          },
+        );
+      }
     },
   };
 }

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -19,11 +19,18 @@ import type {
   Plugin,
 } from "@elizaos/core/edge";
 import { stableStringify } from "@elizaos/core/edge";
+import {
+  hasScheduledTaskApplyReceipt,
+  isScheduledTaskRecurring,
+  scheduledTaskApplyReceiptContext,
+} from "./scheduled-task/runner.js";
 import type {
   ScheduledTask,
   ScheduledTaskApplyResult,
   ScheduledTaskInput,
+  ScheduledTaskReceiptVerb,
   ScheduledTaskRunner,
+  ScheduledTaskStatus,
   ScheduledTaskTrigger,
 } from "./scheduled-task/types.js";
 import { resolveExplicitSharedReminderDelay } from "./shared-reminder-relative-delay.js";
@@ -32,6 +39,39 @@ import { resolveExplicitSharedReminderDelay } from "./shared-reminder-relative-d
 export const SHARED_CUTOVER_GATEWAY_CHANNEL = "shared_gateway_dm";
 export const SHARED_REMINDER_MAX_TEXT_LENGTH = 2000;
 const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+const CLEAR_RECEIPT_CONTEXT_KIND = "shared_reminder_clear_manifest";
+
+type ClearReceiptManifest = {
+  kind: typeof CLEAR_RECEIPT_CONTEXT_KIND;
+  requestId: string;
+  taskIds: string[];
+};
+
+function clearApplyIdempotencyKey(requestId: string, taskId: string): string {
+  return `shared-reminder:${requestId}:clear:${taskId}`;
+}
+
+function parseClearReceiptManifest(
+  context: Record<string, unknown> | undefined,
+  requestId: string,
+): ClearReceiptManifest | undefined {
+  if (
+    context?.kind !== CLEAR_RECEIPT_CONTEXT_KIND ||
+    context.requestId !== requestId ||
+    !Array.isArray(context.taskIds) ||
+    context.taskIds.length === 0 ||
+    context.taskIds.length > 10_000 ||
+    !context.taskIds.every(
+      (taskId) => typeof taskId === "string" && taskId.length > 0,
+    )
+  ) {
+    return undefined;
+  }
+  const taskIds = [...new Set(context.taskIds as string[])].sort();
+  return taskIds.length === context.taskIds.length
+    ? { kind: CLEAR_RECEIPT_CONTEXT_KIND, requestId, taskIds }
+    : undefined;
+}
 
 export const SHARED_REMINDERS_EDGE_COMPATIBILITY = {
   target: "edge",
@@ -275,6 +315,8 @@ export interface SharedRemindersEdgePluginOptions {
   runner: ScheduledTaskRunner;
   agentId: string;
   delivery: SharedReminderDelivery;
+  /** Reject planner-selected operations unless this server boundary supplied intent. */
+  operationIntentRequired?: boolean;
   /** Server-owned provenance that the current turn corrects a grounded reminder. */
   clockCorrection?: boolean;
   /** Server-owned provenance for the immediately preceding clear-all warning. */
@@ -282,7 +324,16 @@ export interface SharedRemindersEdgePluginOptions {
   /** Server-owned classification that the current request targets all reminders. */
   clearAllIntent?: boolean;
   /** High-confidence server classification that dominates a confused planner. */
-  operationIntent?: "create" | "list" | "delete";
+  operationIntent?:
+    | "create"
+    | "list"
+    | "update"
+    | "snooze"
+    | "complete"
+    | "delete"
+    | "dismiss";
+  /** Server-owned visible title or exact task id; planner targets cannot override it. */
+  targetIntent?: string;
   now?: () => Date;
 }
 
@@ -347,15 +398,32 @@ function reportReminderError(
   }
 }
 
-const ACTIVE_REMINDER_STATUSES = new Set([
+const IMMEDIATELY_ACTIVE_REMINDER_STATUSES = new Set([
   "scheduled",
   "fired",
   "acknowledged",
 ] as const);
 
+const QUERYABLE_REMINDER_STATUSES: ScheduledTaskStatus[] = [
+  "scheduled",
+  "fired",
+  "acknowledged",
+  "completed",
+  "skipped",
+  "expired",
+  "failed",
+];
+const ALL_REMINDER_STATUSES: ScheduledTaskStatus[] = [
+  ...QUERYABLE_REMINDER_STATUSES,
+  "dismissed",
+];
+
 function isActiveReminder(task: ScheduledTask): boolean {
-  return ACTIVE_REMINDER_STATUSES.has(
-    task.state.status as "scheduled" | "fired" | "acknowledged",
+  return (
+    IMMEDIATELY_ACTIVE_REMINDER_STATUSES.has(
+      task.state.status as "scheduled" | "fired" | "acknowledged",
+    ) ||
+    (task.state.status !== "dismissed" && isScheduledTaskRecurring(task))
   );
 }
 
@@ -960,15 +1028,37 @@ async function resolveReminderTarget(args: {
   runner: ScheduledTaskRunner;
   delivery: SharedReminderDelivery;
   reference?: string;
+  exactReference?: boolean;
   coalesceExactSemanticDuplicates?: boolean;
+  replay?: {
+    verb: ScheduledTaskReceiptVerb;
+    idempotencyKey: (task: ScheduledTask) => string;
+  };
 }): Promise<ReminderTargetResolution> {
-  const tasks = (
+  const scopedTasks = (
     await args.runner.list({
       kind: "reminder",
       ownerVisibleOnly: true,
-      status: ["scheduled", "fired", "acknowledged"],
+      status: ALL_REMINDER_STATUSES,
     })
   ).filter((task) => isReminderInDeliveryScope(task, args.delivery));
+  const tasks: ScheduledTask[] = [];
+  for (const task of scopedTasks) {
+    if (isActiveReminder(task)) {
+      tasks.push(task);
+      continue;
+    }
+    if (
+      args.replay &&
+      (await hasScheduledTaskApplyReceipt(
+        task,
+        args.replay.verb,
+        args.replay.idempotencyKey(task),
+      ))
+    ) {
+      tasks.push(task);
+    }
+  }
   if (tasks.length === 0) {
     return { kind: "missing", text: "You have no active reminders." };
   }
@@ -1031,6 +1121,13 @@ async function resolveReminderTarget(args: {
     return { kind: "ambiguous", text: ambiguityText(exact) };
   }
 
+  if (args.exactReference) {
+    return {
+      kind: "missing",
+      text: `I couldn't find an active reminder named “${reference}”.`,
+    };
+  }
+
   const partial = tasks.filter((task) => {
     const title = normalizeReminderTargetTitle(reminderText(task));
     return (
@@ -1072,7 +1169,7 @@ function explicitClearConfirmation(
   const confirmation =
     "(?:yes|yep|oui|confirm|confirmed|confirmé|confirmée|i confirm|je confirme|do it|go ahead|vas y|allez y)";
   const clearCommand =
-    "(?:(?:clear|clean|delete|remove) (?:all (?:my )?reminders|the reminder list|the list)|(?:efface|supprime|vide) (?:tous mes rappels|la liste des rappels))";
+    "(?:(?:clear|clean|delete|remove|dismiss|cancel) (?:all (?:my )?reminders|the reminder list|the list)|(?:efface|supprime|vide) (?:tous mes rappels|la liste des rappels))";
   return new RegExp(
     `^(?:${confirmation})(?: (?:${confirmation}))* ${clearCommand}$`,
     "iu",
@@ -1259,6 +1356,21 @@ export function createSharedRemindersEdgeAction(
       const requestedOperation = normalizedOperation(
         textParameter(input, "operation", "action"),
       );
+      if (
+        options.operationIntentRequired === true &&
+        options.clearAllIntent !== true &&
+        options.clockCorrection !== true &&
+        options.operationIntent === undefined
+      ) {
+        return await actionFailure(
+          "I couldn't safely verify that reminder request, so I didn't run it. Please state the reminder action explicitly.",
+          callback,
+          {
+            operation: requestedOperation,
+            failureCode: "REMINDER_OPERATION_UNVERIFIED",
+          },
+        );
+      }
       // Server-owned intent classifications dominate the planner's operation:
       // otherwise delete-without-target could bypass clear confirmation or a
       // grounded correction could delete the user's sole reminder.
@@ -1267,17 +1379,44 @@ export function createSharedRemindersEdgeAction(
         : options.clockCorrection
           ? "update"
           : (options.operationIntent ?? requestedOperation);
+      const enforcedOperationIntent = options.clockCorrection
+        ? "update"
+        : options.operationIntent;
       if (
-        (options.operationIntent === "create" ||
-          options.operationIntent === "list") &&
-        requestedOperation !== options.operationIntent
+        enforcedOperationIntent !== undefined &&
+        requestedOperation !== enforcedOperationIntent
       ) {
         return await actionFailure(
           "I couldn't safely verify that reminder operation, so I didn't run it. Please try again.",
           callback,
           {
-            operation: options.operationIntent,
+            operation: enforcedOperationIntent,
             failureCode: "REMINDER_OPERATION_MISMATCH",
+          },
+        );
+      }
+      if (options.clockCorrection && !options.targetIntent) {
+        return await actionFailure(
+          "I couldn't safely identify the reminder being corrected, so nothing was changed. Please list your reminders and try again.",
+          callback,
+          {
+            operation: "update",
+            failureCode: "REMINDER_CORRECTION_TARGET_UNVERIFIED",
+          },
+        );
+      }
+      if (
+        enforcedOperationIntent !== undefined &&
+        enforcedOperationIntent !== "create" &&
+        enforcedOperationIntent !== "list" &&
+        !options.targetIntent
+      ) {
+        return await actionFailure(
+          "I couldn't safely identify which reminder you meant, so I didn't change anything. Please name the reminder.",
+          callback,
+          {
+            operation: enforcedOperationIntent,
+            failureCode: "REMINDER_TARGET_UNVERIFIED",
           },
         );
       }
@@ -1287,9 +1426,13 @@ export function createSharedRemindersEdgeAction(
             await options.runner.list({
               kind: "reminder",
               ownerVisibleOnly: true,
-              status: ["scheduled", "fired", "acknowledged"],
+              status: QUERYABLE_REMINDER_STATUSES,
             })
-          ).filter((task) => isReminderInDeliveryScope(task, delivery));
+          ).filter(
+            (task) =>
+              isActiveReminder(task) &&
+              isReminderInDeliveryScope(task, delivery),
+          );
           const text =
             tasks.length === 0
               ? "You have no reminders."
@@ -1402,6 +1545,7 @@ export function createSharedRemindersEdgeAction(
                 actionName: "REMINDERS",
                 operation,
                 deduplicated: true,
+                task: outcome.task,
               },
               verifiedUserFacing: true,
               userFacingText: text,
@@ -1453,14 +1597,17 @@ export function createSharedRemindersEdgeAction(
           const target = await resolveReminderTarget({
             runner: options.runner,
             delivery,
-            reference: textParameter(
-              input,
-              "taskId",
-              "target",
-              "targetTitle",
-              "existingTitle",
-              "title",
-            ),
+            exactReference: options.targetIntent !== undefined,
+            reference:
+              options.targetIntent ??
+              textParameter(
+                input,
+                "taskId",
+                "target",
+                "targetTitle",
+                "existingTitle",
+                "title",
+              ),
             coalesceExactSemanticDuplicates: true,
           });
           if (target.kind !== "match") {
@@ -1672,13 +1819,76 @@ export function createSharedRemindersEdgeAction(
               { operation, requiresConfirmation: true },
             );
           }
-          const tasks = (
+          const scopedTasks = (
             await options.runner.list({
               kind: "reminder",
               ownerVisibleOnly: true,
-              status: ["scheduled", "fired", "acknowledged"],
+              status: ALL_REMINDER_STATUSES,
             })
           ).filter((task) => isReminderInDeliveryScope(task, delivery));
+          const requestId = String(message.id);
+          const scopedById = new Map(
+            scopedTasks.map((task) => [task.taskId, task]),
+          );
+          const legacyReplayTasks: ScheduledTask[] = [];
+          let recoveredManifest: ClearReceiptManifest | undefined;
+          for (const task of scopedTasks) {
+            const idempotencyKey = clearApplyIdempotencyKey(
+              requestId,
+              task.taskId,
+            );
+            if (
+              !(await hasScheduledTaskApplyReceipt(
+                task,
+                "dismiss",
+                idempotencyKey,
+              ))
+            ) {
+              continue;
+            }
+            const manifest = parseClearReceiptManifest(
+              await scheduledTaskApplyReceiptContext(
+                task,
+                "dismiss",
+                idempotencyKey,
+              ),
+              requestId,
+            );
+            if (!manifest) {
+              legacyReplayTasks.push(task);
+              continue;
+            }
+            if (
+              recoveredManifest &&
+              stableStringify(recoveredManifest.taskIds) !==
+                stableStringify(manifest.taskIds)
+            ) {
+              return await actionFailure(
+                "I couldn't safely recover the original clear request, so I didn't clear any additional reminders. Please send a new clear request.",
+                callback,
+                {
+                  operation,
+                  failureCode: "REMINDER_CLEAR_MANIFEST_CONFLICT",
+                },
+              );
+            }
+            recoveredManifest = manifest;
+          }
+          // Once any effect commits, its receipt atomically carries the full
+          // original target set. A retry must replay that set rather than
+          // re-listing reminders that may have been created afterward.
+          const manifestTaskIds = recoveredManifest
+            ? recoveredManifest.taskIds
+            : legacyReplayTasks.length > 0
+              ? legacyReplayTasks.map((task) => task.taskId).sort()
+              : scopedTasks
+                  .filter((task) => isActiveReminder(task))
+                  .map((task) => task.taskId)
+                  .sort();
+          const tasks = manifestTaskIds.flatMap((taskId) => {
+            const task = scopedById.get(taskId);
+            return task ? [task] : [];
+          });
           if (tasks.length === 0) {
             const text = "You have no active reminders to clear.";
             await callback?.({ text });
@@ -1696,8 +1906,13 @@ export function createSharedRemindersEdgeAction(
               turnComplete: true,
             };
           }
+          const receiptContext: ClearReceiptManifest = {
+            kind: CLEAR_RECEIPT_CONTEXT_KIND,
+            requestId,
+            taskIds: manifestTaskIds,
+          };
           const receipts: EffectReceipt[] = [];
-          let failedCount = 0;
+          let failedCount = manifestTaskIds.length - tasks.length;
           for (const task of tasks) {
             try {
               const applied = await options.runner.applyWithResult(
@@ -1705,7 +1920,11 @@ export function createSharedRemindersEdgeAction(
                 "dismiss",
                 { reason: "confirmed clear all reminders" },
                 {
-                  idempotencyKey: `shared-reminder:${String(message.id)}:clear:${task.taskId}`,
+                  idempotencyKey: clearApplyIdempotencyKey(
+                    requestId,
+                    task.taskId,
+                  ),
+                  receiptContext,
                 },
               );
               receipts.push(lifecycleReceipt("dismiss", applied));
@@ -1758,7 +1977,9 @@ export function createSharedRemindersEdgeAction(
           const target = await resolveReminderTarget({
             runner: options.runner,
             delivery,
+            exactReference: options.targetIntent !== undefined,
             reference:
+              options.targetIntent ??
               textParameter(
                 input,
                 "taskId",
@@ -1766,11 +1987,16 @@ export function createSharedRemindersEdgeAction(
                 "targetTitle",
                 "title",
                 "reminderText",
-              ) ??
-              (options.operationIntent === "delete"
-                ? message.content?.text
-                : undefined),
+              ),
             coalesceExactSemanticDuplicates: operation === "delete",
+            replay: {
+              verb:
+                operation === "delete" || operation === "dismiss"
+                  ? "dismiss"
+                  : operation,
+              idempotencyKey: (task) =>
+                `shared-reminder:${String(message.id)}:${operation}:${task.taskId}`,
+            },
           });
           if (target.kind !== "match") {
             return await actionFailure(target.text, callback, { operation });

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -550,7 +550,8 @@ function reportReminderError(
   try {
     runtime.reportError?.(scope, error, context);
   } catch {
-    // Diagnostics are best-effort and must never hide the grounded result.
+    // error-policy:J7 diagnostics are best-effort and must never hide the
+    // grounded action result.
   }
 }
 
@@ -769,6 +770,8 @@ function validTimeZone(value: string | undefined): string | undefined {
       timeZone: value,
     }).resolvedOptions().timeZone;
   } catch {
+    // error-policy:J3 an invalid or unsupported timezone remains explicitly
+    // unavailable instead of being replaced with a fabricated zone.
     return undefined;
   }
 }
@@ -1909,6 +1912,8 @@ export function createSharedRemindersEdgeAction(
               );
               receipts.push(lifecycleReceipt("dismiss", dismissed));
             } catch (error) {
+              // error-policy:J1 the action boundary reports an honest partial
+              // replacement result after attempting every original copy.
               failedDismissals += 1;
               reportReminderError(
                 runtime,
@@ -2084,6 +2089,8 @@ export function createSharedRemindersEdgeAction(
               );
               receipts.push(lifecycleReceipt("dismiss", applied));
             } catch (error) {
+              // error-policy:J1 the confirmed-clear action boundary reports
+              // exact succeeded and unverified counts to the user.
               failedCount += 1;
               reportReminderError(
                 runtime,
@@ -2274,6 +2281,8 @@ export function createSharedRemindersEdgeAction(
                 ),
               );
             } catch (error) {
+              // error-policy:J1 delete is an explicit multi-row action whose
+              // boundary returns an honest partial outcome; other verbs rethrow.
               reportReminderError(
                 runtime,
                 "SharedReminders.lifecycleMutation",
@@ -2332,6 +2341,8 @@ export function createSharedRemindersEdgeAction(
           { operation: operation ?? "unknown" },
         );
       } catch (error) {
+        // error-policy:J1 this action boundary translates an unverified durable
+        // mutation into an explicit failure and never claims success.
         reportReminderError(runtime, "SharedReminders.handler", error, {
           operation: operation ?? "unknown",
           phase: "durable-operation",

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -2264,7 +2264,10 @@ export function createSharedRemindersEdgeAction(
             }
           }
           const appliedResults: ScheduledTaskApplyResult[] = [];
-          let failedCount = 0;
+          let failedCount =
+            operation === "delete" && deleteManifest
+              ? deleteManifest.taskIds.length - mutationTargets.length
+              : 0;
           for (const task of mutationTargets) {
             try {
               appliedResults.push(


### PR DESCRIPTION
## Summary

- align Shared reminder lifecycle with Dedicated create/list/update/snooze/complete/delete/clear behavior
- preserve delivery scope and server-owned intent/provenance through retries and contextual turns
- make semantic create/update/delete/clear effects receipt-backed and replay-safe
- report partial durable mutations honestly, including missing members of a recovered delete manifest
- require exact preceding confirmation authority for destructive clear-all

## Exact candidate

- Head: `2cd68171b37f7f195349b7572e786424bedf01f5`
- Base: `develop@6e7c46c9c03`
- Linear restack; no merge commits.
- Independent exact review: APPROVED, no remaining P0-P2.

## Validation

- Scheduling reminder/runner/SQL focused matrix: 155/155 passed.
- Cloud Shared authority/history/chat/reminder focused matrix: 259/259 passed.
- Independent exact reminder rerun: 52/52 passed, 205 assertions.
- plugin-scheduling and cloud-shared typechecks passed.
- Changed-file Biome and `git diff --check` passed.
- Fresh hosted exact-head CI: pending.

The repair adds required J1/J3/J7 annotations to the new boundary catches and fixes replay accounting so a missing or unverifiable delete-manifest member produces `success=false` with exact affected/failed counts. No production data or deployment was changed.

Closes #29688