### PR TITLE
fix(inbox): normalize invalid timestamps

### DIFF
--- a/plugins/plugin-inbox/src/inbox/aggregate.timestamp-render.test.tsx
+++ b/plugins/plugin-inbox/src/inbox/aggregate.timestamp-render.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/ui/api", () => ({
+  client: {
+    getBaseUrl: () => "http://test.local",
+    sendChatMessage: vi.fn(),
+  },
+}));
+
+import {
+  type InboxFetchers,
+  InboxView,
+} from "../components/inbox/InboxView.tsx";
+import { toInboxMessage } from "./aggregate.ts";
+import type { InboundMessage } from "./types.ts";
+
+afterEach(cleanup);
+
+describe("Inbox timestamp render boundary", () => {
+  it("renders a malformed runtime timestamp through the safe fallback", async () => {
+    const message = toInboxMessage(
+      {
+        id: "runtime-malformed",
+        source: "discord",
+        senderName: "runtime sender",
+        channelName: "general",
+        channelType: "group",
+        text: "hello",
+        snippet: "hello",
+        timestamp: Number.NaN,
+      } satisfies InboundMessage,
+      "discord",
+      0,
+    );
+    const fetchers: InboxFetchers = {
+      fetchInbox: async () => ({
+        messages: [message],
+        channelCounts: {
+          gmail: { total: 0, unread: 0 },
+          x_dm: { total: 0, unread: 0 },
+          discord: { total: 1, unread: 1 },
+          telegram: { total: 0, unread: 0 },
+          imessage: { total: 0, unread: 0 },
+          whatsapp: { total: 0, unread: 0 },
+          sms: { total: 0, unread: 0 },
+        },
+        fetchedAt: "2026-06-17T12:00:00.000Z",
+        sources: [],
+      }),
+    };
+
+    render(<InboxView fetchers={fetchers} />);
+
+    await screen.findByText("runtime sender");
+    expect(document.body.textContent).not.toContain("NaN");
+  });
+});

--- a/plugins/plugin-inbox/src/inbox/aggregate.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.ts
@@ -59,8 +59,24 @@ const PHONE_BACKED_INBOX_CHANNELS = new Set<LifeOpsInboxChannel>([
 ]);
 const MISSED_REPLY_GAP_MS = 24 * 60 * 60 * 1000;
 const MISSED_MIN_PRIORITY = 50;
+const INVALID_INBOX_TIMESTAMP_ISO = new Date(0).toISOString();
 
 export type InboxChatType = "dm" | "group" | "channel";
+
+/**
+ * Project the inbound epoch-millisecond contract onto the wire ISO timestamp.
+ * Invalid producer data sorts at the documented epoch fallback instead of
+ * throwing while the inbox DTO is being built.
+ */
+function normalizeInboxReceivedAt(timestamp: unknown): string {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    return INVALID_INBOX_TIMESTAMP_ISO;
+  }
+  const date = new Date(timestamp);
+  return Number.isFinite(date.getTime())
+    ? date.toISOString()
+    : INVALID_INBOX_TIMESTAMP_ISO;
+}
 
 function stripSubjectReplyPrefixes(value: string): string {
   let cursor = 0;
@@ -162,7 +178,7 @@ export function toInboxMessage(
     channel === "gmail"
       ? (message.gmailMessageId ?? message.id)
       : (message.entityId ?? message.roomId ?? message.id);
-  const receivedAt = new Date(message.timestamp).toISOString();
+  const receivedAt = normalizeInboxReceivedAt(message.timestamp);
   const subject =
     channel === "gmail"
       ? message.channelName.startsWith("Email from ")

--- a/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
@@ -80,20 +80,51 @@ describe("x_dm unread derivation", () => {
     expect(inbox.messages[0]?.unread).toBe(true);
   });
 
-  it("maintains strict total ordering in thread groups when timestamp is NaN", () => {
-    const inbox = build([
-      xDm({
-        id: "dm-invalid",
-        threadId: "conv-mixed",
-        timestamp: Number.NaN,
-      }),
-      xDm({
-        id: "dm-valid",
-        threadId: "conv-mixed",
-        timestamp: NOW,
-      }),
-    ]);
-    expect(inbox.threadGroups).toHaveLength(1);
-    expect(inbox.threadGroups?.[0]?.latestMessage.id).toBe("x_dm:dm-valid");
+  describe("timestamp normalization", () => {
+    it.each([
+      ["NaN", Number.NaN],
+      ["positive infinity", Number.POSITIVE_INFINITY],
+      ["negative infinity", Number.NEGATIVE_INFINITY],
+      ["finite but outside the Date range", Number.MAX_VALUE],
+      ["missing", undefined],
+      ["invalid string", "not-a-timestamp"],
+      ["invalid object", {}],
+    ])("maps %s to the safe epoch fallback", (_label, timestamp) => {
+      const inbox = build([
+        xDm({
+          id: "dm-invalid",
+          timestamp: timestamp as number,
+        }),
+      ]);
+
+      expect(inbox.messages[0]?.receivedAt).toBe("1970-01-01T00:00:00.000Z");
+    });
+
+    it.each([
+      [0, "1970-01-01T00:00:00.000Z"],
+      [NOW, "2026-08-18T12:00:00.000Z"],
+      [Date.parse("2026-08-18T07:00:00.000-05:00"), "2026-08-18T12:00:00.000Z"],
+    ])("preserves valid epoch %s as %s", (timestamp, receivedAt) => {
+      const inbox = build([xDm({ timestamp })]);
+
+      expect(inbox.messages[0]?.receivedAt).toBe(receivedAt);
+    });
+
+    it("keeps an invalid timestamp behind a valid message in its thread", () => {
+      const inbox = build([
+        xDm({
+          id: "dm-invalid",
+          threadId: "conv-mixed",
+          timestamp: Number.NaN,
+        }),
+        xDm({
+          id: "dm-valid",
+          threadId: "conv-mixed",
+          timestamp: NOW,
+        }),
+      ]);
+      expect(inbox.threadGroups).toHaveLength(1);
+      expect(inbox.threadGroups?.[0]?.latestMessage.id).toBe("x_dm:dm-valid");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- normalize Inbox epoch-millisecond timestamps before ISO serialization
- map missing, non-numeric, non-finite, and out-of-Date-range producer values to the established epoch-zero fallback
- preserve valid instant/timezone projection and ordering semantics
- add adversarial aggregate table coverage plus a rendered boundary regression

Fixes #29848.

## Exact provenance

- base: `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`
- head: `a0da6456b035c48bc474d0d68d1747abda852dd8`
- tree: `80078e55456507aa3cda7c58058298154fd42b45`

## Verification

- focused aggregate + rendered boundary: 34 passed
- `bun run --cwd plugins/plugin-inbox typecheck`: passed
- `bun run --cwd plugins/plugin-inbox lint:check`: passed
- `git diff --check`: passed
- full plugin package: 248 passed, 2 skipped, 1 pre-existing failure
  - `src/inbox/reflection.test.ts` fails identically on untouched exact `f7a4fbec` (`reasoning.includes("😀")` expected false, received true)

## Error policy

Malformed producer data is validated at the Inbox DTO boundary and translated to the deterministic documented fallback. No exception swallowing, logging-only failure, or fabricated current time is introduced.

## Scope

Three plugin-inbox files only: one production boundary and two focused regression files. No UI production code, source-stack runtime, staging, production, paid resource, or device mutation.