### PR TITLE
fix(lifeops): repair the cross-channel search fixture so its pagination assertions run

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.test.ts
@@ -18,7 +18,7 @@ function memoryAt(index: number): Memory {
       `00000000-0000-4000-8001-${String(index).padStart(12, "0")}` as UUID,
     agentId: "00000000-0000-0000-0000-000000000002" as UUID,
     roomId: ROOM_ID,
-    content: { text: `complete memory ${index}`, source: "discord" },
+    content: { text: `complete memory ${index}`, source: "memory" },
     createdAt: index,
   };
 }
@@ -41,7 +41,7 @@ describe("cross-channel search context integrity", () => {
       searchMemories,
       getRoom: vi.fn(
         async () =>
-          ({ id: ROOM_ID, name: "complete room", source: "discord" }) as Room,
+          ({ id: ROOM_ID, name: "complete room", source: "memory" }) as Room,
       ),
     } as unknown as IAgentRuntime;
 


### PR DESCRIPTION
# Relates to

Closes #29730.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Repairs a suite that is failing on `develop` right now inside `canonical / Tests (client)`.
- [x] Changes no runtime source — the diff is two fixture lines.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] One file differs: `+2/-2`.

# Risks

None to runtime. No production file is touched. The change makes a fixture consistent
with the query the test already issues, and it strictly *increases* what is verified:
two assertions that have never executed now run.

# Background

## What is broken

`canonical / Tests (client)` fails on `develop`, and `@elizaos/plugin-personal-assistant`
exits 1. One of its failures is deterministic and reproduces locally at the current tip:

```
FAIL plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.test.ts
  > returns every memory across internal pages even when a legacy limit is supplied
AssertionError: expected [] to have a length of 501 but got +0
```

[Failing job](https://github.com/elizaOS/eliza/actions/runs/33148332250/job/98774876417)

## Root cause

The test builds 501 memories in a room mocked as `source: "discord"`, then queries with
`channels: ["memory"]`. `memoriesToHits` classifies each memory by **its room's
platform**, not by the search that produced it:

```ts
const platformSource = roomRecord?.source ?? roomRecord?.type;
const channel = classifyMemoryChannel(platformSource);
if (!isChannelEnabled(channel, query.channels)) continue;
```

`classifyMemoryChannel("discord")` is `"discord"`, and
`isChannelEnabled("discord", ["memory"])` is `false` — so all 501 are dropped.

## The retrieval under test is correct

Instrumenting the run isolates the failure to the fixture:

```
DEGRADED: []
HITS: 0
searchMemories calls: 2
first call args: [{"embedding":[0.1,0.2,0.3],"tableName":"messages",
                   "match_threshold":0.55,"limit":500,"offset":0}]
```

Two pages, `limit: 500`, offsets `0` and `500`, no degradation. The caller's `limit: 1`
is correctly ignored — exactly the contract the suite exists to protect.

## Why it has never passed

The file was added by **#28112 (`4333300926`, 2026-08-25)**. Diffing
`cross-channel-search.ts` against that commit's parent (`094f80ad`) shows #28112 rewrote
`searchAgentMemory` from one capped `searchMemories` call into the paging loop and left
`memoriesToHits` and its channel filter **untouched**. The filter is pre-existing; the
new fixture chose a room source it excludes.

Because `expect(result.hits).toHaveLength(501)` is the first assertion, the two
`searchMemories` call assertions after it have **never executed**. This is not added
coverage — it is a suite that has never verified the contract it was written for.

## What is the fix?

Make the fixture a memory-channel room, matching the `channels: ["memory"]` the test
already asks for. `classifyMemoryChannel` returns `"memory"` for any unrecognized source.

```diff
-    content: { text: `complete memory ${index}`, source: "discord" },
+    content: { text: `complete memory ${index}`, source: "memory" },
...
-          ({ id: ROOM_ID, name: "complete room", source: "discord" }) as Room,
+          ({ id: ROOM_ID, name: "complete room", source: "memory" }) as Room,
```

If the intent was instead to prove that memories from **platform** rooms survive
pagination, the alternative is to widen the query to `channels: ["memory", "discord"]`
and keep the discord fixture. That is a product-intent call for the owner of #28112 and
I have deliberately not made it here — the fixture repair matches the test's stated
purpose and changes no behavior. Happy to switch if the wider assertion is wanted.

# Documentation changes needed?

No. Test fixture only.

# Testing

## Where should a reviewer start?

The mutation block, then the fact that two assertions newly execute.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `vitest run src/lifeops/cross-channel-search.test.ts` | **1 passed** (was 1 failed on `develop`) |
| `searchMemories` call assertions (`limit: 500`, offsets `0`/`500`) | now execute, and pass |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| diff vs `develop` | `+2/-2`, one test file, zero runtime files |

Mutation resistance — restoring **only** develop's fixture:

```
AssertionError: expected [] to have a length of 501 but got +0
 Tests  1 failed (1)
```

Byte-for-byte the assertion the hosted `canonical / Tests (client)` job fails with, so
the local reproduction and the CI failure are the same failure.

# Evidence Gate

<!-- evidence-head:305ad2d742d8eb2454d273dd5951043c493dca07 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test fixture repair; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test fixture repair; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable result is the suite's pass/fail, quoted above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the hosted job log is linked and the local reproduction is quoted`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - the embedding call is a deterministic runtime double, by the suite's design`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the returned hit set and the searchMemories call log, both quoted above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Identified and fixed by Claude Code (`claude-opus-5`): hosted `canonical / Tests (client)` triage, local reproduction at the exact `develop` tip, instrumentation isolating the channel filter from the pagination, the `094f80ad`-vs-`4333300926` diff establishing the filter as pre-existing, and the mutation proof.

Attribution status: self-reported

