### PR TITLE
feat(x): publish DM membership evidence (#24372)

### DIFF
--- a/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
+++ b/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
@@ -404,7 +404,9 @@ describe("X membership publisher (real PGlite authority)", () => {
 
     // Simulate a restart: a brand-new publisher over the same runtime. The
     // stable per-(agent, account) publisher id must take the ADOPTION path —
-    // generation, cursor, and version preserved, not bumped.
+    // generation, cursor, and version preserved, not bumped. The adoption
+    // happens at first use (renewSender); capture the durable state right
+    // after that call and require EXACT generation equality.
     const reborn = new XMembershipPublisher(runtime);
     const rebornScope = await reborn.scopeForConversation({
       conversationId,
@@ -421,16 +423,84 @@ describe("X membership publisher (real PGlite authority)", () => {
       permissionSnapshot: { observed: true },
       idempotencyKey: `x:renew:${conversationId}:7300:e900601`,
     });
-    // Evidence committed after the restart chained onto the adopted state,
-    // proving the reborn publisher did NOT reset the chain.
     const after = await membership.getScopeHealth(scope);
     expect(after).not.toBeNull();
+    // Adoption invariant: the authority bumps `generation` on every committed
+    // command (registration=+1, each evidence=+1), so a restart that adopts
+    // and re-proves must show EXACTLY one new commit — generation
+    // before+1 — with the publisher seat UNCHANGED (same publisherInstanceId
+    // and same publisherGeneration). A takeover would bump publisherGeneration
+    // and add a second generation step (re-register + commit).
     if (before && after) {
-      expect(after.generation).toBeGreaterThanOrEqual(before.generation);
+      expect(after.generation).toBe(before.generation + 1);
+      expect(after.publisherInstanceId).toBe(before.publisherInstanceId);
+      expect(after.publisherGeneration).toBe(before.publisherGeneration);
+      expect(after.sourceVersion).toBe(before.sourceVersion + 1);
     }
     const decision = await membership.authorize(scope, principal);
     expect(decision.decision).toBe("allowed");
     expect(decision.reason).toBe("active_membership");
+  });
+
+  it("serializes a concurrent renew→leave→renew sequence without a stale renewal window", async () => {
+    const conversationId = "1999888777660012";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7600",
+    );
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationId}:7600:e900900`,
+      eventAnchoredAt: 1_756_000_012_000,
+    });
+    // Fire renewal, leave, and a fresh observation CONCURRENTLY: per-scope
+    // serialization plus removeRenewalOnCommit must leave the principal
+    // re-proved active (the last observation wins inside the queue), never
+    // suppressed by a stale renewal-window timestamp written after the
+    // leave's revocation.
+    await Promise.allSettled([
+      publisher.renewSender({
+        scope,
+        principalId: principal,
+        worldId: runtime.agentId,
+        roomId: runtime.agentId,
+        roles: ["participant"],
+        permissionSnapshot: { observed: true },
+        idempotencyKey: `x:renew:${conversationId}:7600:e900901`,
+        eventAnchoredAt: 1_756_000_013_000,
+      }),
+      publisher.publishLeave({
+        scope,
+        principalId: principal,
+        worldId: runtime.agentId,
+        roomId: runtime.agentId,
+        reason: "left",
+        idempotencyKey: `x:left:${conversationId}:7600:e900902`,
+        eventAnchoredAt: 1_756_000_014_000,
+      }),
+      publisher.renewSender({
+        scope,
+        principalId: principal,
+        worldId: runtime.agentId,
+        roomId: runtime.agentId,
+        roles: ["participant"],
+        permissionSnapshot: { observed: true },
+        idempotencyKey: `x:renew:${conversationId}:7600:e900903`,
+        eventAnchoredAt: 1_756_000_015_000,
+      }),
+    ]);
+    // Post-leave observation activity re-proves the principal: the record
+    // reflects the LAST serialized observation, not a suppressed renewal.
+    const record = await membership.getMembership(scope, principal);
+    expect(record?.state).toBe("active");
+    expect(record?.reason).toBe("reconciled_present");
   });
 
   it("leave removes the renewal window at commit so the next observation re-proves immediately", async () => {

--- a/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
+++ b/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Real-PGlite coverage for the X DM membership publisher (#24372):
+ * account-scoped observed-only evidence through the landed core
+ * MembershipService + plugin-sql authority, join/leave semantics for group
+ * and 1:1 conversations, own-account participation, idempotent redelivery
+ * of event-anchored proofs, scope isolation, degradation fail-closed, and
+ * per-scope serialization. The runtime, adapter, connector-account row, and
+ * authority are all real; only the X DM timeline events are synthetic.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  AgentRuntime,
+  type MembershipAuthorizationDecision,
+  type MembershipScope,
+  MembershipService,
+  type UUID,
+} from "@elizaos/core";
+import { createDatabaseAdapter } from "@elizaos/plugin-sql";
+import { v4 as uuidv4 } from "uuid";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { XMembershipPublisher, xMembershipPrincipal } from "../src/membership";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup) await cleanup();
+  }
+});
+
+let runtime: AgentRuntime;
+let membership: MembershipService;
+let publisher: XMembershipPublisher;
+let restartDir: string;
+
+const OWN_USER_ID = "990000000000000001";
+
+async function scopeFor(conversationId: string): Promise<MembershipScope> {
+  const scope = await publisher.scopeForConversation({
+    conversationId,
+    accountKey: "default",
+    ownUserId: OWN_USER_ID,
+  });
+  if (!scope) {
+    throw new Error("membership scope resolution failed (publisher null)");
+  }
+  return scope;
+}
+
+beforeAll(async () => {
+  restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "x-membership-24372-"));
+  // The membership authority validates UUID version nibbles, so the test
+  // agent id must be a real v4. Build the runtime directly over a real
+  // PGlite adapter, the same shape plugin-sql's own authority tests use.
+  const agentId = uuidv4() as UUID;
+  const adapter = createDatabaseAdapter({ dataDir: restartDir }, agentId);
+  await (adapter as unknown as { init: () => Promise<void> }).init();
+  runtime = new AgentRuntime({
+    character: {
+      name: "x-membership-24372",
+      id: agentId,
+      plugins: [],
+      settings: {},
+    },
+    agentId,
+    adapter,
+    logLevel: "warn",
+    enableAutonomy: false,
+  });
+  // plugin-sql registers SqlMembershipService; import via the source alias
+  // the real-runtime config provides so the DB schema is the real one.
+  const sqlModule = (await import("@elizaos/plugin-sql")) as {
+    default?: { plugins?: unknown[] };
+    plugin?: { plugins?: unknown[] };
+  };
+  const sqlPlugin =
+    sqlModule.default ??
+    (sqlModule.plugin as { plugins?: unknown[] } | undefined);
+  if (sqlPlugin) {
+    await runtime.registerPlugin(
+      sqlPlugin as unknown as Parameters<AgentRuntime["registerPlugin"]>[0],
+    );
+  }
+  await runtime.initialize();
+  const services = runtime.getServicesByType<MembershipService>(
+    MembershipService.serviceType,
+  );
+  expect(services.length).toBeGreaterThan(0);
+  membership = services[0];
+  publisher = new XMembershipPublisher(runtime);
+  cleanups.push(async () => {
+    await runtime.stop();
+  });
+}, 180_000);
+
+afterAll(async () => {
+  fs.rmSync(restartDir, { recursive: true, force: true });
+}, 60_000);
+
+describe("X membership publisher (real PGlite authority)", () => {
+  it("upserts a durable UUID connector account and derives a stable account-scoped scope", async () => {
+    const scopeA = await scopeFor("199988877766655");
+    const scopeB = await scopeFor("199988877766655");
+    expect(scopeA).toEqual(scopeB);
+    expect(scopeA.connectorId).toBe("x");
+    // The authority requires a UUID connector account id; "default" is not one.
+    expect(scopeA.connectorAccountId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("scopes are account-scoped: a second X user id derives a different connectorAccountId", async () => {
+    const scopeA = await publisher.scopeForConversation({
+      conversationId: "199988877766655",
+      accountKey: "default",
+      ownUserId: OWN_USER_ID,
+    });
+    const scopeB = await publisher.scopeForConversation({
+      conversationId: "199988877766655",
+      accountKey: "second-account",
+      ownUserId: "990000000000000002",
+    });
+    expect(scopeA).not.toBeNull();
+    expect(scopeB).not.toBeNull();
+    expect(scopeA?.connectorAccountId).not.toEqual(scopeB?.connectorAccountId);
+  });
+
+  it("publishes a sender renewal as active point-query evidence that authorizes", async () => {
+    const conversationId = "1999888777660001";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7001",
+    );
+    await publisher.renewSender({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `renew:${conversationId}:7001:e${Date.now()}`,
+    });
+    const decision: MembershipAuthorizationDecision =
+      await membership.authorize(scope, principal);
+    expect(decision.decision).toBe("allowed");
+    expect(decision.reason).toBe("active_membership");
+    const record = await membership.getMembership(scope, principal);
+    expect(record?.state).toBe("active");
+    expect(record?.reason).toBe("reconciled_present");
+    expect(record?.evidenceMode).toBe("point_query");
+  });
+
+  it("join and leave observations transition the same principal with idempotent redelivery", async () => {
+    const conversationId = "1999888777660002";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7002",
+    );
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: "x:join:1999888777660002:7002:e900100",
+      eventAnchoredAt: 1_756_000_000_000,
+    });
+    let record = await membership.getMembership(scope, principal);
+    expect(record?.state).toBe("active");
+    expect(record?.reason).toBe("joined");
+
+    // Redelivery of the same event under the same key is a benign replay:
+    // the publish must not throw and must not corrupt the chain.
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: "x:join:1999888777660002:7002:e900100",
+      eventAnchoredAt: 1_756_000_000_000,
+    });
+    record = await membership.getMembership(scope, principal);
+    expect(record?.state).toBe("active");
+
+    await publisher.publishLeave({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      reason: "left",
+      idempotencyKey: "x:left:1999888777660002:7002:e900101",
+      eventAnchoredAt: 1_756_000_001_000,
+    });
+    record = await membership.getMembership(scope, principal);
+    expect(record?.state).toBe("revoked");
+    expect(record?.reason).toBe("left");
+
+    const decision = await membership.authorize(scope, principal);
+    expect(decision.decision).toBe("denied");
+    expect(decision.reason).toBe("membership_revoked");
+  });
+
+  it("isolates membership per conversation: a leave in one scope never revokes another", async () => {
+    const conversationA = "1999888777660003";
+    const conversationB = "1999888777660004";
+    const scopeA = await scopeFor(conversationA);
+    const scopeB = await scopeFor(conversationB);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7003",
+    );
+    for (const scope of [scopeA, scopeB]) {
+      await publisher.publishJoin({
+        scope,
+        principalId: principal,
+        worldId: runtime.agentId,
+        roomId: runtime.agentId,
+        roles: ["participant"],
+        permissionSnapshot: { observed: true },
+        idempotencyKey: `x:join:${scope.externalRoomId}:7003:e900200`,
+        eventAnchoredAt: 1_756_000_002_000,
+      });
+    }
+    await publisher.publishLeave({
+      scope: scopeA,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      reason: "left",
+      idempotencyKey: `x:left:${conversationA}:7003:e900201`,
+      eventAnchoredAt: 1_756_000_003_000,
+    });
+    const denied = await membership.authorize(scopeA, principal);
+    expect(denied.decision).toBe("denied");
+    const allowed = await membership.authorize(scopeB, principal);
+    expect(allowed.decision).toBe("allowed");
+  });
+
+  it("degrades a scope explicitly and fails authorization closed while degraded", async () => {
+    const conversationId = "1999888777660005";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7004",
+    );
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationId}:7004:e900300`,
+      eventAnchoredAt: 1_756_000_004_000,
+    });
+    await publisher.degradeScope({
+      scope,
+      health: "unavailable",
+      reason: "own_account_removed_from_conversation",
+    });
+    const decision = await membership.authorize(scope, principal);
+    expect(decision.decision).toBe("denied");
+    expect(decision.reason).toBe("authority_unavailable");
+  });
+
+  it("restores a degraded scope by re-registering and re-proving on activity", async () => {
+    const conversationId = "1999888777660006";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7005",
+    );
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationId}:7005:e900400`,
+      eventAnchoredAt: 1_756_000_005_000,
+    });
+    await publisher.degradeScope({
+      scope,
+      health: "unavailable",
+      reason: "own_account_removed_from_conversation",
+    });
+    const degraded = await membership.authorize(scope, principal);
+    expect(degraded.decision).toBe("denied");
+    expect(degraded.reason).toBe("authority_unavailable");
+    await publisher.restoreScope({
+      scope,
+      reason: "account_regained_conversation_access",
+    });
+    // Re-prove on the next observed activity after restoration.
+    await publisher.renewSender({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:renew:${conversationId}:7005:e900401`,
+    });
+    const decision = await membership.authorize(scope, principal);
+    expect(decision.decision).toBe("allowed");
+    expect(decision.reason).toBe("active_membership");
+  });
+
+  it("serializes concurrent observations for one scope without cursor races", async () => {
+    const conversationId = "1999888777660007";
+    const scope = await scopeFor(conversationId);
+    const principals = await Promise.all(
+      ["7101", "7102", "7103", "7104", "7105"].map((xId) =>
+        xMembershipPrincipal(runtime, "default", xId).then(
+          (r) => r.principalId,
+        ),
+      ),
+    );
+    const results = await Promise.all(
+      principals.map((principalId, index) =>
+        publisher.publishJoin({
+          scope,
+          principalId,
+          worldId: runtime.agentId,
+          roomId: runtime.agentId,
+          roles: ["participant"],
+          permissionSnapshot: { observed: true, slot: index },
+          idempotencyKey: `x:join:${conversationId}:${principals[index]}:e9005${index}`,
+          eventAnchoredAt: 1_756_000_006_000 + index,
+        }),
+      ),
+    );
+    expect(results).toHaveLength(5);
+    const decisions = await Promise.all(
+      principals.map((principalId) => membership.authorize(scope, principalId)),
+    );
+    for (const decision of decisions) {
+      expect(decision.decision).toBe("allowed");
+    }
+  });
+
+  it("publishes distinct principals per account for the same X user id (account-scoped ids)", async () => {
+    const defaultPrincipal = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7200",
+    );
+    const secondPrincipal = await xMembershipPrincipal(
+      runtime,
+      "second-account",
+      "7200",
+    );
+    expect(defaultPrincipal.principalId).not.toEqual(
+      secondPrincipal.principalId,
+    );
+    // Both principals are valid v5 UUIDs the authority accepts.
+    for (const principal of [
+      defaultPrincipal.principalId,
+      secondPrincipal.principalId,
+    ]) {
+      expect(principal).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    }
+  });
+
+  it("survives a restart: a new publisher instance adopts durable scope state and re-proves", async () => {
+    const conversationId = "1999888777660008";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7300",
+    );
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationId}:7300:e900600`,
+      eventAnchoredAt: 1_756_000_007_000,
+    });
+    // Simulate a restart: a brand-new publisher over the same runtime.
+    const reborn = new XMembershipPublisher(runtime);
+    const rebornScope = await reborn.scopeForConversation({
+      conversationId,
+      accountKey: "default",
+      ownUserId: OWN_USER_ID,
+    });
+    expect(rebornScope).toEqual(scope);
+    // A DIFFERENT event after restart must chain onto the durable evidence
+    // (adopting generation + cursor), not collide with the old publisher.
+    await reborn.renewSender({
+      scope: rebornScope ?? scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:renew:${conversationId}:7300:e900601`,
+    });
+    const decision = await membership.authorize(scope, principal);
+    expect(decision.decision).toBe("allowed");
+  });
+});

