### PR TITLE
fix(vision): align full-context fixtures

### DIFF
--- a/plugins/plugin-vision/src/eliza1-bridge.test.ts
+++ b/plugins/plugin-vision/src/eliza1-bridge.test.ts
@@ -112,10 +112,8 @@ describe("VisionService eliza-1 IMAGE_DESCRIPTION bridge", () => {
     expect(prompt.detectedText).toBe("Save\nProject settings\nDeploy now");
   });
 
-  // Token-budget guards (#9105): OCR text fused into the IMAGE_DESCRIPTION prompt
-  // is cheap vs re-describing, but must not blow the budget; service.ts clamps
-  // it to SCENE_DESCRIPTION_OCR_LINE_LIMIT (40 lines) and
-  // SCENE_DESCRIPTION_OCR_TEXT_LIMIT (2000 chars) in normalizeOcrTextForPrompt.
+  // OCR normalization may remove blank or duplicate lines, but the model must
+  // receive every remaining line instead of a silent prefix of the screen.
   function sceneWithOcr(service: VisionService, fullScreenOCR: string): void {
     Object.defineProperty(service, "lastEnhancedScene", {
       configurable: true,
@@ -134,16 +132,15 @@ describe("VisionService eliza-1 IMAGE_DESCRIPTION bridge", () => {
     });
   }
 
-  it("clamps the prompt OCR to the 40-line token-budget limit", async () => {
+  it("preserves every normalized OCR line in the model prompt", async () => {
     const { runtime, useModel } = createRuntime({
       imageDescriptionResult: { description: "A long list." },
     });
     const service = new VisionService(runtime);
-    // 60 distinct short lines; without the cap the prompt would carry all 60.
-    sceneWithOcr(
-      service,
-      Array.from({ length: 60 }, (_, i) => `row ${i}`).join("\n"),
+    const fullScreenOCR = Array.from({ length: 60 }, (_, i) => `row ${i}`).join(
+      "\n",
     );
+    sceneWithOcr(service, fullScreenOCR);
     const describeFn = Reflect.get(service, "describeSceneWithVLM") as (
       imageUrl: string,
     ) => Promise<string>;
@@ -158,21 +155,19 @@ describe("VisionService eliza-1 IMAGE_DESCRIPTION bridge", () => {
       throw new Error("Vision bridge did not call the image-description model");
     }
     const prompt = JSON.parse(modelArgs.prompt) as { detectedText?: string };
-    expect(prompt.detectedText).toBeTruthy();
-    expect((prompt.detectedText ?? "").split("\n")).toHaveLength(40);
+    expect(prompt.detectedText).toBe(fullScreenOCR);
+    expect(prompt.detectedText?.split("\n")).toHaveLength(60);
   });
 
-  it("clamps the prompt OCR to the 2000-char token-budget limit", async () => {
+  it("preserves the complete normalized OCR text beyond legacy prompt caps", async () => {
     const { runtime, useModel } = createRuntime({
       imageDescriptionResult: { description: "A wall of text." },
     });
     const service = new VisionService(runtime);
-    // Three distinct ~1000-char lines (~3000 chars total), under the 40-line
-    // cap but well over the 2000-char cap; without the slice it would be ~3000.
-    sceneWithOcr(
-      service,
-      [0, 1, 2].map((i) => `${i} ${"x".repeat(1000)}`).join("\n"),
-    );
+    const fullScreenOCR = [0, 1, 2]
+      .map((i) => `${i} ${"x".repeat(1000)}`)
+      .join("\n");
+    sceneWithOcr(service, fullScreenOCR);
     const describeFn = Reflect.get(service, "describeSceneWithVLM") as (
       imageUrl: string,
     ) => Promise<string>;
@@ -187,9 +182,8 @@ describe("VisionService eliza-1 IMAGE_DESCRIPTION bridge", () => {
       throw new Error("Vision bridge did not call the image-description model");
     }
     const prompt = JSON.parse(modelArgs.prompt) as { detectedText?: string };
-    expect(prompt.detectedText).toBeTruthy();
-    expect((prompt.detectedText ?? "").length).toBeLessThanOrEqual(2000);
-    expect((prompt.detectedText ?? "").length).toBeGreaterThan(1900);
+    expect(prompt.detectedText).toBe(fullScreenOCR);
+    expect(prompt.detectedText).toHaveLength(3008);
   });
 
   it("falls through to detected-objects synthesis when IMAGE_DESCRIPTION returns the unhelpful sentinel", async () => {

--- a/plugins/plugin-vision/src/fusion-prompt.test.ts
+++ b/plugins/plugin-vision/src/fusion-prompt.test.ts
@@ -1,8 +1,8 @@
 /**
  * Prompt-fusion coverage for injecting detector output into VLM scene descriptions.
  *
- * OCR text, YOLO objects, and recognized faces are added as bounded context while
- * the detection-off path remains byte-for-byte unchanged.
+ * OCR text, YOLO objects, and recognized faces are added as complete normalized
+ * context while the detection-off path remains byte-for-byte unchanged.
  */
 
 import { describe, expect, it } from "vitest";
@@ -86,7 +86,7 @@ describe("buildSceneDescriptionPrompt — detector fusion", () => {
     expect(JSON.parse(withoutDetectors).detectedText).toBe("ocr only");
   });
 
-  it("caps objects at top-20 by confidence (descending)", () => {
+  it("preserves every object in descending confidence order", () => {
     const objects: DetectedObject[] = Array.from({ length: 25 }, (_, i) =>
       makeObject(`o${i}`, `type-${i}`, i / 100),
     );
@@ -95,16 +95,23 @@ describe("buildSceneDescriptionPrompt — detector fusion", () => {
       buildSceneDescriptionPrompt(null, null, objects, []),
     ) as { detectedObjects: Array<{ type: string; confidence: number }> };
 
-    expect(payload.detectedObjects).toHaveLength(20);
-    // Highest confidence first; the 5 lowest are dropped.
-    expect(payload.detectedObjects[0].type).toBe("type-24");
-    expect(payload.detectedObjects.at(-1)?.type).toBe("type-5");
+    expect(payload.detectedObjects).toHaveLength(25);
+    expect(payload.detectedObjects.map((object) => object.type)).toEqual(
+      Array.from({ length: 25 }, (_, index) => `type-${24 - index}`),
+    );
+    expect(
+      payload.detectedObjects.every(
+        (object, index, all) =>
+          index === 0 || all[index - 1].confidence >= object.confidence,
+      ),
+    ).toBe(true);
   });
 
-  it("dedupes faces by label and caps at top-10", () => {
+  it("preserves every unique nonblank face label", () => {
     const faces: RecognizedFace[] = [
       { label: "Alice", bbox: bbox(0, 0) },
       { label: "Alice", bbox: bbox(1, 1) },
+      { label: "   ", bbox: bbox(2, 2) },
       ...Array.from({ length: 15 }, (_, i) => ({
         label: `Person-${i}`,
         bbox: bbox(i, i),
@@ -115,11 +122,16 @@ describe("buildSceneDescriptionPrompt — detector fusion", () => {
       buildSceneDescriptionPrompt(null, null, [], faces),
     ) as { recognizedFaces: Array<{ label: string }> };
 
-    expect(payload.recognizedFaces).toHaveLength(10);
+    expect(payload.recognizedFaces).toHaveLength(16);
     const labels = payload.recognizedFaces.map((f) => f.label);
-    // First Alice kept, duplicate dropped.
+    expect(labels).toEqual([
+      "Alice",
+      ...Array.from({ length: 15 }, (_, index) => `Person-${index}`),
+    ]);
     expect(labels.filter((l) => l === "Alice")).toHaveLength(1);
     expect(labels[0]).toBe("Alice");
+    expect(labels.at(-1)).toBe("Person-14");
+    expect(labels.some((label) => label.trim().length === 0)).toBe(false);
   });
 
   it("skips blank face labels", () => {


### PR DESCRIPTION
Closes #29827

## Summary

- update stale plugin-vision tests to assert the current full normalized context
- prove exact OCR preservation, complete object ordering, and face dedupe/blank filtering
- leave production plugin code and prompt behavior untouched

## Exact provenance

- base: `31746131fd49dce9ddfa4816a3824e0c169eaeb1`
- head: `40d918510846821e5d9c91dee5449968dd261977`
- tree: `58b15b062b73d559bb543cd8024ebe752d70a72c`
- scope: exactly two plugin-vision test files

## Verification

- focused plugin-vision Vitest: 12/12 PASS
- plugin-vision TypeScript noEmit: PASS
- Biome exact files: PASS
- `git diff --check`: PASS
- independent review: P0/P1/P2/P3 = 0/0/0/0
- open-PR exact-path overlap: none

## Contract coverage

- 60 normalized OCR lines retained exactly
- 3008-character OCR payload retained exactly
- 25 objects retained in descending-confidence order
- 16 unique nonblank face labels retained with duplicate and blank filtering

## Review evidence

- runtime/visual change: N/A (test-fixture-only)
- auth/security/billing change: N/A
- local full builds withheld under the active disk-capacity hold; hosted checks are required before merge.