### PR TITLE
fix(logger): support native ESM and require dist verification

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,7 +29,7 @@
     "build": "bun run build:dist",
     "build:dist": "node ../scripts/rm-path-recursive.mjs dist && tsc6 --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
+    "test": "bun run build && node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "lint": "node ../scripts/run-biome-typescript.mjs src check",
     "lint:check": "node ../scripts/run-biome-typescript.mjs src check",
     "lint:fix": "node ../scripts/run-biome-typescript.mjs src check --write",

--- a/packages/logger/src/logger.native-esm.test.ts
+++ b/packages/logger/src/logger.native-esm.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Exercises the logger through real native-ESM Node subprocesses so Vitest's
+ * module transform cannot supply CommonJS globals. The source run asserts its
+ * TypeScript loader preserves that boundary; a built package is also checked
+ * through plain Node when `dist` is present.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function verifyNativeEsmTarget({
+  name,
+  url,
+  loaderArgs = [],
+}: {
+  name: string;
+  url: string;
+  loaderArgs?: string[];
+}): void {
+  const directory = mkdtempSync(join(tmpdir(), "eliza-logger-native-esm-"));
+  temporaryDirectories.push(directory);
+
+  const outputMarker = `native-esm-${name}-output`;
+  const promptMarker = `native-esm-${name}-prompt`;
+  const chatMarker = `native-esm-${name}-chat`;
+  const successMarker = `native-esm-${name}-ok`;
+  const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+  const outputPath = join(directory, "output.log");
+  const childScript = `
+      if (typeof require !== "undefined") {
+        throw new Error("native ESM harness unexpectedly exposed require");
+      }
+      const loggerModule = await import(${JSON.stringify(url)});
+      loggerModule.logger.info(${JSON.stringify(outputMarker)});
+      loggerModule.logPrompt("text", ${JSON.stringify(promptMarker)}, {
+        agentName: "native-esm",
+      });
+      loggerModule.logChatIn({
+        agentName: "native-esm",
+        agentId: "agent-native-esm",
+        roomId: "room-native-esm",
+        messageId: "message-native-esm",
+        text: ${JSON.stringify(chatMarker)},
+      });
+      if (!loggerModule.recentLogs().includes(${JSON.stringify(outputMarker)})) {
+        throw new Error("native ESM log entry did not reach recentLogs");
+      }
+      console.log(${JSON.stringify(successMarker)});
+    `;
+
+  const result = spawnSync(
+    process.execPath,
+    [...loaderArgs, "--input-type=module", "--eval", childScript],
+    {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        LOG_FILE: outputPath,
+        LOG_JSON_FORMAT: "true",
+        LOG_LEVEL: "info",
+        NO_COLOR: "1",
+      },
+    },
+  );
+
+  const childOutput = [result.error?.message, result.stdout, result.stderr]
+    .filter(Boolean)
+    .join("\n");
+  expect(result.status, childOutput).toBe(0);
+  expect(result.stdout).toContain(successMarker);
+  expect(readFileSync(outputPath, "utf8")).toContain(outputMarker);
+  expect(readFileSync(join(directory, "prompts.log"), "utf8")).toContain(
+    promptMarker,
+  );
+  expect(readFileSync(join(directory, "chat.log"), "utf8")).toContain(
+    chatMarker,
+  );
+}
+
+describe("native Node ESM", () => {
+  const sourceUrl = new URL("./logger.ts", import.meta.url).href;
+  const distUrl = new URL("../dist/index.js", import.meta.url).href;
+
+  it("initializes source JSON mode and writes every file sink", () => {
+    verifyNativeEsmTarget({
+      name: "source",
+      url: sourceUrl,
+      loaderArgs: ["--import", "tsx"],
+    });
+  });
+
+  it.skipIf(!existsSync(fileURLToPath(distUrl)))(
+    "initializes the built package through plain Node ESM",
+    () => {
+      verifyNativeEsmTarget({ name: "dist", url: distUrl });
+    },
+  );
+});

--- a/packages/logger/src/logger.native-esm.test.ts
+++ b/packages/logger/src/logger.native-esm.test.ts
@@ -1,8 +1,8 @@
 /**
  * Exercises the logger through real native-ESM Node subprocesses so Vitest's
  * module transform cannot supply CommonJS globals. The source run asserts its
- * TypeScript loader preserves that boundary; a built package is also checked
- * through plain Node when `dist` is present.
+ * TypeScript loader preserves that boundary; the package test script builds
+ * `dist` first so plain Node always checks the published-package path too.
  */
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";

