### PR TITLE
fix(agent-orchestrator): stop doubling sentence terminator in sub-agent failure reply

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -211,6 +211,29 @@ describe("subAgentFailureResponseEvaluator", () => {
     expect(result.reply).not.toContain("….");
   });
 
+  // The terminator class also carries the fullwidth/ideographic stops so a
+  // sub-agent narrating in a language that uses them is not doubled. Each stop
+  // is pinned independently: dropping any one member from SENTENCE_TERMINATOR
+  // must turn one of these red, otherwise a later "simplify this regex" cleanup
+  // could silently reintroduce the #29852 doubling for CJK narration.
+  it.each([
+    ["。", "ACP session failed: 接続がタイムアウトしました。"],
+    ["！", "Sub-agent crashed: プロセスが異常終了しました！"],
+    ["？", "Provisioning check: ワークスペースは完了しましたか？"],
+  ])(
+    "does not double when the reason already ends in the '%s' stop (#29852)",
+    (stop, reason) => {
+      const context = makeContext({
+        text: `[sub-agent: text-my-ex (claude) — error]\n${reason}`,
+      });
+      const result = subAgentFailureResponseEvaluator.evaluate(context);
+      expect(result.reply).toBe(
+        `Couldn't finish the "text-my-ex" task — ${reason} Want me to retry?`,
+      );
+      expect(result.reply).not.toContain(`${stop}.`);
+    },
+  );
+
   it("preserves a reason's own '!' terminator without appending a period", () => {
     const context = makeContext({
       text: "[sub-agent: text-my-ex (claude) — error]\nSub-agent process crashed unexpectedly!",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -184,4 +184,61 @@ describe("subAgentFailureResponseEvaluator", () => {
     const result = subAgentFailureResponseEvaluator.evaluate(context);
     expect(result.reply).toBe("Couldn't finish that task. Want me to retry?");
   });
+
+  // Regressions for #29852: the router's error narration is unedited content, so
+  // a reason clause frequently already ends in sentence punctuation. The reply
+  // template must contribute exactly one terminator — never doubling the one the
+  // reason already carries — and must preserve `!`/`?` rather than overriding it.
+  it("does not double a period when the reason already ends in one (#29852)", () => {
+    const context = makeContext({
+      text: "[sub-agent: text-my-ex (claude) — error]\nACP session failed: registration request timed out.",
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — ACP session failed: registration request timed out. Want me to retry?`,
+    );
+    expect(result.reply).not.toContain("..");
+  });
+
+  it("preserves a reason's own '!' terminator without appending a period", () => {
+    const context = makeContext({
+      text: "[sub-agent: text-my-ex (claude) — error]\nSub-agent process crashed unexpectedly!",
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — Sub-agent process crashed unexpectedly! Want me to retry?`,
+    );
+    expect(result.reply).not.toContain("!.");
+  });
+
+  it("preserves a reason's own '?' terminator without appending a period", () => {
+    const context = makeContext({
+      text: "[sub-agent: text-my-ex (claude) — error]\nDid the workspace ever finish provisioning?",
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — Did the workspace ever finish provisioning? Want me to retry?`,
+    );
+    expect(result.reply).not.toContain("?.");
+  });
+
+  it("adds exactly one terminator to a reason with no trailing punctuation", () => {
+    const context = makeContext({
+      text: "[sub-agent: text-my-ex (claude) — error]\nState recovery budget exhausted after 3 attempts",
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — State recovery budget exhausted after 3 attempts. Want me to retry?`,
+    );
+  });
+
+  it("terminates the empty-reason path with exactly one period", () => {
+    const context = makeContext({
+      text: "[internal-code-9931]",
+      metadata: { subAgentLabel: undefined },
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe("Couldn't finish that task. Want me to retry?");
+    expect(result.reply).not.toContain("..");
+  });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -200,6 +200,17 @@ describe("subAgentFailureResponseEvaluator", () => {
     expect(result.reply).not.toContain("..");
   });
 
+  it("does not double when the reason ends in a horizontal ellipsis (#29852)", () => {
+    const context = makeContext({
+      text: "[sub-agent: text-my-ex (claude) — error]\nWorkspace provisioning timed out…",
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — Workspace provisioning timed out… Want me to retry?`,
+    );
+    expect(result.reply).not.toContain("….");
+  });
+
   it("preserves a reason's own '!' terminator without appending a period", () => {
     const context = makeContext({
       text: "[sub-agent: text-my-ex (claude) — error]\nSub-agent process crashed unexpectedly!",

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -126,14 +126,20 @@ const shortReason = extractFailureReason;
 // sentence punctuation ("…timed out.", "…crashed!"), so appending the template's
 // own terminator unconditionally doubled it ("timed out.. Want me…"). This is the
 // one shared boundary that owns the terminator: if the assembled clause already
-// ends in `.`/`!`/`?` we keep that exact punctuation, otherwise we add exactly
-// one period. Only the punctuation composition is normalized — the reason text,
-// label, and question tail are untouched.
+// ends in a sentence terminator we keep that exact punctuation, otherwise we add
+// exactly one period. The class covers the ASCII stops plus the horizontal
+// ellipsis and the fullwidth/ideographic stops, because `extractFailureReason`
+// keeps only the first line of a multi-line narration and routers commonly mark
+// that truncation with `…` (and non-Latin narration may end in `。`/`！`/`？`) —
+// each of those would otherwise be the exact doubling this guards against. Only
+// the punctuation composition is normalized — the reason text, label, and
+// question tail are untouched.
+const SENTENCE_TERMINATOR = /[.!?…。！？]$/u;
 function buildFailureReply(label: string, reason: string): string {
   const what = label ? `the "${label}" task` : "that task";
   const because = reason ? ` — ${reason}` : "";
   const clause = `Couldn't finish ${what}${because}`;
-  const terminator = /[.!?]$/.test(clause) ? "" : ".";
+  const terminator = SENTENCE_TERMINATOR.test(clause) ? "" : ".";
   return `${clause}${terminator} Want me to retry?`;
 }
 

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -121,11 +121,20 @@ export function extractFailureReason(errorOutput: string): string {
 }
 const shortReason = extractFailureReason;
 
+// Compose the single user-facing failure line. The router's error narration is
+// unedited content: a reason clause frequently arrives already ending in
+// sentence punctuation ("…timed out.", "…crashed!"), so appending the template's
+// own terminator unconditionally doubled it ("timed out.. Want me…"). This is the
+// one shared boundary that owns the terminator: if the assembled clause already
+// ends in `.`/`!`/`?` we keep that exact punctuation, otherwise we add exactly
+// one period. Only the punctuation composition is normalized — the reason text,
+// label, and question tail are untouched.
 function buildFailureReply(label: string, reason: string): string {
   const what = label ? `the "${label}" task` : "that task";
-  const normalizedReason = reason.replace(/[.!?]+$/u, "");
-  const because = normalizedReason ? ` — ${normalizedReason}` : "";
-  return `Couldn't finish ${what}${because}. Want me to retry?`;
+  const because = reason ? ` — ${reason}` : "";
+  const clause = `Couldn't finish ${what}${because}`;
+  const terminator = /[.!?]$/.test(clause) ? "" : ".";
+  return `${clause}${terminator} Want me to retry?`;
 }
 
 function respondIfNeeded(messageHandler: MessageHandlerResult) {


### PR DESCRIPTION
# Relates to

Closes #29852

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; focused package gates pass. See **Known gaps** for the one pre-existing, unrelated `bun run verify` blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`c745213d61`); zero conflicts.
- [x] Focused package tests/typecheck/lint pass post-sync; the only `verify` blocker is a pre-existing unrelated `@elizaos/vault` module-resolution error in `packages/auth`, documented in **Known gaps**.

# Risks

Low. Single-boundary string-formatting change in one plugin evaluator. No timeout
semantics, error codes, cause chains, or metadata are touched — only the
punctuation that composes the user-facing failure line. Fully covered by focused
regressions.

# Background

## What does this PR do?

Fixes a mangled sentence terminator in the sub-agent terminal-failure reply. The
`SubAgentRouter` stamps an unedited error narration onto a synthetic inbound
memory; `buildFailureReply()` in
`plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts`
composes the user line and appends its own terminator before ` Want me to
retry?`.

On the current merge base (`c745213d61`) the composer strips a trailing ASCII stop
from the reason and re-adds a period — `reason.replace(/[.!?]+$/, "")` then
`. Want me…`. That ASCII-only normalization has two defects the router's
unedited narration reaches in practice:

- **Flattens the reason's own `!`/`?`.** A reason ending in `!` or `?` is
  stripped and re-terminated with a bland `.`, destroying the terminator:
  `Sub-agent process crashed unexpectedly!` → `…crashed unexpectedly. Want me to
  retry?`.
- **Doubles a non-ASCII stop.** `extractFailureReason` keeps only the first line
  of a multi-line narration and routers commonly mark that truncation with a
  horizontal ellipsis `…`; non-Latin narration ends in the fullwidth/ideographic
  stops `。`/`！`/`？`. None of those are in the ASCII strip class, so a period is
  still appended after them: `…timed out…` → `…timed out…. Want me to retry?`.

(The pure ASCII `.` case no longer doubles on this base — the strip already
handles it — so develop's own suite is green; this PR repairs the two surviving
shapes above and preserves the ASCII `.` behavior.)

The fix replaces strip-and-re-add with a single conditional terminator at the
shared reply-composition boundary: if the assembled clause already ends in a
sentence terminator, that exact punctuation is kept; otherwise exactly one
period is added. The class covers the ASCII stops plus `…` and `。`/`！`/`？`, so
the reason's own terminator is preserved and never doubled. The reason text,
label, question tail, structured error code, original cause chain, and timeout
metadata are all unchanged — punctuation composition only, no special-casing of
any one call site.

```ts
const SENTENCE_TERMINATOR = /[.!?…。！？]$/u;
const clause = `Couldn't finish ${what}${because}`;
const terminator = SENTENCE_TERMINATOR.test(clause) ? "" : ".";
return `${clause}${terminator} Want me to retry?`;
```

## What kind of change is this?

Bug fix (non-breaking change at a production failure boundary). On the current
merge base develop's own suite is green; reverting only the production file to
the merge base and keeping this PR's regressions turns the flattened `!`/`?` and
the doubled `…`/`。`/`！`/`？` cases red (6 failed / 16 passed).

# Documentation changes needed?

My changes do not require a change to the project documentation. A file-level
comment at the fixed boundary documents the invariant.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts`
and the `buildFailureReply` seam it exercises.

## Detailed testing steps

```bash
bun install
cd plugins/plugin-agent-orchestrator
bunx vitest run --config vitest.config.ts __tests__/unit/sub-agent-failure-evaluator.test.ts
```

Reverting ONLY the production file to the merge base (`c745213d61`) and keeping
this PR's tests turns **6 failed / 16 passed**: the ASCII `!`/`?` cases (base
flattens them into `.`) and the four non-ASCII stops `…`/`。`/`！`/`？` (base
doubles them). The regressions cover: reason ending in `.`, `!`, `?`, a
horizontal ellipsis `…`, each of the three fullwidth/ideographic stops
`。`/`！`/`？` (pinned independently via mutation testing so dropping any one
member of the terminator class turns exactly one case red), no trailing
punctuation, and the empty-reason path. All 22 pass after the fix. Full
before/after console output is attached in the evidence rows below.

# Evidence Gate

<!-- evidence-head:5a0cb0e721e4da06ea2cc97c72f992443e0d7cea -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side string formatting in a plugin evaluator; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server-side string formatting in a plugin evaluator; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - deterministic pure-helper unit change; no interactive user flow.`
<!-- evidence-row:backend-logs -->
- [x] Focused vitest output for the real evaluator code path, PR head `5a0cb0e721` vs merge base `c745213d61` (bun 1.3.14, vitest 4.1.10; run from `plugins/plugin-agent-orchestrator`). BEFORE reverts ONLY `src/evaluators/sub-agent-failure.ts` to the merge base and keeps the PR tests:
```
$ bunx vitest run --config vitest.config.ts --reporter=verbose __tests__/unit/sub-agent-failure-evaluator.test.ts
[after / fix applied at 5a0cb0e721]
 Test Files  1 passed (1)
      Tests  22 passed (22)

[before / production file reverted to merge base c745213d61, PR tests kept]
 × does not double when the reason ends in a horizontal ellipsis (#29852)
 × does not double when the reason already ends in the '。' stop (#29852)
 × does not double when the reason already ends in the '！' stop (#29852)
 × does not double when the reason already ends in the '？' stop (#29852)
 × preserves a reason's own '!' terminator without appending a period
 × preserves a reason's own '?' terminator without appending a period
 Test Files  1 failed (1)
      Tests  6 failed | 16 passed (22)
  Received (… ellipsis): "… Workspace provisioning timed out…. Want me to retry?"   (base doubles)
  Received ('!' ASCII):   "… Sub-agent process crashed unexpectedly. Want me to retry?" (base flattens '!' to '.')
$ bunx tsc --noEmit -p tsconfig.json ; echo EXIT=$?   ->   EXIT=0 (no diagnostics)
$ bunx @biomejs/biome check src/... __tests__/...      ->   Checked 2 files. No fixes applied.
```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface; the evaluator runs server-side.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model call is involved; buildFailureReply is a deterministic string composer over router-stamped metadata. The changed path is exercised by real evaluator invocations in the unit suite.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the composed user-facing failure string. Verbatim before (merge base `c745213d61`) / after (PR head) for each acceptance case. `[=]` identical, `[Δ]` changed by the fix:
```
[=] reason ends '.'  before: …timed out. Want me to retry?          after: …timed out. Want me to retry?         (base strip already single)
[Δ] reason ends '!'  before: …crashed unexpectedly. Want me…        after: …crashed unexpectedly! Want me to retry? (base FLATTENED '!'->'.')
[Δ] reason ends '?'  before: …finish provisioning. Want me…         after: …finish provisioning? Want me to retry?  (base FLATTENED '?'->'.')
[Δ] reason ends '…'  before: …timed out…. Want me to retry?         after: …timed out… Want me to retry?          (base DOUBLED)
[Δ] reason ends '。'  before: …しました。. Want me…                  after: …しました。 Want me to retry?            (base DOUBLED)
[Δ] reason ends '！'  before: …しました！. Want me…                  after: …しました！ Want me to retry?            (base DOUBLED)
[Δ] reason ends '？'  before: …しましたか？. Want me…                after: …しましたか？ Want me to retry?          (base DOUBLED)
[=] no punctuation   both:   …exhausted after 3 attempts. Want me to retry?
[=] empty reason     both:   Couldn't finish that task. Want me to retry?
```
Each non-ASCII stop is pinned independently: dropping any one member from `SENTENCE_TERMINATOR` turns exactly one case red.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call in the changed path.`

## Backend + frontend logs

Focused suite — **before** (production file reverted to the merge base `c745213d61`, PR tests kept — the ASCII `!`/`?` flatten and the four non-ASCII `…`/`。`/`！`/`？` doubles). The complete verbose console log is attached in the **backend-logs** evidence row:

<details>
<summary>before — 6 failed / 16 passed</summary>

```
 × does not double when the reason ends in a horizontal ellipsis (#29852)
 × does not double when the reason already ends in the '。' stop (#29852)
 × does not double when the reason already ends in the '！' stop (#29852)
 × does not double when the reason already ends in the '？' stop (#29852)
 × preserves a reason's own '!' terminator without appending a period
 × preserves a reason's own '?' terminator without appending a period

Expected: "Couldn't finish the "text-my-ex" task — Workspace provisioning timed out… Want me to retry?"
Received: "Couldn't finish the "text-my-ex" task — Workspace provisioning timed out…. Want me to retry?"

Expected: "Couldn't finish the "text-my-ex" task — Sub-agent process crashed unexpectedly! Want me to retry?"
Received: "Couldn't finish the "text-my-ex" task — Sub-agent process crashed unexpectedly. Want me to retry?"

 Test Files  1 failed (1)
      Tests  6 failed | 16 passed (22)
```

</details>

**after** (fix applied):

<details>
<summary>after — 22 passed</summary>

```
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

</details>

Typecheck (from the package, exits 0 with no diagnostics on the current base):

```
$ bunx tsc --noEmit -p tsconfig.json ; echo EXIT=$?
EXIT=0
```

Biome on the two changed files:

```
$ bunx @biomejs/biome check src/evaluators/sub-agent-failure.ts __tests__/unit/sub-agent-failure-evaluator.test.ts
Checked 2 files in 25ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no interactive user flow; deterministic string-composition change.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- None at the package level: `bunx tsc --noEmit -p tsconfig.json` from
  `plugins/plugin-agent-orchestrator` exits 0 with no diagnostics once
  `@elizaos/vault` is built (`bun run --cwd packages/vault build`), and Biome is
  clean on the two changed files. Before vault is built, that same command
  surfaces a single `@elizaos/vault` module-resolution error in
  `packages/auth/src/account-storage.ts`; it is a pre-existing workspace-build
  ordering artifact on `develop`, not a defect in this package or this change,
  and it clears as soon as the dependency's `dist` exists.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@8245c4d86bb5b56aec80ab33a487f9f3f22bc2bc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@8245c4d86bb5b56aec80ab33a487f9f3f22bc2bc:packages/skills/skills/contribute-to-eliza"} -->

