### PR TITLE
fix(cloud): retain local embedder for fresh managed agents

### DIFF
--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -303,9 +303,47 @@ describe("managed Eliza environment", () => {
       agentSandboxId: "cloud-agent-1",
     });
 
+    expect(result.environmentVars.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBe("1");
     expect(result.environmentVars.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
     expect(result.environmentVars.EMBEDDING_DIMENSION).toBe("384");
     expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
+  });
+
+  test("does not migrate existing stores or explicit cloud opt-outs to local embeddings", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const existing = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-existing",
+      existingEnv: {
+        ELIZAOS_CLOUD_API_KEY: "eliza_existing_agent_key",
+        EMBEDDING_DIMENSION: "1536",
+        ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS: "1536",
+      },
+    });
+    const optedOut = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-opted-out",
+      existingEnv: { ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "0" },
+    });
+    const cloudPinned = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-cloud-pinned",
+      existingEnv: { ELIZAOS_CLOUD_USE_EMBEDDINGS: "true" },
+    });
+
+    expect(existing.environmentVars.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBeUndefined();
+    expect(existing.environmentVars.EMBEDDING_DIMENSION).toBe("1536");
+    expect(existing.environmentVars.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+    expect(optedOut.environmentVars.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBe("0");
+    expect(optedOut.environmentVars.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
+    expect(optedOut.environmentVars.EMBEDDING_DIMENSION).toBe("1536");
+    expect(cloudPinned.environmentVars.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBeUndefined();
+    expect(cloudPinned.environmentVars.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("true");
+    expect(cloudPinned.environmentVars.EMBEDDING_DIMENSION).toBe("1536");
   });
 
   test("honors explicit per-agent embedding-dimension overrides", async () => {
@@ -346,8 +384,10 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
       "ELIZAOS_CLOUD_LARGE_MODEL",
       "ELIZAOS_CLOUD_SMALL_MODEL",
       "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+      "ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS",
       "EMBEDDING_DIMENSION",
     ]);
+    expect(result.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBe("1");
     expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
     expect(result.EMBEDDING_DIMENSION).toBe("384");
     expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
@@ -363,6 +403,7 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
       ELIZAOS_CLOUD_API_KEY: "eliza_existing_agent_key",
     });
 
+    expect(result.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBeUndefined();
     expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
     expect(result.EMBEDDING_DIMENSION).toBe("1536");
     expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
@@ -375,6 +416,7 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
       ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "0",
     });
 
+    expect(result.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBeUndefined();
     expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
     expect(result.EMBEDDING_DIMENSION).toBe("1536");
     expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
@@ -388,6 +430,7 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
       ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "1",
     });
 
+    expect(result.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBe("1");
     expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
     expect(result.EMBEDDING_DIMENSION).toBe("384");
     expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
@@ -404,6 +447,7 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
       ELIZAOS_CLOUD_USE_EMBEDDINGS: "true",
     });
 
