### PR TITLE
test(app): align decomposed view accessibility fixtures

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -55,8 +55,8 @@ test("calendar decomposed view: day selection and month navigation", async ({
   // belongs to the retired unified CalendarView. The shipped month-grid
   // behavior is covered by SimpleCalendarView.test.tsx.
   // The feed mock anchors "Design sync" at the requested window start (the
-  // grid's first cell), so the populated feed renders as a day-cell event
-  // badge ("1 event on <date>").
+  // grid's first cell), so the populated feed is announced on the owning day
+  // button ("<formatted date>. 1 event").
   const ONE_DAY_MS = 24 * 60 * 60 * 1000;
   const feedWindows: Array<{ timeMin: number; timeMax: number }> = [];
   page.on("request", (request) => {
@@ -81,7 +81,7 @@ test("calendar decomposed view: day selection and month navigation", async ({
     timeout: 15_000,
   });
   await expect(
-    page.getByRole("img", { name: /^1 event on / }).first(),
+    page.getByRole("button", { name: /\. 1 event$/ }).first(),
   ).toBeVisible({ timeout: 15_000 });
   // The initial fetch is a month-grid window (42 local days; ±1 for DST).
   await expect
@@ -149,7 +149,7 @@ test("calendar decomposed view: day selection and month navigation", async ({
     timeout: 15_000,
   });
   await expect(
-    page.getByRole("img", { name: /^1 event on / }).first(),
+    page.getByRole("button", { name: /\. 1 event$/ }).first(),
   ).toBeVisible({ timeout: 15_000 });
 
   // Reverse path: "Today" returns the grid to the current month.
@@ -289,10 +289,10 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
   // /relationships mounts the unified RelationshipsView. The helper mocks
   // GET /api/lifeops/entities + /api/lifeops/relationships with a populated
   // graph (Owner, Pat Doe, Acme Corp), so the view lands on its populated
-  // branch. Toggling the "Organizations" kind filter narrows the node list to
-  // the organization node only; "All" restores it.
+  // branch. Selecting "Organizations" from the kind dropdown narrows the node
+  // list to the organization node only; selecting "All" restores it.
   await openAppPath(page, "/relationships");
-  await expect(page.getByText("Graph (3)").first()).toBeVisible({
+  await expect(page.getByText("3 entities", { exact: true })).toBeVisible({
     timeout: 60_000,
   });
   await expect(page.getByText("Pat Doe").first()).toBeVisible({
@@ -319,10 +319,19 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     }
   }
 
+  const kindFilter = page.locator(
+    '[data-agent-id="relationships-kind-filter"]',
+  );
+  await expectTopmostAtCenter(kindFilter, "Relationships kind filter");
+  await kindFilter.click();
   await page
-    .getByRole("button", { name: "Organizations", exact: true })
+    .getByRole("menuitemradio", { name: "Organizations", exact: true })
     .click();
-  await expect(page.getByText("Graph (1)").first()).toBeVisible({
+  await expect(kindFilter).toHaveAttribute(
+    "aria-label",
+    "Filter relationship type, Organizations selected",
+  );
+  await expect(page.getByText("1 entity", { exact: true })).toBeVisible({
     timeout: 15_000,
   });
   await expect(page.getByText("Pat Doe")).toHaveCount(0, { timeout: 15_000 });
@@ -330,15 +339,16 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 
-  // #11144 guard: the first "All" kind chip is the one that used to sit under
-  // the removed global corner back button. Drive the real restore path through
-  // it, then assert every kind is visible again.
-  const allChip = page
-    .getByRole("button", { name: "All", exact: true })
-    .first();
-  await expectTopmostAtCenter(allChip, "Relationships All kind chip");
-  await allChip.click();
-  await expect(page.getByText("Graph (3)").first()).toBeVisible({
+  // #11144 guard: the kind control occupies the filter surface that used to
+  // sit under the removed global corner back button. Drive the restore path
+  // through the same topmost-checked control, then assert every kind is visible.
+  await kindFilter.click();
+  await page.getByRole("menuitemradio", { name: "All", exact: true }).click();
+  await expect(kindFilter).toHaveAttribute(
+    "aria-label",
+    "Filter relationship type, All selected",
+  );
+  await expect(page.getByText("3 entities", { exact: true })).toBeVisible({
     timeout: 15_000,
   });
   await expect(page.getByText("Pat Doe").first()).toBeVisible({


### PR DESCRIPTION
## Summary
- align the Calendar populated-state assertion with the current accessible day-button contract (`<formatted date>. 1 event`)
- drive the current Relationships type dropdown and entity counts while preserving populated data, filter/restore behavior, mobile width, and topmost hit-test coverage

## Regression contract
Develop Full run [33137173216](https://github.com/elizaOS/eliza/actions/runs/33137173216) rendered the correct populated Calendar and Relationships UI but failed on retired accessibility/UI literals (`img` named `1 event on …` and `Graph (3)`). The Pixel-class consumer boundary remains behavioral: stubbed API data must render, Calendar day selection and month navigation must mutate/refetch correctly, and the Relationships dropdown must filter to Organizations and restore All without viewport overflow or control occlusion.

## Exact source
- base: adc989c26d5b6f14ceb7dc46b2dbda85609a1429
- head: b356f4fa2af9928b2cf0a7be8da7f8771be71611
- tree: 272d041cc1e14e78b1673aa27343b2a0f4d2b2d2
- changed paths: 1 (`packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts`)
- open-PR path overlap: none

## Verification
- Pixel-7 `mobile-chromium`, full decomposed personal-assistant spec: 8/8 passed
- focused Calendar + Relationships Pixel-7 run: 2/2 passed
- `bun run --cwd packages/app typecheck`: passed
- changed-file Biome: passed
- `git diff --check`: passed

## Evidence
- before: both failures reproduced locally on the requested base with Playwright accessibility snapshots showing the correct new button/dropdown/entity-count contracts
- after: exact-current Pixel-7 head passed all eight decomposed-domain interactions
- screenshots / MP4: N/A - test-only accessibility-driver repair; rendered product pixels and runtime behavior are unchanged
- frontend/backend live logs: N/A - deterministic stub-backed browser lane; no live integration or backend behavior changed

## Scope
Test-only. No phone, device, VPS, user browser session, deployment, authentication, billing, staging, production, or live-service action.
