### PR TITLE
test(auth): restore native session and link contracts

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.test.ts
@@ -424,11 +424,12 @@ describe("telegramAdapter.extractEvent", () => {
 
     expect(fetches).toBe(0);
     // "01ABCDEF" contains 0 and 1, which Crockford base32 excludes
-    // (TELEGRAM_GROUP_LINK_COMMAND uses [2-9A-HJ-NP-Z]{8}), so this is not a
-    // link command and falls through to an ambient group turn.
+    // (TELEGRAM_GROUP_LINK_COMMAND uses [2-9A-HJ-NP-Z]{8}), so the generic
+    // slash-command classifier may retain it as a command but the link path
+    // must not perform a membership lookup or attach linking authority.
     expect(event).toMatchObject({
       text: "/eliza_link 01ABCDEF",
-      groupInvocation: "ambient",
+      groupInvocation: "command",
       isCommand: true,
     });
     expect(event?.groupActorRole).toBeUndefined();

--- a/packages/ui/src/cloud/lib/use-session-auth.test.tsx
+++ b/packages/ui/src/cloud/lib/use-session-auth.test.tsx
@@ -18,6 +18,7 @@ const capacitorState = { isNative: false };
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
     isNativePlatform: () => capacitorState.isNative,
+    registerPlugin: () => ({}),
   },
 }));
 

--- a/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
+++ b/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: () => "android",
     isNativePlatform: () => true,
+    registerPlugin: () => ({}),
   },
   CapacitorHttp: {
     request: harness.directCloudRequest,


### PR DESCRIPTION
Closes #29835.

## Summary

- teach the two mobile/session Auth test doubles the current Capacitor `registerPlugin` contract so the suites execute instead of crashing during import
- align the invalid Telegram link-code expectation with the shared generic slash-command classifier
- preserve the security assertions that an invalid code performs zero membership lookups and attaches no linking authority

## Consumer-visible regression protected

A future native-controller import change must not silently disable Android cloud Auth or session bootstrap coverage. A future Telegram parser change must not turn a malformed `/eliza_link` code into a privileged membership lookup or attach group authority merely because generic command classification still recognizes the slash command.

## Exact source

- base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`
- head: `280bbe2d300735758d91585d82585c586e6c95fb`
- changed surface: three test files only; no runtime, provider, credential, environment, workflow, or deployment change

## Verification

| Check | Result |
| --- | --- |
| Gateway full suite | PASS — 35 files, 458 tests |
| Focused UI Auth/session matrix | PASS — 31 files, 301 tests |
| Auth package | PASS — 18 files, 210 tests |
| App-core Auth | PASS — 27 files, 390 tests |
| App-core desktop/mobile focused | PASS — 7 files, 81 tests |
| App focused Auth/service worker | PASS — 4 files, 22 tests |
| Mobile Auth simulator end-state | PASS — 11, SKIP — 1 (no booted iOS simulator) |
| UI typecheck | PASS |
| UI lint/design contracts | PASS (pre-existing warnings only) |
| Changed-file Biome / diff check / redacted secret scan | PASS |
| Gateway typecheck | BASE-BLOCKED — shared billing cannot resolve `@elizaos/cloud-sdk/browser-contracts`; no changed source file participates |
| Root `bun run verify` | BASE-BLOCKED — `@elizaos/capacitor-gateway` SourceKitten cannot load `sourcekitdInProc`; 132/146 tasks completed before the unrelated native-toolchain failure |

Current `develop` Develop Full for this exact base was still running when the PR was opened: https://github.com/elizaOS/eliza/actions/runs/33222441886

## Evidence applicability

- Before/after screenshots: N/A — test fixtures and assertions only; no rendered UI change.
- Walkthrough video: N/A — no product UI or runtime change.
- Provider/live-account evidence: N/A — no provider request or real-account flow was performed.
- Backend/deploy logs: N/A — no service or deployment change.

## Rollback

Revert `280bbe2d300735758d91585d82585c586e6c95fb`; no data, environment, provider, or runtime rollback is required.

@lalalune this is the bounded deterministic Auth/gateway repair. Telegram BotFather/Apple/SMS/provider and staging ownership remain outside this PR.

<!-- evidence-head:280bbe2d300735758d91585d82585c586e6c95fb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change; no runtime flow changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no service, request, or deployment changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser or rendered UI behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, model, prompt, or provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - deterministic test fixture repair; exact commands and counts are recorded in Verification

