### PR TITLE
fix(plugin-native-canvas): balance ctx.save/restore on throwing synchronous draws

### DIFF
--- a/plugins/plugin-native-canvas/src/web-drawimage.test.ts
+++ b/plugins/plugin-native-canvas/src/web-drawimage.test.ts
@@ -193,6 +193,50 @@ describe("CanvasWeb.drawImage save/restore balance", () => {
     expect(ctx.globalAlpha).toBe(1);
   });
 
+  it("balances save/restore when a bad shadow color throws after a successful load", async () => {
+    installFakeImage("load");
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    ctx.saveCount = 0;
+    ctx.restoreCount = 0;
+
+    // The image loads, then applyDrawOptions() throws a TypeError from
+    // colorToString on a null shadow.color AFTER ctx.save() has pushed the
+    // frame. This window is only reachable once the load resolves, so the
+    // load-rejection guard does not cover it; the try/finally must.
+    await expect(
+      canvas.drawImage({
+        canvasId,
+        image: "https://example.test/ok.png",
+        destRect: { x: 0, y: 0, width: 10, height: 10 },
+        drawOptions: {
+          opacity: 0.5,
+          shadow: {
+            color: null as unknown as { r: number; g: number; b: number },
+            blur: 4,
+            offsetX: 1,
+            offsetY: 1,
+          },
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.saveCount).toBe(1);
+    expect(ctx.globalAlpha).toBe(1);
+
+    // A later plain rectangle must fill at alpha 1, not the leaked 0.5.
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 5, height: 5 },
+      fill: { color: { r: 255, g: 0, b: 0 } },
+    });
+
+    expect(ctx.fillAlphas).toEqual([1]);
+  });
+
   it("does not leak opacity through a failed drawBatch image command", async () => {
     installFakeImage("error");
     const canvas = new CanvasWeb();

--- a/plugins/plugin-native-canvas/src/web-gradient-restore.test.ts
+++ b/plugins/plugin-native-canvas/src/web-gradient-restore.test.ts
@@ -3,14 +3,17 @@
 /**
  * Regression tests for the save/restore balance of `CanvasWeb`'s synchronous
  * draw methods (`drawRect`, `drawEllipse`, `drawPath`, `drawLine`, `drawText`)
- * when a gradient fill throws mid-draw. Exercises the real `CanvasWeb` against
- * a stubbed 2D context whose `createRadialGradient`/`createLinearGradient` and
- * `addColorStop` reproduce the browser's `IndexSizeError`/`SyntaxError`
- * behavior for malformed gradients. Guards the contract that a throwing fill
- * must not leak the `ctx.save()` frame or the mutated draw-option state
- * (globalAlpha, blendMode, shadow, transform) onto later unrelated draws — the
- * same balance invariant already proven for the async `drawImage` path — while
- * the success path still restores exactly once at the requested opacity.
+ * when a step between `ctx.save()` and `ctx.restore()` throws mid-draw.
+ * Exercises the real `CanvasWeb` against a stubbed 2D context whose
+ * `createRadialGradient`/`createLinearGradient` and `addColorStop` reproduce
+ * the browser's `IndexSizeError`/`SyntaxError` behavior for malformed
+ * gradients, and covers a throw raised inside `applyDrawOptions` itself (a
+ * malformed shadow color) after `save()` has already pushed the frame. Guards
+ * the contract that such a throw must not leak the `ctx.save()` frame or the
+ * mutated draw-option state (globalAlpha, blendMode, shadow, transform) onto
+ * later unrelated draws — the same balance invariant the async `drawImage`
+ * path holds — while the success path still restores exactly once at the
+ * requested opacity.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -267,6 +270,45 @@ describe("CanvasWeb synchronous draw save/restore balance on gradient failure", 
 
     expect(ctx.saveCount).toBe(ctx.restoreCount);
     expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("drawRect balances save/restore when a bad shadow color throws inside applyDrawOptions", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    // A null shadow.color crosses the plugin boundary as malformed JSON; it
+    // throws a TypeError from colorToString AFTER ctx.save() and globalAlpha
+    // have already been applied, inside applyDrawOptions. The frame must not
+    // survive that throw.
+    await expect(
+      canvas.drawRect({
+        canvasId,
+        rect: { x: 0, y: 0, width: 10, height: 10 },
+        fill: { color: { r: 255, g: 0, b: 0 } },
+        drawOptions: {
+          opacity: 0.5,
+          shadow: {
+            color: null as unknown as { r: number; g: number; b: number },
+            blur: 4,
+            offsetX: 1,
+            offsetY: 1,
+          },
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.saveCount).toBe(1);
+    expect(ctx.globalAlpha).toBe(1);
+
+    // A later plain rectangle fills at alpha 1, proving the leaked frame and
+    // opacity did not survive the throw inside applyDrawOptions.
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 5, height: 5 },
+      fill: { color: { r: 0, g: 0, b: 255 } },
+    });
+
+    expect(ctx.fillAlphas).toEqual([1]);
   });
 
   it("success path restores exactly once and fills at the requested opacity", async () => {

--- a/plugins/plugin-native-canvas/src/web-gradient-restore.test.ts
+++ b/plugins/plugin-native-canvas/src/web-gradient-restore.test.ts
@@ -8,7 +8,9 @@
  * `createRadialGradient`/`createLinearGradient` and `addColorStop` reproduce
  * the browser's `IndexSizeError`/`SyntaxError` behavior for malformed
  * gradients, and covers a throw raised inside `applyDrawOptions` itself (a
- * malformed shadow color) after `save()` has already pushed the frame. Guards
+ * malformed shadow color) after `save()` has already pushed the frame, plus a
+ * malformed stroke/text color that throws from `colorToString` in `drawLine`
+ * and `drawText` after `save()`. Guards
  * the contract that such a throw must not leak the `ctx.save()` frame or the
  * mutated draw-option state (globalAlpha, blendMode, shadow, transform) onto
  * later unrelated draws — the same balance invariant the async `drawImage`
@@ -302,6 +304,69 @@ describe("CanvasWeb synchronous draw save/restore balance on gradient failure", 
 
     // A later plain rectangle fills at alpha 1, proving the leaked frame and
     // opacity did not survive the throw inside applyDrawOptions.
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 5, height: 5 },
+      fill: { color: { r: 0, g: 0, b: 255 } },
+    });
+
+    expect(ctx.fillAlphas).toEqual([1]);
+  });
+
+  it("drawLine balances save/restore when the stroke color is malformed", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    // A null stroke.color reaches colorToString via applyStrokeStyle and throws
+    // a TypeError AFTER applyDrawOptions pushed the frame and set globalAlpha.
+    await expect(
+      canvas.drawLine({
+        canvasId,
+        from: { x: 0, y: 0 },
+        to: { x: 5, y: 5 },
+        stroke: {
+          color: null as unknown as { r: number; g: number; b: number },
+          width: 1,
+        },
+        drawOptions: { opacity: 0.5 },
+      }),
+    ).rejects.toThrow();
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+
+    // A later plain rectangle fills at alpha 1, proving the frame and opacity
+    // did not leak from the failed drawLine.
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 5, height: 5 },
+      fill: { color: { r: 0, g: 0, b: 255 } },
+    });
+
+    expect(ctx.fillAlphas).toEqual([1]);
+  });
+
+  it("drawText balances save/restore when the text color is malformed", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    // A null style.color reaches colorToString and throws a TypeError AFTER
+    // applyDrawOptions pushed the frame and set globalAlpha.
+    await expect(
+      canvas.drawText({
+        canvasId,
+        text: "hi",
+        position: { x: 0, y: 0 },
+        style: {
+          font: "sans-serif",
+          size: 12,
+          color: null as unknown as { r: number; g: number; b: number },
+        },
+        drawOptions: { opacity: 0.5 },
+      }),
+    ).rejects.toThrow();
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+
+    // A later plain rectangle fills at alpha 1, proving the frame and opacity
+    // did not leak from the failed drawText.
     await canvas.drawRect({
       canvasId,
       rect: { x: 0, y: 0, width: 5, height: 5 },

--- a/plugins/plugin-native-canvas/src/web-gradient-restore.test.ts
+++ b/plugins/plugin-native-canvas/src/web-gradient-restore.test.ts
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for the save/restore balance of `CanvasWeb`'s synchronous
+ * draw methods (`drawRect`, `drawEllipse`, `drawPath`, `drawLine`, `drawText`)
+ * when a gradient fill throws mid-draw. Exercises the real `CanvasWeb` against
+ * a stubbed 2D context whose `createRadialGradient`/`createLinearGradient` and
+ * `addColorStop` reproduce the browser's `IndexSizeError`/`SyntaxError`
+ * behavior for malformed gradients. Guards the contract that a throwing fill
+ * must not leak the `ctx.save()` frame or the mutated draw-option state
+ * (globalAlpha, blendMode, shadow, transform) onto later unrelated draws — the
+ * same balance invariant already proven for the async `drawImage` path — while
+ * the success path still restores exactly once at the requested opacity.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasWeb } from "./web";
+
+interface CountingContext extends CanvasRenderingContext2D {
+  saveCount: number;
+  restoreCount: number;
+  fillAlphas: number[];
+}
+
+/**
+ * A 2D context stub that tracks save/restore balance, records `globalAlpha`
+ * at each `fill()`, and models the real browser exceptions thrown by
+ * `createRadialGradient` (negative radius) and `addColorStop` (offset outside
+ * [0,1] or an unparseable color). A leaked alpha from a prior failed draw is
+ * therefore observable on a later successful one.
+ */
+function createCountingContext(): CountingContext {
+  const ctx = {
+    globalAlpha: 1,
+    globalCompositeOperation: "source-over",
+    shadowColor: "",
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    font: "",
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    textAlign: "left",
+    textBaseline: "alphabetic",
+    saveCount: 0,
+    restoreCount: 0,
+    fillAlphas: [] as number[],
+    save(this: CountingContext) {
+      this.saveCount += 1;
+    },
+    restore(this: CountingContext) {
+      this.restoreCount += 1;
+      this.globalAlpha = 1;
+      this.globalCompositeOperation = "source-over";
+      this.shadowBlur = 0;
+    },
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    clearRect: vi.fn(),
+    rect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    ellipse: vi.fn(),
+    arc: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    scale: vi.fn(),
+    transform: vi.fn(),
+    setTransform: vi.fn(),
+    setLineDash: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    createLinearGradient: vi.fn(() => makeGradientStub()),
+    createRadialGradient: vi.fn(
+      (
+        _x0: number,
+        _y0: number,
+        r0: number,
+        _x1: number,
+        _y1: number,
+        r1: number,
+      ) => {
+        if (r0 < 0 || r1 < 0) {
+          throw new DOMException(
+            "The radius provided is negative.",
+            "IndexSizeError",
+          );
+        }
+        return makeGradientStub();
+      },
+    ),
+    getImageData: vi.fn(() => ({
+      data: new Uint8ClampedArray(4),
+      width: 1,
+      height: 1,
+    })),
+    putImageData: vi.fn(),
+  } as unknown as CountingContext;
+
+  ctx.fill = vi.fn(function fill(this: CountingContext) {
+    this.fillAlphas.push(this.globalAlpha);
+  }) as unknown as CanvasRenderingContext2D["fill"];
+
+  return ctx;
+}
+
+/**
+ * A gradient stub whose `addColorStop` throws the way a browser does for an
+ * offset outside [0,1], matching `CanvasGradient.addColorStop`.
+ */
+function makeGradientStub(): CanvasGradient {
+  return {
+    addColorStop(offset: number) {
+      if (offset < 0 || offset > 1) {
+        throw new DOMException(
+          "The provided value is outside the range [0, 1].",
+          "IndexSizeError",
+        );
+      }
+    },
+  } as unknown as CanvasGradient;
+}
+
+describe("CanvasWeb synchronous draw save/restore balance on gradient failure", () => {
+  let ctx: CountingContext;
+
+  beforeEach(() => {
+    ctx = createCountingContext();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  async function makeCanvas(): Promise<{
+    canvas: CanvasWeb;
+    canvasId: string;
+  }> {
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    ctx.saveCount = 0;
+    ctx.restoreCount = 0;
+    return { canvas, canvasId };
+  }
+
+  it("drawRect with a negative-radius radial gradient balances save/restore", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    await expect(
+      canvas.drawRect({
+        canvasId,
+        rect: { x: 0, y: 0, width: 10, height: 10 },
+        fill: {
+          type: "radial",
+          x0: 5,
+          y0: 5,
+          r0: -1,
+          x1: 5,
+          y1: 5,
+          r1: 5,
+          stops: [
+            { offset: 0, color: { r: 255, g: 0, b: 0 } },
+            { offset: 1, color: { r: 0, g: 0, b: 255 } },
+          ],
+        },
+        drawOptions: { opacity: 0.5 },
+      }),
+    ).rejects.toThrow();
+
+    // The save() frame must be fully unwound even though the fill threw.
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.saveCount).toBe(1);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("does not leak the failed draw opacity onto a later plain drawRect", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    await expect(
+      canvas.drawRect({
+        canvasId,
+        rect: { x: 0, y: 0, width: 10, height: 10 },
+        fill: {
+          type: "radial",
+          x0: 5,
+          y0: 5,
+          r0: -1,
+          x1: 5,
+          y1: 5,
+          r1: 5,
+          stops: [{ offset: 0, color: { r: 255, g: 0, b: 0 } }],
+        },
+        drawOptions: { opacity: 0.5 },
+      }),
+    ).rejects.toThrow();
+
+    // A later fully-opaque rectangle must fill at alpha 1, not the leaked 0.5.
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 5, height: 5 },
+      fill: { color: { r: 255, g: 0, b: 0 } },
+    });
+
+    expect(ctx.fillAlphas).toEqual([1]);
+  });
+
+  it("drawEllipse balances save/restore when the gradient fill throws", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    await expect(
+      canvas.drawEllipse({
+        canvasId,
+        center: { x: 5, y: 5 },
+        radiusX: 4,
+        radiusY: 4,
+        fill: {
+          type: "radial",
+          x0: 5,
+          y0: 5,
+          r0: -3,
+          x1: 5,
+          y1: 5,
+          r1: 4,
+          stops: [{ offset: 0, color: { r: 0, g: 255, b: 0 } }],
+        },
+        drawOptions: { opacity: 0.25 },
+      }),
+    ).rejects.toThrow();
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("drawPath balances save/restore when a color stop offset is out of range", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    await expect(
+      canvas.drawPath({
+        canvasId,
+        path: {
+          commands: [
+            { type: "moveTo", args: [0, 0] },
+            { type: "lineTo", args: [10, 10] },
+            { type: "closePath", args: [] },
+          ],
+        },
+        fill: {
+          type: "linear",
+          x0: 0,
+          y0: 0,
+          x1: 10,
+          y1: 10,
+          // 1.5 is outside [0,1] -> addColorStop throws IndexSizeError.
+          stops: [{ offset: 1.5, color: { r: 10, g: 20, b: 30 } }],
+        },
+        drawOptions: { opacity: 0.75 },
+      }),
+    ).rejects.toThrow();
+
+    expect(ctx.saveCount).toBe(ctx.restoreCount);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("success path restores exactly once and fills at the requested opacity", async () => {
+    const { canvas, canvasId } = await makeCanvas();
+
+    await canvas.drawRect({
+      canvasId,
+      rect: { x: 0, y: 0, width: 10, height: 10 },
+      fill: {
+        type: "radial",
+        x0: 5,
+        y0: 5,
+        r0: 0,
+        x1: 5,
+        y1: 5,
+        r1: 5,
+        stops: [
+          { offset: 0, color: { r: 255, g: 0, b: 0 } },
+          { offset: 1, color: { r: 0, g: 0, b: 255 } },
+        ],
+      },
+      drawOptions: { opacity: 0.5 },
+    });
+
+    expect(ctx.saveCount).toBe(1);
+    expect(ctx.restoreCount).toBe(1);
+    expect(ctx.fillAlphas).toEqual([0.5]);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+});

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -457,15 +457,17 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
-    // applyDrawOptions() runs ctx.save() and mutates ctx (globalAlpha,
-    // blendMode, shadow, transform). Any step below can throw — a malformed
-    // gradient fill (negative radius, out-of-range color-stop offset,
-    // unparseable color) throws from createFillStyle. Without try/finally the
-    // ctx.restore() would be skipped, leaking the save() frame and the mutated
-    // draw-option state onto every later draw on this canvas. This mirrors the
-    // balance the async drawImage() path already guarantees.
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    // applyDrawOptions() runs ctx.save() as its first statement, then mutates
+    // ctx (transform, globalAlpha, blendMode, shadow). Keeping that call and
+    // the draw body inside one try/finally means any throw after save() — a
+    // malformed gradient fill (negative radius, out-of-range color-stop
+    // offset, unparseable color) from createFillStyle, or a bad shadow color
+    // inside applyDrawOptions — is unwound by ctx.restore() instead of leaking
+    // the save() frame and the mutated draw-option state onto every later draw
+    // on this canvas. save() is the first statement of applyDrawOptions, so
+    // the finally never fires ctx.restore() on an unpushed frame.
     try {
+      this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
       ctx.beginPath();
 
       if (options.cornerRadius && options.cornerRadius > 0) {
@@ -515,10 +517,10 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
-    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
-    // a malformed gradient fill throws from createFillStyle.
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    // See drawRect: applyDrawOptions() (which owns ctx.save()) and the draw
+    // body share one try/finally, so a throw after save() stays balanced.
     try {
+      this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
       ctx.beginPath();
       ctx.ellipse(
         options.center.x,
@@ -553,10 +555,10 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
-    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
-    // a step between save() and restore() throws.
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    // See drawRect: applyDrawOptions() (which owns ctx.save()) and the draw
+    // body share one try/finally, so a throw after save() stays balanced.
     try {
+      this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
       this.applyStrokeStyle(ctx, options.stroke);
 
       ctx.beginPath();
@@ -577,10 +579,10 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
-    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
-    // a malformed gradient fill throws from createFillStyle.
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    // See drawRect: applyDrawOptions() (which owns ctx.save()) and the draw
+    // body share one try/finally, so a throw after save() stays balanced.
     try {
+      this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
       ctx.beginPath();
 
       for (const cmd of options.path.commands) {
@@ -672,10 +674,10 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
-    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
-    // a step between save() and restore() throws.
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    // See drawRect: applyDrawOptions() (which owns ctx.save()) and the draw
+    // body share one try/finally, so a throw after save() stays balanced.
     try {
+      this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
       ctx.font = `${options.style.size}px ${options.style.font}`;
       ctx.fillStyle = this.colorToString(options.style.color);
       ctx.textAlign = options.style.align || "left";
@@ -714,43 +716,46 @@ export class CanvasWeb extends WebPlugin {
       img.src = `data:image/${options.image.format};base64,${options.image.base64}`;
     }
 
-    // Resolve the image load BEFORE pushing any save()/draw-option state.
-    // applyDrawOptions() runs ctx.save() and mutates ctx (globalAlpha,
-    // blendMode, shadow, transform); holding that frame across the await
-    // would leak the mutated state onto every subsequent draw whenever the
-    // load rejects (bad URL/base64, network, CORS — all normal runtime
-    // conditions). Applying draw options only after a successful load keeps
-    // save()/restore() balanced on both the success and failure paths.
+    // Resolve the image load BEFORE pushing any save()/draw-option state so a
+    // load rejection (bad URL/base64, network, CORS — all normal runtime
+    // conditions) never leaks a save() frame. Once loaded, applyDrawOptions()
+    // (which owns ctx.save()) and the drawImage() call run inside one
+    // try/finally, so a throw after save() — a bad shadow color inside
+    // applyDrawOptions, or drawImage() itself — is still unwound by
+    // ctx.restore() instead of corrupting later draws. This is the same
+    // save()/restore() balance the synchronous draw methods hold.
     await new Promise<void>((resolve, reject) => {
       img.onload = () => resolve();
       img.onerror = () => reject(new Error("Failed to load image"));
     });
 
-    this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    try {
+      this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
 
-    if (options.srcRect) {
-      ctx.drawImage(
-        img,
-        options.srcRect.x,
-        options.srcRect.y,
-        options.srcRect.width,
-        options.srcRect.height,
-        options.destRect.x,
-        options.destRect.y,
-        options.destRect.width,
-        options.destRect.height,
-      );
-    } else {
-      ctx.drawImage(
-        img,
-        options.destRect.x,
-        options.destRect.y,
-        options.destRect.width,
-        options.destRect.height,
-      );
+      if (options.srcRect) {
+        ctx.drawImage(
+          img,
+          options.srcRect.x,
+          options.srcRect.y,
+          options.srcRect.width,
+          options.srcRect.height,
+          options.destRect.x,
+          options.destRect.y,
+          options.destRect.width,
+          options.destRect.height,
+        );
+      } else {
+        ctx.drawImage(
+          img,
+          options.destRect.x,
+          options.destRect.y,
+          options.destRect.width,
+          options.destRect.height,
+        );
+      }
+    } finally {
+      ctx.restore();
     }
-
-    ctx.restore();
   }
 
   async drawBatch(options: {

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -457,43 +457,51 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
+    // applyDrawOptions() runs ctx.save() and mutates ctx (globalAlpha,
+    // blendMode, shadow, transform). Any step below can throw — a malformed
+    // gradient fill (negative radius, out-of-range color-stop offset,
+    // unparseable color) throws from createFillStyle. Without try/finally the
+    // ctx.restore() would be skipped, leaking the save() frame and the mutated
+    // draw-option state onto every later draw on this canvas. This mirrors the
+    // balance the async drawImage() path already guarantees.
     this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    try {
+      ctx.beginPath();
 
-    ctx.beginPath();
+      if (options.cornerRadius && options.cornerRadius > 0) {
+        const r = options.cornerRadius;
+        const { x, y, width, height } = options.rect;
+        ctx.moveTo(x + r, y);
+        ctx.lineTo(x + width - r, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+        ctx.lineTo(x + width, y + height - r);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+        ctx.lineTo(x + r, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+        ctx.lineTo(x, y + r);
+        ctx.quadraticCurveTo(x, y, x + r, y);
+        ctx.closePath();
+      } else {
+        ctx.rect(
+          options.rect.x,
+          options.rect.y,
+          options.rect.width,
+          options.rect.height,
+        );
+      }
 
-    if (options.cornerRadius && options.cornerRadius > 0) {
-      const r = options.cornerRadius;
-      const { x, y, width, height } = options.rect;
-      ctx.moveTo(x + r, y);
-      ctx.lineTo(x + width - r, y);
-      ctx.quadraticCurveTo(x + width, y, x + width, y + r);
-      ctx.lineTo(x + width, y + height - r);
-      ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-      ctx.lineTo(x + r, y + height);
-      ctx.quadraticCurveTo(x, y + height, x, y + height - r);
-      ctx.lineTo(x, y + r);
-      ctx.quadraticCurveTo(x, y, x + r, y);
-      ctx.closePath();
-    } else {
-      ctx.rect(
-        options.rect.x,
-        options.rect.y,
-        options.rect.width,
-        options.rect.height,
-      );
+      if (options.fill) {
+        ctx.fillStyle = this.createFillStyle(ctx, options.fill);
+        ctx.fill();
+      }
+
+      if (options.stroke) {
+        this.applyStrokeStyle(ctx, options.stroke);
+        ctx.stroke();
+      }
+    } finally {
+      ctx.restore();
     }
-
-    if (options.fill) {
-      ctx.fillStyle = this.createFillStyle(ctx, options.fill);
-      ctx.fill();
-    }
-
-    if (options.stroke) {
-      this.applyStrokeStyle(ctx, options.stroke);
-      ctx.stroke();
-    }
-
-    ctx.restore();
   }
 
   async drawEllipse(options: {
@@ -507,30 +515,33 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
+    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
+    // a malformed gradient fill throws from createFillStyle.
     this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    try {
+      ctx.beginPath();
+      ctx.ellipse(
+        options.center.x,
+        options.center.y,
+        options.radiusX,
+        options.radiusY,
+        0,
+        0,
+        Math.PI * 2,
+      );
 
-    ctx.beginPath();
-    ctx.ellipse(
-      options.center.x,
-      options.center.y,
-      options.radiusX,
-      options.radiusY,
-      0,
-      0,
-      Math.PI * 2,
-    );
+      if (options.fill) {
+        ctx.fillStyle = this.createFillStyle(ctx, options.fill);
+        ctx.fill();
+      }
 
-    if (options.fill) {
-      ctx.fillStyle = this.createFillStyle(ctx, options.fill);
-      ctx.fill();
+      if (options.stroke) {
+        this.applyStrokeStyle(ctx, options.stroke);
+        ctx.stroke();
+      }
+    } finally {
+      ctx.restore();
     }
-
-    if (options.stroke) {
-      this.applyStrokeStyle(ctx, options.stroke);
-      ctx.stroke();
-    }
-
-    ctx.restore();
   }
 
   async drawLine(options: {
@@ -542,15 +553,19 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
+    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
+    // a step between save() and restore() throws.
     this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
-    this.applyStrokeStyle(ctx, options.stroke);
+    try {
+      this.applyStrokeStyle(ctx, options.stroke);
 
-    ctx.beginPath();
-    ctx.moveTo(options.from.x, options.from.y);
-    ctx.lineTo(options.to.x, options.to.y);
-    ctx.stroke();
-
-    ctx.restore();
+      ctx.beginPath();
+      ctx.moveTo(options.from.x, options.from.y);
+      ctx.lineTo(options.to.x, options.to.y);
+      ctx.stroke();
+    } finally {
+      ctx.restore();
+    }
   }
 
   async drawPath(options: {
@@ -562,87 +577,90 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
+    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
+    // a malformed gradient fill throws from createFillStyle.
     this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    try {
+      ctx.beginPath();
 
-    ctx.beginPath();
-
-    for (const cmd of options.path.commands) {
-      switch (cmd.type) {
-        case "moveTo":
-          ctx.moveTo(cmd.args[0], cmd.args[1]);
-          break;
-        case "lineTo":
-          ctx.lineTo(cmd.args[0], cmd.args[1]);
-          break;
-        case "quadraticCurveTo":
-          ctx.quadraticCurveTo(
-            cmd.args[0],
-            cmd.args[1],
-            cmd.args[2],
-            cmd.args[3],
-          );
-          break;
-        case "bezierCurveTo":
-          ctx.bezierCurveTo(
-            cmd.args[0],
-            cmd.args[1],
-            cmd.args[2],
-            cmd.args[3],
-            cmd.args[4],
-            cmd.args[5],
-          );
-          break;
-        case "arcTo":
-          ctx.arcTo(
-            cmd.args[0],
-            cmd.args[1],
-            cmd.args[2],
-            cmd.args[3],
-            cmd.args[4],
-          );
-          break;
-        case "arc":
-          ctx.arc(
-            cmd.args[0],
-            cmd.args[1],
-            cmd.args[2],
-            cmd.args[3],
-            cmd.args[4],
-            cmd.args[5] === 1,
-          );
-          break;
-        case "ellipse":
-          ctx.ellipse(
-            cmd.args[0],
-            cmd.args[1],
-            cmd.args[2],
-            cmd.args[3],
-            cmd.args[4],
-            cmd.args[5],
-            cmd.args[6],
-            cmd.args[7] === 1,
-          );
-          break;
-        case "rect":
-          ctx.rect(cmd.args[0], cmd.args[1], cmd.args[2], cmd.args[3]);
-          break;
-        case "closePath":
-          ctx.closePath();
-          break;
+      for (const cmd of options.path.commands) {
+        switch (cmd.type) {
+          case "moveTo":
+            ctx.moveTo(cmd.args[0], cmd.args[1]);
+            break;
+          case "lineTo":
+            ctx.lineTo(cmd.args[0], cmd.args[1]);
+            break;
+          case "quadraticCurveTo":
+            ctx.quadraticCurveTo(
+              cmd.args[0],
+              cmd.args[1],
+              cmd.args[2],
+              cmd.args[3],
+            );
+            break;
+          case "bezierCurveTo":
+            ctx.bezierCurveTo(
+              cmd.args[0],
+              cmd.args[1],
+              cmd.args[2],
+              cmd.args[3],
+              cmd.args[4],
+              cmd.args[5],
+            );
+            break;
+          case "arcTo":
+            ctx.arcTo(
+              cmd.args[0],
+              cmd.args[1],
+              cmd.args[2],
+              cmd.args[3],
+              cmd.args[4],
+            );
+            break;
+          case "arc":
+            ctx.arc(
+              cmd.args[0],
+              cmd.args[1],
+              cmd.args[2],
+              cmd.args[3],
+              cmd.args[4],
+              cmd.args[5] === 1,
+            );
+            break;
+          case "ellipse":
+            ctx.ellipse(
+              cmd.args[0],
+              cmd.args[1],
+              cmd.args[2],
+              cmd.args[3],
+              cmd.args[4],
+              cmd.args[5],
+              cmd.args[6],
+              cmd.args[7] === 1,
+            );
+            break;
+          case "rect":
+            ctx.rect(cmd.args[0], cmd.args[1], cmd.args[2], cmd.args[3]);
+            break;
+          case "closePath":
+            ctx.closePath();
+            break;
+        }
       }
-    }
 
-    if (options.fill) {
-      ctx.fillStyle = this.createFillStyle(ctx, options.fill);
-      ctx.fill();
-    }
+      if (options.fill) {
+        ctx.fillStyle = this.createFillStyle(ctx, options.fill);
+        ctx.fill();
+      }
 
-    if (options.stroke) {
-      this.applyStrokeStyle(ctx, options.stroke);
-      ctx.stroke();
+      if (options.stroke) {
+        this.applyStrokeStyle(ctx, options.stroke);
+        ctx.stroke();
+      }
+    } finally {
+      ctx.restore();
     }
-
-    ctx.restore();
   }
 
   async drawText(options: {
@@ -654,26 +672,29 @@ export class CanvasWeb extends WebPlugin {
   }): Promise<void> {
     const ctx = this.getContext(options.canvasId, options.drawOptions?.layerId);
 
+    // See drawRect: try/finally keeps ctx.save()/restore() balanced even when
+    // a step between save() and restore() throws.
     this.applyDrawOptions(ctx, options.canvasId, options.drawOptions);
+    try {
+      ctx.font = `${options.style.size}px ${options.style.font}`;
+      ctx.fillStyle = this.colorToString(options.style.color);
+      ctx.textAlign = options.style.align || "left";
+      ctx.textBaseline = (options.style.baseline ||
+        "alphabetic") as CanvasTextBaseline;
 
-    ctx.font = `${options.style.size}px ${options.style.font}`;
-    ctx.fillStyle = this.colorToString(options.style.color);
-    ctx.textAlign = options.style.align || "left";
-    ctx.textBaseline = (options.style.baseline ||
-      "alphabetic") as CanvasTextBaseline;
-
-    if (options.style.maxWidth) {
-      ctx.fillText(
-        options.text,
-        options.position.x,
-        options.position.y,
-        options.style.maxWidth,
-      );
-    } else {
-      ctx.fillText(options.text, options.position.x, options.position.y);
+      if (options.style.maxWidth) {
+        ctx.fillText(
+          options.text,
+          options.position.x,
+          options.position.y,
+          options.style.maxWidth,
+        );
+      } else {
+        ctx.fillText(options.text, options.position.x, options.position.y);
+      }
+    } finally {
+      ctx.restore();
     }
-
-    ctx.restore();
   }
 
   async drawImage(options: {


### PR DESCRIPTION
# Relates to

Closes #29894

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; focused package gates (test, typecheck, lint) pass. See **Known gaps** for the repo-wide `bun run verify` note.
- [x] A reviewer can confirm the change works from the failing-before / passing-after evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`1fad1d8e12`); zero conflicts.
- [x] Focused package checks pass post-sync. Repo-wide `bun run verify` note in **Known gaps**.

# Risks

Low. The change is confined to `CanvasWeb`'s five synchronous draw methods in `plugins/plugin-native-canvas/src/web.ts`. It only wraps each already-existing method body in `try { ... } finally { ctx.restore(); }` so the pre-existing `ctx.restore()` still runs exactly once — no behavior changes on the success path, and no public API, type, or export changes. The failure path now unwinds the `ctx.save()` frame that was previously leaked.

# Background

## What does this PR do?

`CanvasWeb`'s synchronous draw methods (`drawRect`, `drawEllipse`, `drawPath`, `drawLine`, `drawText`) call `applyDrawOptions()` — which runs `ctx.save()` and mutates `globalAlpha`/`globalCompositeOperation`/shadow/transform — and only called `ctx.restore()` at the tail of the method body, with **no** `try/finally`. If any step between `save()` and `restore()` throws, `restore()` was skipped: the save frame leaked **and** the mutated draw-option state (e.g. `globalAlpha = 0.5`, blend mode, shadow, transform) persisted onto **every subsequent draw** on that canvas, silently corrupting all later rendering.

A realistic trigger is a malformed gradient fill: `createGradient()` calls `ctx.createRadialGradient()` (throws `IndexSizeError` on a negative radius) or `grad.addColorStop()` (throws on an offset outside `[0,1]` or an unparseable color), and this happens **after** `applyDrawOptions()` has already run `save()` and set the opacity.

This is the same save/restore-balance invariant the project began hardening for the async `drawImage()` path (see `web-drawimage.test.ts`). Note that `drawImage()` had only deferred `applyDrawOptions()` until after the image load resolved, so a *load rejection* could not leak — it did **not** guard a throw *after* `save()` (e.g. inside `applyDrawOptions()` itself). This PR now closes that window on every caller.

The fix wraps `applyDrawOptions()` **and** the draw body of each of the five synchronous draw methods in one `try { ... } finally { ctx.restore(); }`, and wraps `drawImage()`'s post-load `applyDrawOptions()` + `ctx.drawImage()` the same way. Because `ctx.save()` is the **first statement** of `applyDrawOptions()`, nothing before it can throw, so the `finally` never fires `ctx.restore()` on an unpushed frame — and any throw after `save()` (a malformed gradient fill from `createFillStyle`, or a bad shadow color in `colorToString` inside `applyDrawOptions`) is now always unwound. `ctx.restore()` runs exactly once whenever `applyDrawOptions()` ran `ctx.save()`.

(Update, addressing review: an earlier revision started the guard one line *after* `applyDrawOptions()`, leaving the `save()`-owning function itself outside the protected region; the guard now begins at that call on all six callers.)

## What kind of change is this?

Bug fix (non-breaking change which fixes a state-corruption defect).

# Documentation changes needed?

No. Behavior of the public API is unchanged on the success path; only the failure path is corrected. No documented contract changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-canvas/src/web-gradient-restore.test.ts` — a new regression suite extending the `CountingContext` stub harness from the existing `web-drawimage.test.ts`. The context stub models the real browser exceptions: `createRadialGradient()` throws `DOMException('IndexSizeError')` on a negative radius, and `addColorStop()` throws on an offset outside `[0,1]`. Then read the diff in `src/web.ts`.

## Detailed testing steps

```bash
bun install
cd plugins/plugin-native-canvas
bunx vitest run src/web-gradient-restore.test.ts     # new regression suite
bun run test          # full package suite (56 tests)
bun run typecheck
bun run lint:check
```

Reproduction contract (deterministic, no real canvas renderer): a `drawRect` with `drawOptions {opacity: 0.5}` and a radial gradient fill with `r0: -1` rejects; then `ctx.saveCount === ctx.restoreCount` and `ctx.globalAlpha === 1`, and a later plain `drawRect` fills at alpha `1` (not the leaked `0.5`). Same balance assertions for `drawEllipse`, `drawPath`, and — via a malformed (`null`) stroke/text color that throws from `colorToString` after `save()` — `drawLine` and `drawText`; the success path still restores exactly once and fills at the requested `0.5`.

# Evidence Gate

<!-- evidence-head:3cd6679601e5249be77cc950ea187259d426086a -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. This is a headless Canvas 2D-context state-balance fix; the only observable is the stubbed context's save/restore counters and globalAlpha, captured as test logs below.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no interactive user flow; the defect is exercised deterministically by the new Vitest regression suite.`
<!-- evidence-row:backend-logs -->
- [x] [29895-backend-logs.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence/29895-backend-logs.txt)

<details><summary>Backend logs — failing-before vs passing-after Vitest output</summary>

```
=== BEFORE (fix reverted, current test files run against merge-base src/web.ts 1fad1d8) ===
 ❯ src/web-drawimage.test.ts        (5 tests | 1 failed) 48ms
 ❯ src/web-gradient-restore.test.ts (8 tests | 7 failed) 57ms
 FAIL  > does not leak the failed draw opacity onto a later plain drawRect
 AssertionError: expected [ 0.5 ] to deeply equal [ 1 ]
 # the remaining six gradient-restore failures are the save/restore-balance
 # cases for drawRect, drawEllipse, drawPath, the bad-shadow-color drawRect,
 # and the new malformed-color drawLine and drawText cases; the drawimage
 # failure is the bad-shadow-color-after-load case. Only the success-path
 # case and the load-rejection case pass at base.
 Test Files  2 failed | 3 passed (5)
      Tests  8 failed | 48 passed (56)

=== AFTER (fix applied, full package suite + typecheck + lint) ===
 RUN  v4.1.10 .../plugins/plugin-native-canvas
 Test Files  5 passed (5)
      Tests  56 passed (56)
   Duration  4.53s
 $ tsc --noEmit -p tsconfig.json     # typecheck: clean
 $ bunx @biomejs/biome check .        # lint: Checked 11 files. No fixes applied.

 # Cases proving the applyDrawOptions save() window is now guarded on every
 # caller (each FAILs against its own reverted guard, passes after this change):
 #   web-gradient-restore.test.ts > drawRect ... bad shadow color throws inside applyDrawOptions
 #   web-drawimage.test.ts        > bad shadow color throws after a successful load
 #   web-gradient-restore.test.ts > drawLine ... stroke color is malformed
 #   web-gradient-restore.test.ts > drawText ... text color is malformed
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no browser/network round-trip; CanvasWeb is exercised directly under jsdom against a stubbed 2D context.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a Capacitor canvas plugin rendering fix.`
<!-- evidence-row:domain-artifacts -->
- [x] [29895-domain-artifacts.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence/29895-domain-artifacts.txt)

<details><summary>Domain artifact — stubbed 2D-context state (save/restore counters + globalAlpha) output</summary>

```
BEFORE fix (bug), drawRect w/ radial r0=-1, opacity 0.5:
  ctx.saveCount  = 1
  ctx.restoreCount = 0     <- leaked save() frame
  ctx.globalAlpha  = 0.5   <- leaked draw-option state
  later plain drawRect fillAlphas = [0.5]  <- corrupted later draw

AFTER fix (try/finally), same input:
  ctx.saveCount  = 1
  ctx.restoreCount = 1     <- frame unwound
  ctx.globalAlpha  = 1     <- state restored
  later plain drawRect fillAlphas = [1]    <- later draw unaffected
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface (headless state fix).`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend: see the inline `<details>` log block under the **Backend logs** evidence row above (failing-before / passing-after Vitest output). The `expected [ 0.5 ] to deeply equal [ 1 ]` failure is the proof of corruption: an unrelated later `drawRect` fills at the leaked `0.5` alpha. The existing `web-drawimage.test.ts` and `web.test.ts` suites remain green. This revision also adds two `drawLine`/`drawText` cases that throw a malformed (`null`) stroke/text color from `colorToString` *after* `applyDrawOptions()` pushed the frame; per reviewer mutation testing those two `try/finally` guards were previously unpinned (the suite stayed green when either was reverted), and each new case fails against exactly its own reverted guard and passes now — taking the six guards to 6 of 6 pinned. The earlier revision added two more cases (one sync `drawRect`, one async `drawImage`) that throw a malformed shadow color *inside* `applyDrawOptions()` after `save()`, proving the frame-owning call is inside the guard on every caller.

Frontend: `N/A - no browser/network round-trip; CanvasWeb is exercised directly under jsdom against a stubbed 2D context.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - headless state-balance fix; no rendered visual surface.`

### After

`N/A - headless state-balance fix; no rendered visual surface.`

### Walkthrough video

`N/A - no interactive user flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this constrained worktree; the focused package gates that own this change (`bun run --cwd plugins/plugin-native-canvas test | typecheck | lint:check`) all pass and are the authoritative gates for a plugin-scoped change. No files outside `plugins/plugin-native-canvas/src/` are touched.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@3cd6679601e5249be77cc950ea187259d426086a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@3cd6679601e5249be77cc950ea187259d426086a:packages/skills/skills/contribute-to-eliza"} -->

