### PR TITLE
fix(ui): preserve active model across stream snapshots

### DIFF
--- a/packages/ui/src/components/local-inference/LocalInferencePanel.test.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for LocalInferencePanel's SSE state reconciliation.
+ * The deterministic jsdom harness mocks the local-inference API, child views,
+ * and EventSource so downloads-only snapshots cannot erase active model state.
+ */
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelHubSnapshot } from "../../api/client-local-inference";
+
+const clientMock = vi.hoisted(() => ({
+  getLocalInferenceHub: vi.fn(),
+  getVoiceModelPreferences: vi.fn(),
+  listVoiceModels: vi.fn(),
+}));
+
+const eventSourceMock = vi.hoisted(() => ({
+  source: {
+    close: vi.fn(),
+    onerror: null as null | (() => void),
+    onmessage: null as null | ((event: MessageEvent) => void),
+    readyState: 1,
+  },
+}));
+const appStateMock = vi.hoisted(() => ({
+  setActionNotice: vi.fn(),
+  t: (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("../../api", () => ({ client: clientMock }));
+vi.mock("../../hooks/useRenderGuard", () => ({ useRenderGuard: vi.fn() }));
+vi.mock("../../hooks/useRole", () => ({
+  useRole: () => ({ isOwner: true }),
+}));
+vi.mock("../../services/local-inference/catalog-policy", () => ({
+  filterSettingsDefaultLocalModels: (models: unknown[]) => models,
+}));
+vi.mock("../../state", () => ({
+  useAppSelectorShallow: (selector: (state: unknown) => unknown) =>
+    selector(appStateMock),
+}));
+vi.mock("../../utils/asset-url", () => ({
+  resolveApiUrl: (path: string) => path,
+}));
+vi.mock("../../utils/eliza-globals", () => ({
+  getElizaApiToken: () => null,
+}));
+vi.mock("../../utils/event-source", () => ({
+  openEventSource: () => eventSourceMock.source,
+}));
+vi.mock("../../utils/renderer-diagnostics", () => ({
+  reportRendererDiagnostic: vi.fn(),
+}));
+vi.mock("./useDeviceBridgeStatus", () => ({
+  useDeviceBridgeStatus: () => ({}),
+}));
+
+vi.mock("./ActiveModelBar", () => ({
+  ActiveModelBar: ({ active }: { active: { modelId: string | null } }) => (
+    <output data-testid="active-model">{active.modelId ?? "none"}</output>
+  ),
+}));
+vi.mock("./DeviceBridgeStatus", () => ({
+  DeviceBridgeStatusBar: () => null,
+}));
+vi.mock("./DevicesPanel", () => ({ DevicesPanel: () => null }));
+vi.mock("./DownloadQueue", () => ({ DownloadQueue: () => null }));
+vi.mock("./FirstRunOffer", () => ({ FirstRunOffer: () => null }));
+vi.mock("./HardwareBadge", () => ({ HardwareBadge: () => null }));
+vi.mock("./ModelHubView", () => ({ ModelHubView: () => null }));
+vi.mock("./ModelUpdatesPanel", () => ({ ModelUpdatesPanel: () => null }));
+vi.mock("../settings/settings-control-primitives", () => ({
+  AdvancedSettingsDisclosure: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+import { LocalInferencePanel } from "./LocalInferencePanel";
+
+const unassignedSlot = {
+  assigned: false,
+  assignedModelId: null,
+  displayName: null,
+  primaryDownloaded: false,
+  downloaded: false,
+  active: false,
+  ready: false,
+  state: "unassigned" as const,
+  requiredModelIds: [],
+  missingModelIds: [],
+  installedBytes: 0,
+  expectedBytes: 0,
+  errors: [],
+  download: {
+    state: "missing" as const,
+    receivedBytes: 0,
+    totalBytes: 0,
+    percent: null,
+    bytesPerSec: 0,
+    etaMs: null,
+    updatedAt: null,
+    errors: [],
+  },
+};
+const initialHub: ModelHubSnapshot = {
+  active: {
+    loadedAt: "2026-08-28T00:00:00.000Z",
+    modelId: "eliza-1-initial",
+    status: "ready",
+  },
+  catalog: [],
+  downloads: [],
+  hardware: {
+    totalRamGb: 16,
+    freeRamGb: 8,
+    gpu: null,
+    cpuCores: 8,
+    platform: "linux",
+    arch: "x64",
+    appleSilicon: false,
+    recommendedBucket: "small",
+    source: "os-fallback",
+  },
+  assignments: {},
+  textReadiness: {
+    updatedAt: "2026-08-28T00:00:00.000Z",
+    slots: {
+      TEXT_SMALL: { ...unassignedSlot, slot: "TEXT_SMALL" },
+      TEXT_LARGE: { ...unassignedSlot, slot: "TEXT_LARGE" },
+    },
+  },
+  installed: [],
+};
+
+beforeEach(() => {
+  clientMock.getLocalInferenceHub.mockReset();
+  // Keep the unrelated voice bootstrap pending so this focused stream test
+  // cannot schedule state updates after its assertions complete.
+  clientMock.getVoiceModelPreferences.mockImplementation(
+    () => new Promise(() => {}),
+  );
+  clientMock.listVoiceModels.mockImplementation(() => new Promise(() => {}));
+  eventSourceMock.source.close.mockClear();
+  eventSourceMock.source.onerror = null;
+  eventSourceMock.source.onmessage = null;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LocalInferencePanel stream snapshots", () => {
+  it("preserves authoritative active state when a downloads snapshot omits it", async () => {
+    const { promise: hubPromise, resolve: resolveHub } =
+      Promise.withResolvers<ModelHubSnapshot>();
+    clientMock.getLocalInferenceHub.mockReturnValue(hubPromise);
+
+    render(<LocalInferencePanel />);
+    await act(async () => {
+      resolveHub(initialHub);
+      await hubPromise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-model").textContent).toBe(
+        "eliza-1-initial",
+      );
+    });
+
+    act(() => {
+      eventSourceMock.source.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({ downloads: [], type: "snapshot" }),
+        }),
+      );
+    });
+
+    expect(screen.getByTestId("active-model").textContent).toBe(
+      "eliza-1-initial",
+    );
+
+    act(() => {
+      eventSourceMock.source.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            active: {
+              loadedAt: "2026-08-28T00:01:00.000Z",
+              modelId: "eliza-1-next",
+              status: "ready",
+            },
+            type: "active",
+          }),
+        }),
+      );
+    });
+
+    expect(screen.getByTestId("active-model").textContent).toBe("eliza-1-next");
+
+    act(() => {
+      eventSourceMock.source.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "snapshot",
+            downloads: [],
+            active: { modelId: null, loadedAt: null, status: "idle" },
+          }),
+        }),
+      );
+    });
+    expect(screen.getByTestId("active-model").textContent).toBe("none");
+  });
+});

