### PR TITLE
fix(vault): restore typed recovery and load failures

### DIFF
--- a/packages/agent/src/runtime/agent-wallets.ts
+++ b/packages/agent/src/runtime/agent-wallets.ts
@@ -296,9 +296,11 @@ export async function ensureAgentWallets(
       existing = await getAgentWalletDescriptor(vault, agentId, chain);
     } catch (error) {
       if (!(error instanceof VaultDecryptionError)) throw error;
+      if (!error.entryIdentity) throw error;
       const key = walletKey(agentId, chain);
       const quarantined = await vault.quarantineUnreadable(
         key,
+        error.entryIdentity,
         "agent wallet failed authenticated decryption during bootstrap",
         caller ?? "agent-wallets:bootstrap-repair",
       );

--- a/packages/agent/src/runtime/operations/vault-bridge.test.ts
+++ b/packages/agent/src/runtime/operations/vault-bridge.test.ts
@@ -1,7 +1,30 @@
-/** Tests boot-time creation and reuse of the optimized-prompt integrity key. */
+/**
+ * Deterministic mocked and real-PGlite tests for boot-time creation, typed
+ * recovery, forensic quarantine, concurrency, and restart persistence of the
+ * optimized-prompt integrity key.
+ */
 
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  generateMasterKey,
+  inMemoryMasterKey,
+  PgliteVaultImpl,
+  VaultDecryptionError,
+} from "@elizaos/vault";
 import { describe, expect, it, vi } from "vitest";
 import { resolveOptimizedPromptIntegrityKey } from "./vault-bridge.ts";
