### PR TITLE
fix(ci): refresh the stale ui molecular inventory to green the lint gate

### DIFF
--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "sourceAtomicSchemaVersion": 1,
-  "scannedFiles": 898,
+  "scannedFiles": 897,
   "canonicalContracts": [
     {
       "id": "auth-result-shell",
@@ -84,7 +84,7 @@
       "maintainedReferences": 2
     }
   ],
-  "eligibleComponents": 103,
+  "eligibleComponents": 104,
   "clusters": [
     {
       "archetype": "row",

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 898 maintained React files. 103 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 897 maintained React files. 104 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 


### PR DESCRIPTION
# Relates to

Closes #29727.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Restores a gate that is red on `develop` right now, blocking every PR behind it.
- [x] A reviewer can confirm the result from the exit codes below without reading the code.

# Sync with develop

- [x] Built on `origin/develop@cf259c1b`; zero conflicts.
- [x] Two generated artifacts differ, by three lines total.

# Risks

None to runtime. This changes no source, no test, and no disposition — only two stale
counters inside a generated report and the one markdown line that restates them. No
product code imports these artifacts; they exist for the `--check` gate and for review.

# Background

## What is broken

`develop@cf259c1b` is red. `quality / Develop Gate (lint)` and `canonical / Quality`
fail, and **36 checks are failing behind them**, including `tests / Merge Queue Quality
Gate`, all four `Plugin Tests` shards, the `Zero-Key` lanes, and
`canonical / Tests (client|scripts)`.

The root failure is one line:

```
@elizaos/ui:lint:check: Error: Molecular inventory artifacts are stale: json, markdown.
Run bun run --cwd packages/ui audit:molecular-inventory.
@elizaos/ui:lint:check: error: script "lint:check" exited with code 1
```

[Failing job](https://github.com/elizaOS/eliza/actions/runs/33148332250/job/98774524930)

`packages/ui`'s `lint:check` ends with
`node scripts/find-duplicate-molecular-components.mjs --check`, which rebuilds the
inventory from the current source tree and asserts the committed artifacts still match.
The maintained React file set moved; the reports did not.

## What is actually stale

Running the generator produces a 293-line textual diff, but that overstates the change.
Parsing both sides, the committed report differs from the current tree in **exactly two
values**:

```
.scannedFiles:       898 -> 897
.eligibleComponents: 103 -> 104
```

Every other line in that 293-line diff is JSON array re-wrapping from the generator's
`JSON.stringify(report, null, 2)`.

**That re-wrapping is not what the gate compares.** From the gate itself:

```js
if (!isDeepStrictEqual(JSON.parse(artifacts.json), report)) stale.push("json");
if (artifacts.markdown !== renderMolecularMarkdown(report)) stale.push("markdown");
```

The JSON side is deep-equality on the **parsed** object, so its formatting is irrelevant.
Only the markdown side is compared as text, and its single stale line restates the same
two numbers.

## What is the fix?

Update those two values in each artifact. That restores the gate in three lines and
preserves the committed files' existing formatting.

Committing the generator's re-wrapped output would also pass, but it would add ~290 lines
of formatting churn to a file nothing formats: `lint:check` runs Biome over `src` and
`scripts/*.ts` only, so these JSON/MD artifacts are outside its scope. A minimal diff
keeps the next reviewer of this report looking at dispositions rather than at re-flowed
arrays.

# Documentation changes needed?

No. Generated review artifacts only; no public surface, setting, or documented behaviour
changes.

# Testing

## Where should a reviewer start?

The exit codes. This is a gate that either passes or does not.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `node packages/ui/scripts/find-duplicate-molecular-components.mjs --check` | **exit 0** — `Molecular inventory is current with 12 final dispositions.` |
| `bun run --cwd packages/ui lint:check` | **exit 0** |
| semantic JSON comparison, committed vs current tree | exactly 2 differing values, both fixed here |
| diff vs `develop` | `+3/-3` across two generated artifacts |

Mutation resistance — restoring **only** develop's committed artifacts:

```
$ node packages/ui/scripts/find-duplicate-molecular-components.mjs --check
Error: Molecular inventory artifacts are stale: json, markdown. Run bun run --cwd packages/ui audit:molecular-inventory.
EXIT=1
```

That is byte-for-byte the message the hosted `Develop Gate (lint)` job fails with, so the
local reproduction and the CI failure are the same failure.

# Evidence Gate

<!-- evidence-head:b1a65d0bc7df341435a03512da2b4ac7c02cfe4d -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI gate repair on generated review artifacts; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI gate repair on generated review artifacts; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable result is the gate's exit code, quoted above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the hosted job log is linked above and the local reproduction is quoted`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in the inventory gate`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifacts ARE the diff; both are shown in full above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Identified and fixed by Claude Code (`claude-opus-5`): hosted `Develop Gate (lint)` log triage, local reproduction at the exact `develop` tip, the parsed-vs-textual analysis isolating the two genuinely stale values, and the mutation proof.

Attribution status: self-reported
