### PR TITLE
fix(app): align OCR fixture with Character view

### DIFF
--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -375,7 +375,7 @@ ph eg`,
       "< Logs\nAll levels\nAll sources\nAll tags\nINFO\nsmoke\nsmoke API ready",
     ],
     [
-      "builtin-relationships",
+      "builtin-character",
       "< Character\npersonality Relationships skills Experience\nv al v\nsear\nch\n+ PQ\nple.",
     ],
     [


### PR DESCRIPTION
Closes #29815

## Summary

- replace the stale `builtin-relationships` OCR audit fixture with canonical `builtin-character`
- keep production OCR policies and UI behavior unchanged

## Exact provenance

- base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- head: `b864450b9645b848fd4a8f514909ae2ece604145`
- tree: `f0d399c7d84d0c13f63b7036f30fc89bf6531d80`
- scope: one file, one string literal

## Verification

- focused OCR content-rule audit: 43/43 PASS
- `git diff --check`: PASS
- direct resolver: `builtin-character` resolves the current expectation; the retired slug resolves no OCR policy
- open-PR exact-path overlap: none
- independent review: P0/P1/P2/P3 = 0/0/0/0

## Review evidence

- runtime UI change: N/A (test-fixture-only)
- visual evidence: N/A
- security/billing/auth changes: N/A
- Biome: inherited whole-file spaces-to-tabs finding reproduces on the untouched base; this one-token change contains no whitespace delta, so the PR intentionally avoids a 400+ line formatting rewrite.