### PR TITLE
fix(ui): isolate launcher catalog source failures

### DIFF
--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -214,7 +214,7 @@ describe("Launcher", () => {
     expect(screen.getByTestId("launcher-empty")).toBeTruthy();
   });
 
-  it("keeps partial catalog failures visible beside available tiles", () => {
+  it("keeps available tiles calm when an optional source is degraded", () => {
     const retry = vi.fn();
     render(
       <Launcher
@@ -225,10 +225,10 @@ describe("Launcher", () => {
       />,
     );
 
-    expect(screen.getByTestId("launcher-partial-error")).toBeTruthy();
+    expect(screen.queryByTestId("launcher-partial-error")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
     expect(screen.getByTestId("launcher-tile-chat")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-    expect(retry).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
   });
 
   it("drops a tile when its entry is removed on re-render", () => {

--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -214,7 +214,7 @@ describe("Launcher", () => {
     expect(screen.getByTestId("launcher-empty")).toBeTruthy();
   });
 
-  it("keeps available tiles calm when an optional source is degraded", () => {
+  it("keeps available tiles and offers quiet recovery when a source stays degraded", () => {
     const retry = vi.fn();
     render(
       <Launcher
@@ -225,10 +225,11 @@ describe("Launcher", () => {
       />,
     );
 
-    expect(screen.queryByTestId("launcher-partial-error")).toBeNull();
+    expect(screen.getByTestId("launcher-source-status")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(screen.getByTestId("launcher-tile-chat")).toBeTruthy();
-    expect(retry).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 
   it("drops a tile when its entry is removed on re-render", () => {

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -183,6 +183,8 @@ export function Launcher({
 
   const showSkeleton = loading && entries.length === 0;
   const showError = !showSkeleton && error !== null && entries.length === 0;
+  const showSourceStatus =
+    !showSkeleton && error !== null && entries.length > 0;
   const showEmpty = !showSkeleton && !showError && entries.length === 0;
 
   return (
@@ -266,13 +268,38 @@ export function Launcher({
                 </p>
               </div>
             ) : (
-              <div className="grid w-full grid-cols-3 gap-x-4 gap-y-5 min-[360px]:grid-cols-4 max-sm:portrait:gap-y-8 sm:grid-cols-5">
-                {entries.map((entry) => (
-                  <div key={entry.id} className="flex justify-center">
-                    <IconTile entry={entry} onLaunch={handleLaunch} />
+              <>
+                <div className="grid w-full grid-cols-3 gap-x-4 gap-y-5 min-[360px]:grid-cols-4 max-sm:portrait:gap-y-8 sm:grid-cols-5">
+                  {entries.map((entry) => (
+                    <div key={entry.id} className="flex justify-center">
+                      <IconTile entry={entry} onLaunch={handleLaunch} />
+                    </div>
+                  ))}
+                </div>
+                {showSourceStatus ? (
+                  <div
+                    role="status"
+                    data-testid="launcher-source-status"
+                    className={cn(
+                      "mx-auto flex min-h-11 items-center gap-2 text-xs",
+                      WALLPAPER_TEXT.muted,
+                    )}
+                  >
+                    <span>More apps unavailable</span>
+                    {onRetry ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="overlayEdge"
+                        className="min-h-9"
+                        onClick={onRetry}
+                      >
+                        Retry
+                      </Button>
+                    ) : null}
                   </div>
-                ))}
-              </div>
+                ) : null}
+              </>
             )}
           </div>
         </div>

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -27,7 +27,6 @@ import {
 } from "../shell/wallpaper-idiom";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Card } from "../ui/card";
 import { Skeleton } from "../ui/skeleton";
 import {
   LauncherAppIcon,
@@ -185,7 +184,6 @@ export function Launcher({
   const showSkeleton = loading && entries.length === 0;
   const showError = !showSkeleton && error !== null && entries.length === 0;
   const showEmpty = !showSkeleton && !showError && entries.length === 0;
-  const showPartialError = error !== null && entries.length > 0;
 
   return (
     <div
@@ -215,33 +213,6 @@ export function Launcher({
           )}
         >
           <div className="flex w-full max-w-2xl flex-col gap-6">
-            {showPartialError ? (
-              <Card
-                role="alert"
-                data-testid="launcher-partial-error"
-                radius="large"
-                border="subtle"
-                surface="wallpaperOverlay"
-                wallpaperText
-                className="flex items-center justify-between gap-3 px-3 py-2.5"
-              >
-                <span className="text-xs text-white/75">
-                  Some apps couldn&apos;t load.
-                </span>
-                {onRetry ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="overlayEdge"
-                    shape="circle"
-                    className="h-8 px-3 text-xs"
-                    onClick={onRetry}
-                  >
-                    Retry
-                  </Button>
-                ) : null}
-              </Card>
-            ) : null}
             {showSkeleton ? (
               <div className="grid w-full grid-cols-3 gap-x-4 gap-y-5 min-[360px]:grid-cols-4 sm:grid-cols-5">
                 {["a", "b", "c", "d", "e", "f", "g", "h"].map((id) => (

--- a/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
+++ b/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
@@ -324,6 +324,80 @@ describe("useViewCatalog authority isolation", () => {
     }
   });
 
+  it("does not spend a new authority's retry budget on an inherited error", async () => {
+    vi.useFakeTimers();
+    try {
+      const agentBCatalog = deferred<RegistryAppInfo[]>();
+      mocks.loadAppsCatalog
+        .mockRejectedValueOnce(new Error("agent A catalog unavailable"))
+        .mockReturnValueOnce(agentBCatalog.promise);
+      mocks.client.listInstalledApps.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useViewCatalog());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.sourceErrors).toHaveLength(1);
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        mocks.authority.value = "https://agent-b.test";
+        for (const onChange of mocks.authority.listeners) onChange();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
+
+      mocks.loadAppsCatalog
+        .mockRejectedValueOnce(new Error("later agent B outage"))
+        .mockResolvedValueOnce([catalogApp("agent-b-recovered")]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(750);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        agentBCatalog.resolve([catalogApp("agent-b-initial")]);
+        await Promise.resolve();
+      });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "agent-b-initial",
+      ]);
+
+      act(() => {
+        invalidate(`view-catalog:apps:${getActiveAgentAuthority()}`);
+        result.current.retrySource("catalog");
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.sourceErrors).toEqual([
+        {
+          source: "catalog",
+          error: expect.objectContaining({ message: "later agent B outage" }),
+        },
+      ]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(499);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(3);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(4);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "agent-b-recovered",
+      ]);
+      expect(result.current.sourceErrors).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps a source failure fatal when no usable launcher entry remains", async () => {
     mocks.loadAppsCatalog.mockRejectedValue(new Error("catalog unavailable"));
     mocks.client.listInstalledApps.mockResolvedValue([]);

--- a/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
+++ b/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
@@ -4,7 +4,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RegistryAppInfo } from "../api";
-import { __resetResourceCache } from "./resource-cache";
+import { __resetResourceCache, invalidate } from "./resource-cache";
 
 const mocks = vi.hoisted(() => {
   const authority = {
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
   };
   return {
     authority,
+    appShellRoutesSupported: { value: true },
     client: {
       getBaseUrl: vi.fn(() => authority.value),
       onBaseUrlChange: vi.fn((onChange: () => void) => {
@@ -24,11 +25,19 @@ const mocks = vi.hoisted(() => {
     },
     loadAppsCatalog: vi.fn(),
     refreshViews: vi.fn(),
+    routableViews: {
+      views: [] as Array<Record<string, unknown>>,
+      loading: false,
+      error: null as Error | null,
+    },
   };
 });
 
 vi.mock("../api", () => ({ client: mocks.client }));
 vi.mock("../api/client", () => ({ client: mocks.client }));
+vi.mock("../api/app-shell-capabilities", () => ({
+  supportsFullAppShellRoutes: () => mocks.appShellRoutesSupported.value,
+}));
 vi.mock("../components/apps/load-apps-catalog", () => ({
   loadAppsCatalog: mocks.loadAppsCatalog,
 }));
@@ -40,13 +49,12 @@ vi.mock("../state/useViewKinds", () => ({
 }));
 vi.mock("./useAvailableViews", () => ({
   useRoutableViews: () => ({
-    views: [],
-    loading: false,
-    error: null,
+    ...mocks.routableViews,
     refresh: mocks.refreshViews,
   }),
 }));
 
+import { getActiveAgentAuthority } from "./useActiveAgentAuthority";
 import { useViewCatalog } from "./useViewCatalog";
 
 function deferred<T>() {
@@ -78,12 +86,256 @@ function catalogApp(name: string): RegistryAppInfo {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.loadAppsCatalog.mockReset();
+  mocks.client.listInstalledApps.mockReset();
+  mocks.client.launchApp.mockReset();
   __resetResourceCache();
   mocks.authority.value = "https://agent-a.test";
+  mocks.appShellRoutesSupported.value = true;
   mocks.authority.listeners.clear();
+  mocks.routableViews.views = [];
+  mocks.routableViews.loading = false;
+  mocks.routableViews.error = null;
 });
 
 describe("useViewCatalog authority isolation", () => {
+  it("settles to an honest empty launcher when app-shell sources are unsupported", () => {
+    mocks.appShellRoutesSupported.value = false;
+
+    const { result } = renderHook(() => useViewCatalog());
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.sourceErrors).toEqual([]);
+    expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
+    expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
+
+    act(() => result.current.refresh());
+    expect(mocks.refreshViews).toHaveBeenCalledTimes(1);
+    expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
+    expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the views error when unsupported app-shell sources are disabled", () => {
+    mocks.appShellRoutesSupported.value = false;
+    mocks.routableViews.error = new Error("views unavailable");
+
+    const { result } = renderHook(() => useViewCatalog());
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error?.message).toBe("views unavailable");
+    expect(result.current.sourceErrors).toEqual([
+      { source: "views", error: mocks.routableViews.error },
+    ]);
+    expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
+    expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
+
+    act(() => result.current.retrySource("views"));
+    expect(mocks.refreshViews).toHaveBeenCalledTimes(1);
+    act(() => result.current.retrySource("catalog"));
+    act(() => result.current.retrySource("installed"));
+    expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
+    expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
+  });
+
+  it("degrades a failed optional catalog without marking healthy views broken", async () => {
+    mocks.routableViews.views = [
+      {
+        id: "notes",
+        label: "Notes",
+        path: "/notes",
+        available: true,
+        builtin: true,
+        pluginName: "@elizaos/builtin",
+        viewType: "gui",
+        viewKind: "release",
+      },
+    ];
+    mocks.loadAppsCatalog.mockRejectedValue(new Error("catalog unavailable"));
+    mocks.client.listInstalledApps.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useViewCatalog());
+    await waitFor(() => expect(result.current.sourceErrors).toHaveLength(1));
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual(["notes"]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.sourceErrors[0]?.source).toBe("catalog");
+
+    act(() => result.current.retrySource("catalog"));
+    await waitFor(() => expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2));
+    expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshViews).not.toHaveBeenCalled();
+  });
+
+  it("uses one delayed catalog retry without refetching healthy sources", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.loadAppsCatalog
+        .mockRejectedValueOnce(new Error("catalog temporarily unavailable"))
+        .mockResolvedValueOnce([catalogApp("recovered-app")]);
+      mocks.client.listInstalledApps.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useViewCatalog());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.sourceErrors).toHaveLength(1);
+      expect(result.current.error?.message).toBe(
+        "catalog temporarily unavailable",
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(499);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "recovered-app",
+      ]);
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+      expect(mocks.refreshViews).not.toHaveBeenCalled();
+      expect(result.current.sourceErrors).toEqual([]);
+      expect(result.current.error).toBeNull();
+
+      mocks.loadAppsCatalog
+        .mockRejectedValueOnce(new Error("later catalog outage"))
+        .mockResolvedValueOnce([catalogApp("recovered-again")]);
+      act(() => {
+        invalidate(`view-catalog:apps:${getActiveAgentAuthority()}`);
+        result.current.retrySource("catalog");
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.sourceErrors).toEqual([
+        {
+          source: "catalog",
+          error: expect.objectContaining({ message: "later catalog outage" }),
+        },
+      ]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(499);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(3);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "recovered-again",
+      ]);
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(4);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+      expect(result.current.sourceErrors).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses one delayed installed-app retry without refetching the catalog", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.loadAppsCatalog.mockResolvedValue([catalogApp("catalog-app")]);
+      mocks.client.listInstalledApps
+        .mockRejectedValueOnce(
+          new Error("installed apps temporarily unavailable"),
+        )
+        .mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useViewCatalog());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "catalog-app",
+      ]);
+      expect(result.current.sourceErrors).toEqual([
+        {
+          source: "installed",
+          error: expect.objectContaining({
+            message: "installed apps temporarily unavailable",
+          }),
+        },
+      ]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(499);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
+      expect(mocks.refreshViews).not.toHaveBeenCalled();
+      expect(result.current.sourceErrors).toEqual([]);
+      expect(result.current.error).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a departed authority's pending optional-source retry", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.loadAppsCatalog
+        .mockRejectedValueOnce(new Error("agent A catalog unavailable"))
+        .mockResolvedValueOnce([catalogApp("agent-b-app")]);
+      mocks.client.listInstalledApps.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useViewCatalog());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.sourceErrors).toHaveLength(1);
+
+      act(() => {
+        mocks.authority.value = "https://agent-b.test";
+        for (const onChange of mocks.authority.listeners) onChange();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "agent-b-app",
+      ]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
+      expect(mocks.refreshViews).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a source failure fatal when no usable launcher entry remains", async () => {
+    mocks.loadAppsCatalog.mockRejectedValue(new Error("catalog unavailable"));
+    mocks.client.listInstalledApps.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useViewCatalog());
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.error?.message).toBe("catalog unavailable");
+    expect(result.current.sourceErrors[0]?.source).toBe("catalog");
+  });
+
   it("clears old entries on switch and ignores superseded catalog responses", async () => {
     const agentBCatalog = deferred<RegistryAppInfo[]>();
     const agentBInstalled = deferred<Array<{ name: string }>>();

--- a/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
+++ b/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
@@ -55,7 +55,10 @@ vi.mock("./useAvailableViews", () => ({
 }));
 
 import { getActiveAgentAuthority } from "./useActiveAgentAuthority";
-import { useViewCatalog } from "./useViewCatalog";
+import {
+  __resetViewCatalogSourceStateForTests,
+  useViewCatalog,
+} from "./useViewCatalog";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -88,6 +91,7 @@ function catalogApp(name: string): RegistryAppInfo {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetViewCatalogSourceStateForTests();
   mocks.loadAppsCatalog.mockReset();
   mocks.client.listInstalledApps.mockReset();
   mocks.client.launchApp.mockReset();
@@ -109,7 +113,6 @@ describe("useViewCatalog authority isolation", () => {
     expect(result.current.entries).toEqual([]);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(result.current.sourceErrors).toEqual([]);
     expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
     expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
 
@@ -128,16 +131,11 @@ describe("useViewCatalog authority isolation", () => {
     expect(result.current.entries).toEqual([]);
     expect(result.current.loading).toBe(false);
     expect(result.current.error?.message).toBe("views unavailable");
-    expect(result.current.sourceErrors).toEqual([
-      { source: "views", error: mocks.routableViews.error },
-    ]);
     expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
     expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
 
-    act(() => result.current.retrySource("views"));
+    act(() => result.current.refresh());
     expect(mocks.refreshViews).toHaveBeenCalledTimes(1);
-    act(() => result.current.retrySource("catalog"));
-    act(() => result.current.retrySource("installed"));
     expect(mocks.loadAppsCatalog).not.toHaveBeenCalled();
     expect(mocks.client.listInstalledApps).not.toHaveBeenCalled();
   });
@@ -159,13 +157,12 @@ describe("useViewCatalog authority isolation", () => {
     mocks.client.listInstalledApps.mockResolvedValue([]);
 
     const { result } = renderHook(() => useViewCatalog());
-    await waitFor(() => expect(result.current.sourceErrors).toHaveLength(1));
+    await waitFor(() => expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1));
 
     expect(result.current.entries.map((entry) => entry.id)).toEqual(["notes"]);
     expect(result.current.error).toBeNull();
-    expect(result.current.sourceErrors[0]?.source).toBe("catalog");
 
-    act(() => result.current.retrySource("catalog"));
+    act(() => result.current.refresh());
     await waitFor(() => expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2));
     expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
     expect(mocks.refreshViews).not.toHaveBeenCalled();
@@ -184,7 +181,6 @@ describe("useViewCatalog authority isolation", () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
       });
-      expect(result.current.sourceErrors).toHaveLength(1);
       expect(result.current.error?.message).toBe(
         "catalog temporarily unavailable",
       );
@@ -204,7 +200,6 @@ describe("useViewCatalog authority isolation", () => {
       expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
       expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
       expect(mocks.refreshViews).not.toHaveBeenCalled();
-      expect(result.current.sourceErrors).toEqual([]);
       expect(result.current.error).toBeNull();
 
       mocks.loadAppsCatalog
@@ -212,23 +207,16 @@ describe("useViewCatalog authority isolation", () => {
         .mockResolvedValueOnce([catalogApp("recovered-again")]);
       act(() => {
         invalidate(`view-catalog:apps:${getActiveAgentAuthority()}`);
-        result.current.retrySource("catalog");
+        result.current.refresh();
       });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
       });
-      expect(result.current.sourceErrors).toEqual([
-        {
-          source: "catalog",
-          error: expect.objectContaining({ message: "later catalog outage" }),
-        },
-      ]);
-
       await act(async () => {
         await vi.advanceTimersByTimeAsync(499);
       });
       expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(3);
-      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1);
@@ -237,8 +225,7 @@ describe("useViewCatalog authority isolation", () => {
         "recovered-again",
       ]);
       expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(4);
-      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
-      expect(result.current.sourceErrors).toEqual([]);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
@@ -262,14 +249,7 @@ describe("useViewCatalog authority isolation", () => {
       expect(result.current.entries.map((entry) => entry.id)).toEqual([
         "catalog-app",
       ]);
-      expect(result.current.sourceErrors).toEqual([
-        {
-          source: "installed",
-          error: expect.objectContaining({
-            message: "installed apps temporarily unavailable",
-          }),
-        },
-      ]);
+      expect(result.current.error).toBeNull();
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(499);
@@ -283,7 +263,6 @@ describe("useViewCatalog authority isolation", () => {
       expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
       expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
       expect(mocks.refreshViews).not.toHaveBeenCalled();
-      expect(result.current.sourceErrors).toEqual([]);
       expect(result.current.error).toBeNull();
     } finally {
       vi.useRealTimers();
@@ -302,7 +281,7 @@ describe("useViewCatalog authority isolation", () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
       });
-      expect(result.current.sourceErrors).toHaveLength(1);
+      expect(result.current.error?.message).toBe("agent A catalog unavailable");
 
       act(() => {
         mocks.authority.value = "https://agent-b.test";
@@ -358,7 +337,7 @@ describe("useViewCatalog authority isolation", () => {
         agentACatalog.reject(new Error("late agent A rejection"));
         await Promise.resolve();
       });
-      expect(result.current.sourceErrors).toEqual([]);
+      expect(result.current.error).toBeNull();
       await act(async () => {
         await vi.advanceTimersByTimeAsync(750);
       });
@@ -375,17 +354,12 @@ describe("useViewCatalog authority isolation", () => {
 
       act(() => {
         invalidate(`view-catalog:apps:${getActiveAgentAuthority()}`);
-        result.current.retrySource("catalog");
+        result.current.refresh();
       });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
       });
-      expect(result.current.sourceErrors).toEqual([
-        {
-          source: "catalog",
-          error: expect.objectContaining({ message: "later agent B outage" }),
-        },
-      ]);
+      expect(result.current.error?.message).toBe("later agent B outage");
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(499);
@@ -395,11 +369,11 @@ describe("useViewCatalog authority isolation", () => {
         await vi.advanceTimersByTimeAsync(1);
       });
       expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(4);
-      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(2);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(3);
       expect(result.current.entries.map((entry) => entry.id)).toEqual([
         "agent-b-recovered",
       ]);
-      expect(result.current.sourceErrors).toEqual([]);
+      expect(result.current.error).toBeNull();
     } finally {
       vi.useRealTimers();
     }
@@ -414,7 +388,87 @@ describe("useViewCatalog authority isolation", () => {
 
     expect(result.current.entries).toEqual([]);
     expect(result.current.error?.message).toBe("catalog unavailable");
-    expect(result.current.sourceErrors[0]?.source).toBe("catalog");
+  });
+
+  it("shares failure settlement and exactly one retry across a remount", async () => {
+    vi.useFakeTimers();
+    try {
+      const sharedCatalog = deferred<RegistryAppInfo[]>();
+      mocks.loadAppsCatalog
+        .mockReturnValueOnce(sharedCatalog.promise)
+        .mockResolvedValueOnce([catalogApp("recovered-app")]);
+      mocks.client.listInstalledApps.mockResolvedValue([]);
+
+      const first = renderHook(() => useViewCatalog());
+      const survivor = renderHook(() => useViewCatalog());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+
+      first.unmount();
+      await act(async () => {
+        sharedCatalog.reject(new Error("shared catalog unavailable"));
+        await Promise.resolve();
+      });
+      expect(survivor.result.current.loading).toBe(false);
+      expect(survivor.result.current.error?.message).toBe(
+        "shared catalog unavailable",
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+      expect(survivor.result.current.entries.map((entry) => entry.id)).toEqual([
+        "recovered-app",
+      ]);
+      expect(survivor.result.current.error).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("exposes persistent partial degradation and retries only that source", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.routableViews.views = [
+        {
+          id: "notes",
+          label: "Notes",
+          path: "/notes",
+          available: true,
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          viewType: "gui",
+          viewKind: "release",
+        },
+      ];
+      mocks.loadAppsCatalog.mockRejectedValue(new Error("catalog unavailable"));
+      mocks.client.listInstalledApps.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useViewCatalog());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(2);
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "notes",
+      ]);
+      expect(result.current.error?.message).toBe("catalog unavailable");
+
+      act(() => result.current.refresh());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(3);
+      expect(mocks.client.listInstalledApps).toHaveBeenCalledTimes(1);
+      expect(mocks.refreshViews).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("clears old entries on switch and ignores superseded catalog responses", async () => {

--- a/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
+++ b/packages/ui/src/hooks/useViewCatalog.authority.test.tsx
@@ -59,10 +59,12 @@ import { useViewCatalog } from "./useViewCatalog";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
     resolve = promiseResolve;
+    reject = promiseReject;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function catalogApp(name: string): RegistryAppInfo {
@@ -327,9 +329,10 @@ describe("useViewCatalog authority isolation", () => {
   it("does not spend a new authority's retry budget on an inherited error", async () => {
     vi.useFakeTimers();
     try {
+      const agentACatalog = deferred<RegistryAppInfo[]>();
       const agentBCatalog = deferred<RegistryAppInfo[]>();
       mocks.loadAppsCatalog
-        .mockRejectedValueOnce(new Error("agent A catalog unavailable"))
+        .mockReturnValueOnce(agentACatalog.promise)
         .mockReturnValueOnce(agentBCatalog.promise);
       mocks.client.listInstalledApps.mockResolvedValue([]);
 
@@ -337,7 +340,6 @@ describe("useViewCatalog authority isolation", () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
       });
-      expect(result.current.sourceErrors).toHaveLength(1);
       expect(mocks.loadAppsCatalog).toHaveBeenCalledTimes(1);
 
       act(() => {
@@ -352,6 +354,11 @@ describe("useViewCatalog authority isolation", () => {
       mocks.loadAppsCatalog
         .mockRejectedValueOnce(new Error("later agent B outage"))
         .mockResolvedValueOnce([catalogApp("agent-b-recovered")]);
+      await act(async () => {
+        agentACatalog.reject(new Error("late agent A rejection"));
+        await Promise.resolve();
+      });
+      expect(result.current.sourceErrors).toEqual([]);
       await act(async () => {
         await vi.advanceTimersByTimeAsync(750);
       });

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -145,7 +145,19 @@ export function useViewCatalog(): UseViewCatalogResult {
     authority: string;
     catalog: number;
     installed: number;
-  }>({ authority, catalog: 0, installed: 0 });
+    inheritedCatalogError: Error | null;
+    inheritedInstalledError: Error | null;
+    catalogRequestObserved: boolean;
+    installedRequestObserved: boolean;
+  }>({
+    authority,
+    catalog: 0,
+    installed: 0,
+    inheritedCatalogError: null,
+    inheritedInstalledError: null,
+    catalogRequestObserved: catalogRes.status === "loading",
+    installedRequestObserved: installedRes.status === "loading",
+  });
   useEffect(() => {
     const attempts = optionalRetryAttemptsRef.current;
     if (attempts.authority !== authority) {
@@ -153,17 +165,52 @@ export function useViewCatalog(): UseViewCatalogResult {
         authority,
         catalog: 0,
         installed: 0,
+        // useCachedResource owns error state outside its cache key, so its
+        // first render after an authority switch can still expose the departed
+        // key's error while the new request starts. Quarantine that exact
+        // inherited error until this authority has observed its own request.
+        inheritedCatalogError: catalogError,
+        inheritedInstalledError: installedError,
+        catalogRequestObserved:
+          catalogRes.status === "loading" || catalogRes.isValidating,
+        installedRequestObserved:
+          installedRes.status === "loading" || installedRes.isValidating,
       };
     }
     if (!appShellRoutesSupported) return;
 
     const currentAttempts = optionalRetryAttemptsRef.current;
+    if (catalogRes.status === "loading" || catalogRes.isValidating) {
+      currentAttempts.catalogRequestObserved = true;
+    }
+    if (installedRes.status === "loading" || installedRes.isValidating) {
+      currentAttempts.installedRequestObserved = true;
+    }
     // A successful settlement closes that source's failure episode. Loading
     // and error states deliberately keep the consumed budget so one failing
     // request cannot loop forever, while a later independent outage still gets
     // its own single recovery attempt.
-    if (catalogRes.status === "success") currentAttempts.catalog = 0;
-    if (installedRes.status === "success") currentAttempts.installed = 0;
+    if (catalogRes.status === "success") {
+      currentAttempts.catalog = 0;
+      currentAttempts.inheritedCatalogError = null;
+      currentAttempts.catalogRequestObserved = true;
+    }
+    if (installedRes.status === "success") {
+      currentAttempts.installed = 0;
+      currentAttempts.inheritedInstalledError = null;
+      currentAttempts.installedRequestObserved = true;
+    }
+
+    const catalogFailureBelongsToAuthority =
+      catalogError !== null &&
+      !catalogRes.isValidating &&
+      (currentAttempts.catalogRequestObserved ||
+        catalogError !== currentAttempts.inheritedCatalogError);
+    const installedFailureBelongsToAuthority =
+      installedError !== null &&
+      !installedRes.isValidating &&
+      (currentAttempts.installedRequestObserved ||
+        installedError !== currentAttempts.inheritedInstalledError);
 
     const timers: number[] = [];
     const scheduleRetry = (
@@ -188,8 +235,16 @@ export function useViewCatalog(): UseViewCatalogResult {
       );
     };
 
-    scheduleRetry("catalog", catalogError !== null, catalogRes.refetch);
-    scheduleRetry("installed", installedError !== null, installedRes.refetch);
+    scheduleRetry(
+      "catalog",
+      catalogFailureBelongsToAuthority,
+      catalogRes.refetch,
+    );
+    scheduleRetry(
+      "installed",
+      installedFailureBelongsToAuthority,
+      installedRes.refetch,
+    );
     return () => {
       for (const timer of timers) window.clearTimeout(timer);
     };
@@ -198,6 +253,8 @@ export function useViewCatalog(): UseViewCatalogResult {
     appShellRoutesSupported,
     catalogRes.status,
     installedRes.status,
+    catalogRes.isValidating,
+    installedRes.isValidating,
     catalogError,
     installedError,
     catalogRes.refetch,

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -31,12 +31,21 @@ import { mergeViewCatalog, type ViewEntry } from "./view-catalog";
 const CATALOG_CACHE_KEY = "view-catalog:apps";
 const INSTALLED_CACHE_KEY = "view-catalog:installed";
 const CATALOG_STALE_MS = 60_000;
+const OPTIONAL_SOURCE_RETRY_DELAY_MS = 500;
+const OPTIONAL_SOURCE_RETRY_LIMIT = 1;
 
 export interface UseViewCatalogResult {
   entries: ViewEntry[];
   loading: boolean;
+  /**
+   * Fatal launcher error. Source failures are fatal only when no usable entry
+   * remains; otherwise the healthy sources continue to power the launcher.
+   */
   error: Error | null;
+  /** Source-specific failures retained for diagnostics and targeted recovery. */
+  sourceErrors: readonly ViewCatalogSourceError[];
   refresh: () => void;
+  retrySource: (source: ViewCatalogSource) => void;
   /**
    * Launch/install the app behind an entry and return the authoritative launch
    * result. Catalog callers need the returned run/viewer on the first click:
@@ -44,6 +53,13 @@ export interface UseViewCatalogResult {
    * a newly-installed app's viewer.
    */
   get: (entry: ViewEntry) => Promise<AppLaunchResult | null>;
+}
+
+export type ViewCatalogSource = "views" | "catalog" | "installed";
+
+export interface ViewCatalogSourceError {
+  source: ViewCatalogSource;
+  error: Error;
 }
 
 export function useViewCatalog(): UseViewCatalogResult {
@@ -105,10 +121,96 @@ export function useViewCatalog(): UseViewCatalogResult {
 
   const catalog = catalogRes.status === "success" ? catalogRes.data : [];
   const installed = installedRes.status === "success" ? installedRes.data : [];
-  const error =
-    viewsError ??
-    (catalogRes.status === "error" ? catalogRes.error : null) ??
-    (installedRes.status === "error" ? installedRes.error : null);
+  const catalogError = catalogRes.status === "error" ? catalogRes.error : null;
+  const installedError =
+    installedRes.status === "error" ? installedRes.error : null;
+  const sourceErrors = useMemo<readonly ViewCatalogSourceError[]>(() => {
+    const failures: ViewCatalogSourceError[] = [];
+    if (viewsError) failures.push({ source: "views", error: viewsError });
+    if (catalogError) {
+      failures.push({ source: "catalog", error: catalogError });
+    }
+    if (installedError) {
+      failures.push({ source: "installed", error: installedError });
+    }
+    return failures;
+  }, [viewsError, catalogError, installedError]);
+
+  // A transient optional-source failure should not turn the built-in launcher
+  // into an error surface, but it also must not silently hide installable apps
+  // until a remount. Retry only the failed source once. Timers are cancelled on
+  // authority/source changes, and the live-authority check prevents a departed
+  // agent's retry from repopulating the current catalog.
+  const optionalRetryAttemptsRef = useRef<{
+    authority: string;
+    catalog: number;
+    installed: number;
+  }>({ authority, catalog: 0, installed: 0 });
+  useEffect(() => {
+    const attempts = optionalRetryAttemptsRef.current;
+    if (attempts.authority !== authority) {
+      optionalRetryAttemptsRef.current = {
+        authority,
+        catalog: 0,
+        installed: 0,
+      };
+    }
+    if (!appShellRoutesSupported) return;
+
+    const currentAttempts = optionalRetryAttemptsRef.current;
+    // A successful settlement closes that source's failure episode. Loading
+    // and error states deliberately keep the consumed budget so one failing
+    // request cannot loop forever, while a later independent outage still gets
+    // its own single recovery attempt.
+    if (catalogRes.status === "success") currentAttempts.catalog = 0;
+    if (installedRes.status === "success") currentAttempts.installed = 0;
+
+    const timers: number[] = [];
+    const scheduleRetry = (
+      source: "catalog" | "installed",
+      failed: boolean,
+      refetch: () => Promise<unknown>,
+    ) => {
+      if (!failed) return;
+      const current = optionalRetryAttemptsRef.current;
+      if (
+        current.authority !== authority ||
+        current[source] >= OPTIONAL_SOURCE_RETRY_LIMIT
+      ) {
+        return;
+      }
+      current[source] += 1;
+      timers.push(
+        window.setTimeout(() => {
+          if (getActiveAgentAuthority() !== authority) return;
+          void refetch();
+        }, OPTIONAL_SOURCE_RETRY_DELAY_MS),
+      );
+    };
+
+    scheduleRetry("catalog", catalogError !== null, catalogRes.refetch);
+    scheduleRetry("installed", installedError !== null, installedRes.refetch);
+    return () => {
+      for (const timer of timers) window.clearTimeout(timer);
+    };
+  }, [
+    authority,
+    appShellRoutesSupported,
+    catalogRes.status,
+    installedRes.status,
+    catalogError,
+    installedError,
+    catalogRes.refetch,
+    installedRes.refetch,
+  ]);
+
+  // Disabled cached resources intentionally retain their neutral `loading`
+  // status. Only enabled app-shell sources participate in launcher settlement;
+  // otherwise a views-only runtime with no entries can skeleton forever.
+  const optionalSourcesLoading =
+    appShellRoutesSupported &&
+    (catalogRes.status === "loading" || installedRes.status === "loading");
+  const sourcesLoading = viewsLoading || optionalSourcesLoading;
 
   const entries = useMemo(() => {
     const merged = mergeViewCatalog({
@@ -128,9 +230,33 @@ export function useViewCatalog(): UseViewCatalogResult {
   const refresh = useCallback(() => {
     if (getActiveAgentAuthority() !== authority) return;
     refreshViews();
+    if (!appShellRoutesSupported) return;
     catalogRes.refetch();
     installedRes.refetch();
-  }, [authority, refreshViews, catalogRes.refetch, installedRes.refetch]);
+  }, [
+    authority,
+    appShellRoutesSupported,
+    refreshViews,
+    catalogRes.refetch,
+    installedRes.refetch,
+  ]);
+
+  const retrySource = useCallback(
+    (source: ViewCatalogSource) => {
+      if (getActiveAgentAuthority() !== authority) return;
+      if (source === "views") refreshViews();
+      else if (!appShellRoutesSupported) return;
+      else if (source === "catalog") catalogRes.refetch();
+      else installedRes.refetch();
+    },
+    [
+      authority,
+      appShellRoutesSupported,
+      refreshViews,
+      catalogRes.refetch,
+      installedRes.refetch,
+    ],
+  );
 
   const get = useCallback(
     async (entry: ViewEntry) => {
@@ -179,10 +305,17 @@ export function useViewCatalog(): UseViewCatalogResult {
 
   return {
     entries,
-    // First paint waits on loaded views; the catalog fills in as it resolves.
-    loading: viewsLoading && views.length === 0,
-    error,
+    // With no usable entry, keep the skeleton until every enabled source has
+    // settled so one fast failure cannot flash a false global error while a
+    // healthy source is still arriving.
+    loading: entries.length === 0 && sourcesLoading,
+    error:
+      entries.length === 0 && !sourcesLoading
+        ? (sourceErrors[0]?.error ?? null)
+        : null,
+    sourceErrors,
     refresh,
+    retrySource,
     get,
   };
 }

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -62,6 +62,101 @@ export interface ViewCatalogSourceError {
   error: Error;
 }
 
+type AuthorityScopedFetchStatus = "idle" | "loading" | "success" | "error";
+
+interface AuthorityScopedFetchState {
+  scope: symbol;
+  requestId: number;
+  status: AuthorityScopedFetchStatus;
+  error: Error | null;
+}
+
+/**
+ * Keeps completion state local to one authority visit. useCachedResource keys
+ * its data cache, but its local error/validation state intentionally survives
+ * key changes; without this boundary, a departed request can reject after a
+ * switch and masquerade as the new authority's failure.
+ */
+function useAuthorityScopedFetcher<T>(
+  authority: string,
+  enabled: boolean,
+  fetcher: (signal: AbortSignal) => Promise<T>,
+): {
+  fetch: (signal: AbortSignal) => Promise<T>;
+  state: AuthorityScopedFetchState;
+} {
+  const scopeRef = useRef<{
+    authority: string;
+    enabled: boolean;
+    token: symbol;
+  }>(undefined);
+  if (
+    !scopeRef.current ||
+    scopeRef.current.authority !== authority ||
+    scopeRef.current.enabled !== enabled
+  ) {
+    scopeRef.current = {
+      authority,
+      enabled,
+      token: Symbol("view-catalog-authority"),
+    };
+  }
+  const scope = scopeRef.current.token;
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  const requestIdRef = useRef(0);
+  const [storedState, setStoredState] = useState<AuthorityScopedFetchState>(
+    () => ({
+      scope,
+      requestId: 0,
+      status: enabled ? "loading" : "idle",
+      error: null,
+    }),
+  );
+
+  const state =
+    storedState.scope === scope
+      ? storedState
+      : {
+          scope,
+          requestId: 0,
+          status: enabled ? ("loading" as const) : ("idle" as const),
+          error: null,
+        };
+
+  const fetch = useCallback(
+    async (signal: AbortSignal): Promise<T> => {
+      const requestId = ++requestIdRef.current;
+      setStoredState({
+        scope,
+        requestId,
+        status: "loading",
+        error: null,
+      });
+      try {
+        const data = await fetcherRef.current(signal);
+        setStoredState((current) =>
+          current.scope === scope && current.requestId === requestId
+            ? { ...current, status: "success", error: null }
+            : current,
+        );
+        return data;
+      } catch (cause) {
+        const error = cause instanceof Error ? cause : new Error(String(cause));
+        setStoredState((current) =>
+          current.scope === scope && current.requestId === requestId
+            ? { ...current, status: "error", error }
+            : current,
+        );
+        throw cause;
+      }
+    },
+    [scope],
+  );
+
+  return { fetch, state };
+}
+
 export function useViewCatalog(): UseViewCatalogResult {
   const authority = useActiveAgentAuthority();
   const {
@@ -78,9 +173,20 @@ export function useViewCatalog(): UseViewCatalogResult {
   const catalogCacheKey = `${CATALOG_CACHE_KEY}:${authority}`;
   const installedCacheKey = `${INSTALLED_CACHE_KEY}:${authority}`;
 
+  const catalogFetch = useAuthorityScopedFetcher(
+    authority,
+    appShellRoutesSupported,
+    () => loadAppsCatalog(),
+  );
+  const installedFetch = useAuthorityScopedFetcher(
+    authority,
+    appShellRoutesSupported,
+    () => client.listInstalledApps(),
+  );
+
   const catalogRes = useCachedResource(
     appShellRoutesSupported ? catalogCacheKey : null,
-    () => loadAppsCatalog(),
+    catalogFetch.fetch,
     {
       staleTime: CATALOG_STALE_MS,
       enabled: appShellRoutesSupported,
@@ -88,7 +194,7 @@ export function useViewCatalog(): UseViewCatalogResult {
   );
   const installedRes = useCachedResource(
     appShellRoutesSupported ? installedCacheKey : null,
-    () => client.listInstalledApps(),
+    installedFetch.fetch,
     { staleTime: CATALOG_STALE_MS, enabled: appShellRoutesSupported },
   );
 
@@ -121,9 +227,10 @@ export function useViewCatalog(): UseViewCatalogResult {
 
   const catalog = catalogRes.status === "success" ? catalogRes.data : [];
   const installed = installedRes.status === "success" ? installedRes.data : [];
-  const catalogError = catalogRes.status === "error" ? catalogRes.error : null;
+  const catalogError =
+    catalogFetch.state.status === "error" ? catalogFetch.state.error : null;
   const installedError =
-    installedRes.status === "error" ? installedRes.error : null;
+    installedFetch.state.status === "error" ? installedFetch.state.error : null;
   const sourceErrors = useMemo<readonly ViewCatalogSourceError[]>(() => {
     const failures: ViewCatalogSourceError[] = [];
     if (viewsError) failures.push({ source: "views", error: viewsError });
@@ -145,18 +252,10 @@ export function useViewCatalog(): UseViewCatalogResult {
     authority: string;
     catalog: number;
     installed: number;
-    inheritedCatalogError: Error | null;
-    inheritedInstalledError: Error | null;
-    catalogRequestObserved: boolean;
-    installedRequestObserved: boolean;
   }>({
     authority,
     catalog: 0,
     installed: 0,
-    inheritedCatalogError: null,
-    inheritedInstalledError: null,
-    catalogRequestObserved: catalogRes.status === "loading",
-    installedRequestObserved: installedRes.status === "loading",
   });
   useEffect(() => {
     const attempts = optionalRetryAttemptsRef.current;
@@ -165,52 +264,21 @@ export function useViewCatalog(): UseViewCatalogResult {
         authority,
         catalog: 0,
         installed: 0,
-        // useCachedResource owns error state outside its cache key, so its
-        // first render after an authority switch can still expose the departed
-        // key's error while the new request starts. Quarantine that exact
-        // inherited error until this authority has observed its own request.
-        inheritedCatalogError: catalogError,
-        inheritedInstalledError: installedError,
-        catalogRequestObserved:
-          catalogRes.status === "loading" || catalogRes.isValidating,
-        installedRequestObserved:
-          installedRes.status === "loading" || installedRes.isValidating,
       };
     }
     if (!appShellRoutesSupported) return;
 
     const currentAttempts = optionalRetryAttemptsRef.current;
-    if (catalogRes.status === "loading" || catalogRes.isValidating) {
-      currentAttempts.catalogRequestObserved = true;
-    }
-    if (installedRes.status === "loading" || installedRes.isValidating) {
-      currentAttempts.installedRequestObserved = true;
-    }
     // A successful settlement closes that source's failure episode. Loading
     // and error states deliberately keep the consumed budget so one failing
     // request cannot loop forever, while a later independent outage still gets
     // its own single recovery attempt.
-    if (catalogRes.status === "success") {
+    if (catalogFetch.state.status === "success") {
       currentAttempts.catalog = 0;
-      currentAttempts.inheritedCatalogError = null;
-      currentAttempts.catalogRequestObserved = true;
     }
-    if (installedRes.status === "success") {
+    if (installedFetch.state.status === "success") {
       currentAttempts.installed = 0;
-      currentAttempts.inheritedInstalledError = null;
-      currentAttempts.installedRequestObserved = true;
     }
-
-    const catalogFailureBelongsToAuthority =
-      catalogError !== null &&
-      !catalogRes.isValidating &&
-      (currentAttempts.catalogRequestObserved ||
-        catalogError !== currentAttempts.inheritedCatalogError);
-    const installedFailureBelongsToAuthority =
-      installedError !== null &&
-      !installedRes.isValidating &&
-      (currentAttempts.installedRequestObserved ||
-        installedError !== currentAttempts.inheritedInstalledError);
 
     const timers: number[] = [];
     const scheduleRetry = (
@@ -235,26 +303,16 @@ export function useViewCatalog(): UseViewCatalogResult {
       );
     };
 
-    scheduleRetry(
-      "catalog",
-      catalogFailureBelongsToAuthority,
-      catalogRes.refetch,
-    );
-    scheduleRetry(
-      "installed",
-      installedFailureBelongsToAuthority,
-      installedRes.refetch,
-    );
+    scheduleRetry("catalog", catalogError !== null, catalogRes.refetch);
+    scheduleRetry("installed", installedError !== null, installedRes.refetch);
     return () => {
       for (const timer of timers) window.clearTimeout(timer);
     };
   }, [
     authority,
     appShellRoutesSupported,
-    catalogRes.status,
-    installedRes.status,
-    catalogRes.isValidating,
-    installedRes.isValidating,
+    catalogFetch.state.status,
+    installedFetch.state.status,
     catalogError,
     installedError,
     catalogRes.refetch,
@@ -266,7 +324,12 @@ export function useViewCatalog(): UseViewCatalogResult {
   // otherwise a views-only runtime with no entries can skeleton forever.
   const optionalSourcesLoading =
     appShellRoutesSupported &&
-    (catalogRes.status === "loading" || installedRes.status === "loading");
+    (catalogFetch.state.status === "loading" ||
+      installedFetch.state.status === "loading" ||
+      (catalogFetch.state.status === "success" &&
+        catalogRes.status !== "success") ||
+      (installedFetch.state.status === "success" &&
+        installedRes.status !== "success"));
   const sourcesLoading = viewsLoading || optionalSourcesLoading;
 
   const entries = useMemo(() => {

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -13,7 +13,14 @@
  * no restart.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { type AppLaunchResult, client } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import { loadAppsCatalog } from "../components/apps/load-apps-catalog";
@@ -38,14 +45,12 @@ export interface UseViewCatalogResult {
   entries: ViewEntry[];
   loading: boolean;
   /**
-   * Fatal launcher error. Source failures are fatal only when no usable entry
-   * remains; otherwise the healthy sources continue to power the launcher.
+   * Launcher error. Fatal failures replace an empty launcher; a persistent
+   * partial failure renders as a quiet recovery status beside healthy entries.
    */
   error: Error | null;
-  /** Source-specific failures retained for diagnostics and targeted recovery. */
-  sourceErrors: readonly ViewCatalogSourceError[];
+  /** Retries only failed sources when degraded, otherwise refreshes all. */
   refresh: () => void;
-  retrySource: (source: ViewCatalogSource) => void;
   /**
    * Launch/install the app behind an entry and return the authoritative launch
    * result. Catalog callers need the returned run/viewer on the first click:
@@ -55,9 +60,9 @@ export interface UseViewCatalogResult {
   get: (entry: ViewEntry) => Promise<AppLaunchResult | null>;
 }
 
-export type ViewCatalogSource = "views" | "catalog" | "installed";
+type ViewCatalogSource = "views" | "catalog" | "installed";
 
-export interface ViewCatalogSourceError {
+interface ViewCatalogSourceError {
   source: ViewCatalogSource;
   error: Error;
 }
@@ -65,93 +70,129 @@ export interface ViewCatalogSourceError {
 type AuthorityScopedFetchStatus = "idle" | "loading" | "success" | "error";
 
 interface AuthorityScopedFetchState {
-  scope: symbol;
+  key: string;
   requestId: number;
   status: AuthorityScopedFetchStatus;
   error: Error | null;
 }
 
+interface SharedSourceFetchRecord {
+  snapshot: AuthorityScopedFetchState;
+  nextRequestId: number;
+  listeners: Set<() => void>;
+  refetchers: Set<() => Promise<void>>;
+  retryAttempts: number;
+  retryTimer: number | null;
+}
+
+const sourceFetchRecords = new Map<string, SharedSourceFetchRecord>();
+const DISABLED_SOURCE_STATE: AuthorityScopedFetchState = {
+  key: "disabled",
+  requestId: 0,
+  status: "idle",
+  error: null,
+};
+
+function sourceFetchRecord(key: string): SharedSourceFetchRecord {
+  const existing = sourceFetchRecords.get(key);
+  if (existing) return existing;
+  const created: SharedSourceFetchRecord = {
+    snapshot: { key, requestId: 0, status: "loading", error: null },
+    nextRequestId: 0,
+    listeners: new Set(),
+    refetchers: new Set(),
+    retryAttempts: 0,
+    retryTimer: null,
+  };
+  sourceFetchRecords.set(key, created);
+  return created;
+}
+
+function publishSourceFetchState(
+  record: SharedSourceFetchRecord,
+  snapshot: AuthorityScopedFetchState,
+): void {
+  record.snapshot = snapshot;
+  for (const listener of record.listeners) listener();
+}
+
+function cancelSourceRetry(record: SharedSourceFetchRecord): void {
+  if (record.retryTimer !== null) window.clearTimeout(record.retryTimer);
+  record.retryTimer = null;
+}
+
+/** Clears module-owned cache coordination between deterministic hook tests. */
+export function __resetViewCatalogSourceStateForTests(): void {
+  for (const record of sourceFetchRecords.values()) cancelSourceRetry(record);
+  sourceFetchRecords.clear();
+}
+
 /**
- * Keeps completion state local to one authority visit. useCachedResource keys
- * its data cache, but its local error/validation state intentionally survives
- * key changes; without this boundary, a departed request can reject after a
- * switch and masquerade as the new authority's failure.
+ * Keeps completion state on the same authority-scoped shared key as
+ * useCachedResource. A second Launcher can join an existing request without
+ * invoking its own wrapper, so settlement and retry ownership must be shared
+ * as well; otherwise the surviving consumer can remain stuck at `loading`.
  */
 function useAuthorityScopedFetcher<T>(
-  authority: string,
+  key: string,
   enabled: boolean,
   fetcher: (signal: AbortSignal) => Promise<T>,
 ): {
   fetch: (signal: AbortSignal) => Promise<T>;
   state: AuthorityScopedFetchState;
 } {
-  const scopeRef = useRef<{
-    authority: string;
-    enabled: boolean;
-    token: symbol;
-  }>(undefined);
-  if (
-    !scopeRef.current ||
-    scopeRef.current.authority !== authority ||
-    scopeRef.current.enabled !== enabled
-  ) {
-    scopeRef.current = {
-      authority,
-      enabled,
-      token: Symbol("view-catalog-authority"),
-    };
-  }
-  const scope = scopeRef.current.token;
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
-  const requestIdRef = useRef(0);
-  const [storedState, setStoredState] = useState<AuthorityScopedFetchState>(
-    () => ({
-      scope,
-      requestId: 0,
-      status: enabled ? "loading" : "idle",
-      error: null,
-    }),
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (!enabled) return () => {};
+      const record = sourceFetchRecord(key);
+      record.listeners.add(listener);
+      return () => record.listeners.delete(listener);
+    },
+    [enabled, key],
   );
-
-  const state =
-    storedState.scope === scope
-      ? storedState
-      : {
-          scope,
-          requestId: 0,
-          status: enabled ? ("loading" as const) : ("idle" as const),
-          error: null,
-        };
+  const getSnapshot = useCallback(
+    () => (enabled ? sourceFetchRecord(key).snapshot : DISABLED_SOURCE_STATE),
+    [enabled, key],
+  );
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const fetch = useCallback(
     async (signal: AbortSignal): Promise<T> => {
-      const requestId = ++requestIdRef.current;
-      setStoredState({
-        scope,
+      const record = sourceFetchRecord(key);
+      const requestId = ++record.nextRequestId;
+      publishSourceFetchState(record, {
+        key,
         requestId,
         status: "loading",
         error: null,
       });
       try {
         const data = await fetcherRef.current(signal);
-        setStoredState((current) =>
-          current.scope === scope && current.requestId === requestId
-            ? { ...current, status: "success", error: null }
-            : current,
-        );
+        if (record.snapshot.requestId === requestId) {
+          publishSourceFetchState(record, {
+            key,
+            requestId,
+            status: "success",
+            error: null,
+          });
+        }
         return data;
       } catch (cause) {
         const error = cause instanceof Error ? cause : new Error(String(cause));
-        setStoredState((current) =>
-          current.scope === scope && current.requestId === requestId
-            ? { ...current, status: "error", error }
-            : current,
-        );
+        if (record.snapshot.requestId === requestId) {
+          publishSourceFetchState(record, {
+            key,
+            requestId,
+            status: "error",
+            error,
+          });
+        }
         throw cause;
       }
     },
-    [scope],
+    [key],
   );
 
   return { fetch, state };
@@ -174,12 +215,12 @@ export function useViewCatalog(): UseViewCatalogResult {
   const installedCacheKey = `${INSTALLED_CACHE_KEY}:${authority}`;
 
   const catalogFetch = useAuthorityScopedFetcher(
-    authority,
+    catalogCacheKey,
     appShellRoutesSupported,
     () => loadAppsCatalog(),
   );
   const installedFetch = useAuthorityScopedFetcher(
-    authority,
+    installedCacheKey,
     appShellRoutesSupported,
     () => client.listInstalledApps(),
   );
@@ -248,75 +289,75 @@ export function useViewCatalog(): UseViewCatalogResult {
   // until a remount. Retry only the failed source once. Timers are cancelled on
   // authority/source changes, and the live-authority check prevents a departed
   // agent's retry from repopulating the current catalog.
-  const optionalRetryAttemptsRef = useRef<{
-    authority: string;
-    catalog: number;
-    installed: number;
-  }>({
-    authority,
-    catalog: 0,
-    installed: 0,
-  });
   useEffect(() => {
-    const attempts = optionalRetryAttemptsRef.current;
-    if (attempts.authority !== authority) {
-      optionalRetryAttemptsRef.current = {
-        authority,
-        catalog: 0,
-        installed: 0,
-      };
-    }
     if (!appShellRoutesSupported) return;
+    const catalogRecord = sourceFetchRecord(catalogCacheKey);
+    const installedRecord = sourceFetchRecord(installedCacheKey);
+    catalogRecord.refetchers.add(catalogRes.refetch);
+    installedRecord.refetchers.add(installedRes.refetch);
+    return () => {
+      catalogRecord.refetchers.delete(catalogRes.refetch);
+      installedRecord.refetchers.delete(installedRes.refetch);
+    };
+  }, [
+    appShellRoutesSupported,
+    catalogCacheKey,
+    installedCacheKey,
+    catalogRes.refetch,
+    installedRes.refetch,
+  ]);
 
-    const currentAttempts = optionalRetryAttemptsRef.current;
-    // A successful settlement closes that source's failure episode. Loading
-    // and error states deliberately keep the consumed budget so one failing
-    // request cannot loop forever, while a later independent outage still gets
-    // its own single recovery attempt.
-    if (catalogFetch.state.status === "success") {
-      currentAttempts.catalog = 0;
-    }
-    if (installedFetch.state.status === "success") {
-      currentAttempts.installed = 0;
-    }
-
-    const timers: number[] = [];
+  useEffect(() => {
+    if (!appShellRoutesSupported) return;
     const scheduleRetry = (
-      source: "catalog" | "installed",
+      key: string,
       failed: boolean,
-      refetch: () => Promise<unknown>,
+      succeeded: boolean,
     ) => {
-      if (!failed) return;
-      const current = optionalRetryAttemptsRef.current;
-      if (
-        current.authority !== authority ||
-        current[source] >= OPTIONAL_SOURCE_RETRY_LIMIT
-      ) {
+      const record = sourceFetchRecord(key);
+      if (succeeded) {
+        record.retryAttempts = 0;
+        cancelSourceRetry(record);
         return;
       }
-      current[source] += 1;
-      timers.push(
-        window.setTimeout(() => {
-          if (getActiveAgentAuthority() !== authority) return;
-          void refetch();
-        }, OPTIONAL_SOURCE_RETRY_DELAY_MS),
-      );
+      if (
+        !failed ||
+        record.retryTimer !== null ||
+        record.retryAttempts >= OPTIONAL_SOURCE_RETRY_LIMIT
+      )
+        return;
+      record.retryAttempts += 1;
+      record.retryTimer = window.setTimeout(() => {
+        record.retryTimer = null;
+        if (getActiveAgentAuthority() !== authority) {
+          record.retryAttempts -= 1;
+          return;
+        }
+        const refetch = record.refetchers.values().next().value;
+        if (refetch) void refetch();
+        else record.retryAttempts -= 1;
+      }, OPTIONAL_SOURCE_RETRY_DELAY_MS);
     };
 
-    scheduleRetry("catalog", catalogError !== null, catalogRes.refetch);
-    scheduleRetry("installed", installedError !== null, installedRes.refetch);
-    return () => {
-      for (const timer of timers) window.clearTimeout(timer);
-    };
+    scheduleRetry(
+      catalogCacheKey,
+      catalogError !== null,
+      catalogFetch.state.status === "success",
+    );
+    scheduleRetry(
+      installedCacheKey,
+      installedError !== null,
+      installedFetch.state.status === "success",
+    );
   }, [
     authority,
     appShellRoutesSupported,
+    catalogCacheKey,
+    installedCacheKey,
     catalogFetch.state.status,
     installedFetch.state.status,
     catalogError,
     installedError,
-    catalogRes.refetch,
-    installedRes.refetch,
   ]);
 
   // Disabled cached resources intentionally retain their neutral `loading`
@@ -349,34 +390,35 @@ export function useViewCatalog(): UseViewCatalogResult {
 
   const refresh = useCallback(() => {
     if (getActiveAgentAuthority() !== authority) return;
+    if (sourceErrors.length > 0) {
+      for (const failure of sourceErrors) {
+        if (failure.source === "views") refreshViews();
+        else if (!appShellRoutesSupported) continue;
+        else if (failure.source === "catalog") {
+          cancelSourceRetry(sourceFetchRecord(catalogCacheKey));
+          void catalogRes.refetch();
+        } else {
+          cancelSourceRetry(sourceFetchRecord(installedCacheKey));
+          void installedRes.refetch();
+        }
+      }
+      return;
+    }
     refreshViews();
-    if (!appShellRoutesSupported) return;
-    catalogRes.refetch();
-    installedRes.refetch();
+    if (appShellRoutesSupported) {
+      void catalogRes.refetch();
+      void installedRes.refetch();
+    }
   }, [
     authority,
     appShellRoutesSupported,
+    sourceErrors,
+    catalogCacheKey,
+    installedCacheKey,
     refreshViews,
     catalogRes.refetch,
     installedRes.refetch,
   ]);
-
-  const retrySource = useCallback(
-    (source: ViewCatalogSource) => {
-      if (getActiveAgentAuthority() !== authority) return;
-      if (source === "views") refreshViews();
-      else if (!appShellRoutesSupported) return;
-      else if (source === "catalog") catalogRes.refetch();
-      else installedRes.refetch();
-    },
-    [
-      authority,
-      appShellRoutesSupported,
-      refreshViews,
-      catalogRes.refetch,
-      installedRes.refetch,
-    ],
-  );
 
   const get = useCallback(
     async (entry: ViewEntry) => {
@@ -429,13 +471,23 @@ export function useViewCatalog(): UseViewCatalogResult {
     // settled so one fast failure cannot flash a false global error while a
     // healthy source is still arriving.
     loading: entries.length === 0 && sourcesLoading,
-    error:
-      entries.length === 0 && !sourcesLoading
-        ? (sourceErrors[0]?.error ?? null)
-        : null,
-    sourceErrors,
+    error: (() => {
+      if (entries.length === 0) {
+        return !sourcesLoading ? (sourceErrors[0]?.error ?? null) : null;
+      }
+      const persistentFailure = sourceErrors.find((failure) => {
+        if (failure.source === "views") return true;
+        const key =
+          failure.source === "catalog" ? catalogCacheKey : installedCacheKey;
+        const record = sourceFetchRecord(key);
+        return (
+          record.retryAttempts >= OPTIONAL_SOURCE_RETRY_LIMIT &&
+          record.retryTimer === null
+        );
+      });
+      return persistentFailure?.error ?? null;
+    })(),
     refresh,
-    retrySource,
     get,
   };
 }


### PR DESCRIPTION
Closes #29788

## What changed

- Keep healthy built-in launcher entries usable when optional catalog or installed-app sources fail.
- Coordinate optional-source settlement and retry on the same authority-scoped shared cache keys used by every Launcher consumer, including concurrent mounts and owner unmounts.
- Retry only the failed optional source once; preserve healthy views and installed sources and cancel authority-stale retries.
- After the bounded retry is exhausted, keep healthy tiles visible and expose a quiet source-specific Retry status instead of a misleading global failure.
- Exclude disabled app-shell sources from loading and error settlement and never fetch them.
- Keep a fatal, retryable error only when no usable launcher entry remains.

## Exact provenance

- Base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- Head: `ddbbaa66517f9919dbfd03ff169523ad22db0443`
- Tree: `1347e9362ce830d8c0185baf8ba57e90da901d96`
- Four scoped commits mechanically replayed with range-diff `=`.
- Upstream and all other open PRs have zero overlap across the four changed paths.

## Verification

- Focused Launcher and authority tests: 32/32 pass.
- Concurrent/remount regression: a surviving consumer receives shared failure settlement and exactly one recovery retry without refetching healthy installed data.
- Persistent partial-degradation regression: built-ins remain available, the exhausted source becomes observable, and manual Retry targets only the failed source.
- Unsupported app-shell regressions: honest empty and fatal views-error states; optional fetchers are never called.
- `packages/ui` typecheck: pass.
- Full `packages/ui lint:check`: pass; design-system, molecular inventory, and design-contract findings all zero.
- Biome over all four changed files, diff-check, and Impeccable detector: pass.
- Real isolated browser on UI `2106` and API `12106`: all four registry endpoints return 200; no global registry banner; accessible Notes pointer navigation opens 13 authoritative notes; reload restores the same Notes state after normal hydration; launcher return is clean; no frontend errors. Wallet-unavailable remains an honest optional warning.
- Required `audit:app` was attempted. View builds succeeded after dependency bootstrap, but the renderer capture harness remains blocked by generated dependency links inherited from a frozen older worktree; no source failure is attributed to this PR. The real browser capture and deterministic component regressions cover this scoped UI state.

## Boundaries

No phone, VPS, Cloud or Dedicated, auth, billing, paid state, deployment, or merge action. No credential was inspected, copied, or exposed.