### PR TITLE
fix(telegram): prevent silent Shared turn failures

### DIFF
--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -1,6 +1,7 @@
 /** Drives the edge Telegram connector through Hono with real shared state-machine code. */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { PERSONAL_SHARED_FAILURE_REPLY } from "@elizaos/cloud-services-common/personal-shared-failure";
 import { Hono } from "hono";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 import {
@@ -142,6 +143,70 @@ function telegramRequest(updateId = 81601, text = "hey how are you?"): Request {
         from: { id: 123456, first_name: "Nubs" },
         chat: { id: 123456, type: "private" },
         text,
+      },
+    }),
+  });
+}
+
+function telegramGroupRequest(updateId = 81621, text = "hey group"): Request {
+  return new Request("https://api-staging.eliza.app/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Telegram-Bot-Api-Secret-Token": "webhook-secret",
+    },
+    body: JSON.stringify({
+      update_id: updateId,
+      message: {
+        message_id: updateId - 80000,
+        date: Math.floor(Date.now() / 1000),
+        from: { id: 123456, first_name: "Nubs" },
+        chat: { id: -100123456789, type: "supergroup" },
+        text,
+      },
+    }),
+  });
+}
+
+function telegramMembershipRequest(updateId = 81622): Request {
+  return new Request("https://api-staging.eliza.app/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Telegram-Bot-Api-Secret-Token": "webhook-secret",
+    },
+    body: JSON.stringify({
+      update_id: updateId,
+      my_chat_member: {
+        date: Math.floor(Date.now() / 1000),
+        from: { id: 123456, first_name: "Nubs" },
+        chat: { id: -100123456789, type: "supergroup" },
+        new_chat_member: { status: "member" },
+      },
+    }),
+  });
+}
+
+function telegramVoiceRequest(updateId = 81620): Request {
+  return new Request("https://api-staging.eliza.app/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Telegram-Bot-Api-Secret-Token": "webhook-secret",
+    },
+    body: JSON.stringify({
+      update_id: updateId,
+      message: {
+        message_id: updateId - 80000,
+        date: Math.floor(Date.now() / 1000),
+        from: { id: 123456, first_name: "Nubs" },
+        chat: { id: 123456, type: "private" },
+        voice: {
+          file_id: "voice-file-1",
+          duration: 2,
+          file_size: 128,
+          mime_type: "audio/ogg",
+        },
       },
     }),
   });
@@ -601,29 +666,248 @@ describe("Personal Shared Telegram edge", () => {
     expect(JSON.stringify(deliveryBody)).not.toContain(botToken);
   });
 
