### PR TITLE
fix(plugin-elizacloud): keep deployment polling alive across transient API errors

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-container.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-container.ts
@@ -202,33 +202,61 @@ export class CloudContainerService
         return;
       }
 
-      const container = await this.getContainer(containerId);
-      const status = container.status;
-
-      logger.debug(`[CloudContainer] Poll #${attempt} for ${containerId}: status=${status}`);
-
-      if (status === "running") {
-        logger.info(
-          `[CloudContainer] Container ${containerId} is now running at ${container.load_balancer_url}`
-        );
-        this.startHealthMonitoring(containerId);
-        return;
-      }
-
-      if (status === "failed" || status === "stopped" || status === "suspended") {
-        logger.warn(`[CloudContainer] Container ${containerId} reached terminal state: ${status}`);
-        if (container.error_message) {
-          logger.error(`[CloudContainer] Error: ${container.error_message}`);
-        }
-        return;
-      }
-
-      // Schedule next poll with exponential backoff
+      // Exponential backoff shared by the normal reschedule path and the
+      // transient-error retry path below.
       const delay = Math.min(baseInterval * 2 ** Math.min(attempt - 1, 3), maxInterval);
-      tracked.pollingTimer = setTimeout(poll, delay);
+
+      try {
+        const container = await this.getContainer(containerId);
+        const status = container.status;
+
+        logger.debug(`[CloudContainer] Poll #${attempt} for ${containerId}: status=${status}`);
+
+        if (status === "running") {
+          logger.info(
+            `[CloudContainer] Container ${containerId} is now running at ${container.load_balancer_url}`
+          );
+          this.startHealthMonitoring(containerId);
+          return;
+        }
+
+        if (status === "failed" || status === "stopped" || status === "suspended") {
+          logger.warn(
+            `[CloudContainer] Container ${containerId} reached terminal state: ${status}`
+          );
+          if (container.error_message) {
+            logger.error(`[CloudContainer] Error: ${container.error_message}`);
+          }
+          return;
+        }
+
+        // Not terminal yet — keep polling.
+        tracked.pollingTimer = schedulePoll(delay);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(
+          `[CloudContainer] Poll #${attempt} failed for ${containerId}: ${message}. Retrying in ${Math.round(delay / 1000)}s`
+        );
+        // Transient API errors must not kill the poller: reschedule the next
+        // poll (still bounded by maxAttempts) instead of letting the promise
+        // reject and silently stopping the loop.
+        tracked.pollingTimer = schedulePoll(delay);
+      }
     };
 
-    tracked.pollingTimer = setTimeout(poll, baseInterval);
+    // Schedule a poll run, swallowing any rejection so a throw can never
+    // surface as an unhandledRejection that stops the process.
+    const schedulePoll = (delay: number): ReturnType<typeof setTimeout> => {
+      return setTimeout(() => {
+        poll().catch((error: Error) => {
+          logger.error(
+            `[CloudContainer] Unexpected error polling container ${containerId}: ${error.message}`
+          );
+        });
+      }, delay);
+    };
+
+    tracked.pollingTimer = schedulePoll(baseInterval);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #29718. `CloudContainerService.startPolling()` schedules its async `poll` closure with `setTimeout(poll, ...)` but the closure had no try/catch around `await this.getContainer(containerId)`. `getContainer()` performs an HTTP fetch (`client.get`) that rejects on any transient error (network blip, 5xx, timeout) during the documented ~8–12 minute deployment window.

When that happened:
1. the poll promise rejected with no handler → `unhandledRejection`, which terminates the process under Node's default policy, and
2. the reject short-circuited before the next `setTimeout(poll, delay)` was scheduled → the poller stopped permanently. The container was never re-checked, never reached its tracked terminal state, and `startHealthMonitoring()` was never invoked, silently breaking the method's contract ("Poll container status until it reaches a terminal state").

The sibling `startHealthMonitoring()` uses `.then().catch()` and tolerates the same failures, so the poll path was inconsistent with the codebase's own pattern.

## Fix

`plugins/plugin-elizacloud/src/services/cloud-container.ts` — `startPolling()`:

- Wrapped the `getContainer`/status handling in a `try/catch` (mirroring `startHealthMonitoring`'s tolerance).
- On a caught error: log at `warn` and **reschedule the next poll with the existing exponential backoff** (still bounded by `maxAttempts`) instead of letting the promise reject and the poller die.
- Guarded the fire-and-forget scheduling with `poll().catch(...)` so a future throw can never surface as an `unhandledRejection`.
- Backoff delay computation moved up so it is shared by the normal reschedule path and the transient-error retry path.

## Verification

Standalone Node harness (`node verify-poll-resilience.mjs`) replicating the exact patched control flow with scaled timers:

- **Transient error, then success**: `getContainer` rejects once (`ETIMEDOUT`) then returns `running` → `get()` called 2+ times, `startHealthMonitoring()` invoked after `status=running`, **0 unhandled rejections** ✅
- **Persistent errors**: `getContainer` rejects on every attempt → polling stops at exactly `maxAttempts` (120) with the timeout log, **0 unhandled rejections** ✅
- **Regression proof (old logic)**: the pre-fix closure dies after exactly 1 `get()` call and emits 1 unhandled rejection ✅ (bug reproduced, confirming the fix is what changes behavior)

The patched closure structure also type-checks standalone with `tsc --noEmit --strict`.

## Changes

- `plugins/plugin-elizacloud/src/services/cloud-container.ts` (+47 / −19)

Closes #29718