### PR TITLE
feat(app): simplify LifeOps route family

### DIFF
--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -290,7 +290,7 @@ describe("computeVerdict (#8796 verdict precedence)", () => {
       computeVerdict(
         finding({
           slug: "plugin-focus-gui",
-          readableChars: "Idle".length,
+          readableChars: "No focus session active".length,
           semanticReady: true,
         }),
       ),
@@ -304,7 +304,7 @@ describe("computeVerdict (#8796 verdict precedence)", () => {
     expect(
       computeVerdict(
         finding({
-          readableChars: "Idle".length,
+          readableChars: "No focus session active".length,
           semanticReady: true,
           qualityIssues: ["blank pixels"],
         }),

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -1854,12 +1854,12 @@ test.describe("all-views aesthetic audit (#8796)", () => {
     ).resolves.toMatchObject({ semanticReady: false });
 
     await viewRoot.evaluate((root) => {
-      root.textContent = "Idle";
+      root.textContent = "No focus session active";
     });
     await expect(
       readViewPaint(viewRoot, overlay, focusPolicy.expectation),
     ).resolves.toEqual({
-      readableChars: "Idle".length,
+      readableChars: "No focus session active".length,
       semanticReady: true,
       overlayPresent: true,
       loadingStateLabels: [],

--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -171,11 +171,11 @@ test("finances decomposed view: renders the financial summary", async ({
 
 test("focus decomposed view: renders the focus scaffold", async ({ page }) => {
   // The website-blocker mock reports enabled:false, so FocusView resolves to
-  // its idle branch (not loading, not error, not "Focus unavailable").
+  // its inactive branch (not loading, not error, not "Focus unavailable").
   await openAppPath(page, "/focus");
-  await expect(page.getByText("Idle", { exact: true }).first()).toBeVisible({
-    timeout: 60_000,
-  });
+  await expect(
+    page.getByText("No focus session active", { exact: true }).first(),
+  ).toBeVisible({ timeout: 60_000 });
 });
 
 test("goals decomposed view: renders the goals scaffold", async ({ page }) => {

--- a/packages/app/test/ui-smoke/lifeops-focus-request.spec.ts
+++ b/packages/app/test/ui-smoke/lifeops-focus-request.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Exercises the Focus request and retry through the production renderer and
+ * HTTP client, with deterministic upstream responses and recorded UI evidence.
+ */
+import { writeFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import {
+  installDefaultAppRoutes,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+import { saveBrowserVideoArtifact } from "./helpers/video-artifacts";
+
+for (const viewport of [
+  { name: "desktop", width: 1280, height: 800 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`Focus request exposes failure and permits retry on ${viewport.name}`, async ({
+    page,
+  }, testInfo) => {
+    const logs: string[] = [];
+    page.on("console", (message) =>
+      logs.push(`[console:${message.type()}] ${message.text()}`),
+    );
+    page.on("pageerror", (error) => logs.push(`[pageerror] ${error.message}`));
+    page.on("response", (response) =>
+      logs.push(`[response] ${response.status()} ${response.url()}`),
+    );
+    await page.setViewportSize(viewport);
+    await seedAppStorage(page);
+    await installDefaultAppRoutes(page);
+    await page.route("**/api/conversations", async (route) => {
+      if (route.request().method() !== "POST") return route.fallback();
+      await route.fulfill({
+        json: {
+          conversation: {
+            id: "focus-request",
+            title: "Focus",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      });
+    });
+    let shouldFail = true;
+    let requests = 0;
+    await page.route(
+      "**/api/conversations/focus-request/messages",
+      async (route) => {
+        if (route.request().method() !== "POST") return route.fallback();
+        requests += 1;
+        expect(route.request().postDataJSON()).toMatchObject({
+          text: "Start a focus session for me.",
+        });
+        await route.fulfill(
+          shouldFail
+            ? {
+                status: 503,
+                json: { error: "Focus assistant temporarily unavailable" },
+              }
+            : {
+                json: {
+                  text: "Which websites should I block?",
+                  agentName: "Eliza",
+                },
+              },
+        );
+      },
+    );
+    await openAppPath(page, "/focus");
+    const start = page.getByRole("button", {
+      name: "Start focus",
+      exact: true,
+    });
+    await expect(start).toBeVisible({ timeout: 60_000 });
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-focus-rest.jpg`),
+      fullPage: true,
+    });
+    await start.hover();
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-focus-hover.jpg`),
+      fullPage: true,
+    });
+    await start.click();
+    await expect(
+      page.getByText("Focus assistant temporarily unavailable", {
+        exact: false,
+      }),
+    ).toBeVisible();
+    await expect(start).toBeEnabled();
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-focus-error.jpg`),
+      fullPage: true,
+    });
+    shouldFail = false;
+    await start.click();
+    await expect(
+      page.getByText("Which websites should I block?", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("No focus session active", { exact: true }),
+    ).toBeVisible();
+    expect(requests).toBe(2);
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-focus-reply.jpg`),
+      fullPage: true,
+    });
+    const logPath = testInfo.outputPath(`${viewport.name}-console-network.log`);
+    await writeFile(logPath, logs.join("\n"));
+    await testInfo.attach("console and network", {
+      path: logPath,
+      contentType: "text/plain",
+    });
+    const video = page.video();
+    await page.context().close();
+    if (video) {
+      const artifact = await saveBrowserVideoArtifact({
+        video,
+        testInfo,
+        basename: `${viewport.name}-focus-retry`,
+      });
+      await testInfo.attach("focus retry walkthrough", {
+        path: artifact.path,
+        contentType: artifact.contentType,
+      });
+    }
+  });
+}

--- a/packages/app/test/ui-smoke/lifeops-focus-request.spec.ts
+++ b/packages/app/test/ui-smoke/lifeops-focus-request.spec.ts
@@ -67,6 +67,25 @@ for (const viewport of [
         );
       },
     );
+    for (const view of ["finances", "goals", "health", "inbox", "todos"]) {
+      await openAppPath(page, `/${view}`);
+      const control =
+        view === "inbox"
+          ? page.getByRole("button", { name: "Email", exact: true })
+          : view === "todos"
+            ? page.getByRole("button", { name: "Add todo", exact: true })
+            : page.getByRole("combobox").first();
+      await expect(control).toBeVisible({ timeout: 60_000 });
+      await page.screenshot({
+        path: testInfo.outputPath(`${viewport.name}-${view}-rest.jpg`),
+        fullPage: true,
+      });
+      await control.hover();
+      await page.screenshot({
+        path: testInfo.outputPath(`${viewport.name}-${view}-hover.jpg`),
+        fullPage: true,
+      });
+    }
     await openAppPath(page, "/focus");
     const start = page.getByRole("button", {
       name: "Start focus",

--- a/packages/app/test/ui-smoke/lifeops-focus-request.spec.ts
+++ b/packages/app/test/ui-smoke/lifeops-focus-request.spec.ts
@@ -76,6 +76,10 @@ for (const viewport of [
             ? page.getByRole("button", { name: "Add todo", exact: true })
             : page.getByRole("combobox").first();
       await expect(control).toBeVisible({ timeout: 60_000 });
+      await expect(page.getByTestId("chat-pill")).toBeVisible();
+      await page.evaluate(async () => {
+        await document.fonts.ready;
+      });
       await page.screenshot({
         path: testInfo.outputPath(`${viewport.name}-${view}-rest.jpg`),
         fullPage: true,
@@ -92,6 +96,10 @@ for (const viewport of [
       exact: true,
     });
     await expect(start).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByTestId("chat-pill")).toBeVisible();
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
     await page.screenshot({
       path: testInfo.outputPath(`${viewport.name}-focus-rest.jpg`),
       fullPage: true,

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -245,7 +245,7 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["address book", "phone, or email", "search"],
   }),
   "plugin-focus-gui": expected({
-    requireAll: ["Idle"],
+    requireAll: ["No focus session active"],
   }),
   "plugin-calendar-gui": expected({
     requireAny: [

--- a/packages/app/test/ui-smoke/plugin-view-cases.ts
+++ b/packages/app/test/ui-smoke/plugin-view-cases.ts
@@ -9,8 +9,7 @@ export type ViewCase = {
   shellPill: "expected" | "suppressed";
   /**
    * Minimum normalized `<main>` innerText length that counts as "loaded".
-   * Views whose designed keyless empty state is a single short word (the
-   * focus view renders just "Idle") override the
+   * Views with intentionally concise keyless empty states can override the
    * default so the load heuristic cannot false-negative on them.
    */
   minVisibleTextLength: number;

--- a/packages/app/test/ui-smoke/plugin-view-cases.ts
+++ b/packages/app/test/ui-smoke/plugin-view-cases.ts
@@ -34,7 +34,7 @@ export const VIEW_CASES: ViewCase[] = (
     // so it deliberately has no assistant pill/composer at its root.
     ["cloud", "gui", "/cloud", { shellPill: "suppressed" }],
     ["contacts", "gui", "/contacts"],
-    ["focus", "gui", "/focus", { minVisibleTextLength: 4 }],
+    ["focus", "gui", "/focus"],
     ["calendar", "gui", "/calendar"],
     ["family-operations", "gui", "/lifeops/family"],
     ["computer-use-sessions", "gui", "/computer-use-sessions"],

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -500,7 +500,7 @@ function ViewSurfaceFrame({
       reserveChatClearance={!surfaceOwnsViewport(declaration)}
       header={showHeader ? <ViewHeader title={title} /> : undefined}
     >
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {children}
       </div>
     </AppWorkspaceContent>

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
@@ -68,7 +68,7 @@ export function FocusSpatialView({
 }: FocusSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} grow={1} shrink={0}>
       <FocusBody snapshot={snapshot} dispatch={dispatch} />
     </Card>
   );
@@ -137,9 +137,11 @@ function FocusBody({
       return <FocusActiveBody snapshot={snapshot} dispatch={dispatch} />;
     default:
       return (
-        <VStack gap={1}>
-          <Text bold>No focus session active</Text>
-          <Text tone="muted" style="caption">
+        <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+          <Text bold align="center">
+            No focus session active
+          </Text>
+          <Text tone="muted" style="caption" align="center">
             Start a session to temporarily block distracting websites. Eliza
             keeps them unavailable until the session ends.
           </Text>

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
@@ -10,7 +10,15 @@
  * without pulling browser-only runtime imports into the presentational layer.
  */
 
-import { Button, Card, Divider, HStack, List, Text } from "@elizaos/ui/spatial";
+import {
+  Button,
+  Card,
+  Divider,
+  HStack,
+  List,
+  Text,
+  VStack,
+} from "@elizaos/ui/spatial";
 
 /** Which screen of the website-blocking state machine to draw. */
 export type FocusPhase =
@@ -50,7 +58,7 @@ export interface FocusSnapshot {
 
 export interface FocusSpatialViewProps {
   snapshot: FocusSnapshot;
-  /** Dispatch by agent id: `retry` (reload after error), `release` (end block). */
+  /** Dispatch by agent id: `retry`, `start` (chat handoff), `release` (end block). */
   onAction?: (action: string) => void;
 }
 
@@ -129,9 +137,18 @@ function FocusBody({
       return <FocusActiveBody snapshot={snapshot} dispatch={dispatch} />;
     default:
       return (
-        <Text tone="muted" style="caption">
-          Idle
-        </Text>
+        <VStack gap={1}>
+          <Text bold>No focus session active</Text>
+          <Text tone="muted" style="caption">
+            Start a session to temporarily block distracting websites. Eliza
+            keeps them unavailable until the session ends.
+          </Text>
+          <HStack gap={1}>
+            <Button agent="start" onPress={dispatch("start")}>
+              Start focus
+            </Button>
+          </HStack>
+        </VStack>
       );
   }
 }
@@ -151,8 +168,8 @@ function FocusActiveBody({
       {canRelease ? (
         <HStack gap={1}>
           <Button
+            variant="outline"
             tone="danger"
-            grow={1}
             disabled={snapshot.releasing === true}
             agent="release"
             onPress={dispatch("release")}
@@ -162,13 +179,17 @@ function FocusActiveBody({
         </HStack>
       ) : null}
 
-      <Text tone="muted" style="caption">
-        Started {snapshot.startedAt ?? "unknown"}
-        {snapshot.endsAt ? ` - ends ${snapshot.endsAt}` : " - no end time"}
-      </Text>
-      <Text tone="muted" style="caption">
-        Mode: {snapshot.matchMode ?? "exact"}
-      </Text>
+      <VStack gap={0}>
+        <Text tone="muted" style="caption">
+          Started {snapshot.startedAt ?? "unknown"}
+        </Text>
+        <Text tone="muted" style="caption">
+          {snapshot.endsAt ? `Ends ${snapshot.endsAt}` : "No end time"}
+        </Text>
+        <Text tone="muted" style="caption">
+          {snapshot.matchMode ?? "exact"} matching
+        </Text>
+      </VStack>
 
       <Divider label={`${sites.length} blocked`} />
       {sites.length === 0 ? (
@@ -180,7 +201,7 @@ function FocusActiveBody({
           {sites.map((site) => (
             <HStack key={site} gap={1} align="center">
               <Text tone="muted" wrap={false}>
-                x
+                •
               </Text>
               <Text grow={1} wrap={false}>
                 {site}

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
@@ -19,6 +19,7 @@ import {
   Text,
   VStack,
 } from "@elizaos/ui/spatial";
+import type { ReactNode } from "react";
 
 /** Which screen of the website-blocking state machine to draw. */
 export type FocusPhase =
@@ -29,7 +30,13 @@ export type FocusPhase =
   | "active"
   | "empty";
 
+export type FocusRequestState =
+  | { phase: "idle" | "pending" }
+  | { phase: "error" | "complete"; message: string };
+
 export interface FocusSnapshot {
+  /** Assistant request progress and complete reply, independent of block status. */
+  request?: FocusRequestState;
   /** Current state-machine phase. */
   phase: FocusPhase;
   /** Error message (phase: "error"). */
@@ -67,9 +74,21 @@ export function FocusSpatialView({
   onAction,
 }: FocusSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
+  const requestReply =
+    snapshot.request?.phase === "error" ||
+    snapshot.request?.phase === "complete" ? (
+      <Text tone={snapshot.request.phase === "error" ? "danger" : "default"}>
+        {snapshot.request.message}
+      </Text>
+    ) : null;
   return (
     <Card gap={1} padding={1} grow={1} shrink={0}>
-      <FocusBody snapshot={snapshot} dispatch={dispatch} />
+      <FocusBody
+        snapshot={snapshot}
+        dispatch={dispatch}
+        requestReply={requestReply}
+      />
+      {snapshot.phase !== "empty" ? requestReply : null}
     </Card>
   );
 }
@@ -77,9 +96,11 @@ export function FocusSpatialView({
 function FocusBody({
   snapshot,
   dispatch,
+  requestReply,
 }: {
   snapshot: FocusSnapshot;
   dispatch: (action: string) => () => void;
+  requestReply: ReactNode;
 }) {
   switch (snapshot.phase) {
     case "loading":
@@ -146,10 +167,17 @@ function FocusBody({
             keeps them unavailable until the session ends.
           </Text>
           <HStack gap={1}>
-            <Button agent="start" onPress={dispatch("start")}>
-              Start focus
+            <Button
+              agent="start"
+              disabled={snapshot.request?.phase === "pending"}
+              onPress={dispatch("start")}
+            >
+              {snapshot.request?.phase === "pending"
+                ? "Asking Eliza…"
+                : "Start focus"}
             </Button>
           </HStack>
+          {requestReply}
         </VStack>
       );
   }

--- a/plugins/plugin-blocker/src/components/focus/FocusView.test.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-// Drives the FocusView GUI data wrapper through the rendered DOM. Asserts each
-// SelfControlStatus phase (loading, error,
-// unavailable, permission, active, empty), the clickable Retry / Release
-// agent-instrumented controls, the early-release mutation + refetch, and the
-// release-gating when a block can't be unblocked early.
+/**
+ * Exercises the Focus GUI wrapper through its rendered DOM with deterministic
+ * status fetchers. The suite covers every visible phase plus the assistant
+ * handoff, retry, release, refetch, and release-gating behavior.
+ */
 
 import {
   cleanup,
@@ -17,12 +17,23 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { SelfControlStatus } from "../../services/website-blocker/index.js";
 
+const sendChatMessage = vi.hoisted(() => vi.fn());
+
 // `@elizaos/ui` is the giant renderer barrel; the wrapper only touches
 // `client.getBaseUrl()` / `client.stopWebsiteBlock()` on its default fetcher
 // seam, which every test overrides via the injection props.
 vi.mock("@elizaos/ui", () => ({
   client: {
     getBaseUrl: () => "http://test.local",
+    sendChatMessage,
+    stopWebsiteBlock: vi.fn(async () => ({ success: true, removed: true })),
+  },
+}));
+
+vi.mock("@elizaos/ui/api", () => ({
+  client: {
+    getBaseUrl: () => "http://test.local",
+    sendChatMessage,
     stopWebsiteBlock: vi.fn(async () => ({ success: true, removed: true })),
   },
 }));
@@ -121,13 +132,13 @@ describe("FocusView — phases", () => {
 
   it("renders the empty state when available, inactive, nothing blocked", async () => {
     render(<FocusView fetchStatus={async () => EMPTY_STATUS} />);
-    await screen.findByText("Idle");
+    await screen.findByText("No focus session active");
   });
 
   it("renders the active state with times, count, list, and Release control", async () => {
     render(<FocusView fetchStatus={async () => ACTIVE_STATUS} />);
     await screen.findByText(/Focus active/i);
-    expect(screen.getByText(/Mode: subdomain/i)).toBeTruthy();
+    expect(screen.getByText(/subdomain matching/i)).toBeTruthy();
     expect(screen.getByText("x.com")).toBeTruthy();
     expect(screen.getByText("news.google.com")).toBeTruthy();
     expect(agent("release")).toBeTruthy();
@@ -135,6 +146,17 @@ describe("FocusView — phases", () => {
 });
 
 describe("FocusView — actions", () => {
+  it("routes a new focus session through the assistant", async () => {
+    render(<FocusView fetchStatus={async () => EMPTY_STATUS} />);
+
+    await screen.findByText("No focus session active");
+    fireEvent.click(agent("start"));
+
+    expect(sendChatMessage).toHaveBeenCalledWith(
+      "Start a focus session for me.",
+    );
+  });
+
   it("Retry refetches after an error", async () => {
     let attempt = 0;
     const fetchStatus = vi.fn(async () => {
@@ -147,7 +169,7 @@ describe("FocusView — actions", () => {
     await screen.findByText("network down");
     fireEvent.click(agent("retry"));
 
-    await screen.findByText("Idle");
+    await screen.findByText("No focus session active");
     expect(fetchStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -165,7 +187,7 @@ describe("FocusView — actions", () => {
     fireEvent.click(agent("release"));
 
     await waitFor(() => expect(releaseBlock).toHaveBeenCalledTimes(1));
-    await screen.findByText("Idle");
+    await screen.findByText("No focus session active");
     expect(fetchStatus).toHaveBeenCalledTimes(2);
   });
 

--- a/plugins/plugin-blocker/src/components/focus/FocusView.test.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -17,7 +18,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { SelfControlStatus } from "../../services/website-blocker/index.js";
 
-const sendChatMessage = vi.hoisted(() => vi.fn());
+const sendChatRest = vi.hoisted(() => vi.fn());
 
 // `@elizaos/ui` is the giant renderer barrel; the wrapper only touches
 // `client.getBaseUrl()` / `client.stopWebsiteBlock()` on its default fetcher
@@ -25,7 +26,7 @@ const sendChatMessage = vi.hoisted(() => vi.fn());
 vi.mock("@elizaos/ui", () => ({
   client: {
     getBaseUrl: () => "http://test.local",
-    sendChatMessage,
+    sendChatRest,
     stopWebsiteBlock: vi.fn(async () => ({ success: true, removed: true })),
   },
 }));
@@ -33,7 +34,7 @@ vi.mock("@elizaos/ui", () => ({
 vi.mock("@elizaos/ui/api", () => ({
   client: {
     getBaseUrl: () => "http://test.local",
-    sendChatMessage,
+    sendChatRest,
     stopWebsiteBlock: vi.fn(async () => ({ success: true, removed: true })),
   },
 }));
@@ -146,15 +147,55 @@ describe("FocusView — phases", () => {
 });
 
 describe("FocusView — actions", () => {
-  it("routes a new focus session through the assistant", async () => {
+  it("shows the assistant reply without claiming a block started", async () => {
+    sendChatRest.mockResolvedValueOnce({
+      text: "Which websites should I block?",
+      agentName: "Eliza",
+    });
     render(<FocusView fetchStatus={async () => EMPTY_STATUS} />);
 
     await screen.findByText("No focus session active");
     fireEvent.click(agent("start"));
 
-    expect(sendChatMessage).toHaveBeenCalledWith(
-      "Start a focus session for me.",
+    await screen.findByText("Which websites should I block?");
+    expect(screen.getByText("No focus session active")).toBeTruthy();
+  });
+
+  it("prevents duplicate focus requests while the assistant is responding", async () => {
+    let finish!: (response: { text: string; agentName: string }) => void;
+    sendChatRest.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
     );
+    render(<FocusView fetchStatus={async () => EMPTY_STATUS} />);
+    await screen.findByText("No focus session active");
+    fireEvent.click(agent("start"));
+    const pending = screen.getByRole("button", { name: "Asking Eliza…" });
+    expect((pending as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(pending);
+    expect(sendChatRest).toHaveBeenCalledTimes(1);
+    await act(async () =>
+      finish({ text: "Which websites should I block?", agentName: "Eliza" }),
+    );
+    await screen.findByText("Which websites should I block?");
+    expect((agent("start") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("shows a failed assistant request and permits retry", async () => {
+    sendChatRest.mockRejectedValueOnce(new Error("Agent is unavailable"));
+    render(<FocusView fetchStatus={async () => EMPTY_STATUS} />);
+    await screen.findByText("No focus session active");
+    fireEvent.click(agent("start"));
+    await screen.findByText("Agent is unavailable");
+    sendChatRest.mockResolvedValueOnce({
+      text: "Which websites should I block?",
+      agentName: "Eliza",
+    });
+    fireEvent.click(agent("start"));
+    await screen.findByText("Which websites should I block?");
+    expect(screen.queryByText("Agent is unavailable")).toBeNull();
   });
 
   it("Retry refetches after an error", async () => {

--- a/plugins/plugin-blocker/src/components/focus/FocusView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.tsx
@@ -63,6 +63,12 @@ function defaultReleaseBlock(): Promise<unknown> {
   return client.stopWebsiteBlock();
 }
 
+function requestFocusSession(): void {
+  (client as { sendChatMessage?: (text: string) => void }).sendChatMessage?.(
+    "Start a focus session for me.",
+  );
+}
+
 type LoadState =
   | { kind: "loading" }
   | { kind: "error"; message: string }
@@ -181,6 +187,9 @@ export function FocusView({
           return;
         case "release":
           release();
+          return;
+        case "start":
+          requestFocusSession();
           return;
       }
     },

--- a/plugins/plugin-blocker/src/components/focus/FocusView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.tsx
@@ -64,9 +64,7 @@ function defaultReleaseBlock(): Promise<unknown> {
 }
 
 function requestFocusSession(): void {
-  (client as { sendChatMessage?: (text: string) => void }).sendChatMessage?.(
-    "Start a focus session for me.",
-  );
+  client.sendChatMessage("Start a focus session for me.");
 }
 
 type LoadState =

--- a/plugins/plugin-blocker/src/components/focus/FocusView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.tsx
@@ -17,7 +17,11 @@ import { client } from "@elizaos/ui/api";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SelfControlStatus } from "../../services/website-blocker/index.ts";
-import { type FocusSnapshot, FocusSpatialView } from "./FocusSpatialView.tsx";
+import {
+  type FocusRequestState,
+  type FocusSnapshot,
+  FocusSpatialView,
+} from "./FocusSpatialView.tsx";
 
 interface FocusViewProps {
   /** Test/host injection seam. Defaults to a real `/api/website-blocker` GET. */
@@ -61,10 +65,6 @@ async function defaultFetchStatus(
 
 function defaultReleaseBlock(): Promise<unknown> {
   return client.stopWebsiteBlock();
-}
-
-function requestFocusSession(): void {
-  client.sendChatMessage("Start a focus session for me.");
 }
 
 type LoadState =
@@ -119,6 +119,8 @@ export function FocusView({
 }: FocusViewProps = {}) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [releasing, setReleasing] = useState(false);
+  const [request, setRequest] = useState<FocusRequestState>({ phase: "idle" });
+  const requestPending = useRef(false);
   const fetchRef = useRef(fetchStatus);
   fetchRef.current = fetchStatus;
   const releaseRef = useRef(releaseBlock);
@@ -177,6 +179,40 @@ export function FocusView({
     };
   }, [load]);
 
+  const requestFocusSession = useCallback(async () => {
+    if (requestPending.current) return;
+    requestPending.current = true;
+    setRequest({ phase: "pending" });
+    try {
+      const response = await client.sendChatRest(
+        "Start a focus session for me.",
+      );
+      if (!response.text.trim()) {
+        setRequest({
+          phase: "error",
+          message: "Eliza returned no reply. Try again.",
+        });
+        return;
+      }
+      setRequest({
+        phase: response.failureKind ? "error" : "complete",
+        message: response.text,
+      });
+      load(true);
+    } catch (error) {
+      // error-policy:J4 Keep failed focus requests visible and retryable.
+      setRequest({
+        phase: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Could not request a focus session.",
+      });
+    } finally {
+      requestPending.current = false;
+    }
+  }, [load]);
+
   const onAction = useCallback(
     (action: string) => {
       switch (action) {
@@ -187,14 +223,14 @@ export function FocusView({
           release();
           return;
         case "start":
-          requestFocusSession();
+          void requestFocusSession();
           return;
       }
     },
-    [load, release],
+    [load, release, requestFocusSession],
   );
 
-  const snapshot = toSnapshot(state, releasing);
+  const snapshot = { ...toSnapshot(state, releasing), request };
 
   return <FocusSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
@@ -15,7 +15,16 @@
  * or runs financial math. It displays the snapshot and dispatches actions.
  */
 
-import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
+import {
+  Button,
+  Card,
+  Divider,
+  Field,
+  HStack,
+  List,
+  Text,
+  VStack,
+} from "@elizaos/ui/spatial";
 
 /**
  * Which render state the dashboard is in. `reauth` is distinct from `empty`:
@@ -202,10 +211,13 @@ function FinancesEmptyBody({
 }) {
   return (
     <>
-      <Text bold>None</Text>
+      <Text bold>No accounts connected</Text>
+      <Text tone="muted" style="caption">
+        Connect a payment source to see balances and activity here.
+      </Text>
       <HStack gap={1}>
         <Button agent="connect" onPress={dispatch("connect")}>
-          Connect
+          Connect account
         </Button>
       </HStack>
     </>
@@ -297,9 +309,7 @@ function SourcesSection({
   if (sources.length === 0) return null;
   return (
     <>
-      <Text style="caption" tone="muted">
-        Sources ({sources.length})
-      </Text>
+      <Divider label={`Accounts (${sources.length})`} />
       <List gap={0}>
         {sources.map((source) => (
           <HStack key={source.id} gap={1} align="center" width="100%">
@@ -341,20 +351,57 @@ function FiltersSection({
   dispatch: (action: string) => () => void;
 }) {
   if (filters.length === 0) return null;
+  const windowFilters = filters.filter(
+    (filter) =>
+      filter.action === "filter-clear" ||
+      filter.action.startsWith("filter-window-"),
+  );
+  const categoryFilters = filters.filter((filter) =>
+    filter.action.startsWith("filter-category-"),
+  );
+  const activeWindow =
+    windowFilters.find((filter) => filter.active)?.label ?? "All activity";
+  const activeCategory =
+    categoryFilters.find((filter) => filter.active)?.label ?? "All categories";
   return (
-    <HStack gap={1} width="100%">
-      {filters.map((chip) => (
-        <Button
-          key={chip.action}
-          agent={chip.action}
-          tone={chip.active ? "primary" : "muted"}
-          variant={chip.active ? "solid" : "ghost"}
-          pressed={chip.active}
-          onPress={dispatch(chip.action)}
-        >
-          {chip.label}
-        </Button>
-      ))}
+    <HStack gap={1} width="100%" wrap align="end">
+      <Field
+        kind="select"
+        label="Period"
+        value={activeWindow}
+        options={windowFilters.map((filter) => filter.label)}
+        agent="finance-period-filter"
+        onChange={(label) => {
+          const selected = windowFilters.find(
+            (filter) => filter.label === label,
+          );
+          if (selected) dispatch(selected.action)();
+        }}
+        grow={1}
+      />
+      {categoryFilters.length > 0 ? (
+        <Field
+          kind="select"
+          label="Category"
+          value={activeCategory}
+          options={[
+            "All categories",
+            ...categoryFilters.map((filter) => filter.label),
+          ]}
+          agent="finance-category-filter"
+          onChange={(label) => {
+            if (label === "All categories") {
+              dispatch("filter-category-all")();
+              return;
+            }
+            const selected = categoryFilters.find(
+              (filter) => filter.label === label,
+            );
+            if (selected) dispatch(selected.action)();
+          }}
+          grow={1}
+        />
+      ) : null}
     </HStack>
   );
 }
@@ -362,9 +409,7 @@ function FiltersSection({
 function BalanceSection({ balance }: { balance: FinanceBalanceCard }) {
   return (
     <>
-      <Text style="caption" tone="muted">
-        Balance
-      </Text>
+      <Divider label="Balance" />
       <Text bold tone={balance.negative ? "danger" : "primary"} wrap={false}>
         {balance.net}
       </Text>
@@ -395,15 +440,12 @@ function TransactionsSection({
   dispatch: (action: string) => () => void;
 }) {
   const filteredOut = transactionsTotal > transactions.length;
+  const countLabel = filteredOut
+    ? `${transactions.length} of ${transactionsTotal}`
+    : String(transactions.length);
   return (
     <>
-      <Text style="caption" tone="muted">
-        Transactions (
-        {filteredOut
-          ? `${transactions.length} of ${transactionsTotal}`
-          : transactions.length}
-        )
-      </Text>
+      <Divider label={`Transactions (${countLabel})`} />
       {transactions.length === 0 ? (
         <Text tone="muted" style="caption">
           {filteredOut ? "No transactions match the filter" : "None"}
@@ -453,9 +495,7 @@ function RecurringSection({
 }) {
   return (
     <>
-      <Text style="caption" tone="muted">
-        Recurring ({recurring.length})
-      </Text>
+      <Divider label={`Recurring (${recurring.length})`} />
       {recurring.length === 0 ? (
         <Text tone="muted" style="caption">
           None

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
@@ -164,7 +164,7 @@ export function FinancesSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={1} padding={1} shrink={0}>
+    <Card gap={1} padding={1} grow={1} shrink={0}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading
@@ -210,9 +210,11 @@ function FinancesEmptyBody({
   dispatch: (action: string) => () => void;
 }) {
   return (
-    <>
-      <Text bold>No accounts connected</Text>
-      <Text tone="muted" style="caption">
+    <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+      <Text bold align="center">
+        No accounts connected
+      </Text>
+      <Text tone="muted" style="caption" align="center">
         Connect a payment source to see balances and activity here.
       </Text>
       <HStack gap={1}>
@@ -220,7 +222,7 @@ function FinancesEmptyBody({
           Connect account
         </Button>
       </HStack>
-    </>
+    </VStack>
   );
 }
 

--- a/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
@@ -118,6 +118,12 @@ function agent(agentId: string): HTMLElement {
   return el as HTMLElement;
 }
 
+async function selectFilter(agentId: string, option: string): Promise<void> {
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+  fireEvent.keyDown(agent(agentId), { key: "Enter" });
+  fireEvent.click(await screen.findByRole("option", { name: option }));
+}
+
 afterEach(() => {
   cleanup();
   sendChatMessage.mockClear();
@@ -238,7 +244,7 @@ describe("FinancesView — states", () => {
         })}
       />,
     );
-    await screen.findByText("None");
+    await screen.findByText("No accounts connected");
     expect(agent("connect")).toBeTruthy();
     // No fabricated balance surfaces in the disconnected state.
     expect(screen.queryByText("$2,765.50")).toBeNull();
@@ -252,7 +258,7 @@ describe("FinancesView — states", () => {
         })}
       />,
     );
-    await screen.findByText("None");
+    await screen.findByText("No accounts connected");
     fireEvent.click(agent("connect"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
@@ -422,12 +428,12 @@ describe("FinancesView — filters", () => {
     await screen.findByText("Latte");
     expect(screen.getByText("Old purchase")).toBeTruthy();
 
-    fireEvent.click(agent("filter-window-7"));
+    await selectFilter("finance-period-filter", "7d");
     expect(screen.getByText("Latte")).toBeTruthy();
     expect(screen.queryByText("Old purchase")).toBeNull();
     expect(screen.getByText("Transactions (1 of 2)")).toBeTruthy();
 
-    fireEvent.click(agent("filter-clear"));
+    await selectFilter("finance-period-filter", "All");
     expect(screen.getByText("Old purchase")).toBeTruthy();
   });
 
@@ -439,14 +445,14 @@ describe("FinancesView — filters", () => {
     );
     await screen.findByText("Latte");
 
-    fireEvent.click(agent("filter-category-dining"));
+    await selectFilter("finance-category-filter", "dining");
     expect(screen.queryByText("Old purchase")).toBeNull();
     expect(screen.getByText("Latte")).toBeTruthy();
 
     // Stack the 7d window on top: dining + old window would still match Latte;
     // toggle to the shopping category instead so nothing matches.
-    fireEvent.click(agent("filter-category-shopping"));
-    fireEvent.click(agent("filter-window-7"));
+    await selectFilter("finance-category-filter", "shopping");
+    await selectFilter("finance-period-filter", "7d");
     expect(screen.getByText("No transactions match the filter")).toBeTruthy();
     expect(screen.getByText("Transactions (0 of 2)")).toBeTruthy();
   });

--- a/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
@@ -457,6 +457,24 @@ describe("FinancesView — filters", () => {
     expect(screen.getByText("Transactions (0 of 2)")).toBeTruthy();
   });
 
+  it("clears the period while retaining the selected transaction category", async () => {
+    render(
+      <FinancesView
+        fetchers={makeFetchers({ fetchTransactions: twoTransactions })}
+      />,
+    );
+    await screen.findByText("Latte");
+    await selectFilter("finance-category-filter", "shopping");
+    await selectFilter("finance-period-filter", "7d");
+    expect(screen.getByText("No transactions match the filter")).toBeTruthy();
+    await selectFilter("finance-period-filter", "All");
+    expect(screen.getByText("Old purchase")).toBeTruthy();
+    expect(screen.queryByText("Latte")).toBeNull();
+    expect(screen.getByText("Transactions (1 of 2)")).toBeTruthy();
+    await selectFilter("finance-category-filter", "All categories");
+    expect(screen.getByText("Latte")).toBeTruthy();
+  });
+
   it("honors the filtered-view handoff seam (initialFilters)", async () => {
     render(
       <FinancesView

--- a/plugins/plugin-finances/src/components/finances/FinancesView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.tsx
@@ -581,6 +581,10 @@ export function FinancesView(props: FinancesViewProps = {}): ReactNode {
         setFilters(NO_FILTERS);
         return;
       }
+      if (action === "filter-category-all") {
+        setFilters((current) => ({ ...current, category: null }));
+        return;
+      }
       if (action.startsWith("filter-window-")) {
         const days = Number(action.slice("filter-window-".length));
         setFilters((prev) => ({

--- a/plugins/plugin-finances/src/components/finances/FinancesView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.tsx
@@ -402,9 +402,9 @@ function buildFilterChips(
 ): FinanceFilterChip[] {
   const chips: FinanceFilterChip[] = [
     {
-      action: "filter-clear",
+      action: "filter-window-all",
       label: "All",
-      active: filters.windowDays === null && filters.category === null,
+      active: filters.windowDays === null,
     },
   ];
   for (const days of FILTER_WINDOWS_DAYS) {
@@ -583,6 +583,10 @@ export function FinancesView(props: FinancesViewProps = {}): ReactNode {
       }
       if (action === "filter-category-all") {
         setFilters((current) => ({ ...current, category: null }));
+        return;
+      }
+      if (action === "filter-window-all") {
+        setFilters((current) => ({ ...current, windowDays: null }));
         return;
       }
       if (action.startsWith("filter-window-")) {

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
@@ -64,22 +64,11 @@ const STATUS_LABELS: Record<GoalStatus, string> = {
   satisfied: "Achieved",
 };
 
-const REVIEW_LABELS: Record<GoalReviewState, string> = {
-  idle: "not reviewed",
-  on_track: "on track",
-  at_risk: "at risk",
-  needs_attention: "needs attention",
-};
-
-// Width-1 review marker — filled vs hollow vs cross, never emoji or a checkmark.
-//   on_track       → ● (settled)
-//   at_risk / needs_attention → x (flagged)
-//   idle           → ○ (not yet reviewed)
 const REVIEW_GLYPH: Record<GoalReviewState, string> = {
   idle: "○",
   on_track: "●",
-  at_risk: "x",
-  needs_attention: "x",
+  at_risk: "●",
+  needs_attention: "●",
 };
 
 const REVIEW_TONE: Record<GoalReviewState, "muted" | "success" | "danger"> = {
@@ -121,7 +110,7 @@ export function GoalsSpatialView({
   const active = new Set(snapshot.activeStatuses);
 
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} grow={1} shrink={0}>
       {snapshot.status === "loading" ? (
         <Text tone="muted" style="caption">
           Loading goals
@@ -176,9 +165,11 @@ function GoalsReadyBody({
 
   if (snapshot.goals.length === 0) {
     return (
-      <>
-        <Text bold>No goals yet</Text>
-        <Text tone="muted" style="caption">
+      <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+        <Text bold align="center">
+          No goals yet
+        </Text>
+        <Text tone="muted" style="caption" align="center">
           Set an outcome and Eliza will help you keep it moving.
         </Text>
         <HStack gap={1}>
@@ -186,7 +177,7 @@ function GoalsReadyBody({
             Set a goal
           </Button>
         </HStack>
-      </>
+      </VStack>
     );
   }
 
@@ -245,9 +236,10 @@ function GoalsStatusGroup({
 }) {
   return (
     <>
-      <Divider
-        label={`${STATUS_LABELS[group.status]} (${group.goals.length})`}
-      />
+      <Text bold style="caption">
+        {`${STATUS_LABELS[group.status]} (${group.goals.length})`}
+      </Text>
+      <Divider />
       <List gap={0}>
         {group.goals.map((goal) => (
           <GoalRow key={goal.id} goal={goal} />
@@ -262,33 +254,19 @@ function GoalRow({ goal }: { goal: GoalItem }) {
   if (goal.cadenceKind) meta.push(goal.cadenceKind);
   if (goal.target) meta.push(goal.target);
   if (goal.linkedCount > 0) meta.push(`${goal.linkedCount} linked`);
+  meta.push(formatDate(goal.updatedAt));
 
   return (
-    <HStack gap={1} align="center">
-      <Text tone={REVIEW_TONE[goal.reviewState]} wrap={false}>
+    <HStack gap={2} align="center">
+      <Text tone={REVIEW_TONE[goal.reviewState]} wrap={false} shrink={0}>
         {REVIEW_GLYPH[goal.reviewState]}
       </Text>
       <VStack gap={0} grow={1}>
         <Text bold wrap={false}>
           {goal.title}
         </Text>
-        {meta.length > 0 ? (
-          <Text style="caption" tone="muted" wrap={false}>
-            {meta.join(" · ")}
-          </Text>
-        ) : null}
-      </VStack>
-      <VStack gap={0}>
-        <Text
-          style="caption"
-          tone={REVIEW_TONE[goal.reviewState]}
-          wrap={false}
-          align="end"
-        >
-          {REVIEW_LABELS[goal.reviewState]}
-        </Text>
-        <Text style="caption" tone="muted" wrap={false} align="end">
-          {formatDate(goal.updatedAt)}
+        <Text style="caption" tone="muted" wrap={false}>
+          {meta.join(" · ")}
         </Text>
       </VStack>
     </HStack>

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
@@ -16,7 +16,16 @@
  * goal" chat affordance on the empty state.
  */
 
-import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
+import {
+  Button,
+  Card,
+  Divider,
+  Field,
+  HStack,
+  List,
+  Text,
+  VStack,
+} from "@elizaos/ui/spatial";
 import {
   GOAL_STATUSES,
   type GoalItem,
@@ -168,7 +177,10 @@ function GoalsReadyBody({
   if (snapshot.goals.length === 0) {
     return (
       <>
-        <Text bold>None</Text>
+        <Text bold>No goals yet</Text>
+        <Text tone="muted" style="caption">
+          Set an outcome and Eliza will help you keep it moving.
+        </Text>
         <HStack gap={1}>
           <Button agent="new" onPress={dispatch("new")}>
             Set a goal
@@ -196,19 +208,22 @@ function GoalsReadyBody({
         </Text>
       ) : null}
 
-      <HStack gap={1} wrap>
-        {GOAL_STATUSES.map((status) => (
-          <Button
-            key={status}
-            variant={active.has(status) ? "solid" : "outline"}
-            tone={active.has(status) ? "primary" : "default"}
-            agent={`filter:${status}`}
-            onPress={dispatch(`filter:${status}`)}
-          >
-            {STATUS_LABELS[status]}
-          </Button>
-        ))}
-      </HStack>
+      <Field
+        kind="select"
+        label="Status"
+        value={active.size === 1 ? STATUS_LABELS[[...active][0]] : "All goals"}
+        options={[
+          "All goals",
+          ...GOAL_STATUSES.map((status) => STATUS_LABELS[status]),
+        ]}
+        agent="goal-status-filter"
+        onChange={(label) => {
+          const selected = GOAL_STATUSES.find(
+            (status) => STATUS_LABELS[status] === label,
+          );
+          dispatch(`filter-set:${selected ?? "all"}`)();
+        }}
+      />
 
       {groups.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
@@ -230,9 +245,9 @@ function GoalsStatusGroup({
 }) {
   return (
     <>
-      <Text style="caption" tone="muted">
-        {STATUS_LABELS[group.status]} ({group.goals.length})
-      </Text>
+      <Divider
+        label={`${STATUS_LABELS[group.status]} (${group.goals.length})`}
+      />
       <List gap={0}>
         {group.goals.map((goal) => (
           <GoalRow key={goal.id} goal={goal} />

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
@@ -64,11 +64,11 @@ const STATUS_LABELS: Record<GoalStatus, string> = {
   satisfied: "Achieved",
 };
 
-const REVIEW_GLYPH: Record<GoalReviewState, string> = {
-  idle: "○",
-  on_track: "●",
-  at_risk: "●",
-  needs_attention: "●",
+const REVIEW_LABEL: Record<GoalReviewState, string> = {
+  idle: "Not reviewed",
+  on_track: "On track",
+  at_risk: "At risk",
+  needs_attention: "Needs attention",
 };
 
 const REVIEW_TONE: Record<GoalReviewState, "muted" | "success" | "danger"> = {
@@ -258,12 +258,12 @@ function GoalRow({ goal }: { goal: GoalItem }) {
 
   return (
     <HStack gap={2} align="center">
-      <Text tone={REVIEW_TONE[goal.reviewState]} wrap={false} shrink={0}>
-        {REVIEW_GLYPH[goal.reviewState]}
-      </Text>
       <VStack gap={0} grow={1}>
         <Text bold wrap={false}>
           {goal.title}
+        </Text>
+        <Text style="caption" tone={REVIEW_TONE[goal.reviewState]}>
+          {REVIEW_LABEL[goal.reviewState]}
         </Text>
         <Text style="caption" tone="muted" wrap={false}>
           {meta.join(" · ")}

--- a/plugins/plugin-goals/src/components/goals/GoalsView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsView.tsx
@@ -252,6 +252,15 @@ export function GoalsView(props: GoalsViewProps = {}): ReactNode {
 
   const onAction = useCallback(
     (action: string) => {
+      if (action.startsWith("filter-set:")) {
+        const raw = action.slice("filter-set:".length);
+        setActiveStatuses(
+          raw === "all" || !KNOWN_STATUSES.has(raw)
+            ? new Set<GoalStatus>()
+            : new Set<GoalStatus>([raw as GoalStatus]),
+        );
+        return;
+      }
       if (action.startsWith("filter:")) {
         const raw = action.slice("filter:".length);
         if (KNOWN_STATUSES.has(raw)) toggleStatus(raw as GoalStatus);

--- a/plugins/plugin-goals/test/GoalsView.test.tsx
+++ b/plugins/plugin-goals/test/GoalsView.test.tsx
@@ -120,6 +120,12 @@ function queryAgent(agentId: string): HTMLElement | null {
   ) as HTMLElement | null;
 }
 
+async function selectStatus(label: string): Promise<void> {
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+  fireEvent.keyDown(agent("goal-status-filter"), { key: "Enter" });
+  fireEvent.click(await screen.findByRole("option", { name: label }));
+}
+
 afterEach(() => {
   cleanup();
   sendChatMessage.mockClear();
@@ -164,9 +170,8 @@ describe("GoalsView — spatial GUI wrapper", () => {
       screen.getByText(/weekly · 21km continuous run · 2 linked/),
     ).toBeTruthy();
     expect(screen.getByText("Learn Spanish")).toBeTruthy();
-    // The status-filter chips are present and addressable by the agent surface.
-    expect(agent("filter:active")).toBeTruthy();
-    expect(agent("filter:paused")).toBeTruthy();
+    // The compact status filter is addressable by the agent surface.
+    expect(agent("goal-status-filter")).toBeTruthy();
   });
 
   it("shows the empty state when zero goals exist (no fabricated goals)", async () => {
@@ -260,8 +265,8 @@ describe("GoalsView — spatial GUI wrapper", () => {
     await screen.findByText("Run a half marathon");
     expect(screen.getByText("Learn Spanish")).toBeTruthy();
 
-    // Toggle the "Paused" filter: only the paused group should remain.
-    fireEvent.click(agent("filter:paused"));
+    // Select "Paused": only the paused group should remain.
+    await selectStatus("Paused");
     await waitFor(() =>
       expect(screen.queryByText("Run a half marathon")).toBeNull(),
     );

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   Card,
   Escape,
+  Field,
   HStack,
   Text,
   VStack,
@@ -87,7 +88,7 @@ export function HealthSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={1} padding={1} grow={1}>
+    <Card gap={1} padding={1} grow={1} shrink={0}>
       <WindowRange windowDays={snapshot.windowDays} dispatch={dispatch} />
 
       {snapshot.state === "loading" ? (
@@ -113,26 +114,19 @@ function WindowRange({
   dispatch: (action: string) => () => void;
 }) {
   return (
-    <HStack gap={1} align="center">
-      <Text style="caption" tone="muted" shrink={0}>
-        Range
-      </Text>
-      {WINDOW_OPTIONS.map((days) => {
-        const selected = days === windowDays;
-        return (
-          <Button
-            key={days}
-            agent={`window-${days}`}
-            tone={selected ? "primary" : "default"}
-            variant={selected ? "solid" : "ghost"}
-            pressed={selected}
-            onPress={dispatch(`window:${days}`)}
-          >
-            {`${days}d`}
-          </Button>
+    <Field
+      kind="select"
+      label="Range"
+      value={`Last ${windowDays} days`}
+      options={WINDOW_OPTIONS.map((days) => `Last ${days} days`)}
+      agent="health-range-filter"
+      onChange={(label) => {
+        const selected = WINDOW_OPTIONS.find(
+          (days) => `Last ${days} days` === label,
         );
-      })}
-    </HStack>
+        if (selected) dispatch(`window:${selected}`)();
+      }}
+    />
   );
 }
 
@@ -160,9 +154,11 @@ function HealthErrorBody({
 
 function HealthEmptyBody() {
   return (
-    <VStack gap={1}>
-      <Text bold>No sleep data yet</Text>
-      <Text tone="muted" style="caption">
+    <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+      <Text bold align="center">
+        No sleep data yet
+      </Text>
+      <Text tone="muted" style="caption" align="center">
         Connect a health source or record sleep to see patterns here.
       </Text>
     </VStack>

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
@@ -15,7 +15,14 @@
  * or computes — it displays label/value rows and dispatches actions.
  */
 
-import { Button, Card, Escape, HStack, Text } from "@elizaos/ui/spatial";
+import {
+  Button,
+  Card,
+  Escape,
+  HStack,
+  Text,
+  VStack,
+} from "@elizaos/ui/spatial";
 import type { CSSProperties } from "react";
 
 /** A single label/value summary row, already projected to display strings. */
@@ -106,7 +113,10 @@ function WindowRange({
   dispatch: (action: string) => () => void;
 }) {
   return (
-    <HStack gap={1} align="center" padding={{ left: 12 }}>
+    <HStack gap={1} align="center">
+      <Text style="caption" tone="muted" shrink={0}>
+        Range
+      </Text>
       {WINDOW_OPTIONS.map((days) => {
         const selected = days === windowDays;
         return (
@@ -114,7 +124,8 @@ function WindowRange({
             key={days}
             agent={`window-${days}`}
             tone={selected ? "primary" : "default"}
-            variant={selected ? "solid" : "outline"}
+            variant={selected ? "solid" : "ghost"}
+            pressed={selected}
             onPress={dispatch(`window:${days}`)}
           >
             {`${days}d`}
@@ -148,7 +159,14 @@ function HealthErrorBody({
 }
 
 function HealthEmptyBody() {
-  return <Text bold>None</Text>;
+  return (
+    <VStack gap={1}>
+      <Text bold>No sleep data yet</Text>
+      <Text tone="muted" style="caption">
+        Connect a health source or record sleep to see patterns here.
+      </Text>
+    </VStack>
+  );
 }
 
 function HealthReadyBody({ snapshot }: { snapshot: HealthSnapshot }) {
@@ -193,15 +211,17 @@ const proactiveLineStyle: CSSProperties = {
 const readyGridStyle: CSSProperties = {
   alignItems: "start",
   display: "grid",
-  gap: "0.5rem",
-  gridTemplateColumns: "repeat(auto-fit, minmax(min(12rem, 100%), 1fr))",
+  columnGap: "2rem",
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(20rem, 100%), 1fr))",
   minWidth: 0,
+  rowGap: "1.25rem",
 };
 
 const domSectionStyle: CSSProperties = {
+  borderTop: "1px solid var(--border, rgba(255, 255, 255, 0.12))",
   boxSizing: "border-box",
   minWidth: 0,
-  padding: "0.25rem 0.125rem",
+  padding: "0.75rem 0 0",
 };
 
 const domSectionTitleStyle: CSSProperties = {
@@ -209,12 +229,12 @@ const domSectionTitleStyle: CSSProperties = {
   fontSize: "0.72rem",
   fontWeight: 600,
   lineHeight: 1.15,
-  margin: "0 0 0.25rem",
+  margin: "0 0 0.625rem",
 };
 
 const definitionListStyle: CSSProperties = {
   display: "grid",
-  gap: "0.16rem",
+  gap: "0.4rem",
   margin: 0,
   minWidth: 0,
 };

--- a/plugins/plugin-health/src/components/health/HealthView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.test.tsx
@@ -236,7 +236,11 @@ describe("HealthView (fetch-driven)", () => {
       expect.any(AbortSignal),
     );
 
-    fireEvent.click(agent("window-30"));
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    fireEvent.keyDown(agent("health-range-filter"), { key: "Enter" });
+    fireEvent.click(
+      await screen.findByRole("option", { name: "Last 30 days" }),
+    );
 
     await waitFor(() => expect(fetchers.fetchHistory).toHaveBeenCalledTimes(2));
     expect(fetchers.fetchHistory).toHaveBeenLastCalledWith(

--- a/plugins/plugin-health/src/components/health/HealthView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.test.tsx
@@ -160,14 +160,14 @@ describe("HealthView (fetch-driven)", () => {
     await screen.findByText("network down");
     fireEvent.click(agent("retry"));
 
-    await screen.findByText("None");
+    await screen.findByText("No sleep data yet");
     expect(fetchHistory).toHaveBeenCalledTimes(2);
   });
 
   it("renders the empty (connect-a-source) state when no episodes exist", async () => {
     render(<HealthView fetchers={makeFetchers(emptyHistory())} />);
 
-    await screen.findByText("None");
+    await screen.findByText("No sleep data yet");
     expect(screen.queryByText("14d empty")).toBeNull();
   });
 

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
@@ -145,7 +145,7 @@ export function InboxSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={2} padding={1}>
+    <Card gap={2} padding={1} grow={1} shrink={0}>
       {snapshot.status === "loading" ||
       snapshot.hasConnectedChannels ||
       snapshot.items.length > 0 ? (
@@ -281,9 +281,11 @@ function InboxEmptyBody({
       .map((source) => source.label)
       .join(", ");
     return (
-      <VStack gap={1}>
-        <Text bold>No messages from reachable channels</Text>
-        <Text tone="muted" style="caption">
+      <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+        <Text bold align="center">
+          No messages from reachable channels
+        </Text>
+        <Text tone="muted" style="caption" align="center">
           {`${labels} could not be checked; this may not be everything.`}
         </Text>
       </VStack>
@@ -293,9 +295,11 @@ function InboxEmptyBody({
     !snapshot.hasConnectedChannels && snapshot.activeFilterCount === 0;
   if (noChannels) {
     return (
-      <VStack gap={1}>
-        <Text bold>No inboxes connected</Text>
-        <Text tone="muted" style="caption">
+      <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+        <Text bold align="center">
+          No inboxes connected
+        </Text>
+        <Text tone="muted" style="caption" align="center">
           Connect a messaging channel to review conversations here.
         </Text>
         <HStack gap={1}>
@@ -307,9 +311,11 @@ function InboxEmptyBody({
     );
   }
   return (
-    <VStack gap={1}>
-      <Text bold>Inbox zero</Text>
-      <Text tone="muted" style="caption">
+    <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+      <Text bold align="center">
+        Inbox zero
+      </Text>
+      <Text tone="muted" style="caption" align="center">
         Nothing needs your attention right now.
       </Text>
     </VStack>

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
@@ -146,7 +146,11 @@ export function InboxSpatialView({
 
   return (
     <Card gap={2} padding={1}>
-      <InboxChannelFilters filters={snapshot.filters} dispatch={dispatch} />
+      {snapshot.status === "loading" ||
+      snapshot.hasConnectedChannels ||
+      snapshot.items.length > 0 ? (
+        <InboxChannelFilters filters={snapshot.filters} dispatch={dispatch} />
+      ) : null}
       {snapshot.status !== "loading" && snapshot.status !== "error" ? (
         <InboxDegradedBanner
           degradedSources={snapshot.degradedSources}
@@ -208,15 +212,19 @@ function InboxChannelFilters({
 }) {
   return (
     <HStack gap={1} wrap align="center" shrink={0}>
+      <Text style="caption" tone="muted" shrink={0}>
+        Show
+      </Text>
       {filters.map((filter) => (
         <Button
           key={filter.channel}
-          variant={filter.active ? "solid" : "outline"}
-          tone={filter.active ? "primary" : "default"}
+          variant={filter.active ? "solid" : "ghost"}
+          tone={filter.active ? "primary" : "muted"}
+          pressed={filter.active}
           agent={`inbox-channel-${filter.channel}`}
           onPress={dispatch(`channel:${filter.channel}`)}
         >
-          {filter.active ? `* ${filter.label}` : filter.label}
+          {filter.label}
         </Button>
       ))}
     </HStack>
@@ -286,16 +294,24 @@ function InboxEmptyBody({
   if (noChannels) {
     return (
       <VStack gap={1}>
-        <Text bold>None</Text>
-        <Button width="100%" agent="connect" onPress={dispatch("connect")}>
-          Connect
-        </Button>
+        <Text bold>No inboxes connected</Text>
+        <Text tone="muted" style="caption">
+          Connect a messaging channel to review conversations here.
+        </Text>
+        <HStack gap={1}>
+          <Button agent="connect" onPress={dispatch("connect")}>
+            Connect channel
+          </Button>
+        </HStack>
       </VStack>
     );
   }
   return (
     <VStack gap={1}>
       <Text bold>Inbox zero</Text>
+      <Text tone="muted" style="caption">
+        Nothing needs your attention right now.
+      </Text>
     </VStack>
   );
 }
@@ -358,13 +374,13 @@ function InboxChannelGroupBody({
                 </Text>
               </VStack>
               <Button
-                variant="outline"
-                tone="default"
-                agent={`open:${item.id}`}
+                variant="ghost"
+                tone="muted"
+                agent={{ id: `open:${item.id}`, label: `Open ${title}` }}
                 onPress={dispatch(`open:${item.id}`)}
                 shrink={0}
               >
-                Open
+                ›
               </Button>
             </HStack>
           );

--- a/plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx
@@ -198,7 +198,7 @@ describe("InboxView — empty states", () => {
         fetchers={makeFetchers({ fetchInbox: async () => emptyInbox(false) })}
       />,
     );
-    await screen.findByText("None");
+    await screen.findByText("No inboxes connected");
     expect(agent("connect")).toBeTruthy();
   });
 
@@ -208,7 +208,7 @@ describe("InboxView — empty states", () => {
         fetchers={makeFetchers({ fetchInbox: async () => emptyInbox(false) })}
       />,
     );
-    await screen.findByText("None");
+    await screen.findByText("No inboxes connected");
     fireEvent.click(agent("connect"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
@@ -220,7 +220,7 @@ describe("InboxView — empty states", () => {
       />,
     );
     await screen.findByText(/Inbox zero/i);
-    expect(screen.queryByText("None")).toBeNull();
+    expect(screen.queryByText("No inboxes connected")).toBeNull();
   });
 });
 
@@ -302,7 +302,7 @@ describe("InboxView — degraded connector", () => {
       />,
     );
     // Not-connected is the connect empty state, not a degradation warning.
-    await screen.findByText("None");
+    await screen.findByText("No inboxes connected");
     expect(screen.queryByText("Gmail unavailable")).toBeNull();
     expect(agent("connect")).toBeTruthy();
   });

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
@@ -80,7 +80,7 @@ export function TodosSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} grow={1} shrink={0}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading
@@ -124,9 +124,11 @@ function TodosEmptyBody({
   dispatch: (action: string) => () => void;
 }) {
   return (
-    <>
-      <Text bold>No todos yet</Text>
-      <Text tone="muted" style="caption">
+    <VStack grow={1} justify="center" align="center" gap={1} padding={2}>
+      <Text bold align="center">
+        No todos yet
+      </Text>
+      <Text tone="muted" style="caption" align="center">
         Add something you want Eliza to keep track of.
       </Text>
       <HStack gap={1}>
@@ -134,7 +136,7 @@ function TodosEmptyBody({
           Add todo
         </Button>
       </HStack>
-    </>
+    </VStack>
   );
 }
 
@@ -166,23 +168,41 @@ function TodosReadyBody({
           Add todo
         </Button>
       </HStack>
-      {LANES.map((lane) => (
-        <Lane key={lane.id} lane={lane} todos={snapshot.lanes[lane.id]} />
+      {LANES.map((lane, index) => (
+        <Lane
+          key={lane.id}
+          lane={lane}
+          todos={snapshot.lanes[lane.id]}
+          isLast={index === LANES.length - 1}
+        />
       ))}
     </>
   );
 }
 
-function Lane({ lane, todos }: { lane: LaneDef; todos: TodoCard[] }) {
+function Lane({
+  lane,
+  todos,
+  isLast,
+}: {
+  lane: LaneDef;
+  todos: TodoCard[];
+  isLast: boolean;
+}) {
   return (
-    <>
-      <Divider label={`${lane.label} (${todos.length})`} />
+    <VStack gap={1} padding={isLast ? undefined : { bottom: 2 }}>
+      <HStack gap={1} align="center">
+        <Text bold style="caption" wrap={false} shrink={0}>
+          {`${lane.label} (${todos.length})`}
+        </Text>
+        <Divider grow={1} />
+      </HStack>
       {todos.length > 0 ? (
         <List gap={0}>
           {todos.map((todo) => (
             <HStack
               key={todo.id}
-              gap={1}
+              gap={2}
               align="center"
               agent={`todo-${todo.id}`}
             >
@@ -203,6 +223,6 @@ function Lane({ lane, todos }: { lane: LaneDef; todos: TodoCard[] }) {
           ))}
         </List>
       ) : null}
-    </>
+    </VStack>
   );
 }

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
@@ -14,7 +14,15 @@
  * fetches or computes — it displays the snapshot and dispatches actions.
  */
 
-import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
+import {
+  Button,
+  Card,
+  Divider,
+  HStack,
+  List,
+  Text,
+  VStack,
+} from "@elizaos/ui/spatial";
 
 export type LaneId = "today" | "upcoming" | "someday";
 
@@ -82,7 +90,7 @@ export function TodosSpatialView({
       ) : snapshot.state === "empty" ? (
         <TodosEmptyBody dispatch={dispatch} />
       ) : (
-        <TodosReadyBody snapshot={snapshot} />
+        <TodosReadyBody snapshot={snapshot} dispatch={dispatch} />
       )}
     </Card>
   );
@@ -117,26 +125,47 @@ function TodosEmptyBody({
 }) {
   return (
     <>
-      <Text bold>None</Text>
+      <Text bold>No todos yet</Text>
+      <Text tone="muted" style="caption">
+        Add something you want Eliza to keep track of.
+      </Text>
       <HStack gap={1}>
         <Button agent="add" onPress={dispatch("add")}>
-          Add
+          Add todo
         </Button>
       </HStack>
     </>
   );
 }
 
-function TodosReadyBody({ snapshot }: { snapshot: TodosSnapshot }) {
+function TodosReadyBody({
+  snapshot,
+  dispatch,
+}: {
+  snapshot: TodosSnapshot;
+  dispatch: (action: string) => () => void;
+}) {
+  const total = LANES.reduce(
+    (count, lane) => count + snapshot.lanes[lane.id].length,
+    0,
+  );
   return (
     <>
-      {snapshot.overdue > 0 ? (
-        <Text tone="warning" style="caption">
-          {snapshot.overdue === 1
-            ? "1 todo is overdue."
-            : `${snapshot.overdue} todos are overdue.`}
-        </Text>
-      ) : null}
+      <HStack gap={1} align="center">
+        <VStack gap={0} grow={1}>
+          <Text bold>{`${total} open`}</Text>
+          {snapshot.overdue > 0 ? (
+            <Text tone="warning" style="caption">
+              {snapshot.overdue === 1
+                ? "1 overdue"
+                : `${snapshot.overdue} overdue`}
+            </Text>
+          ) : null}
+        </VStack>
+        <Button agent="add" onPress={dispatch("add")}>
+          Add todo
+        </Button>
+      </HStack>
       {LANES.map((lane) => (
         <Lane key={lane.id} lane={lane} todos={snapshot.lanes[lane.id]} />
       ))}
@@ -147,9 +176,7 @@ function TodosReadyBody({ snapshot }: { snapshot: TodosSnapshot }) {
 function Lane({ lane, todos }: { lane: LaneDef; todos: TodoCard[] }) {
   return (
     <>
-      <Text style="caption" tone="muted">
-        {lane.label} ({todos.length})
-      </Text>
+      <Divider label={`${lane.label} (${todos.length})`} />
       {todos.length > 0 ? (
         <List gap={0}>
           {todos.map((todo) => (

--- a/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
@@ -139,7 +139,7 @@ describe("TodosView — states", () => {
         fetchers: makeFetchers({ fetchTodos: async () => ({ todos: [] }) }),
       }),
     );
-    await screen.findByText("None");
+    await screen.findByText("No todos yet");
     expect(screen.queryByText("Overdue task")).toBeNull();
   });
 
@@ -153,7 +153,7 @@ describe("TodosView — states", () => {
         }),
       }),
     );
-    await screen.findByText("None");
+    await screen.findByText("No todos yet");
     expect(screen.queryByText("Done")).toBeNull();
   });
 
@@ -163,7 +163,7 @@ describe("TodosView — states", () => {
         fetchers: makeFetchers({ fetchTodos: async () => ({ todos: [] }) }),
       }),
     );
-    await screen.findByText("None");
+    await screen.findByText("No todos yet");
     fireEvent.click(agent("add"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
@@ -251,7 +251,7 @@ describe("TodosView — proactive overdue line", () => {
   it("surfaces one quiet line when active todos are past due", async () => {
     render(React.createElement(TodosView, { fetchers: makeFetchers() }));
     await screen.findByText("Overdue task");
-    expect(screen.getByText("1 todo is overdue.")).toBeTruthy();
+    expect(screen.getByText("1 overdue")).toBeTruthy();
   });
 
   it("pluralizes the overdue line for multiple past-due todos", async () => {
@@ -275,7 +275,7 @@ describe("TodosView — proactive overdue line", () => {
       }),
     );
     await screen.findByText("Late one");
-    expect(screen.getByText("2 todos are overdue.")).toBeTruthy();
+    expect(screen.getByText("2 overdue")).toBeTruthy();
   });
 
   it("renders no proactive line when nothing is overdue", async () => {


### PR DESCRIPTION
Todos, Inbox, Goals, Health, Finances, and Focus now use compact filters, disclosure rows, and responsive layouts. The review also repairs three behavior defects: Finances preserves category filtering when switching to All, Goals exposes readable action labels, and Focus waits for the actual chat response, blocks duplicate submission, and presents a recoverable failure.

Fixes #29775.

Validation at `9c41b5e1870a964105f97b20a5f7809d2f0fffd3`:

- All six owning plugin suites passed: Todos 124; Inbox 245 with 2 skips; Goals 81 with 1 skip; Health 199 with 4 skips; Finances 199; Focus/app-blocker 46.
- Full app suite passed: 948 Bun tests with 2 skips and 1,606 Vitest tests. Root `bun run verify` passed all 376 Turbo tasks plus repository audits after rebase/install.
- Five visual audit/inspection/iteration cycles completed, followed by a final full 219-case audit and OCR check. All 24 current route/viewport captures were inspected; no affected view retains a broken or needs-work verdict.
- Real browser Focus submission/retry passed on desktop and mobile with explicit HTTP fixtures. A mobile test timed out when bundled after the six-route capture run; its isolated rerun passed. These recordings validate UI/transport behavior, not a live blocking integration or live-model response.
- All five hosted checks passed. Full UI suite: 13,547 passed, 7 skipped.

Current inspected screenshots, recordings, and logs follow. Historical before/after captures from the original PR are retained below for comparison.

Independent desktop review after the repairs, source e67fd59af6a (the final commit only waits for the shell/fonts before captures). Each image pairs rest and hover; the last pairs the Focus failure with the successful retry response. Goals retains readable review labels. Selecting all finance periods preserves the category. Focus awaits the actual HTTP client response, prevents duplicate pending requests, shows failure, and permits retry; it does not claim a blocking session is active merely because the request was sent.

The desktop renderer journey passed. Five audit/inspection cycles are complete; the final full app audit passed 219 checks with zero broken/needs-work views. All six plugin suites passed. Remaining repository gates are still running. These browser journeys use deterministic upstream HTTP responses; they do not claim live website blocking or a live-model turn.

<img width="1280" height="400" alt="29779-desktop-finances" src="https://github.com/user-attachments/assets/97e3b598-cfa4-45f1-8ac9-466329b7b95b" />
<img width="1280" height="400" alt="29779-desktop-goals" src="https://github.com/user-attachments/assets/e9ce0435-2e34-4a29-a315-c0b16fccf00d" />
<img width="1280" height="400" alt="29779-desktop-health" src="https://github.com/user-attachments/assets/acd77426-1afe-4c9e-a080-39b56cf6b13c" />
<img width="1280" height="400" alt="29779-desktop-inbox" src="https://github.com/user-attachments/assets/c2f822fa-ea3e-432a-bebc-6d0807637a0d" />
<img width="1280" height="400" alt="29779-desktop-todos" src="https://github.com/user-attachments/assets/b47b129f-48eb-475e-b95a-88bfa52c8da9" />
<img width="1280" height="400" alt="29779-desktop-focus" src="https://github.com/user-attachments/assets/755ec337-e92f-4e98-8370-e5e1e73c5e5f" />
<img width="1280" height="400" alt="29779-desktop-feedback" src="https://github.com/user-attachments/assets/948f0d96-dd69-4f27-ab60-1bd42144c70d" />


Reviewed mobile rest/hover states for all six LifeOps routes, plus Focus failure and retry. The isolated mobile browser journey passed in 38 seconds. The preceding combined desktop/mobile run passed desktop but hit the overall test timeout during mobile under host load; that failed result remains recorded and was not counted as passing. The isolated rerun used the same code and assertions.

<img width="780" height="844" alt="29779-mobile-finances" src="https://github.com/user-attachments/assets/ea4ee529-c1ec-4fd1-bc19-e5bdac7dfe6e" />
<img width="780" height="844" alt="29779-mobile-goals" src="https://github.com/user-attachments/assets/796b17d0-167d-409d-aac4-2617303bb314" />
<img width="780" height="844" alt="29779-mobile-health" src="https://github.com/user-attachments/assets/1d80ac6b-ff5f-4663-9c20-1bd13b41a791" />
<img width="780" height="844" alt="29779-mobile-inbox" src="https://github.com/user-attachments/assets/3fcf1379-36ac-45ab-ad46-d3b459de6a68" />
<img width="780" height="844" alt="29779-mobile-todos" src="https://github.com/user-attachments/assets/cfdb0b9e-6b60-46d2-a66b-4fb9d290424e" />
<img width="780" height="844" alt="29779-mobile-focus" src="https://github.com/user-attachments/assets/4959fad5-30c6-4d2e-9992-ca884326d34a" />
<img width="780" height="844" alt="29779-mobile-feedback" src="https://github.com/user-attachments/assets/061e7e7d-13dd-4244-812a-9d967a214ca5" />


Recorded walkthroughs from the successful desktop and mobile renderer runs, in that order, with console/network logs. The Focus route sends the original complete prompt, displays the injected HTTP 503 as a visible failure, then displays the complete response after retry. Native website blocking and live-model behavior are outside this browser fixture proof; the recorded response deliberately asks which websites to block and the UI continues to show no active session.


https://github.com/user-attachments/assets/31e674b1-ad1c-431c-8071-af770d3d2fbf


https://github.com/user-attachments/assets/34391057-697f-44c1-8b69-2bf07e7e388c

[29779-desktop-console-network.txt](https://github.com/user-attachments/files/31869168/29779-desktop-console-network.txt)
[29779-mobile-console-network.txt](https://github.com/user-attachments/files/31869169/29779-mobile-console-network.txt)



## Visual evidence

Every image below is a separate full-page capture; no comparison image is composited.

### Todos

| Before desktop | After desktop, populated |
| --- | --- |
| ![Todos before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-before-desktop.png) | ![Todos after desktop populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-populated-desktop-v3.png) |
| After portrait, populated | After portrait, empty |
| ![Todos after portrait populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-populated-portrait-v3.png) | ![Todos after portrait empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-empty-portrait-v2.png) |
| After landscape, populated | After landscape, empty |
| ![Todos after landscape populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-populated-landscape-v3.png) | ![Todos after landscape empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-empty-landscape-v2.png) |

### Inbox

| Before desktop | After desktop, populated |
| --- | --- |
| ![Inbox before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-before-desktop.png) | ![Inbox after desktop populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-populated-desktop-v2.png) |
| After portrait, populated | After portrait, empty |
| ![Inbox after portrait populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-populated-portrait-v2.png) | ![Inbox after portrait empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-empty-portrait-v2.png) |
| After landscape, populated | After landscape, empty |
| ![Inbox after landscape populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-populated-landscape-v2.png) | ![Inbox after landscape empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-empty-landscape-v2.png) |

### Goals

| Before desktop | After desktop, populated |
| --- | --- |
| ![Goals before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-before-desktop.png) | ![Goals after desktop populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-populated-desktop-v2.png) |
| After portrait, populated | After portrait, empty |
| ![Goals after portrait populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-populated-portrait-v2.png) | ![Goals after portrait empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-empty-portrait-v2.png) |
| After landscape, populated | After landscape, empty |
| ![Goals after landscape populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-populated-landscape-v2.png) | ![Goals after landscape empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-empty-landscape-v2.png) |

### Health

| Before desktop | After desktop, populated |
| --- | --- |
| ![Health before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-before-desktop.png) | ![Health after desktop populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-populated-desktop-v2.png) |
| After portrait, populated | After portrait, empty |
| ![Health after portrait populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-populated-portrait-v2.png) | ![Health after portrait empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-empty-portrait-v2.png) |
| After landscape, populated | After landscape, empty |
| ![Health after landscape populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-populated-landscape-v2.png) | ![Health after landscape empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-empty-landscape-v2.png) |

### Finances

| Before desktop | After desktop, populated |
| --- | --- |
| ![Finances before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-before-desktop.png) | ![Finances after desktop populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-populated-desktop-v2.png) |
| After portrait, populated | After portrait, empty |
| ![Finances after portrait populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-populated-portrait-v2.png) | ![Finances after portrait empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-empty-portrait-v2.png) |
| After landscape, populated | After landscape, empty |
| ![Finances after landscape populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-populated-landscape-v2.png) | ![Finances after landscape empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-empty-landscape-v2.png) |

### Focus

| Before desktop | After desktop, populated |
| --- | --- |
| ![Focus before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-before-desktop.png) | ![Focus after desktop populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-after-populated-desktop.png) |
| After portrait, populated | After portrait, empty |
| ![Focus after portrait populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-after-populated-portrait.png) | ![Focus after portrait empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-empty-portrait-v2.png) |
| After landscape, populated | After landscape, empty |
| ![Focus after landscape populated](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-after-populated-landscape.png) | ![Focus after landscape empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-empty-landscape-v2.png) |

### Designed-empty desktop states

| Todos | Inbox |
| --- | --- |
| ![Todos desktop empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-empty-desktop-v2.png) | ![Inbox desktop empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-inbox-empty-desktop-v2.png) |
| Goals | Health |
| ![Goals desktop empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-goals-empty-desktop-v2.png) | ![Health desktop empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-health-empty-desktop-v2.png) |
| Finances | Focus |
| ![Finances desktop empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-finances-empty-desktop-v2.png) | ![Focus desktop empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-focus-empty-desktop-v2.png) |

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-before-desktop.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-todos-populated-desktop-v3.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-lifeops-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend, API, database, worker, or service behavior changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - local UI matrix and package audit results are documented in the PR validation section; no runtime console or network behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, trajectory, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - this is a UI-only layout change; route source, tests, and audit contract are the complete domain artifact

<!-- evidence-row:ocr-review -->
- [x] [29779-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29779-ocr-triage.json)

<!-- evidence-head:59329fae85dace70aa4130ac36d5fe3f420f94b3 -->




