### PR TITLE
fix(orchestrator): block case-insensitive credential keys

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-runner.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-runner.test.ts
@@ -6,7 +6,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { runTaskWithSmithers } from "../../src/services/smithers-task-runner";
 import type {
   TaskApprovalResult,
@@ -26,6 +26,7 @@ interface FakeOpts {
   malformedApproval?: boolean; // requestApproval returns a result missing `approved`
   throwOnTurnCall?: number; // throw a fatal error on the Nth runTurn call
   hangOnTurnCall?: number;
+  onTurnStarted?: () => void;
   delayOnTurnMs?: number;
   abort?: { controller: AbortController; onCall: number }; // abort + hang on the Nth call
 }
@@ -57,6 +58,7 @@ class FakeExecutor implements TaskStepExecutor {
 
   async runTurn(ctx: TaskStepContext): Promise<TaskTurnResult> {
     this.turnCalls.push(ctx);
+    this.opts.onTurnStarted?.();
     const call = this.turnCalls.length;
     if (this.opts.throwOnTurnCall && call === this.opts.throwOnTurnCall) {
       throw new Error("fatal turn failure");
@@ -287,13 +289,31 @@ describe("runTaskWithSmithers (durable Smithers-backed coding task)", () => {
   it(
     "kills a stalled Smithers task at the configured execution deadline",
     async () => {
-      const fake = new FakeExecutor({ hangOnTurnCall: 1 });
-      await expect(
-        runTaskWithSmithers(spec(), fake, { timeoutMs: 5_000 }),
+      const controller = new AbortController();
+      onTestFinished(() => {
+        controller.abort();
+        vi.useRealTimers();
+      });
+      // Advance the parent deadline only after the real worker enters its
+      // stalled turn; subprocess startup speed is not the timeout contract.
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const started = Promise.withResolvers<void>();
+      const fake = new FakeExecutor({
+        hangOnTurnCall: 1,
+        onTurnStarted: () => started.resolve(),
+      });
+      const outcome = expect(
+        runTaskWithSmithers(spec(), fake, {
+          timeoutMs: 5_000,
+          signal: controller.signal,
+        }),
       ).rejects.toMatchObject({
         name: "ElizaError",
         code: "SMITHERS_TASK_TIMEOUT",
       });
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await outcome;
       expect(fake.turnCalls).toHaveLength(1);
       expect(fake.cancellationSignals).toBe(1);
     },

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -2792,7 +2792,7 @@ describe("SubAgentRouter — change-set narration (GAP C)", () => {
         response:
           "[tool output: Read index.html]\n<h1>placeholder</h1>\n[/tool output]\nSearch for the image element.",
       });
-      await new Promise((r) => setTimeout(r, 200));
+      await vi.waitFor(() => expect(handleMessage).toHaveBeenCalled());
 
       const posted = handleMessage.mock.calls[0]?.[1];
       const text = String(posted?.content?.text ?? "");

--- a/plugins/plugin-agent-orchestrator/src/__tests__/diff-review-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/diff-review-gate.test.ts
@@ -231,14 +231,66 @@ describe("reviewDiff — empty diff rejects", () => {
   });
 });
 
-describe("reviewDiff — secret matching parity with core", () => {
-  it("blocks a supported lowercase compound credential name", () => {
-    const diff = addedFileDiff("config.sh", [
-      "client_secret=hunter2hunter2hunter2",
-    ]);
-    const result = reviewDiff({ diff, changedFiles: ["config.sh"] });
+describe("reviewDiff — case-insensitive secret matching (parity with core)", () => {
+  it.each([
+    ["lowercase dotenv", "database_password=fixture-value-123456789"],
+    ["compound credential", "client_secret=fixture-value-123456789"],
+    ["mixed-case dotenv", "serviceCredential=fixture-value-123456789"],
+    [
+      "nested quoted key",
+      'const config = { auth: { "clientSecret": "fixture-value-123456789" } };',
+    ],
+    [
+      "encoded-looking literal",
+      `const config = { accessToken: "${Buffer.from("fixture-value-123456789").toString("base64")}" };`,
+    ],
+  ])("blocks a %s credential assignment", (_case, addedLine) => {
+    const diff = addedFileDiff("config.ts", [addedLine]);
+    const result = reviewDiff({ diff, changedFiles: ["config.ts"] });
     expect(result.passed).toBe(false);
     expect(result.blocking.some((f) => f.check === "secret")).toBe(true);
+  });
+
+  it.each([
+    "this.apiKey = config.apiKey;",
+    "this.maxTokens = config.maxTokens ?? 1024;",
+    "this.tokenCount = tokens.length;",
+    "password == null",
+    "secret => handler(secret)",
+    "password === expected",
+  ])("allows non-literal source expression %s", (line) => {
+    const result = reviewDiff({
+      diff: addedFileDiff("src/credentials.ts", [line]),
+      changedFiles: ["src/credentials.ts"],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.blocking).toEqual([]);
+  });
+
+  it("allows authoritative non-secret env names and key lookalikes", () => {
+    const diff = addedFileDiff("config.sh", [
+      "MAX_TOKENS=8192",
+      "TOKEN_COUNT=42",
+      "TOKEN_ID=build-123",
+      "KEYBOARD_SHORTCUT=cmd-k",
+      "TURNKEY_MODE=enabled",
+    ]);
+    const result = reviewDiff({ diff, changedFiles: ["config.sh"] });
+    expect(result.passed).toBe(true);
+    expect(result.blocking).toHaveLength(0);
+  });
+
+  it("allows credential-handling expressions that do not introduce literal material", () => {
+    const diff = addedFileDiff("credential-service.ts", [
+      "const credential = await resolveCredential();",
+      "return credential;",
+    ]);
+    const result = reviewDiff({
+      diff,
+      changedFiles: ["credential-service.ts"],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.blocking).toHaveLength(0);
   });
 
   it("blocks a lowercase `authorization: bearer …` header", () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/diff-review-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/diff-review-gate.test.ts
@@ -293,6 +293,45 @@ describe("reviewDiff — case-insensitive secret matching (parity with core)", (
     expect(result.blocking).toHaveLength(0);
   });
 
+  it.each([
+    [
+      "indented object field",
+      (value: string) => `  serviceCredential: "${value}",`,
+    ],
+    [
+      "tab-indented object field",
+      (value: string) => `\tclientSecret: '${value}',`,
+    ],
+    [
+      "indented member assignment",
+      (value: string) => `  this.apiKey = "${value}";`,
+    ],
+    [
+      "nested member assignment",
+      (value: string) => `  config.auth.accessToken = '${value}';`,
+    ],
+    [
+      "declared credential",
+      (value: string) => `const credential = "${value}";`,
+    ],
+    [
+      "exported dotenv scalar",
+      (value: string) => `export serviceCredential=${value}`,
+    ],
+  ])("blocks a %s and keeps the value out of findings", (_case, addedLine) => {
+    const value = ["fixture", "credential", "123456789"].join("-");
+    const result = reviewDiff({
+      diff: addedFileDiff("config.ts", [addedLine(value)]),
+      changedFiles: ["config.ts"],
+    });
+    expect(result.passed).toBe(false);
+    expect(result.blocking).toEqual([
+      expect.objectContaining({ check: "secret", severity: "block" }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain(value);
+    expect(summarizeDiffGate(result)).not.toContain(value);
+  });
+
   it("blocks a lowercase `authorization: bearer …` header", () => {
     const diff = addedFileDiff("req.ts", [
       'const h = "authorization: bearer abcdefghijklmnopqrstuvwxyz012345";',

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-service-diff-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-service-diff-gate.test.ts
@@ -263,6 +263,39 @@ describe("CodingWorkspaceService.createPR diff-review boundary", () => {
     );
   });
 
+  it("blocks mixed-case nested credential material without dispatching or disclosing it", async () => {
+    const secretValue = "fixture-value-that-must-not-escape-123456789";
+    capturePrGateChangeSet.mockResolvedValue({
+      changedFiles: ["src/config.ts"],
+      diff:
+        "+++ b/src/config.ts\n" +
+        `+export const config = { nested: { serviceCredential: "${secretValue}" } };\n`,
+      truncated: false,
+      filesTruncated: false,
+    });
+    const { service, finalize, events, reportError } = harness();
+
+    let caught: unknown;
+    try {
+      await service.createPR("workspace-1", options);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(DiffGateBlockedError);
+    expect(finalize).not.toHaveBeenCalled();
+    expect(reportError).not.toHaveBeenCalled();
+    expect(String(caught)).not.toContain(secretValue);
+    expect(JSON.stringify(events)).not.toContain(secretValue);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          diffGate: expect.objectContaining({ outcome: "blocked" }),
+        }),
+      }),
+    );
+  });
+
   it("reports unavailable capture and never finalizes", async () => {
     capturePrGateChangeSet.mockResolvedValue(undefined);
     const { service, finalize, reportError, events } = harness();

--- a/plugins/plugin-agent-orchestrator/src/services/diff-review-gate.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/diff-review-gate.ts
@@ -32,7 +32,11 @@
  */
 
 import { createHash } from "node:crypto";
-import { ElizaError, getDefaultRedactPatterns } from "@elizaos/core";
+import {
+  ElizaError,
+  getDefaultRedactPatterns,
+  isSensitiveKeyName,
+} from "@elizaos/core";
 
 /** Severity of a single gate finding. */
 export type DiffGateSeverity = "block" | "warn";
@@ -212,11 +216,10 @@ function compileSecretPatterns(): RegExp[] {
   for (const raw of getDefaultRedactPatterns()) {
     // Match core's redaction parser: a `/pattern/flags` literal keeps its flags
     // (forcing `g`), otherwise the raw source compiles with `gi`. We add `m` so
-    // matching works line-by-line. Compiling with only `gm` (dropping the `i`)
-    // would miss lowercase credential shapes core's source-of-truth catches
-    // (e.g. `database_password=…`, `authorization: Bearer …`), so we preserve
-    // case-insensitivity exactly as core does. A pattern that fails to compile
-    // is skipped rather than aborting the whole gate.
+    // matching works line-by-line. Literal patterns deliberately preserve their
+    // declared case semantics; name-based case-insensitive classification is
+    // handled separately through core's `isSensitiveKeyName` authority below.
+    // A pattern that fails to compile is skipped rather than aborting the gate.
     const compiledPattern = compileRedactPattern(raw);
     if (compiledPattern) compiled.push(compiledPattern);
   }
@@ -460,11 +463,47 @@ function compileExtraForbidden(patterns?: string[]): RegExp[] {
 }
 
 function matchesSecret(line: string): boolean {
+  if (hasSensitiveLiteralAssignment(line)) return true;
   for (const pattern of SECRET_PATTERNS) {
     pattern.lastIndex = 0;
     if (pattern.test(line)) return true;
   }
   return false;
+}
+
+/**
+ * Detect literal values assigned to credential-named keys using core's
+ * case-insensitive key-name authority. Value-shape patterns remain separate:
+ * this closes lowercase/mixed-case config assignments without treating benign
+ * metadata such as `MAX_TOKENS` or `TOKEN_COUNT` as credentials.
+ *
+ * Only literal-bearing forms are classified here. A normal source expression
+ * such as `const credential = await resolveCredential()` is not itself secret
+ * material and must remain reviewable; quoted literals and dotenv-style scalar
+ * assignments are the pre-write boundary's unambiguous secret-bearing forms.
+ */
+function hasSensitiveLiteralAssignment(line: string): boolean {
+  const quotedKey = /(["'])([^"'\\\r\n]+)\1\s*[:=]\s*(?=["'`])/g;
+  for (const match of line.matchAll(quotedKey)) {
+    if (isSensitiveKeyName(match[2])) return true;
+  }
+
+  const objectKey =
+    /(?:^|[,{]\s*)([A-Za-z_$][A-Za-z0-9_$.-]*)\s*[:=]\s*(?=["'`])/g;
+  for (const match of line.matchAll(objectKey)) {
+    if (isSensitiveKeyName(match[1])) return true;
+  }
+
+  const declaredKey =
+    /\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?=["'`])/g;
+  for (const match of line.matchAll(declaredKey)) {
+    if (isSensitiveKeyName(match[1])) return true;
+  }
+
+  const dotenvKey =
+    /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_-]*)\s*=(?![=>])\s*\S+/;
+  const dotenvMatch = dotenvKey.exec(line);
+  return dotenvMatch ? isSensitiveKeyName(dotenvMatch[1]) : false;
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/diff-review-gate.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/diff-review-gate.ts
@@ -488,8 +488,11 @@ function hasSensitiveLiteralAssignment(line: string): boolean {
     if (isSensitiveKeyName(match[2])) return true;
   }
 
+  // Indentation is valid for both object fields and member assignments. For
+  // members, classify the assigned property, not its path: `this.maxTokens`
+  // must retain core's metadata exemption while `this.apiKey` stays sensitive.
   const objectKey =
-    /(?:^|[,{]\s*)([A-Za-z_$][A-Za-z0-9_$.-]*)\s*[:=]\s*(?=["'`])/g;
+    /(?:^|[,{])\s*(?:[A-Za-z_$][A-Za-z0-9_$]*\.)*([A-Za-z_$][A-Za-z0-9_$-]*)\s*[:=]\s*(?=["'`])/g;
   for (const match of line.matchAll(objectKey)) {
     if (isSensitiveKeyName(match[1])) return true;
   }


### PR DESCRIPTION
Lowercase and mixed-case credential assignments could pass the workspace diff gate. This change uses core's case-insensitive sensitive-key classifier and blocks literal credentials before PR finalization, including indented object properties, while allowing member assignments and equality/arrow expressions such as `this.apiKey = config.apiKey` and `password === expected`.

The workspace regression checks rejection before finalization and verifies that the synthetic credential appears in neither the error nor emitted events. The broader package run also exposed two timing-dependent tests; those now wait for the actual narration result and advance the parent deadline after the real Smithers worker starts its stalled turn.

Validation:

- Scanner and workspace integration suites: 71 passed before the final indentation regression; the expanded scanner suite passed all 46 cases. Restoring the earlier indentation pattern fails four added cases. Restoring the original assignment regex fails all six added expression regressions.
- Package suite: 3,125 passed initially; the three failures were resolved by building the SQL dependency and repairing the two timing tests. Targeted reruns passed the SQL-backed conformance test and all 114 tests in the two repaired suites.
- `bun run verify` passed on commit `296f834ea3f7fb5bcfc9784627bb3755c24e6b19`: all 376 Turbo tasks and repository audits passed, including 11,398 test files with no focused tests or orphaned skips.
- Gitleaks passed after deriving the synthetic base64 fixture at runtime; no literal secret-like value remains in the commit history.
- Biome and diff whitespace checks passed.
- UI, device, and live-model evidence: N/A; this is a deterministic workspace diff boundary with no rendered UI or model dispatch.

Fixes #29847
