### PR TITLE
fix(plugin-cloud-apps): guard GET_APP id-path against stale/foreign UUID 404

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
@@ -233,6 +233,54 @@ describe("GET_APP", () => {
     expect(reply).not.toContain("Cloud API returned an error");
   });
 
+  it("REGRESSION (#29917 review): an id-endpoint 5xx is an error, not app-not-found", async () => {
+    // The degrade-to-list guard must be scoped to the benign 404/403 of a
+    // stale/foreign id. A 500 from the id endpoint is an outage; if it fell
+    // through to listApps the user would be told their app does not exist
+    // (with the org's app names listed) when the truth is "try again in a
+    // moment". The 500 must re-raise into the outer catch.
+    const uuid = "11111111-2222-3333-4444-555555555555";
+    let listCalled = false;
+    setListApps(() => {
+      listCalled = true;
+      return Promise.resolve({
+        success: true,
+        apps: [makeApp({ name: "Acme Bot", slug: "acme-bot" })],
+      });
+    });
+    setGetApp((id) => {
+      expect(id).toBe(uuid);
+      return Promise.reject(
+        Object.assign(new Error("HTTP 500"), {
+          name: "CloudApiError",
+          statusCode: 500,
+          errorBody: { success: false, error: "Internal Server Error" },
+        }),
+      );
+    });
+
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage("tell me about my app"),
+      undefined,
+      { app: uuid },
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(
+      (requireDefined(result, "action result").data as { reason: string })
+        .reason,
+    ).toBe("error");
+    // No list-based resolution: the outage must not be cross-checked against
+    // the org's other apps.
+    expect(listCalled).toBe(false);
+    const errReply = cb.calls[0]?.text ?? "";
+    expect(errReply).toContain("Cloud API returned an error");
+    expect(errReply).not.toContain("Acme Bot");
+  });
+
   it("REGRESSION (#29917 review): delivery failure on the happy id path reports error, not success", async () => {
     // The stale-UUID guard must cover ONLY the getApp fetch. If the try also
     // wrapped formatting/delivery/return, a rejecting callback after a

--- a/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
@@ -232,4 +232,48 @@ describe("GET_APP", () => {
     expect(reply).toContain("Acme Bot");
     expect(reply).not.toContain("Cloud API returned an error");
   });
+
+  it("REGRESSION (#29917 review): delivery failure on the happy id path reports error, not success", async () => {
+    // The stale-UUID guard must cover ONLY the getApp fetch. If the try also
+    // wrapped formatting/delivery/return, a rejecting callback after a
+    // successful fetch would be swallowed and degrade to list resolution —
+    // reporting success: true for a reply the user never received. The
+    // delivery failure must reach the outer catch, as it does at develop.
+    const uuid = "11111111-2222-3333-4444-555555555555";
+    let listCalled = false;
+    setListApps(() => {
+      listCalled = true;
+      return Promise.resolve({ success: true, apps: [] });
+    });
+    setGetApp((id) =>
+      Promise.resolve({
+        success: true,
+        app: makeApp({ id, name: "By Id App", slug: "by-id" }),
+      }),
+    );
+
+    let deliveries = 0;
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage(uuid),
+      undefined,
+      undefined,
+      async () => {
+        deliveries += 1;
+        // Only the first delivery fails; the outer catch's ERROR_MESSAGE
+        // retry must go through so the action can report its error result.
+        if (deliveries === 1) throw new Error("delivery failed");
+      },
+    );
+
+    expect(result?.success).toBe(false);
+    expect(
+      (requireDefined(result, "action result").data as { reason: string })
+        .reason,
+    ).toBe("error");
+    // The happy id path must not degrade into list resolution; the failure
+    // surfaces through the outer catch's error reply instead.
+    expect(listCalled).toBe(false);
+    expect(deliveries).toBe(2);
+  });
 });

--- a/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
@@ -187,4 +187,49 @@ describe("GET_APP", () => {
         .reason,
     ).toBe("error");
   });
