### PR TITLE
test(app): align walkthrough with five-step tutorial

### DIFF
--- a/packages/app/test/ui-smoke/tutorial-chat.spec.ts
+++ b/packages/app/test/ui-smoke/tutorial-chat.spec.ts
@@ -162,10 +162,6 @@ test("the chat-native tour runs end to end in the live transcript", async ({
     timeout: 10_000,
   });
   await choice(page, "next", "navigate").click();
-  await expect(choice(page, "next", "new-chat")).toBeVisible({
-    timeout: 10_000,
-  });
-  await choice(page, "next", "new-chat").click();
 
   // The wrap-up offers Done + Restart; Done completes the tour.
   await expect(choice(page, "next", "done")).toBeVisible({ timeout: 10_000 });

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -848,13 +848,12 @@ async function reachChatReady(ctx: StepContext): Promise<void> {
 
 // --- tutorial driving -------------------------------------------------------
 
-/** The chat-native tour's six steps, in order (tutorial-script.ts). */
+/** The chat-native tour's five steps, in order (tutorial-script.ts). */
 const TUTORIAL_STEP_ORDER = [
   "welcome",
   "send-message",
   "voice",
   "navigate",
-  "new-chat",
   "done",
 ] as const;
 const FIRST_RUN_READY_TIMEOUT_MS = {
@@ -1032,7 +1031,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
   {
     n: "04",
     id: "tutorial",
-    title: "Chat-native tutorial (all 6 steps)",
+    title: "Chat-native tutorial (all 5 steps)",
     expectation:
       "A typed 'start tutorial' command in the chat composer starts the chat-native tour: one conversational turn per step lands in the live transcript, the send-message step auto-advances on a real composer send, and Done completes the run.",
     async run({ page }) {


### PR DESCRIPTION
Closes #29704

## Summary

- align the full walkthrough tutorial matrix with the authoritative five-step chat tutorial
- remove the stale new-chat browser expectation from the focused tutorial flow
- preserve typed start/restart/stop commands, send-message auto-advance, choices, transcript, and Done acceptance

## Root cause

The product intentionally removed new-chat from tutorial-script.ts in #29382, reducing the tour from six turns to five. Both browser fixtures retained the old six-step contract. The captured desktop/mobile failure state showed the chat sheet at the real final Done/Restart turn, so this is stale test coverage rather than an inaccessible product surface.

## Exact provenance

- Base: 68e50ea8f9ae42501d7aa52948cdf03c81d64d37
- Head: df410d8a075ec009219e517e767b4f1a5db7447d
- Tree: b9c94bbd1da655a7eab19dacb3b5db2943d1fe92
- Scope: two browser test files, +2/-7
- Mechanical range-diff: exact equals

## Verification

- Tutorial browser suite: 4/4 PASS
- Full walkthrough desktop: 25/25 steps PASS
- Full walkthrough mobile: 25/25 steps PASS
- Biome changed files: PASS
- git diff --check: PASS
- Worktree clean; one ahead / zero behind current develop

## Evidence

<!-- evidence-head:df410d8a075ec009219e517e767b4f1a5db7447d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Test-contract correction only; captured failure already showed the product tutorial visible at Done.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - No rendered product code changed; desktop and mobile walkthroughs pass all 25 steps.

<!-- evidence-row:walkthrough-video -->
- [x] Full Playwright desktop and mobile walkthroughs passed all 50 combined steps.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] Both exact browser suites completed with no page/console or 5xx gate failure.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Mock-lane test contract only; no model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Exact desktop/mobile recorder and tutorial Playwright receipts are the domain artifacts.