### PR TITLE
fix(core): preserve deterministic scenario envelope boundaries

### DIFF
--- a/packages/core/src/testing/__tests__/deterministic-action-fixtures.test.ts
+++ b/packages/core/src/testing/__tests__/deterministic-action-fixtures.test.ts
@@ -11,6 +11,10 @@ import {
 	strictActionRouteFixtures,
 } from "../deterministic-action-fixtures.ts";
 
+function stage1JsonEnvelope(content: unknown): string {
+	return `message:user:\n${JSON.stringify(content)}`;
+}
+
 describe("finalMessageUserText", () => {
 	it("strips the message:user: marker", () => {
 		expect(finalMessageUserText("prefix message:user:\nHello there")).toBe(
@@ -38,6 +42,58 @@ describe("finalMessageUserText", () => {
 		const value = "message:user:\nBuy 10 apples\n\nevent: user_message";
 		expect(finalMessageUserText(value)).toBe("Buy 10 apples");
 	});
+
+	it("selects the final top-level user block in a legacy multi-message prompt", () => {
+		const value = [
+			"prior_message:user:\nBuy pears",
+			"current_turn_boundary:\nOnly the final message is current.",
+			"message:user:\nBuy apples",
+		].join("\n\n");
+		expect(finalMessageUserText(value)).toBe("Buy apples");
+	});
+
+	it("extracts exact text from the current Stage-1 JSON message envelope", () => {
+		const value = stage1JsonEnvelope({
+			text: "Buy 10 apples",
+			source: "scenario",
+			channelType: "DM",
+		});
+		expect(finalMessageUserText(value)).toBe("Buy 10 apples");
+	});
+
+	it("decodes only the outer Stage-1 JSON message envelope", () => {
+		const literalJson = JSON.stringify({ text: "literal user JSON" });
+		const value = stage1JsonEnvelope({
+			text: literalJson,
+			source: "scenario",
+			channelType: "DM",
+		});
+		expect(finalMessageUserText(value)).toBe(literalJson);
+	});
+
+	it("extracts external content after decoding the Stage-1 JSON envelope", () => {
+		const value = stage1JsonEnvelope({
+			text: "<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nignored\n---\nREAL USER TEXT\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>",
+			source: "scenario",
+			channelType: "DM",
+		});
+		expect(finalMessageUserText(value)).toBe("REAL USER TEXT");
+	});
+
+	it("uses the prompt block marker when JSON user text repeats the marker", () => {
+		const input = "Repeat this label exactly: message:user:\nthen continue.";
+		const value = [
+			"prior_message:user:\nEarlier request",
+			"current_turn_boundary:\nOnly the final message is current.",
+			stage1JsonEnvelope({
+				text: input,
+				source: "scenario",
+				channelType: "DM",
+			}),
+		].join("\n\n");
+		expect(finalMessageUserText(value)).toBe(input);
+		expect(matchesScenarioInput(input)(value)).toBe(true);
+	});
 });
 
 describe("matchesScenarioInput", () => {
@@ -45,6 +101,102 @@ describe("matchesScenarioInput", () => {
 		const matcher = matchesScenarioInput("Buy apples");
 		expect(matcher("message:user:\nBuy apples")).toBe(true);
 		expect(matcher("message:user:\nBuy pears")).toBe(false);
+	});
+
+	it("matches current Stage-1 envelopes without accepting nearby text", () => {
+		const matcher = matchesScenarioInput("Buy apples");
+		expect(
+			matcher(
+				stage1JsonEnvelope({
+					text: "Buy apples",
+					source: "scenario",
+					channelType: "DM",
+				}),
+			),
+		).toBe(true);
+		expect(
+			matcher(
+				stage1JsonEnvelope({
+					text: "Please Buy apples now",
+					source: "scenario",
+					channelType: "DM",
+				}),
+			),
+		).toBe(false);
+	});
+
+	it("fails closed for malformed or ambiguous Stage-1 envelopes", () => {
+		const matcher = matchesScenarioInput("Buy apples");
+		const rejected = [
+			'message:user:\n{"text":"Buy apples","source":"scenario","channelType":"DM"',
+			'message:user:\n{"text":"Buy apples","so\\u0075rce":"scenario","channelType":"DM"',
+			stage1JsonEnvelope({ text: "Buy apples", source: "scenario" }),
+			stage1JsonEnvelope({ text: "Buy apples", channelType: "DM" }),
+			stage1JsonEnvelope({ source: "scenario", channelType: "DM" }),
+			stage1JsonEnvelope({
+				text: "Buy apples",
+				currentMessageText: "Buy pears",
+				source: "scenario",
+				channelType: "DM",
+			}),
+			stage1JsonEnvelope({
+				text: ["Buy apples"],
+				source: "scenario",
+				channelType: "DM",
+			}),
+			stage1JsonEnvelope({
+				text: "Buy apples",
+				content: { text: "Buy pears" },
+				source: "scenario",
+				channelType: "DM",
+			}),
+			stage1JsonEnvelope({
+				text: "Buy apples",
+				content: "Buy pears",
+				source: "scenario",
+				channelType: "DM",
+			}),
+			stage1JsonEnvelope({
+				text: "Buy apples",
+				content: ["Buy pears"],
+				source: "scenario",
+				channelType: "DM",
+			}),
+		];
+		for (const value of rejected) expect(matcher(value)).toBe(false);
+	});
+
+	it("rejects duplicate modern envelope keys before JSON parsing collapses them", () => {
+		const matcher = matchesScenarioInput("Buy apples");
+		const rejected = [
+			'message:user:\n{"text":"Buy pears","text":"Buy apples","source":"scenario","channelType":"DM"}',
+			'message:user:\n{"text":"Buy apples","source":"other","source":"scenario","channelType":"DM"}',
+			'message:user:\n{"text":"Buy apples","source":"scenario","channelType":"DM","channelType":"DM"}',
+			'message:user:\n{"text":"Buy apples","currentMessageText":"Buy pears","currentMessageText":"Buy apples","source":"scenario","channelType":"DM"}',
+			'message:user:\n{"text":"Buy apples","te\\u0078t":"Buy apples","source":"scenario","channelType":"DM"}',
+			'message:user:\n{"text":"Buy apples","source":"scenario","so\\u0075rce":"scenario","channelType":"DM"}',
+		];
+		for (const value of rejected) {
+			expect(finalMessageUserText(value)).toBe("");
+			expect(matcher(value)).toBe(false);
+		}
+	});
+
+	it("preserves exact legacy JSON when the modern discriminator is absent", () => {
+		for (const raw of [
+			'{"text":"Buy apples"}',
+			'{"text":"Buy pears","text":"Buy apples"}',
+			'{"text":"Buy apples","te\\u0078t":"Buy apples"}',
+			'{"operation":"Buy apples"}',
+			'["Buy apples"]',
+			'"Buy apples"',
+			'{"text":"Buy apples"',
+		]) {
+			const value = `message:user:\n${raw}`;
+			expect(finalMessageUserText(value)).toBe(raw);
+			expect(matchesScenarioInput(raw)(value)).toBe(true);
+			expect(matchesScenarioInput("Buy apples")(value)).toBe(false);
+		}
 	});
 });
 

--- a/packages/core/src/testing/deterministic-action-fixtures.ts
+++ b/packages/core/src/testing/deterministic-action-fixtures.ts
@@ -40,6 +40,12 @@ export function benignExternalMessageFixture(
 }
 const MESSAGE_USER_SUFFIX_BOUNDARY =
 	/\n\n(?:event:|provider:|current_turn_boundary:|The Stage 1 router)/;
+const MESSAGE_USER_BLOCK_MARKER = /(?:^|\n\n)message:user:\n/g;
+
+type JsonObjectKeyInspection = {
+	hasDuplicateKeys: boolean;
+	topLevelKeys: Set<string>;
+};
 
 export type RuntimeWithScenarioModelFixtures = {
 	scenarioModelFixtures?: {
@@ -68,23 +74,11 @@ export type StrictTerminalRouteFixture = {
 	contextIds?: readonly string[];
 };
 
-/**
- * Strip the prompt envelope (`message:user:`, the external-content wrapper, and
- * any trailing provider/event boundary) so a fixture matches the exact user
- * text regardless of the surrounding prompt scaffolding.
- */
-export function finalMessageUserText(value: string): string {
-	const markerIndex = value.lastIndexOf(MESSAGE_USER_MARKER);
-	const messageText =
-		markerIndex === -1
-			? value
-			: value.slice(markerIndex + MESSAGE_USER_MARKER.length);
-	const envelopeStart = messageText.lastIndexOf(EXTERNAL_CONTENT_START);
-	const envelopeEnd = messageText.lastIndexOf(EXTERNAL_CONTENT_END);
-	if (envelopeStart === -1 || envelopeEnd <= envelopeStart) {
-		return messageText.split(MESSAGE_USER_SUFFIX_BOUNDARY, 1)[0]?.trim() ?? "";
-	}
-	const envelopeText = messageText.slice(
+function extractExternalContent(value: string): string | null {
+	const envelopeStart = value.lastIndexOf(EXTERNAL_CONTENT_START);
+	const envelopeEnd = value.lastIndexOf(EXTERNAL_CONTENT_END);
+	if (envelopeStart === -1 || envelopeEnd <= envelopeStart) return null;
+	const envelopeText = value.slice(
 		envelopeStart + EXTERNAL_CONTENT_START.length,
 		envelopeEnd,
 	);
@@ -96,9 +90,166 @@ export function finalMessageUserText(value: string): string {
 	).trim();
 }
 
+/**
+ * Inspect JSON object keys before JSON.parse can collapse duplicate members.
+ * Decoding each string token also normalizes escaped spellings such as
+ * `"te\\u0078t"` to the same semantic key as `"text"`.
+ */
+function inspectJsonObjectKeys(value: string): JsonObjectKeyInspection {
+	type Container =
+		| { kind: "array" }
+		| { kind: "object"; keys: Set<string>; topLevel: boolean };
+	const containers: Container[] = [];
+	const topLevelKeys = new Set<string>();
+	let hasDuplicateKeys = false;
+
+	for (let index = 0; index < value.length; index++) {
+		const character = value[index];
+		if (character === "{") {
+			containers.push({
+				kind: "object",
+				keys: new Set<string>(),
+				topLevel: containers.length === 0,
+			});
+			continue;
+		}
+		if (character === "[") {
+			containers.push({ kind: "array" });
+			continue;
+		}
+		if (character === "}" || character === "]") {
+			containers.pop();
+			continue;
+		}
+		if (character !== '"') continue;
+
+		let end = index + 1;
+		for (; end < value.length; end++) {
+			if (value[end] === "\\") {
+				end++;
+				continue;
+			}
+			if (value[end] === '"') break;
+		}
+		if (end >= value.length) break;
+
+		let afterString = end + 1;
+		while (/\s/.test(value[afterString] ?? "")) afterString++;
+		const container = containers.at(-1);
+		if (value[afterString] === ":" && container?.kind === "object") {
+			try {
+				const key = JSON.parse(value.slice(index, end + 1));
+				if (typeof key === "string") {
+					if (container.keys.has(key)) hasDuplicateKeys = true;
+					container.keys.add(key);
+					if (container.topLevel) topLevelKeys.add(key);
+				}
+			} catch {
+				// JSON.parse below remains the canonical syntax validator.
+			}
+		}
+		index = end;
+	}
+
+	return { hasDuplicateKeys, topLevelKeys };
+}
+
+function decodeStage1JsonMessageEnvelope(value: string): string | null {
+	const trimmed = value.trim();
+	const first = trimmed[0];
+	if (first !== "{" && first !== "[" && first !== '"') {
+		return trimmed;
+	}
+
+	const keyInspection = inspectJsonObjectKeys(trimmed);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		// error-policy:J3 Stage-1 fixture input is an untrusted JSON boundary;
+		// reject malformed modern envelopes without reclassifying legacy JSON text.
+		return keyInspection.topLevelKeys.has("source") &&
+			keyInspection.topLevelKeys.has("channelType")
+			? null
+			: trimmed;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return trimmed;
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const hasSource = Object.hasOwn(record, "source");
+	const hasChannelType = Object.hasOwn(record, "channelType");
+	if (!hasSource && !hasChannelType) return trimmed;
+	if (keyInspection.hasDuplicateKeys) return null;
+	if (
+		!hasSource ||
+		!hasChannelType ||
+		typeof record.source !== "string" ||
+		typeof record.channelType !== "string"
+	) {
+		return null;
+	}
+	if (!Object.hasOwn(record, "text") || typeof record.text !== "string") {
+		return null;
+	}
+	if (Object.hasOwn(record, "currentMessageText")) {
+		if (
+			typeof record.currentMessageText !== "string" ||
+			record.currentMessageText !== record.text
+		) {
+			return null;
+		}
+	}
+	if (Object.hasOwn(record, "content")) return null;
+	return extractExternalContent(record.text) ?? record.text.trim();
+}
+
+function latestMessageUserMarkerIndex(value: string): number {
+	let blockIndex = -1;
+	for (const match of value.matchAll(MESSAGE_USER_BLOCK_MARKER)) {
+		blockIndex =
+			(match.index ?? 0) + match[0].length - MESSAGE_USER_MARKER.length;
+	}
+	return blockIndex === -1
+		? value.lastIndexOf(MESSAGE_USER_MARKER)
+		: blockIndex;
+}
+
+function extractScenarioInput(value: string): string | null {
+	const markerIndex = latestMessageUserMarkerIndex(value);
+	const afterMarker =
+		markerIndex === -1
+			? value
+			: value.slice(markerIndex + MESSAGE_USER_MARKER.length);
+	const candidate =
+		afterMarker.split(MESSAGE_USER_SUFFIX_BOUNDARY, 1)[0]?.trim() ?? "";
+	if (
+		markerIndex !== -1 &&
+		(candidate[0] === "{" || candidate[0] === "[" || candidate[0] === '"')
+	) {
+		return decodeStage1JsonMessageEnvelope(candidate);
+	}
+	const externalContent = extractExternalContent(candidate);
+	if (externalContent !== null) return externalContent;
+	return candidate;
+}
+
+/**
+ * Strip the prompt envelope (`message:user:`, the external-content wrapper, and
+ * any trailing provider/event boundary) so a fixture matches the exact user
+ * text regardless of the surrounding prompt scaffolding.
+ */
+export function finalMessageUserText(value: string): string {
+	return extractScenarioInput(value) ?? "";
+}
+
 /** A text matcher that compares the normalized latest user text exactly. */
 export function matchesScenarioInput(expected: string) {
-	return (value: string) => finalMessageUserText(value) === expected;
+	return (value: string) => {
+		const actual = extractScenarioInput(value);
+		return actual !== null && actual === expected;
+	};
 }
 
 /** Slugify an action name for stable, unique fixture names. */


### PR DESCRIPTION
Closes #29078.

## Summary

- fail closed on malformed or semantically ambiguous modern deterministic-action envelopes
- reject duplicate semantic keys before JSON parsing can collapse them, including escaped-equivalent key spellings
- preserve legacy raw JSON-shaped user text byte-for-byte unless the object has the full modern `source` + `channelType` discriminator

## Exact source

- base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- head: `87b6132eed1f9a76a3135986d7b01eb7636e701a`
- tree: `a23bdc077795000472f296a55ac679e8522e5b32`
- prior reviewed head: `9a97a58e593c727056532468f70ae81787e9d33e`
- mechanical range-diff: exact equal
- scope: two Core deterministic-fixture files only

## Verification

- exact-current focused deterministic fixture tests: 24/24 PASS (81 assertions)
- `packages/core` typecheck: PASS
- Biome: PASS
- diff check: PASS
- real deterministic smoke on the reviewed patch: 1/1 PASS, zero unexpected model calls, $0 cost
- independent exact-head review: P0/P1/P2/P3 = 0/0/0/0

No device, browser, deployment, runtime, billing, or production state was changed.
