### PR TITLE
fix(agent): decode container exec stdio as a UTF-8 stream

### DIFF
--- a/packages/agent/src/services/sandbox-engine-exec-encoding.test.ts
+++ b/packages/agent/src/services/sandbox-engine-exec-encoding.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Boundary coverage for container exec stdio decoding. The sandbox exec path
+ * accumulates the child's stdout/stderr across OS pipe chunks, so a multi-byte
+ * code point that straddles a chunk boundary must survive: decoding each chunk
+ * on its own substitutes U+FFFD on both sides of the split. Deterministic
+ * harness — the real DockerEngine.execInContainer over real Readable streams,
+ * with only `spawn` and host-executable resolution stubbed.
+ */
+
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+vi.mock("@elizaos/shared/host-execution-env", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/shared/host-execution-env")>();
+  return { ...actual, resolveHostExecutable: () => "/usr/local/bin/docker" };
+});
+
+import { DockerEngine } from "./sandbox-engine.ts";
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdin = { write: () => {}, end: () => {} };
+  kill(): void {}
+}
+
+/** Let the stream deliver the chunk that was just written before the next one. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("container exec stdio decoding", () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("preserves a code point split across two stdout chunks", async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const pending = new DockerEngine().execInContainer({
+      containerId: "sandbox-1",
+      command: "cat notes.txt",
+    });
+
+    // "é" is 0xC3 0xA9; a 64KiB pipe read can end between the two bytes.
+    child.stdout.write(Buffer.from([0xc3]));
+    await flush();
+    child.stdout.write(Buffer.from([0xa9]));
+    await flush();
+    child.stdout.end();
+    child.emit("close", 0);
+
+    const result = await pending;
+    expect(result.stdout).toBe("é");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves a code point split across two stderr chunks", async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const pending = new DockerEngine().execInContainer({
+      containerId: "sandbox-1",
+      command: "cat notes.txt",
+    });
+
+    // "世" is 0xE4 0xB8 0x96 — a three-byte point split after its first byte.
+    child.stderr.write(Buffer.from([0xe4]));
+    await flush();
+    child.stderr.write(Buffer.from([0xb8, 0x96]));
+    await flush();
+    child.stderr.end();
+    child.emit("close", 1);
+
+    const result = await pending;
+    expect(result.stderr).toBe("世");
+  });
+
+  it("still accumulates multi-chunk ASCII output in order", async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const pending = new DockerEngine().execInContainer({
+      containerId: "sandbox-1",
+      command: "echo hello",
+    });
+
+    child.stdout.write(Buffer.from("hel", "utf8"));
+    await flush();
+    child.stdout.write(Buffer.from("lo\n", "utf8"));
+    await flush();
+    child.stdout.end();
+    child.emit("close", 0);
+
+    const result = await pending;
+    expect(result.stdout).toBe("hello\n");
+  });
+});

--- a/packages/agent/src/services/sandbox-engine.ts
+++ b/packages/agent/src/services/sandbox-engine.ts
@@ -158,11 +158,16 @@ async function runExecInContainer(
     let stderr = "";
     const timeout = setTimeout(() => proc.kill("SIGKILL"), timeoutMs ?? 30_000);
 
-    proc.stdout.on("data", (data: Buffer) => {
-      stdout += data.toString();
+    // Preserve code points split across OS pipe chunks before accumulating,
+    // matching the host shell path in shell-execution-router.ts.
+    proc.stdout.setEncoding("utf8");
+    proc.stderr.setEncoding("utf8");
+
+    proc.stdout.on("data", (data: string) => {
+      stdout += data;
     });
-    proc.stderr.on("data", (data: Buffer) => {
-      stderr += data.toString();
+    proc.stderr.on("data", (data: string) => {
+      stderr += data;
     });
 
     if (stdin) {


### PR DESCRIPTION
# Relates to

Closes #29883 — sandboxed command output corrupts UTF-8 code points that straddle an OS pipe chunk boundary.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`; zero conflicts. Exact head `6c856e2e4301741ce159a633d1923788920090f0`.

# Risks

Low. Two lines set stream encoding on the child's stdout/stderr before the existing accumulation, so the `data` payloads arrive already decoded and the handler concatenates strings instead of per-chunk `Buffer.toString()`. Byte-identical output for ASCII, and for any non-ASCII output that happened not to straddle a boundary. This is the exact shape already in `shell-execution-router.ts:242-244` and `app-core/platforms/electrobun/src/ssh-runtime-rpc.ts:283-284`, and the same fix merged for the sibling defect in `b1c023612e` (#22494).

# Background

## What does this PR do?

`runExecInContainer` (`sandbox-engine.ts:146`) accumulated child output with `stdout += data.toString()` per chunk. A code point spanning two reads was decoded as two incomplete sequences, so both halves became U+FFFD. `setEncoding("utf8")` makes Node hold the partial sequence in its `StringDecoder` until the continuation bytes arrive.

The path is the default one: `local-safe` routes every agent shell exec through `SandboxManager` (`shell-execution-router.ts:7`, with `capability-broker` hardcoding `local-safe` as its default mode), and `sandbox-manager.ts:473` calls `engine.execInContainer`, returning the corrupted `stdout` to the caller verbatim.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/sandbox-engine-exec-encoding.test.ts`. It drives the real `DockerEngine.execInContainer` over real `PassThrough` streams — only `spawn` and host-executable resolution are stubbed — so `setEncoding` is genuinely exercised by Node's own decoder rather than simulated.

## Detailed testing steps

1. Check out exact head `6c856e2e4301741ce159a633d1923788920090f0`.
2. From `packages/agent`: `bun x vitest run src/services/sandbox-engine-exec-encoding.test.ts` → **3/3**.
3. RED control — restore only `src/services/sandbox-engine.ts` to `origin/develop` and rerun: the two split-code-point cases fail with `'��'` and `'���'`, while the multi-chunk ASCII case still passes, showing the split is what breaks rather than the accumulation.
4. Mutation kills, each applied alone and reverted: removing only the stdout `setEncoding` fails only the stdout case; removing only the stderr `setEncoding` fails only the stderr case.
5. Neighbouring sandbox suites (`sandbox-engine`, `sandbox-engine-env`, `sandbox-engine-run-container`, `sandbox-manager`) → **90/90**.
6. Pinned Biome on both files: exit 0.

<!-- evidence-head:6c856e2e4301741ce159a633d1923788920090f0 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — the corruption is in captured process output, not a rendered surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — the corruption is in captured process output, not a rendered surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control and the two per-stream mutation kills below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>RED control on develop, green at head, and both per-stream mutation kills</summary>

```
# RED control: origin/develop sandbox-engine.ts + this PR's test (packages/agent)
 × preserves a code point split across two stdout chunks
   AssertionError: expected '��' to be 'é'
 × preserves a code point split across two stderr chunks
   AssertionError: expected '���' to be '世'
 ✓ still accumulates multi-chunk ASCII output in order
      Tests  2 failed | 1 passed (3)

# head 6c856e2e43
      Tests  3 passed (3)

# mutation A -- remove only proc.stdout.setEncoding("utf8")
 × preserves a code point split across two stdout chunks
      Tests  1 failed | 2 passed (3)

# mutation B -- remove only proc.stderr.setEncoding("utf8")
 × preserves a code point split across two stderr chunks
      Tests  1 failed | 2 passed (3)

# neighbouring sandbox suites at head
      Tests  90 passed (90)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic byte-decoding path with no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Reachability chain, the already-fixed sibling paths, and static gates at exact head</summary>

```
Reachability (line numbers on origin/develop f7a4fbec26):
  shell-execution-router.ts:7    local-safe -- every shell exec routed through SandboxManager
  shell-execution-router.ts:121  capability-broker hardcodes local-safe as its default mode
  sandbox-manager.ts:473         await this.engine.execInContainer({...})
  sandbox-engine.ts:146          runExecInContainer
  sandbox-engine.ts:162,165      stdout += data.toString() / stderr += data.toString()

Same shape already present elsewhere in the repository:
  shell-execution-router.ts:242-244
  app-core/platforms/electrobun/src/ssh-runtime-rpc.ts:283-284
  merged precedent b1c023612e (#22494), sibling path

$ node_modules/.bin/biome check \
    packages/agent/src/services/sandbox-engine.ts \
    packages/agent/src/services/sandbox-engine-exec-encoding.test.ts
Checked 2 files in 15ms. No fixes applied.        (exit 0)

$ git diff --stat origin/develop..HEAD
 .../src/services/sandbox-engine-exec-encoding.test.ts | 112 ++++++++++++++++++
 packages/agent/src/services/sandbox-engine.ts         |  13 ++-
 2 files changed, 121 insertions(+), 4 deletions(-)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- No live container run: this host has neither `docker` nor `container` installed, so the end-to-end sandbox reproduction in the issue could not be executed here. The test drives the real `execInContainer` code path over real Node streams instead, which is where the decoding happens; the container binary only supplies the bytes.
- `bun run verify` and the package `typecheck` were not run clean: this review worktree links packages from a sibling checkout, and `tsc` reports ~1500 pre-existing `TS2307`/`TS7006` errors there from unresolvable third-party deps (`viem`, `@solana/web3.js`, `pg`, `lucide-react`), none naming `sandbox`. The focused suites, the RED control, the two mutation kills, and Biome above stand in.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
