### PR TITLE
test(app-core): await update notice condition

### DIFF
--- a/packages/app-core/src/services/__tests__/update-notifier.test.ts
+++ b/packages/app-core/src/services/__tests__/update-notifier.test.ts
@@ -1,3 +1,4 @@
+/** Tests startup update notices with deterministic provider and terminal fixtures. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({

--- a/packages/app-core/src/services/__tests__/update-notifier.test.ts
+++ b/packages/app-core/src/services/__tests__/update-notifier.test.ts
@@ -72,10 +72,11 @@ describe("scheduleUpdateNotification", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
     mod.scheduleUpdateNotification();
-    await new Promise((r) => setTimeout(r, 10));
-    expect(write).toHaveBeenCalledWith(
-      expect.stringContaining("Update available"),
-    );
+    await vi.waitFor(() => {
+      expect(write).toHaveBeenCalledWith(
+        expect.stringContaining("Update available"),
+      );
+    });
     write.mockRestore();
   });
 });


### PR DESCRIPTION
The update-notifier test waited a fixed 10 ms before checking stderr, which can fail when CI is busy. It now waits for the actual update notice. Production behavior is unchanged; the existing CI environment isolation remains in the base.

Validation for `7587b9e8bfb3f3ad32020813150e4dda646c97c9`:
- Focused notifier tests: 3 passed; Biome passed.
- Full app-core run: 4,459 passed, 25 skipped, two unrelated wallet timeouts. Both affected suites passed on rerun (44 tests).
- Remaining app-core script suites passed.

- Root `bun run verify` passed: all 376 Turbo tasks and repository audits, including the 11,372-file focused/skip audit.
- Current develop `7bb7938d1e397378bab5b4c2cf23919b52e65e97` has no overlapping changes in the notifier source or test.

Hosted Source static smoke, Billing payment replay E2E, Subscription authority PostgreSQL, Windows security, and All Tests Passed checks all passed on this revision: [run 33949254792](https://github.com/elizaOS/eliza/actions/runs/33949254792). UI captures and live integrations are N/A: this changes only the existing test's synchronization and file header.
