### PR TITLE
fix(cloud): preserve hosted logout authority

### DIFF
--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -9,12 +9,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const getCurrentUserMock = mock(
   async (): Promise<{ id: string; organization_id: string } | null> => null,
 );
+const readStewardSessionTokenMock = mock((): string | null => null);
 const endAllUserSessionsMock = mock(async () => undefined);
 const verifyStewardTokenMock = mock(async () => ({
   userId: "steward-1",
   issuedAt: 100,
 }));
 const revokeInferenceSessionsThroughMock = mock(async () => undefined);
+const markSsoBridgeLogoutMock = mock(async () => undefined);
 
 mock.module("@/lib/auth", () => ({
   invalidateSessionCaches: mock(async () => undefined),
@@ -22,6 +24,7 @@ mock.module("@/lib/auth", () => ({
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   getCurrentUser: getCurrentUserMock,
+  readStewardSessionToken: readStewardSessionTokenMock,
 }));
 mock.module("@/lib/auth/steward-client", () => ({
   verifyStewardTokenCached: verifyStewardTokenMock,
@@ -42,6 +45,9 @@ mock.module("@/lib/services/inference-credential-revocation", () => ({
   isInferenceStrongRevocationEnabled: (env: Record<string, unknown>) =>
     env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
   revokeInferenceSessionsThrough: revokeInferenceSessionsThroughMock,
+}));
+mock.module("@/lib/services/sso-bridge-codes", () => ({
+  markSsoBridgeLogout: markSsoBridgeLogoutMock,
 }));
 
 mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
@@ -69,15 +75,42 @@ function deletedCookieNames(res: Response): string[] {
 
 beforeEach(() => {
   getCurrentUserMock.mockResolvedValue(null);
+  readStewardSessionTokenMock.mockReturnValue(null);
   verifyStewardTokenMock.mockResolvedValue({
     userId: "steward-1",
     issuedAt: 100,
   });
   revokeInferenceSessionsThroughMock.mockResolvedValue(undefined);
+  markSsoBridgeLogoutMock.mockClear();
 });
 
 describe("POST /api/auth/logout cookie clearing", () => {
+  test("stamps logout authority for a bearer-authenticated hosted session", async () => {
+    readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer header.payload.signature",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(verifyStewardTokenMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "header.payload.signature",
+    );
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledWith("steward-1");
+  });
+
   test("strong rollout commits the session cutoff before reporting logout success", async () => {
+    readStewardSessionTokenMock.mockReturnValue("prod-token");
     getCurrentUserMock.mockResolvedValue({
       id: "user-1",
       organization_id: "org-1",
@@ -111,6 +144,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
   });
 
   test("strong rollout clears cookies but returns 503 when the cutoff is unconfirmed", async () => {
+    readStewardSessionTokenMock.mockReturnValue("prod-token");
     getCurrentUserMock.mockResolvedValue({
       id: "user-1",
       organization_id: "org-1",

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -5,14 +5,17 @@
  */
 
 import { Hono } from "hono";
-import { deleteCookie, getCookie } from "hono/cookie";
+import { deleteCookie } from "hono/cookie";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { invalidateSessionCaches } from "@/lib/auth";
 import { checkElizaMutatingRequestOrigin } from "@/lib/auth/browser-origin-policy";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import { verifyStewardTokenCached } from "@/lib/auth/steward-client";
 import { stewardCookieNames } from "@/lib/auth/steward-cookies";
-import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
+import {
+  getCurrentUser,
+  readStewardSessionToken,
+} from "@/lib/auth/workers-hono-auth";
 import {
   getRequestIp,
   RateLimitPresets,
@@ -47,12 +50,11 @@ app.post("/", async (c) => {
   }
 
   const cookieNames = stewardCookieNames(c.env.ENVIRONMENT);
-  // Each environment reads only its own scoped cookie. The bounded read-only
-  // migration window that let non-production fall back to the historical
-  // unsuffixed cookie closed on 2026-08-04 (#14130); in production the scoped
-  // names already ARE the unsuffixed names, so `cookieNames.token` covers both
-  // eras and no separate legacy read is needed.
-  const stewardToken = getCookie(c, cookieNames.token);
+  // Hosted SPAs authenticate with a localStorage JWT in Authorization, while
+  // auth-origin pages may use the environment-scoped cookie. Resolve both
+  // through the same JWT-only selection used by getCurrentUser; API-key
+  // bearers are deliberately excluded from browser-session teardown.
+  const stewardToken = readStewardSessionToken(c);
 
   // Clear cookies FIRST. Clearing them is what actually logs the user out, and
   // it must happen even if the server-side teardown below fails (a transient DB
@@ -138,10 +140,8 @@ app.post("/", async (c) => {
   }
 
   try {
-    // Only tear down caches/sessions when this environment owned the token that
-    // was actually presented. The non-production legacy read fallback closed on
-    // 2026-08-04 (#14130), so stewardToken here is always this environment's own
-    // scoped cookie.
+    // Only tear down caches/sessions when the request presented a Steward JWT
+    // through this environment's scoped cookie or Authorization header.
     if (stewardToken) {
       await invalidateSessionCaches(stewardToken);
       logger.debug("[Logout] Invalidated session caches for token");
@@ -161,7 +161,7 @@ app.post("/", async (c) => {
             ip: getRequestIp(c),
             user_agent: c.req.header("user-agent") ?? undefined,
             request_id: c.get("requestId"),
-            metadata: { method: "steward_cookie" },
+            metadata: { method: "steward_session" },
           })
           // error-policy:J7 audit write is diagnostic; logout already succeeded via
           // the cookie clear above, so a dropped audit event is logged, not fatal.

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
@@ -126,6 +126,7 @@ mock.module("../utils/logger", () => ({
 const {
   apiKeyScopeHashPrefix,
   getCurrentUser,
+  readStewardSessionToken,
   requireAdmin,
   requireApiKeyCredential,
   requireCurrentBillingManagerSession,
@@ -212,6 +213,24 @@ beforeEach(() => {
 });
 
 describe("Workers API-key auth", () => {
+  test("selects a bearer Steward JWT for session teardown", () => {
+    const context = contextWithHeaders({
+      authorization: "Bearer header.payload.signature",
+      cookie: "steward-token=cookie.jwt.signature",
+    });
+
+    expect(readStewardSessionToken(context as never)).toBe("header.payload.signature");
+  });
+
+  test("does not mistake an API-key bearer for a Steward session", () => {
+    const context = contextWithHeaders({
+      authorization: "Bearer eliza_live_key",
+      cookie: "steward-token=cookie.jwt.signature",
+    });
+
+    expect(readStewardSessionToken(context as never)).toBe("cookie.jwt.signature");
+  });
+
   test("returns a service-unavailable error when API-key storage throws", async () => {
     await expect(
       requireUserOrApiKey(contextWithApiKey("eliza_live_key") as never),

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -48,6 +48,12 @@ function looksLikeJwt(token: string): boolean {
   return parts.length === 3 && parts.every((p) => p.length > 0);
 }
 
+/** Returns the Steward JWT presented by a browser session, never an API key. */
+export function readStewardSessionToken(c: AppContext): string | null {
+  const bearer = readBearer(c);
+  return bearer && looksLikeJwt(bearer) ? bearer : readStewardCookie(c);
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
@@ -235,9 +241,7 @@ export async function getCurrentUser(c: AppContext): Promise<AuthedUser | null> 
     return testUser;
   }
 
-  const bearer = readBearer(c);
-  const cookieToken = readStewardCookie(c);
-  const token = bearer && looksLikeJwt(bearer) ? bearer : cookieToken;
+  const token = readStewardSessionToken(c);
 
   if (!token) {
     c.set("user", null);

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.sso.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.sso.test.tsx
@@ -172,12 +172,12 @@ describe("AppModeEntryRoute — SSO auto-bridge (managed app origin)", () => {
     expect(replacedUrls).toEqual([]);
   });
 
-  it("a real sign-in clears the logged-out marker (logout suppression ends at the next login)", async () => {
+  it("an authenticated rerender cannot erase an in-flight logout marker", async () => {
     localStorage.setItem(SSO_LOGGED_OUT_KEY, "1");
     signIn();
     renderEntry("/");
     expect(await screen.findByTestId("join-page")).toBeTruthy();
-    expect(localStorage.getItem(SSO_LOGGED_OUT_KEY)).toBeNull();
+    expect(localStorage.getItem(SSO_LOGGED_OUT_KEY)).toBe("1");
     expect(replacedUrls).toEqual([]);
   });
 });

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -27,7 +27,6 @@ import { loadPersistedActiveServer } from "../../state/persistence";
 import { useAgents } from "../instances/lib/data/eliza-agents";
 import { useSessionAuth } from "../lib/use-session-auth";
 import {
-  clearSsoLoggedOut,
   redirectToSsoBridge,
   shouldAutoBridgeToSso,
 } from "../sso-bridge/sso-bridge";
@@ -83,12 +82,7 @@ export function AppModeEntryRoute({
   const [ssoBridging, setSsoBridging] = useState<boolean | null>(null);
   useEffect(() => {
     if (!ready) return;
-    if (authenticated) {
-      // Any live sign-in on this origin re-arms auto-bridging for the future
-      // (the logged-out marker's job ends at the next real login).
-      clearSsoLoggedOut();
-      return;
-    }
+    if (authenticated) return;
     if (ssoDecisionRef.current) return;
     ssoDecisionRef.current = true;
     if (!shouldAutoBridgeToSso()) {

--- a/packages/ui/src/cloud/join/JoinPage.sso-handoff.test.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.sso-handoff.test.tsx
@@ -104,6 +104,16 @@ describe("JoinPage managed-app SSO handoff", () => {
     expect(replacedUrls).toEqual([]);
   });
 
+  it("does not erase an in-flight logout marker while old auth is still rendered", async () => {
+    authenticatedRef.current = true;
+    markSsoLoggedOut();
+    runJoinFlowMock.mockResolvedValue({ agentId: "agent-1" });
+    render(<JoinPage />);
+
+    await waitFor(() => expect(runJoinFlowMock).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem("eliza_sso_logged_out")).toBe("1");
+  });
+
   it("restarts a join request cancelled by the StrictMode probe", async () => {
     authenticatedRef.current = true;
     runJoinFlowMock

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -26,7 +26,6 @@ import { appModeNavigation } from "../app-mode/app-mode";
 import { publishPersonalEntryHandoff } from "../app-mode/use-personal-entry";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import {
-  clearSsoLoggedOut,
   redirectToSsoBridge,
   shouldAutoBridgeToSso,
 } from "../sso-bridge/sso-bridge";
@@ -139,7 +138,6 @@ export default function JoinPage(): React.JSX.Element {
       });
       return;
     }
-    clearSsoLoggedOut();
     if (appHandoff) {
       // The apex is the billing console and cannot boot chat. Hand off before
       // any Shared identity request. Preserve /join so the app host restores

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
@@ -180,6 +180,7 @@ describe("StewardLoginSection email magic-link companion code", () => {
   });
 
   it("redeems only six digits and establishes the session from the verify response", async () => {
+    window.localStorage.setItem("eliza_sso_logged_out", "1");
     renderSection();
     await startEmailLogin();
 
@@ -204,6 +205,7 @@ describe("StewardLoginSection email magic-link companion code", () => {
         "refresh-token",
       ),
     );
+    expect(window.localStorage.getItem("eliza_sso_logged_out")).toBeNull();
   });
 
   it("binds consumed-link recovery to the challenged email", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -71,6 +71,7 @@ import {
   DEFAULT_STEWARD_TENANT_ID,
 } from "../../../shell/steward-config";
 import { resolveBrowserStewardApiUrl } from "../../../shell/steward-url";
+import { clearSsoLoggedOut } from "../../../sso-bridge/sso-bridge";
 import { getErrorMessage } from "../../lib/error-message";
 import {
   consumePendingOAuthReturnTo,
@@ -186,6 +187,7 @@ async function persistStewardToken(token: string): Promise<void> {
       "Eliza Cloud sign-in needs browser storage. Enable storage for this site and try again.",
     );
   }
+  clearSsoLoggedOut();
 }
 
 /**

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -566,6 +566,9 @@ describe("signOutFromSsoBridgedHost", () => {
       expect(new Headers(calls[0].init?.headers).get("content-type")).toBe(
         "application/json",
       );
+      expect(new Headers(calls[0].init?.headers).get("authorization")).toBe(
+        `Bearer ${token}`,
+      );
       expect(proofAtServerLogoutIssue).toBe(false);
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
     } finally {
@@ -625,7 +628,9 @@ describe("prepareSsoAccountSwitch", () => {
     }
   });
 
-  it("marks the account-switch logout request as non-simple", async () => {
+  it("authorizes the non-simple account-switch logout request", async () => {
+    const token = liveToken();
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
     const realFetch = globalThis.fetch;
     globalThis.fetch = (() =>
       Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
@@ -638,6 +643,9 @@ describe("prepareSsoAccountSwitch", () => {
       });
       expect(new Headers(calls[0].init?.headers).get("content-type")).toBe(
         "application/json",
+      );
+      expect(new Headers(calls[0].init?.headers).get("authorization")).toBe(
+        `Bearer ${token}`,
       );
     } finally {
       globalThis.fetch = realFetch;

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -618,6 +618,7 @@ export async function signOutFromSsoBridgedHost(
   hostname: string = window.location.hostname,
   fetchFn: typeof fetch = fetch,
 ): Promise<void> {
+  const stewardToken = readStoredStewardToken();
   // Invalidate before even issuing the server logout request: fetch adapters
   // may have synchronous hooks, and no re-entrant token publication may reuse
   // proof from the authority epoch being ended.
@@ -628,7 +629,10 @@ export async function signOutFromSsoBridgedHost(
     ? fetchFn(`${base}/api/auth/logout`, {
         method: "POST",
         credentials: "include",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(stewardToken ? { Authorization: `Bearer ${stewardToken}` } : {}),
+        },
       })
     : // error-policy:J6 best-effort server teardown — the local marker is
       // already set and the local scrub below always runs.
@@ -652,6 +656,7 @@ export async function prepareSsoAccountSwitch(
   hostname: string = window.location.hostname,
   fetchFn: typeof fetch = fetch,
 ): Promise<void> {
+  const stewardToken = readStoredStewardToken();
   invalidateStewardServerCookieSyncMarker();
   markSsoLoggedOut();
   const base = apiBaseForHostname(hostname);
@@ -663,7 +668,10 @@ export async function prepareSsoAccountSwitch(
   const serverLogout = fetchFn(`${base}/api/auth/logout`, {
     method: "POST",
     credentials: "include",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(stewardToken ? { Authorization: `Bearer ${stewardToken}` } : {}),
+    },
   });
   await clearStaleStewardSession();
   const response = await serverLogout;


### PR DESCRIPTION
# Relates to

Fixes #29889

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed contracts from the regression tests and verification evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `4635c6496e7d898452b0f942538cfb41900f2a7b`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Medium. This changes browser-session logout authority and SSO re-entry suppression. The main risks are rejecting API-key authentication as a browser session, retaining logout suppression after a successful login, or failing to tear down cookie-backed sessions. Dedicated tests cover all three boundaries.

# Background

## What does this PR do?

Hosted app sessions keep their Steward JWT in local storage. Logout previously sent only cookies, so the API returned success without stamping the server-side SSO logout marker when no matching cookie existed. At the same time, authenticated route effects could clear the local logout marker before the old auth state finished rerendering.

This change:

- captures the Steward JWT before local cleanup and sends it to hosted logout;
- resolves logout authority from a JWT-shaped bearer or the environment-scoped Steward cookie, while excluding API-key bearers;
- keeps the local logout marker through stale authenticated rerenders; and
- clears the marker only after an explicit token write succeeds.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed. The behavior restores the documented hosted logout contract.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts`
- `packages/cloud/api/auth/logout/route.test.ts`
- `packages/ui/src/cloud/app-mode/AppModeEntryRoute.sso.test.tsx`

## Detailed testing steps

1. Sign in on a hosted app origin with a local Steward JWT.
2. Sign out and inspect the request: it includes `Content-Type: application/json`, credentials, and the captured bearer JWT.
3. Confirm the API verifies that JWT and writes the SSO logout marker.
4. Confirm stale authenticated renders do not delete the local logout marker.
5. Complete an explicit login and confirm the marker is cleared only after the new token persists.

Automated evidence:

- UI logout/SSO tests: 61 passed.
- shared auth tests: 37 passed.
- logout route tests: 8 passed.
- UI, Cloud shared, and Cloud API typechecks passed.
- UI, Cloud shared, and Cloud API lint gates passed.
- `bun run verify` passed: 375 workspace tasks plus repository audits.

# Evidence Gate

<!-- evidence-head:6350a29942b76a19de6c5067861f4ec5907aba15 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - no rendered layout, styling, or copy changes; this is authentication state sequencing.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered layout, styling, or copy changes; this is authentication state sequencing.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - the fix is not deployed yet; exact browser/API contracts are exercised by regression tests.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - the fix is not deployed yet; the real Hono route test proves JWT verification and SSO marker persistence calls.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - the fix is not deployed yet; browser request shape and storage transitions are asserted directly.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no schema or persistent data shape changed.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A until deployment. The exact request, route, and state contracts are covered by the tests listed above.

## Screenshots (before / after) + video walkthrough

N/A - no pixels or copy changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

`ELIZA_NODE_PATH=/opt/homebrew/Cellar/node@24/24.19.0/bin/node bun run --cwd packages/app audit:app` completed all 215 captures (214 passed) and then failed its existing strict baseline: 12 unrelated `readableChars` findings in builtin camera, builtin rolodex, and plugin cockpit views. None of those files or rendered surfaces are changed here. The repository-wide `bun run verify` gate passed.

Live staging confirmation is intentionally pending deployment of this PR; no claim of deployed success is made here.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
