### PR TITLE
fix(wallet): simplify inventory layout

### DIFF
--- a/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
+++ b/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
@@ -144,6 +144,10 @@ describe("smoke view bundle provenance over HTTP (#15791)", () => {
     expect(byId.get("orchestrator")?.surface).toEqual({
       capabilities: ["agent-surface"],
     });
+    expect(byId.get("wallet")?.surface).toEqual({
+      background: "shared",
+      capabilities: ["agent-surface", "wallpaper"],
+    });
     expect(byId.get("task-coordinator")?.surface).toBeUndefined();
     expect(byId.has("feed")).toBe(false);
   });

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -71,7 +71,18 @@ export const smokeViewDeclarations = [
   ],
   ["messages", "Messages", "plugin-messages", "/messages", "MessagesView"],
   ["phone", "Phone", "plugin-phone", "/phone", "PhoneView"],
-  ["wallet", "Wallet", "plugin-wallet", "/wallet", "InventoryView"],
+  [
+    "wallet",
+    "Wallet",
+    "plugin-wallet",
+    "/wallet",
+    "InventoryView",
+    "gui",
+    {
+      background: "shared",
+      capabilities: ["agent-surface", "wallpaper"],
+    },
+  ],
   ["views-manager", "Views", "plugin-app-control", "/views", "ViewManagerView"],
   ["notes", "Notes", "plugin-notes", "/notes", "NotesView"],
   [

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -707,18 +707,41 @@ function emptyWalletMarketSource(providerId: "coingecko" | "polymarket") {
   };
 }
 
-function emptyWalletMarketOverview() {
+function smokeWalletMarketOverview() {
+  const availableSource = (providerId: "coingecko" | "polymarket") => ({
+    ...emptyWalletMarketSource(providerId),
+    available: true,
+  });
   return {
     generatedAt: SMOKE_GENERATED_AT,
     cacheTtlSeconds: 60,
     stale: false,
     sources: {
-      prices: emptyWalletMarketSource("coingecko"),
-      movers: emptyWalletMarketSource("coingecko"),
-      predictions: emptyWalletMarketSource("polymarket"),
+      prices: availableSource("coingecko"),
+      movers: availableSource("coingecko"),
+      predictions: availableSource("polymarket"),
     },
     prices: [],
-    movers: [],
+    movers: [
+      {
+        id: "solana",
+        symbol: "SOL",
+        name: "Solana",
+        priceUsd: 150,
+        change24hPct: 7.5,
+        marketCapRank: 5,
+        imageUrl: null,
+      },
+      {
+        id: "ethereum",
+        symbol: "ETH",
+        name: "Ethereum",
+        priceUsd: 3600,
+        change24hPct: -1.8,
+        marketCapRank: 2,
+        imageUrl: null,
+      },
+    ],
     predictions: [],
   };
 }
@@ -832,6 +855,13 @@ function smokeWalletNfts() {
             tokenId: "42",
             name: "Smoke Test NFT #42",
             collectionName: "Eliza Smoke Collection",
+            imageUrl: "",
+            tokenUri: "",
+          },
+          {
+            tokenId: "43",
+            name: "ETH / USDC Position",
+            collectionName: "Uniswap V3 Liquidity Pool",
             imageUrl: "",
             tokenUri: "",
           },
@@ -3439,7 +3469,7 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(emptyWalletMarketOverview()),
+      body: JSON.stringify(smokeWalletMarketOverview()),
     });
   });
 

--- a/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
+++ b/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
@@ -294,6 +294,16 @@ test.describe("views deep UX audit capture", () => {
       });
       const sidebar = await openWalletSidebar(page);
       await screenshot(page, `${viewport.name}-wallet-overview`);