--- a/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
@@ -93,7 +93,7 @@ export function LocalInferencePanel() {
           | {
               type: "snapshot";
               downloads: DownloadJob[];
-              active: ActiveModelState;
+              active?: ActiveModelState;
             }
           | {
               type: "progress" | "completed" | "failed" | "cancelled";
@@ -107,7 +107,9 @@ export function LocalInferencePanel() {
               ? {
                   ...prev,
                   downloads: payload.downloads,
-                  active: payload.active,
+                  ...(payload.active === undefined
+                    ? {}
+                    : { active: payload.active }),
                 }
               : prev,
           );


### PR DESCRIPTION
Local inference download snapshots now preserve the currently active model when the stream omits that field. An explicit idle snapshot with a null model ID still clears the active model. The regression exercises real MessageEvent delivery into the mounted component, covering a download snapshot followed by an explicit idle snapshot.

Validation for a0388a395b75937476c2e63e7414ee28614114f7:

- Rebase and normal installation completed. Full repository verification passed.
- Focused component regression passed. Full UI run: 13,524 passed, seven skipped, one unrelated protected-storage teardown timed out. That unchanged suite passed an isolated rerun (16 tests; 60-second import-inclusive budget, actual test execution 9.66 seconds).
- App audit: 219 passed. Focused visual evidence and final hosted admission are being completed before merge.
- No model inference or device installation is changed or claimed by this update.

Real browser acceptance: the actual panel and active-model bar consumed a local HTTP SSE stream in Chromium on desktop and mobile. The original revision crashed the React render on a downloads-only snapshot (undefined active.modelId); this revision retained the model, accepted a later active-model event, and cleared it on an explicit idle snapshot. Unrelated panel children and bootstrap data were fixtures; this does not claim real model inference.

Reviewed browser evidence for a0388a395b75937476c2e63e7414ee28614114f7. Actual settings panel and active-model bar, real HTTP SSE, Chromium desktop/mobile. Original: downloads-only snapshot crashes React on undefined active.modelId. Fixed: retains active model, applies later active event, clears explicit idle. Unrelated children and bootstrap are fixtures; no inference claim.

Before desktop/mobile:
![Before desktop](https://github.com/user-attachments/assets/dacc93ec-bd3d-4d97-ab36-9ba41563ef07)
![Before mobile](https://github.com/user-attachments/assets/5402d600-b0e1-4959-8e00-33cee86115d8)

After desktop/mobile:
![After desktop](https://github.com/user-attachments/assets/64a447d0-228e-4038-87f2-cf8d32fea556)
![After mobile hover](https://github.com/user-attachments/assets/f709a29c-49fa-4166-8f0f-645b866dff5c)

Desktop walkthrough:
https://github.com/user-attachments/assets/57c13093-92e6-4570-9c79-de65784004c7

Mobile walkthrough:
https://github.com/user-attachments/assets/06e47dd0-7262-4a13-8900-f0ed787cc14c

[Source, event/console logs, screenshots and before/after MP4s](https://github.com/user-attachments/files/31866912/29783-reviewed-evidence.zip)
