### PR TITLE
fix(app-core): repair diagnostics collection and auth fixtures

### DIFF
--- a/packages/app-core/scripts/lib/live-stack-safe-diagnostics.test.ts
+++ b/packages/app-core/scripts/lib/live-stack-safe-diagnostics.test.ts
@@ -2,11 +2,12 @@
  * Exercises the live-stack child-output privacy boundary with hostile bytes.
  * The helper is deterministic and writes only schema-owned categories.
  */
-import { describe, expect, test } from "bun:test";
+
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
+import { describe, expect, test } from "vitest";
 import {
   attachSafeChildOutputObserver,
   createSafeChildOutputObserver,

--- a/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
@@ -13,6 +13,7 @@ import http from "node:http";
 import { Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { __resetRuntimeModeSnapshotCacheForTests } from "@elizaos/agent/api/runtime-mode/runtime-mode";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CompatRuntimeState } from "./compat-route-shared";
@@ -45,6 +46,7 @@ const targetHits: Array<{
 }> = [];
 
 beforeEach(async () => {
+  __resetRuntimeModeSnapshotCacheForTests();
   saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
   // Force a non-loopback peer + no token so the request is unauthenticated.
   delete process.env.ELIZA_API_TOKEN;
@@ -110,6 +112,7 @@ afterEach(async () => {
     else process.env[k] = saved[k];
   }
   vi.restoreAllMocks();
+  __resetRuntimeModeSnapshotCacheForTests();
 });
 
 function unauthReq(method: string, pathname: string): http.IncomingMessage {

--- a/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
+++ b/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
@@ -8,7 +8,10 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getRuntimeModeSnapshot } from "@elizaos/agent/api/runtime-mode/runtime-mode";
+import {
+  __resetRuntimeModeSnapshotCacheForTests,
+  getRuntimeModeSnapshot,
+} from "@elizaos/agent/api/runtime-mode/runtime-mode";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const ENV_KEYS = [
@@ -26,6 +29,7 @@ const writeConfig = (config: Record<string, unknown>) => {
 };
 
 beforeEach(() => {
+  __resetRuntimeModeSnapshotCacheForTests();
   savedEnv = Object.fromEntries(
     ENV_KEYS.map((key) => [key, process.env[key]]),
   ) as typeof savedEnv;
@@ -42,6 +46,7 @@ afterEach(() => {
     else process.env[key] = savedEnv[key];
   }
   fs.rmSync(stateDir, { recursive: true, force: true });
+  __resetRuntimeModeSnapshotCacheForTests();
 });
 
 describe("getRuntimeModeSnapshot (disk-backed)", () => {

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -31,6 +31,7 @@ const pluginAppManagerSrc = path.join(
 );
 const appWalletSrc = path.join(monorepoRoot, "plugins/plugin-wallet/src/ui");
 const pluginSqlSrc = path.join(monorepoRoot, "plugins/plugin-sql/src");
+const pluginTodosSrc = path.join(monorepoRoot, "plugins/plugin-todos/src");
 const pluginAgentSkillsSrc = path.join(
   monorepoRoot,
   "plugins/plugin-agent-skills/src",
@@ -158,6 +159,7 @@ export default defineConfig({
       "platforms/electrobun/**",
       "scripts/run-mobile-build-policy.test.mjs",
       "scripts/run-mobile-build-android-app-actions.test.mjs",
+      "scripts/build-experimental-exact-window-helper.test.mjs",
       "scripts/aosp/compile-libllama-fused.test.mjs",
       "scripts/mas-smoke.test.mjs",
       // The runner-based suites above are excluded from vitest because they use
@@ -238,6 +240,18 @@ export default defineConfig({
       {
         find: /^@elizaos\/agent\/(.+)$/,
         replacement: path.join(agentSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/plugin-todos\/plugin$/,
+        replacement: path.join(pluginTodosSrc, "plugin.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-todos\/service$/,
+        replacement: path.join(pluginTodosSrc, "service.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-todos\/db\/schema$/,
+        replacement: path.join(pluginTodosSrc, "db/schema.ts"),
       },
       {
         find: /^@elizaos\/auth$/,


### PR DESCRIPTION
# Relates to

Closes #29821.

- [x] Targets `develop` from exact `origin/develop` `f7a4fbec264f81ff87801fdde65b7533a3d94fd4` with zero conflicts.
- [ ] `bun install` / full `bun run verify` are not claimed; the exact scoped results and baseline-only typecheck blocker are recorded below.
- [x] A reviewer can verify the repaired collection and fixture lifetimes from the exact-head commands below.

# Sync with develop

- [x] Exact base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`.
- [x] Exact head: `b8519c9755db62709640667252fa1b846b0be4e9`.
- [x] Exact tree: `35e0491eba99f895b269e968569ae9a502e79358`.
- [x] Four intended app-core text paths only; no production runtime, native artifact, generated artifact, lockfile, or manifest change.

# Risks

Low. This changes only the app-core Vitest resolver/collection configuration and deterministic test fixtures. The production runtime-mode cache implementation is untouched.

# Background

## What does this PR do?

- Resolves the three exact `@elizaos/plugin-todos` source subpaths that Agent source imports when app-core Vitest collects route tests.
- Runs the safe-diagnostics suite under its actual collector (`vitest`) instead of importing `bun:test`.
- Keeps the `node:test`-only experimental exact-window helper out of Vitest while preserving its dedicated `node --test` coverage.
- Resets the existing test-only runtime-mode snapshot cache around the dispatch and disk fixtures so each new state directory and ephemeral target port is observed.
- Leaves the previously masked wrapped-server `503` assertions unchanged; after the collection and fixture repair they pass.

## What kind of change is this?

Bug fix (non-breaking test/config repair).

# Documentation changes needed?

N/A - no public API, product behavior, or operator workflow changes.

# Testing

## Where should a reviewer start?

`packages/app-core/vitest.config.ts`, then the two runtime-mode fixture files.

## Detailed testing steps

Exact head `b8519c9755db62709640667252fa1b846b0be4e9`:

1. Focused Vitest command covering diagnostics, route dispatch, unchanged wrapped-server assertions, and disk runtime mode: **4 files / 22 tests passed**.
2. `node --test scripts/build-experimental-exact-window-helper.test.mjs`: **4/4 passed**.
3. Vitest targeted at that same node-only helper with `--passWithNoTests`: **No test files found**, proving the runner boundary.
4. Exact Biome check on all four changed files: **passed, no fixes**.
5. `git diff --check`: **passed**.

# Evidence Gate

<!-- evidence-head:b8519c9755db62709640667252fa1b846b0be4e9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic test/config repair only.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed or live backend path changes; exact-head Vitest output is summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request flow changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent behavior, prompt, provider, action, or model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, generated-file, or device artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changes.

## Backend + frontend logs

N/A - test/config-only repair; no live service was started or mutated.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice, TTS, STT, or audio changes.

## Known gaps / failures

- `bun run --cwd packages/app-core typecheck` remains red on both this exact head and the exact `f7a4` parent with the same pre-existing unresolved workspace/private-package set (including plugin app-control, scheduling, Todos subpaths, and Capacitor bridge types). No changed path introduced a new diagnostic. Hosted installation/typecheck remains required.
- A duplicate `bun install` was not completed: the initial sparse checkout correctly rejected missing workspace directories, and after expanding the checkout the active disk-reserve boundary prohibited duplicating the lock-matched 5.3 GiB dependency tree. Focused validation used the existing lock-identical `f7a4` dependency installation.
- Full `bun run verify` was intentionally not run in this disk-bounded focused lane. Hosted checks remain required.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
