### PR TITLE
fix(lifeops): route the cross-channel fixture into the channel it queries

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.test.ts
@@ -18,7 +18,7 @@ function memoryAt(index: number): Memory {
       `00000000-0000-4000-8001-${String(index).padStart(12, "0")}` as UUID,
     agentId: "00000000-0000-0000-0000-000000000002" as UUID,
     roomId: ROOM_ID,
-    content: { text: `complete memory ${index}`, source: "discord" },
+    content: { text: `complete memory ${index}` },
     createdAt: index,
   };
 }
@@ -41,7 +41,11 @@ describe("cross-channel search context integrity", () => {
       searchMemories,
       getRoom: vi.fn(
         async () =>
-          ({ id: ROOM_ID, name: "complete room", source: "discord" }) as Room,
+          // No platform source: classifyMemoryChannel falls through to "memory",
+          // matching the channel this query enables. The prior "discord" source
+          // routed every memory into a disabled channel, so the suite asserted
+          // against an empty result set and the pagination contract never ran.
+          ({ id: ROOM_ID, name: "complete room" }) as Room,
       ),
     } as unknown as IAgentRuntime;
 


### PR DESCRIPTION
# Relates to

Closes #29730 — the cross-channel-search suite added by #28112 has never passed, keeping the canonical Tests (client) lane red on develop.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from current `origin/develop`; zero conflicts. Exact head `1d1678e85445583ba89a450181c76636d889cb5b`.

# Risks

Minimal — a two-line fixture change in one test file. No production source is touched; the change makes the suite exercise the code path it always claimed to.

# Background

## What does this PR do?

The fixture room carried `source: "discord"` while the query enabled `channels: ["memory"]`. `runCrossChannelSearch` classifies each memory by its room's platform source (`cross-channel-search.ts:896-901` → `classifyMemoryChannel`), and `"discord"` maps to the `discord` channel — which the query disables. Every one of the 501 fixture memories was therefore dropped, the search returned `[]`, and the suite's `toHaveLength(501)` failed on every run since #28112 introduced it. Because the suite was red-by-fixture, the pagination assertions it exists for (two `searchMemories` calls at limit 500, offsets 0 and 500) never executed at all.

The room now carries no platform source, which `classifyMemoryChannel` routes to its `default: return "memory"` branch — the channel the query enables. Nothing else changes: the 501-memory count and both pagination assertions are untouched and now actually run.

## What kind of change is this?

Bug fix (repairs a permanently red suite and makes its regression guard real).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

Run the file on `origin/develop` (red since birth), then here.

## Detailed testing steps

1. Check out exact head `1d1678e85445583ba89a450181c76636d889cb5b`.
2. From `plugins/plugin-personal-assistant`: `bun x vitest run src/lifeops/cross-channel-search.test.ts` → **1/1**. On `origin/develop` the same command fails: `expected [] to have a length of 501 but got +0`.
3. **The guard is now real:** capping the SUT's internal pagination loop to a single page (`for (let offset = 0; offset < MEMORY_SEARCH_PAGE_SIZE; …)`) fails the suite — before this fix that mutation passed unnoticed, because the suite compared empty against empty. Restored after.
4. Pinned Biome on the file: exit 0, captured directly.

<!-- evidence-head:1d1678e85445583ba89a450181c76636d889cb5b -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — test-fixture behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — test-fixture behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the red-on-develop / green-here comparison below is the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>develop (red since #28112) vs head, plus the guard-liveness mutation</summary>

```
# origin/develop — plugins/plugin-personal-assistant
$ bun x vitest run src/lifeops/cross-channel-search.test.ts
AssertionError: expected [] to have a length of 501 but got +0
      Tests  1 failed (1)

# head 1d1678e854
      Tests  1 passed (1)

# guard liveness: pagination loop capped at one page (SUT mutation, restored)
      Tests  1 failed (1)     # the suite now catches the silent-cap regression
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic channel classification, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Root cause and static gates at exact head</summary>

```
Root cause (all on origin/develop):
  cross-channel-search.test.ts:44  room record carried source: "discord"
  cross-channel-search.test.ts:50  query: channels: ["memory"]
  cross-channel-search.ts:896-901  platformSource -> classifyMemoryChannel -> isChannelEnabled -> continue
  cross-channel-search.ts:240      case "discord": return "discord"   (disabled by the query)
  cross-channel-search.ts:261      default: return "memory"           (the channel the room record now hits)

$ node_modules/.bin/biome check \
    plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.test.ts
(exit 0, captured directly)

$ git diff --stat origin/develop..HEAD
 .../src/lifeops/cross-channel-search.test.ts | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: hand-wired review worktree (packages linked from the main checkout) cannot support the full gate honestly; the focused red/green comparison, the guard-liveness mutation, and Biome above stand in.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