+
+const INTEGRITY_KEY = "system.optimized-prompt.hmac-key";
+const UNREADABLE_ENTRY_IDENTITY = "test-unreadable-row-identity";
+
+function integrityKeyDecryptionFailure(): VaultDecryptionError {
+  return new VaultDecryptionError(INTEGRITY_KEY, {
+    entryIdentity: UNREADABLE_ENTRY_IDENTITY,
+  });
+}
 
 describe("resolveOptimizedPromptIntegrityKey", () => {
   it("persists one sensitive 256-bit key", async () => {
@@ -13,6 +36,7 @@ describe("resolveOptimizedPromptIntegrityKey", () => {
         if (!value) throw new Error("missing");
         return value;
       }),
+      quarantineUnreadable: vi.fn(async () => false),
       setIfAbsent: vi.fn(
         async (key: string, value: string): Promise<boolean> => {
           if (values.has(key)) return false;
@@ -40,10 +64,372 @@ describe("resolveOptimizedPromptIntegrityKey", () => {
     const vault = {
       has: vi.fn(async () => false),
       get: vi.fn(async () => winner),
+      quarantineUnreadable: vi.fn(async () => false),
       setIfAbsent: vi.fn(async () => false),
     };
 
     expect(await resolveOptimizedPromptIntegrityKey(vault)).toBe(winner);
     expect(vault.get).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["empty", ""],
+    ["short", Buffer.alloc(31, 1).toString("base64")],
+    ["long", Buffer.alloc(33, 1).toString("base64")],
+    ["non-base64", "not-base64"],
+    ["non-canonical", "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwB="],
+  ])("rejects a %s losing-writer key", async (_label, winner) => {
+    const vault = {
+      has: vi.fn(async () => false),
+      get: vi.fn(async () => winner),
+      quarantineUnreadable: vi.fn(async () => false),
+      setIfAbsent: vi.fn(async () => false),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toThrow(
+      /optimized-prompt integrity key/,
+    );
+    expect(vault.get).toHaveBeenCalledOnce();
+  });
+
+  it("recovers only this typed internal-key decryption failure with protected exact read-back", async () => {
+    let stored: string | null = "unreadable-ciphertext";
+    let firstRead = true;
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async (key: string) => {
+        if (firstRead) {
+          firstRead = false;
+          throw new VaultDecryptionError(key, {
+            entryIdentity: UNREADABLE_ENTRY_IDENTITY,
+          });
+        }
+        if (stored === null) throw new Error("replacement missing");
+        return stored;
+      }),
+      quarantineUnreadable: vi.fn(async () => {
+        stored = null;
+        return true;
+      }),
+      setIfAbsent: vi.fn(async (_key: string, value: string) => {
+        if (stored !== null) return false;
+        stored = value;
+        return true;
+      }),
+    };
+
+    const recovered = await resolveOptimizedPromptIntegrityKey(vault);
+
+    expect(Buffer.from(recovered, "base64")).toHaveLength(32);
+    expect(recovered).toBe(stored);
+    expect(vault.quarantineUnreadable).toHaveBeenCalledWith(
+      INTEGRITY_KEY,
+      UNREADABLE_ENTRY_IDENTITY,
+      "optimized-prompt integrity key failed authenticated decryption during runtime boot",
+      "runtime-boot:optimized-prompt-hmac-decryption-recovery",
+    );
+    expect(vault.setIfAbsent).toHaveBeenCalledOnce();
+    expect(vault.setIfAbsent).toHaveBeenCalledWith(INTEGRITY_KEY, recovered, {
+      sensitive: true,
+      caller: "runtime-boot:optimized-prompt-hmac-decryption-recovery",
+    });
+    expect(vault.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not generalize recovery to non-decryption failures", async () => {
+    const failure = new Error("storage unavailable");
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        throw failure;
+      }),
+      quarantineUnreadable: vi.fn(async () => false),
+      setIfAbsent: vi.fn(async () => false),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toBe(
+      failure,
+    );
+    expect(vault.quarantineUnreadable).not.toHaveBeenCalled();
+  });
+
+  it("does not generalize recovery to a typed failure for another key", async () => {
+    const failure = new VaultDecryptionError("provider.openai.api-key", {
+      entryIdentity: UNREADABLE_ENTRY_IDENTITY,
+    });
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        throw failure;
+      }),
+      quarantineUnreadable: vi.fn(async () => false),
+      setIfAbsent: vi.fn(async () => false),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toBe(
+      failure,
+    );
+    expect(vault.quarantineUnreadable).not.toHaveBeenCalled();
+    expect(vault.setIfAbsent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a decryption failure has no exact row identity", async () => {
+    const failure = new VaultDecryptionError(INTEGRITY_KEY);
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        throw failure;
+      }),
+      quarantineUnreadable: vi.fn(async () => false),
+      setIfAbsent: vi.fn(async () => false),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toBe(
+      failure,
+    );
+    expect(vault.quarantineUnreadable).not.toHaveBeenCalled();
+    expect(vault.setIfAbsent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when forensic quarantine fails", async () => {
+    const quarantineFailure = new Error("quarantine unavailable");
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        throw integrityKeyDecryptionFailure();
+      }),
+      quarantineUnreadable: vi.fn(async () => {
+        throw quarantineFailure;
+      }),
+      setIfAbsent: vi.fn(async () => false),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toBe(
+      quarantineFailure,
+    );
+    expect(vault.get).toHaveBeenCalledOnce();
+    expect(vault.setIfAbsent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when replacement creation fails after quarantine", async () => {
+    const creationFailure = new Error("protected create unavailable");
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        throw integrityKeyDecryptionFailure();
+      }),
+      quarantineUnreadable: vi.fn(async () => true),
+      setIfAbsent: vi.fn(async () => {
+        throw creationFailure;
+      }),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toBe(
+      creationFailure,
+    );
+    expect(vault.quarantineUnreadable).toHaveBeenCalledOnce();
+    expect(vault.get).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when exact read-back does not verify the replacement", async () => {
+    let readCount = 0;
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        readCount += 1;
+        if (readCount === 1) {
+          throw integrityKeyDecryptionFailure();
+        }
+        return Buffer.alloc(32, 0x44).toString("base64");
+      }),
+      quarantineUnreadable: vi.fn(async () => true),
+      setIfAbsent: vi.fn(async () => true),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toThrow(
+      /failed exact read-back verification/,
+    );
+    expect(vault.quarantineUnreadable).toHaveBeenCalledOnce();
+    expect(vault.setIfAbsent).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an invalid read-back when another recovery writer wins", async () => {
+    let readCount = 0;
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        readCount += 1;
+        if (readCount === 1) throw integrityKeyDecryptionFailure();
+        return Buffer.alloc(31, 0x55).toString("base64");
+      }),
+      quarantineUnreadable: vi.fn(async () => false),
+      setIfAbsent: vi.fn(async () => false),
+    };
+
+    await expect(resolveOptimizedPromptIntegrityKey(vault)).rejects.toThrow(
+      /exactly 32 bytes/,
+    );
+    expect(vault.quarantineUnreadable).toHaveBeenCalledWith(
+      INTEGRITY_KEY,
+      UNREADABLE_ENTRY_IDENTITY,
+      "optimized-prompt integrity key failed authenticated decryption during runtime boot",
+      "runtime-boot:optimized-prompt-hmac-decryption-recovery",
+    );
+    expect(vault.setIfAbsent).toHaveBeenCalledOnce();
+  });
+
+  it("single-flights concurrent recovery so every caller receives one verified winner", async () => {
+    let stored: string | null = null;
+    let releaseFirstRead: (() => void) | undefined;
+    const firstReadGate = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    let readCount = 0;
+    const vault = {
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        readCount += 1;
+        if (readCount === 1) {
+          await firstReadGate;
+          throw integrityKeyDecryptionFailure();
+        }
+        if (stored === null) throw new Error("replacement missing");
+        return stored;
+      }),
+      quarantineUnreadable: vi.fn(async () => true),
+      setIfAbsent: vi.fn(async (_key: string, value: string) => {
+        stored = value;
+        return true;
+      }),
+    };
+
+    const first = resolveOptimizedPromptIntegrityKey(vault);
+    const second = resolveOptimizedPromptIntegrityKey(vault);
+    releaseFirstRead?.();
+    const [firstValue, secondValue] = await Promise.all([first, second]);
+
+    expect(firstValue).toBe(secondValue);
+    expect(firstValue).toBe(stored);
+    expect(vault.quarantineUnreadable).toHaveBeenCalledOnce();
+    expect(vault.setIfAbsent).toHaveBeenCalledOnce();
+    expect(vault.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses one first-writer winner when distinct resolvers race recovery", async () => {
+    let stored: string | null = "unreadable";
+    let storedIdentity: string | null = UNREADABLE_ENTRY_IDENTITY;
+    let initialFailuresRemaining = 2;
+    let quarantineAttempts = 0;
+    let quarantines = 0;
+    let insertions = 0;
+    const makeVault = () => ({
+      has: vi.fn(async () => true),
+      get: vi.fn(async () => {
+        if (initialFailuresRemaining > 0) {
+          initialFailuresRemaining -= 1;
+          throw integrityKeyDecryptionFailure();
+        }
+        if (stored === null) throw new Error("replacement missing");
+        return stored;
+      }),
+      quarantineUnreadable: vi.fn(
+        async (_key: string, expectedIdentity: string) => {
+          quarantineAttempts += 1;
+          if (stored !== "unreadable" || storedIdentity !== expectedIdentity) {
+            return false;
+          }
+          stored = null;
+          storedIdentity = null;
+          quarantines += 1;
+          return true;
+        },
+      ),
+      setIfAbsent: vi.fn(async (_key: string, value: string) => {
+        if (stored !== null) return false;
+        stored = value;
+        storedIdentity = "healthy-winner-identity";
+        insertions += 1;
+        return true;
+      }),
+    });
+
+    const [first, second] = await Promise.all([
+      resolveOptimizedPromptIntegrityKey(makeVault()),
+      resolveOptimizedPromptIntegrityKey(makeVault()),
+    ]);
+
+    expect(first).toBe(second);
+    expect(first).toBe(stored);
+    expect(quarantineAttempts).toBe(2);
+    expect(quarantines).toBe(1);
+    expect(insertions).toBe(1);
+  });
+
+  it("recovers a persisted key after master-key provenance changes and survives restart", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "vault-hmac-recovery-"));
+    const dataDir = join(workDir, "vault");
+    const auditPath = join(workDir, "audit", "vault.jsonl");
+    const replacementMasterKey = generateMasterKey();
+    let activeVault: PgliteVaultImpl | undefined;
+
+    try {
+      activeVault = new PgliteVaultImpl({
+        dataDir,
+        masterKey: inMemoryMasterKey(generateMasterKey()),
+        auditPath,
+      });
+      await activeVault.set(INTEGRITY_KEY, "superseded-internal-key", {
+        sensitive: true,
+        caller: "test:old-install",
+      });
+      await activeVault.close();
+
+      activeVault = new PgliteVaultImpl({
+        dataDir,
+        masterKey: inMemoryMasterKey(Buffer.from(replacementMasterKey)),
+        auditPath,
+      });
+      const recovered = await resolveOptimizedPromptIntegrityKey(activeVault);
+      expect(Buffer.from(recovered, "base64")).toHaveLength(32);
+      expect(recovered).not.toBe("superseded-internal-key");
+      await activeVault.close();
+
+      activeVault = new PgliteVaultImpl({
+        dataDir,
+        masterKey: inMemoryMasterKey(Buffer.from(replacementMasterKey)),
+        auditPath,
+      });
+      await expect(
+        resolveOptimizedPromptIntegrityKey(activeVault),
+      ).resolves.toBe(recovered);
+
+      await activeVault.close();
+      activeVault = undefined;
+
+      const db = await PGlite.create(dataDir);
+      const preserved = await db.query<{
+        original_key: string;
+        ciphertext: string;
+      }>(
+        `SELECT original_key, ciphertext
+           FROM vault_quarantined_entries WHERE original_key = $1`,
+        [INTEGRITY_KEY],
+      );
+      expect(preserved.rows).toHaveLength(1);
+      expect(preserved.rows[0]?.original_key).toBe(INTEGRITY_KEY);
+      expect(preserved.rows[0]?.ciphertext).not.toContain(
+        "superseded-internal-key",
+      );
+      await db.close();
+
+      const audit = await readFile(auditPath, "utf8");
+      expect(audit).toContain(
+        "runtime-boot:optimized-prompt-hmac-decryption-recovery",
+      );
+      expect(audit).not.toContain(recovered);
+    } finally {
+      await activeVault?.close();
+      await rm(workDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent/src/runtime/operations/vault-bridge.ts
+++ b/packages/agent/src/runtime/operations/vault-bridge.ts
@@ -1,24 +1,17 @@
 /**
- * Vault bridge — the only place runtime-ops talks to `@elizaos/vault`.
- *
- * Enforces:
- *   1. The naming convention for provider API key vault entries
- *      (`providers.<normalizedProvider>.api-key`).
- *   2. Sensitive flag on every write (so the secret is encrypted at rest).
- *   3. Caller tagging for the audit log so a reader of
- *      `<stateDir>/audit/vault.jsonl` can attribute every access to a
- *      runtime-ops phase.
- *
- * The bridge owns NO mutable state. Either pass an explicit
- * SecretsManager (tests), or call `defaultSecretsManager()` (production)
- * which constructs a fresh manager backed by the OS-keychain vault.
+ * Resolves runtime-operation credentials and the optimized-prompt integrity key
+ * through the vault. Sensitive writes retain caller attribution; integrity-key
+ * recovery quarantines only the exact unreadable row and verifies its replacement.
+ * Concurrent integrity-key resolutions share one in-flight result per vault.
  */
 
 import { randomBytes } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import {
   createManager,
   type SecretsManager,
   type Vault,
+  VaultDecryptionError,
   writeSensitiveValueVerified,
 } from "@elizaos/vault";
 import type { OperationErrorCode } from "./types.ts";
@@ -68,16 +61,118 @@ export function parseVaultRef(value: string): string | null {
 export type VaultLike = Pick<Vault, "get" | "has">;
 
 const OPTIMIZED_PROMPT_HMAC_VAULT_KEY = "system.optimized-prompt.hmac-key";
+const OPTIMIZED_PROMPT_HMAC_RECOVERY_CALLER =
+  "runtime-boot:optimized-prompt-hmac-decryption-recovery";
+const OPTIMIZED_PROMPT_HMAC_QUARANTINE_REASON =
+  "optimized-prompt integrity key failed authenticated decryption during runtime boot";
 
-/**
- * Return the persistent integrity key used to authenticate optimized prompts.
- * The vault is authoritative; a key is generated once and encrypted at rest.
- */
-export async function resolveOptimizedPromptIntegrityKey(
-  vault: Pick<Vault, "get" | "has" | "setIfAbsent">,
+type OptimizedPromptIntegrityVault = Pick<
+  Vault,
+  "get" | "has" | "quarantineUnreadable" | "setIfAbsent"
+>;
+
+// Keep the complete read/quarantine/create/read-winner sequence single-flight
+// for the process-wide shared Vault instance. The Vault transaction preserves
+// the unreadable row; `setIfAbsent()` then selects one active replacement if a
+// racing resolver has already filled the now-vacant key.
+const optimizedPromptIntegrityKeyResolutions = new WeakMap<
+  object,
+  Promise<string>
+>();
+
+function isOptimizedPromptIntegrityKeyDecryptionFailure(
+  error: unknown,
+): error is VaultDecryptionError & { readonly entryIdentity: string } {
+  return (
+    error instanceof VaultDecryptionError &&
+    error.key === OPTIMIZED_PROMPT_HMAC_VAULT_KEY &&
+    typeof error.entryIdentity === "string" &&
+    error.entryIdentity.length > 0
+  );
+}
+
+function assertOptimizedPromptIntegrityKey(value: string): string {
+  if (value.length === 0 || value.length % 4 !== 0) {
+    throw new ElizaError(
+      "[runtime-ops:vault] optimized-prompt integrity key has an invalid encoded shape",
+      { code: "OPTIMIZED_PROMPT_INTEGRITY_KEY_INVALID", severity: "fatal" },
+    );
+  }
+  const decoded = Buffer.from(value, "base64");
+  try {
+    if (decoded.length !== 32 || decoded.toString("base64") !== value) {
+      throw new ElizaError(
+        "[runtime-ops:vault] optimized-prompt integrity key must be canonical base64 for exactly 32 bytes",
+        { code: "OPTIMIZED_PROMPT_INTEGRITY_KEY_INVALID", severity: "fatal" },
+      );
+    }
+  } finally {
+    decoded.fill(0);
+  }
+  return value;
+}
+
+async function quarantineAndReplaceUnreadableOptimizedPromptIntegrityKey(
+  vault: OptimizedPromptIntegrityVault,
+  failure: VaultDecryptionError & { readonly entryIdentity: string },
+): Promise<string> {
+  await vault.quarantineUnreadable(
+    OPTIMIZED_PROMPT_HMAC_VAULT_KEY,
+    failure.entryIdentity,
+    OPTIMIZED_PROMPT_HMAC_QUARANTINE_REASON,
+    OPTIMIZED_PROMPT_HMAC_RECOVERY_CALLER,
+  );
+
+  const replacement = randomBytes(32).toString("base64");
+  const inserted = await vault.setIfAbsent(
+    OPTIMIZED_PROMPT_HMAC_VAULT_KEY,
+    replacement,
+    {
+      sensitive: true,
+      caller: OPTIMIZED_PROMPT_HMAC_RECOVERY_CALLER,
+    },
+  );
+  const winner = await vault.get(OPTIMIZED_PROMPT_HMAC_VAULT_KEY);
+  assertOptimizedPromptIntegrityKey(winner);
+  if (inserted && winner !== replacement) {
+    throw new ElizaError(
+      "[runtime-ops:vault] optimized-prompt integrity-key recovery failed exact read-back verification",
+      {
+        code: "OPTIMIZED_PROMPT_INTEGRITY_KEY_READBACK_MISMATCH",
+        severity: "fatal",
+      },
+    );
+  }
+  return winner;
+}
+
+async function readOptimizedPromptIntegrityKeyOrRecover(
+  vault: OptimizedPromptIntegrityVault,
+): Promise<string> {
+  try {
+    return assertOptimizedPromptIntegrityKey(
+      await vault.get(OPTIMIZED_PROMPT_HMAC_VAULT_KEY),
+    );
+  } catch (error) {
+    // error-policy:J4 exact typed recovery — quarantine is an auditable,
+    // visibly distinct recovery state for this regenerable internal key only.
+    // This is the sole recoverable decryption failure: the value is randomly
+    // generated internal HMAC material, never a user/provider credential. A
+    // replacement makes old optimized-prompt artifacts fail their HMAC check;
+    // the core loader rejects them and falls back to baseline prompts.
+    if (!isOptimizedPromptIntegrityKeyDecryptionFailure(error)) throw error;
+    return quarantineAndReplaceUnreadableOptimizedPromptIntegrityKey(
+      vault,
+      error,
+    );
+  }
+}
+
+async function resolveOptimizedPromptIntegrityKeyOnce(
+  vault: OptimizedPromptIntegrityVault,
 ): Promise<string> {
   if (await vault.has(OPTIMIZED_PROMPT_HMAC_VAULT_KEY)) {
-    return vault.get(OPTIMIZED_PROMPT_HMAC_VAULT_KEY);
+    return readOptimizedPromptIntegrityKeyOrRecover(vault);
   }
   const key = randomBytes(32).toString("base64");
   const inserted = await vault.setIfAbsent(
@@ -88,7 +183,33 @@ export async function resolveOptimizedPromptIntegrityKey(
       caller: "runtime-boot",
     },
   );
-  return inserted ? key : vault.get(OPTIMIZED_PROMPT_HMAC_VAULT_KEY);
+  return inserted
+    ? assertOptimizedPromptIntegrityKey(key)
+    : readOptimizedPromptIntegrityKeyOrRecover(vault);
+}
+
+/**
+ * Return the persistent integrity key used to authenticate optimized prompts.
+ * The vault is authoritative; a key is generated once and encrypted at rest.
+ * Only authenticated-decryption failure for this exact regenerable system key
+ * is repaired. The opaque unreadable row is quarantined before first-writer
+ * replacement. All user/provider keys and every other error stay fail-closed.
+ */
+export async function resolveOptimizedPromptIntegrityKey(
+  vault: OptimizedPromptIntegrityVault,
+): Promise<string> {
+  const existing = optimizedPromptIntegrityKeyResolutions.get(vault);
+  if (existing) return existing;
+
+  const resolution = resolveOptimizedPromptIntegrityKeyOnce(vault).finally(
+    () => {
+      if (optimizedPromptIntegrityKeyResolutions.get(vault) === resolution) {
+        optimizedPromptIntegrityKeyResolutions.delete(vault);
+      }
+    },
+  );
+  optimizedPromptIntegrityKeyResolutions.set(vault, resolution);
+  return resolution;
 }
 
 /**

--- a/packages/app/test/ui-smoke/vault-nondestructive-acceptance.spec.ts
+++ b/packages/app/test/ui-smoke/vault-nondestructive-acceptance.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Browser acceptance for metadata, reveal auto-hide, cancel, and reload without
+ * mutating a real Vault. The fixture exists only in the page's route layer; the
+ * test never sends DELETE and never records or prints the revealed value.
+ */
+
+import { expect, test } from "@playwright/test";
+import { openAppPath, seedAppStorage } from "./helpers";
+
+const FIXTURE_KEY = "E2E_NONDESTRUCTIVE_METADATA";
+
+test("keeps a disposable fixture redacted across reveal, cancel, and reload", async ({
+  page,
+}) => {
+  let deleteRequests = 0;
+
+  // Current web smoke boots through the staging-auth shell before handing the
+  // route to the local agent. Keep that shell deterministic and account-free;
+  // this test is about Vault behavior, not a real Cloud login.
+  await page.route("**/api/cloud/login", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        sessionId: "vault-nondestructive-login",
+        browserUrl: "https://example.invalid/auth",
+      }),
+    });
+  });
+  await page.route("**/api/cloud/login/status**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "authenticated",
+        token: "vault-nondestructive-test-token",
+        organizationId: "vault-nondestructive-org",
+        userId: "vault-nondestructive-user",
+      }),
+    });
+  });
+  await page.route("**/api/cloud/login/persist", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
+
+  await page.route("**/api/secrets/inventory", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        entries: [
+          {
+            key: FIXTURE_KEY,
+            category: "provider",
+            label: "Disposable browser QA",
+            backend: "in-house",
+            hasProfiles: false,
+            kind: "secret",
+          },
+        ],
+        securityFindings: [],
+      }),
+    });
+  });
+
+  await page.route(`**/api/secrets/inventory/${FIXTURE_KEY}`, async (route) => {
+    if (route.request().method() === "DELETE") {
+      deleteRequests += 1;
+      await route.fulfill({ status: 500 });
+      return;
+    }
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        value: "disposable-browser-qa-value",
+        source: "vault",
+      }),
+    });
+  });
+
+  await seedAppStorage(page, {
+    "app-workspace-chrome:chat-collapsed": "true",
+  });
+  await openAppPath(page, "/vault");
+  await expect(page.getByTestId("vault-tab-overview")).toBeVisible({
+    timeout: 20_000,
+  });
+  await page.getByTestId("vault-tab-secrets").click();
+
+  const row = page.getByTestId(`vault-entry-row-${FIXTURE_KEY}`);
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await expect(row).toContainText("Disposable browser QA");
+  await expect(
+    row.getByRole("button", { name: "Reveal Disposable browser QA" }),
+  ).toBeVisible();
+
+  await row
+    .getByRole("button", { name: "Reveal Disposable browser QA" })
+    .click();
+  await expect(
+    row.getByRole("button", { name: "Hide Disposable browser QA" }),
+  ).toBeVisible();
+  await expect(
+    row.getByRole("button", { name: "Reveal Disposable browser QA" }),
+  ).toBeVisible({ timeout: 12_000 });
+
+  await row
+    .getByRole("button", { name: "Delete Disposable browser QA" })
+    .click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await page
+    .getByRole("button", { name: "Cancel deleting Disposable browser QA" })
+    .click();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+  expect(deleteRequests).toBe(0);
+
+  await page.reload();
+  await expect(page.getByTestId("vault-tab-overview")).toBeVisible({
+    timeout: 20_000,
+  });
+  await page.getByTestId("vault-tab-secrets").click();
+  await expect(page.getByTestId(`vault-entry-row-${FIXTURE_KEY}`)).toBeVisible({
+    timeout: 10_000,
+  });
+  expect(deleteRequests).toBe(0);
+});

