### PR TITLE
feat(slack): publish Web API membership snapshots and deltas (#24367)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3080,10 +3080,12 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
+        "@elizaos/plugin-sql": "workspace:*",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.2.25",
         "typescript": "^6.0.3",
+        "uuid": "^11.0.5",
         "vitest": "^4.1.10",
       },
       "peerDependencies": {
@@ -10244,6 +10246,8 @@
     "@elizaos/plugin-elizacloud/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@elizaos/plugin-elizacloud/@scure/bip32": ["@scure/bip32@2.2.0", "", { "dependencies": { "@noble/curves": "2.2.0", "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg=="],
+
+    "@elizaos/plugin-slack/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "@elizaos/plugin-wallet/@solana/spl-token": ["@solana/spl-token@0.4.14", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA=="],
 

--- a/plugins/plugin-slack/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-slack/__tests__/membership-authority.real.test.ts
@@ -87,8 +87,8 @@ vi.mock("@slack/bolt", () => ({
   },
 }));
 
-import { slackMembershipPrincipalId } from "./membership-authority";
-import { SlackService } from "./service";
+import { slackMembershipPrincipalId } from "../src/membership-authority";
+import { SlackService } from "../src/service";
 
 const OPS = "C0123ABCD";
 const ALICE = "U0123ABCD";
@@ -170,7 +170,9 @@ afterAll(async () => {
 }, 60_000);
 
 async function membershipScope() {
-  const { slackMembershipAccountId } = await import("./membership-authority");
+  const { slackMembershipAccountId } = await import(
+    "../src/membership-authority"
+  );
   return {
     agentId: runtime.agentId,
     connectorId: "slack",

--- a/plugins/plugin-slack/package.json
+++ b/plugins/plugin-slack/package.json
@@ -81,7 +81,9 @@
     "bun-types": "^1.2.25",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "@elizaos/plugin-sql": "workspace:*",
+    "uuid": "^11.0.5"
   },
   "peerDependencies": {
     "@elizaos/core": "workspace:*"

--- a/plugins/plugin-slack/src/index.ts
+++ b/plugins/plugin-slack/src/index.ts
@@ -206,6 +206,17 @@ export {
   stripSlackFormatting,
   truncateText,
 } from "./formatting";
+export type {
+  SlackMembershipReadResult,
+  SlackMembershipSnapshot,
+  SlackMembershipUnavailable,
+  SlackMembershipUnavailableReason,
+} from "./membership";
+export {
+  classifyMembershipFailure,
+  readChannelMembershipSnapshot,
+  SLACK_MEMBERS_PAGE_LIMIT,
+} from "./membership";
 export {
   isSlackChannelIdKey,
   normalizeSlackSlug,

--- a/plugins/plugin-slack/src/membership-authority.real.test.ts
+++ b/plugins/plugin-slack/src/membership-authority.real.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Real-authority coverage for the canonical Slack membership publication
+ * (#24367): the plugin-sql MembershipService runs over a real PGlite
+ * adapter and the full AgentRuntime, exactly like plugin-sql's own authority
+ * tests. The SlackService under test is real with the Bolt app and
+ * WebClient mocked; the runtime, connector-account row, room/world/entity
+ * rows, and the authority's durable evidence are all real. Proves the
+ * publisher's commands satisfy the authority's validation (UUID pattern
+ * fences, cursor chain, connector-account FK, principal rows) and that a
+ * published roster authorizes its members through MembershipService.authorize.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  AgentRuntime,
+  type IAgentRuntime,
+  MembershipService,
+  type UUID,
+} from "@elizaos/core";
+import { createDatabaseAdapter } from "@elizaos/plugin-sql";
+import { v4 as uuidv4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const bolt = vi.hoisted(() => ({
+  channels: [] as Array<Record<string, unknown>>,
+  users: [] as Array<Record<string, unknown>>,
+}));
+
+function createClient() {
+  return {
+    auth: {
+      test: vi
+        .fn()
+        .mockResolvedValue({ user_id: "U0BOTBOT0", team_id: "T0TEAM000" }),
+    },
+    conversations: {
+      list: vi.fn().mockResolvedValue({ channels: bolt.channels }),
+      info: vi
+        .fn()
+        .mockImplementation(async ({ channel }: { channel: string }) => ({
+          channel: bolt.channels.find((entry) => entry.id === channel),
+        })),
+      members: vi.fn(),
+      history: vi.fn().mockResolvedValue({ messages: [] }),
+      replies: vi.fn().mockResolvedValue({ messages: [] }),
+    },
+    users: {
+      list: vi.fn().mockResolvedValue({ members: bolt.users }),
+      info: vi.fn().mockImplementation(async ({ user }: { user: string }) => ({
+        user: bolt.users.find((entry) => entry.id === user),
+      })),
+    },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ok: true, ts: "1.000001" }),
+    },
+    team: { info: vi.fn().mockResolvedValue({ team: { name: "Sandbox" } }) },
+  };
+}
+
+const apps = vi.hoisted(() => [] as Array<ReturnType<typeof createAppRecord>>);
+
+function createAppRecord() {
+  return {
+    eventHandlers: new Map<string, unknown>(),
+    messageHandler: undefined as unknown,
+    client: createClient(),
+  };
+}
+
+vi.mock("@slack/bolt", () => ({
+  LogLevel: { INFO: "info" },
+  App: class MockBoltApp {
+    private readonly record = createAppRecord();
+    client = this.record.client;
+    constructor() {
+      apps.push(this.record);
+    }
+    message(handler: unknown) {
+      this.record.messageHandler = handler;
+    }
+    event(name: string, handler: unknown) {
+      this.record.eventHandlers.set(name, handler);
+    }
+    async start() {}
+    async stop() {}
+  },
+}));
+
+import { slackMembershipPrincipalId } from "./membership-authority";
+import { SlackService } from "./service";
+
+const OPS = "C0123ABCD";
+const ALICE = "U0123ABCD";
+const BOB = "U0999ZZZZ";
+const TEAM = "T0TEAM000";
+
+let runtime: AgentRuntime;
+let membership: MembershipService;
+let slackService: SlackService;
+let dataDir: string;
+let app: (typeof apps)[number];
+
+beforeAll(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "slack-membership-24367-"));
+  const agentId = uuidv4() as UUID;
+  const adapter = createDatabaseAdapter({ dataDir }, agentId);
+  await (adapter as unknown as { init: () => Promise<void> }).init();
+  runtime = new AgentRuntime({
+    character: {
+      name: "slack-membership-24367",
+      id: agentId,
+      plugins: [],
+      settings: {},
+    },
+    agentId,
+    adapter,
+    logLevel: "warn",
+    enableAutonomy: false,
+  });
+  const sqlModule = (await import("@elizaos/plugin-sql")) as {
+    default?: { plugins?: unknown[] };
+    plugin?: { plugins?: unknown[] };
+  };
+  const sqlPlugin =
+    sqlModule.default ?? (sqlModule.plugin as { plugins?: unknown[] });
+  if (sqlPlugin) {
+    await runtime.registerPlugin(
+      sqlPlugin as Parameters<AgentRuntime["registerPlugin"]>[0],
+    );
+  }
+  await runtime.initialize();
+  const services = runtime.getServicesByType<MembershipService>(
+    MembershipService.serviceType,
+  );
+  expect(services.length).toBeGreaterThan(0);
+  membership = services[0];
+
+  // Configure the Slack account directly on the initialized runtime's
+  // character so account resolution finds tokens.
+  runtime.character.settings = {
+    ...runtime.character.settings,
+    slack: {
+      enabled: true,
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      groupPolicy: "allowlist",
+      channels: { ops: { users: [ALICE] } },
+    },
+  };
+  bolt.channels.push({
+    id: OPS,
+    name: "ops",
+    is_channel: true,
+    is_member: true,
+  });
+  bolt.users.push(
+    { id: ALICE, name: "alice", real_name: "Alice Example" },
+    { id: BOB, name: "bob", real_name: "Bob Example" },
+  );
+  apps.length = 0;
+  slackService = await SlackService.start(runtime as unknown as IAgentRuntime);
+  app = apps.at(-1) as (typeof apps)[number];
+  expect(app).toBeDefined();
+}, 180_000);
+
+afterAll(async () => {
+  await runtime.stop();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+}, 60_000);
+
+async function membershipScope() {
+  const { slackMembershipAccountId } = await import("./membership-authority");
+  return {
+    agentId: runtime.agentId,
+    connectorId: "slack",
+    connectorAccountId: slackMembershipAccountId(
+      "slack-membership-default",
+    ) as UUID,
+    externalWorldId: TEAM,
+    externalRoomId: OPS,
+  };
+}
+
+describe("Slack canonical membership publisher (real PGlite authority)", () => {
+  it("publishes a complete roster snapshot the real authority accepts and authorizes members", async () => {
+    const members = vi.fn().mockResolvedValue({ members: [ALICE, BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await slackService.renewChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+
+    // The authority accepted the publication: authorization decisions must
+    // now succeed for both roster members through the real authority.
+    const scope = await membershipScope();
+    for (const userId of [ALICE, BOB]) {
+      const decision = await membership.authorize(
+        scope,
+        slackMembershipPrincipalId("default", userId),
+      );
+      expect(decision.decision).toBe("allowed");
+    }
+    // The bot user is not a published member: it must not authorize.
+    const botDecision = await membership.authorize(
+      scope,
+      slackMembershipPrincipalId("default", "U0BOTBOT0"),
+    );
+    expect(botDecision.decision).toBe("denied");
+  });
+
+  it("publishes join/leave deltas the real authority chains after the baseline", async () => {
+    // Baseline with only ALICE: BOB must not authorize yet.
+    const members = vi.fn().mockResolvedValue({ members: [ALICE] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    await slackService.renewChannelMembership(OPS);
+
+    const scope = await membershipScope();
+    const bobPrincipal = slackMembershipPrincipalId("default", BOB);
+    const before = await membership.authorize(scope, bobPrincipal);
+    expect(before.decision).toBe("denied");
+
+    const handler = app.eventHandlers.get("member_joined_channel") as
+      | ((args: {
+          event: unknown;
+          client: unknown;
+          body?: unknown;
+        }) => Promise<void>)
+      | undefined;
+    expect(handler).toBeDefined();
+    const joinEvent = {
+      user: BOB,
+      channel: OPS,
+      event_ts: "1700000100.000100",
+    };
+    await handler?.({
+      event: joinEvent,
+      client: app.client,
+      body: { team_id: TEAM, event_id: "Ev-join-bob", event: joinEvent },
+    });
+    const afterJoin = await membership.authorize(scope, bobPrincipal);
+    if (afterJoin.decision !== "allowed") {
+      const record = await membership.getMembership(scope, bobPrincipal);
+      throw new Error(
+        `join delta did not authorize; decision: ${JSON.stringify(afterJoin)}; record: ${JSON.stringify(record)}`,
+      );
+    }
+    expect(afterJoin.decision).toBe("allowed");
+
+    const leaveHandler = app.eventHandlers.get("member_left_channel") as
+      | ((args: {
+          event: unknown;
+          client: unknown;
+          body?: unknown;
+        }) => Promise<void>)
+      | undefined;
+    const leaveEvent = {
+      user: BOB,
+      channel: OPS,
+      event_ts: "1700000200.000100",
+    };
+    await leaveHandler?.({
+      event: leaveEvent,
+      client: app.client,
+      body: { team_id: TEAM, event_id: "Ev-leave-bob", event: leaveEvent },
+    });
+    const afterLeave = await membership.authorize(scope, bobPrincipal);
+    expect(afterLeave.decision).toBe("denied");
+    expect(afterLeave.reason).toBe("membership_revoked");
+  });
+
+  it("a join delta after an unavailable read is suppressed until a fresh snapshot restores the scope", async () => {
+    // Baseline, then degrade via unavailable read.
+    const members = vi.fn().mockResolvedValue({ members: [ALICE] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    await slackService.renewChannelMembership(OPS);
+
+    const scopeError = new Error(
+      "An API error occurred: ratelimited",
+    ) as unknown as { code: string; data: { error: string } };
+    scopeError.code = "slack_webapi_platform_error";
+    scopeError.data = { error: "ratelimited" };
+    const failing = vi.fn().mockRejectedValue(scopeError);
+    (app.client.conversations as { members: typeof failing }).members = failing;
+    await slackService.renewChannelMembership(OPS);
+
+    const scope = await membershipScope();
+
+    // Join delta while degraded: must not authorize (scope stale denies).
+    const joinHandler = app.eventHandlers.get("member_joined_channel") as
+      | ((args: {
+          event: unknown;
+          client: unknown;
+          body?: unknown;
+        }) => Promise<void>)
+      | undefined;
+    const joinEvent = {
+      user: BOB,
+      channel: OPS,
+      event_ts: "1700000300.000100",
+    };
+    await joinHandler?.({
+      event: joinEvent,
+      client: app.client,
+      body: { team_id: TEAM, event_id: "Ev-join-bob-2", event: joinEvent },
+    });
+    const bobPrincipal = slackMembershipPrincipalId("default", BOB);
+    const degradedDecision = await membership.authorize(scope, bobPrincipal);
+    expect(degradedDecision.decision).toBe("denied");
+
+    // Fresh snapshot restores the scope and carries the member.
+    const restored = vi.fn().mockResolvedValue({ members: [ALICE, BOB] });
+    (app.client.conversations as { members: typeof restored }).members =
+      restored;
+    const result = await slackService.renewChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+    const restoredDecision = await membership.authorize(scope, bobPrincipal);
+    expect(restoredDecision.decision).toBe("allowed");
+  });
+
+  it("an unavailable roster read marks the scope health stale, never revokes members", async () => {
+    const members = vi.fn().mockResolvedValue({ members: [ALICE] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    await slackService.renewChannelMembership(OPS);
+
+    const scopeError = new Error(
+      "An API error occurred: missing_scope",
+    ) as unknown as { code: string; data: { error: string } };
+    scopeError.code = "slack_webapi_platform_error";
+    scopeError.data = { error: "missing_scope" };
+    const failing = vi.fn().mockRejectedValue(scopeError);
+    (app.client.conversations as { members: typeof failing }).members = failing;
+    const result = await slackService.renewChannelMembership(OPS);
+    expect(result.kind).toBe("unavailable");
+
+    const scope = await membershipScope();
+    const health = await membership.getScopeHealth(scope);
+    expect(health?.health).toBe("stale");
+    // The member's record survives the unavailable read (no mass revoke).
+    const alicePrincipal = slackMembershipPrincipalId("default", ALICE);
+    const record = await membership.getMembership(scope, alicePrincipal);
+    expect(record?.state).toBe("active");
+  });
+});

--- a/plugins/plugin-slack/src/membership-authority.ts
+++ b/plugins/plugin-slack/src/membership-authority.ts
@@ -1,0 +1,652 @@
+/**
+ * Publishes Slack Web API membership evidence to the canonical
+ * MembershipService authority (issue #24367). `renewChannelMembership` and
+ * the member join/leave handlers feed this publisher: a completed
+ * `conversations.members` walk becomes a complete snapshot, an unavailable
+ * read becomes an incomplete-snapshot report (stale, never mass-revoked),
+ * and join/leave events become ordered deltas. Fencing discipline follows
+ * the authority contract: stable per-process publisher identity, durable
+ * generation adoption across restarts, observation-derived idempotency
+ * keys, and fail-closed degradation. When no MembershipService authority is
+ * registered the publisher is absent and the service keeps legacy
+ * runtime-participation behavior.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  IAgentRuntime,
+  JsonObject,
+  MembershipScope,
+  MembershipService,
+  UUID,
+} from "@elizaos/core";
+import { ElizaError, ServiceType } from "@elizaos/core";
+
+import type { SlackMembershipReadResult } from "./membership";
+
+/** Connector id the authority's connector_accounts provider expects. */
+export const SLACK_MEMBERSHIP_CONNECTOR_ID = "slack";
+
+/** Evidence validity window for roster snapshots (1 hour). */
+export const SLACK_MEMBERSHIP_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * The authority validates UUID version nibbles ([1-8]); createUniqueUuid /
+ * stringToUuid-derived ids carry the custom 0x0 version nibble and are
+ * rejected with MEMBERSHIP_COMMAND_INVALID, so derived runtime ids are only
+ * forwarded when pattern-valid.
+ */
+export const AUTHORITY_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** 16-byte namespace seed for deterministic RFC-4122 v5 principal ids. */
+const SLACK_MEMBERSHIP_NAMESPACE = createHash("sha1")
+  .update("elizaos:plugin-slack:membership:v1")
+  .digest()
+  .subarray(0, 16);
+
+function uuidV5(name: string): UUID {
+  // RFC 4122 4.3: SHA-1 over namespace bytes || name, then set version 5
+  // and variant bits. Implemented with node:crypto so this plugin carries no
+  // uuid dependency.
+  const digest = createHash("sha1")
+    .update(SLACK_MEMBERSHIP_NAMESPACE)
+    .update(Buffer.from(name, "utf8"))
+    .digest();
+  const bytes = digest.subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC variant
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as UUID;
+}
+
+/**
+ * Canonical principal id for one Slack workspace user, for the membership
+ * authority. Deterministic RFC-4122 v5 over (account key, Slack user id):
+ * stable across restarts and publishers, and pattern-valid for the
+ * authority's [1-8] version-nibble check.
+ */
+export function slackMembershipPrincipalId(
+  accountKey: string,
+  slackUserId: string,
+): UUID {
+  return uuidV5(`${accountKey}:${slackUserId}`);
+}
+
+/**
+ * Authority scope for one admitted Slack channel. `externalWorldId` is the
+ * workspace team id (a channel's membership lives inside exactly one
+ * workspace) and `externalRoomId` the channel id, keyed per connector
+ * account so separate account rows never alias scopes.
+ */
+export function slackMembershipScope(input: {
+  agentId: UUID;
+  connectorAccountId: UUID;
+  teamId: string;
+  channelId: string;
+}): MembershipScope {
+  return {
+    agentId: input.agentId,
+    connectorId: SLACK_MEMBERSHIP_CONNECTOR_ID,
+    connectorAccountId: input.connectorAccountId,
+    externalWorldId: input.teamId,
+    externalRoomId: input.channelId,
+  };
+}
+
+/**
+ * Deterministic authority connector-account id for one account record.
+ * Used when the account storage echoes a non-UUID record id: the authority
+ * keys every scope by a versioned-UUID connectorAccountId, so the v5
+ * derivation keeps scope identity stable across restarts.
+ */
+export function slackMembershipAccountId(accountRecordId: string): UUID {
+  return uuidV5(`account:${accountRecordId}`);
+}
+
+export function isMembershipService(
+  service: unknown,
+): service is MembershipService {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    typeof (service as MembershipService).registerPublisher === "function" &&
+    typeof (service as MembershipService).applyCompleteSnapshot === "function"
+  );
+}
+
+export function resolveMembershipService(
+  runtime: IAgentRuntime,
+): MembershipService | null {
+  const service = runtime.getService(ServiceType.MEMBERSHIP);
+  return isMembershipService(service) ? service : null;
+}
+
+function scopeKey(scope: MembershipScope): string {
+  return `${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+}
+
+function membershipErrorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : "";
+}
+
+/** Error codes the authority surfaces for fence collisions. */
+const FENCE_CODES = new Set([
+  "MEMBERSHIP_GENERATION_FENCE",
+  "MEMBERSHIP_GENERATION_MISMATCH",
+  "MEMBERSHIP_PUBLISHER_FENCE",
+  "MEMBERSHIP_PUBLISHER_MISMATCH",
+  "MEMBERSHIP_PUBLISHER_GENERATION_STALE",
+  "MEMBERSHIP_CURSOR_FENCE",
+  "MEMBERSHIP_CURSOR_DISCONTINUITY",
+  "MEMBERSHIP_PUBLISH_TAKEN_OVER",
+]);
+
+interface ScopeTracker {
+  generation: number;
+  publisherGeneration: number;
+  sourceVersion: number;
+  sourceCursor: string | null;
+  degraded: boolean;
+}
+
+/**
+ * Publication failure of one evidence command after fenced retries: the
+ * authority kept rejecting the publish (fence collisions or idempotency
+ * conflicts the retry could not reconcile). The scope keeps its prior
+ * authoritative state; the caller sees the typed failure instead of a
+ * fabricated success, and the snapshot read result still flows back to
+ * runtime-participation renewal.
+ */
+export class SlackMembershipPublishError extends ElizaError {
+  constructor(
+    message: string,
+    options?: { cause?: unknown; context?: Record<string, unknown> },
+  ) {
+    super(message, {
+      code: "SLACK_MEMBERSHIP_PUBLISH_FAILED",
+      context: options?.context,
+      cause: options?.cause,
+      severity: "ephemeral",
+    });
+  }
+}
+
+/** Runtime-mapping derivation the publisher shares with the service. */
+export interface SlackMembershipRuntimeIds {
+  worldId: UUID | null;
+  roomId: UUID | null;
+  entityId: UUID | null;
+}
+
+/**
+ * Publisher of Slack Web API membership evidence to the canonical
+ * MembershipService authority. One instance per (runtime, connector
+ * account). Authority mutations are serialized per scope; the connector
+ * always publishes with evidenceMode "ordered_delta" (snapshots and deltas
+ * share one cursor chain per the authority's registration contract).
+ */
+export class SlackMembershipPublisher {
+  private readonly runtime: IAgentRuntime;
+  private readonly connectorAccountId: UUID;
+  private readonly accountKey: string;
+  private readonly service: MembershipService;
+  private readonly publisherInstanceId: string;
+  private readonly scopes = new Map<string, ScopeTracker>();
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  /** Maps a channel id to its runtime ids, mirroring the service's derivation. */
+  private readonly deriveRuntimeIds: (input: {
+    channelId: string;
+    slackUserId: string;
+  }) => SlackMembershipRuntimeIds;
+  /** Ensures authority-visible principal entity rows exist. */
+  private readonly ensurePrincipalEntity: (
+    principalId: UUID,
+    slackUserId: string,
+  ) => Promise<void>;
+  /** Ensures the authority-visible room and world rows exist. */
+  private readonly ensureRuntimeRoomAndWorld: (
+    runtimeIds: SlackMembershipRuntimeIds,
+    channelId: string,
+  ) => Promise<void>;
+
+  constructor(input: {
+    runtime: IAgentRuntime;
+    connectorAccountId: UUID;
+    accountKey: string;
+    service: MembershipService;
+    publisherInstanceId?: string;
+    deriveRuntimeIds: (input: {
+      channelId: string;
+      slackUserId: string;
+    }) => SlackMembershipRuntimeIds;
+    ensurePrincipalEntity: (
+      principalId: UUID,
+      slackUserId: string,
+    ) => Promise<void>;
+    ensureRuntimeRoomAndWorld: (
+      runtimeIds: SlackMembershipRuntimeIds,
+      channelId: string,
+    ) => Promise<void>;
+  }) {
+    this.runtime = input.runtime;
+    this.connectorAccountId = input.connectorAccountId;
+    this.accountKey = input.accountKey;
+    this.service = input.service;
+    this.publisherInstanceId =
+      input.publisherInstanceId ?? `slack-${randomUUID()}`;
+    this.deriveRuntimeIds = input.deriveRuntimeIds;
+    this.ensurePrincipalEntity = input.ensurePrincipalEntity;
+    this.ensureRuntimeRoomAndWorld = input.ensureRuntimeRoomAndWorld;
+  }
+
+  /** Per-scope serialization: authority mutations for one scope must chain. */
+  private serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.chains.get(key) ?? Promise.resolve();
+    const next = previous.then(fn, fn);
+    this.chains.set(key, next);
+    return next;
+  }
+
+  private trackerFor(scope: MembershipScope): ScopeTracker {
+    const key = scopeKey(scope);
+    let tracker = this.scopes.get(key);
+    if (!tracker) {
+      tracker = {
+        generation: 0,
+        publisherGeneration: 0,
+        sourceVersion: 0,
+        sourceCursor: null,
+        degraded: false,
+      };
+      this.scopes.set(key, tracker);
+    }
+    return tracker;
+  }
+
+  /**
+   * Register this process as the scope publisher, adopting durable scope
+   * state so a restarted process re-binds without losing fencing: when the
+   * durable health row already belongs to this stable publisher identity,
+   * re-bind at the same generation instead of resetting the evidence chain.
+   */
+  private async ensureRegistered(
+    scope: MembershipScope,
+  ): Promise<ScopeTracker> {
+    const tracker = this.trackerFor(scope);
+    if (tracker.generation > 0) return tracker;
+
+    const health = await this.service.getScopeHealth(scope);
+    if (health) {
+      tracker.generation = health.generation;
+      tracker.sourceVersion = health.sourceVersion;
+      tracker.sourceCursor = health.sourceCursor;
+      // Registration must strictly advance the durable publisher
+      // generation (the authority rejects <= current, even for the same
+      // publisher instance re-binding after a restart).
+      tracker.publisherGeneration = (health.publisherGeneration ?? 0) + 1;
+    }
+
+    const receipt = await this.service.registerPublisher({
+      ...scope,
+      publisherInstanceId: this.publisherInstanceId,
+      publisherGeneration: tracker.publisherGeneration,
+      evidenceMode: "ordered_delta",
+      expectedGeneration: tracker.generation,
+      idempotencyKey: `slack:publisher:${this.publisherInstanceId}:${tracker.publisherGeneration}:${scope.externalRoomId}`,
+      observedAt: new Date().toISOString(),
+    });
+    // Registration resets the durable evidence chain (sourceVersion -1,
+    // cursor null) and advances the generation: adopt the post-registration
+    // chain state so the first snapshot starts the cursor at 0.
+    tracker.generation = receipt.committedGeneration;
+    tracker.sourceVersion = -1;
+    tracker.sourceCursor = null;
+    return tracker;
+  }
+
+  /** Re-adopt durable state after a fence collision. */
+  private async readoptFromHealth(
+    scope: MembershipScope,
+  ): Promise<ScopeTracker> {
+    const tracker = this.trackerFor(scope);
+    const health = await this.service.getScopeHealth(scope);
+    if (health) {
+      tracker.generation = health.generation;
+      tracker.sourceVersion = health.sourceVersion;
+      tracker.sourceCursor = health.sourceCursor;
+      // Re-registration must strictly advance the durable publisher
+      // generation (the authority rejects <= current).
+      tracker.publisherGeneration = (health.publisherGeneration ?? 0) + 1;
+    }
+    const receipt = await this.service.registerPublisher({
+      ...scope,
+      publisherInstanceId: this.publisherInstanceId,
+      publisherGeneration: tracker.publisherGeneration,
+      evidenceMode: "ordered_delta",
+      expectedGeneration: tracker.generation,
+      idempotencyKey: `slack:publisher:${this.publisherInstanceId}:${tracker.publisherGeneration}:readopt:${scope.externalRoomId}`,
+      observedAt: new Date().toISOString(),
+    });
+    tracker.generation = receipt.committedGeneration;
+    tracker.sourceVersion = -1;
+    tracker.sourceCursor = null;
+    return tracker;
+  }
+
+  private scopeFor(teamId: string, channelId: string): MembershipScope {
+    return slackMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      teamId,
+      channelId,
+    });
+  }
+
+  /**
+   * Publish a completed `conversations.members` walk as a complete
+   * snapshot. Returns true when the authority committed new evidence; false
+   * on a benign idempotent replay. The caller's runtime-participation
+   * renewal is independent and unaffected by the publish outcome.
+   */
+  async publishSnapshot(input: {
+    teamId: string;
+    channelId: string;
+    memberIds: readonly string[];
+    botUserId: string | null;
+    observedAt?: string;
+  }): Promise<boolean> {
+    const scope = this.scopeFor(input.teamId, input.channelId);
+    const key = scopeKey(scope);
+    return this.serialized(key, async () => {
+      let tracker = await this.ensureRegistered(scope);
+      const observedAt = input.observedAt ?? new Date().toISOString();
+      const observedAtMs = Date.parse(observedAt);
+      if (!Number.isFinite(observedAtMs)) {
+        throw new Error(
+          `membership snapshot observedAt is not a finite timestamp: ${observedAt}`,
+        );
+      }
+      // Idempotency key derived from the observation identity: the authority
+      // journals keys per account and rejects a reused key whose digest
+      // differs, so a restart (counter reset) or a repeated renewal of a
+      // live adapter must never collide with a previously journaled key.
+      const observedToken = observedAtMs.toString(36);
+      const snapshotKey = `slack:snapshot:${this.accountKey}:${input.channelId}:${observedToken}`;
+
+      const members = [];
+      for (const memberId of input.memberIds) {
+        if (memberId === input.botUserId) continue;
+        const principalId = slackMembershipPrincipalId(
+          this.accountKey,
+          memberId,
+        );
+        await this.ensurePrincipalEntity(principalId, memberId);
+        const runtimeIds = this.deriveRuntimeIds({
+          channelId: input.channelId,
+          slackUserId: memberId,
+        });
+        members.push({
+          canonicalPrincipalId: principalId,
+          roles: ["member"],
+          permissionSnapshot: {
+            connector: "slack",
+            accountId: this.accountKey,
+            slackUserId: memberId,
+          } as JsonObject,
+          runtime: runtimeIds,
+        });
+      }
+      const firstRuntimeIds =
+        members.length > 0
+          ? members[0].runtime
+          : this.deriveRuntimeIds({
+              channelId: input.channelId,
+              slackUserId: input.channelId,
+            });
+      await this.ensureRuntimeRoomAndWorld(firstRuntimeIds, input.channelId);
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const sourceVersion = tracker.sourceVersion + 1;
+        const sourceCursor = `slack:${this.accountKey}:${input.channelId}:${sourceVersion}`;
+        const attemptKey =
+          attempt === 0 ? snapshotKey : `${snapshotKey}:r${attempt}`;
+        try {
+          await this.service.applyCompleteSnapshot({
+            ...scope,
+            publisherInstanceId: this.publisherInstanceId,
+            publisherGeneration: tracker.publisherGeneration,
+            evidenceMode: "ordered_delta",
+            expectedGeneration: tracker.generation,
+            sourceVersion,
+            previousSourceCursor: tracker.sourceCursor,
+            sourceCursor,
+            validUntil: new Date(
+              Date.parse(observedAt) + SLACK_MEMBERSHIP_TTL_MS,
+            ).toISOString(),
+            completeness: "complete",
+            members,
+            idempotencyKey: attemptKey,
+            observedAt,
+          });
+          tracker.generation += 1;
+          tracker.sourceVersion = sourceVersion;
+          tracker.sourceCursor = sourceCursor;
+          tracker.degraded = false;
+          return true;
+        } catch (error) {
+          const code = membershipErrorCode(error);
+          if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+            // The reused key carried a DIFFERENT command digest — not an
+            // identical replay. Retrying once under a fresh derived key
+            // reconciles the divergence.
+            continue;
+          }
+          if (FENCE_CODES.has(code)) {
+            tracker = await this.readoptFromHealth(scope);
+            continue;
+          }
+          // error-policy:J2 Non-fencing failures (storage outage) propagate
+          // as a typed wrapper preserving the cause: the scope keeps its
+          // previous authoritative state and the caller sees the failure
+          // instead of a fabricated success.
+          throw new SlackMembershipPublishError(
+            `roster snapshot publish failed: ${membershipErrorCode(error) || "unknown"}`,
+            {
+              cause: error,
+              context: {
+                accountKey: this.accountKey,
+                channelId: input.channelId,
+              },
+            },
+          );
+        }
+      }
+      throw new SlackMembershipPublishError(
+        "roster snapshot commit exhausted its fenced retries",
+        {
+          context: { accountKey: this.accountKey, channelId: input.channelId },
+        },
+      );
+    });
+  }
+
+  /**
+   * Publish one join/leave observation as an ordered delta. Requires a
+   * current complete snapshot in this publisher generation (the authority
+   * rejects deltas before a baseline with MEMBERSHIP_SNAPSHOT_REQUIRED); a
+   * join for an unknown baseline is skipped because the next snapshot sweep
+   * will carry it.
+   */
+  async publishDelta(input: {
+    teamId: string;
+    channelId: string;
+    slackUserId: string;
+    joined: boolean;
+    reason: "joined" | "left" | "kicked";
+    observedAt?: string;
+  }): Promise<boolean> {
+    const scope = this.scopeFor(input.teamId, input.channelId);
+    const key = scopeKey(scope);
+    return this.serialized(key, async () => {
+      const tracker = this.trackerFor(scope);
+      if (tracker.degraded) return false;
+      // Deltas need a current baseline; before the first snapshot the
+      // connector must not fabricate a partial baseline from one event.
+      if (tracker.sourceCursor === null) return false;
+      const principalId = slackMembershipPrincipalId(
+        this.accountKey,
+        input.slackUserId,
+      );
+      await this.ensurePrincipalEntity(principalId, input.slackUserId);
+      const runtimeIds = this.deriveRuntimeIds({
+        channelId: input.channelId,
+        slackUserId: input.slackUserId,
+      });
+      const observedAt = input.observedAt ?? new Date().toISOString();
+      const observedAtMs = Date.parse(observedAt);
+      if (!Number.isFinite(observedAtMs)) {
+        throw new Error(
+          `membership delta observedAt is not a finite timestamp: ${observedAt}`,
+        );
+      }
+      const deltaKey = `slack:delta:${this.accountKey}:${input.channelId}:${input.slackUserId}:${input.reason}:${observedAtMs.toString(36)}`;
+      const sourceVersion = tracker.sourceVersion + 1;
+      const sourceCursor = `slack:${this.accountKey}:${input.channelId}:${sourceVersion}`;
+      try {
+        const receipt = await this.service.applyMembership({
+          ...scope,
+          publisherInstanceId: this.publisherInstanceId,
+          publisherGeneration: tracker.publisherGeneration,
+          evidenceMode: "ordered_delta",
+          expectedGeneration: tracker.generation,
+          canonicalPrincipalId: principalId,
+          state: input.joined ? "active" : "revoked",
+          reason: input.reason,
+          roles: ["member"],
+          permissionSnapshot: {
+            connector: "slack",
+            accountId: this.accountKey,
+            slackUserId: input.slackUserId,
+          } as JsonObject,
+          runtime: runtimeIds,
+          sourceVersion,
+          previousSourceCursor: tracker.sourceCursor,
+          sourceCursor,
+          validUntil: new Date(
+            Date.parse(observedAt) + SLACK_MEMBERSHIP_TTL_MS,
+          ).toISOString(),
+          idempotencyKey: deltaKey,
+          observedAt,
+        });
+        tracker.generation = receipt.committedGeneration;
+        tracker.sourceVersion = sourceVersion;
+        tracker.sourceCursor = sourceCursor;
+        return true;
+      } catch (error) {
+        const code = membershipErrorCode(error);
+        if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+          return false;
+        }
+        if (code === "MEMBERSHIP_SNAPSHOT_REQUIRED") {
+          // No complete baseline in this publisher generation: the next
+          // snapshot sweep is the authoritative evidence path.
+          return false;
+        }
+        if (FENCE_CODES.has(code)) {
+          await this.readoptFromHealth(scope);
+          return false;
+        }
+        // error-policy:J2 Storage failures propagate as a typed wrapper
+        // preserving the cause: the member keeps its prior authoritative
+        // state and the caller sees the failure.
+        throw new SlackMembershipPublishError(
+          `membership delta publish failed: ${membershipErrorCode(error) || "unknown"}`,
+          {
+            cause: error,
+            context: {
+              accountKey: this.accountKey,
+              channelId: input.channelId,
+              slackUserId: input.slackUserId,
+            },
+          },
+        );
+      }
+    });
+  }
+
+  /**
+   * Publish an unavailable roster read as an incomplete snapshot report so
+   * the scope health goes stale — consumers see unavailable evidence, never
+   * an empty roster implying mass removal. A degraded scope stops accepting
+   * deltas until a fresh snapshot restores it.
+   */
+  async reportUnavailable(input: {
+    teamId: string;
+    channelId: string;
+    reason: string;
+    observedAt?: string;
+  }): Promise<void> {
+    const scope = this.scopeFor(input.teamId, input.channelId);
+    const key = scopeKey(scope);
+    await this.serialized(key, async () => {
+      let tracker = this.trackerFor(scope);
+      // Fail-closed from the moment the unavailable read is observed: a
+      // later authority failure must not leave the scope accepting deltas
+      // against the pre-unavailable cursor.
+      tracker.degraded = true;
+      // An unavailable read may be the first authority mutation of this
+      // process: adopt the durable generation before reporting so the fence
+      // accepts the command.
+      if (tracker.generation === 0) {
+        tracker = await this.ensureRegistered(scope);
+        tracker.degraded = true;
+      }
+      try {
+        await this.service.reportIncompleteSnapshot({
+          ...scope,
+          publisherInstanceId: this.publisherInstanceId,
+          publisherGeneration: tracker.publisherGeneration,
+          evidenceMode: "ordered_delta",
+          completeness: "incomplete",
+          expectedGeneration: tracker.generation,
+          reason: input.reason,
+          idempotencyKey: `slack:unavailable:${this.accountKey}:${input.channelId}:${Date.now()}`,
+          observedAt: input.observedAt ?? new Date().toISOString(),
+        });
+        tracker.generation += 1;
+        tracker.degraded = true;
+      } catch (error) {
+        const code = membershipErrorCode(error);
+        if (FENCE_CODES.has(code)) {
+          tracker = await this.readoptFromHealth(scope);
+          // error-policy:J4 The report did not commit; the local degraded
+          // flag still stops deltas and the caller still sees the
+          // unavailable read result. Surface the failure.
+          this.runtime.reportError?.("slack:membership:unavailable", error, {
+            accountKey: this.accountKey,
+            channelId: input.channelId,
+          });
+          return;
+        }
+        // error-policy:J4 The authority itself is unreachable; keep the
+        // local degraded flag (fail-closed) and surface the failure.
+        this.runtime.reportError?.("slack:membership:unavailable", error, {
+          accountKey: this.accountKey,
+          channelId: input.channelId,
+        });
+      }
+    });
+  }
+}
+
+/**
+ * Adapts one SlackMembershipReadResult's unavailable reason to the
+ * incomplete-snapshot report's reason string.
+ */
+export function unavailableReadReason(
+  result: Extract<SlackMembershipReadResult, { kind: "unavailable" }>,
+): string {
+  return `slack conversations.members unavailable: ${result.reason}`;
+}

--- a/plugins/plugin-slack/src/membership.test.ts
+++ b/plugins/plugin-slack/src/membership.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Membership snapshot/delta boundary tests: `conversations.members` paging,
+ * failure classification (scope/permission/pagination), payload preservation
+ * in join/leave events, sender renewal on admitted inbound messages, thread
+ * inheritance configuration, and the unavailable-vs-empty distinction.
+ * The Slack Web API client is mocked; the walk, classification, and service
+ * event paths are the real implementations.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyMembershipFailure,
+  readChannelMembershipSnapshot,
+  SLACK_MEMBERS_PAGE_LIMIT,
+  type SlackMembershipUnavailable,
+} from "./membership";
+
+function page(members: string[], nextCursor?: string) {
+  return {
+    members,
+    ...(nextCursor ? { response_metadata: { next_cursor: nextCursor } } : {}),
+  };
+}
+
+function slackError(code: string) {
+  const error = new Error(`Slack API ${code}`) as Error & {
+    data?: { code?: string };
+  };
+  error.data = { code };
+  return error;
+}
+
+function makeClient(pages: unknown[] = [], throws?: (call: number) => unknown) {
+  let call = 0;
+  const conversationsMembers = vi.fn(async () => {
+    const thrower = throws?.(call);
+    call += 1;
+    if (thrower) throw thrower;
+    const result = pages.shift();
+    if (!result) throw new Error("unexpected extra page request");
+    return result;
+  });
+  return {
+    client: { conversations: { members: conversationsMembers } },
+    conversationsMembers,
+  };
+}
+
+describe("classifyMembershipFailure", () => {
+  it("classifies missing scope family as missing_scope", () => {
+    for (const code of ["missing_scope", "not_allowed"]) {
+      expect(classifyMembershipFailure(slackError(code)).reason).toBe(
+        "missing_scope",
+      );
+    }
+  });
+
+  it("classifies not_in_channel as not_a_member, not empty", () => {
+    const result = classifyMembershipFailure(slackError("not_in_channel"));
+    expect(result.reason).toBe("not_a_member");
+    expect(result.slackErrorCode).toBe("not_in_channel");
+  });
+
+  it("classifies channel_not_found, ratelimited, invalid_cursor distinctly", () => {
+    expect(
+      classifyMembershipFailure(slackError("channel_not_found")).reason,
+    ).toBe("channel_not_found");
+    expect(classifyMembershipFailure(slackError("ratelimited")).reason).toBe(
+      "rate_limited",
+    );
+    expect(classifyMembershipFailure(slackError("invalid_cursor")).reason).toBe(
+      "pagination_loop",
+    );
+  });
+
+  it("falls back to request_failed with the code preserved", () => {
+    const result = classifyMembershipFailure(slackError("internal_error"));
+    expect(result.reason).toBe("request_failed");
+    expect(result.slackErrorCode).toBe("internal_error");
+  });
+});
+
+describe("readChannelMembershipSnapshot", () => {
+  it("walks every page to a terminal cursor and returns the complete roster", async () => {
+    const { client, conversationsMembers } = makeClient([
+      page(["U1", "U2"], "cur-1"),
+      page(["U3"], "cur-2"),
+      page(["U4"]),
+    ]);
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    expect(result.kind).toBe("snapshot");
+    if (result.kind !== "snapshot") return;
+    expect([...result.memberIds]).toEqual(["U1", "U2", "U3", "U4"]);
+    expect(result.completedPages).toBe(3);
+    expect(conversationsMembers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        limit: SLACK_MEMBERS_PAGE_LIMIT,
+      }),
+    );
+  });
+
+  it("requests cursors only after the first page", async () => {
+    const { client, conversationsMembers } = makeClient([
+      page(["U1"], "c1"),
+      page(["U2"]),
+    ]);
+    await readChannelMembershipSnapshot(client as never, "C123");
+    expect(conversationsMembers.mock.calls[0]?.[0]).not.toHaveProperty(
+      "cursor",
+    );
+    expect(conversationsMembers.mock.calls[1]?.[0]).toMatchObject({
+      cursor: "c1",
+    });
+  });
+
+  it("an empty terminal roster is a valid snapshot, not unavailable", async () => {
+    const { client } = makeClient([page([])]);
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    expect(result.kind).toBe("snapshot");
+    if (result.kind !== "snapshot") return;
+    expect(result.memberIds).toHaveLength(0);
+  });
+
+  it("a mid-walk API failure invalidates the whole walk as unavailable", async () => {
+    const { client } = makeClient([page(["U1"], "c1")], () =>
+      slackError("missing_scope"),
+    );
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toBe("missing_scope");
+    expect(result.slackErrorCode).toBe("missing_scope");
+  });
+
+  it("not_in_channel surfaces as unavailable — never an empty roster", async () => {
+    const { client } = makeClient([], () => slackError("not_in_channel"));
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    const unavailable = result as SlackMembershipUnavailable;
+    expect(unavailable.kind).toBe("unavailable");
+    expect(unavailable.reason).toBe("not_a_member");
+  });
+
+  it("a repeated next_cursor is a pagination loop, not completion", async () => {
+    const { client } = makeClient([page(["U1"], "loop"), page(["U2"], "loop")]);
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    const unavailable = result as SlackMembershipUnavailable;
+    expect(unavailable.kind).toBe("unavailable");
+    expect(unavailable.reason).toBe("pagination_loop");
+  });
+
+  it("a page without a members array is malformed, not empty", async () => {
+    const { client } = makeClient([{ response_metadata: {} }]);
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    const unavailable = result as SlackMembershipUnavailable;
+    expect(unavailable.kind).toBe("unavailable");
+    expect(unavailable.reason).toBe("malformed_response");
+  });
+
+  it("a non-string member entry is malformed, not silently dropped", async () => {
+    const { client } = makeClient([page(["U1", 42 as never])]);
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    const unavailable = result as SlackMembershipUnavailable;
+    expect(unavailable.kind).toBe("unavailable");
+    expect(unavailable.reason).toBe("malformed_response");
+  });
+});

--- a/plugins/plugin-slack/src/membership.test.ts
+++ b/plugins/plugin-slack/src/membership.test.ts
@@ -121,6 +121,18 @@ describe("readChannelMembershipSnapshot", () => {
     expect(result.memberIds).toHaveLength(0);
   });
 
+  it("a page-level error body classifies through the walk, not as malformed", async () => {
+    // Slack Web SDK can surface failures as a resolved page carrying the
+    // error payload instead of throwing. The walk must classify the code
+    // (missing_scope) rather than degrade it to malformed_response.
+    const { client } = makeClient([{ error: { code: "missing_scope" } }]);
+    const result = await readChannelMembershipSnapshot(client as never, "C123");
+    const unavailable = result as SlackMembershipUnavailable;
+    expect(unavailable.kind).toBe("unavailable");
+    expect(unavailable.reason).toBe("missing_scope");
+    expect(unavailable.slackErrorCode).toBe("missing_scope");
+  });
+
   it("a mid-walk API failure invalidates the whole walk as unavailable", async () => {
     const { client } = makeClient([page(["U1"], "c1")], () =>
       slackError("missing_scope"),

--- a/plugins/plugin-slack/src/membership.ts
+++ b/plugins/plugin-slack/src/membership.ts
@@ -61,9 +61,11 @@ interface SlackMembersPage {
  *
  * Real `@slack/web-api` platform errors carry the SDK error class in
  * `error.code` (e.g. `slack_webapi_platform_error`) and the Slack error
- * name in `error.data.error` (a string); `rateLimitedErrorWithDelay`
- * likewise exposes `data.error: "ratelimited"`. `error.data.code` is kept
- * only as a legacy fallback for hand-built errors.
+ * name in `error.data.error` (a string); rate-limit errors carry only
+ * `code: "slack_webapi_rate_limited_error"` and `retryAfter` with no
+ * `data` at all (verified against @slack/web-api 7.15.2 dist/errors.js
+ * and WebClient.js). `error.data.code` is kept only as a legacy fallback
+ * for hand-built errors.
  *
  * `missing_scope` / `not_allowed` mean the app lacks read scopes;
  * `channel_not_found` means the channel is gone or invisible;
@@ -81,6 +83,12 @@ export function classifyMembershipFailure(error: unknown): {
           code?: unknown;
         })
       : {};
+  if (slackError.code === "slack_webapi_rate_limited_error") {
+    return {
+      reason: "rate_limited",
+      slackErrorCode: "ratelimited",
+    };
+  }
   const code =
     typeof slackError.data?.error === "string"
       ? slackError.data.error
@@ -144,6 +152,8 @@ export async function readChannelMembershipSnapshot(
         ...(cursor ? { cursor } : {}),
       })) as unknown as SlackMembersPage;
     } catch (error) {
+      // error-policy:J1 boundary translation: an API-layer failure becomes
+      // the typed unavailable result callers consume; no fabricated success.
       const { reason, slackErrorCode } = classifyMembershipFailure(error);
       return {
         kind: "unavailable",

--- a/plugins/plugin-slack/src/membership.ts
+++ b/plugins/plugin-slack/src/membership.ts
@@ -58,6 +58,13 @@ interface SlackMembersPage {
 
 /**
  * Maps a failed `conversations.members` call onto a classified reason.
+ *
+ * Real `@slack/web-api` platform errors carry the SDK error class in
+ * `error.code` (e.g. `slack_webapi_platform_error`) and the Slack error
+ * name in `error.data.error` (a string); `rateLimitedErrorWithDelay`
+ * likewise exposes `data.error: "ratelimited"`. `error.data.code` is kept
+ * only as a legacy fallback for hand-built errors.
+ *
  * `missing_scope` / `not_allowed` mean the app lacks read scopes;
  * `channel_not_found` means the channel is gone or invisible;
  * `not_in_channel` / `method_not_supported_for_channel_type` mean the bot
@@ -69,14 +76,20 @@ export function classifyMembershipFailure(error: unknown): {
 } {
   const slackError =
     typeof error === "object" && error !== null
-      ? (error as { data?: { code?: unknown }; code?: unknown })
+      ? (error as {
+          data?: { error?: unknown; code?: unknown };
+          code?: unknown;
+        })
       : {};
   const code =
-    typeof slackError.code === "string"
-      ? slackError.code
-      : typeof slackError.data?.code === "string"
-        ? slackError.data.code
-        : undefined;
+    typeof slackError.data?.error === "string"
+      ? slackError.data.error
+      : typeof slackError.code === "string" &&
+          !slackError.code.startsWith("slack_webapi_")
+        ? slackError.code
+        : typeof slackError.data?.code === "string"
+          ? slackError.data.code
+          : undefined;
   switch (code) {
     case "missing_scope":
     case "not_allowed":
@@ -170,11 +183,24 @@ export async function readChannelMembershipSnapshot(
     }
     pages += 1;
 
-    const nextCursor =
-      typeof page.response_metadata?.next_cursor === "string"
-        ? page.response_metadata.next_cursor.trim()
-        : "";
-    if (!nextCursor) break;
+    // Only an absent cursor completes the walk. A present-but-non-string
+    // cursor is malformed — treating it as terminal would publish a partial
+    // roster as a complete snapshot.
+    let nextCursor: string;
+    if (page.response_metadata?.next_cursor !== undefined) {
+      if (typeof page.response_metadata.next_cursor !== "string") {
+        return {
+          kind: "unavailable",
+          channelId,
+          reason: "malformed_response",
+          slackErrorCode: undefined,
+        };
+      }
+      nextCursor = page.response_metadata.next_cursor.trim();
+      if (!nextCursor) break;
+    } else {
+      break;
+    }
     if (seenCursors.has(nextCursor)) {
       return {
         kind: "unavailable",

--- a/plugins/plugin-slack/src/membership.ts
+++ b/plugins/plugin-slack/src/membership.ts
@@ -1,0 +1,197 @@
+/**
+ * Per-channel Slack membership evidence: snapshots of `conversations.members`
+ * for admitted channels, join/leave deltas derived from Bolt events, and
+ * explicit unavailable states for scope/permission/pagination failures.
+ *
+ * Slack never returns an empty roster to mean "cannot read" — every failure
+ * mode (missing scope, not-a-member, channel gone, rate limit) must surface
+ * as a typed unavailable result, never as an empty member list. Snapshot
+ * paging is terminal-cursor based: only an absent `next_cursor` completes a
+ * snapshot; any mid-walk failure invalidates the whole walk.
+ */
+import type { WebClient } from "@slack/web-api";
+
+export const SLACK_MEMBERS_PAGE_LIMIT = 200;
+
+/** Classified failure modes for a membership read attempt. */
+export type SlackMembershipUnavailableReason =
+  | "client_not_initialized"
+  | "channel_not_admitted"
+  | "missing_scope"
+  | "not_a_member"
+  | "channel_not_found"
+  | "rate_limited"
+  | "pagination_loop"
+  | "malformed_response"
+  | "request_failed";
+
+/** A completed snapshot walk. `memberIds` may legitimately be empty. */
+export interface SlackMembershipSnapshot {
+  readonly kind: "snapshot";
+  readonly channelId: string;
+  readonly memberIds: readonly string[];
+  readonly completedPages: number;
+  readonly observedAt: string;
+}
+
+/**
+ * A read that cannot produce trustworthy membership evidence. Callers must
+ * treat prior knowledge as stale, not revoke members, and never report an
+ * empty roster on top of this state.
+ */
+export interface SlackMembershipUnavailable {
+  readonly kind: "unavailable";
+  readonly channelId: string;
+  readonly reason: SlackMembershipUnavailableReason;
+  readonly slackErrorCode: string | undefined;
+}
+
+export type SlackMembershipReadResult =
+  | SlackMembershipSnapshot
+  | SlackMembershipUnavailable;
+
+interface SlackMembersPage {
+  members?: unknown;
+  response_metadata?: { next_cursor?: unknown };
+  error?: { code?: unknown };
+}
+
+/**
+ * Maps a failed `conversations.members` call onto a classified reason.
+ * `missing_scope` / `not_allowed` mean the app lacks read scopes;
+ * `channel_not_found` means the channel is gone or invisible;
+ * `not_in_channel` / `method_not_supported_for_channel_type` mean the bot
+ * cannot read this channel's roster; `ratelimited` is transient.
+ */
+export function classifyMembershipFailure(error: unknown): {
+  reason: SlackMembershipUnavailableReason;
+  slackErrorCode: string | undefined;
+} {
+  const slackError =
+    typeof error === "object" && error !== null
+      ? (error as { data?: { code?: unknown }; code?: unknown })
+      : {};
+  const code =
+    typeof slackError.code === "string"
+      ? slackError.code
+      : typeof slackError.data?.code === "string"
+        ? slackError.data.code
+        : undefined;
+  switch (code) {
+    case "missing_scope":
+    case "not_allowed":
+    case "admin_only_channel":
+      return { reason: "missing_scope", slackErrorCode: code };
+    case "channel_not_found":
+    case "channel_is_archived":
+      return { reason: "channel_not_found", slackErrorCode: code };
+    case "not_in_channel":
+    case "method_not_supported_for_channel_type":
+      return { reason: "not_a_member", slackErrorCode: code };
+    case "ratelimited":
+      return { reason: "rate_limited", slackErrorCode: code };
+    case "invalid_cursor":
+      return { reason: "pagination_loop", slackErrorCode: code };
+    default:
+      return { reason: "request_failed", slackErrorCode: code };
+  }
+}
+
+function extractPageError(page: SlackMembersPage): string | undefined {
+  return typeof page.error === "object" && page.error !== null
+    ? typeof (page.error as { code?: unknown }).code === "string"
+      ? (page.error as { code: string }).code
+      : undefined
+    : typeof page.error === "string"
+      ? page.error
+      : undefined;
+}
+
+/**
+ * Walks `conversations.members` to a terminal page and returns either a
+ * complete snapshot or a classified unavailable state. Any page failure,
+ * repeated cursor, or malformed member entry aborts the whole walk — partial
+ * rosters are never reported as complete.
+ */
+export async function readChannelMembershipSnapshot(
+  client: WebClient,
+  channelId: string,
+): Promise<SlackMembershipReadResult> {
+  const memberIds: string[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  let pages = 0;
+
+  for (;;) {
+    let page: SlackMembersPage;
+    try {
+      page = (await client.conversations.members({
+        channel: channelId,
+        limit: SLACK_MEMBERS_PAGE_LIMIT,
+        ...(cursor ? { cursor } : {}),
+      })) as unknown as SlackMembersPage;
+    } catch (error) {
+      const { reason, slackErrorCode } = classifyMembershipFailure(error);
+      return {
+        kind: "unavailable",
+        channelId,
+        reason,
+        slackErrorCode,
+      };
+    }
+
+    const pageError = extractPageError(page);
+    if (pageError) {
+      const { reason, slackErrorCode } = classifyMembershipFailure({
+        code: pageError,
+      });
+      return { kind: "unavailable", channelId, reason, slackErrorCode };
+    }
+
+    const rawMembers = Array.isArray(page.members) ? page.members : null;
+    if (!rawMembers) {
+      return {
+        kind: "unavailable",
+        channelId,
+        reason: "malformed_response",
+        slackErrorCode: undefined,
+      };
+    }
+    for (const member of rawMembers) {
+      if (typeof member !== "string" || !member) {
+        return {
+          kind: "unavailable",
+          channelId,
+          reason: "malformed_response",
+          slackErrorCode: undefined,
+        };
+      }
+      memberIds.push(member);
+    }
+    pages += 1;
+
+    const nextCursor =
+      typeof page.response_metadata?.next_cursor === "string"
+        ? page.response_metadata.next_cursor.trim()
+        : "";
+    if (!nextCursor) break;
+    if (seenCursors.has(nextCursor)) {
+      return {
+        kind: "unavailable",
+        channelId,
+        reason: "pagination_loop",
+        slackErrorCode: "repeated_cursor",
+      };
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+
+  return {
+    kind: "snapshot",
+    channelId,
+    memberIds,
+    completedPages: pages,
+    observedAt: new Date().toISOString(),
+  };
+}

--- a/plugins/plugin-slack/src/policy.ts
+++ b/plugins/plugin-slack/src/policy.ts
@@ -693,7 +693,6 @@ function assertSupportedSecurityPolicy(account: ResolvedSlackAccount): void {
     "historyLimit",
     "dmHistoryLimit",
     "slashCommand",
-    "thread",
   ] as const) {
     if (config[key] !== undefined) unsupported.push(key);
   }

--- a/plugins/plugin-slack/src/service-canonical-membership.test.ts
+++ b/plugins/plugin-slack/src/service-canonical-membership.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Service-level canonical membership publication tests: the real SlackService
+ * path (Bolt event handlers and renewChannelMembership) must publish to the
+ * canonical MembershipService authority — complete snapshots for successful
+ * roster walks, incomplete-snapshot reports for unavailable reads, and
+ * join/leave ordered deltas — with account-scoped fencing. The Bolt app and
+ * WebClient are mocked; the authority is a spy implementing the
+ * MembershipService contract surface the service resolves. Production code
+ * under test is real; nothing asserts the spy's own return values except as
+ * committed receipts.
+ */
+import type {
+  IAgentRuntime,
+  MembershipMutationReceipt,
+  MembershipService,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { projectConnectorSettings } from "../../../packages/agent/src/runtime/project-connector-settings";
+
+const bolt = vi.hoisted(() => ({
+  channels: [] as Array<Record<string, unknown>>,
+  users: [] as Array<Record<string, unknown>>,
+}));
+
+function createClient() {
+  return {
+    auth: {
+      test: vi
+        .fn()
+        .mockResolvedValue({ user_id: "U0BOTBOT0", team_id: "T0TEAM000" }),
+    },
+    conversations: {
+      list: vi.fn().mockResolvedValue({ channels: bolt.channels }),
+      info: vi
+        .fn()
+        .mockImplementation(async ({ channel }: { channel: string }) => ({
+          channel: bolt.channels.find((entry) => entry.id === channel),
+        })),
+      members: vi.fn(),
+      history: vi.fn().mockResolvedValue({ messages: [] }),
+      replies: vi.fn().mockResolvedValue({ messages: [] }),
+    },
+    users: {
+      list: vi.fn().mockResolvedValue({ members: bolt.users }),
+      info: vi.fn().mockImplementation(async ({ user }: { user: string }) => ({
+        user: bolt.users.find((entry) => entry.id === user),
+      })),
+    },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ok: true, ts: "1.000001" }),
+    },
+    team: { info: vi.fn().mockResolvedValue({ team: { name: "Sandbox" } }) },
+  };
+}
+
+const apps = vi.hoisted(() => [] as Array<ReturnType<typeof createAppRecord>>);
+
+function createAppRecord() {
+  const client = createClient();
+  return {
+    eventHandlers: new Map<
+      string,
+      (args: {
+        event: unknown;
+        client: unknown;
+        body?: unknown;
+      }) => Promise<void>
+    >(),
+    messageHandler: undefined as
+      | ((args: {
+          message: unknown;
+          client: unknown;
+          body?: unknown;
+        }) => Promise<void>)
+      | undefined,
+    client,
+  };
+}
+
+vi.mock("@slack/bolt", () => ({
+  LogLevel: { INFO: "info" },
+  App: class MockBoltApp {
+    private readonly record = createAppRecord();
+    client = this.record.client;
+
+    constructor() {
+      apps.push(this.record);
+    }
+
+    message(
+      handler: (args: { message: unknown; client: unknown }) => Promise<void>,
+    ) {
+      this.record.messageHandler = handler;
+    }
+
+    event(
+      name: string,
+      handler: (args: { event: unknown; client: unknown }) => Promise<void>,
+    ) {
+      this.record.eventHandlers.set(name, handler);
+    }
+
+    async start() {}
+    async stop() {}
+  },
+}));
+
+import { SlackService } from "./service";
+
+const OPS = "C0123ABCD";
+const ALICE = "U0123ABCD";
+const BOB = "U0999ZZZZ";
+
+/**
+ * Spy authority: records every command by operation; commits receipts with a
+ * monotonically advancing generation so the publisher's fence math runs for
+ * real. Implements the exact MembershipService surface isMembershipService
+ * checks (registerPublisher + applyCompleteSnapshot).
+ */
+function createAuthoritySpy() {
+  let generation = 0;
+  const commands: Array<{ op: string; command: Record<string, unknown> }> = [];
+  const receipt = (
+    op: MembershipMutationReceipt["operation"],
+  ): MembershipMutationReceipt => {
+    generation += 1;
+    return {
+      contractVersion: 1,
+      operation: op,
+      idempotentReplay: false,
+      committedGeneration: generation,
+      health: {} as never,
+      ...(op === "snapshot"
+        ? { memberships: [], revokedPrincipalIds: [] }
+        : {}),
+      ...(op === "membership" ? { membership: {} as never } : {}),
+    } as MembershipMutationReceipt;
+  };
+  const service: MembershipService = {
+    registerPublisher: vi.fn(async (command) => {
+      commands.push({ op: "publisher", command: command as never });
+      return receipt("publisher");
+    }),
+    applyCompleteSnapshot: vi.fn(async (command) => {
+      commands.push({ op: "snapshot", command: command as never });
+      return receipt("snapshot");
+    }),
+    reportIncompleteSnapshot: vi.fn(async (command) => {
+      commands.push({ op: "incomplete", command: command as never });
+      return receipt("health");
+    }),
+    applyMembership: vi.fn(async (command) => {
+      commands.push({ op: "membership", command: command as never });
+      return receipt("membership");
+    }),
+    setScopeHealth: vi.fn(async (command) => {
+      commands.push({ op: "health", command: command as never });
+      return receipt("health");
+    }),
+    authorize: vi.fn(async () => ({
+      decision: "denied",
+      reason: "no_scope_evidence",
+      generation: null,
+      health: null,
+    })),
+    getMembership: vi.fn(async () => null),
+    getScopeHealth: vi.fn(async () => null),
+    registerInvalidator: vi.fn(() => () => {}),
+  } as unknown as MembershipService;
+  return { service, commands };
+}
+
+function memberEventBody(event: Record<string, unknown>) {
+  return {
+    team_id: "T0TEAM000",
+    event_id: `Ev-${String(event.user)}-${String(event.channel)}-${String(event.event_ts ?? "")}`,
+    event,
+  };
+}
+
+function createRuntime(
+  settings: Record<string, unknown>,
+  authority: MembershipService | null,
+): IAgentRuntime {
+  const projection = projectConnectorSettings({}, { slack: settings });
+  const secretEntries = Object.entries(projection.secrets) as Array<
+    [string, string]
+  >;
+  const character = {
+    name: "Slack Canonical Membership Test",
+    settings: projection.settings,
+    secrets: projection.secrets,
+  };
+  const runtime = {
+    agentId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    character,
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: vi.fn((key: string) => {
+      const settings2 = character.settings as Record<string, unknown>;
+      const secrets2 = character.secrets as Record<string, unknown>;
+      if (Object.hasOwn(settings2, key)) return settings2[key];
+      if (Object.hasOwn(secrets2, key)) return secrets2[key];
+      const match = secretEntries.find(([k]) => k === key);
+      return match ? match[1] : null;
+    }),
+    getWorld: vi.fn().mockResolvedValue(null),
+    createWorld: vi.fn().mockResolvedValue(undefined),
+    getRoom: vi.fn().mockResolvedValue(null),
+    createRoom: vi.fn().mockResolvedValue(undefined),
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+    createMemory: vi.fn().mockResolvedValue(undefined),
+    getMemoryById: vi.fn().mockResolvedValue(null),
+    createEntity: vi.fn().mockResolvedValue(undefined),
+    createEntities: vi.fn().mockResolvedValue(undefined),
+    getEntityById: vi.fn().mockResolvedValue(null),
+    ensureConnection: vi.fn().mockResolvedValue(undefined),
+    removeParticipant: vi.fn().mockResolvedValue(true),
+    reportError: vi.fn(),
+    getService: vi.fn((name: string) =>
+      name === "membership" ? authority : null,
+    ),
+    getServicesByType: vi.fn((name: string) =>
+      name === "membership" && authority ? [authority] : [],
+    ),
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+async function startHarness(
+  overrides: Record<string, unknown> = {},
+  authority: MembershipService | null = null,
+) {
+  const runtime = createRuntime(
+    {
+      enabled: true,
+      botToken: "xoxb-test-token",
+      appToken: "xapp-test-token",
+      groupPolicy: "allowlist",
+      channels: { ops: { users: [ALICE] } },
+      ...overrides,
+    },
+    authority,
+  );
+  bolt.channels.push({
+    id: OPS,
+    name: "ops",
+    is_channel: true,
+    is_member: true,
+  });
+  bolt.users.push(
+    { id: ALICE, name: "alice", real_name: "Alice Example" },
+    { id: BOB, name: "bob", real_name: "Bob Example" },
+  );
+  let service: InstanceType<typeof SlackService>;
+  try {
+    service = await SlackService.start(runtime);
+  } catch (startError) {
+    // error-policy:J2 context-adding rethrow: wrap with the captured log
+    // tail and preserve the original start failure as cause.
+    const calls = (runtime.logger.warn as ReturnType<typeof vi.fn>).mock.calls
+      .concat((runtime.logger.error as ReturnType<typeof vi.fn>).mock.calls)
+      .map((c) => String(c.at(-1)));
+    throw new Error(
+      `SlackService.start failed: ${String(startError)}; logged: ${calls.join(" | ")}`,
+      { cause: startError },
+    );
+  }
+  if (apps.length === 0) {
+    const calls = (
+      runtime.logger.warn as ReturnType<typeof vi.fn>
+    ).mock.calls.map((c) => String(c.at(-1)));
+    throw new Error(`no app registered; logged: ${calls.join(" | ")}`);
+  }
+  const app = apps.at(-1);
+  if (!app)
+    throw new Error(`Bolt app was not registered (apps=${apps.length})`);
+  return { app, runtime, service };
+}
+
+describe("SlackService canonical membership publication", () => {
+  beforeEach(() => {
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("a completed roster walk publishes a complete snapshot with every member", async () => {
+    const { service: authority, commands } = createAuthoritySpy();
+    // Restart the harness with the authority registered at start so the
+    // publisher is constructed during account init.
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app, runtime, service } = await startHarness({}, authority);
+    const members = vi
+      .fn()
+      .mockResolvedValue({ members: [ALICE, BOB, "U0BOTBOT0"] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.renewChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+
+    const snapshot = commands.find((c) => c.op === "snapshot");
+    if (!snapshot) {
+      throw new Error(
+        `no snapshot published; reportError: ${JSON.stringify(vi.mocked(runtime.reportError).mock.calls.map((c) => String(c[1])))}; commands: ${JSON.stringify(commands.map((c) => ({ op: c.op, key: c.command.idempotencyKey })))}; reportError calls: ${vi.mocked(runtime.reportError).mock.calls.length}`,
+      );
+    }
+    expect(snapshot).toBeDefined();
+    const command = snapshot?.command as Record<string, unknown>;
+    expect(command.completeness).toBe("complete");
+    expect(command.externalRoomId).toBe(OPS);
+    expect(command.externalWorldId).toBe("T0TEAM000");
+    const publishedMembers = command.members as Array<{
+      canonicalPrincipalId: string;
+      roles: string[];
+    }>;
+    // Two human members; the bot itself is excluded from the roster evidence.
+    expect(publishedMembers).toHaveLength(2);
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it("an unavailable roster read reports incomplete evidence, never a snapshot", async () => {
+    const { service: authority, commands } = createAuthoritySpy();
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app, service } = await startHarness({}, authority);
+    const scopeError = new Error(
+      "An API error occurred: missing_scope",
+    ) as unknown as {
+      code: string;
+      data: { error: string };
+    };
+    scopeError.code = "slack_webapi_platform_error";
+    scopeError.data = { error: "missing_scope" };
+    const members = vi.fn().mockRejectedValue(scopeError);
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.renewChannelMembership(OPS);
+    expect(result.kind).toBe("unavailable");
+
+    const incomplete = commands.find((c) => c.op === "incomplete");
+    expect(incomplete).toBeDefined();
+    const command = incomplete?.command as Record<string, unknown>;
+    expect(command.completeness).toBe("incomplete");
+    expect(String(command.reason)).toContain("missing_scope");
+    expect(commands.find((c) => c.op === "snapshot")).toBeUndefined();
+  });
+
+  it("member_joined_channel publishes an ordered join delta after a snapshot baseline", async () => {
+    const { service: authority, commands } = createAuthoritySpy();
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app, service } = await startHarness({}, authority);
+    // Baseline snapshot first (deltas require a current snapshot).
+    const members = vi.fn().mockResolvedValue({ members: [ALICE] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    await service.renewChannelMembership(OPS);
+    expect(commands.find((c) => c.op === "snapshot")).toBeDefined();
+
+    const handler = app.eventHandlers.get("member_joined_channel");
+    expect(handler).toBeDefined();
+    const event = {
+      user: BOB,
+      channel: OPS,
+      event_ts: "1700000000.000400",
+    };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+    const delta = commands.find((c) => c.op === "membership");
+    expect(delta).toBeDefined();
+    const command = delta?.command as Record<string, unknown>;
+    expect(command.state).toBe("active");
+    expect(command.reason).toBe("joined");
+  });
+
+  it("member_left_channel publishes an ordered leave delta revoking the member", async () => {
+    const { service: authority, commands } = createAuthoritySpy();
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app, service } = await startHarness({}, authority);
+    const members = vi.fn().mockResolvedValue({ members: [ALICE, BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    await service.renewChannelMembership(OPS);
+
+    const handler = app.eventHandlers.get("member_left_channel");
+    expect(handler).toBeDefined();
+    const event = { user: ALICE, channel: OPS, event_ts: "1700000000.000600" };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+    const delta = commands
+      .filter((c) => c.op === "membership")
+      .find((c) => (c.command as Record<string, unknown>).state === "revoked");
+    expect(delta).toBeDefined();
+    const command = delta?.command as Record<string, unknown>;
+    expect(command.reason).toBe("left");
+  });
+
+  it("join and leave events without a snapshot baseline publish nothing (no fabricated evidence)", async () => {
+    const { service: authority, commands } = createAuthoritySpy();
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app } = await startHarness({}, authority);
+    const join = app.eventHandlers.get("member_joined_channel");
+    const event = { user: ALICE, channel: OPS, event_ts: "1700000000.000100" };
+    await join?.({ event, client: app.client, body: memberEventBody(event) });
+    // Only the publisher registration may exist; no snapshot, no delta.
+    expect(commands.find((c) => c.op === "snapshot")).toBeUndefined();
+    expect(commands.find((c) => c.op === "membership")).toBeUndefined();
+  });
+
+  it("publication is scoped per account: one account's publisher never writes another's scope", async () => {
+    const { service: authority, commands } = createAuthoritySpy();
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { service } = await startHarness(
+      {
+        accounts: {
+          alpha: {
+            botToken: "xoxb-alpha",
+            appToken: "xapp-alpha",
+            groupPolicy: "allowlist",
+            channels: { ops: { users: [ALICE] } },
+          },
+          beta: {
+            botToken: "xoxb-beta",
+            appToken: "xapp-beta",
+            groupPolicy: "allowlist",
+            channels: { ops: { users: [ALICE] } },
+          },
+        },
+      },
+      authority,
+    );
+    expect(apps).toHaveLength(2);
+    const [alphaApp, betaApp] = apps;
+    const alphaMembers = vi.fn().mockResolvedValue({ members: [ALICE] });
+    const betaMembers = vi.fn().mockResolvedValue({ members: [ALICE] });
+    (
+      alphaApp.client.conversations as { members: typeof alphaMembers }
+    ).members = alphaMembers;
+    (betaApp.client.conversations as { members: typeof betaMembers }).members =
+      betaMembers;
+
+    await service.renewChannelMembership(OPS, "alpha");
+    await service.renewChannelMembership(OPS, "beta");
+
+    const snapshots = commands.filter((c) => c.op === "snapshot");
+    expect(snapshots).toHaveLength(2);
+    // Both publishes went through the same account row for this harness;
+    // the scopes must still be distinct per account key through the
+    // idempotency keys.
+    const keys = snapshots.map(
+      (c) => (c.command as Record<string, unknown>).idempotencyKey as string,
+    );
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("authority publication failure does not mask the snapshot result or stop runtime renewal", async () => {
+    const failing = {
+      registerPublisher: vi.fn(async () => {
+        throw Object.assign(new Error("authority down"), {
+          code: "MEMBERSHIP_WRITE_FAILED",
+        });
+      }),
+      applyCompleteSnapshot: vi.fn(async () => {
+        throw Object.assign(new Error("authority down"), {
+          code: "MEMBERSHIP_WRITE_FAILED",
+        });
+      }),
+    } as unknown as MembershipService;
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app, runtime, service } = await startHarness({}, failing);
+    const members = vi.fn().mockResolvedValue({ members: [ALICE, BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.renewChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(2);
+    expect(runtime.reportError).toHaveBeenCalled();
+  });
+
+  it("without a registered authority the service keeps legacy behavior (no publisher)", async () => {
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    const { app, runtime, service } = await startHarness({}, null);
+    const members = vi.fn().mockResolvedValue({ members: [ALICE, BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.renewChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/plugin-slack/src/service-membership.test.ts
+++ b/plugins/plugin-slack/src/service-membership.test.ts
@@ -5,7 +5,7 @@
  * room participant, and inbound messages renew the sender's connection.
  * The Bolt app and WebClient are mocked; the SlackService under test is real.
  */
-import { type IAgentRuntime } from "@elizaos/core";
+import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { projectConnectorSettings } from "../../../packages/agent/src/runtime/project-connector-settings";
 
@@ -78,6 +78,13 @@ function createAppRecord() {
         body?: unknown;
       }) => Promise<void>
     >(),
+    messageHandler: undefined as
+      | ((args: {
+          message: unknown;
+          client: unknown;
+          body?: unknown;
+        }) => Promise<void>)
+      | undefined,
     client,
   };
 }
@@ -92,7 +99,15 @@ vi.mock("@slack/bolt", () => ({
       apps.push(this.record);
     }
 
-    message() {}
+    message(
+      handler: (args: {
+        message: unknown;
+        client: unknown;
+        body?: unknown;
+      }) => Promise<void>,
+    ) {
+      this.record.messageHandler = handler;
+    }
 
     event(
       name: string,
@@ -304,6 +319,64 @@ describe("SlackService membership events", () => {
     expect(runtime.removeParticipant).toHaveBeenCalledTimes(1);
     expect(runtime.createEntity).not.toHaveBeenCalled();
   });
+
+  it("an inbound message from an existing sender renews room participation", async () => {
+    // requireMention=false so the message path itself (not app_mention)
+    // processes the message; the sender's entity already exists (e.g.
+    // rejoined after leaving the room) — renewal must still run so
+    // participation is re-linked.
+    const { app, runtime } = await startHarness({
+      channels: { ops: { users: [ALICE], requireMention: false } },
+    });
+    const handler = app.messageHandler;
+    expect(handler).toBeDefined();
+    (runtime.getEntityById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "existing",
+      names: ["alice"],
+    });
+    await handler?.({
+      message: {
+        type: "message",
+        user: ALICE,
+        channel: OPS,
+        text: "hello from alice",
+        ts: "1700000000.000700",
+      },
+      client: app.client,
+      body: memberEventBody({
+        user: ALICE,
+        channel: OPS,
+        event_ts: "1700000000.000700",
+      }),
+    });
+    expect(runtime.ensureConnection).toHaveBeenCalled();
+  });
+
+  it("an app mention from an existing sender renews room participation", async () => {
+    const { app, runtime } = await startHarness();
+    const handler = app.eventHandlers.get("app_mention");
+    expect(handler).toBeDefined();
+    (runtime.getEntityById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "existing",
+      names: ["alice"],
+    });
+    await handler?.({
+      event: {
+        type: "app_mention",
+        user: ALICE,
+        channel: OPS,
+        text: "<@U0BOTBOT0> hello",
+        ts: "1700000000.000800",
+      },
+      client: app.client,
+      body: memberEventBody({
+        user: ALICE,
+        channel: OPS,
+        event_ts: "1700000000.000800",
+      }),
+    });
+    expect(runtime.ensureConnection).toHaveBeenCalled();
+  });
 });
 
 describe("SlackService membership snapshots", () => {
@@ -340,16 +413,58 @@ describe("SlackService membership snapshots", () => {
 
   it("getChannelMembership maps missing scope to unavailable, not empty", async () => {
     const { app, service } = await startHarness();
-    const scopeError = new Error("missing_scope") as Error & {
-      data?: { code?: string };
+    // Real @slack/web-api platform-error shape: SDK class in `code`, Slack
+    // error name in `data.error` (verified against
+    // platformErrorFromResult in @slack/web-api/dist/errors.js).
+    const scopeError = new Error(
+      "An API error occurred: missing_scope",
+    ) as unknown as {
+      code: string;
+      data: { error: string };
     };
-    scopeError.data = { code: "missing_scope" };
+    scopeError.code = "slack_webapi_platform_error";
+    scopeError.data = { error: "missing_scope" };
     const members = vi.fn().mockRejectedValue(scopeError);
     (app.client.conversations as { members: typeof members }).members = members;
     const result = await service.getChannelMembership(OPS);
     expect(result.kind).toBe("unavailable");
     if (result.kind !== "unavailable") return;
     expect(result.reason).toBe("missing_scope");
+    expect(result.slackErrorCode).toBe("missing_scope");
+  });
+
+  it("getChannelMembership maps a rate-limited platform error with the real SDK shape", async () => {
+    const { app, service } = await startHarness();
+    const rateError = new Error("A rate-limit has been reached") as unknown as {
+      code: string;
+      data: { error: string };
+    };
+    rateError.code = "slack_webapi_rate_limited_error";
+    rateError.data = { error: "ratelimited" };
+    const members = vi.fn().mockRejectedValue(rateError);
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.getChannelMembership(OPS);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toBe("rate_limited");
+  });
+
+  it("getChannelMembership treats a present-but-non-string cursor as malformed, not complete", async () => {
+    const { app, service } = await startHarness();
+    const members = vi
+      .fn()
+      .mockResolvedValueOnce({
+        members: [ALICE],
+        response_metadata: { next_cursor: 12345 },
+      })
+      .mockResolvedValueOnce({ members: [BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.getChannelMembership(OPS);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toBe("malformed_response");
+    // The partial roster must never be reported as a snapshot.
+    expect(members).toHaveBeenCalledTimes(1);
   });
 
   it("renewChannelMembership ensures connections for every snapshot member", async () => {
@@ -359,6 +474,39 @@ describe("SlackService membership snapshots", () => {
     const result = await service.renewChannelMembership(OPS);
     expect(result.kind).toBe("snapshot");
     expect(runtime.ensureConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it("membership evidence is scoped per account: entity/room ids differ across accounts", async () => {
+    // Two accounts admit the same channel id; the derived runtime ids and
+    // the clients used must be account-scoped, never shared.
+    const { app, runtime, service } = await startHarness({
+      accounts: {
+        team: {
+          botToken: "xoxb-team",
+          appToken: "xapp-team",
+          groupPolicy: "allowlist",
+          channels: { ops: { users: [ALICE] } },
+        },
+      },
+    });
+    const secondAccountApp = apps.at(-1);
+    expect(secondAccountApp).toBeDefined();
+    const members = vi.fn().mockResolvedValue({ members: [ALICE] });
+    (
+      (secondAccountApp ?? app).client.conversations as {
+        members: typeof members;
+      }
+    ).members = members;
+    const result = await service.renewChannelMembership(OPS, "team");
+    expect(result.kind).toBe("snapshot");
+    // The connection was ensured with the team account's scoped ids.
+    const call = (
+      runtime.ensureConnection as ReturnType<typeof vi.fn>
+    ).mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(String(call.entityId)).not.toBe("");
+    expect(members).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: OPS }),
+    );
   });
 });
 
@@ -406,12 +554,26 @@ describe("thread inheritance in chat context", () => {
     ]);
   });
 
-  it("inheritParent injects the parent transcript ahead of thread history", async () => {
+  it("inheritParent presents channel and thread transcripts chronologically", async () => {
     const { app, result } = await chatContextHarness({ inheritParent: true });
     expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
     expect(app.client.conversations.replies).toHaveBeenCalledTimes(1);
+    // Both transcripts are newest-first from Slack and reversed together:
+    // the earlier channel message precedes the later thread reply.
     expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "channel message",
       "thread reply",
+    ]);
+  });
+
+  it("historyScope channel takes precedence over inheritParent", async () => {
+    const { app, result } = await chatContextHarness({
+      historyScope: "channel",
+      inheritParent: true,
+    });
+    expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
+    expect(app.client.conversations.replies).not.toHaveBeenCalled();
+    expect(result?.recentMessages.map((m) => m.text)).toEqual([
       "channel message",
     ]);
   });

--- a/plugins/plugin-slack/src/service-membership.test.ts
+++ b/plugins/plugin-slack/src/service-membership.test.ts
@@ -30,6 +30,9 @@ function createClient() {
         })),
       members: vi.fn(),
       history: vi.fn().mockResolvedValue({
+        // Newest-first, as Slack returns. The thread PARENT (ts .000000)
+        // is part of the channel transcript — the same message
+        // conversations.replies repeats first.
         messages: [
           {
             type: "message",
@@ -38,9 +41,18 @@ function createClient() {
             user: ALICE,
             text: "channel message",
           },
+          {
+            type: "message",
+            subtype: undefined,
+            ts: "1700000000.000000",
+            user: ALICE,
+            text: "thread parent",
+          },
         ],
       }),
       replies: vi.fn().mockResolvedValue({
+        // Realistic Slack shape, newest-first: the replies come first, and
+        // the thread PARENT is the oldest message, returned last.
         messages: [
           {
             type: "message",
@@ -48,6 +60,13 @@ function createClient() {
             ts: "1700000000.000002",
             user: ALICE,
             text: "thread reply",
+          },
+          {
+            type: "message",
+            subtype: undefined,
+            ts: "1700000000.000000",
+            user: ALICE,
+            text: "thread parent",
           },
         ],
       }),
@@ -200,6 +219,8 @@ async function startHarness(overrides: Record<string, unknown> = {}) {
   try {
     service = await SlackService.start(runtime);
   } catch (startError) {
+    // error-policy:J3 the harness rethrows with the captured log tail so a
+    // start failure is an explicit invalid state, never a fake pass.
     const calls = (runtime.logger.warn as ReturnType<typeof vi.fn>).mock.calls
       .concat((runtime.logger.error as ReturnType<typeof vi.fn>).mock.calls)
       .map((c) => String(c.at(-1)));
@@ -433,20 +454,23 @@ describe("SlackService membership snapshots", () => {
     expect(result.slackErrorCode).toBe("missing_scope");
   });
 
-  it("getChannelMembership maps a rate-limited platform error with the real SDK shape", async () => {
+  it("getChannelMembership maps a rate-limited error with the real SDK shape (no data)", async () => {
     const { app, service } = await startHarness();
+    // @slack/web-api 7.15.2 rateLimitedErrorWithDelay sets only code +
+    // retryAfter — there is no data property at all.
     const rateError = new Error("A rate-limit has been reached") as unknown as {
       code: string;
-      data: { error: string };
+      retryAfter: number;
     };
     rateError.code = "slack_webapi_rate_limited_error";
-    rateError.data = { error: "ratelimited" };
+    rateError.retryAfter = 30;
     const members = vi.fn().mockRejectedValue(rateError);
     (app.client.conversations as { members: typeof members }).members = members;
     const result = await service.getChannelMembership(OPS);
     expect(result.kind).toBe("unavailable");
     if (result.kind !== "unavailable") return;
     expect(result.reason).toBe("rate_limited");
+    expect(result.slackErrorCode).toBe("ratelimited");
   });
 
   it("getChannelMembership treats a present-but-non-string cursor as malformed, not complete", async () => {
@@ -479,33 +503,63 @@ describe("SlackService membership snapshots", () => {
   it("membership evidence is scoped per account: entity/room ids differ across accounts", async () => {
     // Two accounts admit the same channel id; the derived runtime ids and
     // the clients used must be account-scoped, never shared.
-    const { app, runtime, service } = await startHarness({
+    const { runtime, service } = await startHarness({
       accounts: {
-        team: {
-          botToken: "xoxb-team",
-          appToken: "xapp-team",
+        alpha: {
+          botToken: "xoxb-alpha",
+          appToken: "xapp-alpha",
+          groupPolicy: "allowlist",
+          channels: { ops: { users: [ALICE] } },
+        },
+        beta: {
+          botToken: "xoxb-beta",
+          appToken: "xapp-beta",
           groupPolicy: "allowlist",
           channels: { ops: { users: [ALICE] } },
         },
       },
     });
-    const secondAccountApp = apps.at(-1);
-    expect(secondAccountApp).toBeDefined();
-    const members = vi.fn().mockResolvedValue({ members: [ALICE] });
+    expect(apps).toHaveLength(2);
+    // Accounts start in sorted order: alpha first, beta second.
+    const [alphaApp, betaApp] = apps;
+    const alphaMembers = vi.fn().mockResolvedValue({ members: [ALICE] });
+    const betaMembers = vi.fn().mockResolvedValue({ members: [ALICE] });
     (
-      (secondAccountApp ?? app).client.conversations as {
-        members: typeof members;
-      }
-    ).members = members;
-    const result = await service.renewChannelMembership(OPS, "team");
-    expect(result.kind).toBe("snapshot");
-    // The connection was ensured with the team account's scoped ids.
-    const call = (
+      alphaApp.client.conversations as { members: typeof alphaMembers }
+    ).members = alphaMembers;
+    (betaApp.client.conversations as { members: typeof betaMembers }).members =
+      betaMembers;
+
+    const alphaResult = await service.renewChannelMembership(OPS, "alpha");
+    const betaResult = await service.renewChannelMembership(OPS, "beta");
+    expect(alphaResult.kind).toBe("snapshot");
+    expect(betaResult.kind).toBe("snapshot");
+    // Each renewal read its own account's client.
+    expect(alphaMembers).toHaveBeenCalledTimes(1);
+    expect(betaMembers).toHaveBeenCalledTimes(1);
+
+    // Both accounts renewed the same Slack member in the same channel, so
+    // the derivation — not the roster — must carry the account scope.
+    const calls = (
       runtime.ensureConnection as ReturnType<typeof vi.fn>
-    ).mock.calls.at(-1)?.[0] as Record<string, unknown>;
-    expect(String(call.entityId)).not.toBe("");
-    expect(members).toHaveBeenCalledWith(
-      expect.objectContaining({ channel: OPS }),
+    ).mock.calls.map((c) => c[0] as Record<string, unknown>);
+    expect(calls).toHaveLength(2);
+    const [alphaConnection, betaConnection] = calls;
+    expect(String(alphaConnection.entityId)).not.toBe(
+      String(betaConnection.entityId),
+    );
+    expect(String(alphaConnection.roomId)).not.toBe(
+      String(betaConnection.roomId),
+    );
+    expect(String(alphaConnection.worldId)).not.toBe(
+      String(betaConnection.worldId),
+    );
+    expect(alphaConnection.entityId).not.toBe("");
+    expect(
+      (alphaConnection.metadata as Record<string, unknown>).accountId,
+    ).toBe("alpha");
+    expect((betaConnection.metadata as Record<string, unknown>).accountId).toBe(
+      "beta",
     );
   });
 });
@@ -540,7 +594,12 @@ describe("thread inheritance in chat context", () => {
     const { app, result } = await chatContextHarness({});
     expect(app.client.conversations.replies).toHaveBeenCalledTimes(1);
     expect(app.client.conversations.history).not.toHaveBeenCalled();
-    expect(result?.recentMessages.map((m) => m.text)).toEqual(["thread reply"]);
+    // The replies transcript (parent + reply), oldest-first, no dedup
+    // needed — the channel transcript was never read.
+    expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "thread parent",
+      "thread reply",
+    ]);
   });
 
   it("historyScope channel reads the parent channel transcript instead", async () => {
@@ -550,6 +609,7 @@ describe("thread inheritance in chat context", () => {
     expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
     expect(app.client.conversations.replies).not.toHaveBeenCalled();
     expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "thread parent",
       "channel message",
     ]);
   });
@@ -558,9 +618,11 @@ describe("thread inheritance in chat context", () => {
     const { app, result } = await chatContextHarness({ inheritParent: true });
     expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
     expect(app.client.conversations.replies).toHaveBeenCalledTimes(1);
-    // Both transcripts are newest-first from Slack and reversed together:
-    // the earlier channel message precedes the later thread reply.
+    // The shared parent (ts .000000) appears in BOTH transcripts; it must
+    // be published exactly once, then the later channel and thread items in
+    // chronological order.
     expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "thread parent",
       "channel message",
       "thread reply",
     ]);
@@ -574,6 +636,7 @@ describe("thread inheritance in chat context", () => {
     expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
     expect(app.client.conversations.replies).not.toHaveBeenCalled();
     expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "thread parent",
       "channel message",
     ]);
   });

--- a/plugins/plugin-slack/src/service-membership.test.ts
+++ b/plugins/plugin-slack/src/service-membership.test.ts
@@ -51,22 +51,23 @@ function createClient() {
         ],
       }),
       replies: vi.fn().mockResolvedValue({
-        // Realistic Slack shape, newest-first: the replies come first, and
-        // the thread PARENT is the oldest message, returned last.
+        // Realistic Slack shape per docs: conversations.replies returns
+        // EARLIEST-FIRST — the thread PARENT first, then replies in
+        // chronological order.
         messages: [
-          {
-            type: "message",
-            subtype: undefined,
-            ts: "1700000000.000002",
-            user: ALICE,
-            text: "thread reply",
-          },
           {
             type: "message",
             subtype: undefined,
             ts: "1700000000.000000",
             user: ALICE,
             text: "thread parent",
+          },
+          {
+            type: "message",
+            subtype: undefined,
+            ts: "1700000000.000002",
+            user: ALICE,
+            text: "thread reply",
           },
         ],
       }),
@@ -219,13 +220,14 @@ async function startHarness(overrides: Record<string, unknown> = {}) {
   try {
     service = await SlackService.start(runtime);
   } catch (startError) {
-    // error-policy:J3 the harness rethrows with the captured log tail so a
-    // start failure is an explicit invalid state, never a fake pass.
+    // error-policy:J2 context-adding rethrow: wrap with the captured log
+    // tail and preserve the original start failure as cause.
     const calls = (runtime.logger.warn as ReturnType<typeof vi.fn>).mock.calls
       .concat((runtime.logger.error as ReturnType<typeof vi.fn>).mock.calls)
       .map((c) => String(c.at(-1)));
     throw new Error(
       `SlackService.start failed: ${String(startError)}; logged: ${calls.join(" | ")}`,
+      { cause: startError },
     );
   }
   if (apps.length === 0) {
@@ -594,8 +596,8 @@ describe("thread inheritance in chat context", () => {
     const { app, result } = await chatContextHarness({});
     expect(app.client.conversations.replies).toHaveBeenCalledTimes(1);
     expect(app.client.conversations.history).not.toHaveBeenCalled();
-    // The replies transcript (parent + reply), oldest-first, no dedup
-    // needed — the channel transcript was never read.
+    // Slack returns replies earliest-first (parent first); the published
+    // context must still be chronological oldest-first.
     expect(result?.recentMessages.map((m) => m.text)).toEqual([
       "thread parent",
       "thread reply",

--- a/plugins/plugin-slack/src/service-membership.test.ts
+++ b/plugins/plugin-slack/src/service-membership.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Service-level membership tests through the real Bolt event-registration
+ * path: member join/leave payloads preserve user and channel, joins renew
+ * runtime participation only for admitted channels, leaves remove only the
+ * room participant, and inbound messages renew the sender's connection.
+ * The Bolt app and WebClient are mocked; the SlackService under test is real.
+ */
+import { type IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { projectConnectorSettings } from "../../../packages/agent/src/runtime/project-connector-settings";
+
+const bolt = vi.hoisted(() => ({
+  channels: [] as Array<Record<string, unknown>>,
+  users: [] as Array<Record<string, unknown>>,
+}));
+
+function createClient() {
+  return {
+    auth: {
+      test: vi
+        .fn()
+        .mockResolvedValue({ user_id: "U0BOTBOT0", team_id: "T0TEAM000" }),
+    },
+    conversations: {
+      list: vi.fn().mockResolvedValue({ channels: bolt.channels }),
+      info: vi
+        .fn()
+        .mockImplementation(async ({ channel }: { channel: string }) => ({
+          channel: bolt.channels.find((entry) => entry.id === channel),
+        })),
+      members: vi.fn(),
+      history: vi.fn().mockResolvedValue({
+        messages: [
+          {
+            type: "message",
+            subtype: undefined,
+            ts: "1700000000.000001",
+            user: ALICE,
+            text: "channel message",
+          },
+        ],
+      }),
+      replies: vi.fn().mockResolvedValue({
+        messages: [
+          {
+            type: "message",
+            subtype: undefined,
+            ts: "1700000000.000002",
+            user: ALICE,
+            text: "thread reply",
+          },
+        ],
+      }),
+    },
+    users: {
+      list: vi.fn().mockResolvedValue({ members: bolt.users }),
+      info: vi.fn().mockImplementation(async ({ user }: { user: string }) => ({
+        user: bolt.users.find((entry) => entry.id === user),
+      })),
+    },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ok: true, ts: "1.000001" }),
+    },
+    team: { info: vi.fn().mockResolvedValue({ team: { name: "Sandbox" } }) },
+  };
+}
+
+const apps = vi.hoisted(() => [] as Array<ReturnType<typeof createAppRecord>>);
+
+function createAppRecord() {
+  const client = createClient();
+  return {
+    eventHandlers: new Map<
+      string,
+      (args: {
+        event: unknown;
+        client: unknown;
+        body?: unknown;
+      }) => Promise<void>
+    >(),
+    client,
+  };
+}
+
+vi.mock("@slack/bolt", () => ({
+  LogLevel: { INFO: "info" },
+  App: class MockBoltApp {
+    private readonly record = createAppRecord();
+    client = this.record.client;
+
+    constructor() {
+      apps.push(this.record);
+    }
+
+    message() {}
+
+    event(
+      name: string,
+      handler: (args: {
+        event: unknown;
+        client: unknown;
+        body?: unknown;
+      }) => Promise<void>,
+    ) {
+      this.record.eventHandlers.set(name, handler);
+    }
+
+    async start() {}
+    async stop() {}
+  },
+}));
+
+import { SlackService } from "./service";
+
+const OPS = "C0123ABCD";
+const ALICE = "U0123ABCD";
+const BOB = "U0999ZZZZ";
+
+function memberEventBody(event: Record<string, unknown>) {
+  return {
+    team_id: "T0TEAM000",
+    event_id: `Ev-${String(event.user)}-${String(event.channel)}-${String(event.event_ts ?? "")}`,
+    event,
+  };
+}
+
+function createRuntime(settings: Record<string, unknown>): IAgentRuntime {
+  const projection = projectConnectorSettings({}, { slack: settings });
+  const character = {
+    name: "Slack Membership Test",
+    settings: projection.settings,
+    secrets: projection.secrets,
+  };
+  const secretEntries = Object.entries(projection.secrets) as Array<
+    [string, string]
+  >;
+  const runtime = {
+    agentId: "agent-slack-membership-integration",
+    character,
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: vi.fn((key: string) => {
+      const settings2 = character.settings as Record<string, unknown>;
+      const secrets2 = character.secrets as Record<string, unknown>;
+      if (Object.hasOwn(settings2, key)) return settings2[key];
+      if (Object.hasOwn(secrets2, key)) return secrets2[key];
+      const match = secretEntries.find(([k]) => k === key);
+      return match ? match[1] : null;
+    }),
+    getWorld: vi.fn().mockResolvedValue(null),
+    createWorld: vi.fn().mockResolvedValue(undefined),
+    getRoom: vi.fn().mockResolvedValue(null),
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+    createRoom: vi.fn().mockResolvedValue(undefined),
+    createMemory: vi.fn().mockResolvedValue(undefined),
+    getMemoryById: vi.fn().mockResolvedValue(null),
+    createEntity: vi.fn().mockResolvedValue(undefined),
+    getEntityById: vi.fn().mockResolvedValue(null),
+    ensureConnection: vi.fn().mockResolvedValue(undefined),
+    removeParticipant: vi.fn().mockResolvedValue(true),
+    reportError: vi.fn(),
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+async function startHarness(overrides: Record<string, unknown> = {}) {
+  const runtime = createRuntime({
+    enabled: true,
+    botToken: "xoxb-test-token",
+    appToken: "xapp-test-token",
+    groupPolicy: "allowlist",
+    channels: { ops: { users: [ALICE] } },
+    ...overrides,
+  });
+  bolt.channels.push({
+    id: OPS,
+    name: "ops",
+    is_channel: true,
+    is_member: true,
+  });
+  bolt.users.push(
+    { id: ALICE, name: "alice", real_name: "Alice Example" },
+    { id: BOB, name: "bob", real_name: "Bob Example" },
+  );
+  let service: InstanceType<typeof SlackService> | undefined;
+  try {
+    service = await SlackService.start(runtime);
+  } catch (startError) {
+    const calls = (runtime.logger.warn as ReturnType<typeof vi.fn>).mock.calls
+      .concat((runtime.logger.error as ReturnType<typeof vi.fn>).mock.calls)
+      .map((c) => String(c.at(-1)));
+    throw new Error(
+      `SlackService.start failed: ${String(startError)}; logged: ${calls.join(" | ")}`,
+    );
+  }
+  if (apps.length === 0) {
+    const calls = (
+      runtime.logger.warn as ReturnType<typeof vi.fn>
+    ).mock.calls.map((c) => String(c.at(-1)));
+    throw new Error(
+      `no app registered; start succeeded? logged: ${calls.join(" | ")}`,
+    );
+  }
+  const app = apps.at(-1);
+  if (!app)
+    throw new Error(`Bolt app was not registered (apps=${apps.length})`);
+  return { app, runtime, service };
+}
+
+describe("SlackService membership events", () => {
+  beforeEach(() => {
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+  });
+
+  it("member_joined_channel payload preserves the Slack user and channel", async () => {
+    const { app, runtime } = await startHarness();
+    const handler = app.eventHandlers.get("member_joined_channel");
+    expect(handler).toBeDefined();
+    const event = {
+      user: BOB,
+      channel: OPS,
+      channel_type: "C",
+      event_ts: "1700000000.000200",
+    };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+
+    const [type, payload] = vi
+      .mocked(runtime.emitEvent)
+      .mock.calls.at(-1) as unknown as [string, Record<string, unknown>];
+    expect(type).toBe("SLACK_MEMBER_JOINED_CHANNEL");
+    const slack = (payload.metadata as Record<string, unknown>).slack as Record<
+      string,
+      unknown
+    >;
+    expect(slack.userId).toBe(BOB);
+    expect(slack.channelId).toBe(OPS);
+    expect(slack.eventTs).toBe("1700000000.000200");
+    expect(payload.entityId).toBeDefined();
+  });
+
+  it("member_left_channel payload preserves the Slack user and channel", async () => {
+    const { app, runtime } = await startHarness();
+    const handler = app.eventHandlers.get("member_left_channel");
+    const event = { user: ALICE, channel: OPS, event_ts: "1700000000.000300" };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+    const [type, payload] = vi
+      .mocked(runtime.emitEvent)
+      .mock.calls.at(-1) as unknown as [string, Record<string, unknown>];
+    expect(type).toBe("SLACK_MEMBER_LEFT_CHANNEL");
+    const slack = (payload.metadata as Record<string, unknown>).slack as Record<
+      string,
+      unknown
+    >;
+    expect(slack.userId).toBe(ALICE);
+    expect(slack.channelId).toBe(OPS);
+  });
+
+  it("a member join for an admitted channel renews runtime participation", async () => {
+    const { app, runtime } = await startHarness();
+    const handler = app.eventHandlers.get("member_joined_channel");
+    const event = { user: ALICE, channel: OPS, event_ts: "1700000000.000400" };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+    expect(runtime.ensureConnection).toHaveBeenCalled();
+  });
+
+  it("a member join for a non-admitted channel does not renew participation", async () => {
+    const { app, runtime } = await startHarness();
+    const handler = app.eventHandlers.get("member_joined_channel");
+    const event = {
+      user: ALICE,
+      channel: "C0999ZZZZ",
+      event_ts: "1700000000.000500",
+    };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+  });
+
+  it("a member leave removes only the room participant, not the entity", async () => {
+    const { app, runtime } = await startHarness();
+    const handler = app.eventHandlers.get("member_left_channel");
+    const event = { user: ALICE, channel: OPS, event_ts: "1700000000.000600" };
+    await handler?.({
+      event,
+      client: app.client,
+      body: memberEventBody(event),
+    });
+    expect(runtime.removeParticipant).toHaveBeenCalledTimes(1);
+    expect(runtime.createEntity).not.toHaveBeenCalled();
+  });
+});
+
+describe("SlackService membership snapshots", () => {
+  beforeEach(() => {
+    apps.length = 0;
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+  });
+
+  it("getChannelMembership returns unavailable for a non-admitted channel", async () => {
+    const { service } = await startHarness();
+    const result = await service.getChannelMembership("C0999ZZZZ");
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toBe("channel_not_admitted");
+  });
+
+  it("getChannelMembership pages conversations.members for an admitted channel", async () => {
+    const { app, service } = await startHarness();
+    const members = vi
+      .fn()
+      .mockResolvedValueOnce({
+        members: [ALICE],
+        response_metadata: { next_cursor: "c1" },
+      })
+      .mockResolvedValueOnce({ members: [BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.getChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+    if (result.kind !== "snapshot") return;
+    expect([...result.memberIds]).toEqual([ALICE, BOB]);
+    expect(members).toHaveBeenCalledTimes(2);
+  });
+
+  it("getChannelMembership maps missing scope to unavailable, not empty", async () => {
+    const { app, service } = await startHarness();
+    const scopeError = new Error("missing_scope") as Error & {
+      data?: { code?: string };
+    };
+    scopeError.data = { code: "missing_scope" };
+    const members = vi.fn().mockRejectedValue(scopeError);
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.getChannelMembership(OPS);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toBe("missing_scope");
+  });
+
+  it("renewChannelMembership ensures connections for every snapshot member", async () => {
+    const { app, runtime, service } = await startHarness();
+    const members = vi.fn().mockResolvedValue({ members: [ALICE, BOB] });
+    (app.client.conversations as { members: typeof members }).members = members;
+    const result = await service.renewChannelMembership(OPS);
+    expect(result.kind).toBe("snapshot");
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("thread inheritance in chat context", () => {
+  beforeEach(() => {
+    bolt.channels.length = 0;
+    bolt.users.length = 0;
+    apps.length = 0;
+  });
+
+  async function chatContextHarness(thread: Record<string, unknown>) {
+    const { app, runtime, service } = await startHarness({ thread });
+    bolt.channels.push({
+      id: OPS,
+      name: "ops",
+      is_channel: true,
+      is_member: true,
+    });
+    const context = {
+      runtime,
+      roomId: undefined,
+    };
+    const result = await service.getConnectorChatContext(
+      { channelId: OPS, threadId: "1700000000.000000" },
+      context as never,
+    );
+    return { app, runtime, service, result };
+  }
+
+  it("default reads only the thread transcript for thread targets", async () => {
+    const { app, result } = await chatContextHarness({});
+    expect(app.client.conversations.replies).toHaveBeenCalledTimes(1);
+    expect(app.client.conversations.history).not.toHaveBeenCalled();
+    expect(result?.recentMessages.map((m) => m.text)).toEqual(["thread reply"]);
+  });
+
+  it("historyScope channel reads the parent channel transcript instead", async () => {
+    const { app, result } = await chatContextHarness({
+      historyScope: "channel",
+    });
+    expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
+    expect(app.client.conversations.replies).not.toHaveBeenCalled();
+    expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "channel message",
+    ]);
+  });
+
+  it("inheritParent injects the parent transcript ahead of thread history", async () => {
+    const { app, result } = await chatContextHarness({ inheritParent: true });
+    expect(app.client.conversations.history).toHaveBeenCalledTimes(1);
+    expect(app.client.conversations.replies).toHaveBeenCalledTimes(1);
+    expect(result?.recentMessages.map((m) => m.text)).toEqual([
+      "thread reply",
+      "channel message",
+    ]);
+  });
+});

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -490,6 +490,13 @@ import {
   type SlackMembershipReadResult,
 } from "./membership";
 import {
+  AUTHORITY_UUID_PATTERN,
+  resolveMembershipService,
+  type SlackMembershipPublisher,
+  type SlackMembershipRuntimeIds,
+  slackMembershipAccountId,
+} from "./membership-authority";
+import {
   extractSlackEventWorkspace,
   SlackAccountPolicyResolver,
   type SlackInboundPolicyDecision,
@@ -584,6 +591,12 @@ export class SlackService extends Service implements ISlackService {
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, SlackAccountRuntime> = new Map();
   private accountStarts: Map<string, Promise<SlackAccountRuntime>> = new Map();
+  /**
+   * Canonical membership publishers per account: publishes Web API roster
+   * evidence to the MembershipService authority when one is registered.
+   * Absent (and membership stays runtime-participation-only) otherwise.
+   */
+  private membershipPublishers = new Map<string, SlackMembershipPublisher>();
   private userCache: Map<string, SlackUser> = new Map();
   private channelCache: Map<string, SlackChannel> = new Map();
   private isConnected = false;
@@ -1009,6 +1022,7 @@ export class SlackService extends Service implements ISlackService {
       );
 
       await this.ensureWorkspaceExists(accountId);
+      await this.initMembershipPublisher(accountId, teamId);
       return state;
     })();
 
@@ -1039,6 +1053,7 @@ export class SlackService extends Service implements ISlackService {
         );
       }
       this.accountStates.clear();
+      this.membershipPublishers.clear();
       this.syncDefaultAccountAliases();
       return;
     }
@@ -1053,6 +1068,271 @@ export class SlackService extends Service implements ISlackService {
         { src: "plugin:slack", agentId: this.runtime.agentId },
         "Slack service stopped",
       );
+    }
+  }
+
+  /**
+   * Constructs the canonical membership publisher for one account when a
+   * MembershipService authority is registered. The connector-account row is
+   * upserted through the ConnectorAccountManager so the authority's FK
+   * resolves to a stable durable UUID; a bootstrap failure is reported and
+   * leaves the publisher absent (legacy behavior) rather than crashing the
+   * account connection.
+   */
+  private async initMembershipPublisher(
+    accountId: string,
+    teamId: string,
+  ): Promise<void> {
+    let authority: import("@elizaos/core").MembershipService | null = null;
+    try {
+      authority = resolveMembershipService(this.runtime);
+    } catch (cause) {
+      // error-policy:J4 user-facing degrade: a runtime whose service registry
+      // cannot answer (harness runtimes without getService) degrades to the
+      // visibly-distinct no-authority mode; the failure is surfaced, not
+      // silently treated as healthy.
+      this.runtime.reportError?.(
+        "slack-membership-authority-resolve",
+        new ElizaError("Slack membership authority resolution failed", {
+          code: "SLACK_MEMBERSHIP_AUTHORITY_RESOLVE_FAILED",
+          context: { accountId },
+          cause,
+        }),
+      );
+      authority = null;
+    }
+    if (!authority) {
+      this.runtime.logger.debug(
+        { src: "plugin:slack", accountId },
+        "canonical MembershipService authority not registered; membership evidence is not published",
+      );
+      return;
+    }
+    try {
+      const { getConnectorAccountManager } = await import("@elizaos/core");
+      const manager = getConnectorAccountManager(this.runtime);
+      const accountRecordId = `slack-membership-${accountId}`;
+      const prior = await manager.getAccount(
+        SLACK_SERVICE_NAME,
+        accountRecordId,
+      );
+      const now = Date.now();
+      // The authority requires the connectorAccountId to be a versioned UUID
+      // matching a durable connector-account row. Storages that echo
+      // non-UUID record ids (in-memory fallbacks) get a deterministic v5 id
+      // persisted AS the record id, so the authority's FK resolves exactly.
+      const durableAccountRecordId =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          String(prior?.id),
+        )
+          ? (prior?.id as string)
+          : slackMembershipAccountId(accountRecordId);
+      const stored = await manager.upsertAccount(
+        SLACK_SERVICE_NAME,
+        {
+          ...(prior ?? {
+            provider: SLACK_SERVICE_NAME,
+            label: `Slack membership (${accountId})`,
+            role: "AGENT",
+            purpose: ["messaging", "reading"],
+            accessGate: "open",
+            status: "connected",
+          }),
+          id: durableAccountRecordId,
+          createdAt: prior?.createdAt ?? now,
+          updatedAt: now,
+          metadata: {
+            ...(prior?.metadata as Record<string, unknown> | undefined),
+            source: "slack-membership",
+            teamId,
+          },
+        },
+        durableAccountRecordId,
+      );
+      // The authority keys every scope by a versioned-UUID connector
+      // account id. Storages that echo a non-UUID record id (in-memory
+      // fallbacks) get a deterministic v5 derivation instead, so scope
+      // identity stays stable across restarts.
+      const connectorAccountId =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          String(stored.id),
+        )
+          ? (stored.id as UUID)
+          : slackMembershipAccountId(accountRecordId);
+      const { SlackMembershipPublisher } = await import(
+        "./membership-authority.js"
+      );
+      this.membershipPublishers.set(
+        accountId,
+        new SlackMembershipPublisher({
+          runtime: this.runtime,
+          connectorAccountId: connectorAccountId,
+          accountKey: accountId,
+          service: authority,
+          deriveRuntimeIds: ({ channelId, slackUserId }) =>
+            this.deriveMembershipRuntimeIds(channelId, slackUserId, accountId),
+          ensurePrincipalEntity: (principalId, slackUserId) =>
+            this.ensureMembershipPrincipalEntity(
+              principalId,
+              slackUserId,
+              accountId,
+            ),
+          ensureRuntimeRoomAndWorld: (runtimeIds, channelId) =>
+            this.ensureMembershipRoomAndWorld(runtimeIds, channelId, accountId),
+        }),
+      );
+      this.runtime.logger.info(
+        { src: "plugin:slack", accountId, teamId },
+        "canonical Slack membership publisher registered",
+      );
+    } catch (error) {
+      // error-policy:J7 Publication is a governed overlay: a bootstrap
+      // failure must not take down the account connection; it is reported
+      // and membership stays runtime-participation-only for this process.
+      this.runtime.reportError("slack-membership-publisher-init", error, {
+        accountId,
+      });
+    }
+  }
+
+  /**
+   * Runtime mapping for authority members, mirroring the message path's
+   * derivation: workspace world, channel room, scoped user entity. Derived
+   * ids are only forwarded when they satisfy the authority's UUID pattern
+   * (createUniqueUuid-derived ids carry the custom 0x0 version nibble and
+   * are rejected).
+   */
+  private deriveMembershipRuntimeIds(
+    channelId: string,
+    slackUserId: string,
+    accountId: string,
+  ): SlackMembershipRuntimeIds {
+    const teamId = this.getTeamIdForAccount(accountId);
+    const worldId = teamId
+      ? createUniqueUuid(
+          this.runtime,
+          this.scopedSlackKey("slack-workspace", teamId, accountId),
+        )
+      : null;
+    const roomId = createUniqueUuid(
+      this.runtime,
+      this.scopedSlackKey("slack-room", channelId, accountId),
+    );
+    const entityId = this.getEntityId(slackUserId, accountId);
+    return {
+      worldId: worldId && AUTHORITY_UUID_PATTERN.test(worldId) ? worldId : null,
+      roomId: AUTHORITY_UUID_PATTERN.test(roomId) ? roomId : null,
+      entityId: AUTHORITY_UUID_PATTERN.test(entityId) ? entityId : null,
+    };
+  }
+
+  /**
+   * The authority requires existing entity rows for every principal; create
+   * a stub carrying the Slack identity when missing.
+   */
+  private async ensureMembershipPrincipalEntity(
+    principalId: UUID,
+    slackUserId: string,
+    accountId: string,
+  ): Promise<void> {
+    const existing = await this.runtime.getEntityById?.(principalId);
+    if (existing) return;
+    await this.runtime.createEntities?.([
+      {
+        id: principalId,
+        agentId: this.runtime.agentId,
+        names: [`slack:${accountId}:${slackUserId}`],
+        metadata: {
+          source: "slack-membership",
+          accountId,
+          slackUserId,
+        },
+      },
+    ]);
+  }
+
+  /**
+   * The authority requires existing room/world rows for forwarded runtime
+   * mappings; ensure the channel room (and workspace world when derived
+   * pattern-valid) exists before publishing.
+   */
+  private async ensureMembershipRoomAndWorld(
+    runtimeIds: SlackMembershipRuntimeIds,
+    channelId: string,
+    accountId: string,
+  ): Promise<void> {
+    if (runtimeIds.roomId) {
+      const room = await this.runtime.getRoom?.(runtimeIds.roomId);
+      if (!room) {
+        const state = this.accountStates.get(accountId);
+        const name =
+          state?.channelCache.get(channelId)?.name ??
+          this.channelCache.get(channelId)?.name ??
+          channelId;
+        await this.runtime.createRoom?.({
+          id: runtimeIds.roomId,
+          name,
+          source: "slack",
+          type: ChannelType.GROUP,
+          channelId,
+        });
+      }
+    }
+    if (runtimeIds.worldId) {
+      const world = await this.runtime.getWorld?.(runtimeIds.worldId);
+      if (!world) {
+        const teamId = this.getTeamIdForAccount(accountId);
+        await this.runtime.createWorld?.({
+          id: runtimeIds.worldId,
+          name: `Slack Workspace ${teamId ?? accountId}`,
+          agentId: this.runtime.agentId,
+          metadata: { source: "slack", accountId },
+        });
+      }
+    }
+  }
+
+  /**
+   * Canonical publication for one roster read: a completed walk publishes a
+   * complete snapshot; an unavailable read reports incomplete evidence (the
+   * scope goes stale — never a mass revocation). Publication failures are
+   * reported (J7) and never mask the read result the caller consumes.
+   */
+  private async publishMembershipEvidence(
+    accountId: string,
+    channelId: string,
+    result: SlackMembershipReadResult,
+  ): Promise<void> {
+    const publisher = this.membershipPublishers.get(accountId);
+    if (!publisher) return;
+    const teamId = this.getTeamIdForAccount(accountId);
+    if (!teamId) return;
+    try {
+      if (result.kind === "snapshot") {
+        const botUserId = this.getBotUserIdForAccount(accountId);
+        await publisher.publishSnapshot({
+          teamId,
+          channelId,
+          memberIds: result.memberIds,
+          botUserId,
+          observedAt: result.observedAt,
+        });
+        return;
+      }
+      await publisher.reportUnavailable({
+        teamId,
+        channelId,
+        reason: `slack conversations.members unavailable: ${result.reason}`,
+        observedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      // error-policy:J7 Diagnostics must not kill the renewal path: the
+      // runtime-participation projection below still runs on a snapshot;
+      // the authority keeps its prior state and the failure is reported.
+      this.runtime.reportError("slack-membership-publish", error, {
+        accountId,
+        channelId,
+      });
     }
   }
 
@@ -2063,6 +2343,36 @@ export class SlackService extends Service implements ISlackService {
     ) {
       return;
     }
+    // Canonical delta publication precedes runtime renewal: a committed
+    // join delta makes the new member's authority evidence active even if
+    // the runtime projection below fails, and the projection still runs
+    // when publication is absent (no authority) or skips (no baseline).
+    try {
+      const teamId = this.getTeamIdForAccount(accountId);
+      const publisher = this.membershipPublishers.get(accountId);
+      if (teamId && publisher) {
+        // observedAt anchors on publication time, not the Slack event_ts:
+        // redelivered events can carry arbitrarily old timestamps, and the
+        // evidence TTL must reflect when the connector observed it.
+        await publisher.publishDelta({
+          teamId,
+          channelId: event.channel,
+          slackUserId: event.user,
+          joined: true,
+          reason: "joined",
+        });
+      }
+    } catch (error) {
+      // error-policy:J7 The delta is a governed overlay on the event path;
+      // report the failure and continue into runtime renewal so the event
+      // is not lost.
+      this.runtime.reportError("slack-membership-delta", error, {
+        accountId,
+        channelId: event.channel,
+        userId: event.user,
+        eventType: "member_joined_channel",
+      });
+    }
     try {
       await this.renewChannelMember(event.user, event.channel, accountId);
     } catch (cause) {
@@ -2098,6 +2408,34 @@ export class SlackService extends Service implements ISlackService {
       SlackEventTypes.MEMBER_LEFT_CHANNEL as string,
       this.buildMemberEventPayload(event, accountId),
     );
+
+    // Canonical delta publication precedes runtime participant removal: a
+    // committed leave delta revokes the departing member's authority
+    // evidence even if the runtime projection below fails. Skips benignly
+    // when no authority is registered or no snapshot baseline exists.
+    try {
+      const teamId = this.getTeamIdForAccount(accountId);
+      const publisher = this.membershipPublishers.get(accountId);
+      if (teamId && publisher) {
+        // observedAt anchors on publication time (see the join handler).
+        await publisher.publishDelta({
+          teamId,
+          channelId: event.channel,
+          slackUserId: event.user,
+          joined: false,
+          reason: "left",
+        });
+      }
+    } catch (error) {
+      // error-policy:J7 The delta is a governed overlay on the event path;
+      // report the failure and continue into participant removal.
+      this.runtime.reportError("slack-membership-delta", error, {
+        accountId,
+        channelId: event.channel,
+        userId: event.user,
+        eventType: "member_left_channel",
+      });
+    }
 
     // Leaving one channel never deactivates the workspace entity; only the
     // room participation for this channel is dropped.
@@ -2343,7 +2681,10 @@ export class SlackService extends Service implements ISlackService {
 
   /**
    * Renews a channel's member list into runtime rooms: entities and
-   * participant connections are ensured for every snapshot member. When the
+   * participant connections are ensured for every snapshot member, and the
+   * completed roster is published to the canonical MembershipService
+   * authority when one is registered (a complete snapshot for a successful
+   * walk; an incomplete-snapshot report for an unavailable read). When the
    * read is unavailable nothing is revoked — the prior roster stays as-is
    * and the unavailable reason is surfaced to the caller.
    */
@@ -2352,12 +2693,13 @@ export class SlackService extends Service implements ISlackService {
     accountId?: string | null,
   ): Promise<SlackMembershipReadResult> {
     const result = await this.getChannelMembership(channelId, accountId);
-    if (result.kind !== "snapshot") {
-      return result;
-    }
     const normalized = normalizeAccountId(
       accountId ?? this.defaultAccountId ?? DEFAULT_ACCOUNT_ID,
     );
+    await this.publishMembershipEvidence(normalized, channelId, result);
+    if (result.kind !== "snapshot") {
+      return result;
+    }
     for (const memberId of result.memberIds) {
       if (memberId === this.getBotUserIdForAccount(normalized)) {
         continue;
@@ -3420,12 +3762,7 @@ export class SlackService extends Service implements ISlackService {
       // shared .reverse() below therefore needs the thread transcript
       // pre-reversed so the published order stays chronological.
       rawMessages = (
-        await this.readThreadReplies(
-          channelId,
-          threadTs,
-          undefined,
-          accountId,
-        )
+        await this.readThreadReplies(channelId, threadTs, undefined, accountId)
       ).reverse();
     } else {
       rawMessages = await this.readHistory(channelId, undefined, accountId);

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -486,6 +486,10 @@ import {
 } from "./accounts";
 import { markdownToSlackMrkdwn, splitSlackText } from "./formatting";
 import {
+  readChannelMembershipSnapshot,
+  type SlackMembershipReadResult,
+} from "./membership";
+import {
   extractSlackEventWorkspace,
   SlackAccountPolicyResolver,
   type SlackInboundPolicyDecision,
@@ -1112,7 +1116,9 @@ export class SlackService extends Service implements ISlackService {
       );
     });
 
-    // Handle channel joins/leaves
+    // Handle channel joins/leaves. Payloads preserve the Slack user and
+    // channel so consumers can identify the affected member; membership
+    // evidence is renewed through the same path as snapshots.
     app.event("member_joined_channel", async ({ event, body }) => {
       if (
         !this.isInboundWorkspaceAuthorized(
@@ -1123,7 +1129,17 @@ export class SlackService extends Service implements ISlackService {
       ) {
         return;
       }
-      await this.handleMemberJoinedChannel(event, accountId);
+      await this.handleMemberJoinedChannel(
+        event as {
+          user: string;
+          channel: string;
+          team?: string;
+          channel_type?: string;
+          inviter?: string;
+          event_ts?: string;
+        },
+        accountId,
+      );
     });
 
     app.event("member_left_channel", async ({ event, body }) => {
@@ -1136,7 +1152,15 @@ export class SlackService extends Service implements ISlackService {
       ) {
         return;
       }
-      await this.handleMemberLeftChannel(event, accountId);
+      await this.handleMemberLeftChannel(
+        event as {
+          user: string;
+          channel: string;
+          team?: string;
+          event_ts?: string;
+        },
+        accountId,
+      );
     });
 
     // Handle file shares
@@ -1492,28 +1516,15 @@ export class SlackService extends Service implements ISlackService {
       accountId,
     );
 
-    const existingEntity = await this.runtime.getEntityById(memory.entityId);
-    if (!existingEntity) {
-      const slackUserId = message.user ?? memory.entityId;
-      const user = message.user
-        ? await this.getUser(message.user, accountId)
-        : null;
-      const displayName = user ? getSlackUserDisplayName(user) : slackUserId;
-      await this.runtime.createEntity({
-        id: memory.entityId,
-        names: [displayName],
-        metadata: {
-          source: "slack",
-          accountId,
-          slack: {
-            accountId,
-            id: slackUserId,
-            name: displayName,
-            userName: user?.name || slackUserId,
-          },
-        },
-        agentId: this.runtime.agentId,
-      });
+    // Renew the sender's room participation on every admitted inbound
+    // message: entity creation alone leaves a returning member disconnected.
+    if (message.user) {
+      await this.renewInboundSender(
+        message.user,
+        message.channel,
+        message.thread_ts,
+        accountId,
+      );
     }
 
     const claimedMemory = await this.claimInboundMemory(
@@ -1604,25 +1615,14 @@ export class SlackService extends Service implements ISlackService {
       accountId,
     );
 
-    const existingEntity = await this.runtime.getEntityById(memory.entityId);
-    if (!existingEntity) {
-      const user = await this.getUser(event.user, accountId);
-      const displayName = user ? getSlackUserDisplayName(user) : event.user;
-      await this.runtime.createEntity({
-        id: memory.entityId,
-        names: [displayName],
-        metadata: {
-          source: "slack",
-          accountId,
-          slack: {
-            accountId,
-            id: event.user,
-            name: displayName,
-            userName: user?.name || event.user,
-          },
-        },
-        agentId: this.runtime.agentId,
-      });
+    // Renew the mentioning sender the same way message senders are renewed.
+    if (event.user) {
+      await this.renewInboundSender(
+        event.user,
+        event.channel,
+        event.thread_ts,
+        accountId,
+      );
     }
 
     const claimedMemory = await this.claimInboundMemory(
@@ -2032,6 +2032,9 @@ export class SlackService extends Service implements ISlackService {
       user: string;
       channel: string;
       team?: string;
+      channel_type?: string;
+      inviter?: string;
+      event_ts?: string;
     },
     accountId = this.defaultAccountId,
   ): Promise<void> {
@@ -2045,18 +2048,44 @@ export class SlackService extends Service implements ISlackService {
       }
     }
 
+    // Preserve the Slack user and channel in the emitted payload so
+    // consumers can identify the affected member, then renew runtime
+    // participation for the joining member when the channel is admitted.
+    const payload = this.buildMemberEventPayload(event, accountId);
     await this.runtime.emitEvent(
       SlackEventTypes.MEMBER_JOINED_CHANNEL as string,
-      this.buildEventPayload(accountId),
+      payload,
     );
+
+    if (
+      event.user === this.getBotUserIdForAccount(accountId) ||
+      !this.isChannelAllowed(event.channel, accountId)
+    ) {
+      return;
+    }
+    try {
+      await this.renewChannelMember(event.user, event.channel, accountId);
+    } catch (cause) {
+      // error-policy:J2 Membership renewal is owner-visible; Bolt has already
+      // acknowledged the event, so the typed failure must be reported rather
+      // than swallowed into an empty state.
+      const error = new ElizaError("Slack member join renewal failed", {
+        code: "SLACK_MEMBERSHIP_RENEWAL_FAILED",
+        context: {
+          accountId,
+          channelId: event.channel,
+          userId: event.user,
+          eventType: "member_joined_channel",
+        },
+        cause,
+      });
+      this.runtime.reportError("slack-membership", error);
+      throw error;
+    }
   }
 
   private async handleMemberLeftChannel(
-    event: {
-      user: string;
-      channel: string;
-      team?: string;
-    },
+    event: { user: string; channel: string; team?: string; event_ts?: string },
     accountId = this.defaultAccountId,
   ): Promise<void> {
     if (event.user === this.getBotUserIdForAccount(accountId)) {
@@ -2065,8 +2094,281 @@ export class SlackService extends Service implements ISlackService {
 
     await this.runtime.emitEvent(
       SlackEventTypes.MEMBER_LEFT_CHANNEL as string,
-      this.buildEventPayload(accountId),
+      this.buildMemberEventPayload(event, accountId),
     );
+
+    if (event.user === this.getBotUserIdForAccount(accountId)) {
+      return;
+    }
+    // Leaving one channel never deactivates the workspace entity; only the
+    // room participation for this channel is dropped.
+    try {
+      const roomId = await this.getRoomId(event.channel, undefined, accountId);
+      const entityId = this.getEntityId(event.user, accountId);
+      if (typeof this.runtime.removeParticipant === "function") {
+        await this.runtime.removeParticipant(entityId, roomId);
+      }
+    } catch (cause) {
+      // error-policy:J2 Removal failure is owner-visible diagnostics; the
+      // authoritative Slack roster remains the source of truth on the next
+      // snapshot, so this must not be flattened into a fake success.
+      const error = new ElizaError("Slack member leave renewal failed", {
+        code: "SLACK_MEMBERSHIP_RENEWAL_FAILED",
+        context: {
+          accountId,
+          channelId: event.channel,
+          userId: event.user,
+          eventType: "member_left_channel",
+        },
+        cause,
+      });
+      this.runtime.reportError("slack-membership", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Builds a member-event payload that preserves the Slack user and channel
+   * alongside the runtime identity mapping, so downstream consumers can act
+   * on the affected member without re-deriving it from the account alone.
+   */
+  private buildMemberEventPayload(
+    event: {
+      user: string;
+      channel: string;
+      team?: string;
+      channel_type?: string;
+      inviter?: string;
+      event_ts?: string;
+    },
+    accountId: string,
+  ): EventPayload {
+    const normalized = normalizeAccountId(accountId ?? this.defaultAccountId);
+    const entityId = this.getEntityId(event.user, normalized);
+    const roomId = this.getRoomIdSync(event.channel, normalized);
+    const teamId = event.team ?? this.getTeamIdForAccount(normalized);
+    const worldId = teamId
+      ? createUniqueUuid(
+          this.runtime,
+          this.scopedSlackKey("slack-workspace", teamId, normalized),
+        )
+      : undefined;
+    return {
+      runtime: this.runtime,
+      source: "slack",
+      accountId: normalized,
+      entityId,
+      metadata: {
+        accountId: normalized,
+        slack: {
+          accountId: normalized,
+          userId: event.user,
+          channelId: event.channel,
+          teamId,
+          channelType: event.channel_type,
+          inviterId: event.inviter,
+          eventTs: event.event_ts,
+        },
+        ...(roomId ? { roomId } : {}),
+        ...(worldId ? { worldId } : {}),
+      },
+    } as EventPayload;
+  }
+
+  /** Synchronous roomId derivation for payloads (same keying as getRoomId). */
+  private getRoomIdSync(
+    channelId: string,
+    accountId: string,
+  ): UUID | undefined {
+    try {
+      return createUniqueUuid(
+        this.runtime,
+        this.scopedSlackKey("slack-room", channelId, accountId),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Renews one member's runtime participation in an admitted channel: the
+   * entity is resolved for this account, its name is refreshed from the
+   * workspace directory, and the room/world/participant connection is
+   * ensured idempotently. Never called for non-admitted channels.
+   */
+  private async renewChannelMember(
+    slackUserId: string,
+    channelId: string,
+    accountId: string,
+  ): Promise<void> {
+    const entityId = this.getEntityId(slackUserId, accountId);
+    const roomId = await this.getRoomId(channelId, undefined, accountId);
+    const room = await this.runtime.getRoom(roomId);
+    const teamId = this.getTeamIdForAccount(accountId);
+    const worldId = teamId
+      ? createUniqueUuid(
+          this.runtime,
+          this.scopedSlackKey("slack-workspace", teamId, accountId),
+        )
+      : undefined;
+    const user = await this.getUser(slackUserId, accountId);
+    const displayName = user ? getSlackUserDisplayName(user) : slackUserId;
+    if (worldId) {
+      await this.runtime.ensureConnection({
+        entityId,
+        roomId,
+        roomName: room?.name || channelId,
+        userName: user?.name,
+        name: displayName,
+        source: "slack",
+        channelId,
+        serverId: teamId ?? undefined,
+        type: ChannelType.GROUP,
+        worldId,
+        userId: entityId,
+        metadata: {
+          source: "slack",
+          accountId,
+          slack: { accountId, id: slackUserId, name: displayName },
+        },
+      });
+    }
+  }
+
+  /**
+   * Inbound senders are renewed on every admitted message and mention, not
+   * only when their entity is missing: an existing entity that previously
+   * left the room (participant removed) is re-linked by activity, and the
+   * display name is refreshed from the workspace directory.
+   */
+  private async renewInboundSender(
+    slackUserId: string,
+    channelId: string,
+    threadTs: string | undefined,
+    accountId: string,
+  ): Promise<void> {
+    try {
+      const entityId = this.getEntityId(slackUserId, accountId);
+      const roomId = await this.getRoomId(channelId, threadTs, accountId);
+      const teamId = this.getTeamIdForAccount(accountId);
+      const worldId = teamId
+        ? createUniqueUuid(
+            this.runtime,
+            this.scopedSlackKey("slack-workspace", teamId, accountId),
+          )
+        : undefined;
+      const user = await this.getUser(slackUserId, accountId);
+      const displayName = user ? getSlackUserDisplayName(user) : slackUserId;
+      const existingEntity = await this.runtime.getEntityById(entityId);
+      if (!existingEntity) {
+        await this.runtime.createEntity({
+          id: entityId,
+          names: [displayName],
+          metadata: {
+            source: "slack",
+            accountId,
+            slack: {
+              accountId,
+              id: slackUserId,
+              name: displayName,
+              userName: user?.name || slackUserId,
+            },
+          },
+          agentId: this.runtime.agentId,
+        });
+      }
+      if (worldId) {
+        const room = await this.runtime.getRoom(roomId);
+        await this.runtime.ensureConnection({
+          entityId,
+          roomId,
+          roomName: room?.name || channelId,
+          userName: user?.name,
+          name: displayName,
+          source: "slack",
+          channelId,
+          serverId: teamId ?? undefined,
+          type: ChannelType.GROUP,
+          worldId,
+          userId: entityId,
+          metadata: {
+            source: "slack",
+            accountId,
+            slack: { accountId, id: slackUserId, name: displayName },
+          },
+        });
+      }
+    } catch (cause) {
+      // error-policy:J7 Sender renewal is diagnostics on the inbound path;
+      // the message itself must still flow, with the failure reported.
+      this.runtime.reportError(
+        "slack-membership",
+        new ElizaError("Slack inbound sender renewal failed", {
+          code: "SLACK_SENDER_RENEWAL_FAILED",
+          context: { accountId, channelId, userId: slackUserId },
+          cause,
+        }),
+      );
+    }
+  }
+
+  /**
+   * Reads the authoritative member roster for one channel through
+   * `conversations.members`, but only when the channel is admitted for this
+   * account. Any permission, membership, or pagination failure returns a
+   * typed unavailable state — never an empty roster.
+   */
+  async getChannelMembership(
+    channelId: string,
+    accountId?: string | null,
+  ): Promise<SlackMembershipReadResult> {
+    const normalized = normalizeAccountId(
+      accountId ?? this.defaultAccountId ?? DEFAULT_ACCOUNT_ID,
+    );
+    const client = this.getClientForAccount(normalized);
+    if (!client) {
+      return {
+        kind: "unavailable",
+        channelId,
+        reason: "client_not_initialized",
+        slackErrorCode: undefined,
+      };
+    }
+    if (!this.isChannelAllowed(channelId, normalized)) {
+      return {
+        kind: "unavailable",
+        channelId,
+        reason: "channel_not_admitted",
+        slackErrorCode: undefined,
+      };
+    }
+    return readChannelMembershipSnapshot(client, channelId);
+  }
+
+  /**
+   * Renews a channel's member list into runtime rooms: entities and
+   * participant connections are ensured for every snapshot member. When the
+   * read is unavailable nothing is revoked — the prior roster stays as-is
+   * and the unavailable reason is surfaced to the caller.
+   */
+  async renewChannelMembership(
+    channelId: string,
+    accountId?: string | null,
+  ): Promise<SlackMembershipReadResult> {
+    const result = await this.getChannelMembership(channelId, accountId);
+    if (result.kind !== "snapshot") {
+      return result;
+    }
+    const normalized = normalizeAccountId(
+      accountId ?? this.defaultAccountId ?? DEFAULT_ACCOUNT_ID,
+    );
+    for (const memberId of result.memberIds) {
+      if (memberId === this.getBotUserIdForAccount(normalized)) {
+        continue;
+      }
+      await this.renewChannelMember(memberId, channelId, normalized);
+    }
+    return result;
   }
 
   private async handleFileShared(
@@ -2447,6 +2749,16 @@ export class SlackService extends Service implements ISlackService {
         )
       : undefined;
 
+    // Thread rooms are explicitly linked to their parent channel room so
+    // membership stays channel-scoped and thread history can inherit the
+    // channel transcript when the account opts in.
+    const parentRoomId = threadTs
+      ? createUniqueUuid(
+          this.runtime,
+          this.scopedSlackKey("slack-room", channelId, accountId),
+        )
+      : undefined;
+
     const elizaChannelType =
       channelType === "im"
         ? ChannelType.DM
@@ -2470,11 +2782,13 @@ export class SlackService extends Service implements ISlackService {
         topic: channel?.topic?.value,
         purpose: channel?.purpose?.value,
         serverId: teamId,
+        ...(parentRoomId ? { parentRoomId } : {}),
         slack: {
           accountId,
           teamId,
           channelId,
           threadTs,
+          ...(parentRoomId ? { parentRoomId } : {}),
         },
       },
     };
@@ -3056,9 +3370,38 @@ export class SlackService extends Service implements ISlackService {
       (typeof metadata?.threadTs === "string" ? metadata.threadTs : undefined);
     const channel = await this.getChannel(channelId, accountId);
 
-    const rawMessages = threadTs
-      ? await this.readThreadReplies(channelId, threadTs, undefined, accountId)
-      : await this.readHistory(channelId, undefined, accountId);
+    // Thread inheritance contract: historyScope selects which transcript the
+    // thread room reads ("thread" reads only the thread; "channel" reads the
+    // parent channel), and inheritParent additionally injects the parent
+    // channel transcript ahead of thread history. Defaults preserve the
+    // existing thread-only behavior until the account opts in.
+    const threadConfig =
+      this.getAccountState(accountId)?.account.config.thread ?? {};
+    const historyScope = threadConfig.historyScope ?? "thread";
+    const inheritParent = threadConfig.inheritParent ?? false;
+    let rawMessages: Array<SlackMessage | Record<string, unknown>>;
+    if (threadTs && historyScope === "channel") {
+      rawMessages = await this.readHistory(channelId, undefined, accountId);
+    } else if (threadTs && inheritParent) {
+      rawMessages = [
+        ...(await this.readHistory(channelId, undefined, accountId)),
+        ...(await this.readThreadReplies(
+          channelId,
+          threadTs,
+          undefined,
+          accountId,
+        )),
+      ];
+    } else if (threadTs) {
+      rawMessages = await this.readThreadReplies(
+        channelId,
+        threadTs,
+        undefined,
+        accountId,
+      );
+    } else {
+      rawMessages = await this.readHistory(channelId, undefined, accountId);
+    }
     const recentMessages: MessageConnectorChatContext["recentMessages"] = [];
     for (const rawMessage of rawMessages.slice().reverse()) {
       const text = String((rawMessage as SlackMessage).text ?? "");

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -3372,7 +3372,9 @@ export class SlackService extends Service implements ISlackService {
     // ignored — the channel transcript already contains the thread parent.
     // inheritParent concatenates channel + thread transcripts (not splicing
     // the thread into the channel timeline, which Slack APIs cannot order
-    // reliably) so both are present in chronological order.
+    // reliably) so both are present in chronological order, deduplicated by
+    // ts — the replies response repeats the parent the channel transcript
+    // already contains.
     const threadConfig =
       this.getAccountState(accountId)?.account.config.thread ?? {};
     const historyScope = threadConfig.historyScope ?? "thread";
@@ -3392,14 +3394,24 @@ export class SlackService extends Service implements ISlackService {
         undefined,
         accountId,
       );
-      // Both transcripts are newest-first. Sort by Slack ts descending so
-      // the single reverse below yields one chronological oldest-first
-      // sequence across channel and thread messages.
-      rawMessages = [...channelTranscript, ...threadTranscript].sort(
-        (a, b) =>
-          Number((b as SlackMessage).ts ?? 0) -
-          Number((a as SlackMessage).ts ?? 0),
-      );
+      // Slack's conversations.replies response includes the thread parent
+      // message first, and the channel transcript already contains that
+      // same parent — deduplicate by ts so the parent is never published
+      // twice. Messages without a usable ts are kept as-is.
+      const seenTs = new Set<string>();
+      rawMessages = [...channelTranscript, ...threadTranscript]
+        .filter((message) => {
+          const ts = (message as SlackMessage).ts;
+          if (typeof ts !== "string" || !ts) return true;
+          if (seenTs.has(ts)) return false;
+          seenTs.add(ts);
+          return true;
+        })
+        .sort(
+          (a, b) =>
+            Number((b as SlackMessage).ts ?? 0) -
+            Number((a as SlackMessage).ts ?? 0),
+        );
     } else if (threadTs) {
       rawMessages = await this.readThreadReplies(
         channelId,

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -3366,8 +3366,10 @@ export class SlackService extends Service implements ISlackService {
       (typeof metadata?.threadTs === "string" ? metadata.threadTs : undefined);
     const channel = await this.getChannel(channelId, accountId);
 
-    // Thread inheritance contract. All transcripts are newest-first from
-    // Slack; the final reverse below yields oldest-first. When both options
+    // Thread inheritance contract. Channel history is newest-first;
+    // conversations.replies is EARLIEST-FIRST (parent first). The final
+    // reverse below yields oldest-first for every branch, with the thread
+    // transcript pre-reversed where needed. When both options
     // are set, historyScope=channel takes precedence and inheritParent is
     // ignored — the channel transcript already contains the thread parent.
     // inheritParent concatenates channel + thread transcripts (not splicing
@@ -3413,12 +3415,18 @@ export class SlackService extends Service implements ISlackService {
             Number((a as SlackMessage).ts ?? 0),
         );
     } else if (threadTs) {
-      rawMessages = await this.readThreadReplies(
-        channelId,
-        threadTs,
-        undefined,
-        accountId,
-      );
+      // Slack's conversations.replies returns EARLIEST-FIRST (the parent
+      // message first), the opposite of newest-first channel history; the
+      // shared .reverse() below therefore needs the thread transcript
+      // pre-reversed so the published order stays chronological.
+      rawMessages = (
+        await this.readThreadReplies(
+          channelId,
+          threadTs,
+          undefined,
+          accountId,
+        )
+      ).reverse();
     } else {
       rawMessages = await this.readHistory(channelId, undefined, accountId);
     }

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -2089,7 +2089,9 @@ export class SlackService extends Service implements ISlackService {
     accountId = this.defaultAccountId,
   ): Promise<void> {
     if (event.user === this.getBotUserIdForAccount(accountId)) {
+      // The bot leaving only updates admission state; no participant removal.
       this.getPolicyForAccount(accountId)?.registerBotLeave(event.channel);
+      return;
     }
 
     await this.runtime.emitEvent(
@@ -2097,9 +2099,6 @@ export class SlackService extends Service implements ISlackService {
       this.buildMemberEventPayload(event, accountId),
     );
 
-    if (event.user === this.getBotUserIdForAccount(accountId)) {
-      return;
-    }
     // Leaving one channel never deactivates the workspace entity; only the
     // room participation for this channel is dropped.
     try {
@@ -2169,25 +2168,22 @@ export class SlackService extends Service implements ISlackService {
           inviterId: event.inviter,
           eventTs: event.event_ts,
         },
-        ...(roomId ? { roomId } : {}),
         ...(worldId ? { worldId } : {}),
+        roomId,
       },
     } as EventPayload;
   }
 
-  /** Synchronous roomId derivation for payloads (same keying as getRoomId). */
-  private getRoomIdSync(
-    channelId: string,
-    accountId: string,
-  ): UUID | undefined {
-    try {
-      return createUniqueUuid(
-        this.runtime,
-        this.scopedSlackKey("slack-room", channelId, accountId),
-      );
-    } catch {
-      return undefined;
-    }
+  /**
+   * Synchronous roomId derivation for payloads (same keying as getRoomId).
+   * `createUniqueUuid` is a pure string hash and cannot throw; no error
+   * path exists to catch.
+   */
+  private getRoomIdSync(channelId: string, accountId: string): UUID {
+    return createUniqueUuid(
+      this.runtime,
+      this.scopedSlackKey("slack-room", channelId, accountId),
+    );
   }
 
   /**
@@ -3370,11 +3366,13 @@ export class SlackService extends Service implements ISlackService {
       (typeof metadata?.threadTs === "string" ? metadata.threadTs : undefined);
     const channel = await this.getChannel(channelId, accountId);
 
-    // Thread inheritance contract: historyScope selects which transcript the
-    // thread room reads ("thread" reads only the thread; "channel" reads the
-    // parent channel), and inheritParent additionally injects the parent
-    // channel transcript ahead of thread history. Defaults preserve the
-    // existing thread-only behavior until the account opts in.
+    // Thread inheritance contract. All transcripts are newest-first from
+    // Slack; the final reverse below yields oldest-first. When both options
+    // are set, historyScope=channel takes precedence and inheritParent is
+    // ignored — the channel transcript already contains the thread parent.
+    // inheritParent concatenates channel + thread transcripts (not splicing
+    // the thread into the channel timeline, which Slack APIs cannot order
+    // reliably) so both are present in chronological order.
     const threadConfig =
       this.getAccountState(accountId)?.account.config.thread ?? {};
     const historyScope = threadConfig.historyScope ?? "thread";
@@ -3383,15 +3381,25 @@ export class SlackService extends Service implements ISlackService {
     if (threadTs && historyScope === "channel") {
       rawMessages = await this.readHistory(channelId, undefined, accountId);
     } else if (threadTs && inheritParent) {
-      rawMessages = [
-        ...(await this.readHistory(channelId, undefined, accountId)),
-        ...(await this.readThreadReplies(
-          channelId,
-          threadTs,
-          undefined,
-          accountId,
-        )),
-      ];
+      const channelTranscript = await this.readHistory(
+        channelId,
+        undefined,
+        accountId,
+      );
+      const threadTranscript = await this.readThreadReplies(
+        channelId,
+        threadTs,
+        undefined,
+        accountId,
+      );
+      // Both transcripts are newest-first. Sort by Slack ts descending so
+      // the single reverse below yields one chronological oldest-first
+      // sequence across channel and thread messages.
+      rawMessages = [...channelTranscript, ...threadTranscript].sort(
+        (a, b) =>
+          Number((b as SlackMessage).ts ?? 0) -
+          Number((a as SlackMessage).ts ?? 0),
+      );
     } else if (threadTs) {
       rawMessages = await this.readThreadReplies(
         channelId,

--- a/plugins/plugin-slack/vitest.config.ts
+++ b/plugins/plugin-slack/vitest.config.ts
@@ -1,5 +1,10 @@
 /**
- * Runs Slack connector tests against workspace source packages without a live workspace.
+ * Vitest config for the Slack plugin's fast unit tests. Runs against
+ * workspace source packages without a live workspace.
+ *
+ * `*.real.test.ts` files boot a real PGLite runtime and need the workspace
+ * source aliases from vitest.real-runtime.config.ts — run those via
+ * `test:real-runtime`.
  */
 import { defineConfig } from "vitest/config";
 import { buildWorkspaceSourceAliases } from "../../packages/scripts/vitest/source-aliases.ts";
@@ -13,6 +18,7 @@ export default defineConfig({
   test: {
     alias: workspaceAliases,
     include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "dist/**", "**/*.real.test.ts"],
     environment: "node",
     testTimeout: 60_000,
   },


### PR DESCRIPTION
# feat(slack): publish Web API membership snapshots and deltas (#24367)

Closes #24367

Replaces the event-only Slack membership handlers with permission-aware, account-scoped membership evidence from the Slack Web API, published to the canonical `MembershipService` contract.

## What changes

- **`src/membership.ts` (new, 233 lines)** — snapshot/delta evidence engine: `conversations.members` paging, sender renewals, join/leave deltas, multi-account identity scoping, typed error classification.
- **`src/service.ts` (+479/−55)** — wires `member_joined_channel` / `member_left_channel` / `app_mention` / reconnect events into snapshot + delta publication; partial or failed evidence degrades to `unavailable` — never an empty roster implying mass removal.
- **`src/membership.test.ts` + `src/service-membership.test.ts` (new, 645+ lines)** — deterministic permission matrices, multi-account isolation, stale-evidence-never-removes, replies-ordering regression (earliest-first per Slack docs, RED control pre-fix `[reply, parent]`).

## Key invariants

- Partial/failed/intent-missing evidence reports `unavailable`/`incomplete`; it never implies removals.
- Per-account scoping: one account's degrade never marks another account's evidence stale.
- `conversations.replies` ordering is earliest-first (parent-first) per Slack docs — the harness previously asserted the reverse, which was a production bug fixed with a RED control.

## Verification

| Gate | Result |
|---|---|
| `plugin-slack` typecheck | 0 errors |
| Focused membership suites (fresh capture at publish) | 30/30 (now 31/31 with the page-error seam test) |
| Full plugin unit suite | 215/215 at 01ad69e275 (was 218/218 at 950106dc73 counting the real suite in the unit lane; the real PGlite suite now runs under test:real-runtime — see below) |
| Biome | clean |
| Merge vs develop tip | clean (merge-tree 0 conflicts vs `5c476b4206`) |
| RED controls | replies-ordering pre-fix fail `[reply, parent]`; membership evidence regressions per round |
| RP review | 4 rounds; final APPROVE zero must-fix (session 96BA81A6) |

<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:walkthrough-video -->
N/A - no user-visible surface changed (connector-internal evidence publication)
<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only onto develop 3a7f438a9e (head 119e07dd00 -> 68fe56d4f2, 7 commits, zero conflicts; no behavior change). Gates at new head in isolated worktree (frozen-lockfile install): plugin-slack vitest 215/215 PASS (11 files, 5.29s); plugin-slack typecheck rc=0 (tsc --noEmit clean). Inline transcript: $ bun run --cwd plugins/plugin-slack test => Test Files 11 passed (11), Tests 215 passed (215); $ bun run --cwd plugins/plugin-slack typecheck => tsc --noEmit -p tsconfig.json, exit 0.

 RUN  v4.1.10 /Users/t3rpz/projects/eliza-24367/plugins/plugin-slack


 Test Files  2 passed (2)
      Tests  30 passed (30)
   Start at  08:06:20
   Duration  5.46s (transform 4.22s, setup 0ms, import 5.44s, tests 34ms, environment 0ms)


```
</details>
<!-- evidence-row:frontend-logs -->
N/A - no frontend surface changed (connector-internal evidence publication)
<!-- evidence-row:llm-trajectory -->
N/A - no model/provider path changed (deterministic plugin tests exercise the real service contract without a live model)
<!-- evidence-row:domain-artifacts -->
N/A - no persisted domain artifact surface changed (MembershipService records asserted in tests)
<!-- evidence-row:ocr-review -->
N/A - no OCR surface involved

<!-- evidence-head:2a70d0942b9e9945228ac5a89488c18f1e7c4cd1 -->

---

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->







