### PR TITLE
fix(push): emit privacy-safe APNs provider receipts

### DIFF
--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.test.ts
@@ -1,6 +1,6 @@
 /** Verifies Workerd APNs configuration, ES256 request shaping, and typed provider outcomes. */
 
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { CloudApnsProvider, ELIZA_IOS_BUNDLE_ID, resolveCloudApnsConfig } from "./apns-provider";
 
 async function fixture(production = false) {
@@ -28,6 +28,10 @@ async function fixture(production = false) {
 }
 
 describe("CloudApnsProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("is absent only when every APNs binding is absent", () => {
     expect(resolveCloudApnsConfig({})).toBeNull();
     expect(() => resolveCloudApnsConfig({ ELIZA_APNS_KEY_ID: "partial" })).toThrow("incomplete");
@@ -57,6 +61,7 @@ describe("CloudApnsProvider", () => {
   });
 
   test("sends a sandbox alert with a verifiable provider token", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { config, publicKey } = await fixture();
     let captured: { url: string; init: RequestInit } | undefined;
     const provider = new CloudApnsProvider(config, async (url, init) => {
@@ -93,6 +98,7 @@ describe("CloudApnsProvider", () => {
   test.each(["Unregistered", "BadDeviceToken", "ExpiredToken"] as const)(
     "classifies %s as durable-token cleanup",
     async (reason) => {
+      vi.spyOn(console, "warn").mockImplementation(() => undefined);
       const { config } = await fixture(true);
       const provider = new CloudApnsProvider(config, async () =>
         Response.json({ reason }, { status: reason === "BadDeviceToken" ? 400 : 410 }),
@@ -105,6 +111,7 @@ describe("CloudApnsProvider", () => {
   );
 
   test("single-flights provider-token minting across concurrent sends", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { config } = await fixture();
     const authorizations: string[] = [];
     const provider = new CloudApnsProvider(config, async (_url, init) => {
@@ -123,6 +130,7 @@ describe("CloudApnsProvider", () => {
   });
 
   test("uses one bounded collapse id when an occurrence is replayed", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { config } = await fixture();
     const collapseIds: string[] = [];
     const provider = new CloudApnsProvider(config, async (_url, init) => {
@@ -144,6 +152,7 @@ describe("CloudApnsProvider", () => {
   });
 
   test("preserves non-token rejection status and reason", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { config } = await fixture();
     const provider = new CloudApnsProvider(config, async () =>
       Response.json({ reason: "TooManyRequests" }, { status: 429 }),
@@ -156,6 +165,7 @@ describe("CloudApnsProvider", () => {
   });
 
   test("rejects an oversized alert locally before APNs egress", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { config } = await fixture();
     let calls = 0;
     const provider = new CloudApnsProvider(config, async () => {
@@ -169,4 +179,118 @@ describe("CloudApnsProvider", () => {
     });
     expect(calls).toBe(0);
   });
+
+  test("emits an accepted provider receipt without token or payload content", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { config } = await fixture();
+    const provider = new CloudApnsProvider(
+      config,
+      async () =>
+        new Response(null, {
+          status: 200,
+          headers: { "apns-id": "123e4567-e89b-12d3-a456-4266554400a0" },
+        }),
+    );
+
+    await provider.send("private-device-token", {
+      title: "private notification title",
+      body: "private notification body",
+      data: { deepLink: "eliza://private-destination" },
+    });
+
+    expect(warning).toHaveBeenCalledWith(
+      "[CloudApnsProvider] delivery receipt",
+      expect.objectContaining({
+        src: "cloud-apns",
+        environment: "sandbox",
+        topic: ELIZA_IOS_BUNDLE_ID,
+        outcome: "accepted",
+        apnsId: "123e4567-e89b-12d3-a456-4266554400a0",
+        payloadBytes: expect.any(Number),
+      }),
+    );
+    const logged = JSON.stringify(warning.mock.calls);
+    expect(logged).not.toContain("private-device-token");
+    expect(logged).not.toContain("private notification title");
+    expect(logged).not.toContain("private notification body");
+    expect(logged).not.toContain("eliza://private-destination");
+  });
+
+  test("emits typed terminal and retryable provider receipts", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { config } = await fixture(true);
+    const terminal = new CloudApnsProvider(config, async () =>
+      Response.json(
+        { reason: "Unregistered" },
+        { status: 410, headers: { "apns-id": "123e4567-e89b-12d3-a456-4266554400a1" } },
+      ),
+    );
+    const retryable = new CloudApnsProvider(config, async () =>
+      Response.json(
+        { reason: "TooManyRequests" },
+        { status: 429, headers: { "apns-id": "123e4567-e89b-12d3-a456-4266554400a2" } },
+      ),
+    );
+
+    await terminal.send("terminal-token", { title: "x" });
+    await retryable.send("retryable-token", { title: "x" });
+
+    expect(warning).toHaveBeenCalledWith(
+      "[CloudApnsProvider] delivery receipt",
+      expect.objectContaining({
+        environment: "production",
+        outcome: "unregistered",
+        reason: "Unregistered",
+        apnsId: "123e4567-e89b-12d3-a456-4266554400a1",
+      }),
+    );
+    expect(warning).toHaveBeenCalledWith(
+      "[CloudApnsProvider] delivery receipt",
+      expect.objectContaining({
+        environment: "production",
+        outcome: "rejected",
+        status: 429,
+        reason: "TooManyRequests",
+        apnsId: "123e4567-e89b-12d3-a456-4266554400a2",
+      }),
+    );
+    const logged = JSON.stringify(warning.mock.calls);
+    expect(logged).not.toContain("terminal-token");
+    expect(logged).not.toContain("retryable-token");
+  });
+  test.each([200, 429])(
+    "excludes unexpected provider strings from the %s receipt",
+    async (status) => {
+      const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const { config } = await fixture();
+      const privateValue =
+        "private-device-token private notification body eliza://private-destination";
+      const provider = new CloudApnsProvider(config, async () =>
+        Response.json({ reason: privateValue }, { status, headers: { "apns-id": privateValue } }),
+      );
+      const result = await provider.send("private-device-token", {
+        title: "private notification body",
+      });
+      expect(result).toEqual(
+        status === 200
+          ? { outcome: "accepted", apnsId: privateValue }
+          : { outcome: "rejected", status: 429, reason: privateValue },
+      );
+      expect(warning).toHaveBeenCalledWith(
+        "[CloudApnsProvider] delivery receipt",
+        expect.objectContaining({
+          invalidApnsId: true,
+          ...(status === 429 ? { unrecognizedProviderReason: true } : {}),
+        }),
+      );
+      const logged = JSON.stringify(warning.mock.calls);
+      for (const privateText of [
+        "private-device-token",
+        "private notification body",
+        "eliza://private-destination",
+      ]) {
+        expect(logged).not.toContain(privateText);
+      }
+    },
+  );
 });

--- a/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
+++ b/packages/cloud/shared/src/lib/mobile-push/apns-provider.ts
@@ -1,5 +1,6 @@
 /** Sends APNs alerts from Workerd with provider-token authentication and typed rejection results. */
 
+import { logger } from "../utils/logger";
 import type { MobilePushDeliveryResult, MobilePushMessage } from "./types";
 
 const APNS_SANDBOX_ORIGIN = "https://api.sandbox.push.apple.com";
@@ -65,6 +66,44 @@ function pkcs8Bytes(pem: string): Uint8Array {
   return Uint8Array.from(binary, (character) => character.charCodeAt(0));
 }
 
+// Only documented wire reasons may enter logs; unexpected provider text can
+// contain request data. See Apple's Handling notification responses from APNs.
+const APNS_RECEIPT_REASONS = new Set<string>([
+  "BadCollapseId",
+  "BadDeviceToken",
+  "BadExpirationDate",
+  "BadMessageId",
+  "BadPriority",
+  "BadTopic",
+  "DeviceTokenNotForTopic",
+  "DuplicateHeaders",
+  "IdleTimeout",
+  "InvalidPushType",
+  "MissingDeviceToken",
+  "MissingTopic",
+  "PayloadEmpty",
+  "TopicDisallowed",
+  "BadCertificate",
+  "BadCertificateEnvironment",
+  "ExpiredProviderToken",
+  "Forbidden",
+  "InvalidProviderToken",
+  "MissingProviderToken",
+  "UnrelatedKeyIdInToken",
+  "BadEnvironmentKeyIdInToken",
+  "BadPath",
+  "MethodNotAllowed",
+  "ExpiredToken",
+  "Unregistered",
+  "PayloadTooLarge",
+  "TooManyProviderTokenUpdates",
+  "TooManyRequests",
+  "InternalServerError",
+  "ServiceUnavailable",
+  "Shutdown",
+]);
+const APNS_RECEIPT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
 export class CloudApnsProvider {
   private cachedToken?: CachedProviderToken;
   private importedKey?: Promise<CryptoKey>;
@@ -74,6 +113,40 @@ export class CloudApnsProvider {
     private readonly config: CloudApnsConfig,
     private readonly request: typeof fetch = fetch,
   ) {}
+
+  /**
+   * Emit the provider receipt needed to prove real APNs acceptance without
+   * logging the device token or notification payload. APNs IDs are provider
+   * receipts, not device identifiers, and let an operator correlate a banner
+   * with Apple's response while status/reason preserve reject classification.
+   */
+  private recordReceipt(
+    result: MobilePushDeliveryResult,
+    payloadBytes: number,
+    apnsId?: string,
+  ): MobilePushDeliveryResult {
+    const receiptId = result.outcome === "accepted" ? result.apnsId : apnsId;
+    const reason = result.outcome === "accepted" ? undefined : result.reason;
+    logger.warn("[CloudApnsProvider] delivery receipt", {
+      src: "cloud-apns",
+      environment: this.config.production ? "production" : "sandbox",
+      topic: this.config.topic,
+      payloadBytes,
+      outcome: result.outcome,
+      ...(result.outcome === "rejected" ? { status: result.status } : {}),
+      ...(reason === undefined
+        ? {}
+        : APNS_RECEIPT_REASONS.has(reason)
+          ? { reason }
+          : { unrecognizedProviderReason: true }),
+      ...(receiptId === undefined
+        ? {}
+        : APNS_RECEIPT_ID.test(receiptId)
+          ? { apnsId: receiptId }
+          : { invalidApnsId: true }),
+    });
+    return result;
+  }
 
   private async providerToken(now: number): Promise<string> {
     if (this.cachedToken && now - this.cachedToken.mintedAt < APNS_PROVIDER_TOKEN_TTL_MS) {
@@ -120,8 +193,12 @@ export class CloudApnsProvider {
         sound: "default",
       },
     });
-    if (new TextEncoder().encode(body).length > APNS_MAX_PAYLOAD_BYTES) {
-      return { outcome: "rejected", status: 413, reason: "PayloadTooLarge" };
+    const payloadBytes = new TextEncoder().encode(body).length;
+    if (payloadBytes > APNS_MAX_PAYLOAD_BYTES) {
+      return this.recordReceipt(
+        { outcome: "rejected", status: 413, reason: "PayloadTooLarge" },
+        payloadBytes,
+      );
     }
     const collapseId = message.collapseKey
       ? base64url(
@@ -143,7 +220,12 @@ export class CloudApnsProvider {
       signal: AbortSignal.timeout(APNS_REQUEST_TIMEOUT_MS),
     });
     const apnsId = response.headers.get("apns-id") ?? undefined;
-    if (response.status === 200) return { outcome: "accepted", ...(apnsId ? { apnsId } : {}) };
+    if (response.status === 200) {
+      return this.recordReceipt(
+        { outcome: "accepted", ...(apnsId ? { apnsId } : {}) },
+        payloadBytes,
+      );
+    }
     let errorBody: { reason?: unknown } | null = null;
     try {
       errorBody = (await response.json()) as { reason?: unknown };
@@ -152,8 +234,16 @@ export class CloudApnsProvider {
     }
     const reason = typeof errorBody?.reason === "string" ? errorBody.reason : undefined;
     if (reason === "Unregistered" || reason === "BadDeviceToken" || reason === "ExpiredToken") {
-      return { outcome: "unregistered", reason };
+      return this.recordReceipt({ outcome: "unregistered", reason }, payloadBytes, apnsId);
     }
-    return { outcome: "rejected", status: response.status, ...(reason ? { reason } : {}) };
+    return this.recordReceipt(
+      {
+        outcome: "rejected",
+        status: response.status,
+        ...(reason ? { reason } : {}),
+      },
+      payloadBytes,
+      apnsId,
+    );
   }
 }


### PR DESCRIPTION
APNs delivery logs now distinguish provider acceptance from rejection and include safe receipt metadata. Provider response fields are untrusted: only documented APNs reason codes and canonical UUID receipt IDs enter logs. Unexpected values are recorded as explicit invalid/unrecognized flags, while the complete provider result remains available to the caller.

Review found that logging arbitrary `reason` and `apns-id` strings could copy private content into logs. Adversarial response tests cover both fields and failed against the original implementation.

Validation for `774bf4ffdaea760e872c871ff2a8ff9a61a3e83e`: 14 focused APNs tests passed, including adversarial receipt/reason cases; Cloud shared typecheck and changed-file Biome passed. Full hosted repository verification and formatting passed ([CI run](https://github.com/elizaOS/eliza/actions/runs/33950096416)). The complete Cloud shared package test command now passed locally after a normal isolated installation; the previous failures were caused by cross-worktree dependency links and an audit timeout. All five required original PR checks passed.

The broader optional CI run had unrelated smoke/plugin failures and cancelled server/unit lanes; it is not reported as fully green. Cloud typecheck, integration, stack E2E and E2E lanes passed. No Apple-device delivery or production deployment is claimed.
