### PR TITLE
fix(lifeops): decode module URL roots on Windows

### DIFF
--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   appBase,
   CONNECTOR_PATH_ENV_NAMES,
@@ -54,7 +55,7 @@ function markdownCells(row) {
     .map((cell) => cell.replaceAll("__ESCAPED_PIPE__", "|").trim());
 }
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const IDENTITY_SLOT_CATALOG = resolve(
   ROOT,
   "docs/testing/hitl-identity-slots.md",

--- a/scripts/lifeops/env-layers.mjs
+++ b/scripts/lifeops/env-layers.mjs
@@ -39,7 +39,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 /** Home-layer file: shared across every checkout and worktree of this repo. */
 export const HOME_ENV_PATH = join(homedir(), ".eliza", ".env");

--- a/scripts/lifeops/env-layers.test.mjs
+++ b/scripts/lifeops/env-layers.test.mjs
@@ -24,7 +24,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   applyLayeredEnvToProcess,
   atomicWriteEnvFile,
@@ -38,7 +38,7 @@ import {
   writeSecret,
 } from "./env-layers.mjs";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 // realpath so git-canonicalized paths (macOS /var -> /private/var) compare equal.
 function tempDir(prefix) {

--- a/scripts/lifeops/hitl-credential-dashboard.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.mjs
@@ -79,7 +79,7 @@ import {
   recordOutcomes,
 } from "./hitl-ledger.mjs";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const REPO_ENV_PATH = join(ROOT, ".env");
 const PROBE_CACHE_PATH = join(
   ROOT,

--- a/scripts/lifeops/hitl-credential-dashboard.test.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.test.mjs
@@ -15,12 +15,13 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   dashboardErrorResponse,
   HttpError,
 } from "./hitl-credential-dashboard.mjs";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 test("credential dashboard does not serialize unexpected exception details", () => {
   const marker = "<script>internal/path/database.sql</script>";

--- a/scripts/lifeops/hitl-ledger.mjs
+++ b/scripts/lifeops/hitl-ledger.mjs
@@ -22,8 +22,9 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 export const LEDGER_PATH = join(ROOT, "docs/testing/hitl-ledger.json");
 

--- a/scripts/lifeops/module-roots.test.mjs
+++ b/scripts/lifeops/module-roots.test.mjs
@@ -1,13 +1,18 @@
 /**
- * Regression tests for the repo-root derivation in the lifeops scripts that
- * default their file paths to this checkout. Each module is copied into a
- * temporary checkout whose path contains a space and imported from there, so
- * the test observes the real ROOT the module computes; a root derived from the
- * percent-encoded URL pathname would leak `%20` into every derived path
- * (#29569). Real filesystem, no mocks.
+ * Exercises ledger persistence and credential-layer reads/writes from an isolated
+ * checkout whose path needs URL decoding. Real filesystem operations prove that
+ * operator state stays in the checkout, without accessing actual credentials.
  */
 import assert from "node:assert/strict";
-import { cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -18,7 +23,7 @@ const HERE = fileURLToPath(new URL(".", import.meta.url));
 async function importFromSpacedCheckout(moduleName, run) {
   const base = realpathSync(mkdtempSync(join(tmpdir(), "lifeops-root-")));
   try {
-    const repo = join(base, "sp ace", "repo");
+    const repo = join(base, "sp ace-é#", "repo");
     const scripts = join(repo, "scripts", "lifeops");
     mkdirSync(scripts, { recursive: true });
     cpSync(join(HERE, moduleName), join(scripts, moduleName));
@@ -29,31 +34,54 @@ async function importFromSpacedCheckout(moduleName, run) {
   }
 }
 
-test("hitl-ledger derives LEDGER_PATH from the decoded checkout path", async () => {
+test("ledger outcomes persist in the decoded checkout and survive a reread", async () => {
   await importFromSpacedCheckout("hitl-ledger.mjs", (mod, repo) => {
-    assert.equal(
-      mod.LEDGER_PATH,
-      join(repo, "docs", "testing", "hitl-ledger.json"),
+    const outcome = {
+      pathId: "fixture-calendar",
+      ok: true,
+      at: "2026-09-10T10:00:00.000Z",
+      lane: "fixture",
+      commit: "fixture-commit",
+      counts: { passed: 1, failed: 0, skipped: 0 },
+    };
+    mod.recordOutcome(outcome);
+    const persisted = JSON.parse(
+      readFileSync(join(repo, "docs", "testing", "hitl-ledger.json"), "utf8"),
     );
-    assert.ok(
-      !mod.LEDGER_PATH.includes("%20"),
-      `LEDGER_PATH leaked an encoded space: ${mod.LEDGER_PATH}`,
-    );
+    assert.equal(persisted.entries[outcome.pathId].lastSuccessAt, outcome.at);
+    mod.recordOutcome({
+      ...outcome,
+      ok: false,
+      at: "2026-09-10T11:00:00.000Z",
+      counts: { passed: 0, failed: 1, skipped: 0 },
+    });
+    const reread = mod.readLedger().entries[outcome.pathId];
+    assert.equal(reread.lastSuccessAt, outcome.at);
+    assert.equal(reread.counts.failed, 1);
   });
 });
 
-test("env-layers derives the default repo .env layer from the decoded checkout path", async () => {
+test("credential reads and writes use the decoded checkout's repo layer", async () => {
   await importFromSpacedCheckout("env-layers.mjs", (mod, repo) => {
-    const { layers } = mod.loadLayeredEnv({
-      processEnv: {},
-      homeEnvPath: join(repo, "home", ".env"),
-    });
-    const repoLayer = layers.find((layer) => layer.source === "repo");
-    assert.ok(repoLayer, "loadLayeredEnv must report a repo layer");
-    assert.equal(repoLayer.path, join(repo, ".env"));
-    assert.ok(
-      !repoLayer.path.includes("%20"),
-      `repo layer leaked an encoded space: ${repoLayer.path}`,
+    const envPath = join(repo, ".env");
+    writeFileSync(
+      envPath,
+      "FIXTURE_CALENDAR_TOKEN=before\nFIXTURE_KEEP=retained\n",
     );
+    const options = { processEnv: {}, homeEnvPath: join(repo, "home", ".env") };
+    assert.equal(
+      mod.loadLayeredEnv(options).values.FIXTURE_CALENDAR_TOKEN,
+      "before",
+    );
+    mod.writeSecret("FIXTURE_CALENDAR_TOKEN", "after", {
+      ...options,
+      scope: "repo",
+    });
+    const disk = mod.parseDotenv(readFileSync(envPath, "utf8"));
+    assert.equal(disk.FIXTURE_CALENDAR_TOKEN, "after");
+    assert.equal(disk.FIXTURE_KEEP, "retained");
+    const loaded = mod.loadLayeredEnv({ ...options, processEnv: {} });
+    assert.equal(loaded.values.FIXTURE_CALENDAR_TOKEN, "after");
+    assert.equal(loaded.sources.FIXTURE_CALENDAR_TOKEN, "repo");
   });
 });

--- a/scripts/lifeops/module-roots.test.mjs
+++ b/scripts/lifeops/module-roots.test.mjs
@@ -7,7 +7,7 @@
  * (#29569). Real filesystem, no mocks.
  */
 import assert from "node:assert/strict";
-import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -16,7 +16,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const HERE = fileURLToPath(new URL(".", import.meta.url));
 
 async function importFromSpacedCheckout(moduleName, run) {
-  const base = mkdtempSync(join(tmpdir(), "lifeops-root-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "lifeops-root-")));
   try {
     const repo = join(base, "sp ace", "repo");
     const scripts = join(repo, "scripts", "lifeops");

--- a/scripts/lifeops/module-roots.test.mjs
+++ b/scripts/lifeops/module-roots.test.mjs
@@ -1,0 +1,59 @@
+/**
+ * Regression tests for the repo-root derivation in the lifeops scripts that
+ * default their file paths to this checkout. Each module is copied into a
+ * temporary checkout whose path contains a space and imported from there, so
+ * the test observes the real ROOT the module computes; a root derived from the
+ * percent-encoded URL pathname would leak `%20` into every derived path
+ * (#29569). Real filesystem, no mocks.
+ */
+import assert from "node:assert/strict";
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+
+async function importFromSpacedCheckout(moduleName, run) {
+  const base = mkdtempSync(join(tmpdir(), "lifeops-root-"));
+  try {
+    const repo = join(base, "sp ace", "repo");
+    const scripts = join(repo, "scripts", "lifeops");
+    mkdirSync(scripts, { recursive: true });
+    cpSync(join(HERE, moduleName), join(scripts, moduleName));
+    const mod = await import(pathToFileURL(join(scripts, moduleName)).href);
+    await run(mod, repo);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+test("hitl-ledger derives LEDGER_PATH from the decoded checkout path", async () => {
+  await importFromSpacedCheckout("hitl-ledger.mjs", (mod, repo) => {
+    assert.equal(
+      mod.LEDGER_PATH,
+      join(repo, "docs", "testing", "hitl-ledger.json"),
+    );
+    assert.ok(
+      !mod.LEDGER_PATH.includes("%20"),
+      `LEDGER_PATH leaked an encoded space: ${mod.LEDGER_PATH}`,
+    );
+  });
+});
+
+test("env-layers derives the default repo .env layer from the decoded checkout path", async () => {
+  await importFromSpacedCheckout("env-layers.mjs", (mod, repo) => {
+    const { layers } = mod.loadLayeredEnv({
+      processEnv: {},
+      homeEnvPath: join(repo, "home", ".env"),
+    });
+    const repoLayer = layers.find((layer) => layer.source === "repo");
+    assert.ok(repoLayer, "loadLayeredEnv must report a repo layer");
+    assert.equal(repoLayer.path, join(repo, ".env"));
+    assert.ok(
+      !repoLayer.path.includes("%20"),
+      `repo layer leaked an encoded space: ${repoLayer.path}`,
+    );
+  });
+});


### PR DESCRIPTION
LifeOps resolved repository roots from URL-encoded pathnames, breaking ledger and credential storage in checkouts containing spaces or Unicode and producing invalid drive paths on Windows. The three modules and their test helpers now decode their file URLs with Node’s platform-aware `fileURLToPath()`.

The regression performs real ledger writes/readbacks and credential-layer loads/updates inside a temporary checkout containing spaces, Unicode and `#`. Both tests fail when the two production root expressions are reverted. Original implementation authorship is preserved from #29570.

Closes #29569. Supersedes #29570.

Validation at `e99ecb2cb9e14a7d8ab66c735ba250064395584d`, based on develop `4985223ea31c01d6eec22c5d6aea7d79913ef896`:

- Pinned Node 24.15.0 and Bun 1.3.14; installation, root verification and the complete 82-test LifeOps suite passed.
- [Native Windows validation](https://github.com/elizaOS/eliza/actions/runs/34501456755) checked out this exact candidate, passed both real filesystem regressions, started the actual credential dashboard and read its loopback HTTP page successfully. The validation workflow exists only on a temporary proof branch; it is not part of this PR.
- The negative control failed both storage regressions before the production expressions were restored.

No rendered UI or model behavior changes: screenshots, video, frontend console logs and model trajectories are N/A. Storage evidence uses synthetic values and temporary files; no production credentials were read or changed. This proves the filesystem fix, not complete Bettina deployment acceptance.
