### PR TITLE
fix(ui): fence model config loads by lifecycle

### DIFF
--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -22,6 +22,7 @@ import type {
 interface CapturedAgentElement {
   id: string;
   options?: string[];
+  getValue?: () => unknown;
   onFill?: (value: string) => void;
   onActivate?: () => void;
 }
@@ -54,6 +55,7 @@ const { clientMock, agentElements } = vi.hoisted(() => ({
     string,
     {
       options?: string[];
+      getValue?: () => unknown;
       onFill?: (v: string) => void;
       onActivate?: () => void;
     }
@@ -82,6 +84,7 @@ vi.mock("../../agent-surface", () => ({
   useAgentElement: (spec: CapturedAgentElement) => {
     agentElements.set(spec.id, {
       options: spec.options,
+      getValue: spec.getValue,
       onFill: spec.onFill,
       onActivate: spec.onActivate,
     });
@@ -190,6 +193,36 @@ function fixtureConfig(): ModelsConfigResponse {
           source: "config.env",
         },
         ELIZA_ELIZAOS_MODEL_POWERFUL: null,
+      },
+    },
+  };
+}
+
+function fixtureCatalogWithSmallModel(model: string): ModelCatalog {
+  const catalog = fixtureCatalog();
+  return {
+    providers: {
+      ...catalog.providers,
+      cerebras: [
+        {
+          id: model,
+          display: model,
+          efforts: ["low"],
+          roles: ["small"],
+        },
+      ],
+    },
+  };
+}
+
+function fixtureConfigWithSmallModel(model: string): ModelsConfigResponse {
+  const config = fixtureConfig();
+  return {
+    targets: {
+      ...config.targets,
+      small: {
+        ...config.targets.small,
+        OPENAI_SMALL_MODEL: { value: model, source: "process.env" },
       },
     },
   };
@@ -374,6 +407,80 @@ describe("catalog load states", () => {
       expect(agentElements.has("models-small-provider")).toBe(true),
     );
   });
+
+  it.each(["success", "error"] as const)(
+    "keeps the newer overlapping Retry result when the older load settles with %s",
+    async (olderSettlement) => {
+      const olderCatalog = deferred<unknown>();
+      const olderConfig = deferred<ModelsConfigResponse>();
+      const newerCatalog = deferred<unknown>();
+      const newerConfig = deferred<ModelsConfigResponse>();
+      clientMock.getModelsCatalog
+        .mockReset()
+        .mockRejectedValueOnce(new Error("initial catalog failure"))
+        .mockReturnValueOnce(olderCatalog.promise)
+        .mockReturnValueOnce(newerCatalog.promise);
+      clientMock.getModelsConfig
+        .mockReset()
+        .mockResolvedValueOnce(fixtureConfig())
+        .mockReturnValueOnce(olderConfig.promise)
+        .mockReturnValueOnce(newerConfig.promise);
+
+      render(<ModelConfigurationPanel />);
+      expect((await screen.findByRole("alert")).textContent).toContain(
+        "initial catalog failure",
+      );
+      const retry = agentElements.get("models-retry")?.onActivate;
+      expect(retry).toBeTypeOf("function");
+
+      act(() => {
+        retry?.();
+        retry?.();
+      });
+      await waitFor(() => {
+        expect(clientMock.getModelsCatalog).toHaveBeenCalledTimes(3);
+        expect(clientMock.getModelsConfig).toHaveBeenCalledTimes(3);
+      });
+
+      await act(async () => {
+        newerCatalog.resolve({
+          providers: {},
+          catalog: fixtureCatalogWithSmallModel("current-small"),
+        });
+        newerConfig.resolve(fixtureConfigWithSmallModel("current-small"));
+      });
+      await waitFor(() =>
+        expect(agentElements.get("models-small-model")?.getValue?.()).toBe(
+          "current-small",
+        ),
+      );
+      expect(agentElements.get("models-small-model")?.options).toEqual([
+        "current-small",
+      ]);
+
+      await act(async () => {
+        if (olderSettlement === "success") {
+          olderCatalog.resolve({
+            providers: {},
+            catalog: fixtureCatalogWithSmallModel("stale-small"),
+          });
+          olderConfig.resolve(fixtureConfigWithSmallModel("stale-small"));
+          return;
+        }
+        olderCatalog.reject(new Error("stale catalog failure"));
+        olderConfig.resolve(fixtureConfigWithSmallModel("stale-small"));
+      });
+
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(screen.queryByText("Loading model catalog…")).toBeNull();
+      expect(agentElements.get("models-small-model")?.options).toEqual([
+        "current-small",
+      ]);
+      expect(agentElements.get("models-small-model")?.getValue?.()).toBe(
+        "current-small",
+      );
+    },
+  );
 
   it("renders a readable error for a runtime that predates the model-config API", async () => {
     // An older runtime (or a shapeless stub) answers without the catalog /

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -12,6 +12,7 @@
  */
 
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ModelCatalog,
@@ -23,6 +24,22 @@ interface CapturedAgentElement {
   options?: string[];
   onFill?: (value: string) => void;
   onActivate?: () => void;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 const { clientMock, agentElements } = vi.hoisted(() => ({
@@ -215,6 +232,121 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("catalog load states", () => {
+  it("reaches ready after the StrictMode effect lifecycle replay", async () => {
+    render(
+      <StrictMode>
+        <ModelConfigurationPanel />
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(agentElements.has("models-small-provider")).toBe(true),
+    );
+    expect(screen.queryByText("Loading model catalog…")).toBeNull();
+  });
+
+  it("keeps the current StrictMode load when the stale load succeeds later", async () => {
+    const staleCatalog = deferred<unknown>();
+    const staleConfig = deferred<ModelsConfigResponse>();
+    const currentCatalog = deferred<unknown>();
+    const currentConfig = deferred<ModelsConfigResponse>();
+    clientMock.getModelsCatalog
+      .mockReset()
+      .mockReturnValueOnce(staleCatalog.promise)
+      .mockReturnValueOnce(currentCatalog.promise);
+    clientMock.getModelsConfig
+      .mockReset()
+      .mockReturnValueOnce(staleConfig.promise)
+      .mockReturnValueOnce(currentConfig.promise);
+
+    render(
+      <StrictMode>
+        <ModelConfigurationPanel />
+      </StrictMode>,
+    );
+    await waitFor(() => {
+      expect(clientMock.getModelsCatalog).toHaveBeenCalledTimes(2);
+      expect(clientMock.getModelsConfig).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      currentCatalog.resolve({ providers: {}, catalog: fixtureCatalog() });
+      currentConfig.resolve(fixtureConfig());
+    });
+    await waitFor(() =>
+      expect(agentElements.has("models-small-provider")).toBe(true),
+    );
+
+    await act(async () => {
+      staleCatalog.resolve({ providers: {}, catalog: { providers: {} } });
+      staleConfig.resolve(fixtureConfig());
+    });
+    expect(
+      screen.queryByText(
+        "No configurable models were reported by the runtime.",
+      ),
+    ).toBeNull();
+    expect(screen.queryByText("Loading model catalog…")).toBeNull();
+  });
+
+  it("keeps the current StrictMode load when the stale load fails later", async () => {
+    const staleCatalog = deferred<unknown>();
+    const staleConfig = deferred<ModelsConfigResponse>();
+    const currentCatalog = deferred<unknown>();
+    const currentConfig = deferred<ModelsConfigResponse>();
+    clientMock.getModelsCatalog
+      .mockReset()
+      .mockReturnValueOnce(staleCatalog.promise)
+      .mockReturnValueOnce(currentCatalog.promise);
+    clientMock.getModelsConfig
+      .mockReset()
+      .mockReturnValueOnce(staleConfig.promise)
+      .mockReturnValueOnce(currentConfig.promise);
+
+    render(
+      <StrictMode>
+        <ModelConfigurationPanel />
+      </StrictMode>,
+    );
+    await waitFor(() => {
+      expect(clientMock.getModelsCatalog).toHaveBeenCalledTimes(2);
+      expect(clientMock.getModelsConfig).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      currentCatalog.resolve({ providers: {}, catalog: fixtureCatalog() });
+      currentConfig.resolve(fixtureConfig());
+    });
+    await waitFor(() =>
+      expect(agentElements.has("models-small-provider")).toBe(true),
+    );
+
+    await act(async () => {
+      staleCatalog.reject(new Error("stale catalog failure"));
+      staleConfig.resolve(fixtureConfig());
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByText("Loading model catalog…")).toBeNull();
+  });
+
+  it("ignores a pending load after unmount", async () => {
+    const catalog = deferred<unknown>();
+    const config = deferred<ModelsConfigResponse>();
+    clientMock.getModelsCatalog.mockReset().mockReturnValue(catalog.promise);
+    clientMock.getModelsConfig.mockReset().mockReturnValue(config.promise);
+    const view = render(<ModelConfigurationPanel />);
+    expect(screen.getByText("Loading model catalog…")).toBeTruthy();
+
+    view.unmount();
+    await act(async () => {
+      catalog.resolve({ providers: {}, catalog: fixtureCatalog() });
+      config.resolve(fixtureConfig());
+    });
+
+    expect(document.body.textContent).not.toContain("GPT-5.6-Terra");
+    expect(agentElements.has("models-small-provider")).toBe(false);
+  });
+
   it("renders a loading state while the catalog fetch is pending", async () => {
     let resolveCatalog: (value: unknown) => void = () => {};
     clientMock.getModelsCatalog.mockReturnValue(
@@ -237,7 +369,7 @@ describe("catalog load states", () => {
     const alert = await screen.findByRole("alert");
     expect(alert.textContent).toContain("catalog unreachable");
 
-    agentButton("models-retry").click();
+    act(() => agentButton("models-retry").click());
     await waitFor(() =>
       expect(agentElements.has("models-small-provider")).toBe(true),
     );

--- a/packages/ui/src/components/settings/useModelConfiguration.ts
+++ b/packages/ui/src/components/settings/useModelConfiguration.ts
@@ -453,12 +453,20 @@ export function useModelConfiguration(
   });
 
   const disposedRef = useRef(false);
-  useEffect(
-    () => () => {
+  const lifecycleGenerationRef = useRef(0);
+  const activeLifecycleRef = useRef(0);
+  const loadGenerationRef = useRef(0);
+  useEffect(() => {
+    lifecycleGenerationRef.current += 1;
+    const lifecycleGeneration = lifecycleGenerationRef.current;
+    activeLifecycleRef.current = lifecycleGeneration;
+    disposedRef.current = false;
+    return () => {
+      if (activeLifecycleRef.current !== lifecycleGeneration) return;
+      activeLifecycleRef.current = 0;
       disposedRef.current = true;
-    },
-    [],
-  );
+    };
+  }, []);
   // The catalog the drafts were resolved against, for post-save re-resolution
   // of `configured` markers without threading it through every callback.
   const catalogRef = useRef<ModelCatalog | null>(null);
@@ -488,13 +496,25 @@ export function useModelConfiguration(
   }, []);
 
   const loadAll = useCallback(async () => {
+    const lifecycleGeneration = activeLifecycleRef.current;
+    loadGenerationRef.current += 1;
+    const loadGeneration = loadGenerationRef.current;
+    // A mounted boolean alone cannot distinguish StrictMode's replaced setup
+    // or an older retry that settles after a newer load. Both owners must match
+    // before any response, error, ref, or draft reaches the current panel.
+    const ownsLoad = () =>
+      lifecycleGeneration !== 0 &&
+      activeLifecycleRef.current === lifecycleGeneration &&
+      loadGenerationRef.current === loadGeneration &&
+      !disposedRef.current;
+    if (!ownsLoad()) return;
     setLoad({ phase: "loading" });
     try {
       const [modelsResponse, configResponse] = await Promise.all([
         client.getModelsCatalog(),
         client.getModelsConfig(),
       ]);
-      if (disposedRef.current) return;
+      if (!ownsLoad()) return;
       const data: ReadyData = {
         catalog: parseCatalogResponse(modelsResponse),
         config: parseConfigResponse(configResponse),
@@ -505,7 +525,7 @@ export function useModelConfiguration(
     } catch (err) {
       // error-policy:J4 catalog/config fetch failure renders the panel's
       // designed error state (with retry) instead of a healthy-empty panel.
-      if (disposedRef.current) return;
+      if (!ownsLoad()) return;
       setLoad({ phase: "error", message: failureMessage(err) });
     }
   }, [initializeDrafts]);


### PR DESCRIPTION
Closes #29803

## Summary

- reset the mounted lifetime on each effect setup, including React StrictMode replay
- fence every catalog/config completion by both lifecycle generation and monotonic load generation
- prove current success/error wins over stale responses, unmounted work is ignored, and current Retry still recovers
- prove two overlapping Retry loads in one mounted lifetime cannot let an older success or error replace the newer Ready state, drafts, or catalog

## Exact provenance

- Base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- Head: `0cc701096de4ac9311dc1b33a6712f41376063bb`
- Tree: `c3a4f9b086a71cab1feea2410105a7f773276acf`
- Scope: exactly two Settings hook/test files

## Verification

- committed-head focused StrictMode/lifecycle/retry/overlap regressions: 7/7 PASS
- adversarial negative proof: removing only the monotonic `loadGenerationRef` ownership clause makes both new overlap cases fail; older success replaces the catalog/draft with `stale-small`, and older error replaces Ready with a stale alert
- full `ModelConfigurationPanel` file: 24/25 PASS; sole failure is the pre-existing stale OpenCode expectation (`opencode` was removed by 75916820) outside this patch
- targeted changed-file TypeScript diagnostics: clean; full sparse workspace typecheck is not claimed because absent/mismatched transitive workspace dependencies fail in untouched paths
- Biome 2.5.8 on both owned files: PASS
- diff check: PASS

## Evidence applicability

- Visual delta: none; fixes a catalog that otherwise remains indefinitely Loading under StrictMode
- Real-browser reproduction: exact-current APIs returned 200 while the UI stayed Loading before this fix
- Security/authority boundary: unchanged
- Device/live/production mutation: none
