### PR TITLE
test(agent): align model config contracts

### DIFF
--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -183,8 +183,8 @@ describe("POST /api/models/config validation", () => {
   it("rejects effort on backends without an effort seam", async () => {
     const { ctx, json } = makeHarness("POST", {
       target: "coding",
-      backend: "opencode",
-      model: "cerebras/gpt-oss-120b",
+      backend: "eliza-code",
+      model: "eliza-local",
       effort: "high",
     });
     await handleModelConfigRoutes(ctx as never);
@@ -463,20 +463,18 @@ describe("POST /api/models/config coding writes", () => {
     expect(body).toMatchObject({ applied: true, restart: false });
   });
 
-  it("accepts a free-form opencode model and a defaultBackend switch", async () => {
-    const { ctx, config } = makeHarness("POST", {
+  it("rejects the retired opencode backend without writing", async () => {
+    const { ctx, json, saveElizaConfig } = makeHarness("POST", {
       target: "coding",
       backend: "opencode",
       model: "cerebras/gpt-oss-120b",
       defaultBackend: "opencode",
     });
     await handleModelConfigRoutes(ctx as never);
-    const env = (config as Record<string, unknown>).env as Record<
-      string,
-      unknown
-    >;
-    expect(env.ELIZA_OPENCODE_MODEL_POWERFUL).toBe("cerebras/gpt-oss-120b");
-    expect(env.ELIZA_DEFAULT_AGENT_TYPE).toBe("opencode");
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain('Unknown backend "opencode"');
+    expect(saveElizaConfig).not.toHaveBeenCalled();
   });
 
   it("persists defaultBackend eliza-code under the orchestrator's elizaos spelling", async () => {
@@ -685,13 +683,13 @@ describe("GET /api/models/config activeChat", () => {
       Record<string, { value: string; source: string } | null>
     >;
     // Unpinned cloud tiers report the plugin's code defaults so the operator
-    // sees what actually serves — small gemma, large GLM (genuinely larger).
+    // sees what actually serves — both tiers use the supported Gemma model.
     expect(targets.small?.ELIZAOS_CLOUD_SMALL_MODEL).toEqual({
       value: "gemma-4-31b",
       source: "default",
     });
     expect(targets.large?.ELIZAOS_CLOUD_LARGE_MODEL).toEqual({
-      value: "zai-glm-4.7",
+      value: "gemma-4-31b",
       source: "default",
     });
   });


### PR DESCRIPTION
## Summary
- exercise the supported eliza-code no-effort seam after OpenCode removal
- pin the retired OpenCode backend as a fail-closed validation contract
- align the Agent Cloud large-tier fixture with the canonical supported Gemma default

## Exact evidence
- source/base: 5c49223d19 over f7a4fbec26
- targeted Agent/Cerebras slice: 5 files, 91/91 tests passed
- targeted Biome: passed
- git diff --check: passed
- package-wide typecheck was not counted from this sparse worktree because its reused dependency closure lacks multiple workspace links; hosted source CI remains authoritative
- no live provider, account, credential, device, or production action