### PR TITLE
fix(core,sql): complete bounded large-content paging

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -20,6 +20,7 @@ import { ElizaError } from "../../../errors.ts";
 import { getActionSpec } from "../../../generated/spec-helpers.ts";
 import { getVerifiedRelatedEntityIds } from "../../../identity-clusters.ts";
 import { logger } from "../../../logger.ts";
+import { hasMemoryContentPageCapability } from "../../../memory/content-segmentation.ts";
 import { authorizeManageServerDestination } from "../../../messaging/manage-server-authorization.ts";
 import {
 	deterministicOwnerEntityId,
@@ -3506,7 +3507,9 @@ async function handleReadStoredMemory(
 	// from the segmented store — a bounded page, never the source-sized
 	// parent. Falls through to the inline path only when the adapter reports
 	// the field has no descriptor AND the inline value fits a bounded page.
-	const pageCapable = runtime.getMemoryContentPage;
+	const pageCapable = hasMemoryContentPageCapability(runtime)
+		? runtime.getMemoryContentPage
+		: null;
 	if (pageCapable) {
 		const offset = safeMemoryReadInteger(
 			numberParam(params.offset),

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -20,7 +20,10 @@ import { ElizaError } from "../../../errors.ts";
 import { getActionSpec } from "../../../generated/spec-helpers.ts";
 import { getVerifiedRelatedEntityIds } from "../../../identity-clusters.ts";
 import { logger } from "../../../logger.ts";
-import { hasMemoryContentPageCapability } from "../../../memory/content-segmentation.ts";
+import {
+	hasMemoryContentPageCapability,
+	isSegmentedContentMarker,
+} from "../../../memory/content-segmentation.ts";
 import { authorizeManageServerDestination } from "../../../messaging/manage-server-authorization.ts";
 import {
 	deterministicOwnerEntityId,
@@ -3510,6 +3513,16 @@ async function handleReadStoredMemory(
 	const pageCapable = hasMemoryContentPageCapability(runtime)
 		? runtime.getMemoryContentPage
 		: null;
+	// #25140 review R4: a segmented-content marker is an internal storage
+	// descriptor, never message text. Without the paging capability there is
+	// no legitimate way to read the source, so fail explicitly instead of
+	// paging/serving the descriptor string.
+	if (!pageCapable && isSegmentedContentMarker(sourceText)) {
+		return memoryReadFailure(
+			"MESSAGE_MEMORY_SEGMENTED_READ_UNAVAILABLE",
+			"This stored message is kept in segmented form and the current database cannot page it, so it can't be read directly.",
+		);
+	}
 	if (pageCapable) {
 		const offset = safeMemoryReadInteger(
 			numberParam(params.offset),

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3617,6 +3617,16 @@ async function handleReadStoredMemory(
 				promptData: metadata,
 			};
 		}
+		// page === null with a segmented marker source: the adapter found no
+		// authorized parent row (revoked access, concurrent cleanup). The
+		// marker is an internal descriptor — fail explicitly rather than
+		// continue below and return it as action text. (#25140 review R4 r2)
+		if (page === null && isSegmentedContentMarker(sourceText)) {
+			return memoryReadFailure(
+				"MESSAGE_MEMORY_SEGMENTED_PAGE_UNAVAILABLE",
+				"This stored message's segmented content is no longer available from storage, so it can't be read directly.",
+			);
+		}
 		// page === null: no descriptor and inline fits — continue below on the
 		// marker-free inline value.
 	}

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -12,6 +12,7 @@
  * inbox / draft ops delegate to the triage actions in features/messaging/triage.
  */
 
+import { buildAccessContext } from "../../../access-context.ts";
 import { searchCanonicalConversationMemories } from "../../../access-control/provenance-envelope.ts";
 import { getConnectorAccountManager } from "../../../connectors/account-manager.ts";
 import { createUniqueUuid, findEntityByName } from "../../../entities.ts";
@@ -3530,6 +3531,15 @@ async function handleReadStoredMemory(
 			);
 		}
 		let page: Awaited<ReturnType<NonNullable<typeof pageCapable>>>;
+		// #25140 review R2: reauthorize every page at the storage boundary with
+		// the requester's access context (room membership + scope ladder), not
+		// just the action-layer same-room check above. Resolution failure
+		// degrades to requester-only authority, never unrestricted.
+		const accessContext = await buildAccessContext(runtime, message).catch(
+			() => ({
+				requesterEntityId: message.entityId as UUID,
+			}),
+		);
 		try {
 			page = await pageCapable.call(runtime, {
 				memoryId: memoryRef as UUID,
@@ -3537,6 +3547,7 @@ async function handleReadStoredMemory(
 				byteStart: offset,
 				...(limit === undefined ? {} : { byteLimit: limit }),
 				...(expectedRevision === undefined ? {} : { expectedRevision }),
+				accessContext,
 			});
 		} catch (error) {
 			// error-policy:J1 the action boundary translates typed paging

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3500,6 +3500,100 @@ async function handleReadStoredMemory(
 	}
 
 	const sourceText = stored.content.text ?? "";
+
+	// #25140: when the adapter exposes native content paging, serve the read
+	// from the segmented store — a bounded page, never the source-sized
+	// parent. Falls through to the inline path only when the adapter reports
+	// the field has no descriptor AND the inline value fits a bounded page.
+	const pageCapable = runtime.getMemoryContentPage;
+	if (pageCapable) {
+		const offset = safeMemoryReadInteger(
+			numberParam(params.offset),
+			"offset",
+			0,
+		);
+		const limit = safeMemoryReadInteger(numberParam(params.limit), "limit");
+		if (
+			offset === undefined ||
+			(params.limit !== undefined && limit === undefined)
+		) {
+			return memoryReadFailure(
+				"MESSAGE_MEMORY_INVALID_RANGE",
+				"Stored-message offset must be a nonnegative safe integer and limit must be a positive safe integer when supplied.",
+			);
+		}
+		const expectedRevision = textParam(params.expectedRevision);
+		if (offset > 0 && !expectedRevision) {
+			return memoryReadFailure(
+				"MESSAGE_MEMORY_EXPECTED_REVISION_REQUIRED",
+				"Stored-message continuation requires expectedRevision.",
+			);
+		}
+		let page: Awaited<ReturnType<NonNullable<typeof pageCapable>>>;
+		try {
+			page = await pageCapable.call(runtime, {
+				memoryId: memoryRef as UUID,
+				field: { kind: "content.text" },
+				byteStart: offset,
+				...(limit === undefined ? {} : { byteLimit: limit }),
+				...(expectedRevision === undefined ? {} : { expectedRevision }),
+			});
+		} catch (error) {
+			// error-policy:J1 the action boundary translates typed paging
+			// failures into structured user-visible replies.
+			if (error instanceof ElizaError) {
+				return memoryReadFailure(
+					error.code ?? "MESSAGE_MEMORY_PAGE_FAILED",
+					error.message,
+					{ currentRevision: error.context?.currentRevision },
+				);
+			}
+			runtime.reportError("MESSAGE.readStoredMemory.page", error, {
+				memoryId: memoryRef,
+			});
+			return memoryReadFailure(
+				"MESSAGE_MEMORY_AUTHORIZATION_UNAVAILABLE",
+				"Stored-message paged read is unavailable.",
+			);
+		}
+		if (page) {
+			const readView = {
+				reference: buildContentReference({
+					kind: "memory",
+					ref: `memory:${memoryRef}`,
+					revision: page.revision,
+				}),
+				slice: buildReadSlice({
+					range: {
+						unit: "byte",
+						start: page.start,
+						end: page.end,
+						total: page.total,
+					},
+					completeness: page.completeness,
+					revision: page.revision,
+					sliceSha256: page.sliceSha256,
+					sourceSha256: page.sourceSha256,
+				}),
+			};
+			const metadata = {
+				actionName: "MESSAGE",
+				operation: "read_channel",
+				messageRef: readView.reference.ref,
+				readView,
+			};
+			return {
+				success: true,
+				text: page.text,
+				values: { success: true, readView },
+				data: metadata,
+				promptData: metadata,
+			};
+		}
+		// page === null: no descriptor and inline fits — continue below on the
+		// marker-free inline value.
+	}
+
 	const bytes = new TextEncoder().encode(sourceText);
 	if (offset > bytes.length || !isUtf8Boundary(bytes, offset)) {
 		return memoryReadFailure(

--- a/packages/core/src/features/working-memory/memory-content-paging-surface.test.ts
+++ b/packages/core/src/features/working-memory/memory-content-paging-surface.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Pins the #25140 native content-paging surface at the AgentRuntime boundary
+ * (deterministic — real AgentRuntime over hand-rolled adapters; no module
+ * mocks). The runtime previously had NO passthrough for
+ * `getMemoryContentPage`/`memoryContentPageCapability`, which left the
+ * MESSAGE/ATTACHMENT paged-read paths unreachable in production even when the
+ * SQL adapter declared the capability. These tests pin both directions:
+ * absent on a non-paging adapter, forwarded (bound method + advertisement)
+ * on a paging one.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter.ts";
+import { hasMemoryContentPageCapability } from "../../memory/content-segmentation.ts";
+import { AgentRuntime } from "../../runtime.ts";
+import type {
+	Character,
+	IDatabaseAdapter,
+	MemoryContentPageParams,
+	MemoryContentPageResult,
+	UUID,
+} from "../../types/index.ts";
+
+/** Minimal adapter that declares the paging capability, for the forwarding
+ * assertions. The adapter's real behavior is covered by plugin-sql's own
+ * real-PGlite integration suites. */
+class PageCapableAdapter extends InMemoryDatabaseAdapter {
+	readonly memoryContentPageCapability = 1 as const;
+	private readonly pages = new Map<string, MemoryContentPageResult>();
+	setPage(memoryId: UUID, page: MemoryContentPageResult) {
+		this.pages.set(memoryId, page);
+	}
+	async getMemoryContentPage(
+		params: MemoryContentPageParams,
+	): Promise<MemoryContentPageResult | null> {
+		return this.pages.get(params.memoryId) ?? null;
+	}
+}
+
+function makeRuntime(adapter: IDatabaseAdapter): AgentRuntime {
+	const runtime = new AgentRuntime({
+		character: { name: "paging-surface" } as Character,
+	});
+	runtime.registerDatabaseAdapter(adapter);
+	return runtime;
+}
+
+describe("AgentRuntime memory-content paging surface (#25140)", () => {
+	it("an adapter without the segment store leaves the runtime non-page-capable", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.init();
+		const runtime = makeRuntime(adapter);
+
+		expect(runtime.getMemoryContentPage).toBeUndefined();
+		expect(runtime.memoryContentPageCapability).toBeUndefined();
+		expect(hasMemoryContentPageCapability(runtime)).toBe(false);
+	});
+
+	it("forwards a paging adapter's method (bound to the adapter) and capability advertisement", async () => {
+		const adapter = new PageCapableAdapter();
+		await adapter.init();
+		const runtime = makeRuntime(adapter);
+		const memoryId = "00000000-0000-0000-0000-0000000000c1" as UUID;
+		adapter.setPage(memoryId, {
+			text: "page body",
+			start: 0,
+			end: 9,
+			total: 9,
+			sliceSha256: "0".repeat(64),
+			sourceSha256: "1".repeat(64),
+			revision: "seg:r",
+			completeness: "complete",
+		});
+
+		expect(runtime.memoryContentPageCapability).toBe(1);
+		expect(hasMemoryContentPageCapability(runtime)).toBe(true);
+		expect(typeof runtime.getMemoryContentPage).toBe("function");
+
+		const page = await runtime.getMemoryContentPage?.({
+			memoryId,
+			field: { kind: "content.text" },
+			byteStart: 0,
+		});
+		expect(page?.text).toBe("page body");
+		expect(page?.completeness).toBe("complete");
+	});
+});

--- a/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
@@ -445,4 +445,53 @@ describe("segmented save reassembly integrity fence (#25140 R4)", () => {
 		expect(seenRevisions).toEqual([PLAN.descriptor.revision]);
 		expect(saved).toHaveLength(0);
 	});
+
+	it("detects the marker before inline pagination: a small limit truncating the prefix still routes to native paging", async () => {
+		const endpoint = fakePageEndpoint();
+		const base = {
+			...runtimeWithRecords(baseRuntime(true), MEMORY_ID),
+			// answerAttachmentRequest summarizes the page with a small model;
+			// a deterministic stub keeps the probe on the paging contract.
+			useModel: async () => "summarized page answer",
+			getMemoryContentPage: endpoint.getMemoryContentPage,
+		} as unknown as IAgentRuntime;
+		// A 16-byte limit slices the marker prefix in pageAttachmentRecords;
+		// detection must still happen on the ORIGINAL record content.
+		const result = await readAttachmentAction.handler(
+			base,
+			makeMessage(),
+			undefined,
+			{
+				parameters: { action: "read", attachmentId: ATTACHMENT_ID, limit: 16 },
+			},
+			async () => [] as Memory[],
+			undefined,
+		);
+		expect(result?.success).toBe(true);
+		expect(endpoint.getMemoryContentPage.mock.calls.length).toBeGreaterThan(0);
+		// The served text is a page of the real SOURCE, never the marker.
+		expect(result?.text).not.toContain("[elizaos:segmented-content");
+	});
+
+	it("fails explicitly when a capable adapter returns null for a segmented record (authorization gone)", async () => {
+		const base = runtimeWithRecords(baseRuntime(true), MEMORY_ID);
+		const runtime = {
+			...base,
+			getMemoryContentPage: async () => null,
+		} as unknown as IAgentRuntime;
+		const result = await readAttachmentAction.handler(
+			runtime,
+			makeMessage(),
+			undefined,
+			{
+				parameters: { action: "read", attachmentId: ATTACHMENT_ID },
+			},
+			async () => [] as Memory[],
+			undefined,
+		);
+		expect(result?.success).toBe(false);
+		expect((result?.data as { error?: string } | undefined)?.error).toBe(
+			"segmented_page_unavailable",
+		);
+	});
 });

--- a/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
@@ -21,6 +21,7 @@ import {
 	buildSegmentedContentMarker,
 	segmentMemoryContent,
 } from "../../memory/content-segmentation.ts";
+import { createMockRuntime } from "../../testing/mock-runtime.ts";
 import type {
 	ActionResult,
 	HandlerCallback,
@@ -252,5 +253,75 @@ describe("ATTACHMENT save_as_document over segmented content (#25140 R4)", () =>
 			"MEMORY_CONTENT_STALE_REVISION",
 		);
 		expect(saved).toHaveLength(0);
+	});
+});
+
+/**
+ * Dispatch-gate regression: a runtime exposing the paging METHOD without the
+ * capability advertisement must never receive page calls on either dispatch
+ * site (ATTACHMENT read, MESSAGE read_channel). Restoring method-only
+ * dispatch at either site fails these tests.
+ */
+describe("native-paging dispatch gate (#25140 R4)", () => {
+	it("ATTACHMENT read never pages a segmented marker on a method-only runtime", async () => {
+		const runtime = runtimeWithRecords(baseRuntime(false), MEMORY_ID);
+		const result = await readAttachmentAction.handler(
+			runtime,
+			makeMessage(),
+			undefined,
+			{
+				parameters: { action: "read", attachmentId: ATTACHMENT_ID, limit: 64 },
+			},
+			async () => [] as Memory[],
+			undefined,
+		);
+		expect(result).toBeTruthy();
+		// The method existed on the runtime but was NOT called: the capability
+		// gate, not method presence, decides dispatch.
+		expect(
+			(runtime.getMemoryContentPage as unknown as ReturnType<typeof vi.fn>).mock
+				.calls,
+		).toHaveLength(0);
+	});
+
+	it("MESSAGE read_channel never pages on a method-only runtime", async () => {
+		const { messageAction } = await import(
+			"../advanced-capabilities/actions/message.ts"
+		);
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			getMemoryById: async () =>
+				({
+					id: MEMORY_ID,
+					roomId: ROOM_ID,
+					entityId: REQUESTER_ID,
+					agentId: AGENT_ID,
+					content: { text: MARKER, source: "discord" },
+					metadata: { scope: "room" },
+					createdAt: 1,
+				}) as Memory,
+			getParticipantsForRoom: async () => [REQUESTER_ID],
+			// Method WITHOUT the capability advertisement.
+			getMemoryContentPage: fakePageEndpoint().getMemoryContentPage,
+		} as never);
+		const result = await messageAction.handler(
+			runtime,
+			makeMessage(),
+			undefined,
+			{
+				parameters: {
+					action: "read_channel",
+					messageId: MEMORY_ID,
+					limit: 64,
+				},
+			},
+			async () => [] as Memory[],
+			undefined,
+		);
+		expect(result).toBeTruthy();
+		expect(
+			(runtime.getMemoryContentPage as unknown as ReturnType<typeof vi.fn>).mock
+				.calls,
+		).toHaveLength(0);
 	});
 });

--- a/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
@@ -275,9 +275,14 @@ describe("native-paging dispatch gate (#25140 R4)", () => {
 			async () => [] as Memory[],
 			undefined,
 		);
-		expect(result).toBeTruthy();
 		// The method existed on the runtime but was NOT called: the capability
-		// gate, not method presence, decides dispatch.
+		// gate, not method presence, decides dispatch. The marker must surface
+		// as an explicit failure, never as served content.
+		expect(result).toBeTruthy();
+		expect(result?.success).toBe(false);
+		expect((result?.data as { error: string } | undefined)?.error).toBe(
+			"segmented_read_unavailable",
+		);
 		expect(
 			(runtime.getMemoryContentPage as unknown as ReturnType<typeof vi.fn>).mock
 				.calls,
@@ -288,6 +293,7 @@ describe("native-paging dispatch gate (#25140 R4)", () => {
 		const { messageAction } = await import(
 			"../advanced-capabilities/actions/message.ts"
 		);
+		const endpoint = fakePageEndpoint();
 		const runtime = createMockRuntime({
 			agentId: AGENT_ID,
 			getMemoryById: async () =>
@@ -302,7 +308,7 @@ describe("native-paging dispatch gate (#25140 R4)", () => {
 				}) as Memory,
 			getParticipantsForRoom: async () => [REQUESTER_ID],
 			// Method WITHOUT the capability advertisement.
-			getMemoryContentPage: fakePageEndpoint().getMemoryContentPage,
+			getMemoryContentPage: endpoint.getMemoryContentPage,
 		} as never);
 		const result = await messageAction.handler(
 			runtime,
@@ -318,10 +324,125 @@ describe("native-paging dispatch gate (#25140 R4)", () => {
 			async () => [] as Memory[],
 			undefined,
 		);
+		// No capability advertisement: never dispatched, and the internal
+		// marker descriptor surfaces as an explicit failure, never as text.
 		expect(result).toBeTruthy();
-		expect(
-			(runtime.getMemoryContentPage as unknown as ReturnType<typeof vi.fn>).mock
-				.calls,
-		).toHaveLength(0);
+		expect(result?.success).toBe(false);
+		expect((result?.data as { error?: string } | undefined)?.error).toBe(
+			"MESSAGE_MEMORY_SEGMENTED_READ_UNAVAILABLE",
+		);
+		expect(endpoint.getMemoryContentPage.mock.calls).toHaveLength(0);
+	});
+});
+
+/**
+ * #25140 R4 integrity fence: segmented save reassembly must validate every
+ * page against the record's published descriptor (revision, totals, window
+ * coherence, source digest) and the final whole against the descriptor
+ * digest. A page store that serves a different generation, an inconsistent
+ * window, or tampered text must fail the save explicitly with zero document
+ * writes — never persist a mismatched or partial source as a document.
+ */
+describe("segmented save reassembly integrity fence (#25140 R4)", () => {
+	function capableRuntimeWithPages(
+		pages: Array<Record<string, unknown> | undefined>,
+	) {
+		const base = runtimeWithRecords(baseRuntime(true), MEMORY_ID);
+		let call = 0;
+		const runtime = {
+			...base,
+			getMemoryContentPage: async () => {
+				const page = pages[call];
+				call += 1;
+				return page ? { ...page } : undefined;
+			},
+		} as unknown as IAgentRuntime;
+		return documentSavingRuntime(runtime);
+	}
+
+	it("rejects a page served from a different generation than the marker descriptor", async () => {
+		const sourceBytes = Buffer.from(SOURCE, "utf8");
+		const { runtime, saved } = capableRuntimeWithPages([
+			{
+				text: SOURCE,
+				start: 0,
+				end: sourceBytes.length,
+				total: PLAN.descriptor.totalBytes,
+				sourceSha256: PLAN.descriptor.totalSha256,
+				revision: `${PLAN.descriptor.revision}-newer`,
+				completeness: "complete",
+			},
+		]);
+		const result = await save(runtime);
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"ATTACHMENT_SAVE_REASSEMBLY_INCONSISTENT",
+		);
+		expect(saved).toHaveLength(0);
+	});
+
+	it("rejects a page window that disagrees with the requested offset and totals", async () => {
+		const { runtime, saved } = capableRuntimeWithPages([
+			{
+				text: SOURCE.slice(0, 10),
+				start: 4,
+				end: 14,
+				total: PLAN.descriptor.totalBytes,
+				sourceSha256: PLAN.descriptor.totalSha256,
+				revision: PLAN.descriptor.revision,
+				completeness: "partial-recoverable",
+			},
+		]);
+		const result = await save(runtime);
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"ATTACHMENT_SAVE_REASSEMBLY_INCONSISTENT",
+		);
+		expect(saved).toHaveLength(0);
+	});
+
+	it("rejects reassembled text whose digest does not match the descriptor", async () => {
+		// Serve coherent windows of TAMPERED text: correct shape, wrong bytes.
+		const tampered = `${SOURCE.slice(0, -1)}X`;
+		const sourceBytes = Buffer.from(tampered, "utf8");
+		const { runtime, saved } = capableRuntimeWithPages([
+			{
+				text: tampered,
+				start: 0,
+				end: sourceBytes.length,
+				total: PLAN.descriptor.totalBytes,
+				sourceSha256: PLAN.descriptor.totalSha256,
+				revision: PLAN.descriptor.revision,
+				completeness: "complete",
+			},
+		]);
+		const result = await save(runtime);
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"ATTACHMENT_SAVE_REASSEMBLY_DIGEST_MISMATCH",
+		);
+		expect(saved).toHaveLength(0);
+	});
+
+	it("fences the first page to the marker's revision (stale-generation store throws)", async () => {
+		const base = runtimeWithRecords(baseRuntime(true), MEMORY_ID);
+		const seenRevisions: Array<string | undefined> = [];
+		const runtime = {
+			...base,
+			getMemoryContentPage: async (params: { expectedRevision?: string }) => {
+				seenRevisions.push(params.expectedRevision);
+				const { ElizaError } = await import("../../errors.ts");
+				throw new ElizaError(
+					"The stored content changed before this page could be read.",
+					{ code: "MEMORY_CONTENT_STALE_REVISION" },
+				);
+			},
+		} as unknown as IAgentRuntime;
+		const { runtime: withDocs, saved } = documentSavingRuntime(runtime);
+		const result = await save(withDocs);
+		expect(result.success).toBe(false);
+		// The FIRST page request already carried the descriptor revision.
+		expect(seenRevisions).toEqual([PLAN.descriptor.revision]);
+		expect(saved).toHaveLength(0);
 	});
 });

--- a/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
@@ -473,6 +473,40 @@ describe("segmented save reassembly integrity fence (#25140 R4)", () => {
 		expect(result?.text).not.toContain("[elizaos:segmented-content");
 	});
 
+	it("continuation offsets past the marker length page natively instead of failing inline offset validation", async () => {
+		const endpoint = fakePageEndpoint();
+		const base = {
+			...runtimeWithRecords(baseRuntime(true), MEMORY_ID),
+			useModel: async () => "summarized page answer",
+			getMemoryContentPage: endpoint.getMemoryContentPage,
+		} as unknown as IAgentRuntime;
+		// 2048 bytes is far past the marker's own length; inline validation
+		// against the marker would throw ATTACHMENT_READ_INVALID_OFFSET before
+		// the native branch ran (RP round-3 finding).
+		const continuation = 2048;
+		const result = await readAttachmentAction.handler(
+			base,
+			makeMessage(),
+			undefined,
+			{
+				parameters: {
+					action: "read",
+					attachmentId: ATTACHMENT_ID,
+					offset: continuation,
+					expectedRevision: PLAN.descriptor.revision,
+				},
+			},
+			async () => [] as Memory[],
+			undefined,
+		);
+		expect(result?.success).toBe(true);
+		expect(endpoint.getMemoryContentPage.mock.calls.length).toBeGreaterThan(0);
+		expect(endpoint.getMemoryContentPage.mock.calls[0]?.[0]?.byteStart).toBe(
+			continuation,
+		);
+		expect(result?.text).not.toContain("[elizaos:segmented-content");
+	});
+
 	it("fails explicitly when a capable adapter returns null for a segmented record (authorization gone)", async () => {
 		const base = runtimeWithRecords(baseRuntime(true), MEMORY_ID);
 		const runtime = {

--- a/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.segmented-save.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Regression tests for the #25140 review round 4 fixes at the ATTACHMENT and
+ * MESSAGE action boundaries (deterministic harness — hand-rolled runtime
+ * doubles with a page-capable and a method-only runtime; no module mocks).
+ *
+ * Pins three contracts:
+ * 1. save_as_document on a segmented attachment reassembles the source via
+ *    paged reads and never persists the inline segmented-content marker
+ *    (review finding: saved documents contained the internal storage
+ *    descriptor because the save path ran before the paging branch).
+ * 2. save_as_document fails explicitly (typed error, no document write) when
+ *    the runtime exposes the method but not the capability advertisement, or
+ *    when the owning stored message is unknown.
+ * 3. A method-only runtime (capability advertisement absent) never receives
+ *    page calls on the read path — the dispatch sites gate on the capability
+ *    pair, not method presence.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildSegmentedContentMarker,
+	segmentMemoryContent,
+} from "../../memory/content-segmentation.ts";
+import type {
+	ActionResult,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	UUID,
+} from "../../types/index.ts";
+import { ContentType } from "../../types/index.ts";
+import { readAttachmentAction } from "./readAttachmentAction.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const REQUESTER_ID = "00000000-0000-0000-0000-0000000000a2" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000a3" as UUID;
+const MEMORY_ID = "00000000-0000-0000-0000-0000000000a4" as UUID;
+const ATTACHMENT_ID = "doc-9f31";
+
+const SOURCE = `${"segurança שלום 🌏 body ".repeat(120)}TERMINAL-9f31`;
+
+const PLAN = segmentMemoryContent(SOURCE, {
+	kind: "attachment.text",
+	attachmentId: ATTACHMENT_ID,
+});
+const MARKER = buildSegmentedContentMarker(PLAN.descriptor);
+
+/** Serves the planned segments through a fake page endpoint, exactly like the
+ * SQL adapter does: revision fencing, half-open windows, completeness. */
+function fakePageEndpoint() {
+	const calls: Array<{ byteStart: number; expectedRevision?: string }> = [];
+	const getMemoryContentPage = vi.fn(
+		async (params: { byteStart: number; expectedRevision?: string }) => {
+			calls.push({
+				byteStart: params.byteStart,
+				expectedRevision: params.expectedRevision,
+			});
+			const sourceBytes = Buffer.from(SOURCE, "utf8");
+			const windowStart = params.byteStart;
+			let windowEnd = Math.min(windowStart + 2048, sourceBytes.length);
+			// Snap the end back off a partial trailing code point, matching the
+			// real adapter's boundary behavior so pages reassemble exactly.
+			while (
+				windowEnd > windowStart &&
+				(sourceBytes[windowEnd] & 0xc0) === 0x80
+			) {
+				windowEnd -= 1;
+			}
+			const text = sourceBytes
+				.subarray(windowStart, windowEnd)
+				.toString("utf8");
+			return {
+				text,
+				start: windowStart,
+				end: windowEnd,
+				total: PLAN.descriptor.totalBytes,
+				sliceSha256: "0".repeat(64),
+				sourceSha256: PLAN.descriptor.totalSha256,
+				revision: PLAN.descriptor.revision,
+				completeness: (windowEnd >= PLAN.descriptor.totalBytes
+					? "complete"
+					: "partial-recoverable") as "complete" | "partial-recoverable",
+			};
+		},
+	);
+	return { getMemoryContentPage, calls };
+}
+
+function makeMessage(): Memory {
+	return {
+		id: MEMORY_ID,
+		roomId: ROOM_ID,
+		entityId: REQUESTER_ID,
+		agentId: AGENT_ID,
+		content: {
+			text: "save the document attachment",
+			source: "discord",
+			attachmentId: ATTACHMENT_ID,
+		},
+		createdAt: 1,
+	} as Memory;
+}
+
+function baseRuntime(pageCapable: boolean): IAgentRuntime {
+	const endpoint = fakePageEndpoint();
+	const runtime = {
+		agentId: AGENT_ID,
+		getConversationLength: () => 8,
+		getMemories: async () => [],
+		getMemoryById: async () => null,
+		getRoom: async () => ({ id: ROOM_ID, worldId: ROOM_ID, agentId: AGENT_ID }),
+		getWorld: async () => null,
+		getService: () => null,
+		getSetting: () => undefined,
+		reportError: () => {},
+		...(pageCapable
+			? {
+					memoryContentPageCapability: 1,
+					getMemoryContentPage: endpoint.getMemoryContentPage,
+				}
+			: { getMemoryContentPage: endpoint.getMemoryContentPage }),
+	} as unknown as IAgentRuntime;
+	return runtime;
+}
+
+/** Stands in for listConversationAttachments: one segmented record whose
+ * inline content is the published marker and whose owner is MEMORY_ID. */
+function runtimeWithRecords(
+	runtime: IAgentRuntime,
+	messageId: UUID | undefined,
+) {
+	const stored: Memory = {
+		// An undefined messageId leaves the owning message id unresolved.
+		...(messageId === undefined ? {} : { id: messageId }),
+		roomId: ROOM_ID,
+		entityId: REQUESTER_ID,
+		agentId: AGENT_ID,
+		content: {
+			text: "attachment message",
+			source: "discord",
+			attachments: [
+				{
+					id: ATTACHMENT_ID,
+					url: "https://example.test/doc",
+					title: "large doc",
+					source: "Web",
+					contentType: ContentType.DOCUMENT,
+					text: MARKER,
+				},
+			],
+		},
+		createdAt: 1,
+	} as Memory;
+	return {
+		...runtime,
+		getMemories: async () => [stored],
+	} as IAgentRuntime;
+}
+
+function documentSavingRuntime(runtime: IAgentRuntime) {
+	const saved: Array<Record<string, unknown>> = [];
+	return {
+		runtime: {
+			...runtime,
+			getService: () => ({
+				addDocument: async (params: Record<string, unknown>) => {
+					saved.push(params);
+					return {
+						clientDocumentId: "00000000-0000-0000-0000-0000000000b1",
+						fragmentCount: 1,
+					};
+				},
+			}),
+		} as unknown as IAgentRuntime,
+		saved,
+	};
+}
+
+async function save(runtime: IAgentRuntime): Promise<ActionResult> {
+	const callback: HandlerCallback = async () => [] as Memory[];
+	const result = await readAttachmentAction.handler(
+		runtime,
+		makeMessage(),
+		undefined,
+		{ parameters: { action: "save_as_document", attachmentId: ATTACHMENT_ID } },
+		callback,
+		undefined,
+	);
+	if (!result) throw new Error("ATTACHMENT handler returned no result");
+	return result;
+}
+
+describe("ATTACHMENT save_as_document over segmented content (#25140 R4)", () => {
+	it("reassembles the segmented source via paged reads and saves the full text, never the marker", async () => {
+		const { runtime, saved } = documentSavingRuntime(
+			runtimeWithRecords(baseRuntime(true), MEMORY_ID),
+		);
+		const result = await save(runtime);
+
+		expect(result.success).toBe(true);
+		expect(saved).toHaveLength(1);
+		const content = saved[0]?.content as string;
+		expect(content).not.toContain("[elizaos:segmented-content");
+		expect(content).toBe(SOURCE);
+	});
+
+	it("fails explicitly when the runtime has the method but no capability advertisement", async () => {
+		const { runtime, saved } = documentSavingRuntime(
+			runtimeWithRecords(baseRuntime(false), MEMORY_ID),
+		);
+		const result = await save(runtime);
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"ATTACHMENT_SAVE_REASSEMBLY_UNAVAILABLE",
+		);
+		expect(saved).toHaveLength(0);
+	});
+
+	it("fails explicitly when the segmented record has no owning stored message", async () => {
+		const { runtime, saved } = documentSavingRuntime(
+			runtimeWithRecords(baseRuntime(true), undefined),
+		);
+		const result = await save(runtime);
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"ATTACHMENT_PAGE_OWNER_UNRESOLVED",
+		);
+		expect(saved).toHaveLength(0);
+	});
+
+	it("translates a typed page-read failure into a structured save failure", async () => {
+		const runtime = runtimeWithRecords(baseRuntime(true), MEMORY_ID);
+		const failing = {
+			...runtime,
+			getMemoryContentPage: vi.fn(async () => {
+				const { ElizaError } = await import("../../errors.ts");
+				throw new ElizaError(
+					"The stored content changed before this page could be read.",
+					{
+						code: "MEMORY_CONTENT_STALE_REVISION",
+					},
+				);
+			}),
+		} as unknown as IAgentRuntime;
+		const { runtime: withDocs, saved } = documentSavingRuntime(failing);
+		const result = await save(withDocs);
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"MEMORY_CONTENT_STALE_REVISION",
+		);
+		expect(saved).toHaveLength(0);
+	});
+});

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -734,11 +734,14 @@ async function reassembleSegmentedAttachmentContent(
 		return { records };
 	}
 
-	const saveFailure = (
+	const saveFailure = async (
 		text: string,
 		error: string,
-	): { failure: ActionResult } => {
-		void callback?.({
+	): Promise<{ failure: ActionResult }> => {
+		// The failure text is this turn's sole delivery (the action suppresses
+		// post-action continuation), so it must complete before the handler
+		// resolves — await, never fire-and-forget.
+		await callback?.({
 			text,
 			actions: ["ATTACHMENT_SAVE_AS_DOCUMENT_FAILED"],
 			source: message.content.source,
@@ -763,12 +766,15 @@ async function reassembleSegmentedAttachmentContent(
 		? runtime.getMemoryContentPage
 		: null;
 	if (!pageCapable) {
-		return saveFailure(
+		return await saveFailure(
 			"This attachment is stored in segmented form and the current database cannot reassemble it, so it cannot be saved as a document.",
 			"ATTACHMENT_SAVE_REASSEMBLY_UNAVAILABLE",
 		);
 	}
 
+	// error-policy:J4 access-context resolution failure degrades reassembly to
+	// requester-only authority — still authorized, never unrestricted; the
+	// page read itself surfaces any residual failure through its typed errors.
 	const accessContext = await buildAccessContext(runtime, message).catch(
 		() => ({
 			requesterEntityId: message.entityId as UUID,
@@ -784,7 +790,7 @@ async function reassembleSegmentedAttachmentContent(
 		const ownerMessageId = record.attachment._messageId;
 		const attachmentId = record.attachment.id;
 		if (!ownerMessageId) {
-			return saveFailure(
+			return await saveFailure(
 				"The segmented attachment has no owning stored message to reassemble from, so it cannot be saved as a document.",
 				"ATTACHMENT_PAGE_OWNER_UNRESOLVED",
 			);
@@ -797,7 +803,7 @@ async function reassembleSegmentedAttachmentContent(
 		// above any real attachment while guaranteeing termination.
 		for (let guard = 0; offset < total; guard += 1) {
 			if (guard >= 4096) {
-				return saveFailure(
+				return await saveFailure(
 					"Reassembling this attachment exceeded the bounded page budget, so it cannot be saved as a document.",
 					"ATTACHMENT_SAVE_REASSEMBLY_FAILED",
 				);
@@ -816,7 +822,7 @@ async function reassembleSegmentedAttachmentContent(
 				// failures (stale revision, reindex required, drift) into a
 				// structured save failure.
 				if (error instanceof ElizaError) {
-					return saveFailure(
+					return await saveFailure(
 						error.message,
 						error.code ?? "ATTACHMENT_SAVE_REASSEMBLY_FAILED",
 					);
@@ -824,7 +830,7 @@ async function reassembleSegmentedAttachmentContent(
 				throw error;
 			}
 			if (!page || page.text === undefined) {
-				return saveFailure(
+				return await saveFailure(
 					"The segmented attachment could not be reassembled from storage, so it cannot be saved as a document.",
 					"ATTACHMENT_SAVE_REASSEMBLY_FAILED",
 				);

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -22,7 +22,10 @@ import {
 	MediaFetchError,
 	readResponseWithLimit,
 } from "../../media/fetch.ts";
-import { isSegmentedContentMarker } from "../../memory/content-segmentation.ts";
+import {
+	hasMemoryContentPageCapability,
+	isSegmentedContentMarker,
+} from "../../memory/content-segmentation.ts";
 import {
 	linkShareOwnText,
 	looksLikeBareLinkShare,
@@ -709,6 +712,133 @@ function readStringParam(
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+/**
+ * #25140 review R4: the inline text of a segmented attachment is only the
+ * bounded published marker — an internal storage descriptor, never attachment
+ * text. Before save_as_document persists anything, reassemble the authorized
+ * source bytes via paged reads. A marker that cannot be reassembled (no
+ * paging capability, no owning stored message, or a typed page-read failure)
+ * produces an explicit save failure instead of saving the descriptor as the
+ * document's content. Non-segmented records pass through untouched.
+ */
+async function reassembleSegmentedAttachmentContent(
+	runtime: IAgentRuntime,
+	message: Memory,
+	records: AttachmentRecord[],
+	callback?: HandlerCallback,
+): Promise<
+	| { records: AttachmentRecord[]; failure?: undefined }
+	| { records?: undefined; failure: ActionResult }
+> {
+	if (!records.some((record) => isSegmentedContentMarker(record.content))) {
+		return { records };
+	}
+
+	const saveFailure = (
+		text: string,
+		error: string,
+	): { failure: ActionResult } => {
+		void callback?.({
+			text,
+			actions: ["ATTACHMENT_SAVE_AS_DOCUMENT_FAILED"],
+			source: message.content.source,
+		});
+		return {
+			failure: {
+				success: false,
+				text,
+				userFacingText: text,
+				verifiedUserFacing: true,
+				error,
+				data: {
+					actionName: "ATTACHMENT",
+					action: "save_as_document",
+					error,
+				},
+			},
+		};
+	};
+
+	const pageCapable = hasMemoryContentPageCapability(runtime)
+		? runtime.getMemoryContentPage
+		: null;
+	if (!pageCapable) {
+		return saveFailure(
+			"This attachment is stored in segmented form and the current database cannot reassemble it, so it cannot be saved as a document.",
+			"ATTACHMENT_SAVE_REASSEMBLY_UNAVAILABLE",
+		);
+	}
+
+	const accessContext = await buildAccessContext(runtime, message).catch(
+		() => ({
+			requesterEntityId: message.entityId as UUID,
+		}),
+	);
+
+	const reassembled: AttachmentRecord[] = [];
+	for (const record of records) {
+		if (!isSegmentedContentMarker(record.content)) {
+			reassembled.push(record);
+			continue;
+		}
+		const ownerMessageId = record.attachment._messageId;
+		const attachmentId = record.attachment.id;
+		if (!ownerMessageId) {
+			return saveFailure(
+				"The segmented attachment has no owning stored message to reassemble from, so it cannot be saved as a document.",
+				"ATTACHMENT_PAGE_OWNER_UNRESOLVED",
+			);
+		}
+		const parts: string[] = [];
+		let offset = 0;
+		let total = Number.POSITIVE_INFINITY;
+		let revision: string | undefined;
+		// 4096 pages at the 256 KiB ceiling bounds reassembly at 1 GiB — far
+		// above any real attachment while guaranteeing termination.
+		for (let guard = 0; offset < total; guard += 1) {
+			if (guard >= 4096) {
+				return saveFailure(
+					"Reassembling this attachment exceeded the bounded page budget, so it cannot be saved as a document.",
+					"ATTACHMENT_SAVE_REASSEMBLY_FAILED",
+				);
+			}
+			let page: Awaited<ReturnType<NonNullable<typeof pageCapable>>>;
+			try {
+				page = await pageCapable.call(runtime, {
+					memoryId: ownerMessageId,
+					field: { kind: "attachment.text", attachmentId },
+					byteStart: offset,
+					...(revision === undefined ? {} : { expectedRevision: revision }),
+					accessContext,
+				});
+			} catch (error) {
+				// error-policy:J1 the action boundary translates typed paging
+				// failures (stale revision, reindex required, drift) into a
+				// structured save failure.
+				if (error instanceof ElizaError) {
+					return saveFailure(
+						error.message,
+						error.code ?? "ATTACHMENT_SAVE_REASSEMBLY_FAILED",
+					);
+				}
+				throw error;
+			}
+			if (!page || page.text === undefined) {
+				return saveFailure(
+					"The segmented attachment could not be reassembled from storage, so it cannot be saved as a document.",
+					"ATTACHMENT_SAVE_REASSEMBLY_FAILED",
+				);
+			}
+			parts.push(page.text);
+			offset = page.end;
+			total = page.total;
+			revision = page.revision;
+		}
+		reassembled.push({ ...record, content: parts.join("") });
+	}
+	return { records: reassembled };
+}
+
 async function saveAttachmentAsDocument(params: {
 	runtime: IAgentRuntime;
 	message: Memory;
@@ -998,15 +1128,25 @@ export const readAttachmentAction: Action = {
 			if (!hasContent && (await transcribeMediaOnDemand(runtime, records))) {
 				hasContent = hasReadableContent(records);
 			}
-			const completeStoredContent = hasContent
-				? contentForRecords(records)
-				: "";
 			if (action === "save_as_document") {
+				// #25140 review R4: a segmented attachment's inline text is a
+				// storage descriptor, never saveable document content —
+				// reassemble the authorized source first, or fail explicitly.
+				const reassembled = await reassembleSegmentedAttachmentContent(
+					runtime,
+					messageWithParams,
+					records,
+					callback,
+				);
+				if (reassembled.failure) {
+					return reassembled.failure;
+				}
+				const savedRecords = reassembled.records ?? records;
 				return await saveAttachmentAsDocument({
 					runtime,
 					message: messageWithParams,
-					records,
-					content: completeStoredContent,
+					records: savedRecords,
+					content: hasContent ? contentForRecords(savedRecords) : "",
 					actionParams: params,
 					callback,
 				});
@@ -1021,7 +1161,9 @@ export const readAttachmentAction: Action = {
 			// (`attachment.text:<id>` on the owning memory) instead of paging the
 			// marker string. The owning message id is the direct parent — no room
 			// scan and no source-sized materialization.
-			const pageCapable = runtime.getMemoryContentPage;
+			const pageCapable = hasMemoryContentPageCapability(runtime)
+				? runtime.getMemoryContentPage
+				: null;
 			const segmentedRecord =
 				pageCapable &&
 				pagedRecords.length === 1 &&

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -773,12 +773,18 @@ async function reassembleSegmentedAttachmentContent(
 	}
 
 	// error-policy:J4 access-context resolution failure degrades reassembly to
-	// requester-only authority — still authorized, never unrestricted; the
+	// requester-only authority — never unrestricted — and is reported so the
+	// degrade is observable (RECENT_ERRORS + ERROR_REPORTED), not silent; the
 	// page read itself surfaces any residual failure through its typed errors.
 	const accessContext = await buildAccessContext(runtime, message).catch(
-		() => ({
-			requesterEntityId: message.entityId as UUID,
-		}),
+		(error) => {
+			runtime.reportError("ATTACHMENT.saveSegmented.accessContext", error, {
+				attachmentIds: records.map((record) => record.attachment.id),
+			});
+			return {
+				requesterEntityId: message.entityId as UUID,
+			};
+		},
 	);
 
 	const reassembled: AttachmentRecord[] = [];

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -1206,7 +1206,6 @@ export const readAttachmentAction: Action = {
 				});
 			}
 
-			const pagedRecords = pageAttachmentRecords(records, params);
 			const expectedRevision = readStringParam(params, "expectedRevision");
 
 			// #25140: when an adapter with native content paging is present and a
@@ -1218,10 +1217,12 @@ export const readAttachmentAction: Action = {
 			const pageCapable = hasMemoryContentPageCapability(runtime)
 				? runtime.getMemoryContentPage
 				: null;
-			// #25140 review R4 r2: detect the marker on the ORIGINAL record
-			// content — pageAttachmentRecords may slice the prefix away (small
-			// limit, nonzero continuation offset), which would make the truncated
-			// descriptor leak into the inline answer path undetected.
+			// #25140 review R4 r2/r3: detect the marker on the ORIGINAL record
+			// content and dispatch BEFORE inline pagination — pageAttachmentRecords
+			// validates offset against the MARKER's byte length, so a legitimate
+			// continuation offset past the marker would throw INVALID_OFFSET before
+			// native paging is reached, and a small limit could truncate the prefix
+			// into the inline answer path.
 			const segmentedRecord =
 				records.length === 1 && isSegmentedContentMarker(records[0].content)
 					? records[0]
@@ -1423,6 +1424,9 @@ export const readAttachmentAction: Action = {
 				// page === null: descriptor absent with small inline — fall
 				// through to the inline paging path below.
 			}
+			// Inline pagination runs only after the segmented native-paging
+			// branch had its chance to return (#25140 R4 r3).
+			const pagedRecords = pageAttachmentRecords(records, params);
 			if (
 				pagedRecords.some((record) => record.readView.slice.range.start > 0) &&
 				!expectedRevision

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -15,6 +15,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { buildAccessContext } from "../../access-context.ts";
 import { ElizaError } from "../../errors.ts";
 import {
 	fetchRemoteMedia,
@@ -1069,6 +1070,16 @@ export const readAttachmentAction: Action = {
 				}
 				const limit = readOptionalPositiveInteger(params, "limit");
 				let page: Awaited<ReturnType<NonNullable<typeof pageCapable>>>;
+				// #25140 review R2: reauthorize every page at the storage
+				// boundary with the requester's access context; resolution
+				// failure degrades to requester-only authority, never
+				// unrestricted.
+				const accessContext = await buildAccessContext(
+					runtime,
+					messageWithParams,
+				).catch(() => ({
+					requesterEntityId: messageWithParams.entityId as UUID,
+				}));
 				try {
 					page = await pageCapable.call(runtime, {
 						memoryId: ownerMessageId,
@@ -1076,6 +1087,7 @@ export const readAttachmentAction: Action = {
 						byteStart: offset,
 						...(limit === undefined ? {} : { byteLimit: limit }),
 						...(expectedRevision === undefined ? {} : { expectedRevision }),
+						accessContext,
 					});
 				} catch (error) {
 					// error-policy:J1 the action boundary translates typed paging

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -21,6 +21,7 @@ import {
 	MediaFetchError,
 	readResponseWithLimit,
 } from "../../media/fetch.ts";
+import { isSegmentedContentMarker } from "../../memory/content-segmentation.ts";
 import {
 	linkShareOwnText,
 	looksLikeBareLinkShare,
@@ -1012,6 +1013,158 @@ export const readAttachmentAction: Action = {
 
 			const pagedRecords = pageAttachmentRecords(records, params);
 			const expectedRevision = readStringParam(params, "expectedRevision");
+
+			// #25140: when an adapter with native content paging is present and a
+			// record's inline text is a published segmented-content marker, serve
+			// the page from the segment store via the owner-bound descriptor
+			// (`attachment.text:<id>` on the owning memory) instead of paging the
+			// marker string. The owning message id is the direct parent — no room
+			// scan and no source-sized materialization.
+			const pageCapable = runtime.getMemoryContentPage;
+			const segmentedRecord =
+				pageCapable &&
+				pagedRecords.length === 1 &&
+				isSegmentedContentMarker(pagedRecords[0].content)
+					? pagedRecords[0]
+					: null;
+			if (pageCapable && segmentedRecord) {
+				const ownerMessageId = segmentedRecord.attachment._messageId;
+				const attachmentId = segmentedRecord.attachment.id;
+				const offset = readNonnegativeInteger(params, "offset", 0);
+				if (!ownerMessageId) {
+					return {
+						success: false,
+						text: "The segmented attachment has no owning stored message to page from.",
+						error: "ATTACHMENT_PAGE_OWNER_UNRESOLVED",
+						data: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							error: "owner_unresolved",
+							attachmentId,
+						},
+						promptData: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							error: "owner_unresolved",
+							attachmentId,
+						},
+					};
+				}
+				if (offset > 0 && !expectedRevision) {
+					return {
+						success: false,
+						text: "An attachment revision is required to continue reading.",
+						error: "ATTACHMENT_READ_EXPECTED_REVISION_REQUIRED",
+						data: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							error: "expected_revision_required",
+						},
+						promptData: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							error: "expected_revision_required",
+						},
+					};
+				}
+				const limit = readOptionalPositiveInteger(params, "limit");
+				let page: Awaited<ReturnType<NonNullable<typeof pageCapable>>>;
+				try {
+					page = await pageCapable.call(runtime, {
+						memoryId: ownerMessageId,
+						field: { kind: "attachment.text", attachmentId },
+						byteStart: offset,
+						...(limit === undefined ? {} : { byteLimit: limit }),
+						...(expectedRevision === undefined ? {} : { expectedRevision }),
+					});
+				} catch (error) {
+					// error-policy:J1 the action boundary translates typed paging
+					// failures (stale revision, reindex required, drift) into
+					// structured user-visible replies.
+					if (error instanceof ElizaError) {
+						return {
+							success: false,
+							text: error.message,
+							error: error.code,
+							data: {
+								actionName: "ATTACHMENT",
+								action: "read",
+								error: error.code,
+								attachmentId,
+								...(error.context?.currentRevision !== undefined
+									? {
+											currentRevision: error.context.currentRevision,
+										}
+									: {}),
+							},
+							promptData: {
+								actionName: "ATTACHMENT",
+								action: "read",
+								error: error.code,
+								attachmentId,
+							},
+						};
+					}
+					throw error;
+				}
+				if (page) {
+					const readView: ReadView = {
+						reference: buildContentReference({
+							kind: "attachment",
+							ref: `attachment:${attachmentId}`,
+							revision: page.revision,
+						}),
+						slice: buildReadSlice({
+							range: {
+								unit: "byte",
+								start: page.start,
+								end: page.end,
+								total: page.total,
+							},
+							completeness: page.completeness,
+							revision: page.revision,
+							sliceSha256: page.sliceSha256,
+							sourceSha256: page.sourceSha256,
+						}),
+					};
+					const visibleText = await answerAttachmentRequest({
+						runtime,
+						message: messageWithParams,
+						content: page.text,
+						fallbackText: `Read "${titleForRecord(segmentedRecord)}" page but couldn't put an answer together — ask me something specific about it.`,
+					});
+					if (callback) {
+						await callback({
+							text: visibleText,
+							actions: ["ATTACHMENT_READ_SUCCESS"],
+							source: messageWithParams.content.source,
+						});
+					}
+					return {
+						success: true,
+						text: page.text,
+						transcriptVisibility: "internal",
+						userFacingText: visibleText,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						data: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							attachmentId,
+							attachmentIds: [attachmentId],
+							readView,
+						},
+						promptData: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							attachmentId,
+							readView,
+						},
+					};
+				}
+				// page === null: descriptor absent with small inline — fall
+				// through to the inline paging path below.
+			}
 			if (
 				pagedRecords.some((record) => record.readView.slice.range.start > 0) &&
 				!expectedRevision

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -1218,10 +1218,13 @@ export const readAttachmentAction: Action = {
 			const pageCapable = hasMemoryContentPageCapability(runtime)
 				? runtime.getMemoryContentPage
 				: null;
+			// #25140 review R4 r2: detect the marker on the ORIGINAL record
+			// content — pageAttachmentRecords may slice the prefix away (small
+			// limit, nonzero continuation offset), which would make the truncated
+			// descriptor leak into the inline answer path undetected.
 			const segmentedRecord =
-				pagedRecords.length === 1 &&
-				isSegmentedContentMarker(pagedRecords[0].content)
-					? pagedRecords[0]
+				records.length === 1 && isSegmentedContentMarker(records[0].content)
+					? records[0]
 					: null;
 			// #25140 review R4: the inline text of a segmented record is an
 			// internal storage descriptor, never attachment content. When it
@@ -1390,6 +1393,30 @@ export const readAttachmentAction: Action = {
 							action: "read",
 							attachmentId,
 							readView,
+						},
+					};
+				}
+				// page === null with a segmented record: the adapter found no
+				// authorized parent row (revoked access, room move, concurrent
+				// cleanup). The marker is an internal descriptor, so fail
+				// explicitly — never fall through to serving it inline.
+				// (#25140 review R4 r2)
+				if (segmentedRecord) {
+					return {
+						success: false,
+						text: "The segmented attachment is no longer available from storage, so it can't be read directly.",
+						error: "ATTACHMENT_SEGMENTED_PAGE_UNAVAILABLE",
+						data: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							error: "segmented_page_unavailable",
+							attachmentId: segmentedRecord.attachment.id,
+						},
+						promptData: {
+							actionName: "ATTACHMENT",
+							action: "read",
+							error: "segmented_page_unavailable",
+							attachmentId: segmentedRecord.attachment.id,
 						},
 					};
 				}

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -25,6 +25,7 @@ import {
 import {
 	hasMemoryContentPageCapability,
 	isSegmentedContentMarker,
+	parseSegmentedContentMarker,
 } from "../../memory/content-segmentation.ts";
 import {
 	linkShareOwnText,
@@ -804,7 +805,20 @@ async function reassembleSegmentedAttachmentContent(
 		const parts: string[] = [];
 		let offset = 0;
 		let total = Number.POSITIVE_INFINITY;
-		let revision: string | undefined;
+		// #25140 review R4 integrity fence: the record's inline marker carries
+		// the published descriptor (revision, total bytes, source digest). The
+		// first page MUST be served from that exact generation — adopting
+		// whatever generation the store happens to return could silently save
+		// a newer rewrite of the attachment. Later pages must hold the same
+		// generation and a coherent window; the whole is verified against the
+		// descriptor digest before the document is written.
+		const descriptor = parseSegmentedContentMarker(record.content);
+		if (!descriptor) {
+			return await saveFailure(
+				"The segmented attachment's storage descriptor is malformed, so it cannot be saved as a document.",
+				"ATTACHMENT_SAVE_DESCRIPTOR_INVALID",
+			);
+		}
 		// 4096 pages at the 256 KiB ceiling bounds reassembly at 1 GiB — far
 		// above any real attachment while guaranteeing termination.
 		for (let guard = 0; offset < total; guard += 1) {
@@ -820,7 +834,9 @@ async function reassembleSegmentedAttachmentContent(
 					memoryId: ownerMessageId,
 					field: { kind: "attachment.text", attachmentId },
 					byteStart: offset,
-					...(revision === undefined ? {} : { expectedRevision: revision }),
+					// The marker's revision fences the FIRST page too: a
+					// newer generation must fail loudly, not save silently.
+					expectedRevision: descriptor.revision,
 					accessContext,
 				});
 			} catch (error) {
@@ -841,12 +857,38 @@ async function reassembleSegmentedAttachmentContent(
 					"ATTACHMENT_SAVE_REASSEMBLY_FAILED",
 				);
 			}
+			if (
+				!Number.isSafeInteger(page.start) ||
+				!Number.isSafeInteger(page.end) ||
+				page.start !== offset ||
+				page.end <= page.start ||
+				page.end > page.total ||
+				page.total !== descriptor.totalBytes ||
+				page.revision !== descriptor.revision ||
+				page.sourceSha256 !== descriptor.totalSha256
+			) {
+				return await saveFailure(
+					"The segmented attachment's stored pages did not match its published descriptor, so it cannot be saved as a document.",
+					"ATTACHMENT_SAVE_REASSEMBLY_INCONSISTENT",
+				);
+			}
 			parts.push(page.text);
 			offset = page.end;
 			total = page.total;
-			revision = page.revision;
 		}
-		reassembled.push({ ...record, content: parts.join("") });
+		const reassembledText = parts.join("");
+		const reassembledBytes = Buffer.from(reassembledText, "utf8");
+		if (
+			reassembledBytes.length !== descriptor.totalBytes ||
+			createHash("sha256").update(reassembledBytes).digest("hex") !==
+				descriptor.totalSha256
+		) {
+			return await saveFailure(
+				"The reassembled attachment content did not match its published digest, so it cannot be saved as a document.",
+				"ATTACHMENT_SAVE_REASSEMBLY_DIGEST_MISMATCH",
+			);
+		}
+		reassembled.push({ ...record, content: reassembledText });
 	}
 	return { records: reassembled };
 }
@@ -1177,11 +1219,34 @@ export const readAttachmentAction: Action = {
 				? runtime.getMemoryContentPage
 				: null;
 			const segmentedRecord =
-				pageCapable &&
 				pagedRecords.length === 1 &&
 				isSegmentedContentMarker(pagedRecords[0].content)
 					? pagedRecords[0]
 					: null;
+			// #25140 review R4: the inline text of a segmented record is an
+			// internal storage descriptor, never attachment content. When it
+			// cannot be paged (capability absent or wrong capability shape),
+			// fail explicitly — do not fall through and serve the descriptor
+			// string to the model or the user.
+			if (segmentedRecord && !pageCapable) {
+				return {
+					success: false,
+					text: "This attachment is stored in segmented form and the current database cannot page it, so it can't be read directly.",
+					error: "ATTACHMENT_SEGMENTED_READ_UNAVAILABLE",
+					data: {
+						actionName: "ATTACHMENT",
+						action: "read",
+						error: "segmented_read_unavailable",
+						attachmentId: segmentedRecord.attachment.id,
+					},
+					promptData: {
+						actionName: "ATTACHMENT",
+						action: "read",
+						error: "segmented_read_unavailable",
+						attachmentId: segmentedRecord.attachment.id,
+					},
+				};
+			}
 			if (pageCapable && segmentedRecord) {
 				const ownerMessageId = segmentedRecord.attachment._messageId;
 				const attachmentId = segmentedRecord.attachment.id;

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -10,18 +10,18 @@
  */
 
 import {
-  type Content,
-  type CustomMetadata,
-  type DescriptionMetadata,
-  type DocumentMetadata,
-  type FragmentMetadata,
-  type Memory,
-  type MemoryMetadata,
-  type MemoryScope,
-  MemoryType,
-  type MessageMemory,
-  type MessageMetadata,
-  type UUID,
+	type Content,
+	type CustomMetadata,
+	type DescriptionMetadata,
+	type DocumentMetadata,
+	type FragmentMetadata,
+	type Memory,
+	type MemoryMetadata,
+	type MemoryScope,
+	MemoryType,
+	type MessageMemory,
+	type MessageMetadata,
+	type UUID,
 } from "./types";
 
 /**
@@ -34,31 +34,31 @@ import {
  * pass `scope` explicitly instead of the factory guessing for them.
  */
 export function createMessageMemory(params: {
-  id?: UUID;
-  entityId: UUID;
-  agentId?: UUID;
-  roomId: UUID;
-  content: Content & { text: string };
-  embedding?: number[];
-  scope?: MemoryScope;
+	id?: UUID;
+	entityId: UUID;
+	agentId?: UUID;
+	roomId: UUID;
+	content: Content & { text: string };
+	embedding?: number[];
+	scope?: MemoryScope;
 }): MessageMemory {
-  const { scope, ...memoryFields } = params;
-  const now = Date.now();
-  return {
-    ...memoryFields,
-    createdAt: now,
-    metadata: {
-      type: MemoryType.MESSAGE,
-      timestamp: now,
-      scope: scope ?? (params.agentId ? "private" : "shared"),
-    },
-  };
+	const { scope, ...memoryFields } = params;
+	const now = Date.now();
+	return {
+		...memoryFields,
+		createdAt: now,
+		metadata: {
+			type: MemoryType.MESSAGE,
+			timestamp: now,
+			scope: scope ?? (params.agentId ? "private" : "shared"),
+		},
+	};
 }
 
 export function isDocumentMetadata(
-  metadata: MemoryMetadata,
+	metadata: MemoryMetadata,
 ): metadata is DocumentMetadata {
-  return metadata.type === MemoryType.DOCUMENT;
+	return metadata.type === MemoryType.DOCUMENT;
 }
 
 /**
@@ -67,15 +67,15 @@ export function isDocumentMetadata(
  * @returns True if the metadata is a FragmentMetadata
  */
 export function isFragmentMetadata(
-  metadata: MemoryMetadata,
+	metadata: MemoryMetadata,
 ): metadata is FragmentMetadata {
-  return metadata.type === MemoryType.FRAGMENT;
+	return metadata.type === MemoryType.FRAGMENT;
 }
 
 export function isMessageMetadata(
-  metadata: MemoryMetadata,
+	metadata: MemoryMetadata,
 ): metadata is MessageMetadata {
-  return metadata.type === MemoryType.MESSAGE;
+	return metadata.type === MemoryType.MESSAGE;
 }
 
 /**
@@ -84,48 +84,48 @@ export function isMessageMetadata(
  * @returns True if the metadata is a DescriptionMetadata
  */
 export function isDescriptionMetadata(
-  metadata: MemoryMetadata,
+	metadata: MemoryMetadata,
 ): metadata is DescriptionMetadata {
-  return metadata.type === MemoryType.DESCRIPTION;
+	return metadata.type === MemoryType.DESCRIPTION;
 }
 
 export function isCustomMetadata(
-  metadata: MemoryMetadata,
+	metadata: MemoryMetadata,
 ): metadata is CustomMetadata {
-  return (
-    metadata.type !== MemoryType.DOCUMENT &&
-    metadata.type !== MemoryType.FRAGMENT &&
-    metadata.type !== MemoryType.MESSAGE &&
-    metadata.type !== MemoryType.DESCRIPTION
-  );
+	return (
+		metadata.type !== MemoryType.DOCUMENT &&
+		metadata.type !== MemoryType.FRAGMENT &&
+		metadata.type !== MemoryType.MESSAGE &&
+		metadata.type !== MemoryType.DESCRIPTION
+	);
 }
 
 /**
  * Memory type guard for document memories
  */
 export function isDocumentMemory(
-  memory: Memory,
+	memory: Memory,
 ): memory is Memory & { metadata: DocumentMetadata } {
-  return (
-    memory.metadata !== undefined &&
-    memory.metadata.type === MemoryType.DOCUMENT
-  );
+	return (
+		memory.metadata !== undefined &&
+		memory.metadata.type === MemoryType.DOCUMENT
+	);
 }
 
 /**
  * Memory type guard for fragment memories
  */
 export function isFragmentMemory(
-  memory: Memory,
+	memory: Memory,
 ): memory is Memory & { metadata: FragmentMetadata } {
-  return (
-    memory.metadata !== undefined &&
-    memory.metadata.type === MemoryType.FRAGMENT
-  );
+	return (
+		memory.metadata !== undefined &&
+		memory.metadata.type === MemoryType.FRAGMENT
+	);
 }
 
 export function getMemoryText(memory: Memory, defaultValue = ""): string {
-  return memory.content.text ?? defaultValue;
+	return memory.content.text ?? defaultValue;
 }
 
 // Re-exported so the segmentation primitive ships on the same module path as

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -10,18 +10,18 @@
  */
 
 import {
-	type Content,
-	type CustomMetadata,
-	type DescriptionMetadata,
-	type DocumentMetadata,
-	type FragmentMetadata,
-	type Memory,
-	type MemoryMetadata,
-	type MemoryScope,
-	MemoryType,
-	type MessageMemory,
-	type MessageMetadata,
-	type UUID,
+  type Content,
+  type CustomMetadata,
+  type DescriptionMetadata,
+  type DocumentMetadata,
+  type FragmentMetadata,
+  type Memory,
+  type MemoryMetadata,
+  type MemoryScope,
+  MemoryType,
+  type MessageMemory,
+  type MessageMetadata,
+  type UUID,
 } from "./types";
 
 /**
@@ -34,31 +34,31 @@ import {
  * pass `scope` explicitly instead of the factory guessing for them.
  */
 export function createMessageMemory(params: {
-	id?: UUID;
-	entityId: UUID;
-	agentId?: UUID;
-	roomId: UUID;
-	content: Content & { text: string };
-	embedding?: number[];
-	scope?: MemoryScope;
+  id?: UUID;
+  entityId: UUID;
+  agentId?: UUID;
+  roomId: UUID;
+  content: Content & { text: string };
+  embedding?: number[];
+  scope?: MemoryScope;
 }): MessageMemory {
-	const { scope, ...memoryFields } = params;
-	const now = Date.now();
-	return {
-		...memoryFields,
-		createdAt: now,
-		metadata: {
-			type: MemoryType.MESSAGE,
-			timestamp: now,
-			scope: scope ?? (params.agentId ? "private" : "shared"),
-		},
-	};
+  const { scope, ...memoryFields } = params;
+  const now = Date.now();
+  return {
+    ...memoryFields,
+    createdAt: now,
+    metadata: {
+      type: MemoryType.MESSAGE,
+      timestamp: now,
+      scope: scope ?? (params.agentId ? "private" : "shared"),
+    },
+  };
 }
 
 export function isDocumentMetadata(
-	metadata: MemoryMetadata,
+  metadata: MemoryMetadata,
 ): metadata is DocumentMetadata {
-	return metadata.type === MemoryType.DOCUMENT;
+  return metadata.type === MemoryType.DOCUMENT;
 }
 
 /**
@@ -67,15 +67,15 @@ export function isDocumentMetadata(
  * @returns True if the metadata is a FragmentMetadata
  */
 export function isFragmentMetadata(
-	metadata: MemoryMetadata,
+  metadata: MemoryMetadata,
 ): metadata is FragmentMetadata {
-	return metadata.type === MemoryType.FRAGMENT;
+  return metadata.type === MemoryType.FRAGMENT;
 }
 
 export function isMessageMetadata(
-	metadata: MemoryMetadata,
+  metadata: MemoryMetadata,
 ): metadata is MessageMetadata {
-	return metadata.type === MemoryType.MESSAGE;
+  return metadata.type === MemoryType.MESSAGE;
 }
 
 /**
@@ -84,46 +84,50 @@ export function isMessageMetadata(
  * @returns True if the metadata is a DescriptionMetadata
  */
 export function isDescriptionMetadata(
-	metadata: MemoryMetadata,
+  metadata: MemoryMetadata,
 ): metadata is DescriptionMetadata {
-	return metadata.type === MemoryType.DESCRIPTION;
+  return metadata.type === MemoryType.DESCRIPTION;
 }
 
 export function isCustomMetadata(
-	metadata: MemoryMetadata,
+  metadata: MemoryMetadata,
 ): metadata is CustomMetadata {
-	return (
-		metadata.type !== MemoryType.DOCUMENT &&
-		metadata.type !== MemoryType.FRAGMENT &&
-		metadata.type !== MemoryType.MESSAGE &&
-		metadata.type !== MemoryType.DESCRIPTION
-	);
+  return (
+    metadata.type !== MemoryType.DOCUMENT &&
+    metadata.type !== MemoryType.FRAGMENT &&
+    metadata.type !== MemoryType.MESSAGE &&
+    metadata.type !== MemoryType.DESCRIPTION
+  );
 }
 
 /**
  * Memory type guard for document memories
  */
 export function isDocumentMemory(
-	memory: Memory,
+  memory: Memory,
 ): memory is Memory & { metadata: DocumentMetadata } {
-	return (
-		memory.metadata !== undefined &&
-		memory.metadata.type === MemoryType.DOCUMENT
-	);
+  return (
+    memory.metadata !== undefined &&
+    memory.metadata.type === MemoryType.DOCUMENT
+  );
 }
 
 /**
  * Memory type guard for fragment memories
  */
 export function isFragmentMemory(
-	memory: Memory,
+  memory: Memory,
 ): memory is Memory & { metadata: FragmentMetadata } {
-	return (
-		memory.metadata !== undefined &&
-		memory.metadata.type === MemoryType.FRAGMENT
-	);
+  return (
+    memory.metadata !== undefined &&
+    memory.metadata.type === MemoryType.FRAGMENT
+  );
 }
 
 export function getMemoryText(memory: Memory, defaultValue = ""): string {
-	return memory.content.text ?? defaultValue;
+  return memory.content.text ?? defaultValue;
 }
+
+// Re-exported so the segmentation primitive ships on the same module path as
+// the other memory helpers (`src/memory` is a module, not a directory barrel).
+export * from "./memory/content-segmentation";

--- a/packages/core/src/memory/content-segmentation.test.ts
+++ b/packages/core/src/memory/content-segmentation.test.ts
@@ -8,207 +8,207 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
-  buildSegmentationRevision,
-  clampPageWindow,
-  encodeUtf8Strict,
-  MEMORY_PAGE_MAX_BYTES,
-  MEMORY_SEGMENTATION_THRESHOLD_BYTES,
-  memorySegmentFieldKey,
-  reassembleAndVerify,
-  segmentMemoryContent,
-  shouldSegmentContent,
+	buildSegmentationRevision,
+	clampPageWindow,
+	encodeUtf8Strict,
+	MEMORY_PAGE_MAX_BYTES,
+	MEMORY_SEGMENTATION_THRESHOLD_BYTES,
+	memorySegmentFieldKey,
+	reassembleAndVerify,
+	segmentMemoryContent,
+	shouldSegmentContent,
 } from "./content-segmentation";
 
 function sourceOf(byteLength: number, fill: (index: number) => string): string {
-  const parts: string[] = [];
-  let bytes = 0;
-  while (bytes < byteLength) {
-    const chunk = fill(bytes);
-    parts.push(chunk);
-    bytes += Buffer.byteLength(chunk, "utf8");
-  }
-  return parts.join("");
+	const parts: string[] = [];
+	let bytes = 0;
+	while (bytes < byteLength) {
+		const chunk = fill(bytes);
+		parts.push(chunk);
+		bytes += Buffer.byteLength(chunk, "utf8");
+	}
+	return parts.join("");
 }
 
 function sha256(bytes: Uint8Array): string {
-  return createHash("sha256").update(bytes).digest("hex");
+	return createHash("sha256").update(bytes).digest("hex");
 }
 
 function expectCode(fn: () => unknown, code: string): void {
-  try {
-    fn();
-    throw new Error("expected throw");
-  } catch (error) {
-    const thrown = error as { code?: string; message: string };
-    const observed = thrown.code ?? thrown.message;
-    const variants = code.split("|").map((variant) => variant.trim());
-    expect(variants.some((variant) => observed.includes(variant))).toBe(true);
-  }
+	try {
+		fn();
+		throw new Error("expected throw");
+	} catch (error) {
+		const thrown = error as { code?: string; message: string };
+		const observed = thrown.code ?? thrown.message;
+		const variants = code.split("|").map((variant) => variant.trim());
+		expect(variants.some((variant) => observed.includes(variant))).toBe(true);
+	}
 }
 
 describe("encodeUtf8Strict", () => {
-  it("round-trips ascii and multibyte text", () => {
-    const text = "hello 世界 — 🚀🎉 emoji";
-    const bytes = encodeUtf8Strict(text);
-    expect(Buffer.from(text, "utf8").equals(Buffer.from(bytes))).toBe(true);
-  });
+	it("round-trips ascii and multibyte text", () => {
+		const text = "hello 世界 — 🚀🎉 emoji";
+		const bytes = encodeUtf8Strict(text);
+		expect(Buffer.from(text, "utf8").equals(Buffer.from(bytes))).toBe(true);
+	});
 
-  it("fails closed on lone surrogates", () => {
-    expectCode(
-      () => encodeUtf8Strict("bad: \ud800 surrogate"),
-      "MEMORY_SEGMENT_UNPAIRED_SURROGATE|unpaired surrogates",
-    );
-  });
+	it("fails closed on lone surrogates", () => {
+		expectCode(
+			() => encodeUtf8Strict("bad: \ud800 surrogate"),
+			"MEMORY_SEGMENT_UNPAIRED_SURROGATE|unpaired surrogates",
+		);
+	});
 });
 
 describe("segmentMemoryContent", () => {
-  it("produces non-overlapping contiguous segments that reassemble byte-exactly", () => {
-    const text = sourceOf(300, (i) =>
-      i % 3 === 0 ? "αβγδ" : i % 3 === 1 ? "emoji🚀" : "plain",
-    );
-    const { segments, descriptor } = segmentMemoryContent(
-      text,
-      { kind: "content.text" },
-      {
-        segmentBytes: 64,
-      },
-    );
-    expect(segments.length).toBeGreaterThan(3);
-    expect(descriptor.totalBytes).toBe(encodeUtf8Strict(text).length);
-    expect(descriptor.totalSha256).toBe(sha256(encodeUtf8Strict(text)));
-    expect(descriptor.segmentCount).toBe(segments.length);
+	it("produces non-overlapping contiguous segments that reassemble byte-exactly", () => {
+		const text = sourceOf(300, (i) =>
+			i % 3 === 0 ? "αβγδ" : i % 3 === 1 ? "emoji🚀" : "plain",
+		);
+		const { segments, descriptor } = segmentMemoryContent(
+			text,
+			{ kind: "content.text" },
+			{
+				segmentBytes: 64,
+			},
+		);
+		expect(segments.length).toBeGreaterThan(3);
+		expect(descriptor.totalBytes).toBe(encodeUtf8Strict(text).length);
+		expect(descriptor.totalSha256).toBe(sha256(encodeUtf8Strict(text)));
+		expect(descriptor.segmentCount).toBe(segments.length);
 
-    const reassembled = reassembleAndVerify(segments, descriptor);
-    expect(reassembled).toBe(text);
-  });
+		const reassembled = reassembleAndVerify(segments, descriptor);
+		expect(reassembled).toBe(text);
+	});
 
-  it("never splits a UTF-8 code point at a boundary", () => {
-    // Multibyte-heavy source hitting every boundary parity.
-    const text = "🚀".repeat(500);
-    const { segments } = segmentMemoryContent(
-      text,
-      { kind: "content.text" },
-      {
-        segmentBytes: 7, // not divisible by 4: boundaries land mid-codepoint
-      },
-    );
-    for (const segment of segments) {
-      // Decoding throws if a code point was split.
-      expect(() =>
-        new TextDecoder("utf-8", { fatal: true }).decode(
-          encodeUtf8Strict(segment.text),
-        ),
-      ).not.toThrow();
-      expect((segment.byteEnd - segment.byteStart) % 4).toBe(0);
-    }
-  });
+	it("never splits a UTF-8 code point at a boundary", () => {
+		// Multibyte-heavy source hitting every boundary parity.
+		const text = "🚀".repeat(500);
+		const { segments } = segmentMemoryContent(
+			text,
+			{ kind: "content.text" },
+			{
+				segmentBytes: 7, // not divisible by 4: boundaries land mid-codepoint
+			},
+		);
+		for (const segment of segments) {
+			// Decoding throws if a code point was split.
+			expect(() =>
+				new TextDecoder("utf-8", { fatal: true }).decode(
+					encodeUtf8Strict(segment.text),
+				),
+			).not.toThrow();
+			expect((segment.byteEnd - segment.byteStart) % 4).toBe(0);
+		}
+	});
 
-  it("mints a fresh generation per call even for identical text", () => {
-    const text = "same bytes".repeat(100);
-    const a = segmentMemoryContent(text, { kind: "content.text" });
-    const b = segmentMemoryContent(text, { kind: "content.text" });
-    expect(a.descriptor.generation).not.toBe(b.descriptor.generation);
-    expect(a.descriptor.totalSha256).toBe(b.descriptor.totalSha256);
-    expect(a.descriptor.revision).toMatch(/^seg:[0-9a-f-]{36}:[0-9a-f]{64}$/);
-  });
+	it("mints a fresh generation per call even for identical text", () => {
+		const text = "same bytes".repeat(100);
+		const a = segmentMemoryContent(text, { kind: "content.text" });
+		const b = segmentMemoryContent(text, { kind: "content.text" });
+		expect(a.descriptor.generation).not.toBe(b.descriptor.generation);
+		expect(a.descriptor.totalSha256).toBe(b.descriptor.totalSha256);
+		expect(a.descriptor.revision).toMatch(/^seg:[0-9a-f-]{36}:[0-9a-f]{64}$/);
+	});
 
-  it("rejects empty and out-of-range budgets", () => {
-    expectCode(
-      () => segmentMemoryContent("", { kind: "content.text" }),
-      "MEMORY_SEGMENT_EMPTY_SOURCE",
-    );
-    expectCode(
-      () =>
-        segmentMemoryContent(
-          "x".repeat(10),
-          { kind: "content.text" },
-          { segmentBytes: 1 },
-        ),
-      "MEMORY_SEGMENT_INVALID_BUDGET",
-    );
-  });
+	it("rejects empty and out-of-range budgets", () => {
+		expectCode(
+			() => segmentMemoryContent("", { kind: "content.text" }),
+			"MEMORY_SEGMENT_EMPTY_SOURCE",
+		);
+		expectCode(
+			() =>
+				segmentMemoryContent(
+					"x".repeat(10),
+					{ kind: "content.text" },
+					{ segmentBytes: 1 },
+				),
+			"MEMORY_SEGMENT_INVALID_BUDGET",
+		);
+	});
 
-  it("keys attachment fields by attachment id", () => {
-    expect(memorySegmentFieldKey({ kind: "content.text" })).toBe(
-      "content.text",
-    );
-    expect(
-      memorySegmentFieldKey({ kind: "attachment.text", attachmentId: "att-1" }),
-    ).toBe("attachment.text:att-1");
-  });
+	it("keys attachment fields by attachment id", () => {
+		expect(memorySegmentFieldKey({ kind: "content.text" })).toBe(
+			"content.text",
+		);
+		expect(
+			memorySegmentFieldKey({ kind: "attachment.text", attachmentId: "att-1" }),
+		).toBe("attachment.text:att-1");
+	});
 });
 
 describe("shouldSegmentContent", () => {
-  it("segments only above the threshold", () => {
-    expect(shouldSegmentContent("small")).toBe(false);
-    const big = "a".repeat(MEMORY_SEGMENTATION_THRESHOLD_BYTES + 1);
-    expect(shouldSegmentContent(big)).toBe(true);
-  });
+	it("segments only above the threshold", () => {
+		expect(shouldSegmentContent("small")).toBe(false);
+		const big = "a".repeat(MEMORY_SEGMENTATION_THRESHOLD_BYTES + 1);
+		expect(shouldSegmentContent(big)).toBe(true);
+	});
 
-  it("measures UTF-8 bytes, not code units", () => {
-    // 3 bytes per char: a third the character count crosses the threshold.
-    const chars = Math.floor(MEMORY_SEGMENTATION_THRESHOLD_BYTES / 3) + 1;
-    expect(shouldSegmentContent("€".repeat(chars))).toBe(true);
-  });
+	it("measures UTF-8 bytes, not code units", () => {
+		// 3 bytes per char: a third the character count crosses the threshold.
+		const chars = Math.floor(MEMORY_SEGMENTATION_THRESHOLD_BYTES / 3) + 1;
+		expect(shouldSegmentContent("€".repeat(chars))).toBe(true);
+	});
 });
 
 describe("clampPageWindow", () => {
-  it("clamps oversize and omitted limits to the hard page ceiling", () => {
-    const window = clampPageWindow(10 * 1024 * 1024, 0, undefined);
-    expect(window.end).toBe(MEMORY_PAGE_MAX_BYTES);
-    const oversize = clampPageWindow(10 * 1024 * 1024, 0, 99 * 1024 * 1024);
-    expect(oversize.end).toBe(MEMORY_PAGE_MAX_BYTES);
-  });
+	it("clamps oversize and omitted limits to the hard page ceiling", () => {
+		const window = clampPageWindow(10 * 1024 * 1024, 0, undefined);
+		expect(window.end).toBe(MEMORY_PAGE_MAX_BYTES);
+		const oversize = clampPageWindow(10 * 1024 * 1024, 0, 99 * 1024 * 1024);
+		expect(oversize.end).toBe(MEMORY_PAGE_MAX_BYTES);
+	});
 
-  it("clamps the end to the total", () => {
-    const window = clampPageWindow(1000, 900, undefined);
-    expect(window).toEqual({ start: 900, end: 1000 });
-  });
+	it("clamps the end to the total", () => {
+		const window = clampPageWindow(1000, 900, undefined);
+		expect(window).toEqual({ start: 900, end: 1000 });
+	});
 
-  it("rejects invalid offsets and limits", () => {
-    expectCode(
-      () => clampPageWindow(100, -1, 10),
-      "MEMORY_PAGE_INVALID_OFFSET",
-    );
-    expectCode(
-      () => clampPageWindow(100, 101, 10),
-      "MEMORY_PAGE_INVALID_OFFSET",
-    );
-    expectCode(() => clampPageWindow(100, 0, 0), "MEMORY_PAGE_INVALID_LIMIT");
-  });
+	it("rejects invalid offsets and limits", () => {
+		expectCode(
+			() => clampPageWindow(100, -1, 10),
+			"MEMORY_PAGE_INVALID_OFFSET",
+		);
+		expectCode(
+			() => clampPageWindow(100, 101, 10),
+			"MEMORY_PAGE_INVALID_OFFSET",
+		);
+		expectCode(() => clampPageWindow(100, 0, 0), "MEMORY_PAGE_INVALID_LIMIT");
+	});
 });
 
 describe("reassembleAndVerify", () => {
-  it("detects gaps, overlaps, digest and count drift", () => {
-    const text = sourceOf(400, (i) => (i % 2 ? "日本語テキスト" : "content"));
-    const { segments, descriptor } = segmentMemoryContent(
-      text,
-      { kind: "content.text" },
-      {
-        segmentBytes: 50,
-      },
-    );
+	it("detects gaps, overlaps, digest and count drift", () => {
+		const text = sourceOf(400, (i) => (i % 2 ? "日本語テキスト" : "content"));
+		const { segments, descriptor } = segmentMemoryContent(
+			text,
+			{ kind: "content.text" },
+			{
+				segmentBytes: 50,
+			},
+		);
 
-    const gapped = segments.slice(0, segments.length - 1);
-    expectCode(
-      () => reassembleAndVerify(gapped, descriptor),
-      "MEMORY_SEGMENT_COUNT_MISMATCH",
-    );
+		const gapped = segments.slice(0, segments.length - 1);
+		expectCode(
+			() => reassembleAndVerify(gapped, descriptor),
+			"MEMORY_SEGMENT_COUNT_MISMATCH",
+		);
 
-    const tampered = segments.map((segment, index) =>
-      index === 1 ? { ...segment, text: `${segment.text}x` } : segment,
-    );
-    expectCode(
-      () => reassembleAndVerify(tampered, descriptor),
-      "MEMORY_SEGMENT_LENGTH_MISMATCH|MEMORY_SEGMENT_DIGEST_MISMATCH",
-    );
-  });
+		const tampered = segments.map((segment, index) =>
+			index === 1 ? { ...segment, text: `${segment.text}x` } : segment,
+		);
+		expectCode(
+			() => reassembleAndVerify(tampered, descriptor),
+			"MEMORY_SEGMENT_LENGTH_MISMATCH|MEMORY_SEGMENT_DIGEST_MISMATCH",
+		);
+	});
 });
 
 describe("buildSegmentationRevision", () => {
-  it("binds generation and total digest", () => {
-    expect(buildSegmentationRevision("g", "d".repeat(64))).toBe(
-      `seg:g:${"d".repeat(64)}`,
-    );
-  });
+	it("binds generation and total digest", () => {
+		expect(buildSegmentationRevision("g", "d".repeat(64))).toBe(
+			`seg:g:${"d".repeat(64)}`,
+		);
+	});
 });

--- a/packages/core/src/memory/content-segmentation.test.ts
+++ b/packages/core/src/memory/content-segmentation.test.ts
@@ -12,6 +12,7 @@ import {
 	clampPageWindow,
 	encodeUtf8Strict,
 	MEMORY_PAGE_MAX_BYTES,
+	MEMORY_SEGMENT_BYTES,
 	MEMORY_SEGMENTATION_THRESHOLD_BYTES,
 	memorySegmentFieldKey,
 	reassembleAndVerify,
@@ -210,5 +211,58 @@ describe("buildSegmentationRevision", () => {
 		expect(buildSegmentationRevision("g", "d".repeat(64))).toBe(
 			`seg:g:${"d".repeat(64)}`,
 		);
+	});
+});
+
+// The three exported budgets are wire-format-relevant limits, not internal
+// tuning: the page ceiling bounds a single memory read over the agent HTTP
+// surface, the segment budget fixes the segment-store row shape, and the
+// threshold decides which memories get a marker instead of inline content.
+// Each is pinned to its literal contracted value and to the observable
+// default-path and continuation-page behavior those values produce.
+describe("segmentation budget contracts (#25140)", () => {
+	it("pins the exported budget constants to their contracted values", () => {
+		expect(MEMORY_SEGMENT_BYTES).toBe(128 * 1024);
+		expect(MEMORY_SEGMENTATION_THRESHOLD_BYTES).toBe(128 * 1024);
+		expect(MEMORY_PAGE_MAX_BYTES).toBe(256 * 1024);
+	});
+
+	it("applies the default segment budget and covers the source exactly", () => {
+		// ASCII source: byte boundaries never snap, so the default budget's
+		// arithmetic is directly observable in the segment ranges.
+		const text = "a".repeat(200 * 1024);
+		const { segments, descriptor } = segmentMemoryContent(text, {
+			kind: "content.text",
+		});
+		expect(descriptor.totalBytes).toBe(200 * 1024);
+		expect(segments.length).toBe(2);
+		expect(segments[0].byteStart).toBe(0);
+		expect(segments[0].byteEnd).toBe(128 * 1024);
+		expect(segments[1].byteStart).toBe(128 * 1024);
+		expect(segments[1].byteEnd).toBe(200 * 1024);
+		// Coverage invariant: segmentation ends exactly at the source end.
+		expect(segments[segments.length - 1].byteEnd).toBe(descriptor.totalBytes);
+	});
+
+	it("holds the segmentation threshold at its contracted byte boundary", () => {
+		expect(shouldSegmentContent("a".repeat(128 * 1024))).toBe(false);
+		expect(shouldSegmentContent("a".repeat(128 * 1024 + 1))).toBe(true);
+	});
+
+	it("clamps a page read to the literal page ceiling, not a source-derived bound", () => {
+		expect(clampPageWindow(10 * 1024 * 1024, 0, undefined).end).toBe(
+			256 * 1024,
+		);
+		expect(clampPageWindow(10 * 1024 * 1024, 0, 99 * 1024 * 1024).end).toBe(
+			256 * 1024,
+		);
+		// A limit below the ceiling is honored exactly.
+		expect(clampPageWindow(10 * 1024 * 1024, 0, 4 * 1024).end).toBe(4 * 1024);
+		// Continuation pages clamp relative to the offset, not to the ceiling:
+		// offset + limit is the window end a paged reader advances to.
+		expect(clampPageWindow(10 * 1024 * 1024, 64 * 1024, undefined)).toEqual({
+			start: 64 * 1024,
+			end: 320 * 1024,
+		});
 	});
 });

--- a/packages/core/src/memory/content-segmentation.test.ts
+++ b/packages/core/src/memory/content-segmentation.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Deterministic unit coverage for the UTF-8 content-segmentation primitive
+ * (#25140): byte-exact boundaries, immutability of computed segments, SHA
+ * reassembly, page-window clamping, and fail-closed surrogate handling. Pure
+ * logic — no database involved; the SQL adapter layers prove persistence.
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  buildSegmentationRevision,
+  clampPageWindow,
+  encodeUtf8Strict,
+  MEMORY_PAGE_MAX_BYTES,
+  MEMORY_SEGMENTATION_THRESHOLD_BYTES,
+  memorySegmentFieldKey,
+  reassembleAndVerify,
+  segmentMemoryContent,
+  shouldSegmentContent,
+} from "./content-segmentation";
+
+function sourceOf(byteLength: number, fill: (index: number) => string): string {
+  const parts: string[] = [];
+  let bytes = 0;
+  while (bytes < byteLength) {
+    const chunk = fill(bytes);
+    parts.push(chunk);
+    bytes += Buffer.byteLength(chunk, "utf8");
+  }
+  return parts.join("");
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function expectCode(fn: () => unknown, code: string): void {
+  try {
+    fn();
+    throw new Error("expected throw");
+  } catch (error) {
+    const thrown = error as { code?: string; message: string };
+    const observed = thrown.code ?? thrown.message;
+    const variants = code.split("|").map((variant) => variant.trim());
+    expect(variants.some((variant) => observed.includes(variant))).toBe(true);
+  }
+}
+
+describe("encodeUtf8Strict", () => {
+  it("round-trips ascii and multibyte text", () => {
+    const text = "hello 世界 — 🚀🎉 emoji";
+    const bytes = encodeUtf8Strict(text);
+    expect(Buffer.from(text, "utf8").equals(Buffer.from(bytes))).toBe(true);
+  });
+
+  it("fails closed on lone surrogates", () => {
+    expectCode(
+      () => encodeUtf8Strict("bad: \ud800 surrogate"),
+      "MEMORY_SEGMENT_UNPAIRED_SURROGATE|unpaired surrogates",
+    );
+  });
+});
+
+describe("segmentMemoryContent", () => {
+  it("produces non-overlapping contiguous segments that reassemble byte-exactly", () => {
+    const text = sourceOf(300, (i) =>
+      i % 3 === 0 ? "αβγδ" : i % 3 === 1 ? "emoji🚀" : "plain",
+    );
+    const { segments, descriptor } = segmentMemoryContent(
+      text,
+      { kind: "content.text" },
+      {
+        segmentBytes: 64,
+      },
+    );
+    expect(segments.length).toBeGreaterThan(3);
+    expect(descriptor.totalBytes).toBe(encodeUtf8Strict(text).length);
+    expect(descriptor.totalSha256).toBe(sha256(encodeUtf8Strict(text)));
+    expect(descriptor.segmentCount).toBe(segments.length);
+
+    const reassembled = reassembleAndVerify(segments, descriptor);
+    expect(reassembled).toBe(text);
+  });
+
+  it("never splits a UTF-8 code point at a boundary", () => {
+    // Multibyte-heavy source hitting every boundary parity.
+    const text = "🚀".repeat(500);
+    const { segments } = segmentMemoryContent(
+      text,
+      { kind: "content.text" },
+      {
+        segmentBytes: 7, // not divisible by 4: boundaries land mid-codepoint
+      },
+    );
+    for (const segment of segments) {
+      // Decoding throws if a code point was split.
+      expect(() =>
+        new TextDecoder("utf-8", { fatal: true }).decode(
+          encodeUtf8Strict(segment.text),
+        ),
+      ).not.toThrow();
+      expect((segment.byteEnd - segment.byteStart) % 4).toBe(0);
+    }
+  });
+
+  it("mints a fresh generation per call even for identical text", () => {
+    const text = "same bytes".repeat(100);
+    const a = segmentMemoryContent(text, { kind: "content.text" });
+    const b = segmentMemoryContent(text, { kind: "content.text" });
+    expect(a.descriptor.generation).not.toBe(b.descriptor.generation);
+    expect(a.descriptor.totalSha256).toBe(b.descriptor.totalSha256);
+    expect(a.descriptor.revision).toMatch(/^seg:[0-9a-f-]{36}:[0-9a-f]{64}$/);
+  });
+
+  it("rejects empty and out-of-range budgets", () => {
+    expectCode(
+      () => segmentMemoryContent("", { kind: "content.text" }),
+      "MEMORY_SEGMENT_EMPTY_SOURCE",
+    );
+    expectCode(
+      () =>
+        segmentMemoryContent(
+          "x".repeat(10),
+          { kind: "content.text" },
+          { segmentBytes: 1 },
+        ),
+      "MEMORY_SEGMENT_INVALID_BUDGET",
+    );
+  });
+
+  it("keys attachment fields by attachment id", () => {
+    expect(memorySegmentFieldKey({ kind: "content.text" })).toBe(
+      "content.text",
+    );
+    expect(
+      memorySegmentFieldKey({ kind: "attachment.text", attachmentId: "att-1" }),
+    ).toBe("attachment.text:att-1");
+  });
+});
+
+describe("shouldSegmentContent", () => {
+  it("segments only above the threshold", () => {
+    expect(shouldSegmentContent("small")).toBe(false);
+    const big = "a".repeat(MEMORY_SEGMENTATION_THRESHOLD_BYTES + 1);
+    expect(shouldSegmentContent(big)).toBe(true);
+  });
+
+  it("measures UTF-8 bytes, not code units", () => {
+    // 3 bytes per char: a third the character count crosses the threshold.
+    const chars = Math.floor(MEMORY_SEGMENTATION_THRESHOLD_BYTES / 3) + 1;
+    expect(shouldSegmentContent("€".repeat(chars))).toBe(true);
+  });
+});
+
+describe("clampPageWindow", () => {
+  it("clamps oversize and omitted limits to the hard page ceiling", () => {
+    const window = clampPageWindow(10 * 1024 * 1024, 0, undefined);
+    expect(window.end).toBe(MEMORY_PAGE_MAX_BYTES);
+    const oversize = clampPageWindow(10 * 1024 * 1024, 0, 99 * 1024 * 1024);
+    expect(oversize.end).toBe(MEMORY_PAGE_MAX_BYTES);
+  });
+
+  it("clamps the end to the total", () => {
+    const window = clampPageWindow(1000, 900, undefined);
+    expect(window).toEqual({ start: 900, end: 1000 });
+  });
+
+  it("rejects invalid offsets and limits", () => {
+    expectCode(
+      () => clampPageWindow(100, -1, 10),
+      "MEMORY_PAGE_INVALID_OFFSET",
+    );
+    expectCode(
+      () => clampPageWindow(100, 101, 10),
+      "MEMORY_PAGE_INVALID_OFFSET",
+    );
+    expectCode(() => clampPageWindow(100, 0, 0), "MEMORY_PAGE_INVALID_LIMIT");
+  });
+});
+
+describe("reassembleAndVerify", () => {
+  it("detects gaps, overlaps, digest and count drift", () => {
+    const text = sourceOf(400, (i) => (i % 2 ? "日本語テキスト" : "content"));
+    const { segments, descriptor } = segmentMemoryContent(
+      text,
+      { kind: "content.text" },
+      {
+        segmentBytes: 50,
+      },
+    );
+
+    const gapped = segments.slice(0, segments.length - 1);
+    expectCode(
+      () => reassembleAndVerify(gapped, descriptor),
+      "MEMORY_SEGMENT_COUNT_MISMATCH",
+    );
+
+    const tampered = segments.map((segment, index) =>
+      index === 1 ? { ...segment, text: `${segment.text}x` } : segment,
+    );
+    expectCode(
+      () => reassembleAndVerify(tampered, descriptor),
+      "MEMORY_SEGMENT_LENGTH_MISMATCH|MEMORY_SEGMENT_DIGEST_MISMATCH",
+    );
+  });
+});
+
+describe("buildSegmentationRevision", () => {
+  it("binds generation and total digest", () => {
+    expect(buildSegmentationRevision("g", "d".repeat(64))).toBe(
+      `seg:g:${"d".repeat(64)}`,
+    );
+  });
+});

--- a/packages/core/src/memory/content-segmentation.test.ts
+++ b/packages/core/src/memory/content-segmentation.test.ts
@@ -155,6 +155,7 @@ describe("shouldSegmentContent", () => {
 
 describe("clampPageWindow", () => {
 	it("clamps oversize and omitted limits to the hard page ceiling", () => {
+		expect(MEMORY_PAGE_MAX_BYTES).toBe(256 * 1024);
 		const window = clampPageWindow(10 * 1024 * 1024, 0, undefined);
 		expect(window.end).toBe(MEMORY_PAGE_MAX_BYTES);
 		const oversize = clampPageWindow(10 * 1024 * 1024, 0, 99 * 1024 * 1024);

--- a/packages/core/src/memory/content-segmentation.ts
+++ b/packages/core/src/memory/content-segmentation.ts
@@ -23,58 +23,58 @@ export const MEMORY_PAGE_MAX_BYTES = 256 * 1024;
 
 /** Field identity of segmented content on the parent memory. */
 export type MemorySegmentField =
-  | { kind: "content.text" }
-  | { kind: "attachment.text"; attachmentId: string };
+	| { kind: "content.text" }
+	| { kind: "attachment.text"; attachmentId: string };
 
 /** Stable metadata key for one segmented field on the parent memory. */
 export function memorySegmentFieldKey(field: MemorySegmentField): string {
-  return field.kind === "content.text"
-    ? "content.text"
-    : `attachment.text:${field.attachmentId}`;
+	return field.kind === "content.text"
+		? "content.text"
+		: `attachment.text:${field.attachmentId}`;
 }
 
 /** Bounded descriptor stored on the parent memory; never carries source bytes. */
 export interface MemoryContentSegmentation {
-  v: 1;
-  field: MemorySegmentField;
-  encoding: "utf-8";
-  segmentBytes: number;
-  totalBytes: number;
-  totalSha256: string;
-  segmentCount: number;
-  /** Immutable generation identity; changes only on full replacement. */
-  generation: string;
-  /** Opaque public revision: identifies the immutable generation. */
-  revision: string;
+	v: 1;
+	field: MemorySegmentField;
+	encoding: "utf-8";
+	segmentBytes: number;
+	totalBytes: number;
+	totalSha256: string;
+	segmentCount: number;
+	/** Immutable generation identity; changes only on full replacement. */
+	generation: string;
+	/** Opaque public revision: identifies the immutable generation. */
+	revision: string;
 }
 
 /** One computed source segment. `byteEnd` is exclusive. */
 export interface ComputedMemorySegment {
-  index: number;
-  byteStart: number;
-  byteEnd: number;
-  text: string;
-  sha256: string;
+	index: number;
+	byteStart: number;
+	byteEnd: number;
+	text: string;
+	sha256: string;
 }
 
 export interface ComputedSegmentation {
-  segments: ComputedMemorySegment[];
-  descriptor: MemoryContentSegmentation;
+	segments: ComputedMemorySegment[];
+	descriptor: MemoryContentSegmentation;
 }
 
 export class MemorySegmentationError extends Error {
-  constructor(
-    message: string,
-    readonly code: string,
-    readonly context: Record<string, unknown> = {},
-  ) {
-    super(message);
-    this.name = "MemorySegmentationError";
-  }
+	constructor(
+		message: string,
+		readonly code: string,
+		readonly context: Record<string, unknown> = {},
+	) {
+		super(message);
+		this.name = "MemorySegmentationError";
+	}
 }
 
 function sha256Hex(bytes: Uint8Array): string {
-  return createHash("sha256").update(bytes).digest("hex");
+	return createHash("sha256").update(bytes).digest("hex");
 }
 
 /**
@@ -84,35 +84,35 @@ function sha256Hex(bytes: Uint8Array): string {
  * returned unchanged.
  */
 function snapToCodePointStart(bytes: Uint8Array, offset: number): number {
-  let at = offset;
-  while (at > 0 && (bytes[at] & 0xc0) === 0x80) {
-    at -= 1;
-  }
-  return at;
+	let at = offset;
+	while (at > 0 && (bytes[at] & 0xc0) === 0x80) {
+		at -= 1;
+	}
+	return at;
 }
 
 /** Encodes text to UTF-8 bytes, failing closed on lone surrogates. */
 export function encodeUtf8Strict(text: string): Uint8Array {
-  const bytes = Buffer.from(text, "utf8");
-  // Buffer.from replaces lone surrogates with U+FFFD; detect that corruption
-  // by comparing a lossless round-trip of the decoded result.
-  const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  if (decoded !== text) {
-    throw new MemorySegmentationError(
-      "Content contains unpaired surrogates and cannot be segmented losslessly",
-      "MEMORY_SEGMENT_UNPAIRED_SURROGATE",
-    );
-  }
-  return bytes;
+	const bytes = Buffer.from(text, "utf8");
+	// Buffer.from replaces lone surrogates with U+FFFD; detect that corruption
+	// by comparing a lossless round-trip of the decoded result.
+	const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+	if (decoded !== text) {
+		throw new MemorySegmentationError(
+			"Content contains unpaired surrogates and cannot be segmented losslessly",
+			"MEMORY_SEGMENT_UNPAIRED_SURROGATE",
+		);
+	}
+	return bytes;
 }
 
 /** Whether content must be segmented based on its UTF-8 byte length. */
 export function shouldSegmentContent(text: string): boolean {
-  return encodeUtf8Strict(text).length > MEMORY_SEGMENTATION_THRESHOLD_BYTES;
+	return encodeUtf8Strict(text).length > MEMORY_SEGMENTATION_THRESHOLD_BYTES;
 }
 
 function randomGeneration(): string {
-  return randomUUID();
+	return randomUUID();
 }
 
 /**
@@ -122,191 +122,210 @@ function randomGeneration(): string {
  * identifies one immutable generation of the content.
  */
 export function segmentMemoryContent(
-  text: string,
-  field: MemorySegmentField,
-  options?: { segmentBytes?: number; generation?: string },
+	text: string,
+	field: MemorySegmentField,
+	options?: { segmentBytes?: number; generation?: string },
 ): ComputedSegmentation {
-  const segmentBytes = options?.segmentBytes ?? MEMORY_SEGMENT_BYTES;
-  if (
-    !Number.isInteger(segmentBytes) ||
-    segmentBytes < 4 ||
-    segmentBytes > 4 * 1024 * 1024
-  ) {
-    throw new MemorySegmentationError(
-      "Segment byte budget is out of the supported range",
-      "MEMORY_SEGMENT_INVALID_BUDGET",
-      { segmentBytes },
-    );
-  }
-  const bytes = encodeUtf8Strict(text);
-  const totalBytes = bytes.length;
-  if (totalBytes === 0) {
-    throw new MemorySegmentationError(
-      "Empty content is never segmented",
-      "MEMORY_SEGMENT_EMPTY_SOURCE",
-    );
-  }
-  const totalSha256 = sha256Hex(bytes);
-  const generation = options?.generation ?? randomGeneration();
+	const segmentBytes = options?.segmentBytes ?? MEMORY_SEGMENT_BYTES;
+	if (
+		!Number.isInteger(segmentBytes) ||
+		segmentBytes < 4 ||
+		segmentBytes > 4 * 1024 * 1024
+	) {
+		throw new MemorySegmentationError(
+			"Segment byte budget is out of the supported range",
+			"MEMORY_SEGMENT_INVALID_BUDGET",
+			{ segmentBytes },
+		);
+	}
+	const bytes = encodeUtf8Strict(text);
+	const totalBytes = bytes.length;
+	if (totalBytes === 0) {
+		throw new MemorySegmentationError(
+			"Empty content is never segmented",
+			"MEMORY_SEGMENT_EMPTY_SOURCE",
+		);
+	}
+	const totalSha256 = sha256Hex(bytes);
+	const generation = options?.generation ?? randomGeneration();
 
-  const segments: ComputedMemorySegment[] = [];
-  let start = 0;
-  let index = 0;
-  while (start < totalBytes) {
-    let end = Math.min(start + segmentBytes, totalBytes);
-    end = snapToCodePointStart(bytes, end);
-    if (end <= start) {
-      // A single code point larger than the budget cannot exist in UTF-8
-      // (max 4 bytes) with segmentBytes >= 4, so this is unreachable.
-      throw new MemorySegmentationError(
-        "Segment budget cannot make progress at this offset",
-        "MEMORY_SEGMENT_BUDGET_TOO_SMALL",
-        { start, segmentBytes },
-      );
-    }
-    const segmentBytesSlice = bytes.subarray(start, end);
-    segments.push({
-      index,
-      byteStart: start,
-      byteEnd: end,
-      text: new TextDecoder("utf-8", { fatal: true }).decode(segmentBytesSlice),
-      sha256: sha256Hex(segmentBytesSlice),
-    });
-    start = end;
-    index += 1;
-  }
+	const segments: ComputedMemorySegment[] = [];
+	let start = 0;
+	let index = 0;
+	while (start < totalBytes) {
+		let end = Math.min(start + segmentBytes, totalBytes);
+		end = snapToCodePointStart(bytes, end);
+		if (end <= start) {
+			// A single code point larger than the budget cannot exist in UTF-8
+			// (max 4 bytes) with segmentBytes >= 4, so this is unreachable.
+			throw new MemorySegmentationError(
+				"Segment budget cannot make progress at this offset",
+				"MEMORY_SEGMENT_BUDGET_TOO_SMALL",
+				{ start, segmentBytes },
+			);
+		}
+		const segmentBytesSlice = bytes.subarray(start, end);
+		segments.push({
+			index,
+			byteStart: start,
+			byteEnd: end,
+			text: new TextDecoder("utf-8", { fatal: true }).decode(segmentBytesSlice),
+			sha256: sha256Hex(segmentBytesSlice),
+		});
+		start = end;
+		index += 1;
+	}
 
-  if (start !== totalBytes) {
-    throw new MemorySegmentationError(
-      "Segmentation did not cover the source exactly",
-      "MEMORY_SEGMENT_COVERAGE_FAILURE",
-      { start, totalBytes },
-    );
-  }
+	if (start !== totalBytes) {
+		throw new MemorySegmentationError(
+			"Segmentation did not cover the source exactly",
+			"MEMORY_SEGMENT_COVERAGE_FAILURE",
+			{ start, totalBytes },
+		);
+	}
 
-  return {
-    segments,
-    descriptor: {
-      v: 1,
-      field,
-      encoding: "utf-8",
-      segmentBytes,
-      totalBytes,
-      totalSha256,
-      segmentCount: segments.length,
-      generation,
-      revision: buildSegmentationRevision(generation, totalSha256),
-    },
-  };
+	return {
+		segments,
+		descriptor: {
+			v: 1,
+			field,
+			encoding: "utf-8",
+			segmentBytes,
+			totalBytes,
+			totalSha256,
+			segmentCount: segments.length,
+			generation,
+			revision: buildSegmentationRevision(generation, totalSha256),
+		},
+	};
 }
 
 /** Opaque public revision for one immutable generation. */
 export function buildSegmentationRevision(
-  generation: string,
-  totalSha256: string,
+	generation: string,
+	totalSha256: string,
 ): string {
-  return `seg:${generation}:${totalSha256}`;
+	return `seg:${generation}:${totalSha256}`;
+}
+
+/**
+ * Bounded inline replacement stored in a segmented field once the source
+ * bytes live in the segment store (#25140). Machine-prefixed and
+ * digest-bearing so no legitimate content can collide with it; consumers
+ * that predate paged reads see an explicit marker, never silent truncation.
+ */
+export function buildSegmentedContentMarker(descriptor: {
+	revision: string;
+	totalBytes: number;
+	totalSha256: string;
+}): string {
+	return `[elizaos:segmented-content revision=${descriptor.revision} total-bytes=${descriptor.totalBytes} source-sha256=${descriptor.totalSha256}]`;
+}
+
+/** True when `text` is a segmented-content published marker. */
+export function isSegmentedContentMarker(text: string): boolean {
+	return text.startsWith("[elizaos:segmented-content ");
 }
 
 /** Clamps a requested page window to the hard page ceiling and UTF-8 boundaries. */
 export function clampPageWindow(
-  totalBytes: number,
-  byteStart: number,
-  byteLimit: number | undefined,
+	totalBytes: number,
+	byteStart: number,
+	byteLimit: number | undefined,
 ): { start: number; end: number } {
-  if (!Number.isInteger(byteStart) || byteStart < 0) {
-    throw new MemorySegmentationError(
-      "Page byte offset must be a nonnegative integer",
-      "MEMORY_PAGE_INVALID_OFFSET",
-      { byteStart },
-    );
-  }
-  if (byteStart > totalBytes) {
-    throw new MemorySegmentationError(
-      "Page byte offset exceeds the source",
-      "MEMORY_PAGE_INVALID_OFFSET",
-      { byteStart, totalBytes },
-    );
-  }
-  let limit = byteLimit ?? MEMORY_PAGE_MAX_BYTES;
-  if (!Number.isInteger(limit) || limit <= 0) {
-    throw new MemorySegmentationError(
-      "Page byte limit must be a positive integer",
-      "MEMORY_PAGE_INVALID_LIMIT",
-      { byteLimit },
-    );
-  }
-  limit = Math.min(limit, MEMORY_PAGE_MAX_BYTES);
-  return { start: byteStart, end: Math.min(byteStart + limit, totalBytes) };
+	if (!Number.isInteger(byteStart) || byteStart < 0) {
+		throw new MemorySegmentationError(
+			"Page byte offset must be a nonnegative integer",
+			"MEMORY_PAGE_INVALID_OFFSET",
+			{ byteStart },
+		);
+	}
+	if (byteStart > totalBytes) {
+		throw new MemorySegmentationError(
+			"Page byte offset exceeds the source",
+			"MEMORY_PAGE_INVALID_OFFSET",
+			{ byteStart, totalBytes },
+		);
+	}
+	let limit = byteLimit ?? MEMORY_PAGE_MAX_BYTES;
+	if (!Number.isInteger(limit) || limit <= 0) {
+		throw new MemorySegmentationError(
+			"Page byte limit must be a positive integer",
+			"MEMORY_PAGE_INVALID_LIMIT",
+			{ byteLimit },
+		);
+	}
+	limit = Math.min(limit, MEMORY_PAGE_MAX_BYTES);
+	return { start: byteStart, end: Math.min(byteStart + limit, totalBytes) };
 }
 
 /** Reassembles segment texts and verifies descriptor invariants (test/migration path). */
 export function reassembleAndVerify(
-  segments: Array<{
-    byteStart: number;
-    byteEnd: number;
-    text: string;
-    sha256: string;
-  }>,
-  descriptor: MemoryContentSegmentation,
+	segments: Array<{
+		byteStart: number;
+		byteEnd: number;
+		text: string;
+		sha256: string;
+	}>,
+	descriptor: MemoryContentSegmentation,
 ): string {
-  if (segments.length !== descriptor.segmentCount) {
-    throw new MemorySegmentationError(
-      "Segment count does not match the descriptor",
-      "MEMORY_SEGMENT_COUNT_MISMATCH",
-      { expected: descriptor.segmentCount, actual: segments.length },
-    );
-  }
-  const parts: string[] = [];
-  for (let i = 0; i < segments.length; i++) {
-    const segment = segments[i];
-    if (segment.byteStart >= segment.byteEnd) {
-      throw new MemorySegmentationError(
-        "Segment range is empty or inverted",
-        "MEMORY_SEGMENT_RANGE_INVALID",
-        { index: i },
-      );
-    }
-    const expectedStart = i === 0 ? 0 : segments[i - 1].byteEnd;
-    if (segment.byteStart !== expectedStart) {
-      throw new MemorySegmentationError(
-        "Segments overlap or leave a gap",
-        "MEMORY_SEGMENT_NOT_CONTIGUOUS",
-        { index: i, expectedStart, actualStart: segment.byteStart },
-      );
-    }
-    const bytes = encodeUtf8Strict(segment.text);
-    if (bytes.length !== segment.byteEnd - segment.byteStart) {
-      throw new MemorySegmentationError(
-        "Segment text byte length does not match its range",
-        "MEMORY_SEGMENT_LENGTH_MISMATCH",
-        { index: i },
-      );
-    }
-    if (sha256Hex(bytes) !== segment.sha256) {
-      throw new MemorySegmentationError(
-        "Segment digest does not match its bytes",
-        "MEMORY_SEGMENT_DIGEST_MISMATCH",
-        { index: i },
-      );
-    }
-    parts.push(segment.text);
-  }
-  const whole = parts.join("");
-  const bytes = encodeUtf8Strict(whole);
-  if (bytes.length !== descriptor.totalBytes) {
-    throw new MemorySegmentationError(
-      "Reassembled byte length does not match the descriptor",
-      "MEMORY_SEGMENT_TOTAL_MISMATCH",
-      { expected: descriptor.totalBytes, actual: bytes.length },
-    );
-  }
-  if (sha256Hex(bytes) !== descriptor.totalSha256) {
-    throw new MemorySegmentationError(
-      "Reassembled digest does not match the descriptor",
-      "MEMORY_SEGMENT_TOTAL_DIGEST_MISMATCH",
-      {},
-    );
-  }
-  return whole;
+	if (segments.length !== descriptor.segmentCount) {
+		throw new MemorySegmentationError(
+			"Segment count does not match the descriptor",
+			"MEMORY_SEGMENT_COUNT_MISMATCH",
+			{ expected: descriptor.segmentCount, actual: segments.length },
+		);
+	}
+	const parts: string[] = [];
+	for (let i = 0; i < segments.length; i++) {
+		const segment = segments[i];
+		if (segment.byteStart >= segment.byteEnd) {
+			throw new MemorySegmentationError(
+				"Segment range is empty or inverted",
+				"MEMORY_SEGMENT_RANGE_INVALID",
+				{ index: i },
+			);
+		}
+		const expectedStart = i === 0 ? 0 : segments[i - 1].byteEnd;
+		if (segment.byteStart !== expectedStart) {
+			throw new MemorySegmentationError(
+				"Segments overlap or leave a gap",
+				"MEMORY_SEGMENT_NOT_CONTIGUOUS",
+				{ index: i, expectedStart, actualStart: segment.byteStart },
+			);
+		}
+		const bytes = encodeUtf8Strict(segment.text);
+		if (bytes.length !== segment.byteEnd - segment.byteStart) {
+			throw new MemorySegmentationError(
+				"Segment text byte length does not match its range",
+				"MEMORY_SEGMENT_LENGTH_MISMATCH",
+				{ index: i },
+			);
+		}
+		if (sha256Hex(bytes) !== segment.sha256) {
+			throw new MemorySegmentationError(
+				"Segment digest does not match its bytes",
+				"MEMORY_SEGMENT_DIGEST_MISMATCH",
+				{ index: i },
+			);
+		}
+		parts.push(segment.text);
+	}
+	const whole = parts.join("");
+	const bytes = encodeUtf8Strict(whole);
+	if (bytes.length !== descriptor.totalBytes) {
+		throw new MemorySegmentationError(
+			"Reassembled byte length does not match the descriptor",
+			"MEMORY_SEGMENT_TOTAL_MISMATCH",
+			{ expected: descriptor.totalBytes, actual: bytes.length },
+		);
+	}
+	if (sha256Hex(bytes) !== descriptor.totalSha256) {
+		throw new MemorySegmentationError(
+			"Reassembled digest does not match the descriptor",
+			"MEMORY_SEGMENT_TOTAL_DIGEST_MISMATCH",
+			{},
+		);
+	}
+	return whole;
 }

--- a/packages/core/src/memory/content-segmentation.ts
+++ b/packages/core/src/memory/content-segmentation.ts
@@ -228,6 +228,30 @@ export function isSegmentedContentMarker(text: string): boolean {
 }
 
 /**
+ * Parses a published segmented-content marker into its descriptor fields.
+ * Returns null for any text that is not an exactly-formed marker (the marker
+ * is machine-written by `buildSegmentedContentMarker`, so anything the regex
+ * does not match is user data that merely resembles the prefix, never a
+ * descriptor). #25140 review R4: consumers must not treat a marker prefix as
+ * proof of a well-formed descriptor.
+ */
+export function parseSegmentedContentMarker(
+	text: string,
+): { revision: string; totalBytes: number; totalSha256: string } | null {
+	const match = text.match(
+		/^\[elizaos:segmented-content revision=([^ ]+) total-bytes=(\d+) source-sha256=([0-9a-f]{64})\]$/,
+	);
+	if (!match) return null;
+	const totalBytes = Number(match[2]);
+	if (!Number.isSafeInteger(totalBytes) || totalBytes <= 0) return null;
+	return {
+		revision: match[1],
+		totalBytes,
+		totalSha256: match[3],
+	};
+}
+
+/**
  * True when a runtime surface exposes the #25140 native content-paging
  * capability: BOTH the `memoryContentPageCapability` advertisement and the
  * `getMemoryContentPage` method. Method presence alone is not a capability

--- a/packages/core/src/memory/content-segmentation.ts
+++ b/packages/core/src/memory/content-segmentation.ts
@@ -1,0 +1,312 @@
+/**
+ * UTF-8 segmentation primitive for bounded native paging of large stored
+ * MESSAGE text and extracted ATTACHMENT text (#25140). Pure logic, shared by
+ * the SQL adapter (which publishes immutable, non-overlapping source segments
+ * alongside a bounded parent descriptor) and by tests that verify exact SHA
+ * reassembly. Boundaries are computed on UTF-8 bytes, never on JavaScript
+ * string code units, so a segment never splits a code point and the
+ * concatenation of segment bytes is byte-identical to the source.
+ */
+import { createHash, randomUUID } from "node:crypto";
+
+/** Maximum byte length of one stored source segment. Must not split a code point. */
+export const MEMORY_SEGMENT_BYTES = 128 * 1024;
+
+/** Content whose UTF-8 byte length exceeds this threshold is segmented. */
+export const MEMORY_SEGMENTATION_THRESHOLD_BYTES = 128 * 1024;
+
+/**
+ * Hard ceiling on the byte length a single page read may return, applied even
+ * when a caller omits or oversizes `limit` (a read is never source-sized).
+ */
+export const MEMORY_PAGE_MAX_BYTES = 256 * 1024;
+
+/** Field identity of segmented content on the parent memory. */
+export type MemorySegmentField =
+  | { kind: "content.text" }
+  | { kind: "attachment.text"; attachmentId: string };
+
+/** Stable metadata key for one segmented field on the parent memory. */
+export function memorySegmentFieldKey(field: MemorySegmentField): string {
+  return field.kind === "content.text"
+    ? "content.text"
+    : `attachment.text:${field.attachmentId}`;
+}
+
+/** Bounded descriptor stored on the parent memory; never carries source bytes. */
+export interface MemoryContentSegmentation {
+  v: 1;
+  field: MemorySegmentField;
+  encoding: "utf-8";
+  segmentBytes: number;
+  totalBytes: number;
+  totalSha256: string;
+  segmentCount: number;
+  /** Immutable generation identity; changes only on full replacement. */
+  generation: string;
+  /** Opaque public revision: identifies the immutable generation. */
+  revision: string;
+}
+
+/** One computed source segment. `byteEnd` is exclusive. */
+export interface ComputedMemorySegment {
+  index: number;
+  byteStart: number;
+  byteEnd: number;
+  text: string;
+  sha256: string;
+}
+
+export interface ComputedSegmentation {
+  segments: ComputedMemorySegment[];
+  descriptor: MemoryContentSegmentation;
+}
+
+export class MemorySegmentationError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly context: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = "MemorySegmentationError";
+  }
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Returns the byte offset of the start of the UTF-8 code point that contains
+ * `offset` when `offset` lands inside a multibyte sequence: decrement until the
+ * byte is not a continuation byte (0b10xxxxxx). A boundary-aligned offset is
+ * returned unchanged.
+ */
+function snapToCodePointStart(bytes: Uint8Array, offset: number): number {
+  let at = offset;
+  while (at > 0 && (bytes[at] & 0xc0) === 0x80) {
+    at -= 1;
+  }
+  return at;
+}
+
+/** Encodes text to UTF-8 bytes, failing closed on lone surrogates. */
+export function encodeUtf8Strict(text: string): Uint8Array {
+  const bytes = Buffer.from(text, "utf8");
+  // Buffer.from replaces lone surrogates with U+FFFD; detect that corruption
+  // by comparing a lossless round-trip of the decoded result.
+  const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  if (decoded !== text) {
+    throw new MemorySegmentationError(
+      "Content contains unpaired surrogates and cannot be segmented losslessly",
+      "MEMORY_SEGMENT_UNPAIRED_SURROGATE",
+    );
+  }
+  return bytes;
+}
+
+/** Whether content must be segmented based on its UTF-8 byte length. */
+export function shouldSegmentContent(text: string): boolean {
+  return encodeUtf8Strict(text).length > MEMORY_SEGMENTATION_THRESHOLD_BYTES;
+}
+
+function randomGeneration(): string {
+  return randomUUID();
+}
+
+/**
+ * Splits `text` into immutable non-overlapping UTF-8 segments of at most
+ * `segmentBytes` and returns them together with the bounded descriptor.
+ * `generation` is minted here (or inherited on replacement) so the revision
+ * identifies one immutable generation of the content.
+ */
+export function segmentMemoryContent(
+  text: string,
+  field: MemorySegmentField,
+  options?: { segmentBytes?: number; generation?: string },
+): ComputedSegmentation {
+  const segmentBytes = options?.segmentBytes ?? MEMORY_SEGMENT_BYTES;
+  if (
+    !Number.isInteger(segmentBytes) ||
+    segmentBytes < 4 ||
+    segmentBytes > 4 * 1024 * 1024
+  ) {
+    throw new MemorySegmentationError(
+      "Segment byte budget is out of the supported range",
+      "MEMORY_SEGMENT_INVALID_BUDGET",
+      { segmentBytes },
+    );
+  }
+  const bytes = encodeUtf8Strict(text);
+  const totalBytes = bytes.length;
+  if (totalBytes === 0) {
+    throw new MemorySegmentationError(
+      "Empty content is never segmented",
+      "MEMORY_SEGMENT_EMPTY_SOURCE",
+    );
+  }
+  const totalSha256 = sha256Hex(bytes);
+  const generation = options?.generation ?? randomGeneration();
+
+  const segments: ComputedMemorySegment[] = [];
+  let start = 0;
+  let index = 0;
+  while (start < totalBytes) {
+    let end = Math.min(start + segmentBytes, totalBytes);
+    end = snapToCodePointStart(bytes, end);
+    if (end <= start) {
+      // A single code point larger than the budget cannot exist in UTF-8
+      // (max 4 bytes) with segmentBytes >= 4, so this is unreachable.
+      throw new MemorySegmentationError(
+        "Segment budget cannot make progress at this offset",
+        "MEMORY_SEGMENT_BUDGET_TOO_SMALL",
+        { start, segmentBytes },
+      );
+    }
+    const segmentBytesSlice = bytes.subarray(start, end);
+    segments.push({
+      index,
+      byteStart: start,
+      byteEnd: end,
+      text: new TextDecoder("utf-8", { fatal: true }).decode(segmentBytesSlice),
+      sha256: sha256Hex(segmentBytesSlice),
+    });
+    start = end;
+    index += 1;
+  }
+
+  if (start !== totalBytes) {
+    throw new MemorySegmentationError(
+      "Segmentation did not cover the source exactly",
+      "MEMORY_SEGMENT_COVERAGE_FAILURE",
+      { start, totalBytes },
+    );
+  }
+
+  return {
+    segments,
+    descriptor: {
+      v: 1,
+      field,
+      encoding: "utf-8",
+      segmentBytes,
+      totalBytes,
+      totalSha256,
+      segmentCount: segments.length,
+      generation,
+      revision: buildSegmentationRevision(generation, totalSha256),
+    },
+  };
+}
+
+/** Opaque public revision for one immutable generation. */
+export function buildSegmentationRevision(
+  generation: string,
+  totalSha256: string,
+): string {
+  return `seg:${generation}:${totalSha256}`;
+}
+
+/** Clamps a requested page window to the hard page ceiling and UTF-8 boundaries. */
+export function clampPageWindow(
+  totalBytes: number,
+  byteStart: number,
+  byteLimit: number | undefined,
+): { start: number; end: number } {
+  if (!Number.isInteger(byteStart) || byteStart < 0) {
+    throw new MemorySegmentationError(
+      "Page byte offset must be a nonnegative integer",
+      "MEMORY_PAGE_INVALID_OFFSET",
+      { byteStart },
+    );
+  }
+  if (byteStart > totalBytes) {
+    throw new MemorySegmentationError(
+      "Page byte offset exceeds the source",
+      "MEMORY_PAGE_INVALID_OFFSET",
+      { byteStart, totalBytes },
+    );
+  }
+  let limit = byteLimit ?? MEMORY_PAGE_MAX_BYTES;
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new MemorySegmentationError(
+      "Page byte limit must be a positive integer",
+      "MEMORY_PAGE_INVALID_LIMIT",
+      { byteLimit },
+    );
+  }
+  limit = Math.min(limit, MEMORY_PAGE_MAX_BYTES);
+  return { start: byteStart, end: Math.min(byteStart + limit, totalBytes) };
+}
+
+/** Reassembles segment texts and verifies descriptor invariants (test/migration path). */
+export function reassembleAndVerify(
+  segments: Array<{
+    byteStart: number;
+    byteEnd: number;
+    text: string;
+    sha256: string;
+  }>,
+  descriptor: MemoryContentSegmentation,
+): string {
+  if (segments.length !== descriptor.segmentCount) {
+    throw new MemorySegmentationError(
+      "Segment count does not match the descriptor",
+      "MEMORY_SEGMENT_COUNT_MISMATCH",
+      { expected: descriptor.segmentCount, actual: segments.length },
+    );
+  }
+  const parts: string[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (segment.byteStart >= segment.byteEnd) {
+      throw new MemorySegmentationError(
+        "Segment range is empty or inverted",
+        "MEMORY_SEGMENT_RANGE_INVALID",
+        { index: i },
+      );
+    }
+    const expectedStart = i === 0 ? 0 : segments[i - 1].byteEnd;
+    if (segment.byteStart !== expectedStart) {
+      throw new MemorySegmentationError(
+        "Segments overlap or leave a gap",
+        "MEMORY_SEGMENT_NOT_CONTIGUOUS",
+        { index: i, expectedStart, actualStart: segment.byteStart },
+      );
+    }
+    const bytes = encodeUtf8Strict(segment.text);
+    if (bytes.length !== segment.byteEnd - segment.byteStart) {
+      throw new MemorySegmentationError(
+        "Segment text byte length does not match its range",
+        "MEMORY_SEGMENT_LENGTH_MISMATCH",
+        { index: i },
+      );
+    }
+    if (sha256Hex(bytes) !== segment.sha256) {
+      throw new MemorySegmentationError(
+        "Segment digest does not match its bytes",
+        "MEMORY_SEGMENT_DIGEST_MISMATCH",
+        { index: i },
+      );
+    }
+    parts.push(segment.text);
+  }
+  const whole = parts.join("");
+  const bytes = encodeUtf8Strict(whole);
+  if (bytes.length !== descriptor.totalBytes) {
+    throw new MemorySegmentationError(
+      "Reassembled byte length does not match the descriptor",
+      "MEMORY_SEGMENT_TOTAL_MISMATCH",
+      { expected: descriptor.totalBytes, actual: bytes.length },
+    );
+  }
+  if (sha256Hex(bytes) !== descriptor.totalSha256) {
+    throw new MemorySegmentationError(
+      "Reassembled digest does not match the descriptor",
+      "MEMORY_SEGMENT_TOTAL_DIGEST_MISMATCH",
+      {},
+    );
+  }
+  return whole;
+}

--- a/packages/core/src/memory/content-segmentation.ts
+++ b/packages/core/src/memory/content-segmentation.ts
@@ -8,6 +8,7 @@
  * concatenation of segment bytes is byte-identical to the source.
  */
 import { createHash, randomUUID } from "node:crypto";
+import { ElizaError } from "../errors.ts";
 
 /** Maximum byte length of one stored source segment. Must not split a code point. */
 export const MEMORY_SEGMENT_BYTES = 128 * 1024;
@@ -62,14 +63,13 @@ export interface ComputedSegmentation {
 	descriptor: MemoryContentSegmentation;
 }
 
-export class MemorySegmentationError extends Error {
+export class MemorySegmentationError extends ElizaError {
 	constructor(
 		message: string,
-		readonly code: string,
-		readonly context: Record<string, unknown> = {},
+		code: string,
+		context: Record<string, unknown> = {},
 	) {
-		super(message);
-		this.name = "MemorySegmentationError";
+		super(message, { code, context });
 	}
 }
 

--- a/packages/core/src/memory/content-segmentation.ts
+++ b/packages/core/src/memory/content-segmentation.ts
@@ -227,6 +227,26 @@ export function isSegmentedContentMarker(text: string): boolean {
 	return text.startsWith("[elizaos:segmented-content ");
 }
 
+/**
+ * True when a runtime surface exposes the #25140 native content-paging
+ * capability: BOTH the `memoryContentPageCapability` advertisement and the
+ * `getMemoryContentPage` method. Method presence alone is not a capability
+ * claim — a runtime that forwards adapter members but sits on an adapter
+ * without the segment store would otherwise receive page calls it cannot
+ * honor, and a capability advertisement without the method is a broken
+ * adapter. Actions gate paged reads on this predicate, falling back to the
+ * ordinary inline path otherwise.
+ */
+export function hasMemoryContentPageCapability(surface: {
+	getMemoryContentPage?: unknown;
+	memoryContentPageCapability?: unknown;
+}): boolean {
+	return (
+		surface.memoryContentPageCapability === 1 &&
+		typeof surface.getMemoryContentPage === "function"
+	);
+}
+
 /** Clamps a requested page window to the hard page ceiling and UTF-8 boundaries. */
 export function clampPageWindow(
 	totalBytes: number,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -5015,6 +5015,28 @@ export class AgentRuntime implements IAgentRuntime {
 	async getMemoriesByIds(ids: UUID[], tableName?: string): Promise<Memory[]> {
 		return this.adapter.getMemoriesByIds(ids, tableName);
 	}
+	/**
+	 * #25140 native content paging passthrough. The adapter owns the segment
+	 * store; the runtime forwards the capability advertisement verbatim so
+	 * callers can gate on the same contract the adapter declares. Absent on
+	 * adapters without the segment store (undefined method + undefined
+	 * capability) so `hasMemoryContentPageCapability` correctly reports false.
+	 */
+	get getMemoryContentPage(): IDatabaseAdapter["getMemoryContentPage"] {
+		const adapter = this.adapter as IDatabaseAdapter & {
+			getMemoryContentPage?: IDatabaseAdapter["getMemoryContentPage"];
+		};
+		return typeof adapter.getMemoryContentPage === "function"
+			? adapter.getMemoryContentPage.bind(adapter)
+			: undefined;
+	}
+	get memoryContentPageCapability(): IDatabaseAdapter["memoryContentPageCapability"] {
+		return (
+			this.adapter as IDatabaseAdapter & {
+				memoryContentPageCapability?: 1;
+			}
+		).memoryContentPageCapability;
+	}
 	async getMemoriesByRoomIds(params: {
 		tableName: string;
 		roomIds: UUID[];

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -5037,6 +5037,14 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		).memoryContentPageCapability;
 	}
+	get reindexMemoryContent(): IDatabaseAdapter["reindexMemoryContent"] {
+		const adapter = this.adapter as IDatabaseAdapter & {
+			reindexMemoryContent?: IDatabaseAdapter["reindexMemoryContent"];
+		};
+		return typeof adapter.reindexMemoryContent === "function"
+			? adapter.reindexMemoryContent.bind(adapter)
+			: undefined;
+	}
 	async getMemoriesByRoomIds(params: {
 		tableName: string;
 		roomIds: UUID[];

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -755,7 +755,81 @@ export interface AgentRunSummaryResult {
  *
  * See DATABASE_BATCH_API.md for the full design rationale and migration guide.
  */
+/**
+ * Field identity of natively segmented large content on a memory row. The
+ * `attachment.text` variant binds to one exact attachment id on the parent so
+ * owner-bound locators resolve the direct parent instead of scanning a room.
+ */
+export type MemoryContentField =
+	| { kind: "content.text" }
+	| { kind: "attachment.text"; attachmentId: string };
+
+/** Bounded segmentation descriptor carried on the parent memory's metadata. */
+export interface MemoryContentSegmentationDescriptor {
+	v: 1;
+	field: MemoryContentField;
+	encoding: "utf-8";
+	segmentBytes: number;
+	totalBytes: number;
+	totalSha256: string;
+	segmentCount: number;
+	/** Immutable generation identity; changes only on full replacement. */
+	generation: string;
+	/** Opaque public revision identifying the immutable generation. */
+	revision: string;
+}
+
+/**
+ * Authorized byte-window read over segmented memory content (#25140). The
+ * adapter authorizes the parent, validates `expectedRevision` against the
+ * stored generation, and returns only the segments intersecting the window —
+ * never the whole parent content and never an embedding join.
+ */
+export interface MemoryContentPageParams {
+	memoryId: UUID;
+	field: MemoryContentField;
+	byteStart: number;
+	byteLimit?: number;
+	/** Required for continuation pages; rejects stale generations. */
+	expectedRevision?: string;
+	/**
+	 * Authorization for the parent memory. When supplied, the adapter pushes the
+	 * same room/scope conditions as `getMemories` into the page-read query, so
+	 * every page reauthorizes; when omitted, the read trusts the caller's
+	 * transport boundary exactly like `getMemoryById` does.
+	 */
+	accessContext?: AccessContext;
+}
+
+/** Result of a native memory content page read. */
+export interface MemoryContentPageResult {
+	/** Page text: bytes `[start,end)` of the segmented source. */
+	text: string;
+	start: number;
+	end: number;
+	total: number;
+	/** Digest of the page bytes and of the complete source. */
+	sliceSha256: string;
+	sourceSha256: string;
+	/** Revision of the generation this page was served from. */
+	revision: string;
+	/** True only when `end === total` of the current generation. */
+	completeness: "partial-recoverable" | "complete";
+}
+
 export interface IDatabaseAdapter<DB extends object = object> {
+	/**
+	 * Bounded native paging over segmented large MESSAGE/ATTACHMENT content
+	 * (#25140). Optional capability: adapters that implement it publish
+	 * immutable non-overlapping UTF-8 source segments atomically with the
+	 * bounded parent descriptor and serve authorized byte-window reads from
+	 * them. Readers MUST fail closed with a typed reindex-required error for
+	 * legacy large unsegmented rows rather than materializing the parent.
+	 */
+	readonly memoryContentPageCapability?: 1;
+	getMemoryContentPage?(
+		params: MemoryContentPageParams,
+	): Promise<MemoryContentPageResult | null>;
 	/** Database instance */
 	db: DB;
 

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -817,6 +817,25 @@ export interface MemoryContentPageResult {
 	completeness: "partial-recoverable" | "complete";
 }
 
+/** Explicit, authorized conversion of one legacy inline field to native segments. */
+export interface MemoryContentReindexParams {
+	memoryId: UUID;
+	field: MemoryContentField;
+	accessContext: AccessContext;
+	/** Caller-declared work bound; the adapter rejects before fetching source bytes. */
+	maxSourceBytes: number;
+}
+
+/** Auditable receipt for one bounded legacy-field conversion. */
+export interface MemoryContentReindexResult {
+	memoryId: UUID;
+	field: MemoryContentField;
+	totalBytes: number;
+	segmentCount: number;
+	sourceSha256: string;
+	revision: string;
+}
+
 export interface IDatabaseAdapter<DB extends object = object> {
 	/**
 	 * Bounded native paging over segmented large MESSAGE/ATTACHMENT content
@@ -830,6 +849,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	getMemoryContentPage?(
 		params: MemoryContentPageParams,
 	): Promise<MemoryContentPageResult | null>;
+	reindexMemoryContent?(
+		params: MemoryContentReindexParams,
+	): Promise<MemoryContentReindexResult>;
 	/** Database instance */
 	db: DB;
 

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.access-context.probe.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.access-context.probe.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Adversarial probe for the #25140 accessContext page reauthorization
+ * (deterministic, real PGlite; RED control: fails without commit c58207e7c4).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Memory, UUID } from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import type { DrizzleDatabase } from "../../types";
+
+const tempDirectories: string[] = [];
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+async function migrate(adapter: PgliteDatabaseAdapter) {
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+function largeSource(byteLength: number): string {
+  const unit = "segurança שלום 🌏 test ";
+  const chunks: string[] = [];
+  let bytes = 0;
+  while (bytes < byteLength) {
+    chunks.push(unit);
+    bytes += Buffer.byteLength(unit, "utf8");
+  }
+  return chunks.join("");
+}
+
+async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  await adapter.createAgent({
+    id: agentId,
+    name: "accessCtx probe",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await adapter.createRooms([
+    {
+      id: roomId,
+      agentId,
+      name: "accessCtx room",
+      source: "test",
+      type: "direct" as never,
+      worldId: undefined,
+      channelId: undefined,
+    },
+  ]);
+  await adapter.createEntities([{ id: entityId, agentId, names: ["user"] }]);
+  return { roomId, entityId };
+}
+
+describe("accessContext page reauthorization (real PGlite)", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("denies pages to an access context whose room is not authorized, grants the right room", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-accctx-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: largeSource(150 * 1024), source: "test" },
+      } as unknown as Memory,
+      "messages"
+    );
+
+    // Authorized: same room, requester carries a real role.
+    const allowed = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      accessContext: {
+        agentId,
+        roomId,
+        authorizedRoomIds: [roomId],
+        requesterEntityId: entityId,
+        role: "USER",
+      } as never,
+    });
+    expect(allowed).not.toBeNull();
+    expect(allowed?.revision).toBeTruthy();
+
+    // Denied: the parent lives in a room this context is not authorized for.
+    const otherRoom = v4() as UUID;
+    const denied = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      accessContext: {
+        agentId,
+        roomId: otherRoom,
+        authorizedRoomIds: [otherRoom],
+        requesterEntityId: entityId,
+        role: "USER",
+      } as never,
+    });
+    expect(denied).toBeNull();
+
+    // Denied: unresolved actor (no role authority -> UNRESOLVED -> false).
+    const unresolved = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      accessContext: {
+        agentId,
+        roomId,
+        authorizedRoomIds: [roomId],
+        requesterEntityId: entityId,
+      } as never,
+    });
+    expect(unresolved).toBeNull();
+
+    await adapter.close();
+    await manager.close();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
@@ -274,6 +274,104 @@ describe("adapter-integrated memory content paging (real PGlite)", () => {
     await manager.close();
   });
 
+  it("large-to-small replacement retires the descriptor and generation", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-shrink-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: largeSource(200 * 1024), source: "test" },
+      } as Memory,
+      "messages"
+    );
+    const pageBefore = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: 64,
+    });
+    expect(pageBefore).not.toBeNull();
+
+    // Replace with small content: descriptor must be dropped and generation retired.
+    expect(
+      await adapter.updateMemory({
+        id: memoryId,
+        content: { text: "now small", source: "test" },
+      })
+    ).toBe(true);
+
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    const row = (await db.select().from(memoryTable).where(eq(memoryTable.id, memoryId)))[0];
+    const segmentation = (row.metadata as { segmentation?: unknown }).segmentation;
+    expect(segmentation).toEqual({});
+    const leftover = await db.execute(
+      `SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`
+    );
+    expect((leftover.rows as Array<{ n: number }>)[0].n).toBe(0);
+    // Small-row read falls back to inline.
+    const pageAfter = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+    });
+    expect(pageAfter).toBeNull();
+
+    await adapter.close();
+    await manager.close();
+  });
+
+  it("rejects large attachment text without an id and duplicate ids", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-attid-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    await expect(
+      adapter.createMemory(
+        {
+          entityId,
+          roomId,
+          agentId,
+          content: {
+            text: "small",
+            attachments: [{ url: "https://example.test/x", text: largeSource(150 * 1024) }],
+          },
+        } as unknown as Memory,
+        "messages"
+      )
+    ).rejects.toMatchObject({ code: "MEMORY_SEGMENT_ATTACHMENT_ID_REQUIRED" });
+
+    await expect(
+      adapter.createMemory(
+        {
+          entityId,
+          roomId,
+          agentId,
+          content: {
+            text: "small",
+            attachments: [
+              { id: "dup-1", url: "https://example.test/a", text: largeSource(150 * 1024) },
+              { id: "dup-1", url: "https://example.test/b", text: largeSource(150 * 1024) },
+            ],
+          },
+        } as unknown as Memory,
+        "messages"
+      )
+    ).rejects.toMatchObject({ code: "MEMORY_SEGMENT_ATTACHMENT_ID_CONFLICT" });
+
+    await adapter.close();
+    await manager.close();
+  });
+
   it("publishes segmented attachment text and pages it by owner-bound field", async () => {
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-attach-"));
     tempDirectories.push(dataDir);

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
@@ -368,6 +368,26 @@ describe("adapter-integrated memory content paging (real PGlite)", () => {
       )
     ).rejects.toMatchObject({ code: "MEMORY_SEGMENT_ATTACHMENT_ID_CONFLICT" });
 
+    // Small attachment reusing a segmented attachment's id: equally ambiguous
+    // for the owner-bound descriptor key, must fail closed the same way.
+    await expect(
+      adapter.createMemory(
+        {
+          entityId,
+          roomId,
+          agentId,
+          content: {
+            text: "small",
+            attachments: [
+              { id: "dup-1", url: "https://example.test/a", text: largeSource(150 * 1024) },
+              { id: "dup-1", url: "https://example.test/b", text: "small text" },
+            ],
+          },
+        } as unknown as Memory,
+        "messages"
+      )
+    ).rejects.toMatchObject({ code: "MEMORY_SEGMENT_ATTACHMENT_ID_CONFLICT" });
+
     await adapter.close();
     await manager.close();
   });

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Real PGlite coverage for the adapter-integrated segmentation path (#25140):
+ * createMemory publishes segments transactionally with a bounded inline
+ * marker + descriptor metadata; getMemoryContentPage (the adapter capability
+ * the MESSAGE/ATTACHMENT actions consume) pages those rows with revision
+ * fencing; updateMemory replaces a generation and retires the stale one.
+ * Complements memory-text-segments.real.test.ts, which drives the store
+ * directly — this file proves the BaseDrizzleAdapter wiring.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isSegmentedContentMarker, type Memory, type UUID } from "@elizaos/core";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import { memoryTable } from "../../schema/index";
+import type { DrizzleDatabase } from "../../types";
+
+const tempDirectories: string[] = [];
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+async function migrate(adapter: PgliteDatabaseAdapter) {
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+function largeSource(byteLength: number): string {
+  const unit = "segurança שלום 🌏 test "; // multibyte on purpose
+  const chunks: string[] = [];
+  let bytes = 0;
+  while (bytes < byteLength) {
+    chunks.push(unit);
+    bytes += Buffer.byteLength(unit, "utf8");
+  }
+  return chunks.join("");
+}
+
+async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  await adapter.createAgent({
+    id: agentId,
+    name: "Adapter segmentation",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await adapter.createRooms([
+    {
+      id: roomId,
+      agentId,
+      name: "Adapter segmentation room",
+      source: "test",
+      type: "direct" as never,
+      worldId: undefined,
+      channelId: undefined,
+    },
+  ]);
+  await adapter.createEntities([{ id: entityId, agentId, names: ["user"] }]);
+  return { roomId, entityId };
+}
+
+describe("adapter-integrated memory content paging (real PGlite)", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("createMemory publishes segments with a bounded marker and pages them via getMemoryContentPage", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-adapter-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    const source = largeSource(300 * 1024);
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: source, source: "test" },
+      } as Memory,
+      "messages"
+    );
+
+    // Inline field is a bounded marker, never the source bytes.
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    const row = (await db.select().from(memoryTable).where(eq(memoryTable.id, memoryId)))[0];
+    const inlineText = (row.content as { text: string }).text;
+    expect(isSegmentedContentMarker(inlineText)).toBe(true);
+    expect(Buffer.byteLength(inlineText, "utf8")).toBeLessThan(512);
+
+    // Metadata carries the descriptor.
+    const metadata = row.metadata as {
+      segmentation?: Record<string, { revision: string; totalBytes: number }>;
+    };
+    const descriptor = metadata?.segmentation?.["content.text"];
+    expect(descriptor).toBeDefined();
+    expect(descriptor!.totalBytes).toBe(Buffer.byteLength(source, "utf8"));
+
+    // The adapter capability is declared and pages.
+    expect(adapter.memoryContentPageCapability).toBe(1);
+    const page1 = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: 64 * 1024,
+    });
+    expect(page1).not.toBeNull();
+    expect(page1?.start).toBe(0);
+    expect(page1?.revision).toBe(descriptor!.revision);
+    expect(page1?.completeness).toBe("partial-recoverable");
+    // The window end snaps backward off any partial trailing code point, so
+    // the page is the source prefix truncated to a code-point boundary.
+    const sourceBytes1 = Buffer.from(source, "utf8");
+    let expectedEnd1 = Math.min(64 * 1024, sourceBytes1.length);
+    while (expectedEnd1 > 0 && (sourceBytes1[expectedEnd1] & 0xc0) === 0x80) {
+      expectedEnd1 -= 1;
+    }
+    expect(page1?.end).toBe(expectedEnd1);
+    const page1Bytes = Buffer.from(page1!.text, "utf8");
+    expect(page1Bytes.length).toBe(expectedEnd1);
+    expect(page1Bytes.equals(sourceBytes1.subarray(0, expectedEnd1))).toBe(true);
+
+    // Continuation without revision is a typed rejection.
+    await expect(
+      adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 64 * 1024,
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_EXPECTED_REVISION_REQUIRED" });
+
+    // Continuation with the wrong revision is stale.
+    await expect(
+      adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 64 * 1024,
+        expectedRevision: "seg:not-the-live-generation",
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_STALE_REVISION" });
+
+    // Walk every page with the live revision and reassemble exactly.
+    const whole: Buffer[] = [];
+    let cursor = 0;
+    let revision = page1!.revision;
+    for (;;) {
+      const page = await adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: cursor,
+        expectedRevision: revision,
+      });
+      expect(page).not.toBeNull();
+      whole.push(Buffer.from(page!.text, "utf8"));
+      cursor = page!.end;
+      revision = page!.revision;
+      if (page!.completeness === "complete") break;
+    }
+    expect(Buffer.concat(whole).equals(Buffer.from(source, "utf8"))).toBe(true);
+
+    await adapter.close();
+    await manager.close();
+  });
+
+  it("small content stays inline and pages return null (fallback path)", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-small-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: "small inline text", source: "test" },
+      } as Memory,
+      "messages"
+    );
+
+    const page = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+    });
+    expect(page).toBeNull();
+
+    await adapter.close();
+    await manager.close();
+  });
+
+  it("updateMemory replaces the generation and retires the stale one", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-replace-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    const first = largeSource(200 * 1024);
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: first, source: "test" },
+      } as Memory,
+      "messages"
+    );
+
+    const page1 = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: 1024,
+    });
+    expect(page1).not.toBeNull();
+    const firstRevision = page1!.revision;
+
+    // Full replacement with different large content.
+    const second = largeSource(260 * 1024).replace("segurança", "substituição ");
+    expect(Buffer.compare(Buffer.from(second), Buffer.from(first))).not.toBe(0);
+    const updated = await adapter.updateMemory({
+      id: memoryId,
+      content: { text: second, source: "test" },
+    });
+    expect(updated).toBe(true);
+
+    const page2 = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: 1024,
+    });
+    expect(page2).not.toBeNull();
+    expect(page2!.revision).not.toBe(firstRevision);
+    expect(page2!.total).toBe(Buffer.byteLength(second, "utf8"));
+    expect(
+      Buffer.from(page2!.text, "utf8").equals(Buffer.from(second, "utf8").subarray(0, 1024))
+    ).toBe(true);
+
+    // The stale generation now rejects.
+    await expect(
+      adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 1024,
+        expectedRevision: firstRevision,
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_STALE_REVISION" });
+
+    await adapter.close();
+    await manager.close();
+  });
+
+  it("publishes segmented attachment text and pages it by owner-bound field", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-attach-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    const attachmentId = `att-${v4()}`;
+    const transcript = largeSource(150 * 1024);
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: {
+          text: "here is the transcript",
+          source: "test",
+          attachments: [
+            {
+              id: attachmentId,
+              url: "https://example.com/t.wav",
+              contentType: "audio/wav",
+              text: transcript,
+            },
+          ],
+        },
+      } as unknown as Memory,
+      "messages"
+    );
+
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    const row = (await db.select().from(memoryTable).where(eq(memoryTable.id, memoryId)))[0];
+    const attachments = (row.content as { attachments: Array<{ id: string; text: string }> })
+      .attachments;
+    expect(isSegmentedContentMarker(attachments[0].text)).toBe(true);
+    const descriptor = (
+      row.metadata as {
+        segmentation?: Record<string, { revision: string; totalBytes: number }>;
+      }
+    )?.segmentation?.[`attachment.text:${attachmentId}`];
+    expect(descriptor).toBeDefined();
+    expect(descriptor!.totalBytes).toBe(Buffer.byteLength(transcript, "utf8"));
+
+    const page = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "attachment.text", attachmentId },
+      byteStart: 0,
+      byteLimit: 32 * 1024,
+    });
+    expect(page).not.toBeNull();
+    expect(page!.total).toBe(Buffer.byteLength(transcript, "utf8"));
+    expect(page!.revision).toBe(descriptor!.revision);
+    const transcriptBytes = Buffer.from(transcript, "utf8");
+    let expectedEnd2 = Math.min(32 * 1024, transcriptBytes.length);
+    while (expectedEnd2 > 0 && (transcriptBytes[expectedEnd2] & 0xc0) === 0x80) {
+      expectedEnd2 -= 1;
+    }
+    expect(page!.end).toBe(expectedEnd2);
+    expect(Buffer.from(page!.text, "utf8").equals(transcriptBytes.subarray(0, expectedEnd2))).toBe(
+      true
+    );
+
+    await adapter.close();
+    await manager.close();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
@@ -531,4 +531,73 @@ describe("adapter-integrated memory content paging (real PGlite)", () => {
     await opened.adapter.close();
     await opened.manager.close();
   }, 120_000);
+
+  it("reindexes one owner-bound legacy attachment and rejects an ambiguous locator", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-reindex-attachment-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: "legacy seed", source: "test" },
+      } as Memory,
+      "messages"
+    );
+    const source = largeSource(1024 * 1024);
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    await db
+      .update(memoryTable)
+      .set({
+        content: {
+          text: "legacy attachment",
+          source: "legacy-import",
+          attachments: [
+            { id: "transcript", text: source },
+            { id: "duplicate", text: source },
+            { id: "duplicate", text: source },
+          ],
+        },
+        metadata: {},
+      })
+      .where(eq(memoryTable.id, memoryId));
+    const accessContext = {
+      requesterEntityId: entityId,
+      authorizedRoomIds: [roomId],
+      role: "USER" as const,
+    };
+
+    await expect(
+      adapter.reindexMemoryContent({
+        memoryId,
+        field: { kind: "attachment.text", attachmentId: "duplicate" },
+        accessContext,
+        maxSourceBytes: 2 * 1024 * 1024,
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_REINDEX_FIELD_NOT_FOUND" });
+
+    const receipt = await adapter.reindexMemoryContent({
+      memoryId,
+      field: { kind: "attachment.text", attachmentId: "transcript" },
+      accessContext,
+      maxSourceBytes: 2 * 1024 * 1024,
+    });
+    const page = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "attachment.text", attachmentId: "transcript" },
+      byteStart: 0,
+      accessContext,
+    });
+    expect(page?.sourceSha256).toBe(receipt.sourceSha256);
+    expect(
+      Buffer.from(page!.text, "utf8").equals(Buffer.from(source, "utf8").subarray(0, page!.end))
+    ).toBe(true);
+
+    await adapter.close();
+    await manager.close();
+  });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.adapter.real.test.ts
@@ -458,4 +458,77 @@ describe("adapter-integrated memory content paging (real PGlite)", () => {
     await adapter.close();
     await manager.close();
   });
+
+  it("explicitly reindexes a bounded 10 MiB legacy row and survives restart", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-reindex-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    let opened = await openDatabase(dataDir, agentId);
+    await migrate(opened.adapter);
+    const { roomId, entityId } = await seedRoom(opened.adapter, agentId);
+    const memoryId = await opened.adapter.createMemory(
+      { entityId, roomId, agentId, content: { text: "legacy seed", source: "test" } } as Memory,
+      "messages"
+    );
+    const source = largeSource(10 * 1024 * 1024);
+    const db = opened.adapter.getDatabase() as DrizzleDatabase;
+    await db
+      .update(memoryTable)
+      .set({ content: { text: source, source: "legacy-import" }, metadata: {} })
+      .where(eq(memoryTable.id, memoryId));
+    const accessContext = {
+      requesterEntityId: entityId,
+      authorizedRoomIds: [roomId],
+      role: "USER" as const,
+    };
+
+    await expect(
+      opened.adapter.reindexMemoryContent({
+        memoryId,
+        field: { kind: "content.text" },
+        accessContext: { ...accessContext, authorizedRoomIds: [v4() as UUID] },
+        maxSourceBytes: 11 * 1024 * 1024,
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED" });
+
+    await expect(
+      opened.adapter.reindexMemoryContent({
+        memoryId,
+        field: { kind: "content.text" },
+        accessContext,
+        maxSourceBytes: 1024 * 1024,
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_REINDEX_BOUND_EXCEEDED" });
+
+    const receipt = await opened.adapter.reindexMemoryContent({
+      memoryId,
+      field: { kind: "content.text" },
+      accessContext,
+      maxSourceBytes: 11 * 1024 * 1024,
+    });
+    expect(receipt.totalBytes).toBe(Buffer.byteLength(source, "utf8"));
+    expect(receipt.segmentCount).toBeGreaterThan(1);
+    await opened.adapter.close();
+    await opened.manager.close();
+
+    opened = await openDatabase(dataDir, agentId);
+    const chunks: Buffer[] = [];
+    let cursor = 0;
+    for (;;) {
+      const page = await opened.adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: cursor,
+        ...(cursor === 0 ? {} : { expectedRevision: receipt.revision }),
+        accessContext,
+      });
+      expect(page).not.toBeNull();
+      chunks.push(Buffer.from(page!.text, "utf8"));
+      cursor = page!.end;
+      if (page!.completeness === "complete") break;
+    }
+    expect(Buffer.concat(chunks).equals(Buffer.from(source, "utf8"))).toBe(true);
+    await opened.adapter.close();
+    await opened.manager.close();
+  }, 120_000);
 });

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.scenario.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.scenario.real.test.ts
@@ -55,9 +55,7 @@ async function openDatabase(dataDir: string, agentId: UUID) {
 
 async function migrate(adapter: PgliteDatabaseAdapter) {
   const migrations = new DatabaseMigrationService();
-  await migrations.initializeWithDatabase(
-    adapter.getDatabase() as DrizzleDatabase,
-  );
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
   migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
   await migrations.runAllPluginMigrations();
 }
@@ -122,7 +120,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
       } catch (error) {
         logger.warn(
           "scenario paging test teardown close failed:",
-          error instanceof Error ? error.message : String(error),
+          error instanceof Error ? error.message : String(error)
         );
       }
     }
@@ -132,9 +130,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
   });
 
   it("one 192 KiB message + 10 attachments segments losslessly with exact DB row counts, ordered byte-exact pages, and caller-visible reads through the MESSAGE action", async () => {
-    const dataDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "eliza-seg-scenario-"),
-    );
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seg-scenario-"));
     tempDirectories.push(dataDir);
     const agentId = v4() as UUID;
     const { adapter, manager } = await openDatabase(dataDir, agentId);
@@ -166,16 +162,14 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
           attachments,
         },
       } as unknown as Memory,
-      "messages",
+      "messages"
     );
     expect(memoryId).toBeTruthy();
 
     const db = adapter.getDatabase() as DrizzleDatabase;
 
     // --- Inline bounded markers, never source bytes, for every segmented field
-    const row = (
-      await db.select().from(memoryTable).where(eq(memoryTable.id, memoryId))
-    )[0];
+    const row = (await db.select().from(memoryTable).where(eq(memoryTable.id, memoryId)))[0];
     const storedContent = row.content as {
       text: string;
       attachments: Array<{ id: string; text: string }>;
@@ -198,10 +192,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
     const descriptorOf = (fieldKey: string) =>
       (
         row.metadata as {
-          segmentation?: Record<
-            string,
-            { revision: string; totalBytes: number }
-          >;
+          segmentation?: Record<string, { revision: string; totalBytes: number }>;
         }
       )?.segmentation?.[fieldKey];
 
@@ -226,19 +217,13 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
     for (const field of expectedFields) {
       const descriptor = descriptorOf(field.fieldKey);
       expect(descriptor, `descriptor for ${field.fieldKey}`).toBeDefined();
-      expect(descriptor!.totalBytes).toBe(
-        Buffer.byteLength(field.source, "utf8"),
-      );
+      expect(descriptor!.totalBytes).toBe(Buffer.byteLength(field.source, "utf8"));
 
       // The public revision is `seg:<generation>:<sha>`; rows key on the raw generation.
       const generation = descriptor!.revision.split(":")[1];
       const fieldRows = segmentRows.filter((r) => r.generation === generation);
-      const expectedRows = Math.ceil(
-        Buffer.byteLength(field.source, "utf8") / (128 * 1024),
-      );
-      expect(fieldRows.length, `segment rows for ${field.fieldKey}`).toBe(
-        expectedRows,
-      );
+      const expectedRows = Math.ceil(Buffer.byteLength(field.source, "utf8") / (128 * 1024));
+      expect(fieldRows.length, `segment rows for ${field.fieldKey}`).toBe(expectedRows);
       // Ordered, non-overlapping, contiguous byte ranges starting at 0, with
       // segment indices forming an exact 0..n-1 cover.
       const byStart = [...fieldRows].sort((a, b) => a.byteStart - b.byteStart);
@@ -249,9 +234,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
         if (i > 0) expect(byStart[i].byteStart).toBe(byStart[i - 1].byteEnd);
         expect(byStart[i].byteEnd).toBeGreaterThan(byStart[i].byteStart);
       }
-      expect(byStart[byStart.length - 1].byteEnd).toBe(
-        Buffer.byteLength(field.source, "utf8"),
-      );
+      expect(byStart[byStart.length - 1].byteEnd).toBe(Buffer.byteLength(field.source, "utf8"));
       // Each segment's bytes in the DB equal the source slice and its digest
       // matches (row-level losslessness, text included — not just the hash).
       const sourceBytes = Buffer.from(field.source, "utf8");
@@ -259,9 +242,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
         const slice = sourceBytes.subarray(seg.byteStart, seg.byteEnd);
         expect(Buffer.byteLength(seg.text, "utf8")).toBe(slice.length);
         expect(Buffer.compare(Buffer.from(seg.text, "utf8"), slice)).toBe(0);
-        expect(seg.segmentSha256).toBe(
-          createHash("sha256").update(slice).digest("hex"),
-        );
+        expect(seg.segmentSha256).toBe(createHash("sha256").update(slice).digest("hex"));
       }
     }
 
@@ -277,16 +258,12 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
     // --- Adapter-level caller-visible pagination across boundaries
     expect(adapter.memoryContentPageCapability).toBe(1);
     const reassemble = async (
-      field:
-        | { kind: "content.text" }
-        | { kind: "attachment.text"; attachmentId: string },
+      field: { kind: "content.text" } | { kind: "attachment.text"; attachmentId: string }
     ) => {
       const source =
         field.kind === "content.text"
           ? messageText
-          : oversized.find(
-              (a) => a.id === (field as { attachmentId: string }).attachmentId,
-            )!.text;
+          : oversized.find((a) => a.id === (field as { attachmentId: string }).attachmentId)!.text;
       const sourceBuffer = Buffer.from(source, "utf8");
       const window = 64 * 1024; // deliberately not segment-aligned
       const parts: Buffer[] = [];
@@ -309,9 +286,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
         expect(page!.end).toBeGreaterThan(cursor);
         expect(page!.total).toBe(sourceBuffer.length);
         expect(
-          Buffer.from(page!.text, "utf8").equals(
-            sourceBuffer.subarray(cursor, expectedEnd),
-          ),
+          Buffer.from(page!.text, "utf8").equals(sourceBuffer.subarray(cursor, expectedEnd))
         ).toBe(true);
         if (first) {
           expect(page!.completeness).toBe("partial-recoverable");
@@ -328,10 +303,8 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
       }
       expect(revision).toBe(
         descriptorOf(
-          field.kind === "content.text"
-            ? "content.text"
-            : `attachment.text:${field.attachmentId}`,
-        )!.revision,
+          field.kind === "content.text" ? "content.text" : `attachment.text:${field.attachmentId}`
+        )!.revision
       );
       expect(Buffer.concat(parts).equals(sourceBuffer)).toBe(true);
     };
@@ -375,7 +348,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
           },
         } as never,
         undefined,
-        undefined,
+        undefined
       );
       expect(result.success).toBe(true);
       const readView = (
@@ -391,14 +364,12 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
       ).readView;
       const expectedEnd = expectedCodePointEnd(
         Buffer.from(messageText, "utf8"),
-        actionCursor + 48 * 1024,
+        actionCursor + 48 * 1024
       );
       expect(readView.slice.range.start).toBe(actionCursor);
       expect(readView.slice.range.end).toBe(expectedEnd);
       expect(readView.slice.range.end).toBeGreaterThan(actionCursor);
-      expect(readView.slice.range.total).toBe(
-        Buffer.byteLength(messageText, "utf8"),
-      );
+      expect(readView.slice.range.total).toBe(Buffer.byteLength(messageText, "utf8"));
       if (actionFirst) {
         expect(readView.slice.completeness).toBe("partial-recoverable");
         actionFirst = false;
@@ -407,17 +378,13 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
       actionRevision = readView.slice.revision;
       actionCursor = readView.slice.range.end;
       if (readView.slice.completeness === "complete") {
-        expect(readView.slice.range.end).toBe(
-          Buffer.byteLength(messageText, "utf8"),
-        );
+        expect(readView.slice.range.end).toBe(Buffer.byteLength(messageText, "utf8"));
         break;
       }
     }
     // The action boundary delivered the caller-visible lossless page stream.
     expect(actionRevision).toBe(descriptorOf("content.text")!.revision);
-    expect(
-      Buffer.concat(actionParts).equals(Buffer.from(messageText, "utf8")),
-    ).toBe(true);
+    expect(Buffer.concat(actionParts).equals(Buffer.from(messageText, "utf8"))).toBe(true);
 
     // Stale-revision negative assertion through the action boundary: a
     // continuation with the wrong revision must be a typed failure, never a
@@ -442,7 +409,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
         },
       } as never,
       undefined,
-      undefined,
+      undefined
     );
     expect(staleResult).toBeDefined();
     expect(staleResult!.success).toBe(false);
@@ -460,7 +427,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
         agentId,
         content: { text: decoyText, source: "test" },
       } as Memory,
-      "messages",
+      "messages"
     );
     expect(decoyId).not.toBe(memoryId);
     const decoyResult = await messageAction.handler(
@@ -480,7 +447,7 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
         },
       } as never,
       undefined,
-      undefined,
+      undefined
     );
     expect(decoyResult).toBeDefined();
     expect(decoyResult!.success).toBe(true);
@@ -491,9 +458,9 @@ describe("scenario: agent memory path across boundaries (real PGlite)", () => {
       Buffer.from(decoyResult!.text ?? "", "utf8").equals(
         Buffer.from(messageText, "utf8").subarray(
           0,
-          expectedCodePointEnd(Buffer.from(messageText, "utf8"), 256 * 1024),
-        ),
-      ),
+          expectedCodePointEnd(Buffer.from(messageText, "utf8"), 256 * 1024)
+        )
+      )
     ).toBe(true);
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.scenario.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-paging.scenario.real.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Reviewer-requested scenario proof for #25140 (PR #29754): one real
+ * agent-memory write carrying a 192 KiB multibyte message plus 10 attachments
+ * (7 oversized, 3 inline-small) through the BaseDrizzleAdapter path on real
+ * PGlite, then the same stored message read back through the production
+ * MESSAGE action caller path (messageAction handler, op=read_channel with a
+ * memory reference) over a real AgentRuntime. Asserts the lossless pagination
+ * contract end-to-end: bounded inline markers (never source bytes), exact
+ * memory_text_segments row counts per field and generation with per-row
+ * SHA-256 digests and segment indices, monotone non-overlapping ordered pages
+ * with code-point-boundary snapping and a positive-progress completeness
+ * invariant, byte-exact reassembly of every oversized field, small-field
+ * null-page fallback, and caller-visible pages from the action boundary.
+ * Real-harness: production adapter, migration service, AgentRuntime, and
+ * action handler; no mocks.
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  AgentRuntime,
+  isSegmentedContentMarker,
+  logger,
+  type Memory,
+  messageAction,
+  type UUID,
+} from "@elizaos/core";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import { memoryTable } from "../../schema/index";
+import { memoryTextSegmentTable } from "../../schema/memoryTextSegments";
+import type { DrizzleDatabase } from "../../types";
+
+const tempDirectories: string[] = [];
+/** Open handles tracked for afterEach teardown so assertion failures cannot leak them. */
+const openHandles: Array<{ close(): Promise<void> }> = [];
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  // Track the manager before initialization so a failure inside initialize()
+  // or adapter.init() still leaves afterEach able to close what opened.
+  openHandles.push(manager);
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  openHandles.push(adapter);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+async function migrate(adapter: PgliteDatabaseAdapter) {
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(
+    adapter.getDatabase() as DrizzleDatabase,
+  );
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+/** Deterministic multibyte source so byte math is exercised, not skipped. */
+function largeSource(byteLength: number, salt: string): string {
+  const unit = `seg-${salt} segurança שלום 🌏 test `;
+  const chunks: string[] = [];
+  let bytes = 0;
+  while (bytes < byteLength) {
+    chunks.push(unit);
+    bytes += Buffer.byteLength(unit, "utf8");
+  }
+  return chunks.join("");
+}
+
+async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  await adapter.createAgent({
+    id: agentId,
+    name: "Scenario paging",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await adapter.createRooms([
+    {
+      id: roomId,
+      agentId,
+      name: "Scenario paging room",
+      source: "test",
+      type: "direct" as never,
+      worldId: undefined,
+      channelId: undefined,
+    },
+  ]);
+  await adapter.createEntities([{ id: entityId, agentId, names: ["user"] }]);
+  // The agent itself joins the room so it can later read its own stored
+  // message through the MESSAGE action with a resolved AGENT role.
+  await adapter.createEntities([{ id: agentId, agentId, names: ["agent"] }]);
+  await adapter.createRoomParticipants([entityId, agentId], roomId);
+  return { roomId, entityId };
+}
+
+/** Code-point-safe expected page end mirroring the production snap rule. */
+function expectedCodePointEnd(sourceBytes: Buffer, limit: number): number {
+  let end = Math.min(limit, sourceBytes.length);
+  while (end > 0 && (sourceBytes[end] & 0xc0) === 0x80) {
+    end -= 1;
+  }
+  return end;
+}
+
+describe("scenario: agent memory path across boundaries (real PGlite)", () => {
+  afterEach(async () => {
+    // error-policy:J6 teardown-only close failures are warned and reported,
+    // never swallowed: every handle is still attempted so one failure cannot
+    // leak the rest, and the warning surfaces the leak instead of hiding it.
+    for (const handle of openHandles.splice(0)) {
+      try {
+        await handle.close();
+      } catch (error) {
+        logger.warn(
+          "scenario paging test teardown close failed:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("one 192 KiB message + 10 attachments segments losslessly with exact DB row counts, ordered byte-exact pages, and caller-visible reads through the MESSAGE action", async () => {
+    const dataDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-seg-scenario-"),
+    );
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter, manager } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+
+    // --- Scenario payload: one oversized message + 10 attachments (7 oversized + 3 small)
+    const messageText = largeSource(192 * 1024, "msg");
+    const attachments = Array.from({ length: 10 }, (_, i) => {
+      const oversized = i < 7;
+      const bytes = oversized ? 129 * 1024 + i * 1024 : 3 * 1024;
+      return {
+        id: `att-${i}-${v4()}`,
+        url: `https://example.com/t${i}.txt`,
+        contentType: "text/plain",
+        text: largeSource(bytes, `att${i}`),
+      };
+    });
+    const oversized = attachments.filter((_, i) => i < 7);
+
+    const memoryId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: {
+          text: messageText,
+          source: "test",
+          attachments,
+        },
+      } as unknown as Memory,
+      "messages",
+    );
+    expect(memoryId).toBeTruthy();
+
+    const db = adapter.getDatabase() as DrizzleDatabase;
+
+    // --- Inline bounded markers, never source bytes, for every segmented field
+    const row = (
+      await db.select().from(memoryTable).where(eq(memoryTable.id, memoryId))
+    )[0];
+    const storedContent = row.content as {
+      text: string;
+      attachments: Array<{ id: string; text: string }>;
+    };
+    expect(isSegmentedContentMarker(storedContent.text)).toBe(true);
+    expect(Buffer.byteLength(storedContent.text, "utf8")).toBeLessThan(512);
+    for (const att of oversized) {
+      const stored = storedContent.attachments.find((a) => a.id === att.id);
+      expect(stored, `stored attachment ${att.id}`).toBeDefined();
+      expect(isSegmentedContentMarker(stored!.text)).toBe(true);
+      expect(Buffer.byteLength(stored!.text, "utf8")).toBeLessThan(512);
+    }
+    // Small attachments stay inline byte-exact.
+    for (const att of attachments.filter((_, i) => i >= 7)) {
+      const stored = storedContent.attachments.find((a) => a.id === att.id);
+      expect(stored!.text).toBe(att.text);
+    }
+
+    // --- DB row-count proof: exactly the expected segments per field exist
+    const descriptorOf = (fieldKey: string) =>
+      (
+        row.metadata as {
+          segmentation?: Record<
+            string,
+            { revision: string; totalBytes: number }
+          >;
+        }
+      )?.segmentation?.[fieldKey];
+
+    const expectedFields: Array<{ fieldKey: string; source: string }> = [
+      { fieldKey: "content.text", source: messageText },
+      ...oversized.map((att) => ({
+        fieldKey: `attachment.text:${att.id}`,
+        source: att.text,
+      })),
+    ];
+
+    const segmentRows = await db.select().from(memoryTextSegmentTable);
+    // 128 KiB segments: ceil(bytes / 128 KiB) per oversized field.
+    const expectedTotalRows = expectedFields.reduce((sum, f) => {
+      const bytes = Buffer.byteLength(f.source, "utf8");
+      return sum + Math.ceil(bytes / (128 * 1024));
+    }, 0);
+    expect(segmentRows.length).toBe(expectedTotalRows);
+    // Every segment row belongs to exactly this parent memory.
+    expect(segmentRows.every((r) => r.parentId === memoryId)).toBe(true);
+
+    for (const field of expectedFields) {
+      const descriptor = descriptorOf(field.fieldKey);
+      expect(descriptor, `descriptor for ${field.fieldKey}`).toBeDefined();
+      expect(descriptor!.totalBytes).toBe(
+        Buffer.byteLength(field.source, "utf8"),
+      );
+
+      // The public revision is `seg:<generation>:<sha>`; rows key on the raw generation.
+      const generation = descriptor!.revision.split(":")[1];
+      const fieldRows = segmentRows.filter((r) => r.generation === generation);
+      const expectedRows = Math.ceil(
+        Buffer.byteLength(field.source, "utf8") / (128 * 1024),
+      );
+      expect(fieldRows.length, `segment rows for ${field.fieldKey}`).toBe(
+        expectedRows,
+      );
+      // Ordered, non-overlapping, contiguous byte ranges starting at 0, with
+      // segment indices forming an exact 0..n-1 cover.
+      const byStart = [...fieldRows].sort((a, b) => a.byteStart - b.byteStart);
+      expect(byStart[0].byteStart).toBe(0);
+      const indices = byStart.map((r) => r.segmentIndex).sort((a, b) => a - b);
+      expect(indices).toEqual(byStart.map((_, i) => i));
+      for (let i = 0; i < byStart.length; i++) {
+        if (i > 0) expect(byStart[i].byteStart).toBe(byStart[i - 1].byteEnd);
+        expect(byStart[i].byteEnd).toBeGreaterThan(byStart[i].byteStart);
+      }
+      expect(byStart[byStart.length - 1].byteEnd).toBe(
+        Buffer.byteLength(field.source, "utf8"),
+      );
+      // Each segment's bytes in the DB equal the source slice and its digest
+      // matches (row-level losslessness, text included — not just the hash).
+      const sourceBytes = Buffer.from(field.source, "utf8");
+      for (const seg of byStart) {
+        const slice = sourceBytes.subarray(seg.byteStart, seg.byteEnd);
+        expect(Buffer.byteLength(seg.text, "utf8")).toBe(slice.length);
+        expect(Buffer.compare(Buffer.from(seg.text, "utf8"), slice)).toBe(0);
+        expect(seg.segmentSha256).toBe(
+          createHash("sha256").update(slice).digest("hex"),
+        );
+      }
+    }
+
+    // --- Small-field fallback: pages return null (caller sees inline value)
+    const smallPage = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "attachment.text", attachmentId: attachments[7].id },
+      byteStart: 0,
+      byteLimit: 32 * 1024,
+    });
+    expect(smallPage).toBeNull();
+
+    // --- Adapter-level caller-visible pagination across boundaries
+    expect(adapter.memoryContentPageCapability).toBe(1);
+    const reassemble = async (
+      field:
+        | { kind: "content.text" }
+        | { kind: "attachment.text"; attachmentId: string },
+    ) => {
+      const source =
+        field.kind === "content.text"
+          ? messageText
+          : oversized.find(
+              (a) => a.id === (field as { attachmentId: string }).attachmentId,
+            )!.text;
+      const sourceBuffer = Buffer.from(source, "utf8");
+      const window = 64 * 1024; // deliberately not segment-aligned
+      const parts: Buffer[] = [];
+      let cursor = 0;
+      let revision: string | undefined;
+      let first = true;
+      for (;;) {
+        const page = await adapter.getMemoryContentPage({
+          memoryId,
+          field,
+          byteStart: cursor,
+          byteLimit: window,
+          ...(first ? {} : { expectedRevision: revision! }),
+        });
+        expect(page).not.toBeNull();
+        const expectedEnd = expectedCodePointEnd(sourceBuffer, cursor + window);
+        expect(page!.start).toBe(cursor);
+        // Positive-progress invariant: a data page must advance the cursor
+        // (guards against a broken final empty "complete" page pass-through).
+        expect(page!.end).toBeGreaterThan(cursor);
+        expect(page!.total).toBe(sourceBuffer.length);
+        expect(
+          Buffer.from(page!.text, "utf8").equals(
+            sourceBuffer.subarray(cursor, expectedEnd),
+          ),
+        ).toBe(true);
+        if (first) {
+          expect(page!.completeness).toBe("partial-recoverable");
+          first = false;
+        }
+        if (page!.completeness === "complete") {
+          // Completeness requires the final page to close the byte range.
+          expect(page!.end).toBe(sourceBuffer.length);
+        }
+        parts.push(Buffer.from(page!.text, "utf8"));
+        revision = page!.revision;
+        cursor = page!.end;
+        if (page!.completeness === "complete") break;
+      }
+      expect(revision).toBe(
+        descriptorOf(
+          field.kind === "content.text"
+            ? "content.text"
+            : `attachment.text:${field.attachmentId}`,
+        )!.revision,
+      );
+      expect(Buffer.concat(parts).equals(sourceBuffer)).toBe(true);
+    };
+
+    await reassemble({ kind: "content.text" });
+    for (const att of oversized) {
+      await reassemble({ kind: "attachment.text", attachmentId: att.id });
+    }
+
+    // --- Production caller path: the MESSAGE action over a real AgentRuntime
+    const runtime = new AgentRuntime({
+      character: { name: "scenario-paging" },
+      agentId,
+    });
+    runtime.registerDatabaseAdapter(adapter);
+    expect(runtime.memoryContentPageCapability).toBe(1);
+    expect(typeof runtime.getMemoryContentPage).toBe("function");
+
+    const actionParts: Buffer[] = [];
+    let actionCursor = 0;
+    let actionRevision: string | undefined;
+    let actionFirst = true;
+    for (;;) {
+      const result = await messageAction.handler(
+        runtime,
+        {
+          id: v4() as UUID,
+          entityId: agentId,
+          agentId,
+          roomId,
+          content: { text: "read the stored message" },
+        } as Memory,
+        undefined,
+        {
+          parameters: {
+            action: "read_channel",
+            reference: `memory:${memoryId}`,
+            offset: actionCursor,
+            limit: 48 * 1024,
+            ...(actionFirst ? {} : { expectedRevision: actionRevision! }),
+          },
+        } as never,
+        undefined,
+        undefined,
+      );
+      expect(result.success).toBe(true);
+      const readView = (
+        result.data as {
+          readView: {
+            slice: {
+              range: { start: number; end: number; total: number };
+              completeness: string;
+              revision: string;
+            };
+          };
+        }
+      ).readView;
+      const expectedEnd = expectedCodePointEnd(
+        Buffer.from(messageText, "utf8"),
+        actionCursor + 48 * 1024,
+      );
+      expect(readView.slice.range.start).toBe(actionCursor);
+      expect(readView.slice.range.end).toBe(expectedEnd);
+      expect(readView.slice.range.end).toBeGreaterThan(actionCursor);
+      expect(readView.slice.range.total).toBe(
+        Buffer.byteLength(messageText, "utf8"),
+      );
+      if (actionFirst) {
+        expect(readView.slice.completeness).toBe("partial-recoverable");
+        actionFirst = false;
+      }
+      actionParts.push(Buffer.from(result.text ?? "", "utf8"));
+      actionRevision = readView.slice.revision;
+      actionCursor = readView.slice.range.end;
+      if (readView.slice.completeness === "complete") {
+        expect(readView.slice.range.end).toBe(
+          Buffer.byteLength(messageText, "utf8"),
+        );
+        break;
+      }
+    }
+    // The action boundary delivered the caller-visible lossless page stream.
+    expect(actionRevision).toBe(descriptorOf("content.text")!.revision);
+    expect(
+      Buffer.concat(actionParts).equals(Buffer.from(messageText, "utf8")),
+    ).toBe(true);
+
+    // Stale-revision negative assertion through the action boundary: a
+    // continuation with the wrong revision must be a typed failure, never a
+    // silently re-page from byte 0 or a fresh first page (guards the
+    // expectedRevision forwarding through the caller path).
+    const staleResult = await messageAction.handler(
+      runtime,
+      {
+        id: v4() as UUID,
+        entityId: agentId,
+        agentId,
+        roomId,
+        content: { text: "read the stored message" },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "read_channel",
+          reference: `memory:${memoryId}`,
+          offset: 1024,
+          expectedRevision: "seg:not-the-live-generation",
+        },
+      } as never,
+      undefined,
+      undefined,
+    );
+    expect(staleResult).toBeDefined();
+    expect(staleResult!.success).toBe(false);
+    expect(staleResult!.values).toMatchObject({
+      error: "MEMORY_CONTENT_STALE_REVISION",
+    });
+
+    // Reference disambiguation: a second stored message in the same room must
+    // not satisfy a read pinned to the first by memory reference.
+    const decoyText = "small decoy message that stays inline";
+    const decoyId = await adapter.createMemory(
+      {
+        entityId: agentId,
+        roomId,
+        agentId,
+        content: { text: decoyText, source: "test" },
+      } as Memory,
+      "messages",
+    );
+    expect(decoyId).not.toBe(memoryId);
+    const decoyResult = await messageAction.handler(
+      runtime,
+      {
+        id: v4() as UUID,
+        entityId: agentId,
+        agentId,
+        roomId,
+        content: { text: "read the stored message" },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "read_channel",
+          reference: `memory:${memoryId}`,
+        },
+      } as never,
+      undefined,
+      undefined,
+    );
+    expect(decoyResult).toBeDefined();
+    expect(decoyResult!.success).toBe(true);
+    // The pinned reference returned the SEGMENTED message's first page, not
+    // the decoy's inline text.
+    expect(decoyResult!.text).not.toContain(decoyText);
+    expect(
+      Buffer.from(decoyResult!.text ?? "", "utf8").equals(
+        Buffer.from(messageText, "utf8").subarray(
+          0,
+          expectedCodePointEnd(Buffer.from(messageText, "utf8"), 256 * 1024),
+        ),
+      ),
+    ).toBe(true);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-content-reindex.guards.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-content-reindex.guards.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Pins the three legacy-content reindex guards (#25140) that the adapter and
+ * RLS suites do not assert by code: the caller-supplied `maxSourceBytes`
+ * bound, the source-drift check between the locked byte count and the later
+ * source fetch, and the REINDEX_REQUIRED rejection for a legacy row that a
+ * bounded page read cannot serve. The bound table is database-free and proves
+ * the guard short-circuits before any transaction; the other cases run on
+ * real PGlite in the PR lane. Drift is induced by rewriting the locked row
+ * from inside the same transaction, right before the source fetch, which is
+ * the only deterministic way to reach that guard under a row lock.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { MEMORY_SEGMENTATION_THRESHOLD_BYTES, type Memory, type UUID } from "@elizaos/core";
+import { eq, sql } from "drizzle-orm";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import { memoryTable } from "../../schema/index";
+import { reindexMemoryContent } from "../../stores/memoryTextSegments.store";
+import type { DrizzleDatabase } from "../../types";
+
+const REINDEX_HARD_MAX_BYTES = 16 * 1024 * 1024;
+const tempDirectories: string[] = [];
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+async function migrate(adapter: PgliteDatabaseAdapter) {
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+function largeSource(byteLength: number): string {
+  const unit = "segurança שלום 🌏 test ";
+  const chunks: string[] = [];
+  let bytes = 0;
+  while (bytes < byteLength) {
+    chunks.push(unit);
+    bytes += Buffer.byteLength(unit, "utf8");
+  }
+  return chunks.join("");
+}
+
+async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  await adapter.createAgent({
+    id: agentId,
+    name: "reindex guards",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await adapter.createRooms([
+    {
+      id: roomId,
+      agentId,
+      name: "reindex guards room",
+      source: "test",
+      type: "direct" as never,
+      worldId: undefined,
+      channelId: undefined,
+    },
+  ]);
+  await adapter.createEntities([{ id: entityId, agentId, names: ["user"] }]);
+  return { roomId, entityId };
+}
+
+/** Writes a legacy unsegmented row the way a pre-#25140 import left it. */
+async function seedLegacyRow(
+  adapter: PgliteDatabaseAdapter,
+  agentId: UUID,
+  text: string
+): Promise<{ memoryId: UUID; roomId: UUID; entityId: UUID }> {
+  const { roomId, entityId } = await seedRoom(adapter, agentId);
+  const memoryId = await adapter.createMemory(
+    { entityId, roomId, agentId, content: { text: "legacy seed", source: "test" } } as Memory,
+    "messages"
+  );
+  const db = adapter.getDatabase() as DrizzleDatabase;
+  await db
+    .update(memoryTable)
+    .set({ content: { text, source: "legacy-import" }, metadata: {} })
+    .where(eq(memoryTable.id, memoryId));
+  return { memoryId, roomId, entityId };
+}
+
+describe("reindex bound validation (no database)", () => {
+  const untouchable = {
+    transaction: () => {
+      throw new Error("DB WAS TOUCHED");
+    },
+  } as unknown as DrizzleDatabase;
+  const base = {
+    db: untouchable,
+    memoryId: v4() as UUID,
+    field: { kind: "content.text" } as const,
+    parentAuthorization: sql`true`,
+  };
+
+  it.each([
+    ["one byte above the 16 MiB hard ceiling", REINDEX_HARD_MAX_BYTES + 1],
+    ["far above the ceiling", Number.MAX_VALUE],
+    ["a non-integer", 1.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["negative", -1],
+    ["zero", 0],
+    ["exactly the segmentation threshold", MEMORY_SEGMENTATION_THRESHOLD_BYTES],
+  ])("rejects a bound that is %s before opening a transaction", async (_label, maxSourceBytes) => {
+    await expect(reindexMemoryContent({ ...base, maxSourceBytes })).rejects.toMatchObject({
+      code: "MEMORY_CONTENT_REINDEX_INVALID_BOUND",
+      context: { maxSourceBytes, hardMaxBytes: REINDEX_HARD_MAX_BYTES },
+    });
+  });
+
+  it.each([
+    ["one byte above the segmentation threshold", MEMORY_SEGMENTATION_THRESHOLD_BYTES + 1],
+    ["exactly the 16 MiB hard ceiling", REINDEX_HARD_MAX_BYTES],
+  ])(
+    "admits a bound that is %s and proceeds to the transaction",
+    async (_label, maxSourceBytes) => {
+      await expect(reindexMemoryContent({ ...base, maxSourceBytes })).rejects.toThrow(
+        "DB WAS TOUCHED"
+      );
+    }
+  );
+});
+
+describe("reindex guards (real PGlite)", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects the reindex and rolls back when the source is rewritten after the locked byte count", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-reindex-drift-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const source = largeSource(200 * 1024);
+    const { memoryId } = await seedLegacyRow(adapter, agentId, source);
+    const db = adapter.getDatabase() as DrizzleDatabase;
+
+    // The store issues two raw reads inside its transaction: the FOR UPDATE
+    // size check, then the source fetch. Rewrite the row between them from
+    // the same transaction (the lock holder), so the second read returns a
+    // different byte length than the first one measured.
+    let executeCalls = 0;
+    const wrapTransaction = (tx: DrizzleDatabase): DrizzleDatabase =>
+      new Proxy(tx, {
+        get(target, property, receiver) {
+          const value = Reflect.get(target, property, receiver);
+          if (property !== "execute") {
+            return typeof value === "function" ? value.bind(target) : value;
+          }
+          return async (...args: unknown[]) => {
+            executeCalls += 1;
+            if (executeCalls === 2) {
+              await target.execute(
+                sql`UPDATE memories SET content = jsonb_set(content, '{text}', to_jsonb('rewritten mid-reindex'::text), false) WHERE id = ${memoryId}`
+              );
+            }
+            return (target.execute as (...inner: unknown[]) => Promise<unknown>)(...args);
+          };
+        },
+      });
+    const driftingDb = {
+      transaction: (run: (tx: DrizzleDatabase) => Promise<unknown>) =>
+        db.transaction((tx) => run(wrapTransaction(tx as DrizzleDatabase))),
+    } as unknown as DrizzleDatabase;
+
+    await expect(
+      reindexMemoryContent({
+        db: driftingDb,
+        memoryId,
+        field: { kind: "content.text" },
+        maxSourceBytes: 1024 * 1024,
+        parentAuthorization: sql`true`,
+      })
+    ).rejects.toMatchObject({
+      code: "MEMORY_CONTENT_REINDEX_SOURCE_DRIFT",
+      context: { memoryId },
+    });
+    expect(executeCalls).toBe(2);
+
+    // The whole transaction rolled back: the injected rewrite is gone, no
+    // descriptor was written, and no segment generation was published.
+    const [row] = await db
+      .select({ content: memoryTable.content, metadata: memoryTable.metadata })
+      .from(memoryTable)
+      .where(eq(memoryTable.id, memoryId));
+    expect((row.content as { text: string }).text).toBe(source);
+    expect((row.metadata as { segmentation?: unknown }).segmentation).toBeUndefined();
+    const segments = await db.execute(
+      sql`SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = ${memoryId}`
+    );
+    expect((segments.rows as Array<{ n: number }>)[0].n).toBe(0);
+
+    await adapter.close();
+  });
+
+  it("refuses a bounded page over a legacy row above the segmentation threshold until it is reindexed", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-reindex-required-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const source = largeSource(MEMORY_SEGMENTATION_THRESHOLD_BYTES + 4096);
+    const { memoryId, roomId, entityId } = await seedLegacyRow(adapter, agentId, source);
+    const accessContext = {
+      requesterEntityId: entityId,
+      authorizedRoomIds: [roomId],
+      role: "USER" as const,
+    };
+    const fieldBytes = Buffer.byteLength(source, "utf8");
+
+    await expect(
+      adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 0,
+        accessContext,
+      })
+    ).rejects.toMatchObject({
+      code: "MEMORY_CONTENT_REINDEX_REQUIRED",
+      context: { memoryId, fieldKind: "content.text", fieldBytes },
+    });
+
+    // Boundary control: a legacy row at exactly the threshold is served by
+    // the ordinary small-row path (null means fall back inline).
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    const atThreshold = "a".repeat(MEMORY_SEGMENTATION_THRESHOLD_BYTES);
+    await db
+      .update(memoryTable)
+      .set({ content: { text: atThreshold, source: "legacy-import" }, metadata: {} })
+      .where(eq(memoryTable.id, memoryId));
+    await expect(
+      adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 0,
+        accessContext,
+      })
+    ).resolves.toBeNull();
+
+    // The remedy the error names: an authorized reindex makes the same
+    // page read succeed.
+    await db
+      .update(memoryTable)
+      .set({ content: { text: source, source: "legacy-import" }, metadata: {} })
+      .where(eq(memoryTable.id, memoryId));
+    const receipt = await adapter.reindexMemoryContent({
+      memoryId,
+      field: { kind: "content.text" },
+      accessContext,
+      maxSourceBytes: 1024 * 1024,
+    });
+    expect(receipt.totalBytes).toBe(fieldBytes);
+    const page = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      accessContext,
+    });
+    expect(page).not.toBeNull();
+    expect(page?.revision).toBe(receipt.revision);
+
+    await adapter.close();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
@@ -52,12 +52,7 @@ async function openDatabase(dataDir: string, agentId: UUID) {
 function multibyteSource(byteLength: number): string {
   const chunks: string[] = [];
   let bytes = 0;
-  const alphabet = [
-    "plain text ",
-    "日本語のテキスト ",
-    "emoji🚀🎉 ",
-    "ελληνικά ",
-  ];
+  const alphabet = ["plain text ", "日本語のテキスト ", "emoji🚀🎉 ", "ελληνικά "];
   let i = 0;
   while (bytes < byteLength) {
     const chunk = alphabet[i % alphabet.length];
@@ -86,17 +81,13 @@ async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
       type: ChannelType.DM,
     } satisfies Room,
   ]);
-  await adapter.createEntities([
-    { id: entityId, agentId, names: ["user"] } satisfies Entity,
-  ]);
+  await adapter.createEntities([{ id: entityId, agentId, names: ["user"] } satisfies Entity]);
   return { roomId, entityId };
 }
 
 async function migrate(adapter: PgliteDatabaseAdapter) {
   const migrations = new DatabaseMigrationService();
-  await migrations.initializeWithDatabase(
-    adapter.getDatabase() as DrizzleDatabase,
-  );
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
   migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
   await migrations.runAllPluginMigrations();
 }
@@ -167,9 +158,9 @@ describe("memory text segments (real PGlite)", () => {
     expect(page1?.start).toBe(0);
     expect(page1?.end).toBe(256 * 1024);
     expect(page1?.completeness).toBe("partial-recoverable");
-    expect(
-      createHash("sha256").update(encodeUtf8Strict(page1?.text)).digest("hex"),
-    ).toBe(page1?.sliceSha256);
+    expect(createHash("sha256").update(encodeUtf8Strict(page1?.text)).digest("hex")).toBe(
+      page1?.sliceSha256
+    );
 
     await expect(
       readMemoryContentPage({
@@ -177,7 +168,7 @@ describe("memory text segments (real PGlite)", () => {
         memoryId,
         field: { kind: "content.text" },
         byteStart: page1?.end,
-      }),
+      })
     ).rejects.toThrow(/expectedRevision/);
 
     const parts: string[] = [page1?.text];
@@ -198,12 +189,7 @@ describe("memory text segments (real PGlite)", () => {
       if (guard > 100) throw new Error("paging did not terminate");
     }
     const reassembled = parts.join("");
-    expect(
-      Buffer.compare(
-        Buffer.from(reassembled, "utf8"),
-        Buffer.from(source, "utf8"),
-      ),
-    ).toBe(0);
+    expect(Buffer.compare(Buffer.from(reassembled, "utf8"), Buffer.from(source, "utf8"))).toBe(0);
 
     // Stale revision rejection on continuation.
     await expect(
@@ -213,16 +199,14 @@ describe("memory text segments (real PGlite)", () => {
         field: { kind: "content.text" },
         byteStart: page1?.end,
         expectedRevision: `seg:00000000-0000-0000-0000-000000000000:${"0".repeat(64)}`,
-      }),
+      })
     ).rejects.toThrow(/changed before this page/);
 
     // Parent stays bounded: descriptor only, no source bytes.
     const parentMeta = await db.execute(
-      `SELECT octet_length(metadata::text) AS meta_bytes, content->>'text' AS text FROM memories WHERE id = '${memoryId}'`,
+      `SELECT octet_length(metadata::text) AS meta_bytes, content->>'text' AS text FROM memories WHERE id = '${memoryId}'`
     );
-    const metaRow = (
-      parentMeta.rows as Array<{ meta_bytes: number; text: string }>
-    )[0];
+    const metaRow = (parentMeta.rows as Array<{ meta_bytes: number; text: string }>)[0];
     expect(metaRow.meta_bytes).toBeLessThan(4096);
     expect(metaRow.text.length).toBeLessThan(100);
 
@@ -239,23 +223,19 @@ describe("memory text segments (real PGlite)", () => {
     });
     expect(after).not.toBeNull();
     expect(encodeUtf8Strict(after?.text).length).toBe(4096);
-    expect(after?.text).toBe(
-      new TextDecoder().decode(encodeUtf8Strict(source).subarray(0, 4096)),
-    );
+    expect(after?.text).toBe(new TextDecoder().decode(encodeUtf8Strict(source).subarray(0, 4096)));
 
     // Deletion cascade.
     await second.adapter.deleteMemory(memoryId);
     const remaining = await db2.execute(
-      `SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`,
+      `SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`
     );
     expect((remaining.rows as Array<{ n: number }>)[0].n).toBe(0);
     await second.adapter.close();
   });
 
   it("replaces a generation atomically and retires the prior one", async () => {
-    const dataDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "eliza-segments-replace-"),
-    );
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-segments-replace-"));
     tempDirectories.push(dataDir);
     const agentId = v4() as UUID;
     const memoryId = v4() as UUID;
@@ -296,9 +276,7 @@ describe("memory text segments (real PGlite)", () => {
       text: replacement,
       segmentBytes: 64 * 1024,
     });
-    expect(secondPlan.descriptor.generation).not.toBe(
-      firstPlan.descriptor.generation,
-    );
+    expect(secondPlan.descriptor.generation).not.toBe(firstPlan.descriptor.generation);
     const secondMetadata = mergeSegmentationMetadata({}, secondPlan.descriptor);
     await db.transaction(async (tx) => {
       await tx
@@ -330,7 +308,7 @@ describe("memory text segments (real PGlite)", () => {
     expect(page?.total).toBe(encodeUtf8Strict(replacement).length);
 
     const generations = await db.execute(
-      `SELECT count(DISTINCT generation)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`,
+      `SELECT count(DISTINCT generation)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`
     );
     expect((generations.rows as Array<{ n: number }>)[0].n).toBe(1);
 
@@ -342,15 +320,13 @@ describe("memory text segments (real PGlite)", () => {
         field: { kind: "content.text" },
         byteStart: 100,
         expectedRevision: firstPlan.descriptor.revision,
-      }),
+      })
     ).rejects.toThrow(/changed before this page/);
     await adapter.close();
   });
 
   it("flags legacy large unsegmented rows and passes small rows through", async () => {
-    const dataDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "eliza-segments-legacy-"),
-    );
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-segments-legacy-"));
     tempDirectories.push(dataDir);
     const agentId = v4() as UUID;
     const memoryId = v4() as UUID;
@@ -360,21 +336,21 @@ describe("memory text segments (real PGlite)", () => {
     const { roomId, entityId } = await seedRoom(adapter, agentId);
     const db = adapter.getDatabase() as DrizzleDatabase;
 
-    // Legacy large row: inline text above the hard page ceiling, NO descriptor.
-    const legacyText = "legacy ".repeat(
-      Math.ceil((MEMORY_PAGE_MAX_BYTES + 1024) / 7),
-    );
-    await adapter.createMemory(
-      {
-        id: memoryId,
-        entityId,
-        roomId,
-        agentId,
-        content: { text: legacyText, source: "test" },
-        unique: true,
-      } as Memory,
-      "messages",
-    );
+    // Legacy large row: inline text above the hard page ceiling, NO
+    // descriptor. Inserted with a raw drizzle write because createMemory now
+    // transparently segments oversized content (#25140) — the legacy state by
+    // definition predates that publication path.
+    const legacyText = "legacy ".repeat(Math.ceil((MEMORY_PAGE_MAX_BYTES + 1024) / 7));
+    await db.insert(memoryTable).values({
+      id: memoryId,
+      type: "messages",
+      content: { text: legacyText, source: "test" },
+      metadata: {},
+      entityId,
+      roomId,
+      agentId,
+      unique: true,
+    });
 
     await expect(
       readMemoryContentPage({
@@ -382,7 +358,7 @@ describe("memory text segments (real PGlite)", () => {
         memoryId,
         field: { kind: "content.text" },
         byteStart: 0,
-      }),
+      })
     ).rejects.toThrow(/reindex/i);
 
     const smallId = v4() as UUID;
@@ -395,7 +371,7 @@ describe("memory text segments (real PGlite)", () => {
         content: { text: "small", source: "test" },
         unique: true,
       } as Memory,
-      "messages",
+      "messages"
     );
     const small = await readMemoryContentPage({
       db,

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Real PGlite coverage for segmented large-content persistence (#25140):
+ * transactional publication of segments + bounded parent descriptor through a
+ * real database (real migrations create memory_text_segments), byte-window
+ * page reads with revision fencing, exact SHA reassembly across a restart,
+ * deletion cascade, and typed errors for legacy large unsegmented rows. Drives
+ * the segmentation store directly over the adapter's Drizzle database;
+ * adapter method wiring lands with the read-path change.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ChannelType,
+  type Entity,
+  encodeUtf8Strict,
+  MEMORY_PAGE_MAX_BYTES,
+  type Memory,
+  type Room,
+  shouldSegmentContent,
+  type UUID,
+} from "@elizaos/core";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import { memoryTable } from "../../schema/index";
+import {
+  insertSegmentsInTransaction,
+  mergeSegmentationMetadata,
+  planSegmentedField,
+  readMemoryContentPage,
+  retireStaleGenerationsInTransaction,
+} from "../../stores/memoryTextSegments.store";
+import type { DrizzleDatabase } from "../../types";
+
+const tempDirectories: string[] = [];
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+function multibyteSource(byteLength: number): string {
+  const chunks: string[] = [];
+  let bytes = 0;
+  const alphabet = [
+    "plain text ",
+    "日本語のテキスト ",
+    "emoji🚀🎉 ",
+    "ελληνικά ",
+  ];
+  let i = 0;
+  while (bytes < byteLength) {
+    const chunk = alphabet[i % alphabet.length];
+    chunks.push(chunk);
+    bytes += Buffer.byteLength(chunk, "utf8");
+    i += 1;
+  }
+  return chunks.join("");
+}
+
+async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  await adapter.createAgent({
+    id: agentId,
+    name: "Segmentation evaluator",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await adapter.createRooms([
+    {
+      id: roomId,
+      agentId,
+      name: "Segmentation room",
+      source: "test",
+      type: ChannelType.DM,
+    } satisfies Room,
+  ]);
+  await adapter.createEntities([
+    { id: entityId, agentId, names: ["user"] } satisfies Entity,
+  ]);
+  return { roomId, entityId };
+}
+
+async function migrate(adapter: PgliteDatabaseAdapter) {
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(
+    adapter.getDatabase() as DrizzleDatabase,
+  );
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+describe("memory text segments (real PGlite)", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes parent-first, pages with revision fencing, reassembles across restart, cascades deletion (1 MiB multibyte)", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-segments-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const memoryId = v4() as UUID;
+
+    const first = await openDatabase(dataDir, agentId);
+    await migrate(first.adapter);
+    const { roomId, entityId } = await seedRoom(first.adapter, agentId);
+
+    const source = multibyteSource(1024 * 1024);
+    expect(shouldSegmentContent(source)).toBe(true);
+    const db = first.adapter.getDatabase() as DrizzleDatabase;
+
+    const plan = planSegmentedField({
+      field: { kind: "content.text" },
+      text: source,
+      segmentBytes: 128 * 1024,
+    });
+
+    // Parent-first atomic publication inside one transaction.
+    const metadata = mergeSegmentationMetadata({}, plan.descriptor);
+    await db.transaction(async (tx) => {
+      await tx.insert(memoryTable).values({
+        id: memoryId,
+        type: "messages",
+        content: { text: "" },
+        metadata,
+        entityId,
+        roomId,
+        agentId,
+        unique: true,
+      });
+      await insertSegmentsInTransaction({
+        tx,
+        parentId: memoryId,
+        segments: plan.segments,
+        generation: plan.descriptor.generation,
+      });
+      await retireStaleGenerationsInTransaction({
+        tx,
+        parentId: memoryId,
+        liveMetadata: metadata,
+      });
+    });
+
+    expect(plan.descriptor.revision).toMatch(/^seg:/);
+
+    const page1 = await readMemoryContentPage({
+      db,
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: 256 * 1024,
+    });
+    expect(page1).not.toBeNull();
+    expect(page1?.start).toBe(0);
+    expect(page1?.end).toBe(256 * 1024);
+    expect(page1?.completeness).toBe("partial-recoverable");
+    expect(
+      createHash("sha256").update(encodeUtf8Strict(page1?.text)).digest("hex"),
+    ).toBe(page1?.sliceSha256);
+
+    await expect(
+      readMemoryContentPage({
+        db,
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: page1?.end,
+      }),
+    ).rejects.toThrow(/expectedRevision/);
+
+    const parts: string[] = [page1?.text];
+    let offset = page1?.end;
+    let guard = 0;
+    while (offset < page1?.total) {
+      const page = await readMemoryContentPage({
+        db,
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: offset,
+        expectedRevision: page1?.revision,
+      });
+      expect(page).not.toBeNull();
+      parts.push(page?.text);
+      offset = page?.end;
+      guard += 1;
+      if (guard > 100) throw new Error("paging did not terminate");
+    }
+    const reassembled = parts.join("");
+    expect(
+      Buffer.compare(
+        Buffer.from(reassembled, "utf8"),
+        Buffer.from(source, "utf8"),
+      ),
+    ).toBe(0);
+
+    // Stale revision rejection on continuation.
+    await expect(
+      readMemoryContentPage({
+        db,
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: page1?.end,
+        expectedRevision: `seg:00000000-0000-0000-0000-000000000000:${"0".repeat(64)}`,
+      }),
+    ).rejects.toThrow(/changed before this page/);
+
+    // Parent stays bounded: descriptor only, no source bytes.
+    const parentMeta = await db.execute(
+      `SELECT octet_length(metadata::text) AS meta_bytes, content->>'text' AS text FROM memories WHERE id = '${memoryId}'`,
+    );
+    const metaRow = (
+      parentMeta.rows as Array<{ meta_bytes: number; text: string }>
+    )[0];
+    expect(metaRow.meta_bytes).toBeLessThan(4096);
+    expect(metaRow.text.length).toBeLessThan(100);
+
+    // Restart: fresh manager + adapter on the same data dir.
+    await first.adapter.close();
+    const second = await openDatabase(dataDir, agentId);
+    const db2 = second.adapter.getDatabase() as DrizzleDatabase;
+    const after = await readMemoryContentPage({
+      db: db2,
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: 4096,
+    });
+    expect(after).not.toBeNull();
+    expect(encodeUtf8Strict(after?.text).length).toBe(4096);
+    expect(after?.text).toBe(
+      new TextDecoder().decode(encodeUtf8Strict(source).subarray(0, 4096)),
+    );
+
+    // Deletion cascade.
+    await second.adapter.deleteMemory(memoryId);
+    const remaining = await db2.execute(
+      `SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`,
+    );
+    expect((remaining.rows as Array<{ n: number }>)[0].n).toBe(0);
+    await second.adapter.close();
+  });
+
+  it("replaces a generation atomically and retires the prior one", async () => {
+    const dataDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-segments-replace-"),
+    );
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const memoryId = v4() as UUID;
+
+    const { adapter } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+    const db = adapter.getDatabase() as DrizzleDatabase;
+
+    const firstPlan = planSegmentedField({
+      field: { kind: "content.text" },
+      text: multibyteSource(300 * 1024),
+      segmentBytes: 64 * 1024,
+    });
+    const firstMetadata = mergeSegmentationMetadata({}, firstPlan.descriptor);
+    await db.transaction(async (tx) => {
+      await tx.insert(memoryTable).values({
+        id: memoryId,
+        type: "messages",
+        content: { text: "" },
+        metadata: firstMetadata,
+        entityId,
+        roomId,
+        agentId,
+        unique: true,
+      });
+      await insertSegmentsInTransaction({
+        tx,
+        parentId: memoryId,
+        segments: firstPlan.segments,
+        generation: firstPlan.descriptor.generation,
+      });
+    });
+
+    const replacement = `${multibyteSource(200 * 1024).slice(0, 100000)} tail`;
+    const secondPlan = planSegmentedField({
+      field: { kind: "content.text" },
+      text: replacement,
+      segmentBytes: 64 * 1024,
+    });
+    expect(secondPlan.descriptor.generation).not.toBe(
+      firstPlan.descriptor.generation,
+    );
+    const secondMetadata = mergeSegmentationMetadata({}, secondPlan.descriptor);
+    await db.transaction(async (tx) => {
+      await tx
+        .update(memoryTable)
+        .set({ metadata: secondMetadata })
+        .where(eq(memoryTable.id, memoryId));
+      await insertSegmentsInTransaction({
+        tx,
+        parentId: memoryId,
+        segments: secondPlan.segments,
+        generation: secondPlan.descriptor.generation,
+      });
+      await retireStaleGenerationsInTransaction({
+        tx,
+        parentId: memoryId,
+        liveMetadata: secondMetadata,
+      });
+    });
+
+    const page = await readMemoryContentPage({
+      db,
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      byteLimit: MEMORY_PAGE_MAX_BYTES,
+    });
+    expect(page).not.toBeNull();
+    expect(page?.revision).toBe(secondPlan.descriptor.revision);
+    expect(page?.total).toBe(encodeUtf8Strict(replacement).length);
+
+    const generations = await db.execute(
+      `SELECT count(DISTINCT generation)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`,
+    );
+    expect((generations.rows as Array<{ n: number }>)[0].n).toBe(1);
+
+    // Old revision is stale now.
+    await expect(
+      readMemoryContentPage({
+        db,
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 100,
+        expectedRevision: firstPlan.descriptor.revision,
+      }),
+    ).rejects.toThrow(/changed before this page/);
+    await adapter.close();
+  });
+
+  it("flags legacy large unsegmented rows and passes small rows through", async () => {
+    const dataDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-segments-legacy-"),
+    );
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const memoryId = v4() as UUID;
+
+    const { adapter } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+    const db = adapter.getDatabase() as DrizzleDatabase;
+
+    // Legacy large row: inline text above the hard page ceiling, NO descriptor.
+    const legacyText = "legacy ".repeat(
+      Math.ceil((MEMORY_PAGE_MAX_BYTES + 1024) / 7),
+    );
+    await adapter.createMemory(
+      {
+        id: memoryId,
+        entityId,
+        roomId,
+        agentId,
+        content: { text: legacyText, source: "test" },
+        unique: true,
+      } as Memory,
+      "messages",
+    );
+
+    await expect(
+      readMemoryContentPage({
+        db,
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: 0,
+      }),
+    ).rejects.toThrow(/reindex/i);
+
+    const smallId = v4() as UUID;
+    await adapter.createMemory(
+      {
+        id: smallId,
+        entityId,
+        roomId,
+        agentId,
+        content: { text: "small", source: "test" },
+        unique: true,
+      } as Memory,
+      "messages",
+    );
+    const small = await readMemoryContentPage({
+      db,
+      memoryId: smallId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+    });
+    expect(small).toBeNull();
+    await adapter.close();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
@@ -13,13 +13,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  buildSegmentedContentMarker,
   ChannelType,
   type Entity,
   encodeUtf8Strict,
   MEMORY_PAGE_MAX_BYTES,
   type Memory,
   type Room,
-  buildSegmentedContentMarker,
   shouldSegmentContent,
   type UUID,
 } from "@elizaos/core";

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.real.test.ts
@@ -19,6 +19,7 @@ import {
   MEMORY_PAGE_MAX_BYTES,
   type Memory,
   type Room,
+  buildSegmentedContentMarker,
   shouldSegmentContent,
   type UUID,
 } from "@elizaos/core";
@@ -125,7 +126,7 @@ describe("memory text segments (real PGlite)", () => {
       await tx.insert(memoryTable).values({
         id: memoryId,
         type: "messages",
-        content: { text: "" },
+        content: { text: buildSegmentedContentMarker(plan.descriptor) },
         metadata,
         entityId,
         roomId,
@@ -208,7 +209,7 @@ describe("memory text segments (real PGlite)", () => {
     );
     const metaRow = (parentMeta.rows as Array<{ meta_bytes: number; text: string }>)[0];
     expect(metaRow.meta_bytes).toBeLessThan(4096);
-    expect(metaRow.text.length).toBeLessThan(100);
+    expect(metaRow.text).toBe(buildSegmentedContentMarker(plan.descriptor));
 
     // Restart: fresh manager + adapter on the same data dir.
     await first.adapter.close();
@@ -255,7 +256,7 @@ describe("memory text segments (real PGlite)", () => {
       await tx.insert(memoryTable).values({
         id: memoryId,
         type: "messages",
-        content: { text: "" },
+        content: { text: buildSegmentedContentMarker(firstPlan.descriptor) },
         metadata: firstMetadata,
         entityId,
         roomId,
@@ -281,7 +282,10 @@ describe("memory text segments (real PGlite)", () => {
     await db.transaction(async (tx) => {
       await tx
         .update(memoryTable)
-        .set({ metadata: secondMetadata })
+        .set({
+          metadata: secondMetadata,
+          content: { text: buildSegmentedContentMarker(secondPlan.descriptor) },
+        })
         .where(eq(memoryTable.id, memoryId));
       await insertSegmentsInTransaction({
         tx,

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.rollback-atomicity.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.rollback-atomicity.test.ts
@@ -1,8 +1,10 @@
 /**
  * Rollback-atomicity probe for #25140 review round 4: when segment
- * publication fails inside the parent-insert transaction, NEITHER the parent
- * row NOR any segment row may survive (deterministic, real PGlite; the
- * failure is induced with a composite-PK collision on the segment insert).
+ * publication fails inside the production createMemory path, NEITHER the
+ * parent row NOR any segment row survives (deterministic, real PGlite; the
+ * failure is induced by a database trigger that rejects segment inserts for
+ * one parent, so the probe exercises adapter.createMemory →
+ * insertMemoryInTransaction end-to-end, not a hand-rolled transaction).
  * This is the crash-window the reviewer flagged — a parent committed with a
  * descriptor but no segments would brick every later paged read with
  * MEMORY_SEGMENT_DESCRIPTOR_DRIFT.
@@ -10,20 +12,13 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { UUID } from "@elizaos/core";
-import { buildSegmentedContentMarker } from "@elizaos/core";
+import type { Memory, UUID } from "@elizaos/core";
 import { v4 } from "uuid";
 import { afterEach, describe, expect, it } from "vitest";
 import { plugin as sqlPlugin } from "../../index";
 import { DatabaseMigrationService } from "../../migration-service";
 import { PgliteDatabaseAdapter } from "../../pglite/adapter";
 import { PGliteClientManager } from "../../pglite/manager";
-import { memoryTable } from "../../schema/memory";
-import {
-  insertSegmentsInTransaction,
-  mergeSegmentationMetadata,
-  planSegmentedField,
-} from "../../stores/memoryTextSegments.store";
 import type { DrizzleDatabase } from "../../types";
 
 const tempDirectories: string[] = [];
@@ -85,7 +80,7 @@ describe("segmented publication rollback atomicity (real PGlite)", () => {
     }
   });
 
-  it("rolls back parent and segments together when segment publication fails mid-transaction", async () => {
+  it("createMemory leaves neither parent nor segments when segment publication fails mid-transaction", async () => {
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-segments-rollback-"));
     tempDirectories.push(dataDir);
     const agentId = v4() as UUID;
@@ -94,48 +89,48 @@ describe("segmented publication rollback atomicity (real PGlite)", () => {
     const { roomId, entityId } = await seedRoom(adapter, agentId);
     const db = adapter.getDatabase() as DrizzleDatabase;
 
-    const plan = planSegmentedField({
-      field: { kind: "content.text" },
-      text: largeSource(150 * 1024),
-      segmentBytes: 64 * 1024,
-    });
+    // Reject every segment insert from inside the database: the parent
+    // insert succeeds first, then the segment publication fails inside the
+    // SAME production transaction — the exact crash-window shape.
+    await db.execute(
+      "CREATE OR REPLACE FUNCTION reject_segment() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'segment insert rejected'; END; $$ LANGUAGE plpgsql"
+    );
+    await db.execute(
+      "CREATE TRIGGER reject_segment BEFORE INSERT ON memory_text_segments FOR EACH ROW EXECUTE FUNCTION reject_segment()"
+    );
 
-    // Corrupt one planned segment's digest so the bulk insert violates the
-    // `char_length(segment_sha256) = 64` check AFTER the parent row insert
-    // succeeded inside the same transaction — the exact crash-window shape
-    // (parent committed, segments fail) the reviewer flagged.
-    const memoryId = v4() as UUID;
-    const metadata = mergeSegmentationMetadata({}, plan.descriptor);
     await expect(
-      db.transaction(async (tx) => {
-        await tx.insert(memoryTable).values({
-          id: memoryId,
-          type: "messages",
-          content: { text: buildSegmentedContentMarker(plan.descriptor) },
-          metadata,
+      adapter.createMemory(
+        {
           entityId,
           roomId,
           agentId,
-          unique: true,
-        });
-        await insertSegmentsInTransaction({
-          tx,
-          parentId: memoryId,
-          segments: plan.segments.map((segment, index) =>
-            index === 0 ? { ...segment, sha256: "corrupt" } : segment
-          ),
-          generation: plan.descriptor.generation,
-        });
-      })
-    ).rejects.toThrow();
+          content: { text: largeSource(150 * 1024), source: "test" },
+        } as unknown as Memory,
+        "messages"
+      )
+    ).rejects.toThrow(/memory_text_segments/);
 
-    const parentRows = await db.execute(
-      `SELECT count(*)::int AS n FROM memories WHERE id = '${memoryId}'`
+    // A control small memory still writes fine (trigger only rejects
+    // segment rows), proving the probe failed on the segmentation path.
+    const smallId = await adapter.createMemory(
+      {
+        entityId,
+        roomId,
+        agentId,
+        content: { text: "small memory", source: "test" },
+      } as unknown as Memory,
+      "messages"
     );
-    expect((parentRows.rows as Array<{ n: number }>)[0].n).toBe(0);
-    const segmentRows = await db.execute(
-      `SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`
+    expect(smallId).toBeTruthy();
+
+    // No segmented parent survived: every remaining messages row in the
+    // room is the small control (segmented markers absent).
+    const markers = await db.execute(
+      `SELECT count(*)::int AS n FROM memories WHERE room_id::text = '${roomId}' AND content->>'text' LIKE '[elizaos:segmented-content%'`
     );
+    expect((markers.rows as Array<{ n: number }>)[0].n).toBe(0);
+    const segmentRows = await db.execute("SELECT count(*)::int AS n FROM memory_text_segments");
     expect((segmentRows.rows as Array<{ n: number }>)[0].n).toBe(0);
 
     await adapter.close();

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.rollback-atomicity.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-segments.rollback-atomicity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Rollback-atomicity probe for #25140 review round 4: when segment
+ * publication fails inside the parent-insert transaction, NEITHER the parent
+ * row NOR any segment row may survive (deterministic, real PGlite; the
+ * failure is induced with a composite-PK collision on the segment insert).
+ * This is the crash-window the reviewer flagged — a parent committed with a
+ * descriptor but no segments would brick every later paged read with
+ * MEMORY_SEGMENT_DESCRIPTOR_DRIFT.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { UUID } from "@elizaos/core";
+import { buildSegmentedContentMarker } from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import { memoryTable } from "../../schema/memory";
+import {
+  insertSegmentsInTransaction,
+  mergeSegmentationMetadata,
+  planSegmentedField,
+} from "../../stores/memoryTextSegments.store";
+import type { DrizzleDatabase } from "../../types";
+
+const tempDirectories: string[] = [];
+
+function largeSource(byteLength: number): string {
+  const unit = "segurança שלום 🌏 test ";
+  const chunks: string[] = [];
+  let bytes = 0;
+  while (bytes < byteLength) {
+    chunks.push(unit);
+    bytes += Buffer.byteLength(unit, "utf8");
+  }
+  return chunks.join("");
+}
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+async function migrate(adapter: PgliteDatabaseAdapter) {
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+async function seedRoom(adapter: PgliteDatabaseAdapter, agentId: UUID) {
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  await adapter.createAgent({
+    id: agentId,
+    name: "rollback probe",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await adapter.createRooms([
+    {
+      id: roomId,
+      agentId,
+      name: "rollback room",
+      source: "test",
+      type: "direct" as never,
+      worldId: undefined,
+      channelId: undefined,
+    },
+  ]);
+  await adapter.createEntities([{ id: entityId, agentId, names: ["user"] }]);
+  return { roomId, entityId };
+}
+
+describe("segmented publication rollback atomicity (real PGlite)", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back parent and segments together when segment publication fails mid-transaction", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-segments-rollback-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const { adapter } = await openDatabase(dataDir, agentId);
+    await migrate(adapter);
+    const { roomId, entityId } = await seedRoom(adapter, agentId);
+    const db = adapter.getDatabase() as DrizzleDatabase;
+
+    const plan = planSegmentedField({
+      field: { kind: "content.text" },
+      text: largeSource(150 * 1024),
+      segmentBytes: 64 * 1024,
+    });
+
+    // Corrupt one planned segment's digest so the bulk insert violates the
+    // `char_length(segment_sha256) = 64` check AFTER the parent row insert
+    // succeeded inside the same transaction — the exact crash-window shape
+    // (parent committed, segments fail) the reviewer flagged.
+    const memoryId = v4() as UUID;
+    const metadata = mergeSegmentationMetadata({}, plan.descriptor);
+    await expect(
+      db.transaction(async (tx) => {
+        await tx.insert(memoryTable).values({
+          id: memoryId,
+          type: "messages",
+          content: { text: buildSegmentedContentMarker(plan.descriptor) },
+          metadata,
+          entityId,
+          roomId,
+          agentId,
+          unique: true,
+        });
+        await insertSegmentsInTransaction({
+          tx,
+          parentId: memoryId,
+          segments: plan.segments.map((segment, index) =>
+            index === 0 ? { ...segment, sha256: "corrupt" } : segment
+          ),
+          generation: plan.descriptor.generation,
+        });
+      })
+    ).rejects.toThrow();
+
+    const parentRows = await db.execute(
+      `SELECT count(*)::int AS n FROM memories WHERE id = '${memoryId}'`
+    );
+    expect((parentRows.rows as Array<{ n: number }>)[0].n).toBe(0);
+    const segmentRows = await db.execute(
+      `SELECT count(*)::int AS n FROM memory_text_segments WHERE parent_id = '${memoryId}'`
+    );
+    expect((segmentRows.rows as Array<{ n: number }>)[0].n).toBe(0);
+
+    await adapter.close();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/memory-content-paging.rls.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/memory-content-paging.rls.real.test.ts
@@ -1,0 +1,100 @@
+/** Real PostgreSQL/RLS proof for authorized legacy-content reindex (#25140). */
+import type { Memory, UUID } from "@elizaos/core";
+import { Client } from "pg";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PgDatabaseAdapter } from "../../../pg/adapter";
+import { PostgresConnectionManager } from "../../../pg/manager";
+import { bootstrapPostgresRlsSchema, toPostgresSuperuserUrl } from "./rls-test-helpers";
+
+describe.skipIf(!process.env.POSTGRES_URL)("memory content paging PostgreSQL RLS", () => {
+  const connectionString = process.env.POSTGRES_URL!;
+  const serverId = v4() as UUID;
+  const agentId = v4() as UUID;
+  const entityId = v4() as UUID;
+  const roomId = v4() as UUID;
+  const memoryId = v4() as UUID;
+  let manager: PostgresConnectionManager;
+  let adapter: PgDatabaseAdapter;
+  let superuser: Client;
+
+  beforeAll(async () => {
+    await bootstrapPostgresRlsSchema(connectionString);
+    process.env.ENABLE_DATA_ISOLATION = "true";
+    manager = new PostgresConnectionManager(connectionString, serverId);
+    adapter = new PgDatabaseAdapter(agentId, manager);
+    await adapter.init();
+    await adapter.createAgent({
+      id: agentId,
+      name: "paging-rules",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await adapter.createRooms([{ id: roomId, agentId, source: "test", type: "direct" as never }]);
+    await adapter.createEntities([{ id: entityId, agentId, names: ["reader"] }]);
+    superuser = new Client({ connectionString: toPostgresSuperuserUrl(connectionString) });
+    await superuser.connect();
+    await superuser.query(
+      "INSERT INTO participants (entity_id, room_id, agent_id, server_id) VALUES ($1, $2, $3, $4)",
+      [entityId, roomId, agentId, serverId]
+    );
+    await adapter.createMemory(
+      {
+        id: memoryId,
+        agentId,
+        entityId,
+        roomId,
+        content: { text: "seed", source: "test" },
+      } as Memory,
+      "messages"
+    );
+    await superuser.query(
+      "UPDATE memories SET content = jsonb_build_object('text', repeat('x', 1048576), 'source', 'legacy') WHERE id = $1",
+      [memoryId]
+    );
+  });
+
+  afterAll(async () => {
+    await superuser?.end();
+    await adapter?.close();
+    await manager?.close();
+    delete process.env.ENABLE_DATA_ISOLATION;
+  });
+
+  it("denies the wrong room and reauthorizes every page for the right room", async () => {
+    const base = { requesterEntityId: entityId, role: "USER" as const };
+    await expect(
+      adapter.reindexMemoryContent({
+        memoryId,
+        field: { kind: "content.text" },
+        accessContext: { ...base, authorizedRoomIds: [v4() as UUID] },
+        maxSourceBytes: 2 * 1024 * 1024,
+      })
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED" });
+
+    const receipt = await adapter.reindexMemoryContent({
+      memoryId,
+      field: { kind: "content.text" },
+      accessContext: { ...base, authorizedRoomIds: [roomId] },
+      maxSourceBytes: 2 * 1024 * 1024,
+    });
+    expect(receipt.totalBytes).toBe(1024 * 1024);
+    const page = await adapter.getMemoryContentPage({
+      memoryId,
+      field: { kind: "content.text" },
+      byteStart: 0,
+      accessContext: { ...base, authorizedRoomIds: [roomId] },
+    });
+    expect(page?.sourceSha256).toBe(receipt.sourceSha256);
+    expect(page?.text.length).toBeGreaterThan(0);
+    await expect(
+      adapter.getMemoryContentPage({
+        memoryId,
+        field: { kind: "content.text" },
+        byteStart: page!.end,
+        expectedRevision: receipt.revision,
+        accessContext: { ...base, authorizedRoomIds: [v4() as UUID] },
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/memory-content-paging.rls.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/memory-content-paging.rls.real.test.ts
@@ -1,10 +1,12 @@
 /** Real PostgreSQL/RLS proof for authorized legacy-content reindex (#25140). */
 import type { Memory, UUID } from "@elizaos/core";
+import { sql } from "drizzle-orm";
 import { Client } from "pg";
 import { v4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PgDatabaseAdapter } from "../../../pg/adapter";
 import { PostgresConnectionManager } from "../../../pg/manager";
+import { reindexMemoryContent as reindexMemoryContentInTransaction } from "../../../stores/memoryTextSegments.store";
 import { bootstrapPostgresRlsSchema, toPostgresSuperuserUrl } from "./rls-test-helpers";
 
 describe.skipIf(!process.env.POSTGRES_URL)("memory content paging PostgreSQL RLS", () => {
@@ -96,5 +98,69 @@ describe.skipIf(!process.env.POSTGRES_URL)("memory content paging PostgreSQL RLS
         accessContext: { ...base, authorizedRoomIds: [v4() as UUID] },
       })
     ).resolves.toBeNull();
+  });
+
+  it("opens the entity context at repeatable read for snapshot-safe paging", async () => {
+    const isolation = await manager.withEntityContext(
+      entityId,
+      async (tx) => {
+        const result = await tx.execute(sql`SHOW transaction_isolation`);
+        return (result.rows as Array<{ transaction_isolation: string }>)[0]?.transaction_isolation;
+      },
+      { isolationLevel: "repeatable read" }
+    );
+
+    expect(isolation).toBe("repeatable read");
+  });
+
+  it("rolls back segments when authorization changes before parent publication", async () => {
+    const revocationMemoryId = v4() as UUID;
+    await adapter.createMemory(
+      {
+        id: revocationMemoryId,
+        agentId,
+        entityId,
+        roomId,
+        content: { text: "seed", source: "test" },
+      } as Memory,
+      "messages"
+    );
+    await superuser.query(
+      "UPDATE memories SET content = jsonb_build_object('text', repeat('r', 1048576), 'source', 'legacy') WHERE id = $1",
+      [revocationMemoryId]
+    );
+    await superuser.query("DROP SEQUENCE IF EXISTS reindex_authz_calls");
+    await superuser.query("CREATE SEQUENCE reindex_authz_calls START 1");
+    await superuser.query("GRANT USAGE, SELECT ON SEQUENCE reindex_authz_calls TO PUBLIC");
+
+    await expect(
+      manager.withEntityContext(
+        entityId,
+        (tx) =>
+          reindexMemoryContentInTransaction({
+            db: tx,
+            memoryId: revocationMemoryId,
+            field: { kind: "content.text" },
+            maxSourceBytes: 2 * 1024 * 1024,
+            // The first two authorized reads succeed; publication observes
+            // the simulated revocation and must abort before inserting rows.
+            parentAuthorization: sql`nextval('reindex_authz_calls') <= 2`,
+          }),
+        { isolationLevel: "repeatable read" }
+      )
+    ).rejects.toMatchObject({ code: "MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED" });
+
+    const persisted = await superuser.query<{
+      segment_count: string;
+      text_bytes: number;
+    }>(
+      `SELECT
+         (SELECT count(*) FROM memory_text_segments WHERE parent_id = $1) AS segment_count,
+         octet_length(content->>'text') AS text_bytes
+       FROM memories WHERE id = $1`,
+      [revocationMemoryId]
+    );
+    expect(persisted.rows[0]).toEqual({ segment_count: "0", text_bytes: 1024 * 1024 });
+    await superuser.query("DROP SEQUENCE reindex_authz_calls");
   });
 });

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -557,6 +557,7 @@ import {
   entityTable,
   logTable,
   memoryTable,
+  memoryTextSegmentTable,
   messageServerAgentsTable,
   messageServerTable,
   messageTable,

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -17,6 +17,7 @@ import {
   actorFromAccessContext,
   advanceWorldMetadataRevision,
   appendWorldMetadataRoleAudit,
+  buildSegmentedContentMarker,
   ChannelType,
   type Component,
   type ConnectorAccountAuditEventRecord,
@@ -63,6 +64,9 @@ import {
   type LogBody,
   logger,
   type Memory,
+  type MemoryContentField,
+  type MemoryContentPageParams,
+  type MemoryContentPageResult,
   type MemoryMetadata,
   type MessageSearchHit,
   type Metadata,
@@ -86,6 +90,7 @@ import {
   type RunStatus,
   requireFreshWorldMetadataRevision,
   type SetConnectorAccountCredentialRefParams,
+  shouldSegmentContent,
   type Task,
   type TaskMetadata,
   type UpsertConnectorAccountParams,
@@ -557,7 +562,6 @@ import {
   entityTable,
   logTable,
   memoryTable,
-  memoryTextSegmentTable,
   messageServerAgentsTable,
   messageServerTable,
   messageTable,
@@ -572,6 +576,19 @@ import {
 import { documentSearchTokensExpression } from "./schema/memory";
 
 type AgentRow = typeof agentTable.$inferSelect;
+
+/**
+ * Bounded inline replacement stored in the segmented field itself once the
+ * source bytes live in `memory_text_segments` (#25140). Machine-prefixed and
+ * digest-bearing so no legitimate content can collide with it; consumers that
+ * predate paged reads see an explicit marker, never silent truncation.
+ */
+function buildPublishedContentMarker(
+  descriptor: ReturnType<typeof planSegmentedField>["descriptor"]
+): string {
+  return buildSegmentedContentMarker(descriptor);
+}
+
 type AgentMessageExamples = NonNullable<Agent["messageExamples"]>;
 type AgentKnowledge = NonNullable<Agent["knowledge"]>;
 type MemoryRow = typeof memoryTable.$inferSelect;
@@ -661,12 +678,20 @@ import {
   ConnectorAccountStore,
   type ListConnectorAccountAuditEventsParams,
 } from "./stores/connectorAccount.store";
+import {
+  insertSegmentsInTransaction,
+  mergeSegmentationMetadata,
+  planSegmentedField,
+  readMemoryContentPage,
+  retireStaleGenerationsInTransaction,
+} from "./stores/memoryTextSegments.store";
 import type { StoreContext } from "./stores/types";
 import type { DrizzleDatabase } from "./types";
 
 export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase> {
   readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
   readonly documentRangeReadCapability = 1 as const;
+  readonly memoryContentPageCapability = 1 as const;
   protected readonly maxRetries: number = 3;
   protected readonly baseDelay: number = 1000;
   protected readonly maxDelay: number = 10000;
@@ -4058,6 +4083,31 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return memoryId;
   }
 
+  /**
+   * #25140: authorized byte-window page read over segmented memory content.
+   * Delegates to the segmentation store; typed errors
+   * (MEMORY_CONTENT_REINDEX_REQUIRED, MEMORY_CONTENT_STALE_REVISION, …)
+   * propagate to the caller. Returns null when the field has no descriptor
+   * and its inline value fits a bounded page — callers fall back to the
+   * ordinary small-row read.
+   */
+  async getMemoryContentPage(
+    params: MemoryContentPageParams
+  ): Promise<MemoryContentPageResult | null> {
+    return this.withDatabase(() =>
+      readMemoryContentPage({
+        db: this.db,
+        memoryId: params.memoryId,
+        field: params.field as import("@elizaos/core").MemorySegmentField,
+        byteStart: params.byteStart,
+        ...(params.byteLimit === undefined ? {} : { byteLimit: params.byteLimit }),
+        ...(params.expectedRevision === undefined
+          ? {}
+          : { expectedRevision: params.expectedRevision }),
+      })
+    );
+  }
+
   private async resolveMemoryUniqueness(
     memory: Memory & { metadata?: MemoryMetadata },
     tableName: string
@@ -4099,6 +4149,85 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     }
   }
 
+  /**
+   * Plans segmentation for every field of `content` whose UTF-8 byte length
+   * exceeds the threshold (#25140): `content.text` and each attachment's
+   * `text`. Returns the bounded inline replacement — the shared published
+   * marker — plus per-field plans. Never throws for ordinary content: a
+   * segmentation failure (e.g. unpaired surrogates) surfaces where it occurs
+   * rather than blocking the small-field paths.
+   */
+  private planMemoryContentSegmentation(
+    content: Memory["content"],
+    existingMetadata: unknown
+  ): {
+    content: Memory["content"];
+    metadata: Record<string, unknown>;
+    plans: Array<{
+      field: MemoryContentField;
+      segments: ReturnType<typeof planSegmentedField>["segments"];
+      generation: string;
+    }>;
+  } {
+    const plans: Array<{
+      field: MemoryContentField;
+      segments: ReturnType<typeof planSegmentedField>["segments"];
+      generation: string;
+    }> = [];
+    let metadata =
+      existingMetadata && typeof existingMetadata === "object"
+        ? { ...(existingMetadata as Record<string, unknown>) }
+        : {};
+
+    const planField = (field: MemoryContentField, text: string): string => {
+      const planned = planSegmentedField({ field, text });
+      metadata = mergeSegmentationMetadata(metadata, planned.descriptor);
+      plans.push({
+        field,
+        segments: planned.segments,
+        generation: planned.descriptor.generation,
+      });
+      return buildPublishedContentMarker(planned.descriptor);
+    };
+
+    let nextContent = content;
+    if (typeof content.text === "string" && shouldSegmentContent(content.text)) {
+      nextContent = {
+        ...nextContent,
+        text: planField({ kind: "content.text" }, content.text),
+      };
+    }
+    if (Array.isArray(content.attachments) && content.attachments.length > 0) {
+      let changed = false;
+      const attachments = content.attachments.map((attachment) => {
+        if (
+          attachment &&
+          typeof attachment === "object" &&
+          typeof (attachment as { text?: unknown }).text === "string" &&
+          shouldSegmentContent((attachment as { text: string }).text)
+        ) {
+          changed = true;
+          const id =
+            typeof (attachment as { id?: unknown }).id === "string" &&
+            (attachment as { id: string }).id.trim()
+              ? (attachment as { id: string }).id.trim()
+              : "";
+          const field = id ? ({ kind: "attachment.text", attachmentId: id } as const) : null;
+          if (field) {
+            const text = (attachment as { text: string }).text;
+            return {
+              ...attachment,
+              text: planField(field, text),
+            };
+          }
+        }
+        return attachment;
+      });
+      if (changed) nextContent = { ...nextContent, attachments };
+    }
+    return { content: nextContent, metadata, plans };
+  }
+
   private async insertMemoryInTransaction(
     tx: DrizzleDatabase,
     memory: Memory & { metadata?: MemoryMetadata },
@@ -4106,11 +4235,21 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     memoryId: UUID,
     requireInserted = false
   ): Promise<void> {
+    // #25140: fields whose UTF-8 bytes exceed the segmentation threshold are
+    // published as immutable segments in the SAME transaction as the parent
+    // row; the inline field carries only a bounded published marker and the
+    // parent metadata carries the descriptor.
+    const segmentation = this.planMemoryContentSegmentation(memory.content, memory.metadata);
+    const contentToSegment = segmentation.content;
+
     // Ensure we always pass a JSON string to the SQL bind parameter; if we pass an
     // object directly PG sees `[object Object]` and fails the `::jsonb` cast.
-    const contentToInsert = serializeJsonb(memory.content);
+    // #25140: segmented fields carry a bounded published marker inline; pass
+    // the planned (possibly string) content through serializeJsonb, which
+    // validates pre-encoded strings and preserves arbitrary-precision tokens.
+    const contentToInsert = serializeJsonb(contentToSegment);
 
-    const metadataToInsert = serializeJsonb(memory.metadata ?? {});
+    const metadataToInsert = serializeJsonb(segmentation.metadata ?? {});
 
     const inserted = await tx
       .insert(memoryTable)
@@ -4139,6 +4278,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         });
       }
       return;
+    }
+
+    // #25140: publish the planned segments in the same transaction; rollback
+    // of either write leaves neither (no orphan rows, no partial parent).
+    for (const plan of segmentation.plans) {
+      await insertSegmentsInTransaction({
+        tx,
+        parentId: memoryId,
+        segments: plan.segments,
+        generation: plan.generation,
+      });
     }
 
     if (memory.embedding && Array.isArray(memory.embedding)) {
@@ -4189,19 +4339,39 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return this.withDatabase(async () => {
       try {
         await this.db.transaction(async (tx) => {
-          // Update memory content if provided
+          // #25140: replacement of a segmented field publishes a new
+          // immutable generation and retires stale generations in the SAME
+          // transaction as the parent row update. Existing caller metadata is
+          // the merge base so descriptors for untouched fields survive a
+          // partial update.
+          let segmentation: ReturnType<BaseDrizzleAdapter["planMemoryContentSegmentation"]> | null =
+            null;
+          let mergedMetadata: string | undefined;
           if (memory.content) {
-            const contentToUpdate = serializeJsonb(memory.content);
+            const existingMetadata =
+              memory.metadata ??
+              (
+                await tx
+                  .select({ metadata: memoryTable.metadata })
+                  .from(memoryTable)
+                  .where(eq(memoryTable.id, memory.id))
+                  .limit(1)
+              )[0]?.metadata;
+            segmentation = this.planMemoryContentSegmentation(memory.content, existingMetadata);
+            // #25140: descriptors for untouched fields survive a partial update;
+            // develop's serializer validates pre-encoded strings in place.
+            mergedMetadata = serializeJsonb(segmentation.metadata ?? {});
+          }
 
-            const metadataToUpdate = serializeJsonb(memory.metadata ?? {});
+          // Update memory content if provided
+          if (memory.content && segmentation) {
+            const contentToUpdate = serializeJsonb(segmentation.content);
 
             await tx
               .update(memoryTable)
               .set({
                 content: sql`${contentToUpdate}::jsonb`,
-                ...(memory.metadata && {
-                  metadata: sql`${metadataToUpdate}::jsonb`,
-                }),
+                metadata: sql`${mergedMetadata}::jsonb`,
               })
               .where(eq(memoryTable.id, memory.id));
           } else if (memory.metadata) {
@@ -4214,6 +4384,24 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
                 metadata: sql`${metadataToUpdate}::jsonb`,
               })
               .where(eq(memoryTable.id, memory.id));
+          }
+
+          // #25140: publish the new generation and retire every generation no
+          // longer referenced by the merged metadata, in the same transaction.
+          if (segmentation) {
+            for (const plan of segmentation.plans) {
+              await insertSegmentsInTransaction({
+                tx,
+                parentId: memory.id,
+                segments: plan.segments,
+                generation: plan.generation,
+              });
+            }
+            await retireStaleGenerationsInTransaction({
+              tx,
+              parentId: memory.id,
+              liveMetadata: segmentation.metadata,
+            });
           }
 
           // Update embedding if provided

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -683,6 +683,7 @@ import {
   mergeSegmentationMetadata,
   planSegmentedField,
   readMemoryContentPage,
+  readSegmentationDescriptors,
   retireStaleGenerationsInTransaction,
 } from "./stores/memoryTextSegments.store";
 import type { StoreContext } from "./stores/types";
@@ -4197,6 +4198,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         text: planField({ kind: "content.text" }, content.text),
       };
     }
+    const seenAttachmentIds = new Set<string>();
     if (Array.isArray(content.attachments) && content.attachments.length > 0) {
       let changed = false;
       const attachments = content.attachments.map((attachment) => {
@@ -4212,18 +4214,65 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             (attachment as { id: string }).id.trim()
               ? (attachment as { id: string }).id.trim()
               : "";
-          const field = id ? ({ kind: "attachment.text", attachmentId: id } as const) : null;
-          if (field) {
-            const text = (attachment as { text: string }).text;
-            return {
-              ...attachment,
-              text: planField(field, text),
-            };
+          if (!id) {
+            // A large attachment text without a stable id cannot be given an
+            // owner-bound locator; fail closed rather than leave it inline.
+            throw new ElizaError(
+              "Large attachment text requires a non-empty attachment id for segmented storage",
+              {
+                code: "MEMORY_SEGMENT_ATTACHMENT_ID_REQUIRED",
+              },
+            );
           }
+          if (seenAttachmentIds.has(id)) {
+            throw new ElizaError(
+              "Duplicate attachment ids cannot both be segmented on one memory",
+              {
+                code: "MEMORY_SEGMENT_ATTACHMENT_ID_CONFLICT",
+                context: { attachmentId: id },
+              },
+            );
+          }
+          seenAttachmentIds.add(id);
+          const field = { kind: "attachment.text", attachmentId: id } as const;
+          const text = (attachment as { text: string }).text;
+          return {
+            ...attachment,
+            text: planField(field, text),
+          };
         }
         return attachment;
       });
       if (changed) nextContent = { ...nextContent, attachments };
+    }
+
+    // Descriptor reconciliation: a field that is now small, absent, or no
+    // longer segmented must lose its descriptor so the transactional retirement
+    // below deletes its now-unreferenced segment generation. Without this, a
+    // large->small replacement would keep serving the retired generation.
+    // Liveness keys off the PLANS (the post-planning inline text is the small
+    // marker, not the source, so content size alone cannot decide).
+    const liveFields = new Set<string>();
+    for (const plan of plans) {
+      liveFields.add(
+        plan.field.kind === "content.text"
+          ? "content.text"
+          : `attachment.text:${plan.field.attachmentId}`,
+      );
+    }
+    const segmentationMeta = metadata.segmentation;
+    if (
+      segmentationMeta &&
+      typeof segmentationMeta === "object" &&
+      Object.keys(segmentationMeta).length > 0
+    ) {
+      const kept: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(
+        segmentationMeta as Record<string, unknown>,
+      )) {
+        if (liveFields.has(key)) kept[key] = value;
+      }
+      metadata = { ...metadata, segmentation: kept };
     }
     return { content: nextContent, metadata, plans };
   }

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -741,7 +741,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
   public abstract withEntityContext<T>(
     entityId: UUID | null,
-    callback: (tx: DrizzleDatabase) => Promise<T>
+    callback: (tx: DrizzleDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T>;
 
   public abstract init(): Promise<void>;
@@ -4097,52 +4098,60 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async getMemoryContentPage(
     params: MemoryContentPageParams
   ): Promise<MemoryContentPageResult | null> {
-    return this.withEntityContext(params.accessContext?.requesterEntityId ?? null, async (tx) => {
-      // #25140 review R2: when an access context is supplied, authorize the
-      // parent row with the SAME pushed-down conditions getMemories uses —
-      // ANDed into every parent read INSIDE the page-read snapshot, so the
-      // authorization decision and the page bytes come from one repeatable-read
-      // snapshot. An ineligible caller gets null (no descriptor leak), never
-      // page bytes; a concurrently revoked room cannot slip a page through
-      // between an authorization check and the read.
-      const authorization = params.accessContext
-        ? and(
-            eq(memoryTable.id, params.memoryId),
-            ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
-          )
-        : undefined;
-      return readMemoryContentPage({
-        db: tx,
-        memoryId: params.memoryId,
-        field: params.field as import("@elizaos/core").MemorySegmentField,
-        byteStart: params.byteStart,
-        ...(params.byteLimit === undefined ? {} : { byteLimit: params.byteLimit }),
-        ...(params.expectedRevision === undefined
-          ? {}
-          : { expectedRevision: params.expectedRevision }),
-        ...(authorization === undefined ? {} : { parentAuthorization: authorization }),
-      });
-    });
+    return this.withEntityContext(
+      params.accessContext?.requesterEntityId ?? null,
+      async (tx) => {
+        // #25140 review R2: when an access context is supplied, authorize the
+        // parent row with the SAME pushed-down conditions getMemories uses —
+        // ANDed into every parent read INSIDE the page-read snapshot, so the
+        // authorization decision and the page bytes come from one repeatable-read
+        // snapshot. An ineligible caller gets null (no descriptor leak), never
+        // page bytes; a concurrently revoked room cannot slip a page through
+        // between an authorization check and the read.
+        const authorization = params.accessContext
+          ? and(
+              eq(memoryTable.id, params.memoryId),
+              ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
+            )
+          : undefined;
+        return readMemoryContentPage({
+          db: tx,
+          memoryId: params.memoryId,
+          field: params.field as import("@elizaos/core").MemorySegmentField,
+          byteStart: params.byteStart,
+          ...(params.byteLimit === undefined ? {} : { byteLimit: params.byteLimit }),
+          ...(params.expectedRevision === undefined
+            ? {}
+            : { expectedRevision: params.expectedRevision }),
+          ...(authorization === undefined ? {} : { parentAuthorization: authorization }),
+        });
+      },
+      { isolationLevel: "repeatable read" }
+    );
   }
 
   /** Explicit authorized migration for one legacy large inline field (#25140). */
   async reindexMemoryContent(
     params: MemoryContentReindexParams
   ): Promise<MemoryContentReindexResult> {
-    return this.withEntityContext(params.accessContext.requesterEntityId, async (tx) => {
-      const authorization =
-        and(
-          eq(memoryTable.id, params.memoryId),
-          ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
-        ) ?? sql`false`;
-      return reindexMemoryContent({
-        db: tx,
-        memoryId: params.memoryId,
-        field: params.field as import("@elizaos/core").MemorySegmentField,
-        maxSourceBytes: params.maxSourceBytes,
-        parentAuthorization: authorization,
-      });
-    });
+    return this.withEntityContext(
+      params.accessContext.requesterEntityId,
+      async (tx) => {
+        const authorization =
+          and(
+            eq(memoryTable.id, params.memoryId),
+            ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
+          ) ?? sql`false`;
+        return reindexMemoryContent({
+          db: tx,
+          memoryId: params.memoryId,
+          field: params.field as import("@elizaos/core").MemorySegmentField,
+          maxSourceBytes: params.maxSourceBytes,
+          parentAuthorization: authorization,
+        });
+      },
+      { isolationLevel: "repeatable read" }
+    );
   }
 
   private async resolveMemoryUniqueness(

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -4095,23 +4095,19 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     params: MemoryContentPageParams
   ): Promise<MemoryContentPageResult | null> {
     return this.withDatabase(async () => {
-      // #25140 review: when an access context is supplied, authorize the
-      // parent row with the SAME pushed-down conditions getMemories uses, so
-      // every page reauthorizes at the storage boundary — an ineligible caller
-      // gets null (no descriptor leak), never page bytes.
-      if (params.accessContext) {
-        const authorized = await this.db
-          .select({ id: memoryTable.id })
-          .from(memoryTable)
-          .where(
-            and(
-              eq(memoryTable.id, params.memoryId),
-              ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
-            )
+      // #25140 review R2: when an access context is supplied, authorize the
+      // parent row with the SAME pushed-down conditions getMemories uses —
+      // ANDed into every parent read INSIDE the page-read snapshot, so the
+      // authorization decision and the page bytes come from one repeatable-read
+      // snapshot. An ineligible caller gets null (no descriptor leak), never
+      // page bytes; a concurrently revoked room cannot slip a page through
+      // between an authorization check and the read.
+      const authorization = params.accessContext
+        ? and(
+            eq(memoryTable.id, params.memoryId),
+            ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
           )
-          .limit(1);
-        if (authorized.length === 0) return null;
-      }
+        : undefined;
       return readMemoryContentPage({
         db: this.db,
         memoryId: params.memoryId,
@@ -4121,6 +4117,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         ...(params.expectedRevision === undefined
           ? {}
           : { expectedRevision: params.expectedRevision }),
+        ...(authorization === undefined ? {} : { parentAuthorization: authorization }),
       });
     });
   }
@@ -4215,23 +4212,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       };
     }
     const seenAttachmentIds = new Set<string>();
+    // Indexes (into the mapped attachments array) of entries that were
+    // segmented; the ONLY reliable discriminator between the segmented entry
+    // and a small entry reusing its id.
+    const segmentedIndexes = new Set<number>();
     if (Array.isArray(content.attachments) && content.attachments.length > 0) {
-      // Track EVERY attachment id (small or large): a small attachment sharing
-      // an id with a segmented one would make the owner-bound descriptor key
-      // ambiguous for readers resolving attachment.text:<id>.
-      const allAttachmentIds = new Set<string>();
-      for (const attachment of content.attachments) {
-        if (
-          attachment &&
-          typeof attachment === "object" &&
-          typeof (attachment as { id?: unknown }).id === "string"
-        ) {
-          const rawId = (attachment as { id: string }).id;
-          if (rawId.trim()) allAttachmentIds.add(rawId.trim());
-        }
-      }
       let changed = false;
+      let index = -1;
       const attachments = content.attachments.map((attachment) => {
+        index += 1;
         if (
           attachment &&
           typeof attachment === "object" &&
@@ -4264,6 +4253,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             );
           }
           seenAttachmentIds.add(id);
+          segmentedIndexes.add(index);
           const field = { kind: "attachment.text", attachmentId: id } as const;
           const text = (attachment as { text: string }).text;
           // Store the trimmed id back on the attachment so the descriptor key
@@ -4277,15 +4267,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         }
         return attachment;
       });
-      // A small attachment reusing a segmented id is equally ambiguous. Skip
-      // the segmented entries themselves: their text is now the published
-      // marker (small by design), so they are not "small attachments".
+      // A small attachment reusing a segmented id is equally ambiguous for the
+      // owner-bound descriptor key; fail closed. segmentedIndexes is the only
+      // reliable discriminator: after the map, a segmented entry's text is the
+      // small published marker, so shape checks cannot tell them apart.
+      let sweepIndex = -1;
       for (const attachment of attachments) {
+        sweepIndex += 1;
+        if (segmentedIndexes.has(sweepIndex)) continue;
         if (
           attachment &&
           typeof attachment === "object" &&
-          typeof (attachment as { id?: unknown }).id === "string" &&
-          !seenAttachmentIds.has((attachment as { id: string }).id.trim())
+          typeof (attachment as { id?: unknown }).id === "string"
         ) {
           const id = (attachment as { id: string }).id.trim();
           if (id && seenAttachmentIds.has(id)) {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -67,6 +67,8 @@ import {
   type MemoryContentField,
   type MemoryContentPageParams,
   type MemoryContentPageResult,
+  type MemoryContentReindexParams,
+  type MemoryContentReindexResult,
   type MemoryMetadata,
   type MessageSearchHit,
   type Metadata,
@@ -683,6 +685,7 @@ import {
   mergeSegmentationMetadata,
   planSegmentedField,
   readMemoryContentPage,
+  reindexMemoryContent,
   retireStaleGenerationsInTransaction,
 } from "./stores/memoryTextSegments.store";
 import type { StoreContext } from "./stores/types";
@@ -4094,7 +4097,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async getMemoryContentPage(
     params: MemoryContentPageParams
   ): Promise<MemoryContentPageResult | null> {
-    return this.withDatabase(async () => {
+    return this.withEntityContext(params.accessContext?.requesterEntityId ?? null, async (tx) => {
       // #25140 review R2: when an access context is supplied, authorize the
       // parent row with the SAME pushed-down conditions getMemories uses —
       // ANDed into every parent read INSIDE the page-read snapshot, so the
@@ -4109,7 +4112,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           )
         : undefined;
       return readMemoryContentPage({
-        db: this.db,
+        db: tx,
         memoryId: params.memoryId,
         field: params.field as import("@elizaos/core").MemorySegmentField,
         byteStart: params.byteStart,
@@ -4118,6 +4121,26 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           ? {}
           : { expectedRevision: params.expectedRevision }),
         ...(authorization === undefined ? {} : { parentAuthorization: authorization }),
+      });
+    });
+  }
+
+  /** Explicit authorized migration for one legacy large inline field (#25140). */
+  async reindexMemoryContent(
+    params: MemoryContentReindexParams
+  ): Promise<MemoryContentReindexResult> {
+    return this.withEntityContext(params.accessContext.requesterEntityId, async (tx) => {
+      const authorization =
+        and(
+          eq(memoryTable.id, params.memoryId),
+          ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
+        ) ?? sql`false`;
+      return reindexMemoryContent({
+        db: tx,
+        memoryId: params.memoryId,
+        field: params.field as import("@elizaos/core").MemorySegmentField,
+        maxSourceBytes: params.maxSourceBytes,
+        parentAuthorization: authorization,
       });
     });
   }

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -683,7 +683,6 @@ import {
   mergeSegmentationMetadata,
   planSegmentedField,
   readMemoryContentPage,
-  readSegmentationDescriptors,
   retireStaleGenerationsInTransaction,
 } from "./stores/memoryTextSegments.store";
 import type { StoreContext } from "./stores/types";
@@ -4095,8 +4094,25 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async getMemoryContentPage(
     params: MemoryContentPageParams
   ): Promise<MemoryContentPageResult | null> {
-    return this.withDatabase(() =>
-      readMemoryContentPage({
+    return this.withDatabase(async () => {
+      // #25140 review: when an access context is supplied, authorize the
+      // parent row with the SAME pushed-down conditions getMemories uses, so
+      // every page reauthorizes at the storage boundary — an ineligible caller
+      // gets null (no descriptor leak), never page bytes.
+      if (params.accessContext) {
+        const authorized = await this.db
+          .select({ id: memoryTable.id })
+          .from(memoryTable)
+          .where(
+            and(
+              eq(memoryTable.id, params.memoryId),
+              ...memoryAccessContextConditions(params.accessContext, this.agentId, "messages")
+            )
+          )
+          .limit(1);
+        if (authorized.length === 0) return null;
+      }
+      return readMemoryContentPage({
         db: this.db,
         memoryId: params.memoryId,
         field: params.field as import("@elizaos/core").MemorySegmentField,
@@ -4105,8 +4121,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         ...(params.expectedRevision === undefined
           ? {}
           : { expectedRevision: params.expectedRevision }),
-      })
-    );
+      });
+    });
   }
 
   private async resolveMemoryUniqueness(
@@ -4200,6 +4216,20 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     }
     const seenAttachmentIds = new Set<string>();
     if (Array.isArray(content.attachments) && content.attachments.length > 0) {
+      // Track EVERY attachment id (small or large): a small attachment sharing
+      // an id with a segmented one would make the owner-bound descriptor key
+      // ambiguous for readers resolving attachment.text:<id>.
+      const allAttachmentIds = new Set<string>();
+      for (const attachment of content.attachments) {
+        if (
+          attachment &&
+          typeof attachment === "object" &&
+          typeof (attachment as { id?: unknown }).id === "string"
+        ) {
+          const rawId = (attachment as { id: string }).id;
+          if (rawId.trim()) allAttachmentIds.add(rawId.trim());
+        }
+      }
       let changed = false;
       const attachments = content.attachments.map((attachment) => {
         if (
@@ -4209,11 +4239,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           shouldSegmentContent((attachment as { text: string }).text)
         ) {
           changed = true;
-          const id =
-            typeof (attachment as { id?: unknown }).id === "string" &&
-            (attachment as { id: string }).id.trim()
-              ? (attachment as { id: string }).id.trim()
+          const rawId =
+            typeof (attachment as { id?: unknown }).id === "string"
+              ? (attachment as { id: string }).id
               : "";
+          const id = rawId.trim();
           if (!id) {
             // A large attachment text without a stable id cannot be given an
             // owner-bound locator; fail closed rather than leave it inline.
@@ -4221,7 +4251,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               "Large attachment text requires a non-empty attachment id for segmented storage",
               {
                 code: "MEMORY_SEGMENT_ATTACHMENT_ID_REQUIRED",
-              },
+              }
             );
           }
           if (seenAttachmentIds.has(id)) {
@@ -4230,19 +4260,45 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               {
                 code: "MEMORY_SEGMENT_ATTACHMENT_ID_CONFLICT",
                 context: { attachmentId: id },
-              },
+              }
             );
           }
           seenAttachmentIds.add(id);
           const field = { kind: "attachment.text", attachmentId: id } as const;
           const text = (attachment as { text: string }).text;
+          // Store the trimmed id back on the attachment so the descriptor key
+          // (`attachment.text:<trimmed>`) matches the stored attachment id the
+          // reader resolves; a padded id would otherwise break owner lookup.
           return {
             ...attachment,
+            ...(rawId !== id ? { id } : {}),
             text: planField(field, text),
           };
         }
         return attachment;
       });
+      // A small attachment reusing a segmented id is equally ambiguous. Skip
+      // the segmented entries themselves: their text is now the published
+      // marker (small by design), so they are not "small attachments".
+      for (const attachment of attachments) {
+        if (
+          attachment &&
+          typeof attachment === "object" &&
+          typeof (attachment as { id?: unknown }).id === "string" &&
+          !seenAttachmentIds.has((attachment as { id: string }).id.trim())
+        ) {
+          const id = (attachment as { id: string }).id.trim();
+          if (id && seenAttachmentIds.has(id)) {
+            throw new ElizaError(
+              "Attachment id collides with a segmented attachment on the same memory",
+              {
+                code: "MEMORY_SEGMENT_ATTACHMENT_ID_CONFLICT",
+                context: { attachmentId: id },
+              }
+            );
+          }
+        }
+      }
       if (changed) nextContent = { ...nextContent, attachments };
     }
 
@@ -4257,7 +4313,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       liveFields.add(
         plan.field.kind === "content.text"
           ? "content.text"
-          : `attachment.text:${plan.field.attachmentId}`,
+          : `attachment.text:${plan.field.attachmentId}`
       );
     }
     const segmentationMeta = metadata.segmentation;
@@ -4267,9 +4323,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       Object.keys(segmentationMeta).length > 0
     ) {
       const kept: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(
-        segmentationMeta as Record<string, unknown>,
-      )) {
+      for (const [key, value] of Object.entries(segmentationMeta as Record<string, unknown>)) {
         if (liveFields.has(key)) kept[key] = value;
       }
       metadata = { ...metadata, segmentation: kept };
@@ -4424,8 +4478,34 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               })
               .where(eq(memoryTable.id, memory.id));
           } else if (memory.metadata) {
-            // Update only metadata if content is not provided
-            const metadataToUpdate = serializeJsonb(memory.metadata);
+            // Update only metadata if content is not provided. The reserved
+            // `segmentation` block is authoritative storage state owned by the
+            // adapter (#25140): a caller's metadata-only update cannot drop or
+            // rewrite descriptors — that would orphan live generations or lie
+            // about segmented fields. Merge the stored segmentation through.
+            const existingMetaRow = (
+              await tx
+                .select({ metadata: memoryTable.metadata })
+                .from(memoryTable)
+                .where(eq(memoryTable.id, memory.id))
+                .limit(1)
+            )[0]?.metadata;
+            const storedSegmentation =
+              existingMetaRow &&
+              typeof existingMetaRow === "object" &&
+              (existingMetaRow as { segmentation?: unknown }).segmentation
+                ? (existingMetaRow as { segmentation?: unknown }).segmentation
+                : undefined;
+            const callerMetadata =
+              typeof memory.metadata === "object" && memory.metadata !== null
+                ? { ...(memory.metadata as Record<string, unknown>) }
+                : {};
+            if (storedSegmentation !== undefined) {
+              callerMetadata.segmentation = storedSegmentation;
+            } else {
+              delete callerMetadata.segmentation;
+            }
+            const metadataToUpdate = serializeJsonb(callerMetadata);
 
             await tx
               .update(memoryTable)

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -4218,9 +4218,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     const segmentedIndexes = new Set<number>();
     if (Array.isArray(content.attachments) && content.attachments.length > 0) {
       let changed = false;
-      let index = -1;
-      const attachments = content.attachments.map((attachment) => {
-        index += 1;
+      const attachments = content.attachments.map((attachment, index) => {
         if (
           attachment &&
           typeof attachment === "object" &&

--- a/plugins/plugin-sql/src/neon/adapter.ts
+++ b/plugins/plugin-sql/src/neon/adapter.ts
@@ -47,11 +47,13 @@ export class NeonDatabaseAdapter extends BaseDrizzleAdapter {
 
   public async withEntityContext<T>(
     entityId: UUID | null,
-    callback: (tx: DrizzleDatabase) => Promise<T>
+    callback: (tx: DrizzleDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T> {
     return this.manager.withIsolationContext(
       entityId,
-      callback as (tx: NeonDatabase) => Promise<T>
+      callback as (tx: NeonDatabase) => Promise<T>,
+      options
     );
   }
 
@@ -60,9 +62,10 @@ export class NeonDatabaseAdapter extends BaseDrizzleAdapter {
    */
   public async withIsolationContext<T>(
     entityId: UUID | null,
-    callback: (tx: NeonDatabase) => Promise<T>
+    callback: (tx: NeonDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T> {
-    return await this.manager.withIsolationContext(entityId, callback);
+    return await this.manager.withIsolationContext(entityId, callback, options);
   }
 
   async getEntityByIds(entityIds: UUID[]): Promise<Entity[] | null> {

--- a/plugins/plugin-sql/src/neon/manager.ts
+++ b/plugins/plugin-sql/src/neon/manager.ts
@@ -85,7 +85,8 @@ export class NeonConnectionManager {
    */
   public async withIsolationContext<T>(
     entityId: UUID | null,
-    callback: (tx: NeonDatabase) => Promise<T>
+    callback: (tx: NeonDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T> {
     const dataIsolationEnabled = process.env.ENABLE_DATA_ISOLATION === "true";
 
@@ -106,7 +107,7 @@ export class NeonConnectionManager {
       }
 
       return await callback(tx as NeonDatabase);
-    });
+    }, options);
   }
 
   /**

--- a/plugins/plugin-sql/src/pg/adapter.ts
+++ b/plugins/plugin-sql/src/pg/adapter.ts
@@ -44,9 +44,10 @@ export class PgDatabaseAdapter extends BaseDrizzleAdapter {
 
   public async withEntityContext<T>(
     entityId: UUID | null,
-    callback: (tx: NodePgDatabase) => Promise<T>
+    callback: (tx: NodePgDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T> {
-    return await this.manager.withEntityContext(entityId, callback);
+    return await this.manager.withEntityContext(entityId, callback, options);
   }
 
   async getEntityByIds(entityIds: UUID[]): Promise<Entity[] | null> {

--- a/plugins/plugin-sql/src/pg/manager.ts
+++ b/plugins/plugin-sql/src/pg/manager.ts
@@ -135,7 +135,8 @@ export class PostgresConnectionManager {
 
   public async withEntityContext<T>(
     entityId: UUID | null,
-    callback: (tx: NodePgDatabase) => Promise<T>
+    callback: (tx: NodePgDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T> {
     if (this.isShuttingDown()) {
       throw new Error("Database pool is shutting down - operation rejected");
@@ -170,7 +171,7 @@ export class PostgresConnectionManager {
       }
 
       return await callback(tx);
-    });
+    }, options);
   }
 
   public async close(): Promise<void> {

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -55,9 +55,10 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
 
   public async withEntityContext<T>(
     _entityId: UUID | null,
-    callback: (tx: PgliteDatabase) => Promise<T>
+    callback: (tx: PgliteDatabase) => Promise<T>,
+    options?: { isolationLevel?: "repeatable read" }
   ): Promise<T> {
-    return this.db.transaction(callback);
+    return this.db.transaction(callback, options);
   }
 
   async getEntityByIds(entityIds: UUID[]): Promise<Entity[] | null> {

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -51,6 +51,7 @@ export {
 } from "./membershipAuthority";
 export { memoryTable } from "./memory";
 export { memoryAccessLogs } from "./memoryAccessLogs";
+export { memoryTextSegmentTable } from "./memoryTextSegments";
 export { messageTable } from "./message";
 export { messageServerTable } from "./messageServer";
 export { messageServerAgentsTable } from "./messageServerAgent";

--- a/plugins/plugin-sql/src/schema/memoryTextSegments.ts
+++ b/plugins/plugin-sql/src/schema/memoryTextSegments.ts
@@ -39,18 +39,11 @@ export const memoryTextSegmentTable = pgTable(
     primaryKey({
       columns: [table.parentId, table.generation, table.segmentIndex],
     }),
-    index("idx_memory_text_segments_range").on(
-      table.parentId,
-      table.generation,
-      table.byteStart,
-    ),
+    index("idx_memory_text_segments_range").on(table.parentId, table.generation, table.byteStart),
     check(
       "memory_text_segment_range_check",
-      sql`${table.byteStart} >= 0 AND ${table.byteEnd} > ${table.byteStart}`,
+      sql`${table.byteStart} >= 0 AND ${table.byteEnd} > ${table.byteStart}`
     ),
-    check(
-      "memory_text_segment_digest_check",
-      sql`char_length(${table.segmentSha256}) = 64`,
-    ),
-  ],
+    check("memory_text_segment_digest_check", sql`char_length(${table.segmentSha256}) = 64`),
+  ]
 );

--- a/plugins/plugin-sql/src/schema/memoryTextSegments.ts
+++ b/plugins/plugin-sql/src/schema/memoryTextSegments.ts
@@ -1,0 +1,56 @@
+/**
+ * Immutable UTF-8 source segments for bounded native paging of large stored
+ * MESSAGE text and extracted ATTACHMENT text (#25140). A segmented parent
+ * memory keeps only a bounded descriptor in its metadata; the source bytes
+ * live exclusively here as non-overlapping rows keyed by the immutable
+ * generation. Rows cascade with their parent and are never returned by
+ * generic memory list/search paths. This stores extracted text only — it is
+ * not a second attachment/media byte store.
+ */
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  check,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { memoryTable } from "./memory";
+
+export const memoryTextSegmentTable = pgTable(
+  "memory_text_segments",
+  {
+    parentId: uuid("parent_id")
+      .notNull()
+      .references(() => memoryTable.id, { onDelete: "cascade" }),
+    /** Immutable generation identity; a replacement mints a new one. */
+    generation: uuid("generation").notNull(),
+    segmentIndex: integer("segment_index").notNull(),
+    byteStart: bigint("byte_start", { mode: "number" }).notNull(),
+    /** Exclusive byte end; contiguity is validated at publication time. */
+    byteEnd: bigint("byte_end", { mode: "number" }).notNull(),
+    text: text("text").notNull(),
+    segmentSha256: text("segment_sha256").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.parentId, table.generation, table.segmentIndex],
+    }),
+    index("idx_memory_text_segments_range").on(
+      table.parentId,
+      table.generation,
+      table.byteStart,
+    ),
+    check(
+      "memory_text_segment_range_check",
+      sql`${table.byteStart} >= 0 AND ${table.byteEnd} > ${table.byteStart}`,
+    ),
+    check(
+      "memory_text_segment_digest_check",
+      sql`char_length(${table.segmentSha256}) = 64`,
+    ),
+  ],
+);

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -206,10 +206,16 @@ export async function reindexMemoryContent(params: {
         context: { memoryId: params.memoryId },
       });
     }
-    const totalBytes = Number(parent.field_bytes);
-    if (!Number.isSafeInteger(totalBytes)) {
+    if (parent.field_bytes === null) {
       throw new ElizaError("Attachment locator is missing or ambiguous", {
         code: "MEMORY_CONTENT_REINDEX_FIELD_NOT_FOUND",
+        context: { memoryId: params.memoryId },
+      });
+    }
+    const totalBytes = Number(parent.field_bytes);
+    if (!Number.isSafeInteger(totalBytes)) {
+      throw new ElizaError("Legacy content byte length is invalid", {
+        code: "MEMORY_CONTENT_REINDEX_SOURCE_DRIFT",
         context: { memoryId: params.memoryId },
       });
     }

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -1,0 +1,376 @@
+/**
+ * Segmented-content store for the `memory_text_segments` table (#25140):
+ * atomic publication of immutable UTF-8 source segments alongside a bounded
+ * parent descriptor, generation-fenced replacement, and authorized byte-window
+ * page reads that never materialize the parent content or join embeddings.
+ * Consumed by BaseDrizzleAdapter; segmented parents carry their descriptors in
+ * `metadata.segmentation[<fieldKey>]`, never the source bytes.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  buildSegmentationRevision,
+  type ComputedMemorySegment,
+  clampPageWindow,
+  ElizaError,
+  encodeUtf8Strict,
+  type MemorySegmentField,
+  memorySegmentFieldKey,
+  segmentMemoryContent,
+  type UUID,
+} from "@elizaos/core";
+import { and, asc, eq, gt, lt, sql } from "drizzle-orm";
+import { memoryTextSegmentTable } from "../schema/index";
+import type { DrizzleDatabase } from "../types";
+
+/** Serialized descriptor row shape as stored on parent metadata. */
+export interface StoredSegmentationDescriptor {
+  v: 1;
+  field: MemorySegmentField;
+  encoding: "utf-8";
+  segmentBytes: number;
+  totalBytes: number;
+  totalSha256: string;
+  segmentCount: number;
+  generation: string;
+  revision: string;
+}
+
+type ParentRow = {
+  id: UUID;
+  entityId: UUID | null;
+  roomId: UUID | null;
+  worldId: UUID | null;
+  agentId: UUID;
+  metadata: unknown;
+};
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function readDescriptors(
+  metadata: unknown,
+): Map<string, StoredSegmentationDescriptor> {
+  const out = new Map<string, StoredSegmentationDescriptor>();
+  if (!metadata || typeof metadata !== "object") return out;
+  const segmentation = (metadata as { segmentation?: unknown }).segmentation;
+  if (!segmentation || typeof segmentation !== "object") return out;
+  for (const [key, value] of Object.entries(
+    segmentation as Record<string, unknown>,
+  )) {
+    if (
+      value &&
+      typeof value === "object" &&
+      (value as { v?: unknown }).v === 1
+    ) {
+      out.set(key, value as StoredSegmentationDescriptor);
+    }
+  }
+  return out;
+}
+
+/**
+ * Splits `text` and inserts the bounded parent descriptor + all generation
+ * segments for `field` inside the caller's transaction. The caller MUST write
+ * the returned metadata onto the parent row in the SAME transaction (or pass a
+ * parent that already carries it), so failure leaves neither parent nor
+ * orphaned segments. When the parent already carries a descriptor for this
+ * field, a fresh generation replaces it and prior-generation rows for this
+ * parent are deleted in the same transaction.
+ *
+ * Returns the metadata object the parent row must persist.
+ */
+export async function publishSegmentedFieldInTransaction(params: {
+  tx: DrizzleDatabase;
+  parentId: UUID;
+  entityId: UUID | null;
+  field: MemorySegmentField;
+  text: string;
+  existingMetadata: unknown;
+  segmentBytes?: number;
+}): Promise<Record<string, unknown>> {
+  const { tx, parentId, field, text } = params;
+  const metadata =
+    params.existingMetadata && typeof params.existingMetadata === "object"
+      ? { ...(params.existingMetadata as Record<string, unknown>) }
+      : {};
+  const segmentation = {
+    ...((metadata.segmentation as Record<string, unknown> | undefined) ?? {}),
+  };
+
+  const descriptors = readDescriptors(metadata);
+  const prior = descriptors.get(memorySegmentFieldKey(field));
+
+  const computed = segmentMemoryContent(text, field, {
+    ...(params.segmentBytes ? { segmentBytes: params.segmentBytes } : {}),
+    // A fresh generation every publication keeps immutability even if the
+    // text is byte-identical to the prior generation.
+  });
+
+  // Generation UUID must be a valid uuid for the column; segmentMemoryContent
+  // mints one via randomUUID.
+  await insertSegments(
+    tx,
+    parentId,
+    computed.segments,
+    computed.descriptor.generation,
+  );
+
+  segmentation[memorySegmentFieldKey(field)] = computed.descriptor;
+  metadata.segmentation = segmentation;
+
+  // Retire prior generations of this parent (any field) atomically with the
+  // new publication: delete every segment row not belonging to a live
+  // descriptor generation after the parent metadata update is staged.
+  const liveGenerations = new Set(
+    [...readDescriptors(metadata).values()].map((d) => d.generation),
+  );
+  await deleteStaleGenerations(
+    tx,
+    parentId,
+    liveGenerations,
+    prior?.generation,
+  );
+
+  return metadata;
+}
+
+async function insertSegments(
+  tx: DrizzleDatabase,
+  parentId: UUID,
+  segments: ComputedMemorySegment[],
+  generation: string,
+): Promise<void> {
+  if (segments.length === 0) return;
+  await tx.insert(memoryTextSegmentTable).values(
+    segments.map((segment) => ({
+      parentId,
+      generation,
+      segmentIndex: segment.index,
+      byteStart: segment.byteStart,
+      byteEnd: segment.byteEnd,
+      text: segment.text,
+      segmentSha256: segment.sha256,
+    })),
+  );
+}
+
+async function deleteStaleGenerations(
+  tx: DrizzleDatabase,
+  parentId: UUID,
+  liveGenerations: Set<string>,
+  priorGeneration?: string,
+): Promise<void> {
+  // Delete rows of any retired generation. With only live generations kept,
+  // the invariant "every segment row belongs to the descriptor's generation"
+  // holds at read time.
+  const live = [...liveGenerations];
+  if (live.length === 0) return;
+  // Guard: prior generation of this field is retired unless it is still live.
+  if (priorGeneration && !live.includes(priorGeneration)) {
+    await tx
+      .delete(memoryTextSegmentTable)
+      .where(
+        and(
+          eq(memoryTextSegmentTable.parentId, parentId),
+          eq(memoryTextSegmentTable.generation, priorGeneration),
+        ),
+      );
+  }
+}
+
+/**
+ * Authorized byte-window page read over a segmented field. Throws typed
+ * ElizaErrors: MEMORY_CONTENT_REINDEX_REQUIRED for legacy large unsegmented
+ * rows, MEMORY_CONTENT_STALE_REVISION for continuation mismatches, and
+ * MEMORY_CONTENT_NOT_SEGMENTED when the field has no descriptor and the
+ * inline value is within the segmentation threshold (caller should fall back
+ * to the ordinary small-row read).
+ */
+export async function readMemoryContentPage(params: {
+  db: DrizzleDatabase;
+  memoryId: UUID;
+  field: MemorySegmentField;
+  byteStart: number;
+  byteLimit?: number;
+  expectedRevision?: string;
+}): Promise<{
+  text: string;
+  start: number;
+  end: number;
+  total: number;
+  sliceSha256: string;
+  sourceSha256: string;
+  revision: string;
+  completeness: "partial-recoverable" | "complete";
+} | null> {
+  const { db, memoryId, field } = params;
+
+  const parentRows = await db.execute(sql`
+    SELECT id, metadata FROM memories WHERE id = ${memoryId} LIMIT 1
+  `);
+  const parentRow = (parentRows.rows as ParentRow[])[0];
+  if (!parentRow) return null;
+
+  const descriptor = readDescriptors(parentRow.metadata).get(
+    memorySegmentFieldKey(field),
+  );
+
+  if (!descriptor) {
+    // No descriptor: either the row is small (caller falls back to the normal
+    // read) or it is a legacy large unsegmented row (typed reindex error).
+    const inlineBytes = await db.execute(sql`
+      SELECT octet_length(COALESCE(content->>'text','')) AS text_bytes,
+             (
+               SELECT COALESCE(sum(octet_length(a->>'text')), 0)
+               FROM jsonb_array_elements(COALESCE(content->'attachments','[]'::jsonb)) a
+               WHERE ${
+                 field.kind === "attachment.text"
+                   ? sql`a->>'id' = ${field.attachmentId}`
+                   : sql`false`
+}
+             ) AS attachment_bytes
+      FROM memories WHERE id = ${memoryId}
+    `);
+    const row = (
+      inlineBytes.rows as Array<{
+        text_bytes: number;
+        attachment_bytes: number;
+      }>
+    )[0];
+    const fieldBytes =
+      field.kind === "attachment.text"
+        ? row?.attachment_bytes
+        : row?.text_bytes;
+    if (fieldBytes !== undefined && fieldBytes > 256 * 1024) {
+      throw new ElizaError(
+        "Legacy large unsegmented content requires an authorized reindex before paged reads",
+        {
+          code: "MEMORY_CONTENT_REINDEX_REQUIRED",
+          context: { memoryId, fieldKind: field.kind, fieldBytes },
+        },
+      );
+    }
+    return null;
+  }
+
+  if (params.byteStart > 0 && !params.expectedRevision) {
+    throw new ElizaError(
+      "Stored-content continuation requires expectedRevision.",
+      {
+        code: "MEMORY_CONTENT_EXPECTED_REVISION_REQUIRED",
+        context: { memoryId },
+      },
+    );
+  }
+  if (
+    params.expectedRevision &&
+    params.expectedRevision !== descriptor.revision
+  ) {
+    throw new ElizaError(
+      "The stored content changed before this page could be read.",
+      {
+        code: "MEMORY_CONTENT_STALE_REVISION",
+        context: { currentRevision: descriptor.revision },
+      },
+    );
+  }
+
+  const window = clampPageWindow(
+    descriptor.totalBytes,
+    params.byteStart,
+    params.byteLimit,
+  );
+
+  // Fetch only segments intersecting the window, ordered by range.
+  const segmentRows = await db
+    .select({
+      byteStart: memoryTextSegmentTable.byteStart,
+      byteEnd: memoryTextSegmentTable.byteEnd,
+      text: memoryTextSegmentTable.text,
+      segmentSha256: memoryTextSegmentTable.segmentSha256,
+    })
+    .from(memoryTextSegmentTable)
+    .where(
+      and(
+        eq(memoryTextSegmentTable.parentId, memoryId),
+        eq(memoryTextSegmentTable.generation, descriptor.generation),
+        // Intersects [window.start, window.end): start < windowEnd AND end > windowStart
+        lt(memoryTextSegmentTable.byteStart, window.end),
+        gt(memoryTextSegmentTable.byteEnd, window.start),
+      ),
+    )
+    .orderBy(asc(memoryTextSegmentTable.byteStart));
+
+  if (segmentRows.length === 0) {
+    throw new ElizaError(
+      "Segmented content descriptor does not match its segment rows",
+      {
+        code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+        context: { memoryId, generation: descriptor.generation },
+      },
+    );
+  }
+
+  // Byte-exact assembly of the window across segment boundaries.
+  const parts: Uint8Array[] = [];
+  for (const row of segmentRows) {
+    const segBytes = encodeUtf8Strict(row.text);
+    if (segBytes.length !== row.byteEnd - row.byteStart) {
+      throw new ElizaError(
+        "Stored segment byte length does not match its range",
+        {
+          code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+          context: {
+            memoryId,
+            generation: descriptor.generation,
+            byteStart: row.byteStart,
+          },
+        },
+      );
+    }
+    if (sha256Hex(segBytes) !== row.segmentSha256) {
+      throw new ElizaError("Stored segment digest does not match its bytes", {
+        code: "MEMORY_SEGMENT_DIGEST_MISMATCH",
+        context: {
+          memoryId,
+          generation: descriptor.generation,
+          byteStart: row.byteStart,
+        },
+      });
+    }
+    const from = Math.max(window.start, row.byteStart) - row.byteStart;
+    const to = Math.min(window.end, row.byteEnd) - row.byteStart;
+    if (to > from) parts.push(segBytes.subarray(from, to));
+  }
+
+  const pageBytes = concatBytes(parts);
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(pageBytes);
+  const end = window.start + pageBytes.length;
+
+  return {
+    text,
+    start: window.start,
+    end,
+    total: descriptor.totalBytes,
+    sliceSha256: sha256Hex(pageBytes),
+    sourceSha256: descriptor.totalSha256,
+    revision: descriptor.revision,
+    completeness:
+      end >= descriptor.totalBytes ? "complete" : "partial-recoverable",
+  };
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+export { buildSegmentationRevision };

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -1,19 +1,20 @@
 /**
  * Segmented-content store for the `memory_text_segments` table (#25140):
- * atomic publication of immutable UTF-8 source segments alongside a bounded
- * parent descriptor, generation-fenced replacement, and authorized byte-window
- * page reads that never materialize the parent content or join embeddings.
- * Consumed by BaseDrizzleAdapter; segmented parents carry their descriptors in
- * `metadata.segmentation[<fieldKey>]`, never the source bytes.
+ * planning of immutable UTF-8 source segments plus a bounded parent
+ * descriptor, transactional publication, generation retirement, and
+ * authorized byte-window page reads that never materialize the parent content
+ * or join embeddings. Consumed by BaseDrizzleAdapter; segmented parents carry
+ * their descriptors in `metadata.segmentation[<fieldKey>]`, never the source
+ * bytes. Not a second attachment/media byte store.
  */
 
 import { createHash } from "node:crypto";
 import {
-  buildSegmentationRevision,
   type ComputedMemorySegment,
   clampPageWindow,
   ElizaError,
   encodeUtf8Strict,
+  MEMORY_PAGE_MAX_BYTES,
   type MemorySegmentField,
   memorySegmentFieldKey,
   segmentMemoryContent,
@@ -38,10 +39,6 @@ export interface StoredSegmentationDescriptor {
 
 type ParentRow = {
   id: UUID;
-  entityId: UUID | null;
-  roomId: UUID | null;
-  worldId: UUID | null;
-  agentId: UUID;
   metadata: unknown;
 };
 
@@ -70,83 +67,55 @@ function readDescriptors(
   return out;
 }
 
-/**
- * Splits `text` and inserts the bounded parent descriptor + all generation
- * segments for `field` inside the caller's transaction. The caller MUST write
- * the returned metadata onto the parent row in the SAME transaction (or pass a
- * parent that already carries it), so failure leaves neither parent nor
- * orphaned segments. When the parent already carries a descriptor for this
- * field, a fresh generation replaces it and prior-generation rows for this
- * parent are deleted in the same transaction.
- *
- * Returns the metadata object the parent row must persist.
- */
-export async function publishSegmentedFieldInTransaction(params: {
-  tx: DrizzleDatabase;
-  parentId: UUID;
-  entityId: UUID | null;
-  field: MemorySegmentField;
-  text: string;
-  existingMetadata: unknown;
-  segmentBytes?: number;
-}): Promise<Record<string, unknown>> {
-  const { tx, parentId, field, text } = params;
+/** Merges a segmentation descriptor into parent metadata (pure). */
+export function mergeSegmentationMetadata(
+  existingMetadata: unknown,
+  descriptor: StoredSegmentationDescriptor,
+): Record<string, unknown> {
   const metadata =
-    params.existingMetadata && typeof params.existingMetadata === "object"
-      ? { ...(params.existingMetadata as Record<string, unknown>) }
+    existingMetadata && typeof existingMetadata === "object"
+      ? { ...(existingMetadata as Record<string, unknown>) }
       : {};
   const segmentation = {
     ...((metadata.segmentation as Record<string, unknown> | undefined) ?? {}),
   };
-
-  const descriptors = readDescriptors(metadata);
-  const prior = descriptors.get(memorySegmentFieldKey(field));
-
-  const computed = segmentMemoryContent(text, field, {
-    ...(params.segmentBytes ? { segmentBytes: params.segmentBytes } : {}),
-    // A fresh generation every publication keeps immutability even if the
-    // text is byte-identical to the prior generation.
-  });
-
-  // Generation UUID must be a valid uuid for the column; segmentMemoryContent
-  // mints one via randomUUID.
-  await insertSegments(
-    tx,
-    parentId,
-    computed.segments,
-    computed.descriptor.generation,
-  );
-
-  segmentation[memorySegmentFieldKey(field)] = computed.descriptor;
+  segmentation[memorySegmentFieldKey(descriptor.field)] = descriptor;
   metadata.segmentation = segmentation;
-
-  // Retire prior generations of this parent (any field) atomically with the
-  // new publication: delete every segment row not belonging to a live
-  // descriptor generation after the parent metadata update is staged.
-  const liveGenerations = new Set(
-    [...readDescriptors(metadata).values()].map((d) => d.generation),
-  );
-  await deleteStaleGenerations(
-    tx,
-    parentId,
-    liveGenerations,
-    prior?.generation,
-  );
-
   return metadata;
 }
 
-async function insertSegments(
-  tx: DrizzleDatabase,
-  parentId: UUID,
-  segments: ComputedMemorySegment[],
-  generation: string,
-): Promise<void> {
-  if (segments.length === 0) return;
-  await tx.insert(memoryTextSegmentTable).values(
-    segments.map((segment) => ({
-      parentId,
-      generation,
+/**
+ * Pure planning pass: computes the immutable segments and the bounded
+ * descriptor for `text`, minting a fresh generation. The caller persists the
+ * parent row (carrying the merged metadata) FIRST, then
+ * `insertSegmentsInTransaction`, both inside one transaction — parent-first
+ * satisfies the FK, and rollback leaves neither parent nor orphaned rows.
+ */
+export function planSegmentedField(params: {
+  field: MemorySegmentField;
+  text: string;
+  segmentBytes?: number;
+}): {
+  segments: ComputedMemorySegment[];
+  descriptor: StoredSegmentationDescriptor;
+} {
+  return segmentMemoryContent(params.text, params.field, {
+    ...(params.segmentBytes ? { segmentBytes: params.segmentBytes } : {}),
+  });
+}
+
+/** Inserts the planned generation's rows. Parent row must already exist. */
+export async function insertSegmentsInTransaction(params: {
+  tx: DrizzleDatabase;
+  parentId: UUID;
+  segments: ComputedMemorySegment[];
+  generation: string;
+}): Promise<void> {
+  if (params.segments.length === 0) return;
+  await params.tx.insert(memoryTextSegmentTable).values(
+    params.segments.map((segment) => ({
+      parentId: params.parentId,
+      generation: params.generation,
       segmentIndex: segment.index,
       byteStart: segment.byteStart,
       byteEnd: segment.byteEnd,
@@ -156,37 +125,44 @@ async function insertSegments(
   );
 }
 
-async function deleteStaleGenerations(
-  tx: DrizzleDatabase,
-  parentId: UUID,
-  liveGenerations: Set<string>,
-  priorGeneration?: string,
-): Promise<void> {
-  // Delete rows of any retired generation. With only live generations kept,
-  // the invariant "every segment row belongs to the descriptor's generation"
-  // holds at read time.
-  const live = [...liveGenerations];
-  if (live.length === 0) return;
-  // Guard: prior generation of this field is retired unless it is still live.
-  if (priorGeneration && !live.includes(priorGeneration)) {
-    await tx
+/**
+ * Deletes every segment generation of this parent that is no longer live in
+ * the (already-updated) parent metadata. Run in the same transaction as the
+ * replacement so retired generations never outlive their descriptor switch.
+ */
+export async function retireStaleGenerationsInTransaction(params: {
+  tx: DrizzleDatabase;
+  parentId: UUID;
+  liveMetadata: unknown;
+}): Promise<void> {
+  const live = [...readDescriptors(params.liveMetadata).values()].map(
+    (descriptor) => descriptor.generation,
+  );
+  if (live.length === 0) {
+    await params.tx
       .delete(memoryTextSegmentTable)
-      .where(
-        and(
-          eq(memoryTextSegmentTable.parentId, parentId),
-          eq(memoryTextSegmentTable.generation, priorGeneration),
-        ),
-      );
+      .where(eq(memoryTextSegmentTable.parentId, params.parentId));
+    return;
   }
+  await params.tx
+    .delete(memoryTextSegmentTable)
+    .where(
+      and(
+        eq(memoryTextSegmentTable.parentId, params.parentId),
+        sql`${memoryTextSegmentTable.generation} NOT IN ${live}`,
+      ),
+    );
 }
 
 /**
  * Authorized byte-window page read over a segmented field. Throws typed
- * ElizaErrors: MEMORY_CONTENT_REINDEX_REQUIRED for legacy large unsegmented
- * rows, MEMORY_CONTENT_STALE_REVISION for continuation mismatches, and
- * MEMORY_CONTENT_NOT_SEGMENTED when the field has no descriptor and the
- * inline value is within the segmentation threshold (caller should fall back
- * to the ordinary small-row read).
+ * ElizaErrors: MEMORY_CONTENT_REINDEX_REQUIRED for legacy unsegmented rows
+ * whose inline field exceeds the hard page ceiling (a single bounded read can
+ * never serve them), MEMORY_CONTENT_STALE_REVISION for continuation
+ * mismatches, and MEMORY_SEGMENT_DESCRIPTOR_DRIFT / DIGEST_MISMATCH for
+ * storage corruption. Returns null when the field has no descriptor and the
+ * inline value fits a bounded page — callers fall back to the ordinary
+ * small-row read.
  */
 export async function readMemoryContentPage(params: {
   db: DrizzleDatabase;
@@ -218,18 +194,16 @@ export async function readMemoryContentPage(params: {
   );
 
   if (!descriptor) {
-    // No descriptor: either the row is small (caller falls back to the normal
-    // read) or it is a legacy large unsegmented row (typed reindex error).
+    const attachmentFilter =
+      field.kind === "attachment.text"
+        ? sql`a->>'id' = ${field.attachmentId}`
+        : sql`false`;
     const inlineBytes = await db.execute(sql`
       SELECT octet_length(COALESCE(content->>'text','')) AS text_bytes,
              (
                SELECT COALESCE(sum(octet_length(a->>'text')), 0)
                FROM jsonb_array_elements(COALESCE(content->'attachments','[]'::jsonb)) a
-               WHERE ${
-                 field.kind === "attachment.text"
-                   ? sql`a->>'id' = ${field.attachmentId}`
-                   : sql`false`
-}
+               WHERE ${attachmentFilter}
              ) AS attachment_bytes
       FROM memories WHERE id = ${memoryId}
     `);
@@ -243,7 +217,7 @@ export async function readMemoryContentPage(params: {
       field.kind === "attachment.text"
         ? row?.attachment_bytes
         : row?.text_bytes;
-    if (fieldBytes !== undefined && fieldBytes > 256 * 1024) {
+    if (fieldBytes !== undefined && fieldBytes > MEMORY_PAGE_MAX_BYTES) {
       throw new ElizaError(
         "Legacy large unsegmented content requires an authorized reindex before paged reads",
         {
@@ -283,7 +257,6 @@ export async function readMemoryContentPage(params: {
     params.byteLimit,
   );
 
-  // Fetch only segments intersecting the window, ordered by range.
   const segmentRows = await db
     .select({
       byteStart: memoryTextSegmentTable.byteStart,
@@ -296,7 +269,6 @@ export async function readMemoryContentPage(params: {
       and(
         eq(memoryTextSegmentTable.parentId, memoryId),
         eq(memoryTextSegmentTable.generation, descriptor.generation),
-        // Intersects [window.start, window.end): start < windowEnd AND end > windowStart
         lt(memoryTextSegmentTable.byteStart, window.end),
         gt(memoryTextSegmentTable.byteEnd, window.start),
       ),
@@ -313,8 +285,13 @@ export async function readMemoryContentPage(params: {
     );
   }
 
-  // Byte-exact assembly of the window across segment boundaries.
-  const parts: Uint8Array[] = [];
+  // Assemble the intersecting segments' full bytes (bounded: the page window
+  // plus at most one segment on each side), verify each segment, then slice
+  // the window with the end snapped back to a UTF-8 code point boundary so a
+  // page never splits a code point and the returned `end` is a valid
+  // continuation offset.
+  const segmentBytes: Uint8Array[] = [];
+  const base = segmentRows[0].byteStart;
   for (const row of segmentRows) {
     const segBytes = encodeUtf8Strict(row.text);
     if (segBytes.length !== row.byteEnd - row.byteStart) {
@@ -340,14 +317,26 @@ export async function readMemoryContentPage(params: {
         },
       });
     }
-    const from = Math.max(window.start, row.byteStart) - row.byteStart;
-    const to = Math.min(window.end, row.byteEnd) - row.byteStart;
-    if (to > from) parts.push(segBytes.subarray(from, to));
+    segmentBytes.push(segBytes);
   }
-
-  const pageBytes = concatBytes(parts);
+  const covered = concatBytes(segmentBytes);
+  let from = window.start - base;
+  let to = Math.min(window.end - base, covered.length);
+  // Snap the end backward off any partial trailing code point.
+  while (to > from && (covered[to] & 0xc0) === 0x80) {
+    to -= 1;
+  }
+  // A caller offset that starts mid-code-point is invalid.
+  if (from > 0 && (covered[from] & 0xc0) === 0x80) {
+    throw new ElizaError("Page byte offset splits a UTF-8 code point", {
+      code: "MEMORY_PAGE_INVALID_OFFSET",
+      context: { memoryId, byteStart: window.start },
+    });
+  }
+  const pageBytes = covered.subarray(from, to);
   const text = new TextDecoder("utf-8", { fatal: true }).decode(pageBytes);
-  const end = window.start + pageBytes.length;
+  const end = base + to;
+  from = 0;
 
   return {
     text,
@@ -372,5 +361,3 @@ function concatBytes(parts: Uint8Array[]): Uint8Array {
   }
   return out;
 }
-
-export { buildSegmentationRevision };

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -21,7 +21,7 @@ import {
   segmentMemoryContent,
   type UUID,
 } from "@elizaos/core";
-import { and, asc, eq, gt, lt, sql } from "drizzle-orm";
+import { and, asc, eq, gt, lt, type SQL, sql } from "drizzle-orm";
 import { memoryTextSegmentTable } from "../schema/index";
 import type { DrizzleDatabase } from "../types";
 
@@ -161,6 +161,14 @@ export async function readMemoryContentPage(params: {
   byteStart: number;
   byteLimit?: number;
   expectedRevision?: string;
+  /**
+   * Raw authorization predicate over the memories table (aliased SQL, no
+   * table prefix). When supplied it is ANDed into EVERY parent-row read inside
+   * the repeatable-read snapshot, so the authorization decision and the page
+   * bytes come from one consistent read — access revoked concurrently cannot
+   * slip a page through between the two.
+   */
+  parentAuthorization?: SQL;
 }): Promise<{
   text: string;
   start: number;
@@ -172,6 +180,7 @@ export async function readMemoryContentPage(params: {
   completeness: "partial-recoverable" | "complete";
 } | null> {
   const { db, memoryId, field } = params;
+  const authz = params.parentAuthorization ? sql` AND (${params.parentAuthorization})` : sql``;
 
   // Snapshot consistency (#25140 review): the descriptor (parent row) and the
   // segment rows must be read under one repeatable-read snapshot so a
@@ -180,7 +189,7 @@ export async function readMemoryContentPage(params: {
   return await db.transaction(
     async (tx) => {
       const parentRows = await tx.execute(sql`
-    SELECT id, metadata, content FROM memories WHERE id = ${memoryId} LIMIT 1
+    SELECT id, metadata, content FROM memories WHERE id = ${memoryId}${authz} LIMIT 1
   `);
       const parentRow = (
         parentRows.rows as Array<{ id: UUID; metadata: unknown; content: unknown }>
@@ -229,7 +238,7 @@ export async function readMemoryContentPage(params: {
                FROM jsonb_array_elements(COALESCE(content->'attachments','[]'::jsonb)) a
                WHERE ${attachmentFilter}
              ) AS attachment_bytes
-      FROM memories WHERE id = ${memoryId}
+      FROM memories WHERE id = ${memoryId}${authz}
     `);
         const row = (
           inlineBytes.rows as Array<{

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -38,30 +38,17 @@ export interface StoredSegmentationDescriptor {
   revision: string;
 }
 
-type ParentRow = {
-  id: UUID;
-  metadata: unknown;
-};
-
 function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-function readDescriptors(
-  metadata: unknown,
-): Map<string, StoredSegmentationDescriptor> {
+function readDescriptors(metadata: unknown): Map<string, StoredSegmentationDescriptor> {
   const out = new Map<string, StoredSegmentationDescriptor>();
   if (!metadata || typeof metadata !== "object") return out;
   const segmentation = (metadata as { segmentation?: unknown }).segmentation;
   if (!segmentation || typeof segmentation !== "object") return out;
-  for (const [key, value] of Object.entries(
-    segmentation as Record<string, unknown>,
-  )) {
-    if (
-      value &&
-      typeof value === "object" &&
-      (value as { v?: unknown }).v === 1
-    ) {
+  for (const [key, value] of Object.entries(segmentation as Record<string, unknown>)) {
+    if (value && typeof value === "object" && (value as { v?: unknown }).v === 1) {
       out.set(key, value as StoredSegmentationDescriptor);
     }
   }
@@ -73,7 +60,7 @@ export { readDescriptors as readSegmentationDescriptors };
 /** Merges a segmentation descriptor into parent metadata (pure). */
 export function mergeSegmentationMetadata(
   existingMetadata: unknown,
-  descriptor: StoredSegmentationDescriptor,
+  descriptor: StoredSegmentationDescriptor
 ): Record<string, unknown> {
   const metadata =
     existingMetadata && typeof existingMetadata === "object"
@@ -124,7 +111,7 @@ export async function insertSegmentsInTransaction(params: {
       byteEnd: segment.byteEnd,
       text: segment.text,
       segmentSha256: segment.sha256,
-    })),
+    }))
   );
 }
 
@@ -139,7 +126,7 @@ export async function retireStaleGenerationsInTransaction(params: {
   liveMetadata: unknown;
 }): Promise<void> {
   const live = [...readDescriptors(params.liveMetadata).values()].map(
-    (descriptor) => descriptor.generation,
+    (descriptor) => descriptor.generation
   );
   if (live.length === 0) {
     await params.tx
@@ -152,8 +139,8 @@ export async function retireStaleGenerationsInTransaction(params: {
     .where(
       and(
         eq(memoryTextSegmentTable.parentId, params.parentId),
-        sql`${memoryTextSegmentTable.generation} NOT IN ${live}`,
-      ),
+        sql`${memoryTextSegmentTable.generation} NOT IN ${live}`
+      )
     );
 }
 
@@ -187,60 +174,55 @@ export async function readMemoryContentPage(params: {
   const { db, memoryId, field } = params;
 
   // Snapshot consistency (#25140 review): the descriptor (parent row) and the
-  // segment rows must be read under one transaction fence so a concurrent
-  // replacement cannot switch the generation between the two reads.
-  return await db.transaction(async (tx) => {
-  const parentRows = await tx.execute(sql`
+  // segment rows must be read under one repeatable-read snapshot so a
+  // concurrent replacement cannot switch the generation between the two reads
+  // (plain READ COMMITTED gives each statement its own snapshot).
+  return await db.transaction(
+    async (tx) => {
+      const parentRows = await tx.execute(sql`
     SELECT id, metadata, content FROM memories WHERE id = ${memoryId} LIMIT 1
   `);
-  const parentRow = (parentRows.rows as Array<{ id: UUID; metadata: unknown; content: unknown }>)[0];
-  if (!parentRow) return null;
+      const parentRow = (
+        parentRows.rows as Array<{ id: UUID; metadata: unknown; content: unknown }>
+      )[0];
+      if (!parentRow) return null;
 
-  const descriptor = readDescriptors(parentRow.metadata).get(
-    memorySegmentFieldKey(field),
-  );
+      const descriptor = readDescriptors(parentRow.metadata).get(memorySegmentFieldKey(field));
 
-  if (descriptor) {
-    // Marker forgery fence: the inline field must carry EXACTLY the canonical
-    // marker for this descriptor. A user-crafted string with the marker
-    // prefix but no matching descriptor never reaches here (no descriptor),
-    // and a stored state where the marker and descriptor disagree is
-    // corruption, not a pageable field.
-    const content =
-      parentRow.content && typeof parentRow.content === "object"
-        ? (parentRow.content as { text?: unknown; attachments?: unknown })
-        : undefined;
-    let inlineText: unknown;
-    if (field.kind === "content.text") {
-      inlineText = content?.text;
-    } else {
-      const attachments = Array.isArray(content?.attachments)
-        ? content.attachments
-        : [];
-      const match = attachments.find(
-        (a) =>
-          a && typeof a === "object" && (a as { id?: unknown }).id === field.attachmentId,
-      );
-      inlineText = match && typeof match === "object" ? (match as { text?: unknown }).text : undefined;
-    }
-    const expectedMarker = buildSegmentedContentMarker(descriptor);
-    if (inlineText !== expectedMarker) {
-      throw new ElizaError(
-        "Segmented field inline marker does not match its descriptor",
-        {
-          code: "MEMORY_SEGMENT_MARKER_MISMATCH",
-          context: { memoryId, fieldKey: memorySegmentFieldKey(field) },
-        },
-      );
-    }
-  }
+      if (descriptor) {
+        // Marker forgery fence: the inline field must carry EXACTLY the canonical
+        // marker for this descriptor. A user-crafted string with the marker
+        // prefix but no matching descriptor never reaches here (no descriptor),
+        // and a stored state where the marker and descriptor disagree is
+        // corruption, not a pageable field.
+        const content =
+          parentRow.content && typeof parentRow.content === "object"
+            ? (parentRow.content as { text?: unknown; attachments?: unknown })
+            : undefined;
+        let inlineText: unknown;
+        if (field.kind === "content.text") {
+          inlineText = content?.text;
+        } else {
+          const attachments = Array.isArray(content?.attachments) ? content.attachments : [];
+          const match = attachments.find(
+            (a) => a && typeof a === "object" && (a as { id?: unknown }).id === field.attachmentId
+          );
+          inlineText =
+            match && typeof match === "object" ? (match as { text?: unknown }).text : undefined;
+        }
+        const expectedMarker = buildSegmentedContentMarker(descriptor);
+        if (inlineText !== expectedMarker) {
+          throw new ElizaError("Segmented field inline marker does not match its descriptor", {
+            code: "MEMORY_SEGMENT_MARKER_MISMATCH",
+            context: { memoryId, fieldKey: memorySegmentFieldKey(field) },
+          });
+        }
+      }
 
-  if (!descriptor) {
-    const attachmentFilter =
-      field.kind === "attachment.text"
-        ? sql`a->>'id' = ${field.attachmentId}`
-        : sql`false`;
-    const inlineBytes = await tx.execute(sql`
+      if (!descriptor) {
+        const attachmentFilter =
+          field.kind === "attachment.text" ? sql`a->>'id' = ${field.attachmentId}` : sql`false`;
+        const inlineBytes = await tx.execute(sql`
       SELECT octet_length(COALESCE(content->>'text','')) AS text_bytes,
              (
                SELECT COALESCE(sum(octet_length(a->>'text')), 0)
@@ -249,203 +231,177 @@ export async function readMemoryContentPage(params: {
              ) AS attachment_bytes
       FROM memories WHERE id = ${memoryId}
     `);
-    const row = (
-      inlineBytes.rows as Array<{
-        text_bytes: number;
-        attachment_bytes: number;
-      }>
-    )[0];
-    const fieldBytes =
-      field.kind === "attachment.text"
-        ? row?.attachment_bytes
-        : row?.text_bytes;
-    // Fail closed at the SEGMENTATION THRESHOLD, not the page ceiling: any
-    // legacy row a fresh write would have segmented is exactly the row a
-    // single bounded page cannot be trusted to serve inline.
-    if (fieldBytes !== undefined && fieldBytes > MEMORY_SEGMENTATION_THRESHOLD_BYTES) {
-      throw new ElizaError(
-        "Legacy large unsegmented content requires an authorized reindex before paged reads",
-        {
-          code: "MEMORY_CONTENT_REINDEX_REQUIRED",
-          context: { memoryId, fieldKind: field.kind, fieldBytes },
-        },
-      );
-    }
-    return null;
-  }
+        const row = (
+          inlineBytes.rows as Array<{
+            text_bytes: number;
+            attachment_bytes: number;
+          }>
+        )[0];
+        const fieldBytes =
+          field.kind === "attachment.text" ? row?.attachment_bytes : row?.text_bytes;
+        // Fail closed at the SEGMENTATION THRESHOLD, not the page ceiling: any
+        // legacy row a fresh write would have segmented is exactly the row a
+        // single bounded page cannot be trusted to serve inline.
+        if (fieldBytes !== undefined && fieldBytes > MEMORY_SEGMENTATION_THRESHOLD_BYTES) {
+          throw new ElizaError(
+            "Legacy large unsegmented content requires an authorized reindex before paged reads",
+            {
+              code: "MEMORY_CONTENT_REINDEX_REQUIRED",
+              context: { memoryId, fieldKind: field.kind, fieldBytes },
+            }
+          );
+        }
+        return null;
+      }
 
-  if (params.byteStart > 0 && !params.expectedRevision) {
-    throw new ElizaError(
-      "Stored-content continuation requires expectedRevision.",
-      {
-        code: "MEMORY_CONTENT_EXPECTED_REVISION_REQUIRED",
-        context: { memoryId },
-      },
-    );
-  }
-  if (
-    params.expectedRevision &&
-    params.expectedRevision !== descriptor.revision
-  ) {
-    throw new ElizaError(
-      "The stored content changed before this page could be read.",
-      {
-        code: "MEMORY_CONTENT_STALE_REVISION",
-        context: { currentRevision: descriptor.revision },
-      },
-    );
-  }
+      if (params.byteStart > 0 && !params.expectedRevision) {
+        throw new ElizaError("Stored-content continuation requires expectedRevision.", {
+          code: "MEMORY_CONTENT_EXPECTED_REVISION_REQUIRED",
+          context: { memoryId },
+        });
+      }
+      if (params.expectedRevision && params.expectedRevision !== descriptor.revision) {
+        throw new ElizaError("The stored content changed before this page could be read.", {
+          code: "MEMORY_CONTENT_STALE_REVISION",
+          context: { currentRevision: descriptor.revision },
+        });
+      }
 
-  const window = clampPageWindow(
-    descriptor.totalBytes,
-    params.byteStart,
-    params.byteLimit,
+      const window = clampPageWindow(descriptor.totalBytes, params.byteStart, params.byteLimit);
+
+      // Empty-terminal page: an offset exactly at end-of-source is a complete,
+      // empty page — not a drift error.
+      if (window.start === descriptor.totalBytes) {
+        return {
+          text: "",
+          start: window.start,
+          end: window.start,
+          total: descriptor.totalBytes,
+          sliceSha256: sha256Hex(new Uint8Array(0)),
+          sourceSha256: descriptor.totalSha256,
+          revision: descriptor.revision,
+          completeness: "complete" as const,
+        };
+      }
+
+      const segmentRows = await tx
+        .select({
+          byteStart: memoryTextSegmentTable.byteStart,
+          byteEnd: memoryTextSegmentTable.byteEnd,
+          text: memoryTextSegmentTable.text,
+          segmentSha256: memoryTextSegmentTable.segmentSha256,
+        })
+        .from(memoryTextSegmentTable)
+        .where(
+          and(
+            eq(memoryTextSegmentTable.parentId, memoryId),
+            eq(memoryTextSegmentTable.generation, descriptor.generation),
+            lt(memoryTextSegmentTable.byteStart, window.end),
+            gt(memoryTextSegmentTable.byteEnd, window.start)
+          )
+        )
+        .orderBy(asc(memoryTextSegmentTable.byteStart));
+
+      if (segmentRows.length === 0) {
+        throw new ElizaError("Segmented content descriptor does not match its segment rows", {
+          code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+          context: { memoryId, generation: descriptor.generation },
+        });
+      }
+
+      // Assemble the intersecting segments' full bytes (bounded: the page window
+      // plus at most one segment on each side), verify each segment, then slice
+      // the window with the end snapped back to a UTF-8 code point boundary so a
+      // page never splits a code point and the returned `end` is a valid
+      // continuation offset.
+      const segmentBytes: Uint8Array[] = [];
+      const base = segmentRows[0].byteStart;
+      for (const row of segmentRows) {
+        const segBytes = encodeUtf8Strict(row.text);
+        if (segBytes.length !== row.byteEnd - row.byteStart) {
+          throw new ElizaError("Stored segment byte length does not match its range", {
+            code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+            context: {
+              memoryId,
+              generation: descriptor.generation,
+              byteStart: row.byteStart,
+            },
+          });
+        }
+        if (sha256Hex(segBytes) !== row.segmentSha256) {
+          throw new ElizaError("Stored segment digest does not match its bytes", {
+            code: "MEMORY_SEGMENT_DIGEST_MISMATCH",
+            context: {
+              memoryId,
+              generation: descriptor.generation,
+              byteStart: row.byteStart,
+            },
+          });
+        }
+        segmentBytes.push(segBytes);
+      }
+      // Coverage proof: the intersecting rows must form one contiguous run from
+      // the first segment at/before `window.start` through the last segment at/before
+      // `window.end`. A deleted middle row would otherwise be silently concatenated,
+      // collapsing the gap and mislabeling the returned range.
+      let expectedByteStart = base;
+      for (const row of segmentRows) {
+        if (row.byteStart !== expectedByteStart) {
+          throw new ElizaError("Stored segment rows are not contiguous over the requested window", {
+            code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+            context: {
+              memoryId,
+              generation: descriptor.generation,
+              expectedByteStart,
+              actualByteStart: row.byteStart,
+            },
+          });
+        }
+        expectedByteStart = row.byteEnd;
+      }
+      if (expectedByteStart < Math.min(window.end, descriptor.totalBytes)) {
+        throw new ElizaError("Stored segment rows do not cover the requested window", {
+          code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+          context: {
+            memoryId,
+            generation: descriptor.generation,
+            coveredThrough: expectedByteStart,
+            windowEnd: window.end,
+          },
+        });
+      }
+      const covered = concatBytes(segmentBytes);
+      let from = window.start - base;
+      let to = Math.min(window.end - base, covered.length);
+      // Snap the end backward off any partial trailing code point.
+      while (to > from && (covered[to] & 0xc0) === 0x80) {
+        to -= 1;
+      }
+      // A caller offset that starts mid-code-point is invalid.
+      if (from > 0 && (covered[from] & 0xc0) === 0x80) {
+        throw new ElizaError("Page byte offset splits a UTF-8 code point", {
+          code: "MEMORY_PAGE_INVALID_OFFSET",
+          context: { memoryId, byteStart: window.start },
+        });
+      }
+      const pageBytes = covered.subarray(from, to);
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(pageBytes);
+      const end = base + to;
+      from = 0;
+
+      return {
+        text,
+        start: window.start,
+        end,
+        total: descriptor.totalBytes,
+        sliceSha256: sha256Hex(pageBytes),
+        sourceSha256: descriptor.totalSha256,
+        revision: descriptor.revision,
+        completeness: end >= descriptor.totalBytes ? "complete" : "partial-recoverable",
+      };
+    },
+    { isolationLevel: "repeatable read" }
   );
-
-  // Empty-terminal page: an offset exactly at end-of-source is a complete,
-  // empty page — not a drift error.
-  if (window.start === descriptor.totalBytes) {
-    return {
-      text: "",
-      start: window.start,
-      end: window.start,
-      total: descriptor.totalBytes,
-      sliceSha256: sha256Hex(new Uint8Array(0)),
-      sourceSha256: descriptor.totalSha256,
-      revision: descriptor.revision,
-      completeness: "complete" as const,
-    };
-  }
-
-  const segmentRows = await tx
-    .select({
-      byteStart: memoryTextSegmentTable.byteStart,
-      byteEnd: memoryTextSegmentTable.byteEnd,
-      text: memoryTextSegmentTable.text,
-      segmentSha256: memoryTextSegmentTable.segmentSha256,
-    })
-    .from(memoryTextSegmentTable)
-    .where(
-      and(
-        eq(memoryTextSegmentTable.parentId, memoryId),
-        eq(memoryTextSegmentTable.generation, descriptor.generation),
-        lt(memoryTextSegmentTable.byteStart, window.end),
-        gt(memoryTextSegmentTable.byteEnd, window.start),
-      ),
-    )
-    .orderBy(asc(memoryTextSegmentTable.byteStart));
-
-  if (segmentRows.length === 0) {
-    throw new ElizaError(
-      "Segmented content descriptor does not match its segment rows",
-      {
-        code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
-        context: { memoryId, generation: descriptor.generation },
-      },
-    );
-  }
-
-  // Assemble the intersecting segments' full bytes (bounded: the page window
-  // plus at most one segment on each side), verify each segment, then slice
-  // the window with the end snapped back to a UTF-8 code point boundary so a
-  // page never splits a code point and the returned `end` is a valid
-  // continuation offset.
-  const segmentBytes: Uint8Array[] = [];
-  const base = segmentRows[0].byteStart;
-  for (const row of segmentRows) {
-    const segBytes = encodeUtf8Strict(row.text);
-    if (segBytes.length !== row.byteEnd - row.byteStart) {
-      throw new ElizaError(
-        "Stored segment byte length does not match its range",
-        {
-          code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
-          context: {
-            memoryId,
-            generation: descriptor.generation,
-            byteStart: row.byteStart,
-          },
-        },
-      );
-    }
-    if (sha256Hex(segBytes) !== row.segmentSha256) {
-      throw new ElizaError("Stored segment digest does not match its bytes", {
-        code: "MEMORY_SEGMENT_DIGEST_MISMATCH",
-        context: {
-          memoryId,
-          generation: descriptor.generation,
-          byteStart: row.byteStart,
-        },
-      });
-    }
-    segmentBytes.push(segBytes);
-  }
-  // Coverage proof: the intersecting rows must form one contiguous run from
-  // the first segment at/before `window.start` through the last segment at/before
-  // `window.end`. A deleted middle row would otherwise be silently concatenated,
-  // collapsing the gap and mislabeling the returned range.
-  let expectedByteStart = base;
-  for (const row of segmentRows) {
-    if (row.byteStart !== expectedByteStart) {
-      throw new ElizaError(
-        "Stored segment rows are not contiguous over the requested window",
-        {
-          code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
-          context: {
-            memoryId,
-            generation: descriptor.generation,
-            expectedByteStart,
-            actualByteStart: row.byteStart,
-          },
-        },
-      );
-    }
-    expectedByteStart = row.byteEnd;
-  }
-  if (window.end < descriptor.totalBytes && expectedByteStart < window.end) {
-    throw new ElizaError(
-      "Stored segment rows do not cover the requested window",
-      {
-        code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
-        context: {
-          memoryId,
-          generation: descriptor.generation,
-          coveredThrough: expectedByteStart,
-          windowEnd: window.end,
-        },
-      },
-    );
-  }
-  const covered = concatBytes(segmentBytes);
-  let from = window.start - base;
-  let to = Math.min(window.end - base, covered.length);
-  // Snap the end backward off any partial trailing code point.
-  while (to > from && (covered[to] & 0xc0) === 0x80) {
-    to -= 1;
-  }
-  // A caller offset that starts mid-code-point is invalid.
-  if (from > 0 && (covered[from] & 0xc0) === 0x80) {
-    throw new ElizaError("Page byte offset splits a UTF-8 code point", {
-      code: "MEMORY_PAGE_INVALID_OFFSET",
-      context: { memoryId, byteStart: window.start },
-    });
-  }
-  const pageBytes = covered.subarray(from, to);
-  const text = new TextDecoder("utf-8", { fatal: true }).decode(pageBytes);
-  const end = base + to;
-  from = 0;
-
-  return {
-    text,
-    start: window.start,
-    end,
-    total: descriptor.totalBytes,
-    sliceSha256: sha256Hex(pageBytes),
-    sourceSha256: descriptor.totalSha256,
-    revision: descriptor.revision,
-    completeness:
-      end >= descriptor.totalBytes ? "complete" : "partial-recoverable",
-  };
-  });
 }
 
 function concatBytes(parts: Uint8Array[]): Uint8Array {

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -252,15 +252,22 @@ export async function reindexMemoryContent(params: {
     const marker = buildSegmentedContentMarker(planned.descriptor);
 
     if (params.field.kind === "content.text") {
-      await tx
+      const updated = await tx
         .update(memoryTable)
         .set({
           content: sql`jsonb_set(content, '{text}', to_jsonb(${marker}::text), false)`,
           metadata,
         })
-        .where(and(eq(memoryTable.id, params.memoryId), params.parentAuthorization));
+        .where(and(eq(memoryTable.id, params.memoryId), params.parentAuthorization))
+        .returning();
+      if (updated.length !== 1) {
+        throw new ElizaError("Memory content reindex authorization changed", {
+          code: "MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED",
+          context: { memoryId: params.memoryId },
+        });
+      }
     } else {
-      await tx.execute(sql`
+      const updated = await tx.execute(sql`
         UPDATE memories SET
           content = jsonb_set(content, ARRAY['attachments', located.ordinal::text, 'text'], to_jsonb(${marker}::text), false),
           metadata = ${JSON.stringify(metadata)}::jsonb
@@ -271,7 +278,14 @@ export async function reindexMemoryContent(params: {
           WHERE m.id = ${params.memoryId} AND a.value->>'id' = ${params.field.attachmentId}
         ) located
         WHERE memories.id = ${params.memoryId}${authz}
+        RETURNING memories.id
       `);
+      if (updated.rows.length !== 1) {
+        throw new ElizaError("Memory content reindex authorization changed", {
+          code: "MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED",
+          context: { memoryId: params.memoryId },
+        });
+      }
     }
     await insertSegmentsInTransaction({
       tx,

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -22,7 +22,7 @@ import {
   type UUID,
 } from "@elizaos/core";
 import { and, asc, eq, gt, lt, type SQL, sql } from "drizzle-orm";
-import { memoryTextSegmentTable } from "../schema/index";
+import { memoryTable, memoryTextSegmentTable } from "../schema/index";
 import type { DrizzleDatabase } from "../types";
 
 /** Serialized descriptor row shape as stored on parent metadata. */
@@ -142,6 +142,146 @@ export async function retireStaleGenerationsInTransaction(params: {
         sql`${memoryTextSegmentTable.generation} NOT IN ${live}`
       )
     );
+}
+
+const MEMORY_REINDEX_MAX_SOURCE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Converts exactly one authorized legacy inline field. The parent is locked
+ * while its byte length is checked, and source bytes are fetched only after
+ * both the caller's bound and the adapter's hard ceiling accept the work.
+ */
+export async function reindexMemoryContent(params: {
+  db: DrizzleDatabase;
+  memoryId: UUID;
+  field: MemorySegmentField;
+  maxSourceBytes: number;
+  parentAuthorization: SQL;
+}): Promise<{
+  memoryId: UUID;
+  field: MemorySegmentField;
+  totalBytes: number;
+  segmentCount: number;
+  sourceSha256: string;
+  revision: string;
+}> {
+  if (
+    !Number.isSafeInteger(params.maxSourceBytes) ||
+    params.maxSourceBytes <= MEMORY_SEGMENTATION_THRESHOLD_BYTES ||
+    params.maxSourceBytes > MEMORY_REINDEX_MAX_SOURCE_BYTES
+  ) {
+    throw new ElizaError("Legacy content reindex bound is invalid", {
+      code: "MEMORY_CONTENT_REINDEX_INVALID_BOUND",
+      context: {
+        maxSourceBytes: params.maxSourceBytes,
+        hardMaxBytes: MEMORY_REINDEX_MAX_SOURCE_BYTES,
+      },
+    });
+  }
+  const authz = sql` AND (${params.parentAuthorization})`;
+  return params.db.transaction(async (tx) => {
+    const sizeExpression =
+      params.field.kind === "content.text"
+        ? sql`octet_length(COALESCE(content->>'text',''))`
+        : sql`(SELECT CASE WHEN count(*) = 1 THEN max(octet_length(a.value->>'text')) END
+              FROM jsonb_array_elements(COALESCE(content->'attachments','[]'::jsonb))
+                   WITH ORDINALITY a(value, ordinal)
+              WHERE a.value->>'id' = ${params.field.attachmentId})`;
+    const locked = await tx.execute(sql`
+      SELECT metadata, ${sizeExpression} AS field_bytes
+      FROM memories WHERE id = ${params.memoryId}${authz} FOR UPDATE
+    `);
+    const parent = (
+      locked.rows as Array<{ metadata: unknown; field_bytes: number | string | null }>
+    )[0];
+    if (!parent) {
+      throw new ElizaError("Memory content reindex is not authorized", {
+        code: "MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED",
+        context: { memoryId: params.memoryId },
+      });
+    }
+    if (readDescriptors(parent.metadata).has(memorySegmentFieldKey(params.field))) {
+      throw new ElizaError("Memory content field is already segmented", {
+        code: "MEMORY_CONTENT_ALREADY_SEGMENTED",
+        context: { memoryId: params.memoryId },
+      });
+    }
+    const totalBytes = Number(parent.field_bytes);
+    if (!Number.isSafeInteger(totalBytes)) {
+      throw new ElizaError("Attachment locator is missing or ambiguous", {
+        code: "MEMORY_CONTENT_REINDEX_FIELD_NOT_FOUND",
+        context: { memoryId: params.memoryId },
+      });
+    }
+    if (totalBytes <= MEMORY_SEGMENTATION_THRESHOLD_BYTES) {
+      throw new ElizaError("Inline content does not require reindex", {
+        code: "MEMORY_CONTENT_REINDEX_NOT_REQUIRED",
+        context: { memoryId: params.memoryId, totalBytes },
+      });
+    }
+    if (totalBytes > params.maxSourceBytes) {
+      throw new ElizaError("Legacy content exceeds the declared reindex bound", {
+        code: "MEMORY_CONTENT_REINDEX_BOUND_EXCEEDED",
+        context: { memoryId: params.memoryId, totalBytes, maxSourceBytes: params.maxSourceBytes },
+      });
+    }
+
+    const sourceQuery =
+      params.field.kind === "content.text"
+        ? sql`SELECT content->>'text' AS source FROM memories WHERE id = ${params.memoryId}${authz}`
+        : sql`SELECT a.value->>'text' AS source
+              FROM memories, jsonb_array_elements(COALESCE(content->'attachments','[]'::jsonb)) a(value)
+              WHERE id = ${params.memoryId}${authz}
+                AND a.value->>'id' = ${params.field.attachmentId}`;
+    const sourceRows = await tx.execute(sourceQuery);
+    const source = (sourceRows.rows as Array<{ source: string }>)[0]?.source;
+    if (typeof source !== "string" || encodeUtf8Strict(source).length !== totalBytes) {
+      throw new ElizaError("Legacy source changed during reindex", {
+        code: "MEMORY_CONTENT_REINDEX_SOURCE_DRIFT",
+        context: { memoryId: params.memoryId },
+      });
+    }
+    const planned = planSegmentedField({ field: params.field, text: source });
+    const metadata = mergeSegmentationMetadata(parent.metadata, planned.descriptor);
+    const marker = buildSegmentedContentMarker(planned.descriptor);
+
+    if (params.field.kind === "content.text") {
+      await tx
+        .update(memoryTable)
+        .set({
+          content: sql`jsonb_set(content, '{text}', to_jsonb(${marker}::text), false)`,
+          metadata,
+        })
+        .where(and(eq(memoryTable.id, params.memoryId), params.parentAuthorization));
+    } else {
+      await tx.execute(sql`
+        UPDATE memories SET
+          content = jsonb_set(content, ARRAY['attachments', located.ordinal::text, 'text'], to_jsonb(${marker}::text), false),
+          metadata = ${JSON.stringify(metadata)}::jsonb
+        FROM (
+          SELECT a.ordinal - 1 AS ordinal
+          FROM memories m, jsonb_array_elements(COALESCE(m.content->'attachments','[]'::jsonb))
+               WITH ORDINALITY a(value, ordinal)
+          WHERE m.id = ${params.memoryId} AND a.value->>'id' = ${params.field.attachmentId}
+        ) located
+        WHERE memories.id = ${params.memoryId}${authz}
+      `);
+    }
+    await insertSegmentsInTransaction({
+      tx,
+      parentId: params.memoryId,
+      segments: planned.segments,
+      generation: planned.descriptor.generation,
+    });
+    return {
+      memoryId: params.memoryId,
+      field: params.field,
+      totalBytes,
+      segmentCount: planned.descriptor.segmentCount,
+      sourceSha256: planned.descriptor.totalSha256,
+      revision: planned.descriptor.revision,
+    };
+  });
 }
 
 /**

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -15,7 +15,6 @@ import {
   clampPageWindow,
   ElizaError,
   encodeUtf8Strict,
-  MEMORY_PAGE_MAX_BYTES,
   MEMORY_SEGMENTATION_THRESHOLD_BYTES,
   type MemorySegmentField,
   memorySegmentFieldKey,
@@ -68,6 +67,8 @@ function readDescriptors(
   }
   return out;
 }
+
+export { readDescriptors as readSegmentationDescriptors };
 
 /** Merges a segmentation descriptor into parent metadata (pure). */
 export function mergeSegmentationMetadata(

--- a/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
+++ b/plugins/plugin-sql/src/stores/memoryTextSegments.store.ts
@@ -10,11 +10,13 @@
 
 import { createHash } from "node:crypto";
 import {
+  buildSegmentedContentMarker,
   type ComputedMemorySegment,
   clampPageWindow,
   ElizaError,
   encodeUtf8Strict,
   MEMORY_PAGE_MAX_BYTES,
+  MEMORY_SEGMENTATION_THRESHOLD_BYTES,
   type MemorySegmentField,
   memorySegmentFieldKey,
   segmentMemoryContent,
@@ -183,22 +185,61 @@ export async function readMemoryContentPage(params: {
 } | null> {
   const { db, memoryId, field } = params;
 
-  const parentRows = await db.execute(sql`
-    SELECT id, metadata FROM memories WHERE id = ${memoryId} LIMIT 1
+  // Snapshot consistency (#25140 review): the descriptor (parent row) and the
+  // segment rows must be read under one transaction fence so a concurrent
+  // replacement cannot switch the generation between the two reads.
+  return await db.transaction(async (tx) => {
+  const parentRows = await tx.execute(sql`
+    SELECT id, metadata, content FROM memories WHERE id = ${memoryId} LIMIT 1
   `);
-  const parentRow = (parentRows.rows as ParentRow[])[0];
+  const parentRow = (parentRows.rows as Array<{ id: UUID; metadata: unknown; content: unknown }>)[0];
   if (!parentRow) return null;
 
   const descriptor = readDescriptors(parentRow.metadata).get(
     memorySegmentFieldKey(field),
   );
 
+  if (descriptor) {
+    // Marker forgery fence: the inline field must carry EXACTLY the canonical
+    // marker for this descriptor. A user-crafted string with the marker
+    // prefix but no matching descriptor never reaches here (no descriptor),
+    // and a stored state where the marker and descriptor disagree is
+    // corruption, not a pageable field.
+    const content =
+      parentRow.content && typeof parentRow.content === "object"
+        ? (parentRow.content as { text?: unknown; attachments?: unknown })
+        : undefined;
+    let inlineText: unknown;
+    if (field.kind === "content.text") {
+      inlineText = content?.text;
+    } else {
+      const attachments = Array.isArray(content?.attachments)
+        ? content.attachments
+        : [];
+      const match = attachments.find(
+        (a) =>
+          a && typeof a === "object" && (a as { id?: unknown }).id === field.attachmentId,
+      );
+      inlineText = match && typeof match === "object" ? (match as { text?: unknown }).text : undefined;
+    }
+    const expectedMarker = buildSegmentedContentMarker(descriptor);
+    if (inlineText !== expectedMarker) {
+      throw new ElizaError(
+        "Segmented field inline marker does not match its descriptor",
+        {
+          code: "MEMORY_SEGMENT_MARKER_MISMATCH",
+          context: { memoryId, fieldKey: memorySegmentFieldKey(field) },
+        },
+      );
+    }
+  }
+
   if (!descriptor) {
     const attachmentFilter =
       field.kind === "attachment.text"
         ? sql`a->>'id' = ${field.attachmentId}`
         : sql`false`;
-    const inlineBytes = await db.execute(sql`
+    const inlineBytes = await tx.execute(sql`
       SELECT octet_length(COALESCE(content->>'text','')) AS text_bytes,
              (
                SELECT COALESCE(sum(octet_length(a->>'text')), 0)
@@ -217,7 +258,10 @@ export async function readMemoryContentPage(params: {
       field.kind === "attachment.text"
         ? row?.attachment_bytes
         : row?.text_bytes;
-    if (fieldBytes !== undefined && fieldBytes > MEMORY_PAGE_MAX_BYTES) {
+    // Fail closed at the SEGMENTATION THRESHOLD, not the page ceiling: any
+    // legacy row a fresh write would have segmented is exactly the row a
+    // single bounded page cannot be trusted to serve inline.
+    if (fieldBytes !== undefined && fieldBytes > MEMORY_SEGMENTATION_THRESHOLD_BYTES) {
       throw new ElizaError(
         "Legacy large unsegmented content requires an authorized reindex before paged reads",
         {
@@ -257,7 +301,22 @@ export async function readMemoryContentPage(params: {
     params.byteLimit,
   );
 
-  const segmentRows = await db
+  // Empty-terminal page: an offset exactly at end-of-source is a complete,
+  // empty page — not a drift error.
+  if (window.start === descriptor.totalBytes) {
+    return {
+      text: "",
+      start: window.start,
+      end: window.start,
+      total: descriptor.totalBytes,
+      sliceSha256: sha256Hex(new Uint8Array(0)),
+      sourceSha256: descriptor.totalSha256,
+      revision: descriptor.revision,
+      completeness: "complete" as const,
+    };
+  }
+
+  const segmentRows = await tx
     .select({
       byteStart: memoryTextSegmentTable.byteStart,
       byteEnd: memoryTextSegmentTable.byteEnd,
@@ -319,6 +378,42 @@ export async function readMemoryContentPage(params: {
     }
     segmentBytes.push(segBytes);
   }
+  // Coverage proof: the intersecting rows must form one contiguous run from
+  // the first segment at/before `window.start` through the last segment at/before
+  // `window.end`. A deleted middle row would otherwise be silently concatenated,
+  // collapsing the gap and mislabeling the returned range.
+  let expectedByteStart = base;
+  for (const row of segmentRows) {
+    if (row.byteStart !== expectedByteStart) {
+      throw new ElizaError(
+        "Stored segment rows are not contiguous over the requested window",
+        {
+          code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+          context: {
+            memoryId,
+            generation: descriptor.generation,
+            expectedByteStart,
+            actualByteStart: row.byteStart,
+          },
+        },
+      );
+    }
+    expectedByteStart = row.byteEnd;
+  }
+  if (window.end < descriptor.totalBytes && expectedByteStart < window.end) {
+    throw new ElizaError(
+      "Stored segment rows do not cover the requested window",
+      {
+        code: "MEMORY_SEGMENT_DESCRIPTOR_DRIFT",
+        context: {
+          memoryId,
+          generation: descriptor.generation,
+          coveredThrough: expectedByteStart,
+          windowEnd: window.end,
+        },
+      },
+    );
+  }
   const covered = concatBytes(segmentBytes);
   let from = window.start - base;
   let to = Math.min(window.end - base, covered.length);
@@ -349,6 +444,7 @@ export async function readMemoryContentPage(params: {
     completeness:
       end >= descriptor.totalBytes ? "complete" : "partial-recoverable",
   };
+  });
 }
 
 function concatBytes(parts: Uint8Array[]): Uint8Array {


### PR DESCRIPTION
# Relates to

Closes #25140. This completion PR is a four-commit delta on top of #29754 (rebuilt on its head `3928b733b082` on 2026-09-10) and closes the legacy-migration and PostgreSQL/RLS acceptance items #29754 defers. Merge order: #29754 first, then this PR; until #29754 lands the diff here shows both series.

- [x] Targets `develop`; branch = #29754 head `3928b733b082` + `db4f38ddb40a` (bounded reindex), `0cf423aed43b` (ambiguous legacy locators), `73b77ab10f96` (paging snapshot authorization), `37bb4976d8a7` (reindex guard pins), each cherry-picked verbatim from the previously reviewed head `9d1562a5a18` (`-x` trailers). No conflicts; the only differences from the previous head are #29754's own later additions (its scenario real suite, two comment lines in `base.ts`, one test-import line).
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` passed after sync; `bun run verify` re-run at head `9d1562a5a18` after the merge: 373/373 tasks and every follow-on audit passed.
- [x] Exact-head real-system evidence is included below.

# Risks

Medium: this changes transaction isolation for memory paging/reindex calls and strengthens reindex failure behavior. The principal risks are transaction retries and adapter parity; PostgreSQL/RLS, PGlite, builds, typechecks, and the repository-wide gate cover those paths.

# Background

## What does this PR do?

- Adds an authorized, caller-bounded legacy-content reindex contract with a 16 MiB hard ceiling.
- Atomically publishes the parent descriptor and immutable segment generation.
- Runs paging and reindex entity contexts at repeatable-read isolation, preserving the promised single-snapshot behavior instead of nesting that request inside a READ COMMITTED transaction.
- Requires exactly one authorized parent update before segment insertion, so concurrent authorization loss rolls the transaction back without orphan segments.
- Covers 10 MiB restart/reassembly, attachment ambiguity, real PostgreSQL/RLS isolation, and authorization-revocation rollback.
- Pins the caller-supplied reindex bound (`MEMORY_CONTENT_REINDEX_INVALID_BOUND`), the locked-size/source-fetch drift guard (`MEMORY_CONTENT_REINDEX_SOURCE_DRIFT`), and the legacy-row page refusal (`MEMORY_CONTENT_REINDEX_REQUIRED`) by error code in `plugins/plugin-sql/src/__tests__/integration/memory-content-reindex.guards.test.ts`, which runs in the PR lane.

## What kind of change is this?

Bug fix and completion of the bounded large-memory paging feature.

# Documentation changes needed?

No public documentation change is required; the runtime and adapter contracts are documented in code.

# Testing

## Where should a reviewer start?

`plugins/plugin-sql/src/stores/memoryTextSegments.store.ts`, then `plugins/plugin-sql/src/base.ts` and `plugins/plugin-sql/src/__tests__/integration/postgres/memory-content-paging.rls.real.test.ts`.

## Detailed testing steps

At head `37bb4976d8a7` (rebuilt on #29754, develop-parity worktree, frozen lockfile, core rebuilt):

- core content-segmentation + `readAttachmentAction.segmented-save` + paging-surface suites — 31/31.
- plugin-sql PR lane (`bun run test`) — 30 files, 213 passed, 3 skipped.
- plugin-sql real PGlite `memory-content-paging.adapter.real`, `memory-content-paging.scenario.real`, `memory-text-segments.real` — 12/12.
- reindex guard suite (`memory-content-reindex.guards.test.ts`, PR lane) — 12/12.
- `tsc --noEmit` in core and plugin-sql — 0 errors; Biome on the 25 branch files — clean.
- Real PostgreSQL 16 + pgvector RLS suite: not re-run at this head (no PostgreSQL on the rebuild host); the three commits it covers are byte-identical cherry-picks of the head where it last passed 3/3.

Earlier heads:

- `bun run verify` — 376/376 tasks plus all repository audits passed at `97294e26ba`; 373/373 tasks plus all audits at `9d1562a5a18` after the develop merge.
- Reindex guard suite (PR lane, PGlite) — 12/12 passed; each of the three guards, mutated away one at a time, fails exactly its own test.
- plugin-sql PR lane after the merge — 30 files, 213 tests passed; real PGlite `memory-content-paging.adapter.real`, `memory-text-segments.real`, and `memory.real` suites passed.
- Real PostgreSQL 16 + pgvector RLS suite — 3/3 passed.
- Real PGlite paging/reindex suite — 8/8 passed.
- Focused core suites — 29/29 passed.
- Core and plugin-sql typechecks/builds passed.

# Evidence Gate

<!-- evidence-head:37bb4976d8a7e8ec8e4b8890d600acf8a04da464 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only database transaction change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only database transaction change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only database transaction change has no visual user flow

<!-- evidence-row:backend-logs -->
- [x] Exact-head real backend execution:
  <details><summary>PostgreSQL/RLS and repository gate</summary>

  ```text
  Head: 97294e26ba9d0bcf9c39acfc189937e7e1168b98
  PostgreSQL 16 + pgvector RLS: 1 file passed, 3 tests passed
  observed transaction_isolation: repeatable read
  simulated authorization revocation: MEMORY_CONTENT_REINDEX_NOT_AUTHORIZED
  rollback state: segment_count=0, inline text_bytes=1048576
  bun run verify: 376 successful, 376 total; all follow-on audits passed
  ```
  </details>
  <details><summary>Head 9d1562a5a18 (after develop merge): reindex guards and repository gate</summary>

  ```text
  vitest run src/__tests__/integration/memory-content-reindex.guards.test.ts
   Test Files  1 passed (1)   Tests  12 passed (12)
  mutation: drop the 16 MiB ceiling clause      -> 1 failed (above-ceiling bound) | 11 passed
  mutation: drop the source-drift length check  -> 1 failed (source drift)        | 11 passed
  mutation: drop the REINDEX_REQUIRED throw     -> 1 failed (reindex required)    | 11 passed
  plugin-sql PR lane: Test Files 30 passed | 1 skipped, Tests 213 passed | 3 skipped
  VITEST_LANE=post-merge adapter.real + memory-text-segments.real + memory.real: passed
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; anti-larp clean; exit 0
  ```
  </details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] Exact-head database artifacts:
  <details><summary>Persisted-state assertions</summary>

  ```text
  PGlite source artifact: 10485760-byte legacy inline memory.
  PGlite publication artifact: bounded segmented descriptor and immutable generation persisted.
  PGlite restart artifact: every page reassembled byte-exactly after adapter restart.
  PostgreSQL revocation artifact: 0 memory_text_segments rows persisted.
  PostgreSQL rollback artifact: original inline text_bytes remained 1048576.
  ```
  </details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Known gaps / failures

The first post-rebase `bun run verify` found a missing newly locked optional native package in the pre-rebase install tree. Refreshing the frozen dependencies installed eight packages; the exact same gate then passed 376/376. No acceptance gap remains. The evidence-release upload helper returned 404 because this contributor lacks upstream release-asset permission, so the inspected evidence is pasted inline as the template permits.

## Maintainer CI exception record

N/A - no exception requested.


