### PR TITLE
feat(imessage): native membership snapshots for chats and connectors (#24370)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2051,6 +2051,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
+        "@elizaos/plugin-sql": "workspace:*",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",

--- a/bun.lock
+++ b/bun.lock
@@ -2055,6 +2055,7 @@
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
+        "uuid": "^14.0.0",
         "vitest": "^4.1.10",
       },
     },

--- a/plugins/plugin-imessage/AGENTS.md
+++ b/plugins/plugin-imessage/AGENTS.md
@@ -4,7 +4,7 @@ iMessage connector for Eliza agents using native macOS Messages or a channel-iso
 
 ## Purpose / role
 
-Adds iMessage send/receive capability through either local macOS Messages or Blooio. `IMessageService` polls `~/Library/Messages/chat.db` and uses `osascript` in native mode; in Blooio mode it verifies signed webhook deliveries, requires an exact configured channel id, and sends through the v4 message API. It registers the same `MessageConnector` in both modes.
+Adds iMessage send/receive capability to an Eliza agent running on macOS without an external bridge, third-party daemon, network service, or auxiliary CLI. The plugin registers `IMessageService`, which polls `~/Library/Messages/chat.db` for inbound messages and delivers outbound messages through the built-in `osascript` interface to Messages.app. It also registers the service as a `MessageConnector` so the standard `MESSAGE` operation routes through it. Auto-enabled when `config.connectors.imessage` is present and not explicitly disabled; opt-in otherwise.
 
 ## Plugin surface
 

--- a/plugins/plugin-imessage/CLAUDE.md
+++ b/plugins/plugin-imessage/CLAUDE.md
@@ -4,7 +4,7 @@ iMessage connector for Eliza agents using native macOS Messages or a channel-iso
 
 ## Purpose / role
 
-Adds iMessage send/receive capability through either local macOS Messages or Blooio. `IMessageService` polls `~/Library/Messages/chat.db` and uses `osascript` in native mode; in Blooio mode it verifies signed webhook deliveries, requires an exact configured channel id, and sends through the v4 message API. It registers the same `MessageConnector` in both modes.
+Adds iMessage send/receive capability to an Eliza agent running on macOS without an external bridge, third-party daemon, network service, or auxiliary CLI. The plugin registers `IMessageService`, which polls `~/Library/Messages/chat.db` for inbound messages and delivers outbound messages through the built-in `osascript` interface to Messages.app. It also registers the service as a `MessageConnector` so the standard `MESSAGE` operation routes through it. Auto-enabled when `config.connectors.imessage` is present and not explicitly disabled; opt-in otherwise.
 
 ## Plugin surface
 

--- a/plugins/plugin-imessage/README.md
+++ b/plugins/plugin-imessage/README.md
@@ -19,7 +19,7 @@ Native mode requires macOS. Blooio mode supports Linux servers.
 
 - **macOS**: This plugin only works on macOS
 - **Messages App Access**: Full Disk Access is required for reads; Automation permission is required for sends
-- **No Relay Required**: BlueBubbles, local servers, auxiliary CLIs, and external services are not used
+- **No Relay Required**: no external bridge, local server, auxiliary CLI, or network service is used; the connector reads chat.db directly
 
 ## Installation
 
@@ -107,6 +107,17 @@ The plugin uses two local macOS surfaces: read-only SQLite access to
 `~/Library/Messages/chat.db` for inbound history and Apple's built-in
 AppleScript interface to Messages.app for outbound delivery. It does not run a
 relay server or delegate to a third-party executable.
+
+### Membership evidence
+
+When the canonical `MembershipService` authority is registered (plugin-sql)
+and chat.db is readable, the service publishes native membership evidence:
+complete per-chat roster snapshots derived from `chat_handle_join` (on start
+and on a periodic sweep) plus per-sender point renewals on every inbound
+message. Roster read failures — a Full Disk Access (TCC) revocation, a moved
+or corrupt database — degrade every governed scope fail-closed (health
+`unavailable`, authorization denies) until a later successful sweep restores
+it. An absent authority keeps the legacy ungated behavior.
 
 ### AppleScript Method
 

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -60,6 +60,7 @@
     "@types/node": "^22.19.17",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",
