### PR TITLE
feat(matrix): publish SDK-observed membership evidence (#24368)

### DIFF
--- a/plugins/plugin-matrix/AGENTS.md
+++ b/plugins/plugin-matrix/AGENTS.md
@@ -43,6 +43,13 @@ plugins/plugin-matrix/
                                         + MATRIX_ACCOUNTS JSON); exports resolveMatrixAccountSettings,
                                         listMatrixAccountIds, normalizeMatrixAccountId, readMatrixAccountId
     connector-account-provider.ts     ConnectorAccountProvider adapter for ConnectorAccountManager
+  src/membership.ts                   MatrixMembershipAuthority — publisher-discipline client for the
+                                       canonical MembershipService: complete PREPARED/join roster snapshots
+                                       (incomplete rosters reported incomplete, never empty), ordered
+                                       join/invite/leave/ban deltas, bot self-leave scope termination,
+                                       fenced retries, idempotent evidence keys
+  src/membership-gate.ts              Connector-account bootstrap + per-account admission gate for group
+                                       rooms; DMs bypass; fail-closed under MATRIX_MEMBERSHIP_ENFORCE=1
     types.ts                          MatrixSettings, MatrixMessage, MatrixRoom, IMatrixService,
                                         MatrixEventTypes enum, error classes, utility functions
     fake-indexeddb-auto.d.ts          Type shim for fake-indexeddb used in tests

--- a/plugins/plugin-matrix/CLAUDE.md
+++ b/plugins/plugin-matrix/CLAUDE.md
@@ -43,6 +43,13 @@ plugins/plugin-matrix/
                                         + MATRIX_ACCOUNTS JSON); exports resolveMatrixAccountSettings,
                                         listMatrixAccountIds, normalizeMatrixAccountId, readMatrixAccountId
     connector-account-provider.ts     ConnectorAccountProvider adapter for ConnectorAccountManager
+  src/membership.ts                   MatrixMembershipAuthority — publisher-discipline client for the
+                                       canonical MembershipService: complete PREPARED/join roster snapshots
+                                       (incomplete rosters reported incomplete, never empty), ordered
+                                       join/invite/leave/ban deltas, bot self-leave scope termination,
+                                       fenced retries, idempotent evidence keys
+  src/membership-gate.ts              Connector-account bootstrap + per-account admission gate for group
+                                       rooms; DMs bypass; fail-closed under MATRIX_MEMBERSHIP_ENFORCE=1
     types.ts                          MatrixSettings, MatrixMessage, MatrixRoom, IMatrixService,
                                         MatrixEventTypes enum, error classes, utility functions
     fake-indexeddb-auto.d.ts          Type shim for fake-indexeddb used in tests

--- a/plugins/plugin-matrix/src/__tests__/connector.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/connector.test.ts
@@ -248,11 +248,12 @@ describe("Matrix connector read path (channelId-only targets)", () => {
     expect(runtime.getRoom).not.toHaveBeenCalled();
   });
 
