### PR TITLE
fix(ui): keep conversation ordering total when updatedAt is unparseable

### DIFF
--- a/packages/ui/src/state/startup-phase-hydrate.conversation-order.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.conversation-order.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Pins the total ordering of the ready-phase conversation list.
+ *
+ * Drives the real exported `bindReadyPhase` through the WebSocket handlers it
+ * registers, so both re-sort sites are exercised on their production path. The
+ * `client` module is stubbed at the api boundary to capture handlers; the
+ * ordering under test is the real one.
+ */
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import type { Conversation } from "../api";
+import { bindReadyPhase, type ReadyPhaseDeps } from "./startup-phase-hydrate";
+
+const clientMock = vi.hoisted(() => {
+  const handlers = new Map<string, (data: Record<string, unknown>) => void>();
+  return {
+    connectWs: vi.fn(),
+    disconnectWs: vi.fn(),
+    getCodingAgentStatus: vi.fn(async () => ({ tasks: [] })),
+    handlers,
+    onWsEvent: vi.fn(
+      (event: string, handler: (data: Record<string, unknown>) => void) => {
+        handlers.set(event, handler);
+        return () => handlers.delete(event);
+      },
+    ),
+    sendWsMessage: vi.fn(),
+  };
+});
+
+vi.mock("../api", () => ({
+  client: clientMock,
+}));
+
+vi.mock("../utils", () => ({
+  isTransientOptionalFetchFailure: () => false,
+}));
+
+vi.mock("../bridge/storage-bridge", () => ({
+  setStorageValue: vi.fn(async () => {}),
+}));
+
+function conversation(id: string, updatedAt: string, title = id): Conversation {
+  return {
+    id,
+    title,
+    roomId: `room-${id}`,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt,
+  };
+}
+
+function makeDeps(initial: Conversation[]): {
+  deps: ReadyPhaseDeps;
+  readConversations: () => Conversation[];
+} {
+  let conversations = initial;
+  const deps: ReadyPhaseDeps = {
+    setActionNotice: vi.fn(),
+    setAgentStatusIfChanged: vi.fn(),
+    setPendingRestart: vi.fn(),
+    setPendingRestartReasons: vi.fn(),
+    setSystemWarnings: vi.fn(),
+    showRestartBanner: vi.fn(),
+    setPtySessions: vi.fn(),
+    hasPtySessionsRef: { current: false },
+    agentRunningRef: { current: false },
+    setTabRaw: vi.fn(),
+    setConversationMessages: vi.fn(),
+    setUnreadConversations: vi.fn(),
+    setConversations: vi.fn((value) => {
+      conversations =
+        typeof value === "function" ? value(conversations) : value;
+    }),
+    appendAutonomousEvent: vi.fn(),
+    notifyHeartbeatEvent: vi.fn(),
+    loadPlugins: vi.fn(async () => {}),
+    loadWalletConfig: vi.fn(async () => {}),
+    pollCloudCredits: vi.fn(),
+    activeConversationIdRef: { current: null },
+    elizaCloudPollInterval: { current: null },
+    elizaCloudLoginPollTimer: { current: null },
+  };
+  return { deps, readConversations: () => conversations };
+}
+
+describe("bindReadyPhase conversation ordering", () => {
+  it("keeps a conversation with an unparseable updatedAt from pinning itself above a newly updated one", () => {
+    clientMock.handlers.clear();
+    const { deps, readConversations } = makeDeps([
+      conversation("invalid", ""),
+      conversation("updated", "2026-01-02T00:00:00.000Z", "Old title"),
+      conversation("older", "2026-01-01T00:00:00.000Z"),
+    ]);
+    const cleanup = bindReadyPhase({ current: deps });
+
+    try {
+      clientMock.handlers.get("conversation-updated")?.({
+        conversation: conversation(
+          "updated",
+          "2026-01-03T00:00:00.000Z",
+          "New title",
+        ),
+      });
+
+      expect(readConversations().map(({ id }) => id)).toEqual([
+        "updated",
+        "older",
+        "invalid",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("moves the conversation a proactive message arrived in to the top past an unparseable updatedAt", () => {
+    clientMock.handlers.clear();
+    const { deps, readConversations } = makeDeps([
+      conversation("invalid", "not-a-date"),
+      conversation("newest", "2026-01-03T00:00:00.000Z"),
+      conversation("target", "2026-01-01T00:00:00.000Z"),
+    ]);
+    const cleanup = bindReadyPhase({ current: deps });
+
+    try {
+      clientMock.handlers.get("proactive-message")?.({
+        conversationId: "target",
+        message: {
+          id: "msg-1",
+          role: "assistant",
+          text: "hello",
+          timestamp: Date.parse("2026-01-04T00:00:00.000Z"),
+        },
+      });
+
+      expect(readConversations().map(({ id }) => id)).toEqual([
+        "target",
+        "newest",
+        "invalid",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("breaks a tie on id so equal updatedAt values keep a deterministic order", () => {
+    clientMock.handlers.clear();
+    const { deps, readConversations } = makeDeps([
+      conversation("b-conv", "2026-01-02T00:00:00.000Z"),
+      conversation("a-conv", "2026-01-02T00:00:00.000Z"),
+    ]);
+    const cleanup = bindReadyPhase({ current: deps });
+
+    try {
+      clientMock.handlers.get("conversation-updated")?.({
+        conversation: conversation("a-conv", "2026-01-02T00:00:00.000Z"),
+      });
+
+      expect(readConversations().map(({ id }) => id)).toEqual([
+        "a-conv",
+        "b-conv",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -146,6 +146,27 @@ export interface ReadyPhaseDeps {
   ) => void;
 }
 
+/**
+ * Newest-first conversation ordering that stays a total order when `updatedAt`
+ * is unparseable. `new Date(bad).getTime()` is `NaN`, and a comparator that
+ * returns `NaN` makes `Array.prototype.sort` implementation-defined, so one bad
+ * entry displaces entries that are themselves valid. Follows the convention
+ * already used by `bounded-view-lru.ts` and the agent's
+ * `api/conversation-sort.ts`: a non-finite timestamp collapses to epoch 0 and
+ * the tie breaks on id, so the result is deterministic rather than merely
+ * unpoisoned.
+ */
+function compareConversationsByRecency(
+  left: Conversation,
+  right: Conversation,
+): number {
+  const leftUpdatedAt = new Date(left.updatedAt).getTime();
+  const rightUpdatedAt = new Date(right.updatedAt).getTime();
+  const safeLeft = Number.isFinite(leftUpdatedAt) ? leftUpdatedAt : 0;
+  const safeRight = Number.isFinite(rightUpdatedAt) ? rightUpdatedAt : 0;
+  return safeRight - safeLeft || left.id.localeCompare(right.id);
+}
+
 function normalizeAppEmoteEvent(
   data: Record<string, unknown>,
 ): AppEmoteEventDetail | null {
@@ -917,10 +938,7 @@ export function bindReadyPhase(
         const u = prev.map((c) =>
           c.id === cid ? { ...c, updatedAt: new Date().toISOString() } : c,
         );
-        return u.sort(
-          (a, b) =>
-            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-        );
+        return u.sort(compareConversationsByRecency);
       });
     },
   );
@@ -950,10 +968,7 @@ export function bindReadyPhase(
             }
             return conv;
           });
-          return u.sort(
-            (a, b) =>
-              new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-          );
+          return u.sort(compareConversationsByRecency);
         });
     },
   );


### PR DESCRIPTION
# Relates to

Closes #29716.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Both defective sites are fixed, not just the one the test first surfaced.
- [x] A reviewer can confirm the behaviour from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Two files differ; the production change is one shared comparator replacing two inline ones.

# Risks

Low and strictly narrowing. Every conversation whose `updatedAt` parses keeps exactly its current position relative to other valid conversations. Only entries that previously produced `NaN` change placement, and they move to the end instead of corrupting the ordering of everything else.

# Background

## What does this PR do?

`bindReadyPhase` re-sorts the conversation list in two WebSocket handlers, and both compared `updatedAt` by bare subtraction:

```ts
// line 922, "proactive-message"
// line 955, "conversation-updated"
u.sort(
  (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
);
```

`new Date("").getTime()` is `NaN`, and `NaN - x` is `NaN`. A comparator returning `NaN` is neither negative, zero, nor positive, so the ordering contract is not merely wrong — it is **undefined**. The surviving order depends on the engine's traversal, and conversations that are themselves valid move relative to one another because of a neighbour they were never meaningfully compared against.

**The user-visible result.** This list is the app's sidebar, rendered in the order the sort produces. One conversation with an unparseable `updatedAt` pins itself to the top and stays there, above conversations the user just received a message in. Sending a new message does not dislodge it, because the comparison against it never resolves.

**Reachability.** Both sites are bound to live WebSocket events inside the real exported `bindReadyPhase`. The `conversation-updated` handler takes its payload straight off the wire with an unchecked cast:

```ts
const conv = data.conversation as Conversation;
```

Nothing validates `updatedAt` between the wire and the comparator.

## What is the fix?

One comparator, shared by both sites so they cannot drift, following the convention this repository already uses for exactly this hazard:

```ts
function compareConversationsByRecency(
  left: Conversation,
  right: Conversation,
): number {
  const leftUpdatedAt = new Date(left.updatedAt).getTime();
  const rightUpdatedAt = new Date(right.updatedAt).getTime();
  const safeLeft = Number.isFinite(leftUpdatedAt) ? leftUpdatedAt : 0;
  const safeRight = Number.isFinite(rightUpdatedAt) ? rightUpdatedAt : 0;
  return safeRight - safeLeft || left.id.localeCompare(right.id);
}
```

**This is not a new convention.** Two existing modules already resolve non-finite timestamps to epoch `0` and then tie-break on id:

- `packages/ui/src/state/bounded-view-lru.ts` — `const safeAt = Number.isFinite(at) ? at : 0; ... return a < b ? -1 : a > b ? 1 : 0;`, with dedicated coverage in `bounded-view-lru.safe-sort.test.ts`.
- `packages/agent/src/api/conversation-sort.ts` — `compareConversationsByRecency`, whose header states that `updatedAt` reaches it "from persisted rows and untrusted `PATCH` payloads, so a malformed `updatedAt` string ... can produce `NaN`".

Matching them rather than inventing a third semantic is deliberate. The `id` tie-break is the part a "just avoid `NaN`" fix would miss: two conversations sharing a timestamp previously depended on sort stability for their order, and the third test below pins that.

Extracting the comparator rather than fixing each site inline is also deliberate — the defect was already duplicated once in this file, and a shared comparator is what stops it being duplicated again.

# Documentation changes needed?

No. No public surface, export, setting, or documented behaviour changes.

# Testing

## Where should a reviewer start?

The mutation block. Both tests drive the real exported `bindReadyPhase` through the WebSocket handlers it actually registers — no re-implemented comparator in the test body — and they cover **both** defective sites.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `startup-phase-hydrate.conversation-order.test.ts` | **3 passed** |
| `src/state/startup-phase` (16 suites) | **108 tests passed, 0 failed** |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| production diff vs `develop` | `+23/-8` — one shared comparator replacing two inline ones |

Mutation resistance — running the new tests against **develop's own unpatched file**:

```
× keeps a conversation with an unparseable updatedAt from pinning itself above a newly updated one
  AssertionError: expected [ 'invalid', 'updated', 'older' ] to deeply equal [ 'updated', 'older', 'invalid' ]

× moves the conversation a proactive message arrived in to the top past an unparseable updatedAt
  AssertionError: expected [ 'invalid', 'target', 'newest' ] to deeply equal [ 'target', 'newest', 'invalid' ]

× breaks a tie on id so equal updatedAt values keep a deterministic order
  AssertionError: expected [ 'b-conv', 'a-conv' ] to deeply equal [ 'a-conv', 'b-conv' ]

 Tests  3 failed (3)
```

The invalid entry holds first place in the first two cases. In the first, `updated` and `older` are displaced too — which is the point: the malformed entry does not merely land in the wrong place, it disturbs entries that are themselves perfectly valid.

**Pre-existing failures, stated plainly.** In the `src/state/startup-phase` run, 10 of 16 test *files* fail to import with `Failed to resolve import "@elizaos/capacitor-secure-store" from "src/bridge/storage-bridge.ts"`. That is a local workspace-build artifact, not a behavioural failure: **zero tests fail**, and the identical run against develop's unpatched file fails **11** files. The one-file delta is exactly this PR's new suite, which fails without the fix and passes with it.

# Evidence Gate

<!-- evidence-head:7edbb20a4dd7a1077150a8cfeecf704ec0b89957 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - the observable artifact is the conversation array order, asserted directly against the real bindReadyPhase above; this diff touches no rendering code`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - the observable artifact is the conversation array order, asserted directly above; this diff touches no rendering code`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the behaviour is a returned array order, asserted directly against the real exported handler`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; this is client-side list ordering`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no network call and no console output is involved in the sort`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in conversation ordering`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the conversation ordering, quoted in the mutation block above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface changes`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a comparator-totality sweep of `packages/ui`.
- Independent reproduction against develop's exact file, discovery of the second duplicated site, extraction of the shared comparator, the mutation proof, and the pre-existing-failure control by Claude Code (`claude-opus-5`).

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Attribution status: self-reported

