### PR TITLE
fix(app): simplify Projects Apps management

### DIFF
--- a/packages/app/test/ui-smoke/projects-apps-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/projects-apps-lifecycle.spec.ts
@@ -7,8 +7,8 @@
  *
  * This lane boots the packaged renderer in Chromium and drives the real
  * `AppsManagementSection` mounted inside `TasksPageView`: it asserts the
- * installed inventory renders with its run badges, that "Create new app" and
- * "Load from directory" submit the exact agent-API payloads, and that the
+ * installed inventory renders with its run badges, that create and import
+ * controls submit the exact agent-API payloads, and that the
  * segment survives a round trip through the Tasks segment. The agent app
  * endpoints (`/api/apps/installed`, `/api/apps/runs`, `/api/apps/create`,
  * `/api/apps/load-from-directory`) are route-mocked because this spec proves
@@ -184,10 +184,14 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
     intent: "Track aurora sightings and notify me at dusk.",
   });
 
-  // Import flow — "Load from directory" is the create/import half #17031 calls
-  // out; it must still reach /api/apps/load-from-directory.
-  const loadToggle = page.getByRole("button", { name: "Load from directory" });
-  await loadToggle.click();
+  // Import is progressively disclosed in the app-actions menu, but must still
+  // reach /api/apps/load-from-directory.
+  await page.getByRole("button", { name: "More app actions" }).click();
+  await page.screenshot({
+    path: `${EVIDENCE_DIR}/desktop-05-app-actions-menu.png`,
+    fullPage: true,
+  });
+  await page.getByRole("menuitem", { name: "Import from directory" }).click();
   const directory = page.getByLabel("Directory path");
   await expect(directory).toBeVisible({ timeout: 15_000 });
   await directory.fill("/Users/proof/code/imported-app");
@@ -197,7 +201,7 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
     directory: "/Users/proof/code/imported-app",
   });
   await page.screenshot({
-    path: `${EVIDENCE_DIR}/desktop-05-load-submitted.png`,
+    path: `${EVIDENCE_DIR}/desktop-06-load-submitted.png`,
     fullPage: true,
   });
 
@@ -209,7 +213,7 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
     page.getByTestId(`apps-mgmt-row-${INSTALLED_APP.name}`),
   ).toBeVisible({ timeout: 30_000 });
   await page.screenshot({
-    path: `${EVIDENCE_DIR}/desktop-06-segment-roundtrip.png`,
+    path: `${EVIDENCE_DIR}/desktop-07-segment-roundtrip.png`,
     fullPage: true,
   });
 });

--- a/packages/app/test/ui-smoke/projects-apps-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/projects-apps-lifecycle.spec.ts
@@ -123,6 +123,7 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
 }) => {
   const posts: CapturedPosts = { create: [], load: [] };
   await installAppsApiMocks(page, posts);
+  await page.setViewportSize({ width: 1440, height: 900 });
 
   // Retired standalone slug resolves onto Projects with Apps pre-selected.
   await openProjectsApps(page, "/apps/my-apps");
@@ -142,6 +143,7 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
   // Hover state on the inventory row's launch control.
   const launchButton = page.getByRole("button", {
     name: `Launch ${INSTALLED_APP.displayName}`,
+    exact: true,
   });
   await launchButton.hover();
   await page.screenshot({
@@ -149,13 +151,27 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
     fullPage: true,
   });
 
+  await page
+    .getByRole("button", {
+      name: `More actions for ${INSTALLED_APP.displayName}`,
+    })
+    .click();
+  await expect(page.getByRole("menuitem", { name: "Relaunch" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Stop" })).toBeVisible();
+  await page.screenshot({
+    path: `${EVIDENCE_DIR}/desktop-03-apps-row-menu.png`,
+    fullPage: true,
+  });
+  await page.keyboard.press("Escape");
+
   // Create flow — the exact /api/apps/create payload must still be produced
   // from the consolidated surface.
   const createToggle = page.getByRole("button", { name: "Create new app" });
   await expect(createToggle).toBeVisible();
   await createToggle.focus();
   await page.screenshot({
-    path: `${EVIDENCE_DIR}/desktop-03-create-focus.png`,
+    path: `${EVIDENCE_DIR}/desktop-04-create-focus.png`,
     fullPage: true,
   });
   await createToggle.click();
@@ -181,7 +197,7 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
     directory: "/Users/proof/code/imported-app",
   });
   await page.screenshot({
-    path: `${EVIDENCE_DIR}/desktop-04-load-submitted.png`,
+    path: `${EVIDENCE_DIR}/desktop-05-load-submitted.png`,
     fullPage: true,
   });
 
@@ -193,7 +209,7 @@ test("Projects → Apps keeps the retired My Apps lifecycle controls working", a
     page.getByTestId(`apps-mgmt-row-${INSTALLED_APP.name}`),
   ).toBeVisible({ timeout: 30_000 });
   await page.screenshot({
-    path: `${EVIDENCE_DIR}/desktop-05-segment-roundtrip.png`,
+    path: `${EVIDENCE_DIR}/desktop-06-segment-roundtrip.png`,
     fullPage: true,
   });
 });
