### PR TITLE
fix(cloud): keep staging magic links on the cloud app origin

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1733,6 +1733,9 @@ jobs:
           FORCE: ${{ inputs.force }}
           MONOTONIC_FORWARD_PROGRESS: ${{ steps.env.outputs.deploy_environment == 'staging' }}
           SERVED_SOURCE_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
+          STEWARD_API_URL: ${{ secrets.STEWARD_API_URL }}
+          STEWARD_PLATFORM_KEYS: ${{ secrets.STEWARD_PLATFORM_KEYS }}
+          STEWARD_TENANT_ID: elizacloud-staging
         run: |
           set -euo pipefail
           legacy_onboarding_secret_removed=false
@@ -1797,6 +1800,9 @@ jobs:
             delete_legacy_onboarding_secret ELIZA_APP_ONBOARDING_LOGIN_APP_URL
           fi
           recheck_canonical_source
+          if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+            ENVIRONMENT=staging bun run --cwd "$CHECKOUT_DIR" cloud:reconcile-steward-email-callback
+          fi
           bunx wrangler deploy "${args[@]}"
           trap - ERR
 

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "test:cloud:integration": "node packages/cloud/scripts/admin/run-integration-tests.mjs",
     "cloud:shared-onboarding:live": "bun packages/cloud/scripts/admin/live-cloud-provision-smoke.ts",
     "cloud:verify-steward-email-callback": "bun packages/cloud/scripts/verify-steward-email-callback-config.mjs",
+    "cloud:reconcile-steward-email-callback": "bun packages/cloud/scripts/reconcile-steward-email-callback-config.mjs",
     "cloud:chat-latency": "node packages/cloud/scripts/chat-latency.mjs",
     "test:chat-latency": "node --test packages/cloud/scripts/chat-latency.test.mjs",
     "cloud:inference-auth-latency": "node packages/cloud/scripts/inference-auth-latency.mjs",

