### PR TITLE
test(inference): align exact-current fixture contracts

### DIFF
--- a/plugins/plugin-local-inference/__tests__/provider.test.ts
+++ b/plugins/plugin-local-inference/__tests__/provider.test.ts
@@ -73,11 +73,12 @@ describe("local inference provider", () => {
 		} as never);
 
 		expect(result).toBe(
-			"system:\nYou are Eliza.\n\nuser:\nhello. say hello back",
+			'system:\nYou are Eliza.\n\nuser:\n[{"type":"text","text":"hello. say hello back"}]',
 		);
 		expect(generate).toHaveBeenCalledWith(
 			expect.objectContaining({
-				prompt: "system:\nYou are Eliza.\n\nuser:\nhello. say hello back",
+				prompt:
+					'system:\nYou are Eliza.\n\nuser:\n[{"type":"text","text":"hello. say hello back"}]',
 				maxTokens: 32,
 				topP: 0.9,
 			}),

--- a/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.test.ts
@@ -20,7 +20,7 @@ import {
 } from "./voice-profiles-management-routes";
 
 const OWNER_ENTITY_ID = "entity-owner";
-const JSON_BODY = Symbol.for("eliza.http.cachedJsonBody");
+const CACHED_REQUEST_BODY = Symbol.for("eliza.http.cachedRequestBody");
 
 let rootDir: string;
 let store: VoiceProfileStore;
@@ -53,7 +53,11 @@ function request(
 	req.method = method;
 	req.url = pathname;
 	if (body !== undefined) {
-		(req as http.IncomingMessage & { [JSON_BODY]?: unknown })[JSON_BODY] = body;
+		(
+			req as http.IncomingMessage & {
+				[CACHED_REQUEST_BODY]?: Buffer;
+			}
+		)[CACHED_REQUEST_BODY] = Buffer.from(JSON.stringify(body), "utf8");
 	}
 	return req;
 }

--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
@@ -173,7 +173,7 @@ describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 			op: "generate",
 			prompt: "what is 2+2?",
 			maxTokens: 32,
-			stopSequences: ["<end_of_turn>", "<start_of_turn>"],
+			stopSequences: ["<end_of_turn>", "<start_of_turn>", "<endoftext>"],
 			bundleDir: "/data/x/eliza-1/bundle",
 		});
 	});
@@ -188,7 +188,7 @@ describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 		await loader.loadModel({ modelPath: "/models/flat-model.gguf" });
 		await loader.generate({ prompt: "hi" });
 		expect((seen as { bundleDir?: string } | null)?.bundleDir).toBe("");
-		expect(seen).not.toHaveProperty("maxTokens");
+		expect(seen).toHaveProperty("maxTokens", 256);
 		expect(
 			(seen as { stopSequences?: string[] } | null)?.stopSequences,
 		).toEqual(["<end_of_turn>", "<start_of_turn>", "<endoftext>"]);
@@ -385,7 +385,7 @@ describeLinuxOnly("BionicHostLoader streaming generate (#11913)", () => {
 			prompt: "what is 2+2?",
 			maxTokens: 20,
 			streamStep: 8,
-			stopSequences: ["<end_of_turn>"],
+			stopSequences: ["<end_of_turn>", "<start_of_turn>", "<endoftext>"],
 			bundleDir: "/data/x/eliza-1/bundle",
 		});
 	});
@@ -470,7 +470,7 @@ describeLinuxOnly("BionicHostLoader streaming generate (#11913)", () => {
 		await loader.loadModel({ modelPath: "/m/text/x.gguf" });
 		await expect(
 			loader.generate({ prompt: "x", onTextChunk: () => {} }),
-		).rejects.toMatchObject({ code: "MODEL_INCOMPLETE_OUTPUT" });
+		).rejects.toMatchObject({ code: "MODEL_OUTPUT_INCOMPLETE" });
 	});
 
 	it("throws when the host closes mid-stream before the done frame", async () => {

--- a/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
@@ -26,7 +26,6 @@ import {
   registerAospLlamaLoader,
   registerAospLoaderService,
   removeAospGeneratedStagingDir,
-  resolveAospCompletionBudget,
   shouldEvictChatForAvailMb,
   VOICE_COLOAD_KEEP_AVAIL_MB,
 } from "../src/aosp-local-inference-bootstrap";
@@ -773,46 +772,6 @@ describe("aospAsrAssetsPresent (TRANSCRIPTION registration gate)", () => {
     expect(
       withEnv({ ELIZA_STATE_DIR: root }, () => aospAsrAssetsPresent()),
     ).toBe(false);
-  });
-});
-
-describe("resolveAospCompletionBudget", () => {
-  it("uses every token remaining after the complete prompt when omitted", () => {
-    expect(
-      resolveAospCompletionBudget({
-        contextSize: 4096,
-        promptTokenCount: 1000,
-      }),
-    ).toBe(3096);
-  });
-
-  it("preserves an explicit supported request exactly", () => {
-    expect(
-      resolveAospCompletionBudget({
-        requestedMaxTokens: 2048,
-        contextSize: 4096,
-        promptTokenCount: 1000,
-      }),
-    ).toBe(2048);
-  });
-
-  it("rejects an oversized explicit request instead of clamping it", () => {
-    expect(() =>
-      resolveAospCompletionBudget({
-        requestedMaxTokens: 8192,
-        contextSize: 4096,
-        promptTokenCount: 1000,
-      }),
-    ).toThrow(/refusing to clamp/);
-  });
-
-  it("rejects a complete prompt that does not fit", () => {
-    expect(() =>
-      resolveAospCompletionBudget({
-        contextSize: 4096,
-        promptTokenCount: 4096,
-      }),
-    ).toThrow(/refusing to truncate/);
   });
 });
 