+
+  it("REGRESSION (#29916): a stale/foreign UUID option → not_found which-app reply, not the generic error", async () => {
+    // The UUID must arrive as the planner-supplied option: inlined in the
+    // message text it never reaches the id path (extractAppReference returns
+    // the whole sentence and looksLikeAppId is false). A stale id makes
+    // getApp reject (CloudApiError 404); before the guard that rejection
+    // landed in the outer catch as a retry-never-helps "Cloud API returned
+    // an error" reply. It must now fall through to list-based resolution.
+    const STALE_UUID = "99999999-9999-4999-8999-999999999999";
+    setGetApp((id) => {
+      expect(id).toBe(STALE_UUID);
+      return Promise.reject(
+        Object.assign(new Error("HTTP 404"), {
+          name: "CloudApiError",
+          statusCode: 404,
+          errorBody: { success: false, error: "HTTP 404" },
+        }),
+      );
+    });
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [makeApp({ name: "Acme Bot", slug: "acme-bot" })],
+      }),
+    );
+
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage("tell me about my app"),
+      undefined,
+      { app: STALE_UUID },
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(
+      (requireDefined(result, "action result").data as { reason: string })
+        .reason,
+    ).toBe("not_found");
+    // The which-app reply lists the org's current app, never a retry hint.
+    const reply = cb.calls[0]?.text ?? "";
+    expect(reply).toContain("Acme Bot");
+    expect(reply).not.toContain("Cloud API returned an error");
+  });
 });