+    "uuid": "^14.0.0",
     "vitest": "^4.1.10"
   },
   "eliza": {

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
+    "@elizaos/plugin-sql": "workspace:*",
     "@types/node": "^22.19.17",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",

--- a/plugins/plugin-imessage/src/chatdb-reader.ts
+++ b/plugins/plugin-imessage/src/chatdb-reader.ts
@@ -392,6 +392,15 @@ export interface ChatDbReader {
    * which was slower and returned less data.
    */
   listChats(): ChatDbChatSummary[];
+  /**
+   * Monotonic count of failed `listChats` roster queries on this reader
+   * (issue #24370). `listChats` degrades to `[]` on query failure by
+   * contract, which is indistinguishable from an empty database at the
+   * return-value boundary; this counter lets the membership roster adapter
+   * detect that a failure occurred and fail closed instead of treating a
+   * TCC-revoked or corrupt database as a healthy empty roster.
+   */
+  rosterReadFailureCount(): number;
   /** Close the underlying SQLite handle. Idempotent. */
   close(): void;
 }
@@ -719,6 +728,8 @@ export async function openChatDb(
   `);
 
   let closed = false;
+  /** Monotonic roster-query failure counter backing rosterReadFailureCount. */
+  let rosterFailures = 0;
 
   type RawMessageRow = {
     row_id: number;
@@ -937,11 +948,15 @@ export async function openChatDb(
           lastReadMessageTimestamp: appleDateToJsMs(row.last_read_apple_date ?? 0),
         }));
       } catch (error) {
+        rosterFailures += 1;
         logger.error(
           `[imessage] chat.db listChats query failed: ${error instanceof Error ? error.message : String(error)}`
         );
         return [];
       }
+    },
+    rosterReadFailureCount(): number {
+      return rosterFailures;
     },
     close(): void {
       if (closed) return;

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -184,12 +184,14 @@ export type {
 export {
   IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
   IMessageMembershipPublisher,
-  IMessageMembershipRosterSource as IMessageMembershipRosterSourceType,
-  IMessageRosterMember,
-  IMessageRosterRead,
   IMessageRosterUnavailableError,
   imessageMembershipPrincipalId,
   imessageMembershipScope,
   resolveMembershipService as resolveIMessageMembershipService,
+} from "./membership.js";
+export type {
+  IMessageMembershipRosterSource as IMessageMembershipRosterSourceType,
+  IMessageRosterMember,
+  IMessageRosterRead,
 } from "./membership.js";
 export { createChatDbRosterSource } from "./membership-roster.js";

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -168,8 +168,8 @@ export type {
   RouteRequestMeta as IMessageRouteRequestMeta,
 } from "@elizaos/core";
 // Legacy HTTP route handlers (mounted by the agent's raw HTTP router).
-// BlueBubbles is deliberately not aliased or re-exported here; its separate
-// plugin owns that legacy/remote transport.
+// BlueBubbles is retired: the native plugin reads chat.db directly and the
+// legacy bridge plugin has been removed from the repository.
 export {
   handleIMessageRoute,
   type IMessageRouteState,
@@ -180,3 +180,16 @@ export type {
   IMessageConfig,
   IMessageReactionNotificationMode,
 } from "./config.js";
+// Native membership evidence publisher (issue #24370).
+export {
+  IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+  IMessageMembershipPublisher,
+  IMessageMembershipRosterSource as IMessageMembershipRosterSourceType,
+  IMessageRosterMember,
+  IMessageRosterRead,
+  IMessageRosterUnavailableError,
+  imessageMembershipPrincipalId,
+  imessageMembershipScope,
+  resolveMembershipService as resolveIMessageMembershipService,
+} from "./membership.js";
+export { createChatDbRosterSource } from "./membership-roster.js";

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -180,6 +180,11 @@ export type {
   IMessageConfig,
   IMessageReactionNotificationMode,
 } from "./config.js";
+export type {
+  IMessageMembershipRosterSource as IMessageMembershipRosterSourceType,
+  IMessageRosterMember,
+  IMessageRosterRead,
+} from "./membership.js";
 // Native membership evidence publisher (issue #24370).
 export {
   IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
@@ -188,10 +193,5 @@ export {
   imessageMembershipPrincipalId,
   imessageMembershipScope,
   resolveMembershipService as resolveIMessageMembershipService,
-} from "./membership.js";
-export type {
-  IMessageMembershipRosterSource as IMessageMembershipRosterSourceType,
-  IMessageRosterMember,
-  IMessageRosterRead,
 } from "./membership.js";
 export { createChatDbRosterSource } from "./membership-roster.js";

--- a/plugins/plugin-imessage/src/membership-roster.test.ts
+++ b/plugins/plugin-imessage/src/membership-roster.test.ts
@@ -51,7 +51,9 @@ function makeReader(opts: {
 describe("createChatDbRosterSource failure semantics", () => {
   it("enumerates healthy reads normally", () => {
     const reader = makeReader({
-      chats: [{ chatId: "Imessage;-;+155****101", participants: ["+155****101"] }],
+      chats: [
+        { chatId: "Imessage;-;+155****101", participants: ["+155****101"] },
+      ],
     });
     const source = createChatDbRosterSource(reader);
     expect([...source.listChatIds()]).toEqual(["Imessage;-;+155****101"]);
@@ -60,14 +62,18 @@ describe("createChatDbRosterSource failure semantics", () => {
   });
 
   it("treats a swallowed listChats query failure as a roster read failure", () => {
-    const reader = makeReader({ chats: [{ chatId: "c1", participants: ["+155****102"] }] });
+    const reader = makeReader({
+      chats: [{ chatId: "c1", participants: ["+155****102"] }],
+    });
     const source = createChatDbRosterSource(reader);
     expect([...source.listChatIds()]).toEqual(["c1"]);
 
     // TCC revocation mid-run: the query fails, the reader returns [], and
     // the adapter must convert the observation into a thrown failure.
     reader.failNext();
-    expect(() => source.listChatIds()).toThrow(/roster enumeration query failed/);
+    expect(() => source.listChatIds()).toThrow(
+      /roster enumeration query failed/,
+    );
   });
 
   it("an empty healthy database stays a legitimate empty roster", () => {

--- a/plugins/plugin-imessage/src/membership-roster.test.ts
+++ b/plugins/plugin-imessage/src/membership-roster.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Roster-adapter failure semantics for the native membership publisher
+ * (#24370): the real chat.db reader degrades `listChats` to `[]` on query
+ * failure by contract, so the adapter must detect the swallowed failure
+ * through the reader's monotonic failure counter and throw, letting the
+ * publisher degrade fail-closed — a TCC-revoked or corrupt database must
+ * never look like a healthy empty roster. Harness is synthetic at the
+ * reader seam only; the adapter under test is the production one.
+ */
+import { describe, expect, it } from "vitest";
+import type { ChatDbReader } from "./chatdb-reader";
+import { createChatDbRosterSource } from "./membership-roster";
+
+/** Reader stub mirroring the real degrade-to-empty failure contract. */
+function makeReader(opts: {
+  chats: Array<{ chatId: string; participants: string[] }>;
+  failNextListChats?: boolean;
+}): ChatDbReader & { failNext: () => void } {
+  let failNext = opts.failNextListChats === true;
+  let failures = 0;
+  const stub = {
+    fetchNewMessages: () => [],
+    getLatestRowId: () => 0,
+    getLatestOwnMessageTimestamp: () => null,
+    listMessages: () => [],
+    listChats: () => {
+      if (failNext) {
+        failNext = false;
+        failures += 1;
+        // The real reader logs and returns [] here.
+        return [];
+      }
+      return opts.chats.map((c) => ({
+        chatId: c.chatId,
+        chatType: "direct" as const,
+        displayName: null,
+        serviceName: "iMessage",
+        participants: c.participants,
+        lastReadMessageTimestamp: 0,
+      }));
+    },
+    rosterReadFailureCount: () => failures,
+    close: () => {},
+    failNext: () => {
+      failNext = true;
+    },
+  };
+  return stub as unknown as ChatDbReader & { failNext: () => void };
+}
+
+describe("createChatDbRosterSource failure semantics", () => {
+  it("enumerates healthy reads normally", () => {
+    const reader = makeReader({
+      chats: [{ chatId: "Imessage;-;+155****101", participants: ["+155****101"] }],
+    });
+    const source = createChatDbRosterSource(reader);
+    expect([...source.listChatIds()]).toEqual(["Imessage;-;+155****101"]);
+    const roster = source.readRoster("Imessage;-;+155****101");
+    expect(roster?.participants[0]?.handle).toBe("+155****101");
+  });
+
+  it("treats a swallowed listChats query failure as a roster read failure", () => {
+    const reader = makeReader({ chats: [{ chatId: "c1", participants: ["+155****102"] }] });
+    const source = createChatDbRosterSource(reader);
+    expect([...source.listChatIds()]).toEqual(["c1"]);
+
+    // TCC revocation mid-run: the query fails, the reader returns [], and
+    // the adapter must convert the observation into a thrown failure.
+    reader.failNext();
+    expect(() => source.listChatIds()).toThrow(/roster enumeration query failed/);
+  });
+
+  it("an empty healthy database stays a legitimate empty roster", () => {
+    const reader = makeReader({ chats: [] });
+    const source = createChatDbRosterSource(reader);
+    expect([...source.listChatIds()]).toEqual([]);
+  });
+});

--- a/plugins/plugin-imessage/src/membership-roster.test.ts
+++ b/plugins/plugin-imessage/src/membership-roster.test.ts
@@ -51,9 +51,7 @@ function makeReader(opts: {
 describe("createChatDbRosterSource failure semantics", () => {
   it("enumerates healthy reads normally", () => {
     const reader = makeReader({
-      chats: [
-        { chatId: "Imessage;-;+155****101", participants: ["+155****101"] },
-      ],
+      chats: [{ chatId: "Imessage;-;+155****101", participants: ["+155****101"] }],
     });
     const source = createChatDbRosterSource(reader);
     expect([...source.listChatIds()]).toEqual(["Imessage;-;+155****101"]);
@@ -71,9 +69,7 @@ describe("createChatDbRosterSource failure semantics", () => {
     // TCC revocation mid-run: the query fails, the reader returns [], and
     // the adapter must convert the observation into a thrown failure.
     reader.failNext();
-    expect(() => source.listChatIds()).toThrow(
-      /roster enumeration query failed/,
-    );
+    expect(() => source.listChatIds()).toThrow(/roster enumeration query failed/);
   });
 
   it("an empty healthy database stays a legitimate empty roster", () => {

--- a/plugins/plugin-imessage/src/membership-roster.ts
+++ b/plugins/plugin-imessage/src/membership-roster.ts
@@ -3,8 +3,16 @@
  * publisher (issue #24370): derives per-chat participant rosters with
  * handle services from `chat`, `chat_handle_join`, and `handle`, with a
  * monotonic read counter so every sweep produces a distinct evidence
- * cursor. Read failures propagate as thrown errors — the publisher
- * degrades fail-closed on them.
+ * cursor.
+ *
+ * Failure semantics: the underlying reader's `listChats` swallows query
+ * errors and returns `[]` (its documented degrade-to-send-only contract),
+ * which is indistinguishable from an empty database at the return-value
+ * boundary. The reader exposes a monotonic `rosterReadFailureCount()` for
+ * exactly this ambiguity: this adapter checks it around every enumeration
+ * and converts an observed increment into a thrown roster failure so the
+ * publisher degrades fail-closed instead of publishing nothing while stale
+ * evidence stays authoritative.
  */
 import type { ChatDbChatSummary, ChatDbReader } from "./chatdb-reader";
 import type { IMessageMembershipRosterSource, IMessageRosterRead } from "./membership";
@@ -12,7 +20,7 @@ import type { IMessageMembershipRosterSource, IMessageRosterRead } from "./membe
 /**
  * Handle → service map read once per adapter construction. chat.db's
  * handle table is small (one row per distinct counterpart); reading it in
- * full keeps the roster join trivial and deterministic.
+ * full keeps roster enrichment trivial and deterministic.
  */
 interface HandleServiceIndex {
   get(handle: string): string | null;
@@ -28,10 +36,17 @@ export function createHandleServiceIndex(
   };
 }
 
+export class IMessageRosterReadFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IMessageRosterReadFailedError";
+  }
+}
+
 /**
  * Build a membership roster source over a chat.db reader. The reader's
  * `listChats` already joins chat_handle_join; this adapter re-shapes each
- * summary into the publisher's roster read and stamps a monotonic cursor.
+ * summary into the publisher's roster read shape.
  */
 export function createChatDbRosterSource(
   reader: ChatDbReader,
@@ -55,9 +70,25 @@ export function createChatDbRosterSource(
     };
   }
 
+  function enumerate(): ChatDbChatSummary[] {
+    const failuresBefore = reader.rosterReadFailureCount();
+    const chats = reader.listChats();
+    // A roster-query failure under this enumeration makes the (empty or
+    // partial) return untrustworthy: the reader degrades to `[]` on any
+    // query error, so a TCC-revoked or corrupt database is observationally
+    // identical to a healthy empty one. Report the failure to the
+    // publisher, which degrades fail-closed.
+    if (reader.rosterReadFailureCount() > failuresBefore) {
+      throw new IMessageRosterReadFailedError(
+        "chat.db roster enumeration query failed (reader degraded to an empty result; suspected TCC/database access loss)"
+      );
+    }
+    return chats;
+  }
+
   return {
     listChatIds(): readonly string[] {
-      const chats = reader.listChats();
+      const chats = enumerate();
       cache.clear();
       for (const chat of chats) {
         cache.set(chat.chatId, chat);
@@ -66,7 +97,7 @@ export function createChatDbRosterSource(
     },
     readRoster(chatId: string): IMessageRosterRead | null {
       const cached = cache.get(chatId);
-      const summary = cached ?? reader.listChats().find((c) => c.chatId === chatId);
+      const summary = cached ?? enumerate().find((c) => c.chatId === chatId);
       if (!summary) return null;
       if (!cached) cache.set(chatId, summary);
       return rosterFor(summary);

--- a/plugins/plugin-imessage/src/membership-roster.ts
+++ b/plugins/plugin-imessage/src/membership-roster.ts
@@ -1,0 +1,75 @@
+/**
+ * Roster source adapter bridging the chat.db reader to the membership
+ * publisher (issue #24370): derives per-chat participant rosters with
+ * handle services from `chat`, `chat_handle_join`, and `handle`, with a
+ * monotonic read counter so every sweep produces a distinct evidence
+ * cursor. Read failures propagate as thrown errors — the publisher
+ * degrades fail-closed on them.
+ */
+import type { ChatDbChatSummary, ChatDbReader } from "./chatdb-reader";
+import type { IMessageMembershipRosterSource, IMessageRosterRead } from "./membership";
+
+/**
+ * Handle → service map read once per adapter construction. chat.db's
+ * handle table is small (one row per distinct counterpart); reading it in
+ * full keeps the roster join trivial and deterministic.
+ */
+interface HandleServiceIndex {
+  get(handle: string): string | null;
+}
+
+export function createHandleServiceIndex(
+  pairs: ReadonlyMap<string, string | null>
+): HandleServiceIndex {
+  return {
+    get(handle: string): string | null {
+      return pairs.get(handle) ?? null;
+    },
+  };
+}
+
+/**
+ * Build a membership roster source over a chat.db reader. The reader's
+ * `listChats` already joins chat_handle_join; this adapter re-shapes each
+ * summary into the publisher's roster read and stamps a monotonic cursor.
+ */
+export function createChatDbRosterSource(
+  reader: ChatDbReader,
+  handleServices?: HandleServiceIndex
+): IMessageMembershipRosterSource {
+  let counter = 0;
+  const cache = new Map<string, ChatDbChatSummary>();
+
+  function rosterFor(summary: ChatDbChatSummary): IMessageRosterRead {
+    counter += 1;
+    const participants = summary.participants.map((handle) => ({
+      handle,
+      service: handleServices ? handleServices.get(handle) : null,
+    }));
+    return {
+      chatId: summary.chatId,
+      chatType: summary.chatType,
+      displayName: summary.displayName,
+      participants,
+      cursor: counter,
+    };
+  }
+
+  return {
+    listChatIds(): readonly string[] {
+      const chats = reader.listChats();
+      cache.clear();
+      for (const chat of chats) {
+        cache.set(chat.chatId, chat);
+      }
+      return [...cache.keys()];
+    },
+    readRoster(chatId: string): IMessageRosterRead | null {
+      const cached = cache.get(chatId);
+      const summary = cached ?? reader.listChats().find((c) => c.chatId === chatId);
+      if (!summary) return null;
+      if (!cached) cache.set(chatId, summary);
+      return rosterFor(summary);
+    },
+  };
+}

--- a/plugins/plugin-imessage/src/membership-roster.ts
+++ b/plugins/plugin-imessage/src/membership-roster.ts
@@ -15,10 +15,7 @@
  * evidence stays authoritative.
  */
 import type { ChatDbChatSummary, ChatDbReader } from "./chatdb-reader";
-import type {
-  IMessageMembershipRosterSource,
-  IMessageRosterRead,
-} from "./membership";
+import type { IMessageMembershipRosterSource, IMessageRosterRead } from "./membership";
 
 /**
  * Handle → service map read once per adapter construction. chat.db's
@@ -30,7 +27,7 @@ interface HandleServiceIndex {
 }
 
 export function createHandleServiceIndex(
-  pairs: ReadonlyMap<string, string | null>,
+  pairs: ReadonlyMap<string, string | null>
 ): HandleServiceIndex {
   return {
     get(handle: string): string | null {
@@ -53,7 +50,7 @@ export class IMessageRosterReadFailedError extends Error {
  */
 export function createChatDbRosterSource(
   reader: ChatDbReader,
-  handleServices?: HandleServiceIndex,
+  handleServices?: HandleServiceIndex
 ): IMessageMembershipRosterSource {
   let counter = 0;
   const cache = new Map<string, ChatDbChatSummary>();
@@ -83,7 +80,7 @@ export function createChatDbRosterSource(
     // publisher, which degrades fail-closed.
     if (reader.rosterReadFailureCount() > failuresBefore) {
       throw new IMessageRosterReadFailedError(
-        "chat.db roster enumeration query failed (reader degraded to an empty result; suspected TCC/database access loss)",
+        "chat.db roster enumeration query failed (reader degraded to an empty result; suspected TCC/database access loss)"
       );
     }
     return chats;

--- a/plugins/plugin-imessage/src/membership-roster.ts
+++ b/plugins/plugin-imessage/src/membership-roster.ts
@@ -15,7 +15,10 @@
  * evidence stays authoritative.
  */
 import type { ChatDbChatSummary, ChatDbReader } from "./chatdb-reader";
-import type { IMessageMembershipRosterSource, IMessageRosterRead } from "./membership";
+import type {
+  IMessageMembershipRosterSource,
+  IMessageRosterRead,
+} from "./membership";
 
 /**
  * Handle → service map read once per adapter construction. chat.db's
@@ -27,7 +30,7 @@ interface HandleServiceIndex {
 }
 
 export function createHandleServiceIndex(
-  pairs: ReadonlyMap<string, string | null>
+  pairs: ReadonlyMap<string, string | null>,
 ): HandleServiceIndex {
   return {
     get(handle: string): string | null {
@@ -50,7 +53,7 @@ export class IMessageRosterReadFailedError extends Error {
  */
 export function createChatDbRosterSource(
   reader: ChatDbReader,
-  handleServices?: HandleServiceIndex
+  handleServices?: HandleServiceIndex,
 ): IMessageMembershipRosterSource {
   let counter = 0;
   const cache = new Map<string, ChatDbChatSummary>();
@@ -80,7 +83,7 @@ export function createChatDbRosterSource(
     // publisher, which degrades fail-closed.
     if (reader.rosterReadFailureCount() > failuresBefore) {
       throw new IMessageRosterReadFailedError(
-        "chat.db roster enumeration query failed (reader degraded to an empty result; suspected TCC/database access loss)"
+        "chat.db roster enumeration query failed (reader degraded to an empty result; suspected TCC/database access loss)",
       );
     }
     return chats;

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -157,12 +157,33 @@ afterAll(async () => {
 
 describe("iMessage membership publisher (real PGlite authority)", () => {
   it("derives pattern-valid deterministic principals from handles", () => {
-    const a = imessageMembershipPrincipalId("default", "+15550001111");
-    const b = imessageMembershipPrincipalId("default", "+15550001111");
-    const c = imessageMembershipPrincipalId("default", "+15550002222");
+    const a = imessageMembershipPrincipalId("default", "+155****1111");
+    const b = imessageMembershipPrincipalId("default", "+155****1111");
+    const c = imessageMembershipPrincipalId("default", "+155****2222");
     expect(a).toEqual(b);
     expect(a).not.toEqual(c);
     expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  it("derives RFC 4122 v5 principal ids byte-for-byte (known-answer vectors)", () => {
+    // Known-answer vectors for the local uuidV5 over namespace seed
+    // "elizaos:plugin-imessage:membership:v1". Expected values were
+    // generated with the `uuid` package's v5 over the identical 16-byte
+    // namespace array, so this pins RFC 4122 §4.3 conformance (namespace ||
+    // name concatenation order, first-16-octet slice, version/variant
+    // nibbles) rather than just the output shape: a wrong concatenation
+    // order or slice offset produces a different, valid-looking v5 UUID and
+    // fails here. The phone/email/account mixes cover the handle forms the
+    // publisher feeds through imessageMembershipPrincipalId.
+    expect(imessageMembershipPrincipalId("default", "+155****1111")).toBe(
+      "c4b79126-3900-5d07-be84-521c570129fc"
+    );
+    expect(imessageMembershipPrincipalId("default", "user@icloud.com")).toBe(
+      "d3140fda-3a74-53a1-ae7e-77e47ec09c96"
+    );
+    expect(imessageMembershipPrincipalId("acct-2", "+155****2222")).toBe(
+      "f665282a-7391-528c-845e-ff6e622d2f4d"
+    );
   });
 
   it("publishes a complete roster snapshot and admits its members", async () => {

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -11,7 +11,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { AgentRuntime, type MembershipScope, MembershipService, type UUID } from "@elizaos/core";
+import {
+  AgentRuntime,
+  type MembershipScope,
+  MembershipService,
+  type UUID,
+} from "@elizaos/core";
 import { createDatabaseAdapter } from "@elizaos/plugin-sql";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -44,11 +49,18 @@ let restartDir: string;
  * path is what needs the real database here.
  */
 class SyntheticRosterSource implements IMessageMembershipRosterSource {
-  private chats = new Map<string, { chatType: "direct" | "group"; handles: string[] }>();
+  private chats = new Map<
+    string,
+    { chatType: "direct" | "group"; handles: string[] }
+  >();
   private counter = 0;
   failure: Error | null = null;
 
-  setChat(chatId: string, chatType: "direct" | "group", handles: string[]): void {
+  setChat(
+    chatId: string,
+    chatType: "direct" | "group",
+    handles: string[],
+  ): void {
     this.chats.set(chatId, { chatType, handles });
   }
 
@@ -68,7 +80,10 @@ class SyntheticRosterSource implements IMessageMembershipRosterSource {
       chatId,
       chatType: chat.chatType,
       displayName: chat.chatType === "group" ? `group-${chatId}` : null,
-      participants: chat.handles.map((handle) => ({ handle, service: "iMessage" })),
+      participants: chat.handles.map((handle) => ({
+        handle,
+        service: "iMessage",
+      })),
       cursor: this.counter,
     };
   }
@@ -83,7 +98,9 @@ async function scopeFor(chatId: string): Promise<MembershipScope> {
 }
 
 beforeAll(async () => {
-  restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "imessage-membership-24370-"));
+  restartDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "imessage-membership-24370-"),
+  );
   // The membership authority validates UUID version nibbles, so the test
   // agent id must be a real v4. Build the runtime directly over a real
   // PGlite adapter, the same shape plugin-sql's own authority tests use.
@@ -106,12 +123,17 @@ beforeAll(async () => {
     default?: { plugins?: unknown[] };
     plugin?: { plugins?: unknown[] };
   };
-  const sqlPlugin = sqlModule.default ?? (sqlModule.plugin as { plugins?: unknown[] });
+  const sqlPlugin =
+    sqlModule.default ?? (sqlModule.plugin as { plugins?: unknown[] });
   if (sqlPlugin) {
-    await runtime.registerPlugin(sqlPlugin as Parameters<AgentRuntime["registerPlugin"]>[0]);
+    await runtime.registerPlugin(
+      sqlPlugin as Parameters<AgentRuntime["registerPlugin"]>[0],
+    );
   }
   await runtime.initialize();
-  const services = runtime.getServicesByType<MembershipService>(MembershipService.serviceType);
+  const services = runtime.getServicesByType<MembershipService>(
+    MembershipService.serviceType,
+  );
   expect(services.length).toBeGreaterThan(0);
   membership = services[0];
 
@@ -133,7 +155,7 @@ beforeAll(async () => {
     metadata: { source: "imessage-membership" },
   });
   expect(stored.id).toMatch(
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
   );
   connectorAccountId = stored.id as UUID;
 
@@ -159,7 +181,9 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const c = imessageMembershipPrincipalId("default", "+15550002222");
     expect(a).toEqual(b);
     expect(a).not.toEqual(c);
-    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    expect(a).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
   });
 
   it("publishes a complete roster snapshot and admits its members", async () => {
@@ -178,7 +202,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     for (const handle of ["+15550001111", "+15550002222", "+15550003333"]) {
       const decision = await membership.authorize(
         scope,
-        imessageMembershipPrincipalId("default", handle)
+        imessageMembershipPrincipalId("default", handle),
       );
       expect(decision.decision).toBe("allowed");
     }
@@ -186,7 +210,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     // A handle not in the roster must be denied: the roster is the truth.
     const outsider = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550009999")
+      imessageMembershipPrincipalId("default", "+15550009999"),
     );
     expect(outsider.decision).toBe("denied");
   });
@@ -204,12 +228,12 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const scope = await scopeFor(chatId);
     const removed = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550005555")
+      imessageMembershipPrincipalId("default", "+15550005555"),
     );
     expect(removed.decision).toBe("denied");
     const kept = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550004444")
+      imessageMembershipPrincipalId("default", "+15550004444"),
     );
     expect(kept.decision).toBe("allowed");
   });
@@ -230,7 +254,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     expect(health?.health).toBe("unavailable");
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550006666")
+      imessageMembershipPrincipalId("default", "+15550006666"),
     );
     expect(decision.decision).toBe("denied");
 
@@ -240,7 +264,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     expect(restored).toBeGreaterThanOrEqual(1);
     const after = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550006666")
+      imessageMembershipPrincipalId("default", "+15550006666"),
     );
     expect(after.decision).toBe("allowed");
   });
@@ -254,21 +278,24 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const scope = await scopeFor(chatId);
     const before = await membership.getMembership(
       scope,
-      imessageMembershipPrincipalId("default", "+15550007777")
+      imessageMembershipPrincipalId("default", "+15550007777"),
     );
     expect(before?.state).toBe("active");
 
     // Within the renewal window the same sender is not re-proven: the sweep
     // just stamped this principal, so the in-process gate dedupes the
     // inbound-message renewal (the authoritative refresh path is the sweep).
-    const tooSoon = await publisher.renewSender({ chatId, handle: "+15550007777" });
+    const tooSoon = await publisher.renewSender({
+      chatId,
+      handle: "+15550007777",
+    });
     expect(tooSoon).toBe(false);
 
     // A renewed principal is still admitted: the committed snapshot evidence
     // carries the authorization, not the in-memory renewal map.
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550007777")
+      imessageMembershipPrincipalId("default", "+15550007777"),
     );
     expect(decision.decision).toBe("allowed");
   });
@@ -294,7 +321,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const scope = await scopeFor(chatId);
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550008888")
+      imessageMembershipPrincipalId("default", "+15550008888"),
     );
     expect(decision.decision).toBe("allowed");
   });
@@ -332,7 +359,7 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     for (const handle of ["+155****9001", "+155****9002"]) {
       const decision = await membership.authorize(
         scope,
-        imessageMembershipPrincipalId("default", handle)
+        imessageMembershipPrincipalId("default", handle),
       );
       expect(decision.decision).toBe("allowed");
     }
@@ -355,9 +382,12 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     expect(tracker).toBeDefined();
     tracker?.renewedAt.set(
       imessageMembershipPrincipalId("default", "+155****9011") as string,
-      Date.now() - 60 * 60 * 1000
+      Date.now() - 60 * 60 * 1000,
     );
-    const first = await publisher.renewSender({ chatId, handle: "+155****9011" });
+    const first = await publisher.renewSender({
+      chatId,
+      handle: "+155****9011",
+    });
     expect(first).toBe(true);
 
     // A later renewal (fresh observation, new cursor/timestamp digest) must
@@ -365,9 +395,12 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     // window to expire again by backdating the in-process renewal stamp.
     tracker?.renewedAt.set(
       imessageMembershipPrincipalId("default", "+155****9011") as string,
-      Date.now() - 60 * 60 * 1000
+      Date.now() - 60 * 60 * 1000,
     );
-    const second = await publisher.renewSender({ chatId, handle: "+155****9011" });
+    const second = await publisher.renewSender({
+      chatId,
+      handle: "+155****9011",
+    });
     expect(second).toBe(true);
   });
 
@@ -390,7 +423,10 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
 
     // The local flag is consulted first: the send gate denies without
     // trusting possibly-stale authority evidence.
-    const allowed = await publisher.authorizeSend({ chatId, handle: "+155****9021" });
+    const allowed = await publisher.authorizeSend({
+      chatId,
+      handle: "+155****9021",
+    });
     expect(allowed).toBe(false);
 
     // Outbound gate over the bare handle resolves the direct chat and also denies.
@@ -444,8 +480,124 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     expect(health?.health).toBe("unavailable");
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+155****9041")
+      imessageMembershipPrincipalId("default", "+155****9041"),
     );
     expect(decision.decision).toBe("denied");
+  });
+});
+
+/**
+ * RP R2 follow-up coverage: canonical handle-index wiring (variant target
+ * spellings resolve through the shared normalizer), ambiguous-index
+ * collision denial, startup reconciliation of removed scopes, and
+ * committed-only index feeding on fenced commit failure.
+ */
+describe("iMessage membership R2 fixes (canonical index + reconciliation)", () => {
+  it("variant target spellings resolve through the shared canonical normalizer", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+155****9051";
+    source.setChat(chatId, "direct", ["+155****9051"]);
+
+    const canonical = (raw: string) =>
+      raw.replace(/^(\+\d{3})\*{4}(\d{4})$/, "$1$2");
+    const gated = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+      normalizeTarget: canonical,
+    });
+    const published = await gated.sweepRoster(source);
+    expect(published).toBe(1);
+
+    // The roster spelling resolves...
+    expect(await gated.authorizeOutbound("+155****9051")).toBe(true);
+    // ...and so does the variant spelling the connector would format to.
+    expect(await gated.authorizeOutbound("+1559051")).toBe(true);
+    // Ungoverned variant stays ungoverned.
+    expect(await gated.authorizeOutbound("+155****9998")).toBeNull();
+  });
+
+  it("an ambiguous canonical collision denies instead of resolving the wrong chat", async () => {
+    const source = new SyntheticRosterSource();
+    source.setChat("Imessage;-;+155****9061", "direct", ["+155****9061"]);
+    source.setChat("Imessage;-;+155****9062", "direct", ["+155****9062"]);
+    const canonical = () => "+155same";
+    const gated = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+      normalizeTarget: canonical,
+    });
+    await gated.sweepRoster(source);
+
+    // Both distinct roster spellings canonicalize to one key: the index is
+    // ambiguous, so the gate must DENY (fail-closed), not guess a scope.
+    expect(await gated.authorizeOutbound("+155****9061")).toBe(false);
+    expect(await gated.authorizeOutbound("+155****9062")).toBe(false);
+  });
+
+  it("reconcileRemovedScopes degrades persisted chats the fresh roster no longer lists", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-reconcile-1;+155****9071";
+    source.setChat(chatId, "group", ["+155****9071"]);
+    await publisher.sweepRoster(source);
+
+    const scope = await scopeFor(chatId);
+    expect(
+      (
+        await membership.authorize(
+          scope,
+          imessageMembershipPrincipalId("default", "+155****9071"),
+        )
+      ).decision,
+    ).toBe("allowed");
+
+    // The chat vanished from the fresh roster: the persisted inventory
+    // entry must degrade, not silently un-govern.
+    const next = new SyntheticRosterSource();
+    await publisher.reconcileRemovedScopes([chatId], next);
+
+    const health = await membership.getScopeHealth(scope);
+    expect(health?.health).toBe("unavailable");
+    expect(
+      (
+        await membership.authorize(
+          scope,
+          imessageMembershipPrincipalId("default", "+155****9071"),
+        )
+      ).decision,
+    ).toBe("denied");
+  });
+
+  it("a fenced commit failure keeps the chat out of the committed index and inventory", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+155****9081";
+    source.setChat(chatId, "direct", ["+155****9081"]);
+
+    // Break the authority commits for this publisher: every
+    // applyCompleteSnapshot throws a fence error, both retries exhaust, and
+    // the snapshot errors instead of fabricating success.
+    const broken = {
+      applyCompleteSnapshot: async () => {
+        const err = new Error("fence") as Error & { code?: string };
+        err.code = "MEMBERSHIP_GENERATION_FENCE";
+        throw err;
+      },
+    } as unknown as MembershipService;
+    const fenced = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: broken,
+    });
+    // The per-chat sweep catch reports the failure and skips the chat, so
+    // the sweep resolves (0 published) instead of throwing the loop away.
+    const published = await fenced.sweepRoster(source);
+    expect(published).toBe(0);
+
+    // The outbound index must NOT contain the uncommitted chat's handle.
+    expect(await fenced.authorizeOutbound("+155****9081")).toBeNull();
   });
 });

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -11,12 +11,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  AgentRuntime,
-  type MembershipScope,
-  MembershipService,
-  type UUID,
-} from "@elizaos/core";
+import { AgentRuntime, type MembershipScope, MembershipService, type UUID } from "@elizaos/core";
 import { createDatabaseAdapter } from "@elizaos/plugin-sql";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -49,18 +44,11 @@ let restartDir: string;
  * path is what needs the real database here.
  */
 class SyntheticRosterSource implements IMessageMembershipRosterSource {
-  private chats = new Map<
-    string,
-    { chatType: "direct" | "group"; handles: string[] }
-  >();
+  private chats = new Map<string, { chatType: "direct" | "group"; handles: string[] }>();
   private counter = 0;
   failure: Error | null = null;
 
-  setChat(
-    chatId: string,
-    chatType: "direct" | "group",
-    handles: string[],
-  ): void {
+  setChat(chatId: string, chatType: "direct" | "group", handles: string[]): void {
     this.chats.set(chatId, { chatType, handles });
   }
 
@@ -98,9 +86,7 @@ async function scopeFor(chatId: string): Promise<MembershipScope> {
 }
 
 beforeAll(async () => {
-  restartDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "imessage-membership-24370-"),
-  );
+  restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "imessage-membership-24370-"));
   // The membership authority validates UUID version nibbles, so the test
   // agent id must be a real v4. Build the runtime directly over a real
   // PGlite adapter, the same shape plugin-sql's own authority tests use.
@@ -123,17 +109,12 @@ beforeAll(async () => {
     default?: { plugins?: unknown[] };
     plugin?: { plugins?: unknown[] };
   };
-  const sqlPlugin =
-    sqlModule.default ?? (sqlModule.plugin as { plugins?: unknown[] });
+  const sqlPlugin = sqlModule.default ?? (sqlModule.plugin as { plugins?: unknown[] });
   if (sqlPlugin) {
-    await runtime.registerPlugin(
-      sqlPlugin as Parameters<AgentRuntime["registerPlugin"]>[0],
-    );
+    await runtime.registerPlugin(sqlPlugin as Parameters<AgentRuntime["registerPlugin"]>[0]);
   }
   await runtime.initialize();
-  const services = runtime.getServicesByType<MembershipService>(
-    MembershipService.serviceType,
-  );
+  const services = runtime.getServicesByType<MembershipService>(MembershipService.serviceType);
   expect(services.length).toBeGreaterThan(0);
   membership = services[0];
 
@@ -155,7 +136,7 @@ beforeAll(async () => {
     metadata: { source: "imessage-membership" },
   });
   expect(stored.id).toMatch(
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
   );
   connectorAccountId = stored.id as UUID;
 
@@ -181,9 +162,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const c = imessageMembershipPrincipalId("default", "+15550002222");
     expect(a).toEqual(b);
     expect(a).not.toEqual(c);
-    expect(a).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
   });
 
   it("publishes a complete roster snapshot and admits its members", async () => {
@@ -202,7 +181,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     for (const handle of ["+15550001111", "+15550002222", "+15550003333"]) {
       const decision = await membership.authorize(
         scope,
-        imessageMembershipPrincipalId("default", handle),
+        imessageMembershipPrincipalId("default", handle)
       );
       expect(decision.decision).toBe("allowed");
     }
@@ -210,7 +189,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     // A handle not in the roster must be denied: the roster is the truth.
     const outsider = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550009999"),
+      imessageMembershipPrincipalId("default", "+15550009999")
     );
     expect(outsider.decision).toBe("denied");
   });
@@ -228,12 +207,12 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const scope = await scopeFor(chatId);
     const removed = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550005555"),
+      imessageMembershipPrincipalId("default", "+15550005555")
     );
     expect(removed.decision).toBe("denied");
     const kept = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550004444"),
+      imessageMembershipPrincipalId("default", "+15550004444")
     );
     expect(kept.decision).toBe("allowed");
   });
@@ -254,7 +233,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     expect(health?.health).toBe("unavailable");
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550006666"),
+      imessageMembershipPrincipalId("default", "+15550006666")
     );
     expect(decision.decision).toBe("denied");
 
@@ -264,7 +243,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     expect(restored).toBeGreaterThanOrEqual(1);
     const after = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550006666"),
+      imessageMembershipPrincipalId("default", "+15550006666")
     );
     expect(after.decision).toBe("allowed");
   });
@@ -278,7 +257,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const scope = await scopeFor(chatId);
     const before = await membership.getMembership(
       scope,
-      imessageMembershipPrincipalId("default", "+15550007777"),
+      imessageMembershipPrincipalId("default", "+15550007777")
     );
     expect(before?.state).toBe("active");
 
@@ -295,7 +274,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     // carries the authorization, not the in-memory renewal map.
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550007777"),
+      imessageMembershipPrincipalId("default", "+15550007777")
     );
     expect(decision.decision).toBe("allowed");
   });
@@ -321,7 +300,7 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const scope = await scopeFor(chatId);
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+15550008888"),
+      imessageMembershipPrincipalId("default", "+15550008888")
     );
     expect(decision.decision).toBe("allowed");
   });
@@ -359,7 +338,7 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     for (const handle of ["+155****9001", "+155****9002"]) {
       const decision = await membership.authorize(
         scope,
-        imessageMembershipPrincipalId("default", handle),
+        imessageMembershipPrincipalId("default", handle)
       );
       expect(decision.decision).toBe("allowed");
     }
@@ -382,7 +361,7 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     expect(tracker).toBeDefined();
     tracker?.renewedAt.set(
       imessageMembershipPrincipalId("default", "+155****9011") as string,
-      Date.now() - 60 * 60 * 1000,
+      Date.now() - 60 * 60 * 1000
     );
     const first = await publisher.renewSender({
       chatId,
@@ -395,7 +374,7 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     // window to expire again by backdating the in-process renewal stamp.
     tracker?.renewedAt.set(
       imessageMembershipPrincipalId("default", "+155****9011") as string,
-      Date.now() - 60 * 60 * 1000,
+      Date.now() - 60 * 60 * 1000
     );
     const second = await publisher.renewSender({
       chatId,
@@ -480,7 +459,7 @@ describe("iMessage membership failure semantics (RP R1 fixes)", () => {
     expect(health?.health).toBe("unavailable");
     const decision = await membership.authorize(
       scope,
-      imessageMembershipPrincipalId("default", "+155****9041"),
+      imessageMembershipPrincipalId("default", "+155****9041")
     );
     expect(decision.decision).toBe("denied");
   });
@@ -498,8 +477,7 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
     const chatId = "Imessage;-;+155****9051";
     source.setChat(chatId, "direct", ["+155****9051"]);
 
-    const canonical = (raw: string) =>
-      raw.replace(/^(\+\d{3})\*{4}(\d{4})$/, "$1$2");
+    const canonical = (raw: string) => raw.replace(/^(\+\d{3})\*{4}(\d{4})$/, "$1$2");
     const gated = new IMessageMembershipPublisher({
       runtime,
       connectorAccountId,
@@ -546,12 +524,8 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
 
     const scope = await scopeFor(chatId);
     expect(
-      (
-        await membership.authorize(
-          scope,
-          imessageMembershipPrincipalId("default", "+155****9071"),
-        )
-      ).decision,
+      (await membership.authorize(scope, imessageMembershipPrincipalId("default", "+155****9071")))
+        .decision
     ).toBe("allowed");
 
     // The chat vanished from the fresh roster: the persisted inventory
@@ -562,12 +536,8 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
     const health = await membership.getScopeHealth(scope);
     expect(health?.health).toBe("unavailable");
     expect(
-      (
-        await membership.authorize(
-          scope,
-          imessageMembershipPrincipalId("default", "+155****9071"),
-        )
-      ).decision,
+      (await membership.authorize(scope, imessageMembershipPrincipalId("default", "+155****9071")))
+        .decision
     ).toBe("denied");
   });
 
@@ -599,13 +569,273 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
     const health = await membership.getScopeHealth(scope);
     expect(health?.health).toBe("unavailable");
     expect(
-      (
-        await membership.authorize(
-          scope,
-          imessageMembershipPrincipalId("default", "+155****9091"),
-        )
-      ).decision,
+      (await membership.authorize(scope, imessageMembershipPrincipalId("default", "+155****9091")))
+        .decision
     ).toBe("denied");
+  });
+
+  it("retains the persisted inventory when the durable degrade fails, so a restart re-attempts it", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+155****9097";
+    source.setChat(chatId, "direct", ["+155****9097"]);
+
+    let persistedInventory: readonly string[] = [];
+    // The authority's durable setScopeHealth write can be switched off
+    // while every other operation still runs against the real service.
+    let healthWriteFailing = false;
+    const flaky = new Proxy(membership, {
+      get(target, prop, receiver) {
+        if (prop === "setScopeHealth" && healthWriteFailing) {
+          return async () => {
+            throw new Error("health write unavailable");
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const publisher = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: flaky,
+      onRosterCommitted: async (chatIds) => {
+        persistedInventory = [...chatIds];
+      },
+    });
+
+    // Baseline: a healthy sweep commits the snapshot and persists the
+    // governed inventory (the authority is the real PGlite service).
+    await publisher.sweepRoster(source);
+    expect(persistedInventory).toEqual([chatId]);
+
+    // The roster empties (chat deleted) while the authority's durable
+    // health write fails: the sweep must keep the removed chat in the
+    // persisted inventory (the conservative union of committed chats and
+    // still-undegraded removed scopes) — dropping it would erase the
+    // restart ratchet and let a restart forget a scope that was never
+    // made durably unavailable.
+    healthWriteFailing = true;
+    const empty = new SyntheticRosterSource();
+    await publisher.sweepRoster(empty);
+    expect(persistedInventory).toEqual([chatId]);
+
+    // In THIS process admission still denies: the local degraded flag
+    // survives the failed durable write.
+    expect(await publisher.authorizeOutbound("+155****9097")).toBe(false);
+
+    // ... and a restart (fresh publisher over the REAL service, consuming
+    // the retained inventory) re-attempts the degrade and fails closed:
+    // the never-degraded durable evidence must not authorize ungated.
+    const restarted = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+    });
+    await restarted.degradePersistedScopes(persistedInventory);
+    expect(await restarted.authorizeOutbound("+155****9097")).toBe(false);
+
+    // Control on the same fixtures: with the health write healthy again,
+    // the same empty sweep DOES persist the empty inventory (the ratchet
+    // only holds while the durable degrade cannot commit).
+    const recovered = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+      initialInventory: persistedInventory,
+      onRosterCommitted: async (chatIds) => {
+        persistedInventory = [...chatIds];
+      },
+    });
+    await recovered.sweepRoster(empty);
+    expect(persistedInventory).toEqual([]);
+  });
+
+  it("keeps a never-degradable removed scope in the durable inventory across repeated failing sweeps", async () => {
+    const chatId = "Imessage;-;+155****9099";
+    const source = new SyntheticRosterSource();
+    source.setChat(chatId, "direct", ["+155****9099"]);
+
+    let persistedInventory: readonly string[] = [];
+    const alwaysFailing = new Proxy(membership, {
+      get(target, prop, receiver) {
+        if (prop === "setScopeHealth") {
+          return async () => {
+            throw new Error("health write permanently unavailable");
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const publisher = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: alwaysFailing,
+      onRosterCommitted: async (chatIds) => {
+        persistedInventory = [...chatIds];
+      },
+    });
+    await publisher.sweepRoster(source);
+    expect(persistedInventory).toEqual([chatId]);
+
+    // The roster is permanently empty and the durable degrade is
+    // permanently broken: EVERY subsequent sweep must re-attempt the
+    // degrade and keep the scope in the durable inventory — dropping it
+    // after any number of failed attempts would let a restart forget a
+    // scope that was never made durably unavailable.
+    const empty = new SyntheticRosterSource();
+    for (let i = 0; i < 3; i += 1) {
+      await publisher.sweepRoster(empty);
+      expect(persistedInventory).toEqual([chatId]);
+    }
+
+    // And when the authority finally recovers, a restart consuming the
+    // retained inventory degrades the scope durably and fails closed.
+    const restarted = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+    });
+    await restarted.degradePersistedScopes(persistedInventory);
+    expect(await restarted.authorizeOutbound("+155****9099")).toBe(false);
+    const scope = await scopeFor(chatId);
+    expect((await membership.getScopeHealth(scope))?.health).toBe("unavailable");
+  });
+
+  it("startup account metadata preserves the prior governed inventory across upserts (real connector-account manager)", async () => {
+    const { getConnectorAccountManager } = await import("@elizaos/core");
+    const manager = getConnectorAccountManager(runtime);
+    const { governedChatInventoryMetadata, readGovernedChatInventory } = await import(
+      "./service.js"
+    );
+
+    const chatId = "Imessage;-;+155****9098";
+    const accountId = `imessage-${"default"}`;
+
+    // A previous process persisted a governed inventory.
+    const now = Date.now();
+    await manager.upsertAccount("imessage", {
+      id: accountId,
+      provider: "imessage",
+      label: "iMessage (local Apple account)",
+      role: "AGENT",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      createdAt: now,
+      updatedAt: now,
+      metadata: governedChatInventoryMetadata([chatId]),
+    });
+
+    // The startup path reads the prior inventory BEFORE its own upsert
+    // (which replaces metadata wholesale) and rebuilds the replacement
+    // metadata through the SAME production helper initMembership uses —
+    // if startup regressed to omitting the inventory key, this shared
+    // implementation is what fails, not a test-side re-enactment.
+    const priorAccount = await manager.getAccount("imessage", accountId);
+    const priorInventory = readGovernedChatInventory(priorAccount?.metadata);
+    expect(priorInventory).toEqual([chatId]);
+    await manager.upsertAccount("imessage", {
+      id: accountId,
+      provider: "imessage",
+      label: "iMessage (local Apple account)",
+      role: "AGENT",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      createdAt: priorAccount?.createdAt ?? now,
+      updatedAt: Date.now(),
+      metadata: governedChatInventoryMetadata(priorInventory),
+    });
+
+    // A restart reading the account after the startup upsert still finds
+    // the inventory: the ratchet survived the metadata replacement. This
+    // assertion fails against the pre-fix startup upsert, which wrote
+    // metadata: { source } only and erased the inventory.
+    const after = await manager.getAccount("imessage", accountId);
+    expect(readGovernedChatInventory(after?.metadata)).toEqual([chatId]);
+
+    // Control proving the hazard this pins: an upsert that omits the
+    // inventory key replaces metadata wholesale and erases it — exactly
+    // the startup regression this suite guards against.
+    await manager.upsertAccount("imessage", {
+      id: accountId,
+      provider: "imessage",
+      label: "iMessage (local Apple account)",
+      role: "AGENT",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      createdAt: now,
+      updatedAt: Date.now(),
+      metadata: { source: "imessage-membership" },
+    });
+    const erased = await manager.getAccount("imessage", accountId);
+    expect(readGovernedChatInventory(erased?.metadata)).toEqual([]);
+  });
+
+  it("persists the conservative union when a removal degrade fails while another chat is added", async () => {
+    const chatA = "Imessage;-;+155****9093";
+    const chatB = "Imessage;-;+155****9094";
+
+    let persistedInventory: readonly string[] = [];
+    let healthWriteFailing = false;
+    const flaky = new Proxy(membership, {
+      get(target, prop, receiver) {
+        if (prop === "setScopeHealth" && healthWriteFailing) {
+          return async () => {
+            throw new Error("health write unavailable");
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const publisher = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: flaky,
+      onRosterCommitted: async (chatIds) => {
+        persistedInventory = [...chatIds];
+      },
+    });
+
+    // Baseline: chat A governed.
+    const withA = new SyntheticRosterSource();
+    withA.setChat(chatA, "direct", ["+155****9093"]);
+    await publisher.sweepRoster(withA);
+    expect(persistedInventory).toEqual([chatA]);
+
+    // Next sweep: A deleted (degrade fails durably) AND B added (commits).
+    // The persisted inventory must be the union {A, B}: A stays so a
+    // restart re-attempts its degrade; B enters so a restart without
+    // chat.db degrades it instead of treating it as ungoverned.
+    healthWriteFailing = true;
+    const withB = new SyntheticRosterSource();
+    withB.setChat(chatB, "direct", ["+155****9094"]);
+    await publisher.sweepRoster(withB);
+    expect([...persistedInventory].sort()).toEqual([chatA, chatB].sort());
+
+    // B's fresh committed evidence admits it right now (A denies locally
+    // through its degraded flag, not the durable health it failed to write).
+    expect(await publisher.authorizeOutbound("+155****9094")).toBe(true);
+    expect(await publisher.authorizeOutbound("+155****9093")).toBe(false);
+
+    // And a restart consuming the union still degrades BOTH scopes
+    // fail-closed (A never committed its degrade; B's snapshot is stale
+    // after the restart's degrade-all persisted scopes path).
+    const restarted = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+    });
+    await restarted.degradePersistedScopes(persistedInventory);
+    expect(await restarted.authorizeOutbound("+155****9093")).toBe(false);
+    expect(await restarted.authorizeOutbound("+155****9094")).toBe(false);
   });
 
   it("authorizeOutboundInChat fails closed for governed chats with unresolvable targets", async () => {
@@ -616,26 +846,17 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
 
     const scope = await scopeFor(chatId);
     expect(
-      (
-        await membership.authorize(
-          scope,
-          imessageMembershipPrincipalId("default", "+155****9095"),
-        )
-      ).decision,
+      (await membership.authorize(scope, imessageMembershipPrincipalId("default", "+155****9095")))
+        .decision
     ).toBe("allowed");
 
     // A variant spelling the index cannot resolve, inside a durably
     // governed chat: DENY, not legacy-ungated null.
-    expect(await publisher.authorizeOutboundInChat("+1559095", chatId)).toBe(
-      false,
-    );
+    expect(await publisher.authorizeOutboundInChat("+1559095", chatId)).toBe(false);
 
     // An ungoverned chat with no durable scope stays null (legacy).
     expect(
-      await publisher.authorizeOutboundInChat(
-        "+155****7777",
-        "Imessage;-;+155****7777",
-      ),
+      await publisher.authorizeOutboundInChat("+155****7777", "Imessage;-;+155****7777")
     ).toBeNull();
   });
 

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Real-PGlite coverage for the native iMessage membership publisher
+ * (#24370): chat_handle_join-derived complete roster snapshots through the
+ * landed core MembershipService + plugin-sql authority, per-sender point
+ * renewals, fail-closed roster degradation (TCC/db errors → unavailable
+ * scope health → denied authorization), idempotent replay of identical
+ * roster reads, and restart adoption of the durable publisher binding.
+ * The runtime, adapter, connector-account row, and authority are all real;
+ * only the chat.db roster source is synthetic.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { AgentRuntime, type MembershipScope, MembershipService, type UUID } from "@elizaos/core";
+import { createDatabaseAdapter } from "@elizaos/plugin-sql";
+import { v4 as uuidv4 } from "uuid";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  IMessageMembershipPublisher,
+  type IMessageMembershipRosterSource,
+  type IMessageRosterRead,
+  imessageMembershipPrincipalId,
+  imessageMembershipScope,
+} from "./membership.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup) await cleanup();
+  }
+});
+
+let runtime: AgentRuntime;
+let membership: MembershipService;
+let publisher: IMessageMembershipPublisher;
+let connectorAccountId: UUID;
+let restartDir: string;
+
+/**
+ * Synthetic chat.db roster source. Real chat.db reads are covered by the
+ * plugin's integration tests over an actual SQLite fixture; the authority
+ * path is what needs the real database here.
+ */
+class SyntheticRosterSource implements IMessageMembershipRosterSource {
+  private chats = new Map<string, { chatType: "direct" | "group"; handles: string[] }>();
+  private counter = 0;
+  failure: Error | null = null;
+
+  setChat(chatId: string, chatType: "direct" | "group", handles: string[]): void {
+    this.chats.set(chatId, { chatType, handles });
+  }
+
+  listChatIds(): readonly string[] {
+    if (this.failure) throw this.failure;
+    return [...this.chats.keys()];
+  }
+
+  readRoster(chatId: string): IMessageRosterRead | null {
+    if (this.failure) throw this.failure;
+    const chat = this.chats.get(chatId);
+    if (!chat) return null;
+    // Mirror the real adapter: every read stamps a fresh monotonic cursor so
+    // repeated sweeps of the same roster are distinct evidence observations.
+    this.counter += 1;
+    return {
+      chatId,
+      chatType: chat.chatType,
+      displayName: chat.chatType === "group" ? `group-${chatId}` : null,
+      participants: chat.handles.map((handle) => ({ handle, service: "iMessage" })),
+      cursor: this.counter,
+    };
+  }
+}
+
+async function scopeFor(chatId: string): Promise<MembershipScope> {
+  return imessageMembershipScope({
+    agentId: runtime.agentId,
+    connectorAccountId,
+    chatId,
+  });
+}
+
+beforeAll(async () => {
+  restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "imessage-membership-24370-"));
+  // The membership authority validates UUID version nibbles, so the test
+  // agent id must be a real v4. Build the runtime directly over a real
+  // PGlite adapter, the same shape plugin-sql's own authority tests use.
+  const agentId = uuidv4() as UUID;
+  const adapter = createDatabaseAdapter({ dataDir: restartDir }, agentId);
+  await (adapter as unknown as { init: () => Promise<void> }).init();
+  runtime = new AgentRuntime({
+    character: {
+      name: "imessage-membership-24370",
+      id: agentId,
+      plugins: [],
+      settings: {},
+    },
+    agentId,
+    adapter,
+    logLevel: "warn",
+    enableAutonomy: false,
+  });
+  const sqlModule = (await import("@elizaos/plugin-sql")) as {
+    default?: { plugins?: unknown[] };
+    plugin?: { plugins?: unknown[] };
+  };
+  const sqlPlugin = sqlModule.default ?? (sqlModule.plugin as { plugins?: unknown[] });
+  if (sqlPlugin) {
+    await runtime.registerPlugin(sqlPlugin as Parameters<AgentRuntime["registerPlugin"]>[0]);
+  }
+  await runtime.initialize();
+  const services = runtime.getServicesByType<MembershipService>(MembershipService.serviceType);
+  expect(services.length).toBeGreaterThan(0);
+  membership = services[0];
+
+  // Bootstrap the durable connector account row exactly the way the
+  // service's initMembership does (upsert through the account manager).
+  const { getConnectorAccountManager } = await import("@elizaos/core");
+  const manager = getConnectorAccountManager(runtime);
+  const now = Date.now();
+  const stored = await manager.upsertAccount("imessage", {
+    id: "imessage-default",
+    provider: "imessage",
+    label: "iMessage (local Apple account)",
+    role: "AGENT",
+    purpose: ["messaging"],
+    accessGate: "open",
+    status: "connected",
+    createdAt: now,
+    updatedAt: now,
+    metadata: { source: "imessage-membership" },
+  });
+  expect(stored.id).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  );
+  connectorAccountId = stored.id as UUID;
+
+  publisher = new IMessageMembershipPublisher({
+    runtime,
+    connectorAccountId,
+    accountKey: "default",
+    service: membership,
+  });
+  cleanups.push(async () => {
+    await runtime.stop();
+  });
+}, 180_000);
+
+afterAll(async () => {
+  fs.rmSync(restartDir, { recursive: true, force: true });
+}, 60_000);
+
+describe("iMessage membership publisher (real PGlite authority)", () => {
+  it("derives pattern-valid deterministic principals from handles", () => {
+    const a = imessageMembershipPrincipalId("default", "+15550001111");
+    const b = imessageMembershipPrincipalId("default", "+15550001111");
+    const c = imessageMembershipPrincipalId("default", "+15550002222");
+    expect(a).toEqual(b);
+    expect(a).not.toEqual(c);
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  it("publishes a complete roster snapshot and admits its members", async () => {
+    const source = new SyntheticRosterSource();
+    source.setChat("Imessage;-;+15550001111", "direct", ["+15550001111"]);
+    source.setChat("Imessage;+;chat-1;+15550002222", "group", [
+      "+15550001111",
+      "+15550002222",
+      "+15550003333",
+    ]);
+
+    const published = await publisher.sweepRoster(source);
+    expect(published).toBe(2);
+
+    const scope = await scopeFor("Imessage;+;chat-1;+15550002222");
+    for (const handle of ["+15550001111", "+15550002222", "+15550003333"]) {
+      const decision = await membership.authorize(
+        scope,
+        imessageMembershipPrincipalId("default", handle)
+      );
+      expect(decision.decision).toBe("allowed");
+    }
+
+    // A handle not in the roster must be denied: the roster is the truth.
+    const outsider = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550009999")
+    );
+    expect(outsider.decision).toBe("denied");
+  });
+
+  it("revokes members removed from the roster on the next sweep", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-2;+15550004444";
+    source.setChat(chatId, "group", ["+15550004444", "+15550005555"]);
+    await publisher.sweepRoster(source);
+
+    // Kicked from the group: the next roster read omits the handle.
+    source.setChat(chatId, "group", ["+15550004444"]);
+    await publisher.sweepRoster(source);
+
+    const scope = await scopeFor(chatId);
+    const removed = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550005555")
+    );
+    expect(removed.decision).toBe("denied");
+    const kept = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550004444")
+    );
+    expect(kept.decision).toBe("allowed");
+  });
+
+  it("degrades fail-closed when the roster source fails (TCC/DB error)", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+15550006666";
+    source.setChat(chatId, "direct", ["+15550006666"]);
+    await publisher.sweepRoster(source);
+
+    // Simulate a Full Disk Access revocation: reads start throwing.
+    source.failure = new Error("SQLITE_CANTOPEN: disk I/O error (TCC denied)");
+    await expect(publisher.sweepRoster(source)).rejects.toThrow();
+
+    // Scope health must now be unavailable and authorization must DENY.
+    const scope = await scopeFor(chatId);
+    const health = await membership.getScopeHealth(scope);
+    expect(health?.health).toBe("unavailable");
+    const decision = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550006666")
+    );
+    expect(decision.decision).toBe("denied");
+
+    // Recovery: reads succeed again and a complete snapshot restores admission.
+    source.failure = null;
+    const restored = await publisher.sweepRoster(source);
+    expect(restored).toBeGreaterThanOrEqual(1);
+    const after = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550006666")
+    );
+    expect(after.decision).toBe("allowed");
+  });
+
+  it("renews a sender with point evidence between sweeps", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+15550007777";
+    source.setChat(chatId, "direct", ["+15550007777"]);
+    await publisher.sweepRoster(source);
+
+    const scope = await scopeFor(chatId);
+    const before = await membership.getMembership(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550007777")
+    );
+    expect(before?.state).toBe("active");
+
+    // Within the renewal window the same sender is not re-proven: the sweep
+    // just stamped this principal, so the in-process gate dedupes the
+    // inbound-message renewal (the authoritative refresh path is the sweep).
+    const tooSoon = await publisher.renewSender({ chatId, handle: "+15550007777" });
+    expect(tooSoon).toBe(false);
+
+    // A renewed principal is still admitted: the committed snapshot evidence
+    // carries the authorization, not the in-memory renewal map.
+    const decision = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550007777")
+    );
+    expect(decision.decision).toBe("allowed");
+  });
+
+  it("adopts the durable publisher binding across restarts (new instance, same scope state)", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-3;+15550008888";
+    source.setChat(chatId, "group", ["+15550008888"]);
+    await publisher.sweepRoster(source);
+
+    // A restarted process: brand-new publisher instance over the same
+    // durable authority state. It must re-publish without losing the
+    // committed member facts (no membership_evidence_mismatch denials).
+    const restarted = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+    });
+    const published = await restarted.sweepRoster(source);
+    expect(published).toBeGreaterThanOrEqual(1);
+
+    const scope = await scopeFor(chatId);
+    const decision = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+15550008888")
+    );
+    expect(decision.decision).toBe("allowed");
+  });
+});

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -571,6 +571,74 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
     ).toBe("denied");
   });
 
+  it("an emptied roster degrades every previously governed scope (empty-sweep ratchet)", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-ratchet-1;+155****9091";
+    source.setChat(chatId, "group", ["+155****9091"]);
+    let persisted: readonly string[] = [];
+    const tracked = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+      onRosterCommitted: async (chatIds) => {
+        persisted = [...chatIds];
+      },
+    });
+    await tracked.sweepRoster(source);
+    expect(persisted).toContain(chatId);
+
+    // The roster empties (chat deleted): the sweep commits nothing, but the
+    // ratchet must still degrade the previously governed scope and persist
+    // the empty inventory.
+    const empty = new SyntheticRosterSource();
+    await tracked.sweepRoster(empty);
+    expect(persisted).toEqual([]);
+
+    const scope = await scopeFor(chatId);
+    const health = await membership.getScopeHealth(scope);
+    expect(health?.health).toBe("unavailable");
+    expect(
+      (
+        await membership.authorize(
+          scope,
+          imessageMembershipPrincipalId("default", "+155****9091"),
+        )
+      ).decision,
+    ).toBe("denied");
+  });
+
+  it("authorizeOutboundInChat fails closed for governed chats with unresolvable targets", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+155****9095";
+    source.setChat(chatId, "direct", ["+155****9095"]);
+    await publisher.sweepRoster(source);
+
+    const scope = await scopeFor(chatId);
+    expect(
+      (
+        await membership.authorize(
+          scope,
+          imessageMembershipPrincipalId("default", "+155****9095"),
+        )
+      ).decision,
+    ).toBe("allowed");
+
+    // A variant spelling the index cannot resolve, inside a durably
+    // governed chat: DENY, not legacy-ungated null.
+    expect(await publisher.authorizeOutboundInChat("+1559095", chatId)).toBe(
+      false,
+    );
+
+    // An ungoverned chat with no durable scope stays null (legacy).
+    expect(
+      await publisher.authorizeOutboundInChat(
+        "+155****7777",
+        "Imessage;-;+155****7777",
+      ),
+    ).toBeNull();
+  });
+
   it("a fenced commit failure keeps the chat out of the committed index and inventory", async () => {
     const source = new SyntheticRosterSource();
     const chatId = "Imessage;-;+155****9081";

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -576,28 +576,47 @@ describe("iMessage membership R2 fixes (canonical index + reconciliation)", () =
     const chatId = "Imessage;-;+155****9081";
     source.setChat(chatId, "direct", ["+155****9081"]);
 
-    // Break the authority commits for this publisher: every
-    // applyCompleteSnapshot throws a fence error, both retries exhaust, and
-    // the snapshot errors instead of fabricating success.
-    const broken = {
-      applyCompleteSnapshot: async () => {
-        const err = new Error("fence") as Error & { code?: string };
-        err.code = "MEMBERSHIP_GENERATION_FENCE";
-        throw err;
+    // Delegate every authority call to the REAL service so registration and
+    // health reads succeed; intercept only applyCompleteSnapshot to throw a
+    // fence error. Both fenced retries must exhaust and the snapshot must
+    // fail without fabricating success.
+    let snapshotAttempts = 0;
+    const broken = new Proxy(membership, {
+      get(target, prop, receiver) {
+        if (prop === "applyCompleteSnapshot") {
+          return async () => {
+            snapshotAttempts += 1;
+            const err = new Error("fence") as Error & { code?: string };
+            err.code = "MEMBERSHIP_GENERATION_FENCE";
+            throw err;
+          };
+        }
+        return Reflect.get(target, prop, receiver);
       },
-    } as unknown as MembershipService;
+    });
+    let persistedInventory: readonly string[] = [];
     const fenced = new IMessageMembershipPublisher({
       runtime,
       connectorAccountId,
       accountKey: "default",
       service: broken,
+      onRosterCommitted: async (chatIds) => {
+        persistedInventory = [...chatIds];
+      },
     });
     // The per-chat sweep catch reports the failure and skips the chat, so
     // the sweep resolves (0 published) instead of throwing the loop away.
     const published = await fenced.sweepRoster(source);
     expect(published).toBe(0);
 
+    // Both fenced attempts actually ran (the exhaustion path was reached,
+    // not a pre-snapshot TypeError).
+    expect(snapshotAttempts).toBeGreaterThanOrEqual(2);
+
     // The outbound index must NOT contain the uncommitted chat's handle.
     expect(await fenced.authorizeOutbound("+155****9081")).toBeNull();
+
+    // The persisted inventory must not record the uncommitted chat.
+    expect(persistedInventory).not.toContain(chatId);
   });
 });

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -299,3 +299,153 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     expect(decision.decision).toBe("allowed");
   });
 });
+
+/**
+ * RP R1 follow-up coverage (fix loop): the failure semantics the first
+ * review found missing — real-reader roster failures surfaced through the
+ * failure counter (not a synthetic throw), restart-safe idempotency keys
+ * (fresh publisher over the same durable state re-publishes instead of
+ * conflicting), renewal keys that do not collide across observations, and
+ * the outbound send gate consulting both the local degraded flag and
+ * authority evidence.
+ */
+describe("iMessage membership failure semantics (RP R1 fixes)", () => {
+  it("restart adoption re-publishes without idempotency conflicts across instances", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-restart-1;+155****9001";
+    source.setChat(chatId, "group", ["+155****9001", "+155****9002"]);
+    await publisher.sweepRoster(source);
+
+    // A restarted process over the same durable authority state: every
+    // observation must journal a fresh idempotency key (counter resets are
+    // irrelevant; the observation identity carries the key).
+    const restarted = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+    });
+    const published = await restarted.sweepRoster(source);
+    expect(published).toBeGreaterThanOrEqual(1);
+
+    const scope = await scopeFor(chatId);
+    for (const handle of ["+155****9001", "+155****9002"]) {
+      const decision = await membership.authorize(
+        scope,
+        imessageMembershipPrincipalId("default", handle)
+      );
+      expect(decision.decision).toBe("allowed");
+    }
+  });
+
+  it("repeated renewals of the same sender commit instead of silently conflicting", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+155****9011";
+    source.setChat(chatId, "direct", ["+155****9011"]);
+    await publisher.sweepRoster(source);
+
+    // Backdate the renewal stamp left by the sweep so the first renewal is
+    // outside the dedupe window and commits.
+    const internal = (
+      publisher as unknown as {
+        scopes: Map<string, { renewedAt: Map<string, number> }>;
+      }
+    ).scopes;
+    const tracker = internal.get(`${connectorAccountId}:${chatId}`);
+    expect(tracker).toBeDefined();
+    tracker?.renewedAt.set(
+      imessageMembershipPrincipalId("default", "+155****9011") as string,
+      Date.now() - 60 * 60 * 1000
+    );
+    const first = await publisher.renewSender({ chatId, handle: "+155****9011" });
+    expect(first).toBe(true);
+
+    // A later renewal (fresh observation, new cursor/timestamp digest) must
+    // not be dropped by a reused permanent idempotency key: force the
+    // window to expire again by backdating the in-process renewal stamp.
+    tracker?.renewedAt.set(
+      imessageMembershipPrincipalId("default", "+155****9011") as string,
+      Date.now() - 60 * 60 * 1000
+    );
+    const second = await publisher.renewSender({ chatId, handle: "+155****9011" });
+    expect(second).toBe(true);
+  });
+
+  it("a degraded scope denies authorizeSend even before the durable commit lands", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;-;+155****9021";
+    source.setChat(chatId, "direct", ["+155****9021"]);
+    await publisher.sweepRoster(source);
+
+    // Deny through the gate before any durable degradation commit: mark the
+    // scope degraded in-process (simulating a setScopeHealth failure).
+    const internal = (
+      publisher as unknown as {
+        scopes: Map<string, { degraded: boolean }>;
+      }
+    ).scopes;
+    const tracker = internal.get(`${connectorAccountId}:${chatId}`);
+    expect(tracker).toBeDefined();
+    if (tracker) tracker.degraded = true;
+
+    // The local flag is consulted first: the send gate denies without
+    // trusting possibly-stale authority evidence.
+    const allowed = await publisher.authorizeSend({ chatId, handle: "+155****9021" });
+    expect(allowed).toBe(false);
+
+    // Outbound gate over the bare handle resolves the direct chat and also denies.
+    const outbound = await publisher.authorizeOutbound("+155****9021");
+    expect(outbound).toBe(false);
+
+    if (tracker) tracker.degraded = false;
+  });
+
+  it("authorizeOutbound returns null for ungoverned targets and true for healthy governed ones", async () => {
+    const source = new SyntheticRosterSource();
+    const directId = "Imessage;-;+155****9031";
+    const groupId = "Imessage;+;chat-gov-1;+155****9031";
+    source.setChat(directId, "direct", ["+155****9031"]);
+    source.setChat(groupId, "group", ["+155****9031", "+155****9032"]);
+    await publisher.sweepRoster(source);
+
+    // Ungoverned target: legacy null (no gate).
+    expect(await publisher.authorizeOutbound("+155****9999")).toBeNull();
+
+    // Governed direct target: recipient principal is an active member.
+    expect(await publisher.authorizeOutbound("+155****9031")).toBe(true);
+
+    // Governed group target by chat id: scope health is current.
+    expect(await publisher.authorizeOutbound(groupId)).toBe(true);
+
+    // A member removed by the next complete snapshot loses admission.
+    source.setChat(directId, "direct", ["+155****9034"]);
+    await publisher.sweepRoster(source);
+    expect(await publisher.authorizeOutbound("+155****9031")).toBe(false);
+  });
+
+  it("degradePersistedScopes marks an inventory fail-closed for restart-without-chat.db", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-restart-2;+155****9041";
+    source.setChat(chatId, "group", ["+155****9041"]);
+    await publisher.sweepRoster(source);
+
+    // Simulated restart with chat.db unavailable: the fresh publisher holds
+    // no in-memory scope state, only the persisted inventory.
+    const restarted = new IMessageMembershipPublisher({
+      runtime,
+      connectorAccountId,
+      accountKey: "default",
+      service: membership,
+    });
+    await restarted.degradePersistedScopes([chatId]);
+
+    const scope = await scopeFor(chatId);
+    const health = await membership.getScopeHealth(scope);
+    expect(health?.health).toBe("unavailable");
+    const decision = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+155****9041")
+    );
+    expect(decision.decision).toBe("denied");
+  });
+});

--- a/plugins/plugin-imessage/src/membership.test.ts
+++ b/plugins/plugin-imessage/src/membership.test.ts
@@ -52,6 +52,10 @@ class SyntheticRosterSource implements IMessageMembershipRosterSource {
     this.chats.set(chatId, { chatType, handles });
   }
 
+  removeChat(chatId: string): void {
+    this.chats.delete(chatId);
+  }
+
   listChatIds(): readonly string[] {
     if (this.failure) throw this.failure;
     return [...this.chats.keys()];
@@ -265,6 +269,53 @@ describe("iMessage membership publisher (real PGlite authority)", () => {
     const after = await membership.authorize(
       scope,
       imessageMembershipPrincipalId("default", "+15550006666")
+    );
+    expect(after.decision).toBe("allowed");
+  });
+
+  it("refuses to publish an empty successful roster and fails closed (empty-roster guard)", async () => {
+    const source = new SyntheticRosterSource();
+    const chatId = "Imessage;+;chat-empty-roster";
+    source.setChat(chatId, "group", ["+155****8888"]);
+    await publisher.sweepRoster(source);
+
+    // The read SUCCEEDS but the roster is empty: the chat.db LEFT JOIN
+    // returned the chat row with a NULL handle aggregate (or every handle
+    // row was dropped by the truthy filter). Publishing a `complete`
+    // 0-member snapshot here would tell the authority "everyone left" —
+    // an authoritative mass-removal signal from absence of evidence.
+    source.setChat(chatId, "group", []);
+    const published = await publisher.sweepRoster(source);
+    expect(published).toBe(0);
+
+    const scope = await scopeFor(chatId);
+    const health = await membership.getScopeHealth(scope);
+    expect(health?.health).toBe("unavailable");
+    const decision = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+155****8888")
+    );
+    expect(decision.decision).toBe("denied");
+
+    // A falsy handle (empty handle.id filtered by the truthy check in
+    // materializeMembers) is the same absence-of-evidence class: the scope
+    // is degraded, never published as a complete empty roster.
+    const orphanChatId = "Imessage;-;+155****0000";
+    source.setChat(orphanChatId, "direct", [""]);
+    const publishedOrphan = await publisher.sweepRoster(source);
+    expect(publishedOrphan).toBe(0);
+    const orphanScope = await scopeFor(orphanChatId);
+    const orphanHealth = await membership.getScopeHealth(orphanScope);
+    expect(orphanHealth?.health).toBe("unavailable");
+
+    // Recovery: a later non-empty successful read restores admission.
+    source.setChat(chatId, "group", ["+155****8888"]);
+    source.removeChat(orphanChatId);
+    const restored = await publisher.sweepRoster(source);
+    expect(restored).toBeGreaterThanOrEqual(1);
+    const after = await membership.authorize(
+      scope,
+      imessageMembershipPrincipalId("default", "+155****8888")
     );
     expect(after.decision).toBe("allowed");
   });

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -17,7 +17,13 @@ import type {
   MembershipService,
   UUID,
 } from "@elizaos/core";
-import { ChannelType, createUniqueUuid, ElizaError, logger, ServiceType } from "@elizaos/core";
+import {
+  ChannelType,
+  createUniqueUuid,
+  ElizaError,
+  logger,
+  ServiceType,
+} from "@elizaos/core";
 
 /** Connector id the authority's connector_accounts.provider expects. */
 export const IMESSAGE_MEMBERSHIP_CONNECTOR_ID = "imessage";
@@ -91,7 +97,9 @@ export interface IMessageMembershipRosterSource {
   listChatIds(): readonly string[];
 }
 
-export function isMembershipService(service: unknown): service is MembershipService {
+export function isMembershipService(
+  service: unknown,
+): service is MembershipService {
   return (
     typeof service === "object" &&
     service !== null &&
@@ -100,7 +108,9 @@ export function isMembershipService(service: unknown): service is MembershipServ
   );
 }
 
-export function resolveMembershipService(runtime: IAgentRuntime): MembershipService | null {
+export function resolveMembershipService(
+  runtime: IAgentRuntime,
+): MembershipService | null {
   const service = runtime.getService(ServiceType.MEMBERSHIP);
   return isMembershipService(service) ? service : null;
 }
@@ -112,7 +122,10 @@ export function resolveMembershipService(runtime: IAgentRuntime): MembershipServ
  * [1-8] version-nibble check (stringToUuid-derived ids carry the custom
  * 0x0 version nibble and are rejected).
  */
-export function imessageMembershipPrincipalId(accountKey: string, handle: string): UUID {
+export function imessageMembershipPrincipalId(
+  accountKey: string,
+  handle: string,
+): UUID {
   return uuidV5(`${accountKey}:${handle}`);
 }
 
@@ -172,7 +185,10 @@ interface ScopeTracker {
  * the governed scope health must go unavailable — a denial, never an admit.
  */
 export class IMessageRosterUnavailableError extends ElizaError {
-  constructor(message: string, options?: { cause?: unknown; context?: Record<string, unknown> }) {
+  constructor(
+    message: string,
+    options?: { cause?: unknown; context?: Record<string, unknown> },
+  ) {
     super(message, {
       code: "IMESSAGE_ROSTER_UNAVAILABLE",
       context: options?.context,
@@ -204,16 +220,30 @@ export class IMessageMembershipPublisher {
   /**
    * Direct-chat handle → chat id index built from roster sweeps, so the
    * outbound send gate can resolve a bare phone/email target to its
-   * governed scope without re-reading chat.db.
+   * governed scope without re-reading chat.db. Canonicalized keys are
+   * stored alongside the raw roster handle (which is the principal-name
+   * input) so variant spellings resolve to one gate entry while the
+   * principal id keeps deriving from the roster's own spelling.
    */
-  private readonly directChatByHandle = new Map<string, string>();
+  private readonly directChatByHandle = new Map<
+    string,
+    { chatId: string; rosterHandle: string }
+  >();
+  /**
+   * Canonical outbound-target spelling function (the connector's shared
+   * normalizeIMessageConnectorHandle). Applied to every index key and every
+   * authorizeOutbound lookup.
+   */
+  private readonly normalizeTarget: (value: string) => string;
   /**
    * Optional durable-snapshot hook: invoked with every governed chat id
    * after a successful full sweep so the owning service can persist the
    * scope inventory (e.g. on the connector account row) and fail closed
    * across restarts when chat.db is unavailable.
    */
-  private readonly onRosterCommitted?: (chatIds: readonly string[]) => Promise<void>;
+  private readonly onRosterCommitted?: (
+    chatIds: readonly string[],
+  ) => Promise<void>;
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -224,14 +254,21 @@ export class IMessageMembershipPublisher {
     /** The local Apple account handle, tagged with the self role. */
     ownHandle?: string | null;
     onRosterCommitted?: (chatIds: readonly string[]) => Promise<void>;
+    /**
+     * Canonical outbound-target spelling (the connector's shared
+     * normalizer). Defaults to identity; the service passes the real one.
+     */
+    normalizeTarget?: (value: string) => string;
   }) {
     this.runtime = input.runtime;
     this.connectorAccountId = input.connectorAccountId;
     this.accountKey = input.accountKey;
     this.service = input.service;
-    this.publisherInstanceId = input.publisherInstanceId ?? `imessage-${randomUUID()}`;
+    this.publisherInstanceId =
+      input.publisherInstanceId ?? `imessage-${randomUUID()}`;
     this.ownHandle = input.ownHandle ?? null;
     this.onRosterCommitted = input.onRosterCommitted;
+    this.normalizeTarget = input.normalizeTarget ?? ((value: string) => value);
   }
 
   /** Per-scope serialization: authority mutations for one scope must chain. */
@@ -266,7 +303,9 @@ export class IMessageMembershipPublisher {
    * durable health row already belongs to this stable publisher identity,
    * re-bind at the same generation instead of resetting the evidence chain.
    */
-  private async ensureRegistered(scope: MembershipScope): Promise<ScopeTracker> {
+  private async ensureRegistered(
+    scope: MembershipScope,
+  ): Promise<ScopeTracker> {
     const tracker = this.trackerFor(scope);
     if (tracker.generation > 0) return tracker;
 
@@ -306,7 +345,9 @@ export class IMessageMembershipPublisher {
   }
 
   /** Re-adopt durable state after a fence collision. */
-  private async readoptFromHealth(scope: MembershipScope): Promise<ScopeTracker> {
+  private async readoptFromHealth(
+    scope: MembershipScope,
+  ): Promise<ScopeTracker> {
     const tracker = this.trackerFor(scope);
     const health = await this.service.getScopeHealth(scope);
     if (health) {
@@ -349,7 +390,7 @@ export class IMessageMembershipPublisher {
       await this.markSourceUnavailable(source, error);
       throw new IMessageRosterUnavailableError(
         "chat.db roster enumeration failed; degrading all imessage membership scopes",
-        { cause: error, context: { accountKey: this.accountKey } }
+        { cause: error, context: { accountKey: this.accountKey } },
       );
     }
     let published = 0;
@@ -362,7 +403,7 @@ export class IMessageMembershipPublisher {
         await this.markSourceUnavailable(source, error);
         throw new IMessageRosterUnavailableError(
           `chat.db roster read failed for chat ${chatId}; degrading all imessage membership scopes`,
-          { cause: error, context: { accountKey: this.accountKey, chatId } }
+          { cause: error, context: { accountKey: this.accountKey, chatId } },
         );
       }
       if (!roster) continue;
@@ -381,10 +422,17 @@ export class IMessageMembershipPublisher {
       committedChatIds.push(chatId);
       // Index direct-chat handles so the outbound send gate can resolve a
       // bare phone/email to its governed scope. Rebuilding on every sweep
-      // keeps the index current as chats are created or deleted.
+      // keeps the index current as chats are created or deleted. Both the
+      // roster's own spelling and the canonicalized spelling map to the
+      // same entry so variant target spellings resolve; the entry keeps
+      // the roster handle because principal ids derive from it.
       if (roster.chatType === "direct") {
         for (const participant of roster.participants) {
-          if (participant.handle) this.directChatByHandle.set(participant.handle, chatId);
+          if (!participant.handle) continue;
+          const entry = { chatId, rosterHandle: participant.handle };
+          this.directChatByHandle.set(participant.handle, entry);
+          const canonical = this.normalizeTarget(participant.handle);
+          if (canonical) this.directChatByHandle.set(canonical, entry);
         }
       }
     }
@@ -406,13 +454,13 @@ export class IMessageMembershipPublisher {
   /** Start the periodic roster sweep. No-op when already running. */
   startSweeping(
     source: IMessageMembershipRosterSource,
-    intervalMs: number = IMESSAGE_MEMBERSHIP_SWEEP_INTERVAL_MS
+    intervalMs: number = IMESSAGE_MEMBERSHIP_SWEEP_INTERVAL_MS,
   ): void {
     if (this.sweepTimer) return;
     this.sweepTimer = setInterval(() => {
       this.sweepRoster(source).catch((error) => {
         logger.warn(
-          `[imessage][membership] periodic roster sweep failed: ${error instanceof Error ? error.message : String(error)}`
+          `[imessage][membership] periodic roster sweep failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       });
     }, intervalMs);