--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -35,6 +35,7 @@ import {
 	parseDisabledTasksEnv,
 	parseOptimizedPromptArtifact,
 } from "./optimized-prompt";
+import { resolveOptimizedPrompt } from "./optimized-prompt-resolver";
 
 const TEST_INTEGRITY_KEY = Buffer.alloc(32, 0x5a).toString("base64");
 
@@ -478,6 +479,28 @@ describe("OptimizedPromptService — HMAC integrity (SOC2 CC6.8)", () => {
 		);
 		await service.refresh();
 		expect(service.getPrompt("action_planner")).toBeNull();
+	});
+
+	it("rejects artifacts signed by a superseded recovery key and falls back to baseline", async () => {
+		const oldKey = Buffer.alloc(32, 0x31).toString("base64");
+		const replacementKey = Buffer.alloc(32, 0x32).toString("base64");
+		process.env.ELIZA_OPTIMIZED_PROMPT_HMAC_KEY = oldKey;
+		await service.setPrompt("action_planner", makeArtifact(1));
+
+		// Boot-time recovery replaces only the internal HMAC key. Existing
+		// artifacts are intentionally left untrusted: the new key must reject
+		// their old MAC and the runtime resolver must use its built-in baseline.
+		process.env.ELIZA_OPTIMIZED_PROMPT_HMAC_KEY = replacementKey;
+		await service.refresh();
+
+		expect(service.getPrompt("action_planner")).toBeNull();
+		expect(
+			resolveOptimizedPrompt(
+				service,
+				"action_planner",
+				"baseline after integrity-key recovery",
+			),
+		).toBe("baseline after integrity-key recovery");
 	});
 });
 

