### PR TITLE
fix(agent): sweep expired cloud-pair rate-limit buckets

### DIFF
--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -16,6 +16,7 @@ import {
   truncateWellFormed,
 } from "@elizaos/core";
 import { PostBugReportRequestSchema } from "@elizaos/shared";
+import { sweepExpiredEntries } from "./memory-bounds.ts";
 
 export const DEFAULT_BUG_REPORT_REPO = "elizaOS/eliza";
 export const BUG_REPORT_REPO_ENV_KEY = "ELIZA_BUG_REPORT_REPO";
@@ -78,17 +79,6 @@ function getGithubNewIssueUrl(repo: string): string {
 const BUG_REPORT_WINDOW_MS = 10 * 60 * 1000;
 const BUG_REPORT_MAX_SUBMISSIONS = 5;
 const bugReportAttempts = new Map<string, { count: number; resetAt: number }>();
-
-function sweepExpiredEntries(
-  map: Map<string, { count: number; resetAt: number }>,
-  now: number,
-  threshold: number,
-): void {
-  if (map.size <= threshold) return;
-  for (const [key, value] of map) {
-    if (now > value.resetAt) map.delete(key);
-  }
-}
 
 export function rateLimitBugReport(ip: string | null): boolean {
   const key = ip ?? "unknown";

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@elizaos/shared/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __cloudPairRateLimitBucketCountForTests,
   __resetCloudPairRateLimitForTests,
   handleStandaloneCloudPairRoute,
 } from "./cloud-pair-route.ts";
@@ -1001,5 +1002,127 @@ describe("handleStandaloneCloudPairRoute", () => {
       "https://cloud-staging.eliza.app/cloud/agents",
     );
     expect(harness.body()).not.toContain("www.elizacloud.ai");
+  });
+});
+
+describe("cloud-pair rate-limit bucket sweeping", () => {
+  it("evicts expired buckets once the map passes the sweep threshold (#29715)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Distinct admitted loopback peers each mint one bucket; none expire
+      // during the window, so the map grows past the 100-entry threshold.
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+      );
+      for (let host = 1; host <= 120; host++) {
+        const harness = fakeRes();
+        await handleStandaloneCloudPairRoute(
+          fakeReq({
+            pathname: "/pair",
+            search: "?token=pair-token",
+            ip: `127.0.0.${host}`,
+          }),
+          harness.res,
+        );
+      }
+      expect(__cloudPairRateLimitBucketCountForTests()).toBe(120);
+
+      // Past the 60s window every bucket is expired; the next consume
+      // sweeps them and leaves only the freshly minted bucket behind.
+      vi.advanceTimersByTime(61_000);
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=pair-token",
+          ip: "127.0.0.200",
+        }),
+        harness.res,
+      );
+      expect(__cloudPairRateLimitBucketCountForTests()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an unexpired bucket when the sweep threshold is not reached", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+    );
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({
+        pathname: "/pair",
+        search: "?token=pair-token",
+        ip: "127.0.0.1",
+      }),
+      harness.res,
+    );
+    // Below the threshold nothing is evicted: small maps keep their state
+    // so the per-peer limit stays enforced within the window.
+    expect(__cloudPairRateLimitBucketCountForTests()).toBe(1);
+  });
+
+  it("pins the exact expiry instant: limiter resets at resetAt, sweep deletes only strictly past it", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+      );
+      for (let host = 1; host <= 120; host++) {
+        const harness = fakeRes();
+        await handleStandaloneCloudPairRoute(
+          fakeReq({
+            pathname: "/pair",
+            search: "?token=pair-token",
+            ip: `127.0.0.${host}`,
+          }),
+          harness.res,
+        );
+      }
+      expect(__cloudPairRateLimitBucketCountForTests()).toBe(120);
+
+      // At now === resetAt the limiter already treats the peer's bucket as
+      // expired (resetAt <= now mints a fresh window) while the sweep's
+      // strict now > resetAt predicate declines to delete it — the documented
+      // one-tick gap between the two checks.
+      vi.advanceTimersByTime(60_000);
+      const boundary = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=pair-token",
+          ip: "127.0.0.1",
+        }),
+        boundary.res,
+      );
+      expect(__cloudPairRateLimitBucketCountForTests()).toBe(120);
+
+      // One tick later the sweep deletes every strictly expired bucket; only
+      // the bucket 127.0.0.1 just reset survives, so the sweep does not
+      // over-exclude live state.
+      vi.advanceTimersByTime(1);
+      const after = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          search: "?token=pair-token",
+          ip: "127.0.0.1",
+        }),
+        after.res,
+      );
+      expect(__cloudPairRateLimitBucketCountForTests()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -29,6 +29,7 @@ import {
   renderCloudPairHandoffHtml,
   resolveCloudPairAgentIdFromEnv,
 } from "@elizaos/shared/contracts";
+import { sweepExpiredEntries } from "./memory-bounds.ts";
 import { resolveDirectRequestOrigin } from "./request-origin.js";
 
 const RELAY_TIMEOUT_MS = 15_000;
@@ -46,8 +47,18 @@ export function __resetCloudPairRateLimitForTests(): void {
   rateBuckets.clear();
 }
 
+/** Test-only observation of bucket-map growth for the sweep regression. */
+export function __cloudPairRateLimitBucketCountForTests(): number {
+  return rateBuckets.size;
+}
+
 function rateLimitConsume(key: string | null): boolean {
   const now = Date.now();
+  // A peer that pairs once otherwise leaves its bucket for the process
+  // lifetime. Sweeping is gated on map size (threshold 100, the same as both
+  // sibling limiters); past that gate every consume scans the map — cheap at
+  // these sizes, and the trade the siblings already accept (#29715).
+  sweepExpiredEntries(rateBuckets, now, 100);
   const bucketKey = key || "unknown";
   const current = rateBuckets.get(bucketKey);
   if (!current || current.resetAt <= now) {


### PR DESCRIPTION
# Relates to

Closes #29715

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (built directly on develop@29d6d0a via the Git data API).
- [x] Focused tests pass after sync (exact command and output below).
- [x] A reviewer can confirm the change works from the regressions below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite passes post-sync (below); no unrelated blocker.

# Risks

Low. The sweep is the same size-gated pattern the two sibling limiters in
this package already use (`server-helpers-auth.ts`, `bug-report-routes.ts`).
Below the 100-bucket threshold nothing is evicted, so per-peer limiting within
the 60s window is unchanged; above it, only entries whose `resetAt` has
already elapsed are dropped. The dedupe in `bug-report-routes.ts` swaps a
character-for-character local copy of the helper for the shared import — the
call, threshold, and predicate are unchanged.

# Background

## What does this PR do?

`rateLimitConsume` in `packages/agent/src/api/cloud-pair-route.ts` mints
a bucket per admitted peer address and only replaces an entry when that same
address returns. A peer that connects once leaves its bucket in the
module-level `Map` for the process lifetime, long after `resetAt` has passed.
The relay is loopback/CIDR-bounded (not internet-facing), but `127.0.0.0/8`
alone admits ~16.7M distinct keys from any local process, and a documented
Docker-bridge allowlist adds 65k more (#29715).

`server-helpers-auth.ts:575` already bounds growth through the shared
`sweepExpiredEntries` helper, while `bug-report-routes.ts` carried a
character-for-character local copy of it. This PR makes the cloud-pair limiter
the third user of the pattern and deletes that local copy in favor of the
same import, so all three limiters now share one definition:

```ts
const now = Date.now();
sweepExpiredEntries(rateBuckets, now, 100);
```

It also exports `__cloudPairRateLimitBucketCountForTests()` so the regression
can observe the map size (mirroring the existing
`__resetCloudPairRateLimitForTests` hook).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/cloud-pair-route.ts` — the `rateLimitConsume` sweep
(search `#29715`) — then the three regressions at the end of
`cloud-pair-route.test.ts` in the
`cloud-pair rate-limit bucket sweeping` describe.

## Detailed testing steps

- `cd packages/agent && bunx vitest run src/api/cloud-pair-route.test.ts`
  - 29 pass / 0 fail (26 pre-existing + 3 new regressions).
- `cd packages/agent && bunx vitest run src/services/tee-secret-hygiene.test.ts`
  - 7 pass / 0 fail (its module list references `bug-report-routes.ts`;
    guards the import swap).
- Regression 1 (eviction): 120 distinct admitted loopback peers each mint one
  bucket → map holds 120; advance fake timers past the 60s window and consume
  once more → the sweep drops every expired entry and the map holds exactly
  the one fresh bucket.
- Regression 2 (below-threshold no-op): a single consume leaves the bucket in
  place, so small maps keep state and the per-peer limit still applies within
  the window.
- Regression 3 (exact expiry instant): at `now === resetAt` the limiter already
  resets the peer's bucket while the sweep's strict `now > resetAt` predicate
  declines to delete it; one tick later the sweep clears every strictly
  expired bucket and the freshly reset bucket survives.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:3a908ca8dd2142da9d8d980b602a8cfb4edfb0b6 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; a pure rate-limit map-growth fix covered
      by deterministic unit tests.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - memory-growth defect whose observable effect (map eviction after
      the threshold) is asserted directly by the regression.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no logging is added or changed; the defect and fix are value-level
      and covered by the assertions.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or on-chain output; the
      buckets are an in-process Map observed through the test hook.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
 Tests  29 passed (29)
```

## Known gaps / failures

None for this change. Full-package `bun run verify` could not run in this
environment; the focused vitest suites above and `biome check` on all three touched
files pass locally.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->

