### PR TITLE
fix(local-inference): skip terminal jobs with non-string updatedAt before sorting

### DIFF
--- a/packages/ui/src/services/local-inference/downloader.ts
+++ b/packages/ui/src/services/local-inference/downloader.ts
@@ -444,6 +444,7 @@ export class Downloader {
         if (
           job &&
           typeof job.modelId === "string" &&
+          typeof job.updatedAt === "string" &&
           (job.state === "completed" ||
             job.state === "failed" ||
             job.state === "cancelled")

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -441,6 +441,49 @@ describe("local inference downloader status", () => {
 		expect(job?.error).toBe("network reset");
 	});
 
+	it("skips terminal jobs whose updatedAt is not a string so snapshot sorting cannot crash", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const statusDir = path.join(root, "local-inference");
+		fs.mkdirSync(statusDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(statusDir, "download-status.json"),
+			JSON.stringify({
+				version: 1,
+				jobs: [
+					{
+						jobId: "job-1",
+						modelId: "eliza-1-2b",
+						state: "failed",
+						received: 64,
+						total: 128,
+						bytesPerSec: 0,
+						etaMs: null,
+						startedAt: "2026-05-08T00:00:00.000Z",
+						// updatedAt deliberately missing (legacy/corrupt record)
+						error: "network reset",
+					},
+					{
+						jobId: "job-2",
+						modelId: "eliza-1-2b-vision",
+						state: "completed",
+						received: 64,
+						total: 128,
+						bytesPerSec: 0,
+						etaMs: null,
+						startedAt: "2026-05-08T00:00:00.000Z",
+						updatedAt: 12345, // non-string (corrupt record)
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		const jobs = new Downloader().snapshot();
+
+		expect(jobs).toHaveLength(0);
+	});
+
 	it("installs Eliza-1 manifest bundles with embedded-draft-head MTP metadata", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
 		process.env.ELIZA_STATE_DIR = root;

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -731,6 +731,7 @@ export class Downloader {
 				if (
 					job &&
 					typeof job.modelId === "string" &&
+					typeof job.updatedAt === "string" &&
 					(job.state === "completed" ||
 						job.state === "failed" ||
 						job.state === "cancelled")


### PR DESCRIPTION
## Problem

`loadTerminalDownloads()` loads persisted terminal-download records from `download-status.json` guarded only on `modelId` being a string and the state being terminal. A legacy or corrupt record whose `updatedAt` is missing or non-string passes the filter and poisons the in-memory terminal map. The next `snapshot()` (UI status query) or `rememberTerminalDownload()` (post-download bookkeeping) sort calls `right.updatedAt.localeCompare(...)` on that value and crashes with:

```
TypeError: Cannot read properties of undefined (reading 'localeCompare')
```

The sort in `rememberTerminalDownload` sits outside the J7 try/catch, so the crash propagates into the download-completion path. Same defect exists in both the plugin and the UI copy of the downloader.

## Reproduction

Write a `download-status.json` (under the `local-inference` state dir) containing a terminal job with `updatedAt` missing (or numeric), then construct `Downloader` and call `snapshot()`:

```json
{ "version": 1, "jobs": [ { "jobId": "j1", "modelId": "eliza-1-2b", "state": "failed", "error": "x" } ] }
```

→ `TypeError: Cannot read properties of undefined (reading 'localeCompare')` on old code.

## Change

Guard the load filter the same way `modelId` is already guarded — require `typeof job.updatedAt === "string"` — in both:

- `plugins/plugin-local-inference/src/services/downloader.ts`
- `packages/ui/src/services/local-inference/downloader.ts`

Malformed records are skipped at load; the terminal map only ever holds sortable jobs.

## Testing

New regression test in `plugins/plugin-local-inference/src/services/downloader.test.ts` feeds a status file with a missing-`updatedAt` job and a numeric-`updatedAt` job and asserts the snapshot is empty (both skipped, no crash).

- Without the fix: `1 failed — TypeError: Cannot read properties of undefined (reading 'localeCompare')` (verified RED by reverting the guard)
- With the fix: `29 passed (29)` — full `downloader.test.ts` suite green
- `bunx biome check` on all 3 changed files: clean

<!-- evidence-row:backend-logs -->
- [x] backend-logs: N/A — unit-level behavior fix; local vitest output is the verification (29 passed / RED-before-GREEN-after recorded above)

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
