### PR TITLE
fix(openai): isolate connection warm-up by runtime

### DIFF
--- a/plugins/plugin-openai/__tests__/preconnect.test.ts
+++ b/plugins/plugin-openai/__tests__/preconnect.test.ts
@@ -1,0 +1,83 @@
+/** Real runtime event dispatch with a deterministic connection-warming boundary. */
+import { AgentRuntime, EventType } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openaiPlugin } from "../index";
+
+const runtimes: AgentRuntime[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  for (const runtime of runtimes.splice(0)) await runtime.stop();
+});
+
+async function createRuntime(baseURL: string) {
+  const runtime = new AgentRuntime({
+    character: { name: "preconnect-test", bio: [], settings: { OPENAI_BASE_URL: baseURL } },
+  });
+  runtimes.push(runtime);
+  await runtime.registerPlugin(openaiPlugin);
+  return runtime;
+}
+
+function installPreconnect(preconnect?: (url: string) => void) {
+  const request = vi.fn(async () => {
+    throw new Error("Preconnection must not dispatch an HTTP request");
+  });
+  vi.stubGlobal("fetch", Object.assign(request, { preconnect }));
+  return request;
+}
+
+describe("provider connection warming on ingress", () => {
+  it("throttles repeated text and voice ingress while allowing later warm-up", async () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const preconnect = vi.fn();
+    const request = installPreconnect(preconnect);
+    const runtime = await createRuntime("https://first.example/v1");
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {});
+    await runtime.emitEvent(EventType.VOICE_MESSAGE_RECEIVED, {});
+    expect(preconnect.mock.calls).toEqual([["https://first.example/v1"]]);
+    now = 16_000;
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {});
+    expect(preconnect).toHaveBeenCalledTimes(2);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("warms independent runtimes and changed endpoints during the same throttle window", async () => {
+    const preconnect = vi.fn();
+    installPreconnect(preconnect);
+    const first = await createRuntime("https://first.example/v1");
+    const second = await createRuntime("https://second.example/v1");
+    await first.emitEvent(EventType.MESSAGE_RECEIVED, {});
+    await second.emitEvent(EventType.MESSAGE_RECEIVED, {});
+    first.setSetting("OPENAI_BASE_URL", "https://replacement.example/v1");
+    await first.emitEvent(EventType.VOICE_MESSAGE_RECEIVED, {});
+    expect(preconnect.mock.calls).toEqual([
+      ["https://first.example/v1"],
+      ["https://second.example/v1"],
+      ["https://replacement.example/v1"],
+    ]);
+  });
+
+  it("reports connection failure without rejecting ingress or issuing HTTP", async () => {
+    const cause = new Error("connection unavailable");
+    const request = installPreconnect(() => {
+      throw cause;
+    });
+    const runtime = await createRuntime("https://failure.example/v1");
+    const report = vi.spyOn(runtime, "reportError");
+    await expect(runtime.emitEvent(EventType.MESSAGE_RECEIVED, {})).resolves.toBeUndefined();
+    expect(report).toHaveBeenCalledWith(
+      "openai:preconnect",
+      expect.objectContaining({ code: "OPENAI_PRECONNECT_FAILED", cause })
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("accepts ingress in runtimes without preconnect support", async () => {
+    const request = installPreconnect();
+    const runtime = await createRuntime("https://unsupported.example/v1");
+    await expect(runtime.emitEvent(EventType.MESSAGE_RECEIVED, {})).resolves.toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-openai/index.ts
+++ b/plugins/plugin-openai/index.ts
@@ -26,7 +26,7 @@ import type {
   TextEmbeddingParams,
   TokenizeTextParams,
 } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { ElizaError, EventType, logger, ModelType } from "@elizaos/core";
 import {
   handleActionPlanner,
   handleImageDescription,
@@ -151,7 +151,46 @@ function warnWhenApiKeyIsMissing(runtime: IAgentRuntime): void {
   );
 }
 
+/** Warm the configured endpoint during message preparation without dispatching HTTP. */
+const providerPreconnects = new WeakMap<IAgentRuntime, { baseURL: string; attemptedAt: number }>();
+
+function preconnectProvider(runtime: IAgentRuntime): void {
+  const preconnect = (
+    globalThis.fetch as typeof fetch & {
+      preconnect?: (url: string) => void;
+    }
+  ).preconnect;
+  if (typeof preconnect !== "function") return;
+  try {
+    const baseURL = getBaseURL(runtime);
+    const now = Date.now();
+    const previous = providerPreconnects.get(runtime);
+    if (
+      previous?.baseURL === baseURL &&
+      now >= previous.attemptedAt &&
+      now - previous.attemptedAt < 15_000
+    )
+      return;
+    providerPreconnects.set(runtime, { baseURL, attemptedAt: now });
+    preconnect(baseURL);
+  } catch (cause) {
+    // error-policy:J1 The ingress event reports speculative connection failure;
+    // the eventual model request remains responsible for its own result.
+    runtime.reportError(
+      "openai:preconnect",
+      new ElizaError(
+        "[OpenAI] Provider connection warm-up failed; inspect the configured endpoint",
+        { code: "OPENAI_PRECONNECT_FAILED", severity: "ephemeral", cause }
+      )
+    );
+  }
+}
+
 export const openaiPlugin: Plugin = {
+  events: {
+    [EventType.MESSAGE_RECEIVED]: [async ({ runtime }) => preconnectProvider(runtime)],
+    [EventType.VOICE_MESSAGE_RECEIVED]: [async ({ runtime }) => preconnectProvider(runtime)],
+  },
   name: "openai",
   description: "OpenAI API integration for text, image, audio, and embedding models",
   autoEnable: {


### PR DESCRIPTION
OpenAI connection warm-up now tracks endpoint and retry timing per runtime. One agent's warm-up no longer suppresses another agent's endpoint, and failed warm-ups are reported through the runtime's typed error path. The original PR's other changes are already integrated or superseded; the reviewed diff retains the remaining warm-up behavior and its regression coverage.

Validation for `4fd60e1299b10e663ac95afd0474653d80319cd4`:

- All 426 OpenAI package tests passed across 31 files after rebase.
- Four regressions exercise real AgentRuntime event delivery. The original shared warm-up state fails three of those cases.
- A real Bun TCP check warmed two independent local endpoints, with zero HTTP requests before explicit fetch and one connection per endpoint.
- Normal installation and full repository verification passed, including all 376 tasks and final repository audits. Package typecheck and lint passed.
- All five required original PR checks passed on this exact revision. The earlier optional qualification Quality job was cancelled; local full verification provides the completed root gate.
- UI, device, and live model output evidence are N/A: the change establishes transport connections without dispatching a model request.
