### PR TITLE
fix(core): normalize Windows profile-matrix fixtures

### DIFF
--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -13,6 +13,17 @@ import {
 
 const repositoryRoot = path.resolve(import.meta.dirname, "../../../../..");
 
+function normalizeRelativePath(
+	relativePath: string,
+	separator = path.sep,
+): string {
+	return relativePath.split(separator).join("/");
+}
+
+function normalizeGoldenLineEndings(golden: string): string {
+	return golden.replace(/\r\n/g, "\n");
+}
+
 async function sourceFiles(directory: string): Promise<string[]> {
 	const files: string[] = [];
 	for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
@@ -47,7 +58,7 @@ async function productionRegistrationSites(): Promise<
 			)?.length;
 			if (registrations) {
 				found.push({
-					site: path.relative(pluginsRoot, file),
+					site: normalizeRelativePath(path.relative(pluginsRoot, file)),
 					registrations,
 				});
 			}
@@ -57,6 +68,18 @@ async function productionRegistrationSites(): Promise<
 }
 
 describe("first-party interaction capability matrix", () => {
+	it("normalizes only platform separators and CRLF golden endings", () => {
+		expect(
+			normalizeRelativePath(
+				String.raw`plugin-instagram\src\service.ts`,
+				path.win32.sep,
+			),
+		).toBe("plugin-instagram/src/service.ts");
+		expect(normalizeGoldenLineEndings("first\r\nsecond\rthird\n")).toBe(
+			"first\nsecond\rthird\n",
+		);
+	});
+
 	it("covers every production registration site and invocation", async () => {
 		const declared = [
 			...new Set(
@@ -71,9 +94,11 @@ describe("first-party interaction capability matrix", () => {
 	});
 
 	it("matches the committed reviewer-readable golden artifact", async () => {
-		const golden = await fs.readFile(
-			path.join(import.meta.dirname, "CAPABILITY_MATRIX.md"),
-			"utf8",
+		const golden = normalizeGoldenLineEndings(
+			await fs.readFile(
+				path.join(import.meta.dirname, "CAPABILITY_MATRIX.md"),
+				"utf8",
+			),
 		);
 		expect(`${renderFirstPartyInteractionCapabilityMatrix()}\n`).toBe(golden);
 	});


### PR DESCRIPTION
Closes #29818

## Summary

- normalize filesystem-discovered Windows separators to canonical `/` in the profile-matrix fixture
- normalize only CRLF pairs in the committed golden
- explicitly preserve lone CR and existing LF semantics
- leave production interaction-profile code unchanged

## Exact provenance

- base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`
- head: `7f9c2c444259b41c2b2e2ca58da4396ab2898c0d`
- tree: `93a21d66e6336509d37cec7b3b451366940c2101`
- scope: one Core test file

## Verification

- exact-current focused Vitest: 3/3 PASS
- Biome exact file: PASS
- `git diff --check`: PASS
- independent review: P0/P1/P2/P3 = 0/0/0/0
- exhaustive open-PR exact/semantic path overlap: none

## Failure proof

Develop Full Windows job 99000211965 failed both original profile-matrix assertions because filesystem discovery emitted backslash paths and the checked-out golden used CRLF. The repair is fixture-only, identity on POSIX, and narrows line-ending normalization to `/\r\n/g`.

- runtime/visual/auth/billing change: N/A
- full local builds withheld under the disk-capacity hold; hosted checks required before merge.