### PR TITLE
fix(cloud): scope provisioning deploy cleanliness to used source

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -337,12 +337,14 @@ jobs:
             exit 1
           }
           # Self-hosted runners can retain files created after checkout's own
-          # cleanup hook. Re-establish the exact immutable tree immediately
-          # before migrations; suppress removed paths so runner-local names do
-          # not enter deployment logs.
+          # cleanup hook. Re-establish the exact immutable superproject tree
+          # immediately before migrations; suppress removed paths so runner-
+          # local names do not enter deployment logs. This daemon path never
+          # initializes or consumes the native submodules, so retained dirt
+          # inside those worktrees is outside this deployment boundary.
           git reset --hard --quiet "$EXPECTED_DEPLOY_SHA"
           git clean -ffdx -q
-          [ -z "$(git status --porcelain)" ] || {
+          [ -z "$(git status --porcelain --ignore-submodules=all)" ] || {
             echo "::error::Migration checkout is not clean"
             exit 1
           }

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -393,6 +393,9 @@ describe("provisioning deployment EnvironmentFile wiring", () => {
     );
     expect(workflow).not.toContain("lookup_environment_setting");
     expect(workflow).not.toContain('sudo cat "$ENV_FILE"');
+    expect(workflow).toContain(
+      "git status --porcelain --ignore-submodules=all",
+    );
     expect(workflow).toContain("AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0");
     expect(workflow).toContain('DATABASE_URL="$DATABASE_URL"');
     expect(workflow).toContain(


### PR DESCRIPTION
Closes #29904

## What changed

The exact-SHA provisioning deploy still resets, cleans, and verifies the superproject, but excludes retained dirt inside native submodule worktrees. This daemon/migration path neither initializes nor consumes those submodules.

## Why

Two staging retries stopped before mutation with `Migration checkout is not clean` after a successful exact-SHA checkout/reset/clean. Persistent self-hosted-runner submodule state was outside the deployment boundary but still surfaced through unqualified `git status`.

## Verification

- `bun test packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts` — 12 pass, 179 assertions
- `git diff --check` — pass
- Live staging deployment attempts: both failed closed before migrations/SSH at the old cleanliness fence; no host mutation occurred.

## Evidence

- UI/screenshots/video: N/A — no rendered UI changes.
- Secret handling: N/A — no secret value changes or output.
- Live after evidence: pending merge and exact-SHA staging redeploy.