### PR TITLE
test(core): make plugin path fixtures cross-platform

### DIFF
--- a/packages/core/src/features/plugin-manager/utils/paths.test.ts
+++ b/packages/core/src/features/plugin-manager/utils/paths.test.ts
@@ -1,49 +1,53 @@
+import { homedir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveConfigPath } from "./paths.ts";
 
 describe("resolveConfigPath", () => {
-	const stateDir = "/home/test/.local/state/eliza";
+  const stateDir = "/home/test/.local/state/eliza";
 
-	it("defaults to eliza.json under the state dir", () => {
-		expect(resolveConfigPath({}, stateDir)).toBe(
-			path.join(stateDir, "eliza.json"),
-		);
-	});
+  it("defaults to eliza.json under the state dir", () => {
+    expect(resolveConfigPath({}, stateDir)).toBe(
+      path.join(stateDir, "eliza.json"),
+    );
+  });
 
-	it("ignores a blank ELIZA_CONFIG_PATH override", () => {
-		expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "" }, stateDir)).toBe(
-			path.join(stateDir, "eliza.json"),
-		);
-		expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "   " }, stateDir)).toBe(
-			path.join(stateDir, "eliza.json"),
-		);
-	});
+  it("ignores a blank ELIZA_CONFIG_PATH override", () => {
+    expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "" }, stateDir)).toBe(
+      path.join(stateDir, "eliza.json"),
+    );
+    expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "   " }, stateDir)).toBe(
+      path.join(stateDir, "eliza.json"),
+    );
+  });
 
-	it("resolves an absolute override verbatim", () => {
-		expect(
-			resolveConfigPath(
-				{ ELIZA_CONFIG_PATH: "/etc/eliza/custom.json" },
-				stateDir,
-			),
-		).toBe("/etc/eliza/custom.json");
-	});
+  it("resolves an absolute override verbatim", () => {
+    const absoluteOverride = path.join(
+      path.parse(process.cwd()).root,
+      "etc",
+      "eliza",
+      "custom.json",
+    );
+    expect(
+      resolveConfigPath({ ELIZA_CONFIG_PATH: absoluteOverride }, stateDir),
+    ).toBe(absoluteOverride);
+  });
 
-	it("expands a tilde override to the home directory", () => {
-		const out = resolveConfigPath(
-			{ ELIZA_CONFIG_PATH: "~/eliza.json" },
-			stateDir,
-		);
-		expect(path.isAbsolute(out)).toBe(true);
-		expect(out).toBe(path.join(process.env.HOME ?? "/root", "eliza.json"));
-	});
+  it("expands a tilde override to the home directory", () => {
+    const out = resolveConfigPath(
+      { ELIZA_CONFIG_PATH: "~/eliza.json" },
+      stateDir,
+    );
+    expect(path.isAbsolute(out)).toBe(true);
+    expect(out).toBe(path.join(homedir(), "eliza.json"));
+  });
 
-	it("resolves a relative override against cwd", () => {
-		const out = resolveConfigPath(
-			{ ELIZA_CONFIG_PATH: "config.json" },
-			stateDir,
-		);
-		expect(path.isAbsolute(out)).toBe(true);
-		expect(out).toBe(path.resolve("config.json"));
-	});
+  it("resolves a relative override against cwd", () => {
+    const out = resolveConfigPath(
+      { ELIZA_CONFIG_PATH: "config.json" },
+      stateDir,
+    );
+    expect(path.isAbsolute(out)).toBe(true);
+    expect(out).toBe(path.resolve("config.json"));
+  });
 });