--- a/packages/logger/src/logger.native-esm.test.ts
+++ b/packages/logger/src/logger.native-esm.test.ts
@@ -5,7 +5,7 @@
  * through plain Node when `dist` is present.
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -102,10 +102,7 @@ describe("native Node ESM", () => {
     });
   });
 
-  it.skipIf(!existsSync(fileURLToPath(distUrl)))(
-    "initializes the built package through plain Node ESM",
-    () => {
-      verifyNativeEsmTarget({ name: "dist", url: distUrl });
-    },
-  );
+  it("initializes the built package through plain Node ESM", () => {
+    verifyNativeEsmTarget({ name: "dist", url: distUrl });
+  });
 });

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -799,17 +799,27 @@ let _promptLogFd: number | null = null;
 let _chatLogFd: number | null = null;
 let _promptLogCounter = 0;
 
+/** Load a Node builtin synchronously without breaking browser source imports. */
+function getNodeBuiltin<T>(id: string): T | null {
+  if (
+    typeof process === "undefined" ||
+    typeof process.getBuiltinModule !== "function"
+  ) {
+    return null;
+  }
+  try {
+    return (process.getBuiltinModule(id) as T | undefined) ?? null;
+  } catch {
+    // error-policy:J7 optional Node diagnostics must not prevent logger startup.
+    return null;
+  }
+}
+
 let _fs: typeof import("node:fs") | null = null;
 function getFs(): typeof import("node:fs") | null {
   if (_fs) return _fs;
-  try {
-    _fs = require("node:fs");
-    return _fs;
-  } catch {
-    // error-policy:J7 logger is a leaf and cannot report through itself; no
-    // node:fs (browser build) legitimately means "no file sink", not a failure.
-    return null;
-  }
+  _fs = getNodeBuiltin<typeof import("node:fs")>("node:fs");
+  return _fs;
 }
 
 /**
@@ -872,7 +882,8 @@ function ensureFileLog(): boolean {
 
     const fs = getFs();
     if (!fs) return false;
-    const pathMod = require("node:path");
+    const pathMod = getNodeBuiltin<typeof import("node:path")>("node:path");
+    if (!pathMod) return false;
     const isBooleanFlag = ["true", "1", "yes", "on"].includes(
       logFileEnv.trim().toLowerCase(),
     );
@@ -1394,8 +1405,8 @@ function sealAdze(base: Record<string, unknown>): ReturnType<typeof adze.seal> {
     let hostname = "unknown";
     if (typeof process !== "undefined" && process.platform) {
       // Node.js environment
-      const os = require("node:os");
-      hostname = os.hostname();
+      const os = getNodeBuiltin<typeof import("node:os")>("node:os");
+      if (os) hostname = os.hostname();
     } else {
       // Browser environment
       const browserLocation = (


### PR DESCRIPTION
## Summary

Closes #29543. Supersedes #29551 with the native-ESM logger fix rebased onto current `develop` and makes published-package verification fail closed.

The logger used CommonJS `require("node:*")` inside an ESM package, crashing JSON logger initialization under native Node ESM and preventing file sinks from being created. Node builtins now load synchronously through the supported Node 24 `process.getBuiltinModule` API without adding static Node imports to the browser-consumed leaf.

## Verification repair

The original regression conditionally skipped `dist/index.js` when `dist` was absent. That allowed a green run to exercise only TypeScript source through `tsx`, not the package real consumers import.

This replacement:

- builds `@elizaos/logger` before its package test;
- makes the plain-Node `dist/index.js` ESM test unconditional;
- verifies `output.log`, `prompts.log`, and `chat.log` contain unique markers;
- retains the source-level native-ESM test and its assertion that `require` is absent.

Original production fix and test authorship are preserved from @startrack3r / #29551.

## Local checks

- `git diff --check`: passed.
- Static exact-head audit: no runtime `require("node:*")` sites remain in the changed logger paths; every optional builtin null result is handled.
- Local execution is not claimed because this checkout lacks Eliza's dependency closure. Hosted exact-head CI must run the now fail-closed package test before merge.

## Evidence gate

- Screenshots/video: N/A; no rendered surface changes.
- Backend evidence: native subprocess regression writes and inspects all three real temporary sinks; hosted output pending.
- Frontend logs: N/A; browser import behavior is preserved by capability loading and no static `node:*` imports.
- Real-LLM trajectory: N/A.
- Domain artifacts: temporary log files asserted by content, then removed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex
Attribution status: self-reported
— hermesagent270-commits