--- a/packages/cloud/scripts/__tests__/reconcile-steward-email-callback-config.test.ts
+++ b/packages/cloud/scripts/__tests__/reconcile-steward-email-callback-config.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Steward callback reconciliation tests exercise the HTTP mutation and
+ * readback contract with a deterministic in-process transport.
+ */
+import { describe, expect, test } from "bun:test";
+import { reconcileStewardEmailCallbackConfig } from "../reconcile-steward-email-callback-config.mjs";
+
+const URL =
+  "https://steward.example.test/platform/tenants/elizacloud-staging/email-config";
+
+describe("Steward email callback reconciliation", () => {
+  test("patches only callback fields and reads back the canonical config", async () => {
+    const requests: Request[] = [];
+    let config = {
+      magicLinkBaseUrl: "https://staging.eliza.app",
+      magicLinkCallbackPath: "/auth/callback/email",
+      templateId: "eliza",
+      hasApiKey: true,
+    };
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.redirect).toBe("error");
+      const request = new Request(input, init);
+      requests.push(request.clone());
+      if (request.method === "PATCH") {
+        config = { ...config, ...(await request.json()) };
+        return Response.json({ ok: true, data: { hasApiKey: true } });
+      }
+      return Response.json({ ok: true, data: { emailConfig: config } });
+    };
+
+    await expect(
+      reconcileStewardEmailCallbackConfig({
+        environment: "staging",
+        stewardApiUrl: "https://steward.example.test",
+        tenantId: "elizacloud-staging",
+        platformKey: "platform-secret",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      environment: "staging",
+      callbackUrl: "https://cloud-staging.eliza.app/auth/callback/email",
+    });
+
+    expect(
+      requests.map((request) => `${request.method} ${request.url}`),
+    ).toEqual([`GET ${URL}`, `PATCH ${URL}`, `GET ${URL}`]);
+    expect(await requests[1].clone().json()).toEqual({
+      magicLinkBaseUrl: "https://cloud-staging.eliza.app",
+      magicLinkCallbackPath: "/auth/callback/email",
+    });
+    expect(
+      requests.every(
+        (request) =>
+          request.headers.get("X-Steward-Platform-Key") === "platform-secret",
+      ),
+    ).toBe(true);
+  });
+
+  test("creates callback fields when the live config is absent", async () => {
+    const methods: string[] = [];
+    let config: Record<string, unknown> | null = null;
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      methods.push(request.method);
+      if (request.method === "PATCH") {
+        config = await request.json();
+        return Response.json({ ok: true, data: { hasApiKey: false } });
+      }
+      return Response.json({ ok: true, data: { emailConfig: config } });
+    };
+
+    await reconcileStewardEmailCallbackConfig({
+      environment: "staging",
+      stewardApiUrl: "https://steward.example.test",
+      tenantId: "elizacloud-staging",
+      platformKey: "platform-secret",
+      fetchImpl,
+    });
+    expect(methods).toEqual(["GET", "PATCH", "GET"]);
+  });
+
+  test("does not mutate an already canonical config", async () => {
+    const methods: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      methods.push(request.method);
+      return Response.json({
+        ok: true,
+        data: {
+          emailConfig: {
+            magicLinkBaseUrl: "https://cloud-staging.eliza.app",
+            magicLinkCallbackPath: "/auth/callback/email",
+          },
+        },
+      });
+    };
+
+    await reconcileStewardEmailCallbackConfig({
+      environment: "staging",
+      stewardApiUrl: "https://steward.example.test",
+      tenantId: "elizacloud-staging",
+      platformKey: "platform-secret",
+      fetchImpl,
+    });
+    expect(methods).toEqual(["GET", "GET"]);
+  });
+
+  test("fails closed when post-patch readback remains stale", async () => {
+    const fetchImpl = async () =>
+      Response.json({
+        ok: true,
+        data: {
+          emailConfig: {
+            magicLinkBaseUrl: "https://staging.eliza.app",
+            magicLinkCallbackPath: "/auth/callback/email",
+          },
+        },
+      });
+    await expect(
+      reconcileStewardEmailCallbackConfig({
+        environment: "staging",
+        stewardApiUrl: "https://steward.example.test",
+        tenantId: "elizacloud-staging",
+        platformKey: "platform-secret",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("canonical staging app origin");
+  });
+
+  test("rejects unsafe API URLs and production mutation", async () => {
+    const base = {
+      environment: "staging",
+      tenantId: "elizacloud-staging",
+      platformKey: "platform-secret",
+    };
+    await expect(
+      reconcileStewardEmailCallbackConfig({
+        ...base,
+        stewardApiUrl: "http://steward.test",
+      }),
+    ).rejects.toThrow("absolute HTTPS origin");
+    await expect(
+      reconcileStewardEmailCallbackConfig({
+        ...base,
+        environment: "production",
+        stewardApiUrl: "https://steward.example.test",
+      }),
+    ).rejects.toThrow("ENVIRONMENT must be staging");
+  });
+});

--- a/packages/cloud/scripts/reconcile-steward-email-callback-config.mjs
+++ b/packages/cloud/scripts/reconcile-steward-email-callback-config.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+/**
+ * Reconciles staging Steward's tenant-scoped email callback with the canonical
+ * Eliza app origin, then reads it back so deployment fails on persistent drift.
+ */
+import { pathToFileURL } from "node:url";
+import { ELIZA_DOMAIN_CONTRACTS } from "../../shared/src/elizacloud/domain-contract.ts";
+import { validateStewardEmailCallbackConfig } from "./verify-steward-email-callback-config.mjs";
+
+const CALLBACK_PATH = "/auth/callback/email";
+
+function requiredEnvironmentValue(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function firstPlatformKey(value) {
+  const key = value
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .find(Boolean);
+  if (!key) throw new Error("STEWARD_PLATFORM_KEYS is required");
+  return key;
+}
+
+function canonicalApiOrigin(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    // error-policy:J3 Reject malformed deployment configuration explicitly.
+    throw new Error("STEWARD_API_URL must be an absolute HTTPS origin");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("STEWARD_API_URL must be an absolute HTTPS origin");
+  }
+  return url.origin;
+}
+
+function readEmailConfig(payload) {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Steward email config response was malformed");
+  }
+  const data = payload.data;
+  if (!data || typeof data !== "object") {
+    throw new Error("Steward email config response was malformed");
+  }
+  if (data.emailConfig === null) return {};
+  if (!data.emailConfig || typeof data.emailConfig !== "object") {
+    throw new Error("Steward email config response was malformed");
+  }
+  return data.emailConfig;
+}
+
+async function stewardRequest({ fetchImpl, url, platformKey, init }) {
+  const headers = new Headers(init?.headers);
+  headers.set("Accept", "application/json");
+  headers.set("X-Steward-Platform-Key", platformKey);
+  const response = await fetchImpl(url, {
+    ...init,
+    headers,
+    redirect: "error",
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // error-policy:J3 A non-JSON response is invalid at this API boundary.
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Steward email config request failed with HTTP ${response.status}`,
+    );
+  }
+  return payload;
+}
+
+export async function reconcileStewardEmailCallbackConfig({
+  environment,
+  stewardApiUrl,
+  tenantId,
+  platformKey,
+  fetchImpl = fetch,
+}) {
+  if (environment !== "staging") {
+    throw new Error("ENVIRONMENT must be staging");
+  }
+  const expectedOrigin = ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin;
+  const emailConfigUrl = new URL(
+    `/platform/tenants/${encodeURIComponent(tenantId)}/email-config`,
+    canonicalApiOrigin(stewardApiUrl),
+  );
+  const current = readEmailConfig(
+    await stewardRequest({ fetchImpl, url: emailConfigUrl, platformKey }),
+  );
+
+  if (
+    current.magicLinkBaseUrl !== expectedOrigin ||
+    current.magicLinkCallbackPath !== CALLBACK_PATH
+  ) {
+    await stewardRequest({
+      fetchImpl,
+      url: emailConfigUrl,
+      platformKey,
+      init: {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          magicLinkBaseUrl: expectedOrigin,
+          magicLinkCallbackPath: CALLBACK_PATH,
+        }),
+      },
+    });
+  }
+
+  const verified = readEmailConfig(
+    await stewardRequest({ fetchImpl, url: emailConfigUrl, platformKey }),
+  );
+  return validateStewardEmailCallbackConfig({
+    environment,
+    magicLinkBaseUrl: verified.magicLinkBaseUrl,
+    callbackPath: verified.magicLinkCallbackPath,
+  });
+}
+
+export async function main(environment = process.env) {
+  const result = await reconcileStewardEmailCallbackConfig({
+    environment: requiredEnvironmentValue(environment, "ENVIRONMENT"),
+    stewardApiUrl: requiredEnvironmentValue(environment, "STEWARD_API_URL"),
+    tenantId: requiredEnvironmentValue(environment, "STEWARD_TENANT_ID"),
+    platformKey: firstPlatformKey(
+      requiredEnvironmentValue(environment, "STEWARD_PLATFORM_KEYS"),
+    ),
+  });
+  console.log(
+    `Reconciled ${result.environment} Steward email callback ${result.callbackUrl}.`,
+  );
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    // error-policy:J1 Translate reconciliation failures at the CLI boundary.
+    console.error(
+      `reconcile-steward-email-callback-config: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/scripts/__tests__/cloud-cf-steward-email-callback-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-steward-email-callback-workflow.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Cloudflare release workflow tests keep callback reconciliation between the
+ * final canonical-source check and the staging Worker publication.
+ */
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+const workflowUrl = new URL(
+  "../../../.github/workflows/cloud-cf-release.yml",
+  import.meta.url,
+);
+
+test("staging deploy reconciles Steward immediately before publication", async () => {
+  const workflow = await readFile(workflowUrl, "utf8");
+  const deployStep = workflow.slice(
+    workflow.indexOf("- name: Deploy to Cloudflare Workers"),
+  );
+  const recheckIndex = deployStep.lastIndexOf(
+    "recheck_canonical_source",
+    deployStep.indexOf("bunx wrangler deploy"),
+  );
+  const reconcileIndex = deployStep.indexOf(
+    "cloud:reconcile-steward-email-callback",
+  );
+  const publishIndex = deployStep.indexOf("bunx wrangler deploy");
+
+  expect(recheckIndex).toBeGreaterThan(-1);
+  expect(reconcileIndex).toBeGreaterThan(recheckIndex);
+  expect(publishIndex).toBeGreaterThan(reconcileIndex);
+  expect(deployStep.slice(recheckIndex, publishIndex)).toContain(
+    'if [ "$DEPLOY_ENVIRONMENT" = "staging" ]',
+  );
+  expect(deployStep).toContain(
+    "STEWARD_API_URL: $" + "{{ secrets.STEWARD_API_URL }}",
+  );
+  expect(deployStep).toContain(
+    "STEWARD_PLATFORM_KEYS: $" + "{{ secrets.STEWARD_PLATFORM_KEYS }}",
+  );
+});


### PR DESCRIPTION
Fixes #29893

## What changed

- reconcile the staging Steward tenant callback immediately before Worker publication
- patch only the callback origin and callback path, preserving provider credentials and templates
- read the live tenant config back and fail the deployment if drift remains
- reject redirects, unsafe Steward origins, malformed responses, and production mutation

## Root cause

The repository validated the intended callback origin, but the release path never reconciled the live tenant configuration. The stale Steward value therefore survived otherwise-green staging deployments and sent email callbacks to `staging.eliza.app` instead of `cloud-staging.eliza.app`.

## Verification

- `bun test packages/cloud/scripts/__tests__/reconcile-steward-email-callback-config.test.ts packages/cloud/scripts/__tests__/verify-steward-email-callback-config.test.ts packages/scripts/__tests__/cloud-cf-steward-email-callback-workflow.test.ts` — 23 passed
- `bun run verify` — passed
- two independent adversarial reviews — zero confirmed findings after revisions
- live unauthenticated staging route probe — returned the expected platform-key boundary response; no secret values were read or printed

## Evidence

Pre-fix staging E2E reproduced the failure: the emailed callback used the wrong host, so the requesting tab could not restore its session. Changing only the callback host to the canonical cloud staging host completed sign-in. Post-fix authenticated email-link and replay evidence is intentionally pending merge and staging deployment.

No rendered UI changed, so screenshots and video are N/A.