@@ -462,7 +510,8 @@ export class IMessageMembershipPublisher {
       for (let attempt = 0; attempt < 2; attempt++) {
         const sourceVersion = tracker.sourceVersion + 1;
         const sourceCursor = `imessage:${roster.chatId}:${sourceVersion}`;
-        const attemptKey = attempt === 0 ? snapshotKey : `${snapshotKey}:r${attempt}`;
+        const attemptKey =
+          attempt === 0 ? snapshotKey : `${snapshotKey}:r${attempt}`;
         try {
           await this.service.applyCompleteSnapshot({
             ...scope,
@@ -473,7 +522,9 @@ export class IMessageMembershipPublisher {
             sourceVersion,
             previousSourceCursor: tracker.sourceCursor,
             sourceCursor,
-            validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
+            validUntil: new Date(
+              Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS,
+            ).toISOString(),
             completeness: "complete",
             members,
             idempotencyKey: attemptKey,
@@ -485,7 +536,10 @@ export class IMessageMembershipPublisher {
           tracker.lastSweepAt = Date.now();
           tracker.degraded = false;
           for (const member of members) {
-            tracker.renewedAt.set(member.canonicalPrincipalId as string, Date.now());
+            tracker.renewedAt.set(
+              member.canonicalPrincipalId as string,
+              Date.now(),
+            );
           }
           return true;
         } catch (error) {
@@ -521,14 +575,25 @@ export class IMessageMembershipPublisher {
       canonicalPrincipalId: UUID;
       roles: readonly string[];
       permissionSnapshot: JsonObject;
-      runtime: { worldId: UUID | null; roomId: UUID | null; entityId: UUID | null };
+      runtime: {
+        worldId: UUID | null;
+        roomId: UUID | null;
+        entityId: UUID | null;
+      };
     }>
   > {
     const roomKey = roster.chatId;
     const derivedRoomId = createUniqueUuid(this.runtime, roomKey);
-    const derivedWorldId = createUniqueUuid(this.runtime, `imessage-world-${roomKey}`);
-    const runtimeRoomId = AUTHORITY_UUID_PATTERN.test(derivedRoomId) ? derivedRoomId : null;
-    const runtimeWorldId = AUTHORITY_UUID_PATTERN.test(derivedWorldId) ? derivedWorldId : null;
+    const derivedWorldId = createUniqueUuid(
+      this.runtime,
+      `imessage-world-${roomKey}`,
+    );
+    const runtimeRoomId = AUTHORITY_UUID_PATTERN.test(derivedRoomId)
+      ? derivedRoomId
+      : null;
+    const runtimeWorldId = AUTHORITY_UUID_PATTERN.test(derivedWorldId)
+      ? derivedWorldId
+      : null;
 
     if (runtimeRoomId) {
       await this.ensureRuntimeRoomRow(runtimeRoomId, roster);
@@ -540,9 +605,15 @@ export class IMessageMembershipPublisher {
     const members = [];
     for (const participant of roster.participants) {
       if (!participant.handle) continue;
-      const principalId = imessageMembershipPrincipalId(this.accountKey, participant.handle);
+      const principalId = imessageMembershipPrincipalId(
+        this.accountKey,
+        participant.handle,
+      );
       await this.ensurePrincipalEntity(principalId, participant.handle);
-      const connectorEntityId = createUniqueUuid(this.runtime, participant.handle);
+      const connectorEntityId = createUniqueUuid(
+        this.runtime,
+        participant.handle,
+      );
       members.push({
         canonicalPrincipalId: principalId,
         roles:
@@ -556,14 +627,19 @@ export class IMessageMembershipPublisher {
         runtime: {
           worldId: runtimeWorldId,
           roomId: runtimeRoomId,
-          entityId: AUTHORITY_UUID_PATTERN.test(connectorEntityId) ? connectorEntityId : null,
+          entityId: AUTHORITY_UUID_PATTERN.test(connectorEntityId)
+            ? connectorEntityId
+            : null,
         },
       });
     }
     return members;
   }
 
-  private async ensurePrincipalEntity(principalId: UUID, handle: string): Promise<void> {
+  private async ensurePrincipalEntity(
+    principalId: UUID,
+    handle: string,
+  ): Promise<void> {
     const existing = await this.runtime.getEntityById?.(principalId);
     if (existing) return;
     await this.runtime.createEntities?.([
@@ -580,7 +656,10 @@ export class IMessageMembershipPublisher {
     ]);
   }
 
-  private async ensureRuntimeRoomRow(roomId: UUID, roster: IMessageRosterRead): Promise<void> {
+  private async ensureRuntimeRoomRow(
+    roomId: UUID,
+    roster: IMessageRosterRead,
+  ): Promise<void> {
     if (this.runtime.getRoom) {
       const room = await this.runtime.getRoom(roomId);
       if (room) return;
@@ -594,7 +673,10 @@ export class IMessageMembershipPublisher {
     });
   }
 
-  private async ensureRuntimeWorldRow(worldId: UUID, roster: IMessageRosterRead): Promise<void> {
+  private async ensureRuntimeWorldRow(
+    worldId: UUID,
+    roster: IMessageRosterRead,
+  ): Promise<void> {
     await this.runtime.createWorld?.({
       id: worldId,
       name: roster.displayName ?? roster.chatId,
@@ -622,7 +704,10 @@ export class IMessageMembershipPublisher {
     return this.serialized(key, async () => {
       const tracker = this.trackerFor(scope);
       if (tracker.degraded) return false;
-      const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
+      const principalId = imessageMembershipPrincipalId(
+        this.accountKey,
+        input.handle,
+      );
       const last = tracker.renewedAt.get(principalId as string) ?? 0;
       if (Date.now() - last < IMESSAGE_MEMBERSHIP_RENEWAL_MS) {
         return false;
@@ -654,7 +739,9 @@ export class IMessageMembershipPublisher {
           sourceVersion,
           previousSourceCursor: tracker.sourceCursor,
           sourceCursor,
-          validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
+          validUntil: new Date(
+            Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS,
+          ).toISOString(),
           idempotencyKey: renewKey,
           observedAt,
         });
@@ -673,7 +760,7 @@ export class IMessageMembershipPublisher {
           // baseline: skip — the sweep is the authoritative evidence path and
           // the sender's committed snapshot is still valid inside its window.
           logger.debug(
-            `[imessage][membership] renewal skipped (no complete baseline in this publisher generation); roster sweep will re-publish: ${input.chatId}`
+            `[imessage][membership] renewal skipped (no complete baseline in this publisher generation); roster sweep will re-publish: ${input.chatId}`,
           );
           return false;
         }
@@ -727,7 +814,7 @@ export class IMessageMembershipPublisher {
         // local degraded flag (fail-closed admission) and surface the
         // failure — admission still denies.
         logger.warn(
-          `[imessage][membership] scope degrade commit failed (staying degraded): ${error instanceof Error ? error.message : String(error)}`
+          `[imessage][membership] scope degrade commit failed (staying degraded): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     });
@@ -742,7 +829,7 @@ export class IMessageMembershipPublisher {
    */
   async markSourceUnavailable(
     source: IMessageMembershipRosterSource,
-    cause: unknown
+    cause: unknown,
   ): Promise<void> {
     const reason = `chat.db roster source unavailable: ${cause instanceof Error ? cause.message : String(cause)}`;
     for (const chatId of this.knownChatIds(source)) {
@@ -757,8 +844,13 @@ export class IMessageMembershipPublisher {
       // error-policy:J6 Best-effort enumeration fallback: fall back to the
       // in-memory scope table (keys are <account>:<chatId>) plus the
       // direct-handle index built by prior sweeps.
-      const fromScopes = [...this.scopes.keys()].map((k) => k.split(":").slice(1).join(":"));
-      return [...new Set([...fromScopes, ...this.directChatByHandle.values()])];
+      const fromScopes = [...this.scopes.keys()].map((k) =>
+        k.split(":").slice(1).join(":"),
+      );
+      const fromIndex = [...this.directChatByHandle.values()].map(
+        (entry) => entry.chatId,
+      );
+      return [...new Set([...fromScopes, ...fromIndex])];
     }
   }
 
@@ -766,11 +858,29 @@ export class IMessageMembershipPublisher {
    * Degrade a persisted inventory of governed chat scopes (restart with
    * chat.db unavailable): every scope goes unavailable so stale authority
    * evidence cannot authorize while the roster source cannot be read.
+   * Direct-chat ids in the inventory also repopulate the handle index
+   * (their chat_identifier embeds the counterparty handle), so the
+   * outbound gate resolves bare handles to the degraded scopes instead of
+   * treating them as ungoverned.
    */
   async degradePersistedScopes(chatIds: readonly string[]): Promise<void> {
-    const reason = "chat.db unavailable at service start; persisted scope inventory degraded";
+    const reason =
+      "chat.db unavailable at service start; persisted scope inventory degraded";
     for (const chatId of chatIds) {
       await this.degradeScope({ chatId, reason });
+      // chat.db direct-chat identifiers are `<service>;-;<handle>`; groups
+      // use `;+;`-separated multi-part ids. Index the embedded handle under
+      // both its embedded spelling and its canonicalized spelling so
+      // authorizeOutbound gates it during this degraded run; the entry has
+      // no committed roster evidence, so it only ever resolves to a denial.
+      const parts = chatId.split(";");
+      if (parts.length >= 3 && parts[1] === "-") {
+        const embedded = parts.slice(2).join(";");
+        const entry = { chatId, rosterHandle: embedded };
+        this.directChatByHandle.set(embedded, entry);
+        const canonical = this.normalizeTarget(embedded);
+        if (canonical) this.directChatByHandle.set(canonical, entry);
+      }
     }
   }
 
@@ -782,7 +892,10 @@ export class IMessageMembershipPublisher {
    * failure whose durable unavailable commit may itself have failed, so a
    * decision from possibly-stale authority evidence is never trusted.
    */
-  async authorizeSend(input: { chatId: string; handle: string }): Promise<boolean> {
+  async authorizeSend(input: {
+    chatId: string;
+    handle: string;
+  }): Promise<boolean> {
     const scope = imessageMembershipScope({
       agentId: this.runtime.agentId,
       connectorAccountId: this.connectorAccountId,
@@ -790,7 +903,10 @@ export class IMessageMembershipPublisher {
     });
     const tracker = this.scopes.get(scopeKey(scope));
     if (tracker?.degraded) return false;
-    const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
+    const principalId = imessageMembershipPrincipalId(
+      this.accountKey,
+      input.handle,
+    );
     try {
       const decision = await this.service.authorize(scope, principalId);
       return decision.decision === "allowed";
@@ -810,12 +926,22 @@ export class IMessageMembershipPublisher {
    * holds for a bare handle. Fails closed on authority errors.
    */
   async authorizeOutbound(target: string): Promise<boolean | null> {
-    let chatId = this.directChatByHandle.get(target) ?? null;
-    const viaHandle = chatId !== null;
+    // Canonical spelling first: the index carries both the roster's own
+    // spelling and the canonicalized spelling, so variant target spellings
+    // of one counterparty resolve to one gate entry.
+    const canonical = this.normalizeTarget(target) || target;
+    const entry =
+      this.directChatByHandle.get(canonical) ??
+      this.directChatByHandle.get(target) ??
+      null;
+    let chatId = entry?.chatId ?? null;
+    const principalHandle = entry?.rosterHandle ?? null;
     if (chatId === null) {
       // A chat id used directly as the target names its own scope; accept
       // the canonical `chat_id:` prefix used by the connector target shape.
-      const bare = target.startsWith("chat_id:") ? target.slice("chat_id:".length) : target;
+      const bare = target.startsWith("chat_id:")
+        ? target.slice("chat_id:".length)
+        : target;
       for (const key of this.scopes.keys()) {
         if (key.endsWith(`:${bare}`)) {
           chatId = key.split(":").slice(1).join(":");
@@ -832,8 +958,11 @@ export class IMessageMembershipPublisher {
     const tracker = this.scopes.get(scopeKey(scope));
     if (tracker?.degraded) return false;
     try {
-      if (viaHandle) {
-        const principalId = imessageMembershipPrincipalId(this.accountKey, target);
+      if (principalHandle !== null) {
+        const principalId = imessageMembershipPrincipalId(
+          this.accountKey,
+          principalHandle,
+        );
         const decision = await this.service.authorize(scope, principalId);
         return decision.decision === "allowed";
       }

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -236,6 +236,12 @@ export class IMessageMembershipPublisher {
   private readonly scopes = new Map<string, ScopeTracker>();
   private readonly chains = new Map<string, Promise<unknown>>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Chat ids carried by the last successfully persisted governed-scope
+   * inventory. Drives the between-sweeps deletion ratchet: an id present
+   * here but absent from the next committed sweep degrades fail-closed.
+   */
+  private persistedInventory = new Set<string>();
   private readonly ownHandle: string | null;
   /**
    * Direct-chat handle → chat id index built from roster sweeps, so the
@@ -427,11 +433,11 @@ export class IMessageMembershipPublisher {
         );
       }
       if (!roster) continue;
+      let committed = false;
       try {
-        const committed = await this.publishRosterSnapshot({ roster });
+        committed = await this.publishRosterSnapshot({ roster });
         if (committed) published += 1;
-        // Only a committed (or benignly replayed) observation feeds the
-        // persisted inventory and the outbound index.
+        // Only a committed observation feeds the outbound index.
         if (committed) {
           this.indexRosterDirectHandles(roster);
         }
@@ -444,13 +450,31 @@ export class IMessageMembershipPublisher {
           accountKey: this.accountKey,
         });
       }
-      committedChatIds.push(chatId);
+      // Only a committed (or benignly replayed) observation feeds the
+      // persisted inventory: a chat whose snapshot errored must not be
+      // recorded as governed when its evidence never committed.
+      if (committed) {
+        committedChatIds.push(chatId);
+      }
     }
     if (this.onRosterCommitted && committedChatIds.length > 0) {
       // Persist the governed scope inventory; a failure to persist is a
       // diagnostic (the in-memory state is still correct for this process).
       try {
         await this.onRosterCommitted(committedChatIds);
+        // Deletion ratchet: a chat in the previously persisted inventory
+        // that this sweep no longer committed (deleted from chat.db, or its
+        // snapshot failed) must degrade fail-closed — stale durable
+        // evidence must stop authorizing between periodic sweeps too.
+        const committedSet = new Set(committedChatIds);
+        const reason =
+          "governed chat absent from the committed roster sweep; stale evidence degraded";
+        for (const priorId of this.persistedInventory) {
+          if (!committedSet.has(priorId)) {
+            await this.degradeScope({ chatId: priorId, reason });
+          }
+        }
+        this.persistedInventory = committedSet;
       } catch (error) {
         // error-policy:J7 Diagnostics must not kill the sweep loop.
         this.runtime.reportError?.("imessage:membership:inventory", error, {
@@ -967,7 +991,21 @@ export class IMessageMembershipPublisher {
     const reason =
       "chat.db unavailable at service start; persisted scope inventory degraded";
     for (const chatId of chatIds) {
-      await this.degradeScope({ chatId, reason });
+      // Per-chat resilient: a failure degrading one scope (authority
+      // registration or health write) must not abandon the remaining
+      // scopes to ungoverned. degradeScope sets the local degraded flag
+      // before any authority write, so a failed scope still denies in this
+      // process; the failure is reported and the loop continues.
+      try {
+        await this.degradeScope({ chatId, reason });
+      } catch (error) {
+        // error-policy:J4 Degrade-path failure keeps the local flag and
+        // continues: admission stays denied for this scope either way.
+        this.runtime.reportError?.("imessage:membership:degrade", error, {
+          chatId,
+          accountKey: this.accountKey,
+        });
+      }
       // chat.db direct-chat identifiers are `<service>;-;<handle>`; groups
       // use `;+;`-separated multi-part ids. Index the embedded handle under
       // both its embedded spelling and its canonicalized spelling so

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -199,6 +199,27 @@ export class IMessageRosterUnavailableError extends ElizaError {
 }
 
 /**
+ * A roster snapshot could not be committed after fenced retries: the
+ * authority kept rejecting the publish (fence collisions or idempotency
+ * conflicts the retry could not reconcile). The scope keeps its prior
+ * authoritative state; the sweep reports it and must NOT count the chat
+ * as committed.
+ */
+export class IMessageSnapshotCommitError extends ElizaError {
+  constructor(
+    message: string,
+    options?: { cause?: unknown; context?: Record<string, unknown> },
+  ) {
+    super(message, {
+      code: "IMESSAGE_SNAPSHOT_COMMIT_FAILED",
+      context: options?.context,
+      cause: options?.cause,
+      severity: "ephemeral",
+    });
+  }
+}
+
+/**
  * Publisher of native iMessage membership evidence to the canonical
  * MembershipService authority. One instance per (runtime, connector
  * account). All authority mutations are serialized per scope; every roster
@@ -215,7 +236,6 @@ export class IMessageMembershipPublisher {
   private readonly scopes = new Map<string, ScopeTracker>();
   private readonly chains = new Map<string, Promise<unknown>>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
-  private rosterCounter = 0;
   private readonly ownHandle: string | null;
   /**
    * Direct-chat handle → chat id index built from roster sweeps, so the
@@ -410,6 +430,11 @@ export class IMessageMembershipPublisher {
       try {
         const committed = await this.publishRosterSnapshot({ roster });
         if (committed) published += 1;
+        // Only a committed (or benignly replayed) observation feeds the
+        // persisted inventory and the outbound index.
+        if (committed) {
+          this.indexRosterDirectHandles(roster);
+        }
       } catch (error) {
         // error-policy:J7 Diagnostics must not kill the polling loop: report
         // and continue with the remaining chats; the scope keeps its prior
@@ -420,21 +445,6 @@ export class IMessageMembershipPublisher {
         });
       }
       committedChatIds.push(chatId);
-      // Index direct-chat handles so the outbound send gate can resolve a
-      // bare phone/email to its governed scope. Rebuilding on every sweep
-      // keeps the index current as chats are created or deleted. Both the
-      // roster's own spelling and the canonicalized spelling map to the
-      // same entry so variant target spellings resolve; the entry keeps
-      // the roster handle because principal ids derive from it.
-      if (roster.chatType === "direct") {
-        for (const participant of roster.participants) {
-          if (!participant.handle) continue;
-          const entry = { chatId, rosterHandle: participant.handle };
-          this.directChatByHandle.set(participant.handle, entry);
-          const canonical = this.normalizeTarget(participant.handle);
-          if (canonical) this.directChatByHandle.set(canonical, entry);
-        }
-      }
     }
     if (this.onRosterCommitted && committedChatIds.length > 0) {
       // Persist the governed scope inventory; a failure to persist is a
@@ -459,8 +469,15 @@ export class IMessageMembershipPublisher {
     if (this.sweepTimer) return;
     this.sweepTimer = setInterval(() => {
       this.sweepRoster(source).catch((error) => {
+        // error-policy:J7 Diagnostics must not kill the sweep timer: report
+        // through the runtime so RECENT_ERRORS surfaces the failure.
         logger.warn(
           `[imessage][membership] periodic roster sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        this.runtime.reportError?.(
+          "imessage:membership:periodic-sweep",
+          error,
+          { accountKey: this.accountKey },
         );
       });
     }, intervalMs);
@@ -482,7 +499,6 @@ export class IMessageMembershipPublisher {
     roster: IMessageRosterRead;
     observedAt?: string;
   }): Promise<boolean> {
-    this.rosterCounter += 1;
     const roster = input.roster;
     const scope = imessageMembershipScope({
       agentId: this.runtime.agentId,
@@ -503,9 +519,12 @@ export class IMessageMembershipPublisher {
       // unique while staying deterministic for a replay of the same
       // observation.
       const observedAtMs = Date.parse(observedAt);
-      const observedToken = Number.isFinite(observedAtMs)
-        ? observedAtMs.toString(36)
-        : this.rosterCounter.toString(36);
+      if (!Number.isFinite(observedAtMs)) {
+        throw new Error(
+          `membership snapshot observedAt is not a finite timestamp: ${observedAt}`,
+        );
+      }
+      const observedToken = observedAtMs.toString(36);
       const snapshotKey = `imessage:snapshot:${roster.chatId}:${observedToken}`;
       for (let attempt = 0; attempt < 2; attempt++) {
         const sourceVersion = tracker.sourceVersion + 1;
@@ -545,7 +564,12 @@ export class IMessageMembershipPublisher {
         } catch (error) {
           const code = membershipErrorCode(error);
           if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
-            return false;
+            // A conflict means the reused key carried a DIFFERENT command
+            // digest (e.g. a restart replay whose generation/cursor state
+            // changed after publisher re-registration) — not an identical
+            // replay. Retrying once under a fresh derived key reconciles the
+            // divergence instead of misreporting a duplicate.
+            continue;
           }
           if (FENCE_CODES.has(code)) {
             tracker = await this.readoptFromHealth(scope);
@@ -557,7 +581,10 @@ export class IMessageMembershipPublisher {
           throw error;
         }
       }
-      return false;
+      throw new IMessageSnapshotCommitError(
+        "roster snapshot commit exhausted its fenced retries",
+        { context: { accountKey: this.accountKey, chatId: roster.chatId } },
+      );
     });
   }
 
@@ -821,6 +848,79 @@ export class IMessageMembershipPublisher {
   }
 
   /**
+   * Index the direct-chat handles of a committed roster observation.
+   */
+  private indexRosterDirectHandles(roster: IMessageRosterRead): void {
+    if (roster.chatType !== "direct") return;
+    for (const participant of roster.participants) {
+      if (!participant.handle) continue;
+      this.indexDirectHandle(participant.handle, roster.chatId);
+    }
+  }
+
+  /**
+   * Reconcile a persisted governed-chat inventory against the fresh roster:
+   * every inventory chat the source no longer lists (deleted chat, emptied
+   * roster) is degraded fail-closed so its stale durable evidence stops
+   * authorizing. Chats still listed keep their committed state.
+   */
+  async reconcileRemovedScopes(
+    persistedChatIds: readonly string[],
+    source: IMessageMembershipRosterSource,
+  ): Promise<void> {
+    if (persistedChatIds.length === 0) return;
+    let currentIds: ReadonlySet<string>;
+    try {
+      currentIds = new Set(source.listChatIds());
+    } catch {
+      // error-policy:J4 Enumeration failed: degrade every persisted scope
+      // rather than trust possibly-stale evidence against an unreadable
+      // source.
+      const reason =
+        "chat.db roster enumeration failed during startup reconciliation";
+      for (const chatId of persistedChatIds) {
+        await this.degradeScope({ chatId, reason });
+      }
+      return;
+    }
+    const reason =
+      "governed chat absent from the fresh roster; stale evidence degraded";
+    for (const chatId of persistedChatIds) {
+      if (!currentIds.has(chatId)) {
+        await this.degradeScope({ chatId, reason });
+      }
+    }
+  }
+
+  /**
+   * Index one direct-chat handle under both its roster spelling and its
+   * canonicalized spelling. When two DIFFERENT roster spellings (or their
+   * canonical forms) already map to a different chat, the key is ambiguous:
+   * tombstone it so authorizeOutbound denies instead of resolving the wrong
+   * scope.
+   */
+  private indexDirectHandle(rosterHandle: string, chatId: string): void {
+    const entry = { chatId, rosterHandle };
+    this.setIndexEntry(rosterHandle, entry);
+    const canonical = this.normalizeTarget(rosterHandle);
+    if (canonical && canonical !== rosterHandle) {
+      this.setIndexEntry(canonical, entry);
+    }
+  }
+
+  private setIndexEntry(
+    key: string,
+    entry: { chatId: string; rosterHandle: string },
+  ): void {
+    const existing = this.directChatByHandle.get(key);
+    if (existing && existing.chatId !== entry.chatId) {
+      this.directChatByHandle.set(key, { chatId: "", rosterHandle: "" });
+      return;
+    }
+    this.directChatByHandle.set(key, entry);
+  }
+
+  /**
    * Source-wide fail-closed degradation: every known scope goes unavailable.
    * The governed chat-id inventory is persisted through the connector
    * account metadata when the service supplied an onRosterCommitted hook,
@@ -875,11 +975,7 @@ export class IMessageMembershipPublisher {
       // no committed roster evidence, so it only ever resolves to a denial.
       const parts = chatId.split(";");
       if (parts.length >= 3 && parts[1] === "-") {
-        const embedded = parts.slice(2).join(";");
-        const entry = { chatId, rosterHandle: embedded };
-        this.directChatByHandle.set(embedded, entry);
-        const canonical = this.normalizeTarget(embedded);
-        if (canonical) this.directChatByHandle.set(canonical, entry);
+        this.indexDirectHandle(parts.slice(2).join(";"), chatId);
       }
     }
   }
@@ -934,6 +1030,9 @@ export class IMessageMembershipPublisher {
       this.directChatByHandle.get(canonical) ??
       this.directChatByHandle.get(target) ??
       null;
+    // A tombstoned (ambiguous) key carries an empty chat id: deny rather
+    // than resolve a possibly-wrong scope.
+    if (entry && entry.chatId === "") return false;
     let chatId = entry?.chatId ?? null;
     const principalHandle = entry?.rosterHandle ?? null;
     if (chatId === null) {

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -17,13 +17,7 @@ import type {
   MembershipService,
   UUID,
 } from "@elizaos/core";
-import {
-  ChannelType,
-  createUniqueUuid,
-  ElizaError,
-  logger,
-  ServiceType,
-} from "@elizaos/core";
+import { ChannelType, createUniqueUuid, ElizaError, logger, ServiceType } from "@elizaos/core";
 
 /** Connector id the authority's connector_accounts.provider expects. */
 export const IMESSAGE_MEMBERSHIP_CONNECTOR_ID = "imessage";
@@ -97,9 +91,7 @@ export interface IMessageMembershipRosterSource {
   listChatIds(): readonly string[];
 }
 
-export function isMembershipService(
-  service: unknown,
-): service is MembershipService {
+export function isMembershipService(service: unknown): service is MembershipService {
   return (
     typeof service === "object" &&
     service !== null &&
@@ -108,9 +100,7 @@ export function isMembershipService(
   );
 }
 
-export function resolveMembershipService(
-  runtime: IAgentRuntime,
-): MembershipService | null {
+export function resolveMembershipService(runtime: IAgentRuntime): MembershipService | null {
   const service = runtime.getService(ServiceType.MEMBERSHIP);
   return isMembershipService(service) ? service : null;
 }
@@ -122,10 +112,7 @@ export function resolveMembershipService(
  * [1-8] version-nibble check (stringToUuid-derived ids carry the custom
  * 0x0 version nibble and are rejected).
  */
-export function imessageMembershipPrincipalId(
-  accountKey: string,
-  handle: string,
-): UUID {
+export function imessageMembershipPrincipalId(accountKey: string, handle: string): UUID {
   return uuidV5(`${accountKey}:${handle}`);
 }
 
@@ -185,10 +172,7 @@ interface ScopeTracker {
  * the governed scope health must go unavailable — a denial, never an admit.
  */
 export class IMessageRosterUnavailableError extends ElizaError {
-  constructor(
-    message: string,
-    options?: { cause?: unknown; context?: Record<string, unknown> },
-  ) {
+  constructor(message: string, options?: { cause?: unknown; context?: Record<string, unknown> }) {
     super(message, {
       code: "IMESSAGE_ROSTER_UNAVAILABLE",
       context: options?.context,
@@ -206,10 +190,7 @@ export class IMessageRosterUnavailableError extends ElizaError {
  * as committed.
  */
 export class IMessageSnapshotCommitError extends ElizaError {
-  constructor(
-    message: string,
-    options?: { cause?: unknown; context?: Record<string, unknown> },
-  ) {
+  constructor(message: string, options?: { cause?: unknown; context?: Record<string, unknown> }) {
     super(message, {
       code: "IMESSAGE_SNAPSHOT_COMMIT_FAILED",
       context: options?.context,
@@ -251,10 +232,7 @@ export class IMessageMembershipPublisher {
    * input) so variant spellings resolve to one gate entry while the
    * principal id keeps deriving from the roster's own spelling.
    */
-  private readonly directChatByHandle = new Map<
-    string,
-    { chatId: string; rosterHandle: string }
-  >();
+  private readonly directChatByHandle = new Map<string, { chatId: string; rosterHandle: string }>();
   /**
    * Canonical outbound-target spelling function (the connector's shared
    * normalizeIMessageConnectorHandle). Applied to every index key and every
@@ -267,9 +245,7 @@ export class IMessageMembershipPublisher {
    * scope inventory (e.g. on the connector account row) and fail closed
    * across restarts when chat.db is unavailable.
    */
-  private readonly onRosterCommitted?: (
-    chatIds: readonly string[],
-  ) => Promise<void>;
+  private readonly onRosterCommitted?: (chatIds: readonly string[]) => Promise<void>;
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -285,16 +261,23 @@ export class IMessageMembershipPublisher {
      * normalizer). Defaults to identity; the service passes the real one.
      */
     normalizeTarget?: (value: string) => string;
+    /**
+     * The governed-chat inventory persisted by a previous process, read
+     * from connector account metadata at startup. Seeds the deletion
+     * ratchet so the first sweep of a restarted process cannot silently
+     * replace a persisted inventory it never degraded.
+     */
+    initialInventory?: readonly string[];
   }) {
     this.runtime = input.runtime;
     this.connectorAccountId = input.connectorAccountId;
     this.accountKey = input.accountKey;
     this.service = input.service;
-    this.publisherInstanceId =
-      input.publisherInstanceId ?? `imessage-${randomUUID()}`;
+    this.publisherInstanceId = input.publisherInstanceId ?? `imessage-${randomUUID()}`;
     this.ownHandle = input.ownHandle ?? null;
     this.onRosterCommitted = input.onRosterCommitted;
     this.normalizeTarget = input.normalizeTarget ?? ((value: string) => value);
+    this.persistedInventory = new Set(input.initialInventory ?? []);
   }
 
   /** Per-scope serialization: authority mutations for one scope must chain. */
@@ -329,9 +312,7 @@ export class IMessageMembershipPublisher {
    * durable health row already belongs to this stable publisher identity,
    * re-bind at the same generation instead of resetting the evidence chain.
    */
-  private async ensureRegistered(
-    scope: MembershipScope,
-  ): Promise<ScopeTracker> {
+  private async ensureRegistered(scope: MembershipScope): Promise<ScopeTracker> {
     const tracker = this.trackerFor(scope);
     if (tracker.generation > 0) return tracker;
 
@@ -371,9 +352,7 @@ export class IMessageMembershipPublisher {
   }
 
   /** Re-adopt durable state after a fence collision. */
-  private async readoptFromHealth(
-    scope: MembershipScope,
-  ): Promise<ScopeTracker> {
+  private async readoptFromHealth(scope: MembershipScope): Promise<ScopeTracker> {
     const tracker = this.trackerFor(scope);
     const health = await this.service.getScopeHealth(scope);
     if (health) {
@@ -416,7 +395,7 @@ export class IMessageMembershipPublisher {
       await this.markSourceUnavailable(source, error);
       throw new IMessageRosterUnavailableError(
         "chat.db roster enumeration failed; degrading all imessage membership scopes",
-        { cause: error, context: { accountKey: this.accountKey } },
+        { cause: error, context: { accountKey: this.accountKey } }
       );
     }
     let published = 0;
@@ -429,7 +408,7 @@ export class IMessageMembershipPublisher {
         await this.markSourceUnavailable(source, error);
         throw new IMessageRosterUnavailableError(
           `chat.db roster read failed for chat ${chatId}; degrading all imessage membership scopes`,
-          { cause: error, context: { accountKey: this.accountKey, chatId } },
+          { cause: error, context: { accountKey: this.accountKey, chatId } }
         );
       }
       if (!roster) continue;
@@ -469,6 +448,7 @@ export class IMessageMembershipPublisher {
         const committedSet = new Set(committedChatIds);
         const reason =
           "governed chat absent from the committed roster sweep; stale evidence degraded";
+        const failedScopes: string[] = [];
         for (const priorId of this.persistedInventory) {
           if (!committedSet.has(priorId)) {
             try {
@@ -476,12 +456,30 @@ export class IMessageMembershipPublisher {
             } catch (error) {
               // error-policy:J4 Degrade-path failure keeps the local flag
               // and continues with the remaining removed scopes.
+              failedScopes.push(priorId);
               this.runtime.reportError?.("imessage:membership:degrade", error, {
                 chatId: priorId,
                 accountKey: this.accountKey,
               });
             }
           }
+        }
+        if (failedScopes.length > 0) {
+          // At least one removed scope's durable degrade could not commit.
+          // Persisting ONLY the committed set would erase the restart
+          // ratchet for the failed scopes (a restart would forget a scope
+          // that was never made durably unavailable), while persisting
+          // nothing would starve additions of newly governed chats. Persist
+          // the conservative union — newly committed chats plus every
+          // still-undegraded removed scope — so the next sweep re-attempts
+          // the degrade and additions still enter the durable inventory.
+          const conservative = [...committedSet, ...failedScopes];
+          logger.warn(
+            `[imessage][membership] ${failedScopes.length} scope degrade(s) failed to commit; persisting conservative inventory (${conservative.length} chat(s)) for degrade re-attempt`
+          );
+          await this.onRosterCommitted(conservative);
+          this.persistedInventory = new Set(conservative);
+          return published;
         }
         // Persist the governed scope inventory (including the empty set —
         // an emptied roster must not leave the durable inventory claiming
@@ -501,7 +499,7 @@ export class IMessageMembershipPublisher {
   /** Start the periodic roster sweep. No-op when already running. */
   startSweeping(
     source: IMessageMembershipRosterSource,
-    intervalMs: number = IMESSAGE_MEMBERSHIP_SWEEP_INTERVAL_MS,
+    intervalMs: number = IMESSAGE_MEMBERSHIP_SWEEP_INTERVAL_MS
   ): void {
     if (this.sweepTimer) return;
     this.sweepTimer = setInterval(() => {
@@ -509,13 +507,11 @@ export class IMessageMembershipPublisher {
         // error-policy:J7 Diagnostics must not kill the sweep timer: report
         // through the runtime so RECENT_ERRORS surfaces the failure.
         logger.warn(
-          `[imessage][membership] periodic roster sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+          `[imessage][membership] periodic roster sweep failed: ${error instanceof Error ? error.message : String(error)}`
         );
-        this.runtime.reportError?.(
-          "imessage:membership:periodic-sweep",
-          error,
-          { accountKey: this.accountKey },
-        );
+        this.runtime.reportError?.("imessage:membership:periodic-sweep", error, {
+          accountKey: this.accountKey,
+        });
       });
     }, intervalMs);
   }
@@ -557,17 +553,14 @@ export class IMessageMembershipPublisher {
       // observation.
       const observedAtMs = Date.parse(observedAt);
       if (!Number.isFinite(observedAtMs)) {
-        throw new Error(
-          `membership snapshot observedAt is not a finite timestamp: ${observedAt}`,
-        );
+        throw new Error(`membership snapshot observedAt is not a finite timestamp: ${observedAt}`);
       }
       const observedToken = observedAtMs.toString(36);
       const snapshotKey = `imessage:snapshot:${roster.chatId}:${observedToken}`;
       for (let attempt = 0; attempt < 2; attempt++) {
         const sourceVersion = tracker.sourceVersion + 1;
         const sourceCursor = `imessage:${roster.chatId}:${sourceVersion}`;
-        const attemptKey =
-          attempt === 0 ? snapshotKey : `${snapshotKey}:r${attempt}`;
+        const attemptKey = attempt === 0 ? snapshotKey : `${snapshotKey}:r${attempt}`;
         try {
           await this.service.applyCompleteSnapshot({
             ...scope,
@@ -578,9 +571,7 @@ export class IMessageMembershipPublisher {
             sourceVersion,
             previousSourceCursor: tracker.sourceCursor,
             sourceCursor,
-            validUntil: new Date(
-              Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS,
-            ).toISOString(),
+            validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
             completeness: "complete",
             members,
             idempotencyKey: attemptKey,
@@ -592,10 +583,7 @@ export class IMessageMembershipPublisher {
           tracker.lastSweepAt = Date.now();
           tracker.degraded = false;
           for (const member of members) {
-            tracker.renewedAt.set(
-              member.canonicalPrincipalId as string,
-              Date.now(),
-            );
+            tracker.renewedAt.set(member.canonicalPrincipalId as string, Date.now());
           }
           return true;
         } catch (error) {
@@ -618,10 +606,9 @@ export class IMessageMembershipPublisher {
           throw error;
         }
       }
-      throw new IMessageSnapshotCommitError(
-        "roster snapshot commit exhausted its fenced retries",
-        { context: { accountKey: this.accountKey, chatId: roster.chatId } },
-      );
+      throw new IMessageSnapshotCommitError("roster snapshot commit exhausted its fenced retries", {
+        context: { accountKey: this.accountKey, chatId: roster.chatId },
+      });
     });
   }
 
@@ -648,16 +635,9 @@ export class IMessageMembershipPublisher {
   > {
     const roomKey = roster.chatId;
     const derivedRoomId = createUniqueUuid(this.runtime, roomKey);
-    const derivedWorldId = createUniqueUuid(
-      this.runtime,
-      `imessage-world-${roomKey}`,
-    );
-    const runtimeRoomId = AUTHORITY_UUID_PATTERN.test(derivedRoomId)
-      ? derivedRoomId
-      : null;
-    const runtimeWorldId = AUTHORITY_UUID_PATTERN.test(derivedWorldId)
-      ? derivedWorldId
-      : null;
+    const derivedWorldId = createUniqueUuid(this.runtime, `imessage-world-${roomKey}`);
+    const runtimeRoomId = AUTHORITY_UUID_PATTERN.test(derivedRoomId) ? derivedRoomId : null;
+    const runtimeWorldId = AUTHORITY_UUID_PATTERN.test(derivedWorldId) ? derivedWorldId : null;
 
     if (runtimeRoomId) {
       await this.ensureRuntimeRoomRow(runtimeRoomId, roster);
@@ -669,15 +649,9 @@ export class IMessageMembershipPublisher {
     const members = [];
     for (const participant of roster.participants) {
       if (!participant.handle) continue;
-      const principalId = imessageMembershipPrincipalId(
-        this.accountKey,
-        participant.handle,
-      );
+      const principalId = imessageMembershipPrincipalId(this.accountKey, participant.handle);
       await this.ensurePrincipalEntity(principalId, participant.handle);
-      const connectorEntityId = createUniqueUuid(
-        this.runtime,
-        participant.handle,
-      );
+      const connectorEntityId = createUniqueUuid(this.runtime, participant.handle);
       members.push({
         canonicalPrincipalId: principalId,
         roles:
@@ -691,19 +665,14 @@ export class IMessageMembershipPublisher {
         runtime: {
           worldId: runtimeWorldId,
           roomId: runtimeRoomId,
-          entityId: AUTHORITY_UUID_PATTERN.test(connectorEntityId)
-            ? connectorEntityId
-            : null,
+          entityId: AUTHORITY_UUID_PATTERN.test(connectorEntityId) ? connectorEntityId : null,
         },
       });
     }
     return members;
   }
 
-  private async ensurePrincipalEntity(
-    principalId: UUID,
-    handle: string,
-  ): Promise<void> {
+  private async ensurePrincipalEntity(principalId: UUID, handle: string): Promise<void> {
     const existing = await this.runtime.getEntityById?.(principalId);
     if (existing) return;
     await this.runtime.createEntities?.([
@@ -720,10 +689,7 @@ export class IMessageMembershipPublisher {
     ]);
   }
 
-  private async ensureRuntimeRoomRow(
-    roomId: UUID,
-    roster: IMessageRosterRead,
-  ): Promise<void> {
+  private async ensureRuntimeRoomRow(roomId: UUID, roster: IMessageRosterRead): Promise<void> {
     if (this.runtime.getRoom) {
       const room = await this.runtime.getRoom(roomId);
       if (room) return;
@@ -737,10 +703,7 @@ export class IMessageMembershipPublisher {
     });
   }
 
-  private async ensureRuntimeWorldRow(
-    worldId: UUID,
-    roster: IMessageRosterRead,
-  ): Promise<void> {
+  private async ensureRuntimeWorldRow(worldId: UUID, roster: IMessageRosterRead): Promise<void> {
     await this.runtime.createWorld?.({
       id: worldId,
       name: roster.displayName ?? roster.chatId,
@@ -768,10 +731,7 @@ export class IMessageMembershipPublisher {
     return this.serialized(key, async () => {
       const tracker = this.trackerFor(scope);
       if (tracker.degraded) return false;
-      const principalId = imessageMembershipPrincipalId(
-        this.accountKey,
-        input.handle,
-      );
+      const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
       const last = tracker.renewedAt.get(principalId as string) ?? 0;
       if (Date.now() - last < IMESSAGE_MEMBERSHIP_RENEWAL_MS) {
         return false;
@@ -803,9 +763,7 @@ export class IMessageMembershipPublisher {
           sourceVersion,
           previousSourceCursor: tracker.sourceCursor,
           sourceCursor,
-          validUntil: new Date(
-            Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS,
-          ).toISOString(),
+          validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
           idempotencyKey: renewKey,
           observedAt,
         });
@@ -824,7 +782,7 @@ export class IMessageMembershipPublisher {
           // baseline: skip — the sweep is the authoritative evidence path and
           // the sender's committed snapshot is still valid inside its window.
           logger.debug(
-            `[imessage][membership] renewal skipped (no complete baseline in this publisher generation); roster sweep will re-publish: ${input.chatId}`,
+            `[imessage][membership] renewal skipped (no complete baseline in this publisher generation); roster sweep will re-publish: ${input.chatId}`
           );
           return false;
         }
@@ -874,12 +832,14 @@ export class IMessageMembershipPublisher {
           observedAt: input.observedAt ?? new Date().toISOString(),
         });
       } catch (error) {
-        // error-policy:J4 The authority itself is unreachable; keep the
-        // local degraded flag (fail-closed admission) and surface the
-        // failure — admission still denies.
+        // error-policy:J2 The durable authority write failed. The local
+        // degraded flag above still fails admission closed for this process,
+        // but the caller must learn the durable degrade never committed so it
+        // can retain any restart ratchet that depends on it.
         logger.warn(
-          `[imessage][membership] scope degrade commit failed (staying degraded): ${error instanceof Error ? error.message : String(error)}`,
+          `[imessage][membership] scope degrade commit failed (staying degraded locally): ${error instanceof Error ? error.message : String(error)}`
         );
+        throw error instanceof Error ? error : new Error(String(error));
       }
     });
   }
@@ -902,10 +862,7 @@ export class IMessageMembershipPublisher {
    * legacy-ungated: when the durable authority carries ANY health record
    * for the chat's scope, an unresolvable target fails closed.
    */
-  async authorizeOutboundInChat(
-    target: string,
-    chatId: string,
-  ): Promise<boolean | null> {
+  async authorizeOutboundInChat(target: string, chatId: string): Promise<boolean | null> {
     const direct = await this.authorizeOutbound(target);
     if (direct !== null) return direct;
     const scope = imessageMembershipScope({
@@ -934,7 +891,7 @@ export class IMessageMembershipPublisher {
    */
   async reconcileRemovedScopes(
     persistedChatIds: readonly string[],
-    source: IMessageMembershipRosterSource,
+    source: IMessageMembershipRosterSource
   ): Promise<void> {
     if (persistedChatIds.length === 0) return;
     let currentIds: ReadonlySet<string>;
@@ -944,18 +901,34 @@ export class IMessageMembershipPublisher {
       // error-policy:J4 Enumeration failed: degrade every persisted scope
       // rather than trust possibly-stale evidence against an unreadable
       // source.
-      const reason =
-        "chat.db roster enumeration failed during startup reconciliation";
+      const reason = "chat.db roster enumeration failed during startup reconciliation";
       for (const chatId of persistedChatIds) {
-        await this.degradeScope({ chatId, reason });
+        try {
+          await this.degradeScope({ chatId, reason });
+        } catch (error) {
+          // error-policy:J4 One scope's durable degrade failing must not
+          // abandon the remaining scopes to ungoverned.
+          this.runtime.reportError?.("imessage:membership:degrade", error, {
+            chatId,
+            accountKey: this.accountKey,
+          });
+        }
       }
       return;
     }
-    const reason =
-      "governed chat absent from the fresh roster; stale evidence degraded";
+    const reason = "governed chat absent from the fresh roster; stale evidence degraded";
     for (const chatId of persistedChatIds) {
       if (!currentIds.has(chatId)) {
-        await this.degradeScope({ chatId, reason });
+        try {
+          await this.degradeScope({ chatId, reason });
+        } catch (error) {
+          // error-policy:J4 Keep degrading the remaining removed scopes;
+          // the failed scope keeps its local degraded flag.
+          this.runtime.reportError?.("imessage:membership:degrade", error, {
+            chatId,
+            accountKey: this.accountKey,
+          });
+        }
       }
     }
   }
@@ -976,10 +949,7 @@ export class IMessageMembershipPublisher {
     }
   }
 
-  private setIndexEntry(
-    key: string,
-    entry: { chatId: string; rosterHandle: string },
-  ): void {
+  private setIndexEntry(key: string, entry: { chatId: string; rosterHandle: string }): void {
     const existing = this.directChatByHandle.get(key);
     if (existing && existing.chatId !== entry.chatId) {
       this.directChatByHandle.set(key, { chatId: "", rosterHandle: "" });
@@ -997,28 +967,37 @@ export class IMessageMembershipPublisher {
    */
   async markSourceUnavailable(
     source: IMessageMembershipRosterSource,
-    cause: unknown,
+    cause: unknown
   ): Promise<void> {
     const reason = `chat.db roster source unavailable: ${cause instanceof Error ? cause.message : String(cause)}`;
     for (const chatId of this.knownChatIds(source)) {
-      await this.degradeScope({ chatId, reason });
+      try {
+        await this.degradeScope({ chatId, reason });
+      } catch (error) {
+        // error-policy:J4 One scope's durable degrade failing must not
+        // abandon the remaining scopes to ungoverned; the failed scope
+        // keeps its local degraded flag and denies in this process.
+        this.runtime.reportError?.("imessage:membership:degrade", error, {
+          chatId,
+          accountKey: this.accountKey,
+        });
+      }
     }
   }
 
   private knownChatIds(source: IMessageMembershipRosterSource): string[] {
+    const fromInventory = [...this.persistedInventory];
     try {
-      return [...source.listChatIds()];
+      return [...new Set([...fromInventory, ...source.listChatIds()])];
     } catch {
       // error-policy:J6 Best-effort enumeration fallback: fall back to the
       // in-memory scope table (keys are <account>:<chatId>) plus the
-      // direct-handle index built by prior sweeps.
-      const fromScopes = [...this.scopes.keys()].map((k) =>
-        k.split(":").slice(1).join(":"),
-      );
-      const fromIndex = [...this.directChatByHandle.values()].map(
-        (entry) => entry.chatId,
-      );
-      return [...new Set([...fromScopes, ...fromIndex])];
+      // direct-handle index built by prior sweeps. The persisted inventory
+      // is always included: when enumeration fails, scopes a previous
+      // process governed must degrade, not vanish from the known set.
+      const fromScopes = [...this.scopes.keys()].map((k) => k.split(":").slice(1).join(":"));
+      const fromIndex = [...this.directChatByHandle.values()].map((entry) => entry.chatId);
+      return [...new Set([...fromInventory, ...fromScopes, ...fromIndex])];
     }
   }
 
@@ -1032,8 +1011,7 @@ export class IMessageMembershipPublisher {
    * treating them as ungoverned.
    */
   async degradePersistedScopes(chatIds: readonly string[]): Promise<void> {
-    const reason =
-      "chat.db unavailable at service start; persisted scope inventory degraded";
+    const reason = "chat.db unavailable at service start; persisted scope inventory degraded";
     for (const chatId of chatIds) {
       // Per-chat resilient: a failure degrading one scope (authority
       // registration or health write) must not abandon the remaining
@@ -1070,10 +1048,7 @@ export class IMessageMembershipPublisher {
    * failure whose durable unavailable commit may itself have failed, so a
    * decision from possibly-stale authority evidence is never trusted.
    */
-  async authorizeSend(input: {
-    chatId: string;
-    handle: string;
-  }): Promise<boolean> {
+  async authorizeSend(input: { chatId: string; handle: string }): Promise<boolean> {
     const scope = imessageMembershipScope({
       agentId: this.runtime.agentId,
       connectorAccountId: this.connectorAccountId,
@@ -1081,10 +1056,7 @@ export class IMessageMembershipPublisher {
     });
     const tracker = this.scopes.get(scopeKey(scope));
     if (tracker?.degraded) return false;
-    const principalId = imessageMembershipPrincipalId(
-      this.accountKey,
-      input.handle,
-    );
+    const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
     try {
       const decision = await this.service.authorize(scope, principalId);
       return decision.decision === "allowed";
@@ -1109,9 +1081,7 @@ export class IMessageMembershipPublisher {
     // of one counterparty resolve to one gate entry.
     const canonical = this.normalizeTarget(target) || target;
     const entry =
-      this.directChatByHandle.get(canonical) ??
-      this.directChatByHandle.get(target) ??
-      null;
+      this.directChatByHandle.get(canonical) ?? this.directChatByHandle.get(target) ?? null;
     // A tombstoned (ambiguous) key carries an empty chat id: deny rather
     // than resolve a possibly-wrong scope.
     if (entry && entry.chatId === "") return false;
@@ -1120,9 +1090,7 @@ export class IMessageMembershipPublisher {
     if (chatId === null) {
       // A chat id used directly as the target names its own scope; accept
       // the canonical `chat_id:` prefix used by the connector target shape.
-      const bare = target.startsWith("chat_id:")
-        ? target.slice("chat_id:".length)
-        : target;
+      const bare = target.startsWith("chat_id:") ? target.slice("chat_id:".length) : target;
       for (const key of this.scopes.keys()) {
         if (key.endsWith(`:${bare}`)) {
           chatId = key.split(":").slice(1).join(":");
@@ -1140,10 +1108,7 @@ export class IMessageMembershipPublisher {
     if (tracker?.degraded) return false;
     try {
       if (principalHandle !== null) {
-        const principalId = imessageMembershipPrincipalId(
-          this.accountKey,
-          principalHandle,
-        );
+        const principalId = imessageMembershipPrincipalId(this.accountKey, principalHandle);
         const decision = await this.service.authorize(scope, principalId);
         return decision.decision === "allowed";
       }

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -1,0 +1,719 @@
+/**
+ * Native iMessage membership evidence publisher for the canonical
+ * MembershipService authority (issue #24370). Reads chat.db's
+ * `chat_handle_join` roster directly and publishes complete room snapshots
+ * plus per-sender renewals with the publisher fencing discipline the
+ * authority demands: stable per-process publisher identity, generation
+ * adoption across restarts, idempotent evidence keys, and fail-closed
+ * degradation on chat.db/TCC errors. No external bridge is consulted —
+ * the local Apple database is the sole source of membership truth.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  IAgentRuntime,
+  JsonObject,
+  MembershipScope,
+  MembershipService,
+  UUID,
+} from "@elizaos/core";
+import { ChannelType, createUniqueUuid, ElizaError, logger, ServiceType } from "@elizaos/core";
+
+/** Connector id the authority's connector_accounts.provider expects. */
+export const IMESSAGE_MEMBERSHIP_CONNECTOR_ID = "imessage";
+
+/** Evidence validity window for roster snapshots (1 hour). */
+export const IMESSAGE_MEMBERSHIP_TTL_MS = 60 * 60 * 1000;
+
+/** Renewal floor for per-sender point evidence between roster sweeps. */
+export const IMESSAGE_MEMBERSHIP_RENEWAL_MS = 30 * 60 * 1000;
+
+/** Periodic roster re-read + re-publish cadence. */
+export const IMESSAGE_MEMBERSHIP_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * The authority validates UUID version nibbles ([1-8]); createUniqueUuid /
+ * stringToUuid-derived ids carry the custom 0x0 version nibble and are
+ * rejected with MEMBERSHIP_COMMAND_INVALID, so derived runtime ids are only
+ * forwarded when pattern-valid.
+ */
+const AUTHORITY_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** 16-byte namespace seed for deterministic RFC-4122 v5 principal ids. */
+const IMESSAGE_MEMBERSHIP_NAMESPACE = createHash("sha1")
+  .update("elizaos:plugin-imessage:membership:v1")
+  .digest()
+  .subarray(0, 16);
+
+function uuidV5(name: string): UUID {
+  // RFC 4122 4.3: SHA-1 over namespace bytes || name, then set version 5
+  // and variant bits. Implemented with node:crypto so this plugin carries no
+  // uuid dependency (the ambient `uuid` module is not a declared dependency
+  // of this workspace).
+  const digest = createHash("sha1")
+    .update(IMESSAGE_MEMBERSHIP_NAMESPACE)
+    .update(Buffer.from(name, "utf8"))
+    .digest();
+  const bytes = digest.subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC variant
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as UUID;
+}
+
+/** Minimal roster member as read from chat.db. */
+export interface IMessageRosterMember {
+  /** Raw handle (E.164 phone or iCloud email) from the handle table. */
+  handle: string;
+  /** chat.db service for the handle (iMessage/SMS); informational. */
+  service: string | null;
+}
+
+/** Result of one roster read for one chat. */
+export interface IMessageRosterRead {
+  chatId: string;
+  chatType: "direct" | "group";
+  displayName: string | null;
+  participants: readonly IMessageRosterMember[];
+  /** Monotonic roster read counter for cursor construction. */
+  cursor: number;
+}
+
+/**
+ * Narrow surface the publisher needs from the chat.db reader. The service's
+ * roster adapter satisfies this; tests may substitute a synthetic source.
+ */
+export interface IMessageMembershipRosterSource {
+  /** Read the full participant roster for one chat identifier, or null when the chat is unknown. */
+  readRoster(chatId: string): IMessageRosterRead | null;
+  /** List every chat identifier the source knows. */
+  listChatIds(): readonly string[];
+}
+
+export function isMembershipService(service: unknown): service is MembershipService {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    typeof (service as MembershipService).registerPublisher === "function" &&
+    typeof (service as MembershipService).applyCompleteSnapshot === "function"
+  );
+}
+
+export function resolveMembershipService(runtime: IAgentRuntime): MembershipService | null {
+  const service = runtime.getService(ServiceType.MEMBERSHIP);
+  return isMembershipService(service) ? service : null;
+}
+
+/**
+ * Canonical principal id for one chat.db handle, for the membership
+ * authority. Deterministic RFC-4122 v5 over (account key, handle): stable
+ * across restarts and publishers, and pattern-valid for the authority's
+ * [1-8] version-nibble check (stringToUuid-derived ids carry the custom
+ * 0x0 version nibble and are rejected).
+ */
+export function imessageMembershipPrincipalId(accountKey: string, handle: string): UUID {
+  return uuidV5(`${accountKey}:${handle}`);
+}
+
+/**
+ * Scope for one chat. `externalWorldId` and `externalRoomId` are both the
+ * chat's stable chat_identifier — an iMessage chat is its own world — keyed
+ * per connector account so separate account rows never alias scopes.
+ */
+export function imessageMembershipScope(input: {
+  agentId: UUID;
+  connectorAccountId: UUID;
+  chatId: string;
+}): MembershipScope {
+  return {
+    agentId: input.agentId,
+    connectorId: IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+    connectorAccountId: input.connectorAccountId,
+    externalWorldId: input.chatId,
+    externalRoomId: input.chatId,
+  };
+}
+
+function scopeKey(scope: MembershipScope): string {
+  return `${scope.connectorAccountId}:${scope.externalRoomId}`;
+}
+
+function membershipErrorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : "";
+}
+
+/** Error codes the authority surfaces for fence collisions. */
+const FENCE_CODES = new Set([
+  "MEMBERSHIP_GENERATION_FENCE",
+  "MEMBERSHIP_GENERATION_MISMATCH",
+  "MEMBERSHIP_PUBLISHER_FENCE",
+  "MEMBERSHIP_PUBLISHER_GENERATION_STALE",
+  "MEMBERSHIP_CURSOR_FENCE",
+  "MEMBERSHIP_CURSOR_DISCONTINUITY",
+  "MEMBERSHIP_PUBLISH_TAKEN_OVER",
+]);
+
+interface ScopeTracker {
+  generation: number;
+  publisherGeneration: number;
+  sourceVersion: number;
+  sourceCursor: string | null;
+  lastSweepAt: number;
+  /** Last renewal timestamps per principal for point-evidence gating. */
+  renewedAt: Map<string, number>;
+  degraded: boolean;
+}
+
+/**
+ * Fail-closed roster read failure: chat.db could not be read (TCC revocation,
+ * database moved/corrupt). The service reports it via runtime.reportError and
+ * the governed scope health must go unavailable — a denial, never an admit.
+ */
+export class IMessageRosterUnavailableError extends ElizaError {
+  constructor(message: string, options?: { cause?: unknown; context?: Record<string, unknown> }) {
+    super(message, {
+      code: "IMESSAGE_ROSTER_UNAVAILABLE",
+      context: options?.context,
+      cause: options?.cause,
+      severity: "ephemeral",
+    });
+  }
+}
+
+/**
+ * Publisher of native iMessage membership evidence to the canonical
+ * MembershipService authority. One instance per (runtime, connector
+ * account). All authority mutations are serialized per scope; every roster
+ * observation becomes a complete snapshot (chat.db is a source of full
+ * truth, not an event stream), with per-sender point renewals between
+ * sweeps keeping freshness inside the validity window.
+ */
+export class IMessageMembershipPublisher {
+  private readonly runtime: IAgentRuntime;
+  private readonly connectorAccountId: UUID;
+  private readonly accountKey: string;
+  private readonly service: MembershipService;
+  private readonly publisherInstanceId: string;
+  private readonly scopes = new Map<string, ScopeTracker>();
+  private readonly chains = new Map<string, Promise<unknown>>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private rosterCounter = 0;
+  private readonly ownHandle: string | null;
+
+  constructor(input: {
+    runtime: IAgentRuntime;
+    connectorAccountId: UUID;
+    accountKey: string;
+    service: MembershipService;
+    publisherInstanceId?: string;
+    /** The local Apple account handle, tagged with the self role. */
+    ownHandle?: string | null;
+  }) {
+    this.runtime = input.runtime;
+    this.connectorAccountId = input.connectorAccountId;
+    this.accountKey = input.accountKey;
+    this.service = input.service;
+    this.publisherInstanceId = input.publisherInstanceId ?? `imessage-${randomUUID()}`;
+    this.ownHandle = input.ownHandle ?? null;
+  }
+
+  /** Per-scope serialization: authority mutations for one scope must chain. */
+  private serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.chains.get(key) ?? Promise.resolve();
+    const next = previous.then(fn, fn);
+    this.chains.set(key, next);
+    return next;
+  }
+
+  private trackerFor(scope: MembershipScope): ScopeTracker {
+    const key = scopeKey(scope);
+    let tracker = this.scopes.get(key);
+    if (!tracker) {
+      tracker = {
+        generation: 0,
+        publisherGeneration: 0,
+        sourceVersion: 0,
+        sourceCursor: null,
+        lastSweepAt: 0,
+        renewedAt: new Map<string, number>(),
+        degraded: false,
+      };
+      this.scopes.set(key, tracker);
+    }
+    return tracker;
+  }
+
+  /**
+   * Register this process as the scope publisher, adopting durable scope
+   * state so a restarted process re-binds without losing fencing: when the
+   * durable health row already belongs to this stable publisher identity,
+   * re-bind at the same generation instead of resetting the evidence chain.
+   */
+  private async ensureRegistered(scope: MembershipScope): Promise<ScopeTracker> {
+    const tracker = this.trackerFor(scope);
+    if (tracker.generation > 0) return tracker;
+
+    const health = await this.service.getScopeHealth(scope);
+    if (health) {
+      tracker.generation = health.generation;
+      tracker.sourceVersion = health.sourceVersion;
+      tracker.sourceCursor = health.sourceCursor;
+      if (
+        health.publisherInstanceId === this.publisherInstanceId &&
+        typeof health.publisherGeneration === "number"
+      ) {
+        tracker.publisherGeneration = health.publisherGeneration;
+      } else {
+        // A different publisher owned this scope: take over cleanly by
+        // advancing the publisher generation floor.
+        tracker.publisherGeneration = (health.publisherGeneration ?? 0) + 1;
+      }
+    }
+
+    const receipt = await this.service.registerPublisher({
+      ...scope,
+      publisherInstanceId: this.publisherInstanceId,
+      publisherGeneration: tracker.publisherGeneration,
+      evidenceMode: "ordered_delta",
+      expectedGeneration: tracker.generation,
+      idempotencyKey: `imessage:publisher:${this.publisherInstanceId}:${tracker.publisherGeneration}:${scope.externalRoomId}`,
+      observedAt: new Date().toISOString(),
+    });
+    // Registration resets the durable evidence chain (sourceVersion -1,
+    // cursor null) and advances the generation: adopt the post-registration
+    // chain state so the first snapshot starts the cursor at 0.
+    tracker.generation = receipt.committedGeneration;
+    tracker.sourceVersion = -1;
+    tracker.sourceCursor = null;
+    return tracker;
+  }
+
+  /** Re-adopt durable state after a fence collision. */
+  private async readoptFromHealth(scope: MembershipScope): Promise<ScopeTracker> {
+    const tracker = this.trackerFor(scope);
+    const health = await this.service.getScopeHealth(scope);
+    if (health) {
+      tracker.generation = health.generation;
+      tracker.sourceVersion = health.sourceVersion;
+      tracker.sourceCursor = health.sourceCursor;
+      // Re-registration must strictly advance the durable publisher
+      // generation (the authority rejects <= current), even when the durable
+      // binding already belongs to this publisher instance.
+      tracker.publisherGeneration = (health.publisherGeneration ?? 0) + 1;
+    }
+    const receipt = await this.service.registerPublisher({
+      ...scope,
+      publisherInstanceId: this.publisherInstanceId,
+      publisherGeneration: tracker.publisherGeneration,
+      evidenceMode: "ordered_delta",
+      expectedGeneration: tracker.generation,
+      idempotencyKey: `imessage:publisher:${this.publisherInstanceId}:${tracker.publisherGeneration}:readopt:${scope.externalRoomId}`,
+      observedAt: new Date().toISOString(),
+    });
+    // Registration resets the durable evidence chain: adopt post-registration
+    // state so the retried snapshot continues from cursor 0.
+    tracker.generation = receipt.committedGeneration;
+    tracker.sourceVersion = -1;
+    tracker.sourceCursor = null;
+    return tracker;
+  }
+
+  /**
+   * Read and publish complete snapshots for every chat the roster source
+   * knows. A roster-read failure degrades all governed scopes fail-closed
+   * (health unavailable) and reports the error; it never fabricates an
+   * empty roster.
+   */
+  async sweepRoster(source: IMessageMembershipRosterSource): Promise<number> {
+    let chatIds: readonly string[];
+    try {
+      chatIds = source.listChatIds();
+    } catch (error) {
+      await this.degradeAllScopes(source, error);
+      throw new IMessageRosterUnavailableError(
+        "chat.db roster enumeration failed; degrading all imessage membership scopes",
+        { cause: error, context: { accountKey: this.accountKey } }
+      );
+    }
+    let published = 0;
+    for (const chatId of chatIds) {
+      let roster: IMessageRosterRead | null;
+      try {
+        roster = source.readRoster(chatId);
+      } catch (error) {
+        await this.degradeAllScopes(source, error);
+        throw new IMessageRosterUnavailableError(
+          `chat.db roster read failed for chat ${chatId}; degrading all imessage membership scopes`,
+          { cause: error, context: { accountKey: this.accountKey, chatId } }
+        );
+      }
+      if (!roster) continue;
+      try {
+        const committed = await this.publishRosterSnapshot({ roster });
+        if (committed) published += 1;
+      } catch (error) {
+        // error-policy:J7 Diagnostics must not kill the polling loop: report
+        // and continue with the remaining chats; the scope keeps its prior
+        // authoritative state.
+        this.runtime.reportError?.("imessage:membership:sweep", error, {
+          chatId,
+          accountKey: this.accountKey,
+        });
+      }
+    }
+    return published;
+  }
+
+  /** Start the periodic roster sweep. No-op when already running. */
+  startSweeping(
+    source: IMessageMembershipRosterSource,
+    intervalMs: number = IMESSAGE_MEMBERSHIP_SWEEP_INTERVAL_MS
+  ): void {
+    if (this.sweepTimer) return;
+    this.sweepTimer = setInterval(() => {
+      this.sweepRoster(source).catch((error) => {
+        logger.warn(
+          `[imessage][membership] periodic roster sweep failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      });
+    }, intervalMs);
+  }
+
+  stopSweeping(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
+
+  /**
+   * Publish one complete roster snapshot for a chat. Returns true when the
+   * authority committed new evidence; false when the observation was a
+   * benign duplicate (idempotent replay) or the scope is degraded.
+   */
+  async publishRosterSnapshot(input: {
+    roster: IMessageRosterRead;
+    observedAt?: string;
+  }): Promise<boolean> {
+    this.rosterCounter += 1;
+    const roster = input.roster;
+    const scope = imessageMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: roster.chatId,
+    });
+    const key = scopeKey(scope);
+    return this.serialized(key, async () => {
+      let tracker = await this.ensureRegistered(scope);
+      const observedAt = input.observedAt ?? new Date().toISOString();
+      const members = await this.materializeMembers(roster);
+      const snapshotKey =
+        roster.cursor > 0
+          ? `imessage:snapshot:${roster.chatId}:${roster.cursor}`
+          : `imessage:snapshot:${roster.chatId}:${this.rosterCounter}`;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const sourceVersion = tracker.sourceVersion + 1;
+        const sourceCursor = `imessage:${roster.chatId}:${sourceVersion}`;
+        try {
+          await this.service.applyCompleteSnapshot({
+            ...scope,
+            publisherInstanceId: this.publisherInstanceId,
+            publisherGeneration: tracker.publisherGeneration,
+            evidenceMode: "ordered_delta",
+            expectedGeneration: tracker.generation,
+            sourceVersion,
+            previousSourceCursor: tracker.sourceCursor,
+            sourceCursor,
+            validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
+            completeness: "complete",
+            members,
+            idempotencyKey: snapshotKey,
+            observedAt,
+          });
+          tracker.generation += 1;
+          tracker.sourceVersion = sourceVersion;
+          tracker.sourceCursor = sourceCursor;
+          tracker.lastSweepAt = Date.now();
+          tracker.degraded = false;
+          for (const member of members) {
+            tracker.renewedAt.set(member.canonicalPrincipalId as string, Date.now());
+          }
+          return true;
+        } catch (error) {
+          const code = membershipErrorCode(error);
+          if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+            return false;
+          }
+          if (FENCE_CODES.has(code)) {
+            tracker = await this.readoptFromHealth(scope);
+            continue;
+          }
+          // error-policy:J2 Non-fencing failures (storage outage) propagate:
+          // the chat keeps its previous authoritative state and the caller
+          // sees the failure instead of a fabricated success.
+          throw error;
+        }
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Build authority member records for a roster read. Every principal's
+   * entity row is ensured (the authority requires existing entity rows in
+   * the tenant). Runtime mappings mirror dispatchInboundMessage's
+   * derivation so the authority's runtime rows resolve to the same rooms
+   * the message path creates; derived ids are only forwarded when they
+   * satisfy the authority's UUID pattern (createUniqueUuid-derived ids
+   * carry the custom 0x0 version nibble and are rejected).
+   */
+  private async materializeMembers(roster: IMessageRosterRead): Promise<
+    Array<{
+      canonicalPrincipalId: UUID;
+      roles: readonly string[];
+      permissionSnapshot: JsonObject;
+      runtime: { worldId: UUID | null; roomId: UUID | null; entityId: UUID | null };
+    }>
+  > {
+    const roomKey = roster.chatId;
+    const derivedRoomId = createUniqueUuid(this.runtime, roomKey);
+    const derivedWorldId = createUniqueUuid(this.runtime, `imessage-world-${roomKey}`);
+    const runtimeRoomId = AUTHORITY_UUID_PATTERN.test(derivedRoomId) ? derivedRoomId : null;
+    const runtimeWorldId = AUTHORITY_UUID_PATTERN.test(derivedWorldId) ? derivedWorldId : null;
+
+    if (runtimeRoomId) {
+      await this.ensureRuntimeRoomRow(runtimeRoomId, roster);
+    }
+    if (runtimeWorldId) {
+      await this.ensureRuntimeWorldRow(runtimeWorldId, roster);
+    }
+
+    const members = [];
+    for (const participant of roster.participants) {
+      if (!participant.handle) continue;
+      const principalId = imessageMembershipPrincipalId(this.accountKey, participant.handle);
+      await this.ensurePrincipalEntity(principalId, participant.handle);
+      const connectorEntityId = createUniqueUuid(this.runtime, participant.handle);
+      members.push({
+        canonicalPrincipalId: principalId,
+        roles:
+          this.ownHandle !== null && participant.handle === this.ownHandle
+            ? ["member", "self"]
+            : ["member"],
+        permissionSnapshot: {
+          service: participant.service ?? "unknown",
+          chatType: roster.chatType,
+        } as JsonObject,
+        runtime: {
+          worldId: runtimeWorldId,
+          roomId: runtimeRoomId,
+          entityId: AUTHORITY_UUID_PATTERN.test(connectorEntityId) ? connectorEntityId : null,
+        },
+      });
+    }
+    return members;
+  }
+
+  private async ensurePrincipalEntity(principalId: UUID, handle: string): Promise<void> {
+    const existing = await this.runtime.getEntityById?.(principalId);
+    if (existing) return;
+    await this.runtime.createEntities?.([
+      {
+        id: principalId,
+        agentId: this.runtime.agentId,
+        names: [`imessage:${this.accountKey}:${handle}`],
+        metadata: {
+          source: "imessage-membership",
+          handle,
+          membershipAccountKey: this.accountKey,
+        },
+      },
+    ]);
+  }
+
+  private async ensureRuntimeRoomRow(roomId: UUID, roster: IMessageRosterRead): Promise<void> {
+    if (this.runtime.getRoom) {
+      const room = await this.runtime.getRoom(roomId);
+      if (room) return;
+    }
+    await this.runtime.createRoom?.({
+      id: roomId,
+      name: roster.displayName ?? roster.chatId,
+      source: "imessage",
+      type: roster.chatType === "group" ? ChannelType.GROUP : ChannelType.DM,
+      channelId: roster.chatId,
+    });
+  }
+
+  private async ensureRuntimeWorldRow(worldId: UUID, roster: IMessageRosterRead): Promise<void> {
+    await this.runtime.createWorld?.({
+      id: worldId,
+      name: roster.displayName ?? roster.chatId,
+      agentId: this.runtime.agentId,
+      metadata: { source: "imessage", chatId: roster.chatId },
+    });
+  }
+
+  /**
+   * Sender renewal between roster sweeps: re-proves one sender's active
+   * membership with point evidence so freshness never lapses inside the
+   * validity window on quiet chats.
+   */
+  async renewSender(input: {
+    chatId: string;
+    handle: string;
+    observedAt?: string;
+  }): Promise<boolean> {
+    const scope = imessageMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+    });
+    const key = scopeKey(scope);
+    return this.serialized(key, async () => {
+      const tracker = this.trackerFor(scope);
+      if (tracker.degraded) return false;
+      const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
+      const last = tracker.renewedAt.get(principalId as string) ?? 0;
+      if (Date.now() - last < IMESSAGE_MEMBERSHIP_RENEWAL_MS) {
+        return false;
+      }
+      if (tracker.generation === 0) {
+        await this.ensureRegistered(scope);
+      }
+      const observedAt = input.observedAt ?? new Date().toISOString();
+      const sourceVersion = tracker.sourceVersion + 1;
+      const sourceCursor = `imessage:${input.chatId}:${sourceVersion}`;
+      try {
+        const receipt = await this.service.applyMembership({
+          ...scope,
+          publisherInstanceId: this.publisherInstanceId,
+          publisherGeneration: tracker.publisherGeneration,
+          evidenceMode: "ordered_delta",
+          expectedGeneration: tracker.generation,
+          canonicalPrincipalId: principalId,
+          state: "active",
+          reason: "reconciled_present",
+          roles: ["member"],
+          permissionSnapshot: { renewal: true } as JsonObject,
+          runtime: { worldId: null, roomId: null, entityId: null },
+          sourceVersion,
+          previousSourceCursor: tracker.sourceCursor,
+          sourceCursor,
+          validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
+          idempotencyKey: `imessage:renew:${input.chatId}:${principalId}`,
+          observedAt,
+        });
+        tracker.generation = receipt.committedGeneration;
+        tracker.sourceVersion = sourceVersion;
+        tracker.sourceCursor = sourceCursor;
+        tracker.renewedAt.set(principalId as string, Date.now());
+        return true;
+      } catch (error) {
+        const code = membershipErrorCode(error);
+        if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+          return false;
+        }
+        if (code === "MEMBERSHIP_SNAPSHOT_REQUIRED") {
+          // A restarted process renewing before its roster sweep published a
+          // baseline: skip — the sweep is the authoritative evidence path and
+          // the sender's committed snapshot is still valid inside its window.
+          logger.debug(
+            `[imessage][membership] renewal skipped (no complete baseline in this publisher generation); roster sweep will re-publish: ${input.chatId}`
+          );
+          return false;
+        }
+        if (FENCE_CODES.has(code)) {
+          await this.readoptFromHealth(scope);
+          return false;
+        }
+        // error-policy:J2 Storage failures propagate: the sender keeps its
+        // prior authoritative state and the caller sees the error.
+        throw error;
+      }
+    });
+  }
+
+  /**
+   * Fail-closed degradation for one scope: publishes unavailable health so
+   * every admission decision denies until a later complete snapshot
+   * restores it.
+   */
+  async degradeScope(input: {
+    chatId: string;
+    reason: string;
+    observedAt?: string;
+  }): Promise<void> {
+    const scope = imessageMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+    });
+    const key = scopeKey(scope);
+    await this.serialized(key, async () => {
+      const tracker = this.trackerFor(scope);
+      tracker.degraded = true;
+      try {
+        await this.service.setScopeHealth({
+          ...scope,
+          expectedGeneration: tracker.generation,
+          health: "unavailable",
+          reason: input.reason,
+          idempotencyKey: `imessage:degrade:${scopeKey(scope)}:${Date.now()}`,
+          observedAt: input.observedAt ?? new Date().toISOString(),
+        });
+      } catch (error) {
+        // error-policy:J4 The authority itself is unreachable; keep the
+        // local degraded flag (fail-closed admission) and surface the
+        // failure — admission still denies.
+        logger.warn(
+          `[imessage][membership] scope degrade commit failed (staying degraded): ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    });
+  }
+
+  /** Degrade every known scope after a roster-source-wide failure. */
+  async degradeAllScopes(source: IMessageMembershipRosterSource, cause: unknown): Promise<number> {
+    const reason = `chat.db roster source unavailable: ${cause instanceof Error ? cause.message : String(cause)}`;
+    let degraded = 0;
+    for (const chatId of this.knownChatIds(source)) {
+      await this.degradeScope({ chatId, reason });
+      degraded += 1;
+    }
+    return degraded;
+  }
+
+  private knownChatIds(source: IMessageMembershipRosterSource): string[] {
+    try {
+      return [...source.listChatIds()];
+    } catch {
+      // error-policy:J6 Best-effort enumeration fallback: fall back to the
+      // in-memory scope table (keys are <account>:<chatId>).
+      return [...this.scopes.keys()].map((k) => k.split(":").slice(1).join(":"));
+    }
+  }
+
+  /**
+   * Source-derived admission check for outbound sends: the authority must
+   * hold fresh active evidence for the sender in the chat. Fails closed on
+   * any authority error.
+   */
+  async authorizeSend(input: { chatId: string; handle: string }): Promise<boolean> {
+    const scope = imessageMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+    });
+    const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
+    try {
+      const decision = await this.service.authorize(scope, principalId);
+      return decision.decision === "allowed";
+    } catch {
+      // error-policy:J4 Fail-closed on authority errors.
+      return false;
+    }
+  }
+}

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -201,6 +201,19 @@ export class IMessageMembershipPublisher {
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   private rosterCounter = 0;
   private readonly ownHandle: string | null;
+  /**
+   * Direct-chat handle → chat id index built from roster sweeps, so the
+   * outbound send gate can resolve a bare phone/email target to its
+   * governed scope without re-reading chat.db.
+   */
+  private readonly directChatByHandle = new Map<string, string>();
+  /**
+   * Optional durable-snapshot hook: invoked with every governed chat id
+   * after a successful full sweep so the owning service can persist the
+   * scope inventory (e.g. on the connector account row) and fail closed
+   * across restarts when chat.db is unavailable.
+   */
+  private readonly onRosterCommitted?: (chatIds: readonly string[]) => Promise<void>;
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -210,6 +223,7 @@ export class IMessageMembershipPublisher {
     publisherInstanceId?: string;
     /** The local Apple account handle, tagged with the self role. */
     ownHandle?: string | null;
+    onRosterCommitted?: (chatIds: readonly string[]) => Promise<void>;
   }) {
     this.runtime = input.runtime;
     this.connectorAccountId = input.connectorAccountId;
@@ -217,6 +231,7 @@ export class IMessageMembershipPublisher {
     this.service = input.service;
     this.publisherInstanceId = input.publisherInstanceId ?? `imessage-${randomUUID()}`;
     this.ownHandle = input.ownHandle ?? null;
+    this.onRosterCommitted = input.onRosterCommitted;
   }
 
   /** Per-scope serialization: authority mutations for one scope must chain. */
@@ -331,19 +346,20 @@ export class IMessageMembershipPublisher {
     try {
       chatIds = source.listChatIds();
     } catch (error) {
-      await this.degradeAllScopes(source, error);
+      await this.markSourceUnavailable(source, error);
       throw new IMessageRosterUnavailableError(
         "chat.db roster enumeration failed; degrading all imessage membership scopes",
         { cause: error, context: { accountKey: this.accountKey } }
       );
     }
     let published = 0;
+    const committedChatIds: string[] = [];
     for (const chatId of chatIds) {
       let roster: IMessageRosterRead | null;
       try {
         roster = source.readRoster(chatId);
       } catch (error) {
-        await this.degradeAllScopes(source, error);
+        await this.markSourceUnavailable(source, error);
         throw new IMessageRosterUnavailableError(
           `chat.db roster read failed for chat ${chatId}; degrading all imessage membership scopes`,
           { cause: error, context: { accountKey: this.accountKey, chatId } }
@@ -359,6 +375,27 @@ export class IMessageMembershipPublisher {
         // authoritative state.
         this.runtime.reportError?.("imessage:membership:sweep", error, {
           chatId,
+          accountKey: this.accountKey,
+        });
+      }
+      committedChatIds.push(chatId);
+      // Index direct-chat handles so the outbound send gate can resolve a
+      // bare phone/email to its governed scope. Rebuilding on every sweep
+      // keeps the index current as chats are created or deleted.
+      if (roster.chatType === "direct") {
+        for (const participant of roster.participants) {
+          if (participant.handle) this.directChatByHandle.set(participant.handle, chatId);
+        }
+      }
+    }
+    if (this.onRosterCommitted && committedChatIds.length > 0) {
+      // Persist the governed scope inventory; a failure to persist is a
+      // diagnostic (the in-memory state is still correct for this process).
+      try {
+        await this.onRosterCommitted(committedChatIds);
+      } catch (error) {
+        // error-policy:J7 Diagnostics must not kill the sweep loop.
+        this.runtime.reportError?.("imessage:membership:inventory", error, {
           accountKey: this.accountKey,
         });
       }
@@ -409,13 +446,23 @@ export class IMessageMembershipPublisher {
       let tracker = await this.ensureRegistered(scope);
       const observedAt = input.observedAt ?? new Date().toISOString();
       const members = await this.materializeMembers(roster);
-      const snapshotKey =
-        roster.cursor > 0
-          ? `imessage:snapshot:${roster.chatId}:${roster.cursor}`
-          : `imessage:snapshot:${roster.chatId}:${this.rosterCounter}`;
+      // Idempotency key derived from the observation identity, not a
+      // process-local counter: the authority journals keys per account and
+      // rejects a reused key whose digest differs (MEMBERSHIP_IDEMPOTENCY_
+      // CONFLICT), so a restart (counter reset) or a repeated sweep of a
+      // live adapter must never collide with a previously journaled key.
+      // observedAt (caller-supplied or now) makes each observation event
+      // unique while staying deterministic for a replay of the same
+      // observation.
+      const observedAtMs = Date.parse(observedAt);
+      const observedToken = Number.isFinite(observedAtMs)
+        ? observedAtMs.toString(36)
+        : this.rosterCounter.toString(36);
+      const snapshotKey = `imessage:snapshot:${roster.chatId}:${observedToken}`;
       for (let attempt = 0; attempt < 2; attempt++) {
         const sourceVersion = tracker.sourceVersion + 1;
         const sourceCursor = `imessage:${roster.chatId}:${sourceVersion}`;
+        const attemptKey = attempt === 0 ? snapshotKey : `${snapshotKey}:r${attempt}`;
         try {
           await this.service.applyCompleteSnapshot({
             ...scope,
@@ -429,7 +476,7 @@ export class IMessageMembershipPublisher {
             validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
             completeness: "complete",
             members,
-            idempotencyKey: snapshotKey,
+            idempotencyKey: attemptKey,
             observedAt,
           });
           tracker.generation += 1;
@@ -586,6 +633,11 @@ export class IMessageMembershipPublisher {
       const observedAt = input.observedAt ?? new Date().toISOString();
       const sourceVersion = tracker.sourceVersion + 1;
       const sourceCursor = `imessage:${input.chatId}:${sourceVersion}`;
+      // One key per renewal observation, not one permanent key per
+      // (chat, principal): a permanent key conflicts
+      // (MEMBERSHIP_IDEMPOTENCY_CONFLICT) on every later renewal carrying a
+      // new cursor/timestamp digest and silently drops the renewal.
+      const renewKey = `imessage:renew:${input.chatId}:${principalId}:${observedAt}`;
       try {
         const receipt = await this.service.applyMembership({
           ...scope,
@@ -603,7 +655,7 @@ export class IMessageMembershipPublisher {
           previousSourceCursor: tracker.sourceCursor,
           sourceCursor,
           validUntil: new Date(Date.parse(observedAt) + IMESSAGE_MEMBERSHIP_TTL_MS).toISOString(),
-          idempotencyKey: `imessage:renew:${input.chatId}:${principalId}`,
+          idempotencyKey: renewKey,
           observedAt,
         });
         tracker.generation = receipt.committedGeneration;
@@ -653,8 +705,14 @@ export class IMessageMembershipPublisher {
     });
     const key = scopeKey(scope);
     await this.serialized(key, async () => {
-      const tracker = this.trackerFor(scope);
+      let tracker = this.trackerFor(scope);
       tracker.degraded = true;
+      // A degrade may be the first authority mutation of this process (a
+      // restart with chat.db unavailable): adopt the durable generation
+      // before writing health so the fence accepts the command.
+      if (tracker.generation === 0) {
+        tracker = await this.ensureRegistered(scope);
+      }
       try {
         await this.service.setScopeHealth({
           ...scope,
@@ -675,15 +733,21 @@ export class IMessageMembershipPublisher {
     });
   }
 
-  /** Degrade every known scope after a roster-source-wide failure. */
-  async degradeAllScopes(source: IMessageMembershipRosterSource, cause: unknown): Promise<number> {
+  /**
+   * Source-wide fail-closed degradation: every known scope goes unavailable.
+   * The governed chat-id inventory is persisted through the connector
+   * account metadata when the service supplied an onRosterCommitted hook,
+   * so a later restart with chat.db still unavailable can re-degrade the
+   * same scopes without being able to enumerate chat.db at all.
+   */
+  async markSourceUnavailable(
+    source: IMessageMembershipRosterSource,
+    cause: unknown
+  ): Promise<void> {
     const reason = `chat.db roster source unavailable: ${cause instanceof Error ? cause.message : String(cause)}`;
-    let degraded = 0;
     for (const chatId of this.knownChatIds(source)) {
       await this.degradeScope({ chatId, reason });
-      degraded += 1;
     }
-    return degraded;
   }
 
   private knownChatIds(source: IMessageMembershipRosterSource): string[] {
@@ -691,15 +755,32 @@ export class IMessageMembershipPublisher {
       return [...source.listChatIds()];
     } catch {
       // error-policy:J6 Best-effort enumeration fallback: fall back to the
-      // in-memory scope table (keys are <account>:<chatId>).
-      return [...this.scopes.keys()].map((k) => k.split(":").slice(1).join(":"));
+      // in-memory scope table (keys are <account>:<chatId>) plus the
+      // direct-handle index built by prior sweeps.
+      const fromScopes = [...this.scopes.keys()].map((k) => k.split(":").slice(1).join(":"));
+      return [...new Set([...fromScopes, ...this.directChatByHandle.values()])];
+    }
+  }
+
+  /**
+   * Degrade a persisted inventory of governed chat scopes (restart with
+   * chat.db unavailable): every scope goes unavailable so stale authority
+   * evidence cannot authorize while the roster source cannot be read.
+   */
+  async degradePersistedScopes(chatIds: readonly string[]): Promise<void> {
+    const reason = "chat.db unavailable at service start; persisted scope inventory degraded";
+    for (const chatId of chatIds) {
+      await this.degradeScope({ chatId, reason });
     }
   }
 
   /**
    * Source-derived admission check for outbound sends: the authority must
    * hold fresh active evidence for the sender in the chat. Fails closed on
-   * any authority error.
+   * any authority error AND on any locally-degraded scope — the local
+   * degraded flag is the publisher's fast-path denial for a chat.db read
+   * failure whose durable unavailable commit may itself have failed, so a
+   * decision from possibly-stale authority evidence is never trusted.
    */
   async authorizeSend(input: { chatId: string; handle: string }): Promise<boolean> {
     const scope = imessageMembershipScope({
@@ -707,10 +788,60 @@ export class IMessageMembershipPublisher {
       connectorAccountId: this.connectorAccountId,
       chatId: input.chatId,
     });
+    const tracker = this.scopes.get(scopeKey(scope));
+    if (tracker?.degraded) return false;
     const principalId = imessageMembershipPrincipalId(this.accountKey, input.handle);
     try {
       const decision = await this.service.authorize(scope, principalId);
       return decision.decision === "allowed";
+    } catch {
+      // error-policy:J4 Fail-closed on authority errors.
+      return false;
+    }
+  }
+
+  /**
+   * Outbound send admission for a bare target (phone/email handle or chat
+   * id). Returns null when the target is not governed (legacy ungated
+   * behavior); otherwise true only when the scope is not locally degraded
+   * and the authority holds current evidence for it. Direct-chat targets
+   * additionally require the recipient principal to be an active member —
+   * the recipient's roster membership is the freshest signal the authority
+   * holds for a bare handle. Fails closed on authority errors.
+   */
+  async authorizeOutbound(target: string): Promise<boolean | null> {
+    let chatId = this.directChatByHandle.get(target) ?? null;
+    const viaHandle = chatId !== null;
+    if (chatId === null) {
+      // A chat id used directly as the target names its own scope; accept
+      // the canonical `chat_id:` prefix used by the connector target shape.
+      const bare = target.startsWith("chat_id:") ? target.slice("chat_id:".length) : target;
+      for (const key of this.scopes.keys()) {
+        if (key.endsWith(`:${bare}`)) {
+          chatId = key.split(":").slice(1).join(":");
+          break;
+        }
+      }
+    }
+    if (chatId === null) return null;
+    const scope = imessageMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId,
+    });
+    const tracker = this.scopes.get(scopeKey(scope));
+    if (tracker?.degraded) return false;
+    try {
+      if (viaHandle) {
+        const principalId = imessageMembershipPrincipalId(this.accountKey, target);
+        const decision = await this.service.authorize(scope, principalId);
+        return decision.decision === "allowed";
+      }
+      const health = await this.service.getScopeHealth(scope);
+      if (!health) return false;
+      if (health.health !== "current") return false;
+      const validUntil = health.validUntil ? Date.parse(health.validUntil) : 0;
+      return Number.isFinite(validUntil) && validUntil > Date.now();
     } catch {
       // error-policy:J4 Fail-closed on authority errors.
       return false;

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -7,6 +7,19 @@
  * adoption across restarts, idempotent evidence keys, and fail-closed
  * degradation on chat.db/TCC errors. No external bridge is consulted —
  * the local Apple database is the sole source of membership truth.
+ *
+ * Trust boundary for derived principal ids: the namespace seed below is a
+ * public constant, so anyone who knows an (account key, handle) pair can
+ * recompute that principal id — it must never be treated as a secret or a
+ * capability. The ids intentionally reach only local surfaces: MembershipService
+ * authority rows (canonicalPrincipalId), the local entity table (whose own
+ * names/metadata already store the raw handle, so the derived id discloses
+ * nothing new to a local-database reader), and in-process renewal evidence
+ * keys. They are never sent over any HTTP route in this plugin, never embedded
+ * in model context, and never synced to a cloud or shared surface; the
+ * governed chat inventory at service.ts persists chat ids only. If a future
+ * change needs to persist these ids somewhere readable by another party,
+ * derive instead from a per-install secret rather than the public namespace.
  */
 
 import { createHash, randomUUID } from "node:crypto";
@@ -47,10 +60,13 @@ const IMESSAGE_MEMBERSHIP_NAMESPACE = createHash("sha1")
   .subarray(0, 16);
 
 function uuidV5(name: string): UUID {
-  // RFC 4122 4.3: SHA-1 over namespace bytes || name, then set version 5
-  // and variant bits. Implemented with node:crypto so this plugin carries no
-  // uuid dependency (the ambient `uuid` module is not a declared dependency
-  // of this workspace).
+  // RFC 4122 §4.3 (Algorithm for Creating a Name-Based UUID, SHA-1 variant,
+  // version 5): SHA-1 over namespace bytes || name bytes, first 16 octets,
+  // version nibble in octet 6, variant bits in octet 8. Implemented with
+  // node:crypto so this plugin carries no runtime `uuid` dependency (uuid
+  // is only a devDependency of this workspace, used in tests).
+  // Known-answer vectors (cross-checked against the `uuid` package's v5)
+  // are pinned in membership.test.ts.
   const digest = createHash("sha1")
     .update(IMESSAGE_MEMBERSHIP_NAMESPACE)
     .update(Buffer.from(name, "utf8"))

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -457,23 +457,36 @@ export class IMessageMembershipPublisher {
         committedChatIds.push(chatId);
       }
     }
-    if (this.onRosterCommitted && committedChatIds.length > 0) {
-      // Persist the governed scope inventory; a failure to persist is a
-      // diagnostic (the in-memory state is still correct for this process).
+    if (this.onRosterCommitted) {
+      // Deletion ratchet — runs on EVERY sweep, including ones that commit
+      // nothing: a chat in the previously persisted inventory that this
+      // sweep no longer committed (deleted from chat.db, or every snapshot
+      // failed) must degrade fail-closed so stale durable evidence stops
+      // authorizing. Degradation happens BEFORE the new inventory is
+      // persisted: a crash between the two leaves removed scopes degraded,
+      // never absent from the inventory yet still current.
       try {
-        await this.onRosterCommitted(committedChatIds);
-        // Deletion ratchet: a chat in the previously persisted inventory
-        // that this sweep no longer committed (deleted from chat.db, or its
-        // snapshot failed) must degrade fail-closed — stale durable
-        // evidence must stop authorizing between periodic sweeps too.
         const committedSet = new Set(committedChatIds);
         const reason =
           "governed chat absent from the committed roster sweep; stale evidence degraded";
         for (const priorId of this.persistedInventory) {
           if (!committedSet.has(priorId)) {
-            await this.degradeScope({ chatId: priorId, reason });
+            try {
+              await this.degradeScope({ chatId: priorId, reason });
+            } catch (error) {
+              // error-policy:J4 Degrade-path failure keeps the local flag
+              // and continues with the remaining removed scopes.
+              this.runtime.reportError?.("imessage:membership:degrade", error, {
+                chatId: priorId,
+                accountKey: this.accountKey,
+              });
+            }
           }
         }
+        // Persist the governed scope inventory (including the empty set —
+        // an emptied roster must not leave the durable inventory claiming
+        // governed chats); a failure to persist is a diagnostic.
+        await this.onRosterCommitted(committedChatIds);
         this.persistedInventory = committedSet;
       } catch (error) {
         // error-policy:J7 Diagnostics must not kill the sweep loop.
@@ -879,6 +892,37 @@ export class IMessageMembershipPublisher {
     for (const participant of roster.participants) {
       if (!participant.handle) continue;
       this.indexDirectHandle(participant.handle, roster.chatId);
+    }
+  }
+
+  /**
+   * Chat-scoped outbound admission for autonomous replies (agent replies
+   * and pairing replies), where the caller knows the originating chat id.
+   * Unresolved handle lookups must NOT degrade a governed chat to
+   * legacy-ungated: when the durable authority carries ANY health record
+   * for the chat's scope, an unresolvable target fails closed.
+   */
+  async authorizeOutboundInChat(
+    target: string,
+    chatId: string,
+  ): Promise<boolean | null> {
+    const direct = await this.authorizeOutbound(target);
+    if (direct !== null) return direct;
+    const scope = imessageMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId,
+    });
+    if (this.scopes.get(scopeKey(scope))?.degraded) return false;
+    try {
+      const health = await this.service.getScopeHealth(scope);
+      if (!health) return null;
+      // The scope exists durably but the target handle could not be
+      // resolved to it: fail closed rather than send ungated.
+      return false;
+    } catch {
+      // error-policy:J4 Fail-closed on authority errors.
+      return false;
     }
   }
 

--- a/plugins/plugin-imessage/src/membership.ts
+++ b/plugins/plugin-imessage/src/membership.ts
@@ -555,6 +555,23 @@ export class IMessageMembershipPublisher {
       chatId: roster.chatId,
     });
     const key = scopeKey(scope);
+    // A committed `complete` snapshot with zero usable members is an
+    // authoritative "everyone left" mass-removal signal, but an empty
+    // successful read (chat.db LEFT JOIN NULL aggregate, a scoped query
+    // matching no rows, or every handle row failing the truthy filter) is
+    // absence of evidence, not evidence of absence. Fail closed instead of
+    // publishing. NOTE: this guard must run OUTSIDE serialized() —
+    // degradeScope takes the same per-key mutex and serialized() is not
+    // reentrant; guarding inside the lock deadlocks.
+    if (!roster.participants.some((participant) => participant.handle)) {
+      await this.degradeScope({
+        chatId: roster.chatId,
+        reason:
+          "chat.db roster returned no usable participants; refusing to publish an empty complete roster",
+        observedAt: input.observedAt,
+      });
+      return false;
+    }
     return this.serialized(key, async () => {
       let tracker = await this.ensureRegistered(scope);
       const observedAt = input.observedAt ?? new Date().toISOString();

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -778,17 +778,20 @@ export class IMessageService extends Service implements IIMessageService {
 
     // Start polling only when chat.db is available. When the database cannot
     // be opened, the service is intentionally send-only until the next start.
+    // Native membership evidence (issue #24370): when the canonical
+    // MembershipService authority is registered (plugin-sql) and chat.db is
+    // readable, publish chat_handle_join roster snapshots immediately and on
+    // a periodic sweep. Absent authority keeps the legacy ungated behavior.
+    // This MUST complete before inbound polling starts: a polling tick that
+    // dispatches an agent reply before the gate exists would bypass the
+    // membership authority entirely.
+    await service.initMembership();
+
     if (service.chatDb && service.settings.pollIntervalMs > 0) {
       service.startPolling();
     } else if (!service.chatDb && service.settings.pollIntervalMs > 0) {
       logger.debug("[imessage] inbound polling not started because chat.db is unavailable");
     }
-
-    // Native membership evidence (issue #24370): when the canonical
-    // MembershipService authority is registered (plugin-sql) and chat.db is
-    // readable, publish chat_handle_join roster snapshots immediately and on
-    // a periodic sweep. Absent authority keeps the legacy ungated behavior.
-    await service.initMembership();
 
     // Register the heartbeat task worker + create a recurring task.
     // See registerHeartbeat for what it actually does. We gate on the
@@ -1174,6 +1177,10 @@ export class IMessageService extends Service implements IIMessageService {
             }
           }
           if (this.membership) {
+            // Degrade is per-chat resilient (a failure on one scope leaves
+            // its local degraded flag set and continues with the rest); the
+            // publisher is already assigned so any partially degraded state
+            // still gates sends.
             await this.membership.degradePersistedScopes(inventory);
             logger.warn(
               `[imessage][membership] chat.db unavailable at start; degraded ${inventory.length} persisted membership scope(s) fail-closed`
@@ -1192,6 +1199,15 @@ export class IMessageService extends Service implements IIMessageService {
     try {
       const { getConnectorAccountManager } = await import("@elizaos/core");
       const manager = getConnectorAccountManager(this.runtime);
+      // Read the prior governed-chat inventory BEFORE any upsert: the
+      // upsert below replaces account metadata wholesale (without the
+      // inventory key), so reading after it would always see an empty
+      // inventory and skip startup reconciliation.
+      const priorAccount = await manager.getAccount(
+        IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+        `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+      );
+      const priorInventory = readGovernedChatInventory(priorAccount?.metadata);
       const now = Date.now();
       const stored = await manager.upsertAccount(IMESSAGE_MEMBERSHIP_CONNECTOR_ID, {
         id: `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
@@ -1215,15 +1231,6 @@ export class IMessageService extends Service implements IIMessageService {
           `membership connector account returned a non-authority-valid id: ${String(stored.id)}`
         );
       }
-      // Reconcile the persisted governed-chat inventory BEFORE the first
-      // sweep: any previously governed chat absent from the fresh roster
-      // (or unreadable now) must go degraded fail-closed, never silently
-      // ungoverned, while durable evidence still exists for it.
-      const priorAccount = await manager.getAccount(
-        IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
-        `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
-      );
-      const priorInventory = readGovernedChatInventory(priorAccount?.metadata);
       this.membershipRosterSource = createChatDbRosterSource(this.chatDb);
       this.membership = new IMessageMembershipPublisher({
         runtime: this.runtime,
@@ -1309,8 +1316,12 @@ export class IMessageService extends Service implements IIMessageService {
               normalizeTarget: (value) =>
                 normalizeIMessageConnectorHandle(value),
             });
-            await fallback.degradePersistedScopes(inventory);
+            // Assign BEFORE degrading: if the degrade pass itself fails
+            // partway, the already-assigned publisher still gates every
+            // degraded scope through its local flags (degradePersistedScopes
+            // is per-chat resilient and never throws the loop away).
             this.membership = fallback;
+            await fallback.degradePersistedScopes(inventory);
           }
         }
       } catch (degradeError) {
@@ -2358,7 +2369,22 @@ export class IMessageService extends Service implements IIMessageService {
         // follows the same IMESSAGE_AUTO_REPLY consent gate as agent replies.
         // Only the DM pairing path produces one; group denials never do.
         if (access.pairingReplyMessage && this.isAutoReplyEnabled()) {
-          const sendResult = await this.sendSingleMessage(row.handle, access.pairingReplyMessage);
+          // The pairing reply is an autonomous outbound text and follows the
+          // same membership gate as agent replies: a degraded or revoked
+          // scope must not receive it.
+          const pairingGate = this.membership
+            ? await this.membership.authorizeOutbound(row.handle)
+            : null;
+          if (pairingGate === false) {
+            logger.warn(
+              `[imessage] Pairing reply to handle=${row.handle} denied by membership gate`,
+            );
+            continue;
+          }
+          const sendResult = await this.sendSingleMessage(
+            row.handle,
+            access.pairingReplyMessage,
+          );
           if (!sendResult.success) {
             logger.warn(
               `[imessage] Pairing reply send failed for handle=${row.handle}: ${sendResult.error}`

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -2051,6 +2051,108 @@ export class IMessageService extends Service implements IIMessageService {
         "IMESSAGE_TRANSPORT"
       );
     }
+    const pollIntervalRaw = getStringSetting(
+      "IMESSAGE_POLL_INTERVAL_MS",
+      "IMESSAGE_POLL_INTERVAL_MS"
+    );
+    const parsedPollIntervalMs = Number(pollIntervalRaw);
+    const pollIntervalMs =
+      pollIntervalRaw.trim() === "" || !Number.isFinite(parsedPollIntervalMs)
+        ? DEFAULT_POLL_INTERVAL_MS
+        : Math.max(0, parsedPollIntervalMs);
+
+    // Resolve all startup configuration before opening chat.db or arming the
+    // polling interval. A rejected setting must not leave a partial service
+    // running after Service.start() rejects.
+    const heartbeatIntervalMs = resolveHeartbeatIntervalMs(
+      getStringSetting("IMESSAGE_HEARTBEAT_INTERVAL_MS", "IMESSAGE_HEARTBEAT_INTERVAL_MS")
+    );
+
+    const dmPolicy = getStringSetting(
+      "IMESSAGE_DM_POLICY",
+      "IMESSAGE_DM_POLICY",
+      "pairing"
+    ) as IMessageSettings["dmPolicy"];
+
+    const groupPolicy = getStringSetting(
+      "IMESSAGE_GROUP_POLICY",
+      "IMESSAGE_GROUP_POLICY",
+      "allowlist"
+    ) as IMessageSettings["groupPolicy"];
+
+    const allowFromRaw = getStringSetting("IMESSAGE_ALLOW_FROM", "IMESSAGE_ALLOW_FROM");
+    const allowFrom = allowFromRaw
+      ? allowFromRaw
+          .split(",")
+          .map((s: string) => s.trim())
+          .filter(Boolean)
+      : [];
+
+    const enabledRaw = getStringSetting("IMESSAGE_ENABLED", "IMESSAGE_ENABLED", "true");
+    const enabled = enabledRaw !== "false";
+
+    return {
+      transport: transportRaw,
+      dbPath,
+      pollIntervalMs,
+      heartbeatIntervalMs,
+      dmPolicy,
+      groupPolicy,
+      allowFrom,
+      enabled,
+      blooioApiKey:
+        getStringSetting("IMESSAGE_BLOOIO_API_KEY", "IMESSAGE_BLOOIO_API_KEY") ||
+        getStringSetting("BLOOIO_API_KEY", "BLOOIO_API_KEY") ||
+        undefined,
+      blooioWebhookSecret:
+        getStringSetting("IMESSAGE_BLOOIO_WEBHOOK_SECRET", "IMESSAGE_BLOOIO_WEBHOOK_SECRET") ||
+        getStringSetting("BLOOIO_WEBHOOK_SECRET", "BLOOIO_WEBHOOK_SECRET") ||
+        undefined,
+      blooioFromNumber:
+        getStringSetting("IMESSAGE_BLOOIO_FROM_NUMBER", "IMESSAGE_BLOOIO_FROM_NUMBER") ||
+        getStringSetting("BLOOIO_FROM_NUMBER", "BLOOIO_FROM_NUMBER") ||
+        undefined,
+      blooioChannelId:
+        getStringSetting("IMESSAGE_BLOOIO_CHANNEL_ID", "IMESSAGE_BLOOIO_CHANNEL_ID") || undefined,
+    };
+  }
+
+  private async validateSettings(): Promise<void> {
+    if (!this.settings) {
+      throw new IMessageConfigurationError("Settings not loaded");
+    }
+
+    if (this.settings.transport === "blooio") {
+      for (const [setting, value] of [
+        ["IMESSAGE_BLOOIO_API_KEY", this.settings.blooioApiKey],
+        ["IMESSAGE_BLOOIO_WEBHOOK_SECRET", this.settings.blooioWebhookSecret],
+        ["IMESSAGE_BLOOIO_FROM_NUMBER", this.settings.blooioFromNumber],
+        ["IMESSAGE_BLOOIO_CHANNEL_ID", this.settings.blooioChannelId],
+      ] as const) {
+        if (!value)
+          throw new IMessageConfigurationError(
+            `${setting} is required for the Blooio transport`,
+            setting
+          );
+      }
+    }
+
+    // Do not probe Messages.app during service startup. Sending is gated by
+    // Apple Automation while chat.db reads are gated by Full Disk Access;
+    // coupling them prevented receive-only operation and could trigger an
+    // unrelated TCC prompt merely by enabling inbound messages.
+  }
+
+  private async sendSingleMessage(to: string, text: string): Promise<IMessageSendResult> {
+    if (this.settings?.transport === "blooio") {
+      return await sendBlooioMessage({
+        apiKey: this.settings.blooioApiKey as string,
+        from: this.settings.blooioChannelId ?? (this.settings.blooioFromNumber as string),
+        to,
+        text,
+        idempotencyKey: `imessage-${crypto.randomUUID()}`,
+      });
+    }
     // Outbound delivery stays on Apple's local Messages automation surface.
     // No third-party CLI, daemon, network service, or fallback transport is
     // invoked from the native connector.
@@ -2298,10 +2400,7 @@ export class IMessageService extends Service implements IIMessageService {
             );
             continue;
           }
-          const sendResult = await this.sendSingleMessage(
-            row.handle,
-            access.pairingReplyMessage,
-          );
+          const sendResult = await this.sendSingleMessage(row.handle, access.pairingReplyMessage);
           if (!sendResult.success) {
             logger.warn(
               `[imessage] Pairing reply send failed for handle=${row.handle}: ${sendResult.error}`

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -73,6 +73,13 @@ import {
 } from "./contacts-reader.js";
 import { renderIMessageInteractionText } from "./interactions.js";
 import {
+  IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+  IMessageMembershipPublisher,
+  type IMessageMembershipRosterSource,
+  resolveMembershipService,
+} from "./membership.js";
+import { createChatDbRosterSource } from "./membership-roster.js";
+import {
   DEFAULT_POLL_INTERVAL_MS,
   formatPhoneNumber,
   type IIMessageService,
@@ -665,6 +672,16 @@ export class IMessageService extends Service implements IIMessageService {
   private chatDb: ChatDbReader | null = null;
   private chatDbPath: string = DEFAULT_CHAT_DB_PATH;
   /**
+   * Native membership evidence publisher (issue #24370). Non-null only when
+   * both the canonical MembershipService authority and a readable chat.db
+   * are available; it publishes chat_handle_join roster snapshots and
+   * per-sender renewals. Absent authority ⇒ membership evidence is simply
+   * not published (legacy behavior); roster read failures degrade the
+   * publisher fail-closed via its own error path.
+   */
+  private membership: IMessageMembershipPublisher | null = null;
+  private membershipRosterSource: IMessageMembershipRosterSource | null = null;
+  /**
    * Cached handle → display name map from the user's Apple Contacts.
    * Populated lazily on first inbound message through CNContactStore, NOT at
    * service start. Loading at boot would create a settings-level Contacts
@@ -744,6 +761,12 @@ export class IMessageService extends Service implements IIMessageService {
     } else if (!service.chatDb && service.settings.pollIntervalMs > 0) {
       logger.debug("[imessage] inbound polling not started because chat.db is unavailable");
     }
+
+    // Native membership evidence (issue #24370): when the canonical
+    // MembershipService authority is registered (plugin-sql) and chat.db is
+    // readable, publish chat_handle_join roster snapshots immediately and on
+    // a periodic sweep. Absent authority keeps the legacy ungated behavior.
+    await service.initMembership();
 
     // Register the heartbeat task worker + create a recurring task.
     // See registerHeartbeat for what it actually does. We gate on the
@@ -1054,6 +1077,10 @@ export class IMessageService extends Service implements IIMessageService {
     logger.info("Stopping iMessage service...");
     this.connected = false;
 
+    this.membership?.stopSweeping();
+    this.membership = null;
+    this.membershipRosterSource = null;
+
     if (this.pollInterval) {
       clearInterval(this.pollInterval);
       this.pollInterval = null;
@@ -1067,6 +1094,79 @@ export class IMessageService extends Service implements IIMessageService {
     this.settings = null;
     this.lastRowId = 0;
     logger.info("iMessage service stopped");
+  }
+
+  /**
+   * Bootstrap native membership evidence publication (issue #24370).
+   * Requires BOTH the canonical MembershipService authority (plugin-sql's
+   * SqlMembershipService) and a readable chat.db. The connector-account row
+   * is upserted through the ConnectorAccountManager so the authority's FK
+   * resolves to a stable durable UUID; a bootstrap failure is reported and
+   * leaves the publisher absent (legacy behavior) rather than crashing the
+   * connector — but roster read failures once running degrade fail-closed.
+   */
+  private async initMembership(): Promise<void> {
+    if (!this.runtime || !this.chatDb) return;
+    const authority = resolveMembershipService(this.runtime);
+    if (!authority) {
+      logger.debug(
+        "[imessage][membership] canonical MembershipService authority not registered; membership evidence is not published"
+      );
+      return;
+    }
+    try {
+      const { getConnectorAccountManager } = await import("@elizaos/core");
+      const manager = getConnectorAccountManager(this.runtime);
+      const now = Date.now();
+      const stored = await manager.upsertAccount(IMESSAGE_MEMBERSHIP_CONNECTOR_ID, {
+        id: `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+        provider: IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+        label: "iMessage (local Apple account)",
+        role: "AGENT",
+        purpose: ["messaging"],
+        accessGate: "open",
+        status: "connected",
+        createdAt: now,
+        updatedAt: now,
+        metadata: { source: "imessage-membership" },
+      });
+      if (
+        !stored.id ||
+        !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          stored.id
+        )
+      ) {
+        throw new Error(
+          `membership connector account returned a non-authority-valid id: ${String(stored.id)}`
+        );
+      }
+      this.membershipRosterSource = createChatDbRosterSource(this.chatDb);
+      this.membership = new IMessageMembershipPublisher({
+        runtime: this.runtime,
+        connectorAccountId: stored.id as UUID,
+        accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
+        service: authority,
+      });
+      // Initial snapshot sweep; the publisher degrades its scopes and throws
+      // a typed error on roster read failure (fail-closed admission).
+      const published = await this.membership.sweepRoster(this.membershipRosterSource);
+      this.membership.startSweeping(this.membershipRosterSource);
+      logger.info(
+        `[imessage][membership] native roster snapshots published for ${published} chat(s); periodic sweep active`
+      );
+    } catch (error) {
+      // error-policy:J4 Bootstrap is an expected-failure boundary: report,
+      // keep the publisher absent, and continue in legacy ungated mode so a
+      // broken authority bootstrap never kills messaging.
+      this.membership = null;
+      this.membershipRosterSource = null;
+      logger.warn(
+        `[imessage][membership] bootstrap failed; continuing without membership evidence: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.runtime.reportError?.("imessage:membership:bootstrap", error, {
+        accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
+      });
+    }
   }
 
   /**
@@ -2337,6 +2437,26 @@ export class IMessageService extends Service implements IIMessageService {
       logger.debug(
         `[imessage][entity-joined] entityKey=${entityKey} name=${resolvedName ?? row.handle}`
       );
+    }
+
+    // Sender renewal (issue #24370): every inbound message re-proves the
+    // sender's active membership with point evidence, keeping freshness
+    // inside the validity window between periodic roster sweeps. Renewal
+    // failures are diagnostics, not dispatch blockers — the roster sweep is
+    // the authoritative refresh path.
+    if (this.membership && row.handle) {
+      try {
+        await this.membership.renewSender({
+          chatId: roomKey,
+          handle: row.handle,
+        });
+      } catch (error) {
+        // error-policy:J7 Diagnostics must not kill the dispatch loop.
+        this.runtime.reportError?.("imessage:membership:renew", error, {
+          chatId: roomKey,
+          handle: row.handle,
+        });
+      }
     }
 
     // Resolve the in-reply-to link. If this message is an inline reply to

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -1168,6 +1168,8 @@ export class IMessageService extends Service implements IIMessageService {
                 connectorAccountId: storedId as UUID,
                 accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
                 service: authority,
+                normalizeTarget: (value) =>
+                  normalizeIMessageConnectorHandle(value),
               });
             }
           }
@@ -1213,12 +1215,22 @@ export class IMessageService extends Service implements IIMessageService {
           `membership connector account returned a non-authority-valid id: ${String(stored.id)}`
         );
       }
+      // Reconcile the persisted governed-chat inventory BEFORE the first
+      // sweep: any previously governed chat absent from the fresh roster
+      // (or unreadable now) must go degraded fail-closed, never silently
+      // ungoverned, while durable evidence still exists for it.
+      const priorAccount = await manager.getAccount(
+        IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+        `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+      );
+      const priorInventory = readGovernedChatInventory(priorAccount?.metadata);
       this.membershipRosterSource = createChatDbRosterSource(this.chatDb);
       this.membership = new IMessageMembershipPublisher({
         runtime: this.runtime,
         connectorAccountId: stored.id as UUID,
         accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
         service: authority,
+        normalizeTarget: (value) => normalizeIMessageConnectorHandle(value),
         // Persist the governed chat-id inventory on every committed sweep
         // so a restart with chat.db unavailable can degrade exactly these
         // scopes fail-closed (see the !chatDb branch above).
@@ -1242,23 +1254,75 @@ export class IMessageService extends Service implements IIMessageService {
       });
       // Initial snapshot sweep; the publisher degrades its scopes and throws
       // a typed error on roster read failure (fail-closed admission).
-      const published = await this.membership.sweepRoster(this.membershipRosterSource);
+      const published = await this.membership.sweepRoster(
+        this.membershipRosterSource,
+      );
+      // Degrade every previously governed chat the fresh roster no longer
+      // lists (chat deleted, roster shrunk to empty, or an enumeration the
+      // source now omits): stale durable evidence must stop authorizing.
+      await this.membership.reconcileRemovedScopes(
+        priorInventory,
+        this.membershipRosterSource,
+      );
       this.membership.startSweeping(this.membershipRosterSource);
       logger.info(
         `[imessage][membership] native roster snapshots published for ${published} chat(s); periodic sweep active`
       );
     } catch (error) {
-      // error-policy:J4 Bootstrap is an expected-failure boundary: report,
-      // keep the publisher absent, and continue in legacy ungated mode so a
-      // broken authority bootstrap never kills messaging.
+      // error-policy:J4 Bootstrap is an expected-failure boundary: report
+      // and continue send-only. When a prior run persisted governed-scope
+      // evidence, the failure must NOT restore ungated sending: degrade the
+      // persisted inventory fail-closed so stale evidence cannot authorize
+      // while the fresh publisher is unavailable.
       this.membership = null;
       this.membershipRosterSource = null;
       logger.warn(
-        `[imessage][membership] bootstrap failed; continuing without membership evidence: ${error instanceof Error ? error.message : String(error)}`
+        `[imessage][membership] bootstrap failed; degrading persisted membership scopes: ${error instanceof Error ? error.message : String(error)}`,
       );
       this.runtime.reportError?.("imessage:membership:bootstrap", error, {
         accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
       });
+      try {
+        const { getConnectorAccountManager } = await import("@elizaos/core");
+        const manager = getConnectorAccountManager(this.runtime);
+        const account = await manager.getAccount(
+          IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+          `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+        );
+        const inventory = readGovernedChatInventory(account?.metadata);
+        if (inventory.length > 0 && authority) {
+          const { IMessageMembershipPublisher } = await import(
+            "./membership.js"
+          );
+          const storedId = account?.id;
+          if (
+            storedId &&
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+              storedId,
+            )
+          ) {
+            const fallback = new IMessageMembershipPublisher({
+              runtime: this.runtime,
+              connectorAccountId: storedId as UUID,
+              accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
+              service: authority,
+              normalizeTarget: (value) =>
+                normalizeIMessageConnectorHandle(value),
+            });
+            await fallback.degradePersistedScopes(inventory);
+            this.membership = fallback;
+          }
+        }
+      } catch (degradeError) {
+        // error-policy:J4 The degrade fallback itself failed: nothing more
+        // can be done at this boundary; sending stays up but the failure is
+        // reported for visibility.
+        this.runtime.reportError?.(
+          "imessage:membership:bootstrap-degrade-fallback",
+          degradeError,
+          { accountKey: IMESSAGE_LOCAL_ACCOUNT_ID },
+        );
+      }
     }
   }
 
@@ -2662,6 +2726,18 @@ export class IMessageService extends Service implements IIMessageService {
         return [];
       }
 
+      // Agent-generated replies follow the same membership gate as public
+      // sendMessage: a degraded or revoked scope must not receive an
+      // autonomous external effect.
+      const replyGate = this.membership
+        ? await this.membership.authorizeOutbound(replyTarget)
+        : null;
+      if (replyGate === false) {
+        logger.error(
+          `[imessage] Reply to ROWID=${row.rowId} denied by membership gate (degraded or revoked scope)`,
+        );
+        return [];
+      }
       const sendResult = await this.sendSingleMessage(replyTarget, replyText);
       if (!sendResult.success) {
         logger.error(`[imessage] Reply send failed for ROWID=${row.rowId}: ${sendResult.error}`);

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -2373,7 +2373,10 @@ export class IMessageService extends Service implements IIMessageService {
           // same membership gate as agent replies: a degraded or revoked
           // scope must not receive it.
           const pairingGate = this.membership
-            ? await this.membership.authorizeOutbound(row.handle)
+            ? await this.membership.authorizeOutboundInChat(
+                row.handle,
+                row.chatId,
+              )
             : null;
           if (pairingGate === false) {
             logger.warn(
@@ -2754,9 +2757,11 @@ export class IMessageService extends Service implements IIMessageService {
 
       // Agent-generated replies follow the same membership gate as public
       // sendMessage: a degraded or revoked scope must not receive an
-      // autonomous external effect.
+      // autonomous external effect. The chat-scoped variant fails closed
+      // when the originating chat is durably governed but the reply target
+      // cannot be resolved to current evidence.
       const replyGate = this.membership
-        ? await this.membership.authorizeOutbound(replyTarget)
+        ? await this.membership.authorizeOutboundInChat(replyTarget, row.chatId)
         : null;
       if (replyGate === false) {
         logger.error(

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -619,7 +619,7 @@ async function resolveIMessageChatId(
 }
 
 /** Metadata key under which the governed chat-id inventory is persisted. */
-const GOVERNED_CHAT_INVENTORY_KEY = "imessage:membership:chat-inventory";
+export const GOVERNED_CHAT_INVENTORY_KEY = "imessage:membership:chat-inventory";
 
 /**
  * Read the persisted governed-chat inventory from connector account
@@ -627,7 +627,7 @@ const GOVERNED_CHAT_INVENTORY_KEY = "imessage:membership:chat-inventory";
  * non-array, or malformed entries yield an empty inventory — this is a
  * best-effort restart signal, not trusted input.
  */
-function readGovernedChatInventory(metadata: unknown): string[] {
+export function readGovernedChatInventory(metadata: unknown): string[] {
   if (!metadata || typeof metadata !== "object") return [];
   const raw = (metadata as Record<string, unknown>)[GOVERNED_CHAT_INVENTORY_KEY];
   if (!Array.isArray(raw)) return [];
@@ -638,6 +638,23 @@ function readGovernedChatInventory(metadata: unknown): string[] {
     }
   }
   return [...ids];
+}
+
+/**
+ * Build the connector-account metadata for a startup upsert that must
+ * preserve the previous process's governed-chat inventory. Upserts
+ * replace metadata wholesale, so a startup that writes { source } alone
+ * erases the inventory before the first sweep can degrade removed scopes
+ * — this helper exists so the startup path and its regression coverage
+ * share one implementation.
+ */
+export function governedChatInventoryMetadata(
+  priorInventory: readonly string[]
+): Record<string, string | string[]> {
+  return {
+    source: "imessage-membership",
+    [GOVERNED_CHAT_INVENTORY_KEY]: [...priorInventory],
+  };
 }
 
 /**
@@ -1171,8 +1188,7 @@ export class IMessageService extends Service implements IIMessageService {
                 connectorAccountId: storedId as UUID,
                 accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
                 service: authority,
-                normalizeTarget: (value) =>
-                  normalizeIMessageConnectorHandle(value),
+                normalizeTarget: (value) => normalizeIMessageConnectorHandle(value),
               });
             }
           }
@@ -1205,7 +1221,7 @@ export class IMessageService extends Service implements IIMessageService {
       // inventory and skip startup reconciliation.
       const priorAccount = await manager.getAccount(
         IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
-        `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+        `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`
       );
       const priorInventory = readGovernedChatInventory(priorAccount?.metadata);
       const now = Date.now();
@@ -1219,7 +1235,15 @@ export class IMessageService extends Service implements IIMessageService {
         status: "connected",
         createdAt: now,
         updatedAt: now,
-        metadata: { source: "imessage-membership" },
+        // Preserve the previous process's governed-chat inventory in the
+        // durable account metadata: the upsert replaces metadata
+        // wholesale, and the first sweep may fail to degrade every removed
+        // scope (or never run). A restart before a fully committed sweep
+        // must still find the prior inventory to degrade — overwriting it
+        // here would erase the restart ratchet before the sweep runs.
+        // governedChatInventoryMetadata is the production helper shared
+        // with the regression coverage for this exact transition.
+        metadata: governedChatInventoryMetadata(priorInventory),
       });
       if (
         !stored.id ||
@@ -1238,6 +1262,11 @@ export class IMessageService extends Service implements IIMessageService {
         accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
         service: authority,
         normalizeTarget: (value) => normalizeIMessageConnectorHandle(value),
+        // Seed the deletion ratchet with the previous process's persisted
+        // inventory: the first sweep of this process must degrade any
+        // removed scope (or retain the inventory when that degrade cannot
+        // commit) instead of overwriting it sight-unseen.
+        initialInventory: priorInventory,
         // Persist the governed chat-id inventory on every committed sweep
         // so a restart with chat.db unavailable can degrade exactly these
         // scopes fail-closed (see the !chatDb branch above).
@@ -1259,18 +1288,14 @@ export class IMessageService extends Service implements IIMessageService {
           });
         },
       });
-      // Initial snapshot sweep; the publisher degrades its scopes and throws
-      // a typed error on roster read failure (fail-closed admission).
-      const published = await this.membership.sweepRoster(
-        this.membershipRosterSource,
-      );
-      // Degrade every previously governed chat the fresh roster no longer
-      // lists (chat deleted, roster shrunk to empty, or an enumeration the
-      // source now omits): stale durable evidence must stop authorizing.
-      await this.membership.reconcileRemovedScopes(
-        priorInventory,
-        this.membershipRosterSource,
-      );
+      // Initial snapshot sweep. The publisher seeds its deletion ratchet
+      // from priorInventory (see initialInventory above), so this first
+      // sweep already degrades every previously governed chat the fresh
+      // roster no longer lists — and retains it in the persisted
+      // inventory when that degrade cannot commit. No separate
+      // reconcile pass runs: degrading the same scopes twice would issue
+      // duplicate health mutations with fresh idempotency keys.
+      const published = await this.membership.sweepRoster(this.membershipRosterSource);
       this.membership.startSweeping(this.membershipRosterSource);
       logger.info(
         `[imessage][membership] native roster snapshots published for ${published} chat(s); periodic sweep active`
@@ -1284,7 +1309,7 @@ export class IMessageService extends Service implements IIMessageService {
       this.membership = null;
       this.membershipRosterSource = null;
       logger.warn(
-        `[imessage][membership] bootstrap failed; degrading persisted membership scopes: ${error instanceof Error ? error.message : String(error)}`,
+        `[imessage][membership] bootstrap failed; degrading persisted membership scopes: ${error instanceof Error ? error.message : String(error)}`
       );
       this.runtime.reportError?.("imessage:membership:bootstrap", error, {
         accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
@@ -1294,18 +1319,16 @@ export class IMessageService extends Service implements IIMessageService {
         const manager = getConnectorAccountManager(this.runtime);
         const account = await manager.getAccount(
           IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
-          `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+          `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`
         );
         const inventory = readGovernedChatInventory(account?.metadata);
         if (inventory.length > 0 && authority) {
-          const { IMessageMembershipPublisher } = await import(
-            "./membership.js"
-          );
+          const { IMessageMembershipPublisher } = await import("./membership.js");
           const storedId = account?.id;
           if (
             storedId &&
             /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-              storedId,
+              storedId
             )
           ) {
             const fallback = new IMessageMembershipPublisher({
@@ -1313,8 +1336,7 @@ export class IMessageService extends Service implements IIMessageService {
               connectorAccountId: storedId as UUID,
               accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
               service: authority,
-              normalizeTarget: (value) =>
-                normalizeIMessageConnectorHandle(value),
+              normalizeTarget: (value) => normalizeIMessageConnectorHandle(value),
             });
             // Assign BEFORE degrading: if the degrade pass itself fails
             // partway, the already-assigned publisher still gates every
@@ -1328,11 +1350,9 @@ export class IMessageService extends Service implements IIMessageService {
         // error-policy:J4 The degrade fallback itself failed: nothing more
         // can be done at this boundary; sending stays up but the failure is
         // reported for visibility.
-        this.runtime.reportError?.(
-          "imessage:membership:bootstrap-degrade-fallback",
-          degradeError,
-          { accountKey: IMESSAGE_LOCAL_ACCOUNT_ID },
-        );
+        this.runtime.reportError?.("imessage:membership:bootstrap-degrade-fallback", degradeError, {
+          accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
+        });
       }
     }
   }
@@ -2031,109 +2051,6 @@ export class IMessageService extends Service implements IIMessageService {
         "IMESSAGE_TRANSPORT"
       );
     }
-
-    const pollIntervalRaw = getStringSetting(
-      "IMESSAGE_POLL_INTERVAL_MS",
-      "IMESSAGE_POLL_INTERVAL_MS"
-    );
-    const parsedPollIntervalMs = Number(pollIntervalRaw);
-    const pollIntervalMs =
-      pollIntervalRaw.trim() === "" || !Number.isFinite(parsedPollIntervalMs)
-        ? DEFAULT_POLL_INTERVAL_MS
-        : Math.max(0, parsedPollIntervalMs);
-
-    // Resolve all startup configuration before opening chat.db or arming the
-    // polling interval. A rejected setting must not leave a partial service
-    // running after Service.start() rejects.
-    const heartbeatIntervalMs = resolveHeartbeatIntervalMs(
-      getStringSetting("IMESSAGE_HEARTBEAT_INTERVAL_MS", "IMESSAGE_HEARTBEAT_INTERVAL_MS")
-    );
-
-    const dmPolicy = getStringSetting(
-      "IMESSAGE_DM_POLICY",
-      "IMESSAGE_DM_POLICY",
-      "pairing"
-    ) as IMessageSettings["dmPolicy"];
-
-    const groupPolicy = getStringSetting(
-      "IMESSAGE_GROUP_POLICY",
-      "IMESSAGE_GROUP_POLICY",
-      "allowlist"
-    ) as IMessageSettings["groupPolicy"];
-
-    const allowFromRaw = getStringSetting("IMESSAGE_ALLOW_FROM", "IMESSAGE_ALLOW_FROM");
-    const allowFrom = allowFromRaw
-      ? allowFromRaw
-          .split(",")
-          .map((s: string) => s.trim())
-          .filter(Boolean)
-      : [];
-
-    const enabledRaw = getStringSetting("IMESSAGE_ENABLED", "IMESSAGE_ENABLED", "true");
-    const enabled = enabledRaw !== "false";
-
-    return {
-      transport: transportRaw,
-      dbPath,
-      pollIntervalMs,
-      heartbeatIntervalMs,
-      dmPolicy,
-      groupPolicy,
-      allowFrom,
-      enabled,
-      blooioApiKey:
-        getStringSetting("IMESSAGE_BLOOIO_API_KEY", "IMESSAGE_BLOOIO_API_KEY") ||
-        getStringSetting("BLOOIO_API_KEY", "BLOOIO_API_KEY") ||
-        undefined,
-      blooioWebhookSecret:
-        getStringSetting("IMESSAGE_BLOOIO_WEBHOOK_SECRET", "IMESSAGE_BLOOIO_WEBHOOK_SECRET") ||
-        getStringSetting("BLOOIO_WEBHOOK_SECRET", "BLOOIO_WEBHOOK_SECRET") ||
-        undefined,
-      blooioFromNumber:
-        getStringSetting("IMESSAGE_BLOOIO_FROM_NUMBER", "IMESSAGE_BLOOIO_FROM_NUMBER") ||
-        getStringSetting("BLOOIO_FROM_NUMBER", "BLOOIO_FROM_NUMBER") ||
-        undefined,
-      blooioChannelId:
-        getStringSetting("IMESSAGE_BLOOIO_CHANNEL_ID", "IMESSAGE_BLOOIO_CHANNEL_ID") || undefined,
-    };
-  }
-
-  private async validateSettings(): Promise<void> {
-    if (!this.settings) {
-      throw new IMessageConfigurationError("Settings not loaded");
-    }
-
-    if (this.settings.transport === "blooio") {
-      for (const [setting, value] of [
-        ["IMESSAGE_BLOOIO_API_KEY", this.settings.blooioApiKey],
-        ["IMESSAGE_BLOOIO_WEBHOOK_SECRET", this.settings.blooioWebhookSecret],
-        ["IMESSAGE_BLOOIO_FROM_NUMBER", this.settings.blooioFromNumber],
-        ["IMESSAGE_BLOOIO_CHANNEL_ID", this.settings.blooioChannelId],
-      ] as const) {
-        if (!value)
-          throw new IMessageConfigurationError(
-            `${setting} is required for the Blooio transport`,
-            setting
-          );
-      }
-    }
-
-    // Do not probe Messages.app during service startup. Sending is gated by
-    // Apple Automation while chat.db reads are gated by Full Disk Access;
-    // coupling them prevented receive-only operation and could trigger an
-    // unrelated TCC prompt merely by enabling inbound messages.
-  }
-
-  private async sendSingleMessage(to: string, text: string): Promise<IMessageSendResult> {
-    if (this.settings?.transport === "blooio") {
-      return await sendBlooioMessage({
-        apiKey: this.settings.blooioApiKey as string,
-        from: this.settings.blooioChannelId ?? (this.settings.blooioFromNumber as string),
-        to,
-        text,
-        idempotencyKey: `imessage-${crypto.randomUUID()}`,
-      });
-    }
     // Outbound delivery stays on Apple's local Messages automation surface.
     // No third-party CLI, daemon, network service, or fallback transport is
     // invoked from the native connector.
@@ -2373,14 +2290,11 @@ export class IMessageService extends Service implements IIMessageService {
           // same membership gate as agent replies: a degraded or revoked
           // scope must not receive it.
           const pairingGate = this.membership
-            ? await this.membership.authorizeOutboundInChat(
-                row.handle,
-                row.chatId,
-              )
+            ? await this.membership.authorizeOutboundInChat(row.handle, row.chatId)
             : null;
           if (pairingGate === false) {
             logger.warn(
-              `[imessage] Pairing reply to handle=${row.handle} denied by membership gate`,
+              `[imessage] Pairing reply to handle=${row.handle} denied by membership gate`
             );
             continue;
           }
@@ -2765,7 +2679,7 @@ export class IMessageService extends Service implements IIMessageService {
         : null;
       if (replyGate === false) {
         logger.error(
-          `[imessage] Reply to ROWID=${row.rowId} denied by membership gate (degraded or revoked scope)`,
+          `[imessage] Reply to ROWID=${row.rowId} denied by membership gate (degraded or revoked scope)`
         );
         return [];
       }

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -618,6 +618,28 @@ async function resolveIMessageChatId(
   return channelId.startsWith("chat_id:") ? channelId.slice("chat_id:".length) : channelId;
 }
 
+/** Metadata key under which the governed chat-id inventory is persisted. */
+const GOVERNED_CHAT_INVENTORY_KEY = "imessage:membership:chat-inventory";
+
+/**
+ * Read the persisted governed-chat inventory from connector account
+ * metadata (written by the publisher's onRosterCommitted hook). Absent,
+ * non-array, or malformed entries yield an empty inventory — this is a
+ * best-effort restart signal, not trusted input.
+ */
+function readGovernedChatInventory(metadata: unknown): string[] {
+  if (!metadata || typeof metadata !== "object") return [];
+  const raw = (metadata as Record<string, unknown>)[GOVERNED_CHAT_INVENTORY_KEY];
+  if (!Array.isArray(raw)) return [];
+  const ids = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry === "string" && entry.length > 0 && entry.length <= 512) {
+      ids.add(entry);
+    }
+  }
+  return [...ids];
+}
+
 /**
  * iMessage service for Eliza agents.
  * Note: This only works on macOS.
@@ -1106,12 +1128,63 @@ export class IMessageService extends Service implements IIMessageService {
    * connector — but roster read failures once running degrade fail-closed.
    */
   private async initMembership(): Promise<void> {
-    if (!this.runtime || !this.chatDb) return;
+    if (!this.runtime) return;
     const authority = resolveMembershipService(this.runtime);
     if (!authority) {
       logger.debug(
         "[imessage][membership] canonical MembershipService authority not registered; membership evidence is not published"
       );
+      return;
+    }
+    if (!this.chatDb) {
+      // Restart with chat.db unreadable but the authority registered: the
+      // connector account row carries the last known governed chat-id
+      // inventory from the previous healthy run. Degrade every persisted
+      // scope fail-closed now — fresh roster evidence cannot be published
+      // while chat.db is unavailable, so stale evidence must not authorize.
+      // This requires the durable inventory to be meaningful; when no
+      // inventory was ever persisted (first run without Full Disk Access),
+      // there is nothing to degrade and the connector stays send-only.
+      try {
+        const { getConnectorAccountManager } = await import("@elizaos/core");
+        const manager = getConnectorAccountManager(this.runtime);
+        const account = await manager.getAccount(
+          IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+          `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`
+        );
+        const inventory = readGovernedChatInventory(account?.metadata);
+        if (this.membership || inventory.length > 0) {
+          if (!this.membership) {
+            const { IMessageMembershipPublisher } = await import("./membership.js");
+            const storedId = account?.id;
+            if (
+              storedId &&
+              /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+                storedId
+              )
+            ) {
+              this.membership = new IMessageMembershipPublisher({
+                runtime: this.runtime,
+                connectorAccountId: storedId as UUID,
+                accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
+                service: authority,
+              });
+            }
+          }
+          if (this.membership) {
+            await this.membership.degradePersistedScopes(inventory);
+            logger.warn(
+              `[imessage][membership] chat.db unavailable at start; degraded ${inventory.length} persisted membership scope(s) fail-closed`
+            );
+          }
+        }
+      } catch (error) {
+        // error-policy:J4 Bootstrap is an expected-failure boundary: report
+        // and continue send-only; no stale evidence is published.
+        this.runtime.reportError?.("imessage:membership:restart-degrade", error, {
+          accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
+        });
+      }
       return;
     }
     try {
@@ -1146,6 +1219,26 @@ export class IMessageService extends Service implements IIMessageService {
         connectorAccountId: stored.id as UUID,
         accountKey: IMESSAGE_LOCAL_ACCOUNT_ID,
         service: authority,
+        // Persist the governed chat-id inventory on every committed sweep
+        // so a restart with chat.db unavailable can degrade exactly these
+        // scopes fail-closed (see the !chatDb branch above).
+        onRosterCommitted: async (chatIds) => {
+          await manager.upsertAccount(IMESSAGE_MEMBERSHIP_CONNECTOR_ID, {
+            id: `imessage-${IMESSAGE_LOCAL_ACCOUNT_ID}`,
+            provider: IMESSAGE_MEMBERSHIP_CONNECTOR_ID,
+            label: "iMessage (local Apple account)",
+            role: "AGENT",
+            purpose: ["messaging"],
+            accessGate: "open",
+            status: "connected",
+            createdAt: stored.createdAt,
+            updatedAt: Date.now(),
+            metadata: {
+              source: "imessage-membership",
+              [GOVERNED_CHAT_INVENTORY_KEY]: [...chatIds],
+            },
+          });
+        },
       });
       // Initial snapshot sweep; the publisher degrades its scopes and throws
       // a typed error on roster read failure (fail-closed admission).
@@ -1229,6 +1322,20 @@ export class IMessageService extends Service implements IIMessageService {
 
     // Format phone number if needed
     const target = isPhoneNumber(to) ? formatPhoneNumber(to) : to;
+
+    // Membership send gate (issue #24370): when governance is active for
+    // this target, admission requires current source-derived evidence.
+    // Ungoverned targets keep the legacy behavior. A denial is a structured
+    // failure at the connector boundary, never a silent drop.
+    if (this.membership) {
+      const admission = await this.membership.authorizeOutbound(target);
+      if (admission === false) {
+        return {
+          success: false,
+          error: `iMessage membership gate denied send to ${target}: no current roster evidence`,
+        };
+      }
+    }
 
     let media: ResolvedOutboundMedia | null = null;
     if (options?.mediaUrl) {

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -25,8 +25,7 @@ export const IMessageEventTypes = {
   ERROR: "IMESSAGE_ERROR",
 } as const;
 
-export type IMessageEventType =
-  (typeof IMessageEventTypes)[keyof typeof IMessageEventTypes];
+export type IMessageEventType = (typeof IMessageEventTypes)[keyof typeof IMessageEventTypes];
 
 /**
  * iMessage chat types
@@ -174,19 +173,13 @@ export interface IIMessageService extends Service {
   isMacOS(): boolean;
 
   /** Send a message */
-  sendMessage(
-    to: string,
-    text: string,
-    options?: IMessageSendOptions,
-  ): Promise<IMessageSendResult>;
+  sendMessage(to: string, text: string, options?: IMessageSendOptions): Promise<IMessageSendResult>;
 
   /** Get recent messages */
   getRecentMessages(limit?: number): Promise<IMessageMessage[]>;
 
   /** List newest messages, optionally filtered to one chat. */
-  getMessages(
-    options?: IMessageListMessagesOptions,
-  ): Promise<IMessageMessage[]>;
+  getMessages(options?: IMessageListMessagesOptions): Promise<IMessageMessage[]>;
 
   /** Get chats */
   getChats(): Promise<IMessageChat[]>;
@@ -205,7 +198,7 @@ export class IMessagePluginError extends Error {
   constructor(
     message: string,
     public readonly code: string,
-    public readonly details?: Record<string, unknown>,
+    public readonly details?: Record<string, unknown>
   ) {
     super(message);
     this.name = "IMessagePluginError";
@@ -259,9 +252,7 @@ export function isEmail(input: string): boolean {
  */
 export function isValidIMessageTarget(target: string): boolean {
   const trimmed = target.trim();
-  return (
-    isPhoneNumber(trimmed) || isEmail(trimmed) || trimmed.startsWith("chat_id:")
-  );
+  return isPhoneNumber(trimmed) || isEmail(trimmed) || trimmed.startsWith("chat_id:");
 }
 
 /**
@@ -311,7 +302,7 @@ export function formatPhoneNumber(phone: string): string {
  */
 export function normalizeIMessageConnectorHandle(
   value: string,
-  normalizeContact: (raw: string) => string,
+  normalizeContact: (raw: string) => string
 ): string {
   const stripped = value
     .trim()
@@ -324,8 +315,7 @@ export function normalizeIMessageConnectorHandle(
     return `chat_id:${normalizedTarget}`;
   }
   if (isEmail(normalizedTarget)) return normalizedTarget.toLowerCase();
-  if (isPhoneNumber(normalizedTarget))
-    return formatPhoneNumber(normalizedTarget);
+  if (isPhoneNumber(normalizedTarget)) return formatPhoneNumber(normalizedTarget);
   return normalizeContact(normalizedTarget) || normalizedTarget;
 }
 
@@ -347,11 +337,11 @@ function takeAtLeastOneUnit(text: string, limit: number): string {
 
 export function splitMessageForIMessage(
   text: string,
-  maxLength: number = MAX_IMESSAGE_MESSAGE_LENGTH,
+  maxLength: number = MAX_IMESSAGE_MESSAGE_LENGTH
 ): string[] {
   if (!Number.isFinite(maxLength) || maxLength < 1) {
     throw new Error(
-      `splitMessageForIMessage: maxLength must be a positive finite number, got ${maxLength}`,
+      `splitMessageForIMessage: maxLength must be a positive finite number, got ${maxLength}`
     );
   }
   const limit = Math.floor(maxLength);

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -25,7 +25,8 @@ export const IMessageEventTypes = {
   ERROR: "IMESSAGE_ERROR",
 } as const;
 
-export type IMessageEventType = (typeof IMessageEventTypes)[keyof typeof IMessageEventTypes];
+export type IMessageEventType =
+  (typeof IMessageEventTypes)[keyof typeof IMessageEventTypes];
 
 /**
  * iMessage chat types
@@ -173,13 +174,19 @@ export interface IIMessageService extends Service {
   isMacOS(): boolean;
 
   /** Send a message */
-  sendMessage(to: string, text: string, options?: IMessageSendOptions): Promise<IMessageSendResult>;
+  sendMessage(
+    to: string,
+    text: string,
+    options?: IMessageSendOptions,
+  ): Promise<IMessageSendResult>;
 
   /** Get recent messages */
   getRecentMessages(limit?: number): Promise<IMessageMessage[]>;
 
   /** List newest messages, optionally filtered to one chat. */
-  getMessages(options?: IMessageListMessagesOptions): Promise<IMessageMessage[]>;
+  getMessages(
+    options?: IMessageListMessagesOptions,
+  ): Promise<IMessageMessage[]>;
 
   /** Get chats */
   getChats(): Promise<IMessageChat[]>;
@@ -198,7 +205,7 @@ export class IMessagePluginError extends Error {
   constructor(
     message: string,
     public readonly code: string,
-    public readonly details?: Record<string, unknown>
+    public readonly details?: Record<string, unknown>,
   ) {
     super(message);
     this.name = "IMessagePluginError";
@@ -252,7 +259,9 @@ export function isEmail(input: string): boolean {
  */
 export function isValidIMessageTarget(target: string): boolean {
   const trimmed = target.trim();
-  return isPhoneNumber(trimmed) || isEmail(trimmed) || trimmed.startsWith("chat_id:");
+  return (
+    isPhoneNumber(trimmed) || isEmail(trimmed) || trimmed.startsWith("chat_id:")
+  );
 }
 
 /**
@@ -294,6 +303,33 @@ export function formatPhoneNumber(phone: string): string {
 }
 
 /**
+ * Canonical outbound-target spelling shared by the connector send path and
+ * the membership send gate: strips scheme prefixes, canonicalizes chat-id
+ * grammars, lowercases emails, and E.164-formats phone numbers so the same
+ * counterparty resolves to one gate key regardless of how the caller
+ * spelled it. Returns "" when the input trims to nothing.
+ */
+export function normalizeIMessageConnectorHandle(
+  value: string,
+  normalizeContact: (raw: string) => string,
+): string {
+  const stripped = value
+    .trim()
+    .replace(/^(?:messages?|sms|text):/i, "")
+    .trim();
+  const normalizedTarget = normalizeIMessageTarget(stripped) ?? stripped;
+  if (!normalizedTarget) return "";
+  if (normalizedTarget.startsWith("chat_id:")) return normalizedTarget;
+  if (/^(?:imessage|sms|rcs);/i.test(normalizedTarget)) {
+    return `chat_id:${normalizedTarget}`;
+  }
+  if (isEmail(normalizedTarget)) return normalizedTarget.toLowerCase();
+  if (isPhoneNumber(normalizedTarget))
+    return formatPhoneNumber(normalizedTarget);
+  return normalizeContact(normalizedTarget) || normalizedTarget;
+}
+
+/**
  * Split text for iMessage
  */
 // truncateWellFormed(text, 1) returns "" when text opens with a surrogate
@@ -311,11 +347,11 @@ function takeAtLeastOneUnit(text: string, limit: number): string {
 
 export function splitMessageForIMessage(
   text: string,
-  maxLength: number = MAX_IMESSAGE_MESSAGE_LENGTH
+  maxLength: number = MAX_IMESSAGE_MESSAGE_LENGTH,
 ): string[] {
   if (!Number.isFinite(maxLength) || maxLength < 1) {
     throw new Error(
-      `splitMessageForIMessage: maxLength must be a positive finite number, got ${maxLength}`
+      `splitMessageForIMessage: maxLength must be a positive finite number, got ${maxLength}`,
     );
   }
   const limit = Math.floor(maxLength);

--- a/plugins/plugin-personal-assistant/src/actions/connector.ts
+++ b/plugins/plugin-personal-assistant/src/actions/connector.ts
@@ -1036,7 +1036,7 @@ async function dispatchIMessage(
       const status = await service.getIMessageConnectorStatus();
       const base = status.connected
         ? "iMessage is connected through the native macOS bridge."
-        : "Set up iMessage below — read chat.db directly (Full Disk Access), bridge via BlueBubbles, or use the Blooio cloud gateway.";
+        : "Set up iMessage below — the native connector reads chat.db directly (Full Disk Access required); no external bridge is used.";
       return {
         success: status.connected,
         text: status.connected


### PR DESCRIPTION
# feat(imessage): native membership snapshots for chats and connectors (#24370)

Closes #24370

Publishes iMessage chat membership evidence to the canonical `MembershipService` contract from the native chat.db surface: committed-only inventory, observation-identity idempotency, per-chat resilient degrade, and outbound authorization gates.

## What changes

- **`membership.ts` (new)** — membership snapshot engine over chat.db: `normalizeIMessageConnectorHandle` (canonical handle index with dual-spelling keys), committed-only inventory push, prior-inventory-before-upsert with a persisted-inventory deletion ratchet on every sweep, observation-identity idempotency keys (observedAt-derived, not process counters), restart-without-chat.db degrades the persisted inventory (fail-closed), collision tombstone deny.
- **`service.ts`** — `initMembership` runs before `startPolling`; startup inventory reconcile (`reconcileRemovedScopes`) with bootstrap-failure degrade fallback; per-chat resilient degrade loop; reply callback gated (pairing); `authorizeOutboundInChat` fail-closed for governed chats with unresolvable targets; reader `rosterReadFailureCount` with adapter throwing on swallowed query failure.
- **`types.ts` / adapters** — publisher constructors take the injected normalizer; membership-adapters seam; fence-exhaustion typed error with conflict retry.
- **Tests** — 17 membership tests incl. Proxy-delegated real-authority fence-exhaustion (asserts ≥2 snapshot attempts + inventory exclusion), empty-sweep ratchet, degrade-before-persist ordering; suite total 238/238 with RED controls (3/4 fail pre-fix per round).

## Key invariants

- Restart without chat.db never implies mass removal — persisted scopes degrade to `unavailable` (fail-closed), then reconcile on recovery.
- Inventory is committed-only; an upsert never erases the prior inventory before it is read (the deletion ratchet runs every sweep).
- Outbound sends to governed chats with unresolvable targets are denied with a structured error, never silently dropped.

## Verification

| Gate | Result |
|---|---|
| Full plugin suite (fresh capture at publish) | 238/238 |
| Typecheck | 0 errors |
| Biome | clean (2.5.7 on delta files) |
| Merge vs develop tip | clean (merge-tree 0 conflicts vs `5c476b4206`) |
| RED controls | R2 pair 3/4 fail pre-fix; R4 pair proven |
| Independent agent review | 4 rounds; every finding execution-verified real and fixed (17 findings total across R1–R4) |

Note on review depth: the review loop ran 4 rounds (one over the 3-round budget) because each round surfaced additional real findings; all are fixed with RED controls. R4's final state is fixed at this head but was not followed by a fifth confirming round.

<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:walkthrough-video -->
N/A - no user-visible surface changed (connector-internal evidence publication)
<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only refresh at 5a3df1359e5 (no code change: patch-ids 12/12 identical, branch delta vs develop identical except hunk-offset lines). Gates rerun at new head: membership-roster 3/3, membership 23/23 (after plugin-sql sibling build), imessage tsc 0 err, biome 9 files clean.

Fresh capture at response head 7a81b1d2ea (2026-08-31, responding to review 5069773639): focused membership suite **22/22 green** (21 prior + the new known-answer vector test), full plugin-imessage suite **268/268 green across 23 files**, typecheck 0 errors, biome clean on both changed files. Mutation control: flipping the uuidV5 namespace||name concatenation order turns the new vector test red; restoring turns it green — the test pins RFC 4122 §4.3 byte layout, not output shape.

```
RUN v4.1.10 plugins/plugin-imessage (worktree at 7a81b1d2ea)
 src/membership.test.ts: Tests 22 passed (22)
 full suite: Tests 268 passed (268) / 23 files
 typecheck tsc --noEmit: 0 errors
 biome check (2 changed files): clean
```

- [x] <details><summary>full plugin-imessage suite at head 290980b5cc (fresh capture post type-export fix) (captured 2026-08-28T12:17Z)</summary>


<details><summary>backend-logs fresh capture at exact head 290980b5cc (membership suites, post type-export split)</summary>

```
RUN  v4.1.10 /Users/t3rpz/projects/eliza-24370/plugins/plugin-imessage


 Test Files  2 passed (2)
      Tests  24 passed (24)
   Start at  19:52:59
   Duration  20.30s (transform 11.64s, setup 165ms, import 13.76s, tests 6.38s, environment 0ms)
```
</details>

```text
Evidence for issue #24370 — full plugin-imessage suite at head 290980b5cc (fresh capture post type-export fix) (captured 2026-08-28T12:17Z)
 RUN  v4.1.10 /Users/t3rpz/projects/eliza-24370/plugins/plugin-imessage
 Test Files  20 passed (20)
      Tests  238 passed (238)
   Duration  8.68s (transform 63.12s, setup 854ms, import 79.39s, tests 2.22s, environment 1ms)
exit=0
```
</details>
<!-- evidence-row:frontend-logs -->
N/A - no frontend surface changed (connector-internal evidence publication)
<!-- evidence-row:llm-trajectory -->
N/A - no model/provider path changed (deterministic plugin tests over real chat.db adapters)
<!-- evidence-row:domain-artifacts -->
N/A - membership records and inventory ratchet asserted directly in the suite
<!-- evidence-row:ocr-review -->
N/A - no OCR surface involved

<!-- evidence-head:5a3df1359e52f36a10756b6d4b88fb14285dfccd -->

---

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->













