### PR TITLE
fix(plugin-video): preserve empty subtitle fallbacks

### DIFF
--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -325,4 +325,24 @@ describe("VideoService deterministic behavior", () => {
       embedSubs: true,
     });
   });
+
+  it("degrades gracefully when subtitles/captions array is empty (#29562)", async () => {
+    const runtime = createRuntime();
+    const { service } = createServiceWithYtDlp([
+      {
+        title: "Music Video",
+        description: "Test",
+        categories: ["Music"],
+        subtitles: { en: [] },
+        automatic_captions: { en: [] },
+      },
+    ]);
+
+    const result = await service.processVideo(
+      "https://youtu.be/empty-subtitles-test",
+      runtime,
+    );
+
+    expect(result.text).toBe("No lyrics available.");
+  });
 });

--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -345,4 +345,67 @@ describe("VideoService deterministic behavior", () => {
 
     expect(result.text).toBe("No lyrics available.");
   });
+
+  it("falls through from empty manual subtitles to automatic captions", async () => {
+    const runtime = createRuntime();
+    const { service } = createServiceWithYtDlp([
+      {
+        title: "Captioned Video",
+        description: "Test",
+        subtitles: { en: [] },
+        automatic_captions: {
+          en: [{ url: "https://captions.example.test/track.json" }],
+        },
+      },
+    ]);
+    const downloadCaption = vi
+      .spyOn(
+        service as unknown as {
+          downloadCaption(url: string): Promise<string>;
+        },
+        "downloadCaption",
+      )
+      .mockResolvedValue(
+        JSON.stringify({ events: [{ segs: [{ utf8: "Automatic caption" }] }] }),
+      );
+
+    const result = await service.processVideo(
+      "https://youtu.be/automatic-caption-test",
+      runtime,
+    );
+
+    expect(downloadCaption).toHaveBeenCalledWith(
+      "https://captions.example.test/track.json",
+    );
+    expect(result.text).toBe("Automatic caption ");
+  });
+
+  it("falls through empty subtitle arrays to audio transcription", async () => {
+    const runtime = createRuntime();
+    const { service } = createServiceWithYtDlp([
+      {
+        title: "Spoken Video",
+        description: "Test",
+        categories: ["Education"],
+        subtitles: { en: [] },
+        automatic_captions: { en: [] },
+      },
+    ]);
+    const transcribeAudio = vi
+      .spyOn(service as unknown as {
+        transcribeAudio(url: string, runtime: IAgentRuntime): Promise<string>;
+      }, "transcribeAudio")
+      .mockResolvedValue("Audio transcript");
+
+    const result = await service.processVideo(
+      "https://youtu.be/audio-transcription-test",
+      runtime,
+    );
+
+    expect(transcribeAudio).toHaveBeenCalledWith(
+      "https://youtu.be/audio-transcription-test",
+      runtime,
+    );
+    expect(result.text).toBe("Audio transcript");
+  });
 });

--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -392,9 +392,12 @@ describe("VideoService deterministic behavior", () => {
       },
     ]);
     const transcribeAudio = vi
-      .spyOn(service as unknown as {
-        transcribeAudio(url: string, runtime: IAgentRuntime): Promise<string>;
-      }, "transcribeAudio")
+      .spyOn(
+        service as unknown as {
+          transcribeAudio(url: string, runtime: IAgentRuntime): Promise<string>;
+        },
+        "transcribeAudio",
+      )
       .mockResolvedValue("Audio transcript");
 
     const result = await service.processVideo(

--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -377,7 +377,7 @@ describe("VideoService deterministic behavior", () => {
     expect(downloadCaption).toHaveBeenCalledWith(
       "https://captions.example.test/track.json",
     );
-    expect(result.text).toBe("Automatic caption ");
+    expect(result.text).toBe("Automatic caption");
   });
 
   it("falls through empty subtitle arrays to audio transcription", async () => {

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -576,19 +576,18 @@ export class VideoService extends IVideoService {
     elizaLogger.log("Getting transcript");
     try {
       // Check for manual subtitles
-      if (videoInfo.subtitles?.en) {
+      const manualSubUrl = videoInfo.subtitles?.en?.[0]?.url;
+      if (manualSubUrl) {
         elizaLogger.log("Manual subtitles found");
-        const srtContent = await this.downloadSRT(
-          videoInfo.subtitles.en[0].url,
-        );
+        const srtContent = await this.downloadSRT(manualSubUrl);
         return this.parseSRT(srtContent);
       }
 
       // Check for automatic captions
-      if (videoInfo.automatic_captions?.en) {
+      const autoCaptionUrl = videoInfo.automatic_captions?.en?.[0]?.url;
+      if (autoCaptionUrl) {
         elizaLogger.log("Automatic captions found");
-        const captionUrl = videoInfo.automatic_captions.en[0].url;
-        const captionContent = await this.downloadCaption(captionUrl);
+        const captionContent = await this.downloadCaption(autoCaptionUrl);
         return this.parseCaption(captionContent);
       }
 


### PR DESCRIPTION
## Summary

Closes #29562. Supersedes stale PR #29563 with the original production fix rebased onto current `develop` and complete fallback regression coverage.

When yt-dlp returns `subtitles.en: []`, the array is truthy but `[0]` is undefined. Accessing `.url` therefore crashes instead of continuing through automatic captions, Music degradation, or audio transcription.

## Changes

- Resolve manual and automatic caption URLs with optional indexed access.
- Cover empty manual + automatic arrays for Music degradation.
- Cover empty manual subtitles falling through to a real automatic-caption URL.
- Cover both arrays empty on a non-Music video falling through to audio transcription.

Original production fix authorship is preserved from @teddiesloco / #29563.

## Verification

- `git diff --check`: passed.
- Static audit confirms each fallback test asserts both the resulting transcript and the selected downloader/transcription call.
- Local execution was not claimed: this checkout does not contain Eliza's dependency closure. Hosted exact-head CI is required before merge.

## Evidence gate

- Screenshots/video: N/A; no UI change.
- Backend evidence: focused deterministic regression tests added at the service boundary; hosted exact-head output pending.
- Frontend logs: N/A.
- Real-LLM trajectory: N/A; no model path changes.
- Domain artifacts: N/A; no persistent state change.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex
Attribution status: self-reported
— hermesagent270-commits