--- a/packages/ui/src/components/settings/SecretsManagerSection.load-error.test.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.load-error.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Deterministic mocked-client UI tests proving initial Vault failures remain
+ * actionable instead of spinning forever.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { client } from "../../api/client";
+import { VaultWorkspace } from "./SecretsManagerSection";
+
+vi.mock("../../api/client", () => ({
+  client: {
+    rawRequest: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("VaultWorkspace initial load recovery", () => {
+  it("surfaces the failed endpoint and offers a retry", async () => {
+    vi.mocked(client.rawRequest).mockImplementation(
+      async () => new Response(null, { status: 429 }),
+    );
+
+    render(
+      <VaultWorkspace
+        open
+        onOpenChange={() => undefined}
+        presentation="page"
+      />,
+    );
+
+    expect(screen.getByText("Loading…")).toBeTruthy();
+    const error = await screen.findByTestId("vault-modal-error");
+    expect(error.textContent).toContain("backends: HTTP 429");
+    expect(screen.queryByText("Loading…")).toBeNull();
+
+    vi.mocked(client.rawRequest).mockImplementation(async (path) => {
+      switch (path) {
+        case "/api/secrets/manager/backends":
+          return Response.json({
+            backends: [
+              {
+                id: "in-house",
+                label: "Local encrypted vault",
+                available: true,
+                signedIn: true,
+              },
+            ],
+          });
+        case "/api/secrets/manager/preferences":
+          return Response.json({ preferences: { enabled: ["in-house"] } });
+        case "/api/secrets/manager/install/methods":
+          return Response.json({ methods: {} });
+        case "/api/secrets/inventory":
+          return Response.json({ entries: [], securityFindings: [] });
+        case "/api/secrets/routing":
+          return Response.json({ config: { rules: [] } });
+        case "/api/secrets/manager/protection":
+        case "/api/agents":
+        case "/api/apps":
+          return new Response(null, { status: 404 });
+        default:
+          throw new Error(`Unexpected vault request: ${path}`);
+      }
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry loading the vault" }),
+    );
+    expect(
+      await screen.findByRole("tab", { name: "Overview Vault section" }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("vault-modal-error")).toBeNull();
+    expect(screen.queryByText("Loading…")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -625,9 +625,32 @@ export function VaultWorkspace({
         className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden pt-2"
       >
         {!isReady || !backends || !preferences || !installMethods ? (
-          <div className="flex items-center gap-2 px-1 py-6 text-sm text-muted">
-            <Loader2 className="size-4 animate-spin" aria-hidden /> Loading…
-          </div>
+          !loading && error ? (
+            <Banner
+              variant="error"
+              aria-live="polite"
+              data-testid="vault-modal-error"
+              action={
+                <SettingsActionButton
+                  agentId="vault-load-retry"
+                  agentLabel="Retry loading the vault"
+                  agentGroup="secrets"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0"
+                  onClick={() => void load()}
+                >
+                  Retry
+                </SettingsActionButton>
+              }
+            >
+              {error}
+            </Banner>
+          ) : (
+            <div className="flex items-center gap-2 px-1 py-6 text-sm text-muted">
+              <Loader2 className="size-4 animate-spin" aria-hidden /> Loading…
+            </div>
+          )
         ) : (
           <>
             {error && (

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -512,11 +512,11 @@ const EntryRow = memo(function EntryRow({
     const hideWhenBackgrounded = () => {
       if (document.visibilityState === "hidden") hideRevealedValue();
     };
-    const id = setTimeout(hideRevealedValue, 10_000);
+    const id = window.setTimeout(hideRevealedValue, 10_000);
     window.addEventListener("blur", hideRevealedValue);
     document.addEventListener("visibilitychange", hideWhenBackgrounded);
     return () => {
-      clearTimeout(id);
+      window.clearTimeout(id);
       window.removeEventListener("blur", hideRevealedValue);
       document.removeEventListener("visibilitychange", hideWhenBackgrounded);
     };

--- a/packages/vault/src/pglite-vault.ts
+++ b/packages/vault/src/pglite-vault.ts
@@ -6,7 +6,7 @@
  * locks before opening the database.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -89,6 +89,26 @@ interface EntryRow {
   ref_source: string | null;
   ref_path: string | null;
   last_modified: string | number;
+}
+
+/**
+ * Return a non-reversible identity for one exact persisted row. Recovery
+ * callers may retain this digest, but never the row's opaque ciphertext.
+ */
+function storedEntryIdentity(row: EntryRow): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        row.key,
+        row.kind,
+        row.value,
+        row.ciphertext,
+        row.ref_source,
+        row.ref_path,
+        String(row.last_modified),
+      ]),
+    )
+    .digest("base64url");
 }
 
 export interface PgliteVaultOptions {
@@ -318,53 +338,75 @@ export class PgliteVaultImpl implements Vault {
 
   async quarantineUnreadable(
     key: string,
+    expectedEntryIdentity: string,
     reason: string,
     caller?: string,
   ): Promise<boolean> {
     assertKey(key);
+    if (
+      typeof expectedEntryIdentity !== "string" ||
+      expectedEntryIdentity.trim().length === 0
+    ) {
+      throw new TypeError(
+        "vault.quarantineUnreadable: expected entry identity required",
+      );
+    }
     const normalizedReason = reason.trim();
     if (!normalizedReason) {
       throw new TypeError("vault.quarantineUnreadable: reason required");
     }
     const db = await this.db();
-    await db.exec("BEGIN");
-    try {
-      const row = (
-        await db.query<EntryRow>(
-          `SELECT key, kind, value, ciphertext, ref_source, ref_path, last_modified
-             FROM vault_entries WHERE key = $1 LIMIT 1`,
-          [key],
-        )
-      ).rows[0];
-      if (!row) {
-        await db.exec("COMMIT");
-        return false;
-      }
-      await db.query(
-        `INSERT INTO vault_quarantined_entries (
-           quarantine_id, original_key, kind, value, ciphertext, ref_source,
-           ref_path, last_modified, quarantined_at, reason
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-        [
-          randomUUID(),
-          row.key,
-          row.kind,
-          row.value,
-          row.ciphertext,
-          row.ref_source,
-          row.ref_path,
-          row.last_modified,
-          Date.now(),
-          truncateWellFormed(toWellFormedUnicode(normalizedReason), 500),
-        ],
-      );
-      await db.query(`DELETE FROM vault_entries WHERE key = $1`, [key]);
-      await db.exec("COMMIT");
-    } catch (error) {
-      // error-policy:J2 The original row must remain active unless its opaque
-      // bytes were preserved successfully; roll back and surface the failure.
-      await db.exec("ROLLBACK");
-      throw error;
+    const row = (
+      await db.query<EntryRow>(
+        `SELECT key, kind, value, ciphertext, ref_source, ref_path, last_modified
+           FROM vault_entries WHERE key = $1 LIMIT 1`,
+        [key],
+      )
+    ).rows[0];
+    if (!row) {
+      return false;
+    }
+    if (storedEntryIdentity(row) !== expectedEntryIdentity) {
+      return false;
+    }
+    // One SQL statement makes the move atomic without sharing a manual
+    // transaction with unrelated callers on this single PGlite connection.
+    const moved = await db.query<{ original_key: string }>(
+      `WITH exact_unreadable_row AS (
+         DELETE FROM vault_entries
+          WHERE key = $2
+            AND kind = $3
+            AND value IS NOT DISTINCT FROM $4
+            AND ciphertext IS NOT DISTINCT FROM $5
+            AND ref_source IS NOT DISTINCT FROM $6
+            AND ref_path IS NOT DISTINCT FROM $7
+            AND last_modified = $8
+        RETURNING key, kind, value, ciphertext, ref_source, ref_path,
+                  last_modified
+       )
+       INSERT INTO vault_quarantined_entries (
+         quarantine_id, original_key, kind, value, ciphertext, ref_source,
+         ref_path, last_modified, quarantined_at, reason
+       )
+       SELECT $1, key, kind, value, ciphertext, ref_source, ref_path,
+              last_modified, $9, $10
+         FROM exact_unreadable_row
+       RETURNING original_key`,
+      [
+        randomUUID(),
+        row.key,
+        row.kind,
+        row.value,
+        row.ciphertext,
+        row.ref_source,
+        row.ref_path,
+        row.last_modified,
+        Date.now(),
+        truncateWellFormed(toWellFormedUnicode(normalizedReason), 500),
+      ],
+    );
+    if (moved.rows.length === 0) {
+      return false;
     }
     await this.audit.record({
       action: "quarantine",
@@ -482,7 +524,7 @@ export class PgliteVaultImpl implements Vault {
   private async readValue(key: string): Promise<string> {
     const db = await this.db();
     const res = await db.query<EntryRow>(
-      `SELECT key, kind, value, ciphertext, ref_source, ref_path
+      `SELECT key, kind, value, ciphertext, ref_source, ref_path, last_modified
          FROM vault_entries WHERE key = $1 LIMIT 1`,
       [key],
     );
@@ -509,7 +551,10 @@ export class PgliteVaultImpl implements Vault {
         // error-policy:J2 context-adding rethrow — a decrypt failure means the
         // stored secret is unreadable; surface it, never return a fabricated
         // or empty value that a caller would treat as the real secret.
-        throw new VaultDecryptionError(key, { cause: err });
+        throw new VaultDecryptionError(key, {
+          cause: err,
+          entryIdentity: storedEntryIdentity(row),
+        });
       }
     }
     if (

--- a/packages/vault/src/vault-types.ts
+++ b/packages/vault/src/vault-types.ts
@@ -42,11 +42,15 @@ export interface Vault {
   /**
    * Move an unreadable entry out of the active keyspace without decrypting or
    * deleting its stored bytes. This is a narrow recovery primitive for callers
-   * that already observed {@link VaultDecryptionError}; the quarantined row is
-   * retained in the vault database for forensic/manual recovery.
+   * that already observed {@link VaultDecryptionError}. The opaque entry
+   * identity from that exact failure is a compare-and-swap guard: a stale
+   * caller cannot quarantine a replacement written by another process. The
+   * quarantined row is retained in the vault database for forensic/manual
+   * recovery.
    */
   quarantineUnreadable(
     key: string,
+    expectedEntryIdentity: string,
     reason: string,
     caller?: string,
   ): Promise<boolean>;
@@ -99,14 +103,18 @@ export class VaultMissError extends Error {
 
 /** A stored secret exists but cannot be authenticated with the active key. */
 export class VaultDecryptionError extends Error {
+  /** Opaque identity of the exact persisted row that failed authentication. */
+  readonly entryIdentity: string | undefined;
+
   constructor(
     readonly key: string,
-    options?: ErrorOptions,
+    options?: ErrorOptions & { readonly entryIdentity?: string },
   ) {
     super(
       `vault: failed to decrypt ${JSON.stringify(key)} (wrong master key or corrupt ciphertext)`,
       options,
     );
     this.name = "VaultDecryptionError";
+    this.entryIdentity = options?.entryIdentity;
   }
 }

--- a/packages/vault/test/pglite-vault.test.ts
+++ b/packages/vault/test/pglite-vault.test.ts
@@ -20,6 +20,29 @@ import {
 import { VaultDecryptionError, VaultMissError } from "../src/vault.js";
 import { runtimeVaultCaller } from "./vitest-assertion-shim.js";
 
+function hasEntryIdentity(
+  error: VaultDecryptionError,
+): error is VaultDecryptionError & { readonly entryIdentity: string } {
+  return (
+    typeof error.entryIdentity === "string" && error.entryIdentity.length > 0
+  );
+}
+
+async function captureDecryptionFailure(
+  vault: PgliteVaultImpl,
+  key: string,
+): Promise<VaultDecryptionError & { readonly entryIdentity: string }> {
+  try {
+    await vault.get(key);
+  } catch (error) {
+    if (error instanceof VaultDecryptionError && hasEntryIdentity(error)) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected vault decryption failure");
+}
+
 describe("PgliteVaultImpl", () => {
   let workDir: string;
   let vault: PgliteVaultImpl;
@@ -180,9 +203,14 @@ describe("PgliteVaultImpl", () => {
       masterKey: inMemoryMasterKey(wrongKey),
       auditPath: join(dir, "audit", "vault.jsonl"),
     });
-    await expect(v2.get("k")).rejects.toBeInstanceOf(VaultDecryptionError);
+    const failure = await captureDecryptionFailure(v2, "k");
     expect(
-      await v2.quarantineUnreadable("k", "test wrong-key recovery", "test"),
+      await v2.quarantineUnreadable(
+        "k",
+        failure.entryIdentity,
+        "test wrong-key recovery",
+        "test",
+      ),
     ).toBe(true);
     expect(await v2.has("k")).toBe(false);
     await v2.set("k", "replacement", { sensitive: true });
@@ -202,6 +230,100 @@ describe("PgliteVaultImpl", () => {
     expect(preserved.rows[0]?.ciphertext).not.toContain("secret-value");
     await db.close();
     await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not quarantine a healthy replacement for a stale failure", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vault-pglite-quarantine-cas-"));
+    const dataDir = join(dir, ".vault-pglite");
+    const auditPath = join(dir, "audit", "vault.jsonl");
+    const original = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(generateMasterKey()),
+      auditPath,
+    });
+    await original.set("k", "unreadable-original", { sensitive: true });
+    await original.close();
+
+    const recovery = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(generateMasterKey()),
+      auditPath,
+    });
+    const staleFailure = await captureDecryptionFailure(recovery, "k");
+    expect(
+      await recovery.quarantineUnreadable(
+        "k",
+        staleFailure.entryIdentity,
+        "first resolver",
+        "test:process-a",
+      ),
+    ).toBe(true);
+    await recovery.set("k", "healthy-replacement", { sensitive: true });
+
+    expect(
+      await recovery.quarantineUnreadable(
+        "k",
+        staleFailure.entryIdentity,
+        "stale second resolver",
+        "test:process-b",
+      ),
+    ).toBe(false);
+    expect(await recovery.get("k")).toBe("healthy-replacement");
+    await recovery.close();
+
+    const db = await PGlite.create(dataDir);
+    const quarantined = await db.query<{ n: string | number }>(
+      `SELECT COUNT(*) AS n FROM vault_quarantined_entries
+        WHERE original_key = $1`,
+      ["k"],
+    );
+    expect(Number(quarantined.rows[0]?.n)).toBe(1);
+    await db.close();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("keeps concurrent quarantine failures isolated and preserves both rows", async () => {
+    await vault.set("blocked", "retained-secret", { sensitive: true });
+    await vault.set("movable", "quarantined-secret", { sensitive: true });
+    await vault.close();
+    const dataDir = join(workDir, ".vault-pglite");
+    const setup = await PGlite.create(dataDir);
+    await setup.exec(
+      "ALTER TABLE vault_quarantined_entries ADD CONSTRAINT reject_blocked CHECK (original_key <> 'blocked')",
+    );
+    await setup.close();
+    vault = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(generateMasterKey()),
+      auditPath: join(workDir, "audit", "vault.jsonl"),
+    });
+    const blocked = await captureDecryptionFailure(vault, "blocked");
+    const movable = await captureDecryptionFailure(vault, "movable");
+    const outcomes = await Promise.allSettled([
+      vault.quarantineUnreadable(
+        "blocked",
+        blocked.entryIdentity,
+        "forced insert failure",
+        "test",
+      ),
+      vault.quarantineUnreadable(
+        "movable",
+        movable.entryIdentity,
+        "concurrent recovery",
+        "test",
+      ),
+    ]);
+    expect(outcomes[0].status).toBe("rejected");
+    expect(outcomes[1]).toEqual({ status: "fulfilled", value: true });
+    expect(await vault.has("blocked")).toBe(true);
+    expect(await vault.has("movable")).toBe(false);
+    await vault.close();
+    const inspection = await PGlite.create(dataDir);
+    const retained = await inspection.query<{ original_key: string }>(
+      "SELECT original_key FROM vault_quarantined_entries",
+    );
+    expect(retained.rows).toEqual([{ original_key: "movable" }]);
+    await inspection.close();
   });
 
   it("rejects corrupt persisted rows instead of returning null-ish values", async () => {


### PR DESCRIPTION
Vault recovery now preserves typed failures and quarantines only the exact invalid ciphertext that was inspected. The compare-and-swap check prevents a concurrent credential replacement from being removed. Runtime HMAC initialization is shared across concurrent callers, and vault load failures render an explicit error with retry rather than an empty inventory.

Validation for 96986c4c179aabe1d19bea6ef7e5c116ae16ec49:

- Full vault suite: 224 tests passed; agent vault bridge: 18 passed; core prompt checks: 37 passed; UI error/retry regression: 1 passed.
- Normal installation and full repository verification passed, including 376 tasks and repository audits.
- Full UI suite: all 13,517 tests passed, seven skipped; one React scheduler teardown exception occurred after the inline widget matrix. That unchanged suite passed an isolated rerun (12 tests, no unhandled error).
- App visual audit: 219 passed, with all four vault viewport captures inspected. Actual app desktop/mobile error-and-retry checks passed (2), plus redaction/reveal auto-hide/cancel/reload acceptance (1). Screenshots, MP4 walkthroughs and logs: https://github.com/elizaOS/eliza/pull/29838#issuecomment-5552760239
- Hosted checks will run after this update. No production secrets are read, written or revealed by the browser fixture.
