### PR TITLE
fix(agent): use the tested recency comparator for client_chat delivery

### DIFF
--- a/packages/agent/src/services/client-chat-sender.recency-fallback.test.ts
+++ b/packages/agent/src/services/client-chat-sender.recency-fallback.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Pins the delivery target chosen by the proactive `client_chat` recency
+ * fallback when a conversation carries an unparseable `updatedAt`.
+ *
+ * Drives the real exported `registerClientChatSendHandler` through a runtime
+ * stand-in that mirrors send-handler routing, and asserts where the message was
+ * actually persisted — the observable consequence is the room it landed in, not
+ * the sorted array. Kept in its own file so the case does not depend on the
+ * heavier swarm imports the sibling suite pulls in.
+ */
+import crypto from "node:crypto";
+import type {
+  Content,
+  IAgentRuntime,
+  Memory,
+  SendHandlerFunction,
+  TargetInfo,
+  UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ConversationMeta, ServerState } from "../api/server-types.ts";
+import { registerClientChatSendHandler } from "./client-chat-sender.ts";
+
+function makeRuntime() {
+  const handlers = new Map<string, SendHandlerFunction>();
+  const connectors: Array<{ source: string }> = [];
+  const created: Memory[] = [];
+  const runtime = {
+    agentId: crypto.randomUUID() as UUID,
+    registerSendHandler(source: string, handler: SendHandlerFunction) {
+      handlers.set(source, handler);
+      connectors.push({ source });
+    },
+    registerInternalSendHandler(source: string, handler: SendHandlerFunction) {
+      handlers.set(source, handler);
+    },
+    getMessageConnectors() {
+      return connectors;
+    },
+    createMemory: vi.fn(async (memory: Memory) => {
+      created.push(memory);
+      return memory.id as UUID;
+    }),
+    async sendMessageToTarget(
+      target: TargetInfo,
+      content: Content,
+    ): Promise<Memory | undefined> {
+      const source =
+        typeof target.source === "string" ? target.source.trim() : "";
+      const handler = handlers.get(source);
+      if (!handler) {
+        throw new Error(`No send handler registered for source: ${source}`);
+      }
+      return (await handler(
+        runtime as unknown as IAgentRuntime,
+        target,
+        content,
+      )) as Memory | undefined;
+    },
+  };
+  return { runtime, created };
+}
+
+function makeState(conversations: ConversationMeta[]) {
+  const map = new Map<string, ConversationMeta>();
+  for (const conversation of conversations)
+    map.set(conversation.id, conversation);
+  const broadcastWs = vi.fn();
+  return {
+    state: {
+      conversations: map,
+      activeConversationId: null,
+      broadcastWs,
+    } as unknown as ServerState,
+    broadcastWs,
+  };
+}
+
+function conv(id: string, roomId: string, updatedAt: string): ConversationMeta {
+  return {
+    id,
+    title: id,
+    roomId: roomId as UUID,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt,
+  };
+}
+
+describe("client_chat recency fallback", () => {
+  it("delivers into the genuinely most-recent conversation, not one whose updatedAt is unparseable", async () => {
+    const { runtime, created } = makeRuntime();
+    // No active conversation, so the most-recently-updated fallback is what
+    // picks the delivery target. "stale" carries a malformed updatedAt.
+    const { state } = makeState([
+      conv("stale", "room-stale", "not-a-date"),
+      conv("recent", "room-recent", "2026-01-02T00:00:00.000Z"),
+      conv("older", "room-older", "2026-01-01T00:00:00.000Z"),
+    ]);
+    registerClientChatSendHandler(runtime as unknown as IAgentRuntime, state);
+
+    await runtime.sendMessageToTarget(
+      { source: "client_chat", roomId: "room-unknown" as UUID },
+      { text: "proactive ping" },
+    );
+
+    expect(created).toHaveLength(1);
+    expect(created[0]?.roomId).toBe("room-recent");
+  });
+
+  it("still delivers into the most-recent conversation when every updatedAt is valid", async () => {
+    const { runtime, created } = makeRuntime();
+    const { state } = makeState([
+      conv("older", "room-older", "2026-01-01T00:00:00.000Z"),
+      conv("recent", "room-recent", "2026-01-02T00:00:00.000Z"),
+    ]);
+    registerClientChatSendHandler(runtime as unknown as IAgentRuntime, state);
+
+    await runtime.sendMessageToTarget(
+      { source: "client_chat", roomId: "room-unknown" as UUID },
+      { text: "proactive ping" },
+    );
+
+    expect(created).toHaveLength(1);
+    expect(created[0]?.roomId).toBe("room-recent");
+  });
+});

--- a/packages/agent/src/services/client-chat-sender.ts
+++ b/packages/agent/src/services/client-chat-sender.ts
@@ -19,6 +19,7 @@ import {
   type TargetInfo,
   type UUID,
 } from "@elizaos/core";
