### PR TITLE
fix(ui): complete hosted session logout

### DIFF
--- a/packages/ui/src/cloud/join/JoinPage.sign-out-cleanup.test.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.sign-out-cleanup.test.tsx
@@ -71,7 +71,8 @@ function connectedResult() {
 describe("JoinPage sign-out cleanup ownership", () => {
   beforeEach(() => {
     runJoinFlowMock.mockReset();
-    signOutMock.mockClear();
+    signOutMock.mockReset();
+    signOutMock.mockResolvedValue(undefined);
     replaceMock.mockClear();
   });
 
@@ -101,5 +102,25 @@ describe("JoinPage sign-out cleanup ownership", () => {
     });
     await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
     expect(replaceMock).toHaveBeenCalledWith("/login");
+  });
+
+  it("keeps the user on a retryable error state when hosted logout is refused", async () => {
+    runJoinFlowMock.mockRejectedValue(new Error("agent unavailable"));
+    signOutMock.mockRejectedValue(
+      new Error("Eliza Cloud could not end the browser session (403)."),
+    );
+    render(<JoinPage />);
+    await screen.findByText("agent unavailable");
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    await screen.findByRole("heading", { name: "Couldn't sign out" });
+    await screen.findByText("Could not sign out safely. Please try again.");
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: "Sign out" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    expect(replaceMock).not.toHaveBeenCalledWith("/login");
   });
 });

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -38,7 +38,7 @@ import {
 import { runJoinFlow } from "./lib/run-join-flow";
 import { useJoinSessionAuth } from "./lib/use-join-session";
 
-type JoinPhase = "connecting" | "ready" | "error";
+type JoinPhase = "connecting" | "ready" | "error" | "sign-out-error";
 
 function describeJoinError(err: unknown): string {
   if (err instanceof Error && err.message.trim()) return err.message;
@@ -168,9 +168,21 @@ export default function JoinPage(): React.JSX.Element {
     const { signOutFromSsoBridgedHost } = await import(
       "../sso-bridge/sso-bridge"
     );
-    await signOutFromSsoBridgedHost();
-    appModeNavigation.replace("/login");
-  }, [signingOut]);
+    try {
+      await signOutFromSsoBridgedHost();
+      appModeNavigation.replace("/login");
+    } catch {
+      // error-policy:J4 the server still owns an authenticated session, so
+      // keep the user here and expose a retry instead of claiming sign-out.
+      setError(
+        t("cloud.userMenu.signOutFailed", {
+          defaultValue: "Could not sign out safely. Please try again.",
+        }),
+      );
+      setPhase("sign-out-error");
+      setSigningOut(false);
+    }
+  }, [signingOut, t]);
 
   const signOutButton = (
     <Button
@@ -208,7 +220,19 @@ export default function JoinPage(): React.JSX.Element {
           draggable={false}
         />
 
-        {phase === "error" ? (
+        {phase === "sign-out-error" ? (
+          <div className="flex flex-col items-center gap-4">
+            <h1 className="font-poppins text-lg font-semibold text-white">
+              {t("cloud.join.signOutErrorTitle", {
+                defaultValue: "Couldn't sign out",
+              })}
+            </h1>
+            <p className="text-sm text-white/70" role="alert">
+              {error}
+            </p>
+            {signOutButton}
+          </div>
+        ) : phase === "error" ? (
           <div className="flex flex-col items-center gap-4">
             <h1 className="font-poppins text-lg font-semibold text-white">
               {t("cloud.join.errorTitle", {

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../lib/steward-session-cookie-sync-marker";
 
 import {
+  clearServerStewardSessionCookies,
   clearStaleStewardSession,
   tokenIsExpired,
 } from "./StewardProviderShared";
@@ -270,6 +271,26 @@ describe("clearStaleStewardSession", () => {
         "/api/auth/steward-session",
       ),
     ).toBe(false);
+  });
+});
+
+describe("clearServerStewardSessionCookies", () => {
+  it("marks every cookie-clearing DELETE as a non-simple request", () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    clearServerStewardSessionCookies();
+
+    expect(fetchSpy).toHaveBeenCalled();
+    for (const [url, init] of fetchSpy.mock.calls) {
+      expect(String(url)).toContain("/api/auth/steward-session");
+      expect(init).toMatchObject({
+        method: "DELETE",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      });
+    }
   });
 });
 

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -130,9 +130,11 @@ export function clearServerStewardSessionCookies(): void {
   for (const url of stewardSessionClearUrls()) {
     // error-policy:J6 best-effort sign-out cookie clear across session hosts;
     // the local token is already cleared and an expired cookie self-heals.
-    fetch(url, { method: "DELETE", credentials: "include" }).catch(
-      () => undefined,
-    );
+    fetch(url, {
+      method: "DELETE",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    }).catch(() => undefined);
   }
 }
 

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -559,7 +559,46 @@ describe("signOutFromSsoBridgedHost", () => {
       await signOutFromSsoBridgedHost("cloud.eliza.app", fn);
       expect(isSsoLoggedOut()).toBe(true);
       expect(calls[0].url).toBe("https://cloud.eliza.app/api/auth/logout");
+      expect(calls[0].init).toMatchObject({
+        method: "POST",
+        credentials: "include",
+      });
+      expect(new Headers(calls[0].init?.headers).get("content-type")).toBe(
+        "application/json",
+      );
       expect(proofAtServerLogoutIssue).toBe(false);
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("rejects when the hosted session cannot be ended", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
+    try {
+      const { fn } = fetchStub(() =>
+        json(403, { error: "csrf_marker_required" }),
+      );
+      await expect(
+        signOutFromSsoBridgedHost("cloud.eliza.app", fn),
+      ).rejects.toThrow("could not end the browser session (403)");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("rejects when the hosted logout request cannot reach the server", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
+    try {
+      const networkFailure = new TypeError("network unavailable");
+      const fn = (() => Promise.reject(networkFailure)) as typeof fetch;
+      await expect(
+        signOutFromSsoBridgedHost("cloud.eliza.app", fn),
+      ).rejects.toBe(networkFailure);
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
     } finally {
       globalThis.fetch = realFetch;
@@ -581,6 +620,25 @@ describe("prepareSsoAccountSwitch", () => {
       );
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
       expect(isSsoLoggedOut()).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("marks the account-switch logout request as non-simple", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
+    try {
+      const { fn, calls } = fetchStub(() => json(200, { success: true }));
+      await prepareSsoAccountSwitch("eliza.app", fn);
+      expect(calls[0].init).toMatchObject({
+        method: "POST",
+        credentials: "include",
+      });
+      expect(new Headers(calls[0].init?.headers).get("content-type")).toBe(
+        "application/json",
+      );
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -610,8 +610,9 @@ export function burnSsoBridgeCode(
  * local scrub stays synchronous so the login page never renders over a
  * half-signed-out session. On hostnames outside the deployed map (local dev)
  * the server call is skipped and this degrades to the local scrub, exactly
- * the previous local behavior. The returned promise settles with the
- * server teardown; callers may ignore it.
+ * the previous local behavior. A hosted non-success response or transport
+ * failure rejects so explicit sign-out cannot claim success over a server
+ * session that may still be live.
  */
 export async function signOutFromSsoBridgedHost(
   hostname: string = window.location.hostname,
@@ -627,12 +628,18 @@ export async function signOutFromSsoBridgedHost(
     ? fetchFn(`${base}/api/auth/logout`, {
         method: "POST",
         credentials: "include",
-      }).catch(() => undefined)
+        headers: { "Content-Type": "application/json" },
+      })
     : // error-policy:J6 best-effort server teardown — the local marker is
       // already set and the local scrub below always runs.
       Promise.resolve(undefined);
   await clearStaleStewardSession();
-  await serverLogout;
+  const response = await serverLogout;
+  if (response && !response.ok) {
+    throw new Error(
+      `Eliza Cloud could not end the browser session (${response.status}).`,
+    );
+  }
 }
 
 /**
@@ -656,6 +663,7 @@ export async function prepareSsoAccountSwitch(
   const serverLogout = fetchFn(`${base}/api/auth/logout`, {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
   });
   await clearStaleStewardSession();
   const response = await serverLogout;

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8555,6 +8555,7 @@
   "cloud.join.errorBody": "Something went wrong. Try again.",
   "cloud.join.errorTitle": "Couldn't open your Eliza",
   "cloud.join.retry": "Try again",
+  "cloud.join.signOutErrorTitle": "Couldn't sign out",
   "cloud.join.signingOut": "Signing out...",
   "cloud.join.signOut": "Sign out",
   "cloud.join.signOutAnyway": "Sign out anyway",


### PR DESCRIPTION
# Relates to

Closes #29889.

- [x] Targets `develop` and is based on current `origin/develop`.
- [x] `bun install` and `bun run verify` passed after sync.
- [x] Behavioral tests cover the hosted logout boundary.

# Sync with develop

- [x] Based on `origin/develop` at `f7a4fbec264f81ff87801fdde65b7533a3d94fd4`.
- [x] Zero conflicts.
- [x] Full root verification passes.

# Risks

Low. The change is limited to hosted session teardown requests and explicit sign-out failure presentation.

# Background

## What does this PR do?

- Adds the required JSON non-simple marker to hosted logout POST requests.
- Adds the marker to every Steward-session DELETE request.
- Observes non-2xx and transport failures during explicit sign-out.
- Prevents login navigation when server teardown fails.
- Shows an accessible retryable sign-out failure state.
- Preserves best-effort background cleanup and local-development behavior.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No standalone documentation change is required.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/sso-bridge/sso-bridge.ts` and `packages/ui/src/cloud/join/JoinPage.tsx`.

## Detailed testing steps

1. Sign into the hosted app and enter `/join`.
2. Select Sign out.
3. Confirm successful teardown navigates to login.
4. Simulate a non-2xx or network failure.
5. Confirm the page does not navigate and shows an enabled Sign out retry.

# Evidence Gate

<!-- evidence-head:9f5dd9d714d4ec225b5856736d59ce405e7cead6 -->

- [ ] Before screenshots: pending exact-head inline upload before review-ready.
- [ ] After screenshots: pending exact-head inline upload before review-ready.
- [ ] Walkthrough video: pending exact-head inline upload before review-ready.
- [x] Backend logs: staging boundary behavior is described in #29889.
- [ ] Frontend logs: pending exact-head capture before review-ready.
- [x] LLM trajectory: N/A - no model path changed.
- [x] Domain artifacts: N/A - no schema or persisted-domain change.
- [ ] OCR review: pending exact-head capture before review-ready.

# Evidence Details

## Real LLM-call trajectory

N/A - no model or agent behavior changed.

## Backend + frontend logs

Pending sanitized exact-head frontend capture before review-ready.

## Screenshots (before / after) + video walkthrough

Pending inline upload before this draft is marked ready.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

The implementation gates pass. Required inline visual evidence remains pending, so this PR is opened as a draft.

Verification:

- Five focused test files, 62 tests passed.
- `packages/ui` typecheck passed.
- `bun run check:i18n` passed.
- Biome passed on all seven changed files.
- `git diff --check` passed.
- Full `bun run verify` passed.

## Maintainer CI exception record

N/A - no exception requested.