--- a/plugins/plugin-native-inference/__tests__/inference-priority-lane.test.ts
+++ b/plugins/plugin-native-inference/__tests__/inference-priority-lane.test.ts
@@ -6,7 +6,7 @@
  * This is the host-level lock-instrumented regression the issue asks for:
  * with a long background job mid-flight (and more background work queued), an
  * interactive turn dispatches ahead of queued background work; background jobs
- * must declare an output request supported by the device class; a background
+ * preserve their declared output request; a background
  * job that cannot get the lane within its bounded wait fails typed and
  * classifies as cloud-fallbackable.
  */
@@ -149,24 +149,23 @@ describe("generateOnPriorityLane — lock priority (#11914)", () => {
     }
   });
 
-  it("rejects an unsupported background output request before the loader", async () => {
+  it("preserves a large background output request through the loader", async () => {
     setInferencePriorityGate(new InferencePriorityGate());
     const lane = makeFakeLane();
     lane.setDecodeMs(1);
+    const prompt = "x".repeat(11_169);
 
     await withEnv({ ELIZA_INFERENCE_RAM_CLASS: "constrained" }, async () => {
-      await expect(
-        generateOnPriorityLane(lane.loader, lane.lifecycle, {
-          prompt: "x".repeat(11_169),
-          maxTokens: 8_192,
-          priority: "background",
-        }),
-      ).rejects.toMatchObject({
-        code: "INFERENCE_BACKGROUND_OUTPUT_BUDGET_EXCEEDED",
+      await generateOnPriorityLane(lane.loader, lane.lifecycle, {
+        prompt,
+        maxTokens: 8_192,
+        priority: "background",
       });
     });
 
-    expect(lane.calls).toHaveLength(0);
+    expect(lane.calls).toHaveLength(1);
+    expect(lane.calls[0]?.prompt).toBe(prompt);
+    expect(lane.calls[0]?.maxTokens).toBe(8_192);
   });
 
   it("never rewrites an interactive turn", async () => {

--- a/plugins/plugin-native-llama/src/generate-stream.test.ts
+++ b/plugins/plugin-native-llama/src/generate-stream.test.ts
@@ -138,7 +138,10 @@ describe("CapacitorLlamaAdapter.generateStream", () => {
       timings: { predicted_ms: 50 },
     });
 
-    await expect(generation).rejects.toThrow(/partial text/);
+    await expect(generation).rejects.toMatchObject({
+      code: "MODEL_OUTPUT_INCOMPLETE",
+      message: expect.stringContaining("no partial response was returned"),
+    });
   });
 
   it("ends with an error+done pair when the native call rejects", async () => {


### PR DESCRIPTION
Closes #29853

## Summary

Align six stale native/local inference test fixtures to the contracts already implemented on exact-current `develop`. This is test-only: no production source or manifest changes.

- assert `MODEL_OUTPUT_INCOMPLETE` and the no-partial-response message
- preserve the declared background inference request through the priority lane
- remove expectations for the nonexistent AOSP completion-budget helper
- assert the canonical JSON prompt emitted by `canonicalPromptForModelCall`
- align bionic host defaults, stop sequences, and incomplete-output code
- seed the voice fixture raw request-body cache so POST parsing cannot wait forever on the fake stream

## Contract proof

The provider calls `canonicalPromptForModelCall({ messages })` directly. Core canonical serialization JSON-encodes non-string message content, and the cache-locality regression requires complete JSON tool-call/result content. The JSON expectation therefore reflects the authoritative model-input contract rather than blessing an incidental renderer.

For the voice routes, core `readJsonBody()` first awaits `readRequestBodyBuffer()`. The fixture previously seeded only the parsed-JSON symbol; its fake `IncomingMessage` never emits `end`, which left three POST tests awaiting the stream for 120 seconds. Seeding `Symbol.for("eliza.http.cachedRequestBody")` with the encoded body closes that exact await. No timeout increase or skip was added.

## Exact-current gate

- base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`
- head: `4364f513758851e77d94ea86cd934cf7b9eb1ede`
- tree: `2b997d677d52f8d19808d359285f7070c6137968`

## Focused verification

- native llama: 5 passed
- native inference: 44 passed
- local inference: 16 passed; 17 Linux-only bionic cases skipped on macOS
- package typechecks: native llama, native inference, local inference passed
- configured Biome checks passed for all included target files; provider test is excluded by the package Biome include pattern
- `git diff --check` passed

Never merge without member approval and hosted checks.