### PR TITLE
fix(telegram): enforce one canonical bot identity

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -158,6 +158,55 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: Attest protected Telegram credential before enable
+        if: inputs.enabled == true
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          STAGING_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          STAGING_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf '%s\n' "::error::$1" >&2
+            exit 1
+          }
+          valid_bot_id() {
+            local candidate="$1"
+            [[ "$candidate" =~ ^[1-9][0-9]{0,15}$ ]] || return 1
+            (( 10#$candidate <= 4503599627370495 ))
+          }
+
+          canonical_source="packages/homepage/src/lib/contact.ts"
+          canonical_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
+          canonical_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
+          valid_bot_id "$canonical_id" || fail "The homepage canonical Telegram bot ID is missing or invalid"
+          [[ "$canonical_username" =~ ^[A-Za-z0-9_]{5,32}$ ]] || fail "The homepage canonical Telegram username is missing or invalid"
+          canonical_username_key="$(printf '%s' "$canonical_username" | tr '[:upper:]' '[:lower:]')"
+          [[ "$canonical_username_key" == *bot ]] || fail "The homepage canonical Telegram username must use the managed bot suffix"
+
+          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            expected_id="$canonical_id"
+            expected_username="$canonical_username"
+          else
+            valid_bot_id "$STAGING_TELEGRAM_BOT_ID" || fail "Protected staging VITE_TELEGRAM_BOT_ID is missing or invalid"
+            [[ "$STAGING_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || fail "Protected staging VITE_TELEGRAM_BOT_USERNAME is missing or invalid"
+            staging_username_key="$(printf '%s' "$STAGING_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+            [[ "$staging_username_key" == *bot ]] || fail "Protected staging Telegram username must use the managed bot suffix"
+            if [ "$STAGING_TELEGRAM_BOT_ID" = "$canonical_id" ] || \
+              [ "$staging_username_key" = "$canonical_username_key" ]; then
+              fail "Staging Telegram identity must be fully distinct from production"
+            fi
+            expected_id="$STAGING_TELEGRAM_BOT_ID"
+            expected_username="$STAGING_TELEGRAM_BOT_USERNAME"
+          fi
+
+          TELEGRAM_EXPECTED_BOT_ID="$expected_id" \
+          TELEGRAM_EXPECTED_BOT_USERNAME="$expected_username" \
+          TELEGRAM_ATTESTATION_CONTEXT="$TARGET_ENVIRONMENT" \
+            node packages/cloud/scripts/verify-telegram-bot-identity.mjs
+
       - name: Validate exact served Worker source before enable
         if: inputs.enabled == true
         run: |
@@ -192,6 +241,26 @@ jobs:
           rm -f "$health"
           echo "::error::$TARGET_ENVIRONMENT Worker does not serve the exact requested source and edge beacon"
           exit 1
+
+      - name: Verify served Worker Telegram identity before enable
+        if: inputs.enabled == true
+        run: |
+          set -euo pipefail
+          readiness="$(mktemp)"
+          trap 'rm -f "$readiness"' EXIT
+          worker_origin="${HEALTH_URL%/api/health}"
+          code="$(curl -sS -o "$readiness" -w '%{http_code}' -m 20 \
+            "$worker_origin/api/eliza-app/webhook/telegram/readiness" || echo '000')"
+          if [ "$code" != "200" ] || ! jq -e \
+            'type == "object" and
+             keys == ["project", "status"] and
+             .project == "eliza-app" and
+             .status == "attested"' \
+            "$readiness" >/dev/null; then
+            echo "::error::$TARGET_ENVIRONMENT Worker Telegram identity is not attested"
+            exit 1
+          fi
+          echo "$TARGET_ENVIRONMENT Worker Telegram identity is attested."
 
       - name: Install pinned Railway CLI
         if: inputs.enabled == true
@@ -277,6 +346,7 @@ jobs:
             '.sourceSha == $sha and
              .environment == $environment and
              .service == $service and
+             .telegramIdentity == "attested" and
              (.deploymentId | type == "string" and
               test("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))' \
             "$receipt" >/dev/null; then
@@ -333,6 +403,21 @@ jobs:
             exit 1
           fi
           rm -f "$readiness"
+
+          telegram_readiness="$(mktemp)"
+          code="$(curl -sS -o "$telegram_readiness" -w '%{http_code}' -m 20 \
+            "$GATEWAY_URL/ready/telegram-identity/eliza-app" || echo '000')"
+          if [ "$code" != "200" ] || ! jq -e \
+            'type == "object" and
+             keys == ["project", "status"] and
+             .project == "eliza-app" and
+             .status == "attested"' \
+            "$telegram_readiness" >/dev/null; then
+            rm -f "$telegram_readiness"
+            echo "::error::Exact-source $TARGET_ENVIRONMENT gateway Telegram identity is not attested"
+            exit 1
+          fi
+          rm -f "$telegram_readiness"
           assert_active_gateway after
           echo "deployment_id=$gateway_deployment_id" >> "$GITHUB_OUTPUT"
           echo "Protected gateway run $gateway_run_id has active deployment $gateway_deployment_id on the exact Worker source."

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -269,6 +269,15 @@ jobs:
           printf 'Validated Telegram public identity policy for %s.\n' \
             "$TARGET_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Attest protected Telegram runtime identity
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          TELEGRAM_EXPECTED_BOT_ID: ${{ steps.telegram.outputs.bot_id }}
+          TELEGRAM_EXPECTED_BOT_USERNAME: ${{ steps.telegram.outputs.bot_username }}
+          TELEGRAM_ATTESTATION_CONTEXT: ${{ inputs.target_environment }}
+        run: node packages/cloud/scripts/verify-telegram-bot-identity.mjs
+
       - name: Resolve public WhatsApp configuration
         id: whatsapp
         env:
@@ -1410,9 +1419,9 @@ jobs:
           OIDC_CLIENTS: ${{ secrets.OIDC_CLIENTS }}
           ELIZA_APP_WEBHOOK_GATEWAY_URL: ${{ vars.ELIZA_APP_WEBHOOK_GATEWAY_URL }}
           ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
-          # The edge Telegram route needs both values in the Worker. Queue them
-          # additively now, while the served feature gate remains fail-closed;
-          # activation is a separate protected, live-proven rollout.
+          # The edge Telegram route needs both values in the Worker. They are
+          # required and replaced atomically with the exact attested source;
+          # activation is still a separate protected, live-proven rollout.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
           ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
           # Personal Shared Blooio is the public-number messaging surface in
@@ -1810,6 +1819,17 @@ jobs:
           fi
 
           for name in \
+            ELIZA_APP_TELEGRAM_BOT_TOKEN \
+            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
+          do
+            if ! has_nonblank_value "${!name:-}"; then
+              echo "::error::Required protected $DEPLOY_ENVIRONMENT Telegram secret is absent or blank: $name"
+              exit 1
+            fi
+            queue_secret "$name" || exit 1
+          done
+
+          for name in \
             ELIZA_APP_BLOOIO_API_KEY \
             ELIZA_APP_BLOOIO_PHONE_NUMBER \
             ELIZA_APP_BLOOIO_WEBHOOK_SECRET
@@ -1849,8 +1869,6 @@ jobs:
             OIDC_CLIENTS \
             GATEWAY_INTERNAL_SECRET \
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET \
-            ELIZA_APP_TELEGRAM_BOT_TOKEN \
-            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET \
             ELIZA_APNS_KEY \
             ELIZA_APNS_KEY_ID \
             ELIZA_APNS_TEAM_ID \
@@ -1941,6 +1959,8 @@ jobs:
           FISH_AUDIO_SAMPLE_RATE: "16000"
           FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS: ${{ vars.FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS || '1500' }}
           ELIZA_MOBILE_APP_AUTH_ENABLED: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.ELIZA_MOBILE_APP_AUTH_ENABLED) && 'true' || 'false' }}
+          ELIZA_APP_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
+          ELIZA_APP_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           WORKER_SECRETS_FILE: ${{ steps.worker-secrets.outputs.secrets_file }}
           CANONICAL_REF: ${{ steps.env.outputs.deploy_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
@@ -2001,7 +2021,7 @@ jobs:
             exit 1
           fi
 
-          args=(${{ steps.env.outputs.wrangler_args }} --secrets-file "$WORKER_SECRETS_FILE" --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA" --var ELIZA_MOBILE_APP_AUTH_ENABLED:"$ELIZA_MOBILE_APP_AUTH_ENABLED" --var VOICE_REALTIME_WS_ENABLED:"$VOICE_REALTIME_WS_ENABLED" --var ELIZA_TTS_FISH_ENABLED:"$ELIZA_TTS_FISH_ENABLED" --var FISH_AUDIO_DATA_GOVERNANCE_APPROVED:"$FISH_AUDIO_DATA_GOVERNANCE_APPROVED" --var FISH_AUDIO_MODEL:"$FISH_AUDIO_MODEL" --var FISH_AUDIO_SAMPLE_RATE:"$FISH_AUDIO_SAMPLE_RATE" --var FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS:"$FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS")
+          args=(${{ steps.env.outputs.wrangler_args }} --secrets-file "$WORKER_SECRETS_FILE" --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA" --var ELIZA_MOBILE_APP_AUTH_ENABLED:"$ELIZA_MOBILE_APP_AUTH_ENABLED" --var ELIZA_APP_TELEGRAM_BOT_ID:"$ELIZA_APP_TELEGRAM_BOT_ID" --var ELIZA_APP_TELEGRAM_BOT_USERNAME:"$ELIZA_APP_TELEGRAM_BOT_USERNAME" --var VOICE_REALTIME_WS_ENABLED:"$VOICE_REALTIME_WS_ENABLED" --var ELIZA_TTS_FISH_ENABLED:"$ELIZA_TTS_FISH_ENABLED" --var FISH_AUDIO_DATA_GOVERNANCE_APPROVED:"$FISH_AUDIO_DATA_GOVERNANCE_APPROVED" --var FISH_AUDIO_MODEL:"$FISH_AUDIO_MODEL" --var FISH_AUDIO_SAMPLE_RATE:"$FISH_AUDIO_SAMPLE_RATE" --var FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS:"$FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS")
           if [ -n "${KOKORO_TTS_URL:-}" ]; then
             args+=(--var KOKORO_TTS_URL:"$KOKORO_TTS_URL")
           else
@@ -2062,6 +2082,8 @@ jobs:
               "STEWARD_PLATFORM_KEYS",
               "STEWARD_TENANT_API_KEY",
               "GATEWAY_INTERNAL_SECRET",
+              "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+              "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
             ];
             if (process.env.ELIZA_MOBILE_APP_AUTH_ENABLED === "true") {
               required.push("ELIZA_MOBILE_APP_AUTH_APP_ID");
@@ -2137,6 +2159,31 @@ jobs:
             [ "$attempt" -lt 6 ] && sleep 10
           done
           echo "::error::API health did not serve the deployed commit ${expected_commit} for ${expected_environment}."
+          exit 1
+
+      - name: Verify deployed Telegram identity readiness
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
+        env:
+          API_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
+        run: |
+          set -euo pipefail
+          readiness="$(mktemp)"
+          trap 'rm -f "$readiness"' EXIT
+          for attempt in 1 2 3 4 5 6; do
+            code="$(curl -sS -o "$readiness" -w '%{http_code}' -m 20 \
+              "${API_URL%/}/api/eliza-app/webhook/telegram/readiness" || echo '000')"
+            if [ "$code" = "200" ] && jq -e \
+              'type == "object" and
+               keys == ["project", "status"] and
+               .project == "eliza-app" and
+               .status == "attested"' \
+              "$readiness" >/dev/null; then
+              echo "Deployed Worker Telegram identity is attested."
+              exit 0
+            fi
+            [ "$attempt" -lt 6 ] && sleep 10
+          done
+          echo "::error::Deployed Worker Telegram identity did not attest"
           exit 1
 
       - name: Verify deployed API provider discovery

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -58,6 +58,51 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Resolve protected Telegram public identity
+        env:
+          STAGING_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          STAGING_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf '%s\n' "::error::$1" >&2
+            exit 1
+          }
+          valid_bot_id() {
+            local candidate="$1"
+            [[ "$candidate" =~ ^[1-9][0-9]{0,15}$ ]] || return 1
+            (( 10#$candidate <= 4503599627370495 ))
+          }
+
+          canonical_source="packages/homepage/src/lib/contact.ts"
+          canonical_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
+          canonical_bot_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
+          valid_bot_id "$canonical_bot_id" || fail "The homepage canonical Telegram bot ID is missing or invalid"
+          [[ "$canonical_bot_username" =~ ^[A-Za-z0-9_]{5,32}$ ]] || fail "The homepage canonical Telegram username is missing or invalid"
+          canonical_username_key="$(printf '%s' "$canonical_bot_username" | tr '[:upper:]' '[:lower:]')"
+          [[ "$canonical_username_key" == *bot ]] || fail "The homepage canonical Telegram username must use the managed bot suffix"
+
+          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            resolved_id="$canonical_bot_id"
+            resolved_username="$canonical_bot_username"
+          else
+            valid_bot_id "$STAGING_TELEGRAM_BOT_ID" || fail "Protected staging VITE_TELEGRAM_BOT_ID is missing or invalid"
+            [[ "$STAGING_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || fail "Protected staging VITE_TELEGRAM_BOT_USERNAME is missing or invalid"
+            staging_username_key="$(printf '%s' "$STAGING_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+            [[ "$staging_username_key" == *bot ]] || fail "Protected staging Telegram username must use the managed bot suffix"
+            if [ "$STAGING_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
+              [ "$staging_username_key" = "$canonical_username_key" ]; then
+              fail "Staging Telegram identity must be fully distinct from production"
+            fi
+            resolved_id="$STAGING_TELEGRAM_BOT_ID"
+            resolved_username="$STAGING_TELEGRAM_BOT_USERNAME"
+          fi
+
+          printf 'TELEGRAM_EXPECTED_BOT_ID=%s\n' "$resolved_id" >> "$GITHUB_ENV"
+          printf 'TELEGRAM_EXPECTED_BOT_USERNAME=%s\n' "$resolved_username" >> "$GITHUB_ENV"
+          echo "Resolved the protected $TARGET_ENVIRONMENT Telegram identity without printing its values."
+
       - name: Validate protected canonical configuration
         shell: bash
         run: |
@@ -76,6 +121,8 @@ jobs:
             RAILWAY_ENVIRONMENT_ID
             RAILWAY_SERVICE_ID
             RAILWAY_TOKEN
+            TELEGRAM_EXPECTED_BOT_ID
+            TELEGRAM_EXPECTED_BOT_USERNAME
           )
           missing=()
           for name in "${required_settings[@]}"; do
@@ -205,6 +252,8 @@ jobs:
           WORKER_ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
           WORKER_ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
           WORKER_ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
+          WORKER_ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          WORKER_ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           umask 077
@@ -219,13 +268,22 @@ jobs:
             canonical: {
               ELIZA_CLOUD_URL: .ELIZA_CLOUD_URL,
               AGENT_ROUTER_ORIGIN_HOST: .AGENT_ROUTER_ORIGIN_HOST,
-              ELIZA_CLOUD_AGENT_BASE_DOMAIN: .ELIZA_CLOUD_AGENT_BASE_DOMAIN
+              ELIZA_CLOUD_AGENT_BASE_DOMAIN: .ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+              ELIZA_APP_TELEGRAM_BOT_ID: .ELIZA_APP_TELEGRAM_BOT_ID,
+              ELIZA_APP_TELEGRAM_BOT_USERNAME: .ELIZA_APP_TELEGRAM_BOT_USERNAME
             },
             blooio_nonblank_names: [
               to_entries[] |
               select(.key == "ELIZA_APP_BLOOIO_API_KEY" or
                      .key == "ELIZA_APP_BLOOIO_PHONE_NUMBER" or
                      .key == "ELIZA_APP_BLOOIO_WEBHOOK_SECRET") |
+              select((.value | type) == "string" and (.value | test("\\S"))) |
+              .key
+            ],
+            telegram_nonblank_names: [
+              to_entries[] |
+              select(.key == "ELIZA_APP_TELEGRAM_BOT_TOKEN" or
+                     .key == "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET") |
               select((.value | type) == "string" and (.value | test("\\S"))) |
               .key
             ],
@@ -239,10 +297,10 @@ jobs:
           # A per-run salt makes every digest useless outside this process, so
           # an equality proof never becomes an offline guessing oracle even if
           # a digest were to escape into a log.
-          blooio_match_salt="$(openssl rand -hex 32)"
-          blooio_digest() {
+          protected_match_salt="$(openssl rand -hex 32)"
+          protected_digest() {
             printf '%s' "${1:-}" |
-              openssl dgst -sha256 -hmac "$blooio_match_salt" -r |
+              openssl dgst -sha256 -hmac "$protected_match_salt" -r |
               cut -d' ' -f1
           }
           declare -A railway_blooio_digests=()
@@ -253,9 +311,31 @@ jobs:
             railway_value="$(jq -r --arg name "$name" \
               'if (.[$name] | type) == "string" then .[$name] else "" end' \
               "$variables_raw_path")"
-            railway_blooio_digests["$name"]="$(blooio_digest "$railway_value")"
+            railway_blooio_digests["$name"]="$(protected_digest "$railway_value")"
             railway_value=""
           done
+
+          declare -A railway_telegram_digests=()
+          for name in \
+            ELIZA_APP_TELEGRAM_BOT_TOKEN \
+            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET; do
+            railway_value="$(jq -r --arg name "$name" \
+              'if (.[$name] | type) == "string" then .[$name] else "" end' \
+              "$variables_raw_path")"
+            railway_telegram_digests["$name"]="$(protected_digest "$railway_value")"
+            printf -v "railway_$name" '%s' "$railway_value"
+            railway_value=""
+          done
+
+          env \
+            "TELEGRAM_BOT_TOKEN=${railway_ELIZA_APP_TELEGRAM_BOT_TOKEN:-}" \
+            "TELEGRAM_WEBHOOK_SECRET=${railway_ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:-}" \
+            "TELEGRAM_EXPECTED_BOT_ID=$TELEGRAM_EXPECTED_BOT_ID" \
+            "TELEGRAM_EXPECTED_BOT_USERNAME=$TELEGRAM_EXPECTED_BOT_USERNAME" \
+            "TELEGRAM_ATTESTATION_CONTEXT=$TARGET_ENVIRONMENT" \
+            node packages/cloud/scripts/verify-telegram-bot-identity.mjs
+          railway_ELIZA_APP_TELEGRAM_BOT_TOKEN=""
+          railway_ELIZA_APP_TELEGRAM_WEBHOOK_SECRET=""
           shred -u "$variables_raw_path"
 
           require_exact_variable() {
@@ -285,10 +365,21 @@ jobs:
               exit 1
             fi
           }
+          require_telegram_name() {
+            local name="$1"
+            if ! jq -e --arg name "$name" \
+              '.telegram_nonblank_names | index($name) != null' \
+              "$variables_path" >/dev/null; then
+              echo "::error::Required protected $TARGET_ENVIRONMENT Telegram Railway variable name is absent or blank: $name"
+              exit 1
+            fi
+          }
 
           require_exact_variable ELIZA_CLOUD_URL "$EXPECTED_CLOUD_URL"
           require_exact_variable AGENT_ROUTER_ORIGIN_HOST "$EXPECTED_ROUTER_ORIGIN"
           require_exact_variable ELIZA_CLOUD_AGENT_BASE_DOMAIN "$EXPECTED_AGENT_BASE_DOMAIN"
+          require_exact_variable ELIZA_APP_TELEGRAM_BOT_ID "$TELEGRAM_EXPECTED_BOT_ID"
+          require_exact_variable ELIZA_APP_TELEGRAM_BOT_USERNAME "$TELEGRAM_EXPECTED_BOT_USERNAME"
           for name in \
             GATEWAY_BOOTSTRAP_SECRET \
             GATEWAY_INTERNAL_SECRET \
@@ -301,6 +392,11 @@ jobs:
             ELIZA_APP_BLOOIO_PHONE_NUMBER \
             ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
             require_blooio_name "$name"
+          done
+          for name in \
+            ELIZA_APP_TELEGRAM_BOT_TOKEN \
+            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET; do
+            require_telegram_name "$name"
           done
           # Name presence on both sides still permits Worker secret A and
           # Railway secret B, which passes every names-only check and then
@@ -317,13 +413,29 @@ jobs:
               echo "::error::Required protected $TARGET_ENVIRONMENT Blooio GitHub environment secret is absent or blank: $name"
               exit 1
             fi
-            if [ "$(blooio_digest "$worker_value")" != "${railway_blooio_digests[$name]:-}" ]; then
+            if [ "$(protected_digest "$worker_value")" != "${railway_blooio_digests[$name]:-}" ]; then
               echo "::error::Protected $TARGET_ENVIRONMENT Blooio value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: $name (compared by salted digest; values were not printed)"
               exit 1
             fi
             worker_value=""
           done
           echo "Verified 3 protected $TARGET_ENVIRONMENT Blooio Worker/Railway value matches by salted digest; values were not printed."
+          for name in \
+            ELIZA_APP_TELEGRAM_BOT_TOKEN \
+            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET; do
+            worker_name="WORKER_$name"
+            worker_value="${!worker_name:-}"
+            if [ -z "${worker_value//[[:space:]]/}" ]; then
+              echo "::error::Required protected $TARGET_ENVIRONMENT Telegram GitHub environment secret is absent or blank: $name"
+              exit 1
+            fi
+            if [ "$(protected_digest "$worker_value")" != "${railway_telegram_digests[$name]:-}" ]; then
+              echo "::error::Protected $TARGET_ENVIRONMENT Telegram value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: $name (compared by salted digest; values were not printed)"
+              exit 1
+            fi
+            worker_value=""
+          done
+          echo "Verified the protected $TARGET_ENVIRONMENT Telegram credential pair, selected identity, and getMe attestation; values were not printed."
           if ! jq -e '.nonblank_sensitive_names as $names |
             (($names | index("REDIS_URL")) != null or
              ((($names | index("KV_REST_API_URL")) != null) and
@@ -531,16 +643,22 @@ jobs:
           jq '{
             ELIZA_CLOUD_URL,
             AGENT_ROUTER_ORIGIN_HOST,
-            ELIZA_CLOUD_AGENT_BASE_DOMAIN
+            ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+            ELIZA_APP_TELEGRAM_BOT_ID,
+            ELIZA_APP_TELEGRAM_BOT_USERNAME
           }' "$variables_raw_path" > "$variables_path"
           shred -u "$variables_raw_path"
           jq -e \
             --arg cloud "$EXPECTED_CLOUD_URL" \
             --arg router "$EXPECTED_ROUTER_ORIGIN" \
             --arg domain "$EXPECTED_AGENT_BASE_DOMAIN" \
+            --arg telegram_id "$TELEGRAM_EXPECTED_BOT_ID" \
+            --arg telegram_username "$TELEGRAM_EXPECTED_BOT_USERNAME" \
             '.ELIZA_CLOUD_URL == $cloud and
              .AGENT_ROUTER_ORIGIN_HOST == $router and
-             .ELIZA_CLOUD_AGENT_BASE_DOMAIN == $domain' \
+             .ELIZA_CLOUD_AGENT_BASE_DOMAIN == $domain and
+             .ELIZA_APP_TELEGRAM_BOT_ID == $telegram_id and
+             .ELIZA_APP_TELEGRAM_BOT_USERNAME == $telegram_username' \
             "$variables_path" >/dev/null || {
             echo "::error::Postdeploy canonical cloud/fallback routing pair does not match the selected environment"
             exit 1
@@ -568,8 +686,30 @@ jobs:
             echo "::error::Gateway did not prove the exact enforced eliza-app forwarder-auth contract"
             exit 1
           fi
+
+          telegram_probe_path="$RUNNER_TEMP/gateway-webhook-telegram-identity-readiness.json"
+          if ! telegram_probe_status=$(curl \
+            --silent \
+            --show-error \
+            --max-time 15 \
+            --output "$telegram_probe_path" \
+            --write-out '%{http_code}' \
+            "$GATEWAY_WEBHOOK_URL/ready/telegram-identity/eliza-app"); then
+            echo "::error::Telegram identity readiness probe failed to complete"
+            exit 1
+          fi
+          if [ "$telegram_probe_status" != "200" ] || \
+            ! jq -e \
+              'type == "object" and
+               keys == ["project", "status"] and
+               .project == "eliza-app" and
+               .status == "attested"' \
+              "$telegram_probe_path" >/dev/null; then
+            echo "::error::Gateway did not prove the selected Telegram identity"
+            exit 1
+          fi
           assert_active_deployment after
-          echo "Exact manifest, active deployment identity, live health, canonical fallback, and forwarder-auth readiness passed."
+          echo "Exact manifest, active deployment identity, live health, canonical fallback, Telegram identity, and forwarder-auth readiness passed."
 
       - name: Write exact deployment receipt
         shell: bash
@@ -588,7 +728,8 @@ jobs:
               sourceSha: $sourceSha,
               environment: $environment,
               deploymentId: $deploymentId,
-              service: $service
+              service: $service,
+              telegramIdentity: "attested"
             }' > "$receipt_dir/gateway-webhook-deployment.json"
 
       - name: Publish exact deployment receipt
@@ -615,6 +756,7 @@ jobs:
             echo "- Canonical health: passed"
             echo "- Canonical fallback pair: verified"
             echo "- Forwarder-auth readiness: enforced for eliza-app with exact headerless 401"
+            echo "- Telegram identity: attested for the selected protected environment"
             echo "- Root Railway manifest: verified"
             echo "- Active deployment identity: verified before and after probes"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -636,6 +778,7 @@ jobs:
             "$RUNNER_TEMP/gateway-webhook-postdeploy-deployment.json" \
             "$RUNNER_TEMP/gateway-webhook-active-deployment.json" \
             "$RUNNER_TEMP/gateway-webhook-forwarder-auth-readiness.json" \
+            "$RUNNER_TEMP/gateway-webhook-telegram-identity-readiness.json" \
             "$RUNNER_TEMP/gateway-webhook-postdeploy-variables-raw.json" \
             "$RUNNER_TEMP/gateway-webhook-postdeploy-canonical.json" \
             "$RUNNER_TEMP/gateway-webhook-deployment-receipt/gateway-webhook-deployment.json"; do

--- a/bun.lock
+++ b/bun.lock
@@ -572,6 +572,9 @@
     "packages/cloud/services/_common": {
       "name": "@elizaos/cloud-services-common",
       "version": "1.0.0",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+      },
       "devDependencies": {
         "@types/node": "22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -1,7 +1,16 @@
 /** Drives the edge Telegram connector through Hono with real shared state-machine code. */
 
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { PERSONAL_SHARED_FAILURE_REPLY } from "@elizaos/cloud-services-common/personal-shared-failure";
+import { __resetTelegramIdentityAttestationCacheForTests } from "@elizaos/cloud-services-common/telegram-connector";
 import { Hono } from "hono";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -14,6 +23,44 @@ import telegramRoute from "../eliza-app/webhook/telegram/route";
 
 const TRACE_ID = "11111111-1111-4111-8111-111111111111";
 const originalFetch = globalThis.fetch;
+
+function testBotUsername(botId: string): string {
+  return botId === "456" ? "OtherTestBot" : "ElizaTestBot";
+}
+
+function telegramBindings(
+  botToken = "123:test-token",
+): Pick<
+  AppEnv["Bindings"],
+  | "ELIZA_APP_TELEGRAM_BOT_TOKEN"
+  | "ELIZA_APP_TELEGRAM_BOT_ID"
+  | "ELIZA_APP_TELEGRAM_BOT_USERNAME"
+  | "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET"
+> {
+  const botId = botToken.match(/^([1-9]\d*):/)?.[1] ?? "";
+  return {
+    ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
+    ELIZA_APP_TELEGRAM_BOT_ID: botId,
+    ELIZA_APP_TELEGRAM_BOT_USERNAME: testBotUsername(botId),
+    ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
+  };
+}
+
+function telegramGetMeResponse(
+  input: RequestInfo | URL,
+  overrides: Record<string, unknown> = {},
+): Response {
+  const botId = String(input).match(/\/bot([1-9]\d*):/)?.[1] ?? "123";
+  return Response.json({
+    ok: true,
+    result: {
+      id: Number(botId),
+      is_bot: true,
+      username: testBotUsername(botId),
+      ...overrides,
+    },
+  });
+}
 
 interface LedgerValue {
   delivery?: "uncertain" | "delivered";
@@ -226,6 +273,7 @@ async function run(
   request = telegramRequest(),
   confirmIdentityLink?: TelegramEdgeDeps["confirmIdentityLink"],
   botToken = "123:test-token",
+  getMeOverrides: Record<string, unknown> = {},
 ): Promise<Response> {
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
@@ -239,20 +287,38 @@ async function run(
     }),
   );
   app.onError(() => Response.json({ error: "failed" }, { status: 500 }));
-  return app.fetch(
-    request,
-    {
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
-      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
-      ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
-      PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
-    } as AppEnv["Bindings"],
-    executionContext(),
-  );
+  const providerFetch = globalThis.fetch;
+  globalThis.fetch = ((input, init) =>
+    String(input).endsWith("/getMe")
+      ? Promise.resolve(telegramGetMeResponse(input, getMeOverrides))
+      : providerFetch(input, init)) as typeof fetch;
+  try {
+    return await app.fetch(
+      request,
+      {
+        ...telegramBindings(botToken),
+        ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
+        PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+      } as AppEnv["Bindings"],
+      executionContext(),
+    );
+  } finally {
+    globalThis.fetch = providerFetch;
+  }
 }
+
+beforeEach(() => {
+  globalThis.fetch = mock(async (input) => {
+    if (String(input).endsWith("/getMe")) {
+      return telegramGetMeResponse(input);
+    }
+    throw new Error("unexpected provider call");
+  }) as unknown as typeof fetch;
+});
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  __resetTelegramIdentityAttestationCacheForTests();
   mock.restore();
 });
 
@@ -262,6 +328,9 @@ describe("Personal Shared Telegram edge", () => {
     let sends = 0;
     const bodies: Array<Record<string, unknown>> = [];
     globalThis.fetch = mock(async (input, init) => {
+      if (String(input).endsWith("/getMe")) {
+        return telegramGetMeResponse(input);
+      }
       if (String(input).endsWith("/sendMessage")) {
         sends += 1;
         bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
@@ -269,7 +338,8 @@ describe("Personal Shared Telegram edge", () => {
       return Response.json({ ok: true, result: { message_id: 9010 } });
     }) as unknown as typeof fetch;
     const env = {
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ...telegramBindings(),
+      ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
     const input = {
@@ -299,13 +369,17 @@ describe("Personal Shared Telegram edge", () => {
     const ledger = namespace();
     const bodies: Array<Record<string, unknown>> = [];
     globalThis.fetch = mock(async (input, init) => {
+      if (String(input).endsWith("/getMe")) {
+        return telegramGetMeResponse(input);
+      }
       if (String(input).endsWith("/sendMessage")) {
         bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
       }
       return Response.json({ ok: true, result: { message_id: 9011 } });
     }) as unknown as typeof fetch;
     const env = {
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ...telegramBindings(),
+      ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
     const input = {
@@ -338,7 +412,7 @@ describe("Personal Shared Telegram edge", () => {
       throw new Error("egress must not run");
     }) as unknown as typeof fetch;
     const env = {
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ...telegramBindings(),
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
 
@@ -362,10 +436,47 @@ describe("Personal Shared Telegram edge", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  test("rejects a mismatched reminder bot before ledger or message egress", async () => {
+    const ledger = namespace();
+    const provider = mock(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("/getMe")) {
+        return telegramGetMeResponse(input, { username: "WrongTestBot" });
+      }
+      throw new Error("message egress must not run");
+    });
+    globalThis.fetch = provider as unknown as typeof fetch;
+
+    const result = await dispatchPersonalTelegramReminder(
+      {
+        ...telegramBindings(),
+        ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
+        PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+      } as AppEnv["Bindings"],
+      {
+        project: "eliza-app",
+        connectorAccountId: "bot:123",
+        chatId: "123456",
+        text: "must not send",
+        idempotencyKey: "reminder-identity-mismatch",
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      acceptance: "not_accepted",
+    });
+    expect(ledger.names).toHaveLength(0);
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(String(provider.mock.calls[0]?.[0])).toEndWith("/getMe");
+  });
+
   test("pins reminder delivery to its originating stable bot account", async () => {
     const ledger = namespace();
     let sends = 0;
     globalThis.fetch = mock(async (input) => {
+      if (String(input).endsWith("/getMe")) {
+        return telegramGetMeResponse(input);
+      }
       if (String(input).endsWith("/sendMessage")) sends += 1;
       return Response.json({
         ok: true,
@@ -374,7 +485,8 @@ describe("Personal Shared Telegram edge", () => {
     }) as unknown as typeof fetch;
     const env = (botToken: string) =>
       ({
-        ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
+        ...telegramBindings(botToken),
+        ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
         PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
       }) as AppEnv["Bindings"];
     const input = {
@@ -635,36 +747,25 @@ describe("Personal Shared Telegram edge", () => {
     );
   });
 
-  test("fingerprints an opaque Telegram credential without forwarding the token", async () => {
+  test("rejects an opaque Telegram credential before state or turn work", async () => {
     const botToken = "opaque-test-credential";
-    let deliveryBody: Record<string, unknown> | undefined;
-    const turn = mock(async (body: Record<string, unknown>) => {
-      deliveryBody = body;
-      return Response.json({ data: { reply: "Opaque account reply" } });
-    });
-    globalThis.fetch = mock(async (_input, init) => {
-      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
-      return Response.json({
-        ok: true,
-        result: body.text ? { message_id: 9012 } : true,
-      });
-    }) as unknown as typeof fetch;
-
-    expect(
-      (
-        await run(
-          namespace(),
-          turn,
-          telegramRequest(81611),
-          undefined,
-          botToken,
-        )
-      ).status,
-    ).toBe(200);
-    expect(deliveryBody?.connectorAccountId).toBe(
-      "bot:d437b678c02873c49f7a3ffaaf947cc5ec289fb2676cd1a2063e84087750f9b4",
+    const ledger = namespace();
+    const turn = mock(async () =>
+      Response.json({ data: { reply: "must not run" } }),
     );
-    expect(JSON.stringify(deliveryBody)).not.toContain(botToken);
+
+    const response = await run(
+      ledger,
+      turn,
+      telegramRequest(81611),
+      undefined,
+      botToken,
+    );
+
+    expect(response.status).toBe(503);
+    expect(JSON.stringify(await response.json())).not.toContain(botToken);
+    expect(turn).not.toHaveBeenCalled();
+    expect(ledger.names).toHaveLength(0);
   });
 
   test("delivers one fallback after retryable turn attempts are exhausted", async () => {
@@ -966,6 +1067,60 @@ describe("Personal Shared Telegram edge", () => {
     expect(ledger.values.size).toBe(0);
   });
 
+  test("rejects wrong bot ids and usernames before ledger, typing, or turn work", async () => {
+    for (const mismatch of [{ id: 456 }, { username: "WrongTestBot" }]) {
+      const ledger = namespace();
+      const turn = mock(async () =>
+        Response.json({ data: { reply: "must not run" } }),
+      );
+      const egress = globalThis.fetch;
+
+      const response = await run(
+        ledger,
+        turn,
+        telegramRequest(81640),
+        undefined,
+        "123:test-token",
+        mismatch,
+      );
+
+      expect(response.status).toBe(503);
+      expect(await response.json()).toMatchObject({
+        code: "telegram_identity_not_ready",
+        reason: "identity_mismatch",
+      });
+      expect(turn).not.toHaveBeenCalled();
+      expect(ledger.names).toHaveLength(0);
+      expect(egress).not.toHaveBeenCalled();
+    }
+  });
+
+  test("publishes value-free Worker identity readiness", async () => {
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    const env = telegramBindings() as AppEnv["Bindings"];
+    const url =
+      "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/readiness";
+
+    const ready = await app.fetch(new Request(url), env, executionContext());
+    expect(ready.status).toBe(200);
+    expect((await ready.json()) as Record<string, unknown>).toEqual({
+      project: "eliza-app",
+      status: "attested",
+    });
+
+    __resetTelegramIdentityAttestationCacheForTests();
+    globalThis.fetch = mock(async (input) =>
+      telegramGetMeResponse(input, { username: "WrongTestBot" }),
+    ) as unknown as typeof fetch;
+    const notReady = await app.fetch(new Request(url), env, executionContext());
+    expect(notReady.status).toBe(503);
+    const body = JSON.stringify(await notReady.json());
+    expect(body).toContain("identity_mismatch");
+    expect(body).not.toContain("test-token");
+    expect(body).not.toContain("ElizaTestBot");
+  });
+
   test("confirms LINK codes through the canonical account route instead of model chat", async () => {
     const ledger = namespace();
     const turn = mock(async () => Response.json({ data: { reply: "wrong" } }));
@@ -1065,7 +1220,7 @@ describe("Personal Shared Telegram edge", () => {
     const env = {
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
       ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ...telegramBindings(),
       PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "true",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
@@ -1115,7 +1270,7 @@ describe("Personal Shared Telegram edge", () => {
         {
           ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
           ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
-          ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+          ...telegramBindings(),
           ...(legacyGate === undefined
             ? {}
             : {
@@ -1164,7 +1319,7 @@ describe("Personal Shared Telegram edge", () => {
     const env = {
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
       ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ...telegramBindings(),
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
 
@@ -1307,8 +1462,7 @@ describe("Personal Shared Telegram edge", () => {
       {
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
         ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
-        ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
-        ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+        ...telegramBindings(),
       } as AppEnv["Bindings"],
       executionContext(),
     );
@@ -1331,8 +1485,7 @@ describe("Personal Shared Telegram edge", () => {
       {
         PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "true",
         ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
-        ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
-        ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+        ...telegramBindings(),
       } as AppEnv["Bindings"],
       executionContext(),
     );
@@ -1365,8 +1518,7 @@ describe("Personal Shared Telegram edge", () => {
         {
           PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: legacyCompat,
           ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
-          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
-          ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:rotated-secret",
+          ...telegramBindings("123:rotated-secret"),
           PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
         } as AppEnv["Bindings"],
         executionContext(),

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -249,6 +249,8 @@ export async function personalTelegramIdentityFailure(
     await requirePersonalTelegramIdentity(c.env);
     return null;
   } catch (error) {
+    // error-policy:J1 the authenticated gateway boundary returns a sanitized
+    // fail-closed identity response before delivery state is allocated.
     return personalTelegramIdentityFailureResponse(c, error);
   }
 }
@@ -261,6 +263,8 @@ export async function handlePersonalTelegramIdentityReadiness(
     const identity = await requirePersonalTelegramIdentity(c.env);
     return c.json({ status: "attested", project: identity.project });
   } catch (error) {
+    // error-policy:J1 the public readiness boundary exposes only the bounded
+    // identity reason and never credential or provider details.
     return personalTelegramIdentityFailureResponse(c, error);
   }
 }
@@ -721,6 +725,8 @@ export async function dispatchPersonalTelegramReminder(
   try {
     identity = await requirePersonalTelegramIdentity(env);
   } catch (error) {
+    // error-policy:J1 proactive delivery translates an unattested identity to
+    // an explicit not-accepted result before ledger or provider work.
     return {
       ok: false,
       acceptance: "not_accepted",
@@ -969,6 +975,8 @@ export async function handlePersonalTelegramEdge(
   try {
     identity = await requirePersonalTelegramIdentity(c.env);
   } catch (error) {
+    // error-policy:J1 the provider webhook boundary fails closed with a
+    // sanitized identity response before parsing or allocating delivery state.
     return personalTelegramIdentityFailureResponse(c, error);
   }
   const rawBody = await c.req.text();

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -15,6 +15,7 @@ import {
 } from "@elizaos/cloud-services-common/personal-shared-failure";
 import { executeResponseAttempts } from "@elizaos/cloud-services-common/response-attempts";
 import {
+  attestTelegramBotIdentity,
   parseTelegramWebhook,
   resolveTelegramVoiceNote,
   sendTelegramReply,
@@ -23,6 +24,7 @@ import {
   TelegramApiResponseError,
   type TelegramConnectorConfig,
   type TelegramConnectorEvent,
+  TelegramIdentityAttestationError,
   verifyTelegramWebhook,
 } from "@elizaos/cloud-services-common/telegram-connector";
 import {
@@ -153,6 +155,114 @@ export type PersonalTelegramReminderDispatchResult =
 function readEnvString(env: AppEnv["Bindings"], key: string): string | null {
   const value = env[key];
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function personalTelegramConfig(
+  env: AppEnv["Bindings"],
+): TelegramConnectorConfig {
+  return {
+    botToken: readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_TOKEN") ?? undefined,
+    botId: readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_ID") ?? undefined,
+    botUsername:
+      readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_USERNAME") ?? undefined,
+    webhookSecret:
+      readEnvString(env, "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET") ?? undefined,
+  };
+}
+
+function telegramIdentityFailureReason(
+  error: unknown,
+): TelegramIdentityAttestationError["reason"] {
+  return error instanceof TelegramIdentityAttestationError
+    ? error.reason
+    : "provider_unavailable";
+}
+
+async function requirePersonalTelegramIdentity(
+  env: AppEnv["Bindings"],
+): Promise<{
+  config: TelegramConnectorConfig & {
+    botToken: string;
+    botId: string;
+    botUsername: string;
+    webhookSecret: string;
+  };
+  connectorAccountId: string;
+  project: string;
+}> {
+  const config = personalTelegramConfig(env);
+  if (
+    !config.botToken ||
+    !config.botId ||
+    !config.botUsername ||
+    !config.webhookSecret
+  ) {
+    throw new TelegramIdentityAttestationError("not_configured", false);
+  }
+  await attestTelegramBotIdentity(config);
+  const project =
+    readEnvString(env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
+  if (!DELIVERY_PROJECT_RE.test(project)) {
+    throw new TelegramIdentityAttestationError("configuration_invalid", false);
+  }
+  return {
+    config: config as TelegramConnectorConfig & {
+      botToken: string;
+      botId: string;
+      botUsername: string;
+      webhookSecret: string;
+    },
+    connectorAccountId: await resolveTelegramConnectorAccountId(
+      config.botToken,
+    ),
+    project,
+  };
+}
+
+/** Fails closed without allocating Telegram delivery state or exposing identity values. */
+function personalTelegramIdentityFailureResponse(
+  c: AppContext,
+  error: unknown,
+): Response {
+  const reason = telegramIdentityFailureReason(error);
+  logger.error("[PersonalTelegramEdge] canonical identity is not ready", {
+    reason,
+  });
+  c.header("X-Eliza-Failure-Stage", "connector_identity");
+  c.header("X-Eliza-Failure-Name", "TelegramIdentityAttestationError");
+  return c.json(
+    {
+      success: false,
+      error: "Telegram connector identity is not ready",
+      code: "telegram_identity_not_ready",
+      reason,
+    },
+    503,
+    { "Retry-After": "5" },
+  );
+}
+
+export async function personalTelegramIdentityFailure(
+  c: AppContext,
+): Promise<Response | null> {
+  try {
+    await requirePersonalTelegramIdentity(c.env);
+    return null;
+  } catch (error) {
+    return personalTelegramIdentityFailureResponse(c, error);
+  }
+}
+
+/** Public value-free readiness used by protected release and cutover proofs. */
+export async function handlePersonalTelegramIdentityReadiness(
+  c: AppContext,
+): Promise<Response> {
+  try {
+    const identity = await requirePersonalTelegramIdentity(c.env);
+    return c.json({ status: "attested", project: identity.project });
+  } catch (error) {
+    return personalTelegramIdentityFailureResponse(c, error);
+  }
 }
 
 async function resolveTelegramConnectorAccountId(
@@ -607,12 +717,14 @@ export async function dispatchPersonalTelegramReminder(
       message: "Telegram reminder topic is invalid",
     };
   }
-  const botToken = readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_TOKEN");
-  if (!botToken) {
+  let identity: Awaited<ReturnType<typeof requirePersonalTelegramIdentity>>;
+  try {
+    identity = await requirePersonalTelegramIdentity(env);
+  } catch (error) {
     return {
       ok: false,
       acceptance: "not_accepted",
-      message: "Telegram connector is not configured",
+      message: `Telegram connector identity is not ready (${telegramIdentityFailureReason(error)})`,
     };
   }
   const configuredScope = await configuredPersonalTelegramScope(env);
@@ -658,7 +770,13 @@ export async function dispatchPersonalTelegramReminder(
       event,
     );
     const outcome = await executeTelegramDelivery(ledger, async (hooks) => {
-      await sendTelegramReply({ botToken }, event, input.text, logger, hooks);
+      await sendTelegramReply(
+        identity.config,
+        event,
+        input.text,
+        logger,
+        hooks,
+      );
     });
     if (outcome === "uncertain" || outcome === "in_progress") {
       return {
@@ -836,20 +954,22 @@ export async function handlePersonalTelegramEdge(
 ): Promise<Response> {
   const startedAt = performance.now();
   const traceId = c.get("traceId");
-  const webhookSecret = readEnvString(
-    c.env,
-    "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
-  );
-  const botToken = readEnvString(c.env, "ELIZA_APP_TELEGRAM_BOT_TOKEN");
-  if (!webhookSecret || !botToken) {
+  const configured = personalTelegramConfig(c.env);
+  if (!configured.webhookSecret) {
     logger.error("[PersonalTelegramEdge] connector secret is not configured");
     return c.json(
       { success: false, error: "Telegram connector is not configured" },
       503,
     );
   }
-  if (!verifyTelegramWebhook(c.req.raw, webhookSecret)) {
+  if (!verifyTelegramWebhook(c.req.raw, configured.webhookSecret)) {
     return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+  let identity: Awaited<ReturnType<typeof requirePersonalTelegramIdentity>>;
+  try {
+    identity = await requirePersonalTelegramIdentity(c.env);
+  } catch (error) {
+    return personalTelegramIdentityFailureResponse(c, error);
   }
   const rawBody = await c.req.text();
   const event = parseTelegramWebhook(rawBody, logger);
@@ -858,10 +978,8 @@ export async function handlePersonalTelegramEdge(
     event.providerSentAtMs === undefined
       ? null
       : Date.now() - event.providerSentAtMs;
-  const project =
-    readEnvString(c.env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
-  const config = { botToken, webhookSecret };
-  const connectorAccountId = await resolveTelegramConnectorAccountId(botToken);
+  const { project, connectorAccountId } = identity;
+  const config = identity.config;
   const canonicalMessageId = await telegramCanonicalMessageId(
     project,
     connectorAccountId,

--- a/packages/cloud/api/eliza-app/webhook/telegram/route.ts
+++ b/packages/cloud/api/eliza-app/webhook/telegram/route.ts
@@ -6,15 +6,24 @@ import { forwardToWebhookGateway, safeWebhookSuffix } from "../_forward";
 import {
   handlePersonalTelegramDeliveryLedger,
   handlePersonalTelegramEdge,
+  handlePersonalTelegramIdentityReadiness,
   personalTelegramGatewayConnectorAccountFailure,
+  personalTelegramIdentityFailure,
   verifyPersonalTelegramGatewayRequest,
 } from "../_telegram-edge";
 
 const app = new Hono<AppEnv>();
 const handle = async (c: Parameters<typeof handlePersonalTelegramEdge>[0]) => {
   const suffix = safeWebhookSuffix(new URL(c.req.url).pathname, "telegram");
+  if (c.req.method === "GET" && suffix === "/readiness") {
+    return handlePersonalTelegramIdentityReadiness(c);
+  }
   if (c.req.method === "POST" && suffix === "/delivery") {
-    return handlePersonalTelegramDeliveryLedger(c);
+    if (!verifyPersonalTelegramGatewayRequest(c)) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const identityFailure = await personalTelegramIdentityFailure(c);
+    return identityFailure ?? handlePersonalTelegramDeliveryLedger(c);
   }
   if (c.req.method === "POST" && suffix === "/edge") {
     if (!verifyPersonalTelegramGatewayRequest(c)) {

--- a/packages/cloud/scripts/__tests__/telegram-identity-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/telegram-identity-deploy-contract.test.ts
@@ -1,0 +1,198 @@
+/** Locks protected Telegram identity attestation ahead of every release mutation. */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  if?: string;
+  name?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  needs?: string | string[];
+  steps: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs: Record<string, WorkflowJob>;
+}
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+
+function workflow(name: string): Workflow {
+  return parse(
+    readFileSync(resolve(repoRoot, ".github/workflows", name), "utf8"),
+  ) as Workflow;
+}
+
+function namedStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+function expectBashSyntax(step: WorkflowStep): void {
+  const checked = spawnSync("bash", ["-n"], {
+    encoding: "utf8",
+    input: step.run ?? "",
+  });
+  expect(checked.stderr).toBe("");
+  expect(checked.status).toBe(0);
+}
+
+describe("protected Telegram identity workflow contract", () => {
+  test("Cloudflare preflight attests the selected identity before migration or deploy", () => {
+    const release = workflow("cloud-cf-release.yml");
+    const resolver = release.jobs["resolve-pages-environment-config"];
+    const migrate = release.jobs["migrate-db"];
+    const deploy = release.jobs["deploy-api"];
+    if (!resolver || !migrate || !deploy)
+      throw new Error("Missing release job");
+
+    const select = namedStep(
+      resolver,
+      "Validate Telegram public identity preflight",
+    );
+    const attest = namedStep(
+      resolver,
+      "Attest protected Telegram runtime identity",
+    );
+    expect(resolver.steps.indexOf(attest)).toBeGreaterThan(
+      resolver.steps.indexOf(select),
+    );
+    expect(migrate.needs).toBe("resolve-pages-environment-config");
+    expect(attest.env).toMatchObject({
+      TELEGRAM_BOT_TOKEN: expect.stringContaining(
+        "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      ),
+      TELEGRAM_WEBHOOK_SECRET: expect.stringContaining(
+        "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+      ),
+      TELEGRAM_EXPECTED_BOT_ID: expect.stringContaining(
+        "steps.telegram.outputs.bot_id",
+      ),
+      TELEGRAM_EXPECTED_BOT_USERNAME: expect.stringContaining(
+        "steps.telegram.outputs.bot_username",
+      ),
+    });
+    expect(attest.run).toContain("verify-telegram-bot-identity.mjs");
+    expect(select.run).toContain("packages/homepage/src/lib/contact.ts");
+    expect(select.run).toContain("STAGING_TELEGRAM_BOT_ID");
+
+    const prepare = namedStep(
+      deploy,
+      "Prepare Worker secrets for atomic deploy",
+    );
+    const publish = namedStep(deploy, "Deploy to Cloudflare Workers");
+    const readiness = namedStep(
+      deploy,
+      "Verify deployed Telegram identity readiness",
+    );
+    expect(prepare.run).toContain(
+      "Required protected $DEPLOY_ENVIRONMENT Telegram secret is absent or blank",
+    );
+    expect(prepare.run).toContain('queue_secret "$name"');
+    expect(publish.run).toContain("ELIZA_APP_TELEGRAM_BOT_ID");
+    expect(publish.run).toContain("ELIZA_APP_TELEGRAM_BOT_USERNAME");
+    expect(deploy.steps.indexOf(readiness)).toBeGreaterThan(
+      deploy.steps.indexOf(publish),
+    );
+    expect(readiness.run).toContain(
+      "/api/eliza-app/webhook/telegram/readiness",
+    );
+    for (const step of [select, prepare, readiness]) {
+      expectBashSyntax(step);
+    }
+  });
+
+  test("Railway attests its exact token and paired secret before deployment", () => {
+    const deployWorkflow = workflow("deploy-gateway-webhook.yml");
+    const deploy = deployWorkflow.jobs.deploy;
+    if (!deploy) throw new Error("Missing gateway deploy job");
+
+    const select = namedStep(
+      deploy,
+      "Resolve protected Telegram public identity",
+    );
+    const verify = namedStep(
+      deploy,
+      "Verify canonical Railway variables and sensitive names",
+    );
+    const mutate = namedStep(deploy, "Deploy exact gateway-webhook source");
+    const postdeploy = namedStep(
+      deploy,
+      "Verify deployed health and canonical fallback configuration",
+    );
+    const receipt = namedStep(deploy, "Write exact deployment receipt");
+
+    expect(select.run).toContain("packages/homepage/src/lib/contact.ts");
+    expect(select.run).toContain("STAGING_TELEGRAM_BOT_ID");
+    expect(verify.env).toMatchObject({
+      WORKER_ELIZA_APP_TELEGRAM_BOT_TOKEN: expect.stringContaining(
+        "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      ),
+      WORKER_ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: expect.stringContaining(
+        "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+      ),
+    });
+    expect(verify.run).toContain("verify-telegram-bot-identity.mjs");
+    expect(verify.run).toContain(
+      "require_exact_variable ELIZA_APP_TELEGRAM_BOT_ID",
+    );
+    expect(verify.run).toContain(
+      "require_exact_variable ELIZA_APP_TELEGRAM_BOT_USERNAME",
+    );
+    expect(verify.run).toContain("railway_telegram_digests");
+    expect(deploy.steps.indexOf(verify)).toBeLessThan(
+      deploy.steps.indexOf(mutate),
+    );
+    expect(postdeploy.run).toContain("/ready/telegram-identity/eliza-app");
+    expect(receipt.run).toContain('telegramIdentity: "attested"');
+    for (const step of [select, verify, postdeploy, receipt]) {
+      expectBashSyntax(step);
+    }
+  });
+
+  test("edge enable requires both live identity proofs before cutover mutation", () => {
+    const cutoverWorkflow = workflow(
+      "activate-personal-shared-telegram-edge.yml",
+    );
+    const cutover = cutoverWorkflow.jobs.cutover;
+    if (!cutover) throw new Error("Missing Telegram cutover job");
+
+    const protectedAttestation = namedStep(
+      cutover,
+      "Attest protected Telegram credential before enable",
+    );
+    const workerProof = namedStep(
+      cutover,
+      "Verify served Worker Telegram identity before enable",
+    );
+    const gatewayProof = namedStep(
+      cutover,
+      "Verify exact active gateway before enable",
+    );
+    const mutation = namedStep(cutover, "Apply and verify served edge state");
+
+    expect(protectedAttestation.if).toContain("inputs.enabled == true");
+    expect(protectedAttestation.run).toContain(
+      "verify-telegram-bot-identity.mjs",
+    );
+    expect(workerProof.run).toContain(
+      "/api/eliza-app/webhook/telegram/readiness",
+    );
+    expect(gatewayProof.run).toContain("/ready/telegram-identity/eliza-app");
+    expect(gatewayProof.run).toContain('.telegramIdentity == "attested"');
+    for (const proof of [protectedAttestation, workerProof, gatewayProof]) {
+      expect(cutover.steps.indexOf(proof)).toBeLessThan(
+        cutover.steps.indexOf(mutation),
+      );
+      expectBashSyntax(proof);
+    }
+  });
+});

--- a/packages/cloud/scripts/__tests__/telegram-identity-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/telegram-identity-deploy-contract.test.ts
@@ -82,7 +82,8 @@ describe("protected Telegram identity workflow contract", () => {
     });
     expect(attest.run).toContain("verify-telegram-bot-identity.mjs");
     expect(select.run).toContain("packages/homepage/src/lib/contact.ts");
-    expect(select.run).toContain("STAGING_TELEGRAM_BOT_ID");
+    expect(select.run).toContain("ENVIRONMENT_TELEGRAM_BOT_ID");
+    expect(select.run).toContain("TELEGRAM_IDENTITY_AUTHORITY_SHA256");
 
     const prepare = namedStep(
       deploy,

--- a/packages/cloud/scripts/__tests__/verify-telegram-bot-identity.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-telegram-bot-identity.test.ts
@@ -1,0 +1,89 @@
+/** Tests the deployment-time Telegram identity gate with no live provider calls. */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  TelegramIdentityVerificationError,
+  verifyTelegramBotIdentity,
+} from "../verify-telegram-bot-identity.mjs";
+
+const expected = {
+  botToken: "123456789:test-credential",
+  expectedBotId: "123456789",
+  expectedBotUsername: "ElizaTestBot",
+  webhookSecret: "test-webhook-secret",
+};
+
+function providerIdentity(overrides: Record<string, unknown> = {}): Response {
+  return Response.json({
+    ok: true,
+    result: {
+      id: 123456789,
+      is_bot: true,
+      username: "elizatestbot",
+      ...overrides,
+    },
+  });
+}
+
+describe("verifyTelegramBotIdentity", () => {
+  test("accepts the exact id and a case-insensitive username", async () => {
+    const provider = mock(async () => providerIdentity());
+
+    await expect(
+      verifyTelegramBotIdentity(expected, { fetchImpl: provider }),
+    ).resolves.toBeUndefined();
+    expect(provider).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects absent credentials and token-prefix drift before provider traffic", async () => {
+    const provider = mock(async () => providerIdentity());
+
+    for (const input of [
+      { ...expected, webhookSecret: "" },
+      { ...expected, botToken: "987654321:test-credential" },
+    ]) {
+      const error = await verifyTelegramBotIdentity(input, {
+        fetchImpl: provider,
+      }).catch((failure) => failure);
+      expect(error).toBeInstanceOf(TelegramIdentityVerificationError);
+    }
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  test("rejects wrong provider id and username", async () => {
+    for (const result of [
+      { id: 987654321 },
+      { username: "AnotherManagedBot" },
+    ]) {
+      const error = await verifyTelegramBotIdentity(expected, {
+        fetchImpl: mock(async () => providerIdentity(result)),
+      }).catch((failure) => failure);
+      expect(error).toMatchObject({
+        name: "TelegramIdentityVerificationError",
+        reason: "identity_mismatch",
+      });
+    }
+  });
+
+  test("classifies provider failure without exposing credentials or payload", async () => {
+    const error = await verifyTelegramBotIdentity(expected, {
+      fetchImpl: mock(async () =>
+        Response.json(
+          {
+            ok: false,
+            description: "private-provider-payload",
+          },
+          { status: 503 },
+        ),
+      ),
+    }).catch((failure) => failure);
+
+    expect(error).toMatchObject({
+      message: "Telegram bot identity verification failed",
+      reason: "provider_unavailable",
+    });
+    expect(error).not.toHaveProperty("cause");
+    expect(JSON.stringify(error)).not.toContain("test-credential");
+    expect(JSON.stringify(error)).not.toContain("private-provider-payload");
+  });
+});

--- a/packages/cloud/scripts/__tests__/verify-telegram-bot-identity.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-telegram-bot-identity.test.ts
@@ -1,10 +1,7 @@
 /** Tests the deployment-time Telegram identity gate with no live provider calls. */
 
 import { describe, expect, mock, test } from "bun:test";
-import {
-  TelegramIdentityVerificationError,
-  verifyTelegramBotIdentity,
-} from "../verify-telegram-bot-identity.mjs";
+import { verifyTelegramBotIdentity } from "../verify-telegram-bot-identity.mjs";
 
 const expected = {
   botToken: "123456789:test-credential",
@@ -12,6 +9,17 @@ const expected = {
   expectedBotUsername: "ElizaTestBot",
   webhookSecret: "test-webhook-secret",
 };
+
+async function captureFailure<T>(promise: Promise<T>): Promise<unknown> {
+  try {
+    await promise;
+    throw new Error("Expected Telegram identity verification to reject");
+  } catch (error) {
+    // error-policy:J1 the test assertion boundary observes the exact
+    // deployment-preflight rejection instead of suppressing it.
+    return error;
+  }
+}
 
 function providerIdentity(overrides: Record<string, unknown> = {}): Response {
   return Response.json({
@@ -42,10 +50,13 @@ describe("verifyTelegramBotIdentity", () => {
       { ...expected, webhookSecret: "" },
       { ...expected, botToken: "987654321:test-credential" },
     ]) {
-      const error = await verifyTelegramBotIdentity(input, {
-        fetchImpl: provider,
-      }).catch((failure) => failure);
-      expect(error).toBeInstanceOf(TelegramIdentityVerificationError);
+      const error = await captureFailure(
+        verifyTelegramBotIdentity(input, { fetchImpl: provider }),
+      );
+      expect(error).toMatchObject({
+        code: "TELEGRAM_IDENTITY_VERIFICATION_FAILED",
+        name: "TelegramIdentityVerificationError",
+      });
     }
     expect(provider).not.toHaveBeenCalled();
   });
@@ -55,10 +66,14 @@ describe("verifyTelegramBotIdentity", () => {
       { id: 987654321 },
       { username: "AnotherManagedBot" },
     ]) {
-      const error = await verifyTelegramBotIdentity(expected, {
-        fetchImpl: mock(async () => providerIdentity(result)),
-      }).catch((failure) => failure);
+      const error = await captureFailure(
+        verifyTelegramBotIdentity(expected, {
+          fetchImpl: mock(async () => providerIdentity(result)),
+        }),
+      );
       expect(error).toMatchObject({
+        code: "TELEGRAM_IDENTITY_VERIFICATION_FAILED",
+        context: { reason: "identity_mismatch" },
         name: "TelegramIdentityVerificationError",
         reason: "identity_mismatch",
       });
@@ -66,17 +81,19 @@ describe("verifyTelegramBotIdentity", () => {
   });
 
   test("classifies provider failure without exposing credentials or payload", async () => {
-    const error = await verifyTelegramBotIdentity(expected, {
-      fetchImpl: mock(async () =>
-        Response.json(
-          {
-            ok: false,
-            description: "private-provider-payload",
-          },
-          { status: 503 },
+    const error = await captureFailure(
+      verifyTelegramBotIdentity(expected, {
+        fetchImpl: mock(async () =>
+          Response.json(
+            {
+              ok: false,
+              description: "private-provider-payload",
+            },
+            { status: 503 },
+          ),
         ),
-      ),
-    }).catch((failure) => failure);
+      }),
+    );
 
     expect(error).toMatchObject({
       message: "Telegram bot identity verification failed",

--- a/packages/cloud/scripts/verify-telegram-bot-identity.mjs
+++ b/packages/cloud/scripts/verify-telegram-bot-identity.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+/**
+ * Value-safe deployment preflight for the exact Telegram bot credential.
+ * Never include the token, expected identity, or provider payload in an error.
+ */
+
+import { pathToFileURL } from "node:url";
+
+const TELEGRAM_API_BASE = "https://api.telegram.org";
+const MAX_BOT_ID = 4_503_599_627_370_495;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export class TelegramIdentityVerificationError extends Error {
+  constructor(reason) {
+    super("Telegram bot identity verification failed");
+    this.name = "TelegramIdentityVerificationError";
+    this.reason = reason;
+  }
+}
+
+function fail(reason) {
+  throw new TelegramIdentityVerificationError(reason);
+}
+
+function normalizeInput(input) {
+  const botToken = input.botToken?.trim() ?? "";
+  const expectedBotId = input.expectedBotId?.trim() ?? "";
+  const expectedBotUsername =
+    input.expectedBotUsername?.trim().replace(/^@/, "") ?? "";
+  const webhookSecret = input.webhookSecret?.trim() ?? "";
+  if (!botToken || !expectedBotId || !expectedBotUsername || !webhookSecret) {
+    fail("not_configured");
+  }
+  const botIdNumber = Number(expectedBotId);
+  if (
+    !/^[1-9]\d{0,15}$/.test(expectedBotId) ||
+    !Number.isSafeInteger(botIdNumber) ||
+    botIdNumber > MAX_BOT_ID ||
+    !/^[A-Za-z0-9_]{5,32}$/.test(expectedBotUsername) ||
+    !expectedBotUsername.toLowerCase().endsWith("bot")
+  ) {
+    fail("configuration_invalid");
+  }
+  const tokenBotId = botToken.match(/^([1-9]\d{0,15}):\S+$/)?.[1];
+  if (tokenBotId !== expectedBotId) fail("identity_mismatch");
+  return {
+    botToken,
+    expectedBotId,
+    expectedBotUsernameKey: expectedBotUsername.toLowerCase(),
+  };
+}
+
+export async function verifyTelegramBotIdentity(input, dependencies = {}) {
+  const expected = normalizeInput(input);
+  const fetchImpl = dependencies.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = dependencies.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let response;
+  try {
+    response = await fetchImpl(
+      `${TELEGRAM_API_BASE}/bot${expected.botToken}/getMe`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+  } catch {
+    fail("provider_unavailable");
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    fail("provider_unavailable");
+  }
+  if (!response.ok || payload?.ok !== true) fail("provider_unavailable");
+  const providerId =
+    typeof payload.result?.id === "number" &&
+    Number.isSafeInteger(payload.result.id) &&
+    payload.result.id > 0
+      ? String(payload.result.id)
+      : "";
+  const providerUsername =
+    typeof payload.result?.username === "string"
+      ? payload.result.username.trim().replace(/^@/, "")
+      : "";
+  if (
+    payload.result?.is_bot !== true ||
+    !providerId ||
+    !/^[A-Za-z0-9_]{5,32}$/.test(providerUsername)
+  ) {
+    fail("provider_unavailable");
+  }
+  if (
+    providerId !== expected.expectedBotId ||
+    providerUsername.toLowerCase() !== expected.expectedBotUsernameKey
+  ) {
+    fail("identity_mismatch");
+  }
+}
+
+function safeContext(value) {
+  return /^[a-z0-9][a-z0-9_-]{0,31}$/.test(value ?? "")
+    ? value
+    : "protected-environment";
+}
+
+async function main() {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: protected GitHub workflows inject this standalone preflight context outside Turbo caching.
+  const context = safeContext(process.env.TELEGRAM_ATTESTATION_CONTEXT);
+  try {
+    await verifyTelegramBotIdentity({
+      // biome-ignore lint/suspicious/noUndeclaredEnvVars: protected GitHub workflows inject this standalone preflight credential outside Turbo caching.
+      botToken: process.env.TELEGRAM_BOT_TOKEN,
+      // biome-ignore lint/suspicious/noUndeclaredEnvVars: protected GitHub workflows inject this standalone preflight identity outside Turbo caching.
+      expectedBotId: process.env.TELEGRAM_EXPECTED_BOT_ID,
+      // biome-ignore lint/suspicious/noUndeclaredEnvVars: protected GitHub workflows inject this standalone preflight identity outside Turbo caching.
+      expectedBotUsername: process.env.TELEGRAM_EXPECTED_BOT_USERNAME,
+      // biome-ignore lint/suspicious/noUndeclaredEnvVars: protected GitHub workflows inject this standalone preflight credential outside Turbo caching.
+      webhookSecret: process.env.TELEGRAM_WEBHOOK_SECRET,
+    });
+    console.log(`Telegram identity attestation passed for ${context}.`);
+  } catch (error) {
+    const reason =
+      error instanceof TelegramIdentityVerificationError
+        ? error.reason
+        : "provider_unavailable";
+    console.error(
+      `::error::Telegram identity attestation failed for ${context} (${reason})`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/packages/cloud/scripts/verify-telegram-bot-identity.mjs
+++ b/packages/cloud/scripts/verify-telegram-bot-identity.mjs
@@ -11,10 +11,12 @@ const TELEGRAM_API_BASE = "https://api.telegram.org";
 const MAX_BOT_ID = 4_503_599_627_370_495;
 const DEFAULT_TIMEOUT_MS = 10_000;
 
-export class TelegramIdentityVerificationError extends Error {
+class TelegramIdentityVerificationError extends Error {
   constructor(reason) {
     super("Telegram bot identity verification failed");
     this.name = "TelegramIdentityVerificationError";
+    this.code = "TELEGRAM_IDENTITY_VERIFICATION_FAILED";
+    this.context = { reason };
     this.reason = reason;
   }
 }
@@ -66,6 +68,8 @@ export async function verifyTelegramBotIdentity(input, dependencies = {}) {
       },
     );
   } catch {
+    // error-policy:J1 the provider boundary discards the credential-bearing
+    // transport cause and exposes only a bounded deployment failure reason.
     fail("provider_unavailable");
   }
 
@@ -73,6 +77,8 @@ export async function verifyTelegramBotIdentity(input, dependencies = {}) {
   try {
     payload = await response.json();
   } catch {
+    // error-policy:J3 Telegram response JSON is untrusted and produces an
+    // explicit bounded invalid-provider result.
     fail("provider_unavailable");
   }
   if (!response.ok || payload?.ok !== true) fail("provider_unavailable");
@@ -123,6 +129,8 @@ async function main() {
     });
     console.log(`Telegram identity attestation passed for ${context}.`);
   } catch (error) {
+    // error-policy:J1 the CLI boundary emits only the allowlisted reason and
+    // never provider payloads, expected identity values, or credentials.
     const reason =
       error instanceof TelegramIdentityVerificationError
         ? error.reason

--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -33,7 +33,8 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram
-  webhook verification, parsing, typing, voice download, and reply delivery.
+  webhook verification, parsing, typing, voice download, reply delivery, and
+  value-safe exact-token `getMe` identity attestation.
 - `src/telegram-delivery.ts` (`./telegram-delivery`) — exact-once Telegram
   reply state machine over a runtime-provided atomic ledger.
 
@@ -63,6 +64,10 @@ bun run --cwd packages/cloud/services/_common test         # delivery state-mach
   cheaply.
 - Keep provider protocol and delivery semantics runtime-neutral: Workers and
   Railway must delegate to the same source rather than maintaining forks.
+- Successful Telegram identity attestations are briefly cached by credential
+  plus expected ID/username; failures are never cached. Attestation errors may
+  expose only the safe reason/retryability classification, never their provider
+  payload or a nested cause that can contain the credential-bearing URL.
 
 Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [CLAUDE.md](../../../../CLAUDE.md).
 

--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -1,6 +1,6 @@
 # @elizaos/cloud-services-common
 
-Shared, dependency-free TypeScript utilities for Cloudflare Workers and the
+Shared, import-light TypeScript utilities for Cloudflare Workers and the
 `packages/cloud/services/*` sidecars: connector protocol, retry, delivery,
 structured logging, and Kubernetes ServiceAccount helpers. Private
 (unpublished), ESM, sources consumed directly from `src/` (no build step —
@@ -60,8 +60,8 @@ bun run --cwd packages/cloud/services/_common test         # delivery state-mach
 - This is the one place in cloud-services where `console.*` is intentional —
   it is the logger sink itself. Other cloud-services code should log through
   `createServiceLogger`, not `console`.
-- No runtime dependencies; keep it that way so every service can import it
-  cheaply.
+- Keep the runtime graph minimal so every service can import it cheaply. The
+  sole workspace dependency is the shared `@elizaos/core` error contract.
 - Keep provider protocol and delivery semantics runtime-neutral: Workers and
   Railway must delegate to the same source rather than maintaining forks.
 - Successful Telegram identity attestations are briefly cached by credential

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -33,7 +33,8 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram
-  webhook verification, parsing, typing, voice download, and reply delivery.
+  webhook verification, parsing, typing, voice download, reply delivery, and
+  value-safe exact-token `getMe` identity attestation.
 - `src/telegram-delivery.ts` (`./telegram-delivery`) — exact-once Telegram
   reply state machine over a runtime-provided atomic ledger.
 
@@ -63,6 +64,10 @@ bun run --cwd packages/cloud/services/_common test         # delivery state-mach
   cheaply.
 - Keep provider protocol and delivery semantics runtime-neutral: Workers and
   Railway must delegate to the same source rather than maintaining forks.
+- Successful Telegram identity attestations are briefly cached by credential
+  plus expected ID/username; failures are never cached. Attestation errors may
+  expose only the safe reason/retryability classification, never their provider
+  payload or a nested cause that can contain the credential-bearing URL.
 
 Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [CLAUDE.md](../../../../CLAUDE.md).
 

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -1,6 +1,6 @@
 # @elizaos/cloud-services-common
 
-Shared, dependency-free TypeScript utilities for Cloudflare Workers and the
+Shared, import-light TypeScript utilities for Cloudflare Workers and the
 `packages/cloud/services/*` sidecars: connector protocol, retry, delivery,
 structured logging, and Kubernetes ServiceAccount helpers. Private
 (unpublished), ESM, sources consumed directly from `src/` (no build step —
@@ -60,8 +60,8 @@ bun run --cwd packages/cloud/services/_common test         # delivery state-mach
 - This is the one place in cloud-services where `console.*` is intentional —
   it is the logger sink itself. Other cloud-services code should log through
   `createServiceLogger`, not `console`.
-- No runtime dependencies; keep it that way so every service can import it
-  cheaply.
+- Keep the runtime graph minimal so every service can import it cheaply. The
+  sole workspace dependency is the shared `@elizaos/core` error contract.
 - Keep provider protocol and delivery semantics runtime-neutral: Workers and
   Railway must delegate to the same source rather than maintaining forks.
 - Successful Telegram identity attestations are briefly cached by credential

--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -27,6 +27,9 @@
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format ."
   },
+  "dependencies": {
+    "@elizaos/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "22.19.17",
     "bun-types": "1.3.14",

--- a/packages/cloud/services/_common/src/index.ts
+++ b/packages/cloud/services/_common/src/index.ts
@@ -44,6 +44,8 @@ export {
   type ResponseRetryReason,
 } from "./response-attempts";
 export {
+  __resetTelegramIdentityAttestationCacheForTests,
+  attestTelegramBotIdentity,
   parseTelegramWebhook,
   resolveTelegramVoiceNote,
   sendTelegramReply,
@@ -54,10 +56,13 @@ export {
   TELEGRAM_VOICE_MAX_DURATION_SECONDS,
   TelegramApiResponseError,
   TelegramApiTransportError,
+  type TelegramAttestedBotIdentity,
   type TelegramConnectorConfig,
   type TelegramConnectorEvent,
   type TelegramConnectorLogger,
   type TelegramDeliveryReceipt,
+  TelegramIdentityAttestationError,
+  type TelegramIdentityAttestationFailureReason,
   type TelegramReplyDeliveryHooks,
   type TelegramResolvedVoiceNote,
   verifyTelegramWebhook,

--- a/packages/cloud/services/_common/src/telegram-connector.identity.test.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.identity.test.ts
@@ -1,0 +1,152 @@
+/** Exercises value-safe Telegram getMe attestation without real provider traffic. */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  __resetTelegramIdentityAttestationCacheForTests,
+  attestTelegramBotIdentity,
+  TelegramIdentityAttestationError,
+} from "./telegram-connector";
+
+const originalFetch = globalThis.fetch;
+const expected = {
+  botToken: "123456789:test-credential",
+  botId: "123456789",
+  botUsername: "ElizaTestBot",
+};
+
+function providerIdentity(overrides: Record<string, unknown> = {}): Response {
+  return Response.json({
+    ok: true,
+    result: {
+      id: 123456789,
+      is_bot: true,
+      username: "elizatestbot",
+      ...overrides,
+    },
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __resetTelegramIdentityAttestationCacheForTests();
+  mock.restore();
+});
+
+describe("attestTelegramBotIdentity", () => {
+  test("attests the exact id and case-insensitive username once per cache window", async () => {
+    const provider = mock(async () => providerIdentity());
+    globalThis.fetch = provider as unknown as typeof fetch;
+
+    const [first, concurrent] = await Promise.all([
+      attestTelegramBotIdentity(expected),
+      attestTelegramBotIdentity(expected),
+    ]);
+    const cached = await attestTelegramBotIdentity(expected);
+
+    expect(first).toEqual({
+      botId: "123456789",
+      botUsername: "ElizaTestBot",
+    });
+    expect(concurrent).toEqual(first);
+    expect(cached).toEqual(first);
+    expect(provider).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a token-prefix mismatch before provider traffic", async () => {
+    const provider = mock(async () => providerIdentity());
+    globalThis.fetch = provider as unknown as typeof fetch;
+
+    const error = await attestTelegramBotIdentity({
+      ...expected,
+      botToken: "987654321:test-credential",
+    }).catch((failure) => failure);
+
+    expect(error).toBeInstanceOf(TelegramIdentityAttestationError);
+    expect(error).toMatchObject({
+      reason: "identity_mismatch",
+      retryable: false,
+    });
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  test("rejects provider id and username mismatches", async () => {
+    for (const result of [
+      { id: 987654321 },
+      { username: "AnotherManagedBot" },
+    ]) {
+      __resetTelegramIdentityAttestationCacheForTests();
+      globalThis.fetch = mock(async () =>
+        providerIdentity(result),
+      ) as unknown as typeof fetch;
+      const error = await attestTelegramBotIdentity(expected).catch(
+        (failure) => failure,
+      );
+      expect(error).toMatchObject({
+        name: "TelegramIdentityAttestationError",
+        reason: "identity_mismatch",
+        retryable: false,
+      });
+    }
+  });
+
+  test("treats malformed or unavailable provider identity as retryable and redacted", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({
+        ok: false,
+        error_code: 503,
+        description: "private-provider-payload",
+      }),
+    ) as unknown as typeof fetch;
+
+    const error = await attestTelegramBotIdentity(expected).catch(
+      (failure) => failure,
+    );
+
+    expect(error).toMatchObject({
+      name: "TelegramIdentityAttestationError",
+      message: "Telegram bot identity attestation failed",
+      reason: "provider_unavailable",
+      retryable: true,
+    });
+    expect(error).not.toHaveProperty("cause");
+    expect(JSON.stringify(error)).not.toContain("test-credential");
+    expect(JSON.stringify(error)).not.toContain("private-provider-payload");
+  });
+
+  test("requires a complete well-formed expected identity", async () => {
+    for (const config of [
+      {},
+      { botToken: expected.botToken, botId: expected.botId },
+      { ...expected, botId: "0" },
+      { ...expected, botUsername: "not-a-managed-name" },
+    ]) {
+      const error = await attestTelegramBotIdentity(config).catch(
+        (failure) => failure,
+      );
+      expect(error).toBeInstanceOf(TelegramIdentityAttestationError);
+      expect(error).toMatchObject({ retryable: false });
+    }
+  });
+
+  test("re-attests after token rotation", async () => {
+    const provider = mock(async (input: RequestInfo | URL) => {
+      const tokenId = String(input).includes("987654321:")
+        ? 987654321
+        : 123456789;
+      return providerIdentity({
+        id: tokenId,
+        username: tokenId === 987654321 ? "RotatedTestBot" : "ElizaTestBot",
+      });
+    });
+    globalThis.fetch = provider as unknown as typeof fetch;
+
+    await attestTelegramBotIdentity(expected);
+    await attestTelegramBotIdentity({
+      botToken: "987654321:rotated-test-credential",
+      botId: "987654321",
+      botUsername: "RotatedTestBot",
+    });
+
+    expect(provider).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cloud/services/_common/src/telegram-connector.identity.test.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.identity.test.ts
@@ -1,6 +1,7 @@
 /** Exercises value-safe Telegram getMe attestation without real provider traffic. */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import {
   __resetTelegramIdentityAttestationCacheForTests,
   attestTelegramBotIdentity,
@@ -13,6 +14,17 @@ const expected = {
   botId: "123456789",
   botUsername: "ElizaTestBot",
 };
+
+async function captureFailure<T>(promise: Promise<T>): Promise<unknown> {
+  try {
+    await promise;
+    throw new Error("Expected Telegram identity attestation to reject");
+  } catch (error) {
+    // error-policy:J1 the test assertion boundary observes the exact typed
+    // rejection instead of suppressing it.
+    return error;
+  }
+}
 
 function providerIdentity(overrides: Record<string, unknown> = {}): Response {
   return Response.json({
@@ -56,13 +68,18 @@ describe("attestTelegramBotIdentity", () => {
     const provider = mock(async () => providerIdentity());
     globalThis.fetch = provider as unknown as typeof fetch;
 
-    const error = await attestTelegramBotIdentity({
-      ...expected,
-      botToken: "987654321:test-credential",
-    }).catch((failure) => failure);
+    const error = await captureFailure(
+      attestTelegramBotIdentity({
+        ...expected,
+        botToken: "987654321:test-credential",
+      }),
+    );
 
     expect(error).toBeInstanceOf(TelegramIdentityAttestationError);
+    expect(error).toBeInstanceOf(ElizaError);
     expect(error).toMatchObject({
+      code: "TELEGRAM_IDENTITY_ATTESTATION_FAILED",
+      context: { reason: "identity_mismatch", retryable: false },
       reason: "identity_mismatch",
       retryable: false,
     });
@@ -78,9 +95,7 @@ describe("attestTelegramBotIdentity", () => {
       globalThis.fetch = mock(async () =>
         providerIdentity(result),
       ) as unknown as typeof fetch;
-      const error = await attestTelegramBotIdentity(expected).catch(
-        (failure) => failure,
-      );
+      const error = await captureFailure(attestTelegramBotIdentity(expected));
       expect(error).toMatchObject({
         name: "TelegramIdentityAttestationError",
         reason: "identity_mismatch",
@@ -98,9 +113,7 @@ describe("attestTelegramBotIdentity", () => {
       }),
     ) as unknown as typeof fetch;
 
-    const error = await attestTelegramBotIdentity(expected).catch(
-      (failure) => failure,
-    );
+    const error = await captureFailure(attestTelegramBotIdentity(expected));
 
     expect(error).toMatchObject({
       name: "TelegramIdentityAttestationError",
@@ -120,9 +133,7 @@ describe("attestTelegramBotIdentity", () => {
       { ...expected, botId: "0" },
       { ...expected, botUsername: "not-a-managed-name" },
     ]) {
-      const error = await attestTelegramBotIdentity(config).catch(
-        (failure) => failure,
-      );
+      const error = await captureFailure(attestTelegramBotIdentity(config));
       expect(error).toBeInstanceOf(TelegramIdentityAttestationError);
       expect(error).toMatchObject({ retryable: false });
     }

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -12,6 +12,7 @@ export const TELEGRAM_HOSTED_FILE_MAX_BYTES = 20 * 1024 * 1024;
 export const TELEGRAM_VOICE_MAX_BYTES = 8 * 1024 * 1024;
 const TELEGRAM_API_TIMEOUT_MS = 10_000;
 const TELEGRAM_REJECTION_RETRY_CAP_MS = 5_000;
+const TELEGRAM_IDENTITY_ATTESTATION_TTL_MS = 5 * 60_000;
 export const TELEGRAM_VOICE_MAX_DURATION_SECONDS = 15 * 60;
 const TELEGRAM_FILE_FETCH_TIMEOUT_MS = 30_000;
 
@@ -21,8 +22,36 @@ export interface TelegramConnectorLogger {
 
 export interface TelegramConnectorConfig {
   botToken?: string;
+  /** Expected public bot id for the exact credential in `botToken`. */
+  botId?: string;
   botUsername?: string;
   webhookSecret?: string;
+}
+
+export type TelegramIdentityAttestationFailureReason =
+  | "configuration_invalid"
+  | "identity_mismatch"
+  | "not_configured"
+  | "provider_unavailable";
+
+export interface TelegramAttestedBotIdentity {
+  botId: string;
+  botUsername: string;
+}
+
+/**
+ * A value-safe identity failure. Its message and reason are safe at transport
+ * boundaries; the credential, expected identity, and provider payload are
+ * deliberately excluded.
+ */
+export class TelegramIdentityAttestationError extends Error {
+  constructor(
+    readonly reason: TelegramIdentityAttestationFailureReason,
+    readonly retryable: boolean,
+  ) {
+    super("Telegram bot identity attestation failed");
+    this.name = "TelegramIdentityAttestationError";
+  }
 }
 
 export interface TelegramConnectorEvent {
@@ -462,6 +491,128 @@ async function telegramApi<T>(
   return data.result as T;
 }
 
+interface CachedTelegramIdentity {
+  expiresAt: number;
+  identity: TelegramAttestedBotIdentity;
+}
+
+const telegramIdentityCache = new Map<string, CachedTelegramIdentity>();
+const telegramIdentityPending = new Map<
+  string,
+  Promise<TelegramAttestedBotIdentity>
+>();
+
+function normalizeExpectedTelegramIdentity(config: TelegramConnectorConfig): {
+  botToken: string;
+  botId: string;
+  botUsername: string;
+  botUsernameKey: string;
+} {
+  const botToken = config.botToken?.trim() ?? "";
+  const botId = config.botId?.trim() ?? "";
+  const botUsername = config.botUsername?.trim().replace(/^@/, "") ?? "";
+  const botIdNumber = Number(botId);
+  if (!botToken || !botId || !botUsername) {
+    throw new TelegramIdentityAttestationError("not_configured", false);
+  }
+  if (
+    !/^[1-9]\d{0,15}$/.test(botId) ||
+    !Number.isSafeInteger(botIdNumber) ||
+    botIdNumber > 4_503_599_627_370_495 ||
+    !/^[A-Za-z0-9_]{5,32}$/.test(botUsername) ||
+    !botUsername.toLowerCase().endsWith("bot")
+  ) {
+    throw new TelegramIdentityAttestationError("configuration_invalid", false);
+  }
+  const tokenBotId = botToken.match(/^([1-9]\d{0,15}):\S+$/)?.[1];
+  if (tokenBotId !== botId) {
+    throw new TelegramIdentityAttestationError("identity_mismatch", false);
+  }
+  return {
+    botToken,
+    botId,
+    botUsername,
+    botUsernameKey: botUsername.toLowerCase(),
+  };
+}
+
+/**
+ * Proves that the exact outbound credential belongs to the selected public bot.
+ * Successful results are cached briefly per credential and expected identity;
+ * failures are never cached, so an operator repair can recover immediately.
+ */
+export async function attestTelegramBotIdentity(
+  config: TelegramConnectorConfig,
+): Promise<TelegramAttestedBotIdentity> {
+  const expected = normalizeExpectedTelegramIdentity(config);
+  const cacheKey = `${expected.botToken}\0${expected.botId}\0${expected.botUsernameKey}`;
+  const cached = telegramIdentityCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.identity;
+  telegramIdentityCache.delete(cacheKey);
+
+  let pending = telegramIdentityPending.get(cacheKey);
+  if (!pending) {
+    pending = (async () => {
+      let me: { id?: unknown; is_bot?: unknown; username?: unknown };
+      try {
+        me = await telegramApi<{
+          id?: unknown;
+          is_bot?: unknown;
+          username?: unknown;
+        }>(expected.botToken, "getMe");
+      } catch {
+        throw new TelegramIdentityAttestationError(
+          "provider_unavailable",
+          true,
+        );
+      }
+      const providerBotId =
+        typeof me.id === "number" && Number.isSafeInteger(me.id) && me.id > 0
+          ? String(me.id)
+          : "";
+      const providerUsername =
+        typeof me.username === "string"
+          ? me.username.trim().replace(/^@/, "")
+          : "";
+      if (
+        me.is_bot !== true ||
+        !providerBotId ||
+        !/^[A-Za-z0-9_]{5,32}$/.test(providerUsername)
+      ) {
+        throw new TelegramIdentityAttestationError(
+          "provider_unavailable",
+          true,
+        );
+      }
+      if (
+        providerBotId !== expected.botId ||
+        providerUsername.toLowerCase() !== expected.botUsernameKey
+      ) {
+        throw new TelegramIdentityAttestationError("identity_mismatch", false);
+      }
+      const identity = {
+        botId: expected.botId,
+        botUsername: expected.botUsername,
+      } satisfies TelegramAttestedBotIdentity;
+      telegramIdentityCache.set(cacheKey, {
+        expiresAt: Date.now() + TELEGRAM_IDENTITY_ATTESTATION_TTL_MS,
+        identity,
+      });
+      return identity;
+    })().finally(() => {
+      telegramIdentityPending.delete(cacheKey);
+    });
+    telegramIdentityPending.set(cacheKey, pending);
+  }
+  return pending;
+}
+
+/** Test-only cache reset; production callers never need to invalidate by value. */
+export function __resetTelegramIdentityAttestationCacheForTests(): void {
+  telegramIdentityCache.clear();
+  telegramIdentityPending.clear();
+}
+
 const telegramBotUsernameCache = new Map<string, Promise<string>>();
 
 /** Resolve this credential's public username without exposing the token. */
@@ -469,6 +620,9 @@ export async function resolveTelegramBotUsername(
   config: TelegramConnectorConfig,
 ): Promise<string> {
   const configured = config.botUsername?.trim().replace(/^@/, "");
+  if (config.botId) {
+    return (await attestTelegramBotIdentity(config)).botUsername;
+  }
   if (configured) return configured;
   const botToken = config.botToken;
   if (!botToken) return "";
@@ -583,6 +737,7 @@ export async function sendTelegramReply(
   deliveryHooks?: TelegramReplyDeliveryHooks,
 ): Promise<TelegramDeliveryReceipt> {
   if (!config.botToken) throw new Error("Missing botToken for Telegram reply");
+  if (config.botId) await attestTelegramBotIdentity(config);
   const providerMessageIds: string[] = [];
   const chunks = splitTelegramMessage(text);
   const threadParams = telegramThreadParams(event);
@@ -670,6 +825,7 @@ export async function sendTelegramTyping(
   event: TelegramConnectorEvent,
 ): Promise<void> {
   if (!config.botToken) throw new Error("Missing botToken for Telegram typing");
+  if (config.botId) await attestTelegramBotIdentity(config);
   await telegramApi(config.botToken, "sendChatAction", {
     chat_id: event.chatId,
     ...telegramThreadParams(event),

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -4,6 +4,8 @@
  * Provider credentials stay in the caller's runtime and are never logged.
  */
 
+import { ElizaError } from "@elizaos/core";
+
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const MAX_MESSAGE_LENGTH = 4096;
 export const TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER =
@@ -44,13 +46,18 @@ export interface TelegramAttestedBotIdentity {
  * boundaries; the credential, expected identity, and provider payload are
  * deliberately excluded.
  */
-export class TelegramIdentityAttestationError extends Error {
+export class TelegramIdentityAttestationError extends ElizaError {
+  override readonly name = "TelegramIdentityAttestationError";
+
   constructor(
     readonly reason: TelegramIdentityAttestationFailureReason,
     readonly retryable: boolean,
   ) {
-    super("Telegram bot identity attestation failed");
-    this.name = "TelegramIdentityAttestationError";
+    super("Telegram bot identity attestation failed", {
+      code: "TELEGRAM_IDENTITY_ATTESTATION_FAILED",
+      context: { reason, retryable },
+      severity: retryable ? "ephemeral" : "fatal",
+    });
   }
 }
 
@@ -561,6 +568,8 @@ export async function attestTelegramBotIdentity(
           username?: unknown;
         }>(expected.botToken, "getMe");
       } catch {
+        // error-policy:J1 the provider boundary exposes only a value-safe
+        // attestation classification and discards credential-bearing causes.
         throw new TelegramIdentityAttestationError(
           "provider_unavailable",
           true,

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -16,6 +16,8 @@ system) from trusted in-cluster callers and forwards those to agents.
     `X-Internal-Secret` like `/internal/deliver`; the probe routes stay open.
   - `GET /ready/forwarder-auth/:project` — read-only forwarder-gate readiness;
     a headerless 401 is reserved for an enforced gate on that project.
+  - `GET /ready/telegram-identity/:project` — value-free proof that the exact
+    canonical Telegram credential matches the selected public bot identity.
   - `POST /internal/event` — internal event delivery (auth via
     `X-Internal-Secret`).
   - `GET /webhook/:project/whatsapp[/:agentId]` — WhatsApp `hub.challenge`
@@ -42,6 +44,8 @@ system) from trusted in-cluster callers and forwards those to agents.
   `/internal/event` and shared BFF-forwarder gate state/enforcement.
 - `src/forwarder-auth-readiness.ts` — non-mutating forwarder-gate readiness
   route; it never accepts a secret or enters provider/message handling.
+- `src/telegram-identity.ts` — canonical Telegram startup, ingress, reminder,
+  and readiness attestation shared by the gateway paths.
 - `src/internal-event-handler.ts` — zod-validated internal event ingestion
   (64KB cap), then background forward.
 - `src/webhook-config.ts` / `src/project-config.ts` — per-agent webhook config
@@ -104,6 +108,12 @@ deployment. The route returns distinct non-401 states when the secret is
 disabled or the configured forwarded project does not match, never enters
 provider/message handling, and rejects any supplied forwarder-secret header
 without comparing it.
+Before upload, the workflow proves the Railway token and webhook secret match
+the protected Worker pair and attests that token with Telegram `getMe`. The
+expected production ID/username always comes from
+`packages/homepage/src/lib/contact.ts`; staging uses its selected protected
+Environment pair. The deployed service must then return an exact value-free
+Telegram readiness receipt before the deployment receipt is published.
 The pinned Railway CLI is invoked with no path argument from the repository
 root; do not change this to relative `.` because v5.38.0 cannot strip its
 absolute archive prefix from that relative project path when `--project` is
@@ -185,8 +195,12 @@ Other:
   billing tuning.
 - Per-project secrets are read via `getProjectEnv(project, KEY)`: labeled k8s
   Secrets first, else `<PROJECT_UPPER>_<KEY>` env vars (e.g. `eliza-app` →
-  `ELIZA_APP_TELEGRAM_BOT_TOKEN`). Keys include
-  `TELEGRAM_BOT_TOKEN`/`_WEBHOOK_SECRET`, `BLOOIO_*`, `TWILIO_*`, `WHATSAPP_*`.
+  `ELIZA_APP_TELEGRAM_BOT_TOKEN`). The canonical Telegram project requires the
+  complete `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_ID`,
+  `TELEGRAM_BOT_USERNAME`, and `TELEGRAM_WEBHOOK_SECRET` set; startup,
+  readiness, inbound turns, and proactive delivery fail closed unless the
+  exact token attests to that ID/username. Other keys include `BLOOIO_*`,
+  `TWILIO_*`, and `WHATSAPP_*`.
 
 ## Conventions / gotchas
 

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -16,6 +16,8 @@ system) from trusted in-cluster callers and forwards those to agents.
     `X-Internal-Secret` like `/internal/deliver`; the probe routes stay open.
   - `GET /ready/forwarder-auth/:project` — read-only forwarder-gate readiness;
     a headerless 401 is reserved for an enforced gate on that project.
+  - `GET /ready/telegram-identity/:project` — value-free proof that the exact
+    canonical Telegram credential matches the selected public bot identity.
   - `POST /internal/event` — internal event delivery (auth via
     `X-Internal-Secret`).
   - `GET /webhook/:project/whatsapp[/:agentId]` — WhatsApp `hub.challenge`
@@ -42,6 +44,8 @@ system) from trusted in-cluster callers and forwards those to agents.
   `/internal/event` and shared BFF-forwarder gate state/enforcement.
 - `src/forwarder-auth-readiness.ts` — non-mutating forwarder-gate readiness
   route; it never accepts a secret or enters provider/message handling.
+- `src/telegram-identity.ts` — canonical Telegram startup, ingress, reminder,
+  and readiness attestation shared by the gateway paths.
 - `src/internal-event-handler.ts` — zod-validated internal event ingestion
   (64KB cap), then background forward.
 - `src/webhook-config.ts` / `src/project-config.ts` — per-agent webhook config
@@ -104,6 +108,12 @@ deployment. The route returns distinct non-401 states when the secret is
 disabled or the configured forwarded project does not match, never enters
 provider/message handling, and rejects any supplied forwarder-secret header
 without comparing it.
+Before upload, the workflow proves the Railway token and webhook secret match
+the protected Worker pair and attests that token with Telegram `getMe`. The
+expected production ID/username always comes from
+`packages/homepage/src/lib/contact.ts`; staging uses its selected protected
+Environment pair. The deployed service must then return an exact value-free
+Telegram readiness receipt before the deployment receipt is published.
 The pinned Railway CLI is invoked with no path argument from the repository
 root; do not change this to relative `.` because v5.38.0 cannot strip its
 absolute archive prefix from that relative project path when `--project` is
@@ -185,8 +195,12 @@ Other:
   billing tuning.
 - Per-project secrets are read via `getProjectEnv(project, KEY)`: labeled k8s
   Secrets first, else `<PROJECT_UPPER>_<KEY>` env vars (e.g. `eliza-app` →
-  `ELIZA_APP_TELEGRAM_BOT_TOKEN`). Keys include
-  `TELEGRAM_BOT_TOKEN`/`_WEBHOOK_SECRET`, `BLOOIO_*`, `TWILIO_*`, `WHATSAPP_*`.
+  `ELIZA_APP_TELEGRAM_BOT_TOKEN`). The canonical Telegram project requires the
+  complete `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_ID`,
+  `TELEGRAM_BOT_USERNAME`, and `TELEGRAM_WEBHOOK_SECRET` set; startup,
+  readiness, inbound turns, and proactive delivery fail closed unless the
+  exact token attests to that ID/username. Other keys include `BLOOIO_*`,
+  `TWILIO_*`, and `WHATSAPP_*`.
 
 ## Conventions / gotchas
 

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
@@ -7,9 +7,15 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { credentialFingerprint } from "../src/connector-account";
 import { deliverInternalMessage } from "../src/internal-delivery";
 import type { GatewayRedis } from "../src/redis";
+import {
+  configureTelegramIdentity,
+  resetTelegramIdentityAttestation,
+  TELEGRAM_CONNECTOR_ACCOUNT_ID,
+  TELEGRAM_TEST_TOKEN,
+  withTelegramIdentity,
+} from "./telegram-identity-fixture";
 
 type RedisSetOptions = { ex?: number; nx?: boolean };
 
@@ -49,22 +55,32 @@ class MemoryRedis implements GatewayRedis {
 
 const originalFetch = globalThis.fetch;
 const originalToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+const originalBotId = process.env.ELIZA_APP_TELEGRAM_BOT_ID;
+const originalBotUsername = process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME;
+const originalWebhookSecret = process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET;
 const originalBlooioKey = process.env.ELIZA_APP_BLOOIO_API_KEY;
 const originalBlooioNumber = process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
-const TELEGRAM_TEST_TOKEN = "telegram-test-token";
-const TELEGRAM_CONNECTOR_ACCOUNT_ID = `bot:${credentialFingerprint(TELEGRAM_TEST_TOKEN)}`;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   if (originalToken === undefined)
     delete process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
   else process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = originalToken;
+  if (originalBotId === undefined) delete process.env.ELIZA_APP_TELEGRAM_BOT_ID;
+  else process.env.ELIZA_APP_TELEGRAM_BOT_ID = originalBotId;
+  if (originalBotUsername === undefined)
+    delete process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME;
+  else process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME = originalBotUsername;
+  if (originalWebhookSecret === undefined)
+    delete process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET;
+  else process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET = originalWebhookSecret;
   if (originalBlooioKey === undefined)
     delete process.env.ELIZA_APP_BLOOIO_API_KEY;
   else process.env.ELIZA_APP_BLOOIO_API_KEY = originalBlooioKey;
   if (originalBlooioNumber === undefined)
     delete process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
   else process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = originalBlooioNumber;
+  resetTelegramIdentityAttestation();
   mock.restore();
 });
 
@@ -125,19 +141,19 @@ describe("internal proactive group delivery", () => {
   });
 
   test("sends a Telegram group reminder to its negative chat id unchanged", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
-    globalThis.fetch = mock(
+    globalThis.fetch = withTelegramIdentity(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const outgoing = new Request(input, init);
         expect(outgoing.url).toBe(
-          "https://api.telegram.org/bottelegram-test-token/sendMessage",
+          `https://api.telegram.org/bot${TELEGRAM_TEST_TOKEN}/sendMessage`,
         );
         bodies.push((await outgoing.json()) as Record<string, unknown>);
         return Response.json({ ok: true, result: { message_id: 71 } });
       },
-    ) as typeof fetch;
+    );
 
     const response = await deliverInternalMessage(
       request({
@@ -163,19 +179,19 @@ describe("internal proactive group delivery", () => {
   });
 
   test("keeps a Telegram group reminder inside its forum topic", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
-    globalThis.fetch = mock(
+    globalThis.fetch = withTelegramIdentity(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const outgoing = new Request(input, init);
         expect(outgoing.url).toBe(
-          "https://api.telegram.org/bottelegram-test-token/sendMessage",
+          `https://api.telegram.org/bot${TELEGRAM_TEST_TOKEN}/sendMessage`,
         );
         bodies.push((await outgoing.json()) as Record<string, unknown>);
         return Response.json({ ok: true, result: { message_id: 72 } });
       },
-    ) as typeof fetch;
+    );
 
     const response = await deliverInternalMessage(
       request({

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
@@ -1,9 +1,15 @@
 /** Verifies proactive Telegram delivery ownership and replay against the gateway boundary. */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { credentialFingerprint } from "../src/connector-account";
 import { deliverInternalMessage } from "../src/internal-delivery";
 import type { GatewayRedis } from "../src/redis";
+import {
+  configureTelegramIdentity,
+  resetTelegramIdentityAttestation,
+  TELEGRAM_CONNECTOR_ACCOUNT_ID,
+  TELEGRAM_TEST_TOKEN,
+  withTelegramIdentity,
+} from "./telegram-identity-fixture";
 
 type RedisSetOptions = { ex?: number; nx?: boolean };
 
@@ -53,24 +59,45 @@ class MemoryRedis implements GatewayRedis {
 
 const originalFetch = globalThis.fetch;
 const originalToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+const originalBotId = process.env.ELIZA_APP_TELEGRAM_BOT_ID;
+const originalBotUsername = process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME;
+const originalWebhookSecret = process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET;
 const originalBlooioKey = process.env.ELIZA_APP_BLOOIO_API_KEY;
 const originalBlooioNumber = process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
-const TELEGRAM_TEST_TOKEN = "telegram-test-token";
-const TELEGRAM_CONNECTOR_ACCOUNT_ID = `bot:${credentialFingerprint(TELEGRAM_TEST_TOKEN)}`;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   if (originalToken === undefined)
     delete process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
   else process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = originalToken;
+  if (originalBotId === undefined) delete process.env.ELIZA_APP_TELEGRAM_BOT_ID;
+  else process.env.ELIZA_APP_TELEGRAM_BOT_ID = originalBotId;
+  if (originalBotUsername === undefined)
+    delete process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME;
+  else process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME = originalBotUsername;
+  if (originalWebhookSecret === undefined)
+    delete process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET;
+  else process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET = originalWebhookSecret;
   if (originalBlooioKey === undefined)
     delete process.env.ELIZA_APP_BLOOIO_API_KEY;
   else process.env.ELIZA_APP_BLOOIO_API_KEY = originalBlooioKey;
   if (originalBlooioNumber === undefined)
     delete process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
   else process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = originalBlooioNumber;
+  resetTelegramIdentityAttestation();
   mock.restore();
 });
+
+function installTelegramProvider(
+  handler: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Response | Promise<Response>,
+) {
+  const provider = mock(handler);
+  globalThis.fetch = withTelegramIdentity(provider);
+  return provider;
+}
 
 function request(overrides: Record<string, unknown> = {}) {
   return new Request("https://gateway.example/internal/deliver", {
@@ -94,11 +121,11 @@ function dependencies(redis: GatewayRedis) {
 
 describe("internal proactive delivery", () => {
   test("reports Redis read and claim failures as retryable before egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const send = mock(async () => {
       throw new Error("provider must not run");
     });
-    globalThis.fetch = send as typeof fetch;
+    globalThis.fetch = withTelegramIdentity(send);
     for (const failure of ["read", "claim"] as const) {
       const redis = new MemoryRedis();
       if (failure === "read") redis.failGet = true;
@@ -117,12 +144,12 @@ describe("internal proactive delivery", () => {
   });
 
   test("does not mask an explicit provider rejection when claim release fails", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     redis.failDelete = true;
-    globalThis.fetch = mock(async () =>
+    installTelegramProvider(async () =>
       Response.json({ ok: false, error_code: 403, description: "blocked" }),
-    ) as typeof fetch;
+    );
 
     const response = await deliverInternalMessage(
       request(),
@@ -137,17 +164,17 @@ describe("internal proactive delivery", () => {
   });
 
   test("delivers without Cloud API auth and replays the completed idempotency key", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const telegramBodies: Array<Record<string, unknown>> = [];
-    globalThis.fetch = mock(async (input, init) => {
+    installTelegramProvider(async (input, init) => {
       const outgoing = new Request(input, init);
       expect(outgoing.url).toBe(
-        "https://api.telegram.org/bottelegram-test-token/sendMessage",
+        `https://api.telegram.org/bot${TELEGRAM_TEST_TOKEN}/sendMessage`,
       );
       telegramBodies.push((await outgoing.json()) as Record<string, unknown>);
       return Response.json({ ok: true, result: { message_id: 1 } });
-    }) as typeof fetch;
+    });
 
     const first = await deliverInternalMessage(request(), dependencies(redis));
     const replay = await deliverInternalMessage(request(), dependencies(redis));
@@ -176,16 +203,16 @@ describe("internal proactive delivery", () => {
   test("keeps the bot identity stable across Telegram secret rotation", async () => {
     const redis = new MemoryRedis();
     const connectorAccountId = "bot:123456789";
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123456789:first-secret";
-    globalThis.fetch = mock(async () =>
+    configureTelegramIdentity({ token: "123456789:first-secret" });
+    const provider = installTelegramProvider(async () =>
       Response.json({ ok: true, result: { message_id: 73 } }),
-    ) as typeof fetch;
+    );
 
     const first = await deliverInternalMessage(
       request({ connectorAccountId }),
       dependencies(redis),
     );
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123456789:rotated-secret";
+    configureTelegramIdentity({ token: "123456789:rotated-secret" });
     const replay = await deliverInternalMessage(
       request({ connectorAccountId }),
       dependencies(redis),
@@ -198,19 +225,22 @@ describe("internal proactive delivery", () => {
       replayed: true,
       providerMessageIds: ["73"],
     });
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(provider).toHaveBeenCalledTimes(1);
     expect([...redis.store.keys()]).toEqual([
       "internal-delivery:telegram:eliza-app:task-1:2026-08-14T20:00:00.000Z",
     ]);
   });
 
   test("rejects a missing or different Telegram bot before receipt lookup or egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "987654321:configured-secret";
+    configureTelegramIdentity({
+      token: "987654321:configured-secret",
+      botId: "987654321",
+    });
     const redis = new MemoryRedis();
     redis.failGet = true;
-    globalThis.fetch = mock(async () => {
+    const provider = installTelegramProvider(async () => {
       throw new Error("provider must not run");
-    }) as typeof fetch;
+    });
 
     const missing = await deliverInternalMessage(
       request({ connectorAccountId: undefined }),
@@ -229,7 +259,39 @@ describe("internal proactive delivery", () => {
       acceptance: "not_accepted",
     });
     expect(redis.store).toEqual(new Map());
-    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  test("rejects a provider identity mismatch before reminder receipt or message egress", async () => {
+    configureTelegramIdentity();
+    const redis = new MemoryRedis();
+    redis.failGet = true;
+    const provider = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toEndWith("/getMe");
+      return Response.json({
+        ok: true,
+        result: {
+          id: 987654321,
+          is_bot: true,
+          username: "ElizaTestBot",
+        },
+      });
+    });
+    globalThis.fetch = provider as unknown as typeof fetch;
+
+    const response = await deliverInternalMessage(
+      request(),
+      dependencies(redis),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "telegram-identity-not-ready",
+      reason: "identity_mismatch",
+      status: "not-attested",
+    });
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(redis.store).toEqual(new Map());
   });
 
   test("delivers Blooio iMessage once with the provider idempotency key and receipt", async () => {
@@ -279,7 +341,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("rejects a concurrent duplicate while the first send owns delivery", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     let finishSend: (() => void) | undefined;
     let markSendStarted: (() => void) | undefined;
@@ -289,11 +351,11 @@ describe("internal proactive delivery", () => {
     const pendingSend = new Promise<void>((resolve) => {
       finishSend = resolve;
     });
-    globalThis.fetch = mock(async () => {
+    const provider = installTelegramProvider(async () => {
       markSendStarted?.();
       await pendingSend;
       return Response.json({ ok: true, result: { message_id: 1 } });
-    }) as typeof fetch;
+    });
 
     const firstPromise = deliverInternalMessage(request(), dependencies(redis));
     await sendStarted;
@@ -311,16 +373,16 @@ describe("internal proactive delivery", () => {
     });
     finishSend?.();
     expect((await firstPromise).status).toBe(200);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(provider).toHaveBeenCalledTimes(1);
   });
 
   test("does not resend after Telegram accepts but the completion receipt write fails", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     redis.failCompletionWrite = true;
-    globalThis.fetch = mock(async () =>
+    const provider = installTelegramProvider(async () =>
       Response.json({ ok: true, result: { message_id: 91 } }),
-    ) as typeof fetch;
+    );
 
     const first = await deliverInternalMessage(request(), dependencies(redis));
     const replay = await deliverInternalMessage(request(), dependencies(redis));
@@ -337,22 +399,22 @@ describe("internal proactive delivery", () => {
       acceptanceUnknown: true,
       replayed: true,
     });
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(provider).toHaveBeenCalledTimes(1);
   });
 
   test("retains an indeterminate tombstone when the provider response times out", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
-    globalThis.fetch = mock(async () => {
+    const provider = installTelegramProvider(async () => {
       throw new Error("response timeout");
-    }) as typeof fetch;
+    });
 
     const first = await deliverInternalMessage(request(), dependencies(redis));
     const replay = await deliverInternalMessage(request(), dependencies(redis));
 
     expect(first.status).toBe(202);
     expect(replay.status).toBe(202);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(provider).toHaveBeenCalledTimes(1);
   });
 
   test("does not retry Blooio after a provider 5xx leaves acceptance uncertain", async () => {
@@ -392,15 +454,15 @@ describe("internal proactive delivery", () => {
   });
 
   test("never reports a pre-existing indeterminate tombstone as accepted", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     redis.store.set(
       "internal-delivery:telegram:eliza-app:task-1:2026-08-14T20:00:00.000Z",
       "indeterminate",
     );
-    globalThis.fetch = mock(async () => {
+    const provider = installTelegramProvider(async () => {
       throw new Error("must not resend an indeterminate delivery");
-    }) as typeof fetch;
+    });
 
     const response = await deliverInternalMessage(
       request(),
@@ -414,14 +476,14 @@ describe("internal proactive delivery", () => {
       retryable: false,
       acceptanceUnknown: true,
     });
-    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(provider).not.toHaveBeenCalled();
   });
 
   test("retries without Markdown only after Telegram explicitly rejects formatting", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
-    globalThis.fetch = mock(async (input, init) => {
+    installTelegramProvider(async (input, init) => {
       const outgoing = new Request(input, init);
       bodies.push((await outgoing.json()) as Record<string, unknown>);
       if (bodies.length === 1) {
@@ -432,7 +494,7 @@ describe("internal proactive delivery", () => {
         });
       }
       return Response.json({ ok: true, result: { message_id: 92 } });
-    }) as typeof fetch;
+    });
 
     const response = await deliverInternalMessage(
       request(),
@@ -451,16 +513,16 @@ describe("internal proactive delivery", () => {
   });
 
   test("releases the delivery claim when Telegram explicitly rate-limits the first send", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
-    globalThis.fetch = mock(async () =>
+    const provider = installTelegramProvider(async () =>
       Response.json({
         ok: false,
         error_code: 429,
         description: "Too Many Requests: retry later",
         parameters: { retry_after: 7 },
       }),
-    ) as typeof fetch;
+    );
 
     const first = await deliverInternalMessage(request(), dependencies(redis));
     const retry = await deliverInternalMessage(request(), dependencies(redis));
@@ -472,15 +534,15 @@ describe("internal proactive delivery", () => {
       acceptance: "not_accepted",
     });
     expect(retry.status).toBe(429);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(provider).toHaveBeenCalledTimes(2);
     expect(redis.store).toEqual(new Map());
   });
 
   test("releases the claim when the plain-text retry is explicitly forbidden", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
-    globalThis.fetch = mock(async (input, init) => {
+    installTelegramProvider(async (input, init) => {
       const outgoing = new Request(input, init);
       bodies.push((await outgoing.json()) as Record<string, unknown>);
       if (bodies.length === 1) {
@@ -495,7 +557,7 @@ describe("internal proactive delivery", () => {
         error_code: 403,
         description: "Forbidden: bot was blocked by the user",
       });
-    }) as typeof fetch;
+    });
 
     const response = await deliverInternalMessage(
       request(),

--- a/packages/cloud/services/gateway-webhook/__tests__/personal-telegram-edge-forward.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/personal-telegram-edge-forward.test.ts
@@ -5,6 +5,11 @@ import { TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER } from "@elizaos/cloud-services-co
 import type { ChatEvent, PlatformAdapter } from "../src/adapters/types";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";
+import {
+  configureTelegramIdentity,
+  resetTelegramIdentityAttestation,
+  withTelegramIdentity,
+} from "./telegram-identity-fixture";
 
 class MemoryRedis implements GatewayRedis {
   readonly values = new Map<string, string>();
@@ -42,6 +47,9 @@ class MemoryRedis implements GatewayRedis {
 
 const originalFetch = globalThis.fetch;
 const originalBotToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+const originalBotId = process.env.ELIZA_APP_TELEGRAM_BOT_ID;
+const originalBotUsername = process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME;
+const originalWebhookSecret = process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET;
 const rawPayload = ` { "update_id": 1, "message": { "text": "hey how are you? 👋" } }\n`;
 const event: ChatEvent = {
   platform: "telegram",
@@ -88,21 +96,39 @@ afterEach(() => {
   } else {
     process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = originalBotToken;
   }
+  if (originalBotId === undefined) {
+    delete process.env.ELIZA_APP_TELEGRAM_BOT_ID;
+  } else {
+    process.env.ELIZA_APP_TELEGRAM_BOT_ID = originalBotId;
+  }
+  if (originalBotUsername === undefined) {
+    delete process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME;
+  } else {
+    process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME = originalBotUsername;
+  }
+  if (originalWebhookSecret === undefined) {
+    delete process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET;
+  } else {
+    process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET = originalWebhookSecret;
+  }
+  resetTelegramIdentityAttestation();
   mock.restore();
 });
 
 describe("Personal Telegram gateway-to-edge handoff", () => {
   test("preserves the signed payload and lets the Worker own egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    configureTelegramIdentity({ token: "123:test-token" });
     const redis = new MemoryRedis();
     let forwarded: Request | null = null;
-    globalThis.fetch = mock(async (input, init) => {
-      forwarded = new Request(input, init);
-      expect(
-        redis.values.get("webhook:telegram:scope:message:edge-forward-1"),
-      ).toBe("egress_started");
-      return Response.json({ ok: true });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        forwarded = new Request(input, init);
+        expect(
+          redis.values.get("webhook:telegram:scope:message:edge-forward-1"),
+        ).toBe("egress_started");
+        return Response.json({ ok: true });
+      }),
+    ) as unknown as typeof fetch;
 
     const response = await handleWebhook(
       request(),
@@ -144,27 +170,29 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
   });
 
   test("reopens a connector-account rejection for a corrected retry", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    configureTelegramIdentity({ token: "123:test-token" });
     const redis = new MemoryRedis();
     let edgeAttempts = 0;
-    globalThis.fetch = mock(async (input, init) => {
-      edgeAttempts += 1;
-      const forwarded = new Request(input, init);
-      expect(forwarded.headers.get(TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER)).toBe(
-        "bot:123",
-      );
-      expect(await forwarded.text()).toBe(rawPayload);
-      if (edgeAttempts === 1) {
-        return Response.json(
-          { error: "connector account mismatch" },
-          {
-            status: 409,
-            headers: { "X-Eliza-Failure-Stage": "connector_account" },
-          },
-        );
-      }
-      return Response.json({ ok: true });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        edgeAttempts += 1;
+        const forwarded = new Request(input, init);
+        expect(
+          forwarded.headers.get(TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER),
+        ).toBe("bot:123");
+        expect(await forwarded.text()).toBe(rawPayload);
+        if (edgeAttempts === 1) {
+          return Response.json(
+            { error: "connector account mismatch" },
+            {
+              status: 409,
+              headers: { "X-Eliza-Failure-Stage": "connector_account" },
+            },
+          );
+        }
+        return Response.json({ ok: true });
+      }),
+    ) as unknown as typeof fetch;
 
     const deps = {
       redis,
@@ -200,10 +228,12 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
   });
 
   test("keeps an ambiguous unclassified rejection fenced", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    configureTelegramIdentity({ token: "123:test-token" });
     const redis = new MemoryRedis();
-    globalThis.fetch = mock(async () =>
-      Response.json({ error: "conflict" }, { status: 409 }),
+    globalThis.fetch = mock(
+      withTelegramIdentity(async () =>
+        Response.json({ error: "conflict" }, { status: 409 }),
+      ),
     ) as unknown as typeof fetch;
 
     const response = await handleWebhook(
@@ -225,23 +255,25 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
   });
 
   test("reconciles an old ambiguous Railway send without invoking edge egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    configureTelegramIdentity({ token: "123:test-token" });
     const redis = new MemoryRedis();
     redis.values.set(
       "webhook:telegram:scope:message:edge-forward-1",
       "egress_started",
     );
     let reconciliationBody: Record<string, unknown> = {};
-    globalThis.fetch = mock(async (input, init) => {
-      expect(String(input)).toEndWith(
-        "/api/eliza-app/webhook/telegram/delivery",
-      );
-      reconciliationBody = JSON.parse(String(init?.body)) as Record<
-        string,
-        unknown
-      >;
-      return Response.json({ state: "uncertain" });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        expect(String(input)).toEndWith(
+          "/api/eliza-app/webhook/telegram/delivery",
+        );
+        reconciliationBody = JSON.parse(String(init?.body)) as Record<
+          string,
+          unknown
+        >;
+        return Response.json({ state: "uncertain" });
+      }),
+    ) as unknown as typeof fetch;
 
     const response = await handleWebhook(
       request(),
@@ -264,20 +296,22 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
   });
 
   test("heals a lost gateway receipt without downgrading Worker delivery", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    configureTelegramIdentity({ token: "123:test-token" });
     const redis = new MemoryRedis();
     redis.values.set(
       "webhook:telegram:scope:message:edge-forward-1",
       "egress_started",
     );
     let reconciliationBody: Record<string, unknown> = {};
-    globalThis.fetch = mock(async (_input, init) => {
-      reconciliationBody = JSON.parse(String(init?.body)) as Record<
-        string,
-        unknown
-      >;
-      return Response.json({ state: "delivered" });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (_input, init) => {
+        reconciliationBody = JSON.parse(String(init?.body)) as Record<
+          string,
+          unknown
+        >;
+        return Response.json({ state: "delivered" });
+      }),
+    ) as unknown as typeof fetch;
 
     const response = await handleWebhook(
       request(),
@@ -303,7 +337,12 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
   });
 
   test("keeps a Redis-only old gateway fenced after Worker authority begins", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    configureTelegramIdentity({ token: "123:test-token" });
+    globalThis.fetch = mock(
+      withTelegramIdentity(async () => {
+        throw new Error("edge egress must not run");
+      }),
+    ) as unknown as typeof fetch;
     const redis = new MemoryRedis();
     redis.values.set(
       "webhook:telegram:scope:message:edge-forward-1",

--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-identity-fixture.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-identity-fixture.ts
@@ -1,0 +1,67 @@
+import { __resetTelegramIdentityAttestationCacheForTests } from "@elizaos/cloud-services-common/telegram-connector";
+
+export const TELEGRAM_TEST_TOKEN = "123456789:test-token";
+export const TELEGRAM_TEST_BOT_ID = "123456789";
+export const TELEGRAM_TEST_BOT_USERNAME = "ElizaTestBot";
+export const TELEGRAM_TEST_WEBHOOK_SECRET = "provider-secret";
+export const TELEGRAM_CONNECTOR_ACCOUNT_ID = `bot:${TELEGRAM_TEST_BOT_ID}`;
+
+export function configureTelegramIdentity({
+  token = TELEGRAM_TEST_TOKEN,
+  botId = token.split(":", 1)[0] ?? TELEGRAM_TEST_BOT_ID,
+  botUsername = TELEGRAM_TEST_BOT_USERNAME,
+  webhookSecret = TELEGRAM_TEST_WEBHOOK_SECRET,
+}: {
+  token?: string;
+  botId?: string;
+  botUsername?: string;
+  webhookSecret?: string;
+} = {}): void {
+  process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = token;
+  process.env.ELIZA_APP_TELEGRAM_BOT_ID = botId;
+  process.env.ELIZA_APP_TELEGRAM_BOT_USERNAME = botUsername;
+  process.env.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET = webhookSecret;
+}
+
+export function resetTelegramIdentityAttestation(): void {
+  __resetTelegramIdentityAttestationCacheForTests();
+}
+
+export function isTelegramGetMeRequest(input: RequestInfo | URL): boolean {
+  const url = input instanceof Request ? input.url : String(input);
+  return /\/bot[^/]+\/getMe(?:\?|$)/u.test(url);
+}
+
+export function telegramGetMeResponse(
+  input: RequestInfo | URL,
+  {
+    botId,
+    botUsername = TELEGRAM_TEST_BOT_USERNAME,
+  }: { botId?: number; botUsername?: string } = {},
+): Response {
+  const url = input instanceof Request ? input.url : String(input);
+  const tokenBotId = /^https:\/\/api\.telegram\.org\/bot(\d+):/u.exec(url)?.[1];
+  return Response.json({
+    ok: true,
+    result: {
+      id: botId ?? Number(tokenBotId ?? TELEGRAM_TEST_BOT_ID),
+      is_bot: true,
+      username: botUsername,
+    },
+  });
+}
+
+export function withTelegramIdentity(
+  fallback: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Response | Promise<Response>,
+  providerIdentity: { botId?: number; botUsername?: string } = {},
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (isTelegramGetMeRequest(input)) {
+      return telegramGetMeResponse(input, providerIdentity);
+    }
+    return fallback(input, init);
+  }) as typeof fetch;
+}

--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-identity.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-identity.test.ts
@@ -1,0 +1,165 @@
+/** Proves the Railway ingress gate fails before event, ledger, or egress work. */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { PlatformAdapter } from "../src/adapters/types";
+import type { GatewayRedis } from "../src/redis";
+import { registerTelegramIdentityReadinessRoute } from "../src/telegram-identity";
+import { handleWebhook } from "../src/webhook-handler";
+import {
+  configureTelegramIdentity,
+  resetTelegramIdentityAttestation,
+  telegramGetMeResponse,
+} from "./telegram-identity-fixture";
+
+const originalFetch = globalThis.fetch;
+const envKeys = [
+  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_TELEGRAM_BOT_ID",
+  "ELIZA_APP_TELEGRAM_BOT_USERNAME",
+  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+  "ELIZA_APP_WEBHOOK_PROJECT",
+] as const;
+const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+
+class NoSideEffectRedis implements GatewayRedis {
+  readonly getCall = mock((_key: string) => undefined);
+  readonly setCall = mock((_key: string, _value: string) => undefined);
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    this.getCall(key);
+    return null;
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.setCall(key, value);
+    return "OK";
+  }
+
+  async del(): Promise<unknown> {
+    return 1;
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+function adapter(): PlatformAdapter {
+  return {
+    platform: "telegram",
+    verifyWebhook: mock(async () => true),
+    extractEvent: mock(async () => null),
+    sendTypingIndicator: mock(async () => undefined),
+    sendReply: mock(async () => undefined),
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const key of envKeys) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetTelegramIdentityAttestation();
+  mock.restore();
+});
+
+describe("Railway canonical Telegram identity", () => {
+  test("accepts the exact identity and publishes only a value-free readiness receipt", async () => {
+    configureTelegramIdentity();
+    globalThis.fetch = mock(async (input: RequestInfo | URL) =>
+      telegramGetMeResponse(input, { botUsername: "elizatestbot" }),
+    ) as typeof fetch;
+    const app = new Hono();
+    registerTelegramIdentityReadinessRoute(app);
+
+    const response = await app.request("/ready/telegram-identity/eliza-app");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      project: "eliza-app",
+      status: "attested",
+    });
+  });
+
+  test("treats a blank paired webhook credential as not configured", async () => {
+    configureTelegramIdentity({ webhookSecret: "   " });
+    const provider = mock(async () => {
+      throw new Error("provider must not run");
+    });
+    globalThis.fetch = provider as unknown as typeof fetch;
+    const app = new Hono();
+    registerTelegramIdentityReadinessRoute(app);
+
+    const response = await app.request("/ready/telegram-identity/eliza-app");
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      reason: "not_configured",
+      status: "not-attested",
+    });
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  test("rejects wrong id, wrong username, and provider failure before event or ledger work", async () => {
+    configureTelegramIdentity();
+    const scenarios = [
+      () =>
+        telegramGetMeResponse("https://api.telegram.org", { botId: 987654321 }),
+      () =>
+        telegramGetMeResponse("https://api.telegram.org", {
+          botUsername: "AnotherManagedBot",
+        }),
+      () =>
+        Response.json(
+          { ok: false, description: "private-provider-payload" },
+          { status: 503 },
+        ),
+    ];
+
+    for (const providerResult of scenarios) {
+      resetTelegramIdentityAttestation();
+      globalThis.fetch = mock(async () => providerResult()) as typeof fetch;
+      const redis = new NoSideEffectRedis();
+      const telegramAdapter = adapter();
+
+      const response = await handleWebhook(
+        new Request("https://gateway.example/webhook/eliza-app/telegram", {
+          method: "POST",
+          body: "{}",
+        }),
+        telegramAdapter,
+        {
+          redis,
+          cloudBaseUrl: "https://api.eliza.test",
+          getAuthHeader: () => ({ Authorization: "Bearer fixture" }),
+        },
+        "eliza-app",
+      );
+      const body = await response.text();
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("X-Eliza-Failure-Stage")).toBe(
+        "connector_identity",
+      );
+      expect(body).toContain("telegram-identity-not-ready");
+      expect(body).not.toContain("test-token");
+      expect(body).not.toContain("private-provider-payload");
+      expect(telegramAdapter.extractEvent).not.toHaveBeenCalled();
+      expect(telegramAdapter.sendTypingIndicator).not.toHaveBeenCalled();
+      expect(telegramAdapter.sendReply).not.toHaveBeenCalled();
+      expect(redis.getCall).not.toHaveBeenCalled();
+      expect(redis.setCall).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -10,6 +10,12 @@ import { PlatformDeliveryError } from "../src/adapters/types";
 import { logger } from "../src/logger";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";
+import {
+  configureTelegramIdentity,
+  resetTelegramIdentityAttestation,
+  TELEGRAM_CONNECTOR_ACCOUNT_ID,
+  withTelegramIdentity,
+} from "./telegram-identity-fixture";
 
 type RedisSetOptions = { ex?: number; nx?: boolean };
 
@@ -108,6 +114,9 @@ const envKeys = [
   "ELIZA_APP_TWILIO_AUTH_TOKEN",
   "ELIZA_APP_TWILIO_PHONE_NUMBER",
   "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_TELEGRAM_BOT_ID",
+  "ELIZA_APP_TELEGRAM_BOT_USERNAME",
+  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
   "ELIZA_APP_BLOOIO_PHONE_NUMBER",
 ] as const;
 const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
@@ -151,6 +160,7 @@ describe("gateway webhook handler e2e routing", () => {
         process.env[key] = value;
       }
     }
+    resetTelegramIdentityAttestation();
     mock.restore();
   });
 
@@ -976,7 +986,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("forwards Telegram membership removal without model or provider egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const event: ChatEvent = {
       platform: "telegram",
@@ -999,16 +1009,20 @@ describe("gateway webhook handler e2e routing", () => {
       sendReplyWithReceipt: mock(async () => ({ providerMessageIds: [] })),
     };
     let membershipBody: Record<string, unknown> | null = null;
-    globalThis.fetch = mock(async (input, init) => {
-      const request = new Request(input, init);
-      if (
-        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
-      ) {
-        membershipBody = (await request.json()) as Record<string, unknown>;
-        return Response.json({ success: true, data: { reply: "" } });
-      }
-      throw new Error(`Unexpected fetch: ${request.url}`);
-    }) as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        const request = new Request(input, init);
+        if (
+          request.url.endsWith(
+            "/api/internal/eliza-app/personal-shared/messages",
+          )
+        ) {
+          membershipBody = (await request.json()) as Record<string, unknown>;
+          return Response.json({ success: true, data: { reply: "" } });
+        }
+        throw new Error(`Unexpected fetch: ${request.url}`);
+      }),
+    ) as typeof fetch;
 
     const response = await handleWebhook(
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
@@ -1030,8 +1044,7 @@ describe("gateway webhook handler e2e routing", () => {
       eventType: "membership",
       platform: "telegram",
       project: "eliza-app",
-      connectorAccountId:
-        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
       chatId: "-100123456789",
       messageId: "telegram:eliza-app:membership-update-1",
       membershipChange: "removed",
@@ -1041,7 +1054,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("refuses Telegram egress when another worker atomically claimed delivery", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-1",
@@ -1083,11 +1096,13 @@ describe("gateway webhook handler e2e routing", () => {
     }
     const redis = new EgressContendedRedis();
     globalThis.fetch = mock(
-      async () =>
-        new Response(JSON.stringify({ data: { reply: "agent reply" } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
+      withTelegramIdentity(
+        async () =>
+          new Response(JSON.stringify({ data: { reply: "agent reply" } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
     ) as typeof fetch;
 
     const response = await handleWebhook(
@@ -1112,7 +1127,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("delivers one Telegram fallback after retryable Shared attempts are exhausted", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-retry-before-egress",
@@ -1142,19 +1157,22 @@ describe("gateway webhook handler e2e routing", () => {
       JSON.stringify({ notFound: true }),
     );
     let sharedAttempts = 0;
-    globalThis.fetch = mock(async () => {
-      sharedAttempts += 1;
-      return new Response("private provider detail", {
-        status: 503,
-        headers: {
-          "Retry-After": "0",
-          "X-Eliza-Failure-Stage": "shared_runtime",
-          "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
-          "X-Eliza-Failure-Cause-Name": "SharedRuntimeProviderUnavailableError",
-          "X-Eliza-Retryable": "true",
-        },
-      });
-    }) as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async () => {
+        sharedAttempts += 1;
+        return new Response("private provider detail", {
+          status: 503,
+          headers: {
+            "Retry-After": "0",
+            "X-Eliza-Failure-Stage": "shared_runtime",
+            "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+            "X-Eliza-Failure-Cause-Name":
+              "SharedRuntimeProviderUnavailableError",
+            "X-Eliza-Retryable": "true",
+          },
+        });
+      }),
+    ) as typeof fetch;
     const request = () =>
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
         method: "POST",
@@ -1185,7 +1203,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("delivers one Telegram fallback without replaying a terminal Shared turn", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-terminal-before-egress",
@@ -1216,28 +1234,30 @@ describe("gateway webhook handler e2e routing", () => {
       JSON.stringify({ notFound: true }),
     );
     let sharedAttempts = 0;
-    globalThis.fetch = mock(async () => {
-      sharedAttempts += 1;
-      const body = new ReadableStream({
-        start(controller) {
-          controller.enqueue(
-            new TextEncoder().encode("private action payload"),
-          );
-        },
-        cancel() {
-          throw new Error("private body cleanup detail");
-        },
-      });
-      return new Response(body, {
-        status: 500,
-        headers: {
-          "X-Eliza-Failure-Stage": "shared_runtime",
-          "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
-          "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
-          "X-Eliza-Retryable": "false",
-        },
-      });
-    }) as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async () => {
+        sharedAttempts += 1;
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode("private action payload"),
+            );
+          },
+          cancel() {
+            throw new Error("private body cleanup detail");
+          },
+        });
+        return new Response(body, {
+          status: 500,
+          headers: {
+            "X-Eliza-Failure-Stage": "shared_runtime",
+            "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+            "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
+            "X-Eliza-Retryable": "false",
+          },
+        });
+      }),
+    ) as typeof fetch;
     const request = () =>
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
         method: "POST",
@@ -1261,7 +1281,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("delivers one Telegram fallback when private voice resolution fails", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-voice-resolution-failure",
@@ -1297,7 +1317,7 @@ describe("gateway webhook handler e2e routing", () => {
     const cloudFetch = mock(async () =>
       Response.json({ data: { reply: "must not run" } }),
     );
-    globalThis.fetch = cloudFetch as typeof fetch;
+    globalThis.fetch = mock(withTelegramIdentity(cloudFetch)) as typeof fetch;
 
     expect(
       (
@@ -1341,7 +1361,7 @@ describe("gateway webhook handler e2e routing", () => {
   ])(
     "never injects a fallback into a Telegram %s",
     async (_name, overrides) => {
-      process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+      configureTelegramIdentity();
       const event: ChatEvent = {
         platform: "telegram",
         messageId: `no-fallback-${_name.replaceAll(" ", "-")}`,
@@ -1365,16 +1385,19 @@ describe("gateway webhook handler e2e routing", () => {
       };
       const redis = new MemoryRedis();
       globalThis.fetch = mock(
-        async () =>
-          new Response("private upstream body", {
-            status: 500,
-            headers: {
-              "X-Eliza-Failure-Stage": "shared_runtime",
-              "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
-              "X-Eliza-Failure-Cause-Name": "SharedRuntimeActionContractError",
-              "X-Eliza-Retryable": "false",
-            },
-          }),
+        withTelegramIdentity(
+          async () =>
+            new Response("private upstream body", {
+              status: 500,
+              headers: {
+                "X-Eliza-Failure-Stage": "shared_runtime",
+                "X-Eliza-Failure-Name": "SharedRuntimeTurnError",
+                "X-Eliza-Failure-Cause-Name":
+                  "SharedRuntimeActionContractError",
+                "X-Eliza-Retryable": "false",
+              },
+            }),
+        ),
       ) as typeof fetch;
 
       await expect(
@@ -1398,7 +1421,7 @@ describe("gateway webhook handler e2e routing", () => {
   );
 
   test("never logs raw Shared bodies or malformed classification headers", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-sanitized-diagnostics",
@@ -1421,15 +1444,17 @@ describe("gateway webhook handler e2e routing", () => {
     };
     const warnLog = spyOn(logger, "warn").mockImplementation(() => undefined);
     globalThis.fetch = mock(
-      async () =>
-        new Response("TOP SECRET PROVIDER BODY", {
-          status: 500,
-          headers: {
-            "X-Eliza-Failure-Stage": "TOP_SECRET_STAGE",
-            "X-Eliza-Failure-Name": "PrivateProviderToken",
-            "X-Eliza-Retryable": "false",
-          },
-        }),
+      withTelegramIdentity(
+        async () =>
+          new Response("TOP SECRET PROVIDER BODY", {
+            status: 500,
+            headers: {
+              "X-Eliza-Failure-Stage": "TOP_SECRET_STAGE",
+              "X-Eliza-Failure-Name": "PrivateProviderToken",
+              "X-Eliza-Retryable": "false",
+            },
+          }),
+      ),
     ) as typeof fetch;
 
     expect(
@@ -1456,7 +1481,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("routes an unlinked Telegram DM to rowless personal Shared", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-personal-1",
@@ -1487,32 +1512,34 @@ describe("gateway webhook handler e2e routing", () => {
     );
     let sharedBody: Record<string, unknown> | null = null;
     let sharedTraceId: string | null = null;
-    globalThis.fetch = mock(async (input, init) => {
-      const request = new Request(input, init);
-      const url = request.url;
-      if (url.endsWith("/api/internal/identity/resolve")) {
-        return new Response(JSON.stringify({ error: "not found" }), {
-          status: 404,
-        });
-      }
-      if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
-        sharedTraceId = request.headers.get("x-eliza-trace-id");
-        sharedBody = (await request.json()) as Record<string, unknown>;
-        return new Response(
-          JSON.stringify({
-            data: { reply: "start with the launch checklist" },
-          }),
-          {
-            status: 200,
-            headers: {
-              "content-type": "application/json",
-              "server-timing": "account;dur=5.2, shared;dur=17.8",
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        const request = new Request(input, init);
+        const url = request.url;
+        if (url.endsWith("/api/internal/identity/resolve")) {
+          return new Response(JSON.stringify({ error: "not found" }), {
+            status: 404,
+          });
+        }
+        if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
+          sharedTraceId = request.headers.get("x-eliza-trace-id");
+          sharedBody = (await request.json()) as Record<string, unknown>;
+          return new Response(
+            JSON.stringify({
+              data: { reply: "start with the launch checklist" },
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+                "server-timing": "account;dur=5.2, shared;dur=17.8",
+              },
             },
-          },
-        );
-      }
-      throw new Error(`unexpected request: ${url}`);
-    }) as typeof fetch;
+          );
+        }
+        throw new Error(`unexpected request: ${url}`);
+      }),
+    ) as typeof fetch;
 
     const response = await handleWebhook(
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
@@ -1536,8 +1563,7 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sharedBody).toEqual({
       platform: "telegram",
       project: "eliza-app",
-      connectorAccountId:
-        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
       chatId: "chat-1",
       telegramUserId: "123456789",
       displayName: "Ada",
@@ -1580,7 +1606,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("correlates every retry and preserves prior Cloud timing", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const traceId = "22222222-2222-4222-8222-222222222222";
     const event: ChatEvent = {
       platform: "telegram",
@@ -1611,33 +1637,35 @@ describe("gateway webhook handler e2e routing", () => {
     const warnLog = spyOn(logger, "warn").mockImplementation(() => undefined);
     const forwardedTraceIds: Array<string | null> = [];
     let attempt = 0;
-    globalThis.fetch = mock(async (input, init) => {
-      const request = new Request(input, init);
-      if (
-        !request.url.endsWith(
-          "/api/internal/eliza-app/personal-shared/messages",
-        )
-      ) {
-        throw new Error(`unexpected request: ${request.url}`);
-      }
-      forwardedTraceIds.push(request.headers.get("x-eliza-trace-id"));
-      attempt += 1;
-      if (attempt === 1) {
-        return new Response("cold failure", {
-          status: 503,
-          headers: {
-            "Retry-After": "0",
-            "Server-Timing": "failed_worker;dur=1234",
-            "X-Eliza-Failure-Stage": "shared_runtime",
-            "X-Eliza-Failure-Name": "TypeError",
-          },
-        });
-      }
-      return Response.json(
-        { data: { reply: "retried successfully" } },
-        { headers: { "Server-Timing": "account;dur=4, shared;dur=20" } },
-      );
-    }) as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        const request = new Request(input, init);
+        if (
+          !request.url.endsWith(
+            "/api/internal/eliza-app/personal-shared/messages",
+          )
+        ) {
+          throw new Error(`unexpected request: ${request.url}`);
+        }
+        forwardedTraceIds.push(request.headers.get("x-eliza-trace-id"));
+        attempt += 1;
+        if (attempt === 1) {
+          return new Response("cold failure", {
+            status: 503,
+            headers: {
+              "Retry-After": "0",
+              "Server-Timing": "failed_worker;dur=1234",
+              "X-Eliza-Failure-Stage": "shared_runtime",
+              "X-Eliza-Failure-Name": "TypeError",
+            },
+          });
+        }
+        return Response.json(
+          { data: { reply: "retried successfully" } },
+          { headers: { "Server-Timing": "account;dur=4, shared;dur=20" } },
+        );
+      }),
+    ) as typeof fetch;
 
     const response = await handleWebhook(
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
@@ -1693,7 +1721,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("resolves captionless Telegram voice bytes before the trusted Shared boundary", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const event: ChatEvent = {
       platform: "telegram",
       messageId: "update-voice-1",
@@ -1733,14 +1761,19 @@ describe("gateway webhook handler e2e routing", () => {
     };
     const redis = new MemoryRedis();
     let sharedBody: Record<string, unknown> | null = null;
-    globalThis.fetch = mock(async (input, init) => {
-      const url = String(input);
-      if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
-        sharedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
-        return Response.json({ data: { reply: "I heard you" } });
-      }
-      throw new Error(`unexpected request: ${url}`);
-    }) as typeof fetch;
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        const url = String(input);
+        if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
+          sharedBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return Response.json({ data: { reply: "I heard you" } });
+        }
+        throw new Error(`unexpected request: ${url}`);
+      }),
+    ) as typeof fetch;
 
     const response = await handleWebhook(
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
@@ -1761,8 +1794,7 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sharedBody).toEqual({
       platform: "telegram",
       project: "eliza-app",
-      connectorAccountId:
-        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
       chatId: "chat-1",
       telegramUserId: "123456789",
       displayName: "Ada",

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
@@ -13,6 +13,12 @@ import type { ChatEvent, PlatformAdapter } from "../src/adapters/types";
 import { logger } from "../src/logger";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";
+import {
+  configureTelegramIdentity,
+  resetTelegramIdentityAttestation,
+  TELEGRAM_CONNECTOR_ACCOUNT_ID,
+  withTelegramIdentity,
+} from "./telegram-identity-fixture";
 
 type RedisSetOptions = { ex?: number; nx?: boolean };
 
@@ -61,6 +67,9 @@ class MemoryRedis implements GatewayRedis {
 const originalFetch = globalThis.fetch;
 const envKeys = [
   "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_TELEGRAM_BOT_ID",
+  "ELIZA_APP_TELEGRAM_BOT_USERNAME",
+  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
   "ELIZA_APP_BLOOIO_PHONE_NUMBER",
 ] as const;
 const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
@@ -190,6 +199,7 @@ describe("gateway webhook group egress adversarial paths", () => {
         process.env[key] = value;
       }
     }
+    resetTelegramIdentityAttestation();
     mock.restore();
   });
 
@@ -393,7 +403,7 @@ describe("gateway webhook group egress adversarial paths", () => {
   });
 
   test("runs a Telegram supergroup turn through the delivery ledger, not the edge forward", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    configureTelegramIdentity();
     const redis = new MemoryRedis();
     const event: ChatEvent = {
       platform: "telegram",
@@ -433,40 +443,42 @@ describe("gateway webhook group egress adversarial paths", () => {
       requiresAllAdultsConsent: true,
     };
 
-    globalThis.fetch = mock(async (input, init) => {
-      const request = new Request(input, init);
-      if (request.url.endsWith("/api/eliza-app/webhook/telegram/edge")) {
-        throw new Error(
-          "group turn was rerouted onto the personal edge forward",
-        );
-      }
-      if (request.url.endsWith(SHARED_MESSAGES_PATH)) {
-        const body = (await request.json()) as Record<string, unknown>;
-        if (body.eventType === "delivery_authorization") {
-          authorizationBody = body;
-          return ledger.authorize(body);
+    globalThis.fetch = mock(
+      withTelegramIdentity(async (input, init) => {
+        const request = new Request(input, init);
+        if (request.url.endsWith("/api/eliza-app/webhook/telegram/edge")) {
+          throw new Error(
+            "group turn was rerouted onto the personal edge forward",
+          );
         }
-        if (body.eventType === "delivery_commit") {
-          commitBody = body;
-          return ledger.commit(body);
+        if (request.url.endsWith(SHARED_MESSAGES_PATH)) {
+          const body = (await request.json()) as Record<string, unknown>;
+          if (body.eventType === "delivery_authorization") {
+            authorizationBody = body;
+            return ledger.authorize(body);
+          }
+          if (body.eventType === "delivery_commit") {
+            commitBody = body;
+            return ledger.commit(body);
+          }
+          if (body.eventType === "delivery_receipt") {
+            receiptBody = body;
+            return Response.json({
+              success: true,
+              data: {
+                code: "group_delivery_receipt_recorded",
+                recorded: true,
+                inserted: 1,
+              },
+            });
+          }
+          turnCalls += 1;
+          turnBody = body;
+          return turnResponse("group turn reply", allAdultsAuthority);
         }
-        if (body.eventType === "delivery_receipt") {
-          receiptBody = body;
-          return Response.json({
-            success: true,
-            data: {
-              code: "group_delivery_receipt_recorded",
-              recorded: true,
-              inserted: 1,
-            },
-          });
-        }
-        turnCalls += 1;
-        turnBody = body;
-        return turnResponse("group turn reply", allAdultsAuthority);
-      }
-      throw new Error(`Unexpected fetch: ${request.url}`);
-    }) as typeof fetch;
+        throw new Error(`Unexpected fetch: ${request.url}`);
+      }),
+    ) as typeof fetch;
 
     const deps = {
       redis,
@@ -489,8 +501,7 @@ describe("gateway webhook group egress adversarial paths", () => {
       platform: "telegram",
       chatType: "supergroup",
       project: "eliza-app",
-      connectorAccountId:
-        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
       chatId: "-100123456789",
       providerThreadId: "909",
       actor: {
@@ -510,8 +521,7 @@ describe("gateway webhook group egress adversarial paths", () => {
       eventType: "delivery_receipt",
       platform: "telegram",
       project: "eliza-app",
-      connectorAccountId:
-        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
       chatId: "-100123456789",
       sourceMessageId: "telegram:eliza-app:tg-group-update-1",
       providerMessageIds: ["tg-provider-7"],

--- a/packages/cloud/services/gateway-webhook/railway.toml
+++ b/packages/cloud/services/gateway-webhook/railway.toml
@@ -9,6 +9,10 @@
 #   GATEWAY_INTERNAL_SECRET     Shared secret for internal routes from cloud-api.
 #   AGENT_SERVER_SHARED_SECRET  Shared secret for forwards to agent-server.
 #   ELIZA_APP_WEBHOOK_GATEWAY_SECRET  Shared secret required on BFF forwards.
+#   ELIZA_APP_TELEGRAM_BOT_TOKEN      Exact Telegram egress credential.
+#   ELIZA_APP_TELEGRAM_BOT_ID         Selected protected-environment bot id.
+#   ELIZA_APP_TELEGRAM_BOT_USERNAME   Selected protected-environment username.
+#   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET Telegram inbound signature secret.
 #   REDIS_URL                   Upstash Redis REST URL (or KV_REST_API_URL).
 #   KV_REST_API_TOKEN           Upstash Redis REST token.
 #   AGENT_ROUTER_ORIGIN_HOST    Canonical control-plane router origin hostname.

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -120,6 +120,7 @@ export interface ResolvedVoiceNote {
 export interface WebhookConfig {
   // Telegram
   botToken?: string;
+  botId?: string;
   botUsername?: string;
   webhookSecret?: string;
   // Blooio

--- a/packages/cloud/services/gateway-webhook/src/index.ts
+++ b/packages/cloud/services/gateway-webhook/src/index.ts
@@ -18,6 +18,11 @@ import { initProjectConfig, shutdownProjectConfig } from "./project-config";
 import { createRedis } from "./redis";
 import { requireCanonicalAgentRoutingConfiguration } from "./server-router";
 import {
+  attestCanonicalTelegramProject,
+  registerTelegramIdentityReadinessRoute,
+  telegramIdentityFailureReason,
+} from "./telegram-identity";
+import {
   getSharedWhatsAppVerifyToken,
   resolveWebhookConfig,
 } from "./webhook-config";
@@ -56,11 +61,25 @@ const app = new Hono();
 app.get("/health", (c) =>
   c.json({ status: draining ? "draining" : "healthy", pod: POD_NAME }),
 );
-app.get("/ready", (c) => {
+app.get("/ready", async (c) => {
   if (draining) return c.json({ status: "draining" }, 503);
-  return c.json({ status: "ready" });
+  try {
+    await attestCanonicalTelegramProject();
+    return c.json({ status: "ready" });
+  } catch (error) {
+    return c.json(
+      {
+        status: "not-ready",
+        component: "telegram-identity",
+        reason: telegramIdentityFailureReason(error),
+      },
+      503,
+      { "Retry-After": "5" },
+    );
+  }
 });
 registerForwarderAuthReadinessRoute(app);
+registerTelegramIdentityReadinessRoute(app);
 app.post("/drain", (c) => {
   // Gated on the internal secret like /internal/deliver: this service is the
   // public webhook ingress, so an unauthenticated drain would let anyone who
@@ -193,6 +212,7 @@ async function start() {
   logger.info("Starting webhook gateway", { pod: POD_NAME, port: PORT });
 
   await initProjectConfig();
+  await attestCanonicalTelegramProject();
   await initAuth({
     cloudUrl: ELIZA_CLOUD_URL,
     bootstrapSecret: GATEWAY_BOOTSTRAP_SECRET,

--- a/packages/cloud/services/gateway-webhook/src/index.ts
+++ b/packages/cloud/services/gateway-webhook/src/index.ts
@@ -67,6 +67,8 @@ app.get("/ready", async (c) => {
     await attestCanonicalTelegramProject();
     return c.json({ status: "ready" });
   } catch (error) {
+    // error-policy:J1 the probe boundary exposes only the bounded identity
+    // reason while retaining a fail-closed readiness state.
     return c.json(
       {
         status: "not-ready",

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -6,6 +6,11 @@ import type { ChatEvent } from "./adapters/types";
 import { resolveConnectorAccountId } from "./connector-account";
 import { logger } from "./logger";
 import type { GatewayRedis } from "./redis";
+import {
+  isCanonicalTelegramProject,
+  requireCanonicalTelegramIdentity,
+  telegramIdentityNotReadyResponse,
+} from "./telegram-identity";
 import { resolveSharedWebhookConfig } from "./webhook-config";
 
 interface InternalDeliveryDependencies {
@@ -182,6 +187,16 @@ export async function deliverInternalMessage(
     delivery.platform,
     delivery.project,
   );
+  if (
+    delivery.platform === "telegram" &&
+    isCanonicalTelegramProject(delivery.project)
+  ) {
+    try {
+      await requireCanonicalTelegramIdentity(config);
+    } catch (error) {
+      return telegramIdentityNotReadyResponse(error);
+    }
+  }
   const configuredConnectorAccountId = resolveConnectorAccountId(
     delivery.platform,
     config,

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -194,6 +194,8 @@ export async function deliverInternalMessage(
     try {
       await requireCanonicalTelegramIdentity(config);
     } catch (error) {
+      // error-policy:J1 the authenticated delivery boundary returns a
+      // value-safe failure before connector-account or provider work.
       return telegramIdentityNotReadyResponse(error);
     }
   }

--- a/packages/cloud/services/gateway-webhook/src/telegram-identity.ts
+++ b/packages/cloud/services/gateway-webhook/src/telegram-identity.ts
@@ -1,0 +1,96 @@
+/** Owns value-safe canonical Telegram identity gates for the Railway gateway. */
+
+import {
+  attestTelegramBotIdentity,
+  TelegramIdentityAttestationError,
+  type TelegramIdentityAttestationFailureReason,
+} from "@elizaos/cloud-services-common/telegram-connector";
+import type { Hono } from "hono";
+import type { WebhookConfig } from "./adapters/types";
+import { resolveSharedWebhookConfig } from "./webhook-config";
+
+const JSON_HEADERS = {
+  "cache-control": "no-store",
+  "content-type": "application/json",
+} as const;
+
+export function canonicalTelegramProject(): string {
+  return (
+    (process.env.ELIZA_APP_WEBHOOK_PROJECT ?? "eliza-app").trim() || "eliza-app"
+  );
+}
+
+export function isCanonicalTelegramProject(
+  project: string,
+  agentId?: string,
+): boolean {
+  return !agentId && project === canonicalTelegramProject();
+}
+
+export function telegramIdentityFailureReason(
+  error: unknown,
+): TelegramIdentityAttestationFailureReason {
+  return error instanceof TelegramIdentityAttestationError
+    ? error.reason
+    : "provider_unavailable";
+}
+
+export async function requireCanonicalTelegramIdentity(
+  config: WebhookConfig,
+): Promise<void> {
+  if (!config.webhookSecret?.trim()) {
+    throw new TelegramIdentityAttestationError("not_configured", false);
+  }
+  await attestTelegramBotIdentity(config);
+}
+
+export function telegramIdentityNotReadyResponse(error: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      error: "telegram-identity-not-ready",
+      reason: telegramIdentityFailureReason(error),
+      status: "not-attested",
+    }),
+    {
+      status: 503,
+      headers: {
+        ...JSON_HEADERS,
+        "retry-after": "5",
+        "x-eliza-failure-name": "TelegramIdentityAttestationError",
+        "x-eliza-failure-stage": "connector_identity",
+      },
+    },
+  );
+}
+
+export async function attestCanonicalTelegramProject(): Promise<void> {
+  const project = canonicalTelegramProject();
+  await requireCanonicalTelegramIdentity(
+    resolveSharedWebhookConfig("telegram", project),
+  );
+}
+
+/** Registers a public value-free readiness proof for protected deployments. */
+export function registerTelegramIdentityReadinessRoute(app: Hono): void {
+  app.get("/ready/telegram-identity/:project", async (context) => {
+    const project = context.req.param("project");
+    if (project !== canonicalTelegramProject()) {
+      return new Response(
+        JSON.stringify({
+          error: "telegram-identity-project-mismatch",
+          status: "not-attested",
+        }),
+        { status: 409, headers: JSON_HEADERS },
+      );
+    }
+    try {
+      await attestCanonicalTelegramProject();
+      return new Response(JSON.stringify({ project, status: "attested" }), {
+        status: 200,
+        headers: JSON_HEADERS,
+      });
+    } catch (error) {
+      return telegramIdentityNotReadyResponse(error);
+    }
+  });
+}

--- a/packages/cloud/services/gateway-webhook/src/telegram-identity.ts
+++ b/packages/cloud/services/gateway-webhook/src/telegram-identity.ts
@@ -90,6 +90,8 @@ export function registerTelegramIdentityReadinessRoute(app: Hono): void {
         headers: JSON_HEADERS,
       });
     } catch (error) {
+      // error-policy:J1 the public readiness boundary exposes only the bounded
+      // attestation classification.
       return telegramIdentityNotReadyResponse(error);
     }
   });

--- a/packages/cloud/services/gateway-webhook/src/webhook-config.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-config.ts
@@ -25,9 +25,13 @@ export function resolveSharedWebhookConfig(
 
   switch (platform) {
     case "telegram":
-      base.botToken = getProjectEnv(project, "TELEGRAM_BOT_TOKEN");
-      base.botUsername = getProjectEnv(project, "TELEGRAM_BOT_USERNAME");
-      base.webhookSecret = getProjectEnv(project, "TELEGRAM_WEBHOOK_SECRET");
+      base.botToken = getProjectEnv(project, "TELEGRAM_BOT_TOKEN").trim();
+      base.botId = getProjectEnv(project, "TELEGRAM_BOT_ID").trim();
+      base.botUsername = getProjectEnv(project, "TELEGRAM_BOT_USERNAME").trim();
+      base.webhookSecret = getProjectEnv(
+        project,
+        "TELEGRAM_WEBHOOK_SECRET",
+      ).trim();
       break;
     case "blooio":
       base.apiKey = getProjectEnv(project, "BLOOIO_API_KEY");

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -39,6 +39,11 @@ import {
   resolveAgentServer,
   resolveIdentity,
 } from "./server-router";
+import {
+  isCanonicalTelegramProject,
+  requireCanonicalTelegramIdentity,
+  telegramIdentityNotReadyResponse,
+} from "./telegram-identity";
 import { resolveWebhookConfig } from "./webhook-config";
 
 const PERSONAL_SHARED_DELIVERY_LEASE_MS = 90_000;
@@ -553,6 +558,17 @@ export async function handleWebhook(
       status: 401,
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  if (
+    adapter.platform === "telegram" &&
+    isCanonicalTelegramProject(project, agentId)
+  ) {
+    try {
+      await requireCanonicalTelegramIdentity(config);
+    } catch (error) {
+      return telegramIdentityNotReadyResponse(error);
+    }
   }
 
   const event = await adapter.extractEvent(rawBody, config);

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -567,6 +567,8 @@ export async function handleWebhook(
     try {
       await requireCanonicalTelegramIdentity(config);
     } catch (error) {
+      // error-policy:J1 the authenticated provider boundary returns a
+      // value-safe failure before parsing, deduplication, or provider work.
       return telegramIdentityNotReadyResponse(error);
     }
   }

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -530,6 +530,10 @@ export interface Bindings {
   /** Collision-free secret used by the protected production edge cutover; inert outside production. */
   PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
   ELIZA_APP_TELEGRAM_BOT_TOKEN?: string;
+  /** Public bot id selected by the protected environment and attested through getMe. */
+  ELIZA_APP_TELEGRAM_BOT_ID?: string;
+  /** Public bot username selected by the protected environment and attested through getMe. */
+  ELIZA_APP_TELEGRAM_BOT_USERNAME?: string;
   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET?: string;
   // Dedicated shared secret stamped onto forwarded webhook calls so the internal
   // gateway can reject traffic that didn't transit the BFF forwarder (finding


### PR DESCRIPTION
## Summary

- enforce one canonical Telegram bot identity across the Cloudflare Worker and Railway gateway
- attest each runtime token against its expected bot ID and username before inbound handling, typing, turn work, delivery-ledger mutation, replies, or reminders
- use the homepage identity as the production authority and a protected, fully distinct staging identity
- require live, value-free identity readiness before deployment receipts and Personal Shared edge activation
- cache only successful credential-qualified attestations; all mismatch, malformed, and provider-failure paths remain fail closed

## Safety

- bot ID comparison is exact; username comparison is case-insensitive and otherwise exact
- token-prefix, provider ID, or username mismatch fails before state mutation or egress
- typed identity errors use a stable actionable code and bounded reason/retryability context; credentials, provider payloads, token-bearing URLs, and nested causes are not exposed
- workflow preflights require protected Worker/Railway credentials and current-run identity authority
- readiness responses expose only project and attested status
- the merged #29766 typed fallback boundary and truthful retry-attempt receipts are preserved

## Current-base validation

Final exact head: `2229f445b68a0e13849e8263151d55f64749026e`
Base: `fcb35af23e294039ef97ad91e29b4e48d59dfff8`

- API Telegram edge: 35 passed
- common identity and deployment workflow contracts: 13 passed
- gateway identity, forwarding, e2e, group, internal-delivery, and Docker workspace contracts: 90 passed
- common, Shared, API, and gateway typechecks passed
- API production Wrangler dry-run and gateway build passed
- Biome, actionlint, guide parity, and diff checks passed
- independent exact-head review: APPROVED, no P0-P2 findings
- clean linear two-commit replay onto current `develop`; no merge commits or conflict markers

Closes #29763

Merged as `83227ab22596977427120b23c47ef3839997b11c`. No deployment or live provider receipt is claimed by this PR.