### PR TITLE
test(cloud): restore Shared upgrade stack fixture

### DIFF
--- a/packages/cloud/e2e/src/fixtures/stack.ts
+++ b/packages/cloud/e2e/src/fixtures/stack.ts
@@ -302,6 +302,12 @@ export interface StartCloudStackOptions {
    */
   mockLlmEchoContext?: boolean;
   /**
+   * Expose the mock LLM as the Worker's OpenRouter-compatible gateway as well
+   * as its OpenAI-compatible provider. Defaults to false so OpenAI fault
+   * fixtures cannot silently fall back to the same loopback provider.
+   */
+  mockLlmOpenRouter?: boolean;
+  /**
    * Boot a stateful Stripe-compatible loopback provider. The Worker receives
    * the synthetic key and endpoint only under its explicit Cloud E2E gates.
    */
@@ -349,13 +355,19 @@ export async function startCloudStack(
   });
   const steward = await startStewardMock();
   const mockLlm =
-    opts.mockLlm || opts.mockLlmEchoContext
+    opts.mockLlm || opts.mockLlmEchoContext || opts.mockLlmOpenRouter
       ? await startMockLlm({ echoContext: opts.mockLlmEchoContext ?? false })
       : undefined;
   const mockLlmEnv: Record<string, string> = mockLlm
     ? {
         OPENAI_API_KEY: "mock-llm-key",
         OPENAI_BASE_URL: mockLlm.url,
+        ...(opts.mockLlmOpenRouter
+          ? {
+              OPENROUTER_API_KEY: "mock-llm-key",
+              OPENROUTER_BASE_URL: mockLlm.url,
+            }
+          : {}),
       }
     : {};
   const sharedEnv = buildSharedEnv(
@@ -513,14 +525,7 @@ export async function startCloudStack(
         spawnLogged(
           "frontend",
           BUN,
-          [
-            "run",
-            "dev",
-            "--",
-            "--host",
-            "127.0.0.1",
-            "--cloud-target=offline",
-          ],
+          ["run", "dev", "--", "--host", "127.0.0.1", "--cloud-target=offline"],
           {
             env: frontendEnv,
             cwd: frontendDir,

--- a/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
+++ b/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
@@ -61,6 +61,7 @@ test.use({
     frontend: false,
     mockLlmEchoContext: true,
     env: { ELIZAOS_CLOUD_SMALL_MODEL: "openai/gpt-4o-mini" },
+    mockLlmOpenRouter: true,
   },
 });
 

--- a/packages/cloud/test-mocks/src/control-plane/server.ts
+++ b/packages/cloud/test-mocks/src/control-plane/server.ts
@@ -140,6 +140,14 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     workspaceFiles: {} as Record<string, string>,
   };
 
+  const runtimeSandboxForRequest = (c: Context): Sandbox | undefined => {
+    const auth = c.req.header("authorization") ?? c.req.header("Authorization");
+    const bearer = auth?.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+    const apiKey = c.req.header("x-api-key")?.trim() ?? "";
+    if (bearer && apiKey && bearer !== apiKey) return undefined;
+    return store.getSandboxByRuntimeToken(bearer || apiKey);
+  };
+
   app.use("*", async (c, next) => {
     if (c.req.path === "/health") return next();
     if (
@@ -155,6 +163,15 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     if (c.req.path.startsWith("/api/v1/admin/")) return next();
     // Compat endpoints are public stubs.
     if (c.req.path.startsWith("/api/compat/")) return next();
+    // A Dedicated runtime is rooted at health_url's origin. The mock multiplexes
+    // many runtimes under one origin, so route that root surface by the exact
+    // per-agent token without exposing the token on serialized sandbox state.
+    if (
+      c.req.path.startsWith("/api/conversations/") &&
+      runtimeSandboxForRequest(c)
+    ) {
+      return next();
+    }
     if (expectedAuxToken) {
       const aux = c.req.header("x-container-control-plane-token")?.trim();
       if (aux !== expectedAuxToken) {
@@ -537,6 +554,22 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
               userId,
               agentId,
             });
+            const existingAgent = await agentSandboxesRepository.findByIdAndOrg(
+              agentId,
+              organizationId,
+            );
+            const runtimeToken =
+              existingAgent?.environment_vars &&
+              typeof existingAgent.environment_vars === "object" &&
+              !Array.isArray(existingAgent.environment_vars) &&
+              typeof (existingAgent.environment_vars as Record<string, unknown>)
+                .ELIZA_API_TOKEN === "string"
+                ? (existingAgent.environment_vars as Record<string, string>)
+                    .ELIZA_API_TOKEN
+                : "";
+            if (runtimeToken.trim()) {
+              store.bindSandboxRuntimeToken(sandbox.id, runtimeToken);
+            }
             store.updateSandbox(sandbox.id, { status: "running" });
             const container = store.createContainer({
               name: agentName,
@@ -620,6 +653,14 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
   app.get("/api/health", (c) =>
     c.json({ success: true, status: "ok", ready: true }),
   );
+
+  app.all("/api/conversations/*", async (c) => {
+    const sandbox = runtimeSandboxForRequest(c);
+    if (!sandbox) return c.json({ success: false, error: "Unauthorized" }, 401);
+    const target = new URL(c.req.url);
+    target.pathname = `/api/compat/agents/${encodeURIComponent(sandbox.id)}${target.pathname}`;
+    return app.fetch(new Request(target, c.req.raw));
+  });
   app.post("/api/snapshot", (c) => c.json(runtimeState));
   app.post("/api/restore", async (c) => {
     const body = (await c.req.json().catch(() => null)) as Partial<

--- a/packages/cloud/test-mocks/src/control-plane/store.ts
+++ b/packages/cloud/test-mocks/src/control-plane/store.ts
@@ -258,6 +258,8 @@ function stageTodoCutoverImport(
 export class ControlPlaneStore {
   private readonly jobs = new Map<string, Job>();
   private readonly sandboxes = new Map<string, Sandbox>();
+  /** Runtime bearer authority stays internal and is never serialized with Sandbox. */
+  private readonly sandboxRuntimeTokens = new Map<string, string>();
   private readonly containers = new Map<string, Container>();
   private readonly warmPool = new Map<string, WarmSandbox>();
   private readonly cronCounters = new Map<string, number>();
@@ -450,6 +452,24 @@ export class ControlPlaneStore {
 
   getSandbox(id: string): Sandbox | undefined {
     return this.sandboxes.get(id);
+  }
+
+  bindSandboxRuntimeToken(id: string, token: string): void {
+    if (!this.sandboxes.has(id)) throw new Error(`sandbox '${id}' not found`);
+    const trimmed = token.trim();
+    if (!trimmed) throw new Error("runtime token must be non-empty");
+    this.sandboxRuntimeTokens.set(id, trimmed);
+  }
+
+  getSandboxByRuntimeToken(token: string): Sandbox | undefined {
+    const trimmed = token.trim();
+    if (!trimmed) return undefined;
+    for (const [sandboxId, runtimeToken] of this.sandboxRuntimeTokens) {
+      const sandbox = this.sandboxes.get(sandboxId);
+      if (runtimeToken === trimmed && sandbox?.status === "running")
+        return sandbox;
+    }
+    return undefined;
   }
 
   updateSandbox(id: string, patch: Partial<Sandbox>): Sandbox {

--- a/packages/cloud/test-mocks/test/control-plane-todo-cutover.test.ts
+++ b/packages/cloud/test-mocks/test/control-plane-todo-cutover.test.ts
@@ -15,6 +15,7 @@ import {
 import { type RunningHetznerMock, startHetznerMock } from "../src/hetzner";
 
 const TOKEN = "todo-cutover-token";
+const RUNTIME_TOKEN = "dedicated-runtime-token";
 const CONVERSATION_ID = "personal:todo-cutover-source";
 const DEDICATED_AGENT_ID = "dedicated-todo-target";
 const TODO_ID = "11111111-1111-4111-8111-111111111111";
@@ -40,6 +41,8 @@ beforeAll(async () => {
     userId: "user-1",
     agentId: DEDICATED_AGENT_ID,
   }).id;
+  controlPlane.store.updateSandbox(sandboxId, { status: "running" });
+  controlPlane.store.bindSandboxRuntimeToken(sandboxId, RUNTIME_TOKEN);
 });
 
 afterAll(async () => {
@@ -63,7 +66,54 @@ async function postImport(body: Record<string, unknown>): Promise<Response> {
   );
 }
 
+async function postDirectRuntimeImport(
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return fetch(
+    `${controlPlane.url}/api/conversations/${encodeURIComponent(CONVERSATION_ID)}/import`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RUNTIME_TOKEN}`,
+        "Content-Type": "application/json",
+        "X-API-Key": RUNTIME_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
 describe("control-plane Todo cutover import", () => {
+  test("routes the health-origin runtime surface by exact agent token", async () => {
+    const sandboxHealth = await fetch(
+      `${controlPlane.url}/api/compat/agents/${sandboxId}/api/health`,
+    );
+    expect(sandboxHealth.status).toBe(200);
+
+    const snapshot = await createSharedTodoCutoverSnapshot({
+      sourceAgentId: CONVERSATION_ID,
+      todos: [],
+      mutations: [],
+    });
+    const imported = await postDirectRuntimeImport({
+      messages: [{ role: "user", text: "direct runtime import" }],
+      cutoverToken: "direct-runtime-cutover",
+      todoSnapshot: snapshot,
+    });
+    expect(imported.status).toBe(200);
+    expect(await imported.json()).toMatchObject({
+      complete: true,
+      sourceMessageCount: 1,
+      sourceTodoDigest: snapshot.digest,
+    });
+
+    const denied = await fetch(
+      `${controlPlane.url}/api/conversations/${encodeURIComponent(CONVERSATION_ID)}/messages`,
+      { headers: { Authorization: "Bearer wrong-runtime-token" } },
+    );
+    expect(denied.status).toBe(401);
+  });
+
   test("requires, verifies, stores, and replays the exact digest-bound snapshot", async () => {
     const mutation = {
       version: 1,


### PR DESCRIPTION
## Summary
- route the personal Shared default model through the opt-in local OpenRouter-compatible mock so the upgrade trajectory records a real deterministic user/assistant transcript
- expose the mock Dedicated runtime conversation surface at the canonical health-origin base, selecting the exact running sandbox by its non-serialized per-agent runtime token
- keep connector delivery fixtures current with the required Blooio connector identity

Supports #25076.

## Regression protected
Develop Full run 33216110497 / Cloud stack job 99002198835 returned HTTP 200 for both Shared turns but persisted zero messages, so the Shared→Dedicated trajectory stopped before it exercised import/cutover. The Shared personal model is `gemma-4-31b`; without a direct Cerebras key it correctly resolves through OpenRouter, while the E2E fixture previously bound only OpenAI.

An unchanged local reproduction matched the hosted failure (`expected 4, received 0`). Enabling context echo alone stayed red. Binding the same loopback provider under the explicit OpenRouter fixture made all four turns persist and exposed a second mock contract mismatch: server-side cutover uses the Dedicated health origin, while the multiplexed test runtime only exposed sandbox-prefixed compat routes. The new exact-token root projection exercises that canonical contract without changing production routing or serializing the token.

## Evidence
- `bunx playwright test packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts --config packages/cloud/e2e/playwright.config.ts --workers=1` — PASS, 1/1; real Shared transcript, provision, import, cutover, connector continuation/replay
- `bun --conditions=eliza-source test packages/cloud/test-mocks/test/control-plane-todo-cutover.test.ts` — PASS, 2/2; canonical origin import plus wrong-token denial and Todo replay
- `bun run --cwd packages/cloud/test-mocks typecheck` — PASS
- `bun run --cwd packages/cloud/e2e typecheck` — PASS
- `bunx @biomejs/biome check <five touched files>` — PASS
- `git diff --check` — PASS

Exact base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
Exact head: `e48825f4c766735ed978835cf392f610808bbcc8`
Exact tree: `e6b4431e41b197d1f12f14abf914ff66f857187c`

## Boundaries
- No production runtime behavior changed.
- No deployment, global CI rerun, live service, device, browser, billing, row, adoption, or credential action occurred.
- UI evidence: N/A — API-only deterministic stack regression; no rendered UI changed.
- Live-model evidence: N/A — the regression deliberately uses a local deterministic no-spend provider fixture.
