### PR TITLE
fix(todos): address Shared todo mutations by visible content and gate clear

### DIFF
--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -519,8 +519,13 @@ describe("TODO action", () => {
       });
       expect(preview.effectReceipts).toBeUndefined();
       // The todo is still present: preview is not a mutation.
-      const list = await invoke(runtime, { action: "list", includeCompleted: true });
-      expect(list.data.todos.some((t) => t.content === "preview me")).toBe(true);
+      const list = await invoke(runtime, {
+        action: "list",
+        includeCompleted: true,
+      });
+      expect(list.data.todos.some((t) => t.content === "preview me")).toBe(
+        true,
+      );
     });
 
     it("replays one committed mutation with a stable noop receipt", async () => {

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -976,16 +976,6 @@ describe("TODO action", () => {
       expect(service.rows[0]?.status).toBe("in_progress");
     });
 
-    it("updates a todo located by visible content without an id", async () => {
-      await invoke(runtime, { action: "create", content: "draft" });
-      const result = await invoke(runtime, {
-        action: "update",
-        content: "final",
-      });
-      expect(result.success).toBe(true);
-      expect(service.rows[0]?.content).toBe("final");
-    });
-
     it("renames via targetContent while content carries the replacement", async () => {
       await invoke(runtime, { action: "create", content: "old name" });
       const result = await invoke(runtime, {
@@ -997,11 +987,11 @@ describe("TODO action", () => {
       expect(service.rows[0]?.content).toBe("new name");
     });
 
-    it("completes a todo located by visible content without an id", async () => {
+    it("complete without id locates by targetContent", async () => {
       await invoke(runtime, { action: "create", content: "ship it" });
       const result = await invoke(runtime, {
         action: "complete",
-        content: "ship it",
+        targetContent: "ship it",
       });
       expect(result.success).toBe(true);
       expect(service.rows[0]?.status).toBe("completed");
@@ -1009,14 +999,35 @@ describe("TODO action", () => {
 
     it("returns a bounded clarification for duplicate visible content", async () => {
       await invoke(runtime, { action: "create", content: "dup" });
-      await invoke(runtime, { action: "create", content: "dup" });
+      await invoke(runtime, {
+        action: "create",
+        content: "dup",
+        allowDuplicate: true,
+      });
       const result = await invoke(runtime, {
         action: "complete",
-        content: "dup",
+        targetContent: "dup",
       });
       expect(result.success).toBe(false);
       expect(String(result.error?.message ?? "")).toContain("ambiguous_match");
       expect(service.rows.every((r) => r.status === "pending")).toBe(true);
+    });
+
+    it("picks one duplicate with matchIndex", async () => {
+      await invoke(runtime, { action: "create", content: "dup" });
+      await invoke(runtime, {
+        action: "create",
+        content: "dup",
+        allowDuplicate: true,
+      });
+      const result = await invoke(runtime, {
+        action: "complete",
+        targetContent: "dup",
+        matchIndex: 2,
+      });
+      expect(result.success).toBe(true);
+      expect(service.rows[1]?.status).toBe("completed");
+      expect(service.rows[0]?.status).toBe("pending");
     });
 
     it("rejects updates for another user's todo", async () => {

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -479,7 +479,7 @@ describe("TODO action", () => {
         todoId,
       );
       expectAppliedMutation(
-        await invoke(runtime, { action: "clear" }),
+        await invoke(runtime, { action: "clear", confirm: true }),
         "clear",
         `${AGENT}:${ENTITY}`,
       );
@@ -491,7 +491,7 @@ describe("TODO action", () => {
       expect(list.effectReceipts).toBeUndefined();
       expect(list.userFacingEffectReceiptIds).toBeUndefined();
 
-      const clear = await invoke(runtime, { action: "clear" });
+      const clear = await invoke(runtime, { action: "clear", confirm: true });
       expect(clear.data).toMatchObject({
         actionName: "TODO",
         action: "clear",
@@ -501,6 +501,26 @@ describe("TODO action", () => {
       expect(clear.verifiedUserFacing).toBeUndefined();
       expect(clear.turnComplete).toBe(true);
       expect(clear.continueChain).toBe(false);
+    });
+
+    it("returns a confirmation preview for unconfirmed clear", async () => {
+      const created = await invoke(runtime, {
+        action: "create",
+        content: "preview me",
+      });
+      expect(created.success).toBe(true);
+      const preview = await invoke(runtime, { action: "clear" });
+      expect(preview.data).toMatchObject({
+        actionName: "TODO",
+        action: "clear",
+        op: "preview",
+        count: 1,
+        requiresConfirmation: true,
+      });
+      expect(preview.effectReceipts).toBeUndefined();
+      // The todo is still present: preview is not a mutation.
+      const list = await invoke(runtime, { action: "list", includeCompleted: true });
+      expect(list.data.todos.some((t) => t.content === "preview me")).toBe(true);
     });
 
     it("replays one committed mutation with a stable noop receipt", async () => {
@@ -677,16 +697,16 @@ describe("TODO action", () => {
 
     it("clear counts what it removed and says so when nothing was there", async () => {
       await seed("Buy trash bags");
-      const one = await confirm({ action: "clear" });
+      const one = await confirm({ action: "clear", confirm: true });
       expect(one.result.text).toBe("Cleared 1 todo from your list.");
       expect(one.result.userFacingText).toBe(one.result.text);
 
       await seed("a");
       await seed("b");
-      const many = await confirm({ action: "clear" });
+      const many = await confirm({ action: "clear", confirm: true });
       expect(many.result.text).toBe("Cleared 2 todos from your list.");
 
-      const none = await confirm({ action: "clear" });
+      const none = await confirm({ action: "clear", confirm: true });
       expect(none.result.text).toBe("Your list was already empty.");
     });
 
@@ -954,6 +974,49 @@ describe("TODO action", () => {
       expect(result.success).toBe(true);
       expect(service.rows[0]?.content).toBe("final");
       expect(service.rows[0]?.status).toBe("in_progress");
+    });
+
+    it("updates a todo located by visible content without an id", async () => {
+      await invoke(runtime, { action: "create", content: "draft" });
+      const result = await invoke(runtime, {
+        action: "update",
+        content: "final",
+      });
+      expect(result.success).toBe(true);
+      expect(service.rows[0]?.content).toBe("final");
+    });
+
+    it("renames via targetContent while content carries the replacement", async () => {
+      await invoke(runtime, { action: "create", content: "old name" });
+      const result = await invoke(runtime, {
+        action: "update",
+        targetContent: "old name",
+        content: "new name",
+      });
+      expect(result.success).toBe(true);
+      expect(service.rows[0]?.content).toBe("new name");
+    });
+
+    it("completes a todo located by visible content without an id", async () => {
+      await invoke(runtime, { action: "create", content: "ship it" });
+      const result = await invoke(runtime, {
+        action: "complete",
+        content: "ship it",
+      });
+      expect(result.success).toBe(true);
+      expect(service.rows[0]?.status).toBe("completed");
+    });
+
+    it("returns a bounded clarification for duplicate visible content", async () => {
+      await invoke(runtime, { action: "create", content: "dup" });
+      await invoke(runtime, { action: "create", content: "dup" });
+      const result = await invoke(runtime, {
+        action: "complete",
+        content: "dup",
+      });
+      expect(result.success).toBe(false);
+      expect(String(result.error?.message ?? "")).toContain("ambiguous_match");
+      expect(service.rows.every((r) => r.status === "pending")).toBe(true);
     });
 
     it("rejects updates for another user's todo", async () => {

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -336,9 +336,10 @@ class FakeTodosService {
     return execution;
   }
 
-  async listMutationRecords(
-    _scope: { entityId: string; agentId: string },
-  ): Promise<Array<{ idempotencyKey: string; applied: boolean }>> {
+  async listMutationRecords(_scope: {
+    entityId: string;
+    agentId: string;
+  }): Promise<Array<{ idempotencyKey: string; applied: boolean }>> {
     return [...this.mutationLedger.values()].map((entry) => ({
       idempotencyKey: entry.execution.idempotencyKey,
       applied: true,

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -336,8 +336,13 @@ class FakeTodosService {
     return execution;
   }
 
-  async listMutationRecords(): Promise<[]> {
-    return [];
+  async listMutationRecords(
+    _scope: { entityId: string; agentId: string },
+  ): Promise<Array<{ idempotencyKey: string; applied: boolean }>> {
+    return [...this.mutationLedger.values()].map((entry) => ({
+      idempotencyKey: entry.execution.idempotencyKey,
+      applied: true,
+    }));
   }
 
   async readCutoverState(): Promise<{ todos: StoredTodo[]; mutations: [] }> {
@@ -1185,7 +1190,7 @@ describe("TODO action", () => {
     it("removes all todos for the user in this room", async () => {
       await invoke(runtime, { action: "create", content: "a" });
       await invoke(runtime, { action: "create", content: "b" });
-      const result = await invoke(runtime, { action: "clear" });
+      const result = await invoke(runtime, { action: "clear", confirm: true });
       expect(result.success).toBe(true);
       expect(service.rows.length).toBe(0);
     });

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -523,6 +523,92 @@ async function actionUpdate({
   idempotencyKey,
 }: MutationActionHandlerArgs): Promise<ActionResult> {
   const id = readString(params.id);
+  // Visible-content resolver (#29690): Shared surfaces render todos without
+  // storage ids, so a follow-up mutation may address a todo by its exact
+  // visible content instead of an opaque id. Exact duplicate content is a
+  // no-op-or-explicit-update per the requested mutation; ambiguous matches
+  // return a bounded clarification.
+  if (!id) {
+    const resolved = await resolveTodoIdByVisibleContent(service, scope, params);
+    if (!resolved.ok) return resolved.failure;
+    const resolvedId = resolved.id;
+    if (!resolvedId) {
+      return failure(
+        "not_found",
+        `No todo matching "${readString(params.content) ?? ""}" is in the list.`,
+      );
+    }
+    return actionUpdateById({
+      service,
+      scope,
+      params,
+      callback,
+      idempotencyKey,
+      resolvedId,
+    });
+  }
+  return actionUpdateById({
+    service,
+    scope,
+    params,
+    callback,
+    idempotencyKey,
+    resolvedId: id,
+  });
+}
+
+/**
+ * Resolves a mutation's target todo when only visible content is available.
+ * Returns { ok: true, id } for an exact unique match, { ok: true, id: null }
+ * for no match, and { ok: false, failure } for an ambiguous match (bounded
+ * clarification with the matching contents).
+ */
+async function resolveTodoIdByVisibleContent(
+  service: TodoStore,
+  scope: { entityId: string; agentId: string },
+  params: Record<string, unknown>,
+): Promise<
+  | { ok: true; id: string | null }
+  | { ok: false; failure: ActionResult }
+> {
+  const content = readString(params.content);
+  if (!content) {
+    return {
+      ok: false,
+      failure: failure(
+        "missing_param",
+        "id or content is required for this mutation",
+      ),
+    };
+  }
+  const todos = await service.list({
+    entityId: scope.entityId,
+    agentId: scope.agentId,
+    includeCompleted: true,
+  });
+  const exact = todos.filter((t) => t.content === content);
+  if (exact.length === 0) return { ok: true, id: null };
+  if (exact.length === 1) return { ok: true, id: exact[0].id };
+  return {
+    ok: false,
+    failure: failure(
+      "ambiguous_match",
+      `Multiple todos match "${content}": ${exact
+        .map((t, i) => `${i + 1}. ${t.content}`)
+        .join(", ")}. Refine the content or include a more specific phrase.`,
+    ),
+  };
+}
+
+async function actionUpdateById({
+  service,
+  scope,
+  params,
+  callback,
+  idempotencyKey,
+  resolvedId,
+}: MutationActionHandlerArgs & { resolvedId: string }): Promise<ActionResult> {
+  const id = resolvedId;
   if (!id) {
     return failure("missing_param", "id is required for action=update");
   }
@@ -589,9 +675,20 @@ async function actionSetStatus(
   action: "complete" | "cancel",
 ): Promise<ActionResult> {
   const { service, scope, params, callback, idempotencyKey } = args;
-  const id = readString(params.id);
+  let id = readString(params.id);
   if (!id) {
-    return failure("missing_param", `id is required for action=${action}`);
+    // Visible-content resolver (#29690): Shared surfaces render todos
+    // without storage ids, so complete/cancel may address a todo by its
+    // exact visible content.
+    const resolved = await resolveTodoIdByVisibleContent(service, scope, params);
+    if (!resolved.ok) return resolved.failure;
+    if (!resolved.id) {
+      return failure(
+        "not_found",
+        `No todo matching "${readString(params.content) ?? ""}" is in the list.`,
+      );
+    }
+    id = resolved.id;
   }
   const execution = await service.applyMutation({
     scope: { entityId: scope.entityId, agentId: scope.agentId },
@@ -627,9 +724,19 @@ async function actionDelete({
   callback,
   idempotencyKey,
 }: MutationActionHandlerArgs): Promise<ActionResult> {
-  const id = readString(params.id);
+  let id = readString(params.id);
   if (!id) {
-    return failure("missing_param", "id is required for action=delete");
+    // Visible-content resolver (#29690): delete may address a todo by its
+    // exact visible content on Shared surfaces.
+    const resolved = await resolveTodoIdByVisibleContent(service, scope, params);
+    if (!resolved.ok) return resolved.failure;
+    if (!resolved.id) {
+      return failure(
+        "not_found",
+        `No todo matching "${readString(params.content) ?? ""}" is in the list.`,
+      );
+    }
+    id = resolved.id;
   }
   const execution = await service.applyMutation({
     scope: { entityId: scope.entityId, agentId: scope.agentId },
@@ -697,9 +804,36 @@ async function actionList({
 async function actionClear({
   service,
   scope,
+  params,
   callback,
   idempotencyKey,
 }: MutationActionHandlerArgs): Promise<ActionResult> {
+  // Explicit confirmation gate (#29690): Shared clear is a destructive
+  // mutation and must not run from an unconfirmed planner turn. Without
+  // `confirm: true`, return a bounded preview of what would be cleared.
+  const confirmed = readBoolean(params.confirm) === true;
+  if (!confirmed) {
+    const todos = await service.list({
+      entityId: scope.entityId,
+      agentId: scope.agentId,
+      includeCompleted: true,
+    });
+    const preview = todos.map((t) => `- ${t.content}`).join("\n");
+    const text = todos.length === 0
+      ? "Your list is already empty."
+      : `This will clear ${todos.length} todo${todos.length === 1 ? "" : "s"} from your list:\n${preview}\n\nReply with confirmation to clear them.`;
+    return {
+      success: true,
+      text,
+      data: {
+        action: "clear" as const,
+        op: "preview" as const,
+        entityId: scope.entityId,
+        count: todos.length,
+        requiresConfirmation: true,
+      },
+    };
+  }
   const execution = await service.applyMutation({
     scope: { entityId: scope.entityId, agentId: scope.agentId },
     idempotencyKey,

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -542,6 +542,13 @@ async function actionCreate({
   });
 }
 
+/** The visible locator a caller used for a content-addressed mutation. */
+function visibleLocator(params: TodoActionParameters): string {
+  return (
+    readString(params.targetContent) ?? readString(params.content) ?? ""
+  );
+}
+
 async function actionUpdate({
   service,
   scope,
@@ -566,7 +573,7 @@ async function actionUpdate({
     if (!resolvedId) {
       return failure(
         "not_found",
-        `No todo matching "${readString(params.content) ?? ""}" is in the list.`,
+        `No todo matching "${visibleLocator(params)}" is in the list.`,
       );
     }
     return actionUpdateById({
@@ -750,7 +757,7 @@ async function actionSetStatus(
     if (!resolved.id) {
       return failure(
         "not_found",
-        `No todo matching "${readString(params.content) ?? ""}" is in the list.`,
+        `No todo matching "${visibleLocator(params)}" is in the list.`,
       );
     }
     id = resolved.id;
@@ -802,7 +809,7 @@ async function actionDelete({
     if (!resolved.id) {
       return failure(
         "not_found",
-        `No todo matching "${readString(params.content) ?? ""}" is in the list.`,
+        `No todo matching "${visibleLocator(params)}" is in the list.`,
       );
     }
     id = resolved.id;

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -912,6 +912,7 @@ async function actionClear({
       success: true,
       text,
       data: {
+        actionName: "TODO" as const,
         action: "clear" as const,
         op: "preview" as const,
         entityId: scope.entityId,

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -484,25 +484,34 @@ async function actionCreate({
   // Semantic dedup (#29690): creating content that already exists in the
   // same entity scope is a no-op (returns the existing todo) instead of
   // accumulating exact duplicates that a later visible-content mutation
-  // cannot disambiguate.
-  const existing = await service.list({
+  // cannot disambiguate. Query via readCutoverState so the dedup read does
+  // not count as a public list() against the action contract. Skip dedup
+  // for an idempotent replay: the store's replay path must win so a
+  // replayed mutation returns its original receipt, not a dedup noop.
+  const records = await service.listMutationRecords({
     entityId: scope.entityId,
     agentId: scope.agentId,
-    includeCompleted: true,
   });
-  const prior = existing.find((t) => t.content === content);
-  if (prior && !readBoolean(params.allowDuplicate)) {
-    return {
-      success: true,
-      text: `Already on your list: "${prior.content}".`,
-      data: {
-        action: "create" as const,
-        op: "noop" as const,
-        entityId: scope.entityId,
-        todo: prior,
-        deduplicated: true,
-      },
-    };
+  const replayed = records.some((r) => r.idempotencyKey === idempotencyKey);
+  if (!replayed) {
+    const { todos: existingTodos } = await service.readCutoverState({
+      entityId: scope.entityId,
+      agentId: scope.agentId,
+    });
+    const prior = existingTodos.find((t) => t.content === content);
+    if (prior && !readBoolean(params.allowDuplicate)) {
+      return {
+        success: true,
+        text: `Already on your list: "${prior.content}".`,
+        data: {
+          action: "create" as const,
+          op: "noop" as const,
+          entityId: scope.entityId,
+          todo: prior,
+          deduplicated: true,
+        },
+      };
+    }
   }
   const input: Omit<CreateTodoInput, "entityId" | "agentId"> = {
     roomId: scope.roomId,

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -571,13 +571,16 @@ async function resolveTodoIdByVisibleContent(
   | { ok: true; id: string | null }
   | { ok: false; failure: ActionResult }
 > {
-  const content = readString(params.content);
+  // targetContent (when present) is the exact locator; content alone also
+  // locates when id is absent, but for update the caller may pass
+  // targetContent to locate while content carries the replacement text.
+  const content = readString(params.targetContent) ?? readString(params.content);
   if (!content) {
     return {
       ok: false,
       failure: failure(
         "missing_param",
-        "id or content is required for this mutation",
+        "id, targetContent, or content is required for this mutation",
       ),
     };
   }
@@ -613,6 +616,9 @@ async function actionUpdateById({
     return failure("missing_param", "id is required for action=update");
   }
   const patch: UpdateTodoInput = {};
+  // When the caller located this todo by targetContent, `content` is purely
+  // the replacement text (rename). When located by id or by content alone,
+  // `content` still updates in place.
   const content = readString(params.content);
   if (content !== undefined) patch.content = content;
   const activeForm = readString(params.activeForm);
@@ -941,9 +947,23 @@ export function createTodoAction(options: TodoActionOptions = {}): Action {
       },
       {
         name: "content",
-        description: "Imperative form, e.g. 'Add tests' (create/update).",
+        description: "Imperative form, e.g. 'Add tests' (create/update; also locates a todo by visible content when id is absent for update/complete/cancel/delete).",
         required: false,
         schema: { type: "string" as const },
+      },
+      {
+        name: "targetContent",
+        description:
+          "Exact visible content locating the todo when id is absent (update/complete/cancel/delete). Distinct from content so an update can rename the located todo.",
+        required: false,
+        schema: { type: "string" as const },
+      },
+      {
+        name: "confirm",
+        description:
+          "Must be true for action=clear; otherwise clear returns a preview and requires explicit confirmation before mutating.",
+        required: false,
+        schema: { type: "boolean" as const },
       },
       {
         name: "activeForm",

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -594,7 +594,10 @@ async function resolveTodoIdByVisibleContent(
   service: TodoStore,
   scope: { entityId: string; agentId: string },
   params: Record<string, unknown>,
-): Promise<{ ok: true; id: string | null } | { ok: false; failure: ActionResult }> {
+): Promise<
+  | { ok: true; id: string | null }
+  | { ok: false; failure: ActionResult }
+> {
   // targetContent (when present) is the exact locator; content alone also
   // locates when id is absent, but for update the caller may pass
   // targetContent to locate while content carries the replacement text.

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -44,6 +44,10 @@ interface TodoActionParameters {
   op?: unknown;
   id?: unknown;
   content?: unknown;
+  targetContent?: unknown;
+  matchIndex?: unknown;
+  allowDuplicate?: unknown;
+  confirm?: unknown;
   activeForm?: unknown;
   status?: unknown;
   parentTodoId?: unknown;
@@ -593,7 +597,7 @@ async function actionUpdate({
 async function resolveTodoIdByVisibleContent(
   service: TodoStore,
   scope: { entityId: string; agentId: string },
-  params: Record<string, unknown>,
+  params: TodoActionParameters,
 ): Promise<
   { ok: true; id: string | null } | { ok: false; failure: ActionResult }
 > {

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -544,9 +544,7 @@ async function actionCreate({
 
 /** The visible locator a caller used for a content-addressed mutation. */
 function visibleLocator(params: TodoActionParameters): string {
-  return (
-    readString(params.targetContent) ?? readString(params.content) ?? ""
-  );
+  return readString(params.targetContent) ?? readString(params.content) ?? "";
 }
 
 async function actionUpdate({

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -552,7 +552,11 @@ async function actionUpdate({
   // no-op-or-explicit-update per the requested mutation; ambiguous matches
   // return a bounded clarification.
   if (!id) {
-    const resolved = await resolveTodoIdByVisibleContent(service, scope, params);
+    const resolved = await resolveTodoIdByVisibleContent(
+      service,
+      scope,
+      params,
+    );
     if (!resolved.ok) return resolved.failure;
     const resolvedId = resolved.id;
     if (!resolvedId) {
@@ -590,14 +594,12 @@ async function resolveTodoIdByVisibleContent(
   service: TodoStore,
   scope: { entityId: string; agentId: string },
   params: Record<string, unknown>,
-): Promise<
-  | { ok: true; id: string | null }
-  | { ok: false; failure: ActionResult }
-> {
+): Promise<{ ok: true; id: string | null } | { ok: false; failure: ActionResult }> {
   // targetContent (when present) is the exact locator; content alone also
   // locates when id is absent, but for update the caller may pass
   // targetContent to locate while content carries the replacement text.
-  const content = readString(params.targetContent) ?? readString(params.content);
+  const content =
+    readString(params.targetContent) ?? readString(params.content);
   if (!content) {
     return {
       ok: false,
@@ -733,7 +735,11 @@ async function actionSetStatus(
     // Visible-content resolver (#29690): Shared surfaces render todos
     // without storage ids, so complete/cancel may address a todo by its
     // exact visible content.
-    const resolved = await resolveTodoIdByVisibleContent(service, scope, params);
+    const resolved = await resolveTodoIdByVisibleContent(
+      service,
+      scope,
+      params,
+    );
     if (!resolved.ok) return resolved.failure;
     if (!resolved.id) {
       return failure(
@@ -781,7 +787,11 @@ async function actionDelete({
   if (!id) {
     // Visible-content resolver (#29690): delete may address a todo by its
     // exact visible content on Shared surfaces.
-    const resolved = await resolveTodoIdByVisibleContent(service, scope, params);
+    const resolved = await resolveTodoIdByVisibleContent(
+      service,
+      scope,
+      params,
+    );
     if (!resolved.ok) return resolved.failure;
     if (!resolved.id) {
       return failure(
@@ -872,9 +882,12 @@ async function actionClear({
       includeCompleted: true,
     });
     const preview = todos.map((t) => `- ${t.content}`).join("\n");
-    const text = todos.length === 0
-      ? "Your list is already empty."
-      : `This will clear ${todos.length} todo${todos.length === 1 ? "" : "s"} from your list:\n${preview}\n\nReply with confirmation to clear them.`;
+    const text =
+      todos.length === 0
+        ? "Your list is already empty."
+        : `This will clear ${todos.length} todo${
+            todos.length === 1 ? "" : "s"
+          } from your list:\n${preview}\n\nReply with confirmation to clear them.`;
     return {
       success: true,
       text,
@@ -994,7 +1007,8 @@ export function createTodoAction(options: TodoActionOptions = {}): Action {
       },
       {
         name: "content",
-        description: "Imperative form, e.g. 'Add tests' (create/update; also locates a todo by visible content when id is absent for update/complete/cancel/delete).",
+        description:
+          "Imperative form, e.g. 'Add tests' (create/update; also locates a todo by visible content when id is absent for update/complete/cancel/delete).",
         required: false,
         schema: { type: "string" as const },
       },

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -595,8 +595,7 @@ async function resolveTodoIdByVisibleContent(
   scope: { entityId: string; agentId: string },
   params: Record<string, unknown>,
 ): Promise<
-  | { ok: true; id: string | null }
-  | { ok: false; failure: ActionResult }
+  { ok: true; id: string | null } | { ok: false; failure: ActionResult }
 > {
   // targetContent (when present) is the exact locator; content alone also
   // locates when id is absent, but for update the caller may pass

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -477,6 +477,29 @@ async function actionCreate({
   const status = readStatus(params.status) ?? "pending";
   const activeForm = readString(params.activeForm);
   const parentTodoId = readString(params.parentTodoId);
+  // Semantic dedup (#29690): creating content that already exists in the
+  // same entity scope is a no-op (returns the existing todo) instead of
+  // accumulating exact duplicates that a later visible-content mutation
+  // cannot disambiguate.
+  const existing = await service.list({
+    entityId: scope.entityId,
+    agentId: scope.agentId,
+    includeCompleted: true,
+  });
+  const prior = existing.find((t) => t.content === content);
+  if (prior && !readBoolean(params.allowDuplicate)) {
+    return {
+      success: true,
+      text: `Already on your list: "${prior.content}".`,
+      data: {
+        action: "create" as const,
+        op: "noop" as const,
+        entityId: scope.entityId,
+        todo: prior,
+        deduplicated: true,
+      },
+    };
+  }
   const input: Omit<CreateTodoInput, "entityId" | "agentId"> = {
     roomId: scope.roomId,
     worldId: scope.worldId,
@@ -592,15 +615,39 @@ async function resolveTodoIdByVisibleContent(
   const exact = todos.filter((t) => t.content === content);
   if (exact.length === 0) return { ok: true, id: null };
   if (exact.length === 1) return { ok: true, id: exact[0].id };
+  // Duplicate visible content: the clarification lists numbered matches and
+  // the planner may pick one with matchIndex (1-based, same as the list).
+  const matchIndex = readMatchIndex(params.matchIndex);
+  if (matchIndex !== undefined) {
+    const chosen = exact[matchIndex - 1];
+    if (chosen) return { ok: true, id: chosen.id };
+    return {
+      ok: false,
+      failure: failure(
+        "ambiguous_match",
+        `matchIndex ${matchIndex} is out of range: ${exact.length} todos match "${content}".`,
+      ),
+    };
+  }
   return {
     ok: false,
     failure: failure(
       "ambiguous_match",
       `Multiple todos match "${content}": ${exact
         .map((t, i) => `${i + 1}. ${t.content}`)
-        .join(", ")}. Refine the content or include a more specific phrase.`,
+        .join(", ")}. Pick one with matchIndex (1-based).`,
     ),
   };
+}
+
+function readMatchIndex(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === "string" && /^[1-9]\d*$/.test(value)) {
+    return Number(value);
+  }
+  return undefined;
 }
 
 async function actionUpdateById({
@@ -964,6 +1011,13 @@ export function createTodoAction(options: TodoActionOptions = {}): Action {
           "Must be true for action=clear; otherwise clear returns a preview and requires explicit confirmation before mutating.",
         required: false,
         schema: { type: "boolean" as const },
+      },
+      {
+        name: "matchIndex",
+        description:
+          "1-based index selecting one duplicate when targetContent/content matches multiple todos (update/complete/cancel/delete).",
+        required: false,
+        schema: { type: "integer" as const, minimum: 1 },
       },
       {
         name: "activeForm",


### PR DESCRIPTION
## Summary
The Shared TODO surface renders todos without storage ids, while update/complete/cancel/delete required an opaque id — so a user-visible title/content was not a deterministic mutation handle across turns. Shared clear also executed as an immediate destructive mutation.

## Fix (#29690)
- ****: when a mutation omits `id`, resolve the target by exact visible content within the entity scope:
  - unique match → mutate that todo;
  - no match → typed `not_found` outcome;
  - duplicate content → bounded `ambiguous_match` clarification listing the matching contents.
- **update**, **complete**, **cancel**, and **delete** all fall back to the resolver when `id` is absent.
- **actionClear** now requires explicit `confirm: true`; without it, returns a bounded preview (`requiresConfirmation: true`) instead of mutating.

## Verification
Resolver classification verified independently across 4 cases: unique match (→ id), ambiguous duplicate (→ bounded clarification), no match (→ not_found), missing content (→ missing_param). All pass.

Owner/entity scope, replay keys, durable receipts, and #28015 cross-room semantics are untouched.

Closes #29690.