### PR TITLE
fix(app-core): model keyless smoke empty contracts

### DIFF
--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.contract.test.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.contract.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * Contract coverage for the keyless UI-smoke server's read-only designed-empty
+ * surfaces and its fail-closed write/item boundary.
+ */
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, expect, it } from "vitest";
+
+const stubUrl = new URL("./playwright-ui-smoke-api-stub.mjs", import.meta.url);
+let child;
+let origin;
+
+async function waitForStubReady(processHandle) {
+  let output = "";
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      processHandle.off("error", onError);
+      processHandle.off("exit", onExit);
+      processHandle.stdout.off("data", onOutput);
+      processHandle.stderr.off("data", onErrorOutput);
+    };
+    const fail = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onError = (error) => fail(error);
+    const onExit = (code, signal) =>
+      fail(
+        new Error(
+          `UI smoke stub exited before ready: code=${code} signal=${signal} ${output}`,
+        ),
+      );
+    const onErrorOutput = (chunk) => {
+      output += chunk.toString();
+    };
+    const onOutput = (chunk) => {
+      output += chunk.toString();
+      const address = output.match(
+        /listening on (http:\/\/127\.0\.0\.1:\d+)/,
+      )?.[1];
+      if (!address) return;
+      cleanup();
+      resolve(address);
+    };
+    const timer = setTimeout(
+      () => fail(new Error(`UI smoke stub did not become ready: ${output}`)),
+      15_000,
+    );
+    processHandle.once("error", onError);
+    processHandle.once("exit", onExit);
+    processHandle.stdout.on("data", onOutput);
+    processHandle.stderr.on("data", onErrorOutput);
+  });
+}
+
+beforeAll(async () => {
+  child = spawn(process.execPath, [fileURLToPath(stubUrl)], {
+    env: {
+      ...process.env,
+      ELIZA_UI_SMOKE_API_PORT: "0",
+      ELIZA_UI_SMOKE_STUB_IGNORE_SIGTERM: "0",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  origin = await waitForStubReady(child);
+  child.stdout.resume();
+  child.stderr.resume();
+});
+
+afterAll(async () => {
+  if (!child?.pid || child.exitCode !== null || child.signalCode !== null)
+    return;
+  const exited = new Promise((resolve) => child.once("exit", resolve));
+  const forceStop = setTimeout(() => child.kill("SIGKILL"), 2_000);
+  try {
+    child.kill("SIGTERM");
+    await exited;
+  } finally {
+    clearTimeout(forceStop);
+  }
+});
+
+async function jsonGet(pathname) {
+  const response = await fetch(`${origin}${pathname}`);
+  assert.equal(response.status, 200, pathname);
+  assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+  return response.json();
+}
+
+it("serves truthful designed-empty local inference and owner surfaces", async () => {
+  const auth = await jsonGet("/api/auth/me");
+  assert.equal(auth.identity.kind, "owner");
+
+  const streamResponse = await fetch(
+    `${origin}/api/local-inference/device/stream?token=smoke-owner`,
+  );
+  assert.equal(streamResponse.status, 200);
+  assert.match(
+    streamResponse.headers.get("content-type") ?? "",
+    /text\/event-stream/,
+  );
+  const streamBody = await streamResponse.text();
+  assert.match(streamBody, /^retry: 60000\ndata: /);
+  const streamPayload = JSON.parse(
+    streamBody.match(/data: (.+)\n/)?.[1] ?? "null",
+  );
+  assert.deepEqual(streamPayload, {
+    type: "status",
+    status: {
+      connected: false,
+      devices: [],
+      primaryDeviceId: null,
+      pendingRequests: 0,
+      deviceId: null,
+      capabilities: null,
+      loadedPath: null,
+      connectedSince: null,
+    },
+  });
+
+  assert.deepEqual(await jsonGet("/api/local-inference/voice-models"), {
+    installations: [],
+  });
+  assert.deepEqual(
+    await jsonGet("/api/local-inference/voice-models/preferences"),
+    {
+      preferences: {
+        autoUpdateOnWifi: true,
+        autoUpdateOnCellular: false,
+        autoUpdateOnMetered: false,
+        quietHours: [{ start: "22:00", end: "08:00" }],
+      },
+      isOwner: true,
+    },
+  );
+  assert.deepEqual(await jsonGet("/api/accounts/consumer-keys"), {
+    keys: [],
+  });
+
+  const protection = await jsonGet("/api/secrets/manager/protection");
+  assert.equal(protection.ok, true);
+  assert.deepEqual(protection.protection.localVault.masterKey, {
+    backend: "none",
+    available: false,
+    synchronized: false,
+    scope: "unavailable",
+    access: "unavailable",
+  });
+  assert.equal(protection.protection.localVault.encryptedAtRest, true);
+  assert.equal(
+    protection.protection.nativeSessionState.plaintextFallback,
+    false,
+  );
+
+  assert.deepEqual(await jsonGet("/api/secrets/logins"), {
+    ok: true,
+    logins: [],
+    failures: [],
+  });
+});
+
+it("does not fabricate write or item-route authority", async () => {
+  for (const [method, pathname] of [
+    ["POST", "/api/accounts/consumer-keys"],
+    ["PATCH", "/api/accounts/consumer-keys/smoke-key"],
+    ["GET", "/api/accounts/consumer-keys/smoke-key"],
+    ["POST", "/api/accounts/consumer-keys/smoke-key/rotate"],
+    ["POST", "/api/local-inference/device/stream"],
+    ["GET", "/api/local-inference/voice-models/check"],
+    ["POST", "/api/local-inference/voice-models/preferences"],
+    ["POST", "/api/local-inference/voice-models/smoke-model/update"],
+    ["POST", "/api/local-inference/voice-models/smoke-model/pin"],
+    ["POST", "/api/secrets/manager/protection"],
+    ["POST", "/api/secrets/logins"],
+    ["GET", "/api/secrets/logins/example.test/user"],
+    ["DELETE", "/api/secrets/logins/example.test/user"],
+    ["PUT", "/api/secrets/logins/example.test/autoallow"],
+  ]) {
+    const response = await fetch(`${origin}${pathname}`, { method });
+    expect(response.status, `${method} ${pathname}`).toBe(501);
+  }
+});

--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -83,6 +83,12 @@ const SMOKE_VOICE_TRANSCRIPT = "this is the voice smoke transcript";
 // The spoken reply the stub returns for that transcript — a clean sentence so
 // the overlay's TTS output is non-empty and the assistant bubble is assertable.
 const SMOKE_VOICE_REPLY = "Got it, this is the spoken reply.";
+const SMOKE_NETWORK_POLICY_PREFERENCES = {
+  autoUpdateOnWifi: true,
+  autoUpdateOnCellular: false,
+  autoUpdateOnMetered: false,
+  quietHours: [{ start: "22:00", end: "08:00" }],
+};
 
 // `smokeViewDeclarations` is imported from ./smoke-view-declarations.mjs so it
 // stays pinned to shipping plugins by `checkSmokeViewParity` (removed views such
@@ -3508,6 +3514,16 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  // OWNER-only consumer-key administration is backed by an agent-host facade
+  // in production. The deterministic smoke fixture models a healthy host with
+  // no issued keys for the exact read-only collection route; writes and item
+  // routes deliberately continue to the catch-all 501 below so the fixture
+  // never fabricates key-management authority.
+  if (req.method === "GET" && url.pathname === "/api/accounts/consumer-keys") {
+    sendJson(req, res, 200, { keys: [] });
+    return;
+  }
+
   if (
     (req.method === "GET" || req.method === "PUT") &&
     url.pathname === "/api/secrets/manager/preferences"
@@ -3564,6 +3580,44 @@ const server = http.createServer(async (req, res) => {
     url.pathname === "/api/secrets/manager/install/methods"
   ) {
     sendJson(req, res, 200, { methods: {} });
+    return;
+  }
+  if (
+    req.method === "GET" &&
+    url.pathname === "/api/secrets/manager/protection"
+  ) {
+    // The smoke host has no platform secure-store backend. Preserve the real
+    // protection DTO while reporting that boundary as unavailable rather than
+    // claiming a device key exists.
+    sendJson(req, res, 200, {
+      ok: true,
+      protection: {
+        localVault: {
+          encryptedAtRest: true,
+          cipher: "AES-256-GCM",
+          masterKey: {
+            backend: "none",
+            available: false,
+            synchronized: false,
+            scope: "unavailable",
+            access: "unavailable",
+          },
+        },
+        nativeSessionState: {
+          policy: "platform-protected-store",
+          synchronized: false,
+          plaintextFallback: false,
+        },
+        connectorSessions: {
+          telegramPersonal: "vault-master-key-encrypted",
+        },
+        cloudTrustDomain: "separate-organization-kms",
+      },
+    });
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/api/secrets/logins") {
+    sendJson(req, res, 200, { ok: true, logins: [], failures: [] });
     return;
   }
   if (req.method === "GET" && url.pathname === "/api/secrets/routing") {
@@ -4578,6 +4632,51 @@ const server = http.createServer(async (req, res) => {
   // transcript-in / spoken-reply-out round trip stays deterministic.
   if (
     req.method === "GET" &&
+    url.pathname === "/api/local-inference/device/stream"
+  ) {
+    const payload = {
+      type: "status",
+      status: {
+        connected: false,
+        devices: [],
+        primaryDeviceId: null,
+        pendingRequests: 0,
+        deviceId: null,
+        capabilities: null,
+        loadedPath: null,
+        connectedSince: null,
+      },
+    };
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "close",
+    });
+    res.end(`retry: 60000\ndata: ${JSON.stringify(payload)}\n\n`);
+    return;
+  }
+
+  if (
+    req.method === "GET" &&
+    url.pathname === "/api/local-inference/voice-models"
+  ) {
+    sendJson(req, res, 200, { installations: [] });
+    return;
+  }
+
+  if (
+    req.method === "GET" &&
+    url.pathname === "/api/local-inference/voice-models/preferences"
+  ) {
+    sendJson(req, res, 200, {
+      preferences: SMOKE_NETWORK_POLICY_PREFERENCES,
+      isOwner: true,
+    });
+    return;
+  }
+
+  if (
+    req.method === "GET" &&
     url.pathname === "/api/asr/local-inference/status"
   ) {
     sendJson(req, res, 200, { ready: true, provider: "local-inference" });
@@ -4669,8 +4768,12 @@ function broadcastWsEvent(payload) {
 }
 
 server.listen(port, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("UI smoke stub did not bind a TCP port");
+  }
   console.log(
-    `[playwright-ui-smoke-api-stub] listening on http://127.0.0.1:${port}`,
+    `[playwright-ui-smoke-api-stub] listening on http://127.0.0.1:${address.port}`,
   );
 });
 


### PR DESCRIPTION
The keyless UI-smoke server now provides the read-only empty-state contracts used by the app, while rejecting write and item-specific requests. The real HTTP regression covers the supported reads and fourteen rejected operations.

Review fixes bind the test server directly to port zero, read its actual listening address, and clean up startup listeners and child processes on success or failure. This removes the reserve/release port race and prevents the harness from leaving a server behind. File URL conversion also handles checkout paths containing spaces.

Validation for `ab6f698abcdb70a987ab2f9c028f523e420fbd38`:
- Two real spawned-server HTTP contract tests passed after rebase.
- Normal Bun install completed without dependency changes.
- Full repository verification and formatting passed in [CI](https://github.com/elizaOS/eliza/actions/runs/33951808095).
- Both changed files passed Biome; diff checks passed.

The full owning app-core test command completed with exit code 0 in hosted qualification (36 minutes); the aggregate runner did not extract its test count. All required original PR checks passed. The broader optional server lane later cancelled and other packages failed, so the full optional workflow is not claimed green. UI screenshots and live-model evidence are N/A: this changes the development smoke server and its harness, with no rendered product change or model dispatch.
