### PR TITLE
fix(cloud): fail closed on retained Dedicated authority

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -29,6 +29,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const ORG_A = "11111111-1111-4111-8111-111111111111";
 const ORG_B = "22222222-2222-4222-8222-222222222222";
 const USER_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const USER_A_OPERATOR = "aaaaaaaa-2222-4222-8222-222222222222";
 const USER_B = "bbbbbbbb-1111-4111-8111-111111111111";
 const CHARACTER_A = "eeeeeeee-1111-4111-8111-111111111111";
 const SHARED_A = "cccccccc-1111-4111-8111-111111111111";
@@ -65,8 +66,8 @@ const PERSONAL_C = personalSharedAgentId({
   organizationId: ORG_C,
 });
 
-// Caller identity is switchable so the cross-org denial path is exercised for
-// real (org A's user probing org B's agent).
+// Caller identity is switchable so both cross-org denial and same-org
+// operator lineage authority are exercised through the real route.
 const currentUser = {
   id: USER_A,
   email: "owner-a@test.test",
@@ -231,6 +232,13 @@ beforeAll(async () => {
         organization_id: ORG_A,
         role: "owner",
         steward_user_id: `steward-${USER_A}`,
+      },
+      {
+        id: USER_A_OPERATOR,
+        email: "operator-a@test.test",
+        organization_id: ORG_A,
+        role: "member",
+        steward_user_id: `steward-${USER_A_OPERATOR}`,
       },
       {
         id: USER_B,
@@ -435,7 +443,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     });
   });
 
