### PR TITLE
fix(scripts): classify runtime option skips

### DIFF
--- a/packages/scripts/__tests__/audit-focused-skipped-tests-discovery.test.ts
+++ b/packages/scripts/__tests__/audit-focused-skipped-tests-discovery.test.ts
@@ -252,6 +252,355 @@ describe("anti-larp test discovery", () => {
     ).toEqual(["orphaned-skip", "orphaned-skip", "orphaned-skip"]);
   });
 
+  test("fails closed for shorthand, accessor, method, and spread runner options", () => {
+    const source = `
+      import test from "node:test";
+      const skip = "always skipped via shorthand";
+      const opts = { skip: "always skipped via spread" };
+      test("shorthand", { skip }, () => {});
+      test("getter", { get skip() { return "always skipped via getter"; } }, () => {});
+      test("method", { skip() { return "always skipped via method"; } }, () => {});
+      test("spread", { ...opts }, () => {});
+    `;
+    expect(
+      findViolations("fixture.test.mjs", source).map(({ kind }) => kind),
+    ).toEqual([
+      "orphaned-skip",
+      "orphaned-skip",
+      "orphaned-skip",
+      "orphaned-skip",
+    ]);
+    expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+  });
+
+  test("does not flag statically disabled shorthand or harmless known spreads", () => {
+    const source = `
+      import test from "node:test";
+      const skip = false;
+      const options = { timeout: 1_000 };
+      test("shorthand runs", { skip }, () => {});
+      test("spread runs", { ...options }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", source)).toEqual([]);
+  });
+
+  test("classifies documented runtime Node option skips without blessing lookalikes", () => {
+    const runtimeOption = `
+      import test from "node:test";
+      test("Windows cleanup", {
+        timeout: 15_000,
+        skip: process.platform !== "win32" ? "Windows cleanup contract" : false,
+      }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", runtimeOption)).toEqual([]);
+    expect(findConditionalSkipSites("fixture.test.mjs", runtimeOption)).toEqual(
+      [expect.objectContaining({ form: "conditional-options-skip", line: 3 })],
+    );
+
+    const namedRuntimeGate = `
+      import test from "node:test";
+      const hostIsNode24 =
+        !process.versions.bun && Number(process.versions.node) >= 24;
+      test("host runtime", { skip: !hostIsNode24 }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", namedRuntimeGate)).toEqual([]);
+    expect(
+      findConditionalSkipSites("fixture.test.mjs", namedRuntimeGate),
+    ).toEqual([
+      expect.objectContaining({ form: "conditional-options-skip", line: 5 }),
+    ]);
+
+    const deceptiveNames = `
+      import test from "node:test";
+      const isWindows = true;
+      function WindowsEnabled() { return true; }
+      test("constant binding", { skip: isWindows }, () => {});
+      test("constant call", { skip: WindowsEnabled() }, () => {});
+    `;
+    expect(
+      findViolations("fixture.test.mjs", deceptiveNames).map(
+        ({ kind }) => kind,
+      ),
+    ).toEqual(["orphaned-skip", "orphaned-skip"]);
+    expect(
+      findConditionalSkipSites("fixture.test.mjs", deceptiveNames),
+    ).toEqual([]);
+
+    const shadowedAndMutable = `
+      import test from "node:test";
+      const isWindows = process.platform === "win32";
+      function register(isWindows) {
+        test("shadowed parameter", { skip: isWindows }, () => {});
+      }
+      register(true);
+      let hostIsWindows = process.platform === "win32";
+      hostIsWindows = true;
+      test("reassigned binding", { skip: hostIsWindows }, () => {});
+    `;
+    expect(
+      findViolations("fixture.test.mjs", shadowedAndMutable).map(
+        ({ kind }) => kind,
+      ),
+    ).toEqual(["orphaned-skip", "orphaned-skip"]);
+    expect(
+      findConditionalSkipSites("fixture.test.mjs", shadowedAndMutable),
+    ).toEqual([]);
+
+    const shadowedRuntimeRoots = `
+      import test from "node:test";
+      const process = { platform: "win32", env: { SKIP: "yes" } };
+      const os = { platform: () => "win32" };
+      const gateA = process.platform === "win32";
+      const gateB = process.env.SKIP;
+      const gateC = os.platform() === "win32";
+      test("case one", { skip: gateA }, () => {});
+      test("case two", { skip: gateB }, () => {});
+      test("case three", { skip: gateC }, () => {});
+      function register(process) {
+        const gateD = process.platform === "win32";
+        test("case four", { skip: gateD }, () => {});
+      }
+      register({ platform: "win32" });
+    `;
+    expect(
+      findViolations("fixture.test.mjs", shadowedRuntimeRoots).map(
+        ({ kind }) => kind,
+      ),
+    ).toEqual([
+      "orphaned-skip",
+      "orphaned-skip",
+      "orphaned-skip",
+      "orphaned-skip",
+    ]);
+    expect(
+      findConditionalSkipSites("fixture.test.mjs", shadowedRuntimeRoots),
+    ).toEqual([]);
+
+    const scopeShadowedRuntimeRoots = [
+      `
+        import test from "node:test";
+        for (const process of [{ platform: "win32" }]) {
+          const gate = process.platform === "win32";
+          test("loop binding", { skip: gate }, () => {});
+        }
+      `,
+      `
+        import test from "node:test";
+        for (let process = { platform: "win32" }; false;) {
+          const gate = process.platform === "win32";
+          test("loop initializer", { skip: gate }, () => {});
+        }
+      `,
+      `
+        import test from "node:test";
+        switch (1) {
+          case 1:
+            const process = { platform: "win32" };
+            const gate = process.platform === "win32";
+            test("switch binding", { skip: gate }, () => {});
+            break;
+        }
+      `,
+      `
+        import test from "node:test";
+        function register() {
+          if (false) var process = { platform: "win32" };
+          const gate = process.platform === "win32";
+          test("hoisted function binding", { skip: gate }, () => {});
+        }
+      `,
+      `
+        import test from "node:test";
+        if (false) var process = { platform: "win32" };
+        const gate = process.platform === "win32";
+        test("hoisted source binding", { skip: gate }, () => {});
+      `,
+    ];
+    for (const source of scopeShadowedRuntimeRoots) {
+      expect(
+        findViolations("fixture.test.mjs", source).map(({ kind }) => kind),
+      ).toEqual(["orphaned-skip"]);
+      expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+    }
+
+    const reassignedRuntimeRoots = [
+      `
+        const test = require("node:test");
+        process = { platform: "win32" };
+        const gate = process.platform === "win32";
+        test("case one", { skip: gate }, () => {});
+      `,
+      `
+        const test = require("node:test");
+        process.env.SKIP = "yes";
+        const gate = process.env.SKIP;
+        test("case two", { skip: gate }, () => {});
+      `,
+      `
+        const test = require("node:test");
+        process.runtimeGate++;
+        const gate = process.runtimeGate > 0;
+        test("case three", { skip: gate }, () => {});
+      `,
+      `
+        const test = require("node:test");
+        ({ process } = { process: { platform: "win32" } });
+        const gate = process.platform === "win32";
+        test("case four", { skip: gate }, () => {});
+      `,
+      `
+        const test = require("node:test");
+        globalThis.process = { platform: "win32" };
+        const gate = process.platform === "win32";
+        test("case five", { skip: gate }, () => {});
+      `,
+      `
+        const test = require("node:test");
+        global.process = { platform: "win32" };
+        const gate = process.platform === "win32";
+        test("case six", { skip: gate }, () => {});
+      `,
+      `
+        const test = require("node:test");
+        require = () => ({ platform: () => "win32" });
+        const os = require("node:os");
+        const gate = os.platform() === "win32";
+        test("case seven", { skip: gate }, () => {});
+      `,
+    ];
+    for (const source of reassignedRuntimeRoots) {
+      expect(
+        findViolations("fixture.test.cjs", source).map(({ kind }) => kind),
+      ).toEqual(["orphaned-skip"]);
+      expect(findConditionalSkipSites("fixture.test.cjs", source)).toEqual([]);
+    }
+
+    const adversarial = `
+      import test from "node:test";
+      test("unowned condition", { skip: shouldSkip }, () => {});
+      customRunner("lookalike", {
+        skip: process.platform !== "win32" ? "not a test runner" : false,
+      });
+    `;
+    expect(
+      findViolations("fixture.test.mjs", adversarial).map(({ kind }) => kind),
+    ).toEqual(["orphaned-skip"]);
+    expect(findConditionalSkipSites("fixture.test.mjs", adversarial)).toEqual(
+      [],
+    );
+  });
+
+  test("does not classify static Node option skips as runtime-conditional", () => {
+    const source = `
+      import test from "node:test";
+      test("always runs", { skip: false }, () => {});
+      test("tracked permanent skip", { skip: "requires a Windows host" }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", source)).toEqual([]);
+    expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+  });
+
+  test("folds constant runtime-shaped option skips instead of blessing them", () => {
+    const source = `
+      import test from "node:test";
+      test("same truthy branches", {
+        skip: process.platform === "win32" ? true : true,
+      }, () => {});
+      test("same false branches", {
+        skip: process.platform === "win32" ? false : false,
+      }, () => {});
+      test("truthy OR dominance", {
+        skip: true || process.platform === "win32",
+      }, () => {});
+      test("false AND dominance", {
+        skip: false && process.platform === "win32",
+      }, () => {});
+      test("literal comparison", {
+        // requires a Windows host
+        skip: 1 === 1,
+      }, () => {});
+      test("bare runtime value", { skip: process.platform }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", source)).toEqual([]);
+    expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+  });
+
+  test("uses exact Node option semantics for permanent non-false values", () => {
+    const source = `
+      import test from "node:test";
+      import os from "node:os";
+      test("zero", { /* requires a disabled fixture */ skip: 0 }, () => {});
+      test("empty", { /* requires a disabled fixture */ skip: "" }, () => {});
+      test("null", { /* requires a disabled fixture */ skip: null }, () => {});
+      test("bigint", { /* requires a disabled fixture */ skip: 0n }, () => {});
+      test("object", { /* requires a disabled fixture */ skip: {} }, () => {});
+      test("array", { /* requires a disabled fixture */ skip: [] }, () => {});
+      test("function", {
+        /* requires a disabled fixture */ skip: () => false,
+      }, () => {});
+      test("constructed", {
+        /* requires a disabled fixture */ skip: new Boolean(false),
+      }, () => {});
+      test("platform call", {
+        /* requires a disabled fixture */ skip: os.platform(),
+      }, () => {});
+      test("void runs", { skip: void 0 }, () => {});
+      test("object condition runs", { skip: [] && false }, () => {});
+      test("nullish run", { skip: null ?? false }, () => {});
+      test("runtime string fallback", {
+        skip: process.env.RUNTIME_SKIP ?? "requires a disabled fixture",
+      }, () => {});
+      test("platform boolean", {
+        /* requires a disabled fixture */ skip: !!os.platform(),
+      }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", source)).toEqual([]);
+    expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+  });
+
+  test("fails closed on unevaluated Node option values and evaluates assignments", () => {
+    const source = `
+      import test from "node:test";
+      let gate;
+      test("empty Boolean", { skip: Boolean() }, () => {});
+      test("Boolean ignores later arguments", {
+        skip: Boolean(false, process.platform),
+      }, () => {});
+      test("false assignment runs", { skip: (gate = false) }, () => {});
+      test("object assignment", {
+        /* requires a disabled fixture */ skip: (gate = {}),
+      }, () => {});
+      test("platform assignment", {
+        /* requires a disabled fixture */ skip: (gate = process.platform),
+      }, () => {});
+      test("unclassified call", {
+        /* requires a disabled fixture */ skip: calculateSkip(),
+      }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", source)).toEqual([]);
+    expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+  });
+
+  test("does not infer runtime variability from nested source text", () => {
+    const source = `
+      import test from "node:test";
+      test("unknown nullish", {
+        /* requires a disabled fixture */ skip: calculateSkip() ?? false,
+      }, () => {});
+      test("runtime argument", {
+        /* requires a disabled fixture */ skip: constantFalse(process.platform),
+      }, () => {});
+      test("runtime-looking literal", {
+        /* requires a disabled fixture */ skip: constantFalse("process.platform"),
+      }, () => {});
+      test("awaited runtime value", {
+        /* requires a disabled fixture */ skip: await process.platform,
+      }, () => {});
+    `;
+    expect(findViolations("fixture.test.mjs", source)).toEqual([]);
+    expect(findConditionalSkipSites("fixture.test.mjs", source)).toEqual([]);
+  });
+
   test("rejects option-form focus unless it is statically false", () => {
     const source = `
       const yes = true;
@@ -375,4 +724,16 @@ describe("anti-larp test discovery", () => {
       /cannot be combined/,
     );
   });
+});
+
+test("does not fold shadowed globals into a running test", () => {
+  const sources = [
+    'import test from "node:test"; function define(undefined) { test("hidden", { skip: undefined }, () => {}); } define(true);',
+    'import test from "node:test"; const Boolean = () => true; test("hidden", { skip: Boolean(false) }, () => {});',
+  ];
+  for (const source of sources) {
+    expect(findViolations("fixture.test.ts", source)).toEqual([
+      expect.objectContaining({ kind: "orphaned-skip" }),
+    ]);
+  }
 });

--- a/packages/scripts/audit-focused-skipped-tests.mjs
+++ b/packages/scripts/audit-focused-skipped-tests.mjs
@@ -311,7 +311,14 @@ function bindingIdentifiers(name, identifiers = []) {
   return identifiers;
 }
 
+// Source ASTs are immutable. Cache per scope so every global runner lookup
+// does not rescan the same file; weak keys release completed source trees.
+const directScopeBindingCache = new WeakMap();
+const hoistedVarBindingCache = new WeakMap();
+
 function directScopeBindings(scope) {
+  const cached = directScopeBindingCache.get(scope);
+  if (cached) return cached;
   const bindings = new Map();
   const statements =
     ts.isSourceFile(scope) || ts.isBlock(scope) || ts.isModuleBlock(scope)
@@ -345,6 +352,7 @@ function directScopeBindings(scope) {
       bindings.set(statement.name.text, statement.name);
     }
   }
+  directScopeBindingCache.set(scope, bindings);
   return bindings;
 }
 
@@ -380,9 +388,10 @@ function loopInitializerBinding(scope, identifier) {
 function hoistedVarBinding(scope, identifier) {
   const root = ts.isSourceFile(scope) ? scope : scope.body;
   if (!root || (!ts.isBlock(root) && !ts.isSourceFile(root))) return undefined;
-  let binding;
+  const cached = hoistedVarBindingCache.get(scope);
+  if (cached) return cached.get(identifier.text);
+  const bindings = new Map();
   const visit = (node) => {
-    if (binding) return;
     if (
       node !== root &&
       (ts.isFunctionLike(node) ||
@@ -396,15 +405,15 @@ function hoistedVarBinding(scope, identifier) {
       ts.isVariableDeclarationList(node.parent) &&
       !(node.parent.flags & ts.NodeFlags.BlockScoped)
     ) {
-      binding = bindingIdentifiers(node.name).find(
-        (candidate) => candidate.text === identifier.text,
-      );
-      if (binding) return;
+      for (const binding of bindingIdentifiers(node.name)) {
+        if (!bindings.has(binding.text)) bindings.set(binding.text, binding);
+      }
     }
     ts.forEachChild(node, visit);
   };
   visit(root);
-  return binding;
+  hoistedVarBindingCache.set(scope, bindings);
+  return bindings.get(identifier.text);
 }
 
 function nearestBinding(identifier) {

--- a/packages/scripts/audit-focused-skipped-tests.mjs
+++ b/packages/scripts/audit-focused-skipped-tests.mjs
@@ -17,9 +17,10 @@
  *      when its nearby window carries one of: a tracking ref (`#<number>`, an
  *      issue/PR URL, `TODO(#<number>)`, or a `.pr-deny-list.json` reference), a
  *      self-documenting reason (env/platform/dependency gate), or a Playwright
- *      skip `annotation` with a `description`. Runtime *conditional* skips whose
- *      first argument is not a string literal (`cond ? describe : describe.skip`,
- *      `test.skip(!process.env.X, "…")`) are always allowed. A bare
+ *      skip `annotation` with a `description`. Runtime *conditional* skips
+ *      (`cond ? describe : describe.skip`, `test.skip(!process.env.X, "…")`,
+ *      or Node's documented `{ skip: process.platform !== "…" }` option) are
+ *      allowed. A bare
  *      `it.skip("adds two numbers", fn)` — a real test name, no reason, no owner
  *      — is the orphaned case: a test that silently stopped running.
  *
@@ -132,6 +133,8 @@ const TRACKING_REF =
 // type: "skip", description: "…" }` form.
 const REASON_MARKER =
   /\b(?:requires?|missing|unavailable|lacks?\b[^\n]*\baccess|not\s+(?:run|on|available|installed|supported|enabled|configured)|set\b[^\n]*\b(?:enable|run)|enable\b[^\n]*\b(?:test|suite|run)|only\s+(?:on|under|runs?)|not on PATH|process\.(?:platform|env)|os\.platform|isCI|un-?skip|once\b[^\n]*\blands?\b|until\b|blocked\s+(?:by|on)|no\s+[^\n]{1,80}\s+(?:available|installed|found|loaded|backend|store)|no shared)\b/i;
+const RUNTIME_OPTION_REASON =
+  /\b(?:process\.(?:platform|env|versions)|os\.platform|[A-Za-z_$][\w$]*(?:Platform|Runtime|Node\d*|Windows|Linux|Darwin|Available|Supported|Enabled|Configured|Installed)[\w$]*)\b/;
 
 function normalizeRelativePath(value) {
   return normalizeGitRepositoryPath(value, "anti-larp test source");
@@ -311,7 +314,11 @@ function bindingIdentifiers(name, identifiers = []) {
 function directScopeBindings(scope) {
   const bindings = new Map();
   const statements =
-    ts.isSourceFile(scope) || ts.isBlock(scope) ? scope.statements : [];
+    ts.isSourceFile(scope) || ts.isBlock(scope) || ts.isModuleBlock(scope)
+      ? scope.statements
+      : ts.isCaseBlock(scope)
+        ? scope.clauses.flatMap((clause) => [...clause.statements])
+        : [];
   for (const statement of statements) {
     if (ts.isImportDeclaration(statement)) {
       const clause = statement.importClause;
@@ -341,13 +348,79 @@ function directScopeBindings(scope) {
   return bindings;
 }
 
+function loopInitializerBinding(scope, identifier) {
+  if (
+    !(
+      ts.isForStatement(scope) ||
+      ts.isForInStatement(scope) ||
+      ts.isForOfStatement(scope)
+    ) ||
+    !scope.initializer ||
+    !ts.isVariableDeclarationList(scope.initializer) ||
+    !(scope.initializer.flags & ts.NodeFlags.BlockScoped)
+  ) {
+    return undefined;
+  }
+  if (
+    (ts.isForInStatement(scope) || ts.isForOfStatement(scope)) &&
+    identifier.getStart() >= scope.expression.getStart() &&
+    identifier.getEnd() <= scope.expression.getEnd()
+  ) {
+    return undefined;
+  }
+  for (const declaration of scope.initializer.declarations) {
+    const binding = bindingIdentifiers(declaration.name).find(
+      (candidate) => candidate.text === identifier.text,
+    );
+    if (binding) return binding;
+  }
+  return undefined;
+}
+
+function hoistedVarBinding(scope, identifier) {
+  const root = ts.isSourceFile(scope) ? scope : scope.body;
+  if (!root || (!ts.isBlock(root) && !ts.isSourceFile(root))) return undefined;
+  let binding;
+  const visit = (node) => {
+    if (binding) return;
+    if (
+      node !== root &&
+      (ts.isFunctionLike(node) ||
+        ts.isClassLike(node) ||
+        ts.isModuleDeclaration(node))
+    ) {
+      return;
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isVariableDeclarationList(node.parent) &&
+      !(node.parent.flags & ts.NodeFlags.BlockScoped)
+    ) {
+      binding = bindingIdentifiers(node.name).find(
+        (candidate) => candidate.text === identifier.text,
+      );
+      if (binding) return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return binding;
+}
+
 function nearestBinding(identifier) {
   let current = identifier.parent;
   while (current) {
-    if (ts.isBlock(current) || ts.isSourceFile(current)) {
+    if (
+      ts.isBlock(current) ||
+      ts.isSourceFile(current) ||
+      ts.isModuleBlock(current) ||
+      ts.isCaseBlock(current)
+    ) {
       const binding = directScopeBindings(current).get(identifier.text);
       if (binding) return binding;
     }
+    const loopBinding = loopInitializerBinding(current, identifier);
+    if (loopBinding) return loopBinding;
     if (ts.isFunctionLike(current)) {
       for (const parameter of current.parameters) {
         const binding = bindingIdentifiers(parameter.name).find(
@@ -362,11 +435,17 @@ function nearestBinding(identifier) {
       ) {
         return current.name;
       }
+      const binding = hoistedVarBinding(current, identifier);
+      if (binding) return binding;
     }
     if (ts.isCatchClause(current) && current.variableDeclaration) {
       const binding = bindingIdentifiers(current.variableDeclaration.name).find(
         (candidate) => candidate.text === identifier.text,
       );
+      if (binding) return binding;
+    }
+    if (ts.isSourceFile(current)) {
+      const binding = hoistedVarBinding(current, identifier);
       if (binding) return binding;
     }
     current = current.parent;
@@ -597,36 +676,561 @@ function unwrapExpression(node) {
   return current;
 }
 
-function staticTruthiness(node) {
-  if (!node) return undefined;
+const UNKNOWN_STATIC_VALUE = Symbol("unknown-static-value");
+
+function staticPrimitive(node) {
+  if (!node) return UNKNOWN_STATIC_VALUE;
   const value = unwrapExpression(node);
   if (value.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (value.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (value.kind === ts.SyntaxKind.NullKeyword) return null;
   if (
-    value.kind === ts.SyntaxKind.FalseKeyword ||
-    value.kind === ts.SyntaxKind.NullKeyword ||
-    (ts.isIdentifier(value) && value.text === "undefined")
+    ts.isIdentifier(value) &&
+    value.text === "undefined" &&
+    nearestBinding(value) === undefined
+  )
+    return undefined;
+  if (ts.isStringLiteralLike(value)) return value.text;
+  if (ts.isNumericLiteral(value)) return Number(value.text);
+  if (ts.isBigIntLiteral(value)) return BigInt(value.text.slice(0, -1));
+  if (
+    ts.isPrefixUnaryExpression(value) &&
+    (value.operator === ts.SyntaxKind.PlusToken ||
+      value.operator === ts.SyntaxKind.MinusToken)
   ) {
-    return false;
+    const operand = staticPrimitive(value.operand);
+    if (typeof operand !== "number") return UNKNOWN_STATIC_VALUE;
+    return value.operator === ts.SyntaxKind.MinusToken ? -operand : operand;
   }
-  if (ts.isStringLiteralLike(value)) return value.text.length > 0;
-  if (ts.isNumericLiteral(value)) return Number(value.text) !== 0;
-  if (ts.isPrefixUnaryExpression(value)) {
-    if (value.operator === ts.SyntaxKind.ExclamationToken) {
-      const operand = staticTruthiness(value.operand);
-      return operand === undefined ? undefined : !operand;
+  return UNKNOWN_STATIC_VALUE;
+}
+
+const NODE_OPTION_RUN = "run";
+const NODE_OPTION_SKIP = "skip";
+const NODE_OPTION_CONDITIONAL = "conditional";
+const NODE_OPTION_UNKNOWN = "unknown";
+
+function nodeOptionFromPrimitive(value) {
+  return value === false || value === undefined
+    ? NODE_OPTION_RUN
+    : NODE_OPTION_SKIP;
+}
+
+function knownNodeOptionSkipValue(node) {
+  const value = unwrapExpression(node);
+  if (
+    ts.isObjectLiteralExpression(value) ||
+    ts.isArrayLiteralExpression(value) ||
+    ts.isFunctionExpression(value) ||
+    ts.isArrowFunction(value) ||
+    ts.isClassExpression(value) ||
+    ts.isNewExpression(value) ||
+    ts.isRegularExpressionLiteral(value) ||
+    ts.isNoSubstitutionTemplateLiteral(value) ||
+    ts.isTemplateExpression(value)
+  ) {
+    return true;
+  }
+  if (
+    ts.isIdentifier(value) &&
+    ["globalThis", "Infinity", "NaN"].includes(value.text)
+  ) {
+    return true;
+  }
+  const runtimeChain = trustedRuntimeCallChain(value);
+  const chain = runtimeChain ?? callChain(value);
+  if (
+    runtimeChain?.join(".") === "os.platform" ||
+    (chain?.length === 1 &&
+      [
+        "Array",
+        "BigInt",
+        "Date",
+        "Function",
+        "Number",
+        "Object",
+        "String",
+        "Symbol",
+      ].includes(chain[0]))
+  ) {
+    return true;
+  }
+  return knownTruthyRuntimeValue(value);
+}
+
+function knownOptionalRuntimeString(node) {
+  const chain = trustedRuntimeCallChain(node);
+  return (
+    chain?.[0] === "process" &&
+    chain.length === 3 &&
+    (chain[1] === "env" || chain[1] === "versions")
+  );
+}
+
+function immutablePriorVariableDeclaration(identifier) {
+  const sourceFile = identifier.getSourceFile();
+  const identifierStart = identifier.getStart(sourceFile);
+  const binding = nearestBinding(identifier);
+  if (!binding || !ts.isVariableDeclaration(binding.parent)) return undefined;
+  const declaration = binding.parent;
+  if (
+    declaration.name !== binding ||
+    !declaration.initializer ||
+    declaration.getEnd() > identifierStart
+  ) {
+    return undefined;
+  }
+  const declarationList = declaration.parent;
+  if (
+    !ts.isVariableDeclarationList(declarationList) ||
+    !(declarationList.flags & ts.NodeFlags.Const)
+  ) {
+    return undefined;
+  }
+  return declaration;
+}
+
+function trustedNodeOsIdentifier(identifier) {
+  const binding = nearestBinding(identifier);
+  if (!binding) return false;
+
+  let current = binding.parent;
+  while (current && !ts.isSourceFile(current)) {
+    if (ts.isImportDeclaration(current)) {
+      return (
+        ts.isStringLiteralLike(current.moduleSpecifier) &&
+        current.moduleSpecifier.text === "node:os" &&
+        (current.importClause?.name === binding ||
+          (ts.isNamespaceImport(binding.parent) &&
+            binding.parent.name === binding))
+      );
+    }
+    current = current.parent;
+  }
+
+  const declaration = immutablePriorVariableDeclaration(identifier);
+  if (!declaration) return false;
+  const initializer = unwrapExpression(declaration.initializer);
+  return (
+    ts.isCallExpression(initializer) &&
+    ts.isIdentifier(initializer.expression) &&
+    initializer.expression.text === "require" &&
+    nearestBinding(initializer.expression) === undefined &&
+    !hasPriorWriteToImplicitRoot(initializer.expression) &&
+    initializer.arguments.length === 1 &&
+    ts.isStringLiteralLike(initializer.arguments[0]) &&
+    initializer.arguments[0].text === "node:os"
+  );
+}
+
+function assignmentTargetHasImplicitRoot(node, rootName) {
+  const value = unwrapExpression(node);
+  if (
+    ts.isIdentifier(value) ||
+    ts.isPropertyAccessExpression(value) ||
+    ts.isElementAccessExpression(value)
+  ) {
+    const root = baseIdentifier(value);
+    if (root?.text === rootName && nearestBinding(root) === undefined) {
+      return true;
+    }
+    const chain = callChain(value);
+    return (
+      rootName === "process" &&
+      (chain?.[0] === "globalThis" || chain?.[0] === "global") &&
+      chain[1] === "process" &&
+      root !== undefined &&
+      nearestBinding(root) === undefined
+    );
+  }
+  if (ts.isArrayLiteralExpression(value)) {
+    return value.elements.some((element) =>
+      assignmentTargetHasImplicitRoot(
+        ts.isSpreadElement(element) ? element.expression : element,
+        rootName,
+      ),
+    );
+  }
+  if (ts.isObjectLiteralExpression(value)) {
+    return value.properties.some((property) => {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        return assignmentTargetHasImplicitRoot(property.name, rootName);
+      }
+      if (ts.isPropertyAssignment(property)) {
+        return assignmentTargetHasImplicitRoot(property.initializer, rootName);
+      }
+      if (ts.isSpreadAssignment(property)) {
+        return assignmentTargetHasImplicitRoot(property.expression, rootName);
+      }
+      return false;
+    });
+  }
+  if (
+    ts.isBinaryExpression(value) &&
+    value.operatorToken.kind === ts.SyntaxKind.EqualsToken
+  ) {
+    return assignmentTargetHasImplicitRoot(value.left, rootName);
+  }
+  return false;
+}
+
+function hasPriorWriteToImplicitRoot(identifier) {
+  const sourceFile = identifier.getSourceFile();
+  const identifierStart = identifier.getStart(sourceFile);
+  let found = false;
+  const visit = (node) => {
+    if (found || node.getStart(sourceFile) >= identifierStart) return;
+    if (
+      ts.isBinaryExpression(node) &&
+      ts.isAssignmentOperator(node.operatorToken.kind) &&
+      assignmentTargetHasImplicitRoot(node.left, identifier.text)
+    ) {
+      found = true;
+      return;
     }
     if (
-      value.operator === ts.SyntaxKind.PlusToken ||
-      value.operator === ts.SyntaxKind.MinusToken
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken ||
+        node.operator === ts.SyntaxKind.MinusMinusToken) &&
+      assignmentTargetHasImplicitRoot(node.operand, identifier.text)
     ) {
-      const number = Number(value.getText());
-      return Number.isNaN(number) ? undefined : number !== 0;
+      found = true;
+      return;
+    }
+    if (
+      ts.isDeleteExpression(node) &&
+      assignmentTargetHasImplicitRoot(node.expression, identifier.text)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+function trustedRuntimeCallChain(node) {
+  const chain = callChain(node);
+  if (!chain) return null;
+  const root = baseIdentifier(node);
+  if (!root) return null;
+  if (chain[0] === "process") {
+    return nearestBinding(root) === undefined &&
+      !hasPriorWriteToImplicitRoot(root)
+      ? chain
+      : null;
+  }
+  if (chain[0] === "os") {
+    return trustedNodeOsIdentifier(root) ? chain : null;
+  }
+  return null;
+}
+
+function recognizedRuntimeSignal(node, seenDeclarations = new Set()) {
+  const value = unwrapExpression(node);
+  if (ts.isIdentifier(value)) {
+    const declaration = immutablePriorVariableDeclaration(value);
+    if (!declaration || seenDeclarations.has(declaration)) return false;
+    const nextSeen = new Set(seenDeclarations);
+    nextSeen.add(declaration);
+    return recognizedRuntimeSignal(declaration.initializer, nextSeen);
+  }
+  if (
+    ts.isPropertyAccessExpression(value) ||
+    ts.isElementAccessExpression(value)
+  ) {
+    const chain = trustedRuntimeCallChain(value);
+    return (
+      chain?.[0] === "process" &&
+      (chain[1] === "platform" ||
+        (chain.length >= 3 && (chain[1] === "env" || chain[1] === "versions")))
+    );
+  }
+  if (ts.isPrefixUnaryExpression(value)) {
+    return recognizedRuntimeSignal(value.operand, seenDeclarations);
+  }
+  if (ts.isBinaryExpression(value)) {
+    return (
+      recognizedRuntimeSignal(value.left, seenDeclarations) ||
+      recognizedRuntimeSignal(value.right, seenDeclarations)
+    );
+  }
+  if (ts.isConditionalExpression(value)) {
+    return recognizedRuntimeSignal(value.condition, seenDeclarations);
+  }
+  if (ts.isCallExpression(value)) {
+    const chain = trustedRuntimeCallChain(value.expression);
+    return chain?.join(".") === "os.platform";
+  }
+  return false;
+}
+
+/**
+ * Classify Node's `test(name, { skip }, fn)` option by Node semantics.
+ * Unlike skipIf/focus truthiness, Node runs only for exact false/undefined;
+ * every other value is a skip reason, including 0, an empty string, null,
+ * objects, functions, and known runtime strings such as os.platform().
+ */
+function nodeOptionDisposition(node) {
+  if (!node) return NODE_OPTION_UNKNOWN;
+  const value = unwrapExpression(node);
+  const primitive = staticPrimitive(value);
+  if (primitive !== UNKNOWN_STATIC_VALUE) {
+    return nodeOptionFromPrimitive(primitive);
+  }
+  if (knownNodeOptionSkipValue(value)) return NODE_OPTION_SKIP;
+  if (ts.isVoidExpression(value)) return NODE_OPTION_RUN;
+  if (
+    ts.isTypeOfExpression(value) ||
+    (ts.isPrefixUnaryExpression(value) &&
+      [
+        ts.SyntaxKind.PlusToken,
+        ts.SyntaxKind.MinusToken,
+        ts.SyntaxKind.TildeToken,
+      ].includes(value.operator))
+  ) {
+    return NODE_OPTION_SKIP;
+  }
+  if (ts.isPrefixUnaryExpression(value)) {
+    if (value.operator === ts.SyntaxKind.ExclamationToken) {
+      const truthy = staticTruthiness(value.operand);
+      return truthy === undefined
+        ? recognizedRuntimeSignal(value.operand)
+          ? NODE_OPTION_CONDITIONAL
+          : NODE_OPTION_UNKNOWN
+        : nodeOptionFromPrimitive(!truthy);
+    }
+  }
+  if (ts.isDeleteExpression(value)) return NODE_OPTION_UNKNOWN;
+  if (ts.isConditionalExpression(value)) {
+    const condition = staticTruthiness(value.condition);
+    if (condition === true) return nodeOptionDisposition(value.whenTrue);
+    if (condition === false) return nodeOptionDisposition(value.whenFalse);
+    const whenTrue = nodeOptionDisposition(value.whenTrue);
+    const whenFalse = nodeOptionDisposition(value.whenFalse);
+    if (whenTrue === whenFalse) return whenTrue;
+    return recognizedRuntimeSignal(value.condition)
+      ? NODE_OPTION_CONDITIONAL
+      : NODE_OPTION_UNKNOWN;
+  }
+  if (ts.isBinaryExpression(value)) {
+    if (value.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      return nodeOptionDisposition(value.right);
+    }
+    if (value.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
+      const left = staticPrimitive(value.left);
+      if (left !== UNKNOWN_STATIC_VALUE) {
+        return left === null || left === undefined
+          ? nodeOptionDisposition(value.right)
+          : nodeOptionFromPrimitive(left);
+      }
+      if (knownNodeOptionSkipValue(value.left)) return NODE_OPTION_SKIP;
+      if (knownOptionalRuntimeString(value.left)) {
+        return nodeOptionDisposition(value.right) === NODE_OPTION_SKIP
+          ? NODE_OPTION_SKIP
+          : NODE_OPTION_CONDITIONAL;
+      }
+      return NODE_OPTION_UNKNOWN;
+    }
+    if (value.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+      const left = staticTruthiness(value.left);
+      if (left === false) return nodeOptionDisposition(value.left);
+      if (left === true) return nodeOptionDisposition(value.right);
+      return recognizedRuntimeSignal(value.left)
+        ? NODE_OPTION_CONDITIONAL
+        : NODE_OPTION_UNKNOWN;
+    }
+    if (value.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+      const left = staticTruthiness(value.left);
+      if (left === true) return nodeOptionDisposition(value.left);
+      if (left === false) return nodeOptionDisposition(value.right);
+      return nodeOptionDisposition(value.right) === NODE_OPTION_SKIP
+        ? NODE_OPTION_SKIP
+        : recognizedRuntimeSignal(value.left)
+          ? NODE_OPTION_CONDITIONAL
+          : NODE_OPTION_UNKNOWN;
+    }
+    const comparison = staticComparison(value);
+    if (comparison !== undefined) return nodeOptionFromPrimitive(comparison);
+    if (
+      [
+        ts.SyntaxKind.EqualsEqualsToken,
+        ts.SyntaxKind.ExclamationEqualsToken,
+        ts.SyntaxKind.EqualsEqualsEqualsToken,
+        ts.SyntaxKind.ExclamationEqualsEqualsToken,
+        ts.SyntaxKind.LessThanToken,
+        ts.SyntaxKind.LessThanEqualsToken,
+        ts.SyntaxKind.GreaterThanToken,
+        ts.SyntaxKind.GreaterThanEqualsToken,
+        ts.SyntaxKind.InKeyword,
+        ts.SyntaxKind.InstanceOfKeyword,
+      ].includes(value.operatorToken.kind)
+    ) {
+      return recognizedRuntimeSignal(value)
+        ? NODE_OPTION_CONDITIONAL
+        : NODE_OPTION_UNKNOWN;
+    }
+    if (
+      [
+        ts.SyntaxKind.PlusToken,
+        ts.SyntaxKind.MinusToken,
+        ts.SyntaxKind.AsteriskToken,
+        ts.SyntaxKind.AsteriskAsteriskToken,
+        ts.SyntaxKind.SlashToken,
+        ts.SyntaxKind.PercentToken,
+        ts.SyntaxKind.AmpersandToken,
+        ts.SyntaxKind.BarToken,
+        ts.SyntaxKind.CaretToken,
+        ts.SyntaxKind.LessThanLessThanToken,
+        ts.SyntaxKind.GreaterThanGreaterThanToken,
+        ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken,
+      ].includes(value.operatorToken.kind)
+    ) {
+      return NODE_OPTION_SKIP;
     }
   }
   if (
     ts.isCallExpression(value) &&
     ts.isIdentifier(value.expression) &&
     value.expression.text === "Boolean" &&
+    nearestBinding(value.expression) === undefined &&
+    !hasPriorWriteToImplicitRoot(value.expression)
+  ) {
+    const firstArgument = value.arguments[0];
+    if (!firstArgument) return NODE_OPTION_RUN;
+    const truthy = staticTruthiness(firstArgument);
+    return truthy === undefined
+      ? recognizedRuntimeSignal(firstArgument)
+        ? NODE_OPTION_CONDITIONAL
+        : NODE_OPTION_UNKNOWN
+      : nodeOptionFromPrimitive(truthy);
+  }
+  return recognizedRuntimeSignal(value)
+    ? NODE_OPTION_CONDITIONAL
+    : NODE_OPTION_UNKNOWN;
+}
+
+function staticComparison(node) {
+  if (!ts.isBinaryExpression(node)) return undefined;
+  const left = staticPrimitive(node.left);
+  const right = staticPrimitive(node.right);
+  if (left === UNKNOWN_STATIC_VALUE || right === UNKNOWN_STATIC_VALUE) {
+    return undefined;
+  }
+  switch (node.operatorToken.kind) {
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+      return left === right;
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+      return left !== right;
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsToken: {
+      const comparable =
+        typeof left === typeof right ||
+        ((left === null || left === undefined) &&
+          (right === null || right === undefined));
+      if (!comparable) return undefined;
+      const equal =
+        left === right ||
+        (left === null && right === undefined) ||
+        (left === undefined && right === null);
+      return node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken
+        ? equal
+        : !equal;
+    }
+    case ts.SyntaxKind.LessThanToken:
+      return left < right;
+    case ts.SyntaxKind.LessThanEqualsToken:
+      return left <= right;
+    case ts.SyntaxKind.GreaterThanToken:
+      return left > right;
+    case ts.SyntaxKind.GreaterThanEqualsToken:
+      return left >= right;
+    default:
+      return undefined;
+  }
+}
+
+function knownTruthyRuntimeValue(node) {
+  const chain = trustedRuntimeCallChain(node);
+  return (
+    chain?.join(".") === "os.platform" ||
+    (chain?.[0] === "process" &&
+      ((chain.length === 2 &&
+        (chain[1] === "env" ||
+          chain[1] === "platform" ||
+          chain[1] === "versions")) ||
+        (chain.length === 3 && chain[1] === "versions" && chain[2] === "node")))
+  );
+}
+
+function knownTruthyObjectValue(node) {
+  const value = unwrapExpression(node);
+  return (
+    ts.isObjectLiteralExpression(value) ||
+    ts.isArrayLiteralExpression(value) ||
+    ts.isFunctionExpression(value) ||
+    ts.isArrowFunction(value) ||
+    ts.isClassExpression(value) ||
+    ts.isNewExpression(value) ||
+    ts.isRegularExpressionLiteral(value)
+  );
+}
+
+function staticTruthiness(node) {
+  if (!node) return undefined;
+  const value = unwrapExpression(node);
+  const primitive = staticPrimitive(value);
+  if (primitive !== UNKNOWN_STATIC_VALUE) return Boolean(primitive);
+  if (knownTruthyRuntimeValue(value) || knownTruthyObjectValue(value)) {
+    return true;
+  }
+  if (ts.isPrefixUnaryExpression(value)) {
+    if (value.operator === ts.SyntaxKind.ExclamationToken) {
+      const operand = staticTruthiness(value.operand);
+      return operand === undefined ? undefined : !operand;
+    }
+  }
+  if (ts.isConditionalExpression(value)) {
+    const condition = staticTruthiness(value.condition);
+    if (condition === true) return staticTruthiness(value.whenTrue);
+    if (condition === false) return staticTruthiness(value.whenFalse);
+    const whenTrue = staticTruthiness(value.whenTrue);
+    const whenFalse = staticTruthiness(value.whenFalse);
+    return whenTrue === whenFalse ? whenTrue : undefined;
+  }
+  if (ts.isBinaryExpression(value)) {
+    if (value.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
+      const left = staticPrimitive(value.left);
+      if (left !== UNKNOWN_STATIC_VALUE) {
+        return left === null || left === undefined
+          ? staticTruthiness(value.right)
+          : Boolean(left);
+      }
+      return undefined;
+    }
+    if (value.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+      const left = staticTruthiness(value.left);
+      if (left === false) return false;
+      const right = staticTruthiness(value.right);
+      if (left === true) return right;
+      return right === false ? false : undefined;
+    }
+    if (value.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+      const left = staticTruthiness(value.left);
+      if (left === true) return true;
+      const right = staticTruthiness(value.right);
+      if (left === false) return right;
+      return right === true ? true : undefined;
+    }
+    return staticComparison(value);
+  }
+  if (
+    ts.isCallExpression(value) &&
+    ts.isIdentifier(value.expression) &&
+    value.expression.text === "Boolean" &&
+    nearestBinding(value.expression) === undefined &&
+    !hasPriorWriteToImplicitRoot(value.expression) &&
     value.arguments.length === 1
   ) {
     return staticTruthiness(value.arguments[0]);
@@ -682,19 +1286,112 @@ function hasOuterFocusedCall(node, sourceFile, aliases) {
   return false;
 }
 
-function staticOptionCalls(node) {
+function classifiedOptionCalls(node, sourceFile) {
   const options = [];
-  for (const argument of node.arguments) {
-    const value = unwrapExpression(argument);
-    if (!ts.isObjectLiteralExpression(value)) continue;
-    for (const property of value.properties) {
-      if (
-        ts.isShorthandPropertyAssignment(property) &&
-        property.name.text === "only"
-      ) {
-        options.push({ modifier: "only", documented: false });
+  const activeSpreadDeclarations = new Set();
+
+  const propertyEvidenceIsDocumented = (property) => {
+    const evidence = sourceFile.text.slice(
+      property.getFullStart(),
+      property.getEnd(),
+    );
+    return TRACKING_REF.test(evidence) || REASON_MARKER.test(evidence);
+  };
+
+  const classifyObject = (
+    object,
+    fromSpread = false,
+    spreadEvidenceDocumented = false,
+  ) => {
+    for (const property of object.properties) {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        if (!["only", "skip", "todo"].includes(property.name.text)) continue;
+        if (property.name.text === "only") {
+          options.push({ modifier: "only", documented: false });
+          continue;
+        }
+        const declaration = immutablePriorVariableDeclaration(property.name);
+        const initializer = declaration?.initializer;
+        const truthy = initializer ? staticTruthiness(initializer) : undefined;
+        const skipDisposition =
+          property.name.text === "skip" && initializer
+            ? nodeOptionDisposition(initializer)
+            : undefined;
+        if (
+          (property.name.text === "only" && truthy !== false) ||
+          (property.name.text === "todo" && truthy !== false) ||
+          (property.name.text === "skip" && skipDisposition !== NODE_OPTION_RUN)
+        ) {
+          options.push({
+            modifier: property.name.text,
+            conditional: skipDisposition === NODE_OPTION_CONDITIONAL,
+            documented: propertyEvidenceIsDocumented(property),
+          });
+        }
         continue;
       }
+
+      if (
+        ts.isGetAccessorDeclaration(property) ||
+        ts.isMethodDeclaration(property)
+      ) {
+        if (
+          !property.name ||
+          !(
+            ts.isIdentifier(property.name) ||
+            ts.isStringLiteralLike(property.name)
+          ) ||
+          !["only", "skip", "todo"].includes(property.name.text)
+        ) {
+          continue;
+        }
+        options.push({
+          modifier: property.name.text,
+          conditional: false,
+          documented: propertyEvidenceIsDocumented(property),
+        });
+        continue;
+      }
+
+      if (ts.isSpreadAssignment(property)) {
+        const expression = unwrapExpression(property.expression);
+        if (ts.isObjectLiteralExpression(expression)) {
+          classifyObject(
+            expression,
+            true,
+            propertyEvidenceIsDocumented(property),
+          );
+          continue;
+        }
+        const declaration = ts.isIdentifier(expression)
+          ? immutablePriorVariableDeclaration(expression)
+          : undefined;
+        const initializer = declaration?.initializer
+          ? unwrapExpression(declaration.initializer)
+          : undefined;
+        if (
+          declaration &&
+          initializer &&
+          ts.isObjectLiteralExpression(initializer) &&
+          !activeSpreadDeclarations.has(declaration)
+        ) {
+          activeSpreadDeclarations.add(declaration);
+          classifyObject(
+            initializer,
+            true,
+            propertyEvidenceIsDocumented(property),
+          );
+          activeSpreadDeclarations.delete(declaration);
+          continue;
+        }
+        options.push({
+          modifier: "opaque-options-spread",
+          conditional: false,
+          documented: propertyEvidenceIsDocumented(property),
+        });
+        continue;
+      }
+
       if (
         !ts.isPropertyAssignment(property) ||
         !(
@@ -706,18 +1403,43 @@ function staticOptionCalls(node) {
       }
       if (!["only", "skip", "todo"].includes(property.name.text)) continue;
       const truthy = staticTruthiness(property.initializer);
+      const skipDisposition =
+        property.name.text === "skip"
+          ? nodeOptionDisposition(property.initializer)
+          : undefined;
       if (
         (property.name.text === "only" && truthy !== false) ||
-        (property.name.text !== "only" && truthy === true)
+        (property.name.text !== "only" &&
+          (truthy === true ||
+            (property.name.text === "skip" &&
+              skipDisposition !== NODE_OPTION_RUN)))
       ) {
         const reason = unwrapExpression(property.initializer);
+        const conditional =
+          property.name.text === "skip"
+            ? skipDisposition === NODE_OPTION_CONDITIONAL
+            : truthy === undefined;
         options.push({
           modifier: property.name.text,
-          documented:
-            ts.isStringLiteralLike(reason) && reason.text.trim().length >= 8,
+          conditional,
+          documented: fromSpread
+            ? spreadEvidenceDocumented || propertyEvidenceIsDocumented(property)
+            : (ts.isStringLiteralLike(reason) &&
+                reason.text.trim().length >= 8) ||
+              propertyEvidenceIsDocumented(property) ||
+              (conditional &&
+                RUNTIME_OPTION_REASON.test(
+                  property.initializer.getText(sourceFile),
+                )),
         });
       }
     }
+  };
+
+  for (const argument of node.arguments) {
+    const value = unwrapExpression(argument);
+    if (!ts.isObjectLiteralExpression(value)) continue;
+    classifyObject(value);
   }
   return options;
 }
@@ -862,7 +1584,7 @@ export function findViolations(filePath, content) {
       const alias = resolvedAlias(node.expression, aliases);
       const optionCalls =
         chain && RUNNER_ROOTS.has(chain[0]) && RUNNER_ROOTS.has(chain.at(-1))
-          ? staticOptionCalls(node)
+          ? classifiedOptionCalls(node, sourceFile)
           : [];
       const position = node.getStart(sourceFile);
       if (
@@ -883,7 +1605,7 @@ export function findViolations(filePath, content) {
         }
       } else {
         const optionDisable = optionCalls.find(({ modifier }) =>
-          ["skip", "todo"].includes(modifier),
+          ["skip", "todo", "opaque-options-spread"].includes(modifier),
         );
         const modifier = disabledModifier(chain) ?? optionDisable?.modifier;
         let documented = true;
@@ -955,11 +1677,12 @@ export function findViolations(filePath, content) {
  * A site is runtime-conditional when whether the test skips is decided at run
  * time, not in the source text: a runner ternary (`cond ? describe :
  * describe.skip`), a `skipIf`/`todoIf` whose condition is not statically
- * decidable, or a `skip`/`fixme` whose first argument is a non-literal,
- * non-function condition. Unconditional skips — even documented ones — are
- * never returned, and a file with any gate violation yields zero sites, so
- * consumers (the script-lane JUnit evidence gate) cannot bless a file the
- * anti-larp gate itself rejects. Throws on unparseable input.
+ * decidable, a `skip`/`fixme` whose first argument is a non-literal,
+ * non-function condition, or a documented dynamic `skip` property in a runner
+ * options object. Unconditional skips — even documented ones — are never
+ * returned, and a file with any gate violation yields zero sites, so consumers
+ * (the script-lane JUnit evidence gate) cannot bless a file the anti-larp gate
+ * itself rejects. Throws on unparseable input.
  *
  * @param {string} filePath
  * @param {string} content
@@ -1036,26 +1759,17 @@ export function findConditionalSkipSites(filePath, content) {
         ) {
           record(node, `conditional-${modifier}`);
         }
-      }
-      if (modifier === null && isRunnerReference(chain)) {
-        for (const argument of node.arguments) {
-          const value = unwrapExpression(argument);
-          if (!ts.isObjectLiteralExpression(value)) continue;
-          for (const property of value.properties) {
-            if (
-              !ts.isPropertyAssignment(property) ||
-              !(
-                ts.isIdentifier(property.name) ||
-                ts.isStringLiteralLike(property.name)
-              ) ||
-              property.name.text !== "skip"
-            ) {
-              continue;
-            }
-            if (staticTruthiness(property.initializer) === undefined) {
-              record(property, "conditional-options-skip");
-            }
-          }
+      } else if (
+        chain &&
+        RUNNER_ROOTS.has(chain[0]) &&
+        RUNNER_ROOTS.has(chain.at(-1))
+      ) {
+        const conditionalOption = classifiedOptionCalls(node, sourceFile).find(
+          ({ modifier: optionModifier, conditional }) =>
+            optionModifier === "skip" && conditional,
+        );
+        if (conditionalOption) {
+          record(node, "conditional-options-skip");
         }
       }
     }
@@ -1311,6 +2025,41 @@ function selfTest() {
       name: "conditional: skipIf with a runtime condition is a site",
       src: 'describe.skipIf(!hasBackend)("store", () => {});',
       expect: ["skipIf"],
+    },
+    {
+      name: "conditional: documented Node option skip is a site",
+      src: 'test("Windows contract", { skip: process.platform !== "win32" ? "Windows contract" : false }, () => {});',
+      expect: ["conditional-options-skip"],
+    },
+    {
+      name: "conditional: undocumented Node option skip does not bless",
+      src: 'test("ordinary title", { skip: shouldSkip }, () => {});',
+      expect: [],
+    },
+    {
+      name: "conditional: non-runner option skip is ignored",
+      src: 'customRunner("x", { skip: process.platform !== "win32" ? "Windows contract" : false });',
+      expect: [],
+    },
+    {
+      name: "conditional: same-branch option skip is statically truthy",
+      src: 'test("x", { skip: process.platform === "win32" ? true : true }, () => {});',
+      expect: [],
+    },
+    {
+      name: "conditional: logical option dominance stays static",
+      src: 'test("x", { skip: true || process.platform === "win32" }, () => {});',
+      expect: [],
+    },
+    {
+      name: "conditional: literal comparison option stays static",
+      src: 'test("x", { /* requires Windows */ skip: 1 === 1 }, () => {});',
+      expect: [],
+    },
+    {
+      name: "conditional: bare platform value is always truthy",
+      src: 'test("x", { skip: process.platform }, () => {});',
+      expect: [],
     },
     {
       name: "conditional: statically-true skipIf is not runtime-conditional",


### PR DESCRIPTION
The focused/skip audit now recognizes runtime test-option skip expressions and lexical bindings, so it can distinguish conditional runtime gates from unconditional skipped tests that need tracking. It preserves the focused-test and orphaned-skip checks.

Review fixes cover shadowed `undefined` and `Boolean`, plural conditional option skips, and repeated scope analysis. Immutable scope bindings are cached per syntax tree to avoid recomputing them across large test files.

Validation for `9b1c6cfb9d97080cb82e093e787d4ad74b0f9a4e`:
- 26 discovery regressions and 39 audit self-tests passed.
- The real repository inventory scan passed across 11,364 test files.
- Full `bun run verify`, formatting, and the script-contract lane passed in [CI run 33950159885](https://github.com/elizaOS/eliza/actions/runs/33950159885).
- No upstream overlap in the two touched files at promotion.

All required original PR checks passed on this exact revision. The additional broad manual CI run is not wholly green: its UI suite passed 13,499 tests with one vault blur failure, and that exact suite passed all seven tests on isolated rerun; its Cloud lane reported failures also present on the separate APNs revision. These files change only the static auditor and its regressions. No claim of a clean full Cloud suite is made. UI captures and live-provider evidence are N/A: this changes a static repository test auditor.
