### PR TITLE
test(app): certify existing Dedicated consent in cloud-live proof

### DIFF
--- a/packages/app/test/cloud-live-dedicated-adoption-consent.ts
+++ b/packages/app/test/cloud-live-dedicated-adoption-consent.ts
@@ -25,7 +25,7 @@ interface VisibleDedicatedAdoptionQuote {
   stateDisposition: DedicatedAdoptionStateDisposition;
 }
 
-interface DedicatedAdoptionConsentProof {
+export interface DedicatedAdoptionConsentProof {
   confirmVisibleConsent(confirm: Locator): Promise<void>;
   dispose(): void;
 }

--- a/packages/app/test/cloud-live-dedicated-adoption-consent.ts
+++ b/packages/app/test/cloud-live-dedicated-adoption-consent.ts
@@ -1,0 +1,204 @@
+/**
+ * Certifies the existing-Dedicated consent shown by the real renderer.
+ *
+ * The proof only observes the quote response already requested by the product
+ * and clicks the visible confirmation control. It never calls a Cloud endpoint
+ * itself, so the user's consent boundary remains the only way forward.
+ */
+
+import type { Locator, Page, Response } from "@playwright/test";
+
+type DedicatedAdoptionStateDisposition =
+  | "fresh_boot_no_verified_backup"
+  | "verified_backup_present"
+  | "unreviewed_existing_target";
+
+interface VisibleDedicatedAdoptionQuote {
+  status: string;
+  startsCompute: boolean;
+  hourlyRateUsd: number;
+  dailyRateUsd: number;
+  minimumBalanceUsd: number;
+  minimumRunwayDays: number;
+  balanceUsd: number;
+  deficitUsd: number;
+  stateDisposition: DedicatedAdoptionStateDisposition;
+}
+
+interface DedicatedAdoptionConsentProof {
+  confirmVisibleConsent(confirm: Locator): Promise<void>;
+  dispose(): void;
+}
+
+class CloudLiveDedicatedAdoptionConsentProofError extends Error {
+  readonly code = "CLOUD_LIVE_DEDICATED_ADOPTION_CONSENT_PROOF";
+
+  constructor(readonly phase: "quote" | "copy" | "control") {
+    super(`[cloud-live] Dedicated adoption consent ${phase} proof failed`);
+    this.name = "CloudLiveDedicatedAdoptionConsentProofError";
+  }
+}
+
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function projectVisibleQuote(
+  value: unknown,
+): VisibleDedicatedAdoptionQuote | null {
+  const root = recordOrNull(value);
+  const quote = recordOrNull(root?.data);
+  const status = typeof quote?.status === "string" ? quote.status.trim() : "";
+  const hourlyRateUsd = finiteNumber(quote?.hourlyRateUsd);
+  const dailyRateUsd = finiteNumber(quote?.dailyRateUsd);
+  const minimumBalanceUsd = finiteNumber(quote?.minimumBalanceUsd);
+  const minimumRunwayDays = finiteNumber(quote?.minimumRunwayDays);
+  const balanceUsd = finiteNumber(quote?.balanceUsd);
+  const deficitUsd = finiteNumber(quote?.deficitUsd);
+  const stateDisposition = quote?.stateDisposition;
+  if (
+    root?.success !== true ||
+    !status ||
+    typeof quote?.startsCompute !== "boolean" ||
+    hourlyRateUsd === null ||
+    dailyRateUsd === null ||
+    minimumBalanceUsd === null ||
+    minimumRunwayDays === null ||
+    balanceUsd === null ||
+    deficitUsd === null ||
+    (stateDisposition !== "fresh_boot_no_verified_backup" &&
+      stateDisposition !== "verified_backup_present" &&
+      stateDisposition !== "unreviewed_existing_target") ||
+    quote?.requiresConfirmation !== true ||
+    quote?.action !== "adopt_existing_dedicated"
+  ) {
+    return null;
+  }
+  return {
+    status,
+    startsCompute: quote.startsCompute,
+    hourlyRateUsd,
+    dailyRateUsd,
+    minimumBalanceUsd,
+    minimumRunwayDays,
+    balanceUsd,
+    deficitUsd,
+    stateDisposition,
+  };
+}
+
+function exactVisibleConsentLines(
+  quote: VisibleDedicatedAdoptionQuote,
+): string[] {
+  const disposition =
+    quote.stateDisposition === "verified_backup_present"
+      ? "restore its reviewed backup"
+      : quote.stateDisposition === "fresh_boot_no_verified_backup"
+        ? "start fresh because no verified backup is available"
+        : "keep its current state without a reviewed restore";
+  return [
+    "Use your existing Dedicated agent?",
+    `Current status: ${quote.status}.`,
+    `Hosting: $${quote.hourlyRateUsd.toFixed(2)}/hour ($${quote.dailyRateUsd.toFixed(2)}/day).`,
+    `Balance: $${quote.balanceUsd.toFixed(2)}; minimum required: $${quote.minimumBalanceUsd.toFixed(2)} (${quote.minimumRunwayDays} days of runway); deficit: $${quote.deficitUsd.toFixed(2)}.`,
+    `This action ${quote.startsCompute ? "starts Dedicated compute" : "does not start new compute"} and will ${disposition}.`,
+  ];
+}
+
+function isDedicatedAdoptionQuoteResponse(response: Response): boolean {
+  if (response.request().method() !== "GET" || response.status() !== 200) {
+    return false;
+  }
+  try {
+    return new URL(response.url()).pathname.endsWith(
+      "/upgrade-tier/adopt-existing",
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Observe the product's own quote request and certify the exact consent copy
+ * before performing the same visible click a human uses.
+ */
+export function installDedicatedAdoptionConsentProof(
+  page: Page,
+): DedicatedAdoptionConsentProof {
+  let latestQuoteAttempt: Promise<VisibleDedicatedAdoptionQuote | null> | null =
+    null;
+  let confirmationInFlight = false;
+  const observeResponse = (response: Response): void => {
+    if (!isDedicatedAdoptionQuoteResponse(response)) return;
+    latestQuoteAttempt = response
+      .json()
+      .then(projectVisibleQuote)
+      .catch(() => null);
+  };
+  page.on("response", observeResponse);
+
+  return {
+    async confirmVisibleConsent(confirm) {
+      if (confirmationInFlight) return;
+      confirmationInFlight = true;
+      try {
+        const quoteAttempt = latestQuoteAttempt;
+        if (!quoteAttempt) {
+          throw new CloudLiveDedicatedAdoptionConsentProofError("quote");
+        }
+        const quote = await quoteAttempt;
+        if (!quote) {
+          throw new CloudLiveDedicatedAdoptionConsentProofError("quote");
+        }
+
+        const consentTurn = confirm.locator(
+          "xpath=ancestor::*[@data-testid='thread-line'][1]",
+        );
+        if (!(await consentTurn.isVisible())) {
+          throw new CloudLiveDedicatedAdoptionConsentProofError("copy");
+        }
+        const copyMatches = await consentTurn.evaluate(
+          (element, expectedLines) => {
+            const normalize = (line: string) =>
+              line.replace(/\s+/g, " ").trim();
+            const visibleLines = (element as HTMLElement).innerText
+              .split("\n")
+              .map(normalize)
+              .filter(Boolean);
+            return expectedLines
+              .map(normalize)
+              .every((line) => visibleLines.includes(line));
+          },
+          exactVisibleConsentLines(quote),
+        );
+        if (!copyMatches) {
+          throw new CloudLiveDedicatedAdoptionConsentProofError("copy");
+        }
+        const confirmationControlMatches = await confirm.evaluate(
+          (element) =>
+            (element as HTMLElement).innerText.replace(/\s+/g, " ").trim() ===
+            "Confirm and continue",
+        );
+        if (!confirmationControlMatches || !(await confirm.isEnabled())) {
+          throw new CloudLiveDedicatedAdoptionConsentProofError("control");
+        }
+        try {
+          await confirm.click({ timeout: 15_000 });
+        } catch {
+          throw new CloudLiveDedicatedAdoptionConsentProofError("control");
+        }
+      } finally {
+        confirmationInFlight = false;
+      }
+    },
+    dispose() {
+      page.off("response", observeResponse);
+    },
+  };
+}

--- a/packages/app/test/cloud-live-optional-action.ts
+++ b/packages/app/test/cloud-live-optional-action.ts
@@ -64,9 +64,11 @@ interface WaitForCloudLivePersonalIdentityOptions<T> {
   readBinding: () => Promise<T | null>;
   runtimeCloudRecovery: Locator;
   retryRecovery: Locator;
+  dedicatedAdoptionConsent?: Locator;
   timeoutMs: number;
   runtimeCloudGraceMs: number;
   pollIntervalMs?: number;
+  onDedicatedAdoptionConsent?: () => void | Promise<void>;
   onRecovery?: (
     recovery: CloudLivePersonalIdentityRecovery,
   ) => void | Promise<void>;
@@ -109,20 +111,44 @@ export async function waitForCloudLivePersonalIdentity<T>({
   readBinding,
   runtimeCloudRecovery,
   retryRecovery,
+  dedicatedAdoptionConsent,
   timeoutMs,
   runtimeCloudGraceMs,
   pollIntervalMs = 250,
+  onDedicatedAdoptionConsent,
   onRecovery,
 }: WaitForCloudLivePersonalIdentityOptions<T>): Promise<T> {
   const startedAt = Date.now();
   const deadline = startedAt + timeoutMs;
   let runtimeCloudWasAbsent = false;
+  let dedicatedAdoptionConsentHandled = false;
   for (;;) {
     const binding = await withinCloudLivePersonalIdentityDeadline(
       readBinding,
       deadline,
     );
     if (binding) return binding;
+
+    if (
+      !dedicatedAdoptionConsentHandled &&
+      dedicatedAdoptionConsent &&
+      (await withinCloudLivePersonalIdentityDeadline(
+        () => dedicatedAdoptionConsent.isVisible(),
+        deadline,
+      ))
+    ) {
+      if (!onDedicatedAdoptionConsent) {
+        throw new Error(
+          "[cloud-live] Dedicated adoption consent handler is missing",
+        );
+      }
+      await withinCloudLivePersonalIdentityDeadline(
+        () => Promise.resolve(onDedicatedAdoptionConsent()),
+        deadline,
+      );
+      dedicatedAdoptionConsentHandled = true;
+      continue;
+    }
 
     const retryVisible = await withinCloudLivePersonalIdentityDeadline(
       () => retryRecovery.isVisible(),

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -1,6 +1,7 @@
 /** Real-browser regression coverage for bounded optional Cloud actions. */
 
 import { expect, type Locator, test } from "@playwright/test";
+import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   CloudLiveOptionalActionDeadlineError,
   CloudLivePersonalIdentityDeadlineError,
@@ -209,6 +210,93 @@ test.describe("Cloud live optional action boundary", () => {
       }),
     ).resolves.toBe("dedicated");
     expect(recoveryObserved).toBe(false);
+  });
+
+  test("confirms one visible Dedicated adoption before the binding resolves", async ({
+    page,
+  }) => {
+    await page.route("**/upgrade-tier/adopt-existing", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            status: "stopped",
+            startsCompute: true,
+            hourlyRateUsd: 0.01,
+            dailyRateUsd: 0.24,
+            minimumBalanceUsd: 0.72,
+            minimumRunwayDays: 3,
+            balanceUsd: 115.54059,
+            deficitUsd: 0,
+            stateDisposition: "verified_backup_present",
+            requiresConfirmation: true,
+            action: "adopt_existing_dedicated",
+          },
+        }),
+      });
+    });
+    await page.goto("/");
+    await page.setContent(`
+      <article data-testid="thread-line">
+        <p>Use your existing Dedicated agent?</p>
+        <p>Current status: stopped.</p>
+        <p>Hosting: $0.01/hour ($0.24/day).</p>
+        <p>Balance: $115.54; minimum required: $0.72 (3 days of runway); deficit: $0.00.</p>
+        <p>This action starts Dedicated compute and will restore its reviewed backup.</p>
+        <button data-testid="dedicated-adoption-confirm">Confirm and continue</button>
+        <button>Not now</button>
+      </article>
+      <output data-testid="confirmation-count">0</output>
+      <script>
+        document.addEventListener("click", (event) => {
+          if (!(event.target instanceof HTMLElement)) return;
+          if (event.target.dataset.testid !== "dedicated-adoption-confirm") return;
+          const output = document.querySelector('[data-testid="confirmation-count"]');
+          output.textContent = String(Number(output.textContent) + 1);
+          window.__testActiveBinding = "dedicated";
+        });
+      </script>
+    `);
+    const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
+    await page.evaluate(async () => {
+      const response = await fetch("/upgrade-tier/adopt-existing");
+      await response.json();
+    });
+    let consentHandlerCalls = 0;
+    const dedicatedAdoptionConsent = page.getByTestId(
+      "dedicated-adoption-confirm",
+    );
+
+    try {
+      await expect(
+        waitForCloudLivePersonalIdentity({
+          readBinding: () =>
+            page.evaluate(
+              () =>
+                (window as typeof window & { __testActiveBinding?: string })
+                  .__testActiveBinding ?? null,
+            ),
+          runtimeCloudRecovery: page.getByTestId("runtime-cloud"),
+          retryRecovery: page.getByTestId("identity-retry"),
+          dedicatedAdoptionConsent,
+          timeoutMs: 500,
+          runtimeCloudGraceMs: 50,
+          pollIntervalMs: 5,
+          onDedicatedAdoptionConsent: async () => {
+            consentHandlerCalls += 1;
+            await dedicatedAdoptionProof.confirmVisibleConsent(
+              dedicatedAdoptionConsent,
+            );
+          },
+        }),
+      ).resolves.toBe("dedicated");
+      expect(consentHandlerCalls).toBe(1);
+      await expect(page.getByTestId("confirmation-count")).toHaveText("1");
+    } finally {
+      dedicatedAdoptionProof.dispose();
+    }
   });
 
   test("fails with the closed runtime-cloud recovery after the initial choice reappears", async ({

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -212,10 +212,12 @@ test.describe("Cloud live optional action boundary", () => {
     expect(recoveryObserved).toBe(false);
   });
 
-  test("confirms one visible Dedicated adoption before the binding resolves", async ({
+  test("reuses a Dedicated quote completed before the binding wait", async ({
     page,
   }) => {
+    let quoteGetCount = 0;
     await page.route("**/upgrade-tier/adopt-existing", async (route) => {
+      quoteGetCount += 1;
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -260,11 +262,15 @@ test.describe("Cloud live optional action boundary", () => {
       </script>
     `);
     const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
-    await page.evaluate(async () => {
+    const quoteStatus = await page.evaluate(async () => {
       const response = await fetch("/upgrade-tier/adopt-existing");
       await response.json();
+      return response.status;
     });
+    expect(quoteStatus).toBe(200);
+    expect(quoteGetCount).toBe(1);
     let consentHandlerCalls = 0;
+    let bindingReadCount = 0;
     const dedicatedAdoptionConsent = page.getByTestId(
       "dedicated-adoption-confirm",
     );
@@ -272,12 +278,14 @@ test.describe("Cloud live optional action boundary", () => {
     try {
       await expect(
         waitForCloudLivePersonalIdentity({
-          readBinding: () =>
-            page.evaluate(
+          readBinding: () => {
+            bindingReadCount += 1;
+            return page.evaluate(
               () =>
                 (window as typeof window & { __testActiveBinding?: string })
                   .__testActiveBinding ?? null,
-            ),
+            );
+          },
           runtimeCloudRecovery: page.getByTestId("runtime-cloud"),
           retryRecovery: page.getByTestId("identity-retry"),
           dedicatedAdoptionConsent,
@@ -292,6 +300,8 @@ test.describe("Cloud live optional action boundary", () => {
           },
         }),
       ).resolves.toBe("dedicated");
+      expect(bindingReadCount).toBeGreaterThan(0);
+      expect(quoteGetCount).toBe(1);
       expect(consentHandlerCalls).toBe(1);
       await expect(page.getByTestId("confirmation-count")).toHaveText("1");
     } finally {

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -35,7 +35,10 @@ import {
   installCloudLiveAnchoredRetryChipObserver,
   writeCloudLiveContinuityEvidence,
 } from "../cloud-live-continuity-contract";
-import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
+import {
+  type DedicatedAdoptionConsentProof,
+  installDedicatedAdoptionConsentProof,
+} from "../cloud-live-dedicated-adoption-consent";
 import {
   CloudLiveOptionalActionDeadlineError,
   type CloudLivePersonalIdentityRecovery,
@@ -547,8 +550,11 @@ async function resolvePersonalIdentity(
   page: Page,
   chooseRuntime = true,
   onRecovery?: (recovery: CloudLivePersonalIdentityRecovery) => Promise<void>,
+  existingDedicatedAdoptionProof?: DedicatedAdoptionConsentProof,
 ): Promise<CloudLiveRuntimeBinding> {
-  const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
+  const dedicatedAdoptionProof =
+    existingDedicatedAdoptionProof ??
+    installDedicatedAdoptionConsentProof(page);
   try {
     await prepareCloudLivePersonalIdentity({
       chooseRuntime,
@@ -578,7 +584,9 @@ async function resolvePersonalIdentity(
     );
     return binding;
   } finally {
-    dedicatedAdoptionProof.dispose();
+    if (!existingDedicatedAdoptionProof) {
+      dedicatedAdoptionProof.dispose();
+    }
   }
 }
 
@@ -812,47 +820,57 @@ test.describe("real cloud login + personal identity + chat", () => {
       );
     };
     await writePreIdentityDiagnostic();
-    await chooseCloudRuntime(page, async (state) => {
-      if (state === "attempt") {
-        runtimeChoiceCounters.runtimeCloudActionAttemptCount += 1;
-      } else if (state === "success") {
-        runtimeChoiceCounters.runtimeCloudActionSuccessCount += 1;
-      } else {
-        runtimeChoiceCounters.runtimeCloudActionTimeoutCount += 1;
-      }
-      await writePreIdentityDiagnostic();
-    });
+    const primaryDedicatedAdoptionProof =
+      installDedicatedAdoptionConsentProof(page);
+    const referenceBinding = await (async () => {
+      try {
+        await chooseCloudRuntime(page, async (state) => {
+          if (state === "attempt") {
+            runtimeChoiceCounters.runtimeCloudActionAttemptCount += 1;
+          } else if (state === "success") {
+            runtimeChoiceCounters.runtimeCloudActionSuccessCount += 1;
+          } else {
+            runtimeChoiceCounters.runtimeCloudActionTimeoutCount += 1;
+          }
+          await writePreIdentityDiagnostic();
+        });
 
-    // The join resolves the account-derived Personal Eliza through the canonical
-    // identity endpoint. A correctly prepared proof principal is already bound
-    // to Dedicated; if it is not, the closed quote/activation/cutover counters
-    // expose that control-plane path and the final no-mutation gate fails.
-    await enterTrajectoryPhase(
-      "personal-identity",
-      await readPreIdentityDiagnostic(),
-    );
-    const referenceBinding = await resolvePersonalIdentity(
-      page,
-      false,
-      async (recovery) => {
-        if (recovery === "runtime-cloud") {
-          runtimeChoiceCounters.runtimeCloudRecoveryVisibleCount += 1;
-        } else {
-          runtimeChoiceCounters.personalIdentityRetryVisibleCount += 1;
-        }
+        // The join resolves the account-derived Personal Eliza through the
+        // canonical identity endpoint. A correctly prepared proof principal is
+        // already bound to Dedicated; if it is not, the closed quote/activation/
+        // cutover counters expose that control-plane path and the final
+        // no-mutation gate fails.
         await enterTrajectoryPhase(
           "personal-identity",
           await readPreIdentityDiagnostic(),
         );
-      },
-    ).catch((cause: unknown) =>
-      rethrowCloudLiveFailureAfterDiagnostic(cause, async () => {
-        await enterTrajectoryPhase(
-          "personal-identity",
-          await readPreIdentityDiagnostic(),
+        return await resolvePersonalIdentity(
+          page,
+          false,
+          async (recovery) => {
+            if (recovery === "runtime-cloud") {
+              runtimeChoiceCounters.runtimeCloudRecoveryVisibleCount += 1;
+            } else {
+              runtimeChoiceCounters.personalIdentityRetryVisibleCount += 1;
+            }
+            await enterTrajectoryPhase(
+              "personal-identity",
+              await readPreIdentityDiagnostic(),
+            );
+          },
+          primaryDedicatedAdoptionProof,
+        ).catch((cause: unknown) =>
+          rethrowCloudLiveFailureAfterDiagnostic(cause, async () => {
+            await enterTrajectoryPhase(
+              "personal-identity",
+              await readPreIdentityDiagnostic(),
+            );
+          }),
         );
-      }),
-    );
+      } finally {
+        primaryDedicatedAdoptionProof.dispose();
+      }
+    })();
     const identityAudit = await primaryAudit.snapshot();
     expect(
       identityAudit.successfulPersonalIdentityGetCount,

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -35,6 +35,7 @@ import {
   installCloudLiveAnchoredRetryChipObserver,
   writeCloudLiveContinuityEvidence,
 } from "../cloud-live-continuity-contract";
+import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   CloudLiveOptionalActionDeadlineError,
   type CloudLivePersonalIdentityRecovery,
@@ -547,27 +548,38 @@ async function resolvePersonalIdentity(
   chooseRuntime = true,
   onRecovery?: (recovery: CloudLivePersonalIdentityRecovery) => Promise<void>,
 ): Promise<CloudLiveRuntimeBinding> {
-  await prepareCloudLivePersonalIdentity({
-    chooseRuntime,
-    chatOverlay: page.getByTestId("chat-overlay"),
-    chatOverlayTimeoutMs: 60_000,
-    chooseRuntimeAction: () => chooseCloudRuntime(page),
-  });
-  const binding = await waitForCloudLivePersonalIdentity({
-    readBinding: () => readActiveBinding(page),
-    runtimeCloudRecovery: page.getByTestId(
-      "choice-__first_run__:runtime:cloud",
-    ),
-    retryRecovery: page.getByTestId("choice-__first_run__:error:retry"),
-    timeoutMs: PERSONAL_IDENTITY_ATTEMPT_TIMEOUT_MS,
-    runtimeCloudGraceMs: 15_000,
-    onRecovery,
-  });
-  await clickIfVisible(
-    page.getByTestId("choice-__first_run__:tutorial:skip"),
-    15_000,
-  );
-  return binding;
+  const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
+  try {
+    await prepareCloudLivePersonalIdentity({
+      chooseRuntime,
+      chatOverlay: page.getByTestId("chat-overlay"),
+      chatOverlayTimeoutMs: 60_000,
+      chooseRuntimeAction: () => chooseCloudRuntime(page),
+    });
+    const dedicatedAdoptionConsent = page.getByTestId(
+      "choice-__first_run__:dedicated-adoption:confirm",
+    );
+    const binding = await waitForCloudLivePersonalIdentity({
+      readBinding: () => readActiveBinding(page),
+      runtimeCloudRecovery: page.getByTestId(
+        "choice-__first_run__:runtime:cloud",
+      ),
+      retryRecovery: page.getByTestId("choice-__first_run__:error:retry"),
+      dedicatedAdoptionConsent,
+      timeoutMs: PERSONAL_IDENTITY_ATTEMPT_TIMEOUT_MS,
+      runtimeCloudGraceMs: 15_000,
+      onDedicatedAdoptionConsent: () =>
+        dedicatedAdoptionProof.confirmVisibleConsent(dedicatedAdoptionConsent),
+      onRecovery,
+    });
+    await clickIfVisible(
+      page.getByTestId("choice-__first_run__:tutorial:skip"),
+      15_000,
+    );
+    return binding;
+  } finally {
+    dedicatedAdoptionProof.dispose();
+  }
 }
 
 test.describe("real cloud login + personal identity + chat", () => {

--- a/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
@@ -16,6 +16,7 @@
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
+import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   expectNoPageDiagnostics,
   installPageDiagnosticsGuard,
@@ -250,24 +251,23 @@ test.describe("cloud-only onboarding (production default)", () => {
       "eliza:enable-runtime-chooser": "0",
     });
 
+    const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
     await page.goto("/", { waitUntil: "domcontentloaded" });
     const confirm = page.getByTestId(
       "choice-__first_run__:dedicated-adoption:confirm",
     );
-    await expect(confirm).toBeVisible({ timeout: 20_000 });
-    await expect(page.getByText("Current status: stopped.")).toBeVisible();
-    await expect(
-      page.getByText(
-        /Balance: \$115\.54; minimum required: \$0\.72 \(3 days of runway\)/,
-      ),
-    ).toBeVisible();
-    expect(adoptionPosts).toBe(0);
+    try {
+      await expect(confirm).toBeVisible({ timeout: 20_000 });
+      expect(adoptionPosts).toBe(0);
 
-    await confirm.click();
-    await expect.poll(() => adoptionPosts).toBe(1);
-    await expect(page.getByTestId("home-screen")).toBeVisible({
-      timeout: 20_000,
-    });
-    await settleHomeEntrance(page);
+      await dedicatedAdoptionProof.confirmVisibleConsent(confirm);
+      await expect.poll(() => adoptionPosts).toBe(1);
+      await expect(page.getByTestId("home-screen")).toBeVisible({
+        timeout: 20_000,
+      });
+      await settleHomeEntrance(page);
+    } finally {
+      dedicatedAdoptionProof.dispose();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- let the deployed cloud-live certificate handle the canonical existing-Dedicated consent state during Personal identity resolution
- passively observe the quote response already requested by the renderer, compare the complete visible status, hosting, balance, runway, deficit, and state terms, then click the enabled `Confirm and continue` control
- keep the fresh-mint path unchanged and reuse the same proof helper in the deterministic onboarding browser boundary

## Regression contract

The durable staging certificate identity can legitimately have one existing Dedicated target without an adoption authority. Product UI correctly stops for explicit consent, but the cloud-live proof previously only waited for a binding, so it timed out even though the renderer showed the required consent card.

The consumer is the exact-SHA staging deployment certificate. The existing onboarding browser test owns product behavior; it did not own the deployed certificate orchestration. This change shares one browser-proof helper between both boundaries so the certificate exercises the same visible confirmation a human uses without bypassing the UI or calling the adoption API directly.

## Exact-head evidence

Head: `994263db56d9e749e6a1353bfba54ed192e3f3f1`
Base: `adc989c26d5b6f14ceb7dc46b2dbda85609a1429`

- pinned Biome check on all five touched files: pass
- focused TypeScript check for the new proof helper, identity wait, and isolated browser regression: pass
- Chromium `cloud-live-optional-action.spec.ts`: 17/17 pass
- exact renderer `build:web` with test auth: pass, including chunk-safety and viewport verification
- focused full-app adoption spec setup currently remains at the existing Sign in card on current `develop` before the adoption route is reached; the isolated browser proof covers this diff and the unchanged full-app test remains wired to the same helper

## Evidence applicability

- rendered UI before/after: N/A - test-only change; no product UI changed
- walkthrough video: N/A - test-only certificate orchestration
- backend/domain artifact: N/A - deterministic browser fixture; no live mutation