--- a/packages/core/src/features/plugin-manager/utils/paths.test.ts
+++ b/packages/core/src/features/plugin-manager/utils/paths.test.ts
@@ -4,50 +4,50 @@ import { describe, expect, it } from "vitest";
 import { resolveConfigPath } from "./paths.ts";
 
 describe("resolveConfigPath", () => {
-  const stateDir = "/home/test/.local/state/eliza";
+	const stateDir = "/home/test/.local/state/eliza";
 
-  it("defaults to eliza.json under the state dir", () => {
-    expect(resolveConfigPath({}, stateDir)).toBe(
-      path.join(stateDir, "eliza.json"),
-    );
-  });
+	it("defaults to eliza.json under the state dir", () => {
+		expect(resolveConfigPath({}, stateDir)).toBe(
+			path.join(stateDir, "eliza.json"),
+		);
+	});
 
-  it("ignores a blank ELIZA_CONFIG_PATH override", () => {
-    expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "" }, stateDir)).toBe(
-      path.join(stateDir, "eliza.json"),
-    );
-    expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "   " }, stateDir)).toBe(
-      path.join(stateDir, "eliza.json"),
-    );
-  });
+	it("ignores a blank ELIZA_CONFIG_PATH override", () => {
+		expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "" }, stateDir)).toBe(
+			path.join(stateDir, "eliza.json"),
+		);
+		expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "   " }, stateDir)).toBe(
+			path.join(stateDir, "eliza.json"),
+		);
+	});
 
-  it("resolves an absolute override verbatim", () => {
-    const absoluteOverride = path.join(
-      path.parse(process.cwd()).root,
-      "etc",
-      "eliza",
-      "custom.json",
-    );
-    expect(
-      resolveConfigPath({ ELIZA_CONFIG_PATH: absoluteOverride }, stateDir),
-    ).toBe(absoluteOverride);
-  });
+	it("resolves an absolute override verbatim", () => {
+		const absoluteOverride = path.join(
+			path.parse(process.cwd()).root,
+			"etc",
+			"eliza",
+			"custom.json",
+		);
+		expect(
+			resolveConfigPath({ ELIZA_CONFIG_PATH: absoluteOverride }, stateDir),
+		).toBe(absoluteOverride);
+	});
 
-  it("expands a tilde override to the home directory", () => {
-    const out = resolveConfigPath(
-      { ELIZA_CONFIG_PATH: "~/eliza.json" },
-      stateDir,
-    );
-    expect(path.isAbsolute(out)).toBe(true);
-    expect(out).toBe(path.join(homedir(), "eliza.json"));
-  });
+	it("expands a tilde override to the home directory", () => {
+		const out = resolveConfigPath(
+			{ ELIZA_CONFIG_PATH: "~/eliza.json" },
+			stateDir,
+		);
+		expect(path.isAbsolute(out)).toBe(true);
+		expect(out).toBe(path.join(homedir(), "eliza.json"));
+	});
 
-  it("resolves a relative override against cwd", () => {
-    const out = resolveConfigPath(
-      { ELIZA_CONFIG_PATH: "config.json" },
-      stateDir,
-    );
-    expect(path.isAbsolute(out)).toBe(true);
-    expect(out).toBe(path.resolve("config.json"));
-  });
+	it("resolves a relative override against cwd", () => {
+		const out = resolveConfigPath(
+			{ ELIZA_CONFIG_PATH: "config.json" },
+			stateDir,
+		);
+		expect(path.isAbsolute(out)).toBe(true);
+		expect(out).toBe(path.resolve("config.json"));
+	});
 });


### PR DESCRIPTION
Closes #29800

Exact provenance
- Base: 31746131fd49dce9ddfa4816a3824e0c169eaeb1
- Head: a56f5c24be5f946ae8cb4b1bda78a9aeea1716ff
- Tree: d6bffa5ecfc9c868304290b4128d268dc3dbef71
- Scope: packages/core/src/features/plugin-manager/utils/paths.test.ts only

What changed
- Derive the native absolute-path fixture from the host root instead of hard-coding POSIX /etc.
- Assert tilde expansion against os.homedir(), matching the production resolver contract.
- Production resolver behavior is unchanged.
- Apply the package-owned Biome 2.5.8 tab indentation; the first hosted Source run exposed that the earlier sparse local audit had omitted packages/core/biome.json and therefore used the root formatting policy.

Verification
- Focused Vitest: 5/5 PASS.
- Exact-file TypeScript check with Node types: PASS.
- Repository-resolved Biome 2.5.8 with packages/core/biome.json: PASS.
- Diff check: PASS.
- Independent semantic review on the pre-format head: P0/P1/P2/P3 = 0/0/0/0; the only follow-up change is formatter output.
- Open-PR exact-path audit: no overlap.
- Fresh hosted PR Static Smoke run 33217829886 was automatically requested for exact head a56f5c24be5.

Runtime, visual, browser, device, billing, and deployment evidence: N/A; this is a test-only cross-platform fixture correction.