### PR TITLE
fix(ui): preserve flat trajectory atom ownership

### DIFF
--- a/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.tsx
@@ -7,6 +7,8 @@ import { CheckCircle, Circle, Clock3, XCircle } from "lucide-react";
 import type * as React from "react";
 
 import { Badge } from "../../ui/badge";
+import { Card } from "../../ui/card";
+import { Separator } from "../../ui/separator";
 export type TrajectoryTimelineStatus =
   | "queued"
   | "running"
@@ -59,49 +61,61 @@ export function TrajectoryEventTimeline({
         {heading}
       </div>
       {events.length === 0 ? (
-        <div className="border-y border-dashed border-[color:var(--settings-hairline)] py-6 text-center text-sm text-[color:var(--settings-muted)]">
-          {emptyLabel}
+        <div>
+          <Separator tone="subtle40" />
+          <div className="py-6 text-center text-sm text-[color:var(--settings-muted)]">
+            {emptyLabel}
+          </div>
+          <Separator tone="subtle40" />
         </div>
       ) : (
-        <ol className="divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)]">
-          {events.map((event) => (
-            <li
-              key={event.id}
-              className="grid min-h-14 grid-cols-[1.25rem_minmax(0,1fr)] gap-3 py-3"
-            >
-              <div className="mt-0.5 flex justify-center">
-                {statusIcon(event.status)}
-              </div>
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                  <span className="truncate text-sm font-medium text-[color:var(--settings-foreground)]">
-                    {event.label}
-                  </span>
-                  {event.stage ? (
-                    <Badge asChild variant="trajectoryStage" size="compact">
-                      <span>{event.stage}</span>
-                    </Badge>
-                  ) : null}
-                  {event.timestampLabel ? (
-                    <span className="ml-auto text-xs text-[color:var(--settings-muted)]">
-                      {event.timestampLabel}
-                    </span>
-                  ) : null}
-                </div>
-                {event.description ? (
-                  <div className="mt-1 line-clamp-2 text-xs leading-5 text-[color:var(--settings-muted)]">
-                    {event.description}
+        <div>
+          <Separator tone="subtle40" />
+          <ol>
+            {events.map((event) => (
+              <Card
+                asChild
+                key={event.id}
+                variant="configRow"
+                className="grid min-h-14 grid-cols-[1.25rem_minmax(0,1fr)] gap-3 py-3"
+              >
+                <li>
+                  <div className="mt-0.5 flex justify-center">
+                    {statusIcon(event.status)}
                   </div>
-                ) : null}
-                {event.meta ? (
-                  <div className="mt-1 text-xs text-[color:var(--settings-muted)]">
-                    {event.meta}
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <span className="truncate text-sm font-medium text-[color:var(--settings-foreground)]">
+                        {event.label}
+                      </span>
+                      {event.stage ? (
+                        <Badge asChild variant="trajectoryStage" size="compact">
+                          <span>{event.stage}</span>
+                        </Badge>
+                      ) : null}
+                      {event.timestampLabel ? (
+                        <span className="ml-auto text-xs text-[color:var(--settings-muted)]">
+                          {event.timestampLabel}
+                        </span>
+                      ) : null}
+                    </div>
+                    {event.description ? (
+                      <div className="mt-1 line-clamp-2 text-xs leading-5 text-[color:var(--settings-muted)]">
+                        {event.description}
+                      </div>
+                    ) : null}
+                    {event.meta ? (
+                      <div className="mt-1 text-xs text-[color:var(--settings-muted)]">
+                        {event.meta}
+                      </div>
+                    ) : null}
                   </div>
-                ) : null}
-              </div>
-            </li>
-          ))}
-        </ol>
+                </li>
+              </Card>
+            ))}
+          </ol>
+          <Separator tone="subtle40" />
+        </div>
       )}
     </section>
   );

--- a/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx
@@ -8,6 +8,8 @@ import * as React from "react";
 
 import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
+import { Card } from "../../ui/card";
+import { Separator } from "../../ui/separator";
 import { TrajectoryCodeBlock } from "./trajectory-code-block";
 
 interface CallMetricProps {
@@ -18,7 +20,7 @@ interface CallMetricProps {
 
 function CallMetric({ label, value, meta }: CallMetricProps) {
   return (
-    <div className="px-3 py-3 first:pl-0 last:pr-0">
+    <Card variant="bottomDivider" className="px-3 py-3">
       <div className="text-xs text-[color:var(--settings-muted)]">{label}</div>
       <div className="mt-1 truncate text-sm font-semibold text-[color:var(--settings-foreground)]">
         {value}
@@ -28,7 +30,7 @@ function CallMetric({ label, value, meta }: CallMetricProps) {
           {meta}
         </div>
       ) : null}
-    </div>
+    </Card>
   );
 }
 
@@ -97,8 +99,9 @@ export function TrajectoryLlmCallCard({
   const purposeValue = tags?.length ? tags.join(", ") : "Inference";
 
   return (
-    <section className="border-t border-[color:var(--settings-hairline)] pt-5">
-      <div className="flex flex-col gap-4">
+    <section>
+      <Separator tone="subtle40" />
+      <div className="flex flex-col gap-4 pt-5">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-1.5">
             <div className="text-xs font-medium text-[color:var(--settings-muted)]">
@@ -141,32 +144,35 @@ export function TrajectoryLlmCallCard({
           ) : null}
         </div>
 
-        <div className="grid divide-y divide-[color:var(--settings-hairline)] border-y border-[color:var(--settings-hairline)] md:grid-cols-2 md:divide-x md:divide-y-0 xl:grid-cols-5">
-          <CallMetric
-            label={purposeLabel}
-            value={purposeValue}
-            meta={callLabel}
-          />
-          <CallMetric
-            label={latencyLabel}
-            value={latencyValue}
-            meta={outputLinesLabel}
-          />
-          <CallMetric
-            label={tokensLabel}
-            value={totalTokensValue}
-            meta={tokenBreakdownMeta}
-          />
-          <CallMetric
-            label={maxLabel}
-            value={maxValue}
-            meta={inputLinesLabel}
-          />
-          <CallMetric
-            label={temperatureLabel}
-            value={temperatureValue}
-            meta={systemPrompt ? systemLinesLabel : systemExpandLabel}
-          />
+        <div>
+          <Separator tone="subtle40" />
+          <div className="grid md:grid-cols-2 xl:grid-cols-5">
+            <CallMetric
+              label={purposeLabel}
+              value={purposeValue}
+              meta={callLabel}
+            />
+            <CallMetric
+              label={latencyLabel}
+              value={latencyValue}
+              meta={outputLinesLabel}
+            />
+            <CallMetric
+              label={tokensLabel}
+              value={totalTokensValue}
+              meta={tokenBreakdownMeta}
+            />
+            <CallMetric
+              label={maxLabel}
+              value={maxValue}
+              meta={inputLinesLabel}
+            />
+            <CallMetric
+              label={temperatureLabel}
+              value={temperatureValue}
+              meta={systemPrompt ? systemLinesLabel : systemExpandLabel}
+            />
+          </div>
         </div>
 
         {systemPrompt && showSystem ? (


### PR DESCRIPTION
Fixes #29742
Alternative to #29762.

## Summary

- Keeps the flattened Trajectories hierarchy introduced in #29737.
- Moves timeline row borders from raw molecule hosts to the existing transparent `Card` divider variant.
- Moves group boundaries to the canonical `Separator` atom.
- Keeps model-call metrics on the ambient canvas with quiet dividers instead of restoring nested `PagePanel` and filled inset cards.
- Removes all four `composition/raw-capability-owner` findings without adding design-system debt or a one-off atom variant.

## Why not #29762

#29762 makes the gate green by restoring the two affected files to their pre-flattening versions. That reintroduces padded panels, filled event cards, and tile-like metric composition while the parent page remains flattened. This patch fixes ownership without undoing the reviewed visual hierarchy.

## Validation

- `bun run verify` — passed (375 Turbo tasks and all repository audits).
- `bun run --cwd packages/ui lint:check` — passed.
- `node --import tsx --test packages/ui/scripts/design-contract-graph.test.ts` — 15/15 passed.
- `node --import tsx packages/ui/scripts/check-design-contract-graph.ts --require-tight-debt` — 0 findings, 0 debt.
- Focused populated Trajectories browser interaction — passed.
- Desktop and mobile rendered detail states inspected at the exact commit.

## Visual evidence

The “Before” column is the accepted flat state from merged #29737. The “After” column is this atomic-ownership repair. The ordinary sections remain transparent; only quiet divider ownership changes.

| View | Before: accepted flat hierarchy | After: flat hierarchy with canonical ownership |
| --- | --- | --- |
| Desktop populated detail | ![Accepted flat desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-populated-landscape-detail-after.png) | ![Canonical ownership desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/desktop-flat-atomic-final.png) |
| Mobile populated detail | ![Accepted flat mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29736-trajectories-mobile-portrait-after.png) | ![Canonical ownership mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/mobile-flat-atomic-final.png) |

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Desktop/mobile screenshots | Inline above |
| Walkthrough video | N/A — no interaction behavior changed; populated detail states and the real interaction test cover the affected components |
| Backend logs | N/A — no backend path changed |
| Frontend diagnostics | No page errors during focused browser run |
| LLM trajectory | N/A — no agent behavior changed |
