### PR TITLE
test(app): keep HMR fixture on local origin

### DIFF
--- a/packages/app/playwright.hmr.config.ts
+++ b/packages/app/playwright.hmr.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
       ELIZA_NAMESPACE: process.env.ELIZA_NAMESPACE || "eliza-hmr",
       // Keep the API process watcher off (HMR under test is Vite's, not the
       // API's), quiet logs, and skip optional camera deps in CI.
+      ELIZA_DEV_CLOUD_TARGET: "offline",
       ELIZA_DEV_NO_WATCH: "1",
       ELIZA_DEV_QUIET_LOGS: "1",
       ELIZA_NO_VISION_DEPS: "1",

--- a/packages/app/test/hmr/hmr-dependency-levels.spec.ts
+++ b/packages/app/test/hmr/hmr-dependency-levels.spec.ts
@@ -5,7 +5,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Frame, type Page, test } from "@playwright/test";
 
 // This spec lives at packages/app/test/hmr/, so the repo root is four levels up.
 const repoRoot = path.resolve(
@@ -155,6 +155,34 @@ async function waitForViteClient(page: Page): Promise<void> {
   await page.waitForTimeout(2000);
 }
 
+async function withinLocalOrigin<T>(
+  page: Page,
+  expectedOrigin: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const departure = (frame: Frame): Error | null => {
+    if (frame !== page.mainFrame() || frame.url() === "about:blank")
+      return null;
+    if (new URL(frame.url()).origin === expectedOrigin) return null;
+    return new Error(
+      `HMR fixture left its local origin ${expectedOrigin}: ${frame.url()}`,
+    );
+  };
+  const initialDeparture = departure(page.mainFrame());
+  if (initialDeparture) throw initialDeparture;
+  const { promise: departed, reject } = Promise.withResolvers<never>();
+  const inspect = (frame: Frame) => {
+    const error = departure(frame);
+    if (error) reject(error);
+  };
+  page.on("framenavigated", inspect);
+  try {
+    return await Promise.race([departed, operation()]);
+  } finally {
+    page.off("framenavigated", inspect);
+  }
+}
+
 // Most plugin GUI views are NOT reachable in the dev client's module graph from
 // the "/chat" route: they are served as standalone agent-built bundles loaded by
 // DynamicViewLoader (a separate module graph the app's Vite dev server never
@@ -184,11 +212,43 @@ function isNotInRootGraph(name: string): boolean {
 test.describe("HMR propagation across package dependency levels", () => {
   test.describe.configure({ mode: "serial" });
 
+  test("reports an unexpected main-frame origin immediately", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("HMR fixture requires a local baseURL");
+    const expectedOrigin = new URL(baseURL).origin;
+    await expect(
+      withinLocalOrigin(page, expectedOrigin, () =>
+        page.goto("data:text/html,hmr-origin-guard"),
+      ),
+    ).rejects.toThrow(
+      `HMR fixture left its local origin ${expectedOrigin}: data:text/html,hmr-origin-guard`,
+    );
+  });
+
+  test("rejects an already departed page before running an operation", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("HMR fixture requires a local baseURL");
+    await page.goto("data:text/html,already-departed");
+    let operated = false;
+    await expect(
+      withinLocalOrigin(page, new URL(baseURL).origin, async () => {
+        operated = true;
+      }),
+    ).rejects.toThrow("HMR fixture left its local origin");
+    expect(operated).toBe(false);
+  });
+
   for (const level of LEVELS) {
     const defineTest = isNotInRootGraph(level.name) ? test.skip : test;
     defineTest(
       `edit at ${level.name} reaches the running dev client`,
-      async ({ page }) => {
+      async ({ page, baseURL }) => {
+        if (!baseURL) throw new Error("HMR fixture requires a local baseURL");
+        const expectedOrigin = new URL(baseURL).origin;
         const abs = path.join(repoRoot, level.file);
         expect(
           fs.existsSync(abs),
@@ -201,8 +261,10 @@ test.describe("HMR propagation across package dependency levels", () => {
         // The hosted root can select the lightweight marketing entry, which
         // intentionally excludes main.tsx and @elizaos/ui. Use a full-app route
         // so every asserted dependency is present in the live client graph.
-        await page.goto("/chat");
-        await waitForViteClient(page);
+        await withinLocalOrigin(page, expectedOrigin, () => page.goto("/chat"));
+        await withinLocalOrigin(page, expectedOrigin, () =>
+          waitForViteClient(page),
+        );
 
         // Clear the execution marker before editing. The changed module sets it
         // again when Vite propagates either an HMR update or a full reload.
@@ -219,25 +281,27 @@ test.describe("HMR propagation across package dependency levels", () => {
             abs,
             `${original}\n(globalThis as typeof globalThis & { __elizaHmrProbe?: string }).__elizaHmrProbe = ${JSON.stringify(marker)};\n`,
           );
-          await expect
-            .poll(
-              () =>
-                page
-                  .evaluate(
-                    () =>
-                      (
-                        globalThis as typeof globalThis & {
-                          __elizaHmrProbe?: string;
-                        }
-                      ).__elizaHmrProbe,
-                  )
-                  .catch(() => undefined),
-              {
-                timeout: 30_000,
-                message: `Expected the edited module ${level.file} to execute in the browser. Captured Vite events: ${JSON.stringify(events)}`,
-              },
-            )
-            .toBe(marker);
+          await withinLocalOrigin(page, expectedOrigin, () =>
+            expect
+              .poll(
+                () =>
+                  page
+                    .evaluate(
+                      () =>
+                        (
+                          globalThis as typeof globalThis & {
+                            __elizaHmrProbe?: string;
+                          }
+                        ).__elizaHmrProbe,
+                    )
+                    .catch(() => undefined),
+                {
+                  timeout: 30_000,
+                  message: `Expected the edited module ${level.file} to execute in the browser. Captured Vite events: ${JSON.stringify(events)}`,
+                },
+              )
+              .toBe(marker),
+          );
         } finally {
           fs.writeFileSync(abs, original);
         }


### PR DESCRIPTION
The HMR test fixture stays on its local origin and rejects unexpected navigation immediately. The origin listener is attached for each operation and always removed afterward; already-departed pages fail before the operation runs. The current chat fixture and executable HMR probes remain intact.

Validation for `8f9d458e47b0360463495752418e209ee23671e5`:

- Rebased and installed dependencies normally.
- Full repository verification completed all 376 tasks and repository audits.
- The real browser HMR suite passed all 5 active tests, including edits at three dependency levels and both origin-boundary cases. Its existing 22 plugin-view cases remain skipped.
- Source edits made by the HMR harness were restored; the worktree is clean.
- Product screenshots, app redesign audit, backend model trajectories, and device evidence are N/A: this changes only the HMR test configuration and harness. Browser execution logs provide the relevant evidence.
- All required original PR hosted checks passed on the reviewed revision.