-  test("releases the processing claim after all pre-egress attempts fail", async () => {
+  test("delivers one fallback after retryable turn attempts are exhausted", async () => {
     const ledger = namespace();
-    let available = false;
     const turn = mock(async () =>
-      available
-        ? Response.json({ data: { reply: "Recovered" } })
-        : Response.json(
-            { error: "warming" },
-            { status: 503, headers: { "Retry-After": "0" } },
-          ),
+      Response.json(
+        { error: "private upstream detail" },
+        {
+          status: 503,
+          headers: {
+            "Retry-After": "0",
+            "X-Eliza-Failure-Stage": "shared_runtime",
+            "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+            "X-Eliza-Failure-Cause-Name":
+              "SharedRuntimeProviderUnavailableError",
+            "X-Eliza-Retryable": "true",
+          },
+        },
+      ),
     );
+    const sentTexts: string[] = [];
     globalThis.fetch = mock(async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sentTexts.push(body.text);
       return Response.json({
         ok: true,
         result: body.text ? { message_id: 9002 } : true,
       });
     }) as unknown as typeof fetch;
 
-    expect((await run(ledger, turn, telegramRequest(81602))).status).toBe(500);
-    available = true;
-    expect((await run(ledger, turn, telegramRequest(81602))).status).toBe(200);
-    expect(turn).toHaveBeenCalledTimes(4);
+    const first = await run(ledger, turn, telegramRequest(81602));
+    const duplicate = await run(ledger, turn, telegramRequest(81602));
+
+    expect(first.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(turn).toHaveBeenCalledTimes(3);
+    expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
+    expect(JSON.stringify(sentTexts)).not.toContain("private upstream detail");
+  });
+
+  test("does not replay a terminal turn before delivering one fallback", async () => {
+    const ledger = namespace();
+    const turn = mock(async () =>
+      Response.json(
+        { error: "private action detail" },
+        {
+          status: 500,
+          headers: {
+            "X-Eliza-Failure-Stage": "shared_runtime",
+            "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+            "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
+            "X-Eliza-Retryable": "false",
+          },
+        },
+      ),
+    );
+    const sentTexts: string[] = [];
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sentTexts.push(body.text);
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9003 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramRequest(81614))).status).toBe(200);
+    expect((await run(ledger, turn, telegramRequest(81614))).status).toBe(200);
+    expect(turn).toHaveBeenCalledTimes(1);
+    expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
+    expect(JSON.stringify(sentTexts)).not.toContain("private action detail");
+  });
+
+  test.each([
+    ["group message", telegramGroupRequest(), 200, 0],
+    ["membership update", telegramMembershipRequest(), 500, 1],
+  ])(
+    "does not inject a private fallback for a %s",
+    async (_name, request, expectedStatus, expectedTurnCalls) => {
+      const turn = mock(async () =>
+        Response.json(
+          { error: "private action detail" },
+          {
+            status: 500,
+            headers: {
+              "X-Eliza-Failure-Stage": "shared_runtime",
+              "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+              "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
+              "X-Eliza-Retryable": "false",
+            },
+          },
+        ),
+      );
+      const sentTexts: string[] = [];
+      const providerMethods: string[] = [];
+      globalThis.fetch = mock(async (input, init) => {
+        providerMethods.push(String(input).split("/").at(-1) ?? "");
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          text?: string;
+        };
+        if (body.text) sentTexts.push(body.text);
+        return Response.json({ ok: true, result: { message_id: 9008 } });
+      }) as unknown as typeof fetch;
+
+      expect((await run(namespace(), turn, request)).status).toBe(
+        expectedStatus,
+      );
+      expect(turn).toHaveBeenCalledTimes(expectedTurnCalls);
+      expect(sentTexts).toEqual([]);
+      expect(providerMethods).toEqual([]);
+    },
+  );
+
+  test("reopens a rejected fallback send without claiming ambiguous delivery", async () => {
+    const ledger = namespace();
+    const turn = mock(
+      async () =>
+        new Response("terminal", {
+          status: 500,
+          headers: { "X-Eliza-Retryable": "false" },
+        }),
+    );
+    let rejectFallback = true;
+    let acceptedFallbacks = 0;
+    globalThis.fetch = mock(async (input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (String(input).endsWith("/sendMessage") && body.text) {
+        if (rejectFallback) {
+          rejectFallback = false;
+          return Response.json({
+            ok: false,
+            error_code: 400,
+            description: "provider rejected message",
+          });
+        }
+        acceptedFallbacks += 1;
+        return Response.json({ ok: true, result: { message_id: 9007 } });
+      }
+      return Response.json({ ok: true, result: true });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramRequest(81617))).status).toBe(500);
+    expect((await run(ledger, turn, telegramRequest(81617))).status).toBe(200);
+    expect(turn).toHaveBeenCalledTimes(2);
+    expect(acceptedFallbacks).toBe(1);
+  });
+
+  test("refuses replay when fallback acceptance becomes ambiguous", async () => {
+    const ledger = namespace();
+    const turn = mock(
+      async () =>
+        new Response("terminal", {
+          status: 500,
+          headers: { "X-Eliza-Retryable": "false" },
+        }),
+    );
+    globalThis.fetch = mock(async (input) => {
+      if (String(input).endsWith("/sendMessage")) {
+        throw new Error("provider accepted but response was lost");
+      }
+      return Response.json({ ok: true, result: true });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramRequest(81618))).status).toBe(500);
+    expect((await run(ledger, turn, telegramRequest(81618))).status).toBe(503);
+    expect(turn).toHaveBeenCalledTimes(1);
+  });
+
+  test("delivers one exact-once fallback after transport attempts are exhausted", async () => {
+    const ledger = namespace();
+    const turn = mock(async () => {
+      throw new Error("private transport detail");
+    });
+    const sentTexts: string[] = [];
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sentTexts.push(body.text);
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9004 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramRequest(81615))).status).toBe(200);
+    expect((await run(ledger, turn, telegramRequest(81615))).status).toBe(200);
+    expect(turn).toHaveBeenCalledTimes(3);
+    expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
+    expect(JSON.stringify(sentTexts)).not.toContain("private transport detail");
+  });
+
+  test.each([
+    ["malformed JSON", () => new Response("not json")],
+    ["missing reply", () => Response.json({ data: {} })],
+  ])(
+    "delivers one fallback for a successful turn with %s",
+    async (_name, response) => {
+      const ledger = namespace();
+      const turn = mock(async () => response());
+      const sentTexts: string[] = [];
+      globalThis.fetch = mock(async (_input, init) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          text?: string;
+        };
+        if (body.text) sentTexts.push(body.text);
+        return Response.json({
+          ok: true,
+          result: body.text ? { message_id: 9005 } : true,
+        });
+      }) as unknown as typeof fetch;
+
+      expect((await run(ledger, turn, telegramRequest(81616))).status).toBe(
+        200,
+      );
+      expect((await run(ledger, turn, telegramRequest(81616))).status).toBe(
+        200,
+      );
+      expect(turn).toHaveBeenCalledTimes(1);
+      expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
+    },
+  );
+
+  test("delivers one fallback when a voice note cannot be resolved before the turn", async () => {
+    const ledger = namespace();
+    const turn = mock(async () =>
+      Response.json({ data: { reply: "must not run" } }),
+    );
+    const sentTexts: string[] = [];
+    globalThis.fetch = mock(async (input, init) => {
+      const url = String(input);
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (url.endsWith("/getFile")) {
+        return Response.json({ ok: false, error_code: 404 });
+      }
+      if (body.text) sentTexts.push(body.text);
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9006 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramVoiceRequest())).status).toBe(200);
+    expect((await run(ledger, turn, telegramVoiceRequest())).status).toBe(200);
+    expect(turn).not.toHaveBeenCalled();
+    expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
   });
 
   test("refuses replay after an ambiguous Telegram provider failure", async () => {

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -1,8 +1,9 @@
 /** Drives the edge Telegram connector through Hono with real shared state-machine code. */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { PERSONAL_SHARED_FAILURE_REPLY } from "@elizaos/cloud-services-common/personal-shared-failure";
 import { Hono } from "hono";
+import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 import {
   dispatchPersonalTelegramReminder,
@@ -834,8 +835,10 @@ describe("Personal Shared Telegram edge", () => {
 
   test("delivers one exact-once fallback after transport attempts are exhausted", async () => {
     const ledger = namespace();
+    const info = spyOn(logger, "info").mockImplementation(() => undefined);
+    const warn = spyOn(logger, "warn").mockImplementation(() => undefined);
     const turn = mock(async () => {
-      throw new Error("private transport detail");
+      throw new TypeError("private transport detail");
     });
     const sentTexts: string[] = [];
     globalThis.fetch = mock(async (_input, init) => {
@@ -852,6 +855,31 @@ describe("Personal Shared Telegram edge", () => {
     expect(turn).toHaveBeenCalledTimes(3);
     expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
     expect(JSON.stringify(sentTexts)).not.toContain("private transport detail");
+    expect(warn).toHaveBeenCalledWith(
+      "[PersonalTelegramEdge] pre-egress turn failed; sending safe fallback",
+      expect.objectContaining({ attempts: 3 }),
+    );
+    expect(info).toHaveBeenCalledWith(
+      "[PersonalTelegramEdge] connector message completed",
+      expect.objectContaining({ attempts: 3, fallbackDelivered: true }),
+    );
+  });
+
+  test("propagates an unexpected turn fault without sending a fallback", async () => {
+    const ledger = namespace();
+    const turn = mock(async () => {
+      throw new RangeError("unexpected programmer fault");
+    });
+    const sentTexts: string[] = [];
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sentTexts.push(body.text);
+      return Response.json({ ok: true, result: true });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramRequest(81623))).status).toBe(500);
+    expect(turn).toHaveBeenCalledTimes(3);
+    expect(sentTexts).toEqual([]);
   });
 
   test.each([

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -9,6 +9,10 @@ import {
   extractIdentityLinkCode,
   identityLinkReply,
 } from "@elizaos/cloud-services-common/identity-link-code";
+import {
+  PERSONAL_SHARED_FAILURE_REPLY,
+  readPersonalSharedFailureMetadata,
+} from "@elizaos/cloud-services-common/personal-shared-failure";
 import { executeResponseAttempts } from "@elizaos/cloud-services-common/response-attempts";
 import {
   parseTelegramWebhook,
@@ -52,6 +56,19 @@ const DELIVERY_SENDER_RE = /^\d{1,32}$/;
 const DELIVERY_THREAD_RE = /^[1-9]\d{0,15}$/;
 const DELIVERY_MESSAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,159}$/;
 const TELEGRAM_CONNECTOR_ACCOUNT_RE = /^bot:(?:\d{1,20}|[0-9a-f]{64})$/;
+const SAFE_OBSERVED_ERROR_NAMES = new Set([
+  "AbortError",
+  "Error",
+  "RangeError",
+  "SyntaxError",
+  "TimeoutError",
+  "TypeError",
+]);
+
+function safeObservedErrorName(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+  return SAFE_OBSERVED_ERROR_NAMES.has(name) ? name : "OtherError";
+}
 
 export interface TelegramEdgeDeps {
   runTurn(
@@ -711,12 +728,16 @@ async function runTurnWithRetry(
   const maxAttempts = event.voiceNote ? VOICE_MAX_ATTEMPTS : MAX_ATTEMPTS;
   const result = await executeResponseAttempts({
     maxAttempts,
+    honorExplicitRetryable: true,
     request: () => deps.runTurn(body, traceId, c.env, c.executionCtx),
     retryStatuses: !event.voiceNote,
     retryTransport: !event.voiceNote,
     retryDelayCapMs: RETRY_DELAY_CAP_MS,
     observe: (observation) => {
       const response = observation.response;
+      const failure = response
+        ? readPersonalSharedFailureMetadata(response)
+        : null;
       const context = {
         traceId,
         platform: "telegram",
@@ -730,14 +751,12 @@ async function runTurnWithRetry(
         retryAfterSeconds: observation.retryAfterSeconds,
         retryDelayMs: observation.retryDelayMs,
         workerServerTiming: response?.headers.get("Server-Timing") ?? null,
-        failureStage: response?.headers.get("X-Eliza-Failure-Stage") ?? null,
-        failureName: response?.headers.get("X-Eliza-Failure-Name") ?? null,
+        failureStage: failure?.stage ?? null,
+        failureName: failure?.name ?? null,
+        failureCauseName: failure?.causeName ?? null,
         ...(observation.error
           ? {
-              error:
-                observation.error instanceof Error
-                  ? observation.error.message
-                  : String(observation.error),
+              errorName: safeObservedErrorName(observation.error),
             }
           : {}),
       };
@@ -807,10 +826,13 @@ export async function handlePersonalTelegramEdge(
     let turnMs = 0;
     let egressMs = 0;
     let attempts = 0;
+    let fallbackDelivered = false;
     const outcome = await executeTelegramDelivery(
       ledger,
       async (deliveryHooks) => {
-        const stopTyping = startTyping(config, event);
+        const stopTyping = event.membershipChange
+          ? () => undefined
+          : startTyping(config, event);
         try {
           const linkCode = extractIdentityLinkCode(event.text);
           if (linkCode) {
@@ -860,36 +882,83 @@ export async function handlePersonalTelegramEdge(
             egressMs = Math.round(performance.now() - egressStartedAt);
             return;
           }
-          const voiceNote = event.voiceNote
-            ? await resolveTelegramVoiceNote(config, event)
-            : undefined;
-          const turn = await runTurnWithRetry(
-            c,
-            deps,
-            deliveryBody(
-              project,
-              connectorAccountId,
-              canonicalMessageId,
-              event,
-              voiceNote,
-            ),
-            event,
-            traceId,
-          );
-          turnMs = turn.turnMs;
-          attempts = turn.attempts;
-          if (!turn.response.ok) {
-            const status = turn.response.status;
-            await turn.response.body?.cancel();
-            throw new Error(`Personal Shared edge turn failed (${status})`);
-          }
-          const payload: unknown = await turn.response.json();
-          const reply =
-            payload && typeof payload === "object" && "data" in payload
-              ? (payload.data as { reply?: unknown } | null)?.reply
+          let reply: string | null = null;
+          let fallbackFailure: ReturnType<
+            typeof readPersonalSharedFailureMetadata
+          > | null = null;
+          let preEgressErrorName: string | null = null;
+          try {
+            const voiceNote = event.voiceNote
+              ? await resolveTelegramVoiceNote(config, event)
               : undefined;
-          if (typeof reply !== "string") {
-            throw new Error("Personal Shared edge turn returned no reply");
+            const turn = await runTurnWithRetry(
+              c,
+              deps,
+              deliveryBody(
+                project,
+                connectorAccountId,
+                canonicalMessageId,
+                event,
+                voiceNote,
+              ),
+              event,
+              traceId,
+            );
+            turnMs = turn.turnMs;
+            attempts = turn.attempts;
+            if (!turn.response.ok) {
+              fallbackFailure = readPersonalSharedFailureMetadata(
+                turn.response,
+              );
+              await turn.response.body?.cancel();
+            } else {
+              const payload: unknown = await turn.response.json();
+              const candidate =
+                payload && typeof payload === "object" && "data" in payload
+                  ? (payload.data as { reply?: unknown } | null)?.reply
+                  : undefined;
+              if (typeof candidate !== "string") {
+                throw new TypeError(
+                  "Personal Shared edge turn returned no reply",
+                );
+              }
+              reply = candidate;
+            }
+          } catch (error) {
+            preEgressErrorName = safeObservedErrorName(error);
+          }
+          if (fallbackFailure || preEgressErrorName) {
+            if (event.chatType !== "private" || event.membershipChange) {
+              throw new Error(
+                "Personal Shared non-private turn failed before egress",
+              );
+            }
+            logger.warn(
+              "[PersonalTelegramEdge] pre-egress turn failed; sending safe fallback",
+              {
+                traceId,
+                platform: "telegram",
+                messageId: event.messageId,
+                attempts,
+                status: fallbackFailure?.status ?? null,
+                failureStage: fallbackFailure?.stage ?? null,
+                failureName: fallbackFailure?.name ?? null,
+                failureCauseName: fallbackFailure?.causeName ?? null,
+                retryable: fallbackFailure?.retryable ?? false,
+                preEgressErrorName,
+              },
+            );
+            const egressStartedAt = performance.now();
+            await sendTelegramReply(
+              config,
+              event,
+              PERSONAL_SHARED_FAILURE_REPLY,
+              logger,
+              deliveryHooks,
+            );
+            egressMs = Math.round(performance.now() - egressStartedAt);
+            fallbackDelivered = true;
+            return;
           }
           if (!reply) return;
           const egressStartedAt = performance.now();
@@ -920,6 +989,7 @@ export async function handlePersonalTelegramEdge(
       turnMs,
       attempts,
       egressMs,
+      fallbackDelivered,
       totalMs,
     });
     const response = c.json({ ok: true });

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -70,6 +70,41 @@ function safeObservedErrorName(error: unknown): string {
   return SAFE_OBSERVED_ERROR_NAMES.has(name) ? name : "OtherError";
 }
 
+class PersonalTelegramPreEgressError extends Error {
+  override readonly name = "PersonalTelegramPreEgressError";
+  readonly failure: ReturnType<typeof readPersonalSharedFailureMetadata> | null;
+  readonly attempts: number | null;
+  readonly turnMs: number | null;
+
+  constructor(
+    message: string,
+    options?: {
+      cause?: unknown;
+      failure?: ReturnType<typeof readPersonalSharedFailureMetadata> | null;
+      attempts?: number;
+      turnMs?: number;
+    },
+  ) {
+    super(
+      message,
+      options?.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.failure = options?.failure ?? null;
+    this.attempts = options?.attempts ?? null;
+    this.turnMs = options?.turnMs ?? null;
+  }
+}
+
+function isExpectedTurnTransportFailure(error: unknown): boolean {
+  const transportCause = error instanceof Error ? error.cause : undefined;
+  return (
+    transportCause instanceof TypeError ||
+    (transportCause instanceof DOMException &&
+      (transportCause.name === "AbortError" ||
+        transportCause.name === "TimeoutError"))
+  );
+}
+
 export interface TelegramEdgeDeps {
   runTurn(
     body: Record<string, unknown>,
@@ -726,47 +761,65 @@ async function runTurnWithRetry(
   traceId: string,
 ): Promise<{ response: Response; attempts: number; turnMs: number }> {
   const maxAttempts = event.voiceNote ? VOICE_MAX_ATTEMPTS : MAX_ATTEMPTS;
-  const result = await executeResponseAttempts({
-    maxAttempts,
-    honorExplicitRetryable: true,
-    request: () => deps.runTurn(body, traceId, c.env, c.executionCtx),
-    retryStatuses: !event.voiceNote,
-    retryTransport: !event.voiceNote,
-    retryDelayCapMs: RETRY_DELAY_CAP_MS,
-    observe: (observation) => {
-      const response = observation.response;
-      const failure = response
-        ? readPersonalSharedFailureMetadata(response)
-        : null;
-      const context = {
-        traceId,
-        platform: "telegram",
-        messageId: event.messageId,
-        attempt: observation.attempt,
-        maxAttempts: observation.maxAttempts,
-        durationMs: observation.durationMs,
-        status: response?.status ?? null,
-        retryable: observation.retryable,
-        retryReason: observation.retryReason,
-        retryAfterSeconds: observation.retryAfterSeconds,
-        retryDelayMs: observation.retryDelayMs,
-        workerServerTiming: response?.headers.get("Server-Timing") ?? null,
-        failureStage: failure?.stage ?? null,
-        failureName: failure?.name ?? null,
-        failureCauseName: failure?.causeName ?? null,
-        ...(observation.error
-          ? {
-              errorName: safeObservedErrorName(observation.error),
-            }
-          : {}),
-      };
-      if (response?.ok) {
-        logger.info("[PersonalTelegramEdge] turn attempt completed", context);
-      } else {
-        logger.warn("[PersonalTelegramEdge] turn attempt failed", context);
-      }
-    },
-  });
+  const startedAt = performance.now();
+  let observedAttempts = 0;
+  let result: Awaited<ReturnType<typeof executeResponseAttempts>>;
+  try {
+    result = await executeResponseAttempts({
+      maxAttempts,
+      honorExplicitRetryable: true,
+      request: () => deps.runTurn(body, traceId, c.env, c.executionCtx),
+      retryStatuses: !event.voiceNote,
+      retryTransport: !event.voiceNote,
+      retryDelayCapMs: RETRY_DELAY_CAP_MS,
+      observe: (observation) => {
+        observedAttempts = observation.attempt;
+        const response = observation.response;
+        const failure = response
+          ? readPersonalSharedFailureMetadata(response)
+          : null;
+        const context = {
+          traceId,
+          platform: "telegram",
+          messageId: event.messageId,
+          attempt: observation.attempt,
+          maxAttempts: observation.maxAttempts,
+          durationMs: observation.durationMs,
+          status: response?.status ?? null,
+          retryable: observation.retryable,
+          retryReason: observation.retryReason,
+          retryAfterSeconds: observation.retryAfterSeconds,
+          retryDelayMs: observation.retryDelayMs,
+          workerServerTiming: response?.headers.get("Server-Timing") ?? null,
+          failureStage: failure?.stage ?? null,
+          failureName: failure?.name ?? null,
+          failureCauseName: failure?.causeName ?? null,
+          ...(observation.error
+            ? {
+                errorName: safeObservedErrorName(observation.error),
+              }
+            : {}),
+        };
+        if (response?.ok) {
+          logger.info("[PersonalTelegramEdge] turn attempt completed", context);
+        } else {
+          logger.warn("[PersonalTelegramEdge] turn attempt failed", context);
+        }
+      },
+    });
+  } catch (error) {
+    if (!isExpectedTurnTransportFailure(error)) throw error;
+    // error-policy:J2 preserve the exact observed retry receipt when a known
+    // transport failure exhausts before the caller can receive a result.
+    throw new PersonalTelegramPreEgressError(
+      "Personal Shared turn transport failed before egress",
+      {
+        cause: error,
+        attempts: observedAttempts,
+        turnMs: Math.round(performance.now() - startedAt),
+      },
+    );
+  }
   return {
     response: result.response,
     attempts: result.attempts,
@@ -883,14 +936,23 @@ export async function handlePersonalTelegramEdge(
             return;
           }
           let reply: string | null = null;
-          let fallbackFailure: ReturnType<
-            typeof readPersonalSharedFailureMetadata
-          > | null = null;
-          let preEgressErrorName: string | null = null;
+          let preEgressError: PersonalTelegramPreEgressError | null = null;
           try {
-            const voiceNote = event.voiceNote
-              ? await resolveTelegramVoiceNote(config, event)
-              : undefined;
+            let voiceNote:
+              | Awaited<ReturnType<typeof resolveTelegramVoiceNote>>
+              | undefined;
+            try {
+              voiceNote = event.voiceNote
+                ? await resolveTelegramVoiceNote(config, event)
+                : undefined;
+            } catch (error) {
+              // error-policy:J2 provider-backed voice resolution failures gain
+              // explicit pre-egress context while preserving their cause.
+              throw new PersonalTelegramPreEgressError(
+                "Telegram voice note resolution failed before egress",
+                { cause: error },
+              );
+            }
             const turn = await runTurnWithRetry(
               c,
               deps,
@@ -907,34 +969,71 @@ export async function handlePersonalTelegramEdge(
             turnMs = turn.turnMs;
             attempts = turn.attempts;
             if (!turn.response.ok) {
-              fallbackFailure = readPersonalSharedFailureMetadata(
-                turn.response,
+              const failure = readPersonalSharedFailureMetadata(turn.response);
+              try {
+                await turn.response.body?.cancel();
+              } catch (error) {
+                // error-policy:J6 response cleanup cannot replace the typed
+                // pre-egress failure already established by the status.
+                logger.warn(
+                  "[PersonalTelegramEdge] turn failure body cleanup failed",
+                  {
+                    traceId,
+                    platform: "telegram",
+                    messageId: event.messageId,
+                    status: turn.response.status,
+                    errorName: safeObservedErrorName(error),
+                  },
+                );
+              }
+              throw new PersonalTelegramPreEgressError(
+                `Personal Shared turn failed before egress (${turn.response.status})`,
+                { failure },
               );
-              await turn.response.body?.cancel();
             } else {
-              const payload: unknown = await turn.response.json();
+              let payload: unknown;
+              try {
+                payload = await turn.response.json();
+              } catch (error) {
+                // error-policy:J3 a successful response remains untrusted
+                // until its JSON contract parses before provider egress.
+                throw new PersonalTelegramPreEgressError(
+                  "Personal Shared turn returned invalid JSON",
+                  { cause: error },
+                );
+              }
               const candidate =
                 payload && typeof payload === "object" && "data" in payload
                   ? (payload.data as { reply?: unknown } | null)?.reply
                   : undefined;
               if (typeof candidate !== "string") {
-                throw new TypeError(
+                throw new PersonalTelegramPreEgressError(
                   "Personal Shared edge turn returned no reply",
                 );
               }
               reply = candidate;
             }
           } catch (error) {
-            // error-policy:J4 authenticated private Telegram turns degrade to
-            // the explicit safe failure reply before any provider egress.
-            preEgressErrorName = safeObservedErrorName(error);
+            // error-policy:J4 only the typed, expected pre-egress failure
+            // shape may degrade to the explicit private Telegram reply.
+            if (!(error instanceof PersonalTelegramPreEgressError)) throw error;
+            preEgressError = error;
+            if (error.attempts !== null) attempts = error.attempts;
+            if (error.turnMs !== null) turnMs = error.turnMs;
           }
-          if (fallbackFailure || preEgressErrorName) {
+          if (preEgressError) {
             if (event.chatType !== "private" || event.membershipChange) {
-              throw new Error(
+              // error-policy:J2 add the non-private delivery context while
+              // preserving the exact typed pre-egress failure as the cause.
+              throw new PersonalTelegramPreEgressError(
                 "Personal Shared non-private turn failed before egress",
+                {
+                  cause: preEgressError,
+                  failure: preEgressError.failure,
+                },
               );
             }
+            const fallbackFailure = preEgressError.failure;
             logger.warn(
               "[PersonalTelegramEdge] pre-egress turn failed; sending safe fallback",
               {
@@ -947,7 +1046,7 @@ export async function handlePersonalTelegramEdge(
                 failureName: fallbackFailure?.name ?? null,
                 failureCauseName: fallbackFailure?.causeName ?? null,
                 retryable: fallbackFailure?.retryable ?? false,
-                preEgressErrorName,
+                preEgressErrorName: safeObservedErrorName(preEgressError.cause),
               },
             );
             const egressStartedAt = performance.now();

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -925,6 +925,8 @@ export async function handlePersonalTelegramEdge(
               reply = candidate;
             }
           } catch (error) {
+            // error-policy:J4 authenticated private Telegram turns degrade to
+            // the explicit safe failure reply before any provider egress.
             preEgressErrorName = safeObservedErrorName(error);
           }
           if (fallbackFailure || preEgressErrorName) {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -628,12 +628,14 @@ describe("personal Shared messaging deliveries", () => {
         "shared_runtime",
       );
       expect(response.headers.get("x-eliza-failure-name")).toBe("TypeError");
+      expect(response.headers.get("x-eliza-retryable")).toBe("false");
       expect(errorLog).toHaveBeenCalledWith(
         "[personal-shared-messaging] delivery failed",
         {
           traceId: "22222222-2222-4222-8222-222222222222",
           stage: "shared_runtime",
           errorName: "TypeError",
+          retryable: false,
         },
       );
       expect(JSON.stringify(errorLog.mock.calls)).not.toContain(
@@ -665,12 +667,63 @@ describe("personal Shared messaging deliveries", () => {
     expect(response.headers.get("x-eliza-failure-name")).toBe(
       "SharedRuntimeCacheWarmingError",
     );
+    expect(response.headers.get("x-eliza-retryable")).toBe("true");
     await expect(response.json()).resolves.toEqual({
       success: false,
       error: "Shared Eliza is warming. Retry this turn shortly.",
       code: "service_unavailable",
       retryable: true,
     });
+  });
+
+  test("preserves a transient AgentRuntime cause as a retryable 503", async () => {
+    const { SharedRuntimeTurnError } = await import(
+      "@/lib/services/shared-runtime/shared-runtime-errors"
+    );
+    const provider = Object.assign(new Error("private provider body"), {
+      name: "AI_APICallError",
+      statusCode: 503,
+    });
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      throw new SharedRuntimeTurnError("private turn identity", provider);
+    });
+
+    const response = await request(valid);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(response.headers.get("x-eliza-failure-name")).toBe(
+      "SharedRuntimeTurnError",
+    );
+    expect(response.headers.get("x-eliza-failure-cause-name")).toBe(
+      "SharedRuntimeProviderUnavailableError",
+    );
+    expect(response.headers.get("x-eliza-retryable")).toBe("true");
+    expect(await response.text()).not.toContain("private provider body");
+  });
+
+  test("keeps an action-contract failure terminal and sanitized", async () => {
+    const { SharedRuntimeTurnError } = await import(
+      "@/lib/services/shared-runtime/shared-runtime-errors"
+    );
+    const cause = new Error(
+      "Eliza Shared runtime completed an executable REMINDERS request without an action result",
+    );
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      throw new SharedRuntimeTurnError("private turn identity", cause);
+    });
+
+    const response = await request(valid);
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("x-eliza-failure-name")).toBe(
+      "SharedRuntimeTurnError",
+    );
+    expect(response.headers.get("x-eliza-failure-cause-name")).toBe(
+      "SharedRuntimeActionContractError",
+    );
+    expect(response.headers.get("x-eliza-retryable")).toBe("false");
+    expect(await response.text()).not.toContain("REMINDERS");
   });
 
   test("classifies a both-path account resolution failure as a retryable 503", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1,5 +1,11 @@
 /** Runs a trusted messaging delivery through one rowless personal Shared turn. */
 
+import {
+  ELIZA_FAILURE_CAUSE_NAME_HEADER,
+  ELIZA_FAILURE_NAME_HEADER,
+  ELIZA_FAILURE_STAGE_HEADER,
+  ELIZA_RETRYABLE_HEADER,
+} from "@elizaos/cloud-services-common/personal-shared-failure";
 import { ChannelType } from "@elizaos/core/edge";
 import type { SharedGroupReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import { Hono } from "hono";
@@ -42,7 +48,10 @@ import {
   sharedRestMessageSend,
   sharedTurnServerTiming,
 } from "@/lib/services/shared-runtime/shared-rest-adapter";
-import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
+import {
+  SharedRuntimeCacheWarmingError,
+  SharedRuntimeTurnError,
+} from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -55,8 +64,6 @@ const MAX_TELEGRAM_VOICE_BYTES = 8 * 1024 * 1024;
 const MAX_TELEGRAM_VOICE_BASE64_LENGTH =
   Math.ceil(MAX_TELEGRAM_VOICE_BYTES / 3) * 4;
 const DEFAULT_WHISPER_MODEL = "Systran/faster-whisper-small";
-const FAILURE_STAGE_HEADER = "X-Eliza-Failure-Stage";
-const FAILURE_NAME_HEADER = "X-Eliza-Failure-Name";
 const GROUP_CLAIM_TTL_MS = 10 * 60_000;
 const GROUP_JOIN_CHALLENGE_TTL_MS = 10 * 60_000;
 const GROUP_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
@@ -89,6 +96,7 @@ const SAFE_ERROR_NAMES = new Set([
   "RangeError",
   "RateLimitError",
   "SharedRuntimeCacheWarmingError",
+  "SharedRuntimeTurnError",
   "SharedTurnConflictError",
   "TimeoutError",
   "TypeError",
@@ -97,6 +105,19 @@ const SAFE_ERROR_NAMES = new Set([
 function safeErrorName(error: unknown): string {
   const name = error instanceof Error ? error.name : "";
   return SAFE_ERROR_NAMES.has(name) ? name : "OtherError";
+}
+
+function retryableDeliveryError(error: unknown): boolean {
+  if (error instanceof SharedRuntimeTurnError) return error.retryable;
+  const name = error instanceof Error ? error.name : "";
+  return (
+    error instanceof PersonalDeliveryAccountResolutionError ||
+    error instanceof SharedRuntimeCacheWarmingError ||
+    name === "AbortError" ||
+    name === "RateLimitError" ||
+    name === "TimeoutError" ||
+    isGroupDeliveryPendingError(error)
+  );
 }
 
 function isGroupDeliveryPendingError(error: unknown): boolean {
@@ -1957,11 +1978,16 @@ app.post("/", async (c) => {
   } catch (error) {
     // error-policy:J1 the internal HTTP boundary emits one structured failure.
     const errorName = safeErrorName(error);
+    const retryable = retryableDeliveryError(error);
+    const failureCauseName =
+      error instanceof SharedRuntimeTurnError ? error.failureName : null;
     const traceId = c.get("traceId") ?? resolveElizaTraceId(c.req.raw.headers);
     logger.error("[personal-shared-messaging] delivery failed", {
       traceId,
       stage,
       errorName,
+      ...(failureCauseName ? { failureCauseName } : {}),
+      retryable,
       ...(error instanceof PersonalDeliveryAccountResolutionError
         ? { projectionFailure: error.projectionFailure }
         : {}),
@@ -1976,8 +2002,12 @@ app.post("/", async (c) => {
     // This route is internal-authenticated. Safe classification headers let
     // the connector correlate a retry without exposing exception messages or
     // provider/SQL payloads in its logs.
-    c.header(FAILURE_STAGE_HEADER, stage);
-    c.header(FAILURE_NAME_HEADER, errorName);
+    c.header(ELIZA_FAILURE_STAGE_HEADER, stage);
+    c.header(ELIZA_FAILURE_NAME_HEADER, errorName);
+    c.header(ELIZA_RETRYABLE_HEADER, retryable ? "true" : "false");
+    if (failureCauseName) {
+      c.header(ELIZA_FAILURE_CAUSE_NAME_HEADER, failureCauseName);
+    }
     if (error instanceof PersonalDeliveryAccountResolutionError) {
       // Account resolution only fails here after both the projection and the
       // canonical resolver failed — a transient storage condition the
@@ -1999,6 +2029,18 @@ app.post("/", async (c) => {
         {
           success: false,
           error: "Shared Eliza is warming. Retry this turn shortly.",
+          code: "service_unavailable",
+          retryable: true,
+        },
+        503,
+        { "Retry-After": "1" },
+      );
+    }
+    if (error instanceof SharedRuntimeTurnError && error.retryable) {
+      return c.json(
+        {
+          success: false,
+          error: "Shared Eliza is temporarily unavailable. Retry shortly.",
           code: "service_unavailable",
           retryable: true,
         },

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, expect, mock, test } from "bun:test";
+import { SharedRuntimeTurnError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 
 class RateLimitError extends Error {
   retryAfter?: number;
@@ -188,6 +189,23 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
       }
       if (rpc.id === "rate-limited") {
         throw new RateLimitError("Organization rate limit exceeded.", 29);
+      }
+      if (rpc.id === "provider-unavailable") {
+        throw new SharedRuntimeTurnError(
+          "Shared runtime turn failed for private provider response",
+          Object.assign(new Error("private provider response"), {
+            name: "AI_APICallError",
+            statusCode: 503,
+          }),
+        );
+      }
+      if (rpc.id === "action-contract-failed") {
+        throw new SharedRuntimeTurnError(
+          "Shared runtime turn failed for private action payload",
+          new Error(
+            "Eliza Shared runtime completed an executable REMINDERS request without an action result",
+          ),
+        );
       }
       const channelId = rpc.params?.roomId ?? agent.id;
       const history = await options.historyStore.load(
@@ -469,6 +487,57 @@ test("buffered bridge releases the room before its response body is consumed", a
     ]),
   ).resolves.not.toBe("queue-blocked");
   await firstResponse.arrayBuffer();
+});
+
+test("serializes only safe turn failure classification across the object boundary", async () => {
+  const object = new SharedRuntimeConversation(
+    makeState(new Map<string, unknown>(), []) as never,
+    {} as never,
+  );
+  const invoke = async (id: string) => {
+    const response = await object.fetch(
+      new Request("https://shared-runtime.internal/bridge", {
+        method: "POST",
+        body: JSON.stringify({
+          operation: "bridge",
+          agent: AGENT_FIXTURE,
+          rpc: {
+            jsonrpc: "2.0",
+            id,
+            method: "message.send",
+            params: { text: "hi", roomId: "room-1" },
+          },
+        }),
+      }),
+    );
+    return { status: response.status, body: await response.json() };
+  };
+
+  const retryable = await invoke("provider-unavailable");
+  expect(retryable).toEqual({
+    status: 503,
+    body: {
+      success: false,
+      error: "Shared runtime turn failed.",
+      code: "shared_runtime_turn_failed",
+      failureName: "SharedRuntimeProviderUnavailableError",
+      retryable: true,
+    },
+  });
+  expect(JSON.stringify(retryable)).not.toContain("private provider response");
+
+  const terminal = await invoke("action-contract-failed");
+  expect(terminal).toEqual({
+    status: 500,
+    body: {
+      success: false,
+      error: "Shared runtime turn failed.",
+      code: "shared_runtime_turn_failed",
+      failureName: "SharedRuntimeActionContractError",
+      retryable: false,
+    },
+  });
+  expect(JSON.stringify(terminal)).not.toContain("private action payload");
 });
 
 async function pushOperation(

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -29,6 +29,7 @@ import type {
   SharedTurnClaimStore,
   SharedTurnTerminalResult,
 } from "@/lib/services/shared-runtime/shared-runtime-chat";
+import { SharedRuntimeTurnError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { mergeSharedRuntimeHistoryMessages } from "@/lib/services/shared-runtime/shared-runtime-history-policy";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -2049,9 +2050,9 @@ export class SharedRuntimeConversation {
       return this.releaseWhenConsumed(response, release);
     } catch (error) {
       // error-policy:J1 the Durable Object transport boundary translates cache
-      // warming and credit insufficiency into structured responses (class
-      // identity cannot survive the stub fetch boundary); every other failure
-      // remains observable to Workers.
+      // warming, turn failure classification, and credit insufficiency into
+      // structured responses (class identity cannot survive the stub fetch
+      // boundary); every other failure remains observable to Workers.
       release();
       if (error instanceof Error && error.name === "SharedTurnConflictError") {
         return Response.json(
@@ -2077,6 +2078,18 @@ export class SharedRuntimeConversation {
             retryable: true,
           },
           { status: 503, headers: { "Retry-After": "1" } },
+        );
+      }
+      if (error instanceof SharedRuntimeTurnError) {
+        return Response.json(
+          {
+            success: false,
+            error: "Shared runtime turn failed.",
+            code: "shared_runtime_turn_failed",
+            failureName: error.failureName,
+            retryable: error.retryable,
+          },
+          { status: error.retryable ? 503 : 500 },
         );
       }
       const { InsufficientCreditsError, RateLimitError } = await import(

--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -13,6 +13,7 @@
     "./k8s-deployment-wake": "./src/k8s-deployment-wake.ts",
     "./identity-link-code": "./src/identity-link-code.ts",
     "./gateway-auth": "./src/gateway-auth.ts",
+    "./personal-shared-failure": "./src/personal-shared-failure.ts",
     "./response-attempts": "./src/response-attempts.ts",
     "./telegram-connector": "./src/telegram-connector.ts",
     "./telegram-delivery": "./src/telegram-delivery.ts"

--- a/packages/cloud/services/_common/src/index.ts
+++ b/packages/cloud/services/_common/src/index.ts
@@ -28,6 +28,15 @@ export {
   type ServiceLoggerOptions,
 } from "./logger";
 export {
+  ELIZA_FAILURE_CAUSE_NAME_HEADER,
+  ELIZA_FAILURE_NAME_HEADER,
+  ELIZA_FAILURE_STAGE_HEADER,
+  ELIZA_RETRYABLE_HEADER,
+  PERSONAL_SHARED_FAILURE_REPLY,
+  type PersonalSharedFailureMetadata,
+  readPersonalSharedFailureMetadata,
+} from "./personal-shared-failure";
+export {
   executeResponseAttempts,
   type ResponseAttemptObservation,
   type ResponseAttemptsOptions,

--- a/packages/cloud/services/_common/src/personal-shared-failure.test.ts
+++ b/packages/cloud/services/_common/src/personal-shared-failure.test.ts
@@ -1,0 +1,63 @@
+/** Exercises safe Personal Shared failure metadata parsing at the HTTP boundary. */
+
+import { describe, expect, test } from "bun:test";
+import { readPersonalSharedFailureMetadata } from "./personal-shared-failure";
+
+describe("Personal Shared failure metadata", () => {
+  test("keeps only bounded classifications and an explicit retry disposition", () => {
+    const metadata = readPersonalSharedFailureMetadata(
+      new Response("private provider body", {
+        status: 500,
+        headers: {
+          "Retry-After": "999999",
+          "X-Eliza-Failure-Stage": "shared_runtime",
+          "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+          "X-Eliza-Failure-Cause-Name": "unsafe value with spaces",
+          "X-Eliza-Retryable": "false",
+        },
+      }),
+    );
+
+    expect(metadata).toEqual({
+      status: 500,
+      stage: "shared_runtime",
+      name: "SharedRuntimeTurnError",
+      causeName: null,
+      retryable: false,
+      retryAfterSeconds: 300,
+    });
+    expect(JSON.stringify(metadata)).not.toContain("private provider body");
+  });
+
+  test("rejects malformed retry metadata instead of partially parsing it", () => {
+    const metadata = readPersonalSharedFailureMetadata(
+      new Response(null, {
+        status: 409,
+        headers: {
+          "Retry-After": "1 second",
+          "X-Eliza-Retryable": "TRUE",
+        },
+      }),
+    );
+
+    expect(metadata.retryable).toBe(false);
+    expect(metadata.retryAfterSeconds).toBeNull();
+  });
+
+  test("rejects safe-looking but unrecognized diagnostic classifications", () => {
+    const metadata = readPersonalSharedFailureMetadata(
+      new Response("private body", {
+        status: 500,
+        headers: {
+          "X-Eliza-Failure-Stage": "TOP_SECRET_STAGE",
+          "X-Eliza-Failure-Name": "PrivateProviderToken",
+          "X-Eliza-Failure-Cause-Name": "CustomerIdentifier123",
+        },
+      }),
+    );
+
+    expect(metadata.stage).toBeNull();
+    expect(metadata.name).toBeNull();
+    expect(metadata.causeName).toBeNull();
+  });
+});

--- a/packages/cloud/services/_common/src/personal-shared-failure.ts
+++ b/packages/cloud/services/_common/src/personal-shared-failure.ts
@@ -1,0 +1,113 @@
+/**
+ * Carries sanitized Personal Shared failure metadata across Worker and gateway
+ * HTTP boundaries without exposing exception messages or provider payloads.
+ */
+
+export const ELIZA_FAILURE_STAGE_HEADER = "X-Eliza-Failure-Stage";
+export const ELIZA_FAILURE_NAME_HEADER = "X-Eliza-Failure-Name";
+export const ELIZA_FAILURE_CAUSE_NAME_HEADER = "X-Eliza-Failure-Cause-Name";
+export const ELIZA_RETRYABLE_HEADER = "X-Eliza-Retryable";
+
+/**
+ * Stable across retries so the Telegram exact-once ledger always prepares the
+ * same chunk plan even when the upstream failure classification changes.
+ */
+export const PERSONAL_SHARED_FAILURE_REPLY =
+  "I couldn't complete that request just now. Please try again in a moment.";
+
+const SAFE_FAILURE_STAGES = new Set([
+  "account_claim",
+  "account_resolution",
+  "authentication",
+  "connector_account",
+  "consent",
+  "dedicated_runtime",
+  "media_description",
+  "shared_runtime",
+  "validation",
+  "voice_transcription",
+  "worker_context",
+]);
+const SAFE_FAILURE_NAMES = new Set([
+  "AbortError",
+  "ApiError",
+  "Error",
+  "HTTPException",
+  "InsufficientCreditsError",
+  "OtherError",
+  "PersonalDeliveryAccountResolutionError",
+  "RangeError",
+  "RateLimitError",
+  "SharedRuntimeCacheWarmingError",
+  "SharedRuntimeTurnError",
+  "SharedTurnConflictError",
+  "TimeoutError",
+  "TypeError",
+]);
+const SAFE_FAILURE_CAUSE_NAMES = new Set([
+  "SharedRuntimeActionContractError",
+  "SharedRuntimeNoReplyError",
+  "SharedRuntimeProviderConfigurationError",
+  "SharedRuntimeProviderRejectedError",
+  "SharedRuntimeProviderUnavailableError",
+  "SharedRuntimeTimeoutError",
+  "SharedRuntimeUnknownError",
+]);
+const MAX_RETRY_AFTER_SECONDS = 300;
+
+export interface PersonalSharedFailureMetadata {
+  status: number;
+  stage: string | null;
+  name: string | null;
+  causeName: string | null;
+  retryable: boolean;
+  retryAfterSeconds: number | null;
+}
+
+function safeClassification(
+  value: string | null,
+  allowed: ReadonlySet<string>,
+): string | null {
+  const normalized = value?.trim() ?? "";
+  return allowed.has(normalized) ? normalized : null;
+}
+
+function retryableFromStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+/** Read only bounded, allowlisted classification from an upstream response. */
+export function readPersonalSharedFailureMetadata(
+  response: Response,
+): PersonalSharedFailureMetadata {
+  const retryableHeader = response.headers.get(ELIZA_RETRYABLE_HEADER)?.trim();
+  const retryAfterHeader = response.headers.get("Retry-After")?.trim() ?? "";
+  const parsedRetryAfter = /^(?:0|[1-9]\d*)$/u.test(retryAfterHeader)
+    ? Number(retryAfterHeader)
+    : Number.NaN;
+  return {
+    status: response.status,
+    stage: safeClassification(
+      response.headers.get(ELIZA_FAILURE_STAGE_HEADER),
+      SAFE_FAILURE_STAGES,
+    ),
+    name: safeClassification(
+      response.headers.get(ELIZA_FAILURE_NAME_HEADER),
+      SAFE_FAILURE_NAMES,
+    ),
+    causeName: safeClassification(
+      response.headers.get(ELIZA_FAILURE_CAUSE_NAME_HEADER),
+      SAFE_FAILURE_CAUSE_NAMES,
+    ),
+    retryable:
+      retryableHeader === "true"
+        ? true
+        : retryableHeader === "false"
+          ? false
+          : retryableFromStatus(response.status),
+    retryAfterSeconds:
+      Number.isSafeInteger(parsedRetryAfter) && parsedRetryAfter >= 0
+        ? Math.min(parsedRetryAfter, MAX_RETRY_AFTER_SECONDS)
+        : null,
+  };
+}

--- a/packages/cloud/services/_common/src/response-attempts.test.ts
+++ b/packages/cloud/services/_common/src/response-attempts.test.ts
@@ -1,3 +1,4 @@
+/** Verifies bounded response retries honor explicit upstream disposition. */
 import { describe, expect, mock, test } from "bun:test";
 import { executeResponseAttempts } from "./response-attempts";
 
@@ -63,5 +64,77 @@ describe("executeResponseAttempts", () => {
       }),
     ).rejects.toThrow("still unavailable");
     expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not replay a terminal 500 when the upstream marks it non-retryable", async () => {
+    const request = mock(
+      async () =>
+        new Response("terminal", {
+          status: 500,
+          headers: { "X-Eliza-Retryable": "false" },
+        }),
+    );
+    const observations: boolean[] = [];
+
+    const result = await executeResponseAttempts({
+      maxAttempts: 3,
+      honorExplicitRetryable: true,
+      retryStatuses: true,
+      retryTransport: true,
+      request,
+      observe: (observation) => {
+        observations.push(observation.retryable);
+      },
+    });
+
+    expect(result.response.status).toBe(500);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(observations).toEqual([false]);
+  });
+
+  test("retries an explicitly recoverable non-5xx response", async () => {
+    let attempts = 0;
+    const result = await executeResponseAttempts({
+      maxAttempts: 2,
+      honorExplicitRetryable: true,
+      retryStatuses: true,
+      retryTransport: true,
+      request: async () => {
+        attempts += 1;
+        return attempts === 1
+          ? new Response("pending", {
+              status: 409,
+              headers: {
+                "Retry-After": "0",
+                "X-Eliza-Retryable": "true",
+              },
+            })
+          : new Response("ok", { status: 200 });
+      },
+      observe: () => undefined,
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(attempts).toBe(2);
+  });
+
+  test("keeps legacy status retries unless explicit disposition is opted in", async () => {
+    let attempts = 0;
+    const result = await executeResponseAttempts({
+      maxAttempts: 2,
+      retryStatuses: true,
+      retryTransport: true,
+      request: async () => {
+        attempts += 1;
+        return new Response("terminal for opted-in callers only", {
+          status: 500,
+          headers: { "X-Eliza-Retryable": "false" },
+        });
+      },
+      observe: () => undefined,
+    });
+
+    expect(result.response.status).toBe(500);
+    expect(attempts).toBe(2);
   });
 });

--- a/packages/cloud/services/_common/src/response-attempts.ts
+++ b/packages/cloud/services/_common/src/response-attempts.ts
@@ -4,6 +4,8 @@
  * retry classification, Retry-After bounds, delay, and transport failure.
  */
 
+import { readPersonalSharedFailureMetadata } from "./personal-shared-failure";
+
 export type ResponseRetryReason = "auth_refresh" | "status" | "transport";
 
 export interface ResponseAttemptObservation {
@@ -30,6 +32,12 @@ export interface ResponseAttemptsOptions {
   refreshAuth?(): Promise<void>;
   retryStatuses: boolean;
   retryTransport: boolean;
+  /**
+   * Honor the sanitized `X-Eliza-Retryable` disposition. Opt-in so callers
+   * that do not yet deliver a terminal user-visible fallback retain their
+   * historical status-based retry behavior.
+   */
+  honorExplicitRetryable?: boolean;
   retryDelayCapMs?: number;
   observe(observation: ResponseAttemptObservation): void | Promise<void>;
 }
@@ -38,10 +46,6 @@ export interface ResponseAttemptsResult {
   response: Response;
   attempts: number;
   durationMs: number;
-}
-
-function isRetryableStatus(status: number): boolean {
-  return status === 408 || status === 425 || status === 429 || status >= 500;
 }
 
 export async function executeResponseAttempts(
@@ -94,19 +98,19 @@ export async function executeResponseAttempts(
       }
 
       budgetAttempts += 1;
-      const retryable = isRetryableStatus(response.status);
+      const failure = readPersonalSharedFailureMetadata(response);
+      const retryable = options.honorExplicitRetryable
+        ? failure.retryable
+        : response.status === 408 ||
+          response.status === 425 ||
+          response.status === 429 ||
+          response.status >= 500;
       const shouldRetry =
         !response.ok &&
         retryable &&
         options.retryStatuses &&
         budgetAttempts < options.maxAttempts;
-      const parsedRetryAfter = Number.parseInt(
-        response.headers.get("Retry-After") ?? "",
-        10,
-      );
-      const retryAfterSeconds = Number.isFinite(parsedRetryAfter)
-        ? parsedRetryAfter
-        : null;
+      const retryAfterSeconds = failure.retryAfterSeconds;
       const retryDelayMs = shouldRetry
         ? retryAfterSeconds === null
           ? 200 * budgetAttempts

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -1,5 +1,6 @@
 /** Exercises gateway webhook routing with deterministic cloud-service fixtures. */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { PERSONAL_SHARED_FAILURE_REPLY } from "@elizaos/cloud-services-common/personal-shared-failure";
 import type {
   ChatEvent,
   PlatformAdapter,
@@ -265,6 +266,43 @@ describe("gateway webhook handler e2e routing", () => {
       () => [...redis.store.values()].includes("delivered"),
       "durable delivered state",
     );
+  });
+
+  test("keeps terminal retry headers opt-in so phone attempts do not change", async () => {
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({ messageId: "SM_terminal_retry_scope" });
+    const adapter = createAdapter(event);
+    let sharedAttempts = 0;
+    globalThis.fetch = mock(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
+        sharedAttempts += 1;
+        return new Response("private upstream body", {
+          status: 500,
+          headers: {
+            "Retry-After": "0",
+            "X-Eliza-Retryable": "false",
+          },
+        });
+      }
+      throw new Error(`unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(() => sharedAttempts === 3, "phone Shared retry budget");
+    expect(adapter.replies).toEqual([]);
   });
 
   test("persists an ambiguous provider failure and refuses an unsafe replay", async () => {
@@ -1073,7 +1111,7 @@ describe("gateway webhook handler e2e routing", () => {
     ).toBe(false);
   });
 
-  test("releases Telegram processing ownership after a pre-egress failure so the update can retry immediately", async () => {
+  test("delivers one Telegram fallback after retryable Shared attempts are exhausted", async () => {
     process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
     const event: ChatEvent = {
       platform: "telegram",
@@ -1106,13 +1144,16 @@ describe("gateway webhook handler e2e routing", () => {
     let sharedAttempts = 0;
     globalThis.fetch = mock(async () => {
       sharedAttempts += 1;
-      if (sharedAttempts <= 3) {
-        return new Response("temporarily unavailable", { status: 503 });
-      }
-      return new Response(
-        JSON.stringify({ data: { reply: "personal Shared reply" } }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
+      return new Response("private provider detail", {
+        status: 503,
+        headers: {
+          "Retry-After": "0",
+          "X-Eliza-Failure-Stage": "shared_runtime",
+          "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+          "X-Eliza-Failure-Cause-Name": "SharedRuntimeProviderUnavailableError",
+          "X-Eliza-Retryable": "true",
+        },
+      });
     }) as typeof fetch;
     const request = () =>
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
@@ -1127,15 +1168,291 @@ describe("gateway webhook handler e2e routing", () => {
     const processingKey =
       "webhook:telegram:scope:message:update-retry-before-egress:processing";
 
-    await expect(
-      handleWebhook(request(), adapter, deps, "eliza-app"),
-    ).rejects.toThrow(/personal Shared chat failed \(503\)/);
-    expect(redis.store.has(processingKey)).toBe(false);
+    const first = await handleWebhook(request(), adapter, deps, "eliza-app");
+    const duplicate = await handleWebhook(
+      request(),
+      adapter,
+      deps,
+      "eliza-app",
+    );
 
-    const retry = await handleWebhook(request(), adapter, deps, "eliza-app");
-    expect(retry.status).toBe(200);
+    expect(first.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(sharedAttempts).toBe(3);
     expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[2]).toBe(PERSONAL_SHARED_FAILURE_REPLY);
     expect(redis.store.has(processingKey)).toBe(false);
+  });
+
+  test("delivers one Telegram fallback without replaying a terminal Shared turn", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "update-terminal-before-egress",
+      platformRecordId: "message-terminal-before-egress",
+      chatId: "chat-1",
+      chatType: "private",
+      senderId: "sender-1",
+      senderName: "Ada",
+      text: "remove that reminder",
+      rawPayload: {},
+    };
+    const sendReply = mock(async () => undefined);
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      getDedupeScope: () => "scope",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-terminal-1"] };
+      }),
+    };
+    const redis = new MemoryRedis();
+    redis.store.set(
+      "identity:telegram:sender-1",
+      JSON.stringify({ notFound: true }),
+    );
+    let sharedAttempts = 0;
+    globalThis.fetch = mock(async () => {
+      sharedAttempts += 1;
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode("private action payload"),
+          );
+        },
+        cancel() {
+          throw new Error("private body cleanup detail");
+        },
+      });
+      return new Response(body, {
+        status: 500,
+        headers: {
+          "X-Eliza-Failure-Stage": "shared_runtime",
+          "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+          "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
+          "X-Eliza-Retryable": "false",
+        },
+      });
+    }) as typeof fetch;
+    const request = () =>
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      });
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    };
+
+    expect(
+      (await handleWebhook(request(), adapter, deps, "eliza-app")).status,
+    ).toBe(200);
+    expect(
+      (await handleWebhook(request(), adapter, deps, "eliza-app")).status,
+    ).toBe(200);
+    expect(sharedAttempts).toBe(1);
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[2]).toBe(PERSONAL_SHARED_FAILURE_REPLY);
+  });
+
+  test("delivers one Telegram fallback when private voice resolution fails", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "update-voice-resolution-failure",
+      chatId: "chat-1",
+      chatType: "private",
+      senderId: "sender-1",
+      text: "",
+      voiceNote: {
+        fileId: "private-provider-file-id",
+        durationSeconds: 2,
+        sizeBytes: 8,
+        mimeType: "audio/ogg",
+      },
+      rawPayload: {},
+    };
+    const sendReply = mock(async () => undefined);
+    const resolveVoiceNote = mock(async () => {
+      throw new Error("private provider download detail");
+    });
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      getDedupeScope: () => "scope",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      resolveVoiceNote,
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-voice-fallback-1"] };
+      }),
+    };
+    const cloudFetch = mock(async () =>
+      Response.json({ data: { reply: "must not run" } }),
+    );
+    globalThis.fetch = cloudFetch as typeof fetch;
+
+    expect(
+      (
+        await handleWebhook(
+          new Request("https://gateway.example/webhook/eliza-app/telegram", {
+            method: "POST",
+            body: "{}",
+          }),
+          adapter,
+          {
+            redis: new MemoryRedis(),
+            cloudBaseUrl: "https://api.elizacloud.ai",
+            getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+          },
+          "eliza-app",
+        )
+      ).status,
+    ).toBe(200);
+    expect(resolveVoiceNote).toHaveBeenCalledTimes(1);
+    expect(cloudFetch).not.toHaveBeenCalled();
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[2]).toBe(PERSONAL_SHARED_FAILURE_REPLY);
+  });
+
+  test.each([
+    [
+      "group message",
+      {
+        chatType: "supergroup",
+        text: "@eliza help",
+      },
+    ],
+    [
+      "membership update",
+      {
+        chatType: "supergroup",
+        text: "",
+        membershipChange: "removed" as const,
+      },
+    ],
+  ])(
+    "never injects a fallback into a Telegram %s",
+    async (_name, overrides) => {
+      process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+      const event: ChatEvent = {
+        platform: "telegram",
+        messageId: `no-fallback-${_name.replaceAll(" ", "-")}`,
+        chatId: "-100123456789",
+        senderId: "sender-1",
+        rawPayload: {},
+        ...overrides,
+      };
+      const sendReply = mock(async () => undefined);
+      const sendReplyWithReceipt = mock(async () => ({
+        providerMessageIds: ["must-not-send"],
+      }));
+      const adapter: PlatformAdapter = {
+        platform: "telegram",
+        getDedupeScope: () => "scope",
+        verifyWebhook: mock(async () => true),
+        extractEvent: mock(async () => event),
+        sendTypingIndicator: mock(async () => undefined),
+        sendReply,
+        sendReplyWithReceipt,
+      };
+      const redis = new MemoryRedis();
+      globalThis.fetch = mock(
+        async () =>
+          new Response("private upstream body", {
+            status: 500,
+            headers: {
+              "X-Eliza-Failure-Stage": "shared_runtime",
+              "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+              "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
+              "X-Eliza-Retryable": "false",
+            },
+          }),
+      ) as typeof fetch;
+
+      await expect(
+        handleWebhook(
+          new Request("https://gateway.example/webhook/eliza-app/telegram", {
+            method: "POST",
+            body: "{}",
+          }),
+          adapter,
+          {
+            redis,
+            cloudBaseUrl: "https://api.elizacloud.ai",
+            getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+          },
+          "eliza-app",
+        ),
+      ).rejects.toMatchObject({ name: "PersonalSharedPreEgressError" });
+      expect(sendReply).not.toHaveBeenCalled();
+      expect(sendReplyWithReceipt).not.toHaveBeenCalled();
+    },
+  );
+
+  test("never logs raw Shared bodies or malformed classification headers", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "update-sanitized-diagnostics",
+      chatId: "chat-1",
+      chatType: "private",
+      senderId: "sender-1",
+      text: "hello",
+      rawPayload: {},
+    };
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      getDedupeScope: () => "scope",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply: mock(async () => undefined),
+      sendReplyWithReceipt: mock(async () => ({
+        providerMessageIds: ["provider-sanitized-1"],
+      })),
+    };
+    const warnLog = spyOn(logger, "warn").mockImplementation(() => undefined);
+    globalThis.fetch = mock(
+      async () =>
+        new Response("TOP SECRET PROVIDER BODY", {
+          status: 500,
+          headers: {
+            "X-Eliza-Failure-Stage": "TOP_SECRET_STAGE",
+            "X-Eliza-Failure-Name": "PrivateProviderToken",
+            "X-Eliza-Retryable": "false",
+          },
+        }),
+    ) as typeof fetch;
+
+    expect(
+      (
+        await handleWebhook(
+          new Request("https://gateway.example/webhook/eliza-app/telegram", {
+            method: "POST",
+            body: "{}",
+          }),
+          adapter,
+          {
+            redis: new MemoryRedis(),
+            cloudBaseUrl: "https://api.elizacloud.ai",
+            getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+          },
+          "eliza-app",
+        )
+      ).status,
+    ).toBe(200);
+    const logged = JSON.stringify(warnLog.mock.calls);
+    expect(logged).not.toContain("TOP SECRET PROVIDER BODY");
+    expect(logged).not.toContain("TOP_SECRET_STAGE");
+    expect(logged).not.toContain("PrivateProviderToken");
   });
 
   test("routes an unlinked Telegram DM to rowless personal Shared", async () => {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -5,6 +5,11 @@ import {
   truncateWellFormed,
 } from "@elizaos/cloud-services-common";
 import {
+  PERSONAL_SHARED_FAILURE_REPLY,
+  type PersonalSharedFailureMetadata,
+  readPersonalSharedFailureMetadata,
+} from "@elizaos/cloud-services-common/personal-shared-failure";
+import {
   executeResponseAttempts,
   type ResponseAttemptsResult,
 } from "@elizaos/cloud-services-common/response-attempts";
@@ -72,9 +77,34 @@ const ELIZA_TRACE_ID_HEADER = "X-Eliza-Trace-Id";
 const OPAQUE_TRACE_ID =
   /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
 const ZERO_TRACE_ID = "0".repeat(32);
+const SAFE_OBSERVED_ERROR_NAMES = new Set([
+  "AbortError",
+  "Error",
+  "RangeError",
+  "SyntaxError",
+  "TimeoutError",
+  "TypeError",
+]);
+
+function safeObservedErrorName(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+  return SAFE_OBSERVED_ERROR_NAMES.has(name) ? name : "OtherError";
+}
 
 class PersonalSharedPreEgressError extends Error {
   override readonly name = "PersonalSharedPreEgressError";
+  readonly failure: PersonalSharedFailureMetadata | null;
+
+  constructor(
+    message: string,
+    options?: { cause?: unknown; failure?: PersonalSharedFailureMetadata },
+  ) {
+    super(
+      message,
+      options?.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.failure = options?.failure ?? null;
+  }
 }
 
 class PersonalSharedRecoverablePostEgressError extends Error {
@@ -831,6 +861,37 @@ async function processMessage(
         egressMs: timing.egressMs,
         totalMs: Date.now() - startedAt,
       });
+    } catch (error) {
+      if (
+        adapter.platform === "telegram" &&
+        event.chatType === "private" &&
+        !event.membershipChange &&
+        error instanceof PersonalSharedPreEgressError
+      ) {
+        logger.warn(
+          "Personal Shared Telegram turn failed; delivering safe fallback",
+          {
+            project,
+            platform: adapter.platform,
+            messageId: event.messageId,
+            traceId: trace.traceId,
+            status: error.failure?.status ?? null,
+            failureStage: error.failure?.stage ?? null,
+            failureName: error.failure?.name ?? null,
+            failureCauseName: error.failure?.causeName ?? null,
+            retryable: error.failure?.retryable ?? false,
+          },
+        );
+        await sendReplyWithRequiredReceipt(
+          adapter,
+          config,
+          event,
+          PERSONAL_SHARED_FAILURE_REPLY,
+          deliveryHooks,
+        );
+        return;
+      }
+      throw error;
     } finally {
       stopTyping();
     }
@@ -1145,9 +1206,19 @@ async function sendPersonalSharedReply(
       "group connector cannot return a provider delivery receipt",
     );
   }
-  const voiceNote = event.voiceNote
-    ? await adapter.resolveVoiceNote?.(config, event)
-    : undefined;
+  let voiceNote:
+    | Awaited<ReturnType<NonNullable<PlatformAdapter["resolveVoiceNote"]>>>
+    | undefined;
+  try {
+    voiceNote = event.voiceNote
+      ? await adapter.resolveVoiceNote?.(config, event)
+      : undefined;
+  } catch (error) {
+    throw new PersonalSharedPreEgressError(
+      "connector failed to resolve the supplied voice note",
+      { cause: error },
+    );
+  }
   if (event.voiceNote && !voiceNote) {
     throw new PersonalSharedPreEgressError(
       "connector cannot resolve the supplied voice note",
@@ -1259,6 +1330,7 @@ async function sendPersonalSharedReply(
   try {
     attemptResult = await executeResponseAttempts({
       maxAttempts,
+      honorExplicitRetryable: adapter.platform === "telegram",
       authRefreshAttemptsOutsideBudget: 1,
       request: () => postMessage(authHeader),
       refreshAuth: async () => {
@@ -1269,6 +1341,9 @@ async function sendPersonalSharedReply(
       retryDelayCapMs: PERSONAL_SHARED_RETRY_DELAY_CAP_MS,
       observe: (observation) => {
         const response = observation.response;
+        const failure = response
+          ? readPersonalSharedFailureMetadata(response)
+          : null;
         const attemptContext = {
           traceId,
           project,
@@ -1283,16 +1358,12 @@ async function sendPersonalSharedReply(
           retryAfterSeconds: observation.retryAfterSeconds,
           retryDelayMs: observation.retryDelayMs,
           cloudServerTiming: response?.headers.get("Server-Timing") ?? null,
-          cloudFailureStage:
-            response?.headers.get("X-Eliza-Failure-Stage") ?? null,
-          cloudFailureName:
-            response?.headers.get("X-Eliza-Failure-Name") ?? null,
+          cloudFailureStage: failure?.stage ?? null,
+          cloudFailureName: failure?.name ?? null,
+          cloudFailureCauseName: failure?.causeName ?? null,
           ...(observation.error
             ? {
-                error:
-                  observation.error instanceof Error
-                    ? observation.error.message
-                    : String(observation.error),
+                errorName: safeObservedErrorName(observation.error),
               }
             : {}),
         };
@@ -1318,24 +1389,30 @@ async function sendPersonalSharedReply(
     });
   } catch (error) {
     throw new PersonalSharedPreEgressError(
-      `personal Shared chat transport failed: ${error instanceof Error ? error.message : String(error)}`,
+      "personal Shared chat transport failed",
       { cause: error },
     );
   }
   const { response } = attemptResult;
   if (!response.ok) {
-    let diagnostics: string;
+    const failure = readPersonalSharedFailureMetadata(response);
     try {
-      diagnostics = truncateWellFormed(
-        toWellFormedUnicode(await response.text()),
-        200,
-      );
+      await response.body?.cancel();
     } catch (error) {
-      // error-policy:J1 preserve a failed optional diagnostic body read.
-      diagnostics = `unable to read response body: ${error instanceof Error ? error.message : String(error)}`;
+      // error-policy:J4 response-body cleanup is best-effort and must never
+      // bypass the classified pre-egress failure or the private DM fallback.
+      logger.warn("Personal Shared failure body cleanup failed", {
+        traceId,
+        project,
+        platform: adapter.platform,
+        messageId: event.messageId,
+        status: response.status,
+        errorName: safeObservedErrorName(error),
+      });
     }
     throw new PersonalSharedPreEgressError(
-      `personal Shared chat failed (${response.status}) ${diagnostics}`,
+      `personal Shared chat failed (${response.status})`,
+      { failure },
     );
   }
   const cloudServerTiming = response.headers.get("Server-Timing");

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -862,6 +862,8 @@ async function processMessage(
         totalMs: Date.now() - startedAt,
       });
     } catch (error) {
+      // error-policy:J4 only a typed pre-egress failure on a private Telegram
+      // turn degrades to the explicit safe reply below.
       if (
         adapter.platform === "telegram" &&
         event.chatType === "private" &&
@@ -1214,6 +1216,8 @@ async function sendPersonalSharedReply(
       ? await adapter.resolveVoiceNote?.(config, event)
       : undefined;
   } catch (error) {
+    // error-policy:J2 voice resolution failures gain pre-egress context while
+    // preserving the connector error as their cause.
     throw new PersonalSharedPreEgressError(
       "connector failed to resolve the supplied voice note",
       { cause: error },
@@ -1399,7 +1403,7 @@ async function sendPersonalSharedReply(
     try {
       await response.body?.cancel();
     } catch (error) {
-      // error-policy:J4 response-body cleanup is best-effort and must never
+      // error-policy:J6 response-body cleanup is best-effort and must never
       // bypass the classified pre-egress failure or the private DM fallback.
       logger.warn("Personal Shared failure body cleanup failed", {
         traceId,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -251,6 +251,84 @@ describe("shared conversation coordinator", () => {
     });
   });
 
+  test("rehydrates sanitized turn failures before generic 503 handling", async () => {
+    const agent = {
+      id: "agent-1",
+      organization_id: "org-1",
+      user_id: "user-1",
+      execution_tier: "shared",
+    } as never;
+    const rpc = {
+      jsonrpc: "2.0" as const,
+      id: "rpc-1",
+      method: "message.send",
+      params: { text: "hi", roomId: "room-1" },
+    };
+    const executionCtx = { waitUntil() {} };
+    const namespace = {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json(
+            {
+              error: "Shared runtime turn failed.",
+              code: "shared_runtime_turn_failed",
+              failureName: "SharedRuntimeProviderUnavailableError",
+              retryable: true,
+            },
+            { status: 503 },
+          ),
+      }),
+    };
+
+    await expect(
+      coordinateSharedBridge(agent, rpc, { namespace, executionCtx }),
+    ).rejects.toMatchObject({
+      name: "SharedRuntimeTurnError",
+      message: "Shared runtime turn failed.",
+      failureName: "SharedRuntimeProviderUnavailableError",
+      retryable: true,
+    });
+  });
+
+  test("fails closed when turn failure metadata is forged or inconsistent", async () => {
+    const agent = {
+      id: "agent-1",
+      organization_id: "org-1",
+      user_id: "user-1",
+      execution_tier: "shared",
+    } as never;
+    const rpc = {
+      jsonrpc: "2.0" as const,
+      id: "rpc-1",
+      method: "message.send",
+      params: { text: "hi", roomId: "room-1" },
+    };
+    const executionCtx = { waitUntil() {} };
+    const namespace = {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json(
+            {
+              error: "private provider body",
+              code: "shared_runtime_turn_failed",
+              failureName: "SharedRuntimeActionContractError",
+              retryable: true,
+            },
+            { status: 503 },
+          ),
+      }),
+    };
+
+    await expect(
+      coordinateSharedBridge(agent, rpc, { namespace, executionCtx }),
+    ).rejects.toMatchObject({
+      name: "SharedRuntimeTurnError",
+      message: "Shared runtime turn failed.",
+      failureName: "SharedRuntimeUnknownError",
+      retryable: false,
+    });
+  });
+
   test("keeps history import behind the account-commit boundary and makes replay explicit", async () => {
     const operations: string[] = [];
     const names: string[] = [];

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -19,7 +19,11 @@ import { coordinatorFetch, deadlineBoundCoordinatorStub } from "./coordinator-fe
 import type { SharedRuntimeChannel, SharedTurnMessage } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
-import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
+import {
+  SharedRuntimeCacheWarmingError,
+  SharedRuntimeTurnError,
+  SharedTurnConflictError,
+} from "./shared-runtime-errors";
 import { normalizeSharedRuntimeRoom } from "./shared-runtime-room-identity";
 
 export interface SharedConversationCoordinatorOptions {
@@ -256,35 +260,51 @@ async function requireCoordinatorResponse(response: Response, surface: string): 
   if (response.ok) return response;
   // error-policy:J3 a malformed internal error body remains an explicit typed
   // failure rather than fabricating a successful response.
-  const readErrorMessage = async (): Promise<string | null> => {
-    const body = (await response
-      .clone()
-      .json()
-      .catch(() => null)) as { error?: unknown } | null;
-    return typeof body?.error === "string" ? body.error : null;
-  };
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as {
+    code?: unknown;
+    error?: unknown;
+    failureName?: unknown;
+    retryable?: unknown;
+  } | null;
+  const readErrorMessage = (): string | null =>
+    typeof body?.error === "string" ? body.error : null;
+  if (
+    body?.code === "shared_runtime_turn_failed" &&
+    (response.status === 500 || response.status === 503)
+  ) {
+    const turnError = SharedRuntimeTurnError.fromClassification(body.failureName, body.retryable);
+    const statusMatchesDisposition =
+      (response.status === 503 && turnError.retryable) ||
+      (response.status === 500 && !turnError.retryable);
+    throw statusMatchesDisposition
+      ? turnError
+      : SharedRuntimeTurnError.fromClassification(undefined, undefined);
+  }
   if (response.status === 503) {
     throw new SharedRuntimeCacheWarmingError(
-      (await readErrorMessage()) ?? "Shared runtime cache is warming. Retry shortly.",
+      readErrorMessage() ?? "Shared runtime cache is warming. Retry shortly.",
     );
   }
   // The Durable Object encodes insufficiency as a structured 402 (class
   // identity cannot survive its fetch boundary); rehydrate the typed error so
   // route/stream callers translate it to their canonical 402 instead of a 500.
   if (response.status === 402) {
-    throw new InsufficientCreditsError((await readErrorMessage()) ?? "Insufficient credits");
+    throw new InsufficientCreditsError(readErrorMessage() ?? "Insufficient credits");
   }
   // A reused clientMessageId with a different payload is a structured 409 from
   // the Durable Object claim boundary; rehydrate the typed error so routes can
   // render the canonical non-retryable conflict instead of a 500.
   if (response.status === 409) {
-    const message = await readErrorMessage();
+    const message = readErrorMessage();
     throw message ? new SharedTurnConflictError(message) : new SharedTurnConflictError();
   }
   if (response.status === 429) {
     const retryAfter = Number.parseInt(response.headers.get("Retry-After") ?? "", 10);
     throw new RateLimitError(
-      (await readErrorMessage()) ?? "Organization rate limit exceeded.",
+      readErrorMessage() ?? "Organization rate limit exceeded.",
       Number.isFinite(retryAfter) ? retryAfter : undefined,
     );
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -258,17 +258,20 @@ function requireHistoryCoordinator(
 
 async function requireCoordinatorResponse(response: Response, surface: string): Promise<Response> {
   if (response.ok) return response;
-  // error-policy:J3 a malformed internal error body remains an explicit typed
-  // failure rather than fabricating a successful response.
-  const body = (await response
-    .clone()
-    .json()
-    .catch(() => null)) as {
+  let body: {
     code?: unknown;
     error?: unknown;
     failureName?: unknown;
     retryable?: unknown;
-  } | null;
+  } | null = null;
+  try {
+    const parsed: unknown = await response.clone().json();
+    body = typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    // error-policy:J3 a malformed internal error body remains an explicit
+    // invalid result and is translated by the status-specific typed boundary.
+    body = null;
+  }
   const readErrorMessage = (): string | null =>
     typeof body?.error === "string" ? body.error : null;
   if (

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -69,6 +69,7 @@ import {
   parseSharedReminderActionProvenance,
   sharedPublicWebGrounding,
 } from "./shared-runtime-history-policy";
+import { SharedRuntimeTurnError } from "./shared-runtime-errors";
 import type {
   SharedProviderTimingReceipt,
   SharedRuntimeTimingReceipt,
@@ -1244,9 +1245,9 @@ export async function runSharedAgentTurn(
   } catch (error) {
     // error-policy:J2 the runtime is the sole inference engine; preserve its
     // cause while adding the agent/model identity used by billing boundaries.
-    throw new Error(
+    throw new SharedRuntimeTurnError(
       `[shared-runtime] AgentRuntime turn failed (agent=${input.character.name}, model=${modelId})`,
-      { cause: error },
+      error,
     );
   }
   if (realtimeRequirement) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -65,11 +65,11 @@ import {
   sharedRealtimePromptPolicy,
 } from "./shared-realtime-grounding";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
+import { SharedRuntimeTurnError } from "./shared-runtime-errors";
 import {
   parseSharedReminderActionProvenance,
   sharedPublicWebGrounding,
 } from "./shared-runtime-history-policy";
-import { SharedRuntimeTurnError } from "./shared-runtime-errors";
 import type {
   SharedProviderTimingReceipt,
   SharedRuntimeTimingReceipt,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.test.ts
@@ -1,0 +1,63 @@
+/** Verifies Shared turn failures retain safe cause and retry classification. */
+
+import { describe, expect, test } from "bun:test";
+import { SharedRuntimeTurnError } from "./shared-runtime-errors";
+
+describe("SharedRuntimeTurnError", () => {
+  test("classifies an action receipt invariant as terminal", () => {
+    const cause = new Error(
+      "Eliza Shared runtime completed an executable REMINDERS request without an action result",
+    );
+    const error = new SharedRuntimeTurnError("turn failed", cause);
+
+    expect(error.cause).toBe(cause);
+    expect(error.failureName).toBe("SharedRuntimeActionContractError");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("classifies a nested retry envelope by provider status", () => {
+    const provider = Object.assign(new Error("private provider response"), {
+      name: "AI_APICallError",
+      statusCode: 503,
+    });
+    const retry = Object.assign(new Error("retry exhausted"), {
+      lastError: provider,
+    });
+    const error = new SharedRuntimeTurnError("turn failed", retry);
+
+    expect(error.failureName).toBe("SharedRuntimeProviderUnavailableError");
+    expect(error.retryable).toBe(true);
+    expect(JSON.stringify(error)).not.toContain("private provider response");
+  });
+
+  test("keeps an unknown runtime failure terminal instead of blind replay", () => {
+    const error = new SharedRuntimeTurnError(
+      "turn failed",
+      new TypeError("private invariant detail"),
+    );
+
+    expect(error.failureName).toBe("SharedRuntimeUnknownError");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("rehydrates only allowlisted, internally consistent classifications", () => {
+    expect(
+      SharedRuntimeTurnError.fromClassification("SharedRuntimeProviderUnavailableError", true),
+    ).toMatchObject({
+      name: "SharedRuntimeTurnError",
+      failureName: "SharedRuntimeProviderUnavailableError",
+      retryable: true,
+    });
+
+    expect(
+      SharedRuntimeTurnError.fromClassification("SharedRuntimeActionContractError", true),
+    ).toMatchObject({
+      failureName: "SharedRuntimeUnknownError",
+      retryable: false,
+    });
+    expect(SharedRuntimeTurnError.fromClassification("private provider body", true)).toMatchObject({
+      failureName: "SharedRuntimeUnknownError",
+      retryable: false,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.test.ts
@@ -1,6 +1,7 @@
 /** Verifies Shared turn failures retain safe cause and retry classification. */
 
 import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import { SharedRuntimeTurnError } from "./shared-runtime-errors";
 
 describe("SharedRuntimeTurnError", () => {
@@ -10,6 +11,13 @@ describe("SharedRuntimeTurnError", () => {
     );
     const error = new SharedRuntimeTurnError("turn failed", cause);
 
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error.code).toBe("SHARED_RUNTIME_TURN_FAILED");
+    expect(error.context).toEqual({
+      failureName: "SharedRuntimeActionContractError",
+      retryable: false,
+    });
+    expect(error.severity).toBe("fatal");
     expect(error.cause).toBe(cause);
     expect(error.failureName).toBe("SharedRuntimeActionContractError");
     expect(error.retryable).toBe(false);
@@ -27,6 +35,7 @@ describe("SharedRuntimeTurnError", () => {
 
     expect(error.failureName).toBe("SharedRuntimeProviderUnavailableError");
     expect(error.retryable).toBe(true);
+    expect(error.severity).toBe("ephemeral");
     expect(JSON.stringify(error)).not.toContain("private provider response");
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.ts
@@ -26,3 +26,185 @@ export class SharedTurnConflictError extends Error {
     this.name = "SharedTurnConflictError";
   }
 }
+
+export type SharedRuntimeTurnFailureName =
+  | "SharedRuntimeActionContractError"
+  | "SharedRuntimeNoReplyError"
+  | "SharedRuntimeProviderConfigurationError"
+  | "SharedRuntimeProviderRejectedError"
+  | "SharedRuntimeProviderUnavailableError"
+  | "SharedRuntimeTimeoutError"
+  | "SharedRuntimeUnknownError";
+
+const SHARED_RUNTIME_TURN_FAILURE_NAMES = new Set<SharedRuntimeTurnFailureName>([
+  "SharedRuntimeActionContractError",
+  "SharedRuntimeNoReplyError",
+  "SharedRuntimeProviderConfigurationError",
+  "SharedRuntimeProviderRejectedError",
+  "SharedRuntimeProviderUnavailableError",
+  "SharedRuntimeTimeoutError",
+  "SharedRuntimeUnknownError",
+]);
+
+const SHARED_RUNTIME_TURN_RETRY_DISPOSITION: Record<SharedRuntimeTurnFailureName, boolean> = {
+  SharedRuntimeActionContractError: false,
+  SharedRuntimeNoReplyError: false,
+  SharedRuntimeProviderConfigurationError: false,
+  SharedRuntimeProviderRejectedError: false,
+  SharedRuntimeProviderUnavailableError: true,
+  SharedRuntimeTimeoutError: true,
+  SharedRuntimeUnknownError: false,
+};
+
+interface SharedRuntimeTurnFailureClassification {
+  failureName: SharedRuntimeTurnFailureName;
+  retryable: boolean;
+}
+
+/** Validate the only failure names allowed to cross the coordinator boundary. */
+export function parseSharedRuntimeTurnFailureName(
+  value: unknown,
+): SharedRuntimeTurnFailureName | null {
+  return typeof value === "string" &&
+    SHARED_RUNTIME_TURN_FAILURE_NAMES.has(value as SharedRuntimeTurnFailureName)
+    ? (value as SharedRuntimeTurnFailureName)
+    : null;
+}
+
+function errorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const pending = [error];
+  const seen = new Set<unknown>();
+  while (pending.length > 0 && chain.length < 12) {
+    const current = pending.shift();
+    if (current === undefined || seen.has(current)) continue;
+    seen.add(current);
+    chain.push(current);
+    if ((typeof current === "object" && current !== null) || typeof current === "function") {
+      const candidate = current as {
+        cause?: unknown;
+        lastError?: unknown;
+      };
+      if (candidate.lastError !== undefined) pending.push(candidate.lastError);
+      if (candidate.cause !== undefined) pending.push(candidate.cause);
+    }
+  }
+  return chain;
+}
+
+function boundedProviderStatus(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 100 || value > 599) {
+    return null;
+  }
+  return value;
+}
+
+function classifySharedRuntimeTurnFailure(error: unknown): SharedRuntimeTurnFailureClassification {
+  const chain = errorChain(error);
+  for (const current of chain) {
+    if (!(current instanceof Error)) continue;
+    if (
+      /^Eliza Shared runtime completed an executable [A-Z_]+ request without an action result$/u.test(
+        current.message,
+      )
+    ) {
+      return {
+        failureName: "SharedRuntimeActionContractError",
+        retryable: false,
+      };
+    }
+    if (current.message === "Eliza Shared runtime completed without a user-visible reply") {
+      return {
+        failureName: "SharedRuntimeNoReplyError",
+        retryable: false,
+      };
+    }
+  }
+  for (const current of chain) {
+    const record =
+      (typeof current === "object" && current !== null) || typeof current === "function"
+        ? (current as { name?: unknown; statusCode?: unknown })
+        : null;
+    if (!record) continue;
+    const name = typeof record.name === "string" ? record.name : "";
+    if (name === "ProviderConfigurationError") {
+      return {
+        failureName: "SharedRuntimeProviderConfigurationError",
+        retryable: false,
+      };
+    }
+    if (name === "TimeoutError" || name === "AbortError") {
+      return {
+        failureName: "SharedRuntimeTimeoutError",
+        retryable: true,
+      };
+    }
+    if (name === "RateLimitError") {
+      return {
+        failureName: "SharedRuntimeProviderUnavailableError",
+        retryable: true,
+      };
+    }
+    const status = boundedProviderStatus(record.statusCode);
+    if (status !== null) {
+      return status === 408 || status === 425 || status === 429 || status >= 500
+        ? {
+            failureName: "SharedRuntimeProviderUnavailableError",
+            retryable: true,
+          }
+        : {
+            failureName: "SharedRuntimeProviderRejectedError",
+            retryable: false,
+          };
+    }
+  }
+  return {
+    failureName: "SharedRuntimeUnknownError",
+    retryable: false,
+  };
+}
+
+/**
+ * Adds turn identity while retaining a bounded failure class and disposition.
+ * Raw provider/action messages remain only on `cause` inside the isolate.
+ */
+export class SharedRuntimeTurnError extends Error {
+  override readonly name = "SharedRuntimeTurnError";
+  readonly failureName: SharedRuntimeTurnFailureName;
+  readonly retryable: boolean;
+
+  constructor(
+    message: string,
+    cause: unknown,
+    classification?: SharedRuntimeTurnFailureClassification,
+  ) {
+    super(message, { cause });
+    const resolved = classification ?? classifySharedRuntimeTurnFailure(cause);
+    this.failureName = resolved.failureName;
+    this.retryable = resolved.retryable;
+  }
+
+  /**
+   * Rehydrate only sanitized, allowlisted metadata after a Durable Object
+   * fetch. Invalid or inconsistent input fails closed as a terminal unknown
+   * error instead of trusting transport-controlled classification.
+   */
+  static fromClassification(failureName: unknown, retryable: unknown): SharedRuntimeTurnError {
+    const parsedName = parseSharedRuntimeTurnFailureName(failureName);
+    const classificationIsConsistent =
+      parsedName !== null &&
+      typeof retryable === "boolean" &&
+      SHARED_RUNTIME_TURN_RETRY_DISPOSITION[parsedName] === retryable;
+    const safeClassification: SharedRuntimeTurnFailureClassification = classificationIsConsistent
+      ? { failureName: parsedName, retryable }
+      : {
+          failureName: "SharedRuntimeUnknownError",
+          retryable: false,
+        };
+    return new SharedRuntimeTurnError(
+      "Shared runtime turn failed.",
+      new Error("Sanitized shared runtime failure crossed the coordinator boundary."),
+      safeClassification,
+    );
+  }
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.ts
@@ -7,6 +7,8 @@
  * `error.name` because the class cannot survive the Durable Object fetch
  * boundary).
  */
+import { ElizaError } from "@elizaos/core";
+
 export class SharedRuntimeCacheWarmingError extends Error {
   constructor(message: string) {
     super(message);
@@ -168,7 +170,7 @@ function classifySharedRuntimeTurnFailure(error: unknown): SharedRuntimeTurnFail
  * Adds turn identity while retaining a bounded failure class and disposition.
  * Raw provider/action messages remain only on `cause` inside the isolate.
  */
-export class SharedRuntimeTurnError extends Error {
+export class SharedRuntimeTurnError extends ElizaError {
   override readonly name = "SharedRuntimeTurnError";
   readonly failureName: SharedRuntimeTurnFailureName;
   readonly retryable: boolean;
@@ -178,8 +180,16 @@ export class SharedRuntimeTurnError extends Error {
     cause: unknown,
     classification?: SharedRuntimeTurnFailureClassification,
   ) {
-    super(message, { cause });
     const resolved = classification ?? classifySharedRuntimeTurnFailure(cause);
+    super(message, {
+      code: "SHARED_RUNTIME_TURN_FAILED",
+      context: {
+        failureName: resolved.failureName,
+        retryable: resolved.retryable,
+      },
+      cause,
+      severity: resolved.retryable ? "ephemeral" : "fatal",
+    });
     this.failureName = resolved.failureName;
     this.retryable = resolved.retryable;
   }


### PR DESCRIPTION
## Summary

- preserve bounded Shared runtime failure semantics across Durable Object and internal HTTP boundaries
- retry Telegram turns only when the server or a recognized transport failure marks them retryable
- deliver one exact-once, user-visible fallback for private Telegram DMs that fail before provider egress
- keep unexpected programmer faults fail-fast and preserve causal context for non-private failures
- emit allowlisted failure stage/name/cause metadata without exposing provider bodies or exception messages
- keep Twilio/Blooio behavior unchanged and keep private fallbacks out of groups and membership updates

## Safety

- accepted or ambiguously accepted Telegram replies are never followed by a fallback
- rejected fallback sends may retry; ambiguous provider acceptance remains tombstoned
- duplicate webhook deliveries cannot emit duplicate fallback messages
- action-contract and unknown failures fail closed instead of blindly replaying inference
- only typed, expected pre-egress failures may degrade; an injected unexpected fault propagates and sends no fallback
- exhausted transport receipts preserve the real attempt count and duration; fallback and completion logs both report three attempts in the bounded-retry regression

## Exact-head validation

- exact head: `08a08053b20a5e550cb8056a70e8b1505f083cdf`
- base: merged #29697 at `origin/develop@89d44d71ecc54094500b8aa001a50ee2d7d5004e`
- API direct edge, internal personal route, and Shared Durable Object: 130/130 tests, 646 assertions
- common retry metadata and Shared typed-error/coordinator behavior: 29/29 tests, 90 assertions
- gateway webhook e2e: 43/43 tests, 198 assertions
- common, Shared, API, and gateway typechecks: green
- API router contract and production Wrangler dry-run: green
- Biome on all touched files and `git diff --check`: green
- independent exact-head review: APPROVED, no P0-P2

## Hosted checks

Fresh exact-head PR Static Smoke is required after this repaired head is pushed. Earlier checks belong to obsolete head `fdcd52fcbc4d74d5925b25b06187d09dc804a46a` and are not merge evidence.

Closes #29764

This PR is ready for hosted verification. Merge only when every required check is green for the exact head and GitHub reports the PR cleanly mergeable.
