### PR TITLE
fix(ui): restore view lifecycle recovery fixture

### DIFF
--- a/packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs
+++ b/packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs
@@ -317,7 +317,7 @@ try {
 
   // Recover: disarm the crash, press Retry, confirm the view comes back.
   await lc("uncrash");
-  await p.locator('[data-testid="view-error-retry"]').first().click();
+  await p.getByRole("button", { name: "Retry", exact: true }).click();
   await settle(250);
   const recovered = await p.locator('[data-testid="work-crasher"]').count();
   assert(recovered === 1, "Retry recovered the crashed view");

--- a/packages/ui/src/components/views/__e2e__/view-lifecycle-fixture.tsx
+++ b/packages/ui/src/components/views/__e2e__/view-lifecycle-fixture.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { KeepAliveViewHost } from "../KeepAliveViewHost";
 import { trackSubscription } from "../../../perf/resource-counters";
+import { TranslationCtx } from "../../../state/TranslationContext.hooks";
 import {
   registerViewPolicy,
   viewLifecycleController,
@@ -199,4 +200,19 @@ function Harness(): React.JSX.Element {
 }
 
 const root = document.getElementById("root");
-if (root) createRoot(root).render(<Harness />);
+if (root) {
+  createRoot(root).render(
+    <TranslationCtx.Provider
+      value={{
+        t: (key, values) =>
+          typeof values?.defaultValue === "string"
+            ? values.defaultValue
+            : key,
+        uiLanguage: "en",
+        setUiLanguage: () => {},
+      }}
+    >
+      <Harness />
+    </TranslationCtx.Provider>,
+  );
+}


### PR DESCRIPTION
Closes #29790.

## What changed

- mount the isolated lifecycle harness under the complete translation context required by the real per-view crash fallback
- keep the fixture deterministic and offline by using a minimal English/default-value translator rather than the production provider API/storage sync
- drive recovery through the accessible `Retry` button instead of a removed implementation test id

## Exact source

- Base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- Head: `4eef5310dabb5539b1e8e9ccd4713ba3d70744dd`
- Tree: `e41f973e4b038f4787c6b5998501a6e9399042ff`
- Prior reviewed head: `f32df69dfca10bc97f4c9b513dcfe420feae1844`
- Mechanical range-diff: exact equal
- Scope: exactly two existing `packages/ui/src/components/views/__e2e__` files
- Open-PR exact-path overlap: none at publication

## Verification

- `bun run --cwd packages/ui test:view-lifecycle-e2e` — PASS on the reviewed patch
  - bounded keep-alive retention
  - hidden RAF pause and LRU eviction
  - render-storm and leak telemetry
  - intentional crash contained to the view
  - accessible Retry recovers the view
  - memory trend accepted
  - zero unexpected page errors
- exact-current `bun run --cwd packages/ui typecheck` — PASS
- `git diff --check` — PASS
- exact-file Biome is N/A because the repository intentionally excludes `src/**/__e2e__`; independent review confirmed formatting and found P0/P1/P2/P3 = 0/0/0/0

## Review evidence

Independent review verified the missing translation context as the root cause, the direct context as the correct no-network fixture analogue, and the accessible locator as production-equivalent. No device, VPS, Cloud, deployment, or live-service state was touched.
