### PR TITLE
test(app): use workflow menuitem contract

### DIFF
--- a/packages/app/test/ui-smoke/workflow-editor.spec.ts
+++ b/packages/app/test/ui-smoke/workflow-editor.spec.ts
@@ -286,7 +286,9 @@ test("first trigger saves and refreshes an unsaved workflow", async ({
     timeout: 60_000,
   });
   await page.getByRole("button", { name: "New automation" }).click();
-  await page.getByRole("button", { name: "New workflow" }).click();
+  const createMenu = page.getByTestId("automation-create-menu");
+  await expect(createMenu).toBeVisible();
+  await createMenu.getByRole("menuitem", { name: "New workflow" }).click();
   await page.getByRole("button", { name: "Add workflow trigger" }).click();
   await page.getByRole("button", { name: "Repeat" }).click();
   await page.getByLabel("Interval minutes").fill("15");
@@ -309,7 +311,9 @@ test("workflow studio creates, executes, inspects, and reloads a Smithers workfl
     timeout: 60_000,
   });
   await page.getByRole("button", { name: "New automation" }).click();
-  await page.getByRole("button", { name: "New workflow" }).click();
+  const createMenu = page.getByTestId("automation-create-menu");
+  await expect(createMenu).toBeVisible();
+  await createMenu.getByRole("menuitem", { name: "New workflow" }).click();
 
   await expect(page.getByTestId("workflow-studio")).toBeVisible({
     timeout: 60_000,


### PR DESCRIPTION
Closes #29810

## Summary

- wait for the controlled create menu before selecting a workflow action
- query `New workflow` by its exact `menuitem` role and accessible name
- repair both workflow-editor browser flows without changing production UI

## Exact provenance

- Base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- Head: `ed0c835963566f761b90d6b6511743aa5a032a58`
- Tree: `5143403bfa5760d2e30f53c6dd05e657ab34123e`
- Scope: one browser fixture file, +6/-2

## Verification

- current production role/name contract inspected directly
- existing AutomationsFeed unit proves menuitem selection opens Workflow Studio
- Biome 2.5.8: PASS
- diff check: PASS
- syntax/bundle probe: PASS
- independent review: P0/P1/P2/P3 = 0/0/0/0

## Remaining gate

The isolated sparse checkout has no Playwright/workspace dependencies, so Chromium/WebKit execution was not claimed. Canonical focused browser execution remains required before merge.

## Evidence applicability

- Production/runtime code: unchanged
- Visual semantics: unchanged
- Device/live/Cloud mutation: none
