### PR TITLE
fix(ui): unblock SSH inspection after retarget

### DIFF
--- a/packages/ui/src/components/settings/DevicesRuntimesSection.test.tsx
+++ b/packages/ui/src/components/settings/DevicesRuntimesSection.test.tsx
@@ -1,6 +1,6 @@
 /** Interaction and accessibility coverage for the Devices & Runtimes surface. */
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -224,6 +224,7 @@ describe("DevicesRuntimesSection", () => {
   it("requires inspection before connect and blocks a changed host key", async () => {
     const user = userEvent.setup();
     const onInspectSsh = vi.fn();
+    const onConnectSsh = vi.fn();
     const changed: SshHostInspection = {
       target: "eliza@vps.example",
       host: "vps.example",
@@ -236,7 +237,7 @@ describe("DevicesRuntimesSection", () => {
       changed: true,
     };
     const view = render(
-      <DevicesRuntimesSection {...props({ onInspectSsh })} />,
+      <DevicesRuntimesSection {...props({ onInspectSsh, onConnectSsh })} />,
     );
     await user.click(screen.getByText("Advanced SSH"));
     await user.type(screen.getByLabelText("Name"), "Production VPS");
@@ -250,17 +251,63 @@ describe("DevicesRuntimesSection", () => {
     });
 
     view.rerender(
-      <DevicesRuntimesSection {...props({ sshInspection: changed })} />,
+      <DevicesRuntimesSection
+        {...props({ sshInspection: changed, onInspectSsh, onConnectSsh })}
+      />,
     );
     expect(
       screen.getByText("Host key changed: connection blocked"),
     ).toBeTruthy();
     expect(
+      screen.getByText(
+        /Remove the saved runtime from Devices & Runtimes, then re-enroll it/,
+      ),
+    ).toBeTruthy();
+    expect(
       (
         screen.getByRole("button", {
-          name: "Fingerprint verified, connect",
+          name: "Host key changed",
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(true);
+
+    const targetInput = screen.getByLabelText("SSH target");
+    const form = targetInput.closest("form");
+    if (!form) throw new Error("SSH target is not inside its submission form");
+    fireEvent.submit(form);
+    expect(onConnectSsh).not.toHaveBeenCalled();
+    await user.clear(targetInput);
+    await user.type(targetInput, "eliza@replacement.example");
+    const inspectReplacement = screen.getByRole("button", {
+      name: "Inspect fingerprint",
+    }) as HTMLButtonElement;
+    expect(inspectReplacement.disabled).toBe(false);
+    await user.click(inspectReplacement);
+    expect(onInspectSsh).toHaveBeenLastCalledWith({
+      target: "eliza@replacement.example",
+      sshPort: 22,
+    });
+    expect(onConnectSsh).not.toHaveBeenCalled();
+
+    await user.clear(screen.getByLabelText("SSH target"));
+    await user.type(screen.getByLabelText("SSH target"), "eliza@vps.example");
+    const portInput = screen.getByLabelText("SSH port");
+    await user.clear(portInput);
+    await user.type(portInput, "2222");
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Inspect fingerprint",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    await user.click(
+      screen.getByRole("button", { name: "Inspect fingerprint" }),
+    );
+    expect(onInspectSsh).toHaveBeenLastCalledWith({
+      target: "eliza@vps.example",
+      sshPort: 2222,
+    });
+    expect(onConnectSsh).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/settings/DevicesRuntimesSection.tsx
+++ b/packages/ui/src/components/settings/DevicesRuntimesSection.tsx
@@ -697,10 +697,12 @@ function AdvancedSsh({
         className="grid gap-4 sm:grid-cols-2"
         onSubmit={(event) => {
           event.preventDefault();
+          if (busy || !valid) return;
           if (!inspection || !inspectedTarget) {
             void onInspect({ target: target.trim(), sshPort: Number(sshPort) });
             return;
           }
+          if (inspection.changed) return;
           void (async () => {
             await onConnect({
               label: label.trim(),
@@ -835,8 +837,9 @@ function AdvancedSsh({
             </code>
             {inspection.changed ? (
               <p className="mt-2 text-xs text-destructive">
-                The saved key does not match this server. Confirm the change
-                outside Eliza before replacing trust.
+                The saved key does not match this server. Remove the saved
+                runtime from Devices &amp; Runtimes, then re-enroll it only
+                after confirming the new fingerprint outside Eliza.
               </p>
             ) : null}
           </div>
@@ -845,7 +848,9 @@ function AdvancedSsh({
           <Button
             type="submit"
             size="touch"
-            disabled={busy || !valid || Boolean(inspection?.changed)}
+            disabled={
+              busy || !valid || Boolean(inspectedTarget && inspection?.changed)
+            }
           >
             {busy ? (
               <LoaderCircle
@@ -856,7 +861,9 @@ function AdvancedSsh({
               <ShieldCheck className="mr-1.5 size-4" aria-hidden />
             )}
             {inspection && inspectedTarget
-              ? "Fingerprint verified, connect"
+              ? inspection.changed
+                ? "Host key changed"
+                : "Fingerprint verified, connect"
               : "Inspect fingerprint"}
           </Button>
           <span className="text-xs text-muted">


### PR DESCRIPTION
Changing the SSH destination now clears the previous fingerprint inspection so the user can inspect the new target. A changed host key displays a disabled “Host key changed” action, and the submit handler independently rejects stale, invalid, or busy submissions. This closes the direct form-submit bypass as well as the misleading button state.

Validation for `3e6bce0f3a731ef57a553388928bf373a0d5c0f2`:
- Six focused component tests passed; both changed files passed Biome.
- Full repository verification and formatting passed in [CI](https://github.com/elizaOS/eliza/actions/runs/33950298259).
- App audit: 219 browser checks passed; 216 findings had zero broken or needs-work verdicts.
- The actual component passed 12 focused browser assertions. All 12 before/after desktop and mobile captures were visually inspected, including blocked, rest, and hover states; four MP4 walkthroughs were captured. The harness supplies inspection/connect callbacks, so this is component evidence, not a live SSH transport claim.

All required PR checks passed on this exact head. The hosted UI suite passed 13,500 executed tests with no failures or errors (7 skipped), superseding local timeout failures under load. [Reviewed screenshots, MP4 walkthroughs, audit records and interaction logs](https://github.com/elizaOS/eliza/pull/29872#issuecomment-5550336711) are attached inline.

The additional broad manual smoke shard reported a browser-history response-disposal failure outside these two changed files; that scenario passed on recent develop. The scoped app audit and component browser scenarios passed. No full broad-manual-CI success, live SSH transport, or production deployment is claimed.
