### PR TITLE
test(cloud): repin compute-stop recovery fixture

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
@@ -233,7 +233,14 @@ beforeAll(async () => {
         created_at timestamp NOT NULL, updated_at timestamp NOT NULL
       );
       CREATE TABLE agent_sandboxes (
-        id uuid PRIMARY KEY, organization_id uuid NOT NULL
+        id uuid PRIMARY KEY, organization_id uuid NOT NULL, user_id uuid NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        lifecycle_revision bigint NOT NULL DEFAULT 0,
+        billing_status text NOT NULL DEFAULT 'active',
+        scheduled_shutdown_at timestamptz,
+        execution_tier text NOT NULL DEFAULT 'shared',
+        pool_status text, deletion_attempt_id uuid, deleted_at timestamptz,
+        replacement_cleanup_sandbox_id text
       );
       CREATE TABLE compute_billing_rate_segments (
         id uuid PRIMARY KEY DEFAULT gen_random_uuid(), organization_id uuid NOT NULL,
@@ -579,7 +586,9 @@ realPostgres("compute stop concurrency", () => {
           VALUES (${userId}, ${organizationId}, ${stewardUserId}, 'owner')`,
     );
     await dbWrite.execute(
-      sql`INSERT INTO agent_sandboxes(id, organization_id) VALUES (${agentId}, ${organizationId})`,
+      sql`INSERT INTO agent_sandboxes
+        (id, organization_id, user_id, status, lifecycle_revision, execution_tier)
+        VALUES (${agentId}, ${organizationId}, ${userId}, 'running', 5, 'dedicated-lazy')`,
     );
     const [seededJob] = await dbWrite
       .insert(jobsTable)
@@ -1129,10 +1138,21 @@ realPostgres("compute stop concurrency", () => {
       throw new Error("harness unavailable");
     }
     const organizationId = randomUUID();
+    const userId = randomUUID();
     const agentId = randomUUID();
+    const stewardUserId = `steward:${userId}`;
     await dbWrite.execute(
       sql`INSERT INTO organizations(id, credit_balance) VALUES (${organizationId}, 0)`,
     );
+    await dbWrite.execute(
+      sql`INSERT INTO users(id, organization_id, steward_user_id, role)
+          VALUES (${userId}, ${organizationId}, ${stewardUserId}, 'owner')`,
+    );
+    await dbWrite.execute(sql`INSERT INTO agent_sandboxes
+      (id, organization_id, user_id, status, lifecycle_revision, billing_status,
+       scheduled_shutdown_at, execution_tier)
+      VALUES (${agentId}, ${organizationId}, ${userId}, 'running', 5, 'shutdown_pending',
+        NOW() - interval '1 minute', 'dedicated-lazy')`);
     await dbWrite.execute(sql`INSERT INTO agent_compute_stop_intents
       (organization_id, agent_id, lifecycle_revision, status, attempts, next_attempt_at)
       VALUES (${organizationId}, ${agentId}, 5, 'terminal_attention', 3, NOW() - interval '1 minute')`);


### PR DESCRIPTION
Fixes #29681.

Republishes the already-reviewed fixture-only repair from #29682 onto exact current develop. This is the canonical replacement for stale duplicate PRs #29682 and #29684; those PRs are intentionally left open and unchanged for audit history.

Scope:
- one file only: packages/cloud/shared/src/db/repositories/__tests__/compute-stop-concurrency.integration.test.ts
- aligns the hand-built agent_sandboxes fixture and seeds with the current recovery-query lifecycle, billing, ownership, and execution-tier contract
- no production schema, migration, repository, service, route, UI, workflow, or runtime change

Exact source:
- base: 31746131fd49dce9ddfa4816a3824e0c169eaeb1
- head: dd80fbd7cd662d03e270ea73dcf06ab2950b2024
- tree: 8d9c7b37d350c0ee0b2b5e389e42a8ab3140352c
- stable patch-id: 9fe27666bd76adce5cc9c4e798014ab729b3caa4
- patch-id matches reviewed #29682 commit 6237d9aea02f1448fe56a0a5380b60fb9c899538

Evidence:
- dedicated PostgreSQL 17.10, required real-database mode: 9 pass, 0 fail, 31 assertions
- @elizaos/cloud-shared typecheck: pass
- exact changed-file Biome: pass
- git diff --check: pass
- diff-scoped security contract: no added vi/jest/mock.module or console patterns
- Bun 1.3.14
- UI/device evidence: N/A, test-fixture-only change

No merge, deployment, Develop Full rerun, live-service mutation, billing action, row mutation, adoption, or credential access occurred.