--- a/plugins/plugin-cloud-apps/src/actions/get-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app.ts
@@ -100,7 +100,7 @@ export const getAppAction: Action = {
         // resolveDomainTargetApp. The try guards ONLY the fetch: formatting,
         // delivery and the return stay outside, so a failed callback on the
         // happy path still reaches the outer catch and reports failure (#29917).
-        let app: Awaited<ReturnType<typeof client.getApp>>["app"];
+        let app: Awaited<ReturnType<typeof client.getApp>>["app"] | undefined;
         try {
           ({ app } = await client.getApp(reference));
         } catch {

--- a/plugins/plugin-cloud-apps/src/actions/get-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app.ts
@@ -96,27 +96,31 @@ export const getAppAction: Action = {
         // A stale/foreign UUID makes getApp throw (typically 404/403); that
         // must fall through to list-based resolution and its helpful
         // which-app reply, not land in the outer catch as a generic error
-        // the user can never retry past. Mirrors resolveApp and
-        // resolveDomainTargetApp (#29907/#29916).
+        // the user can never retry past. Mirrors resolveApp (#29908) and
+        // resolveDomainTargetApp. The try guards ONLY the fetch: formatting,
+        // delivery and the return stay outside, so a failed callback on the
+        // happy path still reaches the outer catch and reports failure (#29917).
+        let app: Awaited<ReturnType<typeof client.getApp>>["app"];
         try {
-          const { app } = await client.getApp(reference);
-          if (app) {
-            const detail = formatAppDetail(app);
-            await callback?.({ text: detail, actions: ["GET_APP"] });
-            return {
-              success: true,
-              text: `Fetched app ${app.name}.`,
-              userFacingText: detail,
-              verifiedUserFacing: true,
-              data: { app: { id: app.id, name: app.name, slug: app.slug } },
-            };
-          }
+          ({ app } = await client.getApp(reference));
         } catch {
           // error-policy:J4 degrade to the list-based not-found/which-app
           // reply. The catch is intentionally unconditional to mirror
           // resolveApp; a getApp failure that is not a benign 404/403 is
           // normally re-raised by the listApps() call next, so the action
           // still fails loudly in that case.
+          app = undefined;
+        }
+        if (app) {
+          const detail = formatAppDetail(app);
+          await callback?.({ text: detail, actions: ["GET_APP"] });
+          return {
+            success: true,
+            text: `Fetched app ${app.name}.`,
+            userFacingText: detail,
+            verifiedUserFacing: true,
+            data: { app: { id: app.id, name: app.name, slug: app.slug } },
+          };
         }
       }
 

--- a/plugins/plugin-cloud-apps/src/actions/get-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app.ts
@@ -93,17 +93,30 @@ export const getAppAction: Action = {
     try {
       // Id-shaped reference → direct single-app fetch.
       if (looksLikeAppId(reference)) {
-        const { app } = await client.getApp(reference);
-        if (app) {
-          const detail = formatAppDetail(app);
-          await callback?.({ text: detail, actions: ["GET_APP"] });
-          return {
-            success: true,
-            text: `Fetched app ${app.name}.`,
-            userFacingText: detail,
-            verifiedUserFacing: true,
-            data: { app: { id: app.id, name: app.name, slug: app.slug } },
-          };
+        // A stale/foreign UUID makes getApp throw (typically 404/403); that
+        // must fall through to list-based resolution and its helpful
+        // which-app reply, not land in the outer catch as a generic error
+        // the user can never retry past. Mirrors resolveApp and
+        // resolveDomainTargetApp (#29907/#29916).
+        try {
+          const { app } = await client.getApp(reference);
+          if (app) {
+            const detail = formatAppDetail(app);
+            await callback?.({ text: detail, actions: ["GET_APP"] });
+            return {
+              success: true,
+              text: `Fetched app ${app.name}.`,
+              userFacingText: detail,
+              verifiedUserFacing: true,
+              data: { app: { id: app.id, name: app.name, slug: app.slug } },
+            };
+          }
+        } catch {
+          // error-policy:J4 degrade to the list-based not-found/which-app
+          // reply. The catch is intentionally unconditional to mirror
+          // resolveApp; a getApp failure that is not a benign 404/403 is
+          // normally re-raised by the listApps() call next, so the action
+          // still fails loudly in that case.
         }
       }
 

--- a/plugins/plugin-cloud-apps/src/actions/get-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app.ts
@@ -42,6 +42,15 @@ function notFoundMessage(reference: string, available: string[]): string {
   return `${base} Your apps are: ${available.join(", ")}.`;
 }
 
+// Duck-typed view of the SDK CloudApiError `statusCode` (same shape as
+// cloudApiStatusCode in deploy-gate.ts) so the guard below does not need to
+// import the error class.
+function cloudApiStatusCode(err: unknown): number | null {
+  if (typeof err !== "object" || err === null) return null;
+  const value = (err as Record<string, unknown>).statusCode;
+  return typeof value === "number" ? value : null;
+}
+
 export const getAppAction: Action = {
   name: "GET_APP",
   similes: [
@@ -93,22 +102,24 @@ export const getAppAction: Action = {
     try {
       // Id-shaped reference → direct single-app fetch.
       if (looksLikeAppId(reference)) {
-        // A stale/foreign UUID makes getApp throw (typically 404/403); that
-        // must fall through to list-based resolution and its helpful
-        // which-app reply, not land in the outer catch as a generic error
-        // the user can never retry past. Mirrors resolveApp (#29908) and
-        // resolveDomainTargetApp. The try guards ONLY the fetch: formatting,
-        // delivery and the return stay outside, so a failed callback on the
-        // happy path still reaches the outer catch and reports failure (#29917).
+        // A stale/foreign UUID makes getApp throw a 404/403; that must fall
+        // through to list-based resolution and its helpful which-app reply,
+        // not land in the outer catch as a generic error the user can never
+        // retry past. Mirrors resolveApp (#29908) and resolveDomainTargetApp.
+        // The try guards ONLY the fetch: formatting, delivery and the return
+        // stay outside, so a failed callback on the happy path still reaches
+        // the outer catch and reports failure (#29917).
         let app: Awaited<ReturnType<typeof client.getApp>>["app"] | undefined;
         try {
           ({ app } = await client.getApp(reference));
-        } catch {
-          // error-policy:J4 degrade to the list-based not-found/which-app
-          // reply. The catch is intentionally unconditional to mirror
-          // resolveApp; a getApp failure that is not a benign 404/403 is
-          // normally re-raised by the listApps() call next, so the action
-          // still fails loudly in that case.
+        } catch (err) {
+          // error-policy:J4 degrade ONLY the benign not-found/forbidden
+          // statuses to the list-based which-app reply. A 5xx from the id
+          // endpoint is an outage, not evidence the app is gone: reporting
+          // not_found there would tell the user their app does not exist
+          // (#29917 review). Anything else is re-raised into the outer catch.
+          const status = cloudApiStatusCode(err);
+          if (status !== 404 && status !== 403) throw err;
           app = undefined;
         }
         if (app) {


### PR DESCRIPTION
# Relates to

Closes #29916

- [x] This PR targets `develop` and is built directly on develop@2a4af735 (Git data API), zero conflicts.
- [x] Focused tests pass (exact command and output below), RED→GREEN verified.
- [x] A reviewer can confirm the change works from the regression below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. The guard is the same shape #29908 applied to `resolveApp`, narrowed
per review twice: the `try` wraps ONLY the `getApp` fetch (formatting,
delivery and return stay outside, so a rejecting callback on the happy id
path still reaches the outer catch and reports `reason: "error"` — pinned by
a regression), and the catch degrades ONLY a 404/403 status, re-raising
everything else (a 5xx id-endpoint outage must not be reported as
app-not-found just because `listApps` still succeeds — pinned by a second
regression). Status is read through the same duck-typed `statusCode` view
`deploy-gate.ts` uses.

# Background

## What does this PR do?

`GET_APP` (`plugins/plugin-cloud-apps/src/actions/get-app.ts`) inlines the
same id-then-name resolution shape as `resolveApp`, but without the
stale/foreign-UUID guard #29907/#29908 added there. A planner-carried UUID
the org no longer owns makes `client.getApp` reject (`CloudApiError` 404);
because the call sits inside the handler's outer `try`, the rejection lands
in the generic catch and the user sees "the Cloud API returned an error, try
again in a moment" — a failure that retrying can never fix, since the id is
stale. The name path that matches nothing already produces the helpful
`notFoundMessage(reference, names)` which-app reply; the id path now degrades
to exactly the same outcome.

This is the read-action twin of #29908 (which fixes `src/client.ts`
`resolveApp`); `src/domain-intent.ts` `resolveDomainTargetApp` was already
guarded, so with this PR all three id-resolution sites behave identically.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-cloud-apps/src/actions/get-app.ts` — the guarded id branch
(search `#29916`) — then the REGRESSION test at the end of
`__tests__/get-app.test.ts`.

## Detailed testing steps

- `cd plugins/plugin-cloud-apps && bun test __tests__/get-app.test.ts`
  - 10 pass / 0 fail (7 pre-existing + 3 new regressions).
- RED check: with the source file reverted to develop and the test kept, the
  regression fails (`7 pass / 1 fail`); restoring the fix returns to 8/8.
- Full package suite `bun test __tests__`: 363 pass / 1 fail — the single
  failure is `list-cloud-apps.integration.test.ts`, a live-network
  integration test that runs the real Cloud SDK and fails in this sandbox
  for network reasons; it is untouched by this PR and fails identically on
  develop.
- RED for the review fix: the delivery-failure regression fails on the
  first (wide-try) cut of the guard — `success: true`, no `listApps` guard
  trip — and passes once the `try` is narrowed to the fetch only.
- The delivery regression mirrors the reviewer's probe: owned UUID, first
  callback delivery rejects, the outer catch's ERROR_MESSAGE retry
  succeeds; asserts `reason: "error"`, zero `listApps` calls, 2 deliveries.
- The regression drives the planner-option path (`{ app: STALE_UUID }`),
  which #29916 notes is the only way to reach the id branch — the UUID
  inlined in message text never gets there (`extractAppReference` returns
  the whole sentence, `looksLikeAppId` false).
- RED for the status-scope fix (second review): re-widening the catch to the
  unconditional degrade (the previous head) turns the new 500 regression red
  (`Expected: "error"`, `Received: "not_found"`; 9 pass / 1 fail); the
  narrowed 404/403 guard returns to 10/10. The #29916 fixture stays pinned at
  `statusCode: 404` so an id-endpoint outage can never satisfy
  `reason: "not_found"`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:39367ee386b0f2ab8ab5222b0d3a1f2e97efcd6e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; a handler-level error-reply fix covered
      by deterministic unit tests against the faked SDK boundary.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable effect (not-found reply instead of generic error)
      is asserted directly by the regression.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no logging is added or changed; the defect and fix are
      value-level and covered by the assertions.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or on-chain output; the
      fake client in helpers.ts intercepts the SDK boundary.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
(pass) GET_APP > REGRESSION (#29916): a stale/foreign UUID option → not_found which-app reply, not the generic error
(pass) GET_APP > REGRESSION (#29917 review): delivery failure on the happy id path reports error, not success
(pass) GET_APP > REGRESSION (#29917 review): an id-endpoint 5xx is an error, not app-not-found
 10 pass
 0 fail
Ran 10 tests across 1 file.
```

## Known gaps / failures

`list-cloud-apps.integration.test.ts` requires live network access to the
real Cloud SDK endpoint and fails in this sandbox for that reason on develop
and on this branch alike; all other 31 files (362 tests) pass.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->