@@ -206,7 +222,10 @@ test("bare /apps and /apps/tasks resolve to the right Projects segment", async (
 
   // Bare retired route → Apps segment.
   await openProjectsApps(page, "/apps");
-  await expect(page.getByText("Install, create, and run")).toBeVisible();
+  await expect(page.getByTestId("projects-segment-apps")).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
 
   // Canonical route → Tasks segment (Apps body not mounted).
   await openAppPath(page, "/apps/tasks");
@@ -223,12 +242,29 @@ test("mobile Projects → Apps keeps every lifecycle control reachable", async (
   await page.setViewportSize({ width: 390, height: 844 });
 
   await openProjectsApps(page, "/apps/my-apps");
+  const row = page.getByTestId(`apps-mgmt-row-${INSTALLED_APP.name}`);
   const createToggle = page.getByRole("button", { name: "Create new app" });
   await expect(createToggle).toBeVisible({ timeout: 30_000 });
   await page.screenshot({
     path: `${EVIDENCE_DIR}/mobile-01-apps-rest.png`,
     fullPage: true,
   });
+
+  await page.setViewportSize({ width: 844, height: 390 });
+  await expect(row).toBeVisible();
+  await page.screenshot({
+    path: `${EVIDENCE_DIR}/mobile-landscape-01-apps-rest.png`,
+    fullPage: true,
+  });
+
+  await page.setViewportSize({ width: 768, height: 1024 });
+  await expect(row).toBeVisible();
+  await page.screenshot({
+    path: `${EVIDENCE_DIR}/tablet-01-apps-rest.png`,
+    fullPage: true,
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
 
   // The ambient chat sheet must not swallow the management controls on phone
   // widths — the regression #17031's consolidation introduced and 896da53
@@ -243,7 +279,6 @@ test("mobile Projects → Apps keeps every lifecycle control reachable", async (
   });
 
   // Installed row stays reachable by scrolling within the segment body.
-  const row = page.getByTestId(`apps-mgmt-row-${INSTALLED_APP.name}`);
   await row.scrollIntoViewIfNeeded();
   await expect(row).toBeVisible();
   await page.screenshot({

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -108,7 +108,7 @@
       "maintainedReferences": 2
     }
   ],
-  "eligibleComponents": 104,
+  "eligibleComponents": 103,
   "clusters": [
     {
       "archetype": "row",
@@ -987,80 +987,6 @@
       "archetype": "panel",
       "atomicDependencies": [
         "button",
-        "dropdownMenu"
-      ],
-      "entries": [
-        {
-          "atomicDependencies": [
-            "button",
-            "dropdownMenu"
-          ],
-          "file": "packages/ui/src/components/chat/AppsSection.tsx",
-          "line": 42,
-          "name": "AppsSection",
-          "renderedTags": [
-            "AppIdentityTile",
-            "Button",
-            "DropdownMenu",
-            "DropdownMenuContent",
-            "DropdownMenuItem",
-            "DropdownMenuTrigger",
-            "LayoutGrid",
-            "MoreHorizontal",
-            "WidgetSection",
-            "div"
-          ],
-          "archetype": "panel"
-        },
-        {
-          "atomicDependencies": [
-            "button",
-            "dropdownMenu"
-          ],
-          "file": "packages/ui/src/components/settings/AppsManagementSection.tsx",
-          "line": 164,
-          "name": "AppsManagementSection",
-          "renderedTags": [
-            "AdvancedToggle",
-            "AppRowActions",
-            "Boxes",
-            "Button",
-            "DropdownMenu",
-            "DropdownMenuContent",
-            "DropdownMenuItem",
-            "DropdownMenuTrigger",
-            "Loader2",
-            "MoreHorizontal",
-            "Plus",
-            "SettingsGroup",
-            "SettingsInputRow",
-            "SettingsRow",
-            "SettingsSelectRow",
-            "SettingsStack",
-            "SettingsSwitchRow",
-            "SettingsTextareaRow",
-            "div",
-            "form",
-            "p",
-            "section",
-            "span"
-          ],
-          "archetype": "panel"
-        }
-      ],
-      "signature": "panel:button+dropdownMenu",
-      "disposition": "distinct-domain-compositions",
-      "rationale": "Chat app discovery and installed-app management share canonical action and menu atoms, but own different selection, launch, creation, import, and mutation lifecycles.",
-      "memberComponentIds": [
-        "packages/ui/src/components/chat/AppsSection.tsx:AppsSection",
-        "packages/ui/src/components/settings/AppsManagementSection.tsx:AppsManagementSection"
-      ],
-      "semanticFingerprint": "sha256:c97cf96c69c8b1ce30fa6b977c54467f2583678f829badf746c2ca1c8588f60d"
-    },
-    {
-      "archetype": "panel",
-      "atomicDependencies": [
-        "button",
         "input"
       ],
       "entries": [
@@ -1173,8 +1099,8 @@
     }
   ],
   "summary": {
-    "clusterCount": 13,
-    "clusteredComponents": 32,
+    "clusterCount": 12,
+    "clusteredComponents": 30,
     "largestCluster": 4
   }
 }

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -108,7 +108,7 @@
       "maintainedReferences": 2
     }
   ],
-  "eligibleComponents": 104,
+  "eligibleComponents": 103,
   "clusters": [
     {
       "archetype": "row",

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -108,7 +108,7 @@
       "maintainedReferences": 2
     }
   ],
-  "eligibleComponents": 103,
+  "eligibleComponents": 104,
   "clusters": [
     {
       "archetype": "row",
@@ -987,6 +987,80 @@
       "archetype": "panel",
       "atomicDependencies": [
         "button",
+        "dropdownMenu"
+      ],
+      "entries": [
+        {
+          "atomicDependencies": [
+            "button",
+            "dropdownMenu"
+          ],
+          "file": "packages/ui/src/components/chat/AppsSection.tsx",
+          "line": 42,
+          "name": "AppsSection",
+          "renderedTags": [
+            "AppIdentityTile",
+            "Button",
+            "DropdownMenu",
+            "DropdownMenuContent",
+            "DropdownMenuItem",
+            "DropdownMenuTrigger",
+            "LayoutGrid",
+            "MoreHorizontal",
+            "WidgetSection",
+            "div"
+          ],
+          "archetype": "panel"
+        },
+        {
+          "atomicDependencies": [
+            "button",
+            "dropdownMenu"
+          ],
+          "file": "packages/ui/src/components/settings/AppsManagementSection.tsx",
+          "line": 164,
+          "name": "AppsManagementSection",
+          "renderedTags": [
+            "AdvancedToggle",
+            "AppRowActions",
+            "Boxes",
+            "Button",
+            "DropdownMenu",
+            "DropdownMenuContent",
+            "DropdownMenuItem",
+            "DropdownMenuTrigger",
+            "Loader2",
+            "MoreHorizontal",
+            "Plus",
+            "SettingsGroup",
+            "SettingsInputRow",
+            "SettingsRow",
+            "SettingsSelectRow",
+            "SettingsStack",
+            "SettingsSwitchRow",
+            "SettingsTextareaRow",
+            "div",
+            "form",
+            "p",
+            "section",
+            "span"
+          ],
+          "archetype": "panel"
+        }
+      ],
+      "signature": "panel:button+dropdownMenu",
+      "disposition": "distinct-domain-compositions",
+      "rationale": "Chat app discovery and installed-app management share canonical action and menu atoms, but own different selection, launch, creation, import, and mutation lifecycles.",
+      "memberComponentIds": [
+        "packages/ui/src/components/chat/AppsSection.tsx:AppsSection",
+        "packages/ui/src/components/settings/AppsManagementSection.tsx:AppsManagementSection"
+      ],
+      "semanticFingerprint": "sha256:c97cf96c69c8b1ce30fa6b977c54467f2583678f829badf746c2ca1c8588f60d"
+    },
+    {
+      "archetype": "panel",
+      "atomicDependencies": [
+        "button",
         "input"
       ],
       "entries": [
@@ -1099,8 +1173,8 @@
     }
   ],
   "summary": {
-    "clusterCount": 12,
-    "clusteredComponents": 30,
+    "clusterCount": 13,
+    "clusteredComponents": 32,
     "largestCluster": 4
   }
 }

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 897 maintained React files. 104 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 897 maintained React files. 103 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 897 maintained React files. 103 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 897 maintained React files. 104 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 
@@ -30,6 +30,7 @@ These owners are fail-closed contracts. The audit fails if an owner disappears, 
 | dialog | alert, button, card | 2 | distinct-domain-compositions |
 | form | button, input | 2 | distinct-domain-compositions |
 | panel | badge, button, input | 2 | shared-lifecycle-owner |
+| panel | button, dropdownMenu | 2 | distinct-domain-compositions |
 | panel | button, input | 2 | distinct-domain-compositions |
 | row | button, card, statusDot | 2 | distinct-domain-compositions |
 
@@ -110,6 +111,13 @@ These owners are fail-closed contracts. The audit fails if an owner disappears, 
 - `CloudAgentsSection` in `packages/ui/src/components/settings/CloudAgentsSection.tsx:77`
 - Fingerprint: `sha256:f0e0a109e0fab258115f7e1cc83319bae2890d554c23083a69f95a6700db6757`
 - Decision: **shared-lifecycle-owner**. The cloud-panel-owned useCloudAgentManagement pattern owns list refresh, create, rename, suspend/resume, delete polling, wake-and-switch, persistence, and notices; AgentSection and CloudAgentsSection are distinct presentation adapters with explicit management-token providers.
+
+### panel: button + dropdownMenu
+
+- `AppsSection` in `packages/ui/src/components/chat/AppsSection.tsx:42`
+- `AppsManagementSection` in `packages/ui/src/components/settings/AppsManagementSection.tsx:164`
+- Fingerprint: `sha256:c97cf96c69c8b1ce30fa6b977c54467f2583678f829badf746c2ca1c8588f60d`
+- Decision: **distinct-domain-compositions**. Chat app discovery and installed-app management share canonical action and menu atoms, but own different selection, launch, creation, import, and mutation lifecycles.
 
 ### panel: button + input
 

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 897 maintained React files. 104 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 897 maintained React files. 103 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 
@@ -30,7 +30,6 @@ These owners are fail-closed contracts. The audit fails if an owner disappears, 
 | dialog | alert, button, card | 2 | distinct-domain-compositions |
 | form | button, input | 2 | distinct-domain-compositions |
 | panel | badge, button, input | 2 | shared-lifecycle-owner |
-| panel | button, dropdownMenu | 2 | distinct-domain-compositions |
 | panel | button, input | 2 | distinct-domain-compositions |
 | row | button, card, statusDot | 2 | distinct-domain-compositions |
 
@@ -111,13 +110,6 @@ These owners are fail-closed contracts. The audit fails if an owner disappears, 
 - `CloudAgentsSection` in `packages/ui/src/components/settings/CloudAgentsSection.tsx:77`
 - Fingerprint: `sha256:f0e0a109e0fab258115f7e1cc83319bae2890d554c23083a69f95a6700db6757`
 - Decision: **shared-lifecycle-owner**. The cloud-panel-owned useCloudAgentManagement pattern owns list refresh, create, rename, suspend/resume, delete polling, wake-and-switch, persistence, and notices; AgentSection and CloudAgentsSection are distinct presentation adapters with explicit management-token providers.
-
-### panel: button + dropdownMenu
-
-- `AppsSection` in `packages/ui/src/components/chat/AppsSection.tsx:42`
-- `AppsManagementSection` in `packages/ui/src/components/settings/AppsManagementSection.tsx:164`
-- Fingerprint: `sha256:c97cf96c69c8b1ce30fa6b977c54467f2583678f829badf746c2ca1c8588f60d`
-- Decision: **distinct-domain-compositions**. Chat app discovery and installed-app management share canonical action and menu atoms, but own different selection, launch, creation, import, and mutation lifecycles.
 
 ### panel: button + input
 

--- a/packages/ui/scripts/molecular-inventory-decisions.json
+++ b/packages/ui/scripts/molecular-inventory-decisions.json
@@ -106,6 +106,15 @@
       ],
       "semanticFingerprint": "sha256:7c11e8d4a6401f86006252780a6d7d428dc8d5ade6007d697bf320b213c709af"
     },
+    "panel:button+dropdownMenu": {
+      "disposition": "distinct-domain-compositions",
+      "rationale": "Chat app discovery and installed-app management share canonical action and menu atoms, but own different selection, launch, creation, import, and mutation lifecycles.",
+      "memberComponentIds": [
+        "packages/ui/src/components/chat/AppsSection.tsx:AppsSection",
+        "packages/ui/src/components/settings/AppsManagementSection.tsx:AppsManagementSection"
+      ],
+      "semanticFingerprint": "sha256:c97cf96c69c8b1ce30fa6b977c54467f2583678f829badf746c2ca1c8588f60d"
+    },
     "row:button+card+statusDot": {
       "disposition": "distinct-domain-compositions",
       "rationale": "Rail rows compose the same atomic status indicator while preserving domain-specific navigation and selection behavior.",

--- a/packages/ui/scripts/molecular-inventory-decisions.json
+++ b/packages/ui/scripts/molecular-inventory-decisions.json
@@ -106,15 +106,6 @@
       ],
       "semanticFingerprint": "sha256:7c11e8d4a6401f86006252780a6d7d428dc8d5ade6007d697bf320b213c709af"
     },
-    "panel:button+dropdownMenu": {
-      "disposition": "distinct-domain-compositions",
-      "rationale": "Chat app discovery and installed-app management share canonical action and menu atoms, but own different selection, launch, creation, import, and mutation lifecycles.",
-      "memberComponentIds": [
-        "packages/ui/src/components/chat/AppsSection.tsx:AppsSection",
-        "packages/ui/src/components/settings/AppsManagementSection.tsx:AppsManagementSection"
-      ],
-      "semanticFingerprint": "sha256:c97cf96c69c8b1ce30fa6b977c54467f2583678f829badf746c2ca1c8588f60d"
-    },
     "row:button+card+statusDot": {
       "disposition": "distinct-domain-compositions",
       "rationale": "Rail rows compose the same atomic status indicator while preserving domain-specific navigation and selection behavior.",

--- a/packages/ui/src/components/pages/TasksPageView.test.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.test.tsx
@@ -138,9 +138,7 @@ describe("TasksPageView", () => {
 
     expect(screen.getByTestId("projects-apps-segment")).toBeTruthy();
     expect(screen.queryByTestId("coding-agent-tasks-panel-stub")).toBeNull();
-    expect(
-      screen.getByText("Install, create, and run your elizaOS apps."),
-    ).toBeTruthy();
+    expect(screen.getByRole("region", { name: "App actions" })).toBeTruthy();
     // The reused management surface mounts and finishes its empty catalog load
     // (client.listInstalledApps is the mocked read) without throwing.
     const { client } = await import("../../api/client");

--- a/packages/ui/src/components/pages/TasksPageView.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.tsx
@@ -30,7 +30,10 @@ import {
 import { getWindowNavigationPath } from "../../navigation";
 import { CodingAgentTasksPanel } from "../../slots/task-coordinator-slots.js";
 import { useAppSelector } from "../../state";
-import { AppsManagementSection } from "../settings/AppsManagementSection";
+import {
+  AppsManagementActions,
+  AppsManagementSection,
+} from "../settings/AppsManagementSection";
 import { SettingsGroup, SettingsRow } from "../settings/settings-layout";
 import { useShellControllerContext } from "../shell/ShellControllerContext.hooks";
 import { SegmentedControl } from "../ui/segmented-control";
@@ -112,6 +115,8 @@ export function TasksPageView() {
       typeof window === "undefined" ? "" : getWindowNavigationPath(),
     ),
   );
+  const [showCreate, setShowCreate] = useState(false);
+  const [showLoad, setShowLoad] = useState(false);
   const cloudStudioPath = useCloudAppsStudioPath();
   const cloudConnected = useAppSelector((state) => state.elizaCloudConnected);
   const segments: Array<{ id: ProjectsSegment; label: string }> = [
@@ -169,7 +174,17 @@ export function TasksPageView() {
     <ShellViewAgentSurface viewId="tasks">
       <FramedPage gutterOwner="framed-page" data-testid="tasks-view">
         <FramedPageHeader title="Projects" />
-        <FramedPageNavigation>{segmentControl}</FramedPageNavigation>
+        <FramedPageNavigation className="flex items-center justify-between gap-2">
+          {segmentControl}
+          {segment === "apps" ? (
+            <AppsManagementActions
+              showCreate={showCreate}
+              showLoad={showLoad}
+              setShowCreate={setShowCreate}
+              setShowLoad={setShowLoad}
+            />
+          ) : null}
+        </FramedPageNavigation>
         <FramedPageBody scroll="view" padded={false} className="device-layout">
           {segment === "apps" ? (
             <div
@@ -177,7 +192,13 @@ export function TasksPageView() {
               data-testid="projects-apps-segment"
             >
               <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4 sm:p-6">
-                <AppsManagementSection />
+                <AppsManagementSection
+                  showCreate={showCreate}
+                  showLoad={showLoad}
+                  setShowCreate={setShowCreate}
+                  setShowLoad={setShowLoad}
+                  hideActions
+                />
                 {cloudStudioPath && cloudConnected ? (
                   // Same signed-in gate the launcher applies to cloud surfaces
                   // (LAUNCHER_CLOUD_IDS): the studio is useless without a cloud

--- a/packages/ui/src/components/pages/TasksPageView.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.tsx
@@ -177,9 +177,6 @@ export function TasksPageView() {
               data-testid="projects-apps-segment"
             >
               <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4 sm:p-6">
-                <p className="text-sm text-muted">
-                  Install, create, and run your elizaOS apps.
-                </p>
                 <AppsManagementSection />
                 {cloudStudioPath && cloudConnected ? (
                   // Same signed-in gate the launcher applies to cloud surfaces

--- a/packages/ui/src/components/settings/AppsManagementSection.test.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.test.tsx
@@ -108,6 +108,6 @@ describe("AppsManagementSection failure states", () => {
     await waitFor(() => {
       expect(clientMock.listInstalledApps).toHaveBeenCalledTimes(2);
     });
-    expect(await screen.findByText("No apps installed yet.")).toBeTruthy();
+    expect(await screen.findByRole("status")).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/settings/AppsManagementSection.test.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.test.tsx
@@ -76,8 +76,12 @@ describe("AppsManagementSection failure states", () => {
     });
     render(<AppsManagementSection />);
 
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "More app actions" }),
+      { button: 0, pointerId: 1 },
+    );
     fireEvent.click(
-      screen.getByRole("button", { name: "Load from directory" }),
+      await screen.findByRole("menuitem", { name: "Import from directory" }),
     );
     fireEvent.change(screen.getByLabelText("Directory path"), {
       target: { value: "/workspace/my-app" },

--- a/packages/ui/src/components/settings/AppsManagementSection.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.tsx
@@ -3,7 +3,7 @@
  * "Create new app" and "Load from directory" entry points.
  */
 
-import { Boxes, Loader2, MoreHorizontal, Play } from "lucide-react";
+import { Boxes, Loader2, MoreHorizontal, Play, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api/client";
@@ -453,12 +453,10 @@ export function AppsManagementSection() {
       },
     });
   const { ref: loadToggleRef, agentProps: loadToggleAgentProps } =
-    useAgentElement<HTMLButtonElement>({
+    useAgentElement<HTMLDivElement>({
       id: "apps-load-toggle",
       role: "button",
-      label: t("settings.sections.apps.loadFromDirectory", {
-        defaultValue: "Load from directory",
-      }),
+      label: "Import from directory",
       group: "apps-management",
       status: showLoad ? "active" : "inactive",
       onActivate: () => {
@@ -521,33 +519,49 @@ export function AppsManagementSection() {
   return (
     <SettingsStack>
       <section className="flex flex-col gap-3" aria-label="App actions">
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center justify-end gap-1">
           <Button
             ref={createToggleRef}
             type="button"
             variant="default"
-            size="touch"
+            size="icon"
+            className="size-10"
+            aria-label="Create new app"
+            title="Create new app"
             onClick={() => {
               setShowCreate((v) => !v);
               setShowLoad(false);
             }}
             {...createToggleAgentProps}
           >
-            New app
+            <Plus className="size-4" aria-hidden />
           </Button>
-          <Button
-            ref={loadToggleRef}
-            type="button"
-            variant="ghostMuted"
-            size="touch"
-            onClick={() => {
-              setShowLoad((v) => !v);
-              setShowCreate(false);
-            }}
-            {...loadToggleAgentProps}
-          >
-            Import
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghostMuted"
+                size="icon"
+                className="size-10"
+                aria-label="More app actions"
+                title="More app actions"
+              >
+                <MoreHorizontal className="size-4" aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-44">
+              <DropdownMenuItem
+                ref={loadToggleRef}
+                onSelect={() => {
+                  setShowLoad((v) => !v);
+                  setShowCreate(false);
+                }}
+                {...loadToggleAgentProps}
+              >
+                Import from directory
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </section>
 

--- a/packages/ui/src/components/settings/AppsManagementSection.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.tsx
@@ -3,7 +3,7 @@
  * "Create new app" and "Load from directory" entry points.
  */
 
-import { Loader2, Play, RotateCw, Square } from "lucide-react";
+import { Boxes, Loader2, MoreHorizontal, Play } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api/client";
@@ -15,13 +15,11 @@ import type {
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "../ui/table";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
 import {
@@ -82,6 +80,62 @@ function AppRowActionButton({
   );
 }
 
+function AppRowActions({
+  app,
+  busy,
+  running,
+  onLaunch,
+  onRelaunch,
+  onEdit,
+  onStop,
+}: {
+  app: InstalledAppInfo;
+  busy: boolean;
+  running: boolean;
+  onLaunch: () => void;
+  onRelaunch: () => void;
+  onEdit: () => void;
+  onStop: () => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <AppRowActionButton
+        agentId={`apps-launch-${app.name}`}
+        label={`Launch ${app.displayName}`}
+        group="apps-list"
+        disabled={busy}
+        onClick={onLaunch}
+        className="size-10"
+      >
+        <Play className="size-4" aria-hidden />
+      </AppRowActionButton>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghostMuted"
+            size="icon"
+            className="size-10"
+            disabled={busy}
+            aria-label={`More actions for ${app.displayName}`}
+          >
+            <MoreHorizontal className="size-4" aria-hidden />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-44">
+          <DropdownMenuItem onClick={onRelaunch}>Relaunch</DropdownMenuItem>
+          <DropdownMenuItem onClick={onEdit}>Edit</DropdownMenuItem>
+          {running ? (
+            <DropdownMenuItem className="text-danger" onClick={onStop}>
+              Stop
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 interface CreateAppResponse {
   ok?: boolean;
   status?: string;
@@ -106,9 +160,6 @@ type AsyncStatus =
   | { state: "idle" }
   | { state: "loading"; message?: string }
   | { state: "error"; message: string };
-
-const HEAD_CELL_CLASS = "px-3 py-2 text-xs font-medium text-muted";
-const BODY_CELL_CLASS = "px-3 py-2.5 align-middle text-sm";
 
 export function AppsManagementSection() {
   const setActionNotice = useAppSelector((s) => s.setActionNotice);
@@ -469,11 +520,8 @@ export function AppsManagementSection() {
 
   return (
     <SettingsStack>
-      <SettingsGroup
-        title={t("settings.sections.apps.groupTitle", { defaultValue: "Apps" })}
-        action={<AdvancedToggle label="Advanced" />}
-      >
-        <div className="flex flex-wrap items-center gap-2 pb-1">
+      <section className="flex flex-col gap-3" aria-label="App actions">
+        <div className="flex flex-wrap items-center gap-2">
           <Button
             ref={createToggleRef}
             type="button"
@@ -485,14 +533,12 @@ export function AppsManagementSection() {
             }}
             {...createToggleAgentProps}
           >
-            {t("settings.sections.apps.createNew", {
-              defaultValue: "Create new app",
-            })}
+            New app
           </Button>
           <Button
             ref={loadToggleRef}
             type="button"
-            variant="outline"
+            variant="ghostMuted"
             size="touch"
             onClick={() => {
               setShowLoad((v) => !v);
@@ -500,31 +546,19 @@ export function AppsManagementSection() {
             }}
             {...loadToggleAgentProps}
           >
-            {t("settings.sections.apps.loadFromDirectory", {
-              defaultValue: "Load from directory",
-            })}
+            Import
           </Button>
         </div>
-        {advancedEnabled ? (
-          <SettingsSwitchRow
-            agentId="apps-verify-on-relaunch"
-            group="apps-management"
-            label={t("settings.sections.apps.verifyOnRelaunch", {
-              defaultValue: "Verify on relaunch",
-            })}
-            checked={verifyOnRelaunch}
-            agentStatus={verifyOnRelaunch ? "active" : "inactive"}
-            onCheckedChange={setVerifyOnRelaunch}
-          />
-        ) : null}
-      </SettingsGroup>
+      </section>
 
       {showCreate ? (
         <form onSubmit={handleCreateSubmit}>
           <SettingsGroup
+            bare
             title={t("settings.sections.apps.createNew", {
               defaultValue: "Create new app",
             })}
+            action={<AdvancedToggle label="Advanced" />}
             footer={
               createStatus.state === "error" ? (
                 <span role="alert" className="text-danger">
@@ -627,6 +661,7 @@ export function AppsManagementSection() {
       {showLoad ? (
         <form onSubmit={handleLoadSubmit}>
           <SettingsGroup
+            bare
             title={t("settings.sections.apps.loadFromDirectory", {
               defaultValue: "Load from directory",
             })}
@@ -734,11 +769,18 @@ export function AppsManagementSection() {
         </SettingsGroup>
       ) : installed.length === 0 ? (
         <SettingsGroup bare>
-          <p className="py-4 text-center text-sm text-muted">
-            {t("settings.sections.apps.empty", {
-              defaultValue: "No apps installed yet.",
-            })}
-          </p>
+          <div
+            role="status"
+            className="mx-auto flex min-h-44 max-w-sm flex-col items-center justify-center gap-2 text-center [@media(orientation:landscape)_and_(max-height:520px)]:min-h-24"
+          >
+            <Boxes className="size-8 text-accent" aria-hidden />
+            <p className="text-sm font-semibold text-txt-strong">
+              No apps installed yet
+            </p>
+            <p className="text-xs leading-relaxed text-muted">
+              Create an app or load one from a directory to get started.
+            </p>
+          </div>
         </SettingsGroup>
       ) : (
         <SettingsGroup
@@ -747,123 +789,64 @@ export function AppsManagementSection() {
             defaultValue: "Installed apps",
           })}
         >
-          <div className="overflow-x-auto">
-            <Table className="min-w-[34rem]">
-              <TableHeader>
-                <TableRow className="border-b border-border/50">
-                  <TableHead className={HEAD_CELL_CLASS}>
-                    {t("settings.sections.apps.col.name", {
-                      defaultValue: "App",
-                    })}
-                  </TableHead>
-                  <TableHead className={HEAD_CELL_CLASS}>
-                    {t("settings.sections.apps.col.id", {
-                      defaultValue: "ID",
-                    })}
-                  </TableHead>
-                  <TableHead className={HEAD_CELL_CLASS}>
-                    {t("settings.sections.apps.col.version", {
-                      defaultValue: "Version",
-                    })}
-                  </TableHead>
-                  <TableHead className={HEAD_CELL_CLASS}>
-                    {t("settings.sections.apps.col.runs", {
-                      defaultValue: "Runs",
-                    })}
-                  </TableHead>
-                  <TableHead className={`${HEAD_CELL_CLASS} text-right`}>
-                    {t("settings.sections.apps.col.actions", {
-                      defaultValue: "Actions",
-                    })}
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {installed.map((app) => {
-                  const appRuns = runsByName.get(app.name) ?? [];
-                  const running = appRuns.length > 0;
-                  const busy = busyApp === app.name;
-                  return (
-                    <TableRow
-                      key={app.name}
-                      className="border-t border-border/60 hover:bg-bg-hover/40"
-                      data-testid={`apps-mgmt-row-${app.name}`}
-                    >
-                      <TableCell
-                        className={`${BODY_CELL_CLASS} font-medium text-txt`}
-                      >
-                        {app.displayName}
-                      </TableCell>
-                      <TableCell
-                        className={`${BODY_CELL_CLASS} font-mono text-xs text-muted`}
-                      >
-                        {app.name}
-                      </TableCell>
-                      <TableCell
-                        className={`${BODY_CELL_CLASS} text-xs text-muted`}
-                      >
-                        {app.version || "—"}
-                      </TableCell>
-                      <TableCell className={BODY_CELL_CLASS}>
-                        {running ? (
-                          <span className="inline-flex items-center rounded-full bg-ok/10 px-2 py-0.5 text-xs font-medium text-ok">
-                            {appRuns.length}{" "}
-                            {appRuns.length === 1 ? "run" : "runs"}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-muted">—</span>
-                        )}
-                      </TableCell>
-                      <TableCell className={`${BODY_CELL_CLASS} text-right`}>
-                        <div className="inline-flex items-center gap-1">
-                          <AppRowActionButton
-                            agentId={`apps-launch-${app.name}`}
-                            label={`Launch ${app.displayName}`}
-                            group="apps-list"
-                            disabled={busy}
-                            onClick={() => void handleLaunch(app)}
-                          >
-                            <Play className="size-3.5" aria-hidden />
-                          </AppRowActionButton>
-                          <AppRowActionButton
-                            agentId={`apps-relaunch-${app.name}`}
-                            label={`Relaunch ${app.displayName}`}
-                            group="apps-list"
-                            disabled={busy}
-                            onClick={() => void handleRelaunch(app)}
-                          >
-                            <RotateCw className="size-3.5" aria-hidden />
-                          </AppRowActionButton>
-                          <AppRowActionButton
-                            agentId={`apps-edit-${app.name}`}
-                            label={`Edit ${app.displayName}`}
-                            group="apps-list"
-                            disabled={busy}
-                            onClick={() => void handleEdit(app)}
-                          >
-                            {t("settings.sections.apps.edit", {
-                              defaultValue: "Edit",
-                            })}
-                          </AppRowActionButton>
-                          {running ? (
-                            <AppRowActionButton
-                              agentId={`apps-stop-${app.name}`}
-                              label={`Stop ${app.displayName}`}
-                              group="apps-list"
-                              className="h-7 px-2 text-xs text-danger hover:text-danger"
-                              disabled={busy}
-                              onClick={() => void handleStop(app)}
-                            >
-                              <Square className="size-3.5" aria-hidden />
-                            </AppRowActionButton>
-                          ) : null}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
+          {advancedEnabled ? (
+            <div className="border-y border-border/50 py-2">
+              <SettingsSwitchRow
+                agentId="apps-verify-on-relaunch"
+                group="apps-management"
+                label={t("settings.sections.apps.verifyOnRelaunch", {
+                  defaultValue: "Verify on relaunch",
                 })}
-              </TableBody>
-            </Table>
+                checked={verifyOnRelaunch}
+                agentStatus={verifyOnRelaunch ? "active" : "inactive"}
+                onCheckedChange={setVerifyOnRelaunch}
+              />
+            </div>
+          ) : null}
+          <div className="divide-y divide-border/60 border-y border-border/60">
+            {installed.map((app) => {
+              const appRuns = runsByName.get(app.name) ?? [];
+              const running = appRuns.length > 0;
+              const busy = busyApp === app.name;
+              return (
+                <div
+                  key={app.name}
+                  className="flex min-w-0 items-center gap-3 py-3 transition-colors hover:bg-bg-hover/20"
+                  data-testid={`apps-mgmt-row-${app.name}`}
+                >
+                  <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-surface text-sm font-semibold text-muted-strong">
+                    {app.displayName.slice(0, 1).toUpperCase()}
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate text-sm font-semibold text-txt-strong">
+                      {app.displayName}
+                    </span>
+                    <span className="truncate text-xs text-muted">
+                      {app.name}
+                      {app.version ? ` · v${app.version}` : ""}
+                    </span>
+                  </span>
+                  <span className="hidden shrink-0 sm:inline-flex">
+                    {running ? (
+                      <span className="inline-flex items-center rounded-full bg-ok/10 px-2 py-0.5 text-xs font-medium text-ok">
+                        {appRuns.length} {appRuns.length === 1 ? "run" : "runs"}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-muted">—</span>
+                    )}
+                  </span>
+                  <AppRowActions
+                    app={app}
+                    busy={busy}
+                    running={running}
+                    onLaunch={() => void handleLaunch(app)}
+                    onRelaunch={() => void handleRelaunch(app)}
+                    onEdit={() => void handleEdit(app)}
+                    onStop={() => void handleStop(app)}
+                  />
+                </div>
+              );
+            })}
           </div>
         </SettingsGroup>
       )}

--- a/packages/ui/src/components/settings/AppsManagementSection.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.tsx
@@ -4,7 +4,15 @@
  */
 
 import { Boxes, Loader2, MoreHorizontal, Play, Plus } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api/client";
 import type {
@@ -161,7 +169,113 @@ type AsyncStatus =
   | { state: "loading"; message?: string }
   | { state: "error"; message: string };
 
-export function AppsManagementSection() {
+interface AppsManagementActionsProps {
+  showCreate: boolean;
+  showLoad: boolean;
+  setShowCreate: Dispatch<SetStateAction<boolean>>;
+  setShowLoad: Dispatch<SetStateAction<boolean>>;
+}
+
+export function AppsManagementActions({
+  showCreate,
+  showLoad,
+  setShowCreate,
+  setShowLoad,
+}: AppsManagementActionsProps) {
+  const t = useAppSelector((s) => s.t);
+  const { ref: createToggleRef, agentProps: createToggleAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "apps-create-toggle",
+      role: "button",
+      label: t("settings.sections.apps.createNew", {
+        defaultValue: "Create new app",
+      }),
+      group: "apps-management",
+      status: showCreate ? "active" : "inactive",
+      onActivate: () => {
+        setShowCreate((value) => !value);
+        setShowLoad(false);
+      },
+    });
+  const { ref: loadToggleRef, agentProps: loadToggleAgentProps } =
+    useAgentElement<HTMLDivElement>({
+      id: "apps-load-toggle",
+      role: "button",
+      label: "Import from directory",
+      group: "apps-management",
+      status: showLoad ? "active" : "inactive",
+      onActivate: () => {
+        setShowLoad((value) => !value);
+        setShowCreate(false);
+      },
+    });
+
+  return (
+    <section
+      className="flex items-center justify-end gap-1"
+      aria-label="App actions"
+    >
+      <Button
+        ref={createToggleRef}
+        type="button"
+        variant="default"
+        size="icon"
+        className="size-10"
+        aria-label="Create new app"
+        title="Create new app"
+        onClick={() => {
+          setShowCreate((value) => !value);
+          setShowLoad(false);
+        }}
+        {...createToggleAgentProps}
+      >
+        <Plus className="size-4" aria-hidden />
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghostMuted"
+            size="icon"
+            className="size-10"
+            aria-label="More app actions"
+            title="More app actions"
+          >
+            <MoreHorizontal className="size-4" aria-hidden />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-44">
+          <DropdownMenuItem
+            ref={loadToggleRef}
+            onSelect={() => {
+              setShowLoad((value) => !value);
+              setShowCreate(false);
+            }}
+            {...loadToggleAgentProps}
+          >
+            Import from directory
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </section>
+  );
+}
+
+interface AppsManagementSectionProps {
+  showCreate?: boolean;
+  showLoad?: boolean;
+  setShowCreate?: Dispatch<SetStateAction<boolean>>;
+  setShowLoad?: Dispatch<SetStateAction<boolean>>;
+  hideActions?: boolean;
+}
+
+export function AppsManagementSection({
+  showCreate: controlledShowCreate,
+  showLoad: controlledShowLoad,
+  setShowCreate: controlledSetShowCreate,
+  setShowLoad: controlledSetShowLoad,
+  hideActions = false,
+}: AppsManagementSectionProps = {}) {
   const setActionNotice = useAppSelector((s) => s.setActionNotice);
   const t = useAppSelector((s) => s.t);
   const advancedEnabled = useAdvancedSettingsEnabled();
@@ -173,14 +287,18 @@ export function AppsManagementSection() {
   });
   const [busyApp, setBusyApp] = useState<string | null>(null);
 
-  const [showCreate, setShowCreate] = useState(false);
+  const [internalShowCreate, setInternalShowCreate] = useState(false);
   const [createIntent, setCreateIntent] = useState("");
   const [createEditTarget, setCreateEditTarget] = useState("");
   const [createStatus, setCreateStatus] = useState<AsyncStatus>({
     state: "idle",
   });
 
-  const [showLoad, setShowLoad] = useState(false);
+  const [internalShowLoad, setInternalShowLoad] = useState(false);
+  const showCreate = controlledShowCreate ?? internalShowCreate;
+  const showLoad = controlledShowLoad ?? internalShowLoad;
+  const setShowCreate = controlledSetShowCreate ?? setInternalShowCreate;
+  const setShowLoad = controlledSetShowLoad ?? setInternalShowLoad;
   const [loadDirectory, setLoadDirectory] = useState("");
   const [loadStatus, setLoadStatus] = useState<AsyncStatus>({ state: "idle" });
 
@@ -388,7 +506,7 @@ export function AppsManagementSection() {
         });
       }
     },
-    [createEditTarget, createIntent, refresh, setActionNotice],
+    [createEditTarget, createIntent, refresh, setActionNotice, setShowCreate],
   );
 
   const handleLoadSubmit = useCallback(
@@ -432,38 +550,12 @@ export function AppsManagementSection() {
         });
       }
     },
-    [loadDirectory, refresh, setActionNotice],
+    [loadDirectory, refresh, setActionNotice, setShowLoad],
   );
 
   const isCreating = createStatus.state === "loading";
   const isLoading = loadStatus.state === "loading";
 
-  const { ref: createToggleRef, agentProps: createToggleAgentProps } =
-    useAgentElement<HTMLButtonElement>({
-      id: "apps-create-toggle",
-      role: "button",
-      label: t("settings.sections.apps.createNew", {
-        defaultValue: "Create new app",
-      }),
-      group: "apps-management",
-      status: showCreate ? "active" : "inactive",
-      onActivate: () => {
-        setShowCreate((v) => !v);
-        setShowLoad(false);
-      },
-    });
-  const { ref: loadToggleRef, agentProps: loadToggleAgentProps } =
-    useAgentElement<HTMLDivElement>({
-      id: "apps-load-toggle",
-      role: "button",
-      label: "Import from directory",
-      group: "apps-management",
-      status: showLoad ? "active" : "inactive",
-      onActivate: () => {
-        setShowLoad((v) => !v);
-        setShowCreate(false);
-      },
-    });
   const { ref: createSubmitRef, agentProps: createSubmitAgentProps } =
     useAgentElement<HTMLButtonElement>({
       id: "apps-create-submit",
@@ -518,52 +610,14 @@ export function AppsManagementSection() {
 
   return (
     <SettingsStack>
-      <section className="flex flex-col gap-3" aria-label="App actions">
-        <div className="flex items-center justify-end gap-1">
-          <Button
-            ref={createToggleRef}
-            type="button"
-            variant="default"
-            size="icon"
-            className="size-10"
-            aria-label="Create new app"
-            title="Create new app"
-            onClick={() => {
-              setShowCreate((v) => !v);
-              setShowLoad(false);
-            }}
-            {...createToggleAgentProps}
-          >
-            <Plus className="size-4" aria-hidden />
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghostMuted"
-                size="icon"
-                className="size-10"
-                aria-label="More app actions"
-                title="More app actions"
-              >
-                <MoreHorizontal className="size-4" aria-hidden />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-44">
-              <DropdownMenuItem
-                ref={loadToggleRef}
-                onSelect={() => {
-                  setShowLoad((v) => !v);
-                  setShowCreate(false);
-                }}
-                {...loadToggleAgentProps}
-              >
-                Import from directory
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </section>
+      {!hideActions ? (
+        <AppsManagementActions
+          showCreate={showCreate}
+          showLoad={showLoad}
+          setShowCreate={setShowCreate}
+          setShowLoad={setShowLoad}
+        />
+      ) : null}
 
       {showCreate ? (
         <form onSubmit={handleCreateSubmit}>


### PR DESCRIPTION
# Relates to

Closes #29739

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the unrelated baseline failure is recorded below.
- [x] A reviewer can confirm the change from the inline evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync; the exact unrelated blocker is documented below.

# Risks

Low. The change is confined to the Projects → Apps presentation and its real-renderer coverage. Existing create, import, launch, relaunch, edit, and stop behavior remains wired to the same handlers.

# Background

## What does this PR do?

- Replaces the oversized dark action container with a compact top-right `+` action and quiet overflow menu.
- Presents create and import as transparent inline forms instead of nested dark cards.
- Replaces the wide installed-app table with a responsive separator-led list and progressive action menu.
- Adds a designed empty state and keeps compact phone-landscape content clear of the composer.
- Extends real-renderer evidence across desktop, phone portrait, phone landscape, and tablet states.

## What kind of change is this?

Bug fix and interface improvement.

# Documentation changes needed?

No product documentation change is required.

# Testing

## Where should a reviewer start?

Open Projects → Apps at `/apps` and compare empty, installed, create, and overflow-menu states across desktop and mobile.

## Detailed testing steps

1. Open `/apps` and verify Apps is selected.
2. Verify `+` is the single primary action and Import is disclosed by the adjacent overflow control.
3. Open `+` and confirm the form remains on the ambient route canvas.
4. With an installed app, verify Launch remains direct and Relaunch/Edit/Stop are in the overflow menu.
5. Repeat at phone portrait and landscape widths; confirm no horizontal overflow or composer collision.

# Evidence Gate

<!-- evidence-head:3d108d51e09325ab429ce2c36ef853c73cd62392 -->

<!-- evidence-row:before-screenshots -->
- [x] [Before screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-before-empty-desktop.png) are attached below for empty and populated desktop/mobile states.
<!-- evidence-row:after-screenshots -->
- [x] [After screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-desktop.png) are attached below for desktop, mobile, create, and open-menu states.
<!-- evidence-row:walkthrough-video -->
- [x] [Desktop lifecycle walkthrough (MP4)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-apps-lifecycle-walkthrough.mp4)
<!-- evidence-row:backend-logs -->
- [ ] N/A - UI-only presentation change; agent API endpoints and server behavior are unchanged and route-mocked in the renderer lifecycle proof.
<!-- evidence-row:frontend-logs -->
- [x] [Frontend network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-frontend-network.jsonl) and [console trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-frontend-console.jsonl) record the rendered flow and mocked API requests/responses.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, model, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduler, wallet, or other domain state changed.
<!-- evidence-row:ocr-review -->
- [x] [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-ocr-triage.json) verifies all four `/apps` viewports: 4 verified, 0 broken, 0 needs-eyeball.

# Evidence Details

## Screenshots

Every image below is a separate full-page artifact; the table only arranges them into columns.

### Empty — desktop

| Before | After |
| --- | --- |
| ![Desktop empty before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-before-empty-desktop.png) | ![Desktop empty after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-desktop.png) |

### Empty — phone portrait

| Before | After |
| --- | --- |
| ![Phone portrait empty before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-before-empty-mobile-portrait.png) | ![Phone portrait empty after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-mobile.png) |

### Empty — phone landscape

| Before | After |
| --- | --- |
| ![Phone landscape empty before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-before-empty-mobile-landscape.png) | ![Phone landscape empty after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-landscape.png) |

### Installed apps — desktop

| Before | After |
| --- | --- |
| ![Desktop installed apps before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-before-filled-desktop.png) | ![Desktop installed apps after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-filled-desktop.png) |

### Installed apps — phone portrait

| Before | After |
| --- | --- |
| ![Phone installed apps before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-before-filled-mobile.png) | ![Phone installed apps after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-filled-mobile.png) |

### Additional responsive and interaction states

| Phone landscape | Overflow menu | Inline create form |
| --- | --- | --- |
| ![Phone landscape installed apps](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-landscape.png) | ![Desktop app overflow menu](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-menu.png) | ![Phone inline create form](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-create-mobile.png) |

### Final HIG action toolbar

| Desktop rest | Desktop menu open | Phone portrait | Phone landscape |
| --- | --- | --- | --- |
| ![Desktop compact action toolbar](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-desktop.png) | ![Desktop import menu open](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-menu.png) | ![Phone compact action toolbar](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-mobile.png) | ![Phone landscape compact action toolbar](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29741-after-same-row-empty-landscape.png) |

## Validation

- `bun run --cwd packages/ui typecheck` — pass
- focused UI unit suite — 14 tests pass
- Projects → Apps real-renderer lifecycle — 3 tests pass
- design-system audit — pass, 0 violations
- molecular inventory — pass, no regressions
- full app visual capture — `/apps` is `good` at phone portrait, phone landscape, iPad portrait, and desktop; zero overflow or overlay-clearance findings

## Known gaps / failures

`bun run verify` reaches 374/375 tasks and fails only in the pre-existing UI design-contract graph check (`4 !== 0`). The identical two failing subtests reproduce on the untouched `origin/develop` base at `5c476b4206c18673b518afe2975a1cc06`. The affected package typecheck, focused tests, design-system audit, molecular inventory, lifecycle E2E, and all four `/apps` viewport audits pass.

The repository-wide visual audit also reports unrelated failures on other routes; every affected `/apps` viewport is `good`.

## Maintainer CI exception record

N/A - no exception requested.
