### PR TITLE
fix(agent): let a spent escalation reach its give-up branch

### DIFF
--- a/packages/agent/src/services/escalation.test.ts
+++ b/packages/agent/src/services/escalation.test.ts
@@ -472,16 +472,21 @@ describe("EscalationService.startEscalation", () => {
     );
   });
 
-  test("does not schedule a follow-up when there is one channel and maxRetries is 1", async () => {
+  test("arms the give-up check even when there is one channel and maxRetries is 1", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     configState.current = {
       agents: {
         defaults: { escalation: { channels: ["client_chat"], maxRetries: 1 } },
       },
     };
-    const { runtime } = makeRuntime();
+    const { runtime } = makeRuntime({ handlers: ["client_chat"] });
     await EscalationService.startEscalation(runtime, "once", "no retry");
-    expect(vi.getTimerCount()).toBe(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    // The single attempt is already spent, so this check exists only to notice
+    // an owner reply and then release the escalation.
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(EscalationService.getActiveEscalationSync(runtime)).toBeNull();
     expect(EscalationService._hasPendingTimerBucket(AGENT_ID)).toBe(false);
   });
 
@@ -755,7 +760,7 @@ describe("EscalationService.resolve, cache, and rehydrate", () => {
 });
 
 describe("EscalationService timers", () => {
-  test("scheduled check advances the step and clears the timer bucket when it does not reschedule", async () => {
+  test("scheduled checks advance the step and keep a timer armed until the escalation resolves", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     configState.current = {
       agents: {
@@ -768,7 +773,7 @@ describe("EscalationService timers", () => {
         },
       },
     };
-    const { runtime } = makeRuntime();
+    const { runtime } = makeRuntime({ handlers: ["client_chat"] });
     const state = await EscalationService.startEscalation(
       runtime,
       "timer",
@@ -780,7 +785,86 @@ describe("EscalationService timers", () => {
 
     expect(state.currentStep).toBe(1);
     expect(state.resolved).toBe(false);
+    // Still unresolved, so a timer must still be pending — an unresolved
+    // escalation with no timer can never be retried, resolved, or replaced.
+    expect(EscalationService._hasPendingTimerBucket(AGENT_ID)).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(state.currentStep).toBe(2);
+    expect(state.resolved).toBe(true);
     expect(EscalationService._hasPendingTimerBucket(AGENT_ID)).toBe(false);
+  });
+
+  test("the scheduled chain alone reaches the give-up branch and spends exactly maxRetries sends", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    configState.current = {
+      agents: {
+        defaults: {
+          escalation: {
+            channels: ["client_chat"],
+            maxRetries: 3,
+            waitMinutes: 5,
+          },
+        },
+      },
+    };
+    const { runtime, sends, cache } = makeRuntime({
+      handlers: ["client_chat"],
+    });
+    const state = await EscalationService.startEscalation(
+      runtime,
+      "Systemic failure DB_DOWN reported 3 times",
+      "first burst",
+    );
+
+    // Drive timers only: no manual checkEscalation call stands in for the
+    // scheduler the way the rest of this suite does.
+    for (let tick = 0; tick < 6; tick += 1) {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    }
+
+    expect(sends).toHaveLength(3);
+    expect(state.resolved).toBe(true);
+    expect(cache.has(CACHE_KEY)).toBe(false);
+    expect(EscalationService.getActiveEscalationSync(runtime)).toBeNull();
+  });
+
+  test("a later failure starts a fresh escalation once the previous chain is spent", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    configState.current = {
+      agents: {
+        defaults: {
+          escalation: {
+            channels: ["client_chat"],
+            maxRetries: 3,
+            waitMinutes: 5,
+          },
+        },
+      },
+    };
+    const { runtime, sends } = makeRuntime({ handlers: ["client_chat"] });
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "Systemic failure DB_DOWN reported 3 times",
+      "first burst",
+    );
+    for (let tick = 0; tick < 6; tick += 1) {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    }
+    sends.length = 0;
+
+    const second = await EscalationService.startEscalation(
+      runtime,
+      "Systemic failure MODEL_DOWN reported 3 times",
+      "second burst",
+    );
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.resolved).toBe(false);
+    expect(second.reason).toBe("Systemic failure MODEL_DOWN reported 3 times");
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.content.text).toBe("second burst");
   });
 
   test("config load failure during start still uses the client_chat default", async () => {

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -550,10 +550,12 @@ export class EscalationService {
       }
     }
 
-    const maxRetries = resolveMaxRetries(config);
-    if (channels.length > 1 || maxRetries > 1) {
-      scheduleCheck(runtime, escalationId, waitMs);
-    }
+    // Always arm the next check. It is what notices an owner reply, and once
+    // the retry budget is spent it is what reaches the give-up branch that
+    // releases this state. Every later startEscalation coalesces into an
+    // unresolved escalation, so leaving one unarmed silences the owner channel
+    // for the rest of the process.
+    scheduleCheck(runtime, escalationId, waitMs);
 
     logger.info(
       `[escalation] Started ${escalationId}: channel=${channels[0]}, reason="${reason}"`,
@@ -632,7 +634,10 @@ export class EscalationService {
 
     await persistState(runtime, state);
 
-    if (state.currentStep + 1 < maxRetries) {
+    // `currentStep < maxRetries`, not `currentStep + 1 < maxRetries`: the check
+    // that carries currentStep up to maxRetries is the give-up check. Skipping
+    // it spends the retry budget and then strands the escalation unresolved.
+    if (state.currentStep < maxRetries) {
       scheduleCheck(runtime, escalationId, waitMs);
     }
   }


### PR DESCRIPTION
# Relates to

Closes #29881 — an owner escalation that is never answered is stranded unresolved, and every later systemic-failure escalation is silently folded into that dead state.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`; zero conflicts. Exact head `62a902be64f30e6f47880d347431019694eb7f1f`.

# Risks

Low, and bounded to the escalation timer chain. Two lines of scheduling change in `escalation.ts`; no delivery-path, config, or persistence change. The number of owner deliveries is unchanged — the newly-scheduled terminal check gives up before it sends, which the new coverage pins with an exact send count. The chain is still bounded: `currentStep` strictly increments per check and `resolveMaxRetries` guarantees `maxRetries >= 1`, so the give-up branch always fires.

Two existing tests changed because they asserted the stranded state itself (a timer count of `0` and an empty timer bucket while `resolved === false`). They are rewritten to assert termination rather than deleted, so the timer-bucket lifecycle they covered is still covered.

# Background

## What does this PR do?

`checkEscalation` gives up at `currentStep >= maxRetries` (`escalation.ts:641`) but re-armed the next check only `if (state.currentStep + 1 < maxRetries)` (`:663`). Starting from `currentStep = 0`, the chain therefore always halted at `maxRetries - 1` and the give-up check was the one check never scheduled. `startEscalation` (`:554`) additionally armed no timer at all for a single channel with `maxRetries: 1`.

Nothing else could release the state: `resolveEscalation` has no production caller outside `checkEscalation`, and `checkEscalation` only runs from a scheduled timer. So the escalation stayed unresolved permanently, and because `startEscalation` (`:491-500`) coalesces into any unresolved escalation for that agent — appending the reason, persisting, returning **without arming a timer** — every subsequent repeated systemic failure from `error-escalation.ts:99` was swallowed. Meanwhile `escalation-trigger.ts:98` kept injecting a high-urgency *"Owner has not responded yet"* trigger into the agent's prompt on every autonomous loop.

The fix arms the check unconditionally at start and reschedules while `currentStep < maxRetries`, so the chain always terminates in the give-up branch, drops the cache row, and releases the agent for the next escalation.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/escalation.test.ts`, describe block `EscalationService timers`. Every prior test that reached the give-up branch called `checkEscalation` **by hand** (`:572`, `:603`), so the branch was covered in isolation while unreachable through the scheduler that owns it. The new cases drive `setTimeout` alone.

## Detailed testing steps

1. Check out exact head `62a902be64f30e6f47880d347431019694eb7f1f`.
2. From `packages/agent`: `bun x vitest run src/services/escalation.test.ts` → **38/38**.
3. RED control — restore only `src/services/escalation.ts` to `origin/develop` and rerun: **4 failed / 34 passed**, with the two rewritten tests and both new tests failing.
4. Mutation kills, each applied alone and reverted:
   - re-guarding the start-time schedule → the `maxRetries: 1` case fails (1 failed / 37 passed);
   - restoring `currentStep + 1 < maxRetries` → all three chain cases fail (3 failed / 35 passed).
5. Neighbouring suites: `escalation-agent-isolation`, `escalation-channels`, `error-escalation`, `escalation-trigger` → **108/108** across all five files.
6. Pinned Biome on both changed files: exit 0.

<!-- evidence-head:62a902be64f30e6f47880d347431019694eb7f1f -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — agent-host scheduler state with no visible surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — agent-host scheduler state with no visible surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control and the two independent mutation kills below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>RED control on develop, green at head, and both mutation kills</summary>

```
# RED control: origin/develop escalation.ts + this PR's tests (packages/agent)
 × arms the give-up check even when there is one channel and maxRetries is 1
   AssertionError: expected +0 to be 1
 × scheduled checks advance the step and keep a timer armed until the escalation resolves
   AssertionError: expected false to be true
 × the scheduled chain alone reaches the give-up branch and spends exactly maxRetries sends
   AssertionError: expected false to be true
 × a later failure starts a fresh escalation once the previous chain is spent
   AssertionError: expected 'esc-...-1' not to be 'esc-...-1'
      Tests  4 failed | 34 passed (38)

# head 62a902be64
      Tests  38 passed (38)

# mutation A -- re-guard the start-time schedule
      Tests  1 failed | 37 passed (38)

# mutation B -- restore `state.currentStep + 1 < maxRetries`
      Tests  3 failed | 35 passed (38)

# all five escalation-touching suites at head
      Tests  108 passed (108)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic timer/state-machine path with no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Root cause, the persisted-state consequence, and static gates at exact head</summary>

```
Root cause (line numbers on origin/develop f7a4fbec26):
  escalation.ts:641  give up when state.currentStep >= maxRetries
  escalation.ts:663  reschedule only if state.currentStep + 1 < maxRetries   <-- give-up check never armed
  escalation.ts:554  no timer at all for one channel with maxRetries: 1
  escalation.ts:491  startEscalation coalesces into the stranded state and arms nothing
  error-escalation.ts:99   production caller whose repeat failures are then swallowed
  escalation-trigger.ts:98 keeps injecting "Owner has not responded yet" forever

Persisted-state consequence, asserted at head: the give-up branch calls
persistState with resolved=true, which deletes the agent cache row --
`expect(cache.has(CACHE_KEY)).toBe(false)` now holds through the timer chain
alone, where on develop the row survives indefinitely.

$ node_modules/.bin/biome check \
    packages/agent/src/services/escalation.ts \
    packages/agent/src/services/escalation.test.ts
Checked 2 files in 16ms. No fixes applied.        (exit 0)

$ git diff --stat origin/develop..HEAD
 packages/agent/src/services/escalation.test.ts | 94 ++++++++++++++++++++++++--
 packages/agent/src/services/escalation.ts      | 15 ++--
 2 files changed, 99 insertions(+), 10 deletions(-)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` and `bun run --cwd packages/agent typecheck` were not run clean: this review worktree links packages from a sibling checkout, and `tsc` reports 1536 pre-existing `TS2307`/`TS7006` errors there from unresolvable third-party deps (`viem`, `@solana/web3.js`, `pg`, `lucide-react`). None name `escalation`; the count and the error set are identical with and without this change. The focused suites, the RED control, the two independent mutation kills, and Biome above stand in.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
