### PR TITLE
fix(cloud): widen eliza1 dashboard token sums past int4

### DIFF
--- a/packages/cloud/scripts/eliza1/dashboard-alerts.ts
+++ b/packages/cloud/scripts/eliza1/dashboard-alerts.ts
@@ -124,8 +124,8 @@ async function loadDashboardInputs(
             date_trunc('day', created_at) AS timestamp,
             count(*)::int AS total_requests,
             coalesce(sum(input_cost + output_cost), 0)::numeric AS total_cost,
-            coalesce(sum(input_tokens), 0)::int AS input_tokens,
-            coalesce(sum(output_tokens), 0)::int AS output_tokens,
+            coalesce(sum(input_tokens), 0)::bigint AS input_tokens,
+            coalesce(sum(output_tokens), 0)::bigint AS output_tokens,
             coalesce(
               count(*) FILTER (WHERE is_successful = true)::float /
               nullif(count(*)::float, 0),


### PR DESCRIPTION
# Relates to

Closes #29770 — eliza1 dashboard-alerts token sums overflow `int4` and hard-fail the release-gate evidence path. Same defect class as #29059, which covers the `usage-records` repository but not this script.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from current `origin/develop`; zero conflicts. Exact head `f86bcaa073730a6e43dc2a7ce6bf2a6592b05947`.

# Risks

Minimal. Two SQL casts in one script. `count(*)` (a per-day row count) stays `::int`; `total_cost` stays `::numeric`; only the two token sums widen. The consuming code path is unchanged because it already tolerates the widened type (below).

# Background

## What does this PR do?

`dashboard-alerts.ts` aggregates `usage_records` per day for one organization and casts the token sums to `int4`:

```sql
coalesce(sum(input_tokens), 0)::int  AS input_tokens,
coalesce(sum(output_tokens), 0)::int AS output_tokens,
```

Postgres raises `integer out of range` (SQLSTATE 22003) on an out-of-range cast rather than wrapping. The first day bucket whose token sum crosses 2,147,483,647 therefore makes the query throw, the script exit non-zero, and the `reports/eliza1-release-gates` evidence and projection alerts (`generateProjections` / `generateProjectionAlerts`) disappear — precisely for the heaviest-usage organizations, which are the ones the alerts most need to cover.

#29059 established that these sums reach that scale in production when it widened **all eleven** token aggregates in `packages/cloud/shared/src/db/repositories/usage-records.ts` with a real-PGlite proof at 3e9. This script reads the same table and columns and was outside that PR's diff (verified: it touches only the repository and its test).

**No downstream change is needed.** `pg` returns `bigint` as a string; the script's row type already declares `input_tokens: number | string` and the mapper already wraps with `Number(row.input_tokens)` (dashboard-alerts.ts:154-155). `Number("3000000000")` → `3000000000`, finite and a safe integer.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

The two-line diff, then the cast semantics:

```sql
SELECT 3000000000::bigint::int;  -- ERROR: integer out of range (22003)
SELECT 3000000000::bigint;       -- fine
```

## Detailed testing steps

1. Check out exact head `f86bcaa073730a6e43dc2a7ce6bf2a6592b05947`.
2. Confirm the two casts: `git grep -n '::bigint' packages/cloud/scripts/eliza1/dashboard-alerts.ts` → lines 127-128, and that no `sum(input_tokens|output_tokens)…::int` remains anywhere under `packages/cloud`.
3. Mapper tolerance: `node -e "console.log(Number('3000000000'), Number.isFinite(Number('3000000000')), Number.isSafeInteger(3000000000))"` → `3000000000 true true` — the existing `Number(...)` path handles pg's bigint-as-string with no code change.
4. Pinned Biome on the file: exit 0, captured directly.

<!-- evidence-head:f86bcaa073730a6e43dc2a7ce6bf2a6592b05947 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — a CLI evidence script with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — a CLI evidence script with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the cast semantics below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Cast semantics and mapper tolerance</summary>

```
-- Postgres, any version: int4 casts throw rather than wrap
SELECT 3000000000::bigint::int;
ERROR:  integer out of range          -- SQLSTATE 22003
SELECT 3000000000::bigint;
   int8
------------
 3000000000

# the script's existing mapper already handles bigint-as-string
$ node -e "console.log(Number('3000000000'), Number.isFinite(Number('3000000000')), Number.isSafeInteger(3000000000))"
3000000000 true true

# post-fix state of the query block (dashboard-alerts.ts)
127:            coalesce(sum(input_tokens), 0)::bigint AS input_tokens,
128:            coalesce(sum(output_tokens), 0)::bigint AS output_tokens,
125:            count(*)::int AS total_requests,        # per-day row count, unchanged by design
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic SQL cast behavior, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates and completeness sweep at exact head</summary>

```
$ node_modules/.bin/biome check packages/cloud/scripts/eliza1/dashboard-alerts.ts
(exit 0, captured directly)

$ git diff --stat origin/develop..HEAD
 packages/cloud/scripts/eliza1/dashboard-alerts.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Sweep: with this change and #29059 together, no sum over usage_records
token columns anywhere under packages/cloud carries an ::int cast; the
remaining ::int aggregates in the tree are count(*) row counts and the
single per-day per-credential calls sum flagged as follow-up in the
#29059 review.
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- The script has no test harness of its own and its query needs a live Postgres with `usage_records`; the proof here is the documented cast semantics plus the mapper-tolerance check rather than an executed end-to-end run. #29059's PGlite suite is where the production-scale behavior of these exact sums is exercised.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