+import { compareConversationsByRecency } from "../api/conversation-sort.ts";
 import type { ConversationMeta, ServerState } from "../api/server-types.ts";
 
 /**
@@ -121,7 +122,7 @@ function resolveConversation(
 
   // 3. Most recently updated conversation
   const sorted = Array.from(state.conversations.values()).sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    compareConversationsByRecency,
   );
   return sorted[0];
 }


### PR DESCRIPTION
# Relates to

Closes #29721.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Uses the package's existing tested comparator rather than adding a second one.
- [x] A reviewer can confirm the behaviour from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts. Verified this file is byte-identical between `29d6d0a7` (where the work was done) and the push base.
- [x] Two files differ; the production change is `+2/-1` — one import and one comparator.

# Risks

Low and behaviour-preserving for valid data. `compareConversationsByRecency` orders by `updatedAt` descending exactly as the old expression did; it differs only where the old one returned `NaN`. The added `id` tie-break also makes the fallback deterministic when two conversations share a timestamp, which previously depended on sort stability. The second test below pins that a healthy list is unaffected.

# Background

## What does this PR do?

`resolveConversation` picks where the agent's proactive `client_chat` message gets written. Its third and last fallback sorted with a bare subtraction and took `[0]`:

```ts
// 3. Most recently updated conversation
const sorted = Array.from(state.conversations.values()).sort(
  (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
);
return sorted[0];
```

`new Date("not-a-date").getTime()` is `NaN`, and `NaN - x` is `NaN`. A comparator returning `NaN` leaves `Array.prototype.sort` implementation-defined, so `[0]` is not reliably the most recent conversation.

**Why this is not a display glitch.** `[0]` is the room the message is persisted into and broadcast to. A wrong result delivers the agent's message into a conversation the user was not talking in — which is the exact failure this file says it exists to prevent:

> Programmatic API / unknown sources: never fall through to an unrelated active / recent conversation. The originating room is the only correct delivery target; absent a match the caller records an honest delivery failure instead of **mis-delivering into a stranger's chat**.

The guard against mis-delivery is deliberate and correct. The recency fallback it hands off to was not sound.

**Reachability — the repository already documents this input as untrusted.** From `packages/agent/src/api/conversation-sort.ts`, in the same package:

> Timestamps reaching these comparators come from persisted rows and untrusted `PATCH` payloads, so a malformed `updatedAt` string or a non-numeric `createdAt` can produce `NaN`. A comparator that returns `NaN` makes `Array.prototype.sort` implementation-defined, which surfaces as an unstable conversation list.

**This is the odd one out.** Every other conversation/memory sort in `packages/agent` is already guarded — `conversation-routes.ts` uses `compareConversationsByRecency` and `compareMemoriesByCreatedAt` at four call sites, `page-scoped-context.ts` uses a `safeCreatedAt` helper, `recent-conversations.ts` uses `?? 0`, and `chat-routes.ts` uses `compareCreatedAtAscending`. `client-chat-sender.ts` was the only one still hand-rolling it.

## What is the fix?

Use the comparator that already exists and is already tested:

```diff
+import { compareConversationsByRecency } from "../api/conversation-sort.ts";

   const sorted = Array.from(state.conversations.values()).sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    compareConversationsByRecency,
   );
```

`ConversationMeta` already satisfies `ConversationSortInput` (`id: string`, `updatedAt: string`), so no type change is needed. Reusing it rather than writing a fourth local guard is the point — `conversation-sort.test.ts` already owns the `NaN` contract, including a case named *"keeps a total order when an updatedAt is unparseable"*.

# Documentation changes needed?

No. No public surface, export, setting, or documented behaviour changes.

# Testing

## Where should a reviewer start?

The mutation block. The test drives the real exported `registerClientChatSendHandler` and asserts **where the message was persisted** (`created[0].roomId`) — the observable consequence — not the sorted array.

The case lives in its own file rather than in `client-chat-sender.test.ts`. That sibling suite transitively imports `@elizaos/auth` through `server-helpers-swarm`, and on **pristine `develop`**, before any change of mine, it fails at import with `TypeError: codingProviderSubscriptionBillingMode is not a function`. I verified that on an unmodified checkout and am not claiming it as this PR's result; a separate file keeps this contract runnable and independent of that.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `client-chat-sender.recency-fallback.test.ts` | **2 passed** |
| `conversation-sort.test.ts` + `conversation-restore.test.ts` (regression) | **20 passed** |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| production diff vs `develop` | `+2/-1` — one import, one comparator |

Mutation resistance — reverting **only** the comparator and keeping both tests:

```
× delivers into the genuinely most-recent conversation, not one whose updatedAt is unparseable
  AssertionError: expected 'room-stale' to be 'room-recent'

 Tests  1 failed | 1 passed (2)
```

`room-stale` is the conversation carrying `updatedAt: "not-a-date"`. The agent's message was written into it while a conversation updated a full day later sat behind it.

The second test is the guard in the other direction: with every `updatedAt` valid, delivery still goes to the most recent conversation. It passes in both directions by design, so the fix cannot be mistaken for a change in normal routing.

# Evidence Gate

<!-- evidence-head:eb12224f21f7902e4ddc36fc7b696e0e0b4643b2 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - server-side delivery routing; this diff touches no rendering code`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - server-side delivery routing; this diff touches no rendering code`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the room the message was persisted into, asserted directly against the real exported handler above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the real send handler is driven directly by the suite above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in delivery-target resolution`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the persisted memory's roomId, quoted in the mutation block above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a comparator-totality sweep of `packages/agent`.
- Independent verification of the delivery consequence, discovery that the package's own `conversation-sort.ts` already documents this input as untrusted and already ships the tested comparator, the survey confirming every sibling sort was already guarded, and the mutation proof by Claude Code (`claude-opus-5`).

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Attribution status: self-reported

