### PR TITLE
fix(ui): restore shared Home fixture and card contracts

### DIFF
--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -199,6 +199,13 @@ describe("CalendarUpcomingWidget", () => {
 
     const widget = await screen.findByTestId("chat-widget-calendar-upcoming");
     expect(widget.tagName).toBe("BUTTON");
+    // The shared Home card recipe is also the positioning context for the
+    // absolute status rail. Losing it makes the rail span the whole WidgetHost
+    // and leaves the card transparent with inherited black text.
+    expect(widget.className).toContain("relative");
+    expect(widget.className).toContain("w-full");
+    expect(widget.className).toContain("bg-[var(--brand-black)]");
+    expect(widget.className).toContain("text-[var(--brand-white)]");
     // Only the soonest event renders; later events do not (just a count badge).
     expect(widget.textContent).toContain("Standup");
     expect(widget.textContent).not.toContain("Lunch");

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -204,8 +204,8 @@ describe("CalendarUpcomingWidget", () => {
     // and leaves the card transparent with inherited black text.
     expect(widget.className).toContain("relative");
     expect(widget.className).toContain("w-full");
-    expect(widget.className).toContain("bg-[var(--brand-black)]");
-    expect(widget.className).toContain("text-[var(--brand-white)]");
+    expect(widget.className).toContain("bg-bg-wallpaper-overlay");
+    expect(widget.className).toContain("text-txt-launcher-icon");
     // Only the soonest event renders; later events do not (just a count badge).
     expect(widget.textContent).toContain("Standup");
     expect(widget.textContent).not.toContain("Lunch");

--- a/packages/ui/src/components/chat/widgets/home-widget-card.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.tsx
@@ -94,6 +94,7 @@ export function HomeWidgetCard({
       variant="surface"
       size="card"
       align="start"
+      className={HOME_WIDGET_SOLID_TILE_CLASS}
       data-testid={testId}
       aria-label={ariaLabel}
       title={label}

--- a/packages/ui/src/components/chat/widgets/home-widget-card.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.tsx
@@ -49,9 +49,6 @@ export function useWidgetNavigation(): {
 
 export type HomeWidgetTone = "default" | "danger" | "warn";
 
-export const HOME_WIDGET_SOLID_TILE_CLASS =
-  "group relative flex h-auto w-full overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--brand-white)_20%,var(--brand-black))] bg-[var(--brand-black)] text-left text-[var(--brand-white)]";
-
 const TONE_VALUE_CLASS: Record<HomeWidgetTone, string> = {
   default: "text-[var(--brand-white)]",
   danger: "text-[var(--brand-white)]",
@@ -91,10 +88,9 @@ export function HomeWidgetCard({
 }: HomeWidgetCardProps): React.JSX.Element {
   return (
     <Button
-      variant="surface"
+      variant="homeWidget"
       size="card"
       align="start"
-      className={HOME_WIDGET_SOLID_TILE_CLASS}
       data-testid={testId}
       aria-label={ariaLabel}
       title={label}

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -426,7 +426,7 @@ function ModelProgressCard({
       data-testid="chat-widget-model-download"
       aria-label={ariaLabel}
       onClick={onActivate}
-      variant="surface"
+      variant="homeWidget"
       size="card"
       align="start"
       className="group transition-opacity hover:opacity-80"

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -206,7 +206,7 @@ export function WalletBalanceWidget(
           .map((h) => `${h.symbol} ${formatPrice(h.priceUsd)}`)
           .join(", ")}. Open wallet.`}
         onClick={() => nav.openView("/wallet", "wallet")}
-        variant="surface"
+        variant="homeWidget"
         size="card"
         align="start"
         className="w-full"

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -121,16 +121,17 @@ const stubResolver = {
   },
 };
 
-// The production launcher resolves packaged PNGs relative to the generated
-// module with `new URL(..., import.meta.url)`. This fixture is intentionally an
-// inline IIFE, where esbuild otherwise replaces import.meta with an empty
-// object and every icon URL throws before React can mount. Preserve the real
-// icon module and assets by binding only that module's import.meta.url to its
-// source file URL during the fixture build.
+// The production launcher resolves packaged PNG and SVG assets relative to its
+// icon modules with `new URL(..., import.meta.url)`. This fixture is
+// intentionally an inline IIFE, where esbuild otherwise replaces import.meta
+// with an empty object and every icon URL throws before React can mount.
+// Preserve the real icon modules and assets by binding their import.meta.url to
+// their source file URLs during the fixture build.
+const fixtureIconModule = /(?:view-icons\.generated|launcher-ionicons)\.ts$/;
 const fixtureViewIconUrls = {
   name: "home-fixture-view-icon-urls",
   setup(b) {
-    b.onLoad({ filter: /view-icons\.generated\.ts$/ }, async (args) => {
+    b.onLoad({ filter: fixtureIconModule }, async (args) => {
       const source = await readFile(args.path, "utf8");
       return {
         contents: source.replaceAll(

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -1219,7 +1219,7 @@ try {
   );
 
   // ── Glyph-only app icons (#13453 "deslop the launcher grid"): a launcher tile
-  // is a deterministic branded gradient plate + centered Lucide glyph, never a
+  // is the canonical uniform Card plate + centered official Ionicon, never a
   // generated hero <img> — the hero PNG painted a cartoon over the real glyph
   // (a virus for Settings, a ladybug for Memories: the "icons are slop" report).
   // Each curated tile exposes its `data-view-visual` plate and NO hero image.
@@ -1252,10 +1252,9 @@ try {
   );
 
   // ── Every launcher tile is a glyph-only visual (#13453): a `data-view-visual`
-  // gradient plate carrying its Lucide glyph, and never a hero <img>. The plate
-  // gradients are deterministic per id (id-hashed palette), so distinct tiles
-  // get distinct gradients — a launcher of one flat placeholder would be the
-  // regression this guards against.
+  // canonical Card plate carrying a named official Ionicon, and never a hero
+  // <img>. Plates are intentionally uniform now; distinct `data-ionicon` names
+  // prove the launcher did not regress to one repeated placeholder glyph.
   const visualCount = await mobile.locator("[data-view-visual]").count();
   assert(
     visualCount >= 5,
@@ -1265,18 +1264,27 @@ try {
     (await mobile.locator('[data-testid^="launcher-image-"]').count()) === 0,
     "no launcher tile renders a hero <img> (glyph-only launcher)",
   );
-  const tileGradients = await mobile.$$eval("[data-view-visual]", (els) =>
-    Array.from(
-      new Set(
-        els
-          .map((el) => getComputedStyle(el).backgroundImage)
-          .filter((v) => Boolean(v) && v !== "none"),
-      ),
-    ),
+  const launcherGlyphs = await mobile.$$eval("[data-view-visual]", (els) =>
+    els.map((el) => {
+      const glyph = el.querySelector("[data-launcher-glyph]");
+      return {
+        kind: glyph?.getAttribute("data-launcher-glyph-kind"),
+        ionicon: glyph?.getAttribute("data-ionicon"),
+      };
+    }),
   );
   assert(
-    tileGradients.length >= 3,
-    `launcher glyph plates use varied gradients, not one placeholder (${tileGradients.length} distinct)`,
+    launcherGlyphs.every(
+      ({ kind, ionicon }) => kind === "ionicon" && Boolean(ionicon),
+    ),
+    "every launcher plate carries a named official Ionicon",
+  );
+  const distinctIonicons = new Set(
+    launcherGlyphs.map(({ ionicon }) => ionicon),
+  );
+  assert(
+    distinctIonicons.size >= 3,
+    `launcher uses distinct Ionicons, not one placeholder (${distinctIonicons.size} distinct)`,
   );
 
   // ── The curated launcher is READ-ONLY: a long-press never enters edit mode

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -230,14 +230,12 @@ const stubElizaCore = {
 // The real app's viewport meta + the shell's runtime CSS vars: without the meta,
 // a mobile page falls back to the 980px layout viewport, so CSS `vw` units (the
 // sheet's `w-[min(440px,100vw-1rem)]`) mis-measure and the overlay mis-centers.
-// The brand palette vars (`styles/base.css` :root) are seeded here too: the
-// calendar up-next card colors its text through `var(--brand-white)` /
-// `color-mix(..., var(--brand-white))`, and an undefined var resolves to black —
-// unreadable on the dark ember field, tripping the foreground-contrast gate. The
-// fixture loads no app CSS, so the handful of brand vars the home widgets read
-// must be declared inline.
+// The brand palette and Home surface vars (`styles/base.css` :root) are seeded
+// here too. The fixture loads no app CSS, so leaving the canonical Home Button
+// recipe unresolved would make its foreground fall back to black on the dark
+// ember field and turn this into a fixture failure instead of a product check.
 const headHtml = `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-<style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#000000;--brand-orange:#ff6a1f}</style>`;
+<style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#000000;--brand-orange:#ff6a1f;--bg-wallpaper-overlay:rgb(0 0 0 / 85%);--border-launcher-icon:rgb(255 255 255 / 24%);--txt-launcher-icon:rgb(255 255 255);--bg-launcher-icon-hover:rgb(28 29 32 / 74%)}.bg-bg-wallpaper-overlay{background-color:var(--bg-wallpaper-overlay)}.border-border-launcher-icon{border-color:var(--border-launcher-icon)}.text-txt-launcher-icon{color:var(--txt-launcher-icon)}.hover\\:bg-bg-launcher-icon-hover:hover{background-color:var(--bg-launcher-icon-hover)}</style>`;
 const url = await writeFixturePage({
   entry: join(here, "home-screen-fixture.tsx"),
   outDir,

--- a/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
@@ -147,16 +147,17 @@ const stubResolver = {
   },
 };
 
-// The production launcher resolves packaged PNGs relative to the generated
-// module with `new URL(..., import.meta.url)`. This fixture is intentionally an
-// inline IIFE, where esbuild otherwise replaces import.meta with an empty
-// object and every icon URL throws before React can mount. Bind only that
-// module's import.meta.url to its source file URL, matching the sibling home
+// The production launcher resolves packaged PNG and SVG assets relative to its
+// icon modules with `new URL(..., import.meta.url)`. This fixture is
+// intentionally an inline IIFE, where esbuild otherwise replaces import.meta
+// with an empty object and every icon URL throws before React can mount. Bind
+// their import.meta.url to their source file URLs, matching the sibling home
 // fixture that exercises the same surface.
+const fixtureIconModule = /(?:view-icons\.generated|launcher-ionicons)\.ts$/;
 const fixtureViewIconUrls = {
   name: "launcher-loop-fixture-view-icon-urls",
   setup(b) {
-    b.onLoad({ filter: /view-icons\.generated\.ts$/ }, async (args) => {
+    b.onLoad({ filter: fixtureIconModule }, async (args) => {
       const source = await readFile(args.path, "utf8");
       return {
         contents: source.replaceAll(

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -87,6 +87,8 @@ const buttonVariants = cva(
         transparent: "bg-transparent hover:bg-transparent",
         chatGestureTarget:
           "rounded-none border-0 bg-transparent hover:bg-transparent",
+        homeWidget:
+          "group relative flex h-auto w-full overflow-hidden rounded-2xl border border-border-launcher-icon bg-bg-wallpaper-overlay text-left text-txt-launcher-icon hover:bg-bg-launcher-icon-hover",
         disclosureMuted:
           "w-full justify-between bg-transparent text-xs text-muted hover:bg-transparent hover:text-txt",
         overlayEdge:


### PR DESCRIPTION
## Summary
- preserve launcher Ionicon asset URLs in the inline Home/launcher fixtures so their `import.meta.url` constructors remain valid
- restore the shared Home card surface through a typed canonical `Button` variant used by all three maintained Home widget callers
- keep the Home fixture on the same semantic surface tokens, with explicit fixture mappings because the standalone CDN fixture does not load the repository Tailwind theme
- update the Home E2E launcher assertion from the retired per-tile gradient contract to the current uniform Card plus distinct official Ionicons contract

## Attribution
The first commit is the exact patch from startrack3r in #29247, mechanically rebased onto current develop with original authorship preserved. This PR is a current maintainer integration candidate; it does not close or mutate #29247.

## Review resolution
The requested canonical paint-boundary change is closed: raw visual `className` paint was removed from `HomeWidgetCard`; `homeWidget` is now a typed canonical `Button` variant with three maintained callers. The strict design-system report is zero across every rule, including `visual-override`, `button-axis-reuse`, `off-token-color`, and `token-role-misuse`.

## Exact source
- base: `8166f3a4c8c71e79d5efecb886c58db9cfc6152d`
- head: `8744eaabc6c2ad93facbd41d15ac6cb7eda752c1`
- tree: `b65a2b0ea0ea7db948038704140fdc8cf8ad9e52`
- old-to-new three-commit range-diff: exact `=` / `=` / `=`

## Verification
- full Home screen E2E: PASS on mobile and desktop, including zero widget overlap, readable foregrounds, distinct Ionicons, gesture performance, and zero page errors
- rail-swipe performance: 120 fps, median p95 9.9 ms, 0% dropped frames
- `packages/ui` typecheck: PASS
- strict design-system report: PASS, every rule zero; `homeWidget` has 3 maintained callers
- changed-file Biome and `git diff --check`: PASS

## Scope
Source-only. No phone, VPS, browser session, deployment, authentication, billing, or live-service action.