### PR TITLE
fix(plugin-telegram): serialize TelegramTaskBoard.render so concurrent first renders don't double-post the pinned board

### DIFF
--- a/plugins/plugin-telegram/src/task-board.test.ts
+++ b/plugins/plugin-telegram/src/task-board.test.ts
@@ -313,6 +313,52 @@ describe("TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3)"
     expect(store.map.get("100:")).toBe(2);
   });
 
+  it("a render started after an earlier one settles still serializes behind the queued one", async () => {
+    // Pins the tail check `if (this.inFlight.get(key) === run)` on the chain
+    // cleanup. With three renders A→B→C: A settles while B is still queued, and
+    // only THEN does C arrive. The tail check keeps the map entry pointing at B
+    // (not A) so C serializes behind B. An unconditional `delete` in A's finally
+    // would empty the map, C would read `prior === undefined`, start a fresh
+    // chain, and enter edit() alongside the still-in-flight B — serialization
+    // genuinely lost. Fails against that mutant (edit called twice) and no other.
+    let next = 0;
+    const post = vi.fn(async () => ({ messageId: ++next }));
+    const pin = vi.fn(async () => undefined);
+    const store = asyncBoardStore();
+
+    let releaseEdit: () => void = () => {};
+    const editGate = new Promise<void>((resolve) => {
+      releaseEdit = resolve;
+    });
+    let editCalls = 0;
+    const edit = vi.fn(async () => {
+      editCalls += 1;
+      if (editCalls === 1) await editGate; // hold B inside its op
+      return undefined;
+    });
+
+    const board = new TelegramTaskBoard({ post, edit, pin, store });
+
+    // A posts and settles. B queues behind A and then blocks inside edit().
+    const a = board.render(100, entries);
+    const b = board.render(100, entries);
+    await a;
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
+    // C starts while B is still in flight; it must serialize behind B.
+    const c = board.render(100, entries);
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
+    // C has not entered edit() — only B has, and B is still blocked.
+    expect(edit).toHaveBeenCalledTimes(1);
+
+    releaseEdit();
+    await Promise.all([b, c]);
+    // A posted the single board; B and C both edited it in place.
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps distinct (chat, thread) keys unserialized from each other", async () => {
     let next = 0;
     const post = vi.fn(async () => ({ messageId: ++next }));

--- a/plugins/plugin-telegram/src/task-board.test.ts
+++ b/plugins/plugin-telegram/src/task-board.test.ts
@@ -270,6 +270,49 @@ describe("TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3)"
     expect(post).toHaveBeenCalledTimes(1);
   });
 
+  it("a failed op on the chain does not abort a later render for the same board", async () => {
+    // Pins the documented `enqueue` guarantee: `await prior.catch(() =>
+    // undefined)` waits for the prior op to SETTLE, not succeed, so a rejected
+    // predecessor must not propagate into a later op's promise. This is
+    // reachable in production because `enqueue` is generic — `forget` rides it
+    // too — and any op that actually rejects would otherwise make every queued
+    // render for that board fail with an unrelated earlier error. Fails against
+    // the `await prior;` mutant (no `.catch`) and no other.
+    let next = 0;
+    const post = vi.fn(async () => ({ messageId: ++next }));
+    const edit = vi.fn(async () => undefined);
+    const pin = vi.fn(async () => undefined);
+    const store = asyncBoardStore();
+    let failNextSave = true;
+    const failingStore: BoardMessageStore & { map: Map<string, number> } = {
+      ...store,
+      save: async (key, id) => {
+        if (failNextSave) {
+          failNextSave = false;
+          throw new Error("db write failed");
+        }
+        return store.save(key, id);
+      },
+    };
+    const board = new TelegramTaskBoard({
+      post,
+      edit,
+      pin,
+      store: failingStore,
+    });
+
+    // First render's save rejects, so its chain promise rejects.
+    const first = board.render(100, entries).catch((e) => e);
+    // Second render queues behind it and must still resolve on its own merit.
+    const second = board.render(100, entries);
+
+    await first;
+    await expect(second).resolves.toBeTypeOf("number");
+    // The later render posted and persisted its own board despite the earlier
+    // failure — no id was stranded by the predecessor's rejection.
+    expect(store.map.get("100:")).toBe(2);
+  });
+
   it("keeps distinct (chat, thread) keys unserialized from each other", async () => {
     let next = 0;
     const post = vi.fn(async () => ({ messageId: ++next }));

--- a/plugins/plugin-telegram/src/task-board.test.ts
+++ b/plugins/plugin-telegram/src/task-board.test.ts
@@ -7,6 +7,7 @@
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  type BoardMessageStore,
   composeTaskBoard,
   createInMemoryBoardStore,
   createRuntimeMemoryBoardStore,
@@ -16,6 +17,33 @@ import {
   TelegramTaskBoard,
   taskBoardEmoji,
 } from "./task-board";
+
+/**
+ * A store whose load/save/forget each await a microtask, mirroring the
+ * runtime-memory store's real DB round-trips (getMemoryById → update/create).
+ * This yields to the event loop mid-operation, which is exactly the window that
+ * let two concurrent first renders both observe `undefined` before the fix.
+ */
+function asyncBoardStore(
+  seed?: Map<string, number>,
+): BoardMessageStore & { map: Map<string, number> } {
+  const map = seed ?? new Map<string, number>();
+  return {
+    map,
+    load: async (key) => {
+      await Promise.resolve();
+      return map.get(key);
+    },
+    save: async (key, id) => {
+      await Promise.resolve();
+      map.set(key, id);
+    },
+    forget: async (key) => {
+      await Promise.resolve();
+      map.delete(key);
+    },
+  };
+}
 
 const entries: TaskBoardEntry[] = [
   { id: "1", title: "ship feature", status: "active" },
@@ -114,6 +142,105 @@ describe("TelegramTaskBoard pinning (#8902 AC1)", () => {
     );
     expect(id).toBe(7);
     expect(pin).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3)", () => {
+  it("posts exactly once when two first renders race for the same board", async () => {
+    let next = 0;
+    const post = vi.fn(async () => ({ messageId: ++next }));
+    const edit = vi.fn(async () => undefined);
+    const pin = vi.fn(async () => undefined);
+    const store = asyncBoardStore();
+    const board = new TelegramTaskBoard({ post, edit, pin, store });
+
+    // Fire both concurrently (e.g. the supervisor sink + a `/tasks` command)
+    // for the SAME (chat, thread). Without serialization both would observe
+    // `existing === undefined`, both post, and both pin — a duplicate board.
+    const [id1, id2] = await Promise.all([
+      board.render(100, entries),
+      board.render(100, entries),
+    ]);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(pin).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledTimes(1);
+    // Both callers resolve to the single posted board id.
+    expect(id1).toBe(1);
+    expect(id2).toBe(1);
+    // Exactly one id is persisted — no orphaned message.
+    expect(store.map.get("100:")).toBe(1);
+    // The in-flight chain is cleared once both settle.
+    expect(
+      (board as unknown as { inFlight: Map<string, unknown> }).inFlight.size,
+    ).toBe(0);
+  });
+
+  it("only edits (never posts) when a stored id already exists under concurrency", async () => {
+    const post = vi.fn(async () => ({ messageId: 999 }));
+    const edit = vi.fn(async () => undefined);
+    const pin = vi.fn(async () => undefined);
+    // Seed the store as if a board was posted in a prior process (restart).
+    const store = asyncBoardStore(new Map([["100:", 55]]));
+    const board = new TelegramTaskBoard({ post, edit, pin, store });
+
+    const ids = await Promise.all([
+      board.render(100, entries),
+      board.render(100, entries),
+      board.render(100, entries),
+    ]);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(pin).not.toHaveBeenCalled();
+    expect(edit).toHaveBeenCalledTimes(3);
+    expect(ids).toEqual([55, 55, 55]);
+    for (const call of edit.mock.calls) {
+      expect(call).toEqual([100, 55, expect.any(String), undefined]);
+    }
+  });
+
+  it("reposts exactly once when the first edit fails mid-race (message deleted)", async () => {
+    let next = 10;
+    const post = vi.fn(async () => ({ messageId: ++next }));
+    // First edit rejects (board message was deleted); later edits succeed.
+    const edit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("message to edit not found"))
+      .mockResolvedValue(undefined);
+    const pin = vi.fn(async () => undefined);
+    const store = asyncBoardStore(new Map([["100:", 55]]));
+    const board = new TelegramTaskBoard({ post, edit, pin, store });
+
+    const ids = await Promise.all([
+      board.render(100, entries),
+      board.render(100, entries),
+    ]);
+
+    // The failed edit forgets the stale id and reposts a single fresh board;
+    // the second render then edits that reposted board in place.
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(ids[0]).toBe(11);
+    expect(ids[1]).toBe(11);
+    expect(store.map.get("100:")).toBe(11);
+    expect(pin).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps distinct (chat, thread) keys unserialized from each other", async () => {
+    let next = 0;
+    const post = vi.fn(async () => ({ messageId: ++next }));
+    const edit = vi.fn(async () => undefined);
+    const store = asyncBoardStore();
+    const board = new TelegramTaskBoard({ post, edit, store });
+
+    // Different threads / chats are independent boards — each posts once.
+    await Promise.all([
+      board.render(100, entries),
+      board.render(100, entries, 7),
+      board.render(200, entries),
+    ]);
+
+    expect(post).toHaveBeenCalledTimes(3);
+    expect(edit).not.toHaveBeenCalled();
   });
 });
 

--- a/plugins/plugin-telegram/src/task-board.test.ts
+++ b/plugins/plugin-telegram/src/task-board.test.ts
@@ -225,6 +225,51 @@ describe("TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3)"
     expect(pin).toHaveBeenCalledTimes(1);
   });
 
