### PR TITLE
fix(agent): preserve grounded replies without model provider

### DIFF
--- a/packages/agent/src/actions/grounded-action-reply.test.ts
+++ b/packages/agent/src/actions/grounded-action-reply.test.ts
@@ -6,7 +6,7 @@
  * the module under test is not mocked.
  */
 import type { ActionResult, IAgentRuntime, Memory, State } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
+import { AgentRuntime, ModelType } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractActionResultsFromState,
@@ -429,6 +429,15 @@ describe("renderGroundedActionReply", () => {
   it("returns the fallback when useModel is missing", async () => {
     const { reply } = await renderWith({
       useModel: null,
+      fallback: "Canonical fallback.",
+    });
+    expect(reply).toBe("Canonical fallback.");
+  });
+
+  it("returns the grounded fallback when the runtime has no model provider", async () => {
+    const runtime = new AgentRuntime({ character: { name: "NoProvider" } });
+    const { reply } = await renderWith({
+      useModel: runtime.useModel.bind(runtime),
       fallback: "Canonical fallback.",
     });
     expect(reply).toBe("Canonical fallback.");

--- a/packages/agent/src/actions/grounded-action-reply.ts
+++ b/packages/agent/src/actions/grounded-action-reply.ts
@@ -9,6 +9,7 @@ import type { ActionResult, IAgentRuntime, Memory, State } from "@elizaos/core";
 import {
   ElizaError,
   ModelType,
+  NoModelProviderConfiguredError,
   parseJSONObjectFromText,
   renderActionResultsForModel,
 } from "@elizaos/core";
@@ -205,9 +206,21 @@ export async function renderGroundedActionReply(
     `Canonical fallback: ${JSON.stringify(args.fallback)}`,
   ].join("\n");
 
-  const result = await args.runtime.useModel(ModelType.TEXT_SMALL, {
-    prompt,
-  });
+  let result: unknown;
+  try {
+    result = await args.runtime.useModel(ModelType.TEXT_SMALL, {
+      prompt,
+    });
+  } catch (error) {
+    // error-policy:J4 A zero-key runtime has no model capable of polishing the
+    // already-grounded canonical reply. Return that reply exactly; every
+    // configured-provider failure remains loud so outages cannot masquerade as
+    // successful model output.
+    if (error instanceof NoModelProviderConfiguredError) {
+      return args.fallback;
+    }
+    throw error;
+  }
   if (typeof result !== "string") {
     throw new ElizaError("Grounded reply model returned a non-text response", {
       code: "GROUNDED_REPLY_OUTPUT_INVALID",


### PR DESCRIPTION
Grounded action replies now recognize the typed NoModelProviderConfiguredError raised by the real runtime when no provider is registered. The existing no-provider reply behavior remains available; other provider failures retain their failure path. The regression uses AgentRuntime.useModel rather than relying only on a synthetic error string.

Validation for `326a5f13464fa47686b770aa0e9a31aebed27e98`:
- 36 focused grounded-reply tests passed.
- Full repository verification passed.
- The complete 758-batch agent suite finished with one import-time timeout. That isolated conversation-idempotency suite passed all 41 tests on rerun; all other batches passed.
- Owning typecheck, lint, and diff checks passed in repository verification.

All required hosted PR checks passed on the reviewed revision. This exercises no-provider runtime behavior; live model and UI evidence are N/A because no model is configured and no rendered surface changes.
