### PR TITLE
fix(remote): fail closed on native session cleanup

### DIFF
--- a/packages/ui/src/platform/remote-controller.test.ts
+++ b/packages/ui/src/platform/remote-controller.test.ts
@@ -24,6 +24,7 @@ vi.mock("../bridge/electrobun-rpc", () => ({
   invokeDesktopBridgeRequest: vi.fn(),
 }));
 
+import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 import {
   acknowledgeRemoteCommandEnqueue,
   clearRemoteControllerSessionState,
@@ -34,7 +35,10 @@ import {
 } from "./remote-controller";
 
 describe("Capacitor remote controller bridge", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nativeAvailable.value = true;
+  });
 
   it("uses native identity storage and never accepts a private key", async () => {
     native.getOrCreateIdentity.mockResolvedValue({
@@ -140,6 +144,24 @@ describe("Capacitor remote controller bridge", () => {
     ).rejects.toThrow("native iOS plugin is installed");
     nativeAvailable.value = true;
   });
+
+  it.each([
+    ["command creation", createRemoteCommand],
+    ["enqueue acknowledgement", acknowledgeRemoteCommandEnqueue],
+    ["result decryption", openRemoteCommandResult],
+    ["start receipt", openRemoteCommandStartReceipt],
+    ["session cleanup", clearRemoteControllerSessionState],
+  ] as const)(
+    "rejects %s without native support or desktop dispatch",
+    async (_name, operation) => {
+      nativeAvailable.value = false;
+      await expect(operation({} as never)).rejects.toThrow("native iOS plugin");
+      expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+      for (const method of Object.values(native)) {
+        expect(method).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("rejects malformed acknowledgement and cleanup bridge responses", async () => {
     native.acknowledgeEnqueue.mockResolvedValue({ acknowledged: "yes" });

--- a/packages/ui/src/platform/remote-controller.ts
+++ b/packages/ui/src/platform/remote-controller.ts
@@ -182,6 +182,11 @@ export async function createRemoteCommand(input: {
   recoveredPending: boolean;
   bindingDigest: string;
 }> {
+  if (isUnsupportedNativeIOS()) {
+    throw new Error(
+      "Secure mobile command signing is unavailable until the native iOS plugin is installed.",
+    );
+  }
   if (isNativeController()) {
     const result = await getNativeRemoteController().createCommand({
       ownerId: input.ownerId,
@@ -235,6 +240,11 @@ export async function acknowledgeRemoteCommandEnqueue(input: {
   commandId: string;
   bindingDigest: string;
 }): Promise<boolean> {
+  if (isUnsupportedNativeIOS()) {
+    throw new Error(
+      "Secure mobile enqueue acknowledgement is unavailable until the native iOS plugin is installed.",
+    );
+  }
   if (isNativeController()) {
     const result = await getNativeRemoteController().acknowledgeEnqueue(input);
     if (!isRecord(result) || typeof result.acknowledged !== "boolean") {
@@ -259,6 +269,11 @@ export async function openRemoteCommandResult(input: {
   command: SignedRemoteCommand;
   targetIdentity: RemoteTargetPublicIdentity;
 }): Promise<{ status: string; result?: RemoteJsonValue; errorCode?: string }> {
+  if (isUnsupportedNativeIOS()) {
+    throw new Error(
+      "Secure mobile result decryption is unavailable until the native iOS plugin is installed.",
+    );
+  }
   if (isNativeController()) {
     const result = await getNativeRemoteController().openResult(input);
     if (!isOpenedResult(result))
@@ -286,6 +301,11 @@ export async function openRemoteCommandStartReceipt(input: {
   command: SignedRemoteCommand;
   targetIdentity: RemoteTargetPublicIdentity;
 }): Promise<{ startedAt: number; executionId: string }> {
+  if (isUnsupportedNativeIOS()) {
+    throw new Error(
+      "Secure mobile start receipt verification is unavailable until the native iOS plugin is installed.",
+    );
+  }
   if (isNativeController()) {
     const result = await getNativeRemoteController().openStartReceipt(input);
     if (!isOpenedStartReceipt(result))
@@ -313,6 +333,11 @@ export async function clearRemoteControllerSessionState(input: {
   controllerDeviceId: string;
   sessionId: string;
 }): Promise<boolean> {
+  if (isUnsupportedNativeIOS()) {
+    throw new Error(
+      "Secure mobile session cleanup is unavailable until the native iOS plugin is installed.",
+    );
+  }
   if (isNativeController()) {
     const result = await getNativeRemoteController().clearSessionState(input);
     if (!isRecord(result) || typeof result.cleared !== "boolean") {


### PR DESCRIPTION
Native remote-controller operations now fail explicitly when the platform bridge does not support them. Clearing a session, setting a session, updating a status label, refreshing status, and reading status no longer return fabricated success or empty status through an unavailable native bridge. Supported bridge calls retain their existing behavior.

Validation for `e4c48065bc46a4f715e9e8a943a1d43880322f91`:

- All 11 remote-controller tests passed, covering the supported and unavailable paths.
- Full repository verification and formatting passed in [qualification CI](https://github.com/elizaOS/eliza/actions/runs/33952398274).
- All required original PR checks passed. Full UI package qualification passed 13,513 executed tests with no failures or errors (7 existing skips).
- The optional broad qualification workflow was not fully green: the server lane was cancelled and unrelated lanes failed. The owning UI lane and repository Quality gate passed.
- Rendered screenshots and live-model evidence are N/A: this changes bridge error contracts without changing a view or dispatching a model. No physical-device acceptance is claimed; bridge availability is controlled by the test harness.
