### PR TITLE
fix(core): ignore ungrounded document list zero limit

### DIFF
--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -298,6 +298,22 @@ describe("documentAction.handler structured routing", () => {
 		);
 	});
 
+	it("rejects an explicit zero list limit instead of treating it as a sentinel", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("List 0 documents"),
+			undefined,
+			options({ action: "list", limit: 0, scope: "all-visible" }),
+		);
+
+		expect(service.listDocumentsDetailed).not.toHaveBeenCalled();
+		expect(res?.success).toBe(false);
+		expect(res?.values).toMatchObject({ error: "DOCUMENT_INVALID_LIMIT" });
+	});
+
 	it("keeps query-miss fallback documents separate from matched documents", async () => {
 		const service = makeService();
 		const document = {

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -370,6 +370,16 @@ function getLimit(value: unknown): number | undefined {
 	return value;
 }
 
+function getOptionalPlannerLimit(
+	value: unknown,
+	message: Memory,
+): number | undefined {
+	if (value === 0 && !/(?:^|\D)0(?:\D|$)/.test(message.content.text ?? "")) {
+		return undefined;
+	}
+	return getLimit(value);
+}
+
 function getScope(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -1220,7 +1230,7 @@ async function handleList(
 			? Math.floor(params.offset)
 			: undefined;
 
-	const requestedLimit = getLimit(params.limit);
+	const requestedLimit = getOptionalPlannerLimit(params.limit, message);
 	const listResult = await service.listDocumentsDetailed(message, {
 		...(requestedLimit === undefined ? {} : { limit: requestedLimit }),
 		offset,


### PR DESCRIPTION
## Summary

- treat a strict-decoder `limit: 0` as an omitted list-only parameter when the user did not ask for zero
- preserve the positive-safe-integer fail-closed rule when the user explicitly requests a zero limit
- add regression coverage for the explicit-zero boundary

This repairs the document action failure observed in current `develop` macOS platform smoke without relaxing search/read limit validation.

## Exact authority

- base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`
- head: `246adc8aec61b2e222686f81fa346723c3bc7eda`
- files: `packages/core/src/features/documents/actions.ts`, `packages/core/src/features/documents/__tests__/actions-routing.test.ts`

## Verification

- `bunx @biomejs/biome check packages/core/src/features/documents/actions.ts packages/core/src/features/documents/__tests__/actions-routing.test.ts`
- `bun test packages/core/src/features/documents/__tests__` — 87 passed, 0 failed
- `bun run --cwd packages/core typecheck`
- `git diff --check`

No production, deployment, provider, credential, device, signing, or release action is included.