+  it("serializes forget() with an in-flight render so a reset can't strand the store mid-edit", async () => {
+    // Reproduces the latent race called out in review: forget() mutates the
+    // same (chat, thread) key as render. If it ran outside the chain it could
+    // delete a stored id WHILE a render is blocked inside edit() — the render
+    // then returns the existing id without re-saving, leaving the store empty
+    // while a live pinned board still exists, so the next render double-posts.
+    let releaseEdit: () => void = () => {};
+    const editGate = new Promise<void>((resolve) => {
+      releaseEdit = resolve;
+    });
+    const post = vi.fn(async () => ({ messageId: 999 }));
+    const edit = vi.fn(async () => {
+      await editGate;
+    });
+    // Seed a stored board id, as if posted in a prior process.
+    const store = asyncBoardStore(new Map([["100:", 55]]));
+    const board = new TelegramTaskBoard({ post, edit, store });
+
+    // A render is in flight and blocked inside edit(); a concurrent reset asks
+    // to forget the same board and must queue behind the render.
+    const rendering = board.render(100, entries);
+    const forgetting = board.forget(100);
+
+    // Let the render reach edit() and the forget settle into the queue.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(edit).toHaveBeenCalledTimes(1);
+    // forget is queued, NOT yet applied — the id survives mid-edit.
+    expect(store.map.get("100:")).toBe(55);
+
+    releaseEdit();
+    const id = await rendering;
+    await forgetting;
+
+    // The render edited the existing board (no double-post); forget applied only
+    // after the render completed.
+    expect(id).toBe(55);
+    expect(post).not.toHaveBeenCalled();
+    expect(store.map.has("100:")).toBe(false);
+
+    // A later render after the reset posts exactly one fresh board.
+    const id2 = await board.render(100, entries);
+    expect(id2).toBe(999);
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps distinct (chat, thread) keys unserialized from each other", async () => {
     let next = 0;
     const post = vi.fn(async () => ({ messageId: ++next }));

--- a/plugins/plugin-telegram/src/task-board.ts
+++ b/plugins/plugin-telegram/src/task-board.ts
@@ -202,9 +202,20 @@ export interface TaskBoardDeps {
  * Owns one board message per (chat, thread) and keeps it current: first render
  * posts, later renders edit in place. An edit failure (e.g. the message was
  * deleted) falls back to posting a fresh board so the user always gets one.
+ *
+ * `render` is serialized per (chat, thread) key. The durable store resolves
+ * load/save through real DB round-trips, so two concurrent triggers for the
+ * same board — e.g. the supervisor digest sink firing on a status change while
+ * a user runs `/tasks` — would each observe `existing === undefined`, both post,
+ * and both pin, leaving a duplicate pinned board and an orphaned message id
+ * (last-write-wins on save). Chaining each render onto the in-flight one for its
+ * key makes the load→post→save sequence atomic, so the second render observes
+ * the saved id and edits in place (#8902 AC3).
  */
 export class TelegramTaskBoard {
   private readonly store: BoardMessageStore;
+  /** In-flight render chain per (chat, thread) key — see class doc. */
+  private readonly inFlight = new Map<string, Promise<number>>();
 
   constructor(private readonly deps: TaskBoardDeps) {
     this.store = deps.store ?? createInMemoryBoardStore();
@@ -216,6 +227,32 @@ export class TelegramTaskBoard {
 
   /** Returns the board message id (existing or newly posted). */
   async render(
+    chatId: number | string,
+    entries: TaskBoardEntry[],
+    threadId?: number,
+  ): Promise<number> {
+    const key = this.key(chatId, threadId);
+    const prior = this.inFlight.get(key);
+    const run = (async () => {
+      if (prior) {
+        // Wait for the prior render to settle so its post→save is visible to
+        // our load(); a prior failure must not abort our own render.
+        await prior.catch(() => undefined);
+      }
+      return this.renderOnce(chatId, entries, threadId);
+    })();
+    this.inFlight.set(key, run);
+    try {
+      return await run;
+    } finally {
+      // Only the tail of the chain clears the entry, so a later render already
+      // queued behind us keeps serializing.
+      if (this.inFlight.get(key) === run) this.inFlight.delete(key);
+    }
+  }
+
+  /** One post-or-edit pass; callers go through {@link render} for serialization. */
+  private async renderOnce(
     chatId: number | string,
     entries: TaskBoardEntry[],
     threadId?: number,

--- a/plugins/plugin-telegram/src/task-board.ts
+++ b/plugins/plugin-telegram/src/task-board.ts
@@ -203,19 +203,24 @@ export interface TaskBoardDeps {
  * posts, later renders edit in place. An edit failure (e.g. the message was
  * deleted) falls back to posting a fresh board so the user always gets one.
  *
- * `render` is serialized per (chat, thread) key. The durable store resolves
- * load/save through real DB round-trips, so two concurrent triggers for the
- * same board — e.g. the supervisor digest sink firing on a status change while
- * a user runs `/tasks` — would each observe `existing === undefined`, both post,
- * and both pin, leaving a duplicate pinned board and an orphaned message id
- * (last-write-wins on save). Chaining each render onto the in-flight one for its
- * key makes the load→post→save sequence atomic, so the second render observes
- * the saved id and edits in place (#8902 AC3).
+ * Store mutations are serialized per (chat, thread) key. The durable store
+ * resolves load/save through real DB round-trips, so two concurrent triggers
+ * for the same board — e.g. the supervisor digest sink firing on a status
+ * change while a user runs `/tasks` — would each observe `existing ===
+ * undefined`, both post, and both pin, leaving a duplicate pinned board and an
+ * orphaned message id (last-write-wins on save). Chaining each render onto the
+ * in-flight one for its key makes the load→post→save sequence atomic, so the
+ * second render observes the saved id and edits in place (#8902 AC3).
+ *
+ * `forget` joins the same chain: it deletes under the same key, so running it
+ * outside the chain could strand the store mid-render (delete the id while a
+ * live pinned board still exists, causing the next render to double-post) —
+ * exactly the failure this class serializes render to prevent.
  */
 export class TelegramTaskBoard {
   private readonly store: BoardMessageStore;
-  /** In-flight render chain per (chat, thread) key — see class doc. */
-  private readonly inFlight = new Map<string, Promise<number>>();
+  /** In-flight mutation chain per (chat, thread) key — see class doc. */
+  private readonly inFlight = new Map<string, Promise<unknown>>();
 
   constructor(private readonly deps: TaskBoardDeps) {
     this.store = deps.store ?? createInMemoryBoardStore();
@@ -225,30 +230,42 @@ export class TelegramTaskBoard {
     return `${chatId}:${threadId ?? ""}`;
   }
 
+  /**
+   * Serialize `op` onto the in-flight chain for `key` so every store mutation
+   * for a board — render's load→post→save and forget's delete — runs atomically
+   * with respect to the others. The read-modify-write on the map is safe: the
+   * async IIFE runs synchronously up to its first `await`, so no other call can
+   * interleave between reading `prior` and publishing `run`.
+   */
+  private async enqueue<T>(key: string, op: () => Promise<T>): Promise<T> {
+    const prior = this.inFlight.get(key);
+    const run = (async () => {
+      if (prior) {
+        // Wait for the prior operation to settle so its store writes are visible
+        // to ours; a prior failure must not abort our own operation.
+        await prior.catch(() => undefined);
+      }
+      return op();
+    })();
+    this.inFlight.set(key, run);
+    try {
+      return await run;
+    } finally {
+      // Only the tail of the chain clears the entry, so a later operation
+      // already queued behind us keeps serializing.
+      if (this.inFlight.get(key) === run) this.inFlight.delete(key);
+    }
+  }
+
   /** Returns the board message id (existing or newly posted). */
   async render(
     chatId: number | string,
     entries: TaskBoardEntry[],
     threadId?: number,
   ): Promise<number> {
-    const key = this.key(chatId, threadId);
-    const prior = this.inFlight.get(key);
-    const run = (async () => {
-      if (prior) {
-        // Wait for the prior render to settle so its post→save is visible to
-        // our load(); a prior failure must not abort our own render.
-        await prior.catch(() => undefined);
-      }
-      return this.renderOnce(chatId, entries, threadId);
-    })();
-    this.inFlight.set(key, run);
-    try {
-      return await run;
-    } finally {
-      // Only the tail of the chain clears the entry, so a later render already
-      // queued behind us keeps serializing.
-      if (this.inFlight.get(key) === run) this.inFlight.delete(key);
-    }
+    return this.enqueue(this.key(chatId, threadId), () =>
+      this.renderOnce(chatId, entries, threadId),
+    );
   }
 
   /** One post-or-edit pass; callers go through {@link render} for serialization. */
@@ -291,9 +308,14 @@ export class TelegramTaskBoard {
     return messageId;
   }
 
-  /** Forget a stored board (e.g. when a chat is reset). */
+  /**
+   * Forget a stored board (e.g. when a chat is reset). Serialized on the same
+   * per-key chain as {@link render} so a reset cannot delete the stored id
+   * while a render is mid-flight and strand a live pinned board.
+   */
   async forget(chatId: number | string, threadId?: number): Promise<void> {
-    await this.store.forget(this.key(chatId, threadId));
+    const key = this.key(chatId, threadId);
+    await this.enqueue(key, () => Promise.resolve(this.store.forget(key)));
   }
 }
 


### PR DESCRIPTION
# Relates to

Closes #29899

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; package `test`, `typecheck`, and `lint:check` were run (see evidence). `bun run verify` is a repo-wide gate; the owning-package gates are green and the two unrelated pre-existing package test failures are documented under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the failing-then-passing regression tests attached below.

# Sync with develop

- [x] Branched from and up to date with the latest `origin/develop` (`0bb46bb0a5`); zero conflicts.
- [x] Owning-package gates pass post-sync; the only failing package tests are pre-existing and unrelated (documented below).

# Risks

Low. The change is confined to `TelegramTaskBoard.render` in `plugins/plugin-telegram/src/task-board.ts`. It adds per-`(chat, thread)`-key serialization around the existing post-or-edit body (extracted verbatim into a private `renderOnce`). No public signature, store contract, or existing best-effort error handling changes. Distinct board keys remain independent (proven by a regression test), so throughput for unrelated chats is unaffected.

# Background

## What does this PR do?

`TelegramTaskBoard.render()` was a re-entrant TOCTOU. It did `await this.store.load(key)` and, on a miss, `await this.deps.post(...)` then `await this.store.save(key, messageId)` with no per-key serialization. The production store (`createRuntimeMemoryBoardStore`) resolves `load`/`save` through real DB round-trips (`runtime.getMemoryById` → `updateMemory`/`createMemory`), so any two concurrent triggers for the same `(chat, thread)` — e.g. the orchestrator digest sink (`registerTelegramTaskBoardSupervisorSink`) firing on a task status change while a user runs `/tasks` — both observed `existing === undefined`, both posted a fresh board, and both pinned it. The result was a **duplicate pinned board plus a stale, orphaned message id** that is never edited again (`save` is last-write-wins). This defeats the #8902 AC3 guarantee that the board is never duplicated for one `(chat, thread)` and that `/tasks` after a restart edits the existing pinned board rather than posting a duplicate.

The fix adds a per-key in-flight render chain (`Map<string, Promise<number>>`). Each `render` awaits any in-flight render for its key before running, making the `load → post → save` sequence atomic per board; the second concurrent render then observes the saved `messageId` and edits in place. A prior render's failure does not abort a later one, and the tail of the chain clears its own map entry so a render already queued behind it keeps serializing. The existing best-effort store error handling is preserved unchanged.

## What kind of change is this?

Bug fix (non-breaking change which fixes a concurrency defect).

# Documentation changes needed?

No. The class header in `task-board.ts` was expanded to document the serialization invariant; no user-facing docs change because the observable contract (one pinned board per chat/thread) is what #8902 already promised.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/task-board.test.ts`, the new `describe("TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3)")` block. It builds a **real** `TelegramTaskBoard` with an async store whose `load`/`save`/`forget` each await a microtask, mirroring the runtime-memory store's DB round-trip — the exact window that let two concurrent first renders both observe `undefined`. No mock stands in for the system under test.

## Detailed testing steps

- Fire two `render()` calls for the same chat via `Promise.all` → asserts `post` called once, `pin` once, both callers resolve to the single id, exactly one id persisted, and the in-flight chain is drained.
- Concurrent renders when a stored id already exists → asserts all three edit `55` in place and none post/pin.
- Concurrent renders where the first edit rejects mid-race (message deleted) → asserts a single repost (id `11`), both callers resolve to it, and it is the persisted id.
- Concurrent renders across distinct `(chat, thread)` keys → asserts three posts, zero edits (independence preserved).
- `forget()` serialized with an in-flight render (review follow-up) → a render is blocked inside `edit()` while a concurrent `forget()` is issued; asserts the stored id survives mid-edit, the render edits in place (no double-post), and `forget` applies only after the render completes.
- A failed op on the chain does not abort a later render (review follow-up) → pins the documented `enqueue` guarantee that `await prior.catch(() => undefined)` waits for the prior op to **settle**, not succeed; a first render whose `save` rejects must not propagate into the queued second render, which posts and persists its own board. Discriminating: fails against the `await prior;` mutant (no `.catch`) and no other.

**Reproduction note:** `task-board.ts` is byte-identical between the audited revision and `origin/develop` (`git diff --quiet e858e95f0a origin/develop -- plugins/plugin-telegram/src/task-board.ts` → no diff), so the defect is present on `develop`.

**Failing-then-passing proof** — the new race-window tests fail against the unfixed source and pass after the fix. Re-captured at the current head `90b106ee` (the tail-check test added in that commit brings the new-test count to five and the before-fix failure count to four); the head `task-board.ts` was restored byte-for-byte after capture (`git diff --quiet` → clean).

<details><summary>Before fix (five new tests vs. unfixed base <code>task-board.ts</code> at <code>0bb46bb0a5</code>) — 4 failed</summary>

```
 × posts exactly once when two first renders race for the same board 17ms
 × reposts exactly once when the first edit fails mid-race (message deleted) 7ms
 × serializes forget() with an in-flight render so a reset can't strand the store mid-edit 7ms
 × a render started after an earlier one settles still serializes behind the queued one 2ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  ... > posts exactly once when two first renders race for the same board
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 FAIL  ... > reposts exactly once when the first edit fails mid-race (message deleted)
AssertionError: expected 55 to be 11 // Object.is equality
 FAIL  ... > serializes forget() with an in-flight render so a reset can't strand the store mid-edit
AssertionError: expected undefined to be 55 // Object.is equality
 FAIL  ... > a render started after an earlier one settles still serializes behind the queued one
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
      Tests  4 failed | 15 passed (19)
```
</details>

<details><summary>After fix — full <code>task-board.test.ts</code> suite, 19 passed</summary>

```
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > posts exactly once when two first renders race for the same board 10ms
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > only edits (never posts) when a stored id already exists under concurrency 3ms
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > reposts exactly once when the first edit fails mid-race (message deleted) 6ms
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > serializes forget() with an in-flight render so a reset can't strand the store mid-edit 16ms
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > a failed op on the chain does not abort a later render for the same board 3ms
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > a render started after an earlier one settles still serializes behind the queued one 5ms
 ✓ ... concurrent render serialization (#29899, #8902 AC3) > keeps distinct (chat, thread) keys unserialized from each other 1ms
 Test Files  1 passed (1)
      Tests  19 passed (19)
```
</details>

# Evidence Gate

<!-- evidence-head:90b106ee02b8fb15d5d1e7b9969bccc0c4de495a -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend concurrency fix in the Telegram connector; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend concurrency fix in the Telegram connector; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; the observable behavior is proven by the failing-then-passing concurrency tests above.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - library-level connector class (TelegramTaskBoard), not a running service; no structured server log is emitted. The real post/edit/pin/store code path is exercised end-to-end by the inline failing-then-passing concurrency tests and verbose suite run in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is connector-side render serialization.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the durable artifact is the persisted board message id in the runtime-memory store; the tests assert exactly one id persists after a race (store.map.get('100:')), proving no orphaned board. See inline Evidence Details.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend: `[TelegramTaskBoard]` is the owning subsystem. The verbose suite run exercises the real class through post/edit/pin/store call assertions.

<details><summary>Full <code>task-board.test.ts</code> verbose run (19 passed) — head <code>90b106ee</code></summary>

```
 ✓ composeTaskBoard (#8902) > lists live tasks with status emoji and a closed tail 6ms
 ✓ composeTaskBoard (#8902) > renders an empty state with no tasks 1ms
 ✓ TelegramTaskBoard (#8902) > posts on first render, then edits the same message in place 18ms
 ✓ TelegramTaskBoard (#8902) > keeps separate boards per chat/thread 1ms
 ✓ TelegramTaskBoard (#8902) > reposts a fresh board when an in-place edit fails (message deleted) 1ms
 ✓ TelegramTaskBoard pinning (#8902 AC1) > pins a freshly-posted board once, and NOT on an in-place edit 1ms
 ✓ TelegramTaskBoard pinning (#8902 AC1) > still posts the board when pinning fails (best-effort) 1ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > posts exactly once when two first renders race for the same board 10ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > only edits (never posts) when a stored id already exists under concurrency 3ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > reposts exactly once when the first edit fails mid-race (message deleted) 6ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > serializes forget() with an in-flight render so a reset can't strand the store mid-edit 16ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > a failed op on the chain does not abort a later render for the same board 3ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > a render started after an earlier one settles still serializes behind the queued one 5ms
 ✓ TelegramTaskBoard concurrent render serialization (#29899, #8902 AC3) > keeps distinct (chat, thread) keys unserialized from each other 1ms
 ✓ TelegramTaskBoard persistence (#8902 AC3) > survives a 'restart' via a shared store — edits the persisted board, not re-post 2ms
 ✓ createRuntimeMemoryBoardStore (#8902 AC3) > round-trips a board id (save → load), upserts, and tombstones on forget 3ms
 ✓ Telegram task board supervisor sink (#8902 AC2) > updates the existing pinned board on supervisor status changes instead of posting a digest 8ms
 ✓ Telegram task board supervisor sink (#8902 AC2) > declines supervisor delivery when the Telegram room cannot be resolved 2ms
 ✓ Telegram task board supervisor sink (#8902 AC2) > declines a supervisor update for a different Telegram account 2ms
 Test Files  1 passed (1)
      Tests  19 passed (19)
```
</details>

<details><summary>typecheck + lint:check (owning package) — clean</summary>

```
=== lint:check ===
$ bunx @biomejs/biome check .
Checked 66 files in 462ms. No fixes applied.

=== typecheck ===
$ tsc --noEmit -p tsconfig.json
typecheck exit=0
```
</details>

Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

`N/A - backend concurrency fix; no rendered UI.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- `bun run --cwd plugins/plugin-telegram test` at head `90b106ee` reports **2 failing tests in 1 file** (`messageConnector.test.ts`: "clamps fetch limits and filters room reads to the target account" and "searches fetched connector messages case-insensitively with a sane fallback limit"), out of **282 passed / 2 failed (284) across 28 files**. Both failures are **pre-existing and unrelated** to this change: they live in the message-connector adapter, not `task-board.ts`, and this PR's diff touches only `task-board.ts` and its test. `task-board.test.ts` is fully green (19/19). (The earlier `5 failing files` figure reflected an older `develop`; the package suite has since grown and the unrelated-failure set narrowed to these two.)
- Package `typecheck` requires `@elizaos/vault` and `@elizaos/plugin-commands` to be built first (workspace declaration outputs); after `run-turbo build` for those, `typecheck` is clean, as shown above.
- Evidence artifacts are embedded inline rather than as GitHub-hosted attachment URLs because this PR is authored from a fork by a `pull`-only contributor: the `pr-evidence` release upload requires `push` access to `elizaOS/eliza` (returns HTTP 404 for a fork contributor), and the `user-attachments/files/<id>` route is only mintable through GitHub's web composer session, not a token-authenticated API call. `scripts/check-pr-evidence.mjs` documents this same limitation ("Fork contributors cannot upload to the pr-evidence release (push access required)"). The inline log blocks above are the real, unedited captured output re-verified at head `90b106ee`.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@0bb46bb0a59d795c5e28957640151af75fd2f39f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0bb46bb0a59d795c5e28957640151af75fd2f39f:packages/skills/skills/contribute-to-eliza"} -->





