### PR TITLE
fix(ui): canonicalize trajectories layout

### DIFF
--- a/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
@@ -67,30 +67,6 @@ async function clickRequired(locator: Locator, label: string): Promise<void> {
   await target.click();
 }
 
-async function openVisiblePageSidebar(
-  page: Page,
-  testId: string,
-): Promise<Locator> {
-  const trigger = page.getByTestId("page-layout-mobile-sidebar-trigger");
-  if (await trigger.isVisible().catch(() => false)) {
-    await trigger.click();
-  }
-
-  const sidebar = page.locator(`[data-testid="${testId}"]:visible`).first();
-  await expect(sidebar, `${testId} should be visible`).toBeVisible();
-  return sidebar;
-}
-
-async function closeMobilePageSidebar(page: Page): Promise<void> {
-  const drawer = page.getByTestId("page-layout-mobile-sidebar-drawer");
-  if (!(await drawer.isVisible().catch(() => false))) return;
-  await clickRequired(
-    drawer.getByRole("button", { name: "Close sidebar" }),
-    "close mobile page sidebar",
-  );
-  await expect(drawer).toBeHidden();
-}
-
 async function fulfillJson(
   route: Route,
   body: unknown,
@@ -430,8 +406,9 @@ test("trajectory viewer route refreshes, filters, and changes selected detail", 
   await openRouteCase(page, routeCaseByName("trajectories app window"));
 
   await expect(page.getByTestId("trajectories-view")).toBeVisible();
-  let sidebar = await openVisiblePageSidebar(page, "trajectories-sidebar");
-  await expect(sidebar.getByText("scenario-alpha")).toBeVisible();
+  await expect(
+    page.getByText("chat / scenario-alpha / batch-ui-smoke"),
+  ).toBeVisible();
   // The minimal redesign dropped the manual Refresh button: the list stays
   // current via a silent ~15s background poll. Assert the poll re-queries the
   // list source (no user-facing refresh control).
@@ -439,8 +416,6 @@ test("trajectory viewer route refreshes, filters, and changes selected detail", 
   await expect
     .poll(() => recorder.listRequestCount(), { timeout: 30_000 })
     .toBeGreaterThan(listCount);
-  await closeMobilePageSidebar(page);
-
   await expect(page.getByText("deterministic-model-a").first()).toBeVisible();
   await expect(
     page
@@ -454,25 +429,22 @@ test("trajectory viewer route refreshes, filters, and changes selected detail", 
   );
   await expect(page.getByText(/Showing 1 plan calls/i)).toBeVisible();
 
-  sidebar = await openVisiblePageSidebar(page, "trajectories-sidebar");
   await clickRequired(
-    sidebar.getByText("scenario-beta"),
+    page.getByText("orchestrator / scenario-beta / batch-ui-smoke"),
     "beta trajectory row",
   );
   await expect
     .poll(() => recorder.detailRequests().includes("traj-beta"))
     .toBe(true);
-  await closeMobilePageSidebar(page);
   await expect(page.getByText("deterministic-model-b").first()).toBeVisible();
-  const sparseInput = page.locator('section[aria-label="Input (User)"]');
-  const sparseOutput = page.locator('section[aria-label="Output (Response)"]');
+  const sparseInput = page.getByRole("region", { name: "Input (User)" });
+  const sparseOutput = page.getByRole("region", {
+    name: "Output (Response)",
+  });
   await expect(sparseInput).toHaveText("0");
   await expect(sparseOutput).toHaveText("false");
   await expect(
-    sparseInput.locator("xpath=..").getByText("1 lines", { exact: true }),
-  ).toBeVisible();
-  await expect(
-    sparseOutput.locator("xpath=..").getByText("1 lines", { exact: true }),
+    page.getByText("1 lines", { exact: true }).first(),
   ).toBeVisible();
 
   // NOTE: the trajectories list search moved to the floating chat composer.

--- a/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.tsx
@@ -7,8 +7,6 @@ import { CheckCircle, Circle, Clock3, XCircle } from "lucide-react";
 import type * as React from "react";
 
 import { Badge } from "../../ui/badge";
-import { Card } from "../../ui/card";
-import { PagePanel } from "../page-panel";
 export type TrajectoryTimelineStatus =
   | "queued"
   | "running"
@@ -56,57 +54,55 @@ export function TrajectoryEventTimeline({
   heading,
 }: TrajectoryEventTimelineProps) {
   return (
-    <PagePanel as="section" variant="section" className="px-5 py-4">
+    <section>
       <div className="mb-3 text-sm font-semibold text-[color:var(--settings-foreground)]">
         {heading}
       </div>
       {events.length === 0 ? (
-        <Card variant="dashedEmpty">{emptyLabel}</Card>
+        <div className="border-y border-dashed border-[color:var(--settings-hairline)] py-6 text-center text-sm text-[color:var(--settings-muted)]">
+          {emptyLabel}
+        </div>
       ) : (
-        <ol className="space-y-2">
+        <ol className="divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)]">
           {events.map((event) => (
-            <Card
-              asChild
+            <li
               key={event.id}
-              variant="insetPadded"
-              className="grid min-h-14 grid-cols-[1.25rem_minmax(0,1fr)] gap-3"
+              className="grid min-h-14 grid-cols-[1.25rem_minmax(0,1fr)] gap-3 py-3"
             >
-              <li>
-                <div className="mt-0.5 flex justify-center">
-                  {statusIcon(event.status)}
-                </div>
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="truncate text-sm font-medium text-[color:var(--settings-foreground)]">
-                      {event.label}
+              <div className="mt-0.5 flex justify-center">
+                {statusIcon(event.status)}
+              </div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <span className="truncate text-sm font-medium text-[color:var(--settings-foreground)]">
+                    {event.label}
+                  </span>
+                  {event.stage ? (
+                    <Badge asChild variant="trajectoryStage" size="compact">
+                      <span>{event.stage}</span>
+                    </Badge>
+                  ) : null}
+                  {event.timestampLabel ? (
+                    <span className="ml-auto text-xs text-[color:var(--settings-muted)]">
+                      {event.timestampLabel}
                     </span>
-                    {event.stage ? (
-                      <Badge asChild variant="trajectoryStage" size="compact">
-                        <span>{event.stage}</span>
-                      </Badge>
-                    ) : null}
-                    {event.timestampLabel ? (
-                      <span className="ml-auto text-xs text-[color:var(--settings-muted)]">
-                        {event.timestampLabel}
-                      </span>
-                    ) : null}
-                  </div>
-                  {event.description ? (
-                    <div className="mt-1 line-clamp-2 text-xs leading-5 text-[color:var(--settings-muted)]">
-                      {event.description}
-                    </div>
-                  ) : null}
-                  {event.meta ? (
-                    <div className="mt-1 text-xs text-[color:var(--settings-muted)]">
-                      {event.meta}
-                    </div>
                   ) : null}
                 </div>
-              </li>
-            </Card>
+                {event.description ? (
+                  <div className="mt-1 line-clamp-2 text-xs leading-5 text-[color:var(--settings-muted)]">
+                    {event.description}
+                  </div>
+                ) : null}
+                {event.meta ? (
+                  <div className="mt-1 text-xs text-[color:var(--settings-muted)]">
+                    {event.meta}
+                  </div>
+                ) : null}
+              </div>
+            </li>
           ))}
         </ol>
       )}
-    </PagePanel>
+    </section>
   );
 }

--- a/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx
@@ -8,7 +8,6 @@ import * as React from "react";
 
 import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
-import { PagePanel } from "../page-panel";
 import { TrajectoryCodeBlock } from "./trajectory-code-block";
 
 interface CallMetricProps {
@@ -19,7 +18,7 @@ interface CallMetricProps {
 
 function CallMetric({ label, value, meta }: CallMetricProps) {
   return (
-    <PagePanel.SummaryCard compact className="px-4 py-3">
+    <div className="px-3 py-3 first:pl-0 last:pr-0">
       <div className="text-xs text-[color:var(--settings-muted)]">{label}</div>
       <div className="mt-1 truncate text-sm font-semibold text-[color:var(--settings-foreground)]">
         {value}
@@ -29,7 +28,7 @@ function CallMetric({ label, value, meta }: CallMetricProps) {
           {meta}
         </div>
       ) : null}
-    </PagePanel.SummaryCard>
+    </div>
   );
 }
 
@@ -98,7 +97,7 @@ export function TrajectoryLlmCallCard({
   const purposeValue = tags?.length ? tags.join(", ") : "Inference";
 
   return (
-    <PagePanel as="section" variant="section" className="p-5">
+    <section className="border-t border-[color:var(--settings-hairline)] pt-5">
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-1.5">
@@ -142,7 +141,7 @@ export function TrajectoryLlmCallCard({
           ) : null}
         </div>
 
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <div className="grid divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)] md:grid-cols-2 md:divide-x md:divide-y-0 xl:grid-cols-5">
           <CallMetric
             label={purposeLabel}
             value={purposeValue}
@@ -206,6 +205,6 @@ export function TrajectoryLlmCallCard({
           onCopy={onCopy}
         />
       </div>
-    </PagePanel>
+    </section>
   );
 }

--- a/packages/ui/src/components/composites/trajectories/trajectory-pipeline-graph.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-pipeline-graph.tsx
@@ -48,9 +48,9 @@ function PipelineConnector({ dimmed }: { dimmed?: boolean }) {
       className={`flex items-center ${dimmed ? "opacity-30" : "opacity-60"}`}
     >
       <svg
-        width="36"
+        width="24"
         height="12"
-        viewBox="0 0 36 12"
+        viewBox="0 0 24 12"
         fill="none"
         className="shrink-0"
         aria-hidden="true"
@@ -59,14 +59,14 @@ function PipelineConnector({ dimmed }: { dimmed?: boolean }) {
         <line
           x1="0"
           y1="6"
-          x2="28"
+          x2="17"
           y2="6"
           stroke="currentColor"
           strokeWidth="1.5"
           className="text-muted"
         />
         <path
-          d="M28 2 L34 6 L28 10"
+          d="M17 2 L23 6 L17 10"
           stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
@@ -110,7 +110,7 @@ function PipelineNodeButton({
       size="card"
       data-state={selected ? "on" : "off"}
       onClick={onClick}
-      className="min-w-[7rem] items-center"
+      className="min-w-[6.5rem] items-center"
     >
       <Icon className={`size-5 ${iconColor[node.status]}`} />
       <span className="whitespace-nowrap text-xs font-medium">

--- a/packages/ui/src/components/composites/trajectories/trajectory-sidebar-item.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-sidebar-item.tsx
@@ -14,7 +14,7 @@ function InlineMeta({
 }) {
   return (
     <span className="inline-flex items-center gap-1.5 text-xs text-[color:var(--settings-muted)]">
-      <StatusDot size="compact" color={color} />
+      {color ? <StatusDot size="compact" color={color} /> : null}
       <span>{label}</span>
     </span>
   );

--- a/packages/ui/src/components/pages/TrajectoriesView.tsx
+++ b/packages/ui/src/components/pages/TrajectoriesView.tsx
@@ -30,6 +30,11 @@ import {
 import { useActiveAgentAuthority } from "../../hooks/useActiveAgentAuthority";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+} from "../../layouts/framed-page";
 import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
 import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
@@ -40,9 +45,7 @@ import {
 } from "../../utils/trajectory-format";
 import { PagePanel } from "../composites/page-panel";
 import { TrajectorySidebarItem } from "../composites/trajectories/trajectory-sidebar-item";
-import { SettingsGroup } from "../settings/settings-layout";
 import { ConfirmDeleteControl } from "../shared/confirm-delete-control";
-import { ViewHeader } from "../shared/ViewHeader";
 import { Button, type ButtonProps } from "../ui/button";
 import {
   DropdownMenu,
@@ -54,7 +57,7 @@ import { ListSkeleton } from "../ui/skeleton-layouts";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { TrajectoryDetailView } from "./TrajectoryDetailView";
 
-const MOBILE_WORKSPACE_QUERY = "(max-width: 799px)";
+const MOBILE_WORKSPACE_QUERY = "(max-width: 799px), (max-height: 599px)";
 const PAGE_SIZE = 50;
 
 type TrajectoryLoadIssue =
@@ -282,14 +285,6 @@ function issueCopy(issue: TrajectoryLoadIssue, hasSavedData: boolean) {
         description: "Try again in a moment.",
       };
   }
-}
-
-function TrajectoryStateSurface({ children }: { children: ReactNode }) {
-  return (
-    <div className="overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)]">
-      {children}
-    </div>
-  );
 }
 
 export interface TrajectoriesViewProps {
@@ -605,11 +600,6 @@ function TrajectoriesViewForAuthority({
     setActionNotice,
   ]);
 
-  const deleteDisabled =
-    loading ||
-    clearingAll ||
-    deletingTrajectoryId !== null ||
-    detailTrajectoryId === null;
   const clearAllDisabled =
     loading || clearingAll || deletingTrajectoryId !== null || total === 0;
   const issue = loadIssue
@@ -680,27 +670,26 @@ function TrajectoriesViewForAuthority({
             </AgentDropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <ConfirmDeleteControl
-          agentId="trajectories-delete-current-open"
-          agentLabel="Delete current trajectory"
-          agentGroup="trajectories-toolbar"
-          agentDescription="Delete the selected trajectory"
-          confirmAgentId="trajectories-delete-current-confirm"
-          cancelAgentId="trajectories-delete-current-cancel"
-          triggerVariant="ghost"
-          triggerClassName="h-11 w-11 text-danger hover:bg-danger/10 hover:text-danger"
-          confirmClassName="h-11 border border-danger/25 bg-danger/10 px-4 text-sm font-semibold text-danger hover:bg-danger/15"
-          cancelClassName="h-11 border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)] px-4 text-sm font-semibold text-[color:var(--settings-muted)] hover:bg-[var(--settings-fill)]"
-          disabled={deleteDisabled}
-          triggerLabel={<Trash2 className="size-4" />}
-          triggerTitle="Delete current"
-          promptText="Delete this trajectory?"
-          busyLabel="Deleting..."
-          onConfirm={() => {
-            if (detailTrajectoryId)
-              void handleDeleteTrajectory(detailTrajectoryId);
-          }}
-        />
+        {detailTrajectoryId ? (
+          <ConfirmDeleteControl
+            agentId="trajectories-delete-current-open"
+            agentLabel="Delete current trajectory"
+            agentGroup="trajectories-toolbar"
+            agentDescription="Delete the selected trajectory"
+            confirmAgentId="trajectories-delete-current-confirm"
+            cancelAgentId="trajectories-delete-current-cancel"
+            triggerVariant="ghost"
+            triggerClassName="h-11 w-11 text-danger hover:bg-danger/10 hover:text-danger"
+            confirmClassName="h-11 border border-danger/25 bg-danger/10 px-4 text-sm font-semibold text-danger hover:bg-danger/15"
+            cancelClassName="h-11 border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)] px-4 text-sm font-semibold text-[color:var(--settings-muted)] hover:bg-[var(--settings-fill)]"
+            disabled={loading || clearingAll || deletingTrajectoryId !== null}
+            triggerLabel={<Trash2 className="size-4" />}
+            triggerTitle="Delete current"
+            promptText="Delete this trajectory?"
+            busyLabel="Deleting..."
+            onConfirm={() => void handleDeleteTrajectory(detailTrajectoryId)}
+          />
+        ) : null}
         <ConfirmDeleteControl
           agentId="trajectories-clear-all-open"
           agentLabel="Clear all trajectories"
@@ -724,11 +713,12 @@ function TrajectoriesViewForAuthority({
 
   return (
     <ShellViewAgentSurface viewId="trajectories">
-      <div
-        className="settings-surface settings-canvas flex h-full min-h-0 w-full flex-col overflow-hidden"
+      <FramedPage
+        gutterOwner="framed-page"
+        className="settings-surface"
         data-testid="trajectories-view"
       >
-        <ViewHeader
+        <FramedPageHeader
           title={
             showingMobileDetail
               ? t("trajectorydetailview.Title", {
@@ -748,196 +738,197 @@ function TrajectoriesViewForAuthority({
                 })
               : undefined
           }
-          right={contentHeader}
+          actions={contentHeader}
           className="text-[color:var(--settings-foreground)]"
         />
-        <div className="mx-auto grid min-h-0 w-full max-w-[88rem] flex-1 min-[800px]:grid-cols-[21rem_minmax(0,1fr)] min-[800px]:gap-4 min-[800px]:px-5 min-[800px]:pt-4">
-          <aside
-            className={cn(
-              "min-h-0 flex-col px-4 pt-2 min-[800px]:rounded-t-[20px] min-[800px]:border min-[800px]:border-b-0 min-[800px]:border-[color:var(--settings-hairline)] min-[800px]:bg-[var(--settings-secondary)] min-[800px]:px-3 min-[800px]:pt-3",
-              showList ? "flex" : "hidden",
-            )}
-            aria-label="Trajectory history"
-          >
-            <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 px-1">
-              <div className="min-w-0">
-                <h2 className="text-[15px] font-semibold text-[color:var(--settings-foreground)]">
-                  Activity
-                </h2>
-                <p className="text-xs leading-5 text-[color:var(--settings-muted)]">
-                  {hasActiveFilters
-                    ? `${total} matching ${total === 1 ? "run" : "runs"}`
-                    : `${total} recorded ${total === 1 ? "run" : "runs"}`}
-                </p>
-              </div>
-              {managementActions}
-            </div>
-
-            {issue && trajectories.length > 0 ? (
-              <div
-                role="status"
-                className="mt-2 flex items-start gap-2 rounded-[12px] bg-[var(--settings-fill)] px-3 py-2.5 text-[13px] leading-5 text-[color:var(--settings-muted)]"
-              >
-                <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
-                <div className="min-w-0 flex-1">
-                  <div className="font-medium text-[color:var(--settings-foreground)]">
-                    {issue.title}
-                  </div>
-                  <div>{issue.description}</div>
-                </div>
-                {canRetryIssue ? (
-                  <Button
-                    type="button"
-                    size="touch"
-                    variant="ghostMuted"
-                    className="shrink-0"
-                    onClick={() => void loadTrajectories()}
-                  >
-                    Retry
-                  </Button>
-                ) : null}
-              </div>
-            ) : null}
-
-            <div className="eliza-chat-scroll min-h-0 flex-1 overflow-y-auto pb-4 pt-3">
-              {loading && trajectories.length === 0 ? (
-                <TrajectoryStateSurface>
-                  <div
-                    role="status"
-                    aria-label="Loading trajectory history"
-                    aria-busy="true"
-                    className="p-3"
-                  >
-                    <ListSkeleton rows={6} />
-                  </div>
-                </TrajectoryStateSurface>
-              ) : issue && trajectories.length === 0 ? (
-                <TrajectoryStateSurface>
-                  <PagePanel.ContentState
-                    state="error"
-                    placement="workspace"
-                    tone="warning"
-                    role="status"
-                    className="min-h-[18rem]"
-                    icon={<AlertTriangle className="size-5" />}
-                    title={issue.title}
-                    description={issue.description}
-                    action={
-                      canRetryIssue ? (
-                        <Button
-                          type="button"
-                          size="touch"
-                          variant="outline"
-                          onClick={() => void loadTrajectories()}
-                        >
-                          Retry
-                        </Button>
-                      ) : undefined
-                    }
-                  />
-                </TrajectoryStateSurface>
-              ) : trajectories.length === 0 ? (
-                <TrajectoryStateSurface>
-                  <PagePanel.ContentState
-                    state="empty"
-                    placement="workspace"
-                    className="min-h-[18rem]"
-                    icon={<Route className="size-5" />}
-                    title={
-                      hasActiveFilters
-                        ? "No matching activity"
-                        : "No recorded activity yet"
-                    }
-                    description={
-                      hasActiveFilters
-                        ? "Try a shorter search."
-                        : "Agent runs will appear here when trajectory recording is enabled."
-                    }
-                  />
-                </TrajectoryStateSurface>
-              ) : (
-                <SettingsGroup>
-                  {trajectories.map((trajectory) => (
-                    <AgentTrajectorySidebarItem
-                      key={trajectory.id}
-                      trajectory={trajectory}
-                      selected={selectedTrajectoryId === trajectory.id}
-                      onSelect={() => onSelectTrajectory(trajectory.id)}
-                    />
-                  ))}
-                </SettingsGroup>
-              )}
-
-              {totalPages > 1 ? (
-                <nav
-                  className="mt-3 flex min-h-11 items-center justify-between gap-2 px-1 text-xs text-[color:var(--settings-muted)]"
-                  aria-label="Trajectory pages"
+        <FramedPageBody scroll="view" className="pt-2">
+          {trajectories.length === 0 ? (
+            <div className="flex min-h-0 flex-1 flex-col">
+              {loading ? (
+                <div
+                  role="status"
+                  aria-label="Loading trajectory history"
+                  aria-busy="true"
+                  className="py-3"
                 >
-                  <span>
-                    {page * PAGE_SIZE + 1}-
-                    {Math.min((page + 1) * PAGE_SIZE, total)} of {total}
-                  </span>
-                  <div className="flex gap-1">
-                    <AgentToolbarButton
-                      agentId="trajectories-page-prev"
-                      agentLabel="Previous trajectories page"
-                      agentStatus={page === 0 ? "disabled" : "ready"}
-                      onActivate={() =>
-                        setPage((current) => Math.max(0, current - 1))
-                      }
-                      variant="ghostMuted"
-                      size="touch"
-                      className="px-3"
-                      onClick={() =>
-                        setPage((current) => Math.max(0, current - 1))
-                      }
-                      disabled={page === 0}
-                    >
-                      Previous
-                    </AgentToolbarButton>
-                    <AgentToolbarButton
-                      agentId="trajectories-page-next"
-                      agentLabel="Next trajectories page"
-                      agentStatus={
-                        page >= totalPages - 1 ? "disabled" : "ready"
-                      }
-                      onActivate={() => setPage((current) => current + 1)}
-                      variant="ghostMuted"
-                      size="touch"
-                      className="px-3"
-                      onClick={() => setPage((current) => current + 1)}
-                      disabled={page >= totalPages - 1}
-                    >
-                      Next
-                    </AgentToolbarButton>
-                  </div>
-                </nav>
-              ) : null}
-            </div>
-          </aside>
-
-          <main
-            className={cn(
-              "eliza-chat-scroll min-h-0 overflow-y-auto px-4 pb-4 pt-2 min-[800px]:px-0 min-[800px]:pt-0",
-              showDetail ? "block" : "hidden",
-            )}
-          >
-            {detailTrajectoryId ? (
-              <TrajectoryDetailView trajectoryId={detailTrajectoryId} />
-            ) : (
-              <TrajectoryStateSurface>
+                  <ListSkeleton rows={6} rowClassName="h-16" />
+                </div>
+              ) : issue ? (
+                <PagePanel.ContentState
+                  state="error"
+                  placement="workspace"
+                  tone="warning"
+                  role="status"
+                  className="flex-1"
+                  icon={<AlertTriangle className="size-5" />}
+                  title={issue.title}
+                  description={issue.description}
+                  action={
+                    canRetryIssue ? (
+                      <Button
+                        type="button"
+                        size="touch"
+                        variant="outline"
+                        onClick={() => void loadTrajectories()}
+                      >
+                        Retry
+                      </Button>
+                    ) : undefined
+                  }
+                />
+              ) : (
                 <PagePanel.ContentState
                   state="empty"
                   placement="workspace"
-                  className="min-h-[24rem]"
-                  title="Select a run"
-                  description="Choose recorded activity to inspect its timeline and model calls."
+                  className="flex-1"
+                  icon={<Route className="size-5" />}
+                  title={
+                    hasActiveFilters
+                      ? "No matching activity"
+                      : "No recorded activity yet"
+                  }
+                  description={
+                    hasActiveFilters
+                      ? "Try a shorter search."
+                      : "Agent runs will appear here when trajectory recording is enabled."
+                  }
                 />
-              </TrajectoryStateSurface>
-            )}
-          </main>
-        </div>
-      </div>
+              )}
+            </div>
+          ) : (
+            <div className="grid min-h-0 flex-1 [@media(min-width:800px)_and_(min-height:600px)]:grid-cols-[19rem_minmax(0,1fr)]">
+              <aside
+                className={cn(
+                  "min-h-0 flex-col [@media(min-width:800px)_and_(min-height:600px)]:border-r [@media(min-width:800px)_and_(min-height:600px)]:border-[color:var(--settings-hairline)] [@media(min-width:800px)_and_(min-height:600px)]:pr-4",
+                  showList ? "flex" : "hidden",
+                )}
+                aria-label="Trajectory history"
+              >
+                <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 px-1">
+                  <div className="min-w-0">
+                    <h2 className="text-[15px] font-semibold text-[color:var(--settings-foreground)]">
+                      Activity
+                    </h2>
+                    <p className="text-xs leading-5 text-[color:var(--settings-muted)]">
+                      {hasActiveFilters
+                        ? `${total} matching ${total === 1 ? "run" : "runs"}`
+                        : `${total} recorded ${total === 1 ? "run" : "runs"}`}
+                    </p>
+                  </div>
+                  {managementActions}
+                </div>
+
+                {issue && trajectories.length > 0 ? (
+                  <div
+                    role="status"
+                    className="mt-2 flex items-start gap-2 rounded-[12px] bg-[var(--settings-fill)] px-3 py-2.5 text-[13px] leading-5 text-[color:var(--settings-muted)]"
+                  >
+                    <AlertTriangle
+                      className="mt-0.5 size-4 shrink-0"
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-[color:var(--settings-foreground)]">
+                        {issue.title}
+                      </div>
+                      <div>{issue.description}</div>
+                    </div>
+                    {canRetryIssue ? (
+                      <Button
+                        type="button"
+                        size="touch"
+                        variant="ghostMuted"
+                        className="shrink-0"
+                        onClick={() => void loadTrajectories()}
+                      >
+                        Retry
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                <div className="eliza-chat-scroll min-h-0 flex-1 overflow-y-auto pb-4 pt-3">
+                  <div className="divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)]">
+                    {trajectories.map((trajectory) => (
+                      <AgentTrajectorySidebarItem
+                        key={trajectory.id}
+                        trajectory={trajectory}
+                        selected={selectedTrajectoryId === trajectory.id}
+                        onSelect={() => onSelectTrajectory(trajectory.id)}
+                      />
+                    ))}
+                  </div>
+
+                  {totalPages > 1 ? (
+                    <nav
+                      className="mt-3 flex min-h-11 items-center justify-between gap-2 px-1 text-xs text-[color:var(--settings-muted)]"
+                      aria-label="Trajectory pages"
+                    >
+                      <span>
+                        {page * PAGE_SIZE + 1}-
+                        {Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+                      </span>
+                      <div className="flex gap-1">
+                        <AgentToolbarButton
+                          agentId="trajectories-page-prev"
+                          agentLabel="Previous trajectories page"
+                          agentStatus={page === 0 ? "disabled" : "ready"}
+                          onActivate={() =>
+                            setPage((current) => Math.max(0, current - 1))
+                          }
+                          variant="ghostMuted"
+                          size="touch"
+                          className="px-3"
+                          onClick={() =>
+                            setPage((current) => Math.max(0, current - 1))
+                          }
+                          disabled={page === 0}
+                        >
+                          Previous
+                        </AgentToolbarButton>
+                        <AgentToolbarButton
+                          agentId="trajectories-page-next"
+                          agentLabel="Next trajectories page"
+                          agentStatus={
+                            page >= totalPages - 1 ? "disabled" : "ready"
+                          }
+                          onActivate={() => setPage((current) => current + 1)}
+                          variant="ghostMuted"
+                          size="touch"
+                          className="px-3"
+                          onClick={() => setPage((current) => current + 1)}
+                          disabled={page >= totalPages - 1}
+                        >
+                          Next
+                        </AgentToolbarButton>
+                      </div>
+                    </nav>
+                  ) : null}
+                </div>
+              </aside>
+
+              <main
+                className={cn(
+                  "eliza-chat-scroll min-h-0 overflow-y-auto pb-4 [@media(min-width:800px)_and_(min-height:600px)]:pl-4",
+                  showDetail ? "block" : "hidden",
+                )}
+              >
+                {detailTrajectoryId ? (
+                  <TrajectoryDetailView trajectoryId={detailTrajectoryId} />
+                ) : (
+                  <PagePanel.ContentState
+                    state="empty"
+                    placement="workspace"
+                    className="min-h-[24rem]"
+                    title="Select a run"
+                    description="Choose recorded activity to inspect its timeline and model calls."
+                  />
+                )}
+              </main>
+            </div>
+          )}
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/pages/TrajectoriesView.tsx
+++ b/packages/ui/src/components/pages/TrajectoriesView.tsx
@@ -804,7 +804,7 @@ function TrajectoriesViewForAuthority({
                 )}
                 aria-label="Trajectory history"
               >
-                <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 px-1">
+                <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 px-4">
                   <div className="min-w-0">
                     <h2 className="text-[15px] font-semibold text-[color:var(--settings-foreground)]">
                       Activity

--- a/packages/ui/src/components/pages/TrajectoryDetailView.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.tsx
@@ -692,9 +692,9 @@ export function TrajectoryDetailView({
       : null;
 
   return (
-    <div className="flex min-h-0 flex-col gap-4">
-      <section className="overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)]">
-        <div className="flex min-h-16 items-center gap-2 px-4 py-3">
+    <div className="flex min-h-0 flex-col gap-6">
+      <section>
+        <div className="flex min-h-16 items-center gap-3 py-3">
           <div className="min-w-0 flex-1">
             <h2 className="truncate text-[17px] font-semibold text-[color:var(--settings-foreground)]">
               {formatTrajectoryTimestamp(trajectory.createdAt, "smart")}
@@ -708,7 +708,7 @@ export function TrajectoryDetailView({
             {trajectory.status}
           </span>
         </div>
-        <dl className="grid grid-cols-2 border-t border-[color:var(--settings-hairline)] min-[620px]:grid-cols-4">
+        <dl className="grid grid-cols-2 border-y border-[color:var(--settings-hairline)] min-[620px]:grid-cols-4">
           {[
             {
               label: "Duration",
@@ -726,7 +726,7 @@ export function TrajectoryDetailView({
           ].map((metric) => (
             <div
               key={metric.label}
-              className="border-b border-[color:var(--settings-hairline)] px-4 py-3 odd:border-r min-[620px]:border-b-0 min-[620px]:border-r min-[620px]:last:border-r-0"
+              className="border-b border-[color:var(--settings-hairline)] px-3 py-3 first:pl-0 odd:border-r min-[620px]:border-b-0 min-[620px]:border-r min-[620px]:last:border-r-0 min-[620px]:last:pr-0"
             >
               <dt className="text-xs text-[color:var(--settings-muted)]">
                 {metric.label}
@@ -739,11 +739,11 @@ export function TrajectoryDetailView({
         </dl>
       </section>
       {orchestratorData ? (
-        <section className="overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)]">
-          <h3 className="px-4 pb-2 pt-4 text-sm font-semibold text-[color:var(--settings-foreground)]">
+        <section>
+          <h3 className="mb-3 text-sm font-semibold text-[color:var(--settings-foreground)]">
             Orchestration
           </h3>
-          <dl className="divide-y divide-[color:var(--settings-hairline)]">
+          <dl className="divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)]">
             {[
               {
                 label: t("trajectorydetailview.DecisionType"),
@@ -760,7 +760,7 @@ export function TrajectoryDetailView({
             ].map((item) => (
               <div
                 key={item.label}
-                className="flex min-h-12 items-start justify-between gap-4 px-4 py-3 text-sm"
+                className="flex min-h-12 items-start justify-between gap-4 py-3 text-sm"
               >
                 <dt className="text-[color:var(--settings-muted)]">
                   {item.label}
@@ -777,8 +777,8 @@ export function TrajectoryDetailView({
       {trajectory.metadata &&
       Object.keys(trajectory.metadata).length > 0 &&
       formatProviderPayload(trajectory.metadata).trim().length > 0 ? (
-        <details className="group overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)]">
-          <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-medium text-[color:var(--settings-foreground)] hover:bg-[var(--settings-fill)]">
+        <details className="group border-y border-[color:var(--settings-hairline)]">
+          <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between py-3 text-sm font-medium text-[color:var(--settings-foreground)] hover:text-primary">
             Run metadata
             <span className="text-xs text-[color:var(--settings-muted)] group-open:hidden">
               Show
@@ -787,14 +787,14 @@ export function TrajectoryDetailView({
               Hide
             </span>
           </summary>
-          <pre className="max-h-[20rem] overflow-auto whitespace-pre-wrap break-words border-t border-[color:var(--settings-hairline)] bg-[var(--settings-secondary)] p-4 text-xs leading-6 text-[color:var(--settings-foreground)]">
+          <pre className="max-h-[20rem] overflow-auto whitespace-pre-wrap break-words border-t border-[color:var(--settings-hairline)] py-4 text-xs leading-6 text-[color:var(--settings-foreground)]">
             {formatProviderPayload(trajectory.metadata)}
           </pre>
         </details>
       ) : null}
 
       {llmCalls.length > 0 ? (
-        <section className="overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)] px-4 py-4">
+        <section>
           <h3 className="mb-3 text-sm font-semibold text-[color:var(--settings-foreground)]">
             Pipeline
           </h3>
@@ -838,7 +838,7 @@ export function TrajectoryDetailView({
       />
 
       {toolEvents.length > 0 ? (
-        <section className="overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)] px-4 py-4">
+        <section>
           <h3 className="mb-3 text-sm font-semibold text-[color:var(--settings-foreground)]">
             Tool activity
           </h3>
@@ -878,17 +878,14 @@ export function TrajectoryDetailView({
       ) : null}
 
       {providerAccesses.length > 0 ? (
-        <section className="overflow-hidden rounded-[16px] border border-[color:var(--settings-hairline)] bg-[var(--settings-panel)] px-4 py-4">
+        <section>
           <h3 className="mb-3 text-sm font-semibold text-[color:var(--settings-foreground)]">
             Provider activity
           </h3>
-          <div className="space-y-4">
+          <div className="divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)]">
             {providerAccesses.map((access, index) => (
-              <details
-                key={access.id}
-                className="group overflow-hidden rounded-[12px] bg-[var(--settings-secondary)]"
-              >
-                <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between gap-4 px-4 py-3">
+              <details key={access.id} className="group overflow-hidden">
+                <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between gap-4 py-3">
                   <span className="min-w-0">
                     <span className="block truncate text-sm font-medium text-[color:var(--settings-foreground)]">
                       {access.providerName || "Unknown provider"}
@@ -907,7 +904,7 @@ export function TrajectoryDetailView({
                     Hide
                   </span>
                 </summary>
-                <div className="border-t border-[color:var(--settings-hairline)] p-4">
+                <div className="border-t border-[color:var(--settings-hairline)] py-4">
                   {access.query ? (
                     <div>
                       <div className="text-xs font-medium text-[color:var(--settings-muted)]">


### PR DESCRIPTION
Closes #29736.

## What changed

- Moves Trajectories onto the canonical framed route header, gutters, and continuous page canvas.
- Replaces duplicate empty master/detail panels with one designed empty state.
- Keeps master/detail for genuinely wide workspaces while using a full-width list-to-detail flow on portrait and short landscape.
- Flattens Run Details onto one alignment grid: summary metrics, orchestration, metadata, pipeline, timeline, provider activity, and model calls use section spacing and quiet dividers instead of stacked dark cards.
- Aligns the Activity heading, management actions, separators, and rows to the same leading and trailing edges.
- Removes redundant metadata dots and hides selection-only deletion until a trajectory is selected.
- Updates the populated interaction test to follow the current accessible-region and continuous-list contracts.

## Verification

- Rebased onto current `origin/develop` after #29729 merged.
- Exact PR head: `ddce6af0207ca5630305cff8285e4ea8118708d9`.
- UI typecheck: passed.
- Biome on all changed files: passed.
- Populated Trajectories interaction: passed against an isolated app/API stack.
- Trajectory detail component tests: 5/5 passed.
- Focused Trajectories aesthetic audit: 4/4 passed, all `good`, with zero broken, needs-work, hover, density, or minimalism findings.
- App aesthetic audit: Trajectories is `good` at mobile portrait, short landscape, desktop landscape, and tablet portrait.

The full app audit executed 215 checks: 214 passed. Its aggregate strict verdict remains red for pre-existing low-content Camera, Rolodex, and Cockpit fixtures plus the untouched Apps hub. Trajectories received no `broken` or `needs-work` verdict.

## Evidence gate

<!-- evidence-head:ddce6af0207ca5630305cff8285e4ea8118708d9 -->

- [x] Individual before and after screenshots are paired below; no composites.
- [x] Desktop, tablet, portrait, and short-landscape states are shown.
- [x] Populated desktop master/detail and compact list/detail states are shown below.
- [x] Backend logs: N/A — renderer-only layout changes.
- [x] Model trajectory: N/A — no model, prompt, provider, or action behavior changed.
- [x] Manual full-resolution review completed after capture.

## Visual evidence

### Populated desktop master/detail

| Before | After |
| --- | --- |
| [![Populated Trajectories desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-desktop-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-desktop-before.png) | [![Populated Trajectories desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-desktop-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-desktop-after.png) |

### Populated short-landscape flow

Compact screens deliberately separate collection and detail instead of squeezing both into two unusable columns.

| Activity list | Selected run details |
| --- | --- |
| [![Populated Trajectories landscape list](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-landscape-list-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-landscape-list-after.png) | [![Populated Trajectories landscape detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-landscape-detail-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-landscape-detail-after.png) |

### Mobile portrait

| Before | After |
| --- | --- |
| [![Trajectories mobile portrait before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-portrait-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-portrait-before.png) | [![Trajectories mobile portrait after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-portrait-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-portrait-after.png) |

### Short landscape

| Before | After |
| --- | --- |
| [![Trajectories short landscape before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-landscape-before.png) | [![Trajectories short landscape after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-landscape-after.png) |

### Desktop landscape

| Before | After |
| --- | --- |
| [![Trajectories desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-desktop-landscape-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-desktop-landscape-before.png) | [![Trajectories desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-desktop-landscape-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-desktop-landscape-after.png) |

### Tablet portrait

| Before | After |
| --- | --- |
| [![Trajectories tablet before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-ipad-portrait-before.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-ipad-portrait-before.png) | [![Trajectories tablet after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-ipad-portrait-after.png)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-ipad-portrait-after.png) |

## Evidence notes

- Baseline captures are from the untouched Trajectories route before this commit.
- Final captures use the same deterministic empty-state fixture and exact PR-head UI source.
- Populated desktop and short-landscape list/detail states use the deterministic two-run interaction fixture exercised by the passing browser test.
