### PR TITLE
test(core): make plugin manager path tests platform aware

### DIFF
--- a/packages/core/src/features/plugin-manager/utils/paths.test.ts
+++ b/packages/core/src/features/plugin-manager/utils/paths.test.ts
@@ -1,9 +1,17 @@
+import { homedir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveConfigPath } from "./paths.ts";
 
 describe("resolveConfigPath", () => {
-	const stateDir = "/home/test/.local/state/eliza";
+	const stateDir = path.join(
+		path.parse(process.cwd()).root,
+		"home",
+		"test",
+		".local",
+		"state",
+		"eliza",
+	);
 
 	it("defaults to eliza.json under the state dir", () => {
 		expect(resolveConfigPath({}, stateDir)).toBe(
@@ -21,12 +29,16 @@ describe("resolveConfigPath", () => {
 	});
 
 	it("resolves an absolute override verbatim", () => {
+		const absoluteConfigPath = path.join(
+			path.parse(process.cwd()).root,
+			"etc",
+			"eliza",
+			"custom.json",
+		);
+
 		expect(
-			resolveConfigPath(
-				{ ELIZA_CONFIG_PATH: "/etc/eliza/custom.json" },
-				stateDir,
-			),
-		).toBe("/etc/eliza/custom.json");
+			resolveConfigPath({ ELIZA_CONFIG_PATH: absoluteConfigPath }, stateDir),
+		).toBe(absoluteConfigPath);
 	});
 
 	it("expands a tilde override to the home directory", () => {
@@ -35,7 +47,7 @@ describe("resolveConfigPath", () => {
 			stateDir,
 		);
 		expect(path.isAbsolute(out)).toBe(true);
-		expect(out).toBe(path.join(process.env.HOME ?? "/root", "eliza.json"));
+		expect(out).toBe(path.join(homedir(), "eliza.json"));
 	});
 
 	it("resolves a relative override against cwd", () => {


### PR DESCRIPTION
## Summary
- make plugin-manager config path tests use platform-native absolute path fixtures
- assert tilde expansion against os.homedir(), matching resolveUserPath behavior on Windows/macOS/Linux

## CI context
Latest develop head inspected: f7a4fbec264f81ff87801fdde65b7533a3d94fd4.
Develop Full run 33222441886 is red. One platform-smoke failure is packages/core/src/features/plugin-manager/utils/paths.test.ts expecting POSIX paths on Windows.

## Verification
- bun install --dry-run --frozen-lockfile --ignore-scripts --no-progress
- bun test packages/core/src/features/plugin-manager/utils/paths.test.ts
- bunx @biomejs/biome check packages/core/src/features/plugin-manager/utils/paths.test.ts
- git diff --check

Note: full build/start were skipped because the local volume had roughly 5.6 GiB free after creating the clean worktree; a start probe using a symlinked dependency tree failed before runtime boot due non-portable node_modules resolution.