### PR TITLE
fix(scripts): map plugin-sql route coverage

### DIFF
--- a/packages/scripts/e2e-coverage/manifest.ts
+++ b/packages/scripts/e2e-coverage/manifest.ts
@@ -149,6 +149,9 @@ export const PLUGIN_ROUTE_COVERAGE: Record<string, ManifestEntry> = {
   "plugin-scheduling": existing(
     "plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts",
   ),
+  "plugin-sql": existing(
+    "plugins/plugin-sql/src/__tests__/integration/identity-person-link-attestation.real.test.ts",
+  ),
   "plugin-wallet": existing(
     "plugins/plugin-wallet/src/api/wallet-routes.test.ts",
   ),


### PR DESCRIPTION
Closes #29819

## Summary

- map `plugin-sql` to its existing real migrated-PGlite identity route integration artifact
- restore route-manifest completeness without claiming full HTTP/live dispatch coverage
- leave production SQL and route behavior unchanged

## Exact provenance

- base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`
- head: `3f417154f43c05bf012f82a7a262c68f3b522e5d`
- tree: `749d8172c494bb05ad39aed6ad52d91544a25697`
- scope: one manifest file, three insertions

## Verification

- coverage matrix: 17/21 routes, 4 exempt, 0 blocking, 0 advisory PASS
- real migrated-PGlite identity route test: 4/4 PASS on the reviewed pre-rebase candidate
- post-rebase direct manifest import/assertion: PASS
- Biome and `git diff --check`: PASS
- independent review: P0/P1/P2/P3 = 0/0/0/0
- exhaustive open-PR exact-path overlap: none

## Evidence boundaries

The mapped unchanged artifact invokes both private identity attest/verify handlers with `SqlPrincipalService` against dynamically migrated PGlite, covering persistence, replay, stale generation, forged fields, missing/USER context, concurrency, and no redirect/merge side effects. The manifest uses `existing()` with zero dispatcher signals; it does not claim full HTTP/Hono, browser, or live dispatch certification.

- runtime/visual/auth/billing change: N/A (coverage-manifest-only)
- full local builds withheld under the active disk-capacity hold; hosted checks required before merge.