### PR TITLE
fix(app-core): preserve bounded shell command errors

### DIFF
--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   SHELL_AUTHORITY_COMMAND_MESSAGE,
   SHELL_AUTHORITY_DELIVERY_MESSAGE,
+  SHELL_AUTHORITY_MAX_ERROR_BYTES,
   SHELL_SYNC_PROTOCOL_VERSION,
   ShellControllerAuthority,
 } from "./shell-sync-relay";
@@ -269,7 +270,7 @@ describe("ShellControllerAuthority data paths", () => {
     other.release();
   });
 
-  it("truncates error messages with surrogate safety", async () => {
+  it("preserves complete error messages with surrogate safety", async () => {
     const authority = new ShellControllerAuthority();
     const owner = authority.register("main", vi.fn());
     const follower = authority.register("tray", vi.fn());
@@ -280,7 +281,7 @@ describe("ShellControllerAuthority data paths", () => {
       protocolVersion: SHELL_SYNC_PROTOCOL_VERSION,
     });
 
-    const longError = `${"a".repeat(1999)}😀${"b".repeat(10)}`;
+    const longError = `${"a".repeat(2_001)}😀${"b".repeat(10)}\ud800tail`;
     const outcomePromise = follower.dispatchCommand({
       commandId: "cmd-err-1",
       command: {
@@ -305,9 +306,49 @@ describe("ShellControllerAuthority data paths", () => {
 
     const res = await outcomePromise;
     expect(res.ok).toBe(false);
-    expect(typeof res.error).toBe("string");
-    expect(res.error?.length).toBeLessThanOrEqual(2000);
-    expect(res.error?.endsWith("😀")).toBe(false);
-    expect(res.error?.endsWith("a")).toBe(true);
+    expect(res.error).toBe(`${"a".repeat(2_001)}😀${"b".repeat(10)}�tail`);
+  });
+
+  it("rejects oversized owner errors without retaining their contents", async () => {
+    const authority = new ShellControllerAuthority();
+    const owner = authority.register("main", vi.fn());
+    const follower = authority.register("tray", vi.fn());
+    const ownerState = owner.connect({
+      protocolVersion: SHELL_SYNC_PROTOCOL_VERSION,
+    });
+    const followerState = follower.connect({
+      protocolVersion: SHELL_SYNC_PROTOCOL_VERSION,
+    });
+    const command = {
+      commandId: "cmd-oversized-error",
+      command: {
+        kind: "routeOsIntent" as const,
+        intent: {
+          type: "start-voice" as const,
+          intentId: "launch-oversized",
+          source: "desktop-deep-link" as const,
+          mode: "converse" as const,
+        },
+        deliveryPolicy: "execute" as const,
+      },
+    };
+    const outcomePromise = follower.dispatchCommand(command);
+
+    owner.completeCommand({
+      generation: ownerState.generation,
+      commandId: command.commandId,
+      fromEndpointId: followerState.endpointId,
+      ok: false,
+      error: "x".repeat(SHELL_AUTHORITY_MAX_ERROR_BYTES + 1),
+    });
+
+    await expect(outcomePromise).resolves.toEqual({
+      ok: false,
+      error: "owner-command-error-too-large",
+    });
+    await expect(follower.dispatchCommand(command)).resolves.toEqual({
+      ok: false,
+      error: "owner-command-error-too-large",
+    });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
@@ -6,7 +6,7 @@
  * idempotent redelivery. Renderer heartbeats are driven by native pings so a
  * hidden/throttled webview cannot accidentally create split-brain ownership.
  */
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { toWellFormedUnicode } from "@elizaos/core";
 import { logger } from "./logger";
 
 import type { SendToWebview } from "./types";
@@ -18,6 +18,9 @@ export const SHELL_AUTHORITY_COMMAND_MESSAGE =
 export const SHELL_AUTHORITY_DELIVERY_MESSAGE =
   "shellControllerAuthorityDelivery";
 export const SHELL_AUTHORITY_PING_MESSAGE = "shellControllerAuthorityPing";
+
+/** Maximum UTF-8 size retained for a renderer-supplied command error. */
+export const SHELL_AUTHORITY_MAX_ERROR_BYTES = 64 * 1024;
 
 const PING_INTERVAL_MS = 2_000;
 const ENDPOINT_TTL_MS = 10_000;
@@ -525,14 +528,22 @@ export class ShellControllerAuthority {
     ) {
       return { ok: this.outcomes.has(key) };
     }
+    const ownerError =
+      typeof params.error === "string" && params.error
+        ? params.error
+        : undefined;
     const result: ShellAuthorityCommandResult = params.ok
       ? { ok: true }
       : {
           ok: false,
           error:
-            typeof params.error === "string" && params.error
-              ? truncateWellFormed(toWellFormedUnicode(params.error), 2_000)
-              : "owner-command-failed",
+            ownerError &&
+            Buffer.byteLength(ownerError, "utf8") <=
+              SHELL_AUTHORITY_MAX_ERROR_BYTES
+              ? toWellFormedUnicode(ownerError)
+              : ownerError
+                ? "owner-command-error-too-large"
+                : "owner-command-failed",
         };
     this.rememberOutcome(key, result);
     clearTimeout(pending.timeout);


### PR DESCRIPTION
Closes #29796.

## Summary

- remove silent 2,000-character truncation from supported shell command errors
- define a 64 KiB UTF-8 renderer/native error contract
- preserve supported errors exactly after well-formed Unicode normalization
- fail closed with `owner-command-error-too-large` before oversized content enters the 1,024-entry replay cache

## Exact source

- base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- head: `14bb6b4584348e3747654a42d37f77b182c2a910`
- tree: `6e931c9c23d02323d85d4cddc0201f6c4bf48788`
- prior reviewed head: `84fd61f10fda853930dd297032302cfb54bcfc86`
- mechanical range-diff: exact equal
- scope: two shell-sync relay files only

## Verification

- exact-current shell relay + prompt-integrity policy: 17/17 PASS
- exact-boundary adversarial probes: PASS
- Biome: PASS
- diff check: PASS
- independent review: P0/P1/P2/P3 = 0/0/0/0

Package-wide typecheck is not claimed from this sparse worktree because unrelated workspace modules/declarations are absent; the focused source and policy suites compile and pass. No device, browser, runtime, deployment, billing, or production state was changed.
