### PR TITLE
test(google-workspace): assert the Gmail limit rejection #28112 introduced

### DIFF
--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -1447,7 +1447,7 @@ describe("google plugin", () => {
     });
   });
 
-  it("normalizes hostile Gmail limits before listing messages", async () => {
+  it("rejects an unusable Gmail limit and still normalizes the unresponded-thread window", async () => {
     const fakeGmail = {
       users: {
         messages: {
@@ -1461,25 +1461,38 @@ describe("google plugin", () => {
     const factory = { gmail: vi.fn(async () => fakeGmail) } as GoogleApiClientFactory;
     const client = new GoogleGmailClient(factory);
 
+    // #28112 replaced the silent maxResults clamp with an explicit typed
+    // rejection, so an unusable limit is refused rather than quietly rewritten.
     await expect(
       client.searchGmailMessages({
         accountId: "acct_google_1",
         query: "in:inbox",
         maxResults: Number.POSITIVE_INFINITY,
       })
-    ).resolves.toEqual([]);
-    fakeGmail.users.messages.list.mockClear();
+    ).rejects.toThrow(/maxResults must be a positive integer/);
     await expect(
       client.listGmailUnrespondedThreads({
         accountId: "acct_google_1",
         olderThanDays: -4,
         maxResults: Number.NaN,
       })
-    ).resolves.toEqual([]);
+    ).rejects.toThrow(/maxResults must be a positive integer/);
+
+    // Rejection happens before any request is issued.
+    expect(fakeGmail.users.messages.list).not.toHaveBeenCalled();
+
+    // olderThanDays keeps its documented clamp: -4 normalizes to the 3-day floor.
+    // The window is forwarded without a caller limit, so Gmail is asked for a
+    // full page rather than a silently narrowed one.
+    await client.listGmailUnrespondedThreads({
+      accountId: "acct_google_1",
+      olderThanDays: -4,
+      maxResults: 100,
+    });
 
     expect(fakeGmail.users.messages.list).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ q: "in:sent older_than:3d", maxResults: 100 })
+      expect.objectContaining({ q: "in:sent older_than:3d", maxResults: 500 })
     );
   });
 


### PR DESCRIPTION
# Relates to

Closes #29911.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Repairs a suite failing on `develop` right now inside `tests / Plugin Tests`.
- [x] Changes no runtime source — the diff is one test.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] One file differs: `+18/-5`.

# Risks

None to runtime. No production file is touched, and the change strictly increases what is
pinned: the rejection contract, the absence of a request when the limit is refused, and
the surviving `olderThanDays` clamp.

# Background

## What is broken

```
FAIL src/index.test.ts > normalizes hostile Gmail limits before listing messages
AssertionError: promise rejected "ElizaError: Gmail maxResults must be a positive integer"
                instead of resolving
  ❯ explicitPositiveLimit src/gmail.ts:1446:11
Serialized Error: { code: 'GOOGLE_GMAIL_LIMIT_INVALID', context: { field: 'maxResults', value: Infinity } }
```

## The test asserts behaviour #28112 deliberately removed

`explicitPositiveLimit` was introduced by **#28112** (`4333300926`, "fix(context): remove
remaining silent model-content caps") — verified by counting the symbol across
`gmail.ts`'s history: 0 at every preceding commit, 5 from that one onward. It refuses an
unusable limit instead of quietly rewriting it, which is that PR's whole point.

The test still passes `Number.POSITIVE_INFINITY` and `Number.NaN` and expects both calls
to **resolve**. The code is right; the test is stale.

## Two further stale details

1. `listGmailUnrespondedThreads({ maxResults: NaN })` hits the same validator at
   `gmail.ts:407`, so `users.messages.list` is never reached — the second
   `.resolves.toEqual([])` was unreachable too.
2. The trailing `maxResults: 100` expectation no longer holds. That method bounds the
   **returned** threads (`gmail.ts:470`, `sorted.slice(0, maxResults)`) rather than
   forwarding the caller's limit, so the request carries `GMAIL_LIST_PAGE_SIZE` (500,
   `gmail.ts:60`). Observed directly against the real client:

```json
[{ "userId": "me", "q": "in:sent older_than:3d", "includeSpamTrash": false, "maxResults": 500 }]
```

## What is still genuinely normalized

`olderThanDays` keeps its clamp (`normalizedLimit(params.olderThanDays, 3, 3650)`,
`gmail.ts:406`), so `-4` still becomes the 3-day floor. That part of the original intent
is real and is preserved — now reached with a usable limit so the assertion actually runs.

# Documentation changes needed?

No. Test only.

# Testing

## Where should a reviewer start?

The mutation block, and the fact that three assertions which previously could not be
reached now execute.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `vitest run src/index.test.ts -t "rejects an unusable Gmail limit"` | **1 passed** |
| whole file, before vs after | `8 failed | 27 passed` → `7 failed | 28 passed` |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| diff vs `develop` | `+18/-5`, one test file, zero runtime files |

Mutation resistance — restoring **only** develop's version of the test:

```
AssertionError: promise rejected "ElizaError: Gmail maxResults must be a po… { …(3) }" instead of resolving
Caused by: ElizaError: Gmail maxResults must be a positive integer.
 Tests  1 failed | 34 skipped (35)
```

**Scope, stated plainly.** This fixes one of the eight failures in that file; it does not
green the lane on its own. The other seven are a separate root cause — the OAuth
compensation path added by `a2697aa7b0` reaching for collaborators the harness never
provided — which I filed as #29743 with a reproduction. They are deliberately not bundled
here: this one is a stale assertion against a merged doctrine, those are a harness gap,
and they want different reviewers.

# Evidence Gate

<!-- evidence-head:4be1c8324fd81e0b9ae6bf484500a66db9b9ef92 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-only change to a Gmail client contract; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-only change; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable result is the suite's pass/fail and the recorded request args, both quoted above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the real GoogleGmailClient is driven directly against an API double`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in Gmail limit validation`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the recorded users.messages.list argument object, quoted above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Identified and fixed by Claude Code (`claude-opus-5`): `tests / Plugin Tests` triage, local reproduction at the current `develop` tip, the symbol-count history isolating `explicitPositiveLimit` to #28112, direct observation of the real request arguments, and the mutation proof.

Attribution status: self-reported