+      const detailsButton = sidebar.getByRole("button", {
+        name: "Show wallet details",
+      });
+      if (await detailsButton.isVisible().catch(() => false)) {
+        await detailsButton.click();
+        await screenshot(page, `${viewport.name}-wallet-details`);
+        await sidebar
+          .getByRole("button", { name: "Hide wallet details" })
+          .click();
+      }
       for (const tab of ["tokens", "defi", "nfts"] as const) {
         const tabButton = sidebar.getByTestId(`wallet-tab-${tab}`);
         if (await tabButton.isVisible().catch(() => false)) {
@@ -302,7 +312,26 @@ test.describe("views deep UX audit capture", () => {
           await screenshot(page, `${viewport.name}-wallet-${tab}`);
         }
       }
+      const tokensTab = sidebar.getByTestId("wallet-tab-tokens");
+      if (await tokensTab.isVisible().catch(() => false)) {
+        await tokensTab.click();
+        await page.waitForTimeout(300);
+        const tokenMenu = sidebar
+          .getByRole("button", { name: /^Manage / })
+          .first();
+        if (await tokenMenu.isVisible().catch(() => false)) {
+          await tokenMenu.click();
+          await screenshot(page, `${viewport.name}-wallet-token-actions`);
+          await page.keyboard.press("Escape");
+        }
+      }
       for (const insight of ["Activity", "Markets"] as const) {
+        const disclosure = page.getByRole("button", {
+          name: "Show activity and markets",
+        });
+        if (await disclosure.isVisible().catch(() => false)) {
+          await disclosure.click();
+        }
         const tabButton = page.getByRole("tab", { name: insight });
         if (await tabButton.isVisible().catch(() => false)) {
           await tabButton.click();

--- a/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
+++ b/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
@@ -293,6 +293,17 @@ test.describe("views deep UX audit capture", () => {
           await screenshot(page, `${viewport.name}-wallet-${tab}`);
         }
       }
+      for (const insight of ["Activity", "Markets"] as const) {
+        const tabButton = page.getByRole("tab", { name: insight });
+        if (await tabButton.isVisible().catch(() => false)) {
+          await tabButton.click();
+          await page.waitForTimeout(300);
+          await screenshot(
+            page,
+            `${viewport.name}-wallet-${insight.toLowerCase()}`,
+          );
+        }
+      }
     });
 
     test(`capture browser workspace states @ ${viewport.name}`, async ({

--- a/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
+++ b/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
@@ -13,6 +13,7 @@ import {
   seedAppStorage,
 } from "./helpers";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
+import { seedBackgroundStorage } from "./helpers/view-background";
 
 const OUT_DIR = path.join(
   process.cwd(),
@@ -277,11 +278,19 @@ test.describe("views deep UX audit capture", () => {
         "elizaos:ui:sidebar:eliza:page-sidebar:wallets:defi:collapsed": "false",
         "elizaos:ui:sidebar:eliza:page-sidebar:wallets:nfts:collapsed": "false",
       });
+      await seedBackgroundStorage(page, {
+        mode: "image",
+        color: "#000000",
+        imageUrl: "/bg-sunset.webp",
+      });
       await installDefaultAppRoutes(page);
 
       await openAppPath(page, "/wallet");
       await expect(page.getByTestId("wallet-shell")).toBeVisible({
         timeout: 60_000,
+      });
+      await expect(page.getByTestId("app-background-image")).toBeAttached({
+        timeout: 15_000,
       });
       const sidebar = await openWalletSidebar(page);
       await screenshot(page, `${viewport.name}-wallet-overview`);

--- a/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
+++ b/packages/app/test/ui-smoke/views-deep-audit-capture.spec.ts
@@ -304,7 +304,13 @@ test.describe("views deep UX audit capture", () => {
           .getByRole("button", { name: "Hide wallet details" })
           .click();
       }
-      for (const tab of ["tokens", "defi", "nfts"] as const) {
+      for (const tab of [
+        "tokens",
+        "defi",
+        "nfts",
+        "activity",
+        "markets",
+      ] as const) {
         const tabButton = sidebar.getByTestId(`wallet-tab-${tab}`);
         if (await tabButton.isVisible().catch(() => false)) {
           await tabButton.click();
@@ -323,23 +329,6 @@ test.describe("views deep UX audit capture", () => {
           await tokenMenu.click();
           await screenshot(page, `${viewport.name}-wallet-token-actions`);
           await page.keyboard.press("Escape");
-        }
-      }
-      for (const insight of ["Activity", "Markets"] as const) {
-        const disclosure = page.getByRole("button", {
-          name: "Show activity and markets",
-        });
-        if (await disclosure.isVisible().catch(() => false)) {
-          await disclosure.click();
-        }
-        const tabButton = page.getByRole("tab", { name: insight });
-        if (await tabButton.isVisible().catch(() => false)) {
-          await tabButton.click();
-          await page.waitForTimeout(300);
-          await screenshot(
-            page,
-            `${viewport.name}-wallet-${insight.toLowerCase()}`,
-          );
         }
       }
     });

--- a/packages/app/test/ui-smoke/wallet-inventory.spec.ts
+++ b/packages/app/test/ui-smoke/wallet-inventory.spec.ts
@@ -97,13 +97,6 @@ test("wallet inventory exposes chain badges, rows, copy controls, and hide state
   const sidebar = await openWalletSidebar(page);
 
   await expect(sidebar.getByText("$1,550.50")).toBeVisible();
-  for (const chain of ["ethereum", "base", "bsc", "avax", "solana"]) {
-    await expect(
-      sidebar.getByTestId(`wallet-chain-chip-${chain}`),
-      `${chain} chain badge should be rendered`,
-    ).toBeVisible();
-  }
-
   await expect(
     sidebar.getByTestId("wallet-token-row-ethereum-native-eth"),
   ).toContainText("ETH");
@@ -117,6 +110,13 @@ test("wallet inventory exposes chain badges, rows, copy controls, and hide state
     sidebar.getByTestId("wallet-token-row-solana-native-sol"),
   ).toContainText("SOL");
 
+  await sidebar.getByRole("button", { name: "Show wallet details" }).click();
+  await expect(
+    sidebar.getByTestId("wallet-address-chain-chip-ethereum"),
+  ).toBeVisible();
+  await expect(
+    sidebar.getByTestId("wallet-address-chain-chip-solana"),
+  ).toBeVisible();
   await sidebar.getByTestId("wallet-copy-evm-address").click();
   if (clipboardReadable) {
     await expect
@@ -126,7 +126,7 @@ test("wallet inventory exposes chain badges, rows, copy controls, and hide state
       .toBe("0x1234567890abcdef1234567890abcdef12345678");
   }
 
-  await sidebar.getByTestId("wallet-copy-sol-address").click();
+  await sidebar.getByTestId("wallet-copy-solana-address").click();
   if (clipboardReadable) {
     await expect
       .poll(() => page.evaluate(() => navigator.clipboard.readText()), {
@@ -140,13 +140,14 @@ test("wallet inventory exposes chain badges, rows, copy controls, and hide state
   await expect(sidebar.getByText("Smoke Solana Collectible")).toBeVisible();
 
   await sidebar.getByTestId("wallet-tab-defi").click();
-  await expect(sidebar.getByText("No DeFi positions.")).toBeVisible();
+  await expect(sidebar.getByText("ETH / USDC Position")).toBeVisible();
 
   await sidebar.getByTestId("wallet-tab-tokens").click();
   await expect(
     sidebar.getByTestId("wallet-token-row-ethereum-native-usdc"),
   ).toBeVisible();
-  await sidebar.getByTestId("wallet-token-hide-ethereum-native-usdc").click();
+  await sidebar.getByTestId("wallet-token-manage-ethereum-native-usdc").click();
+  await page.getByTestId("wallet-token-hide-ethereum-native-usdc").click();
   await expect(
     sidebar.getByTestId("wallet-token-row-ethereum-native-usdc"),
   ).toHaveCount(0);

--- a/packages/ui/src/navigation/builtin-route-descriptors.ts
+++ b/packages/ui/src/navigation/builtin-route-descriptors.ts
@@ -165,7 +165,11 @@ export const BUILTIN_ROUTE_DESCRIPTORS = defineBuiltinRoutes({
   },
   automations: { path: "/automations", layout: FRAMED_PAGE_LAYOUT },
   triggers: { aliasOf: "automations" },
-  inventory: { path: "/wallet", layout: SHELL_WIDE_CONTENT_LAYOUT },
+  inventory: {
+    path: "/wallet",
+    layout: SHELL_WIDE_CONTENT_LAYOUT,
+    surface: { background: "shared", capabilities: ["wallpaper"] },
+  },
   documents: {
     path: "/character/documents",
     layout: WORKSPACE_LAYOUT,

--- a/packages/ui/src/navigation/builtin-route-descriptors.ts
+++ b/packages/ui/src/navigation/builtin-route-descriptors.ts
@@ -165,11 +165,7 @@ export const BUILTIN_ROUTE_DESCRIPTORS = defineBuiltinRoutes({
   },
   automations: { path: "/automations", layout: FRAMED_PAGE_LAYOUT },
   triggers: { aliasOf: "automations" },
-  inventory: {
-    path: "/wallet",
-    layout: SHELL_WIDE_CONTENT_LAYOUT,
-    surface: { background: "shared", capabilities: ["wallpaper"] },
-  },
+  inventory: { path: "/wallet", layout: SHELL_WIDE_CONTENT_LAYOUT },
   documents: {
     path: "/character/documents",
     layout: WORKSPACE_LAYOUT,

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
@@ -57,158 +57,253 @@ const bridgeMocks = vi.hoisted(() => ({
 // The plugin vitest config collapses `@elizaos/ui/<subpath>` (incl. `/bridge`)
 // onto this single mock, so `shellLocalStorage` lives here alongside the rest of
 // the `@elizaos/ui` surface the view imports.
-vi.mock("@elizaos/ui", () => ({
-  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
-  shellLocalStorage: {
-    setItem: bridgeMocks.shellSetItem,
-    removeItem: (key: string) => globalThis.window.localStorage.removeItem(key),
-    clear: () => globalThis.window.localStorage.clear(),
-  },
-  client: walletClient,
-  // Mirrors the real guard's contract (an ApiError carries a numeric
-  // `status`); tests reject fetches with Object.assign(new Error(body),
-  // { status }) to model the client's error shape at the network boundary.
-  isApiError: (value: unknown): boolean =>
-    value instanceof Error &&
-    typeof (value as { status?: unknown }).status === "number",
-  Button: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
-    React.createElement("button", { type: "button", ...props }),
-  Avatar: (props: React.HTMLAttributes<HTMLSpanElement>) =>
-    React.createElement("span", props),
-  AvatarImage: (props: React.ImgHTMLAttributes<HTMLImageElement>) =>
-    React.createElement("img", props),
-  AvatarFallback: (props: React.HTMLAttributes<HTMLSpanElement>) =>
-    React.createElement("span", props),
-  Badge: ({
-    asChild: _asChild,
-    variant: _variant,
-    tone: _tone,
-    ...props
-  }: React.HTMLAttributes<HTMLDivElement> & {
-    asChild?: boolean;
-    variant?: string;
-    tone?: string;
-  }) => React.createElement("div", props),
-  PagePanel: Object.assign(
-    ({
-      as: _as,
-      variant: _variant,
-      ...props
-    }: React.ComponentPropsWithoutRef<"section"> & {
-      as?: string;
-      variant?: string;
-    }) => React.createElement("section", props),
-    {
-      Frame: ({
-        as = "div",
-        className,
-        ...props
-      }: React.ComponentPropsWithoutRef<"div"> & { as?: "div" | "main" }) =>
-        React.createElement(as, {
-          ...props,
-          className: ["flex h-full w-full min-h-0", className]
-            .filter(Boolean)
-            .join(" "),
-        }),
-      ContentArea: ({
-        className,
-        tabIndex = 0,
-        ...props
-      }: React.ComponentPropsWithoutRef<"div">) =>
-        React.createElement("div", {
-          ...props,
-          tabIndex,
-          className: ["min-h-0 min-w-0 flex-1 overflow-y-auto", className]
-            .filter(Boolean)
-            .join(" "),
-        }),
-      ContentRail: ({
-        className,
-        width = "standard",
-        ...props
-      }: React.ComponentPropsWithoutRef<"div"> & {
-        width?: "compact" | "standard" | "wide";
-      }) =>
-        React.createElement("div", {
-          ...props,
-          "data-slot": "page-panel-content-rail",
-          "data-width": width,
-          className: ["mx-auto w-full min-w-0 px-4 sm:px-6", className]
-            .filter(Boolean)
-            .join(" "),
-        }),
-      Header: ({
-        heading,
-        description,
-        actions,
-        ...props
-      }: React.ComponentPropsWithoutRef<"div"> & {
-        heading: React.ReactNode;
-        description?: React.ReactNode;
-        actions?: React.ReactNode;
-      }) =>
-        React.createElement(
-          "div",
-          props,
-          heading,
-          description
-            ? React.createElement("span", { className: "sr-only" }, description)
-            : null,
-          actions,
-        ),
-      Notice: ({
-        tone: _tone,
-        actions,
-        children,
-        ...props
-      }: React.ComponentPropsWithoutRef<"div"> & {
-        tone?: string;
-        actions?: React.ReactNode;
-      }) => React.createElement("div", props, children, actions),
-      ContentState: ({
-        state: _state,
-        placement: _placement,
-        title,
-        description,
-        action,
-        ...props
-      }: React.ComponentPropsWithoutRef<"div"> & {
-        state: string;
-        placement?: string;
-        title: string;
-        description?: string;
-        action?: React.ReactNode;
-      }) =>
-        React.createElement(
-          "div",
-          props,
-          React.createElement("h2", null, title),
-          description ? React.createElement("p", null, description) : null,
-          action,
-        ),
+vi.mock("@elizaos/ui", () => {
+  const CollapsibleContext = React.createContext<{
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  } | null>(null);
+  const DropdownContext = React.createContext<{
+    open: boolean;
+    setOpen: (open: boolean) => void;
+  } | null>(null);
+
+  return {
+    useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+    shellLocalStorage: {
+      setItem: bridgeMocks.shellSetItem,
+      removeItem: (key: string) =>
+        globalThis.window.localStorage.removeItem(key),
+      clear: () => globalThis.window.localStorage.clear(),
     },
-  ),
-  ListSkeleton: ({ rows = 4 }: { rows?: number }) =>
-    React.createElement(
-      "div",
-      { "data-testid": "list-skeleton" },
-      ...Array.from({ length: rows }, (_, index) =>
-        React.createElement("span", { key: index }),
-      ),
+    client: walletClient,
+    // Mirrors the real guard's contract (an ApiError carries a numeric
+    // `status`); tests reject fetches with Object.assign(new Error(body),
+    // { status }) to model the client's error shape at the network boundary.
+    isApiError: (value: unknown): boolean =>
+      value instanceof Error &&
+      typeof (value as { status?: unknown }).status === "number",
+    Button: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+      React.createElement("button", { type: "button", ...props }),
+    Avatar: (props: React.HTMLAttributes<HTMLSpanElement>) =>
+      React.createElement("span", props),
+    AvatarImage: (props: React.ImgHTMLAttributes<HTMLImageElement>) =>
+      React.createElement("img", props),
+    AvatarFallback: (props: React.HTMLAttributes<HTMLSpanElement>) =>
+      React.createElement("span", props),
+    Badge: ({
+      asChild: _asChild,
+      variant: _variant,
+      tone: _tone,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      asChild?: boolean;
+      variant?: string;
+      tone?: string;
+    }) => React.createElement("div", props),
+    PagePanel: Object.assign(
+      ({
+        as: _as,
+        variant: _variant,
+        ...props
+      }: React.ComponentPropsWithoutRef<"section"> & {
+        as?: string;
+        variant?: string;
+      }) => React.createElement("section", props),
+      {
+        Frame: ({
+          as = "div",
+          className,
+          ...props
+        }: React.ComponentPropsWithoutRef<"div"> & { as?: "div" | "main" }) =>
+          React.createElement(as, {
+            ...props,
+            className: ["flex h-full w-full min-h-0", className]
+              .filter(Boolean)
+              .join(" "),
+          }),
+        ContentArea: ({
+          className,
+          tabIndex = 0,
+          ...props
+        }: React.ComponentPropsWithoutRef<"div">) =>
+          React.createElement("div", {
+            ...props,
+            tabIndex,
+            className: ["min-h-0 min-w-0 flex-1 overflow-y-auto", className]
+              .filter(Boolean)
+              .join(" "),
+          }),
+        ContentRail: ({
+          className,
+          width = "standard",
+          ...props
+        }: React.ComponentPropsWithoutRef<"div"> & {
+          width?: "compact" | "standard" | "wide";
+        }) =>
+          React.createElement("div", {
+            ...props,
+            "data-slot": "page-panel-content-rail",
+            "data-width": width,
+            className: ["mx-auto w-full min-w-0 px-4 sm:px-6", className]
+              .filter(Boolean)
+              .join(" "),
+          }),
+        Header: ({
+          heading,
+          description,
+          actions,
+          ...props
+        }: React.ComponentPropsWithoutRef<"div"> & {
+          heading: React.ReactNode;
+          description?: React.ReactNode;
+          actions?: React.ReactNode;
+        }) =>
+          React.createElement(
+            "div",
+            props,
+            heading,
+            description
+              ? React.createElement(
+                  "span",
+                  { className: "sr-only" },
+                  description,
+                )
+              : null,
+            actions,
+          ),
+        Notice: ({
+          tone: _tone,
+          actions,
+          children,
+          ...props
+        }: React.ComponentPropsWithoutRef<"div"> & {
+          tone?: string;
+          actions?: React.ReactNode;
+        }) => React.createElement("div", props, children, actions),
+        ContentState: ({
+          state: _state,
+          placement: _placement,
+          title,
+          description,
+          action,
+          ...props
+        }: React.ComponentPropsWithoutRef<"div"> & {
+          state: string;
+          placement?: string;
+          title: string;
+          description?: string;
+          action?: React.ReactNode;
+        }) =>
+          React.createElement(
+            "div",
+            props,
+            React.createElement("h2", null, title),
+            description ? React.createElement("p", null, description) : null,
+            action,
+          ),
+      },
     ),
-  cn: (...classes: unknown[]) => classes.filter(Boolean).join(" "),
-  // Pass through to navigator.clipboard so the copy-button tests keep
-  // asserting the address that reaches the platform clipboard boundary.
-  copyTextToClipboard: (text: string) => navigator.clipboard.writeText(text),
-  getActiveAgentAuthority: () => appHooks.authority,
-  useActiveAgentAuthority: () => appHooks.authority,
-  useActivityEvents: () => appHooks.activityEvents,
-  useApp: appHooks.useApp,
-  useAppSelector: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector(appHooks.useApp()),
-  useAppSelectorShallow: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector(appHooks.useApp()),
-}));
+    ListSkeleton: ({ rows = 4 }: { rows?: number }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "list-skeleton" },
+        ...Array.from({ length: rows }, (_, index) =>
+          React.createElement("span", { key: index }),
+        ),
+      ),
+    Collapsible: ({
+      open = false,
+      onOpenChange = () => undefined,
+      asChild: _asChild,
+      children,
+    }: {
+      open?: boolean;
+      onOpenChange?: (open: boolean) => void;
+      asChild?: boolean;
+      children: React.ReactNode;
+    }) =>
+      React.createElement(
+        CollapsibleContext.Provider,
+        { value: { open, onOpenChange } },
+        children,
+      ),
+    CollapsibleTrigger: ({
+      asChild: _asChild,
+      children,
+    }: {
+      asChild?: boolean;
+      children: React.ReactElement<
+        React.ButtonHTMLAttributes<HTMLButtonElement>
+      >;
+    }) => {
+      const context = React.useContext(CollapsibleContext);
+      return React.cloneElement(children, {
+        onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+          children.props.onClick?.(event);
+          context?.onOpenChange(!context.open);
+        },
+      });
+    },
+    CollapsibleContent: ({ children }: { children: React.ReactNode }) => {
+      const context = React.useContext(CollapsibleContext);
+      return context?.open ? children : null;
+    },
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => {
+      const [open, setOpen] = React.useState(false);
+      return React.createElement(
+        DropdownContext.Provider,
+        { value: { open, setOpen } },
+        children,
+      );
+    },
+    DropdownMenuTrigger: ({
+      asChild: _asChild,
+      children,
+    }: {
+      asChild?: boolean;
+      children: React.ReactElement<
+        React.ButtonHTMLAttributes<HTMLButtonElement>
+      >;
+    }) => {
+      const context = React.useContext(DropdownContext);
+      return React.cloneElement(children, {
+        onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+          children.props.onClick?.(event);
+          context?.setOpen(!context.open);
+        },
+      });
+    },
+    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => {
+      const context = React.useContext(DropdownContext);
+      return context?.open ? React.createElement("div", null, children) : null;
+    },
+    DropdownMenuItem: ({
+      onSelect,
+      children,
+      ...props
+    }: React.HTMLAttributes<HTMLButtonElement> & {
+      onSelect?: () => void;
+    }) =>
+      React.createElement(
+        "button",
+        { ...props, type: "button", onClick: onSelect },
+        children,
+      ),
+    cn: (...classes: unknown[]) => classes.filter(Boolean).join(" "),
+    // Pass through to navigator.clipboard so the copy-button tests keep
+    // asserting the address that reaches the platform clipboard boundary.
+    copyTextToClipboard: (text: string) => navigator.clipboard.writeText(text),
+    getActiveAgentAuthority: () => appHooks.authority,
+    useActiveAgentAuthority: () => appHooks.authority,
+    useActivityEvents: () => appHooks.activityEvents,
+    useApp: appHooks.useApp,
+    useAppSelector: (selector: (s: Record<string, unknown>) => unknown) =>
+      selector(appHooks.useApp()),
+    useAppSelectorShallow: (
+      selector: (s: Record<string, unknown>) => unknown,
+    ) => selector(appHooks.useApp()),
+  };
+});
 
 import { InventoryAppView } from "./InventoryAppView";
 
@@ -229,6 +324,16 @@ function hasFlatText(expected: string) {
       normalize(child.textContent ?? "").includes(expected),
     );
   };
+}
+
+function showWalletDetails(): void {
+  fireEvent.click(screen.getByRole("button", { name: "Show wallet details" }));
+}
+
+function showWalletInsights(): void {
+  fireEvent.click(
+    screen.getByRole("button", { name: "Show activity and markets" }),
+  );
 }
 
 const EVM_ADDRESS = "0x1111111111111111111111111111111111111111";
@@ -539,6 +644,10 @@ describe("InventoryView GUI — populated holdings", () => {
     expect(
       screen.getByRole("heading", { name: "Wallet insights" }),
     ).toBeTruthy();
+    expect(
+      screen.queryByRole("tablist", { name: "Wallet insights" }),
+    ).toBeNull();
+    showWalletInsights();
     const insights = screen.getByRole("tablist", { name: "Wallet insights" });
     expect(
       within(insights).getByRole("tab", { name: "Activity" }),
@@ -565,12 +674,11 @@ describe("InventoryView GUI — populated holdings", () => {
     );
     expect(walletRail.parentElement?.parentElement).toBe(walletShell);
     expect(walletRail.parentElement?.tabIndex).toBe(0);
-    // One EVM identity covers every supported EVM network; Solana stays
-    // separate because it has its own address format and signing path.
-    expect(within(sidebar).getByTitle("EVM RPC ready")).toBeTruthy();
-    expect(within(sidebar).getByTitle("Solana RPC ready")).toBeTruthy();
-    expect(within(sidebar).queryByTitle("ETH RPC ready")).toBeNull();
-    expect(within(sidebar).queryByTitle("BASE RPC ready")).toBeNull();
+    // Low-frequency account identity and network controls stay disclosed until
+    // requested, leaving the primary balance and holdings easy to scan.
+    expect(within(sidebar).queryByText("0x111...1111")).toBeNull();
+    showWalletDetails();
+    expect(within(sidebar).getByTitle(/EVM ready.*Solana ready/)).toBeTruthy();
     // Exactly two address identities render, with no duplicate Base address.
     expect(within(sidebar).getByText("0x111...1111")).toBeTruthy();
     expect(within(sidebar).getByText("So1an...1111")).toBeTruthy();
@@ -618,8 +726,8 @@ describe("InventoryView GUI — populated holdings", () => {
 
     // Both identities connected/ready: this is a funded portfolio, not the empty
     // hero, so the "Your wallet is empty." line must not appear.
-    expect(within(sidebar).getByTitle("EVM RPC ready")).toBeTruthy();
-    expect(within(sidebar).getByTitle("Solana RPC ready")).toBeTruthy();
+    showWalletDetails();
+    expect(within(sidebar).getByTitle(/EVM ready.*Solana ready/)).toBeTruthy();
     expect(screen.queryByText("Your wallet is empty.")).toBeNull();
   });
 
@@ -635,8 +743,10 @@ describe("InventoryView GUI — populated holdings", () => {
     );
     render(React.createElement(InventoryAppView));
     const sidebar = await screen.findByTestId("wallets-sidebar");
-    expect(within(sidebar).getByTitle("EVM RPC ready")).toBeTruthy();
-    expect(within(sidebar).getByTitle("Solana needs RPC")).toBeTruthy();
+    showWalletDetails();
+    expect(
+      within(sidebar).getByTitle(/EVM ready.*Solana needs RPC/),
+    ).toBeTruthy();
   });
 
   it("uses distinct token monograms when remote logo assets fail", async () => {
@@ -712,7 +822,10 @@ describe("InventoryView GUI — hide token", () => {
       within(sidebar).getByText(hasFlatText("100.0000 USDC")),
     ).toBeTruthy();
 
-    fireEvent.click(within(sidebar).getByRole("button", { name: "Hide USDC" }));
+    fireEvent.click(
+      within(sidebar).getByRole("button", { name: "Manage USDC" }),
+    );
+    fireEvent.click(within(sidebar).getByText("Hide token"));
 
     // Row removed.
     await waitFor(() =>
@@ -782,6 +895,7 @@ describe("InventoryView GUI — loading hierarchy", () => {
     render(React.createElement(InventoryAppView));
     const holdings = await screen.findByTestId("wallets-sidebar");
 
+    showWalletDetails();
     expect(within(holdings).getByText("0x111...1111")).toBeTruthy();
     expect(within(holdings).getByText("So1an...1111")).toBeTruthy();
     expect(within(holdings).queryByText("No wallet connected")).toBeNull();
@@ -887,8 +1001,9 @@ describe("InventoryView GUI — loading hierarchy", () => {
     expect(
       screen.queryByText("Failed to fetch balances: API unavailable"),
     ).toBeNull();
-    expect(screen.getByTitle("EVM RPC ready")).toBeTruthy();
-    expect(screen.getByTitle("Solana RPC ready")).toBeTruthy();
+    showWalletDetails();
+    expect(screen.getByTitle(/EVM ready.*Solana ready/)).toBeTruthy();
+    showWalletInsights();
     expect(
       screen.getByRole("tablist", { name: "Wallet insights" }),
     ).toBeTruthy();
@@ -1077,6 +1192,7 @@ describe("InventoryView GUI — loading hierarchy", () => {
     expect(
       screen.queryByText("Failed to refresh balances: API unavailable"),
     ).toBeNull();
+    showWalletInsights();
     expect(screen.getByRole("tab", { name: "Markets" })).toBeTruthy();
 
     state.loadBalances.mockClear();
@@ -1123,6 +1239,7 @@ describe("InventoryView GUI — address copy buttons", () => {
     render(React.createElement(InventoryAppView));
     const sidebar = await screen.findByTestId("wallets-sidebar");
 
+    showWalletDetails();
     const evmCopy = within(sidebar).getByRole("button", {
       name: "Copy EVM address",
     });
@@ -1213,10 +1330,11 @@ describe("InventoryView GUI — background poll + RPC settings", () => {
     render(React.createElement(InventoryAppView));
     const sidebar = await screen.findByTestId("wallets-sidebar");
 
+    showWalletDetails();
     const rpcButton = within(sidebar).getByLabelText("Open network settings");
     // providerLabel: evm "alchemy" -> Alchemy, solana "helius-birdeye" -> Helius + Birdeye.
     expect(rpcButton.getAttribute("title")).toBe(
-      "RPC providers: EVM Alchemy, Solana Helius + Birdeye",
+      "Network settings: EVM ready via Alchemy; Solana ready via Helius + Birdeye",
     );
 
     fireEvent.click(rpcButton);
@@ -1315,6 +1433,7 @@ describe("InventoryView GUI — progressive insights", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
+    showWalletInsights();
     fireEvent.click(screen.getByRole("tab", { name: "Activity" }));
     // The agent activity remains; legacy BSC swap history stays under the hood.
     expect(screen.getByText("Rebalanced portfolio")).toBeTruthy();
@@ -1428,6 +1547,7 @@ describe("InventoryView GUI — calm empty-wallet hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
+    showWalletInsights();
     fireEvent.click(screen.getByRole("tab", { name: "Markets" }));
     expect(await screen.findByText("Market data unavailable")).toBeTruthy();
     expect(screen.getByTitle("Top movers unavailable")).toBeTruthy();
@@ -1453,6 +1573,7 @@ describe("InventoryView GUI — calm empty-wallet hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
+    showWalletInsights();
     fireEvent.click(screen.getByRole("tab", { name: "Markets" }));
     expect(await screen.findByText("Market data unavailable")).toBeTruthy();
     expect(screen.queryByText("network down")).toBeNull();

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
@@ -571,10 +571,6 @@ describe("InventoryView GUI — populated holdings", () => {
     expect(within(sidebar).getByTitle("Solana RPC ready")).toBeTruthy();
     expect(within(sidebar).queryByTitle("ETH RPC ready")).toBeNull();
     expect(within(sidebar).queryByTitle("BASE RPC ready")).toBeNull();
-    expect(
-      within(sidebar).getAllByTestId(/^wallet-identity-chip-/),
-    ).toHaveLength(2);
-
     // Exactly two address identities render, with no duplicate Base address.
     expect(within(sidebar).getByText("0x111...1111")).toBeTruthy();
     expect(within(sidebar).getByText("So1an...1111")).toBeTruthy();

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
@@ -565,9 +565,6 @@ describe("InventoryView GUI — populated holdings", () => {
     );
     expect(walletRail.parentElement?.parentElement).toBe(walletShell);
     expect(walletRail.parentElement?.tabIndex).toBe(0);
-    expect(sidebar.className).toContain("bg-card");
-    expect(sidebar.className).toContain("rounded-xl");
-
     // One EVM identity covers every supported EVM network; Solana stays
     // separate because it has its own address format and signing path.
     expect(within(sidebar).getByTitle("EVM RPC ready")).toBeTruthy();

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.gui.test.tsx
@@ -330,12 +330,6 @@ function showWalletDetails(): void {
   fireEvent.click(screen.getByRole("button", { name: "Show wallet details" }));
 }
 
-function showWalletInsights(): void {
-  fireEvent.click(
-    screen.getByRole("button", { name: "Show activity and markets" }),
-  );
-}
-
 const EVM_ADDRESS = "0x1111111111111111111111111111111111111111";
 const SOL_ADDRESS = "So1ana1111111111111111111111111111111111111";
 const AERO_ADDRESS = "0xAERO000000000000000000000000000000000000";
@@ -636,25 +630,19 @@ describe("InventoryView GUI — populated holdings", () => {
     expect(within(sidebar).getByText("$80.00")).toBeTruthy();
     expect(within(sidebar).getByText("$750.00")).toBeTruthy();
 
-    // One grouped holdings surface and one progressive insights surface keep
-    // the same data scan-friendly without five duplicate dashboard cards.
+    // All peer content modes share one navigation layer; account management
+    // remains the only progressively disclosed region.
+    const contentModes = within(sidebar).getByRole("tablist", {
+      name: "Wallet asset type",
+    });
     expect(
-      within(sidebar).getByRole("tablist", { name: "Wallet asset type" }),
+      within(contentModes).getByRole("tab", { name: "Activity" }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("heading", { name: "Wallet insights" }),
+      within(contentModes).getByRole("tab", { name: "Markets" }),
     ).toBeTruthy();
     expect(
-      screen.queryByRole("tablist", { name: "Wallet insights" }),
-    ).toBeNull();
-    showWalletInsights();
-    const insights = screen.getByRole("tablist", { name: "Wallet insights" });
-    expect(
-      within(insights).getByRole("tab", { name: "Activity" }),
-    ).toBeTruthy();
-    expect(within(insights).getByRole("tab", { name: "Markets" })).toBeTruthy();
-    expect(
-      within(insights).queryByRole("tab", { name: "Performance" }),
+      within(contentModes).queryByRole("tab", { name: "Performance" }),
     ).toBeNull();
     expect(
       screen.queryByRole("heading", { name: "DeFi positions" }),
@@ -1003,9 +991,8 @@ describe("InventoryView GUI — loading hierarchy", () => {
     ).toBeNull();
     showWalletDetails();
     expect(screen.getByTitle(/EVM ready.*Solana ready/)).toBeTruthy();
-    showWalletInsights();
     expect(
-      screen.getByRole("tablist", { name: "Wallet insights" }),
+      screen.getByRole("tablist", { name: "Wallet asset type" }),
     ).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
 
@@ -1051,9 +1038,6 @@ describe("InventoryView GUI — loading hierarchy", () => {
     expect(screen.queryByText("$0.00")).toBeNull();
     expect(
       screen.queryByRole("tablist", { name: "Wallet asset type" }),
-    ).toBeNull();
-    expect(
-      screen.queryByRole("tablist", { name: "Wallet insights" }),
     ).toBeNull();
   });
 
@@ -1192,7 +1176,6 @@ describe("InventoryView GUI — loading hierarchy", () => {
     expect(
       screen.queryByText("Failed to refresh balances: API unavailable"),
     ).toBeNull();
-    showWalletInsights();
     expect(screen.getByRole("tab", { name: "Markets" })).toBeTruthy();
 
     state.loadBalances.mockClear();
@@ -1433,7 +1416,6 @@ describe("InventoryView GUI — progressive insights", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    showWalletInsights();
     fireEvent.click(screen.getByRole("tab", { name: "Activity" }));
     // The agent activity remains; legacy BSC swap history stays under the hood.
     expect(screen.getByText("Rebalanced portfolio")).toBeTruthy();
@@ -1507,9 +1489,6 @@ describe("InventoryView GUI — calm empty-wallet hero", () => {
     // The "Keys" marketing CTA is gone.
     expect(screen.queryByRole("button", { name: "Keys" })).toBeNull();
     // The empty hero no longer pads itself with a market dashboard.
-    expect(
-      screen.queryByRole("tablist", { name: "Wallet insights" }),
-    ).toBeNull();
     expect(screen.queryByText("Cap rank #5")).toBeNull();
 
     // The one functional setup control (Enable wallet) remains and reloads.
@@ -1547,7 +1526,6 @@ describe("InventoryView GUI — calm empty-wallet hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    showWalletInsights();
     fireEvent.click(screen.getByRole("tab", { name: "Markets" }));
     expect(await screen.findByText("Market data unavailable")).toBeTruthy();
     expect(screen.getByTitle("Top movers unavailable")).toBeTruthy();
@@ -1573,7 +1551,6 @@ describe("InventoryView GUI — calm empty-wallet hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    showWalletInsights();
     fireEvent.click(screen.getByRole("tab", { name: "Markets" }));
     expect(await screen.findByText("Market data unavailable")).toBeTruthy();
     expect(screen.queryByText("network down")).toBeNull();

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
@@ -22,7 +22,16 @@ import { Avatar, AvatarFallback, AvatarImage, Button } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client, isApiError } from "@elizaos/ui/api";
 import { shellLocalStorage } from "@elizaos/ui/bridge";
-import { ListSkeleton } from "@elizaos/ui/components";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  ListSkeleton,
+} from "@elizaos/ui/components";
 import { PagePanel } from "@elizaos/ui/components/composites/page-panel";
 import {
   type ActivityEvent,
@@ -41,11 +50,13 @@ import {
   AlertTriangle,
   ArrowLeftRight,
   CheckCircle2,
+  ChevronDown,
   Copy,
   EyeOff,
   Image as ImageIcon,
   Layers3,
   type LucideIcon,
+  MoreHorizontal,
   Sparkles,
   TrendingDown,
   TrendingUp,
@@ -1104,28 +1115,6 @@ function WalletRailAddress({
   );
 }
 
-function WalletConnectionChip({
-  label,
-  ready,
-}: {
-  label: string;
-  ready: boolean;
-}) {
-  const StatusIcon = ready ? CheckCircle2 : AlertTriangle;
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 text-[0.68rem] font-medium text-muted"
-      title={`${label} ${ready ? "RPC ready" : "needs RPC"}`}
-    >
-      <StatusIcon
-        className={cn("size-3.5", ready ? "text-muted-strong" : "text-warn")}
-        aria-hidden
-      />
-      {label}
-    </span>
-  );
-}
-
 function WalletAddressCluster({
   addresses,
 }: {
@@ -1193,6 +1182,8 @@ function WalletRailRpcButton({
     walletConfig?.selectedRpcProviders?.solana,
     "solana",
   );
+  const evmStatus = walletConfig?.evmBalanceReady ? "ready" : "needs RPC";
+  const solanaStatus = walletConfig?.solanaBalanceReady ? "ready" : "needs RPC";
 
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: "account-rpc-settings",
@@ -1208,8 +1199,9 @@ function WalletRailRpcButton({
       size="sm"
       ref={ref}
       type="button"
+      className="self-start sm:self-auto"
       onClick={onOpenSettings}
-      title={`RPC providers: EVM ${evmProvider}, Solana ${solanaProvider}`}
+      title={`Network settings: EVM ${evmStatus} via ${evmProvider}; Solana ${solanaStatus} via ${solanaProvider}`}
       aria-label="Open network settings"
       {...agentProps}
     >
@@ -1230,11 +1222,10 @@ function WalletRailAccount({
   walletConfig: WalletConfigStatus | null;
   onOpenSettings: () => void;
 }) {
-  const evmReady = Boolean(walletConfig?.evmBalanceReady);
-  const solanaReady = Boolean(walletConfig?.solanaBalanceReady);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   return (
-    <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
+    <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+      <div className="flex items-end justify-between gap-3">
         <div className="min-w-0">
           <h2 className="text-xs-tight font-medium text-muted">
             Portfolio balance
@@ -1244,18 +1235,35 @@ function WalletRailAccount({
               {portfolioValueUsd === null ? "—" : formatUsd(portfolioValueUsd)}
             </div>
           </div>
-          <div className="mt-2 flex flex-wrap gap-3">
-            <WalletConnectionChip label="EVM" ready={evmReady} />
-            <WalletConnectionChip label="Solana" ready={solanaReady} />
-          </div>
         </div>
-        <WalletRailRpcButton
-          walletConfig={walletConfig}
-          onOpenSettings={onOpenSettings}
-        />
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghostMuted"
+            size="compact"
+            type="button"
+            aria-label={`${detailsOpen ? "Hide" : "Show"} wallet details`}
+          >
+            Details
+            <ChevronDown
+              className={cn(
+                "size-3.5 transition-transform",
+                detailsOpen && "rotate-180",
+              )}
+              aria-hidden
+            />
+          </Button>
+        </CollapsibleTrigger>
       </div>
-      <WalletAddressCluster addresses={addresses} />
-    </div>
+      <CollapsibleContent>
+        <div className="mt-4 flex flex-col gap-2 border-t border-border/70 pt-3 sm:flex-row sm:items-center sm:justify-between">
+          <WalletAddressCluster addresses={addresses} />
+          <WalletRailRpcButton
+            walletConfig={walletConfig}
+            onOpenSettings={onOpenSettings}
+          />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -1312,13 +1320,13 @@ function TokenRailRowImpl({
   onHideToken: (row: TokenRow) => void;
 }) {
   const slug = tokenAgentSlug(row);
-  const { ref: hideRef, agentProps: hideAgentProps } =
+  const { ref: manageRef, agentProps: manageAgentProps } =
     useAgentElement<HTMLButtonElement>({
-      id: `token-${slug}-hide`,
+      id: `token-${slug}-manage`,
       role: "button",
-      label: `Hide ${row.symbol}`,
+      label: `Manage ${row.symbol}`,
       group: "token-list",
-      description: `Hide the ${row.symbol} token from the list`,
+      description: `Open management actions for the ${row.symbol} token`,
     });
   return (
     <div
@@ -1341,20 +1349,31 @@ function TokenRailRowImpl({
           </div>
           <TokenPerformance row={row} profile={profile} />
         </div>
-        <Button
-          variant="ghostMuted"
-          size="icon"
-          ref={hideRef}
-          type="button"
-          className="opacity-70 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
-          onClick={() => onHideToken(row)}
-          aria-label={`Hide ${row.symbol}`}
-          title={`Hide ${row.symbol}`}
-          data-testid={`wallet-token-hide-${slug}`}
-          {...hideAgentProps}
-        >
-          <EyeOff className="size-3.5" />
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghostMuted"
+              size="icon"
+              ref={manageRef}
+              type="button"
+              aria-label={`Manage ${row.symbol}`}
+              title={`Manage ${row.symbol}`}
+              data-testid={`wallet-token-manage-${slug}`}
+              {...manageAgentProps}
+            >
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem
+              onSelect={() => onHideToken(row)}
+              data-testid={`wallet-token-hide-${slug}`}
+            >
+              <EyeOff className="mr-2 size-3.5" />
+              Hide token
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );
@@ -1819,6 +1838,7 @@ function WalletInsightsPanel({
   marketOverview: WalletMarketOverviewResponse | null;
   marketOverviewLoading: boolean;
 }) {
+  const [open, setOpen] = useState(false);
   const tabs: Array<{
     id: WalletInsightTab;
     label: string;
@@ -1828,50 +1848,71 @@ function WalletInsightsPanel({
   ];
 
   return (
-    <section
-      aria-labelledby="wallet-insights-title"
-      className="overflow-hidden border-t border-border/70"
-    >
-      <h2 id="wallet-insights-title" className="sr-only">
-        Wallet insights
-      </h2>
-      <div className="py-2">
-        <div
-          className="flex items-center gap-1"
-          role="tablist"
-          aria-label="Wallet insights"
-        >
-          {tabs.map((tab) => (
-            <WalletInsightTabButton
-              key={tab.id}
-              tab={tab}
-              active={activeTab === tab.id}
-              onSelect={onSelectTab}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div
-        id={`wallet-insight-panel-${activeTab}`}
-        role="tabpanel"
-        aria-labelledby={`wallet-insight-tab-${activeTab}`}
-        className="border-t border-border/70"
+    <Collapsible open={open} onOpenChange={setOpen} asChild>
+      <section
+        aria-labelledby="wallet-insights-title"
+        className="overflow-hidden border-t border-border/70"
       >
-        {activeTab === "activity" ? (
-          <ActivityLog profile={profile} events={events} />
-        ) : (
-          <div className="py-4 sm:py-5">
-            <PortfolioMoversPanel
-              rows={rows}
-              profile={profile}
-              marketOverview={marketOverview}
-              loading={marketOverviewLoading}
+        <h2 id="wallet-insights-title" className="sr-only">
+          Wallet insights
+        </h2>
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghostMuted"
+            size="default"
+            align="between"
+            className="w-full px-0 py-3"
+            aria-label={`${open ? "Hide" : "Show"} activity and markets`}
+          >
+            <span className="font-medium text-txt">Activity & markets</span>
+            <ChevronDown
+              className={cn(
+                "size-4 transition-transform",
+                open && "rotate-180",
+              )}
+              aria-hidden
             />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="border-t border-border/70 py-2">
+            <div
+              className="flex items-center gap-1"
+              role="tablist"
+              aria-label="Wallet insights"
+            >
+              {tabs.map((tab) => (
+                <WalletInsightTabButton
+                  key={tab.id}
+                  tab={tab}
+                  active={activeTab === tab.id}
+                  onSelect={onSelectTab}
+                />
+              ))}
+            </div>
           </div>
-        )}
-      </div>
-    </section>
+          <div
+            id={`wallet-insight-panel-${activeTab}`}
+            role="tabpanel"
+            aria-labelledby={`wallet-insight-tab-${activeTab}`}
+            className="border-t border-border/70"
+          >
+            {activeTab === "activity" ? (
+              <ActivityLog profile={profile} events={events} />
+            ) : (
+              <div className="py-4 sm:py-5">
+                <PortfolioMoversPanel
+                  rows={rows}
+                  profile={profile}
+                  marketOverview={marketOverview}
+                  loading={marketOverviewLoading}
+                />
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </section>
+    </Collapsible>
   );
 }
 

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
@@ -1393,10 +1393,10 @@ function WalletRailTabButton({
   return (
     <Button
       variant="selection"
-      size="default"
+      size="compact"
       ref={ref}
       type="button"
-      className="min-w-0"
+      className="min-w-0 shrink-0"
       data-state={active ? "on" : "off"}
       onClick={() => onSelect(tab.id)}
       aria-label={tab.label}
@@ -1409,7 +1409,7 @@ function WalletRailTabButton({
       {...agentProps}
     >
       <tab.icon className="size-3.5 shrink-0" />
-      <span className="truncate">{tab.label}</span>
+      <span>{tab.label}</span>
     </Button>
   );
 }
@@ -1436,7 +1436,7 @@ function TokenRailRowImpl({
     });
   return (
     <div
-      className="group flex min-h-[4.75rem] min-w-0 items-center gap-3 px-4 py-3 transition-colors hover:bg-bg-hover focus-within:bg-bg-hover"
+      className="group flex min-h-[4.75rem] min-w-0 items-center gap-3 py-3 transition-colors hover:bg-bg-hover focus-within:bg-bg-hover"
       data-testid={`wallet-token-row-${slug}`}
     >
       <TokenIdentityIcon row={row} size={42} />
@@ -1558,7 +1558,7 @@ function RailNftList({
       {nfts.slice(0, 20).map((nft) => (
         <div
           key={`${nft.chain}:${nft.collectionName}:${nft.name}:${nft.imageUrl}`}
-          className="flex min-h-[4.75rem] min-w-0 items-center gap-3 px-4 py-3 transition-colors hover:bg-bg-hover"
+          className="flex min-h-[4.75rem] min-w-0 items-center gap-3 py-3 transition-colors hover:bg-bg-hover"
         >
           {nft.imageUrl ? (
             <img
@@ -1606,7 +1606,7 @@ function RailPositionList({
       {positions.map((position) => (
         <div
           key={position.id}
-          className="flex min-h-[4.75rem] min-w-0 items-center gap-3 px-4 py-3 transition-colors hover:bg-bg-hover"
+          className="flex min-h-[4.75rem] min-w-0 items-center gap-3 py-3 transition-colors hover:bg-bg-hover"
         >
           {position.imageUrl ? (
             <img
@@ -1736,9 +1736,9 @@ function WalletHoldingsSection({
       <section
         data-testid="wallets-sidebar"
         aria-label="Wallet holdings"
-        className="overflow-hidden rounded-xl border border-border bg-card"
+        className="overflow-hidden"
       >
-        <div className="flex min-h-40 items-center justify-between gap-4 p-4 sm:p-5">
+        <div className="flex min-h-40 items-center justify-between gap-4 py-4 sm:py-5">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-accent-subtle text-accent">
               <Wallet className="size-4.5" aria-hidden />
@@ -1769,9 +1769,9 @@ function WalletHoldingsSection({
     <section
       data-testid="wallets-sidebar"
       aria-label="Wallet holdings"
-      className="overflow-hidden rounded-xl border border-border bg-card"
+      className="overflow-hidden"
     >
-      <div className="space-y-4 p-4 sm:p-5">
+      <div className="space-y-4 py-4 sm:py-5">
         <WalletRailAccount
           addresses={addresses}
           portfolioValueUsd={portfolioValueUsd}
@@ -1784,7 +1784,7 @@ function WalletHoldingsSection({
       </div>
 
       {walletEnabled === false ? (
-        <div className="border-t border-border/70 p-4">
+        <div className="border-t border-border/70 py-4">
           <WalletEmptyHero />
           <Button
             ref={enableWalletRef}
@@ -1797,9 +1797,9 @@ function WalletHoldingsSection({
         </div>
       ) : (
         <>
-          <div className="flex flex-col gap-2 border-t border-border/70 p-2 sm:flex-row sm:items-center">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border/70 py-2">
             <div
-              className="grid min-w-0 flex-1 grid-cols-3 gap-1 rounded-sm bg-surface p-1"
+              className="flex min-w-0 max-w-full items-center gap-1 overflow-x-auto"
               role="tablist"
               aria-label="Wallet asset type"
             >
@@ -1816,7 +1816,7 @@ function WalletHoldingsSection({
               <Button
                 variant="ghostMuted"
                 size="compact"
-                className="w-full sm:w-auto"
+                className="shrink-0"
                 onClick={onRestoreHiddenTokens}
                 aria-label={`Show ${hiddenRowsCount} hidden ${hiddenRowsCount === 1 ? "token" : "tokens"}`}
               >
@@ -1903,9 +1903,9 @@ function WalletInsightTabButton({
     <Button
       ref={ref}
       variant="selection"
-      size="touch"
+      size="compact"
       type="button"
-      className="min-w-0"
+      className="min-w-0 shrink-0"
       role="tab"
       id={`wallet-insight-tab-${tab.id}`}
       aria-controls={`wallet-insight-panel-${tab.id}`}
@@ -1947,14 +1947,14 @@ function WalletInsightsPanel({
   return (
     <section
       aria-labelledby="wallet-insights-title"
-      className="overflow-hidden rounded-xl border border-border bg-card"
+      className="overflow-hidden border-t border-border/70"
     >
       <h2 id="wallet-insights-title" className="sr-only">
         Wallet insights
       </h2>
-      <div className="p-2">
+      <div className="py-2">
         <div
-          className="grid grid-cols-2 gap-1 rounded-sm bg-surface p-1"
+          className="flex items-center gap-1"
           role="tablist"
           aria-label="Wallet insights"
         >
@@ -1978,7 +1978,7 @@ function WalletInsightsPanel({
         {activeTab === "activity" ? (
           <ActivityLog profile={profile} events={events} />
         ) : (
-          <div className="p-4 sm:p-5">
+          <div className="py-4 sm:py-5">
             <PortfolioMoversPanel
               rows={rows}
               profile={profile}
@@ -2026,7 +2026,7 @@ function ActivityLog({
                 ? "bg-danger/10 text-danger"
                 : "bg-bg/55 text-muted";
         const body = (
-          <div className="flex min-h-[4.5rem] min-w-0 items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-bg-hover">
+          <div className="flex min-h-[4.5rem] min-w-0 items-center gap-3 py-3 text-sm transition-colors hover:bg-bg-hover">
             <span
               className={cn(
                 "flex size-8 shrink-0 items-center justify-center rounded-sm",
@@ -2385,7 +2385,7 @@ export function InventoryAppView() {
         <PagePanel.ContentRail
           width="standard"
           data-testid="wallet-content-rail"
-          className="flex flex-col gap-5 pt-3 pb-[var(--view-pad-bottom)] sm:pt-5"
+          className="flex flex-col gap-4 pt-3 pb-[var(--view-pad-bottom)] sm:pt-5"
         >
           {balanceLoadingWithoutSnapshot ||
           walletIdentityLoadingWithoutSnapshot ? (

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
@@ -18,13 +18,7 @@ import type {
   WalletNftsResponse,
   WalletTradingProfileResponse,
 } from "@elizaos/shared";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-  Badge,
-  Button,
-} from "@elizaos/ui";
+import { Avatar, AvatarFallback, AvatarImage, Button } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client, isApiError } from "@elizaos/ui/api";
 import { shellLocalStorage } from "@elizaos/ui/bridge";
@@ -83,11 +77,6 @@ const ALL_INVENTORY_FILTERS: InventoryChainFilters = {
   avax: true,
   solana: true,
 };
-const WALLET_IDENTITY_CHAINS = [
-  { chain: "ethereum", label: "EVM", id: "evm" },
-  { chain: "solana", label: "Solana", id: "solana" },
-] as const;
-
 function isSupportedWalletAssetChain(chain: string): boolean {
   const config = getChainConfig(chain);
   return config?.isEvm === true || config?.chainKey === "solana";
@@ -384,17 +373,6 @@ function tokenValueAvailable(
   return chain?.error === null;
 }
 
-function assetAllocationRows(rows: TokenRow[]): TokenRow[] {
-  return rows
-    .filter((row) => Number.isFinite(row.valueUsd) && row.valueUsd > 0)
-    .sort(
-      (left, right) =>
-        (Number.isFinite(right.valueUsd) ? right.valueUsd : 0) -
-        (Number.isFinite(left.valueUsd) ? left.valueUsd : 0),
-    )
-    .slice(0, 5);
-}
-
 function looksLikeLpPosition(value: string): boolean {
   const text = ` ${value.toLowerCase()} `;
   return (
@@ -587,80 +565,6 @@ function TokenIdentityIcon({
         className="-bottom-0.5 -right-0.5 absolute"
       />
     </span>
-  );
-}
-
-function AssetAllocationStrip({
-  rows,
-  compact = false,
-}: {
-  rows: TokenRow[];
-  compact?: boolean;
-}) {
-  const allocationRows = useMemo(() => assetAllocationRows(rows), [rows]);
-  const total = allocationRows.reduce((sum, row) => sum + row.valueUsd, 0);
-  if (total <= 0 || allocationRows.length === 0) return null;
-
-  return (
-    <div className={cn("space-y-2", compact && "space-y-3")}>
-      <Badge
-        asChild
-        variant="chainDot"
-        tone="muted"
-        className={cn("flex overflow-hidden", compact ? "h-2.5" : "h-2")}
-      >
-        <div>
-          {allocationRows.map((row, index) => (
-            <Badge
-              asChild
-              variant="chainDot"
-              tone={index < 3 ? "accent" : "muted"}
-              key={tokenId(row)}
-              className="h-full"
-            >
-              <span
-                style={{ width: `${(row.valueUsd / total) * 100}%` }}
-                title={`${row.symbol}: ${formatUsd(row.valueUsd)}`}
-              />
-            </Badge>
-          ))}
-        </div>
-      </Badge>
-      {compact ? (
-        <div className="flex flex-wrap gap-2">
-          {allocationRows.slice(0, 3).map((row, index) => (
-            <div
-              key={tokenId(row)}
-              className="inline-flex items-center gap-1.5 text-[0.68rem] font-medium text-txt"
-            >
-              <Badge
-                asChild
-                variant="chainDot"
-                tone={index < 3 ? "accent" : "muted"}
-                className="size-1.5"
-              >
-                <span />
-              </Badge>
-              <span>{row.symbol}</span>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="grid gap-1">
-          {allocationRows.slice(0, 3).map((row) => (
-            <div
-              key={tokenId(row)}
-              className="flex items-center justify-between gap-2 text-[0.68rem]"
-            >
-              <span className="truncate text-muted">{row.symbol}</span>
-              <span className="shrink-0 font-mono text-txt">
-                {formatUsd(row.valueUsd)}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
   );
 }
 
@@ -1222,23 +1126,6 @@ function WalletConnectionChip({
   );
 }
 
-function WalletIdentityCluster() {
-  return (
-    <span className="flex shrink-0 -space-x-1.5">
-      {WALLET_IDENTITY_CHAINS.map((identity) => (
-        <ChainLogoBadge
-          key={identity.id}
-          chain={identity.chain}
-          label={identity.label}
-          size={18}
-          className="ring-1 ring-bg"
-          testId={`wallet-identity-chip-${identity.id}`}
-        />
-      ))}
-    </span>
-  );
-}
-
 function WalletAddressCluster({
   addresses,
 }: {
@@ -1352,11 +1239,10 @@ function WalletRailAccount({
           <h2 className="text-xs-tight font-medium text-muted">
             Portfolio balance
           </h2>
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-2">
+          <div className="mt-1">
             <div className="font-mono text-3xl font-semibold leading-none tracking-tight tabular-nums text-txt">
               {portfolioValueUsd === null ? "—" : formatUsd(portfolioValueUsd)}
             </div>
-            <WalletIdentityCluster />
           </div>
           <div className="mt-2 flex flex-wrap gap-3">
             <WalletConnectionChip label="EVM" ready={evmReady} />
@@ -1778,9 +1664,6 @@ function WalletHoldingsSection({
           walletConfig={walletConfig}
           onOpenSettings={onOpenRpcSettings}
         />
-        {visibleRows.length > 0 ? (
-          <AssetAllocationStrip rows={visibleRows} compact />
-        ) : null}
       </div>
 
       {walletEnabled === false ? (
@@ -2376,11 +2259,7 @@ export function InventoryAppView() {
     (walletConfigStatus === "idle" || walletConfigStatus === "loading");
 
   return (
-    <PagePanel.Frame
-      as="main"
-      data-testid="wallet-shell"
-      className="flex-col bg-bg"
-    >
+    <PagePanel.Frame as="main" data-testid="wallet-shell" className="flex-col">
       <PagePanel.ContentArea>
         <PagePanel.ContentRail
           width="standard"

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
@@ -78,8 +78,7 @@ import { useInventoryData } from "../inventory/useInventoryData.ts";
 // Keep the namespace live even though the standalone view uses the automatic runtime.
 void React;
 
-type WalletRailTab = "tokens" | "defi" | "nfts";
-type WalletInsightTab = "activity" | "markets";
+type WalletRailTab = "tokens" | "defi" | "nfts" | "activity" | "markets";
 
 const ALL_INVENTORY_FILTERS: InventoryChainFilters = {
   ethereum: true,
@@ -1553,6 +1552,9 @@ function WalletHoldingsSection({
   hiddenTokenIds,
   walletConfig,
   profile,
+  events,
+  marketOverview,
+  marketOverviewLoading,
   onHideToken,
   onOpenRpcSettings,
   walletEnabled,
@@ -1575,6 +1577,9 @@ function WalletHoldingsSection({
   hiddenTokenIds: Set<string>;
   walletConfig: WalletConfigStatus | null;
   profile: WalletTradingProfileResponse | null;
+  events: ActivityEvent[];
+  marketOverview: WalletMarketOverviewResponse | null;
+  marketOverviewLoading: boolean;
   onHideToken: (row: TokenRow) => void;
   onOpenRpcSettings: () => void;
   walletEnabled: boolean | null;
@@ -1620,6 +1625,8 @@ function WalletHoldingsSection({
     { id: "tokens", label: "Tokens", icon: Wallet },
     { id: "defi", label: "DeFi", icon: Layers3 },
     { id: "nfts", label: "NFTs", icon: ImageIcon },
+    { id: "activity", label: "Activity", icon: Activity },
+    { id: "markets", label: "Markets", icon: TrendingUp },
   ];
   const { ref: enableWalletRef, agentProps: enableWalletAgentProps } =
     useAgentElement<HTMLButtonElement>({
@@ -1775,144 +1782,22 @@ function WalletHoldingsSection({
                 error={nftsError}
                 onRetry={onRetryNfts}
               />
-            ) : null}
-          </div>
-        </>
-      )}
-    </section>
-  );
-}
-
-function WalletInsightTabButton({
-  tab,
-  active,
-  onSelect,
-}: {
-  tab: { id: WalletInsightTab; label: string };
-  active: boolean;
-  onSelect: (tab: WalletInsightTab) => void;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `wallet-insight-${tab.id}`,
-    role: "tab",
-    label: tab.label,
-    group: "wallet-insights",
-    status: active ? "active" : "inactive",
-    description: `Show wallet ${tab.label.toLowerCase()}`,
-  });
-
-  return (
-    <Button
-      ref={ref}
-      variant="selection"
-      size="compact"
-      type="button"
-      className="min-w-0 shrink-0"
-      role="tab"
-      id={`wallet-insight-tab-${tab.id}`}
-      aria-controls={`wallet-insight-panel-${tab.id}`}
-      aria-selected={active}
-      data-state={active ? "on" : "off"}
-      onClick={() => onSelect(tab.id)}
-      {...agentProps}
-    >
-      <span className="truncate">{tab.label}</span>
-    </Button>
-  );
-}
-
-function WalletInsightsPanel({
-  activeTab,
-  onSelectTab,
-  profile,
-  events,
-  rows,
-  marketOverview,
-  marketOverviewLoading,
-}: {
-  activeTab: WalletInsightTab;
-  onSelectTab: (tab: WalletInsightTab) => void;
-  profile: WalletTradingProfileResponse | null;
-  events: ActivityEvent[];
-  rows: TokenRow[];
-  marketOverview: WalletMarketOverviewResponse | null;
-  marketOverviewLoading: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const tabs: Array<{
-    id: WalletInsightTab;
-    label: string;
-  }> = [
-    { id: "activity", label: "Activity" },
-    { id: "markets", label: "Markets" },
-  ];
-
-  return (
-    <Collapsible open={open} onOpenChange={setOpen} asChild>
-      <section
-        aria-labelledby="wallet-insights-title"
-        className="overflow-hidden border-t border-border/70"
-      >
-        <h2 id="wallet-insights-title" className="sr-only">
-          Wallet insights
-        </h2>
-        <CollapsibleTrigger asChild>
-          <Button
-            variant="ghostMuted"
-            size="default"
-            align="between"
-            className="w-full px-0 py-3"
-            aria-label={`${open ? "Hide" : "Show"} activity and markets`}
-          >
-            <span className="font-medium text-txt">Activity & markets</span>
-            <ChevronDown
-              className={cn(
-                "size-4 transition-transform",
-                open && "rotate-180",
-              )}
-              aria-hidden
-            />
-          </Button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="border-t border-border/70 py-2">
-            <div
-              className="flex items-center gap-1"
-              role="tablist"
-              aria-label="Wallet insights"
-            >
-              {tabs.map((tab) => (
-                <WalletInsightTabButton
-                  key={tab.id}
-                  tab={tab}
-                  active={activeTab === tab.id}
-                  onSelect={onSelectTab}
-                />
-              ))}
-            </div>
-          </div>
-          <div
-            id={`wallet-insight-panel-${activeTab}`}
-            role="tabpanel"
-            aria-labelledby={`wallet-insight-tab-${activeTab}`}
-            className="border-t border-border/70"
-          >
-            {activeTab === "activity" ? (
+            ) : activeTab === "activity" ? (
               <ActivityLog profile={profile} events={events} />
-            ) : (
+            ) : activeTab === "markets" ? (
               <div className="py-4 sm:py-5">
                 <PortfolioMoversPanel
-                  rows={rows}
+                  rows={visibleRows}
                   profile={profile}
                   marketOverview={marketOverview}
                   loading={marketOverviewLoading}
                 />
               </div>
-            )}
+            ) : null}
           </div>
-        </CollapsibleContent>
-      </section>
-    </Collapsible>
+        </>
+      )}
+    </section>
   );
 }
 
@@ -2041,7 +1926,6 @@ export function InventoryAppView() {
   const [hiddenTokenIds, setHiddenTokenIds] = useState<Set<string>>(() =>
     readHiddenTokenIds(),
   );
-  const [insightTab, setInsightTab] = useState<WalletInsightTab>("markets");
   const [marketOverview, setMarketOverview] =
     useState<WalletMarketOverviewResponse | null>(null);
   const [marketOverviewLoading, setMarketOverviewLoading] = useState(false);
@@ -2362,6 +2246,9 @@ export function InventoryAppView() {
                 hiddenTokenIds={hiddenTokenIds}
                 walletConfig={walletConfig}
                 profile={primaryTradingProfile}
+                events={activityEvents}
+                marketOverview={activeMarketOverview}
+                marketOverviewLoading={activeMarketOverviewLoading}
                 onHideToken={handleHideToken}
                 onOpenRpcSettings={handleOpenRpcSettings}
                 walletEnabled={walletEnabled}
@@ -2376,18 +2263,6 @@ export function InventoryAppView() {
                 showWalletEmptyState={showWalletEmptyState}
                 onRestoreHiddenTokens={handleRestoreHiddenTokens}
               />
-
-              {!showWalletEmptyState ? (
-                <WalletInsightsPanel
-                  activeTab={insightTab}
-                  onSelectTab={setInsightTab}
-                  profile={primaryTradingProfile}
-                  events={activityEvents}
-                  rows={displayedAssetRows}
-                  marketOverview={activeMarketOverview}
-                  marketOverviewLoading={activeMarketOverviewLoading}
-                />
-              ) : null}
             </>
           )}
         </PagePanel.ContentRail>

--- a/plugins/plugin-wallet/src/ui/plugin.ts
+++ b/plugins/plugin-wallet/src/ui/plugin.ts
@@ -26,6 +26,10 @@ export const walletAppPlugin: Plugin = {
         tabAffinity: "inventory",
         group: "wallet",
         order: 50,
+        surface: {
+          background: "shared",
+          capabilities: ["wallpaper"],
+        },
         componentExport: "@elizaos/plugin-wallet/ui#InventoryView",
       },
     ],
@@ -46,7 +50,10 @@ export const walletAppPlugin: Plugin = {
       // First-party instrumented view (data-agent-id controls): grant the
       // agent-surface capability so the view broker admits agent-driven
       // fills/clicks (#13452 manifest gate).
-      surface: { capabilities: ["agent-surface"] },
+      surface: {
+        background: "shared",
+        capabilities: ["agent-surface", "wallpaper"],
+      },
       componentExport: "InventoryView",
       tags: ["finance", "crypto", "wallet"],
       anticipatoryIntent:

--- a/plugins/plugin-wallet/src/ui/register-routes.ts
+++ b/plugins/plugin-wallet/src/ui/register-routes.ts
@@ -31,6 +31,10 @@ registerAppShellPage({
   tabAffinity: "inventory",
   group: "wallet",
   order: 50,
+  surface: {
+    background: "shared",
+    capabilities: ["wallpaper"],
+  },
   loader: () =>
     import("./InventoryView.tsx").then((module) => ({
       default: module.InventoryView,


### PR DESCRIPTION
Closes #29759

## Summary

- Flattens non-interactive Wallet sections onto the ambient route canvas.
- Uses one canonical peer tab row for **Tokens, DeFi, NFTs, Activity, and Markets**.
- Aligns account, asset, NFT, activity, and market content to one responsive rail.
- Keeps the tab row horizontally reachable without wrapping into a second navigation layer on mobile.
- Opts both Wallet registrations into the shared app wallpaper instead of the opaque plugin background.
- Removes the duplicate chain-avatar cluster and allocation strip from the portfolio summary.
- Keeps balance and holdings primary; only wallet details, network controls, and per-token management use progressive disclosure.

## Validation

- `bun run --cwd plugins/plugin-wallet test -- InventoryAppView.gui.test.tsx` — 26 passed.
- Wallet browser contract — 1 passed (details, copy, populated DeFi/NFT states, token action menu, persistence).
- Current-revision desktop/mobile evidence capture — 2 passed.
- Combined current-revision UI run — 3 passed.
- Biome check on all three changed files — passed.
- Package typecheck remains blocked by the existing unresolved `@elizaos/plugin-elizacloud` import in `src/api/wallet-routes.ts`.

## Visual evidence

### Desktop

| State | Before | After |
| --- | --- | --- |
| Overview | ![Desktop overview before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-desktop-wallet-overview-before.png) | ![Desktop overview after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-overview-unified-v5.png) |
| Tokens | ![Desktop tokens before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-desktop-wallet-tokens-before.png) | ![Desktop tokens after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-tokens-unified-v5.png) |
| DeFi | ![Desktop DeFi before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-desktop-wallet-defi-before.png) | ![Desktop DeFi after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-defi-unified-v5.png) |
| NFTs | ![Desktop NFTs before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-desktop-wallet-nfts-before.png) | ![Desktop NFTs after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-nfts-unified-v5.png) |

### Mobile

| State | Before | After |
| --- | --- | --- |
| Overview | ![Mobile overview before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-mobile-wallet-overview-before.png) | ![Mobile overview after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-overview-unified-v5.png) |
| Tokens | ![Mobile tokens before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-mobile-wallet-tokens-before.png) | ![Mobile tokens after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-tokens-unified-v5.png) |
| DeFi | ![Mobile DeFi before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-mobile-wallet-defi-before.png) | ![Mobile DeFi after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-defi-unified-v5.png) |
| NFTs | ![Mobile NFTs before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29761-mobile-wallet-nfts-before.png) | ![Mobile NFTs after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-nfts-unified-v5.png) |

### All peer tab states

The deterministic harness uses populated balances, an LP position, three collectibles, and two market movers. Activity remains intentionally empty because it is a live WebSocket stream; this PR does not fabricate production activity.

| Tab | Desktop | Mobile |
| --- | --- | --- |
| Tokens | ![Desktop Tokens filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-tokens-unified-v5.png) | ![Mobile Tokens filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-tokens-unified-v5.png) |
| DeFi | ![Desktop DeFi filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-defi-unified-v5.png) | ![Mobile DeFi filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-defi-unified-v5.png) |
| NFTs | ![Desktop NFTs filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-nfts-unified-v5.png) | ![Mobile NFTs filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-nfts-unified-v5.png) |
| Activity | ![Desktop Activity](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-activity-unified-v5.png) | ![Mobile Activity](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-activity-unified-v5.png) |
| Markets | ![Desktop Markets filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-markets-unified-v5.png) | ![Mobile Markets filled](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-markets-unified-v5.png) |

### Progressive disclosure

| State | Desktop | Mobile |
| --- | --- | --- |
| Wallet details | ![Desktop wallet details](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-details-unified-v5.png) | ![Mobile wallet details](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-details-unified-v5.png) |
| Token actions | ![Desktop token actions](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-wallet-token-actions-unified-v5.png) | ![Mobile token actions](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-wallet-token-actions-unified-v5.png) |

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Before screenshots | Desktop and mobile Overview, Tokens, DeFi, and NFTs above |
| After screenshots | Desktop and mobile Overview plus every peer tab state above |
| Walkthrough video | N/A - layout-only refactor; all interactive tab states are shown separately above |
| Backend logs | N/A - no backend behavior changed |
| Frontend logs | N/A - focused component and browser suites passed; no runtime errors during capture |
| LLM trajectory | N/A - no agent behavior changed |
| Domain artifacts | N/A - no wallet data, signing, transaction, or credential contract changed |
| OCR review | N/A - labels were visually inspected at full capture resolution |