--- a/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
+++ b/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
@@ -8,6 +8,7 @@
  * authority are all real; only the X DM timeline events are synthetic.
  */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -19,7 +20,6 @@ import {
   type UUID,
 } from "@elizaos/core";
 import { createDatabaseAdapter } from "@elizaos/plugin-sql";
-import { v4 as uuidv4 } from "uuid";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { XMembershipPublisher, xMembershipPrincipal } from "../src/membership";
 
@@ -56,7 +56,7 @@ beforeAll(async () => {
   // The membership authority validates UUID version nibbles, so the test
   // agent id must be a real v4. Build the runtime directly over a real
   // PGlite adapter, the same shape plugin-sql's own authority tests use.
-  const agentId = uuidv4() as UUID;
+  const agentId = randomUUID() as UUID;
   const adapter = createDatabaseAdapter({ dataDir: restartDir }, agentId);
   await (adapter as unknown as { init: () => Promise<void> }).init();
   runtime = new AgentRuntime({

--- a/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
+++ b/plugins/plugin-x/__tests__/membership-publisher.real.test.ts
@@ -379,7 +379,7 @@ describe("X membership publisher (real PGlite authority)", () => {
     }
   });
 
-  it("survives a restart: a new publisher instance adopts durable scope state and re-proves", async () => {
+  it("survives a restart: a new publisher instance ADOPTS the durable binding (same generation) and re-proves", async () => {
     const conversationId = "1999888777660008";
     const scope = await scopeFor(conversationId);
     const { principalId: principal } = await xMembershipPrincipal(
@@ -397,7 +397,14 @@ describe("X membership publisher (real PGlite authority)", () => {
       idempotencyKey: `x:join:${conversationId}:7300:e900600`,
       eventAnchoredAt: 1_756_000_007_000,
     });
-    // Simulate a restart: a brand-new publisher over the same runtime.
+    const before = await membership.getScopeHealth(scope);
+    expect(before).not.toBeNull();
+    const beforeState = publisher.scopeState(scope);
+    expect(beforeState).toBeDefined();
+
+    // Simulate a restart: a brand-new publisher over the same runtime. The
+    // stable per-(agent, account) publisher id must take the ADOPTION path —
+    // generation, cursor, and version preserved, not bumped.
     const reborn = new XMembershipPublisher(runtime);
     const rebornScope = await reborn.scopeForConversation({
       conversationId,
@@ -405,8 +412,6 @@ describe("X membership publisher (real PGlite authority)", () => {
       ownUserId: OWN_USER_ID,
     });
     expect(rebornScope).toEqual(scope);
-    // A DIFFERENT event after restart must chain onto the durable evidence
-    // (adopting generation + cursor), not collide with the old publisher.
     await reborn.renewSender({
       scope: rebornScope ?? scope,
       principalId: principal,
@@ -416,7 +421,118 @@ describe("X membership publisher (real PGlite authority)", () => {
       permissionSnapshot: { observed: true },
       idempotencyKey: `x:renew:${conversationId}:7300:e900601`,
     });
+    // Evidence committed after the restart chained onto the adopted state,
+    // proving the reborn publisher did NOT reset the chain.
+    const after = await membership.getScopeHealth(scope);
+    expect(after).not.toBeNull();
+    if (before && after) {
+      expect(after.generation).toBeGreaterThanOrEqual(before.generation);
+    }
     const decision = await membership.authorize(scope, principal);
     expect(decision.decision).toBe("allowed");
+    expect(decision.reason).toBe("active_membership");
+  });
+
+  it("leave removes the renewal window at commit so the next observation re-proves immediately", async () => {
+    const conversationId = "1999888777660009";
+    const scope = await scopeFor(conversationId);
+    const { principalId: principal } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7400",
+    );
+    await publisher.publishJoin({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationId}:7400:e900700`,
+      eventAnchoredAt: 1_756_000_008_000,
+    });
+    await publisher.publishLeave({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      reason: "left",
+      idempotencyKey: `x:left:${conversationId}:7400:e900701`,
+      eventAnchoredAt: 1_756_000_009_000,
+    });
+    // A renewal queued AFTER the leave (activity observed post-revocation)
+    // must not be suppressed by a stale renewal-window entry: the member
+    // re-proves active immediately.
+    await publisher.renewSender({
+      scope,
+      principalId: principal,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:renew:${conversationId}:7400:e900702`,
+    });
+    const record = await membership.getMembership(scope, principal);
+    expect(record?.state).toBe("active");
+    expect(record?.reason).toBe("reconciled_present");
+  });
+
+  it("degrades all scopes for the account and restores them (auth failure and recovery)", async () => {
+    const conversationA = "1999888777660010";
+    const conversationB = "1999888777660011";
+    const scopeA = await scopeFor(conversationA);
+    const scopeB = await scopeFor(conversationB);
+    const { principalId: principalA } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7500",
+    );
+    const { principalId: principalB } = await xMembershipPrincipal(
+      runtime,
+      "default",
+      "7501",
+    );
+    await publisher.publishJoin({
+      scope: scopeA,
+      principalId: principalA,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationA}:7500:e900800`,
+      eventAnchoredAt: 1_756_000_010_000,
+    });
+    await publisher.publishJoin({
+      scope: scopeB,
+      principalId: principalB,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:join:${conversationB}:7501:e900801`,
+      eventAnchoredAt: 1_756_000_011_000,
+    });
+    await publisher.degradeAllScopes("x_auth_failed_401");
+    for (const [scope, principal] of [
+      [scopeA, principalA],
+      [scopeB, principalB],
+    ] as const) {
+      const denied = await membership.authorize(scope, principal);
+      expect(denied.decision).toBe("denied");
+      expect(denied.reason).toBe("authority_unavailable");
+    }
+    await publisher.restoreAllScopes("x_auth_recovered");
+    // Re-prove on the next observed activity after restoration.
+    await publisher.renewSender({
+      scope: scopeA,
+      principalId: principalA,
+      worldId: runtime.agentId,
+      roomId: runtime.agentId,
+      roles: ["participant"],
+      permissionSnapshot: { observed: true },
+      idempotencyKey: `x:renew:${conversationA}:7500:e900802`,
+    });
+    const allowed = await membership.authorize(scopeA, principalA);
+    expect(allowed.decision).toBe("allowed");
   });
 });

--- a/plugins/plugin-x/package.json
+++ b/plugins/plugin-x/package.json
@@ -51,6 +51,7 @@
     "twitter-text": "3.1.0"
   },
   "devDependencies": {
+    "@elizaos/plugin-sql": "workspace:*",
     "@biomejs/biome": "2.5.8",
     "@types/node": "^22.19.17",
     "@types/twitter-text": "3.1.10",
@@ -66,6 +67,7 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:real-runtime": "bunx vitest run --config vitest.real-runtime.config.ts",
     "prepack": "bun run build",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -28,6 +28,7 @@ import type { ClientBase } from "./base";
 import type { AuthenticatedTwitterSession } from "./client/auth";
 import { checkTwitterDmAccess, resolveTwitterDmPolicy } from "./dm-policy";
 import { parseTwitterInterval } from "./environment";
+import { XMembershipPublisher, xMembershipPrincipal } from "./membership";
 import type { TwitterClientState } from "./types";
 import { resolveCloudApiKeyForXEndpoint } from "./utils/cloud-credential-boundary";
 import { createMemorySafe, reconcileTwitterWorld } from "./utils/memory";
@@ -107,6 +108,18 @@ export class TwitterDirectMessageClient {
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private pollInFlight = false;
   private readonly isDryRun: boolean;
+  /**
+   * Membership-evidence publisher (#24372): observed-only point-query proofs
+   * from DM timeline events into the canonical MembershipService authority.
+   * Degrade-only — a null authority never touches the message path.
+   */
+  private readonly membership = new XMembershipPublisher(this.runtime);
+  /**
+   * Conversation ids whose own-account membership has been published this
+   * process, so the account's own participation is proven once per
+   * conversation instead of on every event.
+   */
+  private readonly ownMembershipPublished = new Set<string>();
 
   constructor(
     private readonly client: ClientBase,
@@ -256,7 +269,10 @@ export class TwitterDirectMessageClient {
       ],
       "user.fields": ["id", "username", "name"],
       expansions: ["sender_id"],
-      event_types: ["MessageCreate"],
+      // Membership evidence (#24372): join/leave events are roster-observable
+      // facts in the DM timeline; without them participant departures are
+      // invisible and stale active evidence would keep authorizing.
+      event_types: ["MessageCreate", "ParticipantsJoin", "ParticipantsLeave"],
     })) as DirectMessagePage;
 
     const collectEvents = () =>
@@ -307,6 +323,21 @@ export class TwitterDirectMessageClient {
     );
     for (const event of events) {
       if (compareEventIds(event.id, cursor) <= 0) continue;
+      if (
+        event.event_type === "ParticipantsJoin" ||
+        event.event_type === "ParticipantsLeave"
+      ) {
+        // Membership evidence (#24372): observed-only join/leave proofs.
+        // Event-anchored idempotency keys absorb redelivery; a publish
+        // failure must not hold the poll cursor (degrade-only evidence), so
+        // the cursor advances regardless.
+        await this.publishMembershipFromRosterEvent(
+          event as DirectMessageEvent & { id: string },
+          ownUserId,
+        );
+        await this.runtime.setCache(cursorKey, event.id);
+        continue;
+      }
       if (event.event_type && event.event_type !== "MessageCreate") {
         await this.runtime.setCache(cursorKey, event.id);
         continue;
@@ -316,6 +347,12 @@ export class TwitterDirectMessageClient {
         event.sender_id === ownUserId ||
         !event.text?.trim()
       ) {
+        // A self-sent message still proves the account's own participation
+        // in the conversation; the sender renewal below is skipped for the
+        // own account there, so publish own membership here.
+        if (event.sender_id && event.dm_conversation_id) {
+          await this.publishOwnMembership(event.dm_conversation_id, ownUserId);
+        }
         await this.runtime.setCache(cursorKey, event.id);
         continue;
       }
@@ -408,6 +445,15 @@ export class TwitterDirectMessageClient {
     }
 
     const conversationId = event.dm_conversation_id ?? senderId;
+    // Membership evidence (#24372): the policy-accepted sender's presence in
+    // this conversation is itself the observation; renew their evidence
+    // before the reply loop runs so an authorization read mid-turn sees it.
+    await this.renewSenderMembership(
+      event,
+      conversationId,
+      ownUserId,
+      username,
+    );
     // DMs and public interactions share the sender's canonical X world. Older
     // connector builds already attached DM rooms to this world, so reusing it
     // also repairs their raw platform-id ownership metadata on the next poll.
@@ -655,6 +701,260 @@ export class TwitterDirectMessageClient {
     return this.client.twitterClient.isAuthenticatedSessionCurrent(session);
   }
 
+  /**
+   * Publish membership evidence for one ParticipantsJoin/ParticipantsLeave
+   * event (#24372). Observed-only per-participant point queries: X's DM
+   * roster events name the participants the event is about, but never prove
+   * the absence of unlisted members, so `participant_ids` never becomes a
+   * completeness claim. The account's own removal degrades the scope (the
+   * account can no longer observe the conversation) instead of revoking its
+   * own membership row.
+   */
+  private async publishMembershipFromRosterEvent(
+    event: DirectMessageEvent & { id: string },
+    ownUserId: string,
+  ): Promise<void> {
+    try {
+      const conversationId = event.dm_conversation_id?.trim();
+      if (!conversationId) return;
+      const scope = await this.membership.scopeForConversation({
+        conversationId,
+        accountKey: this.client.accountId,
+        ownUserId,
+      });
+      if (!scope) return;
+      const isJoin = event.event_type === "ParticipantsJoin";
+      const participants = (event.participant_ids ?? []).filter(
+        (id) => typeof id === "string" && id.trim(),
+      );
+      // Without participant_ids there is no principal to publish; the event
+      // still advanced the poll cursor, so record the miss for diagnosis
+      // rather than guessing a sender.
+      if (participants.length === 0) {
+        logger.debug(
+          {
+            src: "plugin:x",
+            accountId: this.client.accountId,
+            conversationId,
+            eventType: event.event_type,
+            eventId: event.id,
+          },
+          "X DM roster event carried no participant_ids; no membership evidence published",
+        );
+        return;
+      }
+      const anchoredAt = event.created_at
+        ? Date.parse(event.created_at)
+        : undefined;
+      const worldId = createUniqueUuid(this.runtime, conversationId);
+      const roomId = createUniqueUuid(
+        this.runtime,
+        `x-dm:${this.client.accountId}:${conversationId}`,
+      );
+      const keyFor = (kind: "join" | "left" | "own-left", pid: string) =>
+        membershipObservationKey({
+          kind: kind === "own-left" ? "left" : kind,
+          conversationId,
+          participantId: pid,
+          eventId: event.id,
+        });
+      for (const participantId of participants) {
+        if (!isJoin && participantId === ownUserId) {
+          // The account itself was removed: revoke own membership (honesty —
+          // own active evidence was published, so its removal is published
+          // too) AND degrade the whole scope so authorization fails closed
+          // and backlogged redeliveries cannot resurrect an unobservable
+          // conversation.
+          const { principalId: ownPrincipal } = await xMembershipPrincipal(
+            this.runtime,
+            this.client.accountId,
+            ownUserId,
+          );
+          await this.membership.publishLeave({
+            scope,
+            principalId: ownPrincipal,
+            worldId,
+            roomId,
+            reason: "left",
+            idempotencyKey: keyFor("own-left", ownUserId),
+            eventAnchoredAt: anchoredAt,
+          });
+          await this.membership.degradeScope({
+            scope,
+            health: "unavailable",
+            reason: "own_account_removed_from_conversation",
+          });
+          continue;
+        }
+        const { principalId } = await xMembershipPrincipal(
+          this.runtime,
+          this.client.accountId,
+          participantId,
+        );
+        const key = keyFor(isJoin ? "join" : "left", participantId);
+        if (isJoin) {
+          await this.publishOwnMembership(conversationId, ownUserId);
+          await this.membership.publishJoin({
+            scope,
+            principalId,
+            worldId,
+            roomId,
+            roles: ["participant"],
+            // sender_id on a ParticipantsJoin is the INVITER (X data
+            // dictionary), not the joiner — context only, never proof.
+            permissionSnapshot: {
+              observed: true,
+              invitedBy: event.sender_id ?? null,
+            },
+            idempotencyKey: key,
+            eventAnchoredAt: anchoredAt,
+          });
+        } else {
+          await this.membership.publishLeave({
+            scope,
+            principalId,
+            worldId,
+            roomId,
+            reason: "left",
+            idempotencyKey: key,
+            eventAnchoredAt: anchoredAt,
+          });
+        }
+      }
+    } catch (error) {
+      // error-policy:J4 Membership evidence is a degrade-only side surface of
+      // the poll path; failures are logged, never propagated into the loop.
+      logger.debug(
+        {
+          src: "plugin:x",
+          accountId: this.client.accountId,
+          eventId: event.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X DM membership evidence publish failed",
+      );
+    }
+  }
+
+  /**
+   * Prove the account's own participation in a conversation once per process.
+   * The account's ability to read the conversation's DM events is itself the
+   * observation; a ParticipantsJoin carrying the account proves it too, but
+   * 1:1 conversations have no join events, so the first observed event
+   * publishes own membership directly.
+   */
+  private async publishOwnMembership(
+    conversationId: string,
+    ownUserId: string,
+  ): Promise<void> {
+    if (this.ownMembershipPublished.has(conversationId)) return;
+    try {
+      const scope = await this.membership.scopeForConversation({
+        conversationId,
+        accountKey: this.client.accountId,
+        ownUserId,
+      });
+      if (!scope) return;
+      const { principalId } = await xMembershipPrincipal(
+        this.runtime,
+        this.client.accountId,
+        ownUserId,
+      );
+      const worldId = createUniqueUuid(this.runtime, conversationId);
+      const roomId = createUniqueUuid(
+        this.runtime,
+        `x-dm:${this.client.accountId}:${conversationId}`,
+      );
+      await this.membership.publishJoin({
+        scope,
+        principalId,
+        worldId,
+        roomId,
+        roles: ["participant", "self"],
+        permissionSnapshot: { observed: true, self: true },
+        idempotencyKey: membershipObservationKey({
+          kind: "own",
+          conversationId,
+          participantId: ownUserId,
+        }),
+      });
+      this.ownMembershipPublished.add(conversationId);
+    } catch (error) {
+      // error-policy:J4 degrade-only side surface; never break the poll path.
+      logger.debug(
+        {
+          src: "plugin:x",
+          accountId: this.client.accountId,
+          conversationId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X DM own-membership publish failed",
+      );
+    }
+  }
+
+  /**
+   * Renew the sender's membership evidence after a policy-accepted inbound
+   * message: the sender's presence in the conversation is itself the
+   * observation (#24372). Event-anchored on the DM event id so cursor
+   * redelivery after a crash journals as an idempotent replay.
+   */
+  private async renewSenderMembership(
+    event: DirectMessageEvent & { id: string; sender_id: string },
+    conversationId: string,
+    ownUserId: string,
+    username: string | undefined,
+  ): Promise<void> {
+    try {
+      const scope = await this.membership.scopeForConversation({
+        conversationId,
+        accountKey: this.client.accountId,
+        ownUserId,
+      });
+      if (!scope) return;
+      const { principalId } = await xMembershipPrincipal(
+        this.runtime,
+        this.client.accountId,
+        event.sender_id,
+      );
+      const worldId = createUniqueUuid(this.runtime, conversationId);
+      const roomId = createUniqueUuid(
+        this.runtime,
+        `x-dm:${this.client.accountId}:${conversationId}`,
+      );
+      await this.publishOwnMembership(conversationId, ownUserId);
+      await this.membership.renewSender({
+        scope,
+        principalId,
+        worldId,
+        roomId,
+        roles: ["participant"],
+        permissionSnapshot: { observed: true, username: username ?? null },
+        idempotencyKey: membershipObservationKey({
+          kind: "renew",
+          conversationId,
+          participantId: event.sender_id,
+          eventId: event.id,
+        }),
+        eventAnchoredAt: event.created_at
+          ? Date.parse(event.created_at)
+          : undefined,
+      });
+    } catch (error) {
+      // error-policy:J4 degrade-only side surface; never break the reply path.
+      logger.debug(
+        {
+          src: "plugin:x",
+          accountId: this.client.accountId,
+          conversationId,
+          senderId: event.sender_id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X DM sender membership renewal failed",
+      );
+    }
+  }
+
   private sessionRotationError(phase: string): ElizaError {
     return new ElizaError(`X credentials rotated ${phase}`, {
       code: "X_AUTH_SESSION_ROTATED",
@@ -690,4 +990,28 @@ function isExplicitTwitterRejection(error: unknown): boolean {
     status >= 400 &&
     status < 500
   );
+}
+
+/**
+ * Deterministic idempotency key for one DM membership observation (#24372).
+ * Event-anchored keys (join/leave/renew carry the DM event id) make cursor
+ * redelivery after a crash journal as an idempotent replay; the "own" key is
+ * process-stable so the once-per-conversation own-membership publish is also
+ * replay-safe across restarts.
+ */
+function membershipObservationKey(options: {
+  kind: "join" | "left" | "renew" | "own";
+  conversationId: string;
+  participantId: string;
+  eventId?: string;
+}): string {
+  const parts = [
+    "x",
+    options.kind,
+    options.conversationId,
+    options.participantId,
+  ];
+  if (options.eventId) parts.push(options.eventId);
+  const key = parts.join(":");
+  return key.length > 1_000 ? key.slice(0, 1_000) : key;
 }

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -115,11 +115,20 @@ export class TwitterDirectMessageClient {
    */
   private readonly membership = new XMembershipPublisher(this.runtime);
   /**
-   * Conversation ids whose own-account membership has been published this
-   * process, so the account's own participation is proven once per
-   * conversation instead of on every event.
+   * Conversation ids whose own-account membership was published this
+   * process, with the publish time — own participation is re-proven after
+   * the evidence TTL lapses (the authority expires evidence at validUntil,
+   * so a lifetime marker would let own proof silently go stale) and after
+   * the scope is degraded (own-leave) so regained access re-proves.
    */
-  private readonly ownMembershipPublished = new Set<string>();
+  private readonly ownMembershipPublishedAt = new Map<string, number>();
+  /** Evidence validity window requested per own-membership proof (6h). */
+  private static readonly OWN_MEMBERSHIP_TTL_MS = 6 * 60 * 60 * 1_000;
+  /**
+   * True while all membership scopes are degraded after a 401/403 poll
+   * failure; the next successful poll clears it and restores the scopes.
+   */
+  private membershipDegradedForAuth = false;
 
   constructor(
     private readonly client: ClientBase,
@@ -225,13 +234,71 @@ export class TwitterDirectMessageClient {
     this.pollInFlight = true;
     try {
       await this.processNewMessages();
+      // Membership evidence (#24372): a successful authenticated poll means
+      // authorization recovered — restore any scopes degraded by a prior
+      // 401/403 so observed activity re-proves participants.
+      if (this.membershipDegradedForAuth) {
+        this.membershipDegradedForAuth = false;
+        await this.restoreMembershipScopes("x_auth_recovered");
+      }
     } catch (error) {
       this.runtime.reportError("XDirectMessages.poll", error, {
         accountId: this.client.accountId,
       });
+      // Membership evidence (#24372): persistent authorization failures
+      // (401/403) mean the account can no longer observe ANY conversation —
+      // degrade every known scope so authorization fails closed instead of
+      // trusting stale evidence. Transient failures (429, 5xx, network) do
+      // NOT write health: the evidence TTL (6h) is the fail-closed
+      // backstop and the next successful poll simply continues renewing.
+      if (isAuthorizationFailure(error)) {
+        this.membershipDegradedForAuth = true;
+        await this.degradeAllMembershipScopes(
+          `x_auth_failed_${errorCodeOf(error) ?? "401"}`,
+        );
+      }
     } finally {
       this.pollInFlight = false;
       this.scheduleNextPoll();
+    }
+  }
+
+  /**
+   * Degrade every membership scope this client has published under (#24372).
+   * Used when the account's authorization fails globally (401/403 on the DM
+   * events endpoint): no conversation remains observable, so all evidence
+   * must fail closed. Degrade-only and failure-contained per J4.
+   */
+  private async degradeAllMembershipScopes(reason: string): Promise<void> {
+    try {
+      await this.membership.degradeAllScopes(reason);
+    } catch (error) {
+      // error-policy:J4 degrade-only side surface; never break the poll path.
+      logger.debug(
+        {
+          src: "plugin:x",
+          accountId: this.client.accountId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X DM membership scope degrade-all failed",
+      );
+    }
+  }
+
+  /** Restore all scopes after authorization recovers; contained per J4. */
+  private async restoreMembershipScopes(reason: string): Promise<void> {
+    try {
+      await this.membership.restoreAllScopes(reason);
+    } catch (error) {
+      // error-policy:J4 degrade-only side surface; never break the poll path.
+      logger.debug(
+        {
+          src: "plugin:x",
+          accountId: this.client.accountId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X DM membership scope restore-all failed",
+      );
     }
   }
 
@@ -784,6 +851,9 @@ export class TwitterDirectMessageClient {
             health: "unavailable",
             reason: "own_account_removed_from_conversation",
           });
+          // Clear the own-membership marker so regained access (re-add) can
+          // re-prove the account in this process.
+          this.ownMembershipPublishedAt.delete(conversationId);
           continue;
         }
         const { principalId } = await xMembershipPrincipal(
@@ -847,7 +917,14 @@ export class TwitterDirectMessageClient {
     conversationId: string,
     ownUserId: string,
   ): Promise<void> {
-    if (this.ownMembershipPublished.has(conversationId)) return;
+    const publishedAt = this.ownMembershipPublishedAt.get(conversationId);
+    if (
+      publishedAt !== undefined &&
+      Date.now() - publishedAt <
+        TwitterDirectMessageClient.OWN_MEMBERSHIP_TTL_MS
+    ) {
+      return;
+    }
     try {
       const scope = await this.membership.scopeForConversation({
         conversationId,
@@ -878,7 +955,7 @@ export class TwitterDirectMessageClient {
           participantId: ownUserId,
         }),
       });
-      this.ownMembershipPublished.add(conversationId);
+      this.ownMembershipPublishedAt.set(conversationId, Date.now());
     } catch (error) {
       // error-policy:J4 degrade-only side surface; never break the poll path.
       logger.debug(
@@ -1014,4 +1091,31 @@ function membershipObservationKey(options: {
   if (options.eventId) parts.push(options.eventId);
   const key = parts.join(":");
   return key.length > 1_000 ? key.slice(0, 1_000) : key;
+}
+
+/** HTTP status embedded in a twitter-api-v2 error shape, when present. */
+function errorCodeOf(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as {
+    code?: unknown;
+    status?: unknown;
+    data?: { status?: unknown };
+    response?: { status?: unknown };
+  };
+  const status =
+    candidate.data?.status ??
+    candidate.response?.status ??
+    candidate.status ??
+    candidate.code;
+  return typeof status === "number" && Number.isInteger(status) ? status : null;
+}
+
+/**
+ * Authorization failures (401/403) on the DM events endpoint mean the
+ * account can no longer observe any conversation; 429 and 5xx are transient
+ * and must not degrade scope health (evidence TTL is the backstop).
+ */
+function isAuthorizationFailure(error: unknown): boolean {
+  const status = errorCodeOf(error);
+  return status === 401 || status === 403;
 }

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -239,6 +239,10 @@ export class TwitterDirectMessageClient {
       // 401/403 so observed activity re-proves participants.
       if (this.membershipDegradedForAuth) {
         this.membershipDegradedForAuth = false;
+        // Clear own-membership markers so restored scopes re-prove the
+        // account's own participation immediately instead of waiting out
+        // the marker window (R2 finding 2).
+        this.ownMembershipPublishedAt.clear();
         await this.restoreMembershipScopes("x_auth_recovered");
       }
     } catch (error) {
@@ -953,6 +957,12 @@ export class TwitterDirectMessageClient {
           kind: "own",
           conversationId,
           participantId: ownUserId,
+          // Anchor the renewal epoch so a TTL-expired re-proof gets a FRESH
+          // journal key: reusing the first epoch's key would collide with
+          // the original entry (different timestamps) and surface as a
+          // non-benign idempotency conflict instead of a clean renewal
+          // (R2 finding 2).
+          eventId: `epoch-${Math.floor(Date.now() / TwitterDirectMessageClient.OWN_MEMBERSHIP_TTL_MS)}`,
         }),
       });
       this.ownMembershipPublishedAt.set(conversationId, Date.now());

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -14,6 +14,8 @@
  * `pairing` via the core PairingService handshake) before any world state or
  * memory is created for the sender.
  */
+
+import type { MembershipScope } from "@elizaos/core";
 import {
   ChannelType,
   type Content,
@@ -233,18 +235,22 @@ export class TwitterDirectMessageClient {
     if (!this.isRunning || this.pollInFlight) return;
     this.pollInFlight = true;
     try {
-      await this.processNewMessages();
       // Membership evidence (#24372): a successful authenticated poll means
-      // authorization recovered — restore any scopes degraded by a prior
-      // 401/403 so observed activity re-proves participants.
-      if (this.membershipDegradedForAuth) {
+      // authorization recovered — restore degraded scopes BEFORE processing
+      // new events, so recovery-poll observations publish against a restored
+      // (re-registered) evidence chain instead of being rejected while
+      // unavailable or erased by a post-hoc reset. The flag is only cleared
+      // after restoration succeeds, so a contained restore failure is
+      // retried on the next poll (R3 finding 3).
+      if (this.membershipDegradedForAuth && this.hasBoundMembershipScopes()) {
+        await this.restoreMembershipScopes("x_auth_recovered");
         this.membershipDegradedForAuth = false;
         // Clear own-membership markers so restored scopes re-prove the
         // account's own participation immediately instead of waiting out
-        // the marker window (R2 finding 2).
+        // the marker window.
         this.ownMembershipPublishedAt.clear();
-        await this.restoreMembershipScopes("x_auth_recovered");
       }
+      await this.processNewMessages();
     } catch (error) {
       this.runtime.reportError("XDirectMessages.poll", error, {
         accountId: this.client.accountId,
@@ -273,6 +279,10 @@ export class TwitterDirectMessageClient {
    * events endpoint): no conversation remains observable, so all evidence
    * must fail closed. Degrade-only and failure-contained per J4.
    */
+  private hasBoundMembershipScopes(): boolean {
+    return this.membership.hasBoundScopes();
+  }
+
   private async degradeAllMembershipScopes(reason: string): Promise<void> {
     try {
       await this.membership.degradeAllScopes(reason);
@@ -302,6 +312,30 @@ export class TwitterDirectMessageClient {
           error: error instanceof Error ? error.message : String(error),
         },
         "X DM membership scope restore-all failed",
+      );
+    }
+  }
+
+  /**
+   * Restore one conversation scope after the account itself rejoins it.
+   * Contained per J4: a failed restore leaves the scope degraded (fail
+   * closed), never breaks the roster-event loop.
+   */
+  private async restoreOneMembershipScope(
+    scope: MembershipScope,
+    reason: string,
+  ): Promise<void> {
+    try {
+      await this.membership.restoreScope({ scope, reason });
+    } catch (error) {
+      // error-policy:J4 degrade-only side surface; never break the poll path.
+      logger.debug(
+        {
+          src: "plugin:x",
+          accountId: this.client.accountId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X DM membership scope restore failed",
       );
     }
   }
@@ -867,6 +901,17 @@ export class TwitterDirectMessageClient {
         );
         const key = keyFor(isJoin ? "join" : "left", participantId);
         if (isJoin) {
+          // An own-account ParticipantsJoin after an own-leave means the
+          // account rejoined the conversation: restore the degraded scope
+          // BEFORE publishing, or the rejoin evidence lands against a
+          // durably `unavailable` scope and authorization stays failed
+          // closed forever (R3 finding 2). Contained per J4.
+          if (participantId === ownUserId) {
+            await this.restoreOneMembershipScope(
+              scope,
+              "own_account_rejoined_conversation",
+            );
+          }
           await this.publishOwnMembership(conversationId, ownUserId);
           await this.membership.publishJoin({
             scope,
@@ -964,6 +1009,17 @@ export class TwitterDirectMessageClient {
           // (R2 finding 2).
           eventId: `epoch-${Math.floor(Date.now() / TwitterDirectMessageClient.OWN_MEMBERSHIP_TTL_MS)}`,
         }),
+        // A restart or forced restoration within the same epoch replays
+        // under the same key with regenerated observedAt/validUntil: the
+        // authority reports an idempotency conflict, and eventAnchoredAt
+        // makes that replay BENIGN (the delta already applied). Any
+        // same-epoch replay necessarily happens while the original proof
+        // is still valid (published-at + 6h always outlives the epoch
+        // boundary), so adopting the durable state is correct (R3 finding 1).
+        eventAnchoredAt:
+          Math.floor(
+            Date.now() / TwitterDirectMessageClient.OWN_MEMBERSHIP_TTL_MS,
+          ) * TwitterDirectMessageClient.OWN_MEMBERSHIP_TTL_MS,
       });
       this.ownMembershipPublishedAt.set(conversationId, Date.now());
     } catch (error) {

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -241,14 +241,25 @@ export class TwitterDirectMessageClient {
       // (re-registered) evidence chain instead of being rejected while
       // unavailable or erased by a post-hoc reset. The flag is only cleared
       // after restoration succeeds, so a contained restore failure is
-      // retried on the next poll (R3 finding 3).
-      if (this.membershipDegradedForAuth && this.hasBoundMembershipScopes()) {
-        await this.restoreMembershipScopes("x_auth_recovered");
+      // retried on the next poll (R3 finding 3, R4 finding 1). With no
+      // bound scopes there is nothing to restore: clear the flag so a later
+      // poll cannot force-restore and reset freshly published evidence
+      // (R4 finding 3 edge).
+      if (this.membershipDegradedForAuth) {
+        if (this.hasBoundMembershipScopes()) {
+          const restored =
+            await this.restoreMembershipScopes("x_auth_recovered");
+          if (!restored) {
+            // Restoration was attempted and failed: keep the degraded
+            // marker so the next poll retries (contained per J4).
+            return;
+          }
+          // Clear own-membership markers so restored scopes re-prove the
+          // account's own participation immediately instead of waiting out
+          // the marker window.
+          this.ownMembershipPublishedAt.clear();
+        }
         this.membershipDegradedForAuth = false;
-        // Clear own-membership markers so restored scopes re-prove the
-        // account's own participation immediately instead of waiting out
-        // the marker window.
-        this.ownMembershipPublishedAt.clear();
       }
       await this.processNewMessages();
     } catch (error) {
@@ -299,44 +310,54 @@ export class TwitterDirectMessageClient {
     }
   }
 
-  /** Restore all scopes after authorization recovers; contained per J4. */
-  private async restoreMembershipScopes(reason: string): Promise<void> {
+  /** Restore all scopes after authorization recovers. Returns false when the
+   * restoration was attempted but failed, so the caller keeps the degraded
+   * marker and retries on the next poll (R4 finding 1: a suppressed restore
+   * failure must not read as recovery). Contained per J4. */
+  private async restoreMembershipScopes(reason: string): Promise<boolean> {
     try {
       await this.membership.restoreAllScopes(reason);
+      return true;
     } catch (error) {
       // error-policy:J4 degrade-only side surface; never break the poll path.
-      logger.debug(
+      logger.warn(
         {
           src: "plugin:x",
           accountId: this.client.accountId,
           error: error instanceof Error ? error.message : String(error),
         },
-        "X DM membership scope restore-all failed",
+        "X DM membership scope restore-all failed; will retry on next poll",
       );
+      return false;
     }
   }
 
   /**
    * Restore one conversation scope after the account itself rejoins it.
-   * Contained per J4: a failed restore leaves the scope degraded (fail
-   * closed), never breaks the roster-event loop.
+   * Returns false when the restoration was attempted but failed, so the
+   * roster-event caller withholds the cursor advance for this event and the
+   * restore is retried on the next poll (R4 finding 2: publishing past a
+   * failed restore would strand the scope durably unavailable). Contained
+   * per J4: never breaks the roster-event loop.
    */
   private async restoreOneMembershipScope(
     scope: MembershipScope,
     reason: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.membership.restoreScope({ scope, reason });
+      return true;
     } catch (error) {
       // error-policy:J4 degrade-only side surface; never break the poll path.
-      logger.debug(
+      logger.warn(
         {
           src: "plugin:x",
           accountId: this.client.accountId,
           error: error instanceof Error ? error.message : String(error),
         },
-        "X DM membership scope restore failed",
+        "X DM membership scope restore failed; withholding cursor advance for retry",
       );
+      return false;
     }
   }
 
@@ -435,11 +456,18 @@ export class TwitterDirectMessageClient {
         // Membership evidence (#24372): observed-only join/leave proofs.
         // Event-anchored idempotency keys absorb redelivery; a publish
         // failure must not hold the poll cursor (degrade-only evidence), so
-        // the cursor advances regardless.
-        await this.publishMembershipFromRosterEvent(
+        // the cursor advances regardless — EXCEPT when an own-account
+        // rejoin's scope restoration failed: publishing or advancing past
+        // it would strand the scope durably unavailable with no retry, so
+        // the cursor is withheld and the event retried next poll (R4
+        // finding 2).
+        const retryable = await this.publishMembershipFromRosterEvent(
           event as DirectMessageEvent & { id: string },
           ownUserId,
         );
+        if (retryable === "retry") {
+          break;
+        }
         await this.runtime.setCache(cursorKey, event.id);
         continue;
       }
@@ -813,21 +841,23 @@ export class TwitterDirectMessageClient {
    * the absence of unlisted members, so `participant_ids` never becomes a
    * completeness claim. The account's own removal degrades the scope (the
    * account can no longer observe the conversation) instead of revoking its
-   * own membership row.
+   * own membership row. Returns "retry" when an own-rejoin scope restoration
+   * failed and the event must be reprocessed on the next poll (R4 finding
+   * 2); all other failures stay contained and the cursor may advance.
    */
   private async publishMembershipFromRosterEvent(
     event: DirectMessageEvent & { id: string },
     ownUserId: string,
-  ): Promise<void> {
+  ): Promise<"ok" | "retry"> {
     try {
       const conversationId = event.dm_conversation_id?.trim();
-      if (!conversationId) return;
+      if (!conversationId) return "ok";
       const scope = await this.membership.scopeForConversation({
         conversationId,
         accountKey: this.client.accountId,
         ownUserId,
       });
-      if (!scope) return;
+      if (!scope) return "ok";
       const isJoin = event.event_type === "ParticipantsJoin";
       const participants = (event.participant_ids ?? []).filter(
         (id) => typeof id === "string" && id.trim(),
@@ -846,7 +876,7 @@ export class TwitterDirectMessageClient {
           },
           "X DM roster event carried no participant_ids; no membership evidence published",
         );
-        return;
+        return "ok";
       }
       const anchoredAt = event.created_at
         ? Date.parse(event.created_at)
@@ -907,10 +937,16 @@ export class TwitterDirectMessageClient {
           // durably `unavailable` scope and authorization stays failed
           // closed forever (R3 finding 2). Contained per J4.
           if (participantId === ownUserId) {
-            await this.restoreOneMembershipScope(
+            const restored = await this.restoreOneMembershipScope(
               scope,
               "own_account_rejoined_conversation",
             );
+            if (!restored) {
+              // Withhold the cursor and reprocess this event next poll:
+              // publishing past a failed restore would strand the scope
+              // durably unavailable (R4 finding 2).
+              return "retry";
+            }
           }
           await this.publishOwnMembership(conversationId, ownUserId);
           await this.membership.publishJoin({
@@ -940,6 +976,7 @@ export class TwitterDirectMessageClient {
           });
         }
       }
+      return "ok";
     } catch (error) {
       // error-policy:J4 Membership evidence is a degrade-only side surface of
       // the poll path; failures are logged, never propagated into the loop.
@@ -952,6 +989,7 @@ export class TwitterDirectMessageClient {
         },
         "X DM membership evidence publish failed",
       );
+      return "ok";
     }
   }
 

--- a/plugins/plugin-x/src/dm-membership.test.ts
+++ b/plugins/plugin-x/src/dm-membership.test.ts
@@ -268,4 +268,107 @@ describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
     await dm.stop();
     expect(degraded.restoreAllScopes).toHaveBeenCalledWith("x_auth_recovered");
   });
+
+  it("retries auth recovery when restore-all fails: flag stays set and restore is re-attempted (R4 finding 1)", async () => {
+    const runtime = fakeRuntime();
+    const before = membershipInstances.length;
+    const { dm, setSession } = buildClient(runtime);
+    const pub = membershipInstances[before];
+    // Enter the degraded state via a 401 poll.
+    setSession({
+      profile: { userId: "990000000000000001" },
+      client: {
+        v2: {
+          listDmEvents: vi.fn().mockRejectedValue({ data: { status: 401 } }),
+        },
+      },
+    } as unknown as AuthenticatedTwitterSession);
+    await dm.start();
+    await dm.stop();
+    expect(pub.degradeAllScopes).toHaveBeenCalledTimes(1);
+    // Restore-all fails on the recovery poll: the failure must NOT be
+    // treated as successful recovery.
+    pub.restoreAllScopes.mockRejectedValueOnce(new Error("restore down"));
+    setSession(fakeSession([]));
+    await dm.start();
+    await dm.stop();
+    expect(pub.restoreAllScopes).toHaveBeenCalledTimes(1);
+    // Next successful poll retries the restore (flag was retained).
+    setSession(fakeSession([]));
+    await dm.start();
+    await dm.stop();
+    expect(pub.restoreAllScopes).toHaveBeenCalledTimes(2);
+    expect(pub.restoreAllScopes).toHaveBeenLastCalledWith("x_auth_recovered");
+  });
+
+  it("clears the degraded flag without restoring when no scopes are bound (R4 hasBoundScopes edge)", async () => {
+    const runtime = fakeRuntime();
+    const before = membershipInstances.length;
+    const { dm, setSession } = buildClient(runtime);
+    const pub = membershipInstances[before];
+    setSession({
+      profile: { userId: "990000000000000001" },
+      client: {
+        v2: {
+          listDmEvents: vi.fn().mockRejectedValue({ data: { status: 401 } }),
+        },
+      },
+    } as unknown as AuthenticatedTwitterSession);
+    await dm.start();
+    await dm.stop();
+    // No bound scopes: recovery clears the flag without any restore call,
+    // so later polls never force-restore and reset fresh evidence.
+    pub.hasBoundScopes.mockReturnValue(false);
+    setSession(fakeSession([]));
+    await dm.start();
+    await dm.stop();
+    expect(pub.restoreAllScopes).not.toHaveBeenCalled();
+    // And a later poll does not resurrect a stale restore either.
+    pub.hasBoundScopes.mockReturnValue(true);
+    setSession(fakeSession([]));
+    await dm.start();
+    await dm.stop();
+    expect(pub.restoreAllScopes).not.toHaveBeenCalled();
+  });
+
+  it("withholds the cursor when own-rejoin scope restore fails, then succeeds on retry (R4 finding 2)", async () => {
+    const runtime = fakeRuntime();
+    const before = membershipInstances.length;
+    const { dm, setSession } = buildClient(runtime);
+    const pub = membershipInstances[before];
+    await runtime.setCache(
+      "twitter/default/990000000000000001/dm_cursor",
+      "400",
+    );
+    // Own account rejoins; the scope restore fails on the first attempt.
+    const rejoinEvent = {
+      id: "401",
+      event_type: "ParticipantsJoin",
+      dm_conversation_id: "1999888777660004",
+      participant_ids: ["990000000000000001"], // own user
+      sender_id: "990000000000000003",
+      created_at: "2026-08-26T00:00:00.000Z",
+    };
+    pub.restoreScope.mockRejectedValueOnce(new Error("restore down"));
+    setSession(fakeSession([rejoinEvent]));
+    await dm.start();
+    await dm.stop();
+    // The restore was attempted and failed: no join evidence may publish
+    // and the cursor must stay before the event so it is retried.
+    expect(pub.restoreScope).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "own_account_rejoined_conversation" }),
+    );
+    expect(pub.publishJoin).not.toHaveBeenCalled();
+    expect(
+      await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
+    ).toBe("400");
+    // Retry: restore succeeds, evidence publishes, cursor advances.
+    setSession(fakeSession([rejoinEvent]));
+    await dm.start();
+    await dm.stop();
+    expect(pub.publishJoin).toHaveBeenCalled();
+    expect(
+      await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
+    ).toBe("401");
+  });
 });

--- a/plugins/plugin-x/src/dm-membership.test.ts
+++ b/plugins/plugin-x/src/dm-membership.test.ts
@@ -38,6 +38,10 @@ vi.mock("./membership", () => {
       degradeScope = vi.fn().mockResolvedValue(undefined);
       degradeAllScopes = vi.fn().mockResolvedValue(undefined);
       restoreAllScopes = vi.fn().mockResolvedValue(undefined);
+      restoreScope = vi.fn().mockResolvedValue(undefined);
+      // The DM client only restores once this publisher has actually bound
+      // at least one scope (process-local knowledge of degraded scopes).
+      hasBoundScopes = vi.fn().mockReturnValue(true);
       constructor() {
         membershipInstances.push(
           this as unknown as Record<string, ReturnType<typeof vi.fn>>,

--- a/plugins/plugin-x/src/dm-membership.test.ts
+++ b/plugins/plugin-x/src/dm-membership.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit coverage for the X DM client's membership wiring (#24372): roster
+ * event routing, own-membership handling, contained publish failures (the
+ * account-global dm_cursor must advance regardless), and the auth
+ * 401/403 degrade + successful-poll restore cycle. The membership
+ * publisher is stubbed at the class boundary (it has its own real-PGlite
+ * vertical in __tests__/membership-publisher.real.test.ts); the harness is
+ * deterministic with fake sessions.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientBase } from "./base";
+import type { AuthenticatedTwitterSession } from "./client/auth";
+import { TwitterDirectMessageClient } from "./direct-messages";
+
+const membershipInstances: Array<Record<string, ReturnType<typeof vi.fn>>> = [];
+
+vi.mock("./membership", () => {
+  return {
+    XMembershipPublisher: class {
+      scopeForConversation = vi.fn().mockResolvedValue(null);
+      publishJoin = vi.fn().mockResolvedValue(undefined);
+      publishLeave = vi.fn().mockRejectedValue(new Error("publish down"));
+      renewSender = vi.fn().mockResolvedValue(undefined);
+      degradeScope = vi.fn().mockResolvedValue(undefined);
+      degradeAllScopes = vi.fn().mockResolvedValue(undefined);
+      restoreAllScopes = vi.fn().mockResolvedValue(undefined);
+      constructor() {
+        membershipInstances.push(
+          this as unknown as Record<string, ReturnType<typeof vi.fn>>,
+        );
+      }
+    },
+    xMembershipPrincipal: vi.fn().mockResolvedValue({
+      principalId: "00000000-0000-4000-8000-000000000001",
+    }),
+  };
+});
+
+const settledWrites: Array<[string, string]> = [];
+
+function fakeRuntime(): IAgentRuntime {
+  const cache = new Map<string, string>();
+  return {
+    agentId: "00000000-0000-4000-8000-0000000000aa",
+    getCache: vi.fn(async (k: string) => cache.get(k) ?? null),
+    setCache: vi.fn(async (k: string, v: string) => {
+      cache.set(k, v);
+      settledWrites.push([k, v]);
+    }),
+    deleteCache: vi.fn(async (k: string) => cache.delete(k)),
+    reportError: vi.fn(),
+    getRoom: vi.fn().mockResolvedValue(null),
+    ensureRoomExists: vi.fn().mockResolvedValue(undefined),
+    ensureWorldExists: vi.fn().mockResolvedValue(undefined),
+    ensureConnection: vi.fn().mockResolvedValue(undefined),
+    getEntityById: vi.fn().mockResolvedValue(null),
+    createEntities: vi.fn().mockResolvedValue(undefined),
+    updateEntity: vi.fn().mockResolvedValue(undefined),
+    getServicesByType: vi.fn().mockReturnValue([]),
+    getSetting: vi.fn().mockReturnValue(undefined),
+  } as unknown as IAgentRuntime;
+}
+
+function fakeSession(events: unknown[], includes?: unknown) {
+  return {
+    profile: { userId: "990000000000000001" },
+    client: {
+      v2: {
+        listDmEvents: vi.fn().mockResolvedValue({
+          events,
+          includes,
+          done: true,
+        }),
+        sendDmToParticipant: vi
+          .fn()
+          .mockResolvedValue({ data: { dm_event_id: "1" } }),
+      },
+    },
+  } as unknown as AuthenticatedTwitterSession;
+}
+
+function buildClient(runtime: IAgentRuntime) {
+  const clientBase = {
+    accountId: "default",
+    twitterClient: {
+      withAuthenticatedSession: vi.fn(
+        async (fn: (s: AuthenticatedTwitterSession) => Promise<void>) =>
+          fn(currentSession),
+      ),
+      isAuthenticatedSessionCurrent: vi.fn().mockReturnValue(true),
+    },
+  } as unknown as ClientBase;
+  let currentSession: AuthenticatedTwitterSession;
+  const dm = new TwitterDirectMessageClient(
+    clientBase,
+    runtime,
+    {} as Parameters<
+      typeof TwitterDirectMessageClient.prototype.start
+    >[0] extends never
+      ? never
+      : Record<string, never>,
+  );
+  return {
+    dm,
+    setSession: (s: AuthenticatedTwitterSession) => {
+      currentSession = s;
+    },
+    clientBase,
+  };
+}
+
+describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
+  beforeEach(() => {
+    settledWrites.length = 0;
+  });
+
+  it("routes a ParticipantsJoin event through the membership path and advances the cursor", async () => {
+    const runtime = fakeRuntime();
+    const { dm, setSession } = buildClient(runtime);
+    await runtime.setCache(
+      "twitter/default/990000000000000001/dm_cursor",
+      "100",
+    );
+    setSession(
+      fakeSession([
+        {
+          id: "101",
+          event_type: "ParticipantsJoin",
+          dm_conversation_id: "1999888777660001",
+          participant_ids: ["990000000000000002"],
+          sender_id: "990000000000000003",
+          created_at: "2026-08-26T00:00:00.000Z",
+        },
+      ]),
+    );
+    // poll() is private; drive the full path through start()'s first poll.
+    await dm.start();
+    await dm.stop();
+    // The roster event was processed (scope resolution returned null in the
+    // stub → no publish) and the cursor still advanced past it.
+    expect(
+      await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
+    ).toBe("101");
+  });
+
+  it("advances the cursor even when a publish would fail (degrade-only containment)", async () => {
+    const runtime = fakeRuntime();
+    const { dm, setSession } = buildClient(runtime);
+    await runtime.setCache(
+      "twitter/default/990000000000000001/dm_cursor",
+      "200",
+    );
+    setSession(
+      fakeSession([
+        {
+          id: "201",
+          event_type: "ParticipantsLeave",
+          dm_conversation_id: "1999888777660002",
+          participant_ids: ["990000000000000004"],
+          created_at: "2026-08-26T00:00:00.000Z",
+        },
+      ]),
+    );
+    await dm.start();
+    await dm.stop();
+    expect(
+      await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
+    ).toBe("201");
+  });
+
+  it("publishes own membership for a self-sent message and advances the cursor", async () => {
+    const runtime = fakeRuntime();
+    const { dm, setSession } = buildClient(runtime);
+    await runtime.setCache(
+      "twitter/default/990000000000000001/dm_cursor",
+      "300",
+    );
+    setSession(
+      fakeSession([
+        {
+          id: "301",
+          event_type: "MessageCreate",
+          dm_conversation_id: "1999888777660003",
+          sender_id: "990000000000000001", // own user
+          text: "self note",
+        },
+      ]),
+    );
+    await dm.start();
+    await dm.stop();
+    expect(
+      await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
+    ).toBe("301");
+  });
+
+  it("degrades all membership scopes on a 401 poll failure and restores on recovery", async () => {
+    const runtime = fakeRuntime();
+    const before = membershipInstances.length;
+    const { dm, setSession } = buildClient(runtime);
+    const degraded = membershipInstances[before];
+    // First poll throws a 401-shaped error.
+    const failing = {
+      profile: { userId: "990000000000000001" },
+      client: {
+        v2: {
+          listDmEvents: vi.fn().mockRejectedValue({ data: { status: 401 } }),
+        },
+      },
+    } as unknown as AuthenticatedTwitterSession;
+    setSession(failing);
+    await dm.start();
+    await dm.stop();
+    expect(degraded).toBeDefined();
+    expect(degraded.degradeAllScopes).toHaveBeenCalledWith("x_auth_failed_401");
+    // A transient 429 must NOT degrade scope health.
+    setSession({
+      profile: { userId: "990000000000000001" },
+      client: {
+        v2: {
+          listDmEvents: vi.fn().mockRejectedValue({ data: { status: 429 } }),
+        },
+      },
+    } as unknown as AuthenticatedTwitterSession);
+    await dm.start();
+    await dm.stop();
+    expect(degraded.degradeAllScopes).toHaveBeenCalledTimes(1);
+    // A subsequent successful poll restores the degraded scopes.
+    setSession(fakeSession([]));
+    await dm.start();
+    await dm.stop();
+    expect(degraded.restoreAllScopes).toHaveBeenCalledWith("x_auth_recovered");
+  });
+});

--- a/plugins/plugin-x/src/dm-membership.test.ts
+++ b/plugins/plugin-x/src/dm-membership.test.ts
@@ -17,9 +17,21 @@ import { TwitterDirectMessageClient } from "./direct-messages";
 const membershipInstances: Array<Record<string, ReturnType<typeof vi.fn>>> = [];
 
 vi.mock("./membership", () => {
+  // Scope returned to the DM client: a plausible MembershipScope so the
+  // publish paths in direct-messages.ts actually execute (R2 finding 3 —
+  // a null scope made the roster tests vacuous).
+  const scopeFor = (conversationId: string) => ({
+    agentId: "00000000-0000-4000-8000-0000000000aa",
+    connectorId: "x",
+    connectorAccountId: "11111111-2222-4333-8444-555555555555",
+    externalWorldId: conversationId,
+    externalRoomId: conversationId,
+  });
   return {
     XMembershipPublisher: class {
-      scopeForConversation = vi.fn().mockResolvedValue(null);
+      scopeForConversation = vi.fn(async (opts: { conversationId: string }) =>
+        scopeFor(opts.conversationId),
+      );
       publishJoin = vi.fn().mockResolvedValue(undefined);
       publishLeave = vi.fn().mockRejectedValue(new Error("publish down"));
       renewSender = vi.fn().mockResolvedValue(undefined);
@@ -119,6 +131,7 @@ describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
   it("routes a ParticipantsJoin event through the membership path and advances the cursor", async () => {
     const runtime = fakeRuntime();
     const { dm, setSession } = buildClient(runtime);
+    const pub = membershipInstances[membershipInstances.length - 1];
     await runtime.setCache(
       "twitter/default/990000000000000001/dm_cursor",
       "100",
@@ -138,16 +151,27 @@ describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
     // poll() is private; drive the full path through start()'s first poll.
     await dm.start();
     await dm.stop();
-    // The roster event was processed (scope resolution returned null in the
-    // stub → no publish) and the cursor still advanced past it.
+    // The roster event was routed to the membership publisher: one join for
+    // the listed participant plus the conversation's first own-membership
+    // proof (the account observed the event, proving its own participation).
+    expect(pub.scopeForConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "1999888777660001" }),
+    );
+    expect(pub.publishJoin).toHaveBeenCalledTimes(2);
+    const rosterCall = pub.publishJoin.mock.calls.find(
+      (call: Array<{ permissionSnapshot: Record<string, unknown> }>) =>
+        !call[0].permissionSnapshot?.self,
+    );
+    expect(rosterCall).toBeDefined();
     expect(
       await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
     ).toBe("101");
   });
 
-  it("advances the cursor even when a publish would fail (degrade-only containment)", async () => {
+  it("advances the cursor even when a publish fails (degrade-only containment)", async () => {
     const runtime = fakeRuntime();
     const { dm, setSession } = buildClient(runtime);
+    const pub = membershipInstances[membershipInstances.length - 1];
     await runtime.setCache(
       "twitter/default/990000000000000001/dm_cursor",
       "200",
@@ -165,6 +189,9 @@ describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
     );
     await dm.start();
     await dm.stop();
+    // The publish was ATTEMPTED and rejected (mock), yet the cursor still
+    // advanced past the event: membership failures never stall the DM loop.
+    expect(pub.publishLeave).toHaveBeenCalledTimes(1);
     expect(
       await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
     ).toBe("201");
@@ -173,6 +200,7 @@ describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
   it("publishes own membership for a self-sent message and advances the cursor", async () => {
     const runtime = fakeRuntime();
     const { dm, setSession } = buildClient(runtime);
+    const pub = membershipInstances[membershipInstances.length - 1];
     await runtime.setCache(
       "twitter/default/990000000000000001/dm_cursor",
       "300",
@@ -190,6 +218,10 @@ describe("TwitterDirectMessageClient membership wiring (#24372)", () => {
     );
     await dm.start();
     await dm.stop();
+    // Own participation was published once for the conversation.
+    expect(pub.publishJoin).toHaveBeenCalledTimes(1);
+    const ownCall = pub.publishJoin.mock.calls[0][0];
+    expect(ownCall.permissionSnapshot).toEqual({ observed: true, self: true });
     expect(
       await runtime.getCache("twitter/default/990000000000000001/dm_cursor"),
     ).toBe("301");

--- a/plugins/plugin-x/src/membership.ts
+++ b/plugins/plugin-x/src/membership.ts
@@ -1,0 +1,890 @@
+/**
+ * Per-conversation X (Twitter) DM membership evidence publisher: the X DM
+ * events API exposes no full-roster enumeration for arbitrary conversations,
+ * so this connector publishes observed-only point-query proofs (sender
+ * renewals, ParticipantsJoin deltas, ParticipantsLeave deltas) into the
+ * canonical `MembershipService` authority instead of fabricating roster
+ * snapshots. `participant_ids` is treated as roster-authoritative only on
+ * ParticipantsJoin events where X semantics name the complete participant
+ * set (and even then as an ordered_delta of the observed roster, never as a
+ * completeness-claimed snapshot); everything else stays observed-only.
+ * Evidence is renewed on activity with a bounded freshness window; every
+ * command is journal-idempotent on the authority side via event-anchored
+ * idempotency keys, so cursor redelivery after a restart cannot double-apply
+ * a delta. In-memory state only tracks fencing cursors and renewal
+ * timestamps and is reconstructable after a restart by adopting the durable
+ * scope state. Public-timeline authors are never roster authority: only DM
+ * timeline events feed this publisher.
+ */
+import {
+  type ConnectorAccount,
+  type ConnectorAccountManager,
+  createUniqueUuid,
+  ElizaError,
+  getConnectorAccountManager,
+  type IAgentRuntime,
+  type JsonObject,
+  logger,
+  type MembershipMutationReceipt,
+  type MembershipScope,
+  type MembershipScopeHealth,
+  MembershipService,
+  type UUID,
+} from "@elizaos/core";
+import { v5 as uuidv5 } from "uuid";
+
+/** Connector id this publisher registers under (matches XService). */
+export const X_MEMBERSHIP_CONNECTOR_ID = "x";
+
+/**
+ * Renewal window for point-query evidence: an active participant observed
+ * inside this window is not re-proven, while anything older is renewed by
+ * the next inbound activity. Well under the authority's 24h MAX_VALIDITY_MS.
+ */
+const MEMBERSHIP_RENEWAL_MS = 60 * 60 * 1_000;
+/** Evidence validity requested per proof; capped by the authority at 24h. */
+const MEMBERSHIP_VALIDITY_MS = 6 * 60 * 60 * 1_000;
+const MEMBERSHIP_IDEMPOTENCY_KEY_MAX = 1_000;
+
+/**
+ * RFC-4122 v5 namespace for X membership principal ids. The membership
+ * authority validates the `[1-8]` version nibble on every principal id,
+ * which the connector's default v0-derived entity ids (`stringToUuid`) never
+ * set — so membership principals use their own deterministic v5 id space,
+ * minted from (account key, X user id), and a matching entity row is ensured
+ * before the first publish for that principal.
+ */
+const X_MEMBERSHIP_NAMESPACE = "c3b1a0f9-3333-4c4d-9d5e-7f6a5b4c3d02";
+
+interface ScopePublisherState {
+  /** Scope generation as of the last successful command (fencing token). */
+  generation: number;
+  /** Publisher generation this process registered under. */
+  publisherGeneration: number;
+  /** Durable evidence cursor of the last successful command. */
+  sourceCursor: string | null;
+  /** Durable evidence version of the last successful command (-1 = none). */
+  currentVersion: number;
+  /** Per-principal last-renewed timestamps (epoch ms) for renewal gating. */
+  renewedAt: Map<UUID, number>;
+  /** Serializes commands per scope: the evidence chain is strictly ordered. */
+  queue: Promise<unknown>;
+  /** True once a publish failure has been warned for this scope. */
+  warned: boolean;
+}
+
+export class XMembershipPublisher {
+  private readonly runtime: IAgentRuntime;
+  private readonly scopes = new Map<string, ScopePublisherState>();
+  /**
+   * Publisher instance id is STABLE per (agent, durable account), derived
+   * like the telegram template's formula — a restarted process re-binds to
+   * the persisted publisher binding (adoption) instead of bumping the
+   * publisher generation and stranding every committed member fact. A
+   * per-process random suffix distinguishes genuinely concurrent processes
+   * fencing each other.
+   */
+  private readonly publisherInstanceSalt = crypto.randomUUID();
+  private readonly publisherInstanceIds = new Map<string, string>();
+  /**
+   * Runtime world/room mapping rows ensured for the authority's
+   * MEMBERSHIP_RUNTIME_MAPPING_INVALID guard, keyed by the requested
+   * (worldId, roomId). Both are createUniqueUuid-derived so the mapping is
+   * stable across processes and the ensure is idempotent by id.
+   */
+  private readonly ensuredMappings = new Set<string>();
+  /**
+   * Durable connector-account rows per configured account key. Keyed by
+   * account (not singleton): each configured X account must resolve its own
+   * row, and a failure for one account must not disable the others.
+   */
+  private readonly durableAccounts = new Map<string, ConnectorAccount | null>();
+  private readonly durableAccountPromises = new Map<
+    string,
+    Promise<ConnectorAccount | null>
+  >();
+  /** Terminal setup failures per account key (publishing disabled). */
+  private readonly unavailableReasons = new Map<string, string>();
+
+  constructor(runtime: IAgentRuntime) {
+    this.runtime = runtime;
+  }
+
+  /**
+   * Stable publisher instance id for one durable account: a restart
+   * re-derives the same id and adopts the persisted publisher binding
+   * instead of bumping the generation and stranding committed evidence.
+   */
+  private publisherInstanceIdFor(scope: MembershipScope): string {
+    const key = scope.connectorAccountId as string;
+    let id = this.publisherInstanceIds.get(key);
+    if (!id) {
+      id = `x:${this.runtime.agentId}:${scope.connectorAccountId}:${this.publisherInstanceSalt}`;
+      this.publisherInstanceIds.set(key, id);
+    }
+    return id;
+  }
+
+  private scopeKey(scope: MembershipScope): string {
+    return `${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+  }
+
+  private membershipService(): MembershipService | null {
+    const services = this.runtime.getServicesByType<MembershipService>(
+      MembershipService.serviceType,
+    );
+    return services.length > 0 ? services[0] : null;
+  }
+
+  private connectorAccountManager(): ConnectorAccountManager | null {
+    try {
+      // Canonical factory: returns the registered service when present and
+      // otherwise creates (and registers) the per-runtime manager, whose
+      // storage lazily resolves to the runtime's database adapter.
+      return getConnectorAccountManager(this.runtime);
+    } catch (error) {
+      logger.debug(
+        {
+          src: "plugin:x",
+          agentId: this.runtime.agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X membership connector account manager unavailable",
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the durable, UUID-keyed connector account for one configured X
+   * account. The membership authority requires a `connector_accounts` row
+   * whose id is a real UUID and whose provider equals the connector id; the
+   * env-mode synthetic account is keyed "default" (string id), so the first
+   * resolution upserts a durable row keyed on the stable account key and
+   * reuses its generated UUID.
+   */
+  private async resolveDurableAccount(
+    accountKey: string,
+    accountLabel: string | undefined,
+  ): Promise<ConnectorAccount | null> {
+    const cached = this.durableAccounts.get(accountKey);
+    if (cached) {
+      return cached;
+    }
+    if (this.unavailableReasons.has(accountKey)) {
+      return null;
+    }
+    let promise = this.durableAccountPromises.get(accountKey);
+    if (!promise) {
+      const manager = this.connectorAccountManager();
+      if (!manager) {
+        this.unavailableReasons.set(
+          accountKey,
+          "connector_account_manager_missing",
+        );
+        logger.debug(
+          {
+            src: "plugin:x",
+            agentId: this.runtime.agentId,
+            accountKey,
+          },
+          "X membership publishing unavailable: no connector account manager",
+        );
+        return null;
+      }
+      promise = ensureDurableConnectorAccount(
+        manager,
+        accountKey,
+        accountLabel,
+      ).catch((error: unknown) => {
+        // error-policy:J4 Membership evidence is a degrade-only surface:
+        // a failed durable-account lookup disables publishing for this
+        // account (recorded once) while message flow continues.
+        this.unavailableReasons.set(
+          accountKey,
+          error instanceof Error ? error.message : "account_resolution_failed",
+        );
+        this.durableAccountPromises.delete(accountKey);
+        logger.warn(
+          {
+            src: "plugin:x",
+            agentId: this.runtime.agentId,
+            accountKey,
+            error: this.unavailableReasons.get(accountKey) ?? "unknown",
+          },
+          "X membership publishing unavailable: durable account resolution failed",
+        );
+        return null;
+      });
+      this.durableAccountPromises.set(accountKey, promise);
+    }
+    const account = await promise;
+    if (account) {
+      this.durableAccounts.set(accountKey, account);
+    }
+    return account;
+  }
+
+  /**
+   * Build the membership scope for one DM conversation. X DM membership is a
+   * property of the conversation, so the scope's external room id is the
+   * conversation id and the runtime DM room carries the mapping. The durable
+   * connector account is keyed on the authenticated X USER id (stable across
+   * config relabeling — the config account label would split the scope
+   * namespace when renamed), mirroring the telegram bootstrap pattern.
+   */
+  async scopeForConversation(options: {
+    conversationId: string;
+    accountKey: string;
+    ownUserId: string;
+    accountLabel?: string;
+  }): Promise<MembershipScope | null> {
+    const account = await this.resolveDurableAccount(
+      options.ownUserId,
+      options.accountLabel ?? options.accountKey,
+    );
+    if (!account?.id || typeof account.id !== "string") {
+      return null;
+    }
+    return {
+      agentId: this.runtime.agentId,
+      connectorId: X_MEMBERSHIP_CONNECTOR_ID,
+      connectorAccountId: account.id as UUID,
+      externalWorldId: options.conversationId,
+      externalRoomId: options.conversationId,
+    };
+  }
+
+  private stateFor(scope: MembershipScope): ScopePublisherState {
+    const key = this.scopeKey(scope);
+    let state = this.scopes.get(key);
+    if (!state) {
+      state = {
+        generation: 0,
+        publisherGeneration: 0,
+        sourceCursor: null,
+        currentVersion: -1,
+        renewedAt: new Map(),
+        queue: Promise.resolve(),
+        warned: false,
+      };
+      this.scopes.set(key, state);
+      return state;
+    }
+    return state;
+  }
+
+  private async readScopeHealth(
+    service: MembershipService,
+    scope: MembershipScope,
+  ): Promise<MembershipScopeHealth | null> {
+    try {
+      return await service.getScopeHealth(scope);
+    } catch (error) {
+      logger.debug(
+        {
+          src: "plugin:x",
+          agentId: this.runtime.agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X membership scope health read failed",
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the runtime mapping for one observation. The authority accepts
+   * null runtime ids (only non-null ids are existence-checked), and the DM
+   * loop's world is sender-scoped while a group room's world depends on
+   * which sender created it — so this publisher never fabricates world/room
+   * rows the message loop would later disagree with. The DM room id is
+   * derived exactly like the inbound path derives it and passed only when
+   * the row already exists (the inbound path owns creation); worldId stays
+   * null because the DM loop's sender-scoped world is not this scope's
+   * world.
+   */
+  private async resolveRuntimeMapping(options: {
+    roomId: UUID;
+  }): Promise<{ worldId: UUID | null; roomId: UUID | null }> {
+    if (this.ensuredMappings.has(options.roomId as string)) {
+      return { worldId: null, roomId: options.roomId };
+    }
+    const room = await this.runtime.getRoom(options.roomId);
+    if (room) {
+      this.ensuredMappings.add(options.roomId as string);
+      return { worldId: null, roomId: options.roomId };
+    }
+    return { worldId: null, roomId: null };
+  }
+
+  /**
+   * Register this process as the scope publisher, adopting durable scope
+   * state first so a restarted process re-binds without losing fencing. A
+   * previous publisher's generation floor is advanced by one to satisfy the
+   * authority's monotonic publisherGeneration requirement.
+   */
+  private async registerPublisher(
+    service: MembershipService,
+    scope: MembershipScope,
+    state: ScopePublisherState,
+  ): Promise<void> {
+    const health = await this.readScopeHealth(service, scope);
+    // Adoption: when the durable publisher binding already belongs to this
+    // stable instance id (a restart of the same process identity), re-bind
+    // at the SAME generation instead of bumping — bumping would reset the
+    // evidence chain (sourceVersion -1) and strand every committed member
+    // fact behind membership_evidence_mismatch denials.
+    if (
+      health &&
+      health.publisherInstanceId === this.publisherInstanceIdFor(scope) &&
+      typeof health.publisherGeneration === "number" &&
+      typeof health.generation === "number"
+    ) {
+      state.generation = health.generation;
+      state.publisherGeneration = health.publisherGeneration;
+      state.sourceCursor = health.sourceCursor;
+      state.currentVersion = health.sourceVersion;
+      // Adoption after a degrade (restore path) must allow immediate
+      // re-proof: the renewal gate would otherwise suppress the first
+      // post-restore observation as "recent".
+      state.renewedAt.clear();
+      return;
+    }
+    const expectedGeneration = health ? health.generation : 0;
+    state.publisherGeneration =
+      health?.publisherGeneration !== null &&
+      typeof health?.publisherGeneration === "number"
+        ? health.publisherGeneration + 1
+        : 0;
+    const receipt = await service.registerPublisher({
+      ...scope,
+      expectedGeneration,
+      publisherInstanceId: this.publisherInstanceIdFor(scope),
+      publisherGeneration: state.publisherGeneration,
+      evidenceMode: "point_query",
+      idempotencyKey: membershipIdempotencyKey([
+        scope.connectorAccountId,
+        scope.externalRoomId,
+        "register",
+        this.publisherInstanceIdFor(scope),
+        String(state.publisherGeneration),
+      ]),
+      observedAt: new Date().toISOString(),
+    });
+    state.generation = receipt.committedGeneration;
+    // A new publisher generation resets the durable evidence chain:
+    // the authority sets sourceVersion back to -1 on registration, so no
+    // principal is currently proven — clear the renewal window too, or a
+    // restore-then-re-prove would be silently skipped as "recent".
+    state.sourceCursor = null;
+    state.currentVersion = -1;
+    state.renewedAt.clear();
+  }
+
+  /**
+   * Publish one observed-only point-query proof. Journal-idempotent on the
+   * authority side via the event-anchored idempotency key, so DM timeline
+   * redelivery cannot double-apply a delta. Fencing mismatches (another
+   * writer advanced the scope) re-register once and retry once; anything
+   * else degrades silently — publishing must never break the inbound
+   * message path.
+   */
+  private async publishPointQuery(options: {
+    scope: MembershipScope;
+    principalId: UUID;
+    worldId: UUID;
+    roomId: UUID;
+    /** Connector-space entity id for the same human, when already known. */
+    runtimeEntityId?: UUID;
+    membershipState: "active" | "revoked";
+    reason:
+      | "joined"
+      | "reconciled_present"
+      | "permission_restored"
+      | "left"
+      | "kicked"
+      | "banned";
+    roles: string[];
+    permissionSnapshot: JsonObject;
+    idempotencyKey: string;
+    /**
+     * Wall-clock ms of the X DM event anchoring this observation, when
+     * known. Event-anchored commands redelivered later treat
+     * MEMBERSHIP_IDEMPOTENCY_CONFLICT as the benign replay outcome (the
+     * authority cannot accept the identical digest a second time because
+     * validUntil must stay in the future); recording the anchor lets tests
+     * and future consumers distinguish redelivery from a genuine collision.
+     */
+    eventAnchoredAt?: number;
+    displayName?: string;
+  }): Promise<MembershipMutationReceipt | null> {
+    const service = this.membershipService();
+    if (!service) {
+      return null;
+    }
+    const state = this.stateFor(options.scope);
+    // Renewal gating happens INSIDE the per-scope serialization below so two
+    // concurrent first observations for one principal cannot both pass the
+    // window check and double-publish.
+    // Serialize per scope: the durable evidence chain requires each
+    // command to name the previous cursor and version, so concurrent
+    // observations for one conversation must not interleave. The runtime
+    // mapping ensure runs INSIDE the serialized section too: concurrent
+    // first observations for one scope would otherwise race on
+    // ensureWorldExists/ensureRoomExists for the same ids.
+    const run = state.queue.then(
+      () => this.publishPointQuerySerialized(service, state, options),
+      () => this.publishPointQuerySerialized(service, state, options),
+    );
+    state.queue = run.catch(() => undefined);
+    return run;
+  }
+
+  private async publishPointQuerySerialized(
+    service: MembershipService,
+    state: ScopePublisherState,
+    options: Parameters<XMembershipPublisher["publishPointQuery"]>[0],
+  ): Promise<MembershipMutationReceipt | null> {
+    // Resolve the runtime mapping INSIDE the serialized section so
+    // concurrent first observations for one scope cannot race on the room
+    // existence probe. worldId stays null (the DM loop's sender-scoped
+    // world is not this scope's world); roomId is passed only when the
+    // inbound path already created the DM room row.
+    const runtimeMapping = await this.resolveRuntimeMapping({
+      roomId: options.roomId,
+    });
+    // Renewal gating INSIDE serialization: a principal whose ACTIVE evidence
+    // is fresher than the renewal window is not re-proven, so concurrent
+    // first observations cannot double-publish. Revoked principals have no
+    // entry (publishLeave removes it and revokes never set it) and always
+    // pass through.
+    if (options.reason === "reconciled_present") {
+      const last = state.renewedAt.get(options.principalId) ?? 0;
+      if (Date.now() - last < MEMBERSHIP_RENEWAL_MS) {
+        return null;
+      }
+    }
+    if (state.generation === 0) {
+      await this.registerPublisher(service, options.scope, state);
+    }
+    // Digest-stable payload: the authority journals the exact command, so
+    // every retry under the same idempotency key must replay byte-equal.
+    // observedAt/validUntil are computed once here, never recomputed.
+    const now = new Date();
+    const observedAt = now.toISOString();
+    const validUntil = new Date(
+      now.getTime() + MEMBERSHIP_VALIDITY_MS,
+    ).toISOString();
+    const renewedAtMs = now.getTime();
+    let attempt = 0;
+    while (attempt < 2) {
+      attempt += 1;
+      try {
+        // Point-query evidence chains like any other: version = current + 1
+        // and previous cursor = the last committed cursor. The authority
+        // validates both against the durable scope row.
+        if (state.sourceCursor === null) {
+          const health = await this.readScopeHealth(service, options.scope);
+          if (health && health.generation > state.generation) {
+            state.generation = health.generation;
+            state.sourceCursor = health.sourceCursor;
+            state.currentVersion = health.sourceVersion;
+          }
+        }
+        const currentVersion = state.currentVersion;
+        const receipt = await service.applyMembership({
+          ...options.scope,
+          expectedGeneration: state.generation,
+          publisherInstanceId: this.publisherInstanceIdFor(options.scope),
+          publisherGeneration: state.publisherGeneration,
+          evidenceMode: "point_query",
+          canonicalPrincipalId: options.principalId,
+          state: options.membershipState,
+          reason: options.reason,
+          roles: options.roles,
+          permissionSnapshot: options.permissionSnapshot,
+          runtime: {
+            worldId: runtimeMapping.worldId,
+            roomId: runtimeMapping.roomId,
+            entityId: options.runtimeEntityId ?? null,
+          },
+          sourceVersion: currentVersion + 1,
+          previousSourceCursor: state.sourceCursor,
+          sourceCursor: `x:${options.idempotencyKey}`,
+          validUntil,
+          idempotencyKey: options.idempotencyKey,
+          observedAt,
+        });
+        state.generation = receipt.committedGeneration;
+        state.sourceCursor = `x:${options.idempotencyKey}`;
+        state.currentVersion = currentVersion + 1;
+        // Only ACTIVE evidence renews: a revoked principal must stay out of
+        // the renewal window so the next observation re-proves (or re-revokes)
+        // instead of being skipped for an hour.
+        if (options.membershipState === "active") {
+          state.renewedAt.set(options.principalId, renewedAtMs);
+        }
+        return receipt;
+      } catch (error) {
+        const code = membershipErrorCode(error);
+        const isFencing =
+          code === "MEMBERSHIP_GENERATION_MISMATCH" ||
+          code === "MEMBERSHIP_PUBLISHER_MISMATCH" ||
+          code === "MEMBERSHIP_PUBLISHER_GENERATION_STALE" ||
+          code === "MEMBERSHIP_CURSOR_DISCONTINUITY";
+        if (isFencing && attempt === 1) {
+          // Another writer (a previous process instance overlapping a
+          // restart) advanced the scope: adopt durable state, take the
+          // publisher seat, and retry exactly once.
+          const health = await this.readScopeHealth(service, options.scope);
+          if (health) {
+            state.generation = health.generation;
+            state.sourceCursor = health.sourceCursor;
+            state.currentVersion = health.sourceVersion;
+          }
+          await this.registerPublisher(service, options.scope, state);
+          continue;
+        }
+        if (
+          code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT" &&
+          options.eventAnchoredAt !== undefined
+        ) {
+          // Event-anchored redelivery: the identical DM event was already
+          // journaled (fresh validUntil/observedAt necessarily change the
+          // digest, so the authority reports a conflict). The delta has
+          // already been applied; adopt the durable cursor position and treat
+          // the redelivery as a benign replay.
+          const health = await this.readScopeHealth(service, options.scope);
+          if (health) {
+            state.generation = health.generation;
+            state.sourceCursor = health.sourceCursor;
+            state.currentVersion = health.sourceVersion;
+          }
+          return null;
+        }
+        logger.debug(
+          {
+            src: "plugin:x",
+            agentId: this.runtime.agentId,
+            idempotencyKey: options.idempotencyKey,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "X membership point query rejected",
+        );
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Renew an active participant on observed activity. Skipped inside the
+   * renewal window; the sender's presence in this conversation is itself the
+   * observation, so no roster fetch happens.
+   */
+  async renewSender(options: {
+    scope: MembershipScope;
+    principalId: UUID;
+    worldId: UUID;
+    roomId: UUID;
+    roles: string[];
+    permissionSnapshot: JsonObject;
+    idempotencyKey: string;
+    eventAnchoredAt?: number;
+    displayName?: string;
+  }): Promise<void> {
+    await this.publishPointQuery({
+      ...options,
+      membershipState: "active",
+      reason: "reconciled_present",
+    });
+  }
+
+  /**
+   * Publish a join observation (ParticipantsJoin event). Observed-only:
+   * `participant_ids` on the event names the participants X says are in the
+   * conversation at event time, but the DM API never proves absence of
+   * unlisted members, so no completeness claim is made.
+   */
+  async publishJoin(options: {
+    scope: MembershipScope;
+    principalId: UUID;
+    worldId: UUID;
+    roomId: UUID;
+    roles: string[];
+    permissionSnapshot: JsonObject;
+    idempotencyKey: string;
+    eventAnchoredAt?: number;
+    displayName?: string;
+  }): Promise<void> {
+    await this.publishPointQuery({
+      ...options,
+      membershipState: "active",
+      reason: "joined",
+    });
+  }
+
+  /**
+   * Publish a leave/kick observation. X's DM event stream does not label who
+   * removed a participant, so the caller picks the reason from the context it
+   * has (own account leaving = scope degrade, not a self-revoke; other
+   * participants = "left" as the neutral observed transition).
+   */
+  async publishLeave(options: {
+    scope: MembershipScope;
+    principalId: UUID;
+    worldId: UUID;
+    roomId: UUID;
+    idempotencyKey: string;
+    reason: "left" | "kicked" | "banned";
+    eventAnchoredAt?: number;
+    displayName?: string;
+  }): Promise<void> {
+    const state = this.stateFor(options.scope);
+    state.renewedAt.delete(options.principalId);
+    await this.publishPointQuery({
+      ...options,
+      membershipState: "revoked",
+      roles: [],
+      permissionSnapshot: {},
+      reason: options.reason,
+    });
+  }
+
+  /**
+   * Degrade a scope when the account can no longer read the conversation
+   * (token revoked, conversation hidden) so `authorize` fails closed with an
+   * explicit authority state instead of trusting stale evidence.
+   */
+  async degradeScope(options: {
+    scope: MembershipScope;
+    health: "stale" | "unavailable" | "unsupported";
+    reason: string;
+  }): Promise<void> {
+    await this.setScopeHealth(options.scope, options.health, options.reason);
+  }
+
+  /**
+   * Restore a degraded scope after the account's access to the conversation
+   * returns. The authority only accepts health transitions that degrade, so
+   * restoration re-registers this process as the scope's publisher: the
+   * registration resets the scope to the stale/awaiting-evidence state and
+   * bumps the generation, after which ordinary point-query evidence
+   * re-proves members on observed activity.
+   */
+  async restoreScope(options: {
+    scope: MembershipScope;
+    reason: string;
+  }): Promise<void> {
+    const service = this.membershipService();
+    if (!service) {
+      return;
+    }
+    const state = this.stateFor(options.scope);
+    // Serialize with any in-flight publishes for this scope.
+    const run = state.queue.then(
+      () => this.registerPublisher(service, options.scope, state),
+      () => this.registerPublisher(service, options.scope, state),
+    );
+    state.queue = run.catch(() => undefined);
+    await run;
+  }
+
+  private async setScopeHealth(
+    scope: MembershipScope,
+    health: "stale" | "unavailable" | "unsupported",
+    reason: string,
+  ): Promise<void> {
+    const service = this.membershipService();
+    if (!service) {
+      return;
+    }
+    const state = this.stateFor(scope);
+    // A fresh process (or a scope first seen through the degrade path) may
+    // not know the durable generation: adopt it before attempting the health
+    // command so the expectedGeneration fence is satisfiable.
+    if (state.generation === 0) {
+      const durable = await this.readScopeHealth(service, scope);
+      if (!durable) {
+        return;
+      }
+      state.generation = durable.generation;
+      state.sourceCursor = durable.sourceCursor;
+      state.currentVersion = durable.sourceVersion;
+    }
+    // Serialize health changes with evidence publishes for this scope.
+    const run = state.queue.then(
+      () =>
+        service.setScopeHealth({
+          ...scope,
+          expectedGeneration: state.generation,
+          health,
+          reason,
+          idempotencyKey: membershipIdempotencyKey([
+            scope.connectorAccountId,
+            scope.externalRoomId,
+            "degrade",
+            reason,
+            String(Date.now()),
+          ]),
+          observedAt: new Date().toISOString(),
+        }),
+      () => undefined,
+    );
+    state.queue = run.catch(() => undefined);
+    try {
+      const receipt = await run;
+      if (receipt) {
+        state.generation = receipt.committedGeneration;
+      }
+    } catch (error) {
+      logger.debug(
+        {
+          src: "plugin:x",
+          agentId: this.runtime.agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "X membership scope degrade rejected",
+      );
+    }
+  }
+
+  /** Exposed for tests: current fencing state of one scope. */
+  scopeState(scope: MembershipScope): ScopePublisherState | undefined {
+    return this.scopes.get(this.scopeKey(scope));
+  }
+}
+
+/**
+ * Canonical principal id for an X user inside one account, for the membership
+ * authority. Deterministic RFC-4122 v5 over (account key, X user id): stable
+ * across restarts and publishers, pattern-valid for the authority's `[1-8]`
+ * version-nibble check, and distinct per account so two configured X
+ * accounts never alias the same human onto one principal. The runtime entity
+ * for the same user remains separate; the authority stores both
+ * (canonicalPrincipalId + runtime.entityId when known).
+ */
+export async function xMembershipPrincipal(
+  runtime: IAgentRuntime,
+  accountId: string,
+  xUserId: string,
+): Promise<{ principalId: UUID; runtimeEntityId?: UUID }> {
+  const principalId = uuidv5(
+    `${accountId}:${xUserId}`,
+    X_MEMBERSHIP_NAMESPACE,
+  ) as UUID;
+  // The authority requires the principal's entity row to exist in this
+  // tenant; ensure it idempotently (createEntities skips existing ids).
+  const existing = await runtime.getEntityById(principalId);
+  if (!existing) {
+    await runtime.createEntities([
+      {
+        id: principalId,
+        agentId: runtime.agentId,
+        names: [`x:${accountId}:${xUserId}`],
+        metadata: {
+          x: { id: xUserId, accountId },
+          source: "x-membership",
+        },
+      },
+    ]);
+  }
+  // Keep the runtime entity and the membership principal linked: the
+  // connector entity carries the account-scoped principal ids it has been
+  // published under, so identity clustering can join the two id spaces and
+  // multiple accounts' principals can coexist on one entity.
+  const connectorEntityId = createUniqueUuid(runtime, xUserId) as UUID;
+  const entity = await runtime.getEntityById(connectorEntityId);
+  if (entity) {
+    const metadata = entity.metadata as Record<string, unknown>;
+    const links = new Map<string, UUID>(
+      Object.entries(
+        (metadata.membershipPrincipals as Record<string, string>) ?? {},
+      )
+        .map(([account, id]) => [account, id as UUID] as const)
+        .filter(
+          (entry): entry is [string, UUID] => typeof entry[1] === "string",
+        ),
+    );
+    if (links.get(accountId) !== principalId) {
+      links.set(accountId, principalId);
+      entity.metadata = {
+        ...metadata,
+        membershipPrincipals: Object.fromEntries(links),
+      };
+      await runtime.updateEntity(entity);
+    }
+  }
+  // Only real v4/v5 runtime entity ids satisfy the authority's UUID
+  // version-nibble validation: stringToUuid-derived connector entity ids
+  // carry the custom 0x0 version nibble and are rejected by
+  // MEMBERSHIP_COMMAND_INVALID. Omit those; the principal<->entity link is
+  // persisted on the entity row's membershipPrincipals metadata instead.
+  const authorityUuid =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return {
+    principalId,
+    runtimeEntityId: authorityUuid.test(connectorEntityId)
+      ? connectorEntityId
+      : undefined,
+  };
+}
+
+function membershipIdempotencyKey(parts: string[]): string {
+  const key = `x:${parts.join(":")}`;
+  return key.length > MEMBERSHIP_IDEMPOTENCY_KEY_MAX
+    ? key.slice(0, MEMBERSHIP_IDEMPOTENCY_KEY_MAX)
+    : key;
+}
+
+function membershipErrorCode(error: unknown): string {
+  if (error instanceof ElizaError && typeof error.code === "string") {
+    return error.code;
+  }
+  return "";
+}
+
+/**
+ * Resolve a durable UUID-keyed connector account row for one X account key,
+ * creating it on first use. Keyed by accountKey so the same configured
+ * account maps to one stable row across restarts; the database assigns the
+ * UUID id when the incoming id is not already a UUID.
+ */
+async function ensureDurableConnectorAccount(
+  manager: ConnectorAccountManager,
+  accountKey: string,
+  accountLabel: string | undefined,
+): Promise<ConnectorAccount> {
+  const storage = manager.getStorage();
+  const existing = await storage.getAccount(
+    X_MEMBERSHIP_CONNECTOR_ID,
+    accountKey,
+  );
+  if (existing) {
+    return existing;
+  }
+  const nowMs = Date.now();
+  const created = await storage.upsertAccount({
+    id: accountKey,
+    provider: X_MEMBERSHIP_CONNECTOR_ID,
+    label: accountLabel ?? `X (${accountKey})`,
+    role: "AGENT",
+    purpose: ["messaging"],
+    accessGate: "open",
+    status: "connected",
+    metadata: { source: "x-membership", accountKey },
+    createdAt: nowMs,
+    updatedAt: nowMs,
+  });
+  if (!created?.id || typeof created.id !== "string") {
+    throw new ElizaError(
+      "X membership account resolution returned no durable id",
+      {
+        code: "X_MEMBERSHIP_ACCOUNT_UNAVAILABLE",
+        context: { accountKey },
+      },
+    );
+  }
+  return created;
+}

--- a/plugins/plugin-x/src/membership.ts
+++ b/plugins/plugin-x/src/membership.ts
@@ -14,6 +14,8 @@
  * Public-timeline authors are never roster authority: only DM timeline
  * events feed this publisher.
  */
+
+import { createHash } from "node:crypto";
 import {
   type ConnectorAccount,
   type ConnectorAccountManager,
@@ -29,7 +31,6 @@ import {
   MembershipService,
   type UUID,
 } from "@elizaos/core";
-import { createHash } from "node:crypto";
 
 /** Connector id this publisher registers under (matches XService). */
 export const X_MEMBERSHIP_CONNECTOR_ID = "x";

--- a/plugins/plugin-x/src/membership.ts
+++ b/plugins/plugin-x/src/membership.ts
@@ -323,18 +323,29 @@ export class XMembershipPublisher {
    * previous publisher's generation floor is advanced by one to satisfy the
    * authority's monotonic publisherGeneration requirement.
    */
+  /**
+   * Register this publisher for a scope. Adoption (a restart of the same
+   * stable publisher identity) re-binds at the SAME generation so committed
+   * evidence survives; a forced registration (restore path) deliberately
+   * takes the takeover branch to reset the durable scope state.
+   */
   private async registerPublisher(
     service: MembershipService,
     scope: MembershipScope,
     state: ScopePublisherState,
+    options?: { force?: boolean },
   ): Promise<void> {
     const health = await this.readScopeHealth(service, scope);
     // Adoption: when the durable publisher binding already belongs to this
     // stable instance id (a restart of the same process identity), re-bind
     // at the SAME generation instead of bumping — bumping would reset the
     // evidence chain (sourceVersion -1) and strand every committed member
-    // fact behind membership_evidence_mismatch denials.
+    // fact behind membership_evidence_mismatch denials. The restore path
+    // passes force to skip this: restoration MUST take the takeover branch
+    // because the authority only accepts health transitions that degrade,
+    // and a re-registration is what resets durable `unavailable` health.
     if (
+      !options?.force &&
       health &&
       health.publisherInstanceId === this.publisherInstanceIdFor(scope) &&
       typeof health.publisherGeneration === "number" &&
@@ -742,10 +753,19 @@ export class XMembershipPublisher {
       return;
     }
     const state = this.stateFor(options.scope);
-    // Serialize with any in-flight publishes for this scope.
+    // Serialize with any in-flight publishes for this scope. Forced
+    // re-registration takes the takeover branch so the durable `unavailable`
+    // health resets to awaiting-evidence; adoption alone would leave the
+    // scope degraded forever (R2 finding 1).
     const run = state.queue.then(
-      () => this.registerPublisher(service, options.scope, state),
-      () => this.registerPublisher(service, options.scope, state),
+      () =>
+        this.registerPublisher(service, options.scope, state, {
+          force: true,
+        }),
+      () =>
+        this.registerPublisher(service, options.scope, state, {
+          force: true,
+        }),
     );
     state.queue = run.catch(() => undefined);
     await run;
@@ -775,7 +795,7 @@ export class XMembershipPublisher {
           state.sourceCursor = durable.sourceCursor;
           state.currentVersion = durable.sourceVersion;
         }
-        return service.setScopeHealth({
+        const receipt = await service.setScopeHealth({
           ...scope,
           expectedGeneration: state.generation,
           health,
@@ -789,15 +809,19 @@ export class XMembershipPublisher {
           ]),
           observedAt: new Date().toISOString(),
         });
+        // Apply receipt-derived fencing state INSIDE the serialized
+        // callback so every subsequently queued operation observes the
+        // committed generation by construction (R2 finding 4).
+        if (receipt) {
+          state.generation = receipt.committedGeneration;
+        }
+        return receipt;
       },
       () => undefined,
     );
     state.queue = run.catch(() => undefined);
     try {
-      const receipt = await run;
-      if (receipt) {
-        state.generation = receipt.committedGeneration;
-      }
+      await run;
     } catch (error) {
       logger.debug(
         {

--- a/plugins/plugin-x/src/membership.ts
+++ b/plugins/plugin-x/src/membership.ts
@@ -690,6 +690,10 @@ export class XMembershipPublisher {
    * authorization failed globally). Scopes published by other processes are
    * unreachable by design; their evidence expires via TTL.
    */
+  hasBoundScopes(): boolean {
+    return this.scopes.size > 0;
+  }
+
   async degradeAllScopes(reason: string): Promise<void> {
     for (const key of this.scopes.keys()) {
       const [connectorAccountId, externalWorldId, externalRoomId] =

--- a/plugins/plugin-x/src/membership.ts
+++ b/plugins/plugin-x/src/membership.ts
@@ -1,20 +1,18 @@
 /**
- * Per-conversation X (Twitter) DM membership evidence publisher: the X DM
- * events API exposes no full-roster enumeration for arbitrary conversations,
- * so this connector publishes observed-only point-query proofs (sender
- * renewals, ParticipantsJoin deltas, ParticipantsLeave deltas) into the
- * canonical `MembershipService` authority instead of fabricating roster
- * snapshots. `participant_ids` is treated as roster-authoritative only on
- * ParticipantsJoin events where X semantics name the complete participant
- * set (and even then as an ordered_delta of the observed roster, never as a
- * completeness-claimed snapshot); everything else stays observed-only.
- * Evidence is renewed on activity with a bounded freshness window; every
- * command is journal-idempotent on the authority side via event-anchored
- * idempotency keys, so cursor redelivery after a restart cannot double-apply
- * a delta. In-memory state only tracks fencing cursors and renewal
- * timestamps and is reconstructable after a restart by adopting the durable
- * scope state. Public-timeline authors are never roster authority: only DM
- * timeline events feed this publisher.
+ * Per-conversation X (Twitter) DM membership evidence publisher. The X DM
+ * events API can never prove the complete roster of a conversation
+ * (participant_ids, per the June 2025 API changelog, names only the
+ * participants who joined or left in that event), so this connector
+ * publishes observed-only point-query proofs (sender renewals,
+ * ParticipantsJoin deltas, ParticipantsLeave deltas) into the canonical
+ * `MembershipService` authority and never claims completeness. Evidence is
+ * renewed on activity with a bounded freshness window; every command is
+ * journal-idempotent on the authority side via event-anchored idempotency
+ * keys, so cursor redelivery after a restart cannot double-apply a delta.
+ * In-memory state only tracks fencing cursors and renewal timestamps and is
+ * reconstructable after a restart by adopting the durable scope state.
+ * Public-timeline authors are never roster authority: only DM timeline
+ * events feed this publisher.
  */
 import {
   type ConnectorAccount,
@@ -77,14 +75,15 @@ export class XMembershipPublisher {
   private readonly runtime: IAgentRuntime;
   private readonly scopes = new Map<string, ScopePublisherState>();
   /**
-   * Publisher instance id is STABLE per (agent, durable account), derived
-   * like the telegram template's formula — a restarted process re-binds to
-   * the persisted publisher binding (adoption) instead of bumping the
-   * publisher generation and stranding every committed member fact. A
-   * per-process random suffix distinguishes genuinely concurrent processes
-   * fencing each other.
+   * Publisher instance id is STABLE per (agent, durable account) — derived
+   * like the telegram template's formula. A restarted process re-derives the
+   * same id and ADOPTS the persisted publisher binding (same generation,
+   * cursor, and version) instead of bumping the publisher generation and
+   * stranding every committed member fact behind evidence-mismatch denials.
+   * Concurrent processes fencing each other still cannot corrupt state: the
+   * authority's generation fencing rejects the loser, which then re-registers
+   * through the normal takeover path.
    */
-  private readonly publisherInstanceSalt = crypto.randomUUID();
   private readonly publisherInstanceIds = new Map<string, string>();
   /**
    * Runtime world/room mapping rows ensured for the authority's
@@ -119,7 +118,7 @@ export class XMembershipPublisher {
     const key = scope.connectorAccountId as string;
     let id = this.publisherInstanceIds.get(key);
     if (!id) {
-      id = `x:${this.runtime.agentId}:${scope.connectorAccountId}:${this.publisherInstanceSalt}`;
+      id = `x:${this.runtime.agentId}:${scope.connectorAccountId}`;
       this.publisherInstanceIds.set(key, id);
     }
     return id;
@@ -418,6 +417,12 @@ export class XMembershipPublisher {
      */
     eventAnchoredAt?: number;
     displayName?: string;
+    /**
+     * Revocation commands remove the principal's renewal-window entry at
+     * commit time (inside serialization) so a stale queued renewal cannot
+     * re-suppress the next observation after a leave.
+     */
+    removeRenewalOnCommit?: boolean;
   }): Promise<MembershipMutationReceipt | null> {
     const service = this.membershipService();
     if (!service) {
@@ -519,10 +524,12 @@ export class XMembershipPublisher {
         state.generation = receipt.committedGeneration;
         state.sourceCursor = `x:${options.idempotencyKey}`;
         state.currentVersion = currentVersion + 1;
-        // Only ACTIVE evidence renews: a revoked principal must stay out of
-        // the renewal window so the next observation re-proves (or re-revokes)
-        // instead of being skipped for an hour.
-        if (options.membershipState === "active") {
+        if (options.removeRenewalOnCommit) {
+          state.renewedAt.delete(options.principalId);
+        } else if (options.membershipState === "active") {
+          // Only ACTIVE evidence renews: a revoked principal must stay out of
+          // the renewal window so the next observation re-proves (or
+          // re-revokes) instead of being skipped for an hour.
           state.renewedAt.set(options.principalId, renewedAtMs);
         }
         return receipt;
@@ -641,14 +648,16 @@ export class XMembershipPublisher {
     eventAnchoredAt?: number;
     displayName?: string;
   }): Promise<void> {
-    const state = this.stateFor(options.scope);
-    state.renewedAt.delete(options.principalId);
+    // The renewedAt removal runs INSIDE the serialized section (not here)
+    // so a queued renewal cannot re-set the timestamp after this revocation
+    // and suppress the next legitimate observation for an hour.
     await this.publishPointQuery({
       ...options,
       membershipState: "revoked",
       roles: [],
       permissionSnapshot: {},
       reason: options.reason,
+      removeRenewalOnCommit: true,
     });
   }
 
@@ -663,6 +672,57 @@ export class XMembershipPublisher {
     reason: string;
   }): Promise<void> {
     await this.setScopeHealth(options.scope, options.health, options.reason);
+  }
+
+  /**
+   * Degrade every scope this publisher has bound in this process (account
+   * authorization failed globally). Scopes published by other processes are
+   * unreachable by design; their evidence expires via TTL.
+   */
+  async degradeAllScopes(reason: string): Promise<void> {
+    for (const key of this.scopes.keys()) {
+      const [connectorAccountId, externalWorldId, externalRoomId] =
+        key.split(":");
+      if (!connectorAccountId || !externalWorldId || !externalRoomId) {
+        continue;
+      }
+      await this.setScopeHealth(
+        {
+          agentId: this.runtime.agentId,
+          connectorId: X_MEMBERSHIP_CONNECTOR_ID,
+          connectorAccountId: connectorAccountId as UUID,
+          externalWorldId,
+          externalRoomId,
+        },
+        "unavailable",
+        reason,
+      );
+    }
+  }
+
+  /**
+   * Restore every degraded scope after a successful authenticated poll
+   * (authorization recovered): re-register each bound scope so fresh
+   * evidence re-proves participants on observed activity.
+   */
+  async restoreAllScopes(reason: string): Promise<void> {
+    for (const key of this.scopes.keys()) {
+      const [connectorAccountId, externalWorldId, externalRoomId] =
+        key.split(":");
+      if (!connectorAccountId || !externalWorldId || !externalRoomId) {
+        continue;
+      }
+      await this.restoreScope({
+        scope: {
+          agentId: this.runtime.agentId,
+          connectorId: X_MEMBERSHIP_CONNECTOR_ID,
+          connectorAccountId: connectorAccountId as UUID,
+          externalWorldId,
+          externalRoomId,
+        },
+        reason,
+      });
+    }
   }
 
   /**
@@ -701,22 +761,21 @@ export class XMembershipPublisher {
       return;
     }
     const state = this.stateFor(scope);
-    // A fresh process (or a scope first seen through the degrade path) may
-    // not know the durable generation: adopt it before attempting the health
-    // command so the expectedGeneration fence is satisfiable.
-    if (state.generation === 0) {
-      const durable = await this.readScopeHealth(service, scope);
-      if (!durable) {
-        return;
-      }
-      state.generation = durable.generation;
-      state.sourceCursor = durable.sourceCursor;
-      state.currentVersion = durable.sourceVersion;
-    }
-    // Serialize health changes with evidence publishes for this scope.
+    // The durable-health read AND the command both run INSIDE the serialized
+    // section: reading generation outside the queue would race an in-flight
+    // publish that advances it, making expectedGeneration stale.
     const run = state.queue.then(
-      () =>
-        service.setScopeHealth({
+      async () => {
+        if (state.generation === 0) {
+          const durable = await this.readScopeHealth(service, scope);
+          if (!durable) {
+            return undefined;
+          }
+          state.generation = durable.generation;
+          state.sourceCursor = durable.sourceCursor;
+          state.currentVersion = durable.sourceVersion;
+        }
+        return service.setScopeHealth({
           ...scope,
           expectedGeneration: state.generation,
           health,
@@ -729,7 +788,8 @@ export class XMembershipPublisher {
             String(Date.now()),
           ]),
           observedAt: new Date().toISOString(),
-        }),
+        });
+      },
       () => undefined,
     );
     state.queue = run.catch(() => undefined);

--- a/plugins/plugin-x/src/membership.ts
+++ b/plugins/plugin-x/src/membership.ts
@@ -29,7 +29,7 @@ import {
   MembershipService,
   type UUID,
 } from "@elizaos/core";
-import { v5 as uuidv5 } from "uuid";
+import { createHash } from "node:crypto";
 
 /** Connector id this publisher registers under (matches XService). */
 export const X_MEMBERSHIP_CONNECTOR_ID = "x";
@@ -52,7 +52,25 @@ const MEMBERSHIP_IDEMPOTENCY_KEY_MAX = 1_000;
  * minted from (account key, X user id), and a matching entity row is ensured
  * before the first publish for that principal.
  */
-const X_MEMBERSHIP_NAMESPACE = "c3b1a0f9-3333-4c4d-9d5e-7f6a5b4c3d02";
+const X_MEMBERSHIP_NAMESPACE = createHash("sha1")
+  .update("elizaos:plugin-x:membership:v1")
+  .digest()
+  .subarray(0, 16);
+
+/** RFC-4122 v5 from node:crypto so this plugin carries no uuid dependency. */
+function xUuidV5(name: string): UUID {
+  // RFC 4122 4.3: SHA-1 over namespace bytes || name, then set version 5 and
+  // variant bits (same construction as plugin-slack membership-authority).
+  const digest = createHash("sha1")
+    .update(X_MEMBERSHIP_NAMESPACE)
+    .update(Buffer.from(name, "utf8"))
+    .digest();
+  const bytes = digest.subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC variant
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as UUID;
+}
 
 interface ScopePublisherState {
   /** Scope generation as of the last successful command (fencing token). */
@@ -858,10 +876,7 @@ export async function xMembershipPrincipal(
   accountId: string,
   xUserId: string,
 ): Promise<{ principalId: UUID; runtimeEntityId?: UUID }> {
-  const principalId = uuidv5(
-    `${accountId}:${xUserId}`,
-    X_MEMBERSHIP_NAMESPACE,
-  ) as UUID;
+  const principalId = xUuidV5(`${accountId}:${xUserId}`);
   // The authority requires the principal's entity row to exist in this
   // tenant; ensure it idempotently (createEntities skips existing ids).
   const existing = await runtime.getEntityById(principalId);

--- a/plugins/plugin-x/vitest.config.ts
+++ b/plugins/plugin-x/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     // `*.real.test.ts` boots a real PGLite runtime and needs the workspace
     // source aliases from vitest.real-runtime.config.ts — run via
     // `test:real-runtime`.
-    exclude: ["**/node_modules/**", "dist/**", "**/*.real.test.ts"],
+    exclude: ["**/node_modules/**", "dist/**", "__tests__/**/*.real.test.ts"],
     coverage: {
       reporter: ["text", "json", "html"],
     },

--- a/plugins/plugin-x/vitest.config.ts
+++ b/plugins/plugin-x/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
       "src/**/__tests__/**/*.test.ts",
       "src/**/*.test.ts",
     ],
+    // `*.real.test.ts` boots a real PGLite runtime and needs the workspace
+    // source aliases from vitest.real-runtime.config.ts — run via
+    // `test:real-runtime`.
+    exclude: ["**/node_modules/**", "dist/**", "**/*.real.test.ts"],
     coverage: {
       reporter: ["text", "json", "html"],
     },

--- a/plugins/plugin-x/vitest.real-runtime.config.ts
+++ b/plugins/plugin-x/vitest.real-runtime.config.ts
@@ -1,0 +1,23 @@
+/**
+ * Vitest config for plugin-x real-runtime suites (#24372): boots a real
+ * PGLite-backed AgentRuntime (adapter, connector-account rows, and the
+ * SqlMembershipService authority are all real) and requires every workspace
+ * `@elizaos/*` package resolved to source, exactly like the shared
+ * real-runtime configs in sibling connectors.
+ */
+import { defineConfig } from "vitest/config";
+import { buildWorkspaceSourceAliases } from "../../packages/scripts/vitest/source-aliases.ts";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.real.test.ts"],
+    exclude: ["dist/**", "**/node_modules/**"],
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    pool: "forks",
+  },
+  resolve: {
+    alias: buildWorkspaceSourceAliases(),
+  },
+});


### PR DESCRIPTION
# feat(x): publish DM membership evidence (#24372)

Closes #24372

Publishes X (Twitter) DM-scope membership evidence to the canonical `MembershipService` contract: account keyed on ownUserId, stable publisher identity with adoption, TTL-anchored own-membership renewal, and auth-degrade/restore semantics that never imply removal on transient failures.

## What changes

- **`membership.ts` (new, 890 lines)** — DM membership authority: account scoped on `ownUserId`; stable `publisherInstanceId` with adoption; own-membership published with TTL-epoch idempotency keys; own-leave revokes and degrades the scope; inviter-as-context on join evidence; all state mutations inside the serialized callback.
- **`direct-messages` wiring** — DM polling loop drives membership publication; renewal-window clears on adoption; mapping resolution inside serialization.
- **Auth recovery semantics** — 401/429 degrade the publisher durably; recovery restores BEFORE `processNewMessages` with the flag cleared only after success (`hasBoundScopes()` gate); contained failure retains the flag and retries next poll; failed own-rejoin restore withholds the roster cursor so the event reprocesses; no-bound-scopes edge clears the flag without force-restore.
- **Tests** — real-runtime PGlite suite 13/13; non-vacuous seam tests (real scope mock, publisher-call assertions, exact adoption invariant: generation=before+1 with publisher seat unchanged); RED controls per round (R4 pair proven failing pre-fix).

## Key invariants

- Degrade never publishes an empty roster: an auth failure marks the scope `unavailable` and retries; removals only ever come from explicit leave events.
- Own-account `ParticipantsJoin` after own-leave calls `restoreScope` BEFORE publishing — rejoin cannot leave the scope durably unavailable.
- Intra-epoch replay of own-proof evidence is benign (eventAnchoredAt=epoch-start on the epoch-anchored key).

## Verification

| Gate | Result |
|---|---|
| Real-runtime suite (fresh capture at publish) | 13/13 |
| Unit suite | 396 pass / 4 fail — the 4 are in `PostService.test.ts` + `x.service.test.ts`, byte-identical to develop (0 diff under `services/`), proven pre-existing on a pristine develop control by prior lanes |
| Typecheck / Biome | clean |
| Merge vs develop tip | clean (merge-tree 0 conflicts vs `5c476b4206`); branch rebased 138 commits onto the tip with the auth-recovery hunk revalidated against develop's cloud credential boundary |
| Independent agent review | 4 rounds (R1: 6, R2: 4, R3: 3, R4: 3 findings) — every finding verified real and fixed with RED controls; R4's fixed state documented without a fifth confirming round |

<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed (connector-internal evidence publication)
<!-- evidence-row:walkthrough-video -->
N/A - no user-visible surface changed (connector-internal evidence publication)
<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only head move (no behavior change); verified at new head: plugin-x default lane 433 pass/13 skip + real-runtime lane 13/13, typecheck rc=0; clean 7-commit rebase onto develop 3a7f438a9e
# 43 files collected (was 33 at the reviewed head): the narrowed exclude
# restores src/client/fetch-error-path.real.test.ts (10 tests) to the lane.
# The 2 failed files / 4 failed tests are PRE-EXISTING at reviewed head
# 4c5726e827 (stash control: identical 4-fail set on the pristine tree,
# src/services/PostService.test.ts + src/services/x.service.test.ts).

$ bun run vitest run --config vitest.real-runtime.config.ts
Test Files  1 passed (1)
     Tests  13 passed (13)
# collects on a clean checkout now: uuid import replaced with
# node:crypto randomUUID (__tests__/membership-publisher.real.test.ts:59)

$ ./node_modules/.bin/biome check src/membership.ts vitest.config.ts __tests__/membership-publisher.real.test.ts
Checked 3 files in 68ms. No fixes applied.

$ bun run typecheck  # tsc --noEmit -p tsconfig.json
exit 0
```

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface changed (connector-internal evidence publication)
<!-- evidence-row:llm-trajectory -->
N/A - no model/provider path changed (deterministic suites over the real service contract)
<!-- evidence-row:domain-artifacts -->
N/A - membership records and adoption invariants asserted directly in the real-runtime suite
<!-- evidence-row:ocr-review -->
N/A - no OCR surface involved

<!-- evidence-head:8d5ff977879dce408780d95b0248359f3db9efd4 -->

---

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->






