### PR TITLE
fix(ui): canonicalize remaining app layouts

### DIFF
--- a/packages/app/test/ui-smoke/files-view.spec.ts
+++ b/packages/app/test/ui-smoke/files-view.spec.ts
@@ -55,10 +55,12 @@ const FILES_FIXTURE = {
 
 const VIEWPORTS = [
   { name: "desktop", width: 1440, height: 1000 },
-  { name: "mobile", width: 390, height: 844 },
+  { name: "tablet", width: 1024, height: 768 },
+  { name: "portrait", width: 390, height: 844 },
+  { name: "landscape", width: 844, height: 390 },
 ] as const;
 
-test.describe("Files view visual + smoke (desktop + mobile)", () => {
+test.describe("Files view visual + smoke (responsive matrix)", () => {
   for (const vp of VIEWPORTS) {
     test(`files ${vp.name}`, async ({ page }) => {
       const screenshotDir =
@@ -106,6 +108,31 @@ test.describe("Files view visual + smoke (desktop + mobile)", () => {
           },
         )
         .toBeGreaterThan(10);
+
+      // PageFrame is the sole outer-gutter owner. Framed navigation and the
+      // continuous list must inherit that rendered edge instead of adding a
+      // second compact-screen inset.
+      const pageContent = page.locator("[data-page-content]");
+      const filesList = page.getByTestId("files-grid");
+      const showLabel = page.getByText("Show", { exact: true });
+      const [pageBox, listBox, showBox, pagePaddingLeft] = await Promise.all([
+        pageContent.boundingBox(),
+        filesList.boundingBox(),
+        showLabel.boundingBox(),
+        pageContent.evaluate((element) =>
+          Number.parseFloat(getComputedStyle(element).paddingLeft),
+        ),
+      ]);
+      expect(pageBox).not.toBeNull();
+      expect(listBox).not.toBeNull();
+      expect(showBox).not.toBeNull();
+      const inheritedContentEdge = (pageBox?.x ?? 0) + pagePaddingLeft;
+      expect(
+        Math.abs((listBox?.x ?? 0) - inheritedContentEdge),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs((showBox?.x ?? 0) - inheritedContentEdge),
+      ).toBeLessThanOrEqual(1);
 
       await captureScreenshotWithQualityRetry(page, `files ${vp.name}`, {
         fullPage: false,

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -1,14 +1,18 @@
 {
   "schemaVersion": 3,
   "sourceAtomicSchemaVersion": 1,
-  "scannedFiles": 898,
+  "scannedFiles": 897,
   "canonicalContracts": [
     {
       "id": "auth-result-shell",
       "owner": "packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.tsx",
       "symbol": "AuthResultShell",
-      "requiredAtomicDependencies": ["card"],
-      "requiredRenderedTags": ["main"],
+      "requiredAtomicDependencies": [
+        "card"
+      ],
+      "requiredRenderedTags": [
+        "main"
+      ],
       "renderedStory": "packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.stories.tsx",
       "behavioralTest": "packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.test.tsx",
       "requiredConsumerFiles": [
@@ -23,8 +27,12 @@
       "id": "connection-capability-tile",
       "owner": "packages/ui/src/cloud/connectors/connection-capability-tile.tsx",
       "symbol": "ConnectionCapabilityTile",
-      "requiredAtomicDependencies": ["card"],
-      "requiredRenderedTags": ["p"],
+      "requiredAtomicDependencies": [
+        "card"
+      ],
+      "requiredRenderedTags": [
+        "p"
+      ],
       "renderedStory": "packages/ui/src/cloud/connectors/connection-capability-tile.stories.tsx",
       "behavioralTest": "packages/ui/src/cloud/connectors/connection-capability-tile.test.tsx",
       "requiredConsumerFiles": [
@@ -39,8 +47,14 @@
       "id": "content-state",
       "owner": "packages/ui/src/components/composites/page-panel/content-state.tsx",
       "symbol": "ContentState",
-      "requiredAtomicDependencies": ["card", "spinner"],
-      "requiredRenderedTags": ["LoadingContent", "PlainEmptyContent"],
+      "requiredAtomicDependencies": [
+        "card",
+        "spinner"
+      ],
+      "requiredRenderedTags": [
+        "LoadingContent",
+        "PlainEmptyContent"
+      ],
       "renderedStory": "packages/ui/src/components/composites/page-panel/content-state.stories.tsx",
       "behavioralTest": "packages/ui/src/components/composites/page-panel/content-state.test.tsx",
       "requiredConsumerFiles": [
@@ -55,8 +69,13 @@
       "id": "settings-row",
       "owner": "packages/ui/src/components/settings/settings-layout.tsx",
       "symbol": "SettingsRow",
-      "requiredAtomicDependencies": ["button", "card"],
-      "requiredRenderedTags": ["Button"],
+      "requiredAtomicDependencies": [
+        "button",
+        "card"
+      ],
+      "requiredRenderedTags": [
+        "Button"
+      ],
       "renderedStory": "packages/ui/src/components/settings/settings-layout.stories.tsx",
       "behavioralTest": "packages/ui/src/components/settings/settings-layout.test.tsx",
       "requiredConsumerFiles": [
@@ -71,8 +90,13 @@
       "id": "action-list-row",
       "owner": "packages/ui/src/components/shared/ActionListRow.tsx",
       "symbol": "ActionListRow",
-      "requiredAtomicDependencies": ["button", "card"],
-      "requiredRenderedTags": ["Button"],
+      "requiredAtomicDependencies": [
+        "button",
+        "card"
+      ],
+      "requiredRenderedTags": [
+        "Button"
+      ],
       "renderedStory": "packages/ui/src/components/shared/ActionListRow.stories.tsx",
       "behavioralTest": "packages/ui/src/components/shared/ActionListRow.test.tsx",
       "requiredConsumerFiles": [
@@ -84,30 +108,51 @@
       "maintainedReferences": 2
     }
   ],
-  "eligibleComponents": 103,
+  "eligibleComponents": 104,
   "clusters": [
     {
       "archetype": "row",
-      "atomicDependencies": ["button", "card"],
+      "atomicDependencies": [
+        "button",
+        "card"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "card"],
+          "atomicDependencies": [
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/components/composites/sidebar/sidebar-content.tsx",
           "line": 174,
           "name": "SidebarItem",
-          "renderedTags": ["Button", "Card", "div"],
+          "renderedTags": [
+            "Button",
+            "Card",
+            "div"
+          ],
           "archetype": "row"
         },
         {
-          "atomicDependencies": ["button", "card"],
+          "atomicDependencies": [
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/components/settings/settings-layout.tsx",
           "line": 298,
           "name": "SettingsRow",
-          "renderedTags": ["Button", "Card", "SettingsRowBody", "div"],
+          "renderedTags": [
+            "Button",
+            "Card",
+            "SettingsRowBody",
+            "div"
+          ],
           "archetype": "row"
         },
         {
-          "atomicDependencies": ["button", "card"],
+          "atomicDependencies": [
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/components/shared/ActionListRow.tsx",
           "line": 115,
           "name": "ActionListRow",
@@ -121,7 +166,10 @@
           "archetype": "row"
         },
         {
-          "atomicDependencies": ["button", "card"],
+          "atomicDependencies": [
+            "button",
+            "card"
+          ],
           "file": "plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx",
           "line": 96,
           "name": "ReasoningCell",
@@ -151,10 +199,16 @@
     },
     {
       "archetype": "dialog",
-      "atomicDependencies": ["button", "dialog"],
+      "atomicDependencies": [
+        "button",
+        "dialog"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "dialog"],
+          "atomicDependencies": [
+            "button",
+            "dialog"
+          ],
           "file": "packages/ui/src/components/pages/skill-detail-panel.tsx",
           "line": 35,
           "name": "EditSkillModal",
@@ -173,7 +227,10 @@
           "archetype": "dialog"
         },
         {
-          "atomicDependencies": ["button", "dialog"],
+          "atomicDependencies": [
+            "button",
+            "dialog"
+          ],
           "file": "packages/ui/src/components/ui/confirm-dialog.tsx",
           "line": 35,
           "name": "ConfirmDialog",
@@ -189,7 +246,10 @@
           "archetype": "dialog"
         },
         {
-          "atomicDependencies": ["button", "dialog"],
+          "atomicDependencies": [
+            "button",
+            "dialog"
+          ],
           "file": "plugins/plugin-calendar/src/components/EventEditorDrawer.tsx",
           "line": 469,
           "name": "EventEditorDrawer",
@@ -230,10 +290,18 @@
     },
     {
       "archetype": "dialog",
-      "atomicDependencies": ["button", "dialog", "input"],
+      "atomicDependencies": [
+        "button",
+        "dialog",
+        "input"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "dialog", "input"],
+          "atomicDependencies": [
+            "button",
+            "dialog",
+            "input"
+          ],
           "file": "packages/ui/src/components/chat/SaveCommandModal.tsx",
           "line": 37,
           "name": "SaveCommandModal",
@@ -255,7 +323,11 @@
           "archetype": "dialog"
         },
         {
-          "atomicDependencies": ["button", "dialog", "input"],
+          "atomicDependencies": [
+            "button",
+            "dialog",
+            "input"
+          ],
           "file": "packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx",
           "line": 41,
           "name": "ChatConversationRenameDialog",
@@ -275,7 +347,11 @@
           "archetype": "dialog"
         },
         {
-          "atomicDependencies": ["button", "dialog", "input"],
+          "atomicDependencies": [
+            "button",
+            "dialog",
+            "input"
+          ],
           "file": "packages/ui/src/components/ui/confirm-dialog.tsx",
           "line": 95,
           "name": "PromptDialog",
@@ -306,10 +382,18 @@
     },
     {
       "archetype": "list",
-      "atomicDependencies": ["badge", "button", "card"],
+      "atomicDependencies": [
+        "badge",
+        "button",
+        "card"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["badge", "button", "card"],
+          "atomicDependencies": [
+            "badge",
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/cloud/organization/credentials-list.tsx",
           "line": 78,
           "name": "CredentialsList",
@@ -337,7 +421,11 @@
           "archetype": "list"
         },
         {
-          "atomicDependencies": ["badge", "button", "card"],
+          "atomicDependencies": [
+            "badge",
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/cloud/organization/members-list.tsx",
           "line": 53,
           "name": "MembersList",
@@ -373,7 +461,11 @@
           "archetype": "list"
         },
         {
-          "atomicDependencies": ["badge", "button", "card"],
+          "atomicDependencies": [
+            "badge",
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/cloud/organization/pending-invites-list.tsx",
           "line": 42,
           "name": "PendingInvitesList",
@@ -418,10 +510,18 @@
     },
     {
       "archetype": "panel",
-      "atomicDependencies": ["button", "card", "input"],
+      "atomicDependencies": [
+        "button",
+        "card",
+        "input"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "card", "input"],
+          "atomicDependencies": [
+            "button",
+            "card",
+            "input"
+          ],
           "file": "packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx",
           "line": 50,
           "name": "MessageSearchPanel",
@@ -438,7 +538,11 @@
           "archetype": "panel"
         },
         {
-          "atomicDependencies": ["button", "card", "input"],
+          "atomicDependencies": [
+            "button",
+            "card",
+            "input"
+          ],
           "file": "packages/ui/src/components/connectors/TelegramAccountConnectorPanel.tsx",
           "line": 72,
           "name": "TelegramAccountConnectorPanel",
@@ -452,7 +556,11 @@
           "archetype": "panel"
         },
         {
-          "atomicDependencies": ["button", "card", "input"],
+          "atomicDependencies": [
+            "button",
+            "card",
+            "input"
+          ],
           "file": "packages/ui/src/components/settings/VoiceConfigView.tsx",
           "line": 64,
           "name": "DesktopTalkModePanel",
@@ -576,10 +684,16 @@
     },
     {
       "archetype": "card",
-      "atomicDependencies": ["button", "input"],
+      "atomicDependencies": [
+        "button",
+        "input"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "input"],
+          "atomicDependencies": [
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/chat/widgets/ChoiceWidget.tsx",
           "line": 60,
           "name": "ChoiceWidget",
@@ -597,7 +711,10 @@
           "archetype": "card"
         },
         {
-          "atomicDependencies": ["button", "input"],
+          "atomicDependencies": [
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/chat/widgets/connector-card.tsx",
           "line": 83,
           "name": "ConnectorCardWidget",
@@ -625,10 +742,18 @@
     },
     {
       "archetype": "dialog",
-      "atomicDependencies": ["alert", "button", "card"],
+      "atomicDependencies": [
+        "alert",
+        "button",
+        "card"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["alert", "button", "card"],
+          "atomicDependencies": [
+            "alert",
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/cloud/organization/contribute-credential-dialog.tsx",
           "line": 56,
           "name": "ContributeCredentialDialog",
@@ -662,7 +787,11 @@
           "archetype": "dialog"
         },
         {
-          "atomicDependencies": ["alert", "button", "card"],
+          "atomicDependencies": [
+            "alert",
+            "button",
+            "card"
+          ],
           "file": "packages/ui/src/cloud/organization/invite-member-dialog.tsx",
           "line": 66,
           "name": "InviteMemberDialog",
@@ -709,10 +838,16 @@
     },
     {
       "archetype": "form",
-      "atomicDependencies": ["button", "input"],
+      "atomicDependencies": [
+        "button",
+        "input"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "input"],
+          "atomicDependencies": [
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/pages/TriggerForm.tsx",
           "line": 231,
           "name": "TriggerForm",
@@ -740,11 +875,21 @@
           "archetype": "form"
         },
         {
-          "atomicDependencies": ["button", "input"],
+          "atomicDependencies": [
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/ui/tag-editor.tsx",
           "line": 29,
           "name": "TagEditor",
-          "renderedTags": ["Button", "Input", "Label", "X", "div", "span"],
+          "renderedTags": [
+            "Button",
+            "Input",
+            "Label",
+            "X",
+            "div",
+            "span"
+          ],
           "archetype": "form"
         }
       ],
@@ -759,10 +904,18 @@
     },
     {
       "archetype": "panel",
-      "atomicDependencies": ["badge", "button", "input"],
+      "atomicDependencies": [
+        "badge",
+        "button",
+        "input"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["badge", "button", "input"],
+          "atomicDependencies": [
+            "badge",
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/settings/cloud-panel/sections/AgentSection.tsx",
           "line": 109,
           "name": "AgentSection",
@@ -791,7 +944,11 @@
           "archetype": "panel"
         },
         {
-          "atomicDependencies": ["badge", "button", "input"],
+          "atomicDependencies": [
+            "badge",
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/settings/CloudAgentsSection.tsx",
           "line": 77,
           "name": "CloudAgentsSection",
@@ -828,10 +985,16 @@
     },
     {
       "archetype": "panel",
-      "atomicDependencies": ["button", "input"],
+      "atomicDependencies": [
+        "button",
+        "input"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "input"],
+          "atomicDependencies": [
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/connectors/TelegramBotSetupPanel.tsx",
           "line": 35,
           "name": "TelegramBotSetupPanel",
@@ -848,7 +1011,10 @@
           "archetype": "panel"
         },
         {
-          "atomicDependencies": ["button", "input"],
+          "atomicDependencies": [
+            "button",
+            "input"
+          ],
           "file": "packages/ui/src/components/release-center/sections.tsx",
           "line": 241,
           "name": "ReleaseNotesSection",
@@ -876,10 +1042,18 @@
     },
     {
       "archetype": "row",
-      "atomicDependencies": ["button", "card", "statusDot"],
+      "atomicDependencies": [
+        "button",
+        "card",
+        "statusDot"
+      ],
       "entries": [
         {
-          "atomicDependencies": ["button", "card", "statusDot"],
+          "atomicDependencies": [
+            "button",
+            "card",
+            "statusDot"
+          ],
           "file": "packages/ui/src/components/composites/chat/chat-conversation-item.tsx",
           "line": 126,
           "name": "ChatConversationItem",
@@ -897,11 +1071,20 @@
           "archetype": "row"
         },
         {
-          "atomicDependencies": ["button", "card", "statusDot"],
+          "atomicDependencies": [
+            "button",
+            "card",
+            "statusDot"
+          ],
           "file": "packages/ui/src/components/composites/sidebar/sidebar-content.tsx",
           "line": 361,
           "name": "SidebarRailItem",
-          "renderedTags": ["Button", "Card", "StatusDot", "span"],
+          "renderedTags": [
+            "Button",
+            "Card",
+            "StatusDot",
+            "span"
+          ],
           "archetype": "row"
         }
       ],

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 898 maintained React files. 103 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 897 maintained React files. 104 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1472,7 +1472,7 @@ function buildStaticTabRenderers(): Record<
     plugins: withHeader("plugins", <LazyPluginsPageView />),
     skills: withHeader("skills", <LazySkillsView />),
     trajectories: wrap(<LazyTrajectoriesView />),
-    transcripts: wrap(<LazyLiveMeetingPageView />),
+    transcripts: withHeader("transcripts", <LazyLiveMeetingPageView />),
     // Relationships is plugin-owned. Its app-shell registration claims the
     // route and supplies the page chrome; an absent plugin is an unavailable
     // feature rather than a host-side duplicate implementation.
@@ -1495,14 +1495,7 @@ function buildStaticTabRenderers(): Record<
       </AppWorkspaceContent>
     ),
     memories: wrapOverlayAware(<LazyMemoryViewerView />),
-    files: ({ pageLayout }) => (
-      <AppWorkspaceContent
-        header={<ViewHeader title={titleForTab("files")} />}
-        pageLayout={pageLayout}
-      >
-        <LazyFilesView />
-      </AppWorkspaceContent>
-    ),
+    files: wrapOverlayAware(<LazyFilesView />),
     runtime: withHeader("runtime", <LazyRuntimeView />),
     database: wrapOverlayAware(<LazyDatabasePageView />),
     logs: withHeader("logs", <LazyLogsView />),

--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -1299,7 +1299,7 @@ export function CharacterEditor({
     return sceneOverlay ? (
       loadingState
     ) : (
-      <FramedPage>
+      <FramedPage gutterOwner="framed-page">
         {pageChrome}
         <FramedPageBody scroll="page">{loadingState}</FramedPageBody>
       </FramedPage>

--- a/packages/ui/src/components/character/CharacterExperienceView.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceView.tsx
@@ -101,7 +101,7 @@ export function CharacterExperienceView({
 
   return (
     <ShellViewAgentSurface viewId="experience">
-      <FramedPage>
+      <FramedPage gutterOwner="framed-page">
         {pageChrome}
         <FramedPageBody className="gap-4 pt-1">
           {error ? (

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -225,7 +225,7 @@ export function CharacterHubView({
   );
 
   return (
-    <FramedPage>
+    <FramedPage gutterOwner="framed-page">
       {pageChrome}
       <FramedPageBody scroll="page" data-testid="character-editor-view">
         <div className="flex min-w-0 flex-col pt-1">

--- a/packages/ui/src/components/character/CharacterSkillsView.tsx
+++ b/packages/ui/src/components/character/CharacterSkillsView.tsx
@@ -17,7 +17,7 @@ export function CharacterSkillsView({
 }) {
   return (
     <ShellViewAgentSurface viewId="character-skills">
-      <FramedPage>
+      <FramedPage gutterOwner="framed-page">
         {pageChrome}
         <FramedPageBody className="gap-4 pt-1">
           <CharacterLearnedSkillsSection showTitle={false} />

--- a/packages/ui/src/components/composites/page-panel/content-state.test.tsx
+++ b/packages/ui/src/components/composites/page-panel/content-state.test.tsx
@@ -39,6 +39,7 @@ describe("ContentState", () => {
         placement="workspace"
         title="No results"
         description="Change the filters and try again."
+        icon={<AlertTriangle data-testid="empty-icon" />}
         data-testid="state"
       />,
     );
@@ -48,6 +49,7 @@ describe("ContentState", () => {
     expect(state.classList.contains("flex-1")).toBe(true);
     expect(state.hasAttribute("data-slot")).toBe(false);
     expect(screen.getByText("No results").tagName).toBe("DIV");
+    expect(screen.getByTestId("empty-icon")).toBeTruthy();
   });
 
   it("keeps loading descriptions screen-reader-only", () => {

--- a/packages/ui/src/components/composites/page-panel/content-state.tsx
+++ b/packages/ui/src/components/composites/page-panel/content-state.tsx
@@ -51,13 +51,19 @@ function PlainEmptyContent({
   action,
   children,
   description,
+  icon,
   title,
 }: Pick<
   EmptyContentStateProps,
-  "action" | "children" | "description" | "title"
+  "action" | "children" | "description" | "icon" | "title"
 >) {
   return (
     <>
+      {icon ? (
+        <Card variant="accentTile" className="mb-3 size-12">
+          {icon}
+        </Card>
+      ) : null}
       <div className="max-w-md space-y-2">
         <div className="text-base font-medium text-txt-strong">{title}</div>
         {description ? (
@@ -150,6 +156,7 @@ export function ContentState(props: ContentStateProps) {
           <PlainEmptyContent
             action={action}
             description={description}
+            icon={icon}
             title={title}
           >
             {children}
@@ -170,6 +177,7 @@ export function ContentState(props: ContentStateProps) {
           <PlainEmptyContent
             action={action}
             description={description}
+            icon={icon}
             title={title}
           >
             {children}

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -664,6 +664,7 @@ export function AutomationsFeed({
   const feedContent = (
     <ShellViewAgentSurface viewId="automations">
       <FramedPage
+        gutterOwner="framed-page"
         data-chat-clearance-aware="true"
         data-testid="automations-layout"
       >

--- a/packages/ui/src/components/pages/DatabasePageView.tsx
+++ b/packages/ui/src/components/pages/DatabasePageView.tsx
@@ -87,7 +87,7 @@ export function DatabasePageView({
   }
   return (
     <ShellViewAgentSurface viewId="database">
-      <FramedPage>
+      <FramedPage gutterOwner="framed-page">
         <FramedPageHeader title="Databases" actions={contentHeader} />
         <FramedPageNavigation>{leftNav}</FramedPageNavigation>
         <FramedPageBody scroll="view" padded={false}>

--- a/packages/ui/src/components/pages/FilesView.test.tsx
+++ b/packages/ui/src/components/pages/FilesView.test.tsx
@@ -112,7 +112,11 @@ describe("FilesView", () => {
     renderFiles();
     await screen.findByText("photo.png");
 
-    fireEvent.click(screen.getByTestId("file-facet-document"));
+    fireEvent.pointerDown(screen.getByTestId("file-type-filter"), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByTestId("file-facet-document"));
 
     await waitFor(() => {
       expect(screen.getAllByTestId("file-card")).toHaveLength(1);
@@ -121,7 +125,11 @@ describe("FilesView", () => {
     expect(screen.queryByText("photo.png")).toBeNull();
 
     // Images facet shows only the image.
-    fireEvent.click(screen.getByTestId("file-facet-image"));
+    fireEvent.pointerDown(screen.getByTestId("file-type-filter"), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByTestId("file-facet-image"));
     await waitFor(() => {
       expect(screen.getAllByTestId("file-card")).toHaveLength(1);
     });
@@ -182,7 +190,11 @@ describe("FilesView", () => {
       .getAllByTestId("file-card")
       .find((c) => c.getAttribute("data-file-name") === "photo.png");
 
-    fireEvent.click(within(imageCard as HTMLElement).getByTestId("file-share"));
+    fireEvent.pointerDown(
+      within(imageCard as HTMLElement).getByTestId("file-actions"),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(await screen.findByTestId("file-share"));
 
     await waitFor(() => {
       expect(downloadShareMock.shareAttachment).toHaveBeenCalledTimes(1);
@@ -209,7 +221,11 @@ describe("FilesView", () => {
       .getAllByTestId("file-card")
       .find((c) => c.getAttribute("data-file-name") === "report.pdf");
 
-    fireEvent.click(within(pdfCard as HTMLElement).getByTestId("file-delete"));
+    fireEvent.pointerDown(
+      within(pdfCard as HTMLElement).getByTestId("file-actions"),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(await screen.findByTestId("file-delete"));
 
     expect(window.confirm).toHaveBeenCalledTimes(1);
 
@@ -231,7 +247,11 @@ describe("FilesView", () => {
     const pdfCard = screen
       .getAllByTestId("file-card")
       .find((c) => c.getAttribute("data-file-name") === "report.pdf");
-    fireEvent.click(within(pdfCard as HTMLElement).getByTestId("file-delete"));
+    fireEvent.pointerDown(
+      within(pdfCard as HTMLElement).getByTestId("file-actions"),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(await screen.findByTestId("file-delete"));
 
     expect(clientMock.deleteFile).not.toHaveBeenCalled();
     expect(screen.getByText("report.pdf")).toBeTruthy();
@@ -245,7 +265,11 @@ describe("FilesView", () => {
     const pdfCard = screen
       .getAllByTestId("file-card")
       .find((c) => c.getAttribute("data-file-name") === "report.pdf");
-    fireEvent.click(within(pdfCard as HTMLElement).getByTestId("file-delete"));
+    fireEvent.pointerDown(
+      within(pdfCard as HTMLElement).getByTestId("file-actions"),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(await screen.findByTestId("file-delete"));
 
     await waitFor(() => {
       expect(clientMock.deleteFile).toHaveBeenCalledWith("report.pdf");

--- a/packages/ui/src/components/pages/FilesView.tsx
+++ b/packages/ui/src/components/pages/FilesView.tsx
@@ -14,6 +14,7 @@
 
 import {
   AlertTriangle,
+  ChevronDown,
   Download,
   FileAudio,
   FileText,
@@ -22,12 +23,19 @@ import {
   ImageIcon,
   Loader2,
   Lock,
+  MoreHorizontal,
   Share2,
   Trash2,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client, type StoredFile } from "../../api";
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+  FramedPageNavigation,
+} from "../../layouts/framed-page";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import {
@@ -44,6 +52,16 @@ import {
 import { PagePanel } from "../composites/page-panel";
 import { RoleGate } from "../RoleGate";
 import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
 /* ── mime → kind facets ───────────────────────────────────────────────── */
@@ -58,6 +76,10 @@ const FACETS: readonly FileFacet[] = [
   "video",
   "document",
 ];
+
+function isFileFacet(value: string): value is FileFacet {
+  return FACETS.some((facet) => facet === value);
+}
 
 /**
  * Map a MIME type to one of the facet kinds. Anything that isn't image/audio/
@@ -113,87 +135,6 @@ function KindIcon({ kind }: { kind: FileKind }) {
   }
 }
 
-function FileFacetButton({
-  facet,
-  label,
-  count,
-  active,
-  onSelect,
-}: {
-  facet: FileFacet;
-  label: string;
-  count: number;
-  active: boolean;
-  onSelect: (facet: FileFacet) => void;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `file-facet-${facet}`,
-    role: "toggle",
-    label: `Show ${label} files`,
-    group: "file-facets",
-    status: active ? "active" : "inactive",
-    description: "Filter the Files view by file type",
-    onActivate: () => onSelect(facet),
-  });
-
-  return (
-    <Button
-      ref={ref}
-      {...agentProps}
-      data-testid={`file-facet-${facet}`}
-      aria-pressed={active}
-      onClick={() => onSelect(facet)}
-      variant="selection"
-      size="pillDense"
-      data-state={active ? "on" : "off"}
-    >
-      {label}
-      <span className="ml-1.5 text-muted">{count}</span>
-    </Button>
-  );
-}
-
-function FileShareButton({
-  file,
-  fileAgentId,
-  t,
-  onShare,
-}: {
-  file: StoredFile;
-  fileAgentId: string;
-  t: (key: string, vars?: Record<string, unknown>) => string;
-  onShare: (file: StoredFile) => void;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `file-share-${fileAgentId}`,
-    role: "button",
-    label: `Share ${file.fileName}`,
-    group: "file-actions",
-    description:
-      "Share this stored file, falling back to download when native sharing is unavailable",
-    onActivate: () => onShare(file),
-  });
-
-  return (
-    <Button
-      ref={ref}
-      {...agentProps}
-      type="button"
-      variant="outline"
-      size="sm"
-      data-testid="file-share"
-      aria-label={t("filesview.shareFile", {
-        name: file.fileName,
-        defaultValue: "Share {{name}}",
-      })}
-      onClick={() => onShare(file)}
-    >
-      <Share2 className="mr-1.5 size-4" aria-hidden />
-      {t("filesview.share", { defaultValue: "Share" })}
-    </Button>
-  );
-}
-
 /* ── per-file card ────────────────────────────────────────────────────── */
 
 interface FileCardProps {
@@ -232,7 +173,16 @@ const FileCard = memo(function FileCard({
     description: "Download this stored file",
     onActivate: () => onDownload(file),
   });
-  const deleteControl = useAgentElement<HTMLButtonElement>({
+  const shareControl = useAgentElement<HTMLDivElement>({
+    id: `file-share-${fileAgentId}`,
+    role: "button",
+    label: `Share ${file.fileName}`,
+    group: "file-actions",
+    description:
+      "Share this stored file, falling back to download when native sharing is unavailable",
+    onActivate: () => onShare(file),
+  });
+  const deleteControl = useAgentElement<HTMLDivElement>({
     id: `file-delete-${fileAgentId}`,
     role: "button",
     label: `Delete ${file.fileName}`,
@@ -244,13 +194,13 @@ const FileCard = memo(function FileCard({
 
   return (
     <li
-      className="flex flex-col gap-3 p-3"
+      className="grid min-h-20 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-1 py-3 sm:px-3"
       data-testid="file-card"
       data-file-name={file.fileName}
       data-file-kind={kind}
     >
-      <div className="flex items-start gap-3">
-        <div className="flex  size-14 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-surface/60">
+      <div className="flex min-w-0 flex-1 items-start gap-3">
+        <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-surface/60">
           {kind === "image" ? (
             <img
               src={previewUrl}
@@ -271,25 +221,26 @@ const FileCard = memo(function FileCard({
           >
             {file.fileName}
           </div>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-2xs font-semibold uppercase tracking-[0.14em] text-muted">
-            <span className="rounded-full px-2 py-0.5 text-accent">
-              {kindLabel}
-            </span>
+          <div
+            className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 text-xs-tight text-muted"
+            title={absoluteDate}
+          >
+            <span>{kindLabel}</span>
+            <span aria-hidden>·</span>
             <span>{sizeLabel}</span>
-          </div>
-          <div className="mt-1 text-xs-tight text-muted" title={absoluteDate}>
-            {dateLabel}
+            <span aria-hidden>·</span>
+            <span>{dateLabel}</span>
           </div>
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex shrink-0 items-center justify-end gap-1">
         <Button
           ref={downloadControl.ref}
           {...downloadControl.agentProps}
           type="button"
           variant="outline"
-          size="sm"
+          size="icon"
           data-testid="file-download"
           aria-label={t("filesview.downloadFile", {
             name: file.fileName,
@@ -297,44 +248,60 @@ const FileCard = memo(function FileCard({
           })}
           onClick={() => onDownload(file)}
         >
-          <Download className="mr-1.5 size-4" aria-hidden />
-          {t("filesview.download", { defaultValue: "Download" })}
+          <Download className="size-4" aria-hidden />
         </Button>
-        {shareSupported ? (
-          <FileShareButton
-            file={file}
-            fileAgentId={fileAgentId}
-            t={t}
-            onShare={onShare}
-          />
-        ) : null}
-        {/* Store-wide destructive affordance: ADMIN+ only (#14781). The API
-            enforces the same tier server-side; the gate keeps lower-tier
-            viewers from seeing a control that can only fail. */}
-        <RoleGate minRole="ADMIN">
-          <Button
-            ref={deleteControl.ref}
-            {...deleteControl.agentProps}
-            type="button"
-            variant="surfaceDestructive"
-            size="sm"
-            className="ml-auto"
-            data-testid="file-delete"
-            disabled={deleting}
-            aria-label={t("filesview.deleteFile", {
-              name: file.fileName,
-              defaultValue: "Delete {{name}}",
-            })}
-            onClick={() => onDelete(file)}
-          >
-            {deleting ? (
-              <Loader2 className="mr-1.5 size-4 animate-spin" aria-hidden />
-            ) : (
-              <Trash2 className="mr-1.5 size-4" aria-hidden />
-            )}
-            {t("filesview.delete", { defaultValue: "Delete" })}
-          </Button>
-        </RoleGate>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={t("filesview.moreActions", {
+                name: file.fileName,
+                defaultValue: "More actions for {{name}}",
+              })}
+              data-testid="file-actions"
+            >
+              <MoreHorizontal className="size-4" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-44">
+            <DropdownMenuLabel className="max-w-56 truncate">
+              {file.fileName}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {shareSupported ? (
+              <DropdownMenuItem
+                ref={shareControl.ref}
+                {...shareControl.agentProps}
+                className="gap-2"
+                data-testid="file-share"
+                onSelect={() => onShare(file)}
+              >
+                <Share2 className="size-4" aria-hidden />
+                {t("filesview.share", { defaultValue: "Share" })}
+              </DropdownMenuItem>
+            ) : null}
+            {/* Store-wide destructive affordance: ADMIN+ only (#14781). */}
+            <RoleGate minRole="ADMIN">
+              <DropdownMenuItem
+                ref={deleteControl.ref}
+                {...deleteControl.agentProps}
+                className="gap-2 text-danger focus:text-danger"
+                data-testid="file-delete"
+                disabled={deleting}
+                onSelect={() => onDelete(file)}
+              >
+                {deleting ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                ) : (
+                  <Trash2 className="size-4" aria-hidden />
+                )}
+                {t("filesview.delete", { defaultValue: "Delete" })}
+              </DropdownMenuItem>
+            </RoleGate>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </li>
   );
@@ -507,41 +474,77 @@ function FilesViewBody() {
     [files, t],
   );
 
-  const facetBar = (
-    <div
-      className="flex flex-wrap gap-2"
-      role="toolbar"
-      aria-label={t("filesview.filterByType", {
-        defaultValue: "Filter files by type",
-      })}
-    >
-      {FACETS.map((f) => {
-        const active = facet === f;
-        const label = facetLabel(t, f);
-        return (
-          <FileFacetButton
-            key={f}
-            facet={f}
-            label={label}
-            count={facetCounts[f]}
-            active={active}
-            onSelect={setFacet}
-          />
-        );
-      })}
-    </div>
+  const filterLabel = t("filesview.filterByType", {
+    defaultValue: "Filter files by type",
+  });
+  const facetControl = useAgentElement<HTMLButtonElement>({
+    id: "file-type-filter",
+    role: "button",
+    label: filterLabel,
+    group: "file-filters",
+    status: facetLabel(t, facet),
+    description: "Choose which file type appears in the Files list",
+  });
+  const facetMenu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          ref={facetControl.ref}
+          {...facetControl.agentProps}
+          type="button"
+          variant="ghost"
+          size="compact"
+          aria-label={`${filterLabel}, ${facetLabel(t, facet)} selected, ${facetCounts[facet]} files`}
+          data-testid="file-type-filter"
+          className="gap-1.5"
+        >
+          {facetLabel(t, facet)}
+          <span className="text-muted">{facetCounts[facet]}</span>
+          <ChevronDown className="size-4 text-muted" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-48">
+        <DropdownMenuLabel>{filterLabel}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          value={facet}
+          onValueChange={(value) => {
+            if (isFileFacet(value)) setFacet(value);
+          }}
+        >
+          {FACETS.map((entry) => (
+            <DropdownMenuRadioItem
+              key={entry}
+              value={entry}
+              data-testid={`file-facet-${entry}`}
+            >
+              <span className="flex min-w-0 flex-1 items-center justify-between gap-4">
+                <span>{facetLabel(t, entry)}</span>
+                <span className="text-muted">{facetCounts[entry]}</span>
+              </span>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 
   return (
-    <section
-      className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 pt-[var(--view-pad-top)] pb-[var(--view-pad-bottom)] sm:px-6"
+    <FramedPage
+      gutterOwner="page-frame"
       data-testid="files-view"
-      aria-label={t("filesview.title", { defaultValue: "Files" })}
       aria-busy={loading}
     >
-      {facetBar}
-
-      <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <FramedPageHeader
+        title={t("filesview.title", { defaultValue: "Files" })}
+      />
+      {!loading && !restricted && files.length > 0 ? (
+        <FramedPageNavigation className="flex items-center justify-between gap-3">
+          <span className="text-sm text-muted">Show</span>
+          {facetMenu}
+        </FramedPageNavigation>
+      ) : null}
+      <FramedPageBody scroll="page" className="device-layout gap-4 py-4">
         {downloadError ? (
           <div role="alert" className="text-sm text-danger">
             {downloadError}
@@ -590,12 +593,19 @@ function FilesViewBody() {
             />
           </div>
         ) : files.length === 0 ? (
-          <div className="flex flex-1 flex-col" data-testid="files-empty">
+          <div
+            className="flex flex-1 flex-col border-y border-border/50"
+            data-testid="files-empty"
+          >
             <PagePanel.Empty
-              className="flex-1"
+              variant="workspace"
+              className="flex-1 [@media(orientation:landscape)_and_(max-height:520px)]:py-4"
               icon={<FolderOpen className="size-6" aria-hidden />}
               title={t("filesview.emptyTitle", {
                 defaultValue: "No files yet",
+              })}
+              description={t("filesview.emptyDescription", {
+                defaultValue: "Files shared with Eliza will appear here.",
               })}
             />
           </div>
@@ -612,7 +622,7 @@ function FilesViewBody() {
           />
         ) : (
           <ul
-            className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+            className="flex flex-col divide-y divide-border/40 border-y border-border/50"
             data-testid="files-grid"
             aria-label={t("filesview.listLabel", { defaultValue: "Files" })}
           >
@@ -632,7 +642,7 @@ function FilesViewBody() {
             ))}
           </ul>
         )}
-      </div>
-    </section>
+      </FramedPageBody>
+    </FramedPage>
   );
 }

--- a/packages/ui/src/components/pages/LogsView.test.tsx
+++ b/packages/ui/src/components/pages/LogsView.test.tsx
@@ -3,7 +3,7 @@
 
 /**
  * Renders `LogsView` in jsdom with mocked state/agent-surface to verify the
- * loading skeleton reserves tall row-shaped space and that the first hydration
+ * loading skeleton reserves row-shaped space and that the first hydration
  * swap is flagged transient (no layout-shift flash on initial paint).
  */
 
@@ -86,7 +86,7 @@ afterEach(() => {
 });
 
 describe("LogsView", () => {
-  it("reserves tall row-shaped skeleton space and marks the initial hydration swap transient", async () => {
+  it("reserves row-shaped skeleton space and marks the initial hydration swap transient", async () => {
     let resolveLoad: (() => void) | undefined;
     const loadLogs = vi.fn(
       () =>

--- a/packages/ui/src/components/pages/LogsView.tsx
+++ b/packages/ui/src/components/pages/LogsView.tsx
@@ -5,7 +5,7 @@
  * never flashes mid-hydration. Mountable standalone or inside a modal.
  */
 
-import { ScrollText } from "lucide-react";
+import { ChevronDown, ScrollText } from "lucide-react";
 import {
   memo,
   type ReactNode,
@@ -28,18 +28,20 @@ import { formatTime } from "../../utils/format";
 import { PagePanel } from "../composites/page-panel";
 import { Button } from "../ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { ListSkeleton } from "../ui/skeleton-layouts";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
 const LOG_HYDRATION_SETTLE_MS = 1200;
 const LOG_INITIAL_SKELETON_ROWS = 4;
-const LOG_INITIAL_SKELETON_ROW_CLASS = "h-[11.375rem]";
+const LOG_INITIAL_SKELETON_ROW_CLASS = "h-16";
 
 function logEntryKey(entry: LogEntry, index: number): string {
   return `${entry.timestamp}|${entry.source}|${entry.level}|${index}`;
@@ -57,64 +59,34 @@ function logEntryKey(entry: LogEntry, index: number): string {
 const LogRow = memo(function LogRow({ entry }: { entry: LogEntry }) {
   return (
     <div
-      className="flex flex-col gap-1 p-3 text-sm md:flex-row md:items-start md:gap-3"
+      className="flex min-w-0 items-start gap-3 border-b border-border/35 px-1 py-4 text-sm last:border-b-0"
       data-testid="log-entry"
     >
-      {/* Timestamp */}
-      <span className="shrink-0 whitespace-nowrap text-xs-tight text-muted tabular-nums md:w-[5.75rem]">
-        {formatTime(entry.timestamp, { fallback: "—" })}
-      </span>
-
-      {/* Level */}
+      <div className="min-w-0 flex-1">
+        <p className="break-words font-medium leading-5 text-txt">
+          {entry.message}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs-tight text-muted">
+          <span className="whitespace-nowrap tabular-nums">
+            {formatTime(entry.timestamp, { fallback: "—" })}
+          </span>
+          <span aria-hidden>·</span>
+          <span className="break-words">{entry.source}</span>
+          {(entry.tags ?? []).map((tag) => (
+            <span key={tag}>· {tag}</span>
+          ))}
+        </div>
+      </div>
       <span
-        className={`shrink-0 font-semibold uppercase tracking-[0.08em] text-xs-tight md:w-14 ${
+        className={`shrink-0 text-xs-tight font-semibold uppercase tracking-[0.08em] ${
           entry.level === "error"
             ? "text-danger"
             : entry.level === "warn"
               ? "text-warning"
-              : entry.level === "info"
-                ? "text-muted-strong"
-                : entry.level === "debug"
-                  ? "text-muted"
-                  : "text-muted"
+              : "text-muted"
         }`}
       >
         {entry.level}
-      </span>
-
-      {/* Source */}
-      <span className="min-w-0 shrink-0 break-words text-xs-tight text-muted md:w-20 md:truncate">
-        [{entry.source}]
-      </span>
-
-      {/* Tag badges */}
-      <span className="inline-flex max-w-full shrink-0 flex-wrap gap-1 md:max-w-[14rem]">
-        {(entry.tags ?? []).map((t: string) => {
-          return (
-            <span
-              key={t}
-              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-2xs font-medium ${
-                (
-                  {
-                    agent: "border-accent/25 bg-accent/10 text-txt-strong",
-                    cloud: "border-accent/20 bg-accent/8 text-accent",
-                    plugins: "border-accent/25 bg-accent/10 text-txt-strong",
-                  } as Record<string, string>
-                )[t] ?? "border-border/35 bg-bg-hover text-muted-strong"
-              }`}
-              style={{
-                fontFamily: "var(--font-body, sans-serif)",
-              }}
-            >
-              <span className="break-all">{t}</span>
-            </span>
-          );
-        })}
-      </span>
-
-      {/* Message */}
-      <span className="min-w-0 flex-1 break-words leading-6 text-txt">
-        {entry.message}
       </span>
     </div>
   );
@@ -221,35 +193,11 @@ function LogsViewBody() {
     setSearchQuery("");
   };
 
-  const levelControl = useAgentElement<HTMLButtonElement>({
-    id: "logs-filter-level",
-    role: "select",
-    label: t("logsview.AllLevels"),
+  const filterControl = useAgentElement<HTMLButtonElement>({
+    id: "logs-filter",
+    role: "button",
+    label: "Filter logs",
     group: "logs",
-    options: ["all", "debug", "info", "warn", "error"],
-    getValue: () => (logLevelFilter === "" ? "all" : logLevelFilter),
-    onFill: (value) => setState("logLevelFilter", value === "all" ? "" : value),
-  });
-
-  const sourceControl = useAgentElement<HTMLButtonElement>({
-    id: "logs-filter-source",
-    role: "select",
-    label: t("logsview.AllSources"),
-    group: "logs",
-    options: ["all", ...logSources],
-    getValue: () => (logSourceFilter === "" ? "all" : logSourceFilter),
-    onFill: (value) =>
-      setState("logSourceFilter", value === "all" ? "" : value),
-  });
-
-  const tagControl = useAgentElement<HTMLButtonElement>({
-    id: "logs-filter-tag",
-    role: "select",
-    label: t("logsview.AllTags"),
-    group: "logs",
-    options: ["all", ...logTags],
-    getValue: () => (logTagFilter === "" ? "all" : logTagFilter),
-    onFill: (value) => setState("logTagFilter", value === "all" ? "" : value),
   });
 
   const clearControl = useAgentElement<HTMLButtonElement>({
@@ -293,104 +241,124 @@ function LogsViewBody() {
 
   return (
     <div className="flex h-full flex-col gap-3" data-testid="logs-view">
-      {/* Filters row — filters left, count beside the title */}
-      <PagePanel variant="section" className="space-y-3">
+      <PagePanel
+        variant="section"
+        className="space-y-3 border-b border-border/35 pb-3"
+      >
         <div className="flex items-center justify-between gap-3">
-          <span className="text-xs text-muted tabular-nums">
-            {filteredLogs.length}
-          </span>
-          {errorCount > 0 ? (
-            <span className="text-xs text-danger tabular-nums">
-              {t("logsview.ErrorCount", {
-                count: errorCount,
-                defaultValue: "{{count}} errors",
-              })}
-            </span>
-          ) : null}
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Select
-            value={logLevelFilter === "" ? "all" : logLevelFilter}
-            onValueChange={(val: string) => {
-              setState("logLevelFilter", val === "all" ? "" : val);
-            }}
-          >
-            <SelectTrigger
-              ref={levelControl.ref}
-              className="h-11 w-40 rounded-sm text-sm text-txt"
-              {...levelControl.agentProps}
-            >
-              <SelectValue placeholder={t("logsview.AllLevels")} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{t("logsview.AllLevels")}</SelectItem>
-              <SelectItem value="debug">{t("logsview.Debug")}</SelectItem>
-              <SelectItem value="info">{t("logsview.Info")}</SelectItem>
-              <SelectItem value="warn">{t("logsview.Warn")}</SelectItem>
-              <SelectItem value="error">{t("common.error")}</SelectItem>
-            </SelectContent>
-          </Select>
-
-          <Select
-            value={logSourceFilter === "" ? "all" : logSourceFilter}
-            onValueChange={(val: string) => {
-              setState("logSourceFilter", val === "all" ? "" : val);
-            }}
-          >
-            <SelectTrigger
-              ref={sourceControl.ref}
-              className="h-11 w-40 rounded-sm text-sm text-txt"
-              {...sourceControl.agentProps}
-            >
-              <SelectValue placeholder={t("logsview.AllSources")} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{t("logsview.AllSources")}</SelectItem>
-              {logSources.map((s) => (
-                <SelectItem key={s} value={s}>
-                  {s}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {logTags.length > 0 && (
-            <Select
-              value={logTagFilter === "" ? "all" : logTagFilter}
-              onValueChange={(val: string) => {
-                setState("logTagFilter", val === "all" ? "" : val);
-              }}
-            >
-              <SelectTrigger
-                ref={tagControl.ref}
-                className="h-11 w-40 rounded-sm text-sm text-txt"
-                {...tagControl.agentProps}
-              >
-                <SelectValue placeholder={t("logsview.AllTags")} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t("logsview.AllTags")}</SelectItem>
-                {logTags.map((tag) => (
-                  <SelectItem key={tag} value={tag}>
-                    {tag}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-
-          {hasActiveFilters && (
-            <Button
-              ref={clearControl.ref}
-              variant="outline"
-              size="sm"
-              className="logs-toolbar-button"
-              onClick={handleClearFilters}
-              {...clearControl.agentProps}
-            >
-              {t("logsview.ClearFilters")}
-            </Button>
-          )}
+          <span className="text-sm text-muted">Show</span>
+          <div className="flex items-center gap-3">
+            {errorCount > 0 ? (
+              <span className="text-xs text-danger tabular-nums">
+                {t("logsview.ErrorCount", {
+                  count: errorCount,
+                  defaultValue: "{{count}} errors",
+                })}
+              </span>
+            ) : null}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  ref={filterControl.ref}
+                  variant="ghost"
+                  size="sm"
+                  className="gap-2"
+                  {...filterControl.agentProps}
+                >
+                  <span>{hasActiveFilters ? "Filtered" : "All logs"}</span>
+                  <span className="text-muted tabular-nums">
+                    {filteredLogs.length}
+                  </span>
+                  <ChevronDown className="size-4 text-muted" aria-hidden />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-56">
+                <DropdownMenuLabel>Level</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={logLevelFilter === "" ? "all" : logLevelFilter}
+                  onValueChange={(value) =>
+                    setState("logLevelFilter", value === "all" ? "" : value)
+                  }
+                >
+                  <DropdownMenuRadioItem value="all">
+                    {t("logsview.AllLevels")}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="debug">
+                    {t("logsview.Debug")}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="info">
+                    {t("logsview.Info")}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="warn">
+                    {t("logsview.Warn")}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="error">
+                    {t("common.error")}
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                {logSources.length > 0 ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>Source</DropdownMenuLabel>
+                    <DropdownMenuRadioGroup
+                      value={logSourceFilter === "" ? "all" : logSourceFilter}
+                      onValueChange={(value) =>
+                        setState(
+                          "logSourceFilter",
+                          value === "all" ? "" : value,
+                        )
+                      }
+                    >
+                      <DropdownMenuRadioItem value="all">
+                        {t("logsview.AllSources")}
+                      </DropdownMenuRadioItem>
+                      {logSources.map((source) => (
+                        <DropdownMenuRadioItem key={source} value={source}>
+                          {source}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </>
+                ) : null}
+                {logTags.length > 0 ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>Tag</DropdownMenuLabel>
+                    <DropdownMenuRadioGroup
+                      value={logTagFilter === "" ? "all" : logTagFilter}
+                      onValueChange={(value) =>
+                        setState("logTagFilter", value === "all" ? "" : value)
+                      }
+                    >
+                      <DropdownMenuRadioItem value="all">
+                        {t("logsview.AllTags")}
+                      </DropdownMenuRadioItem>
+                      {logTags.map((tag) => (
+                        <DropdownMenuRadioItem key={tag} value={tag}>
+                          {tag}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </>
+                ) : null}
+                {hasActiveFilters ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    <Button
+                      ref={clearControl.ref}
+                      variant="ghost"
+                      size="sm"
+                      className="w-full justify-start"
+                      onClick={handleClearFilters}
+                      {...clearControl.agentProps}
+                    >
+                      {t("logsview.ClearFilters")}
+                    </Button>
+                  </>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
         {logLoadError ? (
           <div
@@ -414,7 +382,7 @@ function LogsViewBody() {
       <PagePanel
         variant="section"
         data-testid="logs-entry-panel"
-        className="flex-1 min-h-0 overflow-y-auto font-mono text-sm"
+        className="flex-1 min-h-0 overflow-y-auto text-sm"
         {...logPanelShiftIntentProps}
       >
         {initialLoading && filteredLogs.length === 0 && !logLoadError ? (

--- a/packages/ui/src/components/pages/LogsView.tsx
+++ b/packages/ui/src/components/pages/LogsView.tsx
@@ -294,7 +294,7 @@ function LogsViewBody() {
   return (
     <div className="flex h-full flex-col gap-3" data-testid="logs-view">
       {/* Filters row — filters left, count beside the title */}
-      <PagePanel variant="surface" className="space-y-3">
+      <PagePanel variant="section" className="space-y-3">
         <div className="flex items-center justify-between gap-3">
           <span className="text-xs text-muted tabular-nums">
             {filteredLogs.length}
@@ -412,7 +412,7 @@ function LogsViewBody() {
 
       {/* Log entries — full remaining height */}
       <PagePanel
-        variant="surface"
+        variant="section"
         data-testid="logs-entry-panel"
         className="flex-1 min-h-0 overflow-y-auto font-mono text-sm"
         {...logPanelShiftIntentProps}
@@ -423,9 +423,9 @@ function LogsViewBody() {
             rows={LOG_INITIAL_SKELETON_ROWS}
             rowClassName={LOG_INITIAL_SKELETON_ROW_CLASS}
           />
-        ) : filteredLogs.length === 0 ? (
+        ) : filteredLogs.length === 0 && !logLoadError ? (
           <PagePanel.Empty
-            className="flex-1"
+            className="flex-1 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:gap-2 [@media(max-height:480px)]:p-3"
             icon={<ScrollText className="size-6" aria-hidden />}
             title={
               hasActiveFilters

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -1421,7 +1421,7 @@ function MemoryViewerViewForAuthority({
 
   return (
     <ShellViewAgentSurface viewId="memories">
-      <FramedPage>
+      <FramedPage gutterOwner="framed-page">
         <FramedPageHeader
           title={t("memoryviewer.title", { defaultValue: "Memories" })}
           actions={

--- a/packages/ui/src/components/pages/PluginsView.tsx
+++ b/packages/ui/src/components/pages/PluginsView.tsx
@@ -1242,7 +1242,7 @@ function PluginListView({
         {visiblePlugins.length === 0 ? (
           <PagePanel.Empty
             variant="surface"
-            className="min-h-[18rem] px-5 py-10"
+            className="min-h-[18rem] px-5 py-10 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
             description={
               hasActivePluginFilters
                 ? `Try a different search or category filter for ${resultLabel}.`
@@ -1409,7 +1409,7 @@ function PluginListView({
             {sorted.length === 0 && isLoadingPlugins ? (
               <PagePanel.Loading
                 variant="surface"
-                className="min-h-[18rem] px-5 py-10"
+                className="min-h-[18rem] px-5 py-10 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
                 heading={t("pluginsview.LoadingTitle", {
                   defaultValue: "Loading {{label}}…",
                   label: label.toLowerCase(),
@@ -1418,7 +1418,7 @@ function PluginListView({
             ) : sorted.length === 0 && pluginsLoadError ? (
               <PagePanel.Empty
                 variant="surface"
-                className="min-h-[18rem] px-5 py-10"
+                className="min-h-[18rem] px-5 py-10 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
                 description={t("pluginsview.LoadFailedDesc", {
                   defaultValue:
                     "Couldn't load {{label}}: {{error}}. Check your connection and try again.",
@@ -1444,7 +1444,7 @@ function PluginListView({
             ) : sorted.length === 0 && pluginsLoaded ? (
               <PagePanel.Empty
                 variant="surface"
-                className="min-h-[18rem] px-5 py-10"
+                className="min-h-[18rem] px-5 py-10 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
                 description={t("pluginsview.NoneAvailableDesc", {
                   defaultValue: "No {{label}} are available right now.",
                   label: resultLabel,
@@ -1457,7 +1457,7 @@ function PluginListView({
             ) : sorted.length === 0 ? (
               <PagePanel.Loading
                 variant="surface"
-                className="min-h-[18rem] px-5 py-10"
+                className="min-h-[18rem] px-5 py-10 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
                 heading={t("pluginsview.LoadingTitle", {
                   defaultValue: "Loading {{label}}…",
                   label: label.toLowerCase(),
@@ -1466,7 +1466,7 @@ function PluginListView({
             ) : visiblePlugins.length === 0 ? (
               <PagePanel.Empty
                 variant="surface"
-                className="min-h-[16rem] px-5 py-10"
+                className="min-h-[16rem] px-5 py-10 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
                 description={
                   showSubgroupFilters
                     ? t("pluginsview.NoPluginsMatchCategory", {

--- a/packages/ui/src/components/pages/RuntimeView.tsx
+++ b/packages/ui/src/components/pages/RuntimeView.tsx
@@ -6,6 +6,7 @@
  * distinct fetch parameters revalidate independently instead of colliding.
  */
 
+import { Radio } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -552,8 +553,11 @@ export function RuntimeView({
     defaultValue: "Filter sections",
   });
   const chatBinding = useMemo(
-    () => ({ placeholder: filterPlaceholder, onQuery: setSidebarSearch }),
-    [filterPlaceholder],
+    () =>
+      snapshot?.runtimeAvailable
+        ? { placeholder: filterPlaceholder, onQuery: setSidebarSearch }
+        : null,
+    [filterPlaceholder, snapshot?.runtimeAvailable],
   );
   useRegisterViewChatBinding(chatBinding);
 
@@ -709,7 +713,7 @@ export function RuntimeView({
   return (
     <ShellViewAgentSurface viewId="runtime">
       <PageLayout
-        sidebar={runtimeSidebar}
+        sidebar={snapshot?.runtimeAvailable ? runtimeSidebar : undefined}
         contentHeader={contentHeader}
         data-testid="runtime-view"
       >
@@ -721,17 +725,25 @@ export function RuntimeView({
           {loading && !snapshot ? (
             <DetailSkeleton className="min-h-[24rem]" />
           ) : !snapshot ? (
-            <PagePanel.Empty
-              className="min-h-[24rem] [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
-              description={t("runtimeview.loadingDescription")}
-              title={t("runtimeview.noSnapshotAvailable")}
-            />
+            <div className="grid min-h-[24rem] flex-1 place-items-center px-6 text-center [@media(max-height:480px)]:min-h-[9rem]">
+              <div className="flex max-w-sm flex-col items-center gap-3 text-muted">
+                <Radio className="size-6" aria-hidden />
+                <p className="text-sm">
+                  {t("runtimeview.noSnapshotAvailable")}{" "}
+                  {t("runtimeview.loadingDescription")}
+                </p>
+              </div>
+            </div>
           ) : !snapshot.runtimeAvailable ? (
-            <PagePanel.Empty
-              className="min-h-[24rem] text-warning [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
-              description={t("runtimeview.runtimePendingDescription")}
-              title={t("runtimeview.AgentRuntimeIsNot")}
-            />
+            <div className="grid min-h-[24rem] flex-1 place-items-center px-6 text-center [@media(max-height:480px)]:min-h-[9rem]">
+              <div className="flex max-w-sm flex-col items-center gap-3 text-muted">
+                <Radio className="size-6" aria-hidden />
+                <p className="text-sm">
+                  {t("runtimeview.AgentRuntimeIsNot")}{" "}
+                  {t("runtimeview.runtimePendingDescription")}
+                </p>
+              </div>
+            </div>
           ) : activeSection === "summary" ? (
             <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,22rem),1fr))] gap-4">
               <OrderCard

--- a/packages/ui/src/components/pages/RuntimeView.tsx
+++ b/packages/ui/src/components/pages/RuntimeView.tsx
@@ -722,15 +722,13 @@ export function RuntimeView({
             <DetailSkeleton className="min-h-[24rem]" />
           ) : !snapshot ? (
             <PagePanel.Empty
-              variant="panel"
-              className="min-h-[24rem]"
+              className="min-h-[24rem] [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
               description={t("runtimeview.loadingDescription")}
               title={t("runtimeview.noSnapshotAvailable")}
             />
           ) : !snapshot.runtimeAvailable ? (
             <PagePanel.Empty
-              variant="panel"
-              className="min-h-[24rem] border-warning/25 bg-warning/10 text-warning"
+              className="min-h-[24rem] text-warning [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
               description={t("runtimeview.runtimePendingDescription")}
               title={t("runtimeview.AgentRuntimeIsNot")}
             />

--- a/packages/ui/src/components/pages/SkillsView.test.tsx
+++ b/packages/ui/src/components/pages/SkillsView.test.tsx
@@ -26,6 +26,7 @@ import { SkillsView } from "./SkillsView";
 const appMock = vi.hoisted(() => ({
   value: {} as Record<string, unknown>,
 }));
+const mediaMock = vi.hoisted(() => ({ wideWorkspace: false }));
 
 vi.mock("../../state", () => ({
   useApp: () => appMock.value,
@@ -33,6 +34,10 @@ vi.mock("../../state", () => ({
     sel(appMock.value),
   useAppSelectorShallow: (sel: (value: Record<string, unknown>) => unknown) =>
     sel(appMock.value),
+}));
+
+vi.mock("../../hooks/useMediaQuery", () => ({
+  useMediaQuery: () => mediaMock.wideWorkspace,
 }));
 
 // Translation passthrough: return the provided defaultValue (or key) so we can
@@ -87,12 +92,40 @@ const SKILL_B: SkillInfo = {
 };
 
 beforeEach(() => {
+  mediaMock.wideWorkspace = false;
   appMock.value = makeContext();
 });
 
 afterEach(() => cleanup());
 
 describe("SkillsView", () => {
+  it("uses one continuous wide workspace without duplicating the empty message", () => {
+    mediaMock.wideWorkspace = true;
+
+    render(<SkillsView />);
+
+    expect(screen.queryByTestId("skills-sidebar")).toBeNull();
+    expect(screen.getAllByText("No Skills Installed")).toHaveLength(1);
+  });
+
+  it("exposes skill filters as pressed-state toggle buttons", () => {
+    mediaMock.wideWorkspace = true;
+    appMock.value = makeContext({ skills: [SKILL_A, SKILL_B] });
+
+    render(<SkillsView />);
+
+    expect(
+      screen
+        .getByRole("button", { name: "All (2)" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("button", { name: "common.on (1)" })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
   it("calls loadSkills on mount and renders the empty state when no skills exist", async () => {
     render(<SkillsView />);
 

--- a/packages/ui/src/components/pages/SkillsView.tsx
+++ b/packages/ui/src/components/pages/SkillsView.tsx
@@ -10,7 +10,8 @@ import { memo, type ReactNode, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import type { SkillInfo } from "../../api";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
-import { PageLayout } from "../../layouts/page-layout/page-layout";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+import { WorkspaceLayout } from "../../layouts/workspace-layout";
 import { useAppSelectorShallow } from "../../state";
 import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { PagePanel } from "../composites/page-panel";
@@ -57,7 +58,7 @@ function SkillFilterTab({
       size="badge"
       data-state={isActive ? "on" : "off"}
       type="button"
-      aria-current={isActive ? "true" : undefined}
+      aria-pressed={isActive}
       onClick={onSelect}
       {...agentProps}
     >
@@ -142,6 +143,10 @@ function SkillsFullViewContent({
 }: {
   contentHeader?: ReactNode;
 } = {}) {
+  const isWideSkillsWorkspace = useMediaQuery(
+    "(min-width: 820px) and (min-height: 600px)",
+  );
+  const isShortViewport = useMediaQuery("(max-height: 480px)");
   const {
     skills,
     skillCreateFormOpen,
@@ -374,7 +379,111 @@ function SkillsFullViewContent({
     },
   });
 
-  const skillsSidebar = (
+  const skillsCollectionContent = (
+    <>
+      {isWideSkillsWorkspace || skills.length > 0 ? (
+        <SidebarContent.Toolbar className="mb-3">
+          <SidebarContent.ToolbarPrimary
+            className={isWideSkillsWorkspace ? "flex-none" : undefined}
+          >
+            <Button
+              ref={newSkillButton.ref}
+              variant={skillCreateFormOpen ? "outlineMuted" : "default"}
+              size="pill"
+              type="button"
+              className={isWideSkillsWorkspace ? undefined : "w-full"}
+              onClick={() => {
+                setState("skillCreateFormOpen", !skillCreateFormOpen);
+                if (skillCreateFormOpen) handleCancelCreate();
+              }}
+              {...newSkillButton.agentProps}
+            >
+              {skillCreateFormOpen
+                ? t("common.cancel")
+                : `+ ${t("skillsview.NewSkill", { defaultValue: "New Skill" })}`}
+            </Button>
+          </SidebarContent.ToolbarPrimary>
+          <SidebarContent.ToolbarActions>
+            <Button
+              ref={installButton.ref}
+              variant="outline"
+              size="pill"
+              type="button"
+              onClick={() => setInstallModalOpen(true)}
+              {...installButton.agentProps}
+            >
+              {t("common.install", { defaultValue: "Install" })}
+            </Button>
+          </SidebarContent.ToolbarActions>
+        </SidebarContent.Toolbar>
+      ) : null}
+
+      {skills.length > 0 ? (
+        <div className="mb-3 flex flex-wrap gap-2">
+          {filterTabs.map((tab) => (
+            <SkillFilterTab
+              key={tab.key}
+              tabKey={tab.key}
+              label={tab.label}
+              isActive={filterTab === tab.key}
+              onSelect={() => setFilterTab(tab.key)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {filteredSkills.length === 0 &&
+      isWideSkillsWorkspace &&
+      skills.length === 0 ? null : filteredSkills.length === 0 ? (
+        <SidebarContent.EmptyState>
+          {skills.length === 0
+            ? t("skillsview.noSkillsInstalled", {
+                defaultValue: "No Skills Installed",
+              })
+            : t("skillsview.noSkillsMatchFilter", {
+                defaultValue: 'No skills match "{{filter}}"',
+                filter: filterText,
+              })}
+        </SidebarContent.EmptyState>
+      ) : (
+        <div className="space-y-1.5">
+          {filteredSkills.map((skill) => {
+            const needsAttention =
+              skill.scanStatus === "warning" ||
+              skill.scanStatus === "critical" ||
+              skill.scanStatus === "blocked";
+            const selected = selectedSkillId === skill.id;
+
+            return (
+              <SkillRowButton
+                key={skill.id}
+                skill={skill}
+                active={selected}
+                enabled={skill.enabled}
+                icon={skill.name.charAt(0).toUpperCase()}
+                description={skill.description || t("skillsview.noDescription")}
+                onLabel={t("common.on")}
+                offLabel={t("common.off")}
+                onSelect={() => {
+                  setSelectedId(skill.id);
+                  setState("skillCreateFormOpen", false);
+                }}
+                attentionLabel={
+                  needsAttention
+                    ? skill.scanStatus === "blocked"
+                      ? t("skillsview.statusBlocked")
+                      : t("skillsview.statusWarning")
+                    : undefined
+                }
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+
+  const skillsSidebar = !isWideSkillsWorkspace ? (
     <AppPageSidebar
       testId="skills-sidebar"
       collapsible
@@ -402,136 +511,75 @@ function SkillsFullViewContent({
       })}
     >
       <SidebarScrollRegion>
-        <SidebarPanel>
-          <SidebarContent.Toolbar className="mb-3">
-            <SidebarContent.ToolbarPrimary>
-              <Button
-                ref={newSkillButton.ref}
-                variant={skillCreateFormOpen ? "outlineMuted" : "default"}
-                size="pill"
-                type="button"
-                className="w-full"
-                onClick={() => {
-                  setState("skillCreateFormOpen", !skillCreateFormOpen);
-                  if (skillCreateFormOpen) {
-                    handleCancelCreate();
-                  }
-                }}
-                {...newSkillButton.agentProps}
-              >
-                {skillCreateFormOpen
-                  ? t("common.cancel")
-                  : `+ ${t("skillsview.NewSkill", { defaultValue: "New Skill" })}`}
-              </Button>
-            </SidebarContent.ToolbarPrimary>
-            <SidebarContent.ToolbarActions>
-              <Button
-                ref={installButton.ref}
-                variant="outline"
-                size="pill"
-                type="button"
-                onClick={() => setInstallModalOpen(true)}
-                {...installButton.agentProps}
-              >
-                {t("common.install", { defaultValue: "Install" })}
-              </Button>
-            </SidebarContent.ToolbarActions>
-          </SidebarContent.Toolbar>
-
-          <div className="mb-3 flex flex-wrap gap-2">
-            {filterTabs.map((tab) => (
-              <SkillFilterTab
-                key={tab.key}
-                tabKey={tab.key}
-                label={tab.label}
-                isActive={filterTab === tab.key}
-                onSelect={() => setFilterTab(tab.key)}
-              />
-            ))}
-          </div>
-
-          {filteredSkills.length === 0 ? (
-            <SidebarContent.EmptyState>
-              {skills.length === 0
-                ? t("skillsview.noSkillsInstalled", {
-                    defaultValue: "No Skills Installed",
-                  })
-                : t("skillsview.noSkillsMatchFilter", {
-                    defaultValue: 'No skills match "{{filter}}"',
-                    filter: filterText,
-                  })}
-            </SidebarContent.EmptyState>
-          ) : (
-            <div className="space-y-1.5">
-              {filteredSkills.map((skill) => {
-                const needsAttention =
-                  skill.scanStatus === "warning" ||
-                  skill.scanStatus === "critical" ||
-                  skill.scanStatus === "blocked";
-                const selected = selectedSkillId === skill.id;
-
-                return (
-                  <SkillRowButton
-                    key={skill.id}
-                    skill={skill}
-                    active={selected}
-                    enabled={skill.enabled}
-                    icon={skill.name.charAt(0).toUpperCase()}
-                    description={
-                      skill.description || t("skillsview.noDescription")
-                    }
-                    onLabel={t("common.on")}
-                    offLabel={t("common.off")}
-                    onSelect={() => {
-                      setSelectedId(skill.id);
-                      setState("skillCreateFormOpen", false);
-                    }}
-                    attentionLabel={
-                      needsAttention
-                        ? skill.scanStatus === "blocked"
-                          ? t("skillsview.statusBlocked")
-                          : t("skillsview.statusWarning")
-                        : undefined
-                    }
-                  />
-                );
-              })}
-            </div>
-          )}
-        </SidebarPanel>
+        <SidebarPanel>{skillsCollectionContent}</SidebarPanel>
       </SidebarScrollRegion>
     </AppPageSidebar>
-  );
+  ) : undefined;
 
   return (
     <>
-      <PageLayout
+      <WorkspaceLayout
         data-testid="skills-shell"
         sidebar={skillsSidebar}
         contentHeader={contentHeader}
-        contentInnerClassName="mx-auto w-full max-w-[76rem]"
+        contentInnerClassName="mx-auto w-full max-w-4xl"
+        headerPlacement="outside"
       >
+        {isWideSkillsWorkspace ? (
+          <PagePanel variant="section" className="mb-4 p-4 sm:px-5">
+            {skillsCollectionContent}
+          </PagePanel>
+        ) : null}
         <div data-testid="skills-detail">
           <PagePanel variant="section">
             <div className="p-4 sm:px-5">
               {skills.length === 0 && !skillCreateFormOpen ? (
                 <div
                   data-testid="skills-empty-state"
-                  className="flex min-h-[20rem]"
+                  className={`flex ${isShortViewport ? "min-h-[7rem]" : "min-h-[20rem]"}`}
                 >
                   <PagePanel.Empty
-                    className="flex-1"
+                    className={`flex-1 ${isShortViewport ? "min-h-[7rem] gap-2 p-2" : ""}`}
                     icon={<Brain className="size-6" aria-hidden />}
                     title={t("skillsview.noSkillsInstalled", {
                       defaultValue: "No Skills Installed",
                     })}
+                    action={
+                      !isWideSkillsWorkspace ? (
+                        <div className="flex flex-wrap justify-center gap-2">
+                          <Button
+                            ref={newSkillButton.ref}
+                            variant="default"
+                            size="pill"
+                            type="button"
+                            onClick={() =>
+                              setState("skillCreateFormOpen", true)
+                            }
+                            {...newSkillButton.agentProps}
+                          >
+                            {t("skillsview.NewSkill", {
+                              defaultValue: "New Skill",
+                            })}
+                          </Button>
+                          <Button
+                            ref={installButton.ref}
+                            variant="outline"
+                            size="pill"
+                            type="button"
+                            onClick={() => setInstallModalOpen(true)}
+                            {...installButton.agentProps}
+                          >
+                            {t("common.install", { defaultValue: "Install" })}
+                          </Button>
+                        </div>
+                      ) : undefined
+                    }
                   />
                 </div>
               ) : filteredSkills.length === 0 && !skillCreateFormOpen ? (
                 <PagePanel.Empty
                   data-testid="skills-filter-empty"
-                  variant="surface"
-                  className="min-h-[16rem] rounded-sm px-6 py-12"
+                  className="min-h-[16rem] px-6 py-12 [@media(max-height:480px)]:min-h-[9rem] [@media(max-height:480px)]:py-3"
                   title={t("skillsview.noMatchingSkills", {
                     defaultValue: "No matching skills",
                   })}
@@ -794,22 +842,12 @@ function SkillsFullViewContent({
                       <PagePanel.Notice tone="accent">
                         {t("skillsview.LoadingScanReport")}
                       </PagePanel.Notice>
-                    ) : (
-                      <PagePanel variant="inset" className="p-4 sm:p-5">
-                        <div className="text-sm leading-relaxed text-muted">
-                          {t("skillsview.SkillSourceEditorDescription", {
-                            defaultValue:
-                              "Open the skill source editor to inspect or modify `SKILL.md`, or review findings here when a skill needs attention.",
-                          })}
-                        </div>
-                      </PagePanel>
-                    )}
+                    ) : null}
                   </div>
                 </PagePanel>
               ) : (
                 <PagePanel.Empty
-                  variant="surface"
-                  className="min-h-[16rem] rounded-sm px-6 py-12"
+                  className="min-h-[16rem] px-6 py-12"
                   title={t("skillsview.SelectATalentToConf", {
                     defaultValue: "Select a talent to configure",
                   })}
@@ -818,7 +856,7 @@ function SkillsFullViewContent({
             </div>
           </PagePanel>
         </div>
-      </PageLayout>
+      </WorkspaceLayout>
       {editingSkill && (
         <EditSkillModal
           skillId={editingSkill.id}

--- a/packages/ui/src/components/pages/TasksPageView.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.tsx
@@ -167,7 +167,7 @@ export function TasksPageView() {
   );
   return (
     <ShellViewAgentSurface viewId="tasks">
-      <FramedPage data-testid="tasks-view">
+      <FramedPage gutterOwner="framed-page" data-testid="tasks-view">
         <FramedPageHeader title="Projects" />
         <FramedPageNavigation>{segmentControl}</FramedPageNavigation>
         <FramedPageBody scroll="view" padded={false} className="device-layout">

--- a/packages/ui/src/components/pages/VaultPageView.tsx
+++ b/packages/ui/src/components/pages/VaultPageView.tsx
@@ -16,7 +16,11 @@ import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 export function VaultPageView(): React.JSX.Element {
   return (
     <ShellViewAgentSurface viewId="vault">
-      <FramedPage data-testid="vault-page" data-chat-clearance-aware="true">
+      <FramedPage
+        gutterOwner="framed-page"
+        data-testid="vault-page"
+        data-chat-clearance-aware="true"
+      >
         <FramedPageHeader
           title="Vault"
           description="Encrypted credentials and references available to this agent. Organization credential pools remain managed in Eliza Cloud."

--- a/packages/ui/src/components/transcripts/LiveMeetingPage.tsx
+++ b/packages/ui/src/components/transcripts/LiveMeetingPage.tsx
@@ -22,7 +22,6 @@ import { Radio } from "lucide-react";
 import * as React from "react";
 import { client } from "../../api/client";
 import { parseMeetingStatusEvent } from "../../api/client-meetings";
-import { ViewHeader } from "../shared/ViewHeader";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { LiveMeetingPane } from "./LiveMeetingPane";
 import { MeetingJoinBar } from "./MeetingJoinBar";
@@ -173,7 +172,6 @@ export function LiveMeetingPage(): React.JSX.Element {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
-      <ViewHeader title="Live meeting" />
       <ShellViewAgentSurface viewId="transcripts">
         <div
           data-testid="live-meeting-page"

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -3234,6 +3234,7 @@
   "filesview.facet.video": "Video",
   "filesview.filterByType": "Filter files by type",
   "filesview.listLabel": "Files",
+  "filesview.moreActions": "More actions",
   "filesview.loadFailed": "Failed to load files: {{message}}",
   "filesview.loading": "Loading files…",
   "filesview.noMatchesDescription": "Try a different type filter.",

--- a/packages/ui/src/layouts/framed-page/framed-page.tsx
+++ b/packages/ui/src/layouts/framed-page/framed-page.tsx
@@ -1,36 +1,60 @@
 /**
- * Canonical anatomy for ordinary framed product pages. It fixes header,
- * navigation, content-width, scrolling, and composer-clearance geometry while
- * leaving full-canvas surfaces outside this boundary.
+ * Canonical inner anatomy for ordinary framed product pages. PageFrame owns
+ * the single outer width and gutter; this layer aligns header, navigation, and
+ * body to that inherited edge while owning view scrolling and composer
+ * clearance. Full-canvas surfaces stay outside this boundary.
  */
-import type { HTMLAttributes, ReactNode } from "react";
+import {
+  createContext,
+  type HTMLAttributes,
+  type ReactNode,
+  useContext,
+} from "react";
 
 import { ViewHeader } from "../../components/shared/ViewHeader";
 import { cn } from "../../lib/utils";
 
 export interface FramedPageProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
+  /** Names the one layer responsible for the route's outer X-axis gutter. */
+  gutterOwner: "page-frame" | "framed-page";
   reserveComposer?: boolean;
+}
+
+const FramedPageGutterOwnerContext = createContext<
+  FramedPageProps["gutterOwner"] | null
+>(null);
+
+function useFramedPageGutterOwner(): FramedPageProps["gutterOwner"] {
+  const owner = useContext(FramedPageGutterOwnerContext);
+  if (owner === null) {
+    throw new Error("Framed page regions must be nested inside FramedPage");
+  }
+  return owner;
 }
 
 export function FramedPage({
   className,
   children,
+  gutterOwner,
   reserveComposer = true,
   ...props
 }: FramedPageProps) {
   return (
-    <div
-      className={cn(
-        "flex h-full min-h-0 w-full min-w-0 flex-col",
-        reserveComposer && "pb-[var(--eliza-chat-clearance,5.25rem)]",
-        className,
-      )}
-      data-framed-page=""
-      {...props}
-    >
-      {children}
-    </div>
+    <FramedPageGutterOwnerContext.Provider value={gutterOwner}>
+      <div
+        className={cn(
+          "flex h-full min-h-0 w-full min-w-0 flex-col",
+          reserveComposer && "pb-[var(--eliza-chat-clearance,5.25rem)]",
+          className,
+        )}
+        data-framed-page=""
+        data-framed-page-gutter-owner={gutterOwner}
+        {...props}
+      >
+        {children}
+      </div>
+    </FramedPageGutterOwnerContext.Provider>
   );
 }
 
@@ -53,9 +77,12 @@ export function FramedPageHeader({
   showBack,
   className,
 }: FramedPageHeaderProps) {
+  const gutterOwner = useFramedPageGutterOwner();
+  const inheritsPageFrameGutter = gutterOwner === "page-frame";
   return (
     <div className={cn("shrink-0", className)} data-framed-page-header="">
       <ViewHeader
+        className={inheritsPageFrameGutter ? "px-0 sm:px-0" : undefined}
         title={title}
         right={actions}
         onBack={onBack}
@@ -63,7 +90,12 @@ export function FramedPageHeader({
         showBack={showBack}
       />
       {description ? (
-        <div className="mx-auto w-full max-w-5xl px-4 pb-3 text-sm text-muted sm:px-6 lg:px-8">
+        <div
+          className={cn(
+            "mx-auto w-full max-w-5xl pb-3 text-sm text-muted",
+            !inheritsPageFrameGutter && "px-4 sm:px-6 lg:px-8",
+          )}
+        >
           {description}
         </div>
       ) : null}
@@ -74,20 +106,23 @@ export function FramedPageHeader({
 export interface FramedPageNavigationProps
   extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
+  /** Adds a local inset only for deliberately nested navigation regions. */
   padded?: boolean;
 }
 
 export function FramedPageNavigation({
   children,
   className,
-  padded = true,
+  padded,
   ...props
 }: FramedPageNavigationProps) {
+  const gutterOwner = useFramedPageGutterOwner();
+  const usesLocalPadding = padded ?? gutterOwner === "framed-page";
   return (
     <div
       className={cn(
         "mx-auto w-full max-w-5xl min-w-0 shrink-0 pb-2",
-        padded && "px-4 sm:px-6 lg:px-8",
+        usesLocalPadding && "px-4 sm:px-6 lg:px-8",
         className,
       )}
       data-framed-page-navigation=""
@@ -101,6 +136,7 @@ export function FramedPageNavigation({
 export interface FramedPageBodyProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   scroll?: "page" | "view";
+  /** Adds a local inset only when the body is a deliberately nested region. */
   padded?: boolean;
 }
 
@@ -108,14 +144,16 @@ export function FramedPageBody({
   children,
   className,
   scroll = "page",
-  padded = true,
+  padded,
   ...props
 }: FramedPageBodyProps) {
+  const gutterOwner = useFramedPageGutterOwner();
+  const usesLocalPadding = padded ?? gutterOwner === "framed-page";
   return (
     <div
       className={cn(
         "mx-auto flex min-h-0 w-full max-w-5xl min-w-0 flex-1 flex-col",
-        padded && "px-4 sm:px-6 lg:px-8",
+        usesLocalPadding && "px-4 sm:px-6 lg:px-8",
         scroll === "page"
           ? "eliza-chat-scroll overflow-y-auto"
           : "overflow-hidden",

--- a/packages/ui/src/layouts/page-layout/page-layout-types.ts
+++ b/packages/ui/src/layouts/page-layout/page-layout-types.ts
@@ -8,7 +8,8 @@ import type { WorkspaceLayoutProps } from "../workspace-layout/workspace-layout-
 
 export interface PageLayoutProps
   extends Omit<WorkspaceLayoutProps, "headerPlacement" | "sidebar"> {
-  sidebar: React.ReactElement<SidebarProps>;
+  /** Optional master-navigation pane; omit it for loading and unavailable states. */
+  sidebar?: React.ReactElement<SidebarProps>;
 }
 
 export interface PageLayoutMobileDrawerProps {

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsPage.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsPage.tsx
@@ -14,7 +14,7 @@ export function RelationshipsPage({
   pageChrome?: ReactNode;
 }): JSX.Element {
   return (
-    <FramedPage reserveComposer={false}>
+    <FramedPage gutterOwner="framed-page" reserveComposer={false}>
       {pageChrome}
       <FramedPageBody>
         <RelationshipsView />


### PR DESCRIPTION
Closes #29724.

## What changed

- Gives Transcripts, Files, Plugins, Skills, Runtime, and Logs the same routed page hierarchy and compact-screen behavior.
- Removes the duplicated Transcripts header and the desktop Skills inspector split; Skills now uses one continuous collection/detail flow, with the canonical drawer on compact screens.
- Replaces card-like Files rows and Logs/Runtime empty surfaces with continuous, readable page content. Files now uses one compact type filter, stable rows, one primary download action, and an overflow menu for secondary actions. Runtime unavailable states now match Transcripts and suppress irrelevant sidebar/search controls; Logs uses one filter menu and scan-first rows.
- Keeps populated Files controls and Skills empty-state actions clear of the floating composer in short landscape.
- Makes outer-gutter ownership explicit on every canonical `FramedPage`; `PageFrame`-owned routes can no longer silently stack a second framed-page inset.
- Regenerates the fail-closed molecular inventory after the component composition changes.

## Sync and verification

- Rebased onto `origin/develop` at `cf259c1bd4094d184112ef929e0c6964726e2594` with no conflicts.
- Exact PR head: `58c488bc7ba93030d831ca2b8fefb8b90a046cf0`.
- `bun run verify`: passed, 375/375 workspace tasks.
- Focused Files, Skills, and Logs tests: 23 passed.
- UI typecheck and Biome: passed.
- Design-system audit: 0 violations.
- Design-contract graph: 0 findings, 0 debt, and 0 raw capability claims inside inferred molecules.
- Exact-route capture suite: 44 final screenshots across desktop, tablet, portrait, and short landscape.
- Three independent adversarial HIG audits completed; every confirmed in-scope finding was addressed.
- Responsive Files geometry smoke: 4/4 across desktop, tablet, mobile portrait, and short landscape; the rendered list and filter edges must equal the canonical page-content edge.
- Runtime and Logs exact-route browser review: 6/6 across desktop, mobile portrait, and short landscape.

The full app audit executed 215 checks: 214 passed. Its aggregate strict verdict remains red for pre-existing low-content Camera, Rolodex, and Cockpit fixtures plus the untouched Projects/Apps hub. None of the six routes changed here received a `broken` or `needs-work` verdict.

## Evidence gate

<!-- evidence-head:58c488bc7ba93030d831ca2b8fefb8b90a046cf0 -->

- [x] Individual before and after screenshots are paired below; no composites.
- [x] Desktop and short-landscape states are shown for every affected route.
- [x] Populated evidence is used where row density and composer clearance matter.
- [x] Backend logs: N/A — renderer-only layout changes.
- [x] Model trajectory: N/A — no model, prompt, provider, or action behavior changed.
- [x] Manual full-resolution review completed after the exact-head capture.

## Visual evidence

### Transcripts — desktop

| Before | After |
| --- | --- |
| [![Transcripts desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-desktop-before.png) | [![Transcripts desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-desktop-after.png) |

### Transcripts — short landscape

| Before | After |
| --- | --- |
| [![Transcripts landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-landscape-before.png) | [![Transcripts landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-transcripts-landscape-after.png) |

### Files — populated desktop

| Before | After |
| --- | --- |
| [![Files desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-desktop-before.png) | [![Files desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-desktop-after.png) |

### Files — populated short landscape

| Before | After |
| --- | --- |
| [![Files landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-landscape-before.png) | [![Files landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-landscape-after.png) |

### Files — empty desktop

| Prior PR revision | Final |
| --- | --- |
| [![Files empty desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-desktop-before.png) | [![Files empty desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-desktop-after.png) |

### Files — empty tablet

| Prior PR revision | Final |
| --- | --- |
| [![Files empty tablet before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-tablet-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-tablet-before.png) | [![Files empty tablet after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-tablet-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-tablet-after.png) |

### Files — empty portrait

| Prior PR revision | Final |
| --- | --- |
| [![Files empty portrait before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-portrait-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-portrait-before.png) | [![Files empty portrait after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-portrait-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-portrait-after.png) |

### Files — empty short landscape

| Prior PR revision | Final |
| --- | --- |
| [![Files empty landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-landscape-before.png) | [![Files empty landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-empty-landscape-after.png) |

### Files — populated mobile portrait

| Before | After |
| --- | --- |
| [![Files populated portrait before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-populated-portrait-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-populated-portrait-before.png) | [![Files populated portrait after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-populated-portrait-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-populated-portrait-after.png) |

### Files — populated tablet

[![Files populated tablet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-populated-tablet-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-populated-tablet-after.png)

### Files — disclosure menus

| Type filter — portrait | Row actions — short landscape |
| --- | --- |
| [![Files filter menu portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-filter-menu-portrait-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-filter-menu-portrait-after.png) | [![Files action menu landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-action-menu-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-files-action-menu-landscape-after.png) |

### Plugins — desktop

| Before | After |
| --- | --- |
| [![Plugins desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-desktop-before.png) | [![Plugins desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-desktop-after.png) |

### Plugins — short landscape

| Before | After |
| --- | --- |
| [![Plugins landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-landscape-before.png) | [![Plugins landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-plugins-landscape-after.png) |

### Skills — desktop

| Before | After |
| --- | --- |
| [![Skills desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-desktop-before.png) | [![Skills desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-desktop-after.png) |

### Skills — short landscape

| Before | After |
| --- | --- |
| [![Skills landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-landscape-before.png) | [![Skills landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-skills-landscape-after.png) |

### Runtime — desktop

| Before | After |
| --- | --- |
| [![Runtime desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-desktop-before.png) | [![Runtime desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-desktop-after.png) |

### Runtime — short landscape

| Before | After |
| --- | --- |
| [![Runtime landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-landscape-before.png) | [![Runtime landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-runtime-landscape-after.png) |

### Logs — populated desktop

| Before | After |
| --- | --- |
| [![Logs desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-desktop-before.png) | [![Logs desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-desktop-after.png) |

### Logs — populated short landscape

| Before | After |
| --- | --- |
| [![Logs landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-landscape-before.png) | [![Logs landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29724-logs-landscape-after.png) |

## Evidence notes

- Baseline captures come from untouched `origin/develop` at `cf259c1bd4094d184112ef929e0c6964726e2594`.
- Final captures come from the same deterministic API fixtures and the exact UI source in this PR head.
- The local final evidence folder also includes tablet and portrait captures for all six routes plus populated Files, Plugins, Skills, Runtime, and Logs states.