-  test("a retained authority with no target returns an actionable 409 before mint", async () => {
+  test("a same-org operator cannot bypass another user's retained source authority", async () => {
     expect(pgliteReady).toBe(true);
     const { dbWrite } = await import("@/db/client");
     const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
@@ -463,45 +471,53 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
 
     const agentsBefore = await dbWrite.select().from(agentSandboxes);
     const keysBefore = await dbWrite.select().from(apiKeys);
-    const response = await upgrade(SHARED_RETAINED_AUTHORITY);
-    expect(response.status).toBe(409);
-    expect(await response.json()).toMatchObject({
-      success: false,
-      code: "dedicated_activation_reset_required",
-      retryable: false,
-    });
-    expect(await dbWrite.select().from(agentSandboxes)).toEqual(agentsBefore);
-    expect(await dbWrite.select().from(apiKeys)).toEqual(keysBefore);
-    expect(
+    const previousUserId = currentUser.id;
+    const previousEmail = currentUser.email;
+    currentUser.id = USER_A_OPERATOR;
+    currentUser.email = "operator-a@test.test";
+    try {
+      const response = await upgrade(SHARED_RETAINED_AUTHORITY);
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        success: false,
+        code: "dedicated_activation_reset_required",
+        retryable: false,
+      });
+      expect(await dbWrite.select().from(agentSandboxes)).toEqual(agentsBefore);
+      expect(await dbWrite.select().from(apiKeys)).toEqual(keysBefore);
+      expect(
+        await dbWrite
+          .select()
+          .from(jobs)
+          .where(eq(jobs.agent_id, MISSING_RETAINED_TARGET)),
+      ).toHaveLength(0);
+      expect(
+        await dbWrite
+          .select()
+          .from(personalDedicatedUpgradeAuthorities)
+          .where(
+            eq(
+              personalDedicatedUpgradeAuthorities.source_agent_id,
+              SHARED_RETAINED_AUTHORITY,
+            ),
+          ),
+      ).toHaveLength(1);
+    } finally {
+      currentUser.id = previousUserId;
+      currentUser.email = previousEmail;
       await dbWrite
-        .select()
-        .from(jobs)
-        .where(eq(jobs.agent_id, MISSING_RETAINED_TARGET)),
-    ).toHaveLength(0);
-    expect(
-      await dbWrite
-        .select()
-        .from(personalDedicatedUpgradeAuthorities)
+        .delete(personalDedicatedUpgradeAuthorities)
         .where(
           eq(
             personalDedicatedUpgradeAuthorities.source_agent_id,
             SHARED_RETAINED_AUTHORITY,
           ),
-        ),
-    ).toHaveLength(1);
-
-    await dbWrite
-      .delete(personalDedicatedUpgradeAuthorities)
-      .where(
-        eq(
-          personalDedicatedUpgradeAuthorities.source_agent_id,
-          SHARED_RETAINED_AUTHORITY,
-        ),
-      );
-    await dbWrite
-      .delete(agentSandboxes)
-      .where(eq(agentSandboxes.id, SHARED_RETAINED_AUTHORITY));
-    await setOrgBalance(ORG_A, "0.50");
+        );
+      await dbWrite
+        .delete(agentSandboxes)
+        .where(eq(agentSandboxes.id, SHARED_RETAINED_AUTHORITY));
+      await setOrgBalance(ORG_A, "0.50");
+    }
   });
 
   test("quotes Dedicated from server-owned pricing for only the caller's personal Eliza", async () => {

--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -47,6 +47,8 @@ const SHARED_FULL = "cccccccc-ffff-4fff-8fff-ffffffffffff";
 const SHARED_SELECTED = "cccccccc-f111-4f11-8f11-111111111111";
 const SELECTED_EXISTING = "dddddddd-f111-4f11-8f11-111111111111";
 const SELECTED_STALE = "dddddddd-f222-4f22-8f22-222222222222";
+const SHARED_RETAINED_AUTHORITY = "cccccccc-f333-4f33-8f33-333333333333";
+const MISSING_RETAINED_TARGET = "dddddddd-f333-4f33-8f33-333333333333";
 const PERSONAL_A = personalSharedAgentId({
   userId: USER_A,
   organizationId: ORG_A,
@@ -431,6 +433,75 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     expect(await res.json()).toMatchObject({
       code: "dedicated_confirmation_required",
     });
+  });
+
+  test("a retained authority with no target returns an actionable 409 before mint", async () => {
+    expect(pgliteReady).toBe(true);
+    const { dbWrite } = await import("@/db/client");
+    const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+    const { apiKeys } = await import("@/db/schemas/api-keys");
+    const { jobs } = await import("@/db/schemas/jobs");
+    const { personalDedicatedUpgradeAuthorities } = await import(
+      "@/db/schemas/personal-dedicated-upgrade-authorities"
+    );
+    await setOrgBalance(ORG_A, "10");
+    await dbWrite.insert(agentSandboxes).values({
+      id: SHARED_RETAINED_AUTHORITY,
+      organization_id: ORG_A,
+      user_id: USER_A,
+      agent_name: "Retained authority source",
+      execution_tier: "shared",
+      status: "running",
+      database_status: "none",
+    });
+    await dbWrite.insert(personalDedicatedUpgradeAuthorities).values({
+      organization_id: ORG_A,
+      user_id: USER_A,
+      source_agent_id: SHARED_RETAINED_AUTHORITY,
+      dedicated_agent_id: MISSING_RETAINED_TARGET,
+    });
+
+    const agentsBefore = await dbWrite.select().from(agentSandboxes);
+    const keysBefore = await dbWrite.select().from(apiKeys);
+    const response = await upgrade(SHARED_RETAINED_AUTHORITY);
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      code: "dedicated_activation_reset_required",
+      retryable: false,
+    });
+    expect(await dbWrite.select().from(agentSandboxes)).toEqual(agentsBefore);
+    expect(await dbWrite.select().from(apiKeys)).toEqual(keysBefore);
+    expect(
+      await dbWrite
+        .select()
+        .from(jobs)
+        .where(eq(jobs.agent_id, MISSING_RETAINED_TARGET)),
+    ).toHaveLength(0);
+    expect(
+      await dbWrite
+        .select()
+        .from(personalDedicatedUpgradeAuthorities)
+        .where(
+          eq(
+            personalDedicatedUpgradeAuthorities.source_agent_id,
+            SHARED_RETAINED_AUTHORITY,
+          ),
+        ),
+    ).toHaveLength(1);
+
+    await dbWrite
+      .delete(personalDedicatedUpgradeAuthorities)
+      .where(
+        eq(
+          personalDedicatedUpgradeAuthorities.source_agent_id,
+          SHARED_RETAINED_AUTHORITY,
+        ),
+      );
+    await dbWrite
+      .delete(agentSandboxes)
+      .where(eq(agentSandboxes.id, SHARED_RETAINED_AUTHORITY));
+    await setOrgBalance(ORG_A, "0.50");
   });
 
   test("quotes Dedicated from server-owned pricing for only the caller's personal Eliza", async () => {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
@@ -47,6 +47,7 @@ import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import {
   createTierUpgradeTargetWithProvision,
   findLiveTierUpgradeTarget,
+  PersonalDedicatedAuthorityRetainedError,
   PersonalDedicatedSelectionRequiredError,
 } from "@/lib/services/agent-tier-upgrade-target";
 import { buildDefaultAgentCharacterConfig } from "@/lib/services/default-agent-character";
@@ -546,6 +547,18 @@ async function __hono_POST(
             code: "dedicated_adoption_selection_required",
             error:
               "An existing Dedicated agent is selected for this account. Continue with same-row adoption instead of creating another agent.",
+          },
+          409,
+        );
+      }
+      if (error instanceof PersonalDedicatedAuthorityRetainedError) {
+        return json(
+          {
+            success: false,
+            code: "dedicated_activation_reset_required",
+            error:
+              "This Personal Eliza has retained Dedicated activation history. Reconcile or reset the retired target before starting another Dedicated activation.",
+            retryable: false,
           },
           409,
         );

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
@@ -317,9 +317,7 @@ describe("createTierUpgradeTargetWithProvision — durable single-flight boundar
 
       const callsBefore = prepCalls;
       await expect(
-        svc.createTierUpgradeTargetWithProvision(
-          upgradeParams(SRC_RETAINED_AUTHORITY),
-        ),
+        svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_RETAINED_AUTHORITY)),
       ).rejects.toMatchObject({
         name: "PersonalDedicatedAuthorityRetainedError",
         code: "PERSONAL_DEDICATED_AUTHORITY_RETAINED",
@@ -331,12 +329,7 @@ describe("createTierUpgradeTargetWithProvision — durable single-flight boundar
         await dbWrite
           .select()
           .from(personalDedicatedUpgradeAuthorities)
-          .where(
-            eq(
-              personalDedicatedUpgradeAuthorities.source_agent_id,
-              SRC_RETAINED_AUTHORITY,
-            ),
-          ),
+          .where(eq(personalDedicatedUpgradeAuthorities.source_agent_id, SRC_RETAINED_AUTHORITY)),
       ).toHaveLength(1);
       await expectNoOrphanAgentKeys();
     },

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
@@ -148,6 +148,8 @@ const SRC_RACE_2 = "cccccccc-dddd-4ddd-8ddd-dddddddddddd";
 const SRC_RACE_CREATE = "cccccccc-eeee-4eee-8eee-eeeeeeeeeeee";
 const SRC_SELECTED = "cccccccc-f111-4f11-8f11-111111111111";
 const SRC_UNSELECTED = "cccccccc-f222-4f22-8f22-222222222222";
+const SRC_RETAINED_AUTHORITY = "cccccccc-f333-4f33-8f33-333333333333";
+const MISSING_RETAINED_TARGET = "dddddddd-f333-4f33-8f33-333333333333";
 const SELECTED_TARGET = "dddddddd-f111-4f11-8f11-111111111111";
 const UNSELECTED_TARGET = "dddddddd-f222-4f22-8f22-222222222222";
 const QUOTA_EXISTING = "dddddddd-1111-4111-8111-111111111111";
@@ -162,6 +164,7 @@ let agentSandboxes: typeof import("../../db/schemas/agent-sandboxes").agentSandb
 let jobs: typeof import("../../db/schemas/jobs").jobs;
 let apiKeys: typeof import("../../db/schemas/api-keys").apiKeys;
 let personalDedicatedAdoptionSelections: typeof import("../../db/schemas/personal-dedicated-adoption-selections").personalDedicatedAdoptionSelections;
+let personalDedicatedUpgradeAuthorities: typeof import("../../db/schemas/personal-dedicated-upgrade-authorities").personalDedicatedUpgradeAuthorities;
 let svc: typeof import("./agent-tier-upgrade-target");
 
 beforeAll(async () => {
@@ -184,6 +187,9 @@ beforeAll(async () => {
     ({ jobs } = await import("../../db/schemas/jobs"));
     ({ personalDedicatedAdoptionSelections } = await import(
       "../../db/schemas/personal-dedicated-adoption-selections"
+    ));
+    ({ personalDedicatedUpgradeAuthorities } = await import(
+      "../../db/schemas/personal-dedicated-upgrade-authorities"
     ));
     // Plain DDL instead of drizzle-kit pushSchema: the coverage lane co-runs
     // every changed suite in ONE bun process, and drizzle-kit answers internal
@@ -298,6 +304,45 @@ async function expectNoOrphanAgentKeys() {
 }
 
 describe("createTierUpgradeTargetWithProvision — durable single-flight boundary", () => {
+  test(
+    "a retained authority whose target is absent fails typed before credential preparation",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      await dbWrite.insert(personalDedicatedUpgradeAuthorities).values({
+        organization_id: ORG_A,
+        user_id: USER_A,
+        source_agent_id: SRC_RETAINED_AUTHORITY,
+        dedicated_agent_id: MISSING_RETAINED_TARGET,
+      });
+
+      const callsBefore = prepCalls;
+      await expect(
+        svc.createTierUpgradeTargetWithProvision(
+          upgradeParams(SRC_RETAINED_AUTHORITY),
+        ),
+      ).rejects.toMatchObject({
+        name: "PersonalDedicatedAuthorityRetainedError",
+        code: "PERSONAL_DEDICATED_AUTHORITY_RETAINED",
+      });
+      expect(prepCalls).toBe(callsBefore);
+      expect(await targetsForSource(SRC_RETAINED_AUTHORITY)).toHaveLength(0);
+      expect(await jobsForAgent(MISSING_RETAINED_TARGET)).toHaveLength(0);
+      expect(
+        await dbWrite
+          .select()
+          .from(personalDedicatedUpgradeAuthorities)
+          .where(
+            eq(
+              personalDedicatedUpgradeAuthorities.source_agent_id,
+              SRC_RETAINED_AUTHORITY,
+            ),
+          ),
+      ).toHaveLength(1);
+      await expectNoOrphanAgentKeys();
+    },
+    PGLITE_TIMEOUT,
+  );
+
   test(
     "an unselected same-owner Dedicated row blocks the normal mint path before credential preparation",
     async () => {

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -334,7 +334,10 @@ export class PersonalDedicatedSelectionRequiredError extends ElizaError {
  * rewrite history or collide with the source-unique authority constraint, so
  * the ordinary mint path must stop before preparing credentials. An explicit
  * operator reconciliation may retire the tombstone after proving the target
- * is absent; request-serving code never does that implicitly.
+ * is absent; request-serving code never does that implicitly. Lineage is
+ * organization/source scoped because another same-organization operator may
+ * invoke the row-backed route; the receipt user identifies its target owner,
+ * not a separate lineage that the operator may recreate.
  */
 export class PersonalDedicatedAuthorityRetainedError extends ElizaError {
   override readonly name = "PersonalDedicatedAuthorityRetainedError";
@@ -342,7 +345,7 @@ export class PersonalDedicatedAuthorityRetainedError extends ElizaError {
 
 async function assertNoRetainedUpgradeAuthorityInTx(
   tx: DbTransaction,
-  params: Pick<CreateTierUpgradeTargetParams, "organizationId" | "userId" | "sourceAgentId">,
+  params: Pick<CreateTierUpgradeTargetParams, "organizationId" | "sourceAgentId">,
 ): Promise<void> {
   const [authority] = await tx
     .select({ id: personalDedicatedUpgradeAuthorities.id })
@@ -350,7 +353,6 @@ async function assertNoRetainedUpgradeAuthorityInTx(
     .where(
       and(
         eq(personalDedicatedUpgradeAuthorities.organization_id, params.organizationId),
-        eq(personalDedicatedUpgradeAuthorities.user_id, params.userId),
         eq(personalDedicatedUpgradeAuthorities.source_agent_id, params.sourceAgentId),
         eq(personalDedicatedUpgradeAuthorities.schema_version, 1),
       ),
@@ -363,7 +365,6 @@ async function assertNoRetainedUpgradeAuthorityInTx(
         code: "PERSONAL_DEDICATED_AUTHORITY_RETAINED",
         context: {
           organizationId: params.organizationId,
-          userId: params.userId,
           sourceAgentId: params.sourceAgentId,
         },
       },

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -328,6 +328,52 @@ export class PersonalDedicatedSelectionRequiredError extends ElizaError {
   override readonly name = "PersonalDedicatedSelectionRequiredError";
 }
 
+/**
+ * A source-owned authority receipt deliberately survives target deletion as an
+ * audit tombstone. Starting a second target behind that receipt would either
+ * rewrite history or collide with the source-unique authority constraint, so
+ * the ordinary mint path must stop before preparing credentials. An explicit
+ * operator reconciliation may retire the tombstone after proving the target
+ * is absent; request-serving code never does that implicitly.
+ */
+export class PersonalDedicatedAuthorityRetainedError extends ElizaError {
+  override readonly name = "PersonalDedicatedAuthorityRetainedError";
+}
+
+async function assertNoRetainedUpgradeAuthorityInTx(
+  tx: DbTransaction,
+  params: Pick<
+    CreateTierUpgradeTargetParams,
+    "organizationId" | "userId" | "sourceAgentId"
+  >,
+): Promise<void> {
+  const [authority] = await tx
+    .select({ id: personalDedicatedUpgradeAuthorities.id })
+    .from(personalDedicatedUpgradeAuthorities)
+    .where(
+      and(
+        eq(personalDedicatedUpgradeAuthorities.organization_id, params.organizationId),
+        eq(personalDedicatedUpgradeAuthorities.user_id, params.userId),
+        eq(personalDedicatedUpgradeAuthorities.source_agent_id, params.sourceAgentId),
+        eq(personalDedicatedUpgradeAuthorities.schema_version, 1),
+      ),
+    )
+    .limit(1);
+  if (authority) {
+    throw new PersonalDedicatedAuthorityRetainedError(
+      "Dedicated activation authority is retained after its target became unavailable",
+      {
+        code: "PERSONAL_DEDICATED_AUTHORITY_RETAINED",
+        context: {
+          organizationId: params.organizationId,
+          userId: params.userId,
+          sourceAgentId: params.sourceAgentId,
+        },
+      },
+    );
+  }
+}
+
 async function assertNoExistingAdoptionCandidateInTx(
   tx: DbTransaction,
   params: Pick<CreateTierUpgradeTargetParams, "organizationId" | "userId" | "sourceAgentId">,
@@ -1767,6 +1813,7 @@ export async function createTierUpgradeTargetWithProvision(
     );
     const existing = await findLiveTargetInTx(tx, params.organizationId, params.sourceAgentId);
     if (existing) return existing;
+    await assertNoRetainedUpgradeAuthorityInTx(tx, params);
     await assertNoExistingAdoptionCandidateInTx(tx, params);
     // Refuse over-quota upgrades before any credential is minted. The locked
     // insert transaction below re-asserts this authoritatively.
@@ -1818,6 +1865,7 @@ export async function createTierUpgradeTargetWithProvision(
 
       const existing = await findLiveTargetInTx(tx, params.organizationId, params.sourceAgentId);
       if (existing) return { created: false as const, agent: existing };
+      await assertNoRetainedUpgradeAuthorityInTx(tx, params);
       await assertNoExistingAdoptionCandidateInTx(tx, params);
 
       await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -342,10 +342,7 @@ export class PersonalDedicatedAuthorityRetainedError extends ElizaError {
 
 async function assertNoRetainedUpgradeAuthorityInTx(
   tx: DbTransaction,
-  params: Pick<
-    CreateTierUpgradeTargetParams,
-    "organizationId" | "userId" | "sourceAgentId"
-  >,
+  params: Pick<CreateTierUpgradeTargetParams, "organizationId" | "userId" | "sourceAgentId">,
 ): Promise<void> {
   const [authority] = await tx
     .select({ id: personalDedicatedUpgradeAuthorities.id })


### PR DESCRIPTION
## Summary

- detect retained Personal Dedicated authority receipts before credential preparation or target mint
- return an actionable non-retryable 409 instead of falling through to a source-unique collision and 500
- preserve the audit tombstone and require explicit operator reconciliation; request-serving code never retargets or deletes it

## Root cause

A hard-deleted Dedicated target left its source-owned authority receipt by design. Live-target lookup ignored the absent target, so a subsequent activation minted a candidate target and then collided with `personal_dedicated_upgrade_authorities_source_unique`, rolling back and surfacing as a generic 500.

## Verification

- `bun test --config=/dev/null --isolate packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts` (18/18)
- `bun test --config=/dev/null --isolate packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts` (18/18)
- Biome check/write on the four changed files
- `git diff --check`

Staging-only cleanup/proof is tracked separately; this PR does not delete or retarget any authority.