### PR TITLE
test(scripts): anchor the deploy-fence ordering check on a stable guard prefix

### DIFF
--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -153,8 +153,11 @@ describe("provisioning worker deployment contract", () => {
       verify,
     );
     const clean = workflow.indexOf("git clean -ffdx -q", verify);
+    // Ordering anchor only: match the guard's stable prefix so adding or
+    // removing a `git status` flag cannot silently turn this index into -1 and
+    // fail the ordering assertion instead of the ordering itself.
     const cleanVerdict = workflow.indexOf(
-      '[ -z "$(git status --porcelain)" ] || {',
+      '[ -z "$(git status --porcelain',
       verify,
     );
     expect(reset).toBeGreaterThan(exactSourceCheck);


### PR DESCRIPTION
# Relates to

Closes #29913.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Repairs two lanes that are red on `develop` right now.
- [x] Changes no runtime source and no workflow — the diff is one test anchor.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] One file differs: `+4/-1`.

# Risks

None. No production file, no workflow, and no assertion is removed — the same
`exactSourceCheck → reset → clean → cleanVerdict → migration` ordering is still pinned.
The change makes the anchor that locates one of those steps tolerant of flag changes to
the step itself.

# Background

## What is broken

`canonical / Tests (scripts)` and `tests / Script Tests (Linux)` are red on `develop`.
Exactly one test fails, and it reproduces locally at the current tip:

```
(fail) provisioning worker deployment contract > runs canonical migrations from the exact SHA before any SSH mutation
error: expect(received).toBeGreaterThan(expected)
Expected: > 20011
 1 fail
 418 expect() calls
```

## Root cause

The suite locates workflow steps by exact substring and asserts their order. Its anchor
for the migration-checkout cleanliness guard was a hardcoded copy of that line:

```ts
const cleanVerdict = workflow.indexOf(
  '[ -z "$(git status --porcelain)" ] || {',
  verify,
);
```

**#29905** (`4635c6496e`, "fix(cloud): ignore unused submodule dirt in deploy fence",
2026-08-29T10:22) changed the guard in
`.github/workflows/deploy-eliza-provisioning-worker.yml:347`:

```yaml
[ -z "$(git status --porcelain --ignore-submodules=all)" ] || {
```

Verified by counting `ignore-submodules=all` across that workflow's history — 0 at every
preceding commit, 1 from `4635c6496e` onward. The test file last changed on 2026-08-28
(`681c659974`), so it predates the flag.

`indexOf` returns `-1`, and the assertion fails on the **anchor** rather than on the
ordering it exists to protect.

**The workflow is right.** Ignoring submodule dirt in that fence is the entire point of
#29905 — this repository carries submodules and unrelated submodule state should not fail
a deployment cleanliness check. Nothing there needs reverting.

## What is the fix?

`cleanVerdict` occurs once in the file and is used only inside `toBeGreaterThan`, so it is
an ordering index and nothing else. Anchor it on the guard's stable prefix:

```diff
+    // Ordering anchor only: match the guard's stable prefix so adding or
+    // removing a `git status` flag cannot silently turn this index into -1 and
+    // fail the ordering assertion instead of the ordering itself.
     const cleanVerdict = workflow.indexOf(
-      '[ -z "$(git status --porcelain)" ] || {',
+      '[ -z "$(git status --porcelain',
       verify,
     );
```

`git status --porcelain` occurs exactly once in that workflow, so the anchor stays
unambiguous. Re-hardcoding the new flag would green the lane too, but would break again
the next time the guard's flags move — which is what just happened.

# Documentation changes needed?

No. Test only.

# Testing

## Where should a reviewer start?

The mutation block, and the fact that the ordering assertions themselves are untouched.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts` | **25 pass, 0 fail** |
| `grep -c 'git status --porcelain' <workflow>` | `1` — the prefix anchor is unambiguous |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| diff vs `develop` | `+4/-1`, one test file, zero runtime or workflow files |

Mutation resistance — restoring **only** develop's version of the anchor:

```
error: expect(received).toBeGreaterThan(expected)
Expected: > 20011
(fail) provisioning worker deployment contract > runs canonical migrations from the exact SHA before any SSH mutation
 1 fail
```

That is the same assertion the hosted `Script Tests (Linux)` job fails with, so the local
reproduction and the CI failure are the same failure. In the hosted log this is the only
non-zero fail count in the lane, so this one test is what takes both script jobs red.

# Evidence Gate

<!-- evidence-head:a98ee8f442fb356012fabe68c470ccf477dbec00 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI test anchor repair; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI test anchor repair; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable result is the suite's pass/fail, quoted above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the suite reads the committed workflow file`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the workflow guard line, quoted above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Identified and fixed by Claude Code (`claude-opus-5`): `Script Tests (Linux)` log triage down to the single non-zero fail count, local reproduction at the exact `develop` tip, the flag-count history isolating the change to #29905, uniqueness check on the replacement anchor, and the mutation proof.

Attribution status: self-reported
