### PR TITLE
test(registry): restore Cloud authority mock contract

### DIFF
--- a/plugins/plugin-registry/src/api/plugin-routes.encoding.test.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.encoding.test.ts
@@ -37,11 +37,23 @@ vi.mock("@elizaos/shared", () => {
   };
 
   return {
+    DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS: [
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "ELIZA_STEWARD_AGENT_ID",
+      "STEWARD_API_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TRADE_SESSION_ID",
+      "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+      "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+    ],
     asRecord: (value: unknown) =>
       value && typeof value === "object" && !Array.isArray(value)
         ? (value as Record<string, unknown>)
         : null,
     isElizaSettingsDebugEnabled: vi.fn(() => false),
+    resolveDevCloudEnvAuthority: vi.fn(() => false),
     PostPluginCoreToggleRequestSchema: schema,
     PostPluginInstallRequestSchema: schema,
     PostPluginUninstallRequestSchema: schema,


### PR DESCRIPTION
Closes #29812

## Summary

- supply the exact canonical Steward operational key list in the encoding fixture's shared mock
- keep development Cloud authority disabled so the suite remains route-encoding-only
- restore module evaluation without changing production authority behavior

## Exact provenance

- Base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- Head: `cbc483dc07f669d8686065657d2fdc912cdd2c67`
- Tree: `396e53b9a369735c8b1cbcf56d82793930f01063`
- Scope: one test file, +12

## Verification

- exact encoding suite: 7/7 PASS
- full plugin-registry suite: 77/77 PASS
- canonical key comparison: 9/9 exact, including order
- Biome 2.5.8: PASS
- diff check: PASS
- independent review: P0/P1/P2/P3 = 0/0/0/0

## Evidence applicability

- Production source/authority semantics: unchanged
- Visual evidence: N/A
- Device/live/Cloud mutation: none