-  it("falls back to stored memories keyed by the core UUID derived from the raw matrix id", async () => {
+  it("falls back to stored memories keyed by the account-scoped UUID derived from the matrix id", async () => {
     const service = createService();
     // Live timeline empty -> the stored-memory fallback must key by
-    // createUniqueUuid(runtime, "!abc:server"), matching how inbound Matrix
-    // memories are stored (matrixMessageToMemory).
+    // createUniqueUuid(runtime, `${accountId}:${matrixRoomId}`), matching how
+    // inbound Matrix memories are stored (matrixMessageToMemory scopes by
+    // account so multi-account runtimes never blend rooms).
     vi.spyOn(service, "getRoomMessages").mockResolvedValue([]);
     const { runtime, registration } = registerAndGetConnector(service);
     const stored = [memory("$s", "stored", 50)];
@@ -266,7 +267,7 @@ describe("Matrix connector read path (channelId-only targets)", () => {
     expect(runtime.getMemories).toHaveBeenCalledWith(
       expect.objectContaining({
         tableName: "messages",
-        roomId: createUniqueUuid(runtime, "!abc:server"),
+        roomId: createUniqueUuid(runtime, "work:!abc:server"),
         limit: 50,
       })
     );

--- a/plugins/plugin-matrix/src/__tests__/connector.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/connector.test.ts
@@ -250,10 +250,11 @@ describe("Matrix connector read path (channelId-only targets)", () => {
 
   it("falls back to stored memories keyed by the account-scoped UUID derived from the matrix id", async () => {
     const service = createService();
-    // Live timeline empty -> the stored-memory fallback must key by
-    // createUniqueUuid(runtime, `${accountId}:${matrixRoomId}`), matching how
-    // inbound Matrix memories are stored (matrixMessageToMemory scopes by
-    // account so multi-account runtimes never blend rooms).
+    // Live timeline empty -> the stored-memory fallback must key by the
+    // authority-compatible matrixScopedUuid derivation over
+    // `${accountId}:${matrixRoomId}`, matching how inbound Matrix memories are
+    // stored (matrixMessageToMemory scopes by account so multi-account runtimes
+    // never blend rooms, and membership authority rows accept the derived id).
     vi.spyOn(service, "getRoomMessages").mockResolvedValue([]);
     const { runtime, registration } = registerAndGetConnector(service);
     const stored = [memory("$s", "stored", 50)];
@@ -267,7 +268,7 @@ describe("Matrix connector read path (channelId-only targets)", () => {
     expect(runtime.getMemories).toHaveBeenCalledWith(
       expect.objectContaining({
         tableName: "messages",
-        roomId: createUniqueUuid(runtime, "work:!abc:server"),
+        roomId: `${createUniqueUuid(runtime, "work:!abc:server").slice(0, 14)}5${createUniqueUuid(runtime, "work:!abc:server").slice(15, 19)}8${createUniqueUuid(runtime, "work:!abc:server").slice(20)}`,
         limit: 50,
       })
     );

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -186,6 +186,62 @@ describe("persisted non-current scope health triggers recovery", () => {
     expect(h.authority.snapshots).toHaveLength(0);
     expect(h.authority.clearTransientRoomIncompleteness).toHaveBeenCalled();
   });
+
+  it("publishes a shrunken fresh roster when BOTH a transient flag and a persisted non-current scope exist", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    h.authority.scopeHealth = vi.fn(async () => ({ health: "stale" }));
+    h.client.members.mockResolvedValue({
+      "@one:example": [{ content: { membership: "join" } }],
+      "@bot:example": [{ content: { membership: "join" } }],
+    });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, true);
+    // The persisted stale scope must be restored by the (small) complete
+    // roster, not left stranded by a flag-only clear.
+    expect(h.authority.snapshots).toHaveLength(1);
+  });
+
+  it("fails closed on a scope-health probe failure instead of publishing the SDK cache", async () => {
+    const h = createHarness();
+    h.authority.scopeHealth = vi.fn(async () => {
+      throw new Error("db down");
+    });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, true);
+    // Probe failure must route through fresh-roster recovery; the fresh
+    // fetch succeeds here, so the published roster is the fresh one.
+    expect(h.client.members).toHaveBeenCalled();
+    expect(h.authority.snapshots).toHaveLength(1);
+  });
+
+  it("never publishes from the SDK cache on a non-first sync", async () => {
+    const h = createHarness();
+    // No incompleteness, current persisted health — but firstSync=false.
+    h.authority.scopeHealth = vi.fn(async () => ({ health: "current" }));
+    h.client.members.mockRejectedValue(new Error("network down"));
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    // Fail closed: no fresh roster => no publication at all (the SDK cache
+    // is not evidence on a reconnect pass), and the room is flagged.
+    expect(h.authority.snapshots).toHaveLength(0);
+    expect(h.authority.reportIncomplete).toHaveBeenCalled();
+  });
 });
 
 describe("unknown membership values are reported, never recorded as leave", () => {

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -8,6 +8,7 @@
  * authority surfaces are in-memory doubles — no live homeserver.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { createUniqueUuid } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 import { MatrixService } from "../service.js";
@@ -34,6 +35,8 @@ function createAuthority() {
     clearTransientRoomIncompleteness: vi.fn(() => true),
     scopeHealth: vi.fn(async (): Promise<{ health: string } | null> => null),
     clearScopeRemoval: vi.fn(() => {}),
+    markScopeUnavailable: vi.fn(async () => {}),
+    recordTransition: vi.fn(async () => {}),
     publishSnapshot: vi.fn(
       async (input: { roomId: string; members: { canonicalPrincipalId: string }[] }) => {
         snapshots.push({
@@ -76,11 +79,16 @@ function createHarness(): Harness {
   const client = {
     getRooms: vi.fn(() => [] as unknown[]),
     getRoom: vi.fn(() => null),
+    // Real boundary shape (matrix-js-sdk 41.x): client.members() resolves the
+    // raw homeserver /members envelope consumed via response.chunk — see
+    // Room.loadMembersFromServer() — not a userId -> event-arrays map.
     members: vi.fn(async () => ({
-      "@fresh1:example": [{ content: { membership: "join" } }],
-      "@fresh2:example": [{ content: { membership: "join" } }],
-      "@fresh3:example": [{ content: { membership: "join" } }],
-      "@bot:example": [{ content: { membership: "join" } }],
+      chunk: [
+        { state_key: "@fresh1:example", content: { membership: "join" } },
+        { state_key: "@fresh2:example", content: { membership: "join" } },
+        { state_key: "@fresh3:example", content: { membership: "join" } },
+        { state_key: "@bot:example", content: { membership: "join" } },
+      ],
     })),
   };
   const state: Record<string, unknown> = {
@@ -173,8 +181,10 @@ describe("persisted non-current scope health triggers recovery", () => {
     const h = createHarness();
     h.authority.isRoomIncomplete = vi.fn(() => true);
     h.client.members.mockResolvedValue({
-      "@one:example": [{ content: { membership: "join" } }],
-      "@bot:example": [{ content: { membership: "join" } }],
+      chunk: [
+        { state_key: "@one:example", content: { membership: "join" } },
+        { state_key: "@bot:example", content: { membership: "join" } },
+      ],
     });
     const room = createRoomDouble();
     h.client.getRooms.mockReturnValue([room]);
@@ -192,8 +202,10 @@ describe("persisted non-current scope health triggers recovery", () => {
     h.authority.isRoomIncomplete = vi.fn(() => true);
     h.authority.scopeHealth = vi.fn(async () => ({ health: "stale" }));
     h.client.members.mockResolvedValue({
-      "@one:example": [{ content: { membership: "join" } }],
-      "@bot:example": [{ content: { membership: "join" } }],
+      chunk: [
+        { state_key: "@one:example", content: { membership: "join" } },
+        { state_key: "@bot:example", content: { membership: "join" } },
+      ],
     });
     const room = createRoomDouble();
     h.client.getRooms.mockReturnValue([room]);
@@ -271,5 +283,209 @@ describe("unknown membership values are reported, never recorded as leave", () =
     await handler.call(h.service, h.state, event, member, oldMembership);
     expect(h.runtime.reportError).toHaveBeenCalled();
     expect(h.authority.publishSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("a peer leave in a direct room must not create authority evidence (review control)", async () => {
+    const h = createHarness();
+    const event = {
+      getSender: vi.fn(() => "@peer:example"),
+      getRoomId: vi.fn(() => "!dm:example"),
+      getId: vi.fn(() => "$dm-leave"),
+      getTs: vi.fn(() => 1),
+    };
+    const member = { userId: "@peer:example", membership: "leave", previousMembership: "join" };
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    // The SDK Room model for a direct room: at most two joined members.
+    const dmRoom = createRoomDouble({
+      roomId: "!dm:example",
+      getJoinedMemberCount: vi.fn(() => 1),
+    });
+    h.client.getRoom.mockReturnValue(dmRoom);
+    await handler.call(h.service, h.state, event, member, "join", dmRoom);
+    expect(h.authority.recordTransition).not.toHaveBeenCalled();
+    expect(h.authority.markScopeUnavailable).not.toHaveBeenCalled();
+    expect(h.runtime.createEntity).not.toHaveBeenCalled();
+  });
+
+  it("a peer leave in a GROUP room still records the ordered-delta transition", async () => {
+    const h = createHarness();
+    const event = {
+      getSender: vi.fn(() => "@peer:example"),
+      getRoomId: vi.fn(() => "!ops:example"),
+      getId: vi.fn(() => "$ops-leave"),
+      getTs: vi.fn(() => 1),
+    };
+    const member = { userId: "@peer:example", membership: "leave", previousMembership: "join" };
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    const groupRoom = createRoomDouble();
+    h.client.getRoom.mockReturnValue(groupRoom);
+    await handler.call(h.service, h.state, event, member, "join", groupRoom);
+    expect(h.authority.recordTransition).toHaveBeenCalledTimes(1);
+    expect(h.runtime.createEntity).toHaveBeenCalled();
+  });
+
+  it("the bot's own ban in a <=2-member room still tombstones the scope", async () => {
+    const h = createHarness();
+    const event = {
+      getSender: vi.fn(() => "@admin:example"),
+      getRoomId: vi.fn(() => "!dm:example"),
+      getId: vi.fn(() => "$bot-ban"),
+      getTs: vi.fn(() => 1),
+    };
+    // The bot's OWN transition in a room reporting <=2 joined members — the
+    // direct-room skip must NOT swallow the bot self-leave lifecycle.
+    const member = { userId: "@bot:example", membership: "ban", previousMembership: "join" };
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    const dmRoom = createRoomDouble({
+      roomId: "!dm:example",
+      getJoinedMemberCount: vi.fn(() => 1),
+    });
+    h.client.getRoom.mockReturnValue(dmRoom);
+    await handler.call(h.service, h.state, event, member, "join", dmRoom);
+    expect(h.authority.markScopeUnavailable).toHaveBeenCalledWith({
+      roomId: "!dm:example",
+      reason: "bot_banned",
+    });
+    expect(h.authority.recordTransition).not.toHaveBeenCalled();
+  });
+});
+
+describe("fresh roster parsing matches the homeserver /members envelope", () => {
+  it("parses the SDK /members chunk response instead of the invented map shape", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    // Real boundary shape (matrix-js-sdk 41.x): client.members() resolves the
+    // raw homeserver /members envelope, and Room.loadMembersFromServer()
+    // consumes response.chunk — a { chunk: IStateEventWithRoomId[] } object,
+    // NOT a userId -> event-arrays map.
+    h.client.members.mockResolvedValue({
+      chunk: [
+        { state_key: "@fresh1:example", content: { membership: "join" } },
+        { state_key: "@fresh2:example", content: { membership: "join" } },
+        { state_key: "@fresh3:example", content: { membership: "join" } },
+        { state_key: "@bot:example", content: { membership: "join" } },
+      ],
+    });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.snapshots).toHaveLength(1);
+    // Exact identities, not just counts: assert the EXACT derived principal
+    // UUIDs (same derivation production uses) so a parser emitting wrong
+    // identifiers (e.g. the literal "chunk" key) fails here.
+    const expected = ["@fresh1:example", "@fresh2:example", "@fresh3:example", "@bot:example"].map(
+      (matrixId) => createUniqueUuid(h.runtime, `work:${matrixId}`)
+    );
+    expect(h.authority.snapshots[0]?.members.sort()).toEqual(expected.sort());
+  });
+
+  it("ignores non-join chunk events (leave/invite) on the fresh roster", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    h.client.members.mockResolvedValue({
+      chunk: [
+        { state_key: "@fresh1:example", content: { membership: "join" } },
+        { state_key: "@fresh2:example", content: { membership: "join" } },
+        { state_key: "@gone:example", content: { membership: "leave" } },
+        { state_key: "@invited:example", content: { membership: "invite" } },
+        { state_key: "@bot:example", content: { membership: "join" } },
+      ],
+    });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.snapshots).toHaveLength(1);
+    expect(h.authority.snapshots[0]?.members).toHaveLength(3);
+  });
+
+  it("fails closed on a malformed envelope (no chunk array): no snapshot, room stays incomplete", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    // A homeserver/SDK response that is an object but NOT the expected
+    // { chunk: [...] } envelope (e.g. an error body): the parser must return
+    // null so the room stays incomplete — never publish a complete snapshot
+    // from an unparseable roster.
+    h.client.members.mockResolvedValue({ error: "M_UNKNOWN", not_chunk: true });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.snapshots).toHaveLength(0);
+    expect(h.authority.reportIncomplete).toHaveBeenCalled();
+    // The transient flag is NOT cleared: recovery will retry next pass.
+    expect(h.authority.clearTransientRoomIncompleteness).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a structurally invalid chunk ENTRY: no partial roster becomes a baseline", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    // Valid joins plus ONE malformed entry (missing content.membership): the
+    // parser cannot know the skipped event was irrelevant — skipping it would
+    // publish a partial roster as a complete snapshot and clear the flag.
+    h.client.members.mockResolvedValue({
+      chunk: [
+        { state_key: "@fresh1:example", content: { membership: "join" } },
+        { state_key: "@fresh2:example", content: { membership: "join" } },
+        { state_key: "@bot:example" },
+        { state_key: "@fresh3:example", content: { membership: "join" } },
+      ],
+    });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.snapshots).toHaveLength(0);
+    expect(h.authority.reportIncomplete).toHaveBeenCalled();
+    expect(h.authority.clearTransientRoomIncompleteness).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -16,6 +16,17 @@ import { MatrixService } from "../service.js";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
+/**
+ * Mirrors the production matrixScopedUuid derivation in service.ts: core's
+ * createUniqueUuid stamps a version nibble of 0, which the canonical
+ * membership authority rejects, so Matrix-derived rows re-stamp the RFC 4122
+ * version (5) and variant (8) nibbles on top of the same deterministic base.
+ */
+function matrixScopedUuidForTest(runtime: IAgentRuntime, seed: string): string {
+  const base = createUniqueUuid(runtime, seed);
+  return `${base.slice(0, 14)}5${base.slice(15, 19)}8${base.slice(20)}`;
+}
+
 function createRuntime(): IAgentRuntime {
   return {
     agentId: AGENT_ID,
@@ -24,6 +35,8 @@ function createRuntime(): IAgentRuntime {
     createWorld: vi.fn().mockResolvedValue(undefined),
     createRoom: vi.fn().mockResolvedValue(undefined),
     createEntity: vi.fn().mockResolvedValue(undefined),
+    ensureWorldExists: vi.fn().mockResolvedValue(undefined),
+    ensureRoomExists: vi.fn().mockResolvedValue(undefined),
   } as unknown as IAgentRuntime;
 }
 
@@ -358,6 +371,127 @@ describe("unknown membership values are reported, never recorded as leave", () =
     expect(h.runtime.createEntity).toHaveBeenCalled();
   });
 
+  it("a peer leave in a governed room that shrank to 2 members still records the revocation", async () => {
+    // The DM skip must key on the authority's persisted scope row, not room
+    // size: a governed group that lost members down to two joined (bot +
+    // subject) looks DM-sized, and a size-keyed skip would strand the
+    // departing member as active in canonical authority state forever.
+    const h = createHarness();
+    const event = {
+      getSender: vi.fn(() => "@peer:example"),
+      getRoomId: vi.fn(() => "!shrunk:example"),
+      getId: vi.fn(() => "$shrunk-leave"),
+      getTs: vi.fn(() => 1),
+    };
+    const member = { userId: "@peer:example", membership: "leave", previousMembership: "join" };
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    // Persisted scope row EXISTS (governed evidence) while the SDK model
+    // reports a DM-shaped room: 1 remaining joined member (the bot) + the
+    // leaving subject = 2 total.
+    h.authority.scopeHealth.mockResolvedValue({ health: "current" });
+    const shrunkRoom = createRoomDouble({
+      roomId: "!shrunk:example",
+      getJoinedMemberCount: vi.fn(() => 1),
+    });
+    h.client.getRoom.mockReturnValue(shrunkRoom);
+    await handler.call(h.service, h.state, event, member, "join", shrunkRoom);
+    expect(h.authority.scopeHealth).toHaveBeenCalledWith({ roomId: "!shrunk:example" });
+    expect(h.authority.recordTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it("a peer leave with a failed scope-health probe reports and drops without creating authority evidence", async () => {
+    // The authority store itself is down — recordTransition would hit the
+    // same store and its ensureRegistered would MINT a scope row for a
+    // possible DM as a side effect of a doomed write (and that
+    // publisher-only scope row would later block the grown-room baseline
+    // bootstrap, which only runs when scopeHealth is null). The safe
+    // behavior is report-and-drop: the next roster publication pass
+    // re-derives the full baseline from fresh server state.
+    const h = createHarness();
+    const event = {
+      getSender: vi.fn(() => "@peer:example"),
+      getRoomId: vi.fn(() => "!maybe:example"),
+      getId: vi.fn(() => "$probe-fail-leave"),
+      getTs: vi.fn(() => 1),
+    };
+    const member = { userId: "@peer:example", membership: "leave", previousMembership: "join" };
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    h.authority.scopeHealth.mockRejectedValue(new Error("store down"));
+    const dmRoom = createRoomDouble({
+      roomId: "!maybe:example",
+      getJoinedMemberCount: vi.fn(() => 1),
+    });
+    h.client.getRoom.mockReturnValue(dmRoom);
+    await handler.call(h.service, h.state, event, member, "join", dmRoom);
+    expect(h.runtime.reportError).toHaveBeenCalledWith(
+      "matrix:membership-transition",
+      expect.any(Error),
+      expect.objectContaining({ roomId: "!maybe:example" })
+    );
+    expect(h.authority.recordTransition).not.toHaveBeenCalled();
+  });
+
+  it("a bootstrap (ensureWorldExists) rejection propagates out of the transition and is reported, not silently logged", async () => {
+    // The transition handler's runtime bootstrap (ensureWorldExists) can
+    // fail (store down); the Membership event callback must surface the
+    // dropped evidence via runtime.reportError so RECENT_ERRORS shows it —
+    // a logger.error alone hides permanently lost membership evidence.
+    const h = createHarness();
+    vi.mocked(h.runtime.ensureWorldExists).mockRejectedValueOnce(new Error("world store down"));
+    const event = {
+      getSender: vi.fn(() => "@peer:example"),
+      getRoomId: vi.fn(() => "!ops:example"),
+      getId: vi.fn(() => "$boot-fail"),
+      getTs: vi.fn(() => 1),
+    };
+    const member = { userId: "@peer:example", membership: "leave", previousMembership: "join" };
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    const groupRoom = createRoomDouble();
+    h.client.getRoom.mockReturnValue(groupRoom);
+    // The handler itself must REJECT (bootstrap failure propagates); the
+    // event callback's catch is what reports it in production.
+    await expect(
+      handler.call(h.service, h.state, event, member, "join", groupRoom)
+    ).rejects.toThrow("world store down");
+    expect(h.authority.recordTransition).not.toHaveBeenCalled();
+  });
+
   it("the bot's own ban in a <=2-member room still tombstones the scope", async () => {
     const h = createHarness();
     const event = {
@@ -424,7 +558,7 @@ describe("fresh roster parsing matches the homeserver /members envelope", () => 
     // UUIDs (same derivation production uses) so a parser emitting wrong
     // identifiers (e.g. the literal "chunk" key) fails here.
     const expected = ["@fresh1:example", "@fresh2:example", "@fresh3:example", "@bot:example"].map(
-      (matrixId) => createUniqueUuid(h.runtime, `work:${matrixId}`)
+      (matrixId) => matrixScopedUuidForTest(h.runtime, `work:${matrixId}`)
     );
     expect(h.authority.snapshots[0]?.members.sort()).toEqual(expected.sort());
   });

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -28,8 +28,10 @@ function createRuntime(): IAgentRuntime {
 /** Minimal authority double exposing only what the publication pass uses. */
 function createAuthority() {
   const snapshots: { roomId: string; members: string[] }[] = [];
+  const staleCalls: { roomId: string; reason: string }[] = [];
   return {
     snapshots,
+    staleCalls,
     isRoomIncomplete: vi.fn((): boolean => false),
     reportIncomplete: vi.fn(async () => {}),
     clearTransientRoomIncompleteness: vi.fn(() => true),
@@ -37,6 +39,9 @@ function createAuthority() {
     clearScopeRemoval: vi.fn(() => {}),
     markScopeUnavailable: vi.fn(async () => {}),
     recordTransition: vi.fn(async () => {}),
+    markScopeStale: vi.fn(async (input: { roomId: string; reason: string }) => {
+      staleCalls.push({ roomId: input.roomId, reason: input.reason });
+    }),
     publishSnapshot: vi.fn(
       async (input: { roomId: string; members: { canonicalPrincipalId: string }[] }) => {
         snapshots.push({
@@ -487,5 +492,43 @@ describe("fresh roster parsing matches the homeserver /members envelope", () => 
     expect(h.authority.snapshots).toHaveLength(0);
     expect(h.authority.reportIncomplete).toHaveBeenCalled();
     expect(h.authority.clearTransientRoomIncompleteness).not.toHaveBeenCalled();
+  });
+});
+
+describe("reconnect degrade attempts every joined room even when one durable write fails", () => {
+  it("one failed markScopeStale write does not abort degradation of later rooms (ss251 CR control)", async () => {
+    const h = createHarness();
+    const first = createRoomDouble({ roomId: "!first:example" });
+    const second = createRoomDouble({ roomId: "!second:example" });
+    h.client.getRooms.mockReturnValue([first, second]);
+    h.authority.markScopeStale.mockImplementation(
+      async (input: { roomId: string; reason: string }) => {
+        if (input.roomId === "!first:example") {
+          throw new Error("durable write failed");
+        }
+        h.authority.staleCalls.push({ roomId: input.roomId, reason: input.reason });
+      }
+    );
+    // The aggregate failure must surface (the reconnect handler logs it and
+    // the next sync retries) — never swallowed silently.
+    await expect(
+      (
+        h.service as unknown as {
+          degradeAllMembershipScopes: (s: unknown, reason: string) => Promise<void>;
+        }
+      ).degradeAllMembershipScopes(h.state, "sync_error")
+    ).rejects.toThrow("durable write failed");
+    // The failing room's write rejected, but the SECOND room must still have
+    // been attempted (its principals must not stay authorized on stale
+    // evidence across the reconnect gap).
+    expect(h.authority.markScopeStale).toHaveBeenCalledTimes(2);
+    expect(h.authority.markScopeStale).toHaveBeenNthCalledWith(1, {
+      roomId: "!first:example",
+      reason: "sync_error",
+    });
+    expect(h.authority.markScopeStale).toHaveBeenNthCalledWith(2, {
+      roomId: "!second:example",
+      reason: "sync_error",
+    });
   });
 });

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -7,6 +7,7 @@
  * membership values being reported instead of recorded as leave. All SDK and
  * authority surfaces are in-memory doubles — no live homeserver.
  */
+import { EventEmitter } from "node:events";
 import type { IAgentRuntime } from "@elizaos/core";
 import { createUniqueUuid } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -19,6 +20,7 @@ function createRuntime(): IAgentRuntime {
   return {
     agentId: AGENT_ID,
     reportError: vi.fn(),
+    emitEvent: vi.fn(),
     createWorld: vi.fn().mockResolvedValue(undefined),
     createRoom: vi.fn().mockResolvedValue(undefined),
     createEntity: vi.fn().mockResolvedValue(undefined),
@@ -81,9 +83,12 @@ interface Harness {
 function createHarness(): Harness {
   const runtime = createRuntime();
   const authority = createAuthority();
-  const client = {
+  const client = Object.assign(new EventEmitter(), {
     getRooms: vi.fn(() => [] as unknown[]),
     getRoom: vi.fn(() => null),
+    // Absent crypto: the verification-auto-accept tail of
+    // setupEventHandlers is inert for these sync-path tests.
+    getCrypto: vi.fn(() => undefined),
     // Real boundary shape (matrix-js-sdk 41.x): client.members() resolves the
     // raw homeserver /members envelope consumed via response.chunk — see
     // Room.loadMembersFromServer() — not a userId -> event-arrays map.
@@ -95,7 +100,7 @@ function createHarness(): Harness {
         { state_key: "@bot:example", content: { membership: "join" } },
       ],
     })),
-  };
+  });
   const state: Record<string, unknown> = {
     accountId: "work",
     settings: { userId: "@bot:example", accountId: "work" },
@@ -552,5 +557,66 @@ describe("non-Error rejection values still surface from the degrade loop", () =>
       ).degradeAllMembershipScopes(h.state, "sync_error")
     ).rejects.toBeNull();
     expect(h.authority.markScopeStale).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("a CACHED PREPARED must not publish the SDK store as fresh evidence", () => {
+  // Drives the REAL setupEventHandlers sync listener (not a direct
+  // publishMembershipSnapshots call): a restart that resumes from the SDK
+  // store reports PREPARED with syncData.fromCache=true. The firstPrepared
+  // predicate must treat it as non-first, so publication can only come from
+  // a genuinely fresh server roster — with the network down the room stays
+  // unpublished rather than restoring a possibly-stale cached roster as
+  // current evidence.
+  function emitPrepared(
+    h: Harness,
+    syncData: { oldSyncToken: string | null; fromCache: boolean } | undefined
+  ): void {
+    // Wire the REAL sync listener (setupEventHandlers registers it against
+    // sdk.ClientEvent.Sync === "sync"), then emit through it. getCrypto is
+    // absent on the double, so the verification tail is inert.
+    const svc = h.service as unknown as { setupEventHandlers: (s: unknown) => void };
+    svc.setupEventHandlers(h.state);
+    (h.client as unknown as EventEmitter).emit("sync", "PREPARED", null, syncData);
+  }
+
+  async function waitForPass(): Promise<void> {
+    // The sync handler fires publication as a void promise; let pending
+    // microtasks (and any awaited authority calls inside the pass) settle.
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  it("skips publication on a fromCache PREPARED even when the SDK room model is complete", async () => {
+    const h = createHarness();
+    // A complete, healthy room in the SDK store: no incompleteness flag,
+    // current persisted health, joined members present. Only a fresh server
+    // roster could legitimately publish it — and the network is down.
+    h.authority.scopeHealth = vi.fn(async () => ({ health: "current" }));
+    h.client.members.mockRejectedValue(new Error("network down"));
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    emitPrepared(h, { oldSyncToken: null, fromCache: true });
+    await waitForPass();
+    // Fail closed: a cached PREPARED is not fresh evidence, and the dead
+    // network means no fresh roster — nothing may be published.
+    expect(h.authority.snapshots).toHaveLength(0);
+    expect(h.client.members).toHaveBeenCalled();
+    expect(h.authority.reportIncomplete).toHaveBeenCalled();
+  });
+
+  it("publishes on a fresh PREPARED (no syncData) when the roster is complete", async () => {
+    const h = createHarness();
+    h.authority.scopeHealth = vi.fn(async () => ({ health: "current" }));
+    h.client.members.mockRejectedValue(new Error("network down"));
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    // Fresh PREPARED with no syncData at all: firstPrepared is true, and the
+    // SDK room model is complete (5 joined members) so the snapshot path
+    // publishes directly without a fresh-roster fetch.
+    emitPrepared(h, undefined);
+    await waitForPass();
+    expect(h.authority.snapshots).toHaveLength(1);
   });
 });

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Recovery-path tests for MatrixService membership publication: the r4
+ * review fixes for issue #24368. Covers (1) recovery publishing the FRESH
+ * server roster rather than the SDK's cached one, (2) persisted non-current
+ * scope health triggering recovery even without an in-memory flag, and
+ * direct-room ordering (recovery before the <=2 skip), (3) unknown
+ * membership values being reported instead of recorded as leave. All SDK and
+ * authority surfaces are in-memory doubles — no live homeserver.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { MatrixService } from "../service.js";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    reportError: vi.fn(),
+    createWorld: vi.fn().mockResolvedValue(undefined),
+    createRoom: vi.fn().mockResolvedValue(undefined),
+    createEntity: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IAgentRuntime;
+}
+
+/** Minimal authority double exposing only what the publication pass uses. */
+function createAuthority() {
+  const snapshots: { roomId: string; members: string[] }[] = [];
+  return {
+    snapshots,
+    isRoomIncomplete: vi.fn((): boolean => false),
+    reportIncomplete: vi.fn(async () => {}),
+    clearTransientRoomIncompleteness: vi.fn(() => true),
+    scopeHealth: vi.fn(async (): Promise<{ health: string } | null> => null),
+    clearScopeRemoval: vi.fn(() => {}),
+    publishSnapshot: vi.fn(
+      async (input: { roomId: string; members: { canonicalPrincipalId: string }[] }) => {
+        snapshots.push({
+          roomId: input.roomId,
+          members: input.members.map((m) => m.canonicalPrincipalId),
+        });
+        return true;
+      }
+    ),
+  };
+}
+
+function createRoomDouble(overrides: Record<string, unknown> = {}) {
+  return {
+    roomId: "!ops:example",
+    name: "Ops",
+    getMyMembership: vi.fn(() => "join"),
+    getJoinedMemberCount: vi.fn(() => 5),
+    getJoinedMembers: vi.fn(() => [
+      { userId: "@stale:example", powerLevel: 0 },
+      { userId: "@bot:example", powerLevel: 0 },
+    ]),
+    getMember: vi.fn(() => null),
+    loadMembersIfNeeded: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+interface Harness {
+  service: MatrixService;
+  state: Record<string, unknown>;
+  authority: ReturnType<typeof createAuthority>;
+  client: Record<string, ReturnType<typeof vi.fn>>;
+  runtime: IAgentRuntime;
+}
+
+function createHarness(): Harness {
+  const runtime = createRuntime();
+  const authority = createAuthority();
+  const client = {
+    getRooms: vi.fn(() => [] as unknown[]),
+    getRoom: vi.fn(() => null),
+    members: vi.fn(async () => ({
+      "@fresh1:example": [{ content: { membership: "join" } }],
+      "@fresh2:example": [{ content: { membership: "join" } }],
+      "@fresh3:example": [{ content: { membership: "join" } }],
+      "@bot:example": [{ content: { membership: "join" } }],
+    })),
+  };
+  const state: Record<string, unknown> = {
+    accountId: "work",
+    settings: { userId: "@bot:example", accountId: "work" },
+    client,
+    membershipAuthority: authority,
+    membershipSnapshotCounter: 0,
+    membershipSnapshotToken: "tok",
+    connected: true,
+    syncing: true,
+  };
+  const service = Object.create(MatrixService.prototype) as MatrixService;
+  Object.assign(service, { runtime });
+  (service as unknown as { states: Map<string, unknown> }).states = new Map([["work", state]]);
+  return {
+    service,
+    state,
+    authority,
+    client,
+    runtime,
+  };
+}
+
+describe("recovery publishes the fresh server roster, not the stale SDK roster", () => {
+  it("feeds the client.members roster into the snapshot when the room is flagged incomplete", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.client.members).toHaveBeenCalledWith("!ops:example", "join");
+    expect(h.authority.snapshots).toHaveLength(1);
+    // The published roster must be the FRESH fetch (4 fresh ids), not the
+    // SDK Room model's stale roster (2 ids).
+    expect(h.authority.snapshots[0]?.members).toHaveLength(4);
+  });
+
+  it("fails closed when the fresh fetch fails, leaving the room incomplete", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    h.client.members.mockRejectedValue(new Error("network"));
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.reportIncomplete).toHaveBeenCalled();
+    expect(h.authority.snapshots).toHaveLength(0);
+  });
+});
+
+describe("persisted non-current scope health triggers recovery", () => {
+  it("recovers a stale persisted scope even without an in-memory incompleteness flag", async () => {
+    const h = createHarness();
+    h.authority.scopeHealth = vi.fn(async () => ({ health: "stale" }));
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.scopeHealth).toHaveBeenCalledWith({ roomId: "!ops:example" });
+    expect(h.authority.snapshots).toHaveLength(1);
+  });
+
+  it("checks recovery BEFORE the direct-room skip so a partial group is not stranded", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    // SDK Room model reports a lazily-loaded group as <=2 members.
+    const room = createRoomDouble({ getJoinedMemberCount: vi.fn(() => 1) });
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    // Recovery still ran (fresh fetch, publish) despite the <=2 SDK count.
+    expect(h.authority.snapshots).toHaveLength(1);
+  });
+
+  it("clears the transient flag without publishing when a fresh roster shows a true direct room", async () => {
+    const h = createHarness();
+    h.authority.isRoomIncomplete = vi.fn(() => true);
+    h.client.members.mockResolvedValue({
+      "@one:example": [{ content: { membership: "join" } }],
+      "@bot:example": [{ content: { membership: "join" } }],
+    });
+    const room = createRoomDouble();
+    h.client.getRooms.mockReturnValue([room]);
+    await (
+      h.service as unknown as {
+        publishMembershipSnapshots: (s: unknown, first: boolean) => Promise<void>;
+      }
+    ).publishMembershipSnapshots(h.state, false);
+    expect(h.authority.snapshots).toHaveLength(0);
+    expect(h.authority.clearTransientRoomIncompleteness).toHaveBeenCalled();
+  });
+});
+
+describe("unknown membership values are reported, never recorded as leave", () => {
+  it("reports and skips a knock transition instead of revoking the principal", async () => {
+    const h = createHarness();
+    const event = {
+      getSender: vi.fn(() => "@alice:example"),
+      getRoomId: vi.fn(() => "!ops:example"),
+      getId: vi.fn(() => "$e"),
+      getTs: vi.fn(() => 1),
+    };
+    const member = { userId: "@alice:example", membership: "knock", previousMembership: "join" };
+    const oldMembership = "join";
+    const svc = h.service as unknown as Record<string, unknown>;
+    const handler = svc.handleMembershipTransition as
+      | ((
+          s: unknown,
+          e: unknown,
+          m: unknown,
+          old: string | undefined,
+          room?: unknown
+        ) => Promise<void>)
+      | undefined;
+    if (typeof handler !== "function") {
+      throw new Error("handleMembershipTransition not found on MatrixService prototype");
+    }
+    await handler.call(h.service, h.state, event, member, oldMembership);
+    expect(h.runtime.reportError).toHaveBeenCalled();
+    expect(h.authority.publishSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership-recovery.test.ts
@@ -496,7 +496,7 @@ describe("fresh roster parsing matches the homeserver /members envelope", () => 
 });
 
 describe("reconnect degrade attempts every joined room even when one durable write fails", () => {
-  it("one failed markScopeStale write does not abort degradation of later rooms (ss251 CR control)", async () => {
+  it("one failed markScopeStale write does not abort degradation of later rooms", async () => {
     const h = createHarness();
     const first = createRoomDouble({ roomId: "!first:example" });
     const second = createRoomDouble({ roomId: "!second:example" });
@@ -530,5 +530,27 @@ describe("reconnect degrade attempts every joined room even when one durable wri
       roomId: "!second:example",
       reason: "sync_error",
     });
+  });
+});
+
+describe("non-Error rejection values still surface from the degrade loop", () => {
+  it("a null rejection is retained and rethrown, not swallowed by the sentinel", async () => {
+    const h = createHarness();
+    const first = createRoomDouble({ roomId: "!first:example" });
+    const second = createRoomDouble({ roomId: "!second:example" });
+    h.client.getRooms.mockReturnValue([first, second]);
+    h.authority.markScopeStale.mockImplementation(async (input: { roomId: string }) => {
+      if (input.roomId === "!first:example") {
+        throw null; // eslint-disable-line no-throw-literal -- the sentinel-under-test
+      }
+    });
+    await expect(
+      (
+        h.service as unknown as {
+          degradeAllMembershipScopes: (s: unknown, reason: string) => Promise<void>;
+        }
+      ).degradeAllMembershipScopes(h.state, "sync_error")
+    ).rejects.toBeNull();
+    expect(h.authority.markScopeStale).toHaveBeenCalledTimes(2);
   });
 });

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -480,6 +480,37 @@ describe("MatrixMembershipMessageGate", () => {
     expect(commands.some((c) => c.op === "applyMembership")).toBe(false);
   });
 
+  it("roster-miss denial never reaches the authority roster-evidence seam (review control)", async () => {
+    // The suite-level double above has no publisher binding registered for
+    // the room, so its applyMembership assertion passes even when the gate
+    // reconciles a roster-miss: the write is swallowed into reportError and
+    // the test observes the fake, not the gate. Against a real authority
+    // with a live binding, a forced reconcile would fabricate a join
+    // transition for a user the live roster does not contain. This control
+    // observes the authority surface directly — a roster-miss denial must
+    // never reach recordTransitionFromRoster.
+    const recordSpy = vi.fn(async () => true);
+    const authority = {
+      authorize: vi.fn(async () => ({
+        decision: "denied",
+        reason: "no_membership",
+        generation: null,
+        health: null,
+      })),
+      recordTransitionFromRoster: recordSpy,
+    } as unknown as MatrixMembershipAuthority;
+    const gate = gateWith(authority);
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: false,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => ["@someone-else:example"],
+    });
+    expect(allowed).toBe(false);
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+
   it("reconciles a roster-present sender and re-authorizes", async () => {
     let call = 0;
     const decisions: MembershipAuthorizationDecision[] = [

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -271,6 +271,15 @@ describe("matrix membership scope and mapping", () => {
     expect(classifyMatrixTransition("leave", "ban")).toBe<MatrixMembershipTransition>("leave");
   });
 
+  it("refuses to classify unknown or missing membership as a leave", () => {
+    // Revoking a principal requires an explicit leave/ban decision — a
+    // missing value or a valid-but-unsupported Matrix state (knock) must be
+    // reported and skipped, never silently interpreted as absence.
+    expect(classifyMatrixTransition(undefined, "join")).toBeNull();
+    expect(classifyMatrixTransition("knock", "join")).toBeNull();
+    expect(classifyMatrixTransition("future_state", undefined)).toBeNull();
+  });
+
   it("derives roles from power levels", () => {
     expect(matrixMemberRoles(100)).toContain("owner");
     expect(matrixMemberRoles(50)).toContain("administrator");

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -23,6 +23,7 @@ import {
   type MatrixMembershipTransition,
   matrixMemberRoles,
   matrixMembershipScope,
+  matrixObservedAt,
   matrixTransitionToMembership,
 } from "../membership.js";
 import { MatrixMembershipMessageGate } from "../membership-gate.js";
@@ -284,6 +285,29 @@ describe("matrix membership scope and mapping", () => {
     expect(matrixMemberRoles(100)).toContain("owner");
     expect(matrixMemberRoles(50)).toContain("administrator");
     expect(matrixMemberRoles(0)).toEqual(["member"]);
+  });
+
+  it("matrixObservedAt never throws on missing or out-of-range timestamps", () => {
+    // Lazy-loaded state events can surface without a server timestamp
+    // (undefined/NaN), and a finite-but-out-of-range value (1e16 ms is
+    // past the ±8.64e15 Date limit) still constructs an Invalid Date —
+    // either would throw in toISOString() inside the evidence command
+    // and drop the transition. The guard must fall back to wall-clock.
+    expect(() => matrixObservedAt(Number.NaN)).not.toThrow();
+    expect(() => matrixObservedAt(1e16)).not.toThrow();
+    const wallClock = new Date("2026-08-29T00:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(wallClock);
+    try {
+      expect(matrixObservedAt(Number.NaN)).toBe("2026-08-29T00:00:00.000Z");
+      expect(matrixObservedAt(1e16)).toBe("2026-08-29T00:00:00.000Z");
+      // In-range timestamps stay deterministic — the evidence ordering
+      // contract (observedAt monotonicity within a room) relies on it.
+      expect(matrixObservedAt(0)).toBe("1970-01-01T00:00:00.000Z");
+      expect(matrixObservedAt(8.64e15 - 1)).toBe("+275760-09-12T23:59:59.999Z");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -525,6 +525,29 @@ describe("MatrixMembershipMessageGate", () => {
       getJoinedMemberIds: () => ["@alice:example"],
     });
     expect(allowed).toBe(false);
+    // Direct rooms too: a configured authority that failed bootstrap must
+    // never be bypassed by room shape.
+    const directAllowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: true,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => ["@alice:example"],
+    });
+    expect(directAllowed).toBe(false);
+  });
+
+  it("clears a limited-sync incompleteness only for its recorded reason", async () => {
+    const { service } = createAuthorityService();
+    const authority = createAuthority(service);
+    authority.markRoomIncomplete(ROOM, "limited_sync_timeline_reset");
+    expect(authority.isRoomIncomplete(ROOM)).toBe(true);
+    // A different reason must NOT clear it.
+    expect(authority.clearRoomIncomplete(ROOM, "member_load_failed")).toBe(false);
+    expect(authority.isRoomIncomplete(ROOM)).toBe(true);
+    // The recorded reason clears it.
+    expect(authority.clearRoomIncomplete(ROOM, "limited_sync_timeline_reset")).toBe(true);
+    expect(authority.isRoomIncomplete(ROOM)).toBe(false);
   });
 
   it("fails closed when no authority is configured but enforcement is strict", async () => {

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -559,6 +559,114 @@ describe("MatrixMembershipMessageGate", () => {
     expect(authority.isRoomIncomplete(ROOM)).toBe(false);
   });
 
+  it("fails closed locally when persisting incompleteness fails", async () => {
+    const { service } = createAuthorityService();
+    const authority = createAuthority(service);
+    await publishBaseline(authority);
+    // The authority store goes down AFTER a current baseline: the next
+    // incompleteness report must still fail admission closed locally.
+    let failIncomplete = false;
+    const rawReport = service.reportIncompleteSnapshot as ReturnType<typeof vi.fn>;
+    rawReport.mockImplementation(async () => {
+      if (failIncomplete) {
+        throw new Error("authority store outage");
+      }
+      return {
+        contractVersion: 1,
+        operation: "health" as const,
+        idempotentReplay: false,
+        committedGeneration: 1,
+        health: {} as MembershipScopeHealth,
+      };
+    });
+    failIncomplete = true;
+    await authority.reportIncomplete({
+      roomId: ROOM,
+      reason: "member_list_incomplete",
+      observedAt: "2026-08-26T00:05:00.000Z",
+    });
+    failIncomplete = false;
+    expect(authority.isRoomIncomplete(ROOM)).toBe(true);
+    // The underlying authority would still say allowed — the LOCAL incomplete
+    // flag must fail the room closed anyway (ss251 review control).
+    const decision = await authority.authorize({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+    });
+    expect(decision.decision).toBe("denied");
+    expect(decision.reason).toBe("authority_stale");
+    // Recovery: a complete snapshot clears the flag and reopens admission.
+    const ok = await authority.publishSnapshot({
+      roomId: ROOM,
+      observedAt: "2026-08-26T00:10:00.000Z",
+      members: [
+        {
+          canonicalPrincipalId: PRINCIPAL_A,
+          roles: ["member"],
+          permissionSnapshot: { membership: "join" },
+          runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+        },
+      ],
+      idempotencyKey: "recovery-after-failed-incomplete",
+    });
+    expect(ok).toBe(true);
+    expect(authority.isRoomIncomplete(ROOM)).toBe(false);
+    const after = await authority.authorize({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+    });
+    expect(after.decision).toBe("allowed");
+  });
+
+  it("an authorize queued behind a failing reportIncomplete is denied (no TOCTOU)", async () => {
+    const { service } = createAuthorityService();
+    const authority = createAuthority(service);
+    await publishBaseline(authority);
+    let releaseReport: (() => void) | undefined;
+    let fail = false;
+    const rawReport = service.reportIncompleteSnapshot as ReturnType<typeof vi.fn>;
+    rawReport.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          if (!fail) {
+            resolve({
+              contractVersion: 1,
+              operation: "health" as const,
+              idempotentReplay: false,
+              committedGeneration: 1,
+              health: {} as MembershipScopeHealth,
+            });
+            return;
+          }
+          releaseReport = () => reject(new Error("authority store outage"));
+        })
+    );
+    // Start reportIncomplete and pause its storage call while it HOLDS the
+    // serialized scope chain.
+    fail = true;
+    const reporting = authority.reportIncomplete({
+      roomId: ROOM,
+      reason: "member_list_incomplete",
+      observedAt: "2026-08-26T00:05:00.000Z",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    // Queue an authorize behind the in-flight report. The incomplete flag is
+    // not set yet — the pre-serialization state RP flagged as a TOCTOU gap.
+    const authorizing = authority.authorize({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    // The report's persist fails: it must set the local flag before releasing
+    // the chain, so the queued authorize — running AFTER it — must see it.
+    releaseReport?.();
+    await reporting;
+    const decision = await authorizing;
+    expect(authority.isRoomIncomplete(ROOM)).toBe(true);
+    expect(decision.decision).toBe("denied");
+    expect(decision.reason).toBe("authority_stale");
+  });
+
   it("fails closed when no authority is configured but enforcement is strict", async () => {
     process.env.MATRIX_MEMBERSHIP_ENFORCE = "1";
     try {

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -61,9 +61,37 @@ function createAuthorityService(
 ) {
   const commands: RecordedCommand[] = [];
   let scopeHealth: MembershipScopeHealth | null = null;
+  // Mirrors SqlMembershipService: one binding per scope, and every evidence
+  // command must match the registered publisher instance/generation/mode with
+  // exact cursor continuity. This is what makes the snapshot->delta lifecycle
+  // tests below meaningful against the real authority contract.
+  const bindings = new Map<
+    string,
+    {
+      publisherInstanceId: string;
+      publisherGeneration: number;
+      evidenceMode: string;
+      sourceVersion: number;
+      sourceCursor: string | null;
+      seenKeys: Set<string>;
+    }
+  >();
+  const authorityError = (code: string, message: string) => {
+    const err = new Error(`MEMBERSHIP_${code}: ${message}`);
+    (err as Error & { code?: string }).code = `MEMBERSHIP_${code}`;
+    return err;
+  };
   const service: MembershipService = {
     registerPublisher: vi.fn(async (command) => {
       commands.push({ op: "registerPublisher", command: command as never });
+      bindings.set(`${command.agentId}:${command.connectorAccountId}:${command.externalRoomId}`, {
+        publisherInstanceId: command.publisherInstanceId,
+        publisherGeneration: command.publisherGeneration,
+        evidenceMode: command.evidenceMode,
+        sourceVersion: -1,
+        sourceCursor: null,
+        seenKeys: new Set(),
+      });
       return {
         contractVersion: 1,
         operation: "publisher",
@@ -73,6 +101,26 @@ function createAuthorityService(
       } satisfies MembershipMutationReceipt;
     }),
     applyCompleteSnapshot: vi.fn(async (command) => {
+      const binding = bindings.get(
+        `${command.agentId}:${command.connectorAccountId}:${command.externalRoomId}`
+      );
+      if (!binding) throw authorityError("SCOPE_NOT_FOUND", "no publisher registered");
+      if (
+        binding.publisherInstanceId !== command.publisherInstanceId ||
+        binding.publisherGeneration !== command.publisherGeneration ||
+        binding.evidenceMode !== command.evidenceMode
+      )
+        throw authorityError("PUBLISHER_MISMATCH", "mode or publisher generation changed");
+      if (binding.seenKeys.has(command.idempotencyKey))
+        throw authorityError("IDEMPOTENCY_CONFLICT", "key already used for different bytes");
+      if (
+        command.sourceVersion !== binding.sourceVersion + 1 ||
+        command.previousSourceCursor !== binding.sourceCursor
+      )
+        throw authorityError("CURSOR_DISCONTINUITY", "evidence is not the next cursor");
+      binding.seenKeys.add(command.idempotencyKey);
+      binding.sourceVersion = command.sourceVersion;
+      binding.sourceCursor = command.sourceCursor;
       commands.push({ op: "applyCompleteSnapshot", command: command as never });
       return {
         contractVersion: 1,
@@ -95,6 +143,28 @@ function createAuthorityService(
       } satisfies MembershipMutationReceipt;
     }),
     applyMembership: vi.fn(async (command) => {
+      const binding = bindings.get(
+        `${command.agentId}:${command.connectorAccountId}:${command.externalRoomId}`
+      );
+      if (!binding) throw authorityError("SCOPE_NOT_FOUND", "no publisher registered");
+      if (
+        binding.publisherInstanceId !== command.publisherInstanceId ||
+        binding.publisherGeneration !== command.publisherGeneration ||
+        binding.evidenceMode !== command.evidenceMode
+      )
+        throw authorityError("PUBLISHER_MISMATCH", "mode or publisher generation changed");
+      if (binding.evidenceMode === "ordered_delta" && binding.sourceVersion < 0)
+        throw authorityError("SNAPSHOT_REQUIRED", "deltas need a complete baseline first");
+      if (binding.seenKeys.has(command.idempotencyKey))
+        throw authorityError("IDEMPOTENCY_CONFLICT", "key already used for different bytes");
+      if (
+        command.sourceVersion !== binding.sourceVersion + 1 ||
+        command.previousSourceCursor !== binding.sourceCursor
+      )
+        throw authorityError("CURSOR_DISCONTINUITY", "evidence is not the next cursor");
+      binding.seenKeys.add(command.idempotencyKey);
+      binding.sourceVersion = command.sourceVersion;
+      binding.sourceCursor = command.sourceCursor;
       commands.push({ op: "applyMembership", command: command as never });
       return {
         contractVersion: 1,
@@ -137,6 +207,24 @@ function createAuthority(
     connectorAccountId: ACCOUNT_ID,
     service,
   });
+}
+
+/** Publishes a one-member complete baseline for ROOM on the authority. */
+async function publishBaseline(authority: MatrixMembershipAuthority): Promise<void> {
+  const published = await authority.publishSnapshot({
+    roomId: ROOM,
+    observedAt: "2026-08-26T00:00:00.000Z",
+    members: [
+      {
+        canonicalPrincipalId: PRINCIPAL_A,
+        roles: ["member"],
+        permissionSnapshot: { membership: "join" },
+        runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+      },
+    ],
+    idempotencyKey: "baseline-0",
+  });
+  expect(published).toBe(true);
 }
 
 describe("matrix membership scope and mapping", () => {
@@ -214,7 +302,10 @@ describe("MatrixMembershipAuthority snapshots", () => {
       | { completeness?: string; evidenceMode?: string; members?: unknown[] }
       | undefined;
     expect(command?.completeness).toBe("complete");
-    expect(command?.evidenceMode).toBe("complete_snapshot");
+    // Single publisher mode per scope (the SQL authority requires every
+    // command's mode to equal the registered mode): snapshots are the
+    // complete baseline of an ordered_delta publisher.
+    expect(command?.evidenceMode).toBe("ordered_delta");
     expect(command?.members?.length).toBe(1);
   });
 
@@ -236,9 +327,10 @@ describe("MatrixMembershipAuthority snapshots", () => {
 });
 
 describe("MatrixMembershipAuthority transitions", () => {
-  it("records a join transition as ordered-delta evidence keyed by the event id", async () => {
+  it("records a join transition as ordered-delta evidence after a snapshot baseline", async () => {
     const { service, commands } = createAuthorityService();
     const authority = createAuthority(service);
+    await publishBaseline(authority);
     await authority.recordTransition({
       roomId: ROOM,
       canonicalPrincipalId: PRINCIPAL_A,
@@ -256,6 +348,26 @@ describe("MatrixMembershipAuthority transitions", () => {
     expect(applied?.command.state).toBe("active");
     expect(applied?.command.reason).toBe("joined");
     expect(applied?.command.idempotencyKey).toContain("$m1");
+  });
+
+  it("drops a delta when no snapshot baseline exists (real authority requires one)", async () => {
+    const { service, commands } = createAuthorityService();
+    const authority = createAuthority(service);
+    // No publishSnapshot first: the SQL authority rejects an ordered_delta
+    // without a current complete baseline, so the evidence is dropped and the
+    // denial stands — never a fabricated success.
+    await authority.recordTransition({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+      transition: "join",
+      roles: ["member"],
+      permissionSnapshot: {},
+      runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+      eventId: "$no-baseline",
+      matrixUserId: "@alice:example",
+      observedAt: "2026-08-26T00:00:01.000Z",
+    });
+    expect(commands.some((c) => c.op === "applyMembership")).toBe(false);
   });
 
   it("skips an out-of-order redelivery that would resurrect a committed revocation", async () => {
@@ -285,8 +397,10 @@ describe("MatrixMembershipAuthority transitions", () => {
     const { service, commands } = createAuthorityService();
     const authority = createAuthority(service);
     await authority.markScopeUnavailable({ roomId: ROOM, reason: "bot_left" });
+    // No persisted scope row exists yet: degradation is local (the tombstone
+    // below); setScopeHealth only runs when there is a scope to degrade.
     const degrade = commands.find((c) => c.op === "setScopeHealth");
-    expect(degrade?.command.health).toBe("unavailable");
+    expect(degrade).toBeUndefined();
     // Post-leave evidence is tombstoned.
     const published = await authority.publishSnapshot({
       roomId: ROOM,
@@ -371,7 +485,9 @@ describe("MatrixMembershipMessageGate", () => {
     ];
     const { service, commands } = createAuthorityService();
     (service as { authorize: unknown }).authorize = vi.fn(async () => decisions[call++]);
-    const gate = gateWith(createAuthority(service));
+    const authority = createAuthority(service);
+    await publishBaseline(authority);
+    const gate = gateWith(authority);
     const allowed = await gate.authorizeMessage({
       roomId: ROOM,
       isDirectRoom: false,
@@ -395,6 +511,20 @@ describe("MatrixMembershipMessageGate", () => {
       getJoinedMemberIds: () => [],
     });
     expect(allowed).toBe(true);
+  });
+
+  it("fails closed for every room once the gate is marked broken", async () => {
+    const { service } = createAuthorityService();
+    const gate = gateWith(createAuthority(service));
+    gate.markBroken();
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: false,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => ["@alice:example"],
+    });
+    expect(allowed).toBe(false);
   });
 
   it("fails closed when no authority is configured but enforcement is strict", async () => {

--- a/plugins/plugin-matrix/src/__tests__/membership.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/membership.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Deterministic tests for the Matrix membership authority wiring: complete
+ * PREPARED snapshots vs incomplete (limited-sync/lazy-load) rosters, join/
+ * invite/leave/ban transition consumption, bot self-leave scope termination,
+ * account-scoped UUID derivation, and fail-closed message admission. All
+ * authority and SDK surfaces are in-memory test doubles — no live homeserver.
+ */
+
+import type {
+  IAgentRuntime,
+  MembershipAuthorizationDecision,
+  MembershipMutationReceipt,
+  MembershipRecord,
+  MembershipScopeHealth,
+  MembershipService,
+  UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  classifyMatrixTransition,
+  MatrixMembershipAuthority,
+  type MatrixMembershipTransition,
+  matrixMemberRoles,
+  matrixMembershipScope,
+  matrixTransitionToMembership,
+} from "../membership.js";
+import { MatrixMembershipMessageGate } from "../membership-gate.js";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const ACCOUNT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const PRINCIPAL_A = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const _PRINCIPAL_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ROOM = "!ops:example";
+
+function createRuntime(overrides: Record<string, unknown> = {}): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    reportError: vi.fn(),
+    getCache: vi.fn().mockResolvedValue(undefined),
+    setCache: vi.fn().mockResolvedValue(true),
+    deleteCache: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  } as unknown as IAgentRuntime;
+}
+
+interface RecordedCommand {
+  op: string;
+  command: Record<string, unknown>;
+}
+
+function createAuthorityService(
+  membership: MembershipRecord | null = null,
+  decision: MembershipAuthorizationDecision = {
+    decision: "allowed",
+    reason: "active_membership",
+    generation: 1,
+    health: "current",
+    membership: {} as MembershipRecord,
+  }
+) {
+  const commands: RecordedCommand[] = [];
+  let scopeHealth: MembershipScopeHealth | null = null;
+  const service: MembershipService = {
+    registerPublisher: vi.fn(async (command) => {
+      commands.push({ op: "registerPublisher", command: command as never });
+      return {
+        contractVersion: 1,
+        operation: "publisher",
+        idempotentReplay: false,
+        committedGeneration: (command.expectedGeneration ?? 0) + 1,
+        health: {} as MembershipScopeHealth,
+      } satisfies MembershipMutationReceipt;
+    }),
+    applyCompleteSnapshot: vi.fn(async (command) => {
+      commands.push({ op: "applyCompleteSnapshot", command: command as never });
+      return {
+        contractVersion: 1,
+        operation: "snapshot",
+        idempotentReplay: false,
+        committedGeneration: command.expectedGeneration + 1,
+        health: {} as MembershipScopeHealth,
+        memberships: [],
+        revokedPrincipalIds: [],
+      } satisfies MembershipMutationReceipt;
+    }),
+    reportIncompleteSnapshot: vi.fn(async (command) => {
+      commands.push({ op: "reportIncompleteSnapshot", command: command as never });
+      return {
+        contractVersion: 1,
+        operation: "health",
+        idempotentReplay: false,
+        committedGeneration: command.expectedGeneration,
+        health: {} as MembershipScopeHealth,
+      } satisfies MembershipMutationReceipt;
+    }),
+    applyMembership: vi.fn(async (command) => {
+      commands.push({ op: "applyMembership", command: command as never });
+      return {
+        contractVersion: 1,
+        operation: "membership",
+        idempotentReplay: false,
+        committedGeneration: command.expectedGeneration + 1,
+        membership: {} as MembershipRecord,
+      } satisfies MembershipMutationReceipt;
+    }),
+    setScopeHealth: vi.fn(async (command) => {
+      commands.push({ op: "setScopeHealth", command: command as never });
+      return {
+        contractVersion: 1,
+        operation: "health",
+        idempotentReplay: false,
+        committedGeneration: command.expectedGeneration,
+        health: {} as MembershipScopeHealth,
+      } satisfies MembershipMutationReceipt;
+    }),
+    authorize: vi.fn(async () => decision),
+    getMembership: vi.fn(async () => membership),
+    getScopeHealth: vi.fn(async () => scopeHealth),
+    registerInvalidator: vi.fn(() => () => {}),
+  } as unknown as MembershipService;
+  return {
+    service,
+    commands,
+    setScopeHealth: (health: MembershipScopeHealth | null) => {
+      scopeHealth = health;
+    },
+  };
+}
+
+function createAuthority(
+  service: MembershipService,
+  runtime: IAgentRuntime = createRuntime()
+): MatrixMembershipAuthority {
+  return new MatrixMembershipAuthority({
+    runtime,
+    connectorAccountId: ACCOUNT_ID,
+    service,
+  });
+}
+
+describe("matrix membership scope and mapping", () => {
+  it("scopes externalWorldId and externalRoomId to the raw Matrix room id under connector matrix", () => {
+    const scope = matrixMembershipScope({
+      agentId: AGENT_ID,
+      connectorAccountId: ACCOUNT_ID,
+      roomId: ROOM,
+    });
+    expect(scope.connectorId).toBe("matrix");
+    expect(scope.externalWorldId).toBe(ROOM);
+    expect(scope.externalRoomId).toBe(ROOM);
+    expect(scope.connectorAccountId).toBe(ACCOUNT_ID);
+  });
+
+  it("maps every membership transition to the correct authority state and reason", () => {
+    expect(matrixTransitionToMembership("join")).toEqual({
+      state: "active",
+      reason: "joined",
+    });
+    // An invite is not admission.
+    expect(matrixTransitionToMembership("invite")).toEqual({
+      state: "revoked",
+      reason: "left",
+    });
+    expect(matrixTransitionToMembership("leave")).toEqual({
+      state: "revoked",
+      reason: "left",
+    });
+    expect(matrixTransitionToMembership("ban")).toEqual({
+      state: "revoked",
+      reason: "banned",
+    });
+  });
+
+  it("classifies raw SDK membership strings into transitions", () => {
+    expect(classifyMatrixTransition("join", undefined)).toBe<MatrixMembershipTransition>("join");
+    expect(classifyMatrixTransition("invite", undefined)).toBe<MatrixMembershipTransition>(
+      "invite"
+    );
+    expect(classifyMatrixTransition("leave", "join")).toBe<MatrixMembershipTransition>("leave");
+    expect(classifyMatrixTransition("ban", "join")).toBe<MatrixMembershipTransition>("ban");
+    // An unban resets membership to leave: still not active.
+    expect(classifyMatrixTransition("leave", "ban")).toBe<MatrixMembershipTransition>("leave");
+  });
+
+  it("derives roles from power levels", () => {
+    expect(matrixMemberRoles(100)).toContain("owner");
+    expect(matrixMemberRoles(50)).toContain("administrator");
+    expect(matrixMemberRoles(0)).toEqual(["member"]);
+  });
+});
+
+describe("MatrixMembershipAuthority snapshots", () => {
+  it("publishes a complete snapshot for complete state", async () => {
+    const { service, commands } = createAuthorityService();
+    const authority = createAuthority(service);
+    const published = await authority.publishSnapshot({
+      roomId: ROOM,
+      observedAt: "2026-08-26T00:00:00.000Z",
+      members: [
+        {
+          canonicalPrincipalId: PRINCIPAL_A,
+          roles: ["member"],
+          permissionSnapshot: { membership: "join" },
+          runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+        },
+      ],
+      idempotencyKey: `mx:${ACCOUNT_ID}:${ROOM}:prepared:first:1`,
+    });
+    expect(published).toBe(true);
+    const snapshot = commands.find((c) => c.op === "applyCompleteSnapshot");
+    expect(snapshot).toBeDefined();
+    const command = snapshot?.command as
+      | { completeness?: string; evidenceMode?: string; members?: unknown[] }
+      | undefined;
+    expect(command?.completeness).toBe("complete");
+    expect(command?.evidenceMode).toBe("complete_snapshot");
+    expect(command?.members?.length).toBe(1);
+  });
+
+  it("reports incomplete instead of publishing an empty roster", async () => {
+    const { service, commands } = createAuthorityService();
+    const authority = createAuthority(service);
+    await authority.reportIncomplete({
+      roomId: ROOM,
+      reason: "member_list_incomplete",
+      observedAt: "2026-08-26T00:00:00.000Z",
+    });
+    expect(commands.some((c) => c.op === "applyCompleteSnapshot")).toBe(false);
+    const report = commands.find((c) => c.op === "reportIncompleteSnapshot");
+    expect(report?.command.completeness).toBe("incomplete");
+    expect(report?.command.reason).toBe("member_list_incomplete");
+    // A room marked incomplete refuses later snapshots until complete state.
+    expect(authority.isRoomIncomplete(ROOM)).toBe(true);
+  });
+});
+
+describe("MatrixMembershipAuthority transitions", () => {
+  it("records a join transition as ordered-delta evidence keyed by the event id", async () => {
+    const { service, commands } = createAuthorityService();
+    const authority = createAuthority(service);
+    await authority.recordTransition({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+      transition: "join",
+      roles: ["member"],
+      permissionSnapshot: {},
+      runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+      eventId: "$m1",
+      matrixUserId: "@alice:example",
+      observedAt: "2026-08-26T00:00:01.000Z",
+    });
+    const applied = commands.find((c) => c.op === "applyMembership");
+    expect(applied).toBeDefined();
+    expect(applied?.command.evidenceMode).toBe("ordered_delta");
+    expect(applied?.command.state).toBe("active");
+    expect(applied?.command.reason).toBe("joined");
+    expect(applied?.command.idempotencyKey).toContain("$m1");
+  });
+
+  it("skips an out-of-order redelivery that would resurrect a committed revocation", async () => {
+    const revoked: MembershipRecord = {
+      contractVersion: 1,
+      state: "revoked",
+      reason: "left",
+      observedAt: "2026-08-26T00:00:05.000Z",
+    } as unknown as MembershipRecord;
+    const { service, commands } = createAuthorityService(revoked);
+    const authority = createAuthority(service);
+    await authority.recordTransition({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+      // Same instant as the committed leave: an equal-stamp join must not
+      // resurrect.
+      transition: "join",
+      eventId: "$old-join",
+      matrixUserId: "@alice:example",
+      observedAt: "2026-08-26T00:00:05.000Z",
+      runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+    });
+    expect(commands.some((c) => c.op === "applyMembership")).toBe(false);
+  });
+
+  it("terminates the scope on bot self-leave and refuses later evidence", async () => {
+    const { service, commands } = createAuthorityService();
+    const authority = createAuthority(service);
+    await authority.markScopeUnavailable({ roomId: ROOM, reason: "bot_left" });
+    const degrade = commands.find((c) => c.op === "setScopeHealth");
+    expect(degrade?.command.health).toBe("unavailable");
+    // Post-leave evidence is tombstoned.
+    const published = await authority.publishSnapshot({
+      roomId: ROOM,
+      observedAt: "2026-08-26T00:00:10.000Z",
+      members: [],
+      idempotencyKey: "after-leave",
+    });
+    expect(published).toBe(false);
+    expect(commands.some((c) => c.op === "applyCompleteSnapshot")).toBe(false);
+  });
+});
+
+describe("MatrixMembershipMessageGate", () => {
+  function gateWith(
+    authority: MatrixMembershipAuthority | null,
+    runtime = createRuntime()
+  ): MatrixMembershipMessageGate {
+    return new MatrixMembershipMessageGate({ runtime, authority });
+  }
+
+  it("allows direct rooms without consulting the authority", async () => {
+    const { service } = createAuthorityService();
+    const authorize = vi.fn();
+    (service as { authorize: unknown }).authorize = authorize;
+    const gate = gateWith(createAuthority(service));
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: true,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => [],
+    });
+    expect(allowed).toBe(true);
+    expect(authorize).not.toHaveBeenCalled();
+  });
+
+  it("allows group messages on an allowed authority decision", async () => {
+    const { service } = createAuthorityService();
+    const gate = gateWith(createAuthority(service));
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: false,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => ["@alice:example"],
+    });
+    expect(allowed).toBe(true);
+  });
+
+  it("fails closed when the authority denies and the roster does not contain the sender", async () => {
+    const denied: MembershipAuthorizationDecision = {
+      decision: "denied",
+      reason: "no_membership",
+      generation: null,
+      health: null,
+    };
+    const { service, commands } = createAuthorityService(null, denied);
+    const gate = gateWith(createAuthority(service));
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: false,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => ["@someone-else:example"],
+    });
+    expect(allowed).toBe(false);
+    // Roster-miss: no reconciled evidence recorded.
+    expect(commands.some((c) => c.op === "applyMembership")).toBe(false);
+  });
+
+  it("reconciles a roster-present sender and re-authorizes", async () => {
+    let call = 0;
+    const decisions: MembershipAuthorizationDecision[] = [
+      { decision: "denied", reason: "no_membership", generation: null, health: null },
+      {
+        decision: "allowed",
+        reason: "active_membership",
+        generation: 2,
+        health: "current",
+        membership: {} as MembershipRecord,
+      },
+    ];
+    const { service, commands } = createAuthorityService();
+    (service as { authorize: unknown }).authorize = vi.fn(async () => decisions[call++]);
+    const gate = gateWith(createAuthority(service));
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: false,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => ["@alice:example"],
+    });
+    expect(allowed).toBe(true);
+    // The reconcile recorded reconciled_present evidence.
+    const applied = commands.find((c) => c.op === "applyMembership");
+    expect(applied?.command.reason).toBe("joined");
+  });
+
+  it("degrades to allow with a warning when no authority service is configured", async () => {
+    const gate = gateWith(null);
+    const allowed = await gate.authorizeMessage({
+      roomId: ROOM,
+      isDirectRoom: false,
+      principalEntityId: PRINCIPAL_A,
+      matrixUserId: "@alice:example",
+      getJoinedMemberIds: () => [],
+    });
+    expect(allowed).toBe(true);
+  });
+
+  it("fails closed when no authority is configured but enforcement is strict", async () => {
+    process.env.MATRIX_MEMBERSHIP_ENFORCE = "1";
+    try {
+      const gate = gateWith(null);
+      const allowed = await gate.authorizeMessage({
+        roomId: ROOM,
+        isDirectRoom: false,
+        principalEntityId: PRINCIPAL_A,
+        matrixUserId: "@alice:example",
+        getJoinedMemberIds: () => [],
+      });
+      expect(allowed).toBe(false);
+    } finally {
+      delete process.env.MATRIX_MEMBERSHIP_ENFORCE;
+    }
+  });
+});
+
+describe("MatrixMembershipAuthority fencing", () => {
+  function fencedService(fenceError: Error & { code?: string }) {
+    const { service, commands } = createAuthorityService();
+    let calls = 0;
+    (service as { applyMembership: unknown }).applyMembership = vi.fn(async (command) => {
+      calls += 1;
+      if (calls === 1) throw fenceError;
+      commands.push({ op: "applyMembership", command: command as never });
+      return {
+        contractVersion: 1,
+        operation: "membership",
+        idempotentReplay: false,
+        committedGeneration: command.expectedGeneration + 1,
+        membership: {} as MembershipRecord,
+      } satisfies MembershipMutationReceipt;
+    });
+    return { service, commands };
+  }
+
+  it("re-adopts after a cursor-discontinuity fence failure and commits", async () => {
+    const fenceError = new Error("MEMBERSHIP_CURSOR_DISCONTINUITY");
+    fenceError.code = "MEMBERSHIP_CURSOR_DISCONTINUITY";
+    const { service, commands } = fencedService(fenceError);
+    const authority = createAuthority(service);
+    await authority.recordTransition({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+      transition: "join",
+      eventId: "$fenced",
+      matrixUserId: "@alice:example",
+      observedAt: "2026-08-26T00:00:02.000Z",
+      runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+    });
+    expect(commands.some((c) => c.op === "applyMembership")).toBe(true);
+  });
+
+  it("treats an idempotency conflict as a benign duplicate", async () => {
+    const { service, commands } = createAuthorityService();
+    const conflict = new Error("MEMBERSHIP_IDEMPOTENCY_CONFLICT");
+    conflict.code = "MEMBERSHIP_IDEMPOTENCY_CONFLICT";
+    (service as { applyMembership: unknown }).applyMembership = vi.fn(async () => {
+      throw conflict;
+    });
+    const authority = createAuthority(service);
+    await authority.recordTransition({
+      roomId: ROOM,
+      canonicalPrincipalId: PRINCIPAL_A,
+      transition: "join",
+      eventId: "$dup",
+      matrixUserId: "@alice:example",
+      observedAt: "2026-08-26T00:00:03.000Z",
+      runtime: { worldId: null, roomId: null, entityId: PRINCIPAL_A },
+    });
+    // Benign duplicate: no evidence command committed, not thrown.
+    expect(commands.some((c) => c.op === "applyMembership")).toBe(false);
+  });
+});

--- a/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
@@ -5,7 +5,13 @@
  * gate is exercised deterministically — no live homeserver.
  */
 import { EventEmitter } from "node:events";
-import { type Content, EventType, type HandlerCallback, type IAgentRuntime } from "@elizaos/core";
+import {
+  type Content,
+  createUniqueUuid,
+  EventType,
+  type HandlerCallback,
+  type IAgentRuntime,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 // The vitest @elizaos/core shim (packages/scripts/vitest/shims) is a curated subset
@@ -313,6 +319,39 @@ describe("Matrix service hardening", () => {
           content: expect.objectContaining({ text: "hello bot", source: "matrix" }),
         }),
       })
+    );
+  });
+
+  it("persists the inbound message with the same authority-compatible room key the connector read fallback uses", async () => {
+    // Write/read contract: dispatchToAgent persists via
+    // matrixMessageToMemory (account-scoped matrixScopedUuid) and the
+    // connector's stored-memory fallback (readMessagesForTarget) reads by
+    // the SAME derivation. A v0 createUniqueUuid write key would make
+    // every stored message invisible to the reader — this round-trip pins
+    // both derivations to identical bytes.
+    const { runtime, service, state } = createService();
+    await callDispatch(service, state, createMatrixMessage(), createMatrixRoom());
+
+    const written = vi.mocked(runtime.createMemory).mock.calls[0]?.[0];
+    expect(written).toBeDefined();
+    const writtenRoomId = written?.roomId;
+
+    // Derive the reader's expected key independently: the production
+    // matrixScopedUuid (createUniqueUuid base + v5/8 nibble re-stamp)
+    // over `work:!ops:example`.
+    const base = createUniqueUuid(runtime, "work:!ops:example");
+    const expectedReaderKey = `${base.slice(0, 14)}5${base.slice(15, 19)}8${base.slice(20)}`;
+    expect(writtenRoomId).toBe(expectedReaderKey);
+
+    // And the version nibble is RFC 4122-valid (the canonical membership
+    // authority rejects version-0 ids) while remaining deterministic.
+    expect(writtenRoomId?.[14]).toBe("5");
+    expect(writtenRoomId?.[19]).toBe("8");
+    expect(writtenRoomId).toBe(
+      (() => {
+        const again = createUniqueUuid(runtime, "work:!ops:example");
+        return `${again.slice(0, 14)}5${again.slice(15, 19)}8${again.slice(20)}`;
+      })()
     );
   });
 

--- a/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
@@ -611,4 +611,35 @@ describe("Matrix service hardening", () => {
       vi.useRealTimers();
     }
   });
+
+  it("leaveRoom terminates the membership scope before reporting success", async () => {
+    const { service, state } = createService();
+    const markScopeUnavailable = vi.fn().mockResolvedValue(undefined);
+    Object.assign(state, { membershipAuthority: { markScopeUnavailable } });
+    (state.client as { leave: ReturnType<typeof vi.fn> }).leave = vi
+      .fn()
+      .mockResolvedValue(undefined);
+
+    await service.leaveRoom("!ops:example");
+
+    expect(state.client.leave).toHaveBeenCalledWith("!ops:example");
+    // The homeserver confirmed the leave: the scope must be tombstoned NOW,
+    // not left authorizing until an SDK membership event arrives.
+    expect(markScopeUnavailable).toHaveBeenCalledWith({
+      roomId: "!ops:example",
+      reason: "bot_left_explicit",
+    });
+  });
+
+  it("leaveRoom propagates the leave error without terminating the scope", async () => {
+    const { service, state } = createService();
+    const markScopeUnavailable = vi.fn().mockResolvedValue(undefined);
+    Object.assign(state, { membershipAuthority: { markScopeUnavailable } });
+    (state.client as { leave: ReturnType<typeof vi.fn> }).leave = vi
+      .fn()
+      .mockRejectedValue(new Error("homeserver 403"));
+
+    await expect(service.leaveRoom("!ops:example")).rejects.toThrow("homeserver 403");
+    expect(markScopeUnavailable).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/plugin-matrix/src/membership-gate.ts
+++ b/plugins/plugin-matrix/src/membership-gate.ts
@@ -1,0 +1,236 @@
+/**
+ * Membership admission gate for inbound Matrix room messages: consults the
+ * canonical membership authority, reconciles against the SDK's live joined
+ * roster on evidence-miss denials (backfill for never-seen members), and
+ * fails closed when the authority cannot produce fresh evidence. Direct
+ * rooms (two joined members) are not membership-governed — a DM is
+ * inherently addressed — and bypass the gate.
+ */
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
+import type { MatrixMembershipAuthority } from "./membership";
+import { matrixMembershipShouldReconcile, resolveMembershipService } from "./membership";
+
+const CONNECTOR_ACCOUNT_PROVIDER = "matrix";
+
+/**
+ * Durable connector-account bootstrap: upserts the (agent, "matrix",
+ * <account>) row through the ConnectorAccountManager so the membership
+ * authority's connector-account FK resolves to a stable UUID.
+ */
+export async function bootstrapMatrixMembershipAccount(input: {
+  runtime: IAgentRuntime;
+  /** Normalized Matrix account id (DEFAULT_MATRIX_ACCOUNT_ID for the default). */
+  matrixAccountId: string;
+  /** Full Matrix user id for this account (@bot:server). */
+  matrixUserId: string;
+  /** Personal (OWNER) accounts act as the user; the default bot is AGENT. */
+  personal: boolean;
+}): Promise<UUID | null> {
+  try {
+    const { getConnectorAccountManager } = await import("@elizaos/core");
+    const manager = getConnectorAccountManager(input.runtime);
+    const now = Date.now();
+    const account = {
+      id: `matrix-${input.matrixAccountId}`,
+      provider: CONNECTOR_ACCOUNT_PROVIDER,
+      label: `Matrix account ${input.matrixUserId}`,
+      role: input.personal ? ("OWNER" as const) : ("AGENT" as const),
+      purpose: ["messaging"],
+      accessGate: input.personal ? ("owner_binding" as const) : ("open" as const),
+      status: "connected" as const,
+      externalId: input.matrixUserId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const stored = await manager.upsertAccount(CONNECTOR_ACCOUNT_PROVIDER, account);
+    if (!stored.id || !isUuidLike(stored.id)) {
+      // The authority service IS configured, but its connector-account store
+      // returned a malformed result. This must NOT degrade to the
+      // absent-authority legacy allow mode: throw so the caller marks the
+      // admission gate broken and every room admission fails closed.
+      throw new ElizaError("Matrix membership bootstrap received a non-UUID connector account id", {
+        code: "MATRIX_MEMBERSHIP_BOOTSTRAP_INVALID_ACCOUNT",
+        context: {
+          matrixAccountId: input.matrixAccountId,
+          storedId: stored.id ?? null,
+        },
+      });
+    }
+    return stored.id as UUID;
+  } catch (error) {
+    // error-policy:J2 Bootstrap failure must stay distinguishable from an
+    // absent connector-account manager: wrap and rethrow so the service
+    // records a BROKEN gate (fail-closed room admission) instead of silently
+    // degrading to the absent-authority legacy allow mode.
+    throw new ElizaError("Matrix membership connector-account bootstrap failed", {
+      code: "MATRIX_MEMBERSHIP_BOOTSTRAP_FAILED",
+      cause: error,
+    });
+  }
+}
+
+function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+export interface MatrixMembershipGate {
+  authority: MatrixMembershipAuthority;
+  connectorAccountId: UUID;
+}
+
+/**
+ * Builds the per-account membership gate, or null when the authority service
+ * is absent (deployments without plugin-sql keep the legacy ungated mode with
+ * a once-per-room warning; MATRIX_MEMBERSHIP_ENFORCE=1 opts into strict
+ * fail-closed).
+ */
+export async function createMatrixMembershipGate(input: {
+  runtime: IAgentRuntime;
+  matrixAccountId: string;
+  matrixUserId: string;
+  personal: boolean;
+}): Promise<MatrixMembershipGate | null> {
+  const service = resolveMembershipService(input.runtime);
+  if (!service) {
+    return null;
+  }
+  const connectorAccountId = await bootstrapMatrixMembershipAccount({
+    runtime: input.runtime,
+    matrixAccountId: input.matrixAccountId,
+    matrixUserId: input.matrixUserId,
+    personal: input.personal,
+  });
+  if (!connectorAccountId) {
+    return null;
+  }
+  const { MatrixMembershipAuthority: Authority } = await import("./membership");
+  return {
+    authority: new Authority({
+      runtime: input.runtime,
+      connectorAccountId,
+      service,
+    }),
+    connectorAccountId,
+  };
+}
+
+/** Decision input for one inbound message's membership admission. */
+export interface MatrixMembershipGateDecisionInput {
+  roomId: string;
+  /** True for direct rooms (bypass — DMs are not membership-governed). */
+  isDirectRoom: boolean;
+  principalEntityId: UUID;
+  matrixUserId: string;
+  /** Live joined roster straight from the SDK state, for reconcile. */
+  getJoinedMemberIds: () => string[];
+}
+
+export class MatrixMembershipMessageGate {
+  private readonly runtime: IAgentRuntime;
+  private authority: MatrixMembershipAuthority | null;
+  private broken = false;
+  private readonly warned = new Set<string>();
+
+  constructor(input: {
+    runtime: IAgentRuntime;
+    authority: MatrixMembershipAuthority | null;
+  }) {
+    this.runtime = input.runtime;
+    this.authority = input.authority;
+  }
+
+  /** Marks the gate broken: authority bootstrap failed while configured. */
+  markBroken(): void {
+    this.broken = true;
+    this.authority = null;
+    this.warned.clear();
+  }
+
+  /** True when the message may proceed to agent dispatch. */
+  async authorizeMessage(input: MatrixMembershipGateDecisionInput): Promise<boolean> {
+    if (input.isDirectRoom) {
+      return true;
+    }
+    if (this.broken || (!this.authority && process.env.MATRIX_MEMBERSHIP_ENFORCE === "1")) {
+      this.warnOnce(
+        `authority-broken:${input.roomId}`,
+        "Matrix room admission denied: membership authority is unavailable",
+        { roomId: input.roomId }
+      );
+      return false;
+    }
+    if (!this.authority) {
+      // The membership authority service was never registered (deployment
+      // without plugin-sql): admission degrades to allow with a once-per-room
+      // structured warning. MATRIX_MEMBERSHIP_ENFORCE opts into strict
+      // fail-closed. When the service IS present but scope evidence is stale
+      // or unavailable, the deny path below still fails closed.
+      this.warnOnce(
+        `authority-absent:${input.roomId}`,
+        "Matrix room admission running without a membership authority service; membership checks disabled",
+        { roomId: input.roomId }
+      );
+      return true;
+    }
+    const decision = await this.authority.authorize({
+      roomId: input.roomId,
+      canonicalPrincipalId: input.principalEntityId,
+    });
+    if (decision.decision === "allowed") {
+      return true;
+    }
+    if (matrixMembershipShouldReconcile(decision)) {
+      // Reconcile against the SDK's live joined roster (m.room.member state is
+      // unencrypted, so this works in E2EE rooms too).
+      const joined = input.getJoinedMemberIds();
+      if (joined.includes(input.matrixUserId)) {
+        await this.authority.recordTransitionFromRoster({
+          roomId: input.roomId,
+          matrixUserId: input.matrixUserId,
+          canonicalPrincipalId: input.principalEntityId,
+        });
+        const recheck = await this.authority.authorize({
+          roomId: input.roomId,
+          canonicalPrincipalId: input.principalEntityId,
+        });
+        if (recheck.decision === "allowed") {
+          return true;
+        }
+        this.logDenial(input, recheck.reason, "post-reconcile");
+        return false;
+      }
+      this.logDenial(input, decision.reason, "roster-miss");
+      return false;
+    }
+    this.logDenial(input, decision.reason, "authority");
+    return false;
+  }
+
+  private logDenial(input: MatrixMembershipGateDecisionInput, reason: string, stage: string): void {
+    logger.warn(
+      {
+        src: "plugin:matrix",
+        agentId: this.runtime.agentId,
+        roomId: input.roomId,
+        matrixUserId: input.matrixUserId,
+        reason,
+        stage,
+      },
+      "Matrix room message denied by membership authority"
+    );
+  }
+
+  private warnOnce(key: string, message: string, context: unknown): void {
+    if (this.warned.has(key)) return;
+    this.warned.add(key);
+    logger.warn(
+      {
+        src: "plugin:matrix",
+        agentId: this.runtime.agentId,
+        ...(context as { roomId?: string }),
+      },
+      message
+    );
+  }
+}

--- a/plugins/plugin-matrix/src/membership-gate.ts
+++ b/plugins/plugin-matrix/src/membership-gate.ts
@@ -149,10 +149,21 @@ export class MatrixMembershipMessageGate {
 
   /** True when the message may proceed to agent dispatch. */
   async authorizeMessage(input: MatrixMembershipGateDecisionInput): Promise<boolean> {
+    // A BROKEN gate fails closed for EVERY room, direct rooms included: a
+    // configured authority that failed bootstrap must never be bypassed by
+    // room shape. (The absent-authority legacy mode below still allows DMs.)
+    if (this.broken) {
+      this.warnOnce(
+        `authority-broken:${input.roomId}`,
+        "Matrix room admission denied: membership authority is unavailable",
+        { roomId: input.roomId }
+      );
+      return false;
+    }
     if (input.isDirectRoom) {
       return true;
     }
-    if (this.broken || (!this.authority && process.env.MATRIX_MEMBERSHIP_ENFORCE === "1")) {
+    if (!this.authority && process.env.MATRIX_MEMBERSHIP_ENFORCE === "1") {
       this.warnOnce(
         `authority-broken:${input.roomId}`,
         "Matrix room admission denied: membership authority is unavailable",

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -141,7 +141,13 @@ export function matrixMemberRoles(powerLevel: number): readonly string[] {
 
 /** Deterministic observation time for a Matrix event. */
 export function matrixObservedAt(eventTs: number): string {
-  return new Date(eventTs).toISOString();
+  // Lazy-loaded membership state events can surface without a server
+  // timestamp, and a finite-but-out-of-range value (|ts| >= 8.64e15) still
+  // yields an Invalid Date — either would throw in toISOString() and
+  // poison the evidence command. Fall back to wall-clock observation.
+  const parsed = Number.isFinite(eventTs) ? new Date(eventTs) : new Date();
+  const observed = Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  return observed.toISOString();
 }
 
 function scopeKey(scope: MembershipScope): string {

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -781,13 +781,29 @@ export class MatrixMembershipAuthority {
 
   /**
    * Clears a recorded incompleteness once the caller has independently
-   * established complete state (a fully resolved roster in a fresh sync).
-   * Scoped to ONE reason at a time so a caller may only clear the flag it
-   * just disproved — never blanket-clear flags other observers set.
+   * established complete state. Scoped to ONE reason at a time so a caller
+   * may only clear the flag it just disproved — never blanket-clear flags
+   * other observers set.
    */
   clearRoomIncomplete(roomId: string, reason: string): boolean {
     const recorded = this.incompleteReasons.get(roomId);
     if (recorded !== reason) {
+      return false;
+    }
+    this.incompleteRooms.delete(roomId);
+    this.incompleteReasons.delete(roomId);
+    return true;
+  }
+
+  /**
+   * Clears every TRANSIENT incompleteness reason after the caller performed
+   * a genuinely fresh server-side member fetch that returned a full roster
+   * (client.members, not the SDK's one-shot cached loadMembersIfNeeded).
+   * A verified fresh fetch disproves member_load_failed, empty_roster,
+   * member_list_incomplete, and limited_sync_timeline_reset at once.
+   */
+  clearTransientRoomIncompleteness(roomId: string): boolean {
+    if (!this.incompleteRooms.has(roomId)) {
       return false;
     }
     this.incompleteRooms.delete(roomId);

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -221,14 +221,18 @@ export class MatrixMembershipAuthority {
    * Registers the scope publisher or adopts the persisted binding this
    * publisher already owns. Callers already hold the per-scope chain.
    */
-  private async ensureRegistered(
-    scope: MembershipScope,
-    evidenceMode: "complete_snapshot" | "ordered_delta"
-  ): Promise<ScopeTracker> {
+  private async ensureRegistered(scope: MembershipScope): Promise<ScopeTracker> {
     const key = scopeKey(scope);
     const cached = this.scopes.get(key);
     if (cached) return cached;
     const health = await this.service.getScopeHealth(scope);
+    // Single evidence mode for a scope's whole lifetime: the SQL authority
+    // requires every evidence command's mode to equal the registered
+    // publisher mode, and ordered_delta publishers may submit complete
+    // snapshots as their baseline. Registering a Matrix scope as
+    // "ordered_delta" up front keeps roster snapshots and join/leave deltas on
+    // one binding instead of fighting MEMBERSHIP_PUBLISHER_MISMATCH.
+    const evidenceMode = "ordered_delta" as const;
     if (
       health &&
       health.publisherInstanceId === this.publisherInstanceId &&
@@ -271,10 +275,7 @@ export class MatrixMembershipAuthority {
   }
 
   /** Re-reads persisted scope state after a pre-commit fencing failure. */
-  private async readoptFromHealth(
-    scope: MembershipScope,
-    evidenceMode: "complete_snapshot" | "ordered_delta"
-  ): Promise<ScopeTracker> {
+  private async readoptFromHealth(scope: MembershipScope): Promise<ScopeTracker> {
     const health = await this.service.getScopeHealth(scope);
     if (health && health.publisherInstanceId !== this.publisherInstanceId) {
       const publisherGeneration = (health.publisherGeneration ?? -1) + 1;
@@ -282,7 +283,7 @@ export class MatrixMembershipAuthority {
         ...scope,
         publisherInstanceId: this.publisherInstanceId,
         publisherGeneration,
-        evidenceMode,
+        evidenceMode: "ordered_delta",
         expectedGeneration: health.generation,
         idempotencyKey: `mx:${this.connectorAccountId}:publisher:${scope.externalRoomId}:${publisherGeneration}`,
         observedAt: new Date().toISOString(),
@@ -325,7 +326,12 @@ export class MatrixMembershipAuthority {
     const key = scopeKey(input.scope);
     for (let attempt = 0; attempt < 3; attempt++) {
       const health = await this.service.getScopeHealth(input.scope);
-      const expectedGeneration = health?.generation ?? 0;
+      if (!health) {
+        // No scope row exists (the room was never snapshotted): nothing to
+        // degrade, and no evidence was ever authorizing. Not an error.
+        return;
+      }
+      const expectedGeneration = health.generation;
       try {
         const receipt = await this.service.setScopeHealth({
           ...input.scope,
@@ -397,7 +403,7 @@ export class MatrixMembershipAuthority {
       if (!this.predateCheck(key, input.observedAt, input.roomId, "snapshot")) {
         return false;
       }
-      let tracker = await this.ensureRegistered(scope, "complete_snapshot");
+      let tracker = await this.ensureRegistered(scope);
       for (let attempt = 0; attempt < 2; attempt++) {
         const sourceVersion = tracker.sourceVersion + 1;
         const sourceCursor = `mx:${sourceVersion}`;
@@ -406,7 +412,10 @@ export class MatrixMembershipAuthority {
             ...scope,
             publisherInstanceId: this.publisherInstanceId,
             publisherGeneration: tracker.publisherGeneration,
-            evidenceMode: "complete_snapshot",
+            // Baseline submitted under the scope's single publisher mode;
+            // ordered_delta publishers establish their complete baseline with
+            // applyCompleteSnapshot and then stream deltas.
+            evidenceMode: "ordered_delta",
             expectedGeneration: tracker.generation,
             sourceVersion,
             previousSourceCursor: tracker.sourceCursor,
@@ -426,11 +435,11 @@ export class MatrixMembershipAuthority {
           this.incompleteRooms.delete(input.roomId);
           return true;
         } catch (error) {
-          if (this.handleFenceOrDuplicate(error, attempt, scope, "complete_snapshot")) {
+          if (this.handleFenceOrDuplicate(error, attempt, scope, "ordered_delta")) {
             if (authorityErrorCode(error) === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
               return false;
             }
-            tracker = await this.readoptFromHealth(scope, "complete_snapshot");
+            tracker = await this.readoptFromHealth(scope);
             continue;
           }
           // error-policy:J2 A non-fencing failure (storage outage) propagates:
@@ -461,14 +470,17 @@ export class MatrixMembershipAuthority {
     });
     const key = scopeKey(scope);
     await this.serialized(key, async () => {
-      let tracker = await this.ensureRegistered(scope, "complete_snapshot");
+      // ensureRegistered creates the scope row when absent, so an incomplete
+      // observation on a fresh room persists explicit stale evidence
+      // (fail-closed) rather than relying on the absence of evidence.
+      let tracker = await this.ensureRegistered(scope);
       for (let attempt = 0; attempt < 2; attempt++) {
         try {
           await this.service.reportIncompleteSnapshot({
             ...scope,
             publisherInstanceId: this.publisherInstanceId,
             publisherGeneration: tracker.publisherGeneration,
-            evidenceMode: "complete_snapshot",
+            evidenceMode: "ordered_delta",
             expectedGeneration: tracker.generation,
             idempotencyKey: `mx:${this.connectorAccountId}:${input.roomId}:incomplete:${input.reason}:${tracker.generation}:${attempt}`,
             observedAt: input.observedAt,
@@ -478,11 +490,11 @@ export class MatrixMembershipAuthority {
           this.markRoomIncomplete(input.roomId);
           return;
         } catch (error) {
-          if (this.handleFenceOrDuplicate(error, attempt, scope, "complete_snapshot")) {
+          if (this.handleFenceOrDuplicate(error, attempt, scope, "ordered_delta")) {
             if (authorityErrorCode(error) === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
               return;
             }
-            tracker = await this.readoptFromHealth(scope, "complete_snapshot");
+            tracker = await this.readoptFromHealth(scope);
             continue;
           }
           // error-policy:J7 Incompleteness reporting is diagnostic: the scope
@@ -539,7 +551,7 @@ export class MatrixMembershipAuthority {
         if (!this.predateCheck(key, input.observedAt, input.roomId, "transition")) {
           return;
         }
-        let tracker = await this.ensureRegistered(scope, "ordered_delta");
+        let tracker = await this.ensureRegistered(scope);
         // Out-of-order guard: a fact older than the principal's committed
         // evidence must never overwrite it. STRICT on the dangerous
         // direction: only a strictly newer active observation may replace a
@@ -611,7 +623,7 @@ export class MatrixMembershipAuthority {
                 );
                 return;
               }
-              tracker = await this.readoptFromHealth(scope, "ordered_delta");
+              tracker = await this.readoptFromHealth(scope);
               // The competing write may have committed NEWER evidence for
               // THIS principal: re-run the out-of-order guard before retrying.
               const recommitted = await this.service.getMembership(
@@ -800,7 +812,7 @@ export class MatrixMembershipAuthority {
     error: unknown,
     attempt: number,
     _scope: MembershipScope,
-    _mode: "complete_snapshot" | "ordered_delta"
+    _mode: "ordered_delta"
   ): boolean {
     const code = authorityErrorCode(error);
     if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -1,0 +1,816 @@
+/**
+ * Matrix-side client for the canonical membership authority
+ * (`MembershipService`, core contract + SqlMembershipService in plugin-sql).
+ *
+ * Owns the connector's publisher discipline for Matrix room scopes: complete
+ * `getJoinedMembers` snapshots published only for complete state (first
+ * PREPARED sync, explicit joins, and reconnects that re-saw the full room),
+ * ordered join/invite/leave/ban deltas from `RoomMemberEvent.Membership`,
+ * and fail-closed admission decisions for group rooms. Direct-message rooms
+ * are not membership-governed (a two-member room is inherently addressed) and
+ * never register a scope.
+ */
+import type {
+  IAgentRuntime,
+  JsonObject,
+  MembershipAuthorizationDecision,
+  MembershipScope,
+  MembershipScopeHealth,
+  MembershipService,
+  UUID,
+} from "@elizaos/core";
+import { ElizaError, logger, ServiceType } from "@elizaos/core";
+
+/** Evidence freshness window for Matrix facts (under the authority's 24h cap). */
+export const MATRIX_MEMBERSHIP_TTL_MS = 60 * 60 * 1_000;
+
+export type MatrixMembershipReason = "joined" | "reconciled_present" | "left" | "kicked" | "banned";
+
+export type MatrixMembershipTransition = "join" | "invite" | "leave" | "ban";
+
+interface ScopeTracker {
+  generation: number;
+  sourceVersion: number;
+  sourceCursor: string | null;
+  publisherGeneration: number;
+}
+
+/**
+ * Denied reasons that warrant a reconcile before failing admission (the
+ * authority has no fresh evidence for this principal).
+ */
+const RECONCILE_MISS_REASONS = new Set([
+  "no_scope_evidence",
+  "no_membership",
+  "membership_evidence_mismatch",
+  "membership_evidence_expired",
+  "authority_expired",
+]);
+
+export function matrixMembershipShouldReconcile(
+  decision: MembershipAuthorizationDecision
+): boolean {
+  return decision.decision === "denied" && RECONCILE_MISS_REASONS.has(decision.reason);
+}
+
+export function isMembershipService(service: unknown): service is MembershipService {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    typeof (service as MembershipService).registerPublisher === "function" &&
+    typeof (service as MembershipService).authorize === "function"
+  );
+}
+
+export function resolveMembershipService(runtime: IAgentRuntime): MembershipService | null {
+  const service = runtime.getService(ServiceType.MEMBERSHIP);
+  return isMembershipService(service) ? service : null;
+}
+
+/**
+ * Room-granular scope. `externalWorldId` and `externalRoomId` are both the raw
+ * Matrix room id (`!room:server`) — a Matrix room is its own world — which
+ * keeps the scope stable across process restarts and account rotations.
+ */
+export function matrixMembershipScope(input: {
+  agentId: UUID;
+  connectorAccountId: UUID;
+  roomId: string;
+}): MembershipScope {
+  return {
+    agentId: input.agentId,
+    // Must equal the connector_accounts row provider ("matrix").
+    connectorId: "matrix",
+    connectorAccountId: input.connectorAccountId,
+    externalWorldId: input.roomId,
+    externalRoomId: input.roomId,
+  };
+}
+
+/**
+ * Matrix membership transition -> authority (state, reason). A kick is a leave
+ * event whose sender differs from the subject; the caller classifies it.
+ */
+export function matrixTransitionToMembership(transition: MatrixMembershipTransition): {
+  state: "active" | "revoked";
+  reason: MatrixMembershipReason;
+} {
+  switch (transition) {
+    case "join":
+      return { state: "active", reason: "joined" };
+    case "invite":
+      // An invite is not admission; record it as revoked so a pending invite
+      // alone can never authorize group participation.
+      return { state: "revoked", reason: "left" };
+    case "leave":
+      return { state: "revoked", reason: "left" };
+    case "ban":
+      return { state: "revoked", reason: "banned" };
+  }
+}
+
+/** Classify a membership transition for a subject from old/new membership. */
+export function classifyMatrixTransition(
+  membership: string | undefined,
+  previousMembership: string | undefined
+): MatrixMembershipTransition {
+  switch (membership) {
+    case "join":
+      return "join";
+    case "invite":
+      return "invite";
+    case "ban":
+      return "ban";
+    case "leave":
+      // A leave arriving while the subject was banned is an un-ban (the
+      // membership resets to leave); treat as leave — it is still not active.
+      return previousMembership === "ban" ? "leave" : "leave";
+  }
+  return "leave";
+}
+
+/** Role snapshot derived from a Matrix power level (default 0 = member). */
+export function matrixMemberRoles(powerLevel: number): readonly string[] {
+  if (powerLevel >= 100) return ["owner"];
+  if (powerLevel >= 50) return ["administrator"];
+  return ["member"];
+}
+
+/** Deterministic observation time for a Matrix event. */
+export function matrixObservedAt(eventTs: number): string {
+  return new Date(eventTs).toISOString();
+}
+
+function scopeKey(scope: MembershipScope): string {
+  return `${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+}
+
+function authorityErrorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : "";
+}
+
+function scopeLog(runtime: IAgentRuntime, message: string, context: Record<string, unknown>): void {
+  logger.debug({ src: "plugin:matrix", agentId: runtime.agentId, ...context }, message);
+}
+
+/**
+ * Per-(agent, Matrix account) client for the membership authority. Matrix is a
+ * snapshot-capable publisher: the first PREPARED sync (and each explicit join)
+ * publishes a complete roster snapshot, and live member transitions publish
+ * ordered deltas on top. Scope trackers are seeded from persisted scope health
+ * so a restarted process continues the persisted publisher binding instead of
+ * re-registering (which would strand member facts behind a publisher mismatch).
+ */
+export class MatrixMembershipAuthority {
+  private readonly runtime: IAgentRuntime;
+  private readonly connectorAccountId: UUID;
+  private readonly service: MembershipService;
+  private readonly publisherInstanceId: string;
+  private readonly scopes = new Map<string, ScopeTracker>();
+  private readonly chains = new Map<string, Promise<unknown>>();
+  /**
+   * Bot-leave tombstones by scope key. Once the bot itself has left a room, no
+   * further evidence may advance that scope back to current: a backlogged
+   * transition after the leave would otherwise re-authorize stale member facts
+   * for a room the bot can no longer observe. Only an explicit bot rejoin
+   * clears the tombstone.
+   */
+  private readonly leftScopes = new Map<string, string>();
+  /**
+   * Rejoin watermarks by scope key (epoch ms). After the bot rejoins, evidence
+   * observed BEFORE the rejoin moment is backlogged and must not authorize.
+   */
+  private readonly scopeRejoinWatermarks = new Map<string, number>();
+  /**
+   * Rooms whose member list is known incomplete (lazy loading unresolved or a
+   * limited sync gap). Snapshots are reported incomplete — never as empty or
+   * complete — until complete state is observed.
+   */
+  private readonly incompleteRooms = new Set<string>();
+
+  constructor(input: {
+    runtime: IAgentRuntime;
+    connectorAccountId: UUID;
+    service: MembershipService;
+  }) {
+    this.runtime = input.runtime;
+    this.connectorAccountId = input.connectorAccountId;
+    this.service = input.service;
+    this.publisherInstanceId = `matrix:${input.runtime.agentId}:${input.connectorAccountId}`;
+  }
+
+  /** Serializes authority command issuance per scope. */
+  private serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prior = this.chains.get(key) ?? Promise.resolve();
+    const run = prior.then(
+      () => fn(),
+      () => fn()
+    );
+    this.chains.set(
+      key,
+      // error-policy:J5 The chain placeholder must never reject: the same
+      // rejection is already observed by the caller awaiting `run`; swallowing
+      // it here only keeps the chain link settled.
+      run.catch(() => {})
+    );
+    return run;
+  }
+
+  /**
+   * Registers the scope publisher or adopts the persisted binding this
+   * publisher already owns. Callers already hold the per-scope chain.
+   */
+  private async ensureRegistered(
+    scope: MembershipScope,
+    evidenceMode: "complete_snapshot" | "ordered_delta"
+  ): Promise<ScopeTracker> {
+    const key = scopeKey(scope);
+    const cached = this.scopes.get(key);
+    if (cached) return cached;
+    const health = await this.service.getScopeHealth(scope);
+    if (
+      health &&
+      health.publisherInstanceId === this.publisherInstanceId &&
+      health.evidenceMode === evidenceMode
+    ) {
+      // Adoption: continue the persisted binding.
+      const tracker: ScopeTracker = {
+        generation: health.generation,
+        sourceVersion: health.sourceVersion,
+        sourceCursor: health.sourceCursor,
+        publisherGeneration: health.publisherGeneration ?? 0,
+      };
+      this.scopes.set(key, tracker);
+      return tracker;
+    }
+    const publisherGeneration = (health?.publisherGeneration ?? -1) + 1;
+    const receipt = await this.service.registerPublisher({
+      ...scope,
+      publisherInstanceId: this.publisherInstanceId,
+      publisherGeneration,
+      evidenceMode,
+      expectedGeneration: health?.generation ?? 0,
+      idempotencyKey: `mx:${this.connectorAccountId}:publisher:${scope.externalRoomId}:${publisherGeneration}`,
+      observedAt: new Date().toISOString(),
+    });
+    if (receipt.operation !== "publisher") {
+      throw new ElizaError(
+        `Matrix membership publisher registration returned ${receipt.operation}`,
+        { code: "MATRIX_MEMBERSHIP_PUBLISHER_PROTOCOL" }
+      );
+    }
+    const tracker: ScopeTracker = {
+      generation: receipt.committedGeneration,
+      sourceVersion: -1,
+      sourceCursor: null,
+      publisherGeneration,
+    };
+    this.scopes.set(key, tracker);
+    return tracker;
+  }
+
+  /** Re-reads persisted scope state after a pre-commit fencing failure. */
+  private async readoptFromHealth(
+    scope: MembershipScope,
+    evidenceMode: "complete_snapshot" | "ordered_delta"
+  ): Promise<ScopeTracker> {
+    const health = await this.service.getScopeHealth(scope);
+    if (health && health.publisherInstanceId !== this.publisherInstanceId) {
+      const publisherGeneration = (health.publisherGeneration ?? -1) + 1;
+      const receipt = await this.service.registerPublisher({
+        ...scope,
+        publisherInstanceId: this.publisherInstanceId,
+        publisherGeneration,
+        evidenceMode,
+        expectedGeneration: health.generation,
+        idempotencyKey: `mx:${this.connectorAccountId}:publisher:${scope.externalRoomId}:${publisherGeneration}`,
+        observedAt: new Date().toISOString(),
+      });
+      if (receipt.operation !== "publisher") {
+        throw new ElizaError(`Matrix membership publisher takeover returned ${receipt.operation}`, {
+          code: "MATRIX_MEMBERSHIP_PUBLISHER_PROTOCOL",
+        });
+      }
+      const tracker: ScopeTracker = {
+        generation: receipt.committedGeneration,
+        sourceVersion: -1,
+        sourceCursor: null,
+        publisherGeneration,
+      };
+      this.scopes.set(scopeKey(scope), tracker);
+      return tracker;
+    }
+    const tracker: ScopeTracker = {
+      generation: health?.generation ?? 0,
+      sourceVersion: health?.sourceVersion ?? -1,
+      sourceCursor: health?.sourceCursor ?? null,
+      publisherGeneration: health?.publisherGeneration ?? 0,
+    };
+    this.scopes.set(scopeKey(scope), tracker);
+    return tracker;
+  }
+
+  /**
+   * Degrades the scope to a non-current health so admission fails closed.
+   * Retries generation fencing; THROWS on persistent failure so callers can
+   * escalate — failure is never silently converted back to an authorizing
+   * state.
+   */
+  private async degradeScope(input: {
+    scope: MembershipScope;
+    health: "stale" | "unavailable";
+    reason: string;
+  }): Promise<void> {
+    const key = scopeKey(input.scope);
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const health = await this.service.getScopeHealth(input.scope);
+      const expectedGeneration = health?.generation ?? 0;
+      try {
+        const receipt = await this.service.setScopeHealth({
+          ...input.scope,
+          expectedGeneration,
+          idempotencyKey: `mx:${this.connectorAccountId}:${input.scope.externalRoomId}:${input.health}:${input.reason}:${expectedGeneration}:${attempt}`,
+          health: input.health,
+          reason: input.reason,
+          observedAt: new Date().toISOString(),
+        });
+        if (receipt.operation === "health") {
+          this.scopes.delete(key);
+          return;
+        }
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("MEMBERSHIP_GENERATION_MISMATCH") &&
+          attempt < 2
+        ) {
+          continue;
+        }
+        // error-policy:J2 Generation moved persistently under us: wrap and
+        // rethrow so the caller can escalate rather than treating the scope as
+        // successfully degraded.
+        throw error;
+      }
+    }
+    throw new ElizaError(
+      `Matrix membership scope ${input.health}-degrade exhausted retries for ${input.scope.externalRoomId}`,
+      { code: "MATRIX_MEMBERSHIP_DEGRADE_EXHAUSTED" }
+    );
+  }
+
+  /**
+   * Publishes a complete room roster snapshot. ONLY call when the member list
+   * is known complete (the SDK state holds every joined member — first
+   * PREPARED sync after lazy-load resolution, or an explicit join).
+   */
+  async publishSnapshot(input: {
+    roomId: string;
+    observedAt: string;
+    members: readonly {
+      canonicalPrincipalId: UUID;
+      roles: readonly string[];
+      permissionSnapshot: JsonObject;
+      runtime: {
+        worldId: UUID | null;
+        roomId: UUID | null;
+        entityId: UUID | null;
+      };
+    }[];
+    idempotencyKey: string;
+  }): Promise<boolean> {
+    const scope = matrixMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      roomId: input.roomId,
+    });
+    const key = scopeKey(scope);
+    return this.serialized(key, async () => {
+      const removalReason = this.leftScopes.get(key);
+      if (removalReason !== undefined) {
+        scopeLog(this.runtime, "Matrix membership snapshot rejected for a left scope; skipping", {
+          roomId: input.roomId,
+          removalReason,
+        });
+        return false;
+      }
+      if (!this.predateCheck(key, input.observedAt, input.roomId, "snapshot")) {
+        return false;
+      }
+      let tracker = await this.ensureRegistered(scope, "complete_snapshot");
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const sourceVersion = tracker.sourceVersion + 1;
+        const sourceCursor = `mx:${sourceVersion}`;
+        try {
+          await this.service.applyCompleteSnapshot({
+            ...scope,
+            publisherInstanceId: this.publisherInstanceId,
+            publisherGeneration: tracker.publisherGeneration,
+            evidenceMode: "complete_snapshot",
+            expectedGeneration: tracker.generation,
+            sourceVersion,
+            previousSourceCursor: tracker.sourceCursor,
+            sourceCursor,
+            validUntil: new Date(
+              Date.parse(input.observedAt) + MATRIX_MEMBERSHIP_TTL_MS
+            ).toISOString(),
+            completeness: "complete",
+            members: input.members,
+            idempotencyKey:
+              attempt === 0 ? input.idempotencyKey : `${input.idempotencyKey}:retry${attempt}`,
+            observedAt: input.observedAt,
+          });
+          tracker.generation += 1;
+          tracker.sourceVersion = sourceVersion;
+          tracker.sourceCursor = sourceCursor;
+          this.incompleteRooms.delete(input.roomId);
+          return true;
+        } catch (error) {
+          if (this.handleFenceOrDuplicate(error, attempt, scope, "complete_snapshot")) {
+            if (authorityErrorCode(error) === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+              return false;
+            }
+            tracker = await this.readoptFromHealth(scope, "complete_snapshot");
+            continue;
+          }
+          // error-policy:J2 A non-fencing failure (storage outage) propagates:
+          // the room keeps its previous authoritative state and callers see
+          // the failure rather than a fabricated success.
+          throw error;
+        }
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Reports a room scope as having an incomplete snapshot (lazy loading
+   * unresolved or a limited sync gap): consumers see unavailable
+   * (indeterminate) rather than empty. A later complete snapshot may restore
+   * the scope.
+   */
+  async reportIncomplete(input: {
+    roomId: string;
+    reason: string;
+    observedAt: string;
+  }): Promise<void> {
+    const scope = matrixMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      roomId: input.roomId,
+    });
+    const key = scopeKey(scope);
+    await this.serialized(key, async () => {
+      let tracker = await this.ensureRegistered(scope, "complete_snapshot");
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          await this.service.reportIncompleteSnapshot({
+            ...scope,
+            publisherInstanceId: this.publisherInstanceId,
+            publisherGeneration: tracker.publisherGeneration,
+            evidenceMode: "complete_snapshot",
+            expectedGeneration: tracker.generation,
+            idempotencyKey: `mx:${this.connectorAccountId}:${input.roomId}:incomplete:${input.reason}:${tracker.generation}:${attempt}`,
+            observedAt: input.observedAt,
+            completeness: "incomplete",
+            reason: input.reason,
+          });
+          this.markRoomIncomplete(input.roomId);
+          return;
+        } catch (error) {
+          if (this.handleFenceOrDuplicate(error, attempt, scope, "complete_snapshot")) {
+            if (authorityErrorCode(error) === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+              return;
+            }
+            tracker = await this.readoptFromHealth(scope, "complete_snapshot");
+            continue;
+          }
+          // error-policy:J7 Incompleteness reporting is diagnostic: the scope
+          // keeps its prior health and the sync loop must survive. Report and
+          // stop rather than fail the caller's sync handling.
+          this.runtime.reportError("matrix:membership-incomplete-report", error, {
+            roomId: input.roomId,
+            reason: input.reason,
+          });
+          return;
+        }
+      }
+    });
+  }
+
+  /**
+   * Records a join/invite/leave/ban observation from a Matrix membership state
+   * event. Deterministic idempotency key (membership event id) makes duplicate
+   * and out-of-order redeliveries non-resurrecting.
+   */
+  async recordTransition(input: {
+    roomId: string;
+    canonicalPrincipalId: UUID;
+    transition: MatrixMembershipTransition;
+    roles?: readonly string[];
+    permissionSnapshot?: JsonObject;
+    runtime: {
+      worldId: UUID | null;
+      roomId: UUID | null;
+      entityId: UUID | null;
+    };
+    eventId: string;
+    matrixUserId: string;
+    observedAt: string;
+  }): Promise<void> {
+    const scope = matrixMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      roomId: input.roomId,
+    });
+    const mapped = matrixTransitionToMembership(input.transition);
+    const key = scopeKey(scope);
+    try {
+      await this.serialized(key, async () => {
+        const removalReason = this.leftScopes.get(key);
+        if (removalReason !== undefined) {
+          scopeLog(
+            this.runtime,
+            "Matrix membership transition rejected for a left scope; skipping",
+            { roomId: input.roomId, removalReason }
+          );
+          return;
+        }
+        if (!this.predateCheck(key, input.observedAt, input.roomId, "transition")) {
+          return;
+        }
+        let tracker = await this.ensureRegistered(scope, "ordered_delta");
+        // Out-of-order guard: a fact older than the principal's committed
+        // evidence must never overwrite it. STRICT on the dangerous
+        // direction: only a strictly newer active observation may replace a
+        // committed revocation; an equal-stamp active-after-revoked is skipped
+        // (Matrix origin_server_ts has millisecond resolution, but two events
+        // for the same subject can still share a stamp).
+        const committed = await this.service.getMembership(scope, input.canonicalPrincipalId);
+        const committedAt = committed ? Date.parse(committed.observedAt) : 0;
+        const observedAtMs = Date.parse(input.observedAt);
+        const wouldResurrect = committed?.state === "revoked" && mapped.state === "active";
+        if (
+          committed &&
+          (observedAtMs < committedAt || (observedAtMs === committedAt && wouldResurrect))
+        ) {
+          scopeLog(
+            this.runtime,
+            "Matrix membership fact is older than committed evidence; skipping",
+            {
+              roomId: input.roomId,
+              matrixUserId: input.matrixUserId,
+              incomingObservedAt: input.observedAt,
+              committedObservedAt: committed.observedAt,
+            }
+          );
+          return;
+        }
+        for (let attempt = 0; attempt < 2; attempt++) {
+          const sourceVersion = tracker.sourceVersion + 1;
+          const sourceCursor = `mx:${sourceVersion}`;
+          try {
+            await this.service.applyMembership({
+              ...scope,
+              publisherInstanceId: this.publisherInstanceId,
+              publisherGeneration: tracker.publisherGeneration,
+              evidenceMode: "ordered_delta",
+              expectedGeneration: tracker.generation,
+              sourceVersion,
+              previousSourceCursor: tracker.sourceCursor,
+              sourceCursor,
+              validUntil: new Date(
+                Date.parse(input.observedAt) + MATRIX_MEMBERSHIP_TTL_MS
+              ).toISOString(),
+              canonicalPrincipalId: input.canonicalPrincipalId,
+              state: mapped.state,
+              reason: mapped.reason,
+              roles: [...(input.roles ?? ["member"])],
+              permissionSnapshot: input.permissionSnapshot ?? {},
+              runtime: input.runtime,
+              idempotencyKey:
+                attempt === 0
+                  ? `mx:${this.connectorAccountId}:${input.roomId}:event:${input.eventId}`
+                  : `mx:${this.connectorAccountId}:${input.roomId}:event:${input.eventId}:retry${attempt}`,
+              observedAt: input.observedAt,
+            });
+            tracker.generation += 1;
+            tracker.sourceVersion = sourceVersion;
+            tracker.sourceCursor = sourceCursor;
+            return;
+          } catch (error) {
+            if (this.handleFenceOrDuplicate(error, attempt, scope, "ordered_delta")) {
+              if (authorityErrorCode(error) === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+                scopeLog(
+                  this.runtime,
+                  "Matrix membership transition rejected as a duplicate; skipping",
+                  {
+                    roomId: input.roomId,
+                    eventId: input.eventId,
+                  }
+                );
+                return;
+              }
+              tracker = await this.readoptFromHealth(scope, "ordered_delta");
+              // The competing write may have committed NEWER evidence for
+              // THIS principal: re-run the out-of-order guard before retrying.
+              const recommitted = await this.service.getMembership(
+                scope,
+                input.canonicalPrincipalId
+              );
+              const recommittedAt = recommitted ? Date.parse(recommitted.observedAt) : 0;
+              const nowResurrects = recommitted?.state === "revoked" && mapped.state === "active";
+              if (
+                recommitted &&
+                (observedAtMs < recommittedAt || (observedAtMs === recommittedAt && nowResurrects))
+              ) {
+                scopeLog(
+                  this.runtime,
+                  "Matrix membership retry would overwrite newer committed evidence; skipping",
+                  {
+                    roomId: input.roomId,
+                    matrixUserId: input.matrixUserId,
+                    fenceRetry: true,
+                  }
+                );
+                return;
+              }
+              continue;
+            }
+            // error-policy:J2 A non-fencing failure propagates to the outer
+            // catch, which reports it without killing the sync loop.
+            throw error;
+          }
+        }
+      });
+    } catch (error) {
+      // error-policy:J7 Authority diagnostics must not kill the sync loop.
+      this.runtime.reportError("matrix:membership-evidence", error, {
+        roomId: input.roomId,
+        matrixUserId: input.matrixUserId,
+        transition: input.transition,
+      });
+    }
+  }
+
+  /**
+   * Point-query reconcile against the SDK's live joined roster: when the
+   * subject is present in the current joined-member state, records a
+   * reconciled_present membership fact. A roster miss records nothing (the
+   * denial stands); the SDK roster is authoritative presence, not absence.
+   */
+  async recordTransitionFromRoster(input: {
+    roomId: string;
+    matrixUserId: string;
+    canonicalPrincipalId: UUID;
+  }): Promise<void> {
+    await this.recordTransition({
+      roomId: input.roomId,
+      canonicalPrincipalId: input.canonicalPrincipalId,
+      transition: "join",
+      roles: ["member"],
+      permissionSnapshot: { reconciled: "roster" },
+      runtime: { worldId: null, roomId: null, entityId: null },
+      eventId: `roster:${input.matrixUserId}:${Date.now()}`,
+      matrixUserId: input.matrixUserId,
+      observedAt: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Fail-closed admission decision for a group room scope. Runs inside the
+   * per-scope chain so it is ordered behind evidence writes already queued.
+   */
+  async authorize(input: {
+    roomId: string;
+    canonicalPrincipalId: UUID;
+  }): Promise<MembershipAuthorizationDecision> {
+    const scope = matrixMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      roomId: input.roomId,
+    });
+    return this.serialized(scopeKey(scope), () =>
+      this.service.authorize(scope, input.canonicalPrincipalId)
+    );
+  }
+
+  /**
+   * Marks a room scope unavailable (the bot left or was removed/kicked/banned):
+   * every later admission for the scope fails closed with
+   * `authority_unavailable`, and further evidence is tombstoned until the bot
+   * explicitly rejoins. THROWS on persistent fencing failure so the caller can
+   * escalate.
+   */
+  async markScopeUnavailable(input: { roomId: string; reason: string }): Promise<void> {
+    const scope = matrixMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      roomId: input.roomId,
+    });
+    const key = scopeKey(scope);
+    await this.serialized(key, async () => {
+      await this.degradeScope({
+        scope,
+        health: "unavailable",
+        reason: input.reason,
+      });
+      this.leftScopes.set(key, input.reason);
+    });
+  }
+
+  /**
+   * Marks a room scope stale (transient evidence trouble) so admission fails
+   * closed until fresh evidence lands.
+   */
+  async markScopeStale(input: { roomId: string; reason: string }): Promise<void> {
+    const scope = matrixMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      roomId: input.roomId,
+    });
+    await this.serialized(scopeKey(scope), () =>
+      this.degradeScope({ scope, health: "stale", reason: input.reason })
+    );
+  }
+
+  /**
+   * Clears the bot-leave tombstone after an explicit rejoin. The next evidence
+   * write re-registers the publisher from persisted health, so
+   * re-authorization requires fresh evidence — pre-leave member facts stay
+   * non-authorizing.
+   */
+  clearScopeRemoval(input: { roomId: string }): void {
+    const key = scopeKey(
+      matrixMembershipScope({
+        agentId: this.runtime.agentId,
+        connectorAccountId: this.connectorAccountId,
+        roomId: input.roomId,
+      })
+    );
+    this.leftScopes.delete(key);
+    this.scopeRejoinWatermarks.set(key, Date.now());
+  }
+
+  /**
+   * Marks a room's member list as known-incomplete. Snapshots for the room are
+   * reported incomplete until complete state is observed.
+   */
+  markRoomIncomplete(roomId: string): void {
+    this.incompleteRooms.add(roomId);
+  }
+
+  isRoomIncomplete(roomId: string): boolean {
+    return this.incompleteRooms.has(roomId);
+  }
+
+  /** Read-only scope health accessor (tests and diagnostics). */
+  async scopeHealth(input: { roomId: string }): Promise<MembershipScopeHealth | null> {
+    return this.service.getScopeHealth(
+      matrixMembershipScope({
+        agentId: this.runtime.agentId,
+        connectorAccountId: this.connectorAccountId,
+        roomId: input.roomId,
+      })
+    );
+  }
+
+  /**
+   * Rejoin-watermark check shared by snapshot and transition paths. Returns
+   * true when the observation may proceed (not predating a rejoin).
+   */
+  private predateCheck(key: string, observedAt: string, roomId: string, kind: string): boolean {
+    const rejoinWatermark = this.scopeRejoinWatermarks.get(key);
+    if (rejoinWatermark !== undefined && Date.parse(observedAt) < rejoinWatermark) {
+      scopeLog(this.runtime, `Matrix membership ${kind} predates the bot rejoin; skipping`, {
+        roomId,
+        observedAt,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Classifies an authority error for the retry loop. Returns true when the
+   * error is handled (fencing failure worth one re-adopt retry, or a benign
+   * duplicate); callers consult authorityErrorCode for the duplicate case.
+   */
+  private handleFenceOrDuplicate(
+    error: unknown,
+    attempt: number,
+    _scope: MembershipScope,
+    _mode: "complete_snapshot" | "ordered_delta"
+  ): boolean {
+    const code = authorityErrorCode(error);
+    if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+      return true;
+    }
+    return (
+      attempt === 0 &&
+      (code === "MEMBERSHIP_CURSOR_DISCONTINUITY" ||
+        code === "MEMBERSHIP_GENERATION_MISMATCH" ||
+        code === "MEMBERSHIP_PUBLISHER_MISMATCH")
+    );
+  }
+}

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -502,9 +502,12 @@ export class MatrixMembershipAuthority {
             tracker = await this.readoptFromHealth(scope);
             continue;
           }
-          // error-policy:J7 Incompleteness reporting is diagnostic: the scope
-          // keeps its prior health and the sync loop must survive. Report and
-          // stop rather than fail the caller's sync handling.
+          // error-policy:J7 Incompleteness reporting is diagnostic for the
+          // sync loop, but it must fail admission CLOSED locally: when the
+          // authority store cannot persist the degraded health, the room is
+          // still known-incomplete here, and authorize() must not let a
+          // stale-current persisted decision speak for it.
+          this.markRoomIncomplete(input.roomId, input.reason);
           this.runtime.reportError("matrix:membership-incomplete-report", error, {
             roomId: input.roomId,
             reason: input.reason,
@@ -707,9 +710,26 @@ export class MatrixMembershipAuthority {
       connectorAccountId: this.connectorAccountId,
       roomId: input.roomId,
     });
-    return this.serialized(scopeKey(scope), () =>
-      this.service.authorize(scope, input.canonicalPrincipalId)
-    );
+    // Fail closed locally while the room is known-incomplete: the connector
+    // has observed an unreliable member list (limited sync, lazy-load gap, or
+    // a failed incompleteness persist), so even a persisted current decision
+    // cannot speak for the room. Not a reconcile-miss reason — the SDK roster
+    // is exactly what we distrust — so a hard denial, cleared only by a later
+    // complete snapshot or a fresh-server-roster recovery pass. Checked INSIDE
+    // the serialized section: an authorize queued behind an in-flight
+    // reportIncomplete must observe a flag the report sets while it holds the
+    // scope chain, not a pre-queue snapshot of it.
+    return this.serialized(scopeKey(scope), async () => {
+      if (this.incompleteRooms.has(input.roomId)) {
+        return {
+          decision: "denied",
+          reason: "authority_stale",
+          generation: null,
+          health: "stale",
+        } as MembershipAuthorizationDecision;
+      }
+      return this.service.authorize(scope, input.canonicalPrincipalId);
+    });
   }
 
   /**

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -188,6 +188,7 @@ export class MatrixMembershipAuthority {
    * complete — until complete state is observed.
    */
   private readonly incompleteRooms = new Set<string>();
+  private readonly incompleteReasons = new Map<string, string>();
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -433,6 +434,7 @@ export class MatrixMembershipAuthority {
           tracker.sourceVersion = sourceVersion;
           tracker.sourceCursor = sourceCursor;
           this.incompleteRooms.delete(input.roomId);
+          this.incompleteReasons.delete(input.roomId);
           return true;
         } catch (error) {
           if (this.handleFenceOrDuplicate(error, attempt, scope, "ordered_delta")) {
@@ -487,7 +489,7 @@ export class MatrixMembershipAuthority {
             completeness: "incomplete",
             reason: input.reason,
           });
-          this.markRoomIncomplete(input.roomId);
+          this.markRoomIncomplete(input.roomId, input.reason);
           return;
         } catch (error) {
           if (this.handleFenceOrDuplicate(error, attempt, scope, "ordered_delta")) {
@@ -768,12 +770,29 @@ export class MatrixMembershipAuthority {
    * Marks a room's member list as known-incomplete. Snapshots for the room are
    * reported incomplete until complete state is observed.
    */
-  markRoomIncomplete(roomId: string): void {
+  markRoomIncomplete(roomId: string, reason = "unknown"): void {
     this.incompleteRooms.add(roomId);
+    this.incompleteReasons.set(roomId, reason);
   }
 
   isRoomIncomplete(roomId: string): boolean {
     return this.incompleteRooms.has(roomId);
+  }
+
+  /**
+   * Clears a recorded incompleteness once the caller has independently
+   * established complete state (a fully resolved roster in a fresh sync).
+   * Scoped to ONE reason at a time so a caller may only clear the flag it
+   * just disproved — never blanket-clear flags other observers set.
+   */
+  clearRoomIncomplete(roomId: string, reason: string): boolean {
+    const recorded = this.incompleteReasons.get(roomId);
+    if (recorded !== reason) {
+      return false;
+    }
+    this.incompleteRooms.delete(roomId);
+    this.incompleteReasons.delete(roomId);
+    return true;
   }
 
   /** Read-only scope health accessor (tests and diagnostics). */

--- a/plugins/plugin-matrix/src/membership.ts
+++ b/plugins/plugin-matrix/src/membership.ts
@@ -113,7 +113,7 @@ export function matrixTransitionToMembership(transition: MatrixMembershipTransit
 export function classifyMatrixTransition(
   membership: string | undefined,
   previousMembership: string | undefined
-): MatrixMembershipTransition {
+): MatrixMembershipTransition | null {
   switch (membership) {
     case "join":
       return "join";
@@ -126,7 +126,10 @@ export function classifyMatrixTransition(
       // membership resets to leave); treat as leave — it is still not active.
       return previousMembership === "ban" ? "leave" : "leave";
   }
-  return "leave";
+  // Unknown or missing membership (undefined, "knock", future values) must
+  // never be interpreted as absence: revoking a principal requires an
+  // explicit leave/ban decision. Callers skip and report these.
+  return null;
 }
 
 /** Role snapshot derived from a Matrix power level (default 0 = member). */

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1173,10 +1173,15 @@ export class MatrixService extends Service implements IMatrixService {
         // First PREPARED after start (oldSyncToken null/undefined): publish
         // complete membership snapshots for joined rooms. Later PREPAREDs
         // (reconnects) re-publish from the SDK's accumulated state, which is
-        // complete for rooms already synced.
+        // complete for rooms already synced. A CACHED PREPARED (syncData
+        // fromCache, e.g. after a restart resuming from the store) is NOT
+        // fresh server state — publishing from it would restore possibly
+        // stale rosters as current evidence, so skip publication and let the
+        // recovery paths (scope-health probing) establish fresh state.
+        const firstPrepared = syncData?.oldSyncToken == null && syncData?.fromCache !== true;
         // error-policy:J7 snapshot publication is diagnostic and must not
         // kill the sync loop; the failure is logged for operator escalation.
-        void this.publishMembershipSnapshots(state, syncData?.oldSyncToken == null).catch((err) =>
+        void this.publishMembershipSnapshots(state, firstPrepared).catch((err) =>
           logger.error(
             `Matrix membership snapshot publication failed: ${err instanceof Error ? err.message : String(err)}`
           )
@@ -1329,21 +1334,42 @@ export class MatrixService extends Service implements IMatrixService {
         });
         continue;
       }
-      // Direct rooms are not membership-governed (assessed after the member
-      // list resolved, so a lazily-loaded group is never misclassified).
-      if (room.getJoinedMemberCount() <= 2) {
-        continue;
+      // Recovery check comes BEFORE the direct-room skip: a lazily-loaded
+      // group can transiently report <= 2 members, and skipping first would
+      // leave a partial roster unrecovered indefinitely. Only a room the
+      // authority already knows (in-memory flag OR persisted non-current
+      // health) needs recovery; a never-registered true DM has no scope row
+      // and must not be published.
+      const incomplete = authority.isRoomIncomplete(room.roomId);
+      let persistedNonCurrent = false;
+      if (!incomplete) {
+        const health = await authority
+          .scopeHealth({ roomId: room.roomId })
+          .catch((err: unknown) => {
+            // error-policy:J7 health probe failure is diagnostic; treat as
+            // not needing recovery rather than blocking the whole pass.
+            logger.error(
+              `Matrix membership scope health probe failed for ${room.roomId}: ${err instanceof Error ? err.message : String(err)}`
+            );
+            return null;
+          });
+        // A scope the SQL authority holds as stale/unavailable must recover
+        // through a fresh-roster republication even when this process has no
+        // in-memory incompleteness flag (e.g. after a restart).
+        persistedNonCurrent = health !== null && health.health !== "current";
       }
-      if (authority.isRoomIncomplete(room.roomId)) {
+      if (incomplete || persistedNonCurrent) {
         // Recovery requires a GENUINELY FRESH server-side roster:
         // loadMembersIfNeeded is one-shot and cached by the SDK, so a cached
         // resolve does NOT disprove a later timeline-reset gap. Perform a
         // fresh client.members fetch; a successful full fetch disproves every
         // transient incompleteness reason (timeline reset, member load
-        // failure, empty roster) at once. On failure the room stays
+        // failure, empty roster) at once. The FETCHED roster (not the SDK's
+        // cached Room model, which client.members does not update) becomes
+        // the published baseline. On failure the room stays
         // incomplete — fail closed.
-        const refreshed = await this.fetchFreshServerRoster(state, room.roomId);
-        if (!refreshed) {
+        const freshRoster = await this.fetchFreshServerRoster(state, room.roomId);
+        if (freshRoster === null) {
           await authority.reportIncomplete({
             roomId: room.roomId,
             reason: "member_list_incomplete",
@@ -1351,32 +1377,62 @@ export class MatrixService extends Service implements IMatrixService {
           });
           continue;
         }
+        if (freshRoster.length <= 2 && !persistedNonCurrent) {
+          // The fresh server roster shows this is (now) a direct-sized room
+          // with no persisted authority scope: publish nothing, but clear the
+          // transient flag so the room stops entering recovery every pass.
+          // (A room WITH a persisted non-current scope still publishes — the
+          // shrunken roster is complete evidence and restores health.)
+          authority.clearTransientRoomIncompleteness(room.roomId);
+          continue;
+        }
         authority.clearTransientRoomIncompleteness(room.roomId);
-        // Fall through: publish the complete baseline.
+        // Fall through: publish the complete baseline from the fresh roster.
+        await this.publishSingleRoomMembershipSnapshot(state, room, freshRoster);
+        continue;
+      }
+      // Direct rooms are not membership-governed (assessed after recovery,
+      // so a lazily-loaded group is never misclassified nor left stuck).
+      if (room.getJoinedMemberCount() <= 2) {
+        continue;
       }
       await this.publishSingleRoomMembershipSnapshot(state, room);
     }
   }
 
   /**
-   * Performs a genuinely fresh server-side member fetch for recovery paths.
-   * Room.loadMembersIfNeeded is one-shot and cached by the SDK, so only a
-   * direct client.members call proves the roster is complete NOW (disproving
-   * a timeline-reset gap or a failed member load from an earlier pass).
-   * Returns true when the server returned a usable member map.
+   * Fetches a GENUINELY FRESH server-side joined roster for a room via the
+   * homeserver API (`client.members` — a plain HTTP request that does NOT
+   * touch the SDK's cached Room model, unlike the one-shot
+   * `room.loadMembersIfNeeded`). Returns the joined user IDs, or null on
+   * failure (fail closed — the caller keeps the room incomplete).
    */
   private async fetchFreshServerRoster(
     state: MatrixAccountState,
     roomId: string
-  ): Promise<boolean> {
+  ): Promise<string[] | null> {
     try {
       const result = await state.client.members(roomId, "join");
-      return result !== null && typeof result === "object";
+      if (result === null || typeof result !== "object") {
+        return null;
+      }
+      const joined: string[] = [];
+      for (const [userId, events] of Object.entries(result)) {
+        // One authoritative membership event per user; only an explicit
+        // "join" counts as presence on the fresh server roster.
+        const latest = Array.isArray(events) ? events[events.length - 1] : undefined;
+        if (latest?.content?.membership === "join") {
+          joined.push(userId);
+        }
+      }
+      return joined;
     } catch (err) {
       logger.error(
         `Matrix fresh member fetch failed for ${roomId}: ${err instanceof Error ? err.message : String(err)}`
       );
-      return false;
+      return null;
+      // error-policy:J6 fetch failure leaves the room incomplete; recovery
+      // is retried on the next publication pass.
     }
   }
 
@@ -1389,20 +1445,45 @@ export class MatrixService extends Service implements IMatrixService {
    */
   private async publishSingleRoomMembershipSnapshot(
     state: MatrixAccountState,
-    room: sdk.Room
+    room: sdk.Room,
+    freshJoinedUserIds?: string[]
   ): Promise<boolean> {
     const authority = state.membershipAuthority;
     if (!authority) {
       return false;
     }
-    const joinedMembers = room.getJoinedMembers();
-    if (joinedMembers.length === 0) {
-      await authority.reportIncomplete({
-        roomId: room.roomId,
-        reason: "empty_roster",
-        observedAt: new Date().toISOString(),
-      });
-      return false;
+    // A caller-supplied fresh server roster (from client.members) overrides
+    // the SDK Room model: the plain HTTP fetch does not update the Room's
+    // cached members, so reading room.getJoinedMembers() after a fresh fetch
+    // would republish the stale/partial roster that triggered recovery.
+    let memberEntries: { userId: string; powerLevel: number }[];
+    if (freshJoinedUserIds !== undefined) {
+      if (freshJoinedUserIds.length === 0) {
+        await authority.reportIncomplete({
+          roomId: room.roomId,
+          reason: "empty_roster",
+          observedAt: new Date().toISOString(),
+        });
+        return false;
+      }
+      memberEntries = freshJoinedUserIds.map((userId) => ({
+        userId,
+        powerLevel: room.getMember(userId)?.powerLevel ?? 0,
+      }));
+    } else {
+      const joinedMembers = room.getJoinedMembers();
+      if (joinedMembers.length === 0) {
+        await authority.reportIncomplete({
+          roomId: room.roomId,
+          reason: "empty_roster",
+          observedAt: new Date().toISOString(),
+        });
+        return false;
+      }
+      memberEntries = joinedMembers.map((m) => ({
+        userId: m.userId,
+        powerLevel: m.powerLevel,
+      }));
     }
     // Snapshot members must reference existing entity/room/world rows; the
     // gate path creates them lazily, and synced rooms may carry members the
@@ -1423,7 +1504,7 @@ export class MatrixService extends Service implements IMatrixService {
       worldId,
     });
     const memberRecords = [];
-    for (const roomMember of joinedMembers) {
+    for (const roomMember of memberEntries) {
       const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${roomMember.userId}`);
       await this.runtime.createEntity({
         id: entityId,
@@ -1584,8 +1665,19 @@ export class MatrixService extends Service implements IMatrixService {
         }
       }
     }
-    const transition = classifyMatrixTransition(member.membership, oldMembership);
     const matrixUserId = member.userId || event.getSender() || "unknown";
+    const transition = classifyMatrixTransition(member.membership, oldMembership);
+    if (transition === null) {
+      // Unknown/missing membership must not become leave authority (an
+      // explicit decision is required to revoke a principal).
+      // error-policy:J7 diagnostic report only; the loop continues.
+      this.runtime.reportError(
+        "matrix:membership-transition",
+        new Error(`Unsupported Matrix membership value: ${String(member.membership)}`),
+        { roomId, subject: matrixUserId, membership: member.membership ?? null }
+      );
+      return;
+    }
     const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${matrixUserId}`);
     const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${roomId}`);
     // Evidence requires entity/room/world rows: bootstrap them for members the
@@ -2239,13 +2331,27 @@ export class MatrixService extends Service implements IMatrixService {
     if (state.membershipAuthority) {
       state.membershipAuthority.clearScopeRemoval({ roomId });
       // error-policy:J7 post-join publication is diagnostic; the join itself
-      // already succeeded. The publication pass performs verified
-      // complete-state checks before publishing anything.
-      void this.publishMembershipSnapshots(state, false).catch((err) =>
-        logger.error(
-          `Matrix membership snapshot after join failed: ${err instanceof Error ? err.message : String(err)}`
+      // already succeeded. Publish THIS room directly from the Room object
+      // the homeserver call returned — the store scan inside the general
+      // publication pass only sees rooms whose getMyMembership() is already
+      // "join" in the SDK's possibly-not-yet-synced state, which is exactly
+      // the missed-event case this recovery exists for.
+      void this.publishSingleRoomMembershipSnapshot(state, response)
+        .catch((err) =>
+          logger.error(
+            `Matrix membership snapshot after join failed: ${err instanceof Error ? err.message : String(err)}`
+          )
         )
-      );
+        .then((published) => {
+          // Snapshot-only room (no other members yet): also run the general
+          // pass so rooms already in the store get their snapshots too.
+          void this.publishMembershipSnapshots(state, false).catch((err) =>
+            logger.error(
+              `Matrix membership snapshot sweep after join failed: ${err instanceof Error ? err.message : String(err)}`
+            )
+          );
+          return published;
+        });
     }
 
     logger.info(`Joined room ${roomId}`);

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -86,7 +86,9 @@ function normalizeSearchQuery(query: string): string {
  * every id that flows into a MembershipService command (principal entities,
  * scope worlds/rooms, gate lookups) must carry RFC 4122 version/variant bits
  * instead. Re-stamping only those two nibbles keeps the id deterministic per
- * (agent, seed) and collision-free with the base scheme.
+ * (agent, seed); the scoped space is disjoint from the base scheme (base
+ * always carries version nibble 0, scoped always 5) and 2 bits narrower than
+ * the base scheme within it (variant nibble collapse), still 120 bits.
  */
 function matrixScopedUuid(runtime: IAgentRuntime, seed: string): UUID {
   const base = createUniqueUuid(runtime, seed);
@@ -2235,7 +2237,9 @@ export class MatrixService extends Service implements IMatrixService {
         return [];
       }
       const outbound: Memory = {
-        id: createUniqueUuid(this.runtime, result.eventId ?? `${roomId}:reply:${Date.now()}`),
+        // A primary key that never reaches the authority, but scoped v5 keeps
+        // every "messages" row id homogeneous with its inbound siblings.
+        id: matrixScopedUuid(this.runtime, result.eventId ?? `${roomId}:reply:${Date.now()}`),
         entityId: this.runtime.agentId,
         agentId: this.runtime.agentId,
         roomId: coreRoomId,

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -475,6 +475,9 @@ function buildMatrixMessage(event: sdk.MatrixEvent, room: sdk.Room): MatrixMessa
 /**
  * Build a core Memory from a MatrixMessage, deriving deterministic ids the same
  * way the inbound dispatch path does so reads and the live message loop agree.
+ * When `accountScope` is set (multi-account runtime), every seed is prefixed
+ * with the account id so two Matrix accounts observing the same room never
+ * share room/entity ids.
  */
 function matrixMessageToMemory(
   runtime: IAgentRuntime,
@@ -482,19 +485,21 @@ function matrixMessageToMemory(
     MatrixMessage,
     "roomId" | "eventId" | "timestamp" | "sender" | "content" | "replyTo"
   >,
-  channelType: ChannelType
+  channelType: ChannelType,
+  accountScope?: string
 ): Memory {
   const roomId = message.roomId;
+  const scoped = (seed: string) => (accountScope ? `${accountScope}:${seed}` : seed);
   return {
-    id: createUniqueUuid(runtime, message.eventId || `${roomId}:${message.timestamp}`),
-    entityId: createUniqueUuid(runtime, message.sender || roomId),
+    id: createUniqueUuid(runtime, scoped(message.eventId || `${roomId}:${message.timestamp}`)),
+    entityId: createUniqueUuid(runtime, scoped(message.sender || roomId)),
     agentId: runtime.agentId,
-    roomId: createUniqueUuid(runtime, message.roomId),
+    roomId: createUniqueUuid(runtime, scoped(message.roomId)),
     content: {
       text: message.content,
       source: MATRIX_SERVICE_NAME,
       channelType,
-      ...(message.replyTo ? { inReplyTo: createUniqueUuid(runtime, message.replyTo) } : {}),
+      ...(message.replyTo ? { inReplyTo: createUniqueUuid(runtime, scoped(message.replyTo)) } : {}),
     },
     createdAt: message.timestamp,
   };
@@ -1656,7 +1661,7 @@ export class MatrixService extends Service implements IMatrixService {
       metadata: { accountId: state.accountId },
     });
 
-    const coreMessage = matrixMessageToMemory(this.runtime, message, channelType);
+    const coreMessage = matrixMessageToMemory(this.runtime, message, channelType, state.accountId);
 
     // Auto-reply is gated (default off, matching plugin-discord/telegram) so the
     // agent never speaks unprompted; passive LifeOps mode also suppresses it.
@@ -1869,7 +1874,7 @@ export class MatrixService extends Service implements IMatrixService {
       const event = events[i];
       const message = buildMatrixMessage(event, room);
       if (message) {
-        const memory = matrixMessageToMemory(this.runtime, message, channelType);
+        const memory = matrixMessageToMemory(this.runtime, message, channelType, state.accountId);
         memory.content.name = message.senderInfo.displayName || message.sender;
         out.push(memory);
         continue;
@@ -1893,7 +1898,8 @@ export class MatrixService extends Service implements IMatrixService {
               "🔒 [end-to-end encrypted message this device can't read — its device isn't cross-signed, so senders withhold the decryption keys. This needs a one-time device verification (or the account password) to unblock; it is NOT a sync or pagination issue.]",
             timestamp: event.getTs(),
           },
-          channelType
+          channelType,
+          state.accountId
         );
         placeholder.content.name = room.getMember(sender)?.name || sender;
         out.push(placeholder);

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -195,7 +195,18 @@ type MatrixAccountState = {
   membershipGate?: MatrixMembershipMessageGate;
   /** Authority handle for evidence publication; null when absent. */
   membershipAuthority?: MatrixMembershipAuthority;
+  /**
+   * Per-process monotonically increasing snapshot observation counter plus a
+   * boot token: together they make every snapshot idempotency key unique to
+   * one observation, so restarts and resyncs never collide with prior runs.
+   */
+  membershipSnapshotCounter: number;
 };
+
+// Per-process boot token for snapshot idempotency keys: distinguishes this
+// process's observations from a previous process's, so a restart's snapshots
+// are new evidence rather than idempotency conflicts against stale keys.
+const MATRIX_SNAPSHOT_BOOT_TOKEN = crypto.randomUUID().split("-")[0];
 
 /**
  * Serialized form of an IndexedDB database: object-store schemas plus their
@@ -850,6 +861,7 @@ export class MatrixService extends Service implements IMatrixService {
         }),
         connected: false,
         syncing: false,
+        membershipSnapshotCounter: 0,
       };
 
       this.states.set(state.accountId, state);
@@ -864,12 +876,20 @@ export class MatrixService extends Service implements IMatrixService {
         matrixUserId: settings.userId,
         personal: settings.personal,
       }).catch((err) => {
+        // error-policy:J2 Bootstrap failure must stay distinguishable from
+        // the absent-authority mode: the service IS configured but failed, so
+        // report and surface a BROKEN gate below (fail-closed admission)
+        // instead of silently degrading to the legacy allow mode.
         runtime.reportError("matrix:membership-bootstrap", err, {
           accountId: state.accountId,
         });
-        return null;
+        return "broken" as const;
       });
-      if (gate) {
+      if (gate === "broken") {
+        const brokenGate = new MatrixMembershipMessageGate({ runtime, authority: null });
+        brokenGate.markBroken();
+        state.membershipGate = brokenGate;
+      } else if (gate) {
         state.membershipAuthority = gate.authority;
         state.membershipGate = new MatrixMembershipMessageGate({
           runtime,
@@ -1155,9 +1175,23 @@ export class MatrixService extends Service implements IMatrixService {
         // complete membership snapshots for joined rooms. Later PREPAREDs
         // (reconnects) re-publish from the SDK's accumulated state, which is
         // complete for rooms already synced.
+        // error-policy:J7 snapshot publication is diagnostic and must not
+        // kill the sync loop; the failure is logged for operator escalation.
         void this.publishMembershipSnapshots(state, syncData?.oldSyncToken == null).catch((err) =>
           logger.error(
             `Matrix membership snapshot publication failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+      } else if (syncState === "SYNCING" && _prevState === "RECONNECTING") {
+        // The SDK recovers RECONNECTING -> SYNCING (PREPARED does NOT recur
+        // after initial sync), so the republish that clears STALE scopes must
+        // run here. Complete-state rules inside publishMembershipSnapshots
+        // (lazy-load resolution + incompleteness checks) still gate what is
+        // actually published.
+        state.syncing = true;
+        void this.publishMembershipSnapshots(state, false).catch((err) =>
+          logger.error(
+            `Matrix membership snapshot recovery failed: ${err instanceof Error ? err.message : String(err)}`
           )
         );
       } else if (syncState === "ERROR" || syncState === "RECONNECTING") {
@@ -1168,6 +1202,8 @@ export class MatrixService extends Service implements IMatrixService {
         // self-leave/ban, where only an explicit rejoin may clear it — a
         // transient reconnect must never permanently kill a scope.
         if (state.membershipAuthority) {
+          // error-policy:J7 degrade is diagnostic; failed degrades surface
+          // via the authority's own error path and the next sync retries.
           void this.degradeAllMembershipScopes(state, `sync_${syncState.toLowerCase()}`).catch(
             (err) =>
               logger.error(
@@ -1184,9 +1220,24 @@ export class MatrixService extends Service implements IMatrixService {
     // trusted as complete for this room until the next full sync — record
     // incompleteness, never publish the partial roster as complete.
     state.client.on(sdk.RoomEvent.TimelineReset, (room) => {
-      if (room) {
-        state.membershipAuthority?.markRoomIncomplete(room.roomId);
+      if (!room || !state.membershipAuthority) {
+        return;
       }
+      // A limited-sync gap invalidates roster completeness immediately: the
+      // persisted scope is degraded to STALE (fail-closed admission) rather
+      // than left authorizing on an untrustworthy roster. The room is also
+      // marked locally incomplete so a later publication pass re-establishes
+      // a complete baseline instead of streaming deltas over the gap.
+      state.membershipAuthority.markRoomIncomplete(room.roomId);
+      // error-policy:J7 stale-degrade is diagnostic; a failed degrade leaves
+      // the local incompleteness flag set, so publication stays blocked.
+      void state.membershipAuthority
+        .markScopeStale({ roomId: room.roomId, reason: "limited_sync_timeline_reset" })
+        .catch((err) =>
+          logger.error(
+            `Matrix membership stale-degrade after timeline reset failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
     });
 
     // Room timeline events (messages)
@@ -1216,6 +1267,8 @@ export class MatrixService extends Service implements IMatrixService {
 
     // Room membership events
     state.client.on(sdk.RoomMemberEvent.Membership, (event, member, oldMembership) => {
+      // error-policy:J7 transition handling is diagnostic (the authority's
+      // evidence path already reports its own failures); never kill sync.
       void this.handleMembershipTransition(state, event, member, oldMembership).catch((err) =>
         logger.error(
           `Matrix membership transition handling failed: ${err instanceof Error ? err.message : String(err)}`
@@ -1235,7 +1288,7 @@ export class MatrixService extends Service implements IMatrixService {
    */
   private async publishMembershipSnapshots(
     state: MatrixAccountState,
-    firstSync: boolean
+    _firstSync: boolean
   ): Promise<void> {
     const authority = state.membershipAuthority;
     if (!authority) {
@@ -1320,11 +1373,17 @@ export class MatrixService extends Service implements IMatrixService {
           runtime: { worldId, roomId: worldId, entityId },
         });
       }
+      const snapshotObservedAt = new Date().toISOString();
+      // Idempotency keys must identify ONE observation, not a class of sync
+      // events: a per-process monotonically increasing token keeps restarts
+      // and resyncs distinct (a reused key is an idempotency CONFLICT, and
+      // publishSnapshot would silently skip a changed roster).
+      state.membershipSnapshotCounter += 1;
       const published = await authority.publishSnapshot({
         roomId: room.roomId,
-        observedAt: new Date().toISOString(),
+        observedAt: snapshotObservedAt,
         members: memberRecords,
-        idempotencyKey: `mx:${state.accountId}:${room.roomId}:prepared:${firstSync ? "first" : "resync"}:${rooms.length}`,
+        idempotencyKey: `mx:${state.accountId}:${room.roomId}:snapshot:${state.membershipSnapshotCounter}:${MATRIX_SNAPSHOT_BOOT_TOKEN}`,
       });
       if (published) {
         logger.debug(
@@ -1403,6 +1462,8 @@ export class MatrixService extends Service implements IMatrixService {
       }
       if (member.membership === "join" && oldMembership !== "join") {
         authority.clearScopeRemoval({ roomId });
+        // error-policy:J7 post-join republish is diagnostic; the join itself
+        // already succeeded.
         await this.publishMembershipSnapshots(state, false).catch((err) =>
           logger.error(
             `Matrix membership snapshot after join failed: ${err instanceof Error ? err.message : String(err)}`
@@ -1581,7 +1642,20 @@ export class MatrixService extends Service implements IMatrixService {
     // Check mention requirement. Skipped in 1:1 DMs: a direct message is
     // inherently addressed to the bot, so requiring an @mention there would
     // make it ignore the user. Group rooms still honor the gate.
-    const isDirectRoom = room.getJoinedMemberCount() <= 2;
+    // A lazy-loaded room's member count is unreliable until the out-of-band
+    // roster resolves (a large group can transiently look like a 1-member
+    // room). Only a RESOLVED <=2 roster counts as direct: otherwise the room
+    // is treated as governed and the membership gate decides, so a group can
+    // never bypass admission via a partial roster.
+    let rosterResolved = true;
+    if (typeof room.loadMembersIfNeeded === "function") {
+      try {
+        await room.loadMembersIfNeeded();
+      } catch {
+        rosterResolved = false;
+      }
+    }
+    const isDirectRoom = rosterResolved && room.getJoinedMemberCount() <= 2;
     if (state.settings.requireMention && !isDirectRoom) {
       const localpart = getMatrixLocalpart(state.settings.userId);
       const mentionPattern = new RegExp(`@?${escapeRegExp(localpart)}`, "i");
@@ -1632,6 +1706,8 @@ export class MatrixService extends Service implements IMatrixService {
     } as EventPayload);
 
     // Drive the core message loop so the agent actually reads and replies.
+    // error-policy:J7 dispatch failure is reported after the loop; dispatch
+    // must not take down the SDK event handler.
     void this.dispatchToAgent(state, message, matrixRoom).catch((err) =>
       logger.error(
         `Matrix dispatchToAgent failed: ${err instanceof Error ? err.message : String(err)}`
@@ -2078,6 +2154,17 @@ export class MatrixService extends Service implements IMatrixService {
     }
 
     await state.client.leave(normalizedRoomId);
+    // The homeserver confirmed the leave: terminate the room's authority
+    // scope NOW (unavailable + tombstone) instead of waiting for the SDK
+    // membership event — otherwise persisted membership stays current (and
+    // authorizing) after an explicit leave, potentially beyond this
+    // process's lifetime if the event never arrives.
+    if (state.membershipAuthority) {
+      await state.membershipAuthority.markScopeUnavailable({
+        roomId: normalizedRoomId,
+        reason: "bot_left_explicit",
+      });
+    }
     logger.info(`Left room ${normalizedRoomId}`);
     this.runtime.emitEvent(MatrixEventTypes.ROOM_LEFT, {
       roomId: normalizedRoomId,
@@ -2181,6 +2268,7 @@ export class MatrixService extends Service implements IMatrixService {
         client: legacy.client ?? ({} as sdk.MatrixClient),
         connected: legacy.connected ?? true,
         syncing: legacy.syncing ?? true,
+        membershipSnapshotCounter: 0,
       };
     }
 

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1335,16 +1335,15 @@ export class MatrixService extends Service implements IMatrixService {
         continue;
       }
       if (authority.isRoomIncomplete(room.roomId)) {
-        // Recovery: a limited-sync gap (timeline reset) is disproved by a
-        // FULLY RESOLVED out-of-band member list in this pass — the SDK just
-        // told us the roster is complete again. Clear exactly that reason and
-        // fall through to publish a fresh complete baseline; other
-        // incompleteness reasons (member load failed, empty roster) still
-        // report incomplete and skip. Without this, one timeline reset would
-        // leave the scope permanently stale.
-        const recovered =
-          membersReady && authority.clearRoomIncomplete(room.roomId, "limited_sync_timeline_reset");
-        if (!recovered) {
+        // Recovery requires a GENUINELY FRESH server-side roster:
+        // loadMembersIfNeeded is one-shot and cached by the SDK, so a cached
+        // resolve does NOT disprove a later timeline-reset gap. Perform a
+        // fresh client.members fetch; a successful full fetch disproves every
+        // transient incompleteness reason (timeline reset, member load
+        // failure, empty roster) at once. On failure the room stays
+        // incomplete — fail closed.
+        const refreshed = await this.fetchFreshServerRoster(state, room.roomId);
+        if (!refreshed) {
           await authority.reportIncomplete({
             roomId: room.roomId,
             reason: "member_list_incomplete",
@@ -1352,9 +1351,32 @@ export class MatrixService extends Service implements IMatrixService {
           });
           continue;
         }
+        authority.clearTransientRoomIncompleteness(room.roomId);
         // Fall through: publish the complete baseline.
       }
       await this.publishSingleRoomMembershipSnapshot(state, room);
+    }
+  }
+
+  /**
+   * Performs a genuinely fresh server-side member fetch for recovery paths.
+   * Room.loadMembersIfNeeded is one-shot and cached by the SDK, so only a
+   * direct client.members call proves the roster is complete NOW (disproving
+   * a timeline-reset gap or a failed member load from an earlier pass).
+   * Returns true when the server returned a usable member map.
+   */
+  private async fetchFreshServerRoster(
+    state: MatrixAccountState,
+    roomId: string
+  ): Promise<boolean> {
+    try {
+      const result = await state.client.members(roomId, "join");
+      return result !== null && typeof result === "object";
+    } catch (err) {
+      logger.error(
+        `Matrix fresh member fetch failed for ${roomId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return false;
     }
   }
 
@@ -1449,8 +1471,12 @@ export class MatrixService extends Service implements IMatrixService {
     if (!authority) {
       return;
     }
+    // Degrade EVERY joined room scope: during a reconnect gap the SDK member
+    // count is unreliable (lazy loading can make a group look like a <=2
+    // direct room), so the count must not gate degradation. Rooms that were
+    // never snapshotted (true DMs, unpublished rooms) are skipped inside
+    // degradeScope — no scope row, nothing authorizing.
     for (const room of state.client.getRooms().filter((r) => r.getMyMembership() === "join")) {
-      if (room.getJoinedMemberCount() <= 2) continue;
       await authority.markScopeStale({ roomId: room.roomId, reason });
     }
   }
@@ -1530,9 +1556,10 @@ export class MatrixService extends Service implements IMatrixService {
     // A previously ungoverned (direct) room that grew past two members has NO
     // snapshot baseline, and the SQL authority rejects ordered deltas without
     // one — the delta below would be dropped, leaving the new group
-    // permanently denied. When the room has crossed into group territory and
-    // carries no current scope evidence, publish the complete baseline first;
-    // the transition delta then lands on top of it.
+    // permanently denied. Bootstrap ONLY a scope that does not exist at all;
+    // a scope with stale or degraded health must recover through the
+    // verified-fresh-roster path in the publication pass, never by promoting
+    // possibly-incomplete state to current.
     if (room && room.getJoinedMemberCount() > 2 && member.membership === "join") {
       const health = await authority.scopeHealth({ roomId }).catch((err: unknown) => {
         logger.error(
@@ -1540,12 +1567,21 @@ export class MatrixService extends Service implements IMatrixService {
         );
         return null;
       });
-      if (health?.health !== "current") {
-        await this.publishSingleRoomMembershipSnapshot(state, room).catch((err) =>
-          logger.error(
-            `Matrix membership baseline for grown room failed: ${err instanceof Error ? err.message : String(err)}`
-          )
+      if (health === null && !authority.isRoomIncomplete(roomId)) {
+        const published = await this.publishSingleRoomMembershipSnapshot(state, room).catch(
+          (err) => {
+            logger.error(
+              `Matrix membership baseline for grown room failed: ${err instanceof Error ? err.message : String(err)}`
+            );
+            return false;
+          }
         );
+        if (!published) {
+          // No baseline exists: the delta below would be rejected anyway
+          // (SNAPSHOT_REQUIRED). Return so the failure is visible rather than
+          // falling through as if a baseline existed.
+          return;
+        }
       }
     }
     const transition = classifyMatrixTransition(member.membership, oldMembership);
@@ -2196,6 +2232,21 @@ export class MatrixService extends Service implements IMatrixService {
 
     const response = await state.client.joinRoom(normalizedRoomIdOrAlias);
     const roomId = response.roomId;
+
+    // The homeserver confirmed the join: clear any prior leave tombstone NOW.
+    // Relying solely on the SDK membership event would leave the scope
+    // tombstoned (snapshots rejected) whenever that event is missed.
+    if (state.membershipAuthority) {
+      state.membershipAuthority.clearScopeRemoval({ roomId });
+      // error-policy:J7 post-join publication is diagnostic; the join itself
+      // already succeeded. The publication pass performs verified
+      // complete-state checks before publishing anything.
+      void this.publishMembershipSnapshots(state, false).catch((err) =>
+        logger.error(
+          `Matrix membership snapshot after join failed: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
+    }
 
     logger.info(`Joined room ${roomId}`);
     this.runtime.emitEvent(MatrixEventTypes.ROOM_JOINED, {

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -52,6 +52,13 @@ import {
 } from "./accounts.js";
 import { waitForMatrixPrepared } from "./matrix-sync.js";
 import {
+  classifyMatrixTransition,
+  type MatrixMembershipAuthority,
+  matrixMemberRoles,
+  matrixObservedAt,
+} from "./membership.js";
+import { createMatrixMembershipGate, MatrixMembershipMessageGate } from "./membership-gate.js";
+import {
   getMatrixLocalpart,
   type IMatrixService,
   isValidMatrixRoomAlias,
@@ -184,6 +191,10 @@ type MatrixAccountState = {
   connected: boolean;
   syncing: boolean;
   cryptoSnapshotTimer?: ReturnType<typeof setInterval>;
+  /** Membership-authority gate for this account; null when absent/failed. */
+  membershipGate?: MatrixMembershipMessageGate;
+  /** Authority handle for evidence publication; null when absent. */
+  membershipAuthority?: MatrixMembershipAuthority;
 };
 
 /**
@@ -834,6 +845,28 @@ export class MatrixService extends Service implements IMatrixService {
       await this.initCrypto(state);
       this.startCryptoSnapshot(state);
       this.setupEventHandlers(state);
+      // Membership-authority gate: null when the authority service is absent
+      // (legacy ungated mode); a broken bootstrap records a fail-closed gate.
+      const gate = await createMatrixMembershipGate({
+        runtime,
+        matrixAccountId: state.accountId,
+        matrixUserId: settings.userId,
+        personal: settings.personal,
+      }).catch((err) => {
+        runtime.reportError("matrix:membership-bootstrap", err, {
+          accountId: state.accountId,
+        });
+        return null;
+      });
+      if (gate) {
+        state.membershipAuthority = gate.authority;
+        state.membershipGate = new MatrixMembershipMessageGate({
+          runtime,
+          authority: gate.authority,
+        });
+      } else {
+        state.membershipGate = new MatrixMembershipMessageGate({ runtime, authority: null });
+      }
       await this.connect(state);
       MatrixService.registerSendHandlers(runtime, this, state.accountId);
 
@@ -1099,7 +1132,7 @@ export class MatrixService extends Service implements IMatrixService {
    */
   private setupEventHandlers(state: MatrixAccountState): void {
     // Sync events
-    state.client.on(sdk.ClientEvent.Sync, (syncState) => {
+    state.client.on(sdk.ClientEvent.Sync, (syncState, _prevState, syncData) => {
       if (syncState === "PREPARED") {
         state.syncing = true;
         logger.info("Matrix sync complete");
@@ -1107,6 +1140,38 @@ export class MatrixService extends Service implements IMatrixService {
           runtime: this.runtime,
           accountId: state.accountId,
         } as EventPayload);
+        // First PREPARED after start (oldSyncToken null/undefined): publish
+        // complete membership snapshots for joined rooms. Later PREPAREDs
+        // (reconnects) re-publish from the SDK's accumulated state, which is
+        // complete for rooms already synced.
+        void this.publishMembershipSnapshots(state, syncData?.oldSyncToken == null).catch((err) =>
+          logger.error(
+            `Matrix membership snapshot publication failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+      } else if (syncState === "ERROR" || syncState === "RECONNECTING") {
+        // Connection trouble: room evidence may be stale. Degrade every
+        // currently-tracked room scope to unavailable so admission fails
+        // closed until a fresh PREPARED re-publishes complete state.
+        if (state.membershipAuthority) {
+          void this.degradeAllMembershipScopes(state, `sync_${syncState.toLowerCase()}`).catch(
+            (err) =>
+              logger.error(
+                `Matrix membership scope degrade failed: ${err instanceof Error ? err.message : String(err)}`
+              )
+          );
+        }
+      }
+    });
+
+    // Limited-sync gaps: the SDK resets the live timeline when a sync response
+    // is limited, which means state events (including m.room.member) may be
+    // missing from the accumulated room state. The roster can no longer be
+    // trusted as complete for this room until the next full sync — record
+    // incompleteness, never publish the partial roster as complete.
+    state.client.on(sdk.RoomEvent.TimelineReset, (room) => {
+      if (room) {
+        state.membershipAuthority?.markRoomIncomplete(room.roomId);
       }
     });
 
@@ -1121,7 +1186,7 @@ export class MatrixService extends Service implements IMatrixService {
       if (event.isEncrypted() && event.getType() === "m.room.encrypted") {
         event.once(sdk.MatrixEventEvent.Decrypted, () => {
           if (event.getType() === "m.room.message") {
-            this.handleRoomMessage(state, event, room);
+            void this.handleRoomMessage(state, event, room);
           } else if (event.isDecryptionFailure()) {
             logger.warn(
               `Matrix could not decrypt event ${event.getId()} in ${event.getRoomId()} — the sender has not shared the megolm key with this device yet.`
@@ -1132,25 +1197,244 @@ export class MatrixService extends Service implements IMatrixService {
       }
 
       if (event.getType() !== "m.room.message") return;
-      this.handleRoomMessage(state, event, room);
+      void this.handleRoomMessage(state, event, room);
     });
 
     // Room membership events
-    state.client.on(sdk.RoomMemberEvent.Membership, (event, member) => {
-      if (member.userId !== state.settings.userId) return;
-
-      if (member.membership === "invite" && state.settings.autoJoin) {
-        const roomId = event.getRoomId();
-        if (roomId) {
-          logger.info(`Auto-joining room ${roomId}`);
-          state.client.joinRoom(roomId).catch((err) => {
-            logger.error(`Failed to auto-join room: ${err.message}`);
-          });
-        }
-      }
+    state.client.on(sdk.RoomMemberEvent.Membership, (event, member, oldMembership) => {
+      void this.handleMembershipTransition(state, event, member, oldMembership).catch((err) =>
+        logger.error(
+          `Matrix membership transition handling failed: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
     });
 
     this.setupVerificationAutoAccept(state);
+  }
+
+  /**
+   * Publish complete membership snapshots for every joined room of an
+   * account. Only called for known-complete state: the first PREPARED sync
+   * (after lazy-loaded member lists resolve) or an explicit join. Rooms whose
+   * member list is marked incomplete are reported incomplete instead — never
+   * as empty or complete.
+   */
+  private async publishMembershipSnapshots(
+    state: MatrixAccountState,
+    firstSync: boolean
+  ): Promise<void> {
+    const authority = state.membershipAuthority;
+    if (!authority) {
+      return;
+    }
+    const rooms = state.client.getRooms().filter((room) => room.getMyMembership() === "join");
+    for (const room of rooms) {
+      if (room.getJoinedMemberCount() <= 2) {
+        // Direct rooms are not membership-governed.
+        continue;
+      }
+      if (authority.isRoomIncomplete(room.roomId)) {
+        await authority.reportIncomplete({
+          roomId: room.roomId,
+          reason: "member_list_incomplete",
+          observedAt: new Date().toISOString(),
+        });
+        continue;
+      }
+      // Lazy loading: until the out-of-band member list resolves, the SDK's
+      // roster is partial. Wait for it (bounded) before publishing; a timeout
+      // is incompleteness, not emptiness.
+      let membersReady = true;
+      if (typeof room.loadMembersIfNeeded === "function") {
+        try {
+          await room.loadMembersIfNeeded();
+        } catch {
+          membersReady = false;
+        }
+      }
+      const joinedMembers = room.getJoinedMembers();
+      if (!membersReady || joinedMembers.length === 0) {
+        await authority.reportIncomplete({
+          roomId: room.roomId,
+          reason: membersReady ? "empty_roster" : "member_load_failed",
+          observedAt: new Date().toISOString(),
+        });
+        continue;
+      }
+      // Snapshot members must reference existing entity/room/world rows; the
+      // gate path creates them lazily, and PREPARED rooms may carry members
+      // the runtime has never seen — bootstrap rows before publishing.
+      const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${room.roomId}`);
+      await this.runtime.createWorld({
+        id: worldId,
+        name: room.name || room.roomId,
+        agentId: this.runtime.agentId,
+        metadata: { source: MATRIX_SERVICE_NAME, accountId: state.accountId, roomId: room.roomId },
+      });
+      await this.runtime.createRoom({
+        id: worldId,
+        name: room.name || room.roomId,
+        source: MATRIX_SERVICE_NAME,
+        type: ChannelType.GROUP,
+        channelId: room.roomId,
+        worldId,
+      });
+      const memberRecords = [];
+      for (const member of joinedMembers) {
+        const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${member.userId}`);
+        await this.runtime.createEntity({
+          id: entityId,
+          agentId: this.runtime.agentId,
+          names: [`matrix-${getMatrixLocalpart(member.userId)}`],
+          metadata: { source: MATRIX_SERVICE_NAME, matrixUserId: member.userId },
+        });
+        memberRecords.push({
+          canonicalPrincipalId: entityId,
+          roles: matrixMemberRoles(member.powerLevel),
+          permissionSnapshot: { membership: "join" },
+          runtime: { worldId, roomId: worldId, entityId },
+        });
+      }
+      const published = await authority.publishSnapshot({
+        roomId: room.roomId,
+        observedAt: new Date().toISOString(),
+        members: memberRecords,
+        idempotencyKey: `mx:${state.accountId}:${room.roomId}:prepared:${firstSync ? "first" : "resync"}:${rooms.length}`,
+      });
+      if (published) {
+        logger.debug(
+          `Matrix membership snapshot published for ${room.roomId}: ${memberRecords.length} members`
+        );
+      }
+    }
+  }
+
+  /**
+   * Degrade every tracked room scope for an account to unavailable (sync
+   * trouble). Used on ERROR/RECONNECTING so admission fails closed until a
+   * fresh PREPARED re-publishes.
+   */
+  private async degradeAllMembershipScopes(
+    state: MatrixAccountState,
+    reason: string
+  ): Promise<void> {
+    const authority = state.membershipAuthority;
+    if (!authority) {
+      return;
+    }
+    for (const room of state.client.getRooms().filter((r) => r.getMyMembership() === "join")) {
+      if (room.getJoinedMemberCount() <= 2) continue;
+      await authority.markScopeUnavailable({ roomId: room.roomId, reason });
+    }
+  }
+
+  /**
+   * Consume one m.room.member transition: record authority evidence for the
+   * subject; self-transitions (the bot's own membership) additionally manage
+   * the scope lifecycle (leave/ban terminates the publisher with a tombstone;
+   * join clears it and publishes a fresh complete snapshot).
+   */
+  private async handleMembershipTransition(
+    state: MatrixAccountState,
+    event: sdk.MatrixEvent,
+    member: sdk.RoomMember,
+    oldMembership: string | undefined
+  ): Promise<void> {
+    const authority = state.membershipAuthority;
+    const roomId = event.getRoomId();
+    if (!authority || !roomId) {
+      // No authority configured: preserve the legacy self-invite auto-join
+      // behavior even in ungated deployments.
+      if (
+        roomId &&
+        member.userId === state.settings.userId &&
+        member.membership === "invite" &&
+        state.settings.autoJoin
+      ) {
+        logger.info(`Auto-joining room ${roomId}`);
+        state.client.joinRoom(roomId).catch((err) => {
+          logger.error(`Failed to auto-join room: ${err.message}`);
+        });
+      }
+      return;
+    }
+    const room = state.client.getRoom(roomId);
+    if (room && room.getJoinedMemberCount() <= 2 && member.membership !== "join") {
+      // Direct rooms are not membership-governed; only bot-join lifecycle
+      // (which can grow a DM out of a group) is tracked below.
+    }
+    // Bot self-transitions own the scope lifecycle.
+    if (member.userId === state.settings.userId) {
+      if (member.membership === "leave" || member.membership === "ban") {
+        const reason =
+          member.membership === "ban"
+            ? "bot_banned"
+            : oldMembership === "invite"
+              ? "invite_declined"
+              : "bot_left";
+        await authority.markScopeUnavailable({ roomId, reason });
+        logger.info(`Matrix membership scope terminated for ${roomId} (${reason})`);
+        return;
+      }
+      if (member.membership === "join" && oldMembership !== "join") {
+        authority.clearScopeRemoval({ roomId });
+        await this.publishMembershipSnapshots(state, false).catch((err) =>
+          logger.error(
+            `Matrix membership snapshot after join failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+        return;
+      }
+      if (member.membership === "invite" && state.settings.autoJoin) {
+        logger.info(`Auto-joining room ${roomId}`);
+        state.client.joinRoom(roomId).catch((err) => {
+          logger.error(`Failed to auto-join room: ${err.message}`);
+        });
+      }
+      return;
+    }
+    // Other members' transitions become ordered-delta evidence.
+    if (room && room.getJoinedMemberCount() <= 2 && member.membership === "join") {
+      // Direct rooms are not membership-governed.
+      return;
+    }
+    const transition = classifyMatrixTransition(member.membership, oldMembership);
+    const matrixUserId = member.userId || event.getSender() || "unknown";
+    const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${matrixUserId}`);
+    const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${roomId}`);
+    // Evidence requires entity/room/world rows: bootstrap them for members the
+    // runtime has never seen (idempotent creates).
+    await this.runtime.createEntity({
+      id: entityId,
+      agentId: this.runtime.agentId,
+      names: [`matrix-${getMatrixLocalpart(matrixUserId)}`],
+      metadata: { source: MATRIX_SERVICE_NAME, matrixUserId },
+    });
+    await this.runtime.createWorld({
+      id: worldId,
+      name: roomId,
+      agentId: this.runtime.agentId,
+      metadata: { source: MATRIX_SERVICE_NAME, accountId: state.accountId, roomId },
+    });
+    await this.runtime.createRoom({
+      id: worldId,
+      name: roomId,
+      source: MATRIX_SERVICE_NAME,
+      type: ChannelType.GROUP,
+      channelId: roomId,
+      worldId,
+    });
+    await authority.recordTransition({
+      roomId,
+      canonicalPrincipalId: entityId,
+      transition,
+      roles: matrixMemberRoles(member.powerLevel),
+      permissionSnapshot: { membership: member.membership ?? "unknown" },
+      runtime: { worldId, roomId: worldId, entityId },
+      eventId: event.getId() || `${roomId}:${event.getTs()}`,
+      matrixUserId,
+      observedAt: matrixObservedAt(event.getTs()),
+    });
   }
 
   /**
@@ -1257,11 +1541,11 @@ export class MatrixService extends Service implements IMatrixService {
   /**
    * Handle an incoming room message.
    */
-  private handleRoomMessage(
+  private async handleRoomMessage(
     state: MatrixAccountState,
     event: sdk.MatrixEvent,
     room: sdk.Room | undefined
-  ): void {
+  ): Promise<void> {
     if (!room) return;
 
     const message = buildMatrixMessage(event, room);
@@ -1299,6 +1583,21 @@ export class MatrixService extends Service implements IMatrixService {
       `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${truncateWellFormed(toWellFormedUnicode(message.content), 50)}...`
     );
 
+    // Membership admission (group rooms only; DMs bypass). Fail-closed when
+    // the authority is configured but cannot produce fresh evidence.
+    if (state.membershipGate) {
+      const allowed = await state.membershipGate.authorizeMessage({
+        roomId,
+        isDirectRoom,
+        principalEntityId: createUniqueUuid(this.runtime, `${state.accountId}:${message.sender}`),
+        matrixUserId: message.sender,
+        getJoinedMemberIds: () => room.getJoinedMembers().map((m) => m.userId),
+      });
+      if (!allowed) {
+        return;
+      }
+    }
+
     // Plugin-local event other code may listen for (the MatrixMessage/MatrixRoom payload).
     this.runtime.emitEvent(MatrixEventTypes.MESSAGE_RECEIVED, {
       message,
@@ -1328,9 +1627,14 @@ export class MatrixService extends Service implements IMatrixService {
     room: MatrixRoom
   ): Promise<void> {
     const roomId = room.roomId;
-    const entityId = createUniqueUuid(this.runtime, message.sender || roomId);
-    const coreRoomId = createUniqueUuid(this.runtime, roomId);
-    const worldId = createUniqueUuid(this.runtime, roomId);
+    // Account-scoped derivations: two Matrix accounts on one runtime observing
+    // the same room must never share room/world/entity UUIDs (the authority
+    // scopes membership per connector account, and cross-account memory
+    // blending is a privacy violation).
+    const scoped = (seed: string) => createUniqueUuid(this.runtime, `${state.accountId}:${seed}`);
+    const entityId = scoped(message.sender || roomId);
+    const coreRoomId = scoped(roomId);
+    const worldId = scoped(roomId);
     // Member count is the reliable DM signal (m.direct account data is often
     // unset for a bot) and matches the mention-gate check in handleRoomMessage.
     const channelType = room.memberCount <= 2 ? ChannelType.DM : ChannelType.GROUP;

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1429,13 +1429,39 @@ export class MatrixService extends Service implements IMatrixService {
       if (result === null || typeof result !== "object") {
         return null;
       }
+      // The homeserver /members endpoint (and matrix-js-sdk's
+      // MatrixClient.members, which returns the raw response — see
+      // Room.loadMembersFromServer consuming response.chunk) answers with
+      // { chunk: IStateEventWithRoomId[] }, one state event per member with
+      // the subject in state_key. Parse the chunk, not a map keyed by userId.
+      const chunk = (result as { chunk?: unknown }).chunk;
+      if (!Array.isArray(chunk)) {
+        return null;
+      }
       const joined: string[] = [];
-      for (const [userId, events] of Object.entries(result)) {
-        // One authoritative membership event per user; only an explicit
-        // "join" counts as presence on the fresh server roster.
-        const latest = Array.isArray(events) ? events[events.length - 1] : undefined;
-        if (latest?.content?.membership === "join") {
-          joined.push(userId);
+      for (const event of chunk) {
+        if (event === null || typeof event !== "object") {
+          // A structurally invalid entry means the roster cannot be known
+          // complete — skipping it could publish a partial roster as a
+          // complete baseline. Fail closed.
+          return null;
+        }
+        const { state_key: stateKey, content } = event as {
+          state_key?: unknown;
+          content?: { membership?: unknown } | null;
+        };
+        if (
+          typeof stateKey !== "string" ||
+          content === null ||
+          typeof content !== "object" ||
+          typeof content.membership !== "string"
+        ) {
+          return null;
+        }
+        // Only an explicit "join" counts as presence on the fresh server roster;
+        // well-formed leave/invite events are simply not presence.
+        if (content.membership === "join") {
+          joined.push(stateKey);
         }
       }
       return joined;
@@ -1606,9 +1632,20 @@ export class MatrixService extends Service implements IMatrixService {
       return;
     }
     const room = state.client.getRoom(roomId);
-    if (room && room.getJoinedMemberCount() <= 2 && member.membership !== "join") {
-      // Direct rooms are not membership-governed; only bot-join lifecycle
-      // (which can grow a DM out of a group) is tracked below.
+    if (
+      room &&
+      room.getJoinedMemberCount() <= 2 &&
+      member.membership !== "join" &&
+      member.userId !== state.settings.userId
+    ) {
+      // Direct rooms are not membership-governed; a PEER's leave/ban in a
+      // <=2-member room must create NO authority evidence. Returning here is
+      // load-bearing: falling through would register a publisher scope for a
+      // DM and record an ordered delta with no snapshot baseline, poisoning
+      // the grown-room bootstrap below if the DM later becomes a group. The
+      // bot's OWN leave/ban is excluded: the self-transition block below must
+      // still tombstone a governed scope (e.g. a group that shrank to two).
+      return;
     }
     // Bot self-transitions own the scope lifecycle.
     if (member.userId === state.settings.userId) {

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1602,21 +1602,25 @@ export class MatrixService extends Service implements IMatrixService {
     // for the whole reconnect gap. Attempt ALL rooms, retain the first
     // failure, and rethrow it after the loop so the reconnect handler's
     // catch logs it and the next sync retries — a swallow would disguise a
-    // scope that never degraded (error policy: J2, rethrow with cause).
+    // scope that never degraded. A boolean flag marks failure: the rejection
+    // value itself may be null (error-policy:J7 — a failed degrade write
+    // must not kill the degrade loop; the aggregate surfaces after it).
     let firstFailure: unknown = null;
+    let sawFailure = false;
     for (const room of state.client.getRooms().filter((r) => r.getMyMembership() === "join")) {
       try {
         await authority.markScopeStale({ roomId: room.roomId, reason });
       } catch (error) {
-        if (firstFailure === null) {
+        if (!sawFailure) {
           firstFailure = error;
+          sawFailure = true;
         }
         logger.error(
           `Matrix membership scope stale-degrade failed for ${room.roomId}: ${error instanceof Error ? error.message : String(error)}`
         );
       }
     }
-    if (firstFailure !== null) {
+    if (sawFailure) {
       throw firstFailure;
     }
   }

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1603,8 +1603,9 @@ export class MatrixService extends Service implements IMatrixService {
     // failure, and rethrow it after the loop so the reconnect handler's
     // catch logs it and the next sync retries — a swallow would disguise a
     // scope that never degraded. A boolean flag marks failure: the rejection
-    // value itself may be null (error-policy:J7 — a failed degrade write
-    // must not kill the degrade loop; the aggregate surfaces after it).
+    // value itself may be null.
+    // error-policy:J7 a failed degrade write must not kill the degrade loop;
+    // the aggregate rejection surfaces after every room is attempted.
     let firstFailure: unknown = null;
     let sawFailure = false;
     for (const room of state.client.getRooms().filter((r) => r.getMyMembership() === "join")) {

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -79,6 +79,20 @@ function normalizeSearchQuery(query: string): string {
   return query.trim().toLowerCase();
 }
 
+/**
+ * Deterministic, authority-compatible UUID for Matrix-derived rows. Core's
+ * createUniqueUuid stamps a custom version nibble of 0, which the canonical
+ * membership authority's UUID validation (version nibble [1-8]) rejects — so
+ * every id that flows into a MembershipService command (principal entities,
+ * scope worlds/rooms, gate lookups) must carry RFC 4122 version/variant bits
+ * instead. Re-stamping only those two nibbles keeps the id deterministic per
+ * (agent, seed) and collision-free with the base scheme.
+ */
+function matrixScopedUuid(runtime: IAgentRuntime, seed: string): UUID {
+  const base = createUniqueUuid(runtime, seed);
+  return `${base.slice(0, 14)}5${base.slice(15, 19)}8${base.slice(20)}` as UUID;
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -499,16 +513,20 @@ function matrixMessageToMemory(
 ): Memory {
   const roomId = message.roomId;
   const scoped = (seed: string) => (accountScope ? `${accountScope}:${seed}` : seed);
+  // Write path must key memories by the SAME authority-compatible
+  // derivation the read fallback (readMessagesForTarget) uses — a v0
+  // createUniqueUuid here would make every stored message invisible to
+  // the matrixScopedUuid-keyed reader.
   return {
-    id: createUniqueUuid(runtime, scoped(message.eventId || `${roomId}:${message.timestamp}`)),
-    entityId: createUniqueUuid(runtime, scoped(message.sender || roomId)),
+    id: matrixScopedUuid(runtime, scoped(message.eventId || `${roomId}:${message.timestamp}`)),
+    entityId: matrixScopedUuid(runtime, scoped(message.sender || roomId)),
     agentId: runtime.agentId,
-    roomId: createUniqueUuid(runtime, scoped(message.roomId)),
+    roomId: matrixScopedUuid(runtime, scoped(message.roomId)),
     content: {
       text: message.content,
       source: MATRIX_SERVICE_NAME,
       channelType,
-      ...(message.replyTo ? { inReplyTo: createUniqueUuid(runtime, scoped(message.replyTo)) } : {}),
+      ...(message.replyTo ? { inReplyTo: matrixScopedUuid(runtime, scoped(message.replyTo)) } : {}),
     },
     createdAt: message.timestamp,
   };
@@ -594,7 +612,7 @@ async function readMessagesForTarget(
   // memories since the account-scoping change.
   return readStoredMessageMemories(
     runtime,
-    createUniqueUuid(runtime, `${accountId}:${matrixRoomId}`),
+    matrixScopedUuid(runtime, `${accountId}:${matrixRoomId}`),
     limit
   );
 }
@@ -1237,9 +1255,21 @@ export class MatrixService extends Service implements IMatrixService {
       // the local incompleteness flag set, so publication stays blocked.
       void state.membershipAuthority
         .markScopeStale({ roomId: room.roomId, reason: "limited_sync_timeline_reset" })
+        .then(() =>
+          // A timeline reset marks the room incomplete but nothing else
+          // schedules the recovery publication: PREPARED does not recur, and
+          // without this pass the room stays incomplete indefinitely with
+          // stale roster facts. The recovery publication fetches a FRESH
+          // server roster (never the just-distrusted SDK model) and either
+          // re-establishes the complete baseline or leaves the room
+          // fail-closed incomplete on fetch failure — where the bounded
+          // backoff below retries the same fresh-fetch path (never a cached
+          // roster) until it succeeds or the room leaves the joined set.
+          this.recoverMembershipAfterTimelineReset(state, room.roomId, 1)
+        )
         .catch((err) =>
           logger.error(
-            `Matrix membership stale-degrade after timeline reset failed: ${err instanceof Error ? err.message : String(err)}`
+            `Matrix membership recovery after timeline reset failed: ${err instanceof Error ? err.message : String(err)}`
           )
         );
     });
@@ -1286,14 +1316,79 @@ export class MatrixService extends Service implements IMatrixService {
     state.client.on(sdk.RoomMemberEvent.Membership, (event, member, oldMembership) => {
       // error-policy:J7 transition handling is diagnostic (the authority's
       // evidence path already reports its own failures); never kill sync.
-      void this.handleMembershipTransition(state, event, member, oldMembership).catch((err) =>
+      // Bootstrap (ensure*) rejections propagate here and are reported so
+      // RECENT_ERRORS surfaces dropped membership evidence, not just the log.
+      void this.handleMembershipTransition(state, event, member, oldMembership).catch((err) => {
         logger.error(
           `Matrix membership transition handling failed: ${err instanceof Error ? err.message : String(err)}`
-        )
-      );
+        );
+        this.runtime.reportError("matrix:membership-transition", err as Error, {
+          roomId: event.getRoomId?.() ?? undefined,
+          matrixUserId: member?.userId,
+        });
+      });
     });
 
     this.setupVerificationAutoAccept(state);
+  }
+
+  /**
+   * Bounded-backoff recovery for a room flagged incomplete by a timeline
+   * reset. Each attempt runs the full publication pass, which fetches a
+   * FRESH server roster (never the cached SDK model); on failure the room
+   * stays fail-closed incomplete and the next attempt retries. Retries stop
+   * early once the room is no longer flagged incomplete (a concurrent pass
+   * or a later PREPARED recovered it) or the bot left the room. Attempt
+   * count, not wall-clock, bounds the schedule so timers stay deterministic
+   * under test.
+   */
+  private async recoverMembershipAfterTimelineReset(
+    state: MatrixAccountState,
+    roomId: string,
+    attempt: number
+  ): Promise<void> {
+    const authority = state.membershipAuthority;
+    if (!authority) {
+      return;
+    }
+    try {
+      await this.publishMembershipSnapshots(state, false);
+      // Success: any room still incomplete after a successful pass failed
+      // its own fresh fetch; those rooms schedule their own retry below via
+      // the per-room loop only if this pass threw — a clean return means
+      // every room either published or reported incomplete, and the rooms
+      // that reported incomplete are re-covered by the retry below.
+      const stillIncomplete = authority.isRoomIncomplete(roomId);
+      if (!stillIncomplete) {
+        return;
+      }
+      throw new Error(`room ${roomId} still incomplete after recovery publication`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // error-policy:J7 diagnostics must not kill the sync loop; the room
+      // remains fail-closed incomplete (admission denied) until a retry
+      // publishes a complete fresh roster.
+      logger.warn(`Matrix membership recovery attempt ${attempt} for ${roomId} failed: ${message}`);
+      this.runtime.reportError(
+        "matrix:membership-recovery",
+        err instanceof Error ? err : new Error(message),
+        { roomId, attempt }
+      );
+    }
+    if (attempt >= 5) {
+      logger.error(
+        `Matrix membership recovery for ${roomId} exhausted after ${attempt} attempts; room stays fail-closed until the next sync/join trigger`
+      );
+      return;
+    }
+    const delayMs = Math.min(30_000, 2_000 * 2 ** (attempt - 1));
+    const timer = setTimeout(() => {
+      void this.recoverMembershipAfterTimelineReset(state, roomId, attempt + 1);
+    }, delayMs);
+    // Never keep the process alive for a retry timer.
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
   }
 
   /**
@@ -1396,8 +1491,30 @@ export class MatrixService extends Service implements IMatrixService {
           // transient flag so the room stops entering recovery every pass.
           // (A room WITH a persisted non-current scope still publishes — the
           // shrunken roster is complete evidence and restores health.)
-          authority.clearTransientRoomIncompleteness(room.roomId);
-          continue;
+          // A room with a CURRENT persisted scope is also governed evidence:
+          // the shrunken roster is the complete truth (a governed group that
+          // lost members), and skipping here would strand revoked members as
+          // active forever. Skip only on a DEFINITIVE no-scope probe; a
+          // failed probe stays fail-closed and publishes.
+          let noScope = false;
+          {
+            const health = await authority
+              .scopeHealth({ roomId: room.roomId })
+              .then((h) => h === null)
+              .catch(() => false);
+            // The transient incompleteness flag is deliberately NOT consulted
+            // here: reaching this point means the fresh server roster fetch
+            // SUCCEEDED in full, which disproves every transient incompleteness
+            // reason. Requiring !isRoomIncomplete as well would make this skip
+            // unreachable exactly when a transient flag is set (the recovery
+            // case), publishing a DM-sized room as a governed scope. Only the
+            // persisted probe decides: definitive no-scope => true direct room.
+            noScope = health;
+          }
+          if (noScope) {
+            authority.clearTransientRoomIncompleteness(room.roomId);
+            continue;
+          }
         }
         authority.clearTransientRoomIncompleteness(room.roomId);
         // Fall through: publish the complete baseline from the fresh roster.
@@ -1526,15 +1643,19 @@ export class MatrixService extends Service implements IMatrixService {
     }
     // Snapshot members must reference existing entity/room/world rows; the
     // gate path creates them lazily, and synced rooms may carry members the
-    // runtime has never seen — bootstrap rows before publishing.
-    const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${room.roomId}`);
-    await this.runtime.createWorld({
+    // runtime has never seen — bootstrap rows before publishing. ensure* (not
+    // create*): the PREPARED publication pass and the membership-transition
+    // handler run concurrently on the same room in a real sync (both observe
+    // the join), and a plain createWorld would throw WORLD_ALREADY_EXISTS
+    // from the loser and kill evidence publication.
+    const worldId = matrixScopedUuid(this.runtime, `${state.accountId}:${room.roomId}`);
+    await this.runtime.ensureWorldExists({
       id: worldId,
       name: room.name || room.roomId,
       agentId: this.runtime.agentId,
       metadata: { source: MATRIX_SERVICE_NAME, accountId: state.accountId, roomId: room.roomId },
     });
-    await this.runtime.createRoom({
+    await this.runtime.ensureRoomExists({
       id: worldId,
       name: room.name || room.roomId,
       source: MATRIX_SERVICE_NAME,
@@ -1544,7 +1665,7 @@ export class MatrixService extends Service implements IMatrixService {
     });
     const memberRecords = [];
     for (const roomMember of memberEntries) {
-      const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${roomMember.userId}`);
+      const entityId = matrixScopedUuid(this.runtime, `${state.accountId}:${roomMember.userId}`);
       await this.runtime.createEntity({
         id: entityId,
         agentId: this.runtime.agentId,
@@ -1657,20 +1778,49 @@ export class MatrixService extends Service implements IMatrixService {
       return;
     }
     const room = state.client.getRoom(roomId);
-    if (
-      room &&
-      room.getJoinedMemberCount() <= 2 &&
-      member.membership !== "join" &&
-      member.userId !== state.settings.userId
-    ) {
-      // Direct rooms are not membership-governed; a PEER's leave/ban in a
-      // <=2-member room must create NO authority evidence. Returning here is
-      // load-bearing: falling through would register a publisher scope for a
-      // DM and record an ordered delta with no snapshot baseline, poisoning
-      // the grown-room bootstrap below if the DM later becomes a group. The
-      // bot's OWN leave/ban is excluded: the self-transition block below must
-      // still tombstone a governed scope (e.g. a group that shrank to two).
-      return;
+    if (room && member.membership !== "join" && member.userId !== state.settings.userId) {
+      // Direct rooms are not membership-governed; a PEER's leave/ban must
+      // create NO authority evidence. Room SIZE is not the governor signal
+      // though — a governed room that shrank can be any size. The definitive
+      // signal is the authority's own scope row: a scope that exists (in any
+      // health) means this room IS governed and the leaving peer's revocation
+      // must record. Only a definitive no-scope probe lets the DM skip run;
+      // a failed probe reports and drops (recording against the same failing
+      // store would mint a scope row for a possible DM as a side effect of a
+      // doomed write). Returning via the size heuristic alone would strand
+      // revoked members of shrinking groups as active forever.
+      let governed = true;
+      const health = await authority.scopeHealth({ roomId }).catch((err: unknown) => {
+        logger.error(
+          `Matrix membership scope health probe failed for ${roomId}: ${err instanceof Error ? err.message : String(err)}`
+        );
+        return "probe-failed" as const;
+      });
+      if (health === "probe-failed") {
+        // The authority store itself just failed — recordTransition would
+        // hit the same store and its ensureRegistered would MINT a scope
+        // row for a possible DM as a side effect of a doomed write. Report
+        // and drop instead: the next roster publication pass for this room
+        // re-derives the full baseline from fresh server state.
+        this.runtime.reportError(
+          "matrix:membership-transition",
+          new Error("scope health probe failed"),
+          {
+            roomId,
+            matrixUserId: member.userId,
+            transition: "leave",
+          }
+        );
+        return;
+      }
+      if (health === null && room.getJoinedMemberCount() + 1 <= 2) {
+        // Definitive no-scope AND direct-sized (even counting the subject):
+        // a true DM peer leave.
+        governed = false;
+      }
+      if (!governed) {
+        return;
+      }
     }
     // Bot self-transitions own the scope lifecycle.
     if (member.userId === state.settings.userId) {
@@ -1753,8 +1903,8 @@ export class MatrixService extends Service implements IMatrixService {
       );
       return;
     }
-    const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${matrixUserId}`);
-    const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${roomId}`);
+    const entityId = matrixScopedUuid(this.runtime, `${state.accountId}:${matrixUserId}`);
+    const worldId = matrixScopedUuid(this.runtime, `${state.accountId}:${roomId}`);
     // Evidence requires entity/room/world rows: bootstrap them for members the
     // runtime has never seen (idempotent creates).
     await this.runtime.createEntity({
@@ -1763,13 +1913,19 @@ export class MatrixService extends Service implements IMatrixService {
       names: [`matrix-${getMatrixLocalpart(matrixUserId)}`],
       metadata: { source: MATRIX_SERVICE_NAME, matrixUserId },
     });
-    await this.runtime.createWorld({
+    // ensure* (not create*): the PREPARED publication pass and the
+    // membership-transition handler run concurrently on the same room in a
+    // real sync (both observe the join); ensure* is idempotent by contract
+    // (read-compare-upsert with CAS retry), so whichever wins, this call
+    // completes without WORLD_ALREADY_EXISTS dropping the transition.
+    // Bootstrap failures propagate to the caller's J7 report handler.
+    await this.runtime.ensureWorldExists({
       id: worldId,
       name: roomId,
       agentId: this.runtime.agentId,
       metadata: { source: MATRIX_SERVICE_NAME, accountId: state.accountId, roomId },
     });
-    await this.runtime.createRoom({
+    await this.runtime.ensureRoomExists({
       id: worldId,
       name: roomId,
       source: MATRIX_SERVICE_NAME,
@@ -1955,7 +2111,7 @@ export class MatrixService extends Service implements IMatrixService {
       const allowed = await state.membershipGate.authorizeMessage({
         roomId,
         isDirectRoom,
-        principalEntityId: createUniqueUuid(this.runtime, `${state.accountId}:${message.sender}`),
+        principalEntityId: matrixScopedUuid(this.runtime, `${state.accountId}:${message.sender}`),
         matrixUserId: message.sender,
         getJoinedMemberIds: () => room.getJoinedMembers().map((m) => m.userId),
       });
@@ -1999,7 +2155,9 @@ export class MatrixService extends Service implements IMatrixService {
     // the same room must never share room/world/entity UUIDs (the authority
     // scopes membership per connector account, and cross-account memory
     // blending is a privacy violation).
-    const scoped = (seed: string) => createUniqueUuid(this.runtime, `${state.accountId}:${seed}`);
+    // Authority-compatible derivation: the membership scope's entity/room/world
+    // rows must match the ids publication bootstrapped (matrixScopedUuid).
+    const scoped = (seed: string) => matrixScopedUuid(this.runtime, `${state.accountId}:${seed}`);
     const entityId = scoped(message.sender || roomId);
     const coreRoomId = scoped(roomId);
     const worldId = scoped(roomId);

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1596,8 +1596,28 @@ export class MatrixService extends Service implements IMatrixService {
     // direct room), so the count must not gate degradation. Rooms that were
     // never snapshotted (true DMs, unpublished rooms) are skipped inside
     // degradeScope — no scope row, nothing authorizing.
+    //
+    // Per-room containment is load-bearing: one failed durable write must not
+    // abort the loop, or every later room keeps authorizing stale evidence
+    // for the whole reconnect gap. Attempt ALL rooms, retain the first
+    // failure, and rethrow it after the loop so the reconnect handler's
+    // catch logs it and the next sync retries — a swallow would disguise a
+    // scope that never degraded (error policy: J2, rethrow with cause).
+    let firstFailure: unknown = null;
     for (const room of state.client.getRooms().filter((r) => r.getMyMembership() === "join")) {
-      await authority.markScopeStale({ roomId: room.roomId, reason });
+      try {
+        await authority.markScopeStale({ roomId: room.roomId, reason });
+      } catch (error) {
+        if (firstFailure === null) {
+          firstFailure = error;
+        }
+        logger.error(
+          `Matrix membership scope stale-degrade failed for ${room.roomId}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+    if (firstFailure !== null) {
+      throw firstFailure;
     }
   }
 

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1305,7 +1305,7 @@ export class MatrixService extends Service implements IMatrixService {
    */
   private async publishMembershipSnapshots(
     state: MatrixAccountState,
-    _firstSync: boolean
+    firstSync: boolean
   ): Promise<void> {
     const authority = state.membershipAuthority;
     if (!authority) {
@@ -1339,26 +1339,39 @@ export class MatrixService extends Service implements IMatrixService {
       // leave a partial roster unrecovered indefinitely. Only a room the
       // authority already knows (in-memory flag OR persisted non-current
       // health) needs recovery; a never-registered true DM has no scope row
-      // and must not be published.
+      // and must not be published. A non-first sync (reconnect republish,
+      // post-join sweep) NEVER publishes from the SDK cache directly — only
+      // a fresh server roster may become evidence on those passes.
       const incomplete = authority.isRoomIncomplete(room.roomId);
+      // error-policy:J7 a failed health probe is diagnostic and must fail
+      // CLOSED for publication: an unknown persisted-health state cannot be
+      // treated as "recovery unnecessary" (that would publish the possibly
+      // stale SDK roster). Treat a probe failure as needing fresh recovery.
       let persistedNonCurrent = false;
-      if (!incomplete) {
+      let healthProbeFailed = false;
+      {
         const health = await authority
           .scopeHealth({ roomId: room.roomId })
           .catch((err: unknown) => {
-            // error-policy:J7 health probe failure is diagnostic; treat as
-            // not needing recovery rather than blocking the whole pass.
             logger.error(
               `Matrix membership scope health probe failed for ${room.roomId}: ${err instanceof Error ? err.message : String(err)}`
             );
-            return null;
+            return "probe-failed" as const;
           });
-        // A scope the SQL authority holds as stale/unavailable must recover
-        // through a fresh-roster republication even when this process has no
-        // in-memory incompleteness flag (e.g. after a restart).
-        persistedNonCurrent = health !== null && health.health !== "current";
+        if (health === "probe-failed") {
+          healthProbeFailed = true;
+        } else {
+          // A scope the SQL authority holds as stale/unavailable must
+          // recover through a fresh-roster republication even when this
+          // process has no in-memory incompleteness flag (e.g. restart).
+          // Probed even when the in-memory flag is set: a room with BOTH a
+          // transient flag and a persisted scope must still publish its
+          // (shrunken) fresh roster to restore the persisted scope, not just
+          // clear the flag.
+          persistedNonCurrent = health !== null && health.health !== "current";
+        }
       }
-      if (incomplete || persistedNonCurrent) {
+      if (incomplete || persistedNonCurrent || healthProbeFailed || !firstSync) {
         // Recovery requires a GENUINELY FRESH server-side roster:
         // loadMembersIfNeeded is one-shot and cached by the SDK, so a cached
         // resolve does NOT disprove a later timeline-reset gap. Perform a
@@ -2335,22 +2348,28 @@ export class MatrixService extends Service implements IMatrixService {
       // the homeserver call returned — the store scan inside the general
       // publication pass only sees rooms whose getMyMembership() is already
       // "join" in the SDK's possibly-not-yet-synced state, which is exactly
-      // the missed-event case this recovery exists for.
-      void this.publishSingleRoomMembershipSnapshot(state, response)
+      // the missed-event case this recovery exists for. Direct rooms (>2
+      // exclusion) never register membership scopes — guard here the same
+      // way the publication pass does.
+      const directPublish =
+        typeof response.getJoinedMemberCount === "function" && response.getJoinedMemberCount() > 2
+          ? this.publishSingleRoomMembershipSnapshot(state, response)
+          : Promise.resolve(false);
+      void directPublish
         .catch((err) =>
           logger.error(
             `Matrix membership snapshot after join failed: ${err instanceof Error ? err.message : String(err)}`
           )
         )
-        .then((published) => {
-          // Snapshot-only room (no other members yet): also run the general
-          // pass so rooms already in the store get their snapshots too.
+        .then(() => {
+          // Sweep the store too: rooms already known to the SDK get their
+          // snapshots through the general pass (which enforces its own
+          // freshness and direct-room rules).
           void this.publishMembershipSnapshots(state, false).catch((err) =>
             logger.error(
               `Matrix membership snapshot sweep after join failed: ${err instanceof Error ? err.message : String(err)}`
             )
           );
-          return published;
         });
     }
 

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -581,7 +581,13 @@ async function readMessagesForTarget(
   if (live.length > 0) {
     return live;
   }
-  return readStoredMessageMemories(runtime, createUniqueUuid(runtime, matrixRoomId), limit);
+  // Account-scoped key, matching how matrixMessageToMemory persists inbound
+  // memories since the account-scoping change.
+  return readStoredMessageMemories(
+    runtime,
+    createUniqueUuid(runtime, `${accountId}:${matrixRoomId}`),
+    limit
+  );
 }
 
 function filterMemoriesByQuery(
@@ -1156,8 +1162,11 @@ export class MatrixService extends Service implements IMatrixService {
         );
       } else if (syncState === "ERROR" || syncState === "RECONNECTING") {
         // Connection trouble: room evidence may be stale. Degrade every
-        // currently-tracked room scope to unavailable so admission fails
-        // closed until a fresh PREPARED re-publishes complete state.
+        // currently-tracked room scope to STALE (fail-closed admission, no
+        // tombstone) so a fresh PREPARED can re-publish complete state and
+        // restore admission. Unavailable+tombstone is reserved for bot
+        // self-leave/ban, where only an explicit rejoin may clear it — a
+        // transient reconnect must never permanently kill a scope.
         if (state.membershipAuthority) {
           void this.degradeAllMembershipScopes(state, `sync_${syncState.toLowerCase()}`).catch(
             (err) =>
@@ -1234,8 +1243,30 @@ export class MatrixService extends Service implements IMatrixService {
     }
     const rooms = state.client.getRooms().filter((room) => room.getMyMembership() === "join");
     for (const room of rooms) {
+      // Lazy loading: until the out-of-band member list resolves, the SDK's
+      // roster is partial AND the joined-member count is unreliable (a large
+      // room can transiently look like a 1-member "direct" room). Load members
+      // FIRST, then classify the room — never publish or skip on a partial
+      // roster.
+      let membersReady = true;
+      if (typeof room.loadMembersIfNeeded === "function") {
+        try {
+          await room.loadMembersIfNeeded();
+        } catch {
+          membersReady = false;
+        }
+      }
+      if (!membersReady) {
+        await authority.reportIncomplete({
+          roomId: room.roomId,
+          reason: "member_load_failed",
+          observedAt: new Date().toISOString(),
+        });
+        continue;
+      }
+      // Direct rooms are not membership-governed (assessed after the member
+      // list resolved, so a lazily-loaded group is never misclassified).
       if (room.getJoinedMemberCount() <= 2) {
-        // Direct rooms are not membership-governed.
         continue;
       }
       if (authority.isRoomIncomplete(room.roomId)) {
@@ -1246,22 +1277,11 @@ export class MatrixService extends Service implements IMatrixService {
         });
         continue;
       }
-      // Lazy loading: until the out-of-band member list resolves, the SDK's
-      // roster is partial. Wait for it (bounded) before publishing; a timeout
-      // is incompleteness, not emptiness.
-      let membersReady = true;
-      if (typeof room.loadMembersIfNeeded === "function") {
-        try {
-          await room.loadMembersIfNeeded();
-        } catch {
-          membersReady = false;
-        }
-      }
       const joinedMembers = room.getJoinedMembers();
-      if (!membersReady || joinedMembers.length === 0) {
+      if (joinedMembers.length === 0) {
         await authority.reportIncomplete({
           roomId: room.roomId,
-          reason: membersReady ? "empty_roster" : "member_load_failed",
+          reason: "empty_roster",
           observedAt: new Date().toISOString(),
         });
         continue;
@@ -1315,9 +1335,9 @@ export class MatrixService extends Service implements IMatrixService {
   }
 
   /**
-   * Degrade every tracked room scope for an account to unavailable (sync
-   * trouble). Used on ERROR/RECONNECTING so admission fails closed until a
-   * fresh PREPARED re-publishes.
+   * Degrade every tracked room scope for an account to STALE (transient sync
+   * trouble): admission fails closed until a fresh PREPARED re-publishes, and
+   * NO tombstone is installed so the re-publish is accepted.
    */
   private async degradeAllMembershipScopes(
     state: MatrixAccountState,
@@ -1329,7 +1349,7 @@ export class MatrixService extends Service implements IMatrixService {
     }
     for (const room of state.client.getRooms().filter((r) => r.getMyMembership() === "join")) {
       if (room.getJoinedMemberCount() <= 2) continue;
-      await authority.markScopeUnavailable({ roomId: room.roomId, reason });
+      await authority.markScopeStale({ roomId: room.roomId, reason });
     }
   }
 

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -196,17 +196,15 @@ type MatrixAccountState = {
   /** Authority handle for evidence publication; null when absent. */
   membershipAuthority?: MatrixMembershipAuthority;
   /**
-   * Per-process monotonically increasing snapshot observation counter plus a
-   * boot token: together they make every snapshot idempotency key unique to
-   * one observation, so restarts and resyncs never collide with prior runs.
+   * Snapshot evidence identity: a per-STATE instance token (rotates whenever
+   * account state is constructed) plus a monotonically increasing observation
+   * counter. Together they make every snapshot idempotency key unique to one
+   * observation by one state instance, so restarts, resyncs, and in-process
+   * state reconstruction never reuse keys.
    */
+  membershipSnapshotToken: string;
   membershipSnapshotCounter: number;
 };
-
-// Per-process boot token for snapshot idempotency keys: distinguishes this
-// process's observations from a previous process's, so a restart's snapshots
-// are new evidence rather than idempotency conflicts against stale keys.
-const MATRIX_SNAPSHOT_BOOT_TOKEN = crypto.randomUUID().split("-")[0];
 
 /**
  * Serialized form of an IndexedDB database: object-store schemas plus their
@@ -861,6 +859,7 @@ export class MatrixService extends Service implements IMatrixService {
         }),
         connected: false,
         syncing: false,
+        membershipSnapshotToken: crypto.randomUUID(),
         membershipSnapshotCounter: 0,
       };
 
@@ -1228,7 +1227,7 @@ export class MatrixService extends Service implements IMatrixService {
       // than left authorizing on an untrustworthy roster. The room is also
       // marked locally incomplete so a later publication pass re-establishes
       // a complete baseline instead of streaming deltas over the gap.
-      state.membershipAuthority.markRoomIncomplete(room.roomId);
+      state.membershipAuthority.markRoomIncomplete(room.roomId, "limited_sync_timeline_reset");
       // error-policy:J7 stale-degrade is diagnostic; a failed degrade leaves
       // the local incompleteness flag set, so publication stays blocked.
       void state.membershipAuthority
@@ -1251,7 +1250,14 @@ export class MatrixService extends Service implements IMatrixService {
       if (event.isEncrypted() && event.getType() === "m.room.encrypted") {
         event.once(sdk.MatrixEventEvent.Decrypted, () => {
           if (event.getType() === "m.room.message") {
-            void this.handleRoomMessage(state, event, room);
+            // error-policy:J7 admission/dispatch failures are reported and
+            // swallowed here: the SDK event callback must not become an
+            // unhandled rejection source.
+            void this.handleRoomMessage(state, event, room).catch((err) =>
+              logger.error(
+                `Matrix room message handling failed: ${err instanceof Error ? err.message : String(err)}`
+              )
+            );
           } else if (event.isDecryptionFailure()) {
             logger.warn(
               `Matrix could not decrypt event ${event.getId()} in ${event.getRoomId()} — the sender has not shared the megolm key with this device yet.`
@@ -1262,7 +1268,13 @@ export class MatrixService extends Service implements IMatrixService {
       }
 
       if (event.getType() !== "m.room.message") return;
-      void this.handleRoomMessage(state, event, room);
+      // error-policy:J7 see the Decrypted branch above — never leak an
+      // unhandled rejection into the SDK event handler.
+      void this.handleRoomMessage(state, event, room).catch((err) =>
+        logger.error(
+          `Matrix room message handling failed: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
     });
 
     // Room membership events
@@ -1323,74 +1335,105 @@ export class MatrixService extends Service implements IMatrixService {
         continue;
       }
       if (authority.isRoomIncomplete(room.roomId)) {
-        await authority.reportIncomplete({
-          roomId: room.roomId,
-          reason: "member_list_incomplete",
-          observedAt: new Date().toISOString(),
-        });
-        continue;
+        // Recovery: a limited-sync gap (timeline reset) is disproved by a
+        // FULLY RESOLVED out-of-band member list in this pass — the SDK just
+        // told us the roster is complete again. Clear exactly that reason and
+        // fall through to publish a fresh complete baseline; other
+        // incompleteness reasons (member load failed, empty roster) still
+        // report incomplete and skip. Without this, one timeline reset would
+        // leave the scope permanently stale.
+        const recovered =
+          membersReady && authority.clearRoomIncomplete(room.roomId, "limited_sync_timeline_reset");
+        if (!recovered) {
+          await authority.reportIncomplete({
+            roomId: room.roomId,
+            reason: "member_list_incomplete",
+            observedAt: new Date().toISOString(),
+          });
+          continue;
+        }
+        // Fall through: publish the complete baseline.
       }
-      const joinedMembers = room.getJoinedMembers();
-      if (joinedMembers.length === 0) {
-        await authority.reportIncomplete({
-          roomId: room.roomId,
-          reason: "empty_roster",
-          observedAt: new Date().toISOString(),
-        });
-        continue;
-      }
-      // Snapshot members must reference existing entity/room/world rows; the
-      // gate path creates them lazily, and PREPARED rooms may carry members
-      // the runtime has never seen — bootstrap rows before publishing.
-      const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${room.roomId}`);
-      await this.runtime.createWorld({
-        id: worldId,
-        name: room.name || room.roomId,
-        agentId: this.runtime.agentId,
-        metadata: { source: MATRIX_SERVICE_NAME, accountId: state.accountId, roomId: room.roomId },
-      });
-      await this.runtime.createRoom({
-        id: worldId,
-        name: room.name || room.roomId,
-        source: MATRIX_SERVICE_NAME,
-        type: ChannelType.GROUP,
-        channelId: room.roomId,
-        worldId,
-      });
-      const memberRecords = [];
-      for (const member of joinedMembers) {
-        const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${member.userId}`);
-        await this.runtime.createEntity({
-          id: entityId,
-          agentId: this.runtime.agentId,
-          names: [`matrix-${getMatrixLocalpart(member.userId)}`],
-          metadata: { source: MATRIX_SERVICE_NAME, matrixUserId: member.userId },
-        });
-        memberRecords.push({
-          canonicalPrincipalId: entityId,
-          roles: matrixMemberRoles(member.powerLevel),
-          permissionSnapshot: { membership: "join" },
-          runtime: { worldId, roomId: worldId, entityId },
-        });
-      }
-      const snapshotObservedAt = new Date().toISOString();
-      // Idempotency keys must identify ONE observation, not a class of sync
-      // events: a per-process monotonically increasing token keeps restarts
-      // and resyncs distinct (a reused key is an idempotency CONFLICT, and
-      // publishSnapshot would silently skip a changed roster).
-      state.membershipSnapshotCounter += 1;
-      const published = await authority.publishSnapshot({
-        roomId: room.roomId,
-        observedAt: snapshotObservedAt,
-        members: memberRecords,
-        idempotencyKey: `mx:${state.accountId}:${room.roomId}:snapshot:${state.membershipSnapshotCounter}:${MATRIX_SNAPSHOT_BOOT_TOKEN}`,
-      });
-      if (published) {
-        logger.debug(
-          `Matrix membership snapshot published for ${room.roomId}: ${memberRecords.length} members`
-        );
-      }
+      await this.publishSingleRoomMembershipSnapshot(state, room);
     }
+  }
+
+  /**
+   * Publishes ONE room's complete membership snapshot (the ordered-delta
+   * baseline): bootstraps entity/room/world rows for members the runtime has
+   * never seen, then submits the roster under a unique observation key.
+   * Shared by the sync-driven publication pass and the grown-room baseline
+   * path in the membership-transition handler. Returns true when published.
+   */
+  private async publishSingleRoomMembershipSnapshot(
+    state: MatrixAccountState,
+    room: sdk.Room
+  ): Promise<boolean> {
+    const authority = state.membershipAuthority;
+    if (!authority) {
+      return false;
+    }
+    const joinedMembers = room.getJoinedMembers();
+    if (joinedMembers.length === 0) {
+      await authority.reportIncomplete({
+        roomId: room.roomId,
+        reason: "empty_roster",
+        observedAt: new Date().toISOString(),
+      });
+      return false;
+    }
+    // Snapshot members must reference existing entity/room/world rows; the
+    // gate path creates them lazily, and synced rooms may carry members the
+    // runtime has never seen — bootstrap rows before publishing.
+    const worldId = createUniqueUuid(this.runtime, `${state.accountId}:${room.roomId}`);
+    await this.runtime.createWorld({
+      id: worldId,
+      name: room.name || room.roomId,
+      agentId: this.runtime.agentId,
+      metadata: { source: MATRIX_SERVICE_NAME, accountId: state.accountId, roomId: room.roomId },
+    });
+    await this.runtime.createRoom({
+      id: worldId,
+      name: room.name || room.roomId,
+      source: MATRIX_SERVICE_NAME,
+      type: ChannelType.GROUP,
+      channelId: room.roomId,
+      worldId,
+    });
+    const memberRecords = [];
+    for (const roomMember of joinedMembers) {
+      const entityId = createUniqueUuid(this.runtime, `${state.accountId}:${roomMember.userId}`);
+      await this.runtime.createEntity({
+        id: entityId,
+        agentId: this.runtime.agentId,
+        names: [`matrix-${getMatrixLocalpart(roomMember.userId)}`],
+        metadata: { source: MATRIX_SERVICE_NAME, matrixUserId: roomMember.userId },
+      });
+      memberRecords.push({
+        canonicalPrincipalId: entityId,
+        roles: matrixMemberRoles(roomMember.powerLevel),
+        permissionSnapshot: { membership: "join" },
+        runtime: { worldId, roomId: worldId, entityId },
+      });
+    }
+    // Idempotency keys must identify ONE observation, not a class of sync
+    // events: a per-state instance token + monotonic counter keeps restarts,
+    // resyncs, and in-process state reconstruction distinct (a reused key is
+    // an idempotency CONFLICT, and publishSnapshot would silently skip a
+    // changed roster).
+    state.membershipSnapshotCounter += 1;
+    const published = await authority.publishSnapshot({
+      roomId: room.roomId,
+      observedAt: new Date().toISOString(),
+      members: memberRecords,
+      idempotencyKey: `mx:${state.accountId}:${room.roomId}:snapshot:${state.membershipSnapshotToken}:${state.membershipSnapshotCounter}`,
+    });
+    if (published) {
+      logger.debug(
+        `Matrix membership snapshot published for ${room.roomId}: ${memberRecords.length} members`
+      );
+    }
+    return published;
   }
 
   /**
@@ -1483,6 +1526,27 @@ export class MatrixService extends Service implements IMatrixService {
     if (room && room.getJoinedMemberCount() <= 2 && member.membership === "join") {
       // Direct rooms are not membership-governed.
       return;
+    }
+    // A previously ungoverned (direct) room that grew past two members has NO
+    // snapshot baseline, and the SQL authority rejects ordered deltas without
+    // one — the delta below would be dropped, leaving the new group
+    // permanently denied. When the room has crossed into group territory and
+    // carries no current scope evidence, publish the complete baseline first;
+    // the transition delta then lands on top of it.
+    if (room && room.getJoinedMemberCount() > 2 && member.membership === "join") {
+      const health = await authority.scopeHealth({ roomId }).catch((err: unknown) => {
+        logger.error(
+          `Matrix membership scope health probe failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+        return null;
+      });
+      if (health?.health !== "current") {
+        await this.publishSingleRoomMembershipSnapshot(state, room).catch((err) =>
+          logger.error(
+            `Matrix membership baseline for grown room failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+      }
     }
     const transition = classifyMatrixTransition(member.membership, oldMembership);
     const matrixUserId = member.userId || event.getSender() || "unknown";
@@ -2268,6 +2332,7 @@ export class MatrixService extends Service implements IMatrixService {
         client: legacy.client ?? ({} as sdk.MatrixClient),
         connected: legacy.connected ?? true,
         syncing: legacy.syncing ?? true,
+        membershipSnapshotToken: crypto.randomUUID(),
         membershipSnapshotCounter: 0,
       };
     }


### PR DESCRIPTION
# feat(matrix): publish SDK-observed membership evidence (#24368)

Closes #24368

Adds `MatrixMembershipAuthority` — a publisher-discipline client for the canonical `MembershipService` contract — plus a connector-account admission gate, replacing inferred room membership with SDK-observed snapshots and ordered deltas.

## What changes

- **`src/membership.ts` (new, 886 lines)** — complete PREPARED/join roster snapshots (incomplete rosters reported incomplete, never empty), ordered join/invite/leave/ban deltas, bot self-leave scope termination, fenced retries, idempotent evidence keys.
- **`src/membership-gate.ts` (new)** — connector-account bootstrap + per-account admission gate for group rooms; DMs bypass; fail-closed under `MATRIX_MEMBERSHIP_ENFORCE=1`.
- **`src/service.ts` (+713)** — wires SDK sync states, join/leave events, and reconnects into the authority; fresh-server roster fetch on recovery (`fetchFreshServerRoster` returns the parsed fresh roster); fail-closed on cached rosters and probe failures.
- **Tests** — 9 new recovery tests (RED control 5/6 fail pre-fix) + recovery suite; suite total 96/96 at 56091fabdb (91/91 at prior head 9b32a65b48, then five new regression tests at 3bc4a4d716).

## Key invariants

- Incomplete/missing rosters are reported `incomplete`/`unavailable` — never an empty roster implying mass removal.
- Cached PREPARED state (syncData.fromCache) never publishes stale evidence; publication probes persisted scopeHealth and fails closed on probe failure.
- Explicit `joinRoom` publishes the returned Room directly, guarded against self-joins beyond direct rooms.
- Unknown/missing/knock membership transitions report via `runtime.reportError('matrix:membership-transition')` and skip — never recorded as a leave.

## Verification

| Gate | Result |
|---|---|
| `plugin-matrix` typecheck | 0 errors |
| Full plugin suite (fresh capture at publish) | 96/96 at 56091fabdb |
| Biome | clean |
| Merge vs develop tip | clean at review time (merge-tree 0 conflicts vs `5c476b4206`) |
| RED controls | recovery tests 5/6 fail pre-fix |
| RP review | 6 rounds (17 P1s fixed over r1–r3; r4/r5 follow-ons; r6 FINAL APPROVE zero must-fix, session 59A00748) |

<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:walkthrough-video -->
N/A - no user-visible surface changed (connector-internal evidence publication)
<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only head move a340401d844a -> 47fa30876ac (no behavior change); verified at current head: plugin-matrix vitest 96/96 pass, typecheck rc=0, biome clean; real-homeserver Synapse run evidence attached in PR comments 2026-09-09T16:10Z (connect/sync/autojoin/membership/E2EE-decrypt/reconnect-stale all observed via real MatrixService at head a340401d84, delta since = rebase only)

$ bun run --cwd plugins/plugin-matrix typecheck   # rc=0

$ bunx biome check <7 changed plugin-matrix files>
Checked 7 files in 62ms. No fixes applied.
```

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface changed (connector-internal evidence publication)
<!-- evidence-row:llm-trajectory -->
N/A - no model/provider path changed (deterministic plugin tests exercise the real service contract without a live model)
<!-- evidence-row:domain-artifacts -->
N/A - no persisted domain artifact surface changed (MembershipService records asserted in tests)
<!-- evidence-row:ocr-review -->
N/A - no OCR surface involved

<!-- evidence-head:c9b6670b69e2b75b2b84879156357c8f5f6c0c55 -->

---

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->