+    expect(result.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBeUndefined();
     expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
     expect(result.EMBEDDING_DIMENSION).toBe("1536");
     expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
@@ -217,6 +217,10 @@ export function mergeManagedPublicBaseUrl(
  * ways: ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1 opts an existing agent in (only
  * after re-embedding its store), =0 keeps a fresh agent on the cloud path, and
  * ELIZAOS_CLOUD_USE_EMBEDDINGS=true always restores cloud embeddings.
+ * Whenever this helper selects local-primary, it also stamps the lean-chat
+ * opt-in consumed by the agent plugin resolver. Without that shared decision,
+ * the control plane can pin 384-d local semantics while the container drops
+ * the only plugin that registers the local TEXT_EMBEDDING handler.
  *
  * NOTE on dimensions: EMBEDDING_DIMENSION / ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS
  * set the width of the vectors the plugin-elizacloud TEXT_EMBEDDING handler
@@ -239,7 +243,12 @@ export function applyManagedAgentInferenceEnvDefaults(
     existingEnv.ELIZAOS_CLOUD_USE_EMBEDDINGS?.trim().toLowerCase() !== "true";
   const embeddingDimension = localPrimaryEmbeddings ? "384" : "1536";
   return {
-    ...(localPrimaryEmbeddings ? { ELIZAOS_CLOUD_USE_EMBEDDINGS: "false" } : {}),
+    ...(localPrimaryEmbeddings
+      ? {
+          ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "1",
+          ELIZAOS_CLOUD_USE_EMBEDDINGS: "false",
+        }
+      : {}),
     ELIZAOS_CLOUD_EMBEDDING_URL:
       existingEnv.ELIZAOS_CLOUD_EMBEDDING_URL ?? resolveCloudApiBaseUrl(),
     EMBEDDING_DIMENSION: existingEnv.EMBEDDING_DIMENSION ?? embeddingDimension,
@@ -327,10 +336,11 @@ export async function prepareManagedElizaBaseEnvironment(
       // BOTH embedding-output dimensions to the handler's output width, and pin
       // the healthy Cerebras-direct small/large models so the container never
       // resolves a tier to the `:nitro` default. For the explicit
-      // ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1 rollout lane, the helper yields the
-      // cloud embedding slot and uses 384-dim hints so local gte-small,
-      // ensureEmbeddingDimension, and storage agree. Embedding controls honor
-      // explicit per-agent overrides; managed small/large model pins do not.
+      // local-primary lane, the helper stamps the lean-chat plugin opt-in,
+      // yields the cloud embedding slot, and uses 384-dim hints so local
+      // gte-small, ensureEmbeddingDimension, and storage agree. Embedding
+      // controls honor explicit per-agent overrides; managed small/large model
+      // pins do not.
       ...applyManagedAgentInferenceEnvDefaults(existingEnv),
       // New managed agents keep agent-state in a LOCAL in-container DB (PGlite on
       // the persistent /root/.eliza volume) instead of the shared cloud Postgres;

--- a/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
@@ -12,9 +12,10 @@
  *      the embedded PGlite adapter — not the shared remote Postgres. (A revert
  *      that leaks `DATABASE_URL` back in would flip this and is the exact #8783
  *      regression.)
- *   2. PLUGIN SET = lean. `@elizaos/agent`'s `collectPluginNames`, driven by the
- *      env's `ELIZA_PLUGIN_SET=lean-chat` + `ELIZAOS_CLOUD_*`, must EXCLUDE
- *      local-inference / wallet / workflow but INCLUDE elizacloud (#8434).
+ *   2. PLUGIN SET = lean + local embeddings. `@elizaos/agent`'s
+ *      `collectPluginNames`, driven by the managed env, must RETAIN
+ *      local-inference (the TEXT_EMBEDDING owner), exclude wallet/workflow, and
+ *      include elizacloud for the remaining model routes (#8434).
  *   3. EMBEDDING COLUMN = dim384. A FRESH provision (no ELIZAOS_CLOUD_API_KEY in
  *      existingEnv) defaults to local-primary gte-small embeddings, so the env
  *      pins `EMBEDDING_DIMENSION=384` and the 384-d vectors land in the
@@ -68,7 +69,7 @@ async function buildManagedEnv(): Promise<Record<string, string>> {
 }
 
 describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
-  test("managed env pins local state + lean chat + 1536-d embeddings (no DATABASE_URL)", async () => {
+  test("managed env pins local state + lean chat + 384-d local embeddings (no DATABASE_URL)", async () => {
     const env = await buildManagedEnv();
     expect(env.ELIZA_AGENT_LOCAL_STATE).toBe("1");
     expect(env.ELIZA_PLUGIN_SET).toBe("lean-chat");
@@ -76,6 +77,7 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
     // gte-small embeddings, 384-d hints, cloud embeddings off.
     expect(env.EMBEDDING_DIMENSION).toBe("384");
     expect(env.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
+    expect(env.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS).toBe("1");
     expect(env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
     expect(env.ELIZAOS_CLOUD_ENABLED).toBe("true");
     // The load-bearing absence: the producer must NOT carry DATABASE_URL.
@@ -106,7 +108,7 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
     expect(adapter.constructor.name).toBe("PgliteDatabaseAdapter");
   });
 
-  test("(2) resolved lean-chat plugin set excludes local-inference/wallet/workflow, includes elizacloud", async () => {
+  test("(2) resolved lean-chat plugin set retains the local TEXT_EMBEDDING owner", async () => {
     const env = await buildManagedEnv();
     // The plugin resolver reads these signals from process.env directly.
     // Managed env producer always injects ELIZA_CLOUD_PROVISIONED=1 so the
@@ -121,7 +123,7 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
 
     const has = (needle: string) => plugins.some((p) => p.includes(needle));
     expect(has("plugin-elizacloud")).toBe(true);
-    expect(has("plugin-local-inference")).toBe(false);
+    expect(has("plugin-local-inference")).toBe(true);
     expect(has("plugin-wallet")).toBe(false);
     expect(has("plugin-workflow")).toBe(false);
   }, 30_000);


### PR DESCRIPTION
Closes #29710

## Summary

- stamp ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1 whenever the managed inference defaults select local-primary embeddings
- feed the prepared fresh environment through the real lean-chat plugin resolver and require plugin-local-inference to remain loaded as the TEXT_EMBEDDING owner
- preserve existing keyed 1536-dimensional stores, explicit local opt-out, and explicit Cloud-embedding override semantics

## Failure fixed

Fresh provisioning already selected 384-dimensional local-primary embeddings and disabled Cloud embeddings. The downstream plugin resolver independently required ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1, so it could drop plugin-local-inference and leave the selected TEXT_EMBEDDING path unavailable. The producer now carries its decision across that boundary.

## Exact revision

- base: 961a5de0e49bb436d78721988db8232114261c68
- head: adf222282504000c057ef0e0190e50e2acaea25e

## Validation

- bun --config=/dev/null test packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts — 29 pass, 0 fail
- bun --config=/dev/null test packages/agent/src/runtime/plugin-collector-lean-chat.test.ts — 18 pass, 0 fail
- bun run --cwd packages/cloud/shared typecheck — pass
- bunx @biomejs/biome check on all three changed files — pass
- git diff --check — pass

## Evidence

- Real behavior boundary: the integration suite uses the produced managed environment, the real agent plugin resolver, real PGlite migrations, and a 384-dimensional memory insert; the 1536-dimensional negative control remains rejected.
- UI screenshots: N/A — no rendered UI changes.
- Walkthrough video: N/A — no rendered or native interaction changes.
- Live-model trajectory: N/A for this PR — the defect is deterministic environment-to-plugin selection; post-merge staging chat/latency evidence is the release gate and is not represented as completed here.
- Production mutation: N/A — this PR does not deploy or touch production.