### PR TITLE
fix(cloud): harden exact restore secret transport

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
@@ -11,6 +11,8 @@ import * as dockerPortAllocation from "../docker-port-allocation";
 import { DockerSandboxProvider } from "../docker-sandbox-provider";
 import {
   getReplacementCandidateObservedReceipt,
+  getReplacementControlSecretEnvPath,
+  getReplacementControlVaultPassphrasePath,
   getReplacementDockerCreateQuiescentReceipt,
   getReplacementSecretArtifactsCleanupReceipt,
 } from "../docker-sandbox-utils";
@@ -1845,7 +1847,11 @@ describe("DockerSandboxProvider replacement cleanup", () => {
       expect(events).toEqual(["started", "intent", "created", "settled"]);
       expect(prepareVpn).not.toHaveBeenCalled();
       expect(waitForVpn).not.toHaveBeenCalled();
-      expect(commands.some((command) => command.includes("docker create"))).toBe(true);
+      const dockerCreateCommand = commands.find((command) => command.includes("docker create"));
+      expect(dockerCreateCommand).toBeDefined();
+      expect(dockerCreateCommand).toContain(getReplacementControlSecretEnvPath(ATTEMPT_ID));
+      expect(dockerCreateCommand).toContain(getReplacementControlVaultPassphrasePath(ATTEMPT_ID));
+      expect(dockerCreateCommand).not.toContain(`${VOLUME_PATH}/.container-env-${ATTEMPT_ID}`);
       expect(
         commands.some((command) =>
           command.includes("tailscale --socket=/tmp/tailscaled.sock ip -4"),

--- a/packages/cloud/shared/src/lib/services/agent-backup-restore-vault-seed.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-restore-vault-seed.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Exercises the restore vault seed transport with deterministic in-memory
+ * adapters and the exact shell command against a temporary local directory.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  AGENT_BACKUP_RESTORE_STAGING_VOLUME_PATH_DERIVATION_V1,
+  AGENT_BACKUP_RESTORE_VAULT_PASSPHRASE_BYTES,
+  AGENT_BACKUP_RESTORE_VAULT_VOLUME_SEED_RECEIPT_FORMAT,
+  buildRestoreVolumeVaultSeedReceiptV1,
+  deriveRestoreStagingVolumePathV1,
+  seedRestoreVolumeVaultPassphraseBytes,
+} from "./agent-backup-restore-vault-seed";
+import {
+  buildVolumeVaultPassphraseCommand,
+  getVolumeVaultPassphrasePath,
+  shellQuote,
+  VOLUME_VAULT_STDIN_FRAME_END,
+  VOLUME_VAULT_STDIN_FRAME_VERSION,
+} from "./docker-sandbox-utils";
+
+const AGENT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const RESTORE_ATTEMPT_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const REPLACEMENT_ATTEMPT_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const SYMLINK_ATTEMPT_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const RESTORE_ROOT = "/data/agents/.restore";
+const AGENT_ROOT = `${RESTORE_ROOT}/${AGENT_ID}`;
+const VOLUME_PATH = `${AGENT_ROOT}/${RESTORE_ATTEMPT_ID}`;
+
+function sha256Utf8(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function safePassphrase(fill: number): Uint8Array {
+  return new Uint8Array(64).fill(fill);
+}
+
+function allZero(bytes: Uint8Array): boolean {
+  return bytes.every((byte) => byte === 0);
+}
+
+function expectedSafeDirectoryProof(path: string): string[] {
+  const quoted = shellQuote(path);
+  return [
+    `test -d ${quoted} && test ! -L ${quoted} || exit 45`,
+    `test "$(stat -c '%u' -- ${quoted})" = 0 || exit 45`,
+    `directory_mode=$(stat -c '%a' -- ${quoted}); case "$directory_mode" in *[2367][0-7]|*[0-7][2367]) exit 45 ;; esac`,
+  ];
+}
+
+function expectedDirectoryPreparation(path: string): string[] {
+  const quoted = shellQuote(path);
+  return [
+    `if test -e ${quoted} || test -L ${quoted}; then ${expectedSafeDirectoryProof(path).join("; ")}; else install -d -m 700 ${quoted}; fi`,
+    ...expectedSafeDirectoryProof(path),
+  ];
+}
+
+async function execLocalShell(
+  command: string,
+  stdin: Buffer,
+  signal: AbortSignal,
+  env?: NodeJS.ProcessEnv,
+): Promise<void> {
+  const child = spawn("/bin/sh", ["-c", command], { env: { ...process.env, ...env } });
+  await new Promise<void>((resolve, reject) => {
+    let stderr = "";
+    const abort = () => child.kill("SIGTERM");
+    signal.addEventListener("abort", abort, { once: true });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      signal.removeEventListener("abort", abort);
+      if (signal.aborted) reject(signal.reason);
+      else if (code === 0) resolve();
+      else reject(Object.assign(new Error(stderr || `shell exited ${code}`), { code }));
+    });
+    child.stdin.end(stdin);
+  });
+}
+
+describe("seedRestoreVolumeVaultPassphraseBytes", () => {
+  test("derives only an attempt-scoped staging path", () => {
+    expect(deriveRestoreStagingVolumePathV1(AGENT_ID, RESTORE_ATTEMPT_ID)).toBe(VOLUME_PATH);
+    expect(VOLUME_PATH).toStartWith("/data/agents/.restore/");
+    expect(VOLUME_PATH).not.toBe(`/data/agents/${AGENT_ID}`);
+    expect(() =>
+      deriveRestoreStagingVolumePathV1(AGENT_ID.toUpperCase(), RESTORE_ATTEMPT_ID),
+    ).toThrow(/canonical lowercase UUID/);
+    expect(() => deriveRestoreStagingVolumePathV1(AGENT_ID, "not-a-uuid")).toThrow(
+      /canonical lowercase UUID/,
+    );
+  });
+
+  test("sends the exact V1 frame as bytes and returns a canonical non-secret receipt", async () => {
+    class NonStringifiablePassphrase extends Uint8Array {
+      override toString(): string {
+        throw new Error("secret bytes must not be converted to a string");
+      }
+    }
+
+    const passphrase = new NonStringifiablePassphrase(safePassphrase(0x61));
+    const controller = new AbortController();
+    let observedCommand = "";
+    let observedFrame: Buffer | undefined;
+    let frameBeforeReturn: Buffer | undefined;
+    let observedSignal: AbortSignal | undefined;
+
+    const result = await seedRestoreVolumeVaultPassphraseBytes({
+      agentId: AGENT_ID,
+      restoreAttemptId: RESTORE_ATTEMPT_ID,
+      replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+      passphrase,
+      signal: controller.signal,
+      execStdin: async (command, stdin, signal) => {
+        observedCommand = command;
+        observedFrame = stdin;
+        frameBeforeReturn = Buffer.from(stdin);
+        observedSignal = signal;
+      },
+    });
+
+    const expectedCommand = buildVolumeVaultPassphraseCommand(
+      VOLUME_PATH,
+      passphrase.byteLength,
+      REPLACEMENT_ATTEMPT_ID,
+      [
+        ...expectedSafeDirectoryProof("/data"),
+        ...expectedSafeDirectoryProof("/data/agents"),
+        ...expectedDirectoryPreparation(RESTORE_ROOT),
+        ...expectedDirectoryPreparation(AGENT_ROOT),
+        ...expectedDirectoryPreparation(VOLUME_PATH),
+        ...expectedDirectoryPreparation(`${VOLUME_PATH}/eliza`),
+      ],
+    );
+    const expectedFrame = Buffer.alloc(
+      Buffer.byteLength(`${VOLUME_VAULT_STDIN_FRAME_VERSION} 64\n`) +
+        passphrase.byteLength +
+        Buffer.byteLength(`\n${VOLUME_VAULT_STDIN_FRAME_END}\n`),
+    );
+    let offset = expectedFrame.write(`${VOLUME_VAULT_STDIN_FRAME_VERSION} 64\n`, "utf8");
+    expectedFrame.set(passphrase, offset);
+    offset += passphrase.byteLength;
+    expectedFrame.write(`\n${VOLUME_VAULT_STDIN_FRAME_END}\n`, offset, "utf8");
+
+    expect(observedCommand).toBe(expectedCommand);
+    expect(observedCommand.indexOf('test ! -e "$attempt_cancelled"')).toBeLessThan(
+      observedCommand.indexOf("install -d"),
+    );
+    expect(observedCommand).not.toContain("a".repeat(64));
+    expect(observedSignal).toBe(controller.signal);
+    expect(Buffer.isBuffer(observedFrame)).toBe(true);
+    expect(frameBeforeReturn).toEqual(expectedFrame);
+    expect(observedFrame).toBeDefined();
+    expect(allZero(observedFrame!)).toBe(true);
+    expect(passphrase).toEqual(safePassphrase(0x61));
+
+    const expectedReceipt = {
+      format: AGENT_BACKUP_RESTORE_VAULT_VOLUME_SEED_RECEIPT_FORMAT,
+      transport: VOLUME_VAULT_STDIN_FRAME_VERSION,
+      pathDerivation: AGENT_BACKUP_RESTORE_STAGING_VOLUME_PATH_DERIVATION_V1,
+      agentId: AGENT_ID,
+      restoreAttemptId: RESTORE_ATTEMPT_ID,
+      replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+      volumePathSha256: sha256Utf8(VOLUME_PATH),
+      commandSha256: sha256Utf8(expectedCommand),
+      passphraseByteLength: 64,
+      completed: true as const,
+    };
+    expect(result.receipt).toEqual(expectedReceipt);
+    expect(result.receiptDigest).toBe(sha256Utf8(JSON.stringify(expectedReceipt)));
+    expect(JSON.stringify(result)).not.toContain(VOLUME_PATH);
+    expect(JSON.stringify(result)).not.toContain("a".repeat(64));
+    expect(
+      buildRestoreVolumeVaultSeedReceiptV1({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphraseByteLength: passphrase.byteLength,
+      }),
+    ).toEqual(result);
+  });
+
+  test("zeroizes the frame when the injected transport throws", async () => {
+    const passphrase = safePassphrase(0x62);
+    const failure = new Error("transport failed");
+    let observedFrame: Buffer | undefined;
+
+    await expect(
+      seedRestoreVolumeVaultPassphraseBytes({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphrase,
+        signal: new AbortController().signal,
+        execStdin: async (_command, stdin) => {
+          observedFrame = stdin;
+          throw failure;
+        },
+      }),
+    ).rejects.toBe(failure);
+
+    expect(observedFrame).toBeDefined();
+    expect(allZero(observedFrame!)).toBe(true);
+    expect(passphrase).toEqual(safePassphrase(0x62));
+  });
+
+  test("keeps stdin stable through transport cancellation, then wipes it after settlement", async () => {
+    const passphrase = safePassphrase(0x63);
+    const controller = new AbortController();
+    const abortReason = new Error("restore claim cancelled");
+    let observedFrame: Buffer | undefined;
+    let wasZeroInsideTransportAbort = false;
+
+    const pending = seedRestoreVolumeVaultPassphraseBytes({
+      agentId: AGENT_ID,
+      restoreAttemptId: RESTORE_ATTEMPT_ID,
+      replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+      passphrase,
+      signal: controller.signal,
+      execStdin: async (_command, stdin, signal) => {
+        observedFrame = stdin;
+        await new Promise<void>((resolve) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              wasZeroInsideTransportAbort = allZero(stdin);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+
+    controller.abort(abortReason);
+    await expect(pending).rejects.toBe(abortReason);
+    expect(wasZeroInsideTransportAbort).toBe(false);
+    expect(observedFrame).toBeDefined();
+    expect(allZero(observedFrame!)).toBe(true);
+    expect(passphrase).toEqual(safePassphrase(0x63));
+  });
+
+  test("does not invoke the transport for a pre-aborted signal or unsafe secret bytes", async () => {
+    let calls = 0;
+    const execStdin = async (): Promise<void> => {
+      calls += 1;
+    };
+    const controller = new AbortController();
+    const abortReason = new Error("already cancelled");
+    controller.abort(abortReason);
+
+    await expect(
+      seedRestoreVolumeVaultPassphraseBytes({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphrase: safePassphrase(0x64),
+        signal: controller.signal,
+        execStdin,
+      }),
+    ).rejects.toBe(abortReason);
+
+    for (const passphrase of [
+      new Uint8Array(0),
+      new Uint8Array(63).fill(0x65),
+      new Uint8Array(65).fill(0x65),
+      new Uint8Array(64).fill(0x20),
+      Uint8Array.from([...new Uint8Array(63).fill(0x65), 0x7f]),
+    ]) {
+      await expect(
+        seedRestoreVolumeVaultPassphraseBytes({
+          agentId: AGENT_ID,
+          restoreAttemptId: RESTORE_ATTEMPT_ID,
+          replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+          passphrase,
+          signal: new AbortController().signal,
+          execStdin,
+        }),
+      ).rejects.toThrow(/passphrase/);
+    }
+    expect(() =>
+      buildRestoreVolumeVaultSeedReceiptV1({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphraseByteLength: 11,
+      }),
+    ).toThrow(/passphrase/);
+    expect(AGENT_BACKUP_RESTORE_VAULT_PASSPHRASE_BYTES).toBe(64);
+    expect(calls).toBe(0);
+  });
+
+  test("returns the same receipt digest for replay-equivalent non-secret metadata", async () => {
+    const seed = async (passphrase: Uint8Array) =>
+      seedRestoreVolumeVaultPassphraseBytes({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphrase,
+        signal: new AbortController().signal,
+        execStdin: async () => undefined,
+      });
+
+    const first = await seed(safePassphrase(0x66));
+    const replay = await seed(safePassphrase(0x66));
+    const sameLengthDifferentSecret = await seed(safePassphrase(0x67));
+
+    expect(replay).toEqual(first);
+    expect(sameLengthDifferentSecret).toEqual(first);
+    expect(
+      buildRestoreVolumeVaultSeedReceiptV1({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        passphraseByteLength: AGENT_BACKUP_RESTORE_VAULT_PASSPHRASE_BYTES,
+      }).receiptDigest,
+    ).not.toBe(first.receiptDigest);
+  });
+
+  test("pre-creates an absent volume and seeds it idempotently in one stdin command", async () => {
+    const parent = mkdtempSync(join(tmpdir(), "eliza-restore-vault-seed-"));
+    const relocatedDataRoot = join(parent, "data");
+    const relocatedAgentsRoot = join(relocatedDataRoot, "agents");
+    const relocatedRoot = join(relocatedAgentsRoot, ".restore");
+    const relocatedControlRoot = join(parent, "replacement-attempts");
+    const relocatedAgentRoot = join(relocatedRoot, AGENT_ID);
+    const volumePath = join(relocatedAgentRoot, RESTORE_ATTEMPT_ID);
+    const passphrase = safePassphrase(0x68);
+    const bin = join(parent, "bin");
+    mkdirSync(relocatedAgentsRoot, { recursive: true, mode: 0o700 });
+    mkdirSync(bin, { mode: 0o700 });
+    const fakeStat = join(bin, "stat");
+    writeFileSync(
+      fakeStat,
+      '#!/bin/sh\ncase "$2" in "%u") printf 0 ;; "%a") if test -d "$4"; then printf 700; else printf 600; fi ;; "%h") printf 1 ;; "%d:%i") printf "1:1" ;; "%d:%i:%s:%y:%z") printf stable-fingerprint ;; *) exit 64 ;; esac\n',
+      { mode: 0o700 },
+    );
+    chmodSync(fakeStat, 0o700);
+    const relocatedExec = (command: string, stdin: Buffer, signal: AbortSignal) =>
+      execLocalShell(
+        command
+          .replaceAll("/data", relocatedDataRoot)
+          .replaceAll("/var/lib/eliza/replacement-attempts", relocatedControlRoot)
+          // macOS does not ship Linux flock(1); static utility tests retain the
+          // exact production command while this local filesystem test stubs it.
+          .replace("command -v flock >/dev/null 2>&1", ":")
+          .replace("flock -w 30 9", ":")
+          .replaceAll("chmod 700 --", "chmod 700")
+          .replaceAll("chmod 600 --", "chmod 600"),
+        stdin,
+        signal,
+        { PATH: `${bin}:${process.env.PATH ?? ""}` },
+      );
+    try {
+      const first = await seedRestoreVolumeVaultPassphraseBytes({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphrase,
+        signal: new AbortController().signal,
+        execStdin: relocatedExec,
+      });
+      const replay = await seedRestoreVolumeVaultPassphraseBytes({
+        agentId: AGENT_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+        passphrase,
+        signal: new AbortController().signal,
+        execStdin: relocatedExec,
+      });
+
+      expect(readFileSync(getVolumeVaultPassphrasePath(volumePath))).toEqual(
+        Buffer.from(passphrase),
+      );
+      expect(statSync(getVolumeVaultPassphrasePath(volumePath)).mode & 0o777).toBe(0o600);
+      expect(statSync(relocatedRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(relocatedAgentRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(volumePath).mode & 0o777).toBe(0o700);
+      expect(statSync(join(volumePath, "eliza")).mode & 0o777).toBe(0o700);
+      expect(statSync(join(volumePath, "eliza")).isDirectory()).toBe(true);
+      expect(replay).toEqual(first);
+
+      const symlinkAttemptPath = join(relocatedAgentRoot, SYMLINK_ATTEMPT_ID);
+      const symlinkTarget = join(parent, "symlink-target");
+      mkdirSync(symlinkTarget, { mode: 0o700 });
+      symlinkSync(symlinkTarget, symlinkAttemptPath);
+      await expect(
+        seedRestoreVolumeVaultPassphraseBytes({
+          agentId: AGENT_ID,
+          restoreAttemptId: SYMLINK_ATTEMPT_ID,
+          replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+          passphrase,
+          signal: new AbortController().signal,
+          execStdin: relocatedExec,
+        }),
+      ).rejects.toMatchObject({ code: 45 });
+      expect(readdirSync(symlinkTarget)).toEqual([]);
+
+      rmSync(relocatedAgentsRoot, { recursive: true, force: true });
+      const ancestorSymlinkTarget = join(parent, "ancestor-symlink-target");
+      mkdirSync(ancestorSymlinkTarget, { mode: 0o700 });
+      symlinkSync(ancestorSymlinkTarget, relocatedAgentsRoot);
+      await expect(
+        seedRestoreVolumeVaultPassphraseBytes({
+          agentId: AGENT_ID,
+          restoreAttemptId: RESTORE_ATTEMPT_ID,
+          replacementAttemptId: REPLACEMENT_ATTEMPT_ID,
+          passphrase,
+          signal: new AbortController().signal,
+          execStdin: relocatedExec,
+        }),
+      ).rejects.toMatchObject({ code: 45 });
+      expect(readdirSync(ancestorSymlinkTarget)).toEqual([]);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-restore-vault-seed.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-restore-vault-seed.ts
@@ -1,0 +1,266 @@
+/**
+ * Builds and executes the byte-native stdin handoff that seeds one quarantined
+ * restore volume. The exact attempt-derived path and deterministic receipt are
+ * independent of providers and database access so callers must compose them
+ * with the durable restore authority before invoking any transport.
+ */
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { isValidUUID } from "../utils/validation";
+import {
+  buildVolumeVaultPassphraseCommand,
+  shellQuote,
+  VOLUME_VAULT_STDIN_FRAME_END,
+  VOLUME_VAULT_STDIN_FRAME_VERSION,
+  validateVolumePath,
+} from "./docker-sandbox-utils";
+
+export const AGENT_BACKUP_RESTORE_VAULT_VOLUME_SEED_RECEIPT_FORMAT =
+  "eliza.agent-backup-restore.vault-volume-seed-receipt.v1" as const;
+export const AGENT_BACKUP_RESTORE_STAGING_VOLUME_PATH_DERIVATION_V1 =
+  "eliza.agent-backup-restore.staging-volume-path.v1" as const;
+const RESTORE_STAGING_VOLUME_ROOT = "/data/agents/.restore";
+export const AGENT_BACKUP_RESTORE_VAULT_PASSPHRASE_BYTES = 64;
+
+export interface AgentBackupRestoreVaultVolumeSeedReceiptV1 {
+  format: typeof AGENT_BACKUP_RESTORE_VAULT_VOLUME_SEED_RECEIPT_FORMAT;
+  transport: typeof VOLUME_VAULT_STDIN_FRAME_VERSION;
+  pathDerivation: typeof AGENT_BACKUP_RESTORE_STAGING_VOLUME_PATH_DERIVATION_V1;
+  agentId: string;
+  restoreAttemptId: string;
+  replacementAttemptId: string;
+  volumePathSha256: string;
+  commandSha256: string;
+  passphraseByteLength: number;
+  completed: true;
+}
+
+export interface AgentBackupRestoreVaultVolumeSeedResult {
+  receipt: Readonly<AgentBackupRestoreVaultVolumeSeedReceiptV1>;
+  receiptDigest: string;
+}
+
+/**
+ * The injected transport owns process/channel cancellation and must settle
+ * only after it has stopped reading `stdin`. The mandatory signal prevents a
+ * future caller from selecting a non-cancellable SSH adapter.
+ */
+export type AgentBackupRestoreVaultSeedExecStdin = (
+  command: string,
+  stdin: Buffer,
+  signal: AbortSignal,
+) => Promise<unknown>;
+
+export interface SeedRestoreVolumeVaultPassphraseBytesInput {
+  agentId: string;
+  restoreAttemptId: string;
+  replacementAttemptId: string;
+  passphrase: Uint8Array;
+  signal: AbortSignal;
+  execStdin: AgentBackupRestoreVaultSeedExecStdin;
+}
+
+export interface BuildRestoreVolumeVaultSeedReceiptV1Input {
+  agentId: string;
+  restoreAttemptId: string;
+  replacementAttemptId: string;
+  passphraseByteLength: number;
+}
+
+function sha256Utf8(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function requireCanonicalUuid(value: string, field: string): string {
+  if (!isValidUUID(value) || value !== value.toLowerCase()) {
+    throw new Error(`${field} must be a canonical lowercase UUID.`);
+  }
+  return value;
+}
+
+function validatePassphraseByteLength(passphraseByteLength: number): void {
+  if (passphraseByteLength !== AGENT_BACKUP_RESTORE_VAULT_PASSPHRASE_BYTES) {
+    throw new Error(
+      `Restore vault passphrase must contain exactly ${AGENT_BACKUP_RESTORE_VAULT_PASSPHRASE_BYTES} safe bytes.`,
+    );
+  }
+}
+
+function validatePassphraseBytes(passphrase: Uint8Array): void {
+  if (!(passphrase instanceof Uint8Array)) {
+    throw new Error("Restore vault passphrase must be byte-native.");
+  }
+  validatePassphraseByteLength(passphrase.byteLength);
+  for (const byte of passphrase) {
+    // Matches the V1 remote command's LC_ALL=C [:space:]/[:cntrl:] guard
+    // without decoding secret bytes into an immutable JavaScript string.
+    if (byte <= 0x20 || byte === 0x7f) {
+      throw new Error("Restore vault passphrase contains an unsafe byte.");
+    }
+  }
+}
+
+/** Immutable V1 derivation for quarantined restore staging volumes. */
+export function deriveRestoreStagingVolumePathV1(
+  agentId: string,
+  restoreAttemptId: string,
+): string {
+  const canonicalAgentId = requireCanonicalUuid(agentId, "agentId");
+  const canonicalRestoreAttemptId = requireCanonicalUuid(restoreAttemptId, "restoreAttemptId");
+  return `${RESTORE_STAGING_VOLUME_ROOT}/${canonicalAgentId}/${canonicalRestoreAttemptId}`;
+}
+
+function buildVaultStdinFrame(passphrase: Uint8Array): Buffer {
+  const header = `${VOLUME_VAULT_STDIN_FRAME_VERSION} ${passphrase.byteLength}\n`;
+  const trailer = `\n${VOLUME_VAULT_STDIN_FRAME_END}\n`;
+  const headerByteLength = Buffer.byteLength(header, "utf8");
+  const trailerByteLength = Buffer.byteLength(trailer, "utf8");
+  const frame = Buffer.alloc(headerByteLength + passphrase.byteLength + trailerByteLength);
+  frame.write(header, 0, headerByteLength, "utf8");
+  frame.set(passphrase, headerByteLength);
+  frame.write(trailer, headerByteLength + passphrase.byteLength, trailerByteLength, "utf8");
+  return frame;
+}
+
+function safeRestoreDirectoryProof(path: string): string[] {
+  const quoted = shellQuote(path);
+  return [
+    `test -d ${quoted} && test ! -L ${quoted} || exit 45`,
+    `test "$(stat -c '%u' -- ${quoted})" = 0 || exit 45`,
+    `directory_mode=$(stat -c '%a' -- ${quoted}); case "$directory_mode" in *[2367][0-7]|*[0-7][2367]) exit 45 ;; esac`,
+  ];
+}
+
+function prepareRestoreDirectoryCommands(path: string): string[] {
+  const quoted = shellQuote(path);
+  return [
+    `if test -e ${quoted} || test -L ${quoted}; then ${safeRestoreDirectoryProof(path).join("; ")}; else install -d -m 700 ${quoted}; fi`,
+    ...safeRestoreDirectoryProof(path),
+  ];
+}
+
+function buildPrecreatedVolumeVaultSeedCommand(input: {
+  agentId: string;
+  volumePath: string;
+  replacementAttemptId: string;
+  passphraseByteLength: number;
+}): string {
+  const agentRoot = `${RESTORE_STAGING_VOLUME_ROOT}/${input.agentId}`;
+  const elizaPath = `${input.volumePath}/eliza`;
+  return buildVolumeVaultPassphraseCommand(
+    input.volumePath,
+    input.passphraseByteLength,
+    input.replacementAttemptId,
+    [
+      ...safeRestoreDirectoryProof("/data"),
+      ...safeRestoreDirectoryProof("/data/agents"),
+      ...prepareRestoreDirectoryCommands(RESTORE_STAGING_VOLUME_ROOT),
+      ...prepareRestoreDirectoryCommands(agentRoot),
+      ...prepareRestoreDirectoryCommands(input.volumePath),
+      ...prepareRestoreDirectoryCommands(elizaPath),
+    ],
+  );
+}
+
+function canonicalReceiptJson(
+  receipt: Readonly<AgentBackupRestoreVaultVolumeSeedReceiptV1>,
+): string {
+  return JSON.stringify({
+    format: receipt.format,
+    transport: receipt.transport,
+    pathDerivation: receipt.pathDerivation,
+    agentId: receipt.agentId,
+    restoreAttemptId: receipt.restoreAttemptId,
+    replacementAttemptId: receipt.replacementAttemptId,
+    volumePathSha256: receipt.volumePathSha256,
+    commandSha256: receipt.commandSha256,
+    passphraseByteLength: receipt.passphraseByteLength,
+    completed: receipt.completed,
+  });
+}
+
+interface RestoreVolumeVaultSeedPlan {
+  command: string;
+  result: Readonly<AgentBackupRestoreVaultVolumeSeedResult>;
+}
+
+function buildRestoreVolumeVaultSeedPlanV1(
+  input: Readonly<BuildRestoreVolumeVaultSeedReceiptV1Input>,
+): RestoreVolumeVaultSeedPlan {
+  validatePassphraseByteLength(input.passphraseByteLength);
+  const volumePath = deriveRestoreStagingVolumePathV1(input.agentId, input.restoreAttemptId);
+  const replacementAttemptId = requireCanonicalUuid(
+    input.replacementAttemptId,
+    "replacementAttemptId",
+  );
+  validateVolumePath(volumePath);
+  const command = buildPrecreatedVolumeVaultSeedCommand({
+    agentId: input.agentId,
+    volumePath,
+    replacementAttemptId,
+    passphraseByteLength: input.passphraseByteLength,
+  });
+  const receipt = Object.freeze<AgentBackupRestoreVaultVolumeSeedReceiptV1>({
+    format: AGENT_BACKUP_RESTORE_VAULT_VOLUME_SEED_RECEIPT_FORMAT,
+    transport: VOLUME_VAULT_STDIN_FRAME_VERSION,
+    pathDerivation: AGENT_BACKUP_RESTORE_STAGING_VOLUME_PATH_DERIVATION_V1,
+    agentId: input.agentId,
+    restoreAttemptId: input.restoreAttemptId,
+    replacementAttemptId,
+    volumePathSha256: sha256Utf8(volumePath),
+    commandSha256: sha256Utf8(command),
+    passphraseByteLength: input.passphraseByteLength,
+    completed: true,
+  });
+  return {
+    command,
+    result: Object.freeze({
+      receipt,
+      receiptDigest: sha256Utf8(canonicalReceiptJson(receipt)),
+    }),
+  };
+}
+
+/** Pure recomputation surface for the durable database receipt authority. */
+export function buildRestoreVolumeVaultSeedReceiptV1(
+  input: Readonly<BuildRestoreVolumeVaultSeedReceiptV1Input>,
+): Readonly<AgentBackupRestoreVaultVolumeSeedResult> {
+  return buildRestoreVolumeVaultSeedPlanV1(input).result;
+}
+
+/**
+ * Seed a pre-created restore volume with an already-authorized passphrase.
+ *
+ * This function has no provider, SSH, database, or production caller. Secret
+ * bytes exist only in the caller-owned passphrase and one V1 stdin frame; the
+ * frame is wiped in `finally`, only after the mandatory cancellable transport
+ * has settled and therefore stopped reading caller-owned stdin bytes.
+ * The returned receipt contains only deterministic, non-secret completion
+ * metadata. A caller must first authorize these exact agent/attempt identities
+ * in durable pre-creation authority; the path can never select the live agent
+ * volume.
+ */
+export async function seedRestoreVolumeVaultPassphraseBytes(
+  input: Readonly<SeedRestoreVolumeVaultPassphraseBytesInput>,
+): Promise<Readonly<AgentBackupRestoreVaultVolumeSeedResult>> {
+  validatePassphraseBytes(input.passphrase);
+  const plan = buildRestoreVolumeVaultSeedPlanV1({
+    agentId: input.agentId,
+    restoreAttemptId: input.restoreAttemptId,
+    replacementAttemptId: input.replacementAttemptId,
+    passphraseByteLength: input.passphrase.byteLength,
+  });
+  input.signal.throwIfAborted();
+
+  const frame = buildVaultStdinFrame(input.passphrase);
+
+  try {
+    input.signal.throwIfAborted();
+    await input.execStdin(plan.command, frame, input.signal);
+    input.signal.throwIfAborted();
+    return plan.result;
+  } finally {
+    frame.fill(0);
+  }
+}

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -59,6 +59,8 @@ import {
   getContainerName,
   getContainerSecretEnvPath,
   getReplacementCandidateObservedReceipt,
+  getReplacementControlSecretEnvPath,
+  getReplacementControlVaultPassphrasePath,
   getReplacementDockerCreateQuiescentReceipt,
   getReplacementSecretArtifactsCleanupReceipt,
   getVolumePath,
@@ -2502,7 +2504,12 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       const envTransport = buildDockerContainerEnvTransport(allEnv);
-      const secretEnvPath = getContainerSecretEnvPath(volumePath, replacementAttemptId);
+      const secretEnvPath = remoteCompletionTracker
+        ? getReplacementControlSecretEnvPath(replacementAttemptId)
+        : getContainerSecretEnvPath(volumePath, replacementAttemptId);
+      const vaultPassphrasePath = remoteCompletionTracker
+        ? getReplacementControlVaultPassphrasePath(replacementAttemptId)
+        : getVolumeVaultPassphrasePath(volumePath);
 
       const dockerCreateCmd = [
         "docker create",
@@ -2563,7 +2570,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       const dockerCreateWithSecretEnvCmd = buildDockerCreateWithSecretEnvCommand({
         dockerCreateCommand: dockerCreateCmd,
         secretEnvPath,
-        vaultPassphrasePath: getVolumeVaultPassphrasePath(volumePath),
+        vaultPassphrasePath,
         ...(remoteCompletionTracker
           ? { exactReplacement: { containerName, replacementAttemptId } }
           : {}),

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -1009,6 +1009,92 @@ describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
     expect(VOLUME_VAULT_STDIN_FRAME_END).toBe("ELIZA_VAULT_STDIN_V1_END");
   });
 
+  test("places the fenced publication candidate on the durable key filesystem", () => {
+    const volume = "/data/agents/11111111-1111-4111-8111-111111111111";
+    const attemptId = "33333333-3333-4333-8333-333333333333";
+    const keyPath = getVolumeVaultPassphrasePath(volume);
+    const candidatePath = `${keyPath}.candidate.${attemptId}`;
+    const command = buildVolumeVaultPassphraseCommand(volume, 0, attemptId);
+    const cleanupCommand = buildReplacementSecretArtifactsCleanupCommand(
+      getContainerName("11111111-1111-4111-8111-111111111111"),
+      attemptId,
+    );
+
+    expect(command).toContain(
+      `generated_file='/var/lib/eliza/replacement-attempts/${attemptId}/vault-generated'`,
+    );
+    expect(command).toContain(`key_candidate_file='${candidatePath}'`);
+    expect(command).toContain('if exec 8>"$key_candidate_file"');
+    expect(command).toContain("secure_private_regular_fd_proof 8");
+    expect(command).toContain('ln "$key_candidate_file" "$key_file"');
+    expect(command).not.toContain('ln "$generated_file" "$key_file"');
+    expect(cleanupCommand).toContain(candidatePath);
+  });
+
+  test.skipIf(process.platform !== "linux")(
+    "publishes a fenced key when control and target paths are on distinct filesystems",
+    async () => {
+      const { spawn } = await import("node:child_process");
+      const fs = await import("node:fs");
+      const os = await import("node:os");
+      const path = await import("node:path");
+      const targetFilesystemRoot = ["/dev/shm", "/run/shm"].find((candidate) => {
+        try {
+          fs.accessSync(candidate, fs.constants.W_OK);
+          return fs.statSync(candidate).dev !== fs.statSync(os.tmpdir()).dev;
+        } catch {
+          return false;
+        }
+      });
+      if (!targetFilesystemRoot) return;
+
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-crossfs-control-"));
+      const volume = fs.mkdtempSync(path.join(targetFilesystemRoot, "eliza-crossfs-volume-"));
+      const bin = path.join(root, "bin");
+      const attempts = path.join(root, "attempts");
+      const productionVolume = "/data/agents/11111111-1111-4111-8111-111111111111";
+      const productionAttempts = "/var/lib/eliza/replacement-attempts";
+      const attemptId = "33333333-3333-4333-8333-333333333333";
+      const override = "cross-filesystem-vault-secret";
+      fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(path.join(bin, "flock"), "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+      fs.writeFileSync(
+        path.join(bin, "stat"),
+        '#!/bin/sh\ncase "$2" in "%u") printf 0 ;; "%a") if test -d "$4"; then printf 700; else printf 600; fi ;; "%h") printf 1 ;; "%d:%i") printf "1:1" ;; "%d:%i:%s:%y:%z") printf stable-fingerprint ;; *) exit 64 ;; esac\n',
+        { mode: 0o700 },
+      );
+
+      try {
+        expect(fs.statSync(root).dev).not.toBe(fs.statSync(volume).dev);
+        const command = buildVolumeVaultPassphraseCommand(
+          productionVolume,
+          Buffer.byteLength(override),
+          attemptId,
+        )
+          .replaceAll(productionVolume, volume)
+          .replaceAll(productionAttempts, attempts);
+        const frame = `${VOLUME_VAULT_STDIN_FRAME_VERSION} ${Buffer.byteLength(override)}\n${override}\n${VOLUME_VAULT_STDIN_FRAME_END}\n`;
+        const result = await new Promise<{ code: number | null; output: string }>((resolve) => {
+          const child = spawn("/bin/sh", ["-c", command], {
+            env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
+          });
+          let output = "";
+          child.stdout.on("data", (chunk) => (output += chunk.toString()));
+          child.stderr.on("data", (chunk) => (output += chunk.toString()));
+          child.on("close", (code) => resolve({ code, output }));
+          child.stdin.end(frame);
+        });
+
+        expect(result).toEqual({ code: 0, output: "" });
+        expect(fs.readFileSync(getVolumeVaultPassphrasePath(volume), "utf8")).toBe(override);
+        expect(fs.readdirSync(volume)).toEqual([".vault-passphrase"]);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+        fs.rmSync(volume, { recursive: true, force: true });
+      }
+    },
+  );
+
   test("exact vault staging replaces control symlinks and rejects a durable-key symlink", async () => {
     const { spawn } = await import("node:child_process");
     const fs = await import("node:fs");

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -403,7 +403,10 @@ describe("secret container environment transport (#22060)", () => {
     expect(volumeCleanupCommand).toContain("flock -w 30 9");
     expect(volumeCleanupCommand).toContain("docker container ls -aq --no-trunc");
     expect(volumeCleanupCommand).toContain("docker inspect --format");
-    expect(volumeCleanupCommand).toContain("findmnt -rn -o FSROOT,TARGET | awk");
+    expect(volumeCleanupCommand).toContain(
+      "mount_inventory=$(findmnt -rn -o FSROOT,TARGET) || exit 76",
+    );
+    expect(volumeCleanupCommand).toContain(`printf '%s\n' "$mount_inventory" | awk`);
     expect(volumeCleanupCommand).toContain('index($0, root "/") == 1');
     expect(volumeCleanupCommand).toContain('index(root, $0 "/") == 1');
     expect(volumeCleanupCommand).toContain("rm -rf --one-file-system --");
@@ -460,7 +463,7 @@ describe("secret container environment transport (#22060)", () => {
     );
     fs.writeFileSync(
       path.join(bin, "findmnt"),
-      '#!/bin/sh\nif test -n "$ELIZA_TEST_HOST_MOUNT_SOURCE"; then printf "%s %s\\n" "$ELIZA_TEST_HOST_MOUNT_SOURCE" /outside-consumer; elif test -n "$ELIZA_TEST_HOST_MOUNT_TARGET"; then printf "%s %s\\n" / "$ELIZA_TEST_HOST_MOUNT_TARGET"; fi\n',
+      '#!/bin/sh\nif test -n "$ELIZA_TEST_FINDMNT_FAILURE"; then exit 64; elif test -n "$ELIZA_TEST_HOST_MOUNT_SOURCE"; then printf "%s %s\\n" "$ELIZA_TEST_HOST_MOUNT_SOURCE" /outside-consumer; elif test -n "$ELIZA_TEST_HOST_MOUNT_TARGET"; then printf "%s %s\\n" / "$ELIZA_TEST_HOST_MOUNT_TARGET"; fi\n',
       { mode: 0o700 },
     );
     fs.writeFileSync(
@@ -505,6 +508,10 @@ describe("secret container environment transport (#22060)", () => {
       expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
 
       expect(await run({ ELIZA_TEST_HOST_MOUNT_SOURCE: `${volume}/eliza` })).toBe(76);
+      expect(fs.existsSync(rmMarker)).toBe(false);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
+
+      expect(await run({ ELIZA_TEST_FINDMNT_FAILURE: "1" })).toBe(76);
       expect(fs.existsSync(rmMarker)).toBe(false);
       expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
 

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -10,7 +10,9 @@ import {
   buildAgentContainerLabelFlags,
   buildDockerContainerEnvTransport,
   buildDockerCreateWithSecretEnvCommand,
+  buildExactRestoreStagingVolumeCleanupCommand,
   buildReplacementCandidateObservedCommand,
+  buildReplacementCreatedContainerIdProofCommand,
   buildReplacementSecretArtifactsCleanupCommand,
   buildVolumeVaultPassphraseCommand,
   CONTAINER_DURABLE_STATE_DIR,
@@ -19,7 +21,10 @@ import {
   extractDockerCreateContainerId,
   getContainerName,
   getContainerSecretEnvPath,
+  getExactRestoreStagingVolumeCleanupReceipt,
   getReplacementCandidateObservedReceipt,
+  getReplacementControlSecretEnvPath,
+  getReplacementControlVaultPassphrasePath,
   getReplacementDockerCreateQuiescentReceipt,
   getReplacementSecretArtifactsCleanupReceipt,
   getVolumePath,
@@ -35,6 +40,8 @@ import {
   resolveStewardContainerUrl,
   resolveVpnTeardown,
   shellQuote,
+  VOLUME_VAULT_STDIN_FRAME_END,
+  VOLUME_VAULT_STDIN_FRAME_VERSION,
   validateAgentId,
   validateContainerName,
   validateEnvKey,
@@ -310,12 +317,13 @@ describe("secret container environment transport (#22060)", () => {
     const containerName = getContainerName(agentId);
     const volumePath = getVolumePath(agentId);
     const attemptId = "33333333-3333-4333-8333-333333333333";
-    const secretEnvPath = getContainerSecretEnvPath(volumePath, attemptId);
+    const secretEnvPath = getReplacementControlSecretEnvPath(attemptId);
+    const vaultSnapshotPath = getReplacementControlVaultPassphrasePath(attemptId);
     const vaultCommand = buildVolumeVaultPassphraseCommand(volumePath, 0, attemptId);
     const dockerCommand = buildDockerCreateWithSecretEnvCommand({
       dockerCreateCommand: `docker create --env-file ${shellQuote(secretEnvPath)} image:latest`,
       secretEnvPath,
-      vaultPassphrasePath: getVolumeVaultPassphrasePath(volumePath),
+      vaultPassphrasePath: vaultSnapshotPath,
       exactReplacement: { containerName, replacementAttemptId: attemptId },
     });
     const cleanupCommand = buildReplacementSecretArtifactsCleanupCommand(containerName, attemptId);
@@ -324,18 +332,21 @@ describe("secret container environment transport (#22060)", () => {
     for (const producer of [vaultCommand, dockerCommand]) {
       expect(producer).toContain("flock -w 30 9");
       expect(producer).toContain('test ! -e "$attempt_cancelled"');
-      expect(producer.indexOf("attempt_cancelled")).toBeLessThan(producer.indexOf("cat >"));
+      expect(producer).not.toMatch(/cat >\s*["']?\$/);
+      expect(producer).not.toMatch(/sed [^;]+ > /);
     }
-    expect(vaultCommand).not.toContain(': > "$attempt_active"');
-    expect(dockerCommand).toContain(': > "$attempt_active"');
-    expect(vaultCommand).toContain(`.vault-passphrase.stdin.${attemptId}`);
+    expect(vaultCommand).not.toContain('secure_reset_control_file "$attempt_active"');
+    expect(dockerCommand).toContain('secure_reset_control_file "$attempt_active"');
+    expect(dockerCommand).not.toContain("stat -Lf");
+    expect(vaultCommand).toContain(`/replacement-attempts/${attemptId}/vault-stdin`);
     expect(vaultCommand).not.toContain(".$$;");
-    expect(cleanupCommand.indexOf("attempt_cancelled")).toBeLessThan(
-      cleanupCommand.indexOf("rm -f --"),
+    expect(cleanupCommand.indexOf('secure_reset_control_file "$attempt_cancelled"')).toBeLessThan(
+      cleanupCommand.indexOf(`rm -f -- '${secretEnvPath}'`),
     );
     expect(cleanupCommand).toContain(secretEnvPath);
+    expect(cleanupCommand).toContain(vaultSnapshotPath);
     for (const kind of ["stdin", "override", "generated", "normalized"]) {
-      expect(cleanupCommand).toContain(`.vault-passphrase.${kind}.${attemptId}`);
+      expect(cleanupCommand).toContain(`/replacement-attempts/${attemptId}/vault-${kind}`);
     }
     expect(cleanupCommand).toContain("if test -e");
     expect(cleanupCommand).toContain("|| test -L");
@@ -345,10 +356,172 @@ describe("secret container environment transport (#22060)", () => {
     expect(candidateCommand).toContain(
       getReplacementCandidateObservedReceipt(attemptId, "a".repeat(64)),
     );
-    expect(candidateCommand).toContain('test -f "$attempt_cancelled"');
+    expect(candidateCommand).toContain('secure_private_regular_file_proof "$attempt_cancelled" 75');
   });
 
-  test("executes the exact tombstone protocol and keeps Docker ambiguity fail-closed", async () => {
+  test("fences restore-staging env input and durably records the full Docker ID", () => {
+    const agentId = "11111111-1111-4111-8111-111111111111";
+    const restoreAttemptId = "22222222-2222-4222-8222-222222222222";
+    const replacementAttemptId = "33333333-3333-4333-8333-333333333333";
+    const containerName = `agent-restore-${agentId}-${restoreAttemptId}`;
+    const volumePath = `/data/agents/.restore/${agentId}/${restoreAttemptId}`;
+    const secretEnvPath = getReplacementControlSecretEnvPath(replacementAttemptId);
+    const createCommand = buildDockerCreateWithSecretEnvCommand({
+      dockerCreateCommand: "docker create image@sha256:deadbeef",
+      secretEnvPath,
+      vaultPassphrasePath: getReplacementControlVaultPassphrasePath(replacementAttemptId),
+      exactReplacement: {
+        containerName,
+        replacementAttemptId,
+        volumePath,
+        recordContainerId: true,
+      },
+    });
+    const cleanupCommand = buildReplacementSecretArtifactsCleanupCommand(
+      containerName,
+      replacementAttemptId,
+      volumePath,
+    );
+    const proofCommand = buildReplacementCreatedContainerIdProofCommand(replacementAttemptId);
+    const volumeCleanupCommand = buildExactRestoreStagingVolumeCleanupCommand(
+      containerName,
+      replacementAttemptId,
+      volumePath,
+    );
+
+    expect(createCommand).toContain('secure_reset_control_file "$attempt_active"');
+    expect(createCommand).toContain("candidate_id=$(docker create");
+    expect(createCommand).toContain('test "${#candidate_id}" = 64');
+    expect(createCommand).toContain('mv -- "$candidate_tmp" "$attempt_candidate_id"');
+    expect(cleanupCommand).toContain(secretEnvPath);
+    expect(cleanupCommand).not.toContain(getVolumePath(agentId));
+    expect(proofCommand).toContain('secure_private_regular_file_proof "$attempt_candidate_id"');
+    expect(proofCommand).toContain('test "${#candidate_id}" = 64');
+    expect(volumeCleanupCommand).toContain(
+      'secure_private_regular_file_proof "$attempt_cancelled" 75',
+    );
+    expect(volumeCleanupCommand).toContain("flock -w 30 9");
+    expect(volumeCleanupCommand).toContain("docker container ls -aq --no-trunc");
+    expect(volumeCleanupCommand).toContain("docker inspect --format");
+    expect(volumeCleanupCommand).toContain("findmnt -rn -o FSROOT,TARGET | awk");
+    expect(volumeCleanupCommand).toContain('index($0, root "/") == 1');
+    expect(volumeCleanupCommand).toContain('index(root, $0 "/") == 1');
+    expect(volumeCleanupCommand).toContain("rm -rf --one-file-system --");
+    expect(volumeCleanupCommand).toContain(`test -L '${volumePath}'`);
+    expect(volumeCleanupCommand).toContain(
+      getExactRestoreStagingVolumeCleanupReceipt(replacementAttemptId, restoreAttemptId),
+    );
+    expect(volumeCleanupCommand.indexOf("docker container ls")).toBeLessThan(
+      volumeCleanupCommand.indexOf("rm -rf"),
+    );
+    expect(volumeCleanupCommand).not.toContain(getVolumePath(agentId));
+    expect(() =>
+      buildExactRestoreStagingVolumeCleanupCommand(
+        containerName,
+        replacementAttemptId,
+        `${volumePath}-wrong`,
+      ),
+    ).toThrow("differs from its container identity");
+  });
+
+  test("refuses descendant Docker binds and nested host mounts before staging deletion", async () => {
+    const { spawn } = await import("node:child_process");
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-restore-volume-cleanup-"));
+    const bin = path.join(root, "bin");
+    const relocatedData = path.join(root, "data");
+    const agentId = "11111111-1111-4111-8111-111111111111";
+    const restoreAttemptId = "22222222-2222-4222-8222-222222222222";
+    const replacementAttemptId = "33333333-3333-4333-8333-333333333333";
+    const containerName = `agent-restore-${agentId}-${restoreAttemptId}`;
+    const productionVolume = `/data/agents/.restore/${agentId}/${restoreAttemptId}`;
+    const volume = path.join(relocatedData, "agents", ".restore", agentId, restoreAttemptId);
+    const attempts = path.join(root, "attempts");
+    const attemptDirectory = path.join(attempts, replacementAttemptId);
+    const rmMarker = path.join(root, "rm-invoked");
+    const sentinel = path.join(volume, "must-survive");
+    fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(volume, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(attemptDirectory, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(attemptDirectory, "cancelled"), "cancelled\n", { mode: 0o600 });
+    fs.writeFileSync(sentinel, "durable-data", { mode: 0o600 });
+    fs.writeFileSync(path.join(bin, "flock"), "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    fs.writeFileSync(
+      path.join(bin, "stat"),
+      '#!/bin/sh\ncase "$2" in "%u") printf 0 ;; "%a") if test -d "$4"; then printf 700; else printf 600; fi ;; "%h") printf 1 ;; *) exit 64 ;; esac\n',
+      { mode: 0o700 },
+    );
+    fs.writeFileSync(
+      path.join(bin, "docker"),
+      '#!/bin/sh\ncase "$*" in *"--filter"*) exit 0 ;; "container ls -aq --no-trunc") if test -n "$ELIZA_TEST_DOCKER_MOUNT_SOURCE" || test -n "$ELIZA_TEST_DOCKER_CONTAINER_PRESENT"; then printf "%s\\n" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; fi ;; inspect*) printf "%s\\n" "$ELIZA_TEST_DOCKER_MOUNT_SOURCE" ;; *) exit 64 ;; esac\n',
+      { mode: 0o700 },
+    );
+    fs.writeFileSync(
+      path.join(bin, "findmnt"),
+      '#!/bin/sh\nif test -n "$ELIZA_TEST_HOST_MOUNT_SOURCE"; then printf "%s %s\\n" "$ELIZA_TEST_HOST_MOUNT_SOURCE" /outside-consumer; elif test -n "$ELIZA_TEST_HOST_MOUNT_TARGET"; then printf "%s %s\\n" / "$ELIZA_TEST_HOST_MOUNT_TARGET"; fi\n',
+      { mode: 0o700 },
+    );
+    fs.writeFileSync(
+      path.join(bin, "rm"),
+      '#!/bin/sh\nprintf invoked > "$ELIZA_TEST_RM_MARKER"\ncase "$*" in *"--one-file-system"*) if test -n "$ELIZA_TEST_RM_DELETE_VOLUME"; then /bin/rm -rf "$ELIZA_TEST_RM_DELETE_VOLUME"; fi ;; esac\nexit 0\n',
+      { mode: 0o700 },
+    );
+
+    const command = buildExactRestoreStagingVolumeCleanupCommand(
+      containerName,
+      replacementAttemptId,
+      productionVolume,
+    )
+      .replaceAll("/var/lib/eliza/replacement-attempts", attempts)
+      .replaceAll("/data", relocatedData)
+      .replaceAll("chmod 700 --", "chmod 700")
+      .replaceAll("chmod 600 --", "chmod 600");
+    const run = (env: NodeJS.ProcessEnv): Promise<number | null> =>
+      new Promise((resolve) => {
+        const child = spawn("/bin/sh", ["-c", command], {
+          env: {
+            ...process.env,
+            ...env,
+            PATH: `${bin}:${process.env.PATH ?? ""}`,
+            ELIZA_TEST_RM_MARKER: rmMarker,
+          },
+        });
+        child.on("close", resolve);
+      });
+
+    try {
+      expect(await run({ ELIZA_TEST_DOCKER_MOUNT_SOURCE: `${volume}/eliza` })).toBe(76);
+      expect(fs.existsSync(rmMarker)).toBe(false);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
+
+      expect(await run({ ELIZA_TEST_DOCKER_MOUNT_SOURCE: path.dirname(volume) })).toBe(76);
+      expect(fs.existsSync(rmMarker)).toBe(false);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
+
+      expect(await run({ ELIZA_TEST_HOST_MOUNT_TARGET: `${volume}/nested-bind` })).toBe(76);
+      expect(fs.existsSync(rmMarker)).toBe(false);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
+
+      expect(await run({ ELIZA_TEST_HOST_MOUNT_SOURCE: `${volume}/eliza` })).toBe(76);
+      expect(fs.existsSync(rmMarker)).toBe(false);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("durable-data");
+
+      expect(
+        await run({
+          ELIZA_TEST_DOCKER_CONTAINER_PRESENT: "1",
+          ELIZA_TEST_RM_DELETE_VOLUME: volume,
+        }),
+      ).toBe(0);
+      expect(fs.existsSync(rmMarker)).toBe(true);
+      expect(fs.existsSync(volume)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("distinguishes pre-effect, definitive, and ambiguous Docker-create failures", async () => {
     const { spawn } = await import("node:child_process");
     const fs = await import("node:fs");
     const os = await import("node:os");
@@ -366,6 +539,11 @@ describe("secret container environment transport (#22060)", () => {
     fs.mkdirSync(bin, { recursive: true });
     fs.mkdirSync(volume, { recursive: true });
     fs.writeFileSync(path.join(bin, "flock"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(bin, "stat"),
+      '#!/bin/sh\ncase "$2" in "%u") printf 0 ;; "%a") if test -d "$4"; then printf 700; else printf 600; fi ;; "%h") if test -n "$ELIZA_TEST_HARDLINK_PATH" && test "$4" = "$ELIZA_TEST_HARDLINK_PATH"; then printf 2; else printf 1; fi ;; "%d:%i") printf "1:1" ;; *) exit 64 ;; esac\n',
+      { mode: 0o755 },
+    );
     fs.writeFileSync(path.join(volume, ".vault-passphrase"), "persisted-vault-value", {
       mode: 0o600,
     });
@@ -380,15 +558,24 @@ describe("secret container environment transport (#22060)", () => {
         .replaceAll("chmod 600 --", "chmod 600")
         .replaceAll("cat -- ", "cat ")
         .replaceAll("mv -- ", "mv ");
+    const seedControlVaultSnapshot = (replacementAttemptId: string): void => {
+      const attemptDirectory = path.join(attempts, replacementAttemptId);
+      fs.mkdirSync(attemptDirectory, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(path.join(attemptDirectory, "vault-passphrase"), "persisted-vault-value", {
+        mode: 0o600,
+      });
+    };
     const run = (
       command: string,
       input = "",
       extraPath?: string,
+      extraEnv: NodeJS.ProcessEnv = {},
     ): Promise<{ code: number | null; output: string }> =>
       new Promise((resolve) => {
         const child = spawn("/bin/sh", ["-c", remap(command)], {
           env: {
             ...process.env,
+            ...extraEnv,
             PATH: `${extraPath ? `${extraPath}:` : ""}${bin}:${process.env.PATH}`,
           },
         });
@@ -400,21 +587,134 @@ describe("secret container environment transport (#22060)", () => {
       });
 
     try {
-      const secretEnvPath = getContainerSecretEnvPath(productionVolume, attemptId);
-      const failedProducer = buildDockerCreateWithSecretEnvCommand({
-        dockerCreateCommand: "false",
-        secretEnvPath,
-        vaultPassphrasePath: getVolumeVaultPassphrasePath(productionVolume),
-        exactReplacement: { containerName, replacementAttemptId: attemptId },
-      });
       const secretInput = buildDockerContainerEnvTransport({
         API_KEY: "one-shot-secret-sentinel",
       }).secretInput;
+
+      const legacyAttemptId = "22222222-2222-4222-8222-222222222223";
+      const legacyVaultPath = path.join(volume, ".vault-passphrase");
+      const legacyArtifactPaths = [
+        path.join(volume, `.container-env-${legacyAttemptId}`),
+        path.join(volume, `.container-env-${legacyAttemptId}.body`),
+        ...["stdin", "override", "generated", "normalized"].map(
+          (kind) => `${legacyVaultPath}.${kind}.${legacyAttemptId}`,
+        ),
+      ];
+      for (const artifactPath of legacyArtifactPaths) {
+        fs.writeFileSync(artifactPath, "legacy-plaintext", { mode: 0o600 });
+      }
+      const legacyCleanup = await run(
+        buildReplacementSecretArtifactsCleanupCommand(containerName, legacyAttemptId),
+      );
+      expect(legacyCleanup).toEqual({
+        code: 0,
+        output: `${getReplacementSecretArtifactsCleanupReceipt(legacyAttemptId)}\n${getReplacementDockerCreateQuiescentReceipt(legacyAttemptId)}\n`,
+      });
+      for (const artifactPath of legacyArtifactPaths) {
+        expect(fs.existsSync(artifactPath)).toBe(false);
+      }
+
+      const hardlinkAttemptId = "22222222-2222-4222-8222-222222222224";
+      const hardlinkedLegacyEnv = path.join(volume, `.container-env-${hardlinkAttemptId}`);
+      const retainedHardlink = path.join(root, "retained-legacy-env-hardlink");
+      fs.writeFileSync(hardlinkedLegacyEnv, "hardlinked-plaintext", { mode: 0o600 });
+      fs.linkSync(hardlinkedLegacyEnv, retainedHardlink);
+      const hardlinkCleanup = await run(
+        buildReplacementSecretArtifactsCleanupCommand(containerName, hardlinkAttemptId),
+        "",
+        undefined,
+        { ELIZA_TEST_HARDLINK_PATH: hardlinkedLegacyEnv },
+      );
+      expect(hardlinkCleanup.code).toBe(70);
+      expect(hardlinkCleanup.output).not.toContain(
+        getReplacementSecretArtifactsCleanupReceipt(hardlinkAttemptId),
+      );
+      expect(fs.readFileSync(hardlinkedLegacyEnv, "utf8")).toBe("hardlinked-plaintext");
+      expect(fs.readFileSync(retainedHardlink, "utf8")).toBe("hardlinked-plaintext");
+
+      const symlinkAttemptId = "99999999-9999-4999-8999-999999999999";
+      const symlinkSecretPath = getReplacementControlSecretEnvPath(symlinkAttemptId);
+      const symlinkAttemptDirectory = path.join(attempts, symlinkAttemptId);
+      const externalEnvTarget = path.join(root, "external-env-target");
+      const externalBodyTarget = path.join(root, "external-env-body-target");
+      seedControlVaultSnapshot(symlinkAttemptId);
+      fs.writeFileSync(externalEnvTarget, "external-env-must-not-change", { mode: 0o640 });
+      fs.writeFileSync(externalBodyTarget, "external-body-must-not-change", { mode: 0o640 });
+      fs.symlinkSync(externalEnvTarget, path.join(symlinkAttemptDirectory, "container-env"));
+      fs.symlinkSync(externalBodyTarget, path.join(symlinkAttemptDirectory, "container-env.body"));
+      const symlinkProducer = buildDockerCreateWithSecretEnvCommand({
+        dockerCreateCommand: "true",
+        secretEnvPath: symlinkSecretPath,
+        vaultPassphrasePath: getReplacementControlVaultPassphrasePath(symlinkAttemptId),
+        exactReplacement: { containerName, replacementAttemptId: symlinkAttemptId },
+      });
+      expect(await run(symlinkProducer, secretInput)).toEqual({ code: 0, output: "" });
+      expect(fs.readFileSync(externalEnvTarget, "utf8")).toBe("external-env-must-not-change");
+      expect(fs.readFileSync(externalBodyTarget, "utf8")).toBe("external-body-must-not-change");
+      expect(fs.statSync(externalEnvTarget).mode & 0o777).toBe(0o640);
+      expect(fs.statSync(externalBodyTarget).mode & 0o777).toBe(0o640);
+      expect(fs.existsSync(path.join(symlinkAttemptDirectory, "container-env"))).toBe(false);
+      expect(fs.existsSync(path.join(symlinkAttemptDirectory, "container-env.body"))).toBe(false);
+
+      const malformedAttemptId = "77777777-7777-4777-8777-777777777777";
+      const malformedSecretPath = getReplacementControlSecretEnvPath(malformedAttemptId);
+      seedControlVaultSnapshot(malformedAttemptId);
+      const malformedProducer = buildDockerCreateWithSecretEnvCommand({
+        dockerCreateCommand: `: > ${shellQuote(marker)}`,
+        secretEnvPath: malformedSecretPath,
+        vaultPassphrasePath: getReplacementControlVaultPassphrasePath(malformedAttemptId),
+        exactReplacement: { containerName, replacementAttemptId: malformedAttemptId },
+      });
+      const malformed = await run(malformedProducer, "API_KEY=truncated-without-sentinel\n");
+      expect(malformed.code).not.toBe(0);
+      expect(fs.existsSync(marker)).toBe(false);
+      expect(fs.existsSync(path.join(attempts, malformedAttemptId, "active"))).toBe(false);
+      expect(fs.existsSync(path.join(attempts, malformedAttemptId, "container-env"))).toBe(false);
+      const malformedCleanup = await run(
+        buildReplacementSecretArtifactsCleanupCommand(containerName, malformedAttemptId),
+      );
+      expect(malformedCleanup).toEqual({
+        code: 0,
+        output: `${getReplacementSecretArtifactsCleanupReceipt(malformedAttemptId)}\n${getReplacementDockerCreateQuiescentReceipt(malformedAttemptId)}\n`,
+      });
+
+      const definitiveAttemptId = "88888888-8888-4888-8888-888888888888";
+      const definitiveSecretPath = getReplacementControlSecretEnvPath(definitiveAttemptId);
+      seedControlVaultSnapshot(definitiveAttemptId);
+      const definitiveProducer = buildDockerCreateWithSecretEnvCommand({
+        dockerCreateCommand: `sh -c ${shellQuote(
+          "printf '%s\\n' 'docker: Error response from daemon: Conflict. The container name is already in use by container' >&2; exit 125",
+        )}`,
+        secretEnvPath: definitiveSecretPath,
+        vaultPassphrasePath: getReplacementControlVaultPassphrasePath(definitiveAttemptId),
+        exactReplacement: { containerName, replacementAttemptId: definitiveAttemptId },
+      });
+      const definitive = await run(definitiveProducer, secretInput);
+      expect(definitive.code).toBe(125);
+      expect(definitive.output).not.toContain("Conflict. The container name");
+      expect(fs.existsSync(path.join(attempts, definitiveAttemptId, "active"))).toBe(false);
+      expect(fs.existsSync(path.join(attempts, definitiveAttemptId, "docker-error"))).toBe(false);
+      const definitiveCleanup = await run(
+        buildReplacementSecretArtifactsCleanupCommand(containerName, definitiveAttemptId),
+      );
+      expect(definitiveCleanup).toEqual({
+        code: 0,
+        output: `${getReplacementSecretArtifactsCleanupReceipt(definitiveAttemptId)}\n${getReplacementDockerCreateQuiescentReceipt(definitiveAttemptId)}\n`,
+      });
+
+      const secretEnvPath = getReplacementControlSecretEnvPath(attemptId);
+      seedControlVaultSnapshot(attemptId);
+      const failedProducer = buildDockerCreateWithSecretEnvCommand({
+        dockerCreateCommand: "false",
+        secretEnvPath,
+        vaultPassphrasePath: getReplacementControlVaultPassphrasePath(attemptId),
+        exactReplacement: { containerName, replacementAttemptId: attemptId },
+      });
       const failed = await run(failedProducer, secretInput);
       expect(failed.code).not.toBe(0);
       expect(failed.output).not.toContain("one-shot-secret-sentinel");
       expect(fs.existsSync(path.join(attempts, attemptId, "active"))).toBe(true);
-      expect(fs.existsSync(path.join(volume, path.basename(secretEnvPath)))).toBe(false);
+      expect(fs.existsSync(path.join(attempts, attemptId, "container-env"))).toBe(false);
 
       const cleanup = await run(
         buildReplacementSecretArtifactsCleanupCommand(containerName, attemptId),
@@ -443,7 +743,7 @@ describe("secret container environment transport (#22060)", () => {
       const replay = buildDockerCreateWithSecretEnvCommand({
         dockerCreateCommand: `: > ${shellQuote(marker)}`,
         secretEnvPath,
-        vaultPassphrasePath: getVolumeVaultPassphrasePath(productionVolume),
+        vaultPassphrasePath: getReplacementControlVaultPassphrasePath(attemptId),
         exactReplacement: { containerName, replacementAttemptId: attemptId },
       });
       const rejectedReplay = await run(replay, secretInput);
@@ -452,11 +752,12 @@ describe("secret container environment transport (#22060)", () => {
       expect(fs.existsSync(marker)).toBe(false);
 
       const successfulAttemptId = "66666666-6666-4666-8666-666666666666";
-      const successfulSecretPath = getContainerSecretEnvPath(productionVolume, successfulAttemptId);
+      const successfulSecretPath = getReplacementControlSecretEnvPath(successfulAttemptId);
+      seedControlVaultSnapshot(successfulAttemptId);
       const successfulProducer = buildDockerCreateWithSecretEnvCommand({
         dockerCreateCommand: `printf '%s\\n' ${shellQuote("a".repeat(64))}`,
         secretEnvPath: successfulSecretPath,
-        vaultPassphrasePath: getVolumeVaultPassphrasePath(productionVolume),
+        vaultPassphrasePath: getReplacementControlVaultPassphrasePath(successfulAttemptId),
         exactReplacement: {
           containerName,
           replacementAttemptId: successfulAttemptId,
@@ -477,11 +778,15 @@ describe("secret container environment transport (#22060)", () => {
         ["44444444-4444-4444-8444-444444444444", "file"],
         ["55555555-5555-4555-8555-555555555555", "symlink"],
       ] as const) {
-        const survivingPath = path.join(volume, `.container-env-${suffix}`);
+        const attemptDirectory = path.join(attempts, suffix);
+        fs.mkdirSync(attemptDirectory, { recursive: true, mode: 0o700 });
+        const survivingPath = path.join(attemptDirectory, "container-env");
+        const externalTarget = path.join(root, `external-cleanup-target-${suffix}`);
         if (kind === "file") {
           fs.writeFileSync(survivingPath, "must-survive-fake-rm", { mode: 0o600 });
         } else {
-          fs.symlinkSync(path.join(root, "missing-target"), survivingPath);
+          fs.writeFileSync(externalTarget, "external-target-must-survive", { mode: 0o640 });
+          fs.symlinkSync(externalTarget, survivingPath);
         }
         const fakeRmBin = path.join(root, `fake-rm-${kind}`);
         fs.mkdirSync(fakeRmBin);
@@ -493,11 +798,15 @@ describe("secret container environment transport (#22060)", () => {
         );
         expect(refused.code).toBe(70);
         expect(refused.output).not.toContain(getReplacementSecretArtifactsCleanupReceipt(suffix));
+        if (kind === "symlink") {
+          expect(fs.readFileSync(externalTarget, "utf8")).toBe("external-target-must-survive");
+          expect(fs.statSync(externalTarget).mode & 0o777).toBe(0o640);
+        }
       }
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 10_000);
 
   test("derives exact cleanup paths from the canonical container name only", () => {
     const attemptId = "33333333-3333-4333-8333-333333333333";
@@ -695,6 +1004,103 @@ describe("resolveVpnTeardown (#16565)", () => {
 });
 
 describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
+  test("keeps the exported V1 framing labels stable for byte-native producers", () => {
+    expect(VOLUME_VAULT_STDIN_FRAME_VERSION).toBe("ELIZA_VAULT_STDIN_V1");
+    expect(VOLUME_VAULT_STDIN_FRAME_END).toBe("ELIZA_VAULT_STDIN_V1_END");
+  });
+
+  test("exact vault staging replaces control symlinks and rejects a durable-key symlink", async () => {
+    const { spawn } = await import("node:child_process");
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-exact-vault-symlink-"));
+    const bin = path.join(root, "bin");
+    const volume = path.join(root, "volume");
+    const attempts = path.join(root, "attempts");
+    const productionVolume = "/data/agents/11111111-1111-4111-8111-111111111111";
+    const productionAttempts = "/var/lib/eliza/replacement-attempts";
+    fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(volume, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(bin, "flock"), "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    fs.writeFileSync(
+      path.join(bin, "stat"),
+      '#!/bin/sh\ncase "$2" in "%u") printf 0 ;; "%a") if test -d "$4"; then printf 700; else printf 600; fi ;; "%h") printf 1 ;; "%d:%i") printf "1:1" ;; "%d:%i:%s:%y:%z") printf stable-fingerprint ;; *) exit 64 ;; esac\n',
+      { mode: 0o700 },
+    );
+    const remap = (command: string): string =>
+      command
+        .replaceAll(productionVolume, volume)
+        .replaceAll(productionAttempts, attempts)
+        .replaceAll("chmod 700 --", "chmod 700")
+        .replaceAll("chmod 600 --", "chmod 600")
+        .replaceAll("mv -- ", "mv ");
+    const run = (
+      command: string,
+      input: string,
+    ): Promise<{ code: number | null; output: string }> =>
+      new Promise((resolve) => {
+        const child = spawn("/bin/sh", ["-c", remap(command)], {
+          env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => (output += chunk.toString()));
+        child.stderr.on("data", (chunk) => (output += chunk.toString()));
+        child.on("close", (code) => resolve({ code, output }));
+        child.stdin.end(input);
+      });
+    const frame = (override: string): string =>
+      `${VOLUME_VAULT_STDIN_FRAME_VERSION} ${Buffer.byteLength(override)}\n${override}\n${VOLUME_VAULT_STDIN_FRAME_END}\n`;
+
+    try {
+      const attemptId = "33333333-3333-4333-8333-333333333333";
+      const attemptDirectory = path.join(attempts, attemptId);
+      const externalTarget = path.join(root, "external-transient-target");
+      const override = "exact-vault-secret-value";
+      fs.mkdirSync(attemptDirectory, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(externalTarget, "external-transient-must-not-change", { mode: 0o640 });
+      for (const name of [
+        "vault-stdin",
+        "vault-override",
+        "vault-generated",
+        "vault-normalized",
+        "vault-passphrase",
+      ]) {
+        fs.symlinkSync(externalTarget, path.join(attemptDirectory, name));
+      }
+      const command = buildVolumeVaultPassphraseCommand(
+        productionVolume,
+        Buffer.byteLength(override),
+        attemptId,
+      );
+      const seeded = await run(command, frame(override));
+      expect(seeded).toEqual({ code: 0, output: "" });
+      expect(fs.readFileSync(externalTarget, "utf8")).toBe("external-transient-must-not-change");
+      expect(fs.statSync(externalTarget).mode & 0o777).toBe(0o640);
+      expect(fs.readFileSync(path.join(volume, ".vault-passphrase"), "utf8")).toBe(override);
+      expect(fs.readFileSync(path.join(attemptDirectory, "vault-passphrase"), "utf8")).toBe(
+        override,
+      );
+
+      const rejectedAttemptId = "44444444-4444-4444-8444-444444444444";
+      const externalKeyTarget = path.join(root, "external-durable-key-target");
+      fs.writeFileSync(externalKeyTarget, "external-key-must-not-change", { mode: 0o640 });
+      fs.unlinkSync(path.join(volume, ".vault-passphrase"));
+      fs.symlinkSync(externalKeyTarget, path.join(volume, ".vault-passphrase"));
+      const rejected = await run(
+        buildVolumeVaultPassphraseCommand(productionVolume, 0, rejectedAttemptId),
+        frame(""),
+      );
+      expect(rejected.code).toBe(70);
+      expect(rejected.output).not.toContain("external-key-must-not-change");
+      expect(fs.readFileSync(externalKeyTarget, "utf8")).toBe("external-key-must-not-change");
+      expect(fs.statSync(externalKeyTarget).mode & 0o777).toBe(0o640);
+      expect(fs.existsSync(path.join(attempts, rejectedAttemptId, "vault-passphrase"))).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   // The real-process cases run the exact shell program sent over SSH against
   // local /bin/sh and a temp agent volume. They cover shell mutation and trap
   // behavior, but not SSH channel or supported-node behavior.
@@ -741,10 +1147,7 @@ describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
       const temporaryFiles = fs
         .readdirSync(volume)
         .filter((name) => name.startsWith(".vault-passphrase."));
-      expect(temporaryFiles.length).toBeGreaterThan(0);
-      expect(
-        temporaryFiles.some((name) => fs.readFileSync(`${volume}/${name}`, "utf8") === override),
-      ).toBe(true);
+      expect(temporaryFiles).toEqual([]);
     } finally {
       fs.rmSync(volume, { recursive: true, force: true });
     }

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -1412,7 +1412,7 @@ export function buildExactRestoreStagingVolumeCleanupCommand(
     safeDirectoryProof(restoreRoot, false),
     safeDirectoryProof(agentRoot, true),
     `if test -L ${volume}; then exit 76; fi`,
-    `if test -e ${volume}; then ${safeDirectoryProof(exactVolumePath, false)}; if findmnt -rn -o FSROOT,TARGET | awk -v root=${volume} '$1 == root || index($1, root "/") == 1 || $2 == root || index($2, root "/") == 1 { found=1 } END { exit found ? 0 : 1 }'; then exit 76; fi; rm -rf --one-file-system -- ${volume}; fi`,
+    `if test -e ${volume}; then ${safeDirectoryProof(exactVolumePath, false)}; mount_inventory=$(findmnt -rn -o FSROOT,TARGET) || exit 76; if printf '%s\n' "$mount_inventory" | awk -v root=${volume} '$1 == root || index($1, root "/") == 1 || $2 == root || index($2, root "/") == 1 { found=1 } END { exit found ? 0 : 1 }'; then exit 76; fi; rm -rf --one-file-system -- ${volume}; fi`,
     `if test -e ${volume} || test -L ${volume}; then exit 76; fi`,
     `if test -e ${shellQuote(agentRoot)} && test ! -L ${shellQuote(agentRoot)}; then rmdir -- ${shellQuote(agentRoot)} 2>/dev/null || :; fi`,
     'secure_private_regular_file_proof "$attempt_cancelled" 75',

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -903,6 +903,14 @@ export function getVolumeVaultPassphrasePath(volumePath: string): string {
   return `${volumePath}/.vault-passphrase`;
 }
 
+function getVolumeVaultPassphrasePublicationCandidatePath(
+  volumePath: string,
+  replacementAttemptId: string,
+): string {
+  assertCanonicalReplacementPathAttemptId(replacementAttemptId);
+  return `${getVolumeVaultPassphrasePath(volumePath)}.candidate.${replacementAttemptId}`;
+}
+
 /**
  * Shell command that establishes and validates the per-agent vault master
  * passphrase persisted on the host volume. A versioned frame containing an
@@ -938,10 +946,33 @@ export function buildVolumeVaultPassphraseCommand(
   const vaultSnapshotFile = replacementAttemptId
     ? shellQuote(getReplacementControlVaultPassphrasePath(replacementAttemptId))
     : undefined;
-  const cleanupTargets = '"$stdin_file" "$override_file" "$generated_file" "$normalized_file"';
+  // The publication candidate must share the durable key's filesystem: `ln`
+  // is the atomic first-writer primitive and cannot cross a mount boundary.
+  // Other plaintext temporaries remain in the root-only control directory.
+  const keyCandidateFile = replacementAttemptId
+    ? shellQuote(getVolumeVaultPassphrasePublicationCandidatePath(volumePath, replacementAttemptId))
+    : undefined;
+  const cleanupTargets = [
+    '"$stdin_file"',
+    '"$override_file"',
+    '"$generated_file"',
+    '"$normalized_file"',
+    ...(keyCandidateFile ? ['"$key_candidate_file"'] : []),
+  ].join(" ");
+  const cleanupAbsenceProof = [
+    'test -e "$stdin_file"',
+    'test -L "$stdin_file"',
+    'test -e "$override_file"',
+    'test -L "$override_file"',
+    'test -e "$generated_file"',
+    'test -L "$generated_file"',
+    'test -e "$normalized_file"',
+    'test -L "$normalized_file"',
+    ...(keyCandidateFile ? ['test -e "$key_candidate_file"', 'test -L "$key_candidate_file"'] : []),
+  ].join(" || ");
   const cleanupFunction =
     `cleanup_vault_temp_files() { cleanup_status=$?; if ! rm -f -- ${cleanupTargets}; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ` +
-    'if test -e "$stdin_file" || test -L "$stdin_file" || test -e "$override_file" || test -L "$override_file" || test -e "$generated_file" || test -L "$generated_file" || test -e "$normalized_file" || test -L "$normalized_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ' +
+    `if ${cleanupAbsenceProof}; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ` +
     (vaultSnapshotFile
       ? 'if test "$cleanup_status" -ne 0 || test "$vault_snapshot_ready" -ne 1; then if ! rm -f -- "$vault_snapshot_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; if test -e "$vault_snapshot_file" || test -L "$vault_snapshot_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; fi; '
       : "") +
@@ -954,11 +985,50 @@ export function buildVolumeVaultPassphraseCommand(
     1 +
     Buffer.byteLength(VOLUME_VAULT_STDIN_FRAME_END) +
     1;
+  const createFencedDurableKeyCommand = [
+    'if test -e "$key_file" || test -L "$key_file"; then',
+    'secure_private_regular_file_proof "$key_file";',
+    "else",
+    // Generate under the root-only control tree first, then copy through
+    // verified descriptors into an exclusively-created candidate beside the
+    // durable key. Only that final candidate crosses into the agent volume.
+    'secure_reset_file "$generated_file";',
+    'exec 8>>"$generated_file";',
+    'if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; exec 7<"$override_file"; secure_private_regular_fd_proof 7; cat <&7 >&8; exec 7<&-; else head -c 32 /dev/urandom | od -An -tx1 | tr -d \' \\n\' >&8; fi;',
+    "exec 8>&-;",
+    'secure_private_regular_file_proof "$generated_file";',
+    'if ! rm -f -- "$key_candidate_file"; then exit 70; fi;',
+    "set -C;",
+    'if exec 8>"$key_candidate_file"; then set +C; else set +C; exit 70; fi;',
+    "secure_private_regular_fd_proof 8;",
+    "key_candidate_fd_identity=$(secure_fd_stat_identity 8);",
+    'secure_private_regular_file_proof "$key_candidate_file";',
+    'test "$(secure_stat_identity "$key_candidate_file")" = "$key_candidate_fd_identity" || exit 70;',
+    'exec 7<"$generated_file";',
+    "secure_private_regular_fd_proof 7;",
+    "generated_fd_identity=$(secure_fd_stat_identity 7);",
+    "generated_fd_fingerprint_before=$(secure_fd_stat_fingerprint 7);",
+    'test "$(secure_stat_identity "$generated_file")" = "$generated_fd_identity" || exit 70;',
+    "cat <&7 >&8;",
+    "generated_fd_fingerprint_after=$(secure_fd_stat_fingerprint 7);",
+    'test "$generated_fd_fingerprint_before" = "$generated_fd_fingerprint_after" || exit 70;',
+    "exec 7<&-;",
+    "secure_private_regular_fd_proof 8;",
+    'test "$(secure_fd_stat_identity 8)" = "$key_candidate_fd_identity" || exit 70;',
+    'secure_private_regular_file_proof "$key_candidate_file";',
+    'test "$(secure_stat_identity "$key_candidate_file")" = "$key_candidate_fd_identity" || exit 70;',
+    "exec 8>&-;",
+    'secure_private_regular_file_proof "$key_candidate_file";',
+    'test "$(secure_stat_identity "$key_candidate_file")" = "$key_candidate_fd_identity" || exit 70;',
+    "created_key_identity=$key_candidate_fd_identity;",
+    'if ln "$key_candidate_file" "$key_file" 2>/dev/null; then rm -f -- "$key_candidate_file"; test ! -e "$key_candidate_file" && test ! -L "$key_candidate_file" || exit 70; elif test -e "$key_file" || test -L "$key_file"; then created_key_identity=; secure_private_regular_file_proof "$key_file"; else exit 43; fi;',
+    "fi",
+  ].join(" ");
   const durableKeyCommands = replacementAttemptId
     ? [
         `key_file=${keyFile}`,
         "created_key_identity=",
-        'if test -e "$key_file" || test -L "$key_file"; then secure_private_regular_file_proof "$key_file"; else secure_reset_file "$generated_file"; exec 8>>"$generated_file"; if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; exec 7<"$override_file"; cat <&7 >&8; exec 7<&-; else head -c 32 /dev/urandom | od -An -tx1 | tr -d \' \\n\' >&8; fi; exec 8>&-; secure_private_regular_file_proof "$generated_file"; created_key_identity=$(secure_stat_identity "$generated_file"); if ln "$generated_file" "$key_file" 2>/dev/null; then rm -f -- "$generated_file"; elif test -e "$key_file" || test -L "$key_file"; then created_key_identity=; secure_private_regular_file_proof "$key_file"; else exit 43; fi; fi',
+        createFencedDurableKeyCommand,
         'secure_private_regular_file_proof "$key_file"',
         'key_identity_before=$(secure_stat_identity "$key_file")',
         'if test -n "$created_key_identity"; then test "$key_identity_before" = "$created_key_identity" || exit 70; fi',
@@ -1034,6 +1104,7 @@ export function buildVolumeVaultPassphraseCommand(
     `override_file=${overrideFile}`,
     `generated_file=${generatedFile}`,
     `normalized_file=${normalizedFile}`,
+    ...(keyCandidateFile ? [`key_candidate_file=${keyCandidateFile}`] : []),
     ...(vaultSnapshotFile
       ? [`vault_snapshot_file=${vaultSnapshotFile}`, "vault_snapshot_ready=0"]
       : []),
@@ -1232,6 +1303,7 @@ export function buildReplacementSecretArtifactsCleanupCommand(
     ...(["stdin", "override", "generated", "normalized"] as const).map(
       (kind) => `${legacyVaultPassphrasePath}.${kind}.${replacementAttemptId}`,
     ),
+    getVolumeVaultPassphrasePublicationCandidatePath(volumePath, replacementAttemptId),
   ];
   const existingArtifactProof = artifactPaths
     .map(

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -39,6 +39,7 @@ const REPLACEMENT_ATTEMPT_CONTROL_ROOT = "/var/lib/eliza/replacement-attempts";
 const REPLACEMENT_ARTIFACT_PURGE_RECEIPT = "ELIZA_REPLACEMENT_SECRET_PURGED_V1";
 const REPLACEMENT_CANDIDATE_OBSERVED_RECEIPT = "ELIZA_REPLACEMENT_CANDIDATE_OBSERVED_V1";
 const REPLACEMENT_DOCKER_CREATE_QUIESCENT_RECEIPT = "ELIZA_REPLACEMENT_DOCKER_CREATE_QUIESCENT_V1";
+const EXACT_RESTORE_STAGING_VOLUME_PURGE_RECEIPT = "ELIZA_EXACT_RESTORE_STAGING_VOLUME_PURGED_V1";
 const REPLACEMENT_ATTEMPT_LOCK_TIMEOUT_SECONDS = 30;
 
 export type DockerNodeArchitecture = "amd64" | "arm64";
@@ -735,6 +736,58 @@ function assertCanonicalReplacementPathAttemptId(replacementAttemptId: string): 
   }
 }
 
+function getReplacementAttemptControlDirectory(replacementAttemptId: string): string {
+  assertCanonicalReplacementPathAttemptId(replacementAttemptId);
+  return `${REPLACEMENT_ATTEMPT_CONTROL_ROOT}/${replacementAttemptId}`;
+}
+
+/**
+ * Root-only host path used for one exact replacement's transient Docker env.
+ *
+ * The agent volume is intentionally not used: a prior runtime can write that
+ * mount and could retain secret bytes through a symlink or hardlink even after
+ * the provisioner's nominal cleanup succeeds.
+ */
+export function getReplacementControlSecretEnvPath(replacementAttemptId: string): string {
+  return `${getReplacementAttemptControlDirectory(replacementAttemptId)}/container-env`;
+}
+
+/** Root-only snapshot consumed by one exact replacement's Docker create. */
+export function getReplacementControlVaultPassphrasePath(replacementAttemptId: string): string {
+  return `${getReplacementAttemptControlDirectory(replacementAttemptId)}/vault-passphrase`;
+}
+
+function getReplacementControlVaultArtifactPath(
+  replacementAttemptId: string,
+  kind: "stdin" | "override" | "generated" | "normalized",
+): string {
+  return `${getReplacementAttemptControlDirectory(replacementAttemptId)}/vault-${kind}`;
+}
+
+function secureFileShellPrelude(expectedUid: "0" | "$(id -u)"): string[] {
+  return [
+    "command -v stat >/dev/null 2>&1",
+    ...(expectedUid === "$(id -u)" ? ["command -v id >/dev/null 2>&1"] : []),
+    `secure_expected_uid=${expectedUid}`,
+    "secure_stat_uid() { stat -c '%u' -- \"$1\" 2>/dev/null || stat -f '%u' \"$1\"; }",
+    "secure_stat_links() { stat -c '%h' -- \"$1\" 2>/dev/null || stat -f '%l' \"$1\"; }",
+    "secure_stat_mode() { stat -c '%a' -- \"$1\" 2>/dev/null || stat -f '%Lp' \"$1\"; }",
+    "secure_stat_identity() { stat -c '%d:%i' -- \"$1\" 2>/dev/null || stat -f '%d:%i' \"$1\"; }",
+    // Exact secret transport runs only on GNU/Linux Docker nodes. BSD stat on
+    // /dev/fd reports fdescfs metadata rather than the opened inode, so the
+    // FD-bound proof must fail closed instead of advertising a false fallback.
+    "secure_fd_stat_uid() { stat -Lc '%u' -- \"/dev/fd/$1\"; }",
+    "secure_fd_stat_links() { stat -Lc '%h' -- \"/dev/fd/$1\"; }",
+    "secure_fd_stat_mode() { stat -Lc '%a' -- \"/dev/fd/$1\"; }",
+    "secure_fd_stat_identity() { stat -Lc '%d:%i' -- \"/dev/fd/$1\"; }",
+    "secure_fd_stat_fingerprint() { stat -Lc '%d:%i:%s:%y:%z' -- \"/dev/fd/$1\"; }",
+    'secure_regular_file_proof() { secure_path=$1; secure_code=${2:-70}; test -f "$secure_path" && test ! -L "$secure_path" || exit "$secure_code"; test "$(secure_stat_uid "$secure_path")" = "$secure_expected_uid" || exit "$secure_code"; test "$(secure_stat_links "$secure_path")" = 1 || exit "$secure_code"; }',
+    'secure_private_regular_file_proof() { secure_path=$1; secure_code=${2:-70}; secure_regular_file_proof "$secure_path" "$secure_code"; test "$(secure_stat_mode "$secure_path")" = 600 || exit "$secure_code"; }',
+    'secure_private_regular_fd_proof() { secure_fd=$1; secure_code=${2:-70}; test -f "/dev/fd/$secure_fd" || exit "$secure_code"; test "$(secure_fd_stat_uid "$secure_fd")" = "$secure_expected_uid" || exit "$secure_code"; test "$(secure_fd_stat_links "$secure_fd")" = 1 || exit "$secure_code"; test "$(secure_fd_stat_mode "$secure_fd")" = 600 || exit "$secure_code"; }',
+    'secure_reset_file() { secure_path=$1; if ! rm -f -- "$secure_path"; then exit 70; fi; if ! (set -C; : > "$secure_path") 2>/dev/null; then exit 70; fi; secure_regular_file_proof "$secure_path"; chmod 600 "$secure_path"; secure_private_regular_file_proof "$secure_path"; }',
+  ];
+}
+
 function getReplacementVolumePath(containerName: string): string {
   validateContainerName(containerName);
   if (!containerName.startsWith(AGENT_CONTAINER_NAME_PREFIX)) {
@@ -758,18 +811,29 @@ function getReplacementVolumePath(containerName: string): string {
 
 function replacementAttemptControlPrelude(replacementAttemptId: string): string[] {
   assertCanonicalReplacementPathAttemptId(replacementAttemptId);
-  const attemptDirectory = `${REPLACEMENT_ATTEMPT_CONTROL_ROOT}/${replacementAttemptId}`;
+  const attemptDirectory = getReplacementAttemptControlDirectory(replacementAttemptId);
   return [
     "command -v flock >/dev/null 2>&1",
+    ...secureFileShellPrelude("0"),
     `attempt_root=${shellQuote(REPLACEMENT_ATTEMPT_CONTROL_ROOT)}`,
     `attempt_dir=${shellQuote(attemptDirectory)}`,
     'attempt_lock="$attempt_dir/lock"',
     'attempt_cancelled="$attempt_dir/cancelled"',
     'attempt_active="$attempt_dir/active"',
     'attempt_candidate_id="$attempt_dir/candidate-id"',
-    'mkdir -p -- "$attempt_root" "$attempt_dir"',
-    'chmod 700 -- "$attempt_root" "$attempt_dir"',
-    'exec 9>"$attempt_lock"',
+    'attempt_docker_error="$attempt_dir/docker-error"',
+    'secure_parent_directory_proof() { secure_path=$1; test -d "$secure_path" && test ! -L "$secure_path" || exit 70; test "$(secure_stat_uid "$secure_path")" = 0 || exit 70; secure_mode=$(secure_stat_mode "$secure_path"); case "$secure_mode" in *[2367][0-7]|*[0-7][2367]) exit 70 ;; esac; }',
+    'secure_private_directory_proof() { secure_parent_directory_proof "$1"; test "$(secure_stat_mode "$1")" = 700 || exit 70; }',
+    'secure_prepare_control_parent() { secure_path=$1; if test -e "$secure_path" || test -L "$secure_path"; then secure_parent_directory_proof "$secure_path"; else mkdir -p -- "$secure_path"; secure_parent_directory_proof "$secure_path"; fi; }',
+    'secure_prepare_private_directory() { secure_path=$1; if test -e "$secure_path" || test -L "$secure_path"; then secure_parent_directory_proof "$secure_path"; else mkdir -p -- "$secure_path"; secure_parent_directory_proof "$secure_path"; fi; chmod 700 -- "$secure_path"; secure_private_directory_proof "$secure_path"; }',
+    'secure_existing_control_file() { secure_path=$1; if test -e "$secure_path" || test -L "$secure_path"; then secure_regular_file_proof "$secure_path"; else if ! (set -C; : > "$secure_path") 2>/dev/null; then secure_regular_file_proof "$secure_path"; fi; fi; secure_regular_file_proof "$secure_path"; chmod 600 -- "$secure_path"; secure_private_regular_file_proof "$secure_path"; }',
+    'secure_reset_control_file() { secure_reset_file "$1"; }',
+    "control_parent=${attempt_root%/*}",
+    'secure_prepare_control_parent "$control_parent"',
+    'secure_prepare_private_directory "$attempt_root"',
+    'secure_prepare_private_directory "$attempt_dir"',
+    'secure_existing_control_file "$attempt_lock"',
+    'exec 9>>"$attempt_lock"',
     `flock -w ${REPLACEMENT_ATTEMPT_LOCK_TIMEOUT_SECONDS} 9`,
   ];
 }
@@ -806,6 +870,16 @@ export function getReplacementDockerCreateQuiescentReceipt(replacementAttemptId:
   return `${REPLACEMENT_DOCKER_CREATE_QUIESCENT_RECEIPT} ${replacementAttemptId}`;
 }
 
+/** Exact non-secret receipt proving one abandoned restore staging path is absent. */
+export function getExactRestoreStagingVolumeCleanupReceipt(
+  replacementAttemptId: string,
+  restoreAttemptId: string,
+): string {
+  assertCanonicalReplacementPathAttemptId(replacementAttemptId);
+  assertCanonicalReplacementPathAttemptId(restoreAttemptId);
+  return `${EXACT_RESTORE_STAGING_VOLUME_PURGE_RECEIPT} ${replacementAttemptId} ${restoreAttemptId}`;
+}
+
 // ---------------------------------------------------------------------------
 // Durable per-agent vault state (#18080 / #19225)
 // ---------------------------------------------------------------------------
@@ -820,8 +894,9 @@ export function getReplacementDockerCreateQuiescentReceipt(replacementAttemptId:
  */
 export const CONTAINER_DURABLE_STATE_DIR = "/root/.eliza";
 
-const VOLUME_VAULT_STDIN_FRAME_VERSION = "ELIZA_VAULT_STDIN_V1";
-const VOLUME_VAULT_STDIN_FRAME_END = "ELIZA_VAULT_STDIN_V1_END";
+/** Stable public labels for byte-native producers of the vault stdin frame. */
+export const VOLUME_VAULT_STDIN_FRAME_VERSION = "ELIZA_VAULT_STDIN_V1";
+export const VOLUME_VAULT_STDIN_FRAME_END = "ELIZA_VAULT_STDIN_V1_END";
 
 /** Host-side path of the persisted per-agent vault master passphrase. */
 export function getVolumeVaultPassphrasePath(volumePath: string): string {
@@ -839,6 +914,7 @@ export function buildVolumeVaultPassphraseCommand(
   volumePath: string,
   overrideByteLength = 0,
   replacementAttemptId?: string,
+  fencedPreparationCommands: readonly string[] = [],
 ): string {
   if (!Number.isSafeInteger(overrideByteLength) || overrideByteLength < 0) {
     throw new Error("Vault passphrase override byte length must be a non-negative integer.");
@@ -847,18 +923,28 @@ export function buildVolumeVaultPassphraseCommand(
   if (replacementAttemptId !== undefined) {
     assertCanonicalReplacementPathAttemptId(replacementAttemptId);
   }
-  const fenced = replacementAttemptId !== undefined;
-  const attemptSuffix = replacementAttemptId ? `.${replacementAttemptId}` : "";
+  if (fencedPreparationCommands.length > 0 && replacementAttemptId === undefined) {
+    throw new Error("Vault preparation commands require a fenced replacement attempt.");
+  }
   const keyFile = shellQuote(keyPath);
-  const processSuffix = fenced ? "" : ".$$";
-  const stdinFile = `${shellQuote(`${keyPath}.stdin${attemptSuffix}`)}${processSuffix}`;
-  const overrideFile = `${shellQuote(`${keyPath}.override${attemptSuffix}`)}${processSuffix}`;
-  const generatedFile = `${shellQuote(`${keyPath}.generated${attemptSuffix}`)}${processSuffix}`;
-  const normalizedFile = `${shellQuote(`${keyPath}.normalized${attemptSuffix}`)}${processSuffix}`;
+  const transientPath = (kind: "stdin" | "override" | "generated" | "normalized"): string =>
+    replacementAttemptId
+      ? shellQuote(getReplacementControlVaultArtifactPath(replacementAttemptId, kind))
+      : `${shellQuote(`${keyPath}.${kind}`)}.$$`;
+  const stdinFile = transientPath("stdin");
+  const overrideFile = transientPath("override");
+  const generatedFile = transientPath("generated");
+  const normalizedFile = transientPath("normalized");
+  const vaultSnapshotFile = replacementAttemptId
+    ? shellQuote(getReplacementControlVaultPassphrasePath(replacementAttemptId))
+    : undefined;
   const cleanupTargets = '"$stdin_file" "$override_file" "$generated_file" "$normalized_file"';
   const cleanupFunction =
     `cleanup_vault_temp_files() { cleanup_status=$?; if ! rm -f -- ${cleanupTargets}; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ` +
     'if test -e "$stdin_file" || test -L "$stdin_file" || test -e "$override_file" || test -L "$override_file" || test -e "$generated_file" || test -L "$generated_file" || test -e "$normalized_file" || test -L "$normalized_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ' +
+    (vaultSnapshotFile
+      ? 'if test "$cleanup_status" -ne 0 || test "$vault_snapshot_ready" -ne 1; then if ! rm -f -- "$vault_snapshot_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; if test -e "$vault_snapshot_file" || test -L "$vault_snapshot_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; fi; '
+      : "") +
     'trap - EXIT; exit "$cleanup_status"; }';
   const expectedHeader = `${VOLUME_VAULT_STDIN_FRAME_VERSION} ${overrideByteLength}`;
   const expectedFrameByteLength =
@@ -868,52 +954,133 @@ export function buildVolumeVaultPassphraseCommand(
     1 +
     Buffer.byteLength(VOLUME_VAULT_STDIN_FRAME_END) +
     1;
+  const durableKeyCommands = replacementAttemptId
+    ? [
+        `key_file=${keyFile}`,
+        "created_key_identity=",
+        'if test -e "$key_file" || test -L "$key_file"; then secure_private_regular_file_proof "$key_file"; else secure_reset_file "$generated_file"; exec 8>>"$generated_file"; if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; exec 7<"$override_file"; cat <&7 >&8; exec 7<&-; else head -c 32 /dev/urandom | od -An -tx1 | tr -d \' \\n\' >&8; fi; exec 8>&-; secure_private_regular_file_proof "$generated_file"; created_key_identity=$(secure_stat_identity "$generated_file"); if ln "$generated_file" "$key_file" 2>/dev/null; then rm -f -- "$generated_file"; elif test -e "$key_file" || test -L "$key_file"; then created_key_identity=; secure_private_regular_file_proof "$key_file"; else exit 43; fi; fi',
+        'secure_private_regular_file_proof "$key_file"',
+        'key_identity_before=$(secure_stat_identity "$key_file")',
+        'if test -n "$created_key_identity"; then test "$key_identity_before" = "$created_key_identity" || exit 70; fi',
+        'exec 7<"$key_file"',
+        "secure_private_regular_fd_proof 7",
+        "key_fd_identity=$(secure_fd_stat_identity 7)",
+        "key_fd_fingerprint_before=$(secure_fd_stat_fingerprint 7)",
+        'secure_private_regular_file_proof "$key_file"',
+        'test "$(secure_stat_identity "$key_file")" = "$key_fd_identity" || exit 70',
+        'test "$key_identity_before" = "$key_fd_identity" || exit 70',
+        'secure_reset_file "$vault_snapshot_file"',
+        'exec 8>>"$vault_snapshot_file"',
+        "cat <&7 >&8",
+        "key_fd_fingerprint_after=$(secure_fd_stat_fingerprint 7)",
+        'secure_private_regular_file_proof "$key_file"',
+        'test "$(secure_stat_identity "$key_file")" = "$key_fd_identity" || exit 70',
+        'test "$key_fd_fingerprint_before" = "$key_fd_fingerprint_after" || exit 70',
+        "exec 7<&-",
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$vault_snapshot_file"',
+        'secure_private_regular_file_proof "$vault_snapshot_file"',
+        "line_count=$(awk 'END { print NR }' \"$vault_snapshot_file\")",
+        'if test "$line_count" != 1; then exit 43; fi',
+        'secure_reset_file "$normalized_file"',
+        'exec 8>>"$normalized_file"',
+        'secure_private_regular_file_proof "$vault_snapshot_file"',
+        "tr -d '\\n' < \"$vault_snapshot_file\" >&8",
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$normalized_file"',
+        'secure_private_regular_file_proof "$normalized_file"',
+        "key_length=$(wc -c < \"$normalized_file\" | tr -d ' ')",
+        'secure_private_regular_file_proof "$normalized_file"',
+        "safe_length=$(LC_ALL=C tr -d '[:space:][:cntrl:]' < \"$normalized_file\" | wc -c | tr -d ' ')",
+        'if test "$key_length" -lt 12 || test "$key_length" != "$safe_length"; then exit 43; fi',
+        'secure_private_regular_file_proof "$normalized_file"',
+        'secure_private_regular_file_proof "$vault_snapshot_file"',
+        'if ! cmp -s "$normalized_file" "$vault_snapshot_file"; then mv -- "$normalized_file" "$vault_snapshot_file"; fi',
+        'secure_private_regular_file_proof "$vault_snapshot_file"',
+        'if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; secure_private_regular_file_proof "$vault_snapshot_file"; if ! cmp -s "$override_file" "$vault_snapshot_file"; then exit 42; fi; fi',
+        "vault_snapshot_ready=1",
+      ]
+    : [
+        `key_file=${keyFile}`,
+        'if test -e "$key_file" || test -L "$key_file"; then secure_regular_file_proof "$key_file"; else secure_reset_file "$generated_file"; exec 8>>"$generated_file"; if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; exec 7<"$override_file"; cat <&7 >&8; exec 7<&-; else head -c 32 /dev/urandom | od -An -tx1 | tr -d \' \\n\' >&8; fi; exec 8>&-; secure_private_regular_file_proof "$generated_file"; if ln "$generated_file" "$key_file" 2>/dev/null; then rm -f -- "$generated_file"; elif test -e "$key_file" || test -L "$key_file"; then secure_regular_file_proof "$key_file"; else exit 43; fi; fi',
+        'secure_regular_file_proof "$key_file"',
+        'chmod 600 "$key_file"',
+        'secure_private_regular_file_proof "$key_file"',
+        'secure_private_regular_file_proof "$key_file"',
+        "line_count=$(awk 'END { print NR }' \"$key_file\")",
+        'if test "$line_count" != 1; then exit 43; fi',
+        'secure_reset_file "$normalized_file"',
+        'exec 8>>"$normalized_file"',
+        'secure_private_regular_file_proof "$key_file"',
+        "tr -d '\\n' < \"$key_file\" >&8",
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$normalized_file"',
+        'secure_private_regular_file_proof "$normalized_file"',
+        "key_length=$(wc -c < \"$normalized_file\" | tr -d ' ')",
+        'secure_private_regular_file_proof "$normalized_file"',
+        "safe_length=$(LC_ALL=C tr -d '[:space:][:cntrl:]' < \"$normalized_file\" | wc -c | tr -d ' ')",
+        'if test "$key_length" -lt 12 || test "$key_length" != "$safe_length"; then exit 43; fi',
+        'secure_private_regular_file_proof "$normalized_file"',
+        'secure_private_regular_file_proof "$key_file"',
+        'if ! cmp -s "$normalized_file" "$key_file"; then mv "$normalized_file" "$key_file"; fi',
+        'secure_regular_file_proof "$key_file"',
+        'chmod 600 "$key_file"',
+        'secure_private_regular_file_proof "$key_file"',
+        'if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; secure_private_regular_file_proof "$key_file"; if ! cmp -s "$override_file" "$key_file"; then exit 42; fi; fi',
+      ];
   return [
     "set -eu",
     `stdin_file=${stdinFile}`,
     `override_file=${overrideFile}`,
     `generated_file=${generatedFile}`,
     `normalized_file=${normalizedFile}`,
+    ...(vaultSnapshotFile
+      ? [`vault_snapshot_file=${vaultSnapshotFile}`, "vault_snapshot_ready=0"]
+      : []),
     "umask 077",
     ...(replacementAttemptId
       ? [
           ...replacementAttemptControlPrelude(replacementAttemptId),
           'test ! -e "$attempt_cancelled" && test ! -L "$attempt_cancelled" || exit 75',
           'chmod 600 -- "$attempt_lock"',
+          ...fencedPreparationCommands,
         ]
-      : []),
+      : secureFileShellPrelude("$(id -u)")),
     cleanupFunction,
     "trap cleanup_vault_temp_files EXIT",
     "trap 'exit 1' HUP INT TERM",
-    'cat > "$stdin_file"',
+    'secure_reset_file "$stdin_file"',
+    'exec 8>>"$stdin_file"',
+    "cat >&8",
+    "exec 8>&-",
+    'secure_private_regular_file_proof "$stdin_file"',
+    'secure_private_regular_file_proof "$stdin_file"',
     `stdin_length=$(wc -c < "$stdin_file" | tr -d ' ')`,
     `if test "$stdin_length" != ${expectedFrameByteLength}; then exit 44; fi`,
+    'secure_private_regular_file_proof "$stdin_file"',
     `frame_header=$(sed -n '1p' "$stdin_file")`,
     `if test "$frame_header" != ${shellQuote(expectedHeader)}; then exit 44; fi`,
+    'secure_private_regular_file_proof "$stdin_file"',
     "frame_lines=$(awk 'END { print NR }' \"$stdin_file\")",
     'if test "$frame_lines" != 3; then exit 44; fi',
+    'secure_private_regular_file_proof "$stdin_file"',
     `if test "$(tail -n 1 "$stdin_file")" != ${shellQuote(VOLUME_VAULT_STDIN_FRAME_END)}; then exit 44; fi`,
-    'sed \'1d;$d\' "$stdin_file" > "$override_file"',
+    'secure_reset_file "$override_file"',
+    'exec 8>>"$override_file"',
+    'secure_private_regular_file_proof "$stdin_file"',
+    "sed '1d;$d' \"$stdin_file\" >&8",
+    "exec 8>&-",
+    'secure_private_regular_file_proof "$override_file"',
+    'secure_private_regular_file_proof "$override_file"',
     "override_framed_length=$(wc -c < \"$override_file\" | tr -d ' ')",
     'if test "$override_framed_length" -lt 1; then exit 44; fi',
+    'secure_private_regular_file_proof "$override_file"',
     'truncate -s -1 "$override_file"',
+    'secure_private_regular_file_proof "$override_file"',
     "override_length=$(wc -c < \"$override_file\" | tr -d ' ')",
     `if test "$override_length" != ${overrideByteLength}; then exit 44; fi`,
-    'if test -s "$override_file"; then override_safe_length=$(LC_ALL=C tr -d \'[:space:][:cntrl:]\' < "$override_file" | wc -c | tr -d \' \'); if test "$override_length" -lt 12 || test "$override_length" != "$override_safe_length"; then exit 43; fi; fi',
-    `if test ! -s ${keyFile}; then if test -s "$override_file"; then candidate_file="$override_file"; else head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \\n' > "$generated_file"; candidate_file="$generated_file"; fi; if ln "$candidate_file" ${keyFile} 2>/dev/null; then :; elif test -s ${keyFile}; then :; else exit 43; fi; fi`,
-    // A shell variable cannot represent NUL bytes: command substitution would
-    // silently delete them and rewrite the durable key. Validate the raw file
-    // before normalization, accepting at most one trailing newline from an
-    // operator-provisioned text file and rejecting every other control byte.
-    `line_count=$(awk 'END { print NR }' ${keyFile})`,
-    'if test "$line_count" != 1; then exit 43; fi',
-    `tr -d '\\n' < ${keyFile} > "$normalized_file"`,
-    `key_length=$(wc -c < "$normalized_file" | tr -d ' ')`,
-    `safe_length=$(LC_ALL=C tr -d '[:space:][:cntrl:]' < "$normalized_file" | wc -c | tr -d ' ')`,
-    'if test "$key_length" -lt 12 || test "$key_length" != "$safe_length"; then exit 43; fi',
-    `if ! cmp -s "$normalized_file" ${keyFile}; then mv "$normalized_file" ${keyFile}; fi`,
-    `chmod 600 ${keyFile}`,
-    `if test -s "$override_file" && ! cmp -s "$override_file" ${keyFile}; then exit 42; fi`,
+    'if test -s "$override_file"; then secure_private_regular_file_proof "$override_file"; override_safe_length=$(LC_ALL=C tr -d \'[:space:][:cntrl:]\' < "$override_file" | wc -c | tr -d \' \'); if test "$override_length" -lt 12 || test "$override_length" != "$override_safe_length"; then exit 43; fi; fi',
+    ...durableKeyCommands,
   ].join("; ");
 }
 
@@ -1041,19 +1208,37 @@ export function getContainerSecretEnvPath(
 export function buildReplacementSecretArtifactsCleanupCommand(
   containerName: string,
   replacementAttemptId: string,
+  exactVolumePath?: string,
 ): string {
   assertCanonicalReplacementPathAttemptId(replacementAttemptId);
-  const volumePath = getReplacementVolumePath(containerName);
-  const secretEnvPath = getContainerSecretEnvPath(volumePath, replacementAttemptId);
+  const volumePath = exactVolumePath ?? getReplacementVolumePath(containerName);
+  if (exactVolumePath !== undefined) {
+    validateContainerName(containerName);
+    validateVolumePath(exactVolumePath);
+  }
+  const secretEnvPath = getReplacementControlSecretEnvPath(replacementAttemptId);
   const secretEnvBodyPath = `${secretEnvPath}.body`;
-  const vaultPassphrasePath = getVolumeVaultPassphrasePath(volumePath);
+  const legacySecretEnvPath = getContainerSecretEnvPath(volumePath, replacementAttemptId);
+  const legacyVaultPassphrasePath = getVolumeVaultPassphrasePath(volumePath);
   const artifactPaths = [
     secretEnvPath,
     secretEnvBodyPath,
-    ...["stdin", "override", "generated", "normalized"].map(
-      (kind) => `${vaultPassphrasePath}.${kind}.${replacementAttemptId}`,
+    getReplacementControlVaultPassphrasePath(replacementAttemptId),
+    ...(["stdin", "override", "generated", "normalized"] as const).map((kind) =>
+      getReplacementControlVaultArtifactPath(replacementAttemptId, kind),
+    ),
+    legacySecretEnvPath,
+    `${legacySecretEnvPath}.body`,
+    ...(["stdin", "override", "generated", "normalized"] as const).map(
+      (kind) => `${legacyVaultPassphrasePath}.${kind}.${replacementAttemptId}`,
     ),
   ];
+  const existingArtifactProof = artifactPaths
+    .map(
+      (path) =>
+        `if test -e ${shellQuote(path)}; then secure_private_regular_file_proof ${shellQuote(path)}; fi`,
+    )
+    .join("; ");
   const cleanupTargets = artifactPaths.map(shellQuote).join(" ");
   const absenceProof = artifactPaths
     .map(
@@ -1067,15 +1252,100 @@ export function buildReplacementSecretArtifactsCleanupCommand(
     "set -eu",
     "umask 077",
     ...replacementAttemptControlPrelude(replacementAttemptId),
-    'printf "%s\\n" cancelled > "$attempt_cancelled"',
-    'chmod 600 -- "$attempt_lock" "$attempt_cancelled"',
-    `rm -f -- ${cleanupTargets}`,
+    'secure_reset_control_file "$attempt_cancelled"',
+    'exec 8>>"$attempt_cancelled"',
+    'printf "%s\\n" cancelled >&8',
+    "exec 8>&-",
+    'secure_private_regular_file_proof "$attempt_cancelled"',
+    'chmod 600 -- "$attempt_lock"',
+    existingArtifactProof,
+    `rm -f -- ${cleanupTargets} "$attempt_docker_error"`,
     absenceProof,
     `printf '%s\\n' ${shellQuote(receipt)}`,
-    'if test -e "$attempt_active" || test -L "$attempt_active"; then test -f "$attempt_active" && test ! -L "$attempt_active" || exit 70; else ' +
+    'if test -e "$attempt_active" || test -L "$attempt_active"; then secure_private_regular_file_proof "$attempt_active"; else ' +
       `printf '%s\\n' ${shellQuote(quiescentReceipt)}; fi`,
-    'if test -e "$attempt_candidate_id" || test -L "$attempt_candidate_id"; then test -f "$attempt_candidate_id" && test ! -L "$attempt_candidate_id" || exit 70; candidate_id=$(cat -- "$attempt_candidate_id"); case "$candidate_id" in ""|*[!0-9a-f]*) exit 70 ;; esac; candidate_id_length=${#candidate_id}; if test "$candidate_id_length" -lt 12 || test "$candidate_id_length" -gt 64; then exit 70; fi; ' +
+    'if test -e "$attempt_candidate_id" || test -L "$attempt_candidate_id"; then secure_private_regular_file_proof "$attempt_candidate_id"; candidate_id=$(cat -- "$attempt_candidate_id"); case "$candidate_id" in ""|*[!0-9a-f]*) exit 70 ;; esac; candidate_id_length=${#candidate_id}; if test "$candidate_id_length" -lt 12 || test "$candidate_id_length" -gt 64; then exit 70; fi; ' +
       `printf '%s %s\\n' ${shellQuote(candidateReceiptPrefix)} "$candidate_id"; fi`,
+  ].join("; ");
+}
+
+/**
+ * Delete only the canonical staging directory of one abandoned exact restore.
+ *
+ * The caller must boot-fence this command and run it only after attempting to
+ * remove the exact Docker candidate. The attempt flock serializes this proof
+ * with vault seeding and Docker create; the durable tombstone remains in the
+ * control directory so a response-lost replay cannot recreate the volume.
+ */
+export function buildExactRestoreStagingVolumeCleanupCommand(
+  containerName: string,
+  replacementAttemptId: string,
+  exactVolumePath: string,
+): string {
+  assertCanonicalReplacementPathAttemptId(replacementAttemptId);
+  validateContainerName(containerName);
+  validateVolumePath(exactVolumePath);
+  const match = /^agent-restore-([0-9a-f-]{36})-([0-9a-f-]{36})$/.exec(containerName);
+  if (!match) {
+    throw new ElizaError("Exact restore staging cleanup requires a canonical container name.", {
+      code: "SANDBOX_EXACT_RESTORE_STAGING_CLEANUP_IDENTITY_INVALID",
+      severity: "fatal",
+    });
+  }
+  const agentId = match[1]!;
+  const restoreAttemptId = match[2]!;
+  assertCanonicalReplacementPathAttemptId(agentId);
+  assertCanonicalReplacementPathAttemptId(restoreAttemptId);
+  const expectedVolumePath = `/data/agents/.restore/${agentId}/${restoreAttemptId}`;
+  if (exactVolumePath !== expectedVolumePath) {
+    throw new ElizaError(
+      "Exact restore staging cleanup path differs from its container identity.",
+      {
+        code: "SANDBOX_EXACT_RESTORE_STAGING_CLEANUP_PATH_INVALID",
+        severity: "fatal",
+      },
+    );
+  }
+
+  const restoreRoot = "/data/agents/.restore";
+  const agentRoot = `${restoreRoot}/${agentId}`;
+  const receipt = getExactRestoreStagingVolumeCleanupReceipt(
+    replacementAttemptId,
+    restoreAttemptId,
+  );
+  const safeDirectoryProof = (path: string, optional: boolean): string => {
+    const quoted = shellQuote(path);
+    const proof =
+      `test -d ${quoted} && test ! -L ${quoted} || exit 76; ` +
+      `test "$(stat -c '%u' -- ${quoted})" = 0 || exit 76; ` +
+      `directory_mode=$(stat -c '%a' -- ${quoted}); ` +
+      'case "$directory_mode" in *[2367][0-7]|*[0-7][2367]) exit 76 ;; esac';
+    return optional ? `if test -e ${quoted} || test -L ${quoted}; then ${proof}; fi` : proof;
+  };
+  const volume = shellQuote(exactVolumePath);
+  return [
+    "set -eu",
+    "umask 077",
+    "command -v docker >/dev/null 2>&1",
+    "command -v stat >/dev/null 2>&1",
+    "command -v findmnt >/dev/null 2>&1",
+    ...replacementAttemptControlPrelude(replacementAttemptId),
+    'secure_private_regular_file_proof "$attempt_cancelled" 75',
+    'if test -e "$attempt_active" || test -L "$attempt_active"; then secure_private_regular_file_proof "$attempt_active" 76; secure_private_regular_file_proof "$attempt_candidate_id" 76; fi',
+    'if test -e "$attempt_candidate_id" || test -L "$attempt_candidate_id"; then secure_private_regular_file_proof "$attempt_candidate_id" 76; candidate_id=$(cat -- "$attempt_candidate_id"); case "$candidate_id" in ""|*[!0-9a-f]*) exit 76 ;; esac; test "${#candidate_id}" = 64 || exit 76; candidate_matches=$(docker container ls -aq --no-trunc --filter "id=$candidate_id"); test -z "$candidate_matches" || exit 76; fi',
+    `name_matches=$(docker container ls -aq --no-trunc --filter ${shellQuote(`name=^/${containerName}$`)}); test -z "$name_matches" || exit 76`,
+    `all_container_ids=$(docker container ls -aq --no-trunc); for existing_id in $all_container_ids; do mount_sources=$(docker inspect --format '{{range .Mounts}}{{println .Source}}{{end}}' "$existing_id"); if printf '%s\n' "$mount_sources" | awk -v root=${volume} 'length($0) > 0 && ($0 == root || index($0, root "/") == 1 || $0 == "/" || index(root, $0 "/") == 1) { found=1 } END { exit found ? 0 : 1 }'; then exit 76; fi; done`,
+    safeDirectoryProof("/data", false),
+    safeDirectoryProof("/data/agents", false),
+    safeDirectoryProof(restoreRoot, false),
+    safeDirectoryProof(agentRoot, true),
+    `if test -L ${volume}; then exit 76; fi`,
+    `if test -e ${volume}; then ${safeDirectoryProof(exactVolumePath, false)}; if findmnt -rn -o FSROOT,TARGET | awk -v root=${volume} '$1 == root || index($1, root "/") == 1 || $2 == root || index($2, root "/") == 1 { found=1 } END { exit found ? 0 : 1 }'; then exit 76; fi; rm -rf --one-file-system -- ${volume}; fi`,
+    `if test -e ${volume} || test -L ${volume}; then exit 76; fi`,
+    `if test -e ${shellQuote(agentRoot)} && test ! -L ${shellQuote(agentRoot)}; then rmdir -- ${shellQuote(agentRoot)} 2>/dev/null || :; fi`,
+    'secure_private_regular_file_proof "$attempt_cancelled" 75',
+    'if test -e "$attempt_active" || test -L "$attempt_active"; then secure_private_regular_file_proof "$attempt_active" 76; secure_private_regular_file_proof "$attempt_candidate_id" 76; fi',
+    `printf '%s\n' ${shellQuote(receipt)}`,
   ].join("; ");
 }
 
@@ -1096,12 +1366,29 @@ export function buildReplacementCandidateObservedCommand(
     "set -eu",
     "umask 077",
     ...replacementAttemptControlPrelude(replacementAttemptId),
-    'test -f "$attempt_cancelled" && test ! -L "$attempt_cancelled" || exit 75',
-    'if test -e "$attempt_candidate_id" || test -L "$attempt_candidate_id"; then test -f "$attempt_candidate_id" && test ! -L "$attempt_candidate_id" || exit 70; test "$(cat -- "$attempt_candidate_id")" = ' +
-      `${shellQuote(containerId)} || exit 70; else candidate_tmp="$attempt_dir/candidate-id.tmp"; rm -f -- "$candidate_tmp"; printf '%s\\n' ${shellQuote(containerId)} > "$candidate_tmp"; chmod 600 -- "$candidate_tmp"; mv -- "$candidate_tmp" "$attempt_candidate_id"; fi`,
-    'test -f "$attempt_candidate_id" && test ! -L "$attempt_candidate_id"',
+    'secure_private_regular_file_proof "$attempt_cancelled" 75',
+    'if test -e "$attempt_candidate_id" || test -L "$attempt_candidate_id"; then secure_private_regular_file_proof "$attempt_candidate_id"; test "$(cat -- "$attempt_candidate_id")" = ' +
+      `${shellQuote(containerId)} || exit 70; else candidate_tmp="$attempt_dir/candidate-id.tmp"; secure_reset_control_file "$candidate_tmp"; exec 8>>"$candidate_tmp"; printf '%s\\n' ${shellQuote(containerId)} >&8; exec 8>&-; secure_private_regular_file_proof "$candidate_tmp"; mv -- "$candidate_tmp" "$attempt_candidate_id"; fi`,
+    'secure_private_regular_file_proof "$attempt_candidate_id"',
     `test "$(cat -- "$attempt_candidate_id")" = ${shellQuote(containerId)}`,
     `printf '%s\\n' ${shellQuote(receipt)}`,
+  ].join("; ");
+}
+
+/** Read the full Docker ID durably recorded by one fenced create producer. */
+export function buildReplacementCreatedContainerIdProofCommand(
+  replacementAttemptId: string,
+): string {
+  assertCanonicalReplacementPathAttemptId(replacementAttemptId);
+  return [
+    "set -eu",
+    ...replacementAttemptControlPrelude(replacementAttemptId),
+    'test ! -e "$attempt_cancelled" && test ! -L "$attempt_cancelled" || exit 75',
+    'secure_private_regular_file_proof "$attempt_candidate_id"',
+    'candidate_id=$(cat -- "$attempt_candidate_id")',
+    'case "$candidate_id" in ""|*[!0-9a-f]*) exit 70 ;; esac',
+    'test "${#candidate_id}" = 64',
+    'printf "%s\\n" "$candidate_id"',
   ].join("; ");
 }
 
@@ -1116,12 +1403,22 @@ export function buildDockerCreateWithSecretEnvCommand(options: {
   dockerCreateCommand: string;
   secretEnvPath: string;
   vaultPassphrasePath: string;
-  exactReplacement?: { containerName: string; replacementAttemptId: string };
+  exactReplacement?: {
+    containerName: string;
+    replacementAttemptId: string;
+    /** Alternate exact volume derivation used only by restore staging. */
+    volumePath?: string;
+    /** Persist the full Docker ID before the secret-bearing channel settles. */
+    recordContainerId?: true;
+  };
 }): string {
   const replacementAttemptId = options.exactReplacement?.replacementAttemptId;
   if (options.exactReplacement) {
-    const expectedPath = getContainerSecretEnvPath(
-      getReplacementVolumePath(options.exactReplacement.containerName),
+    const exactVolumePath =
+      options.exactReplacement.volumePath ??
+      getReplacementVolumePath(options.exactReplacement.containerName);
+    validateVolumePath(exactVolumePath);
+    const expectedPath = getReplacementControlSecretEnvPath(
       options.exactReplacement.replacementAttemptId,
     );
     if (options.secretEnvPath !== expectedPath) {
@@ -1134,44 +1431,129 @@ export function buildDockerCreateWithSecretEnvCommand(options: {
         severity: "fatal",
       });
     }
+    const expectedVaultPath = getReplacementControlVaultPassphrasePath(
+      options.exactReplacement.replacementAttemptId,
+    );
+    if (options.vaultPassphrasePath !== expectedVaultPath) {
+      throw new ElizaError("Exact replacement vault snapshot path is not canonical.", {
+        code: "SANDBOX_REPLACEMENT_VAULT_SNAPSHOT_PATH_NONCANONICAL",
+        context: {
+          containerName: options.exactReplacement.containerName,
+          replacementAttemptId: options.exactReplacement.replacementAttemptId,
+        },
+        severity: "fatal",
+      });
+    }
   }
   const envFile = shellQuote(options.secretEnvPath);
   const envBodyFile = shellQuote(`${options.secretEnvPath}.body`);
   const vaultFile = shellQuote(options.vaultPassphrasePath);
   const fenced = replacementAttemptId !== undefined;
-  const cleanupTargets = '"$env_file" "$env_body_file"';
+  const cleanupTargets = fenced
+    ? '"$env_file" "$env_body_file" "$vault_file"'
+    : '"$env_file" "$env_body_file"';
   const cleanupFunction =
     `cleanup_secret_env_files() { cleanup_status=$?; if ! rm -f -- ${cleanupTargets}; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ` +
-    'if test -e "$env_file" || test -L "$env_file" || test -e "$env_body_file" || test -L "$env_body_file"; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ' +
+    'if test -e "$env_file" || test -L "$env_file" || test -e "$env_body_file" || test -L "$env_body_file"' +
+    (fenced ? ' || test -e "$vault_file" || test -L "$vault_file"' : "") +
+    '; then if test "$cleanup_status" -eq 0; then cleanup_status=70; fi; fi; ' +
     (fenced
       ? 'if test "$cleanup_status" -eq 0; then if ! rm -f -- "$attempt_active"; then cleanup_status=70; elif test -e "$attempt_active" || test -L "$attempt_active"; then cleanup_status=70; fi; fi; '
       : "") +
     'trap - EXIT; exit "$cleanup_status"; }';
+  const definitiveDockerFailurePatterns = [
+    "Conflict. The container name",
+    "is already in use by container",
+    "invalid reference format",
+    "No such image",
+    "invalid mount config",
+    "invalid volume specification",
+    "unknown flag:",
+  ]
+    .map((marker) => `-e ${shellQuote(marker)}`)
+    .join(" ");
+  const clearDefinitiveDockerFailure = fenced
+    ? `secure_private_regular_file_proof "$attempt_docker_error"; if grep -F ${definitiveDockerFailurePatterns} -- "$attempt_docker_error" >/dev/null 2>&1; then rm -f -- "$attempt_active" || exit 70; test ! -e "$attempt_active" && test ! -L "$attempt_active" || exit 70; fi`
+    : ":";
+  const dockerCreateCommand = options.exactReplacement?.recordContainerId
+    ? [
+        'exec 8>>"$attempt_docker_error"',
+        `if candidate_id=$(${options.dockerCreateCommand} 2>&8); then docker_status=0; else docker_status=$?; fi`,
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$attempt_docker_error"',
+        `if test "$docker_status" -ne 0; then ${clearDefinitiveDockerFailure}; rm -f -- "$attempt_docker_error"; exit "$docker_status"; fi`,
+        'rm -f -- "$attempt_docker_error"',
+        'test ! -e "$attempt_docker_error" && test ! -L "$attempt_docker_error" || exit 70',
+        'case "$candidate_id" in ""|*[!0-9a-f]*) exit 70 ;; esac',
+        'test "${#candidate_id}" = 64',
+        'candidate_tmp="$attempt_dir/candidate-id.tmp"',
+        'secure_reset_control_file "$candidate_tmp"',
+        'exec 8>>"$candidate_tmp"',
+        'printf "%s\\n" "$candidate_id" >&8',
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$candidate_tmp"',
+        'mv -- "$candidate_tmp" "$attempt_candidate_id"',
+        'secure_private_regular_file_proof "$attempt_candidate_id"',
+      ].join("; ")
+    : fenced
+      ? [
+          'exec 8>>"$attempt_docker_error"',
+          `if ${options.dockerCreateCommand} 2>&8; then docker_status=0; else docker_status=$?; fi`,
+          "exec 8>&-",
+          'secure_private_regular_file_proof "$attempt_docker_error"',
+          `if test "$docker_status" -ne 0; then ${clearDefinitiveDockerFailure}; rm -f -- "$attempt_docker_error"; exit "$docker_status"; fi`,
+          'rm -f -- "$attempt_docker_error"',
+          'test ! -e "$attempt_docker_error" && test ! -L "$attempt_docker_error" || exit 70',
+        ].join("; ")
+      : options.dockerCreateCommand;
   return [
     "set -eu",
     `env_file=${envFile}`,
     `env_body_file=${envBodyFile}`,
+    `vault_file=${vaultFile}`,
     "umask 077",
     ...(replacementAttemptId
       ? [
           ...replacementAttemptControlPrelude(replacementAttemptId),
           'test ! -e "$attempt_cancelled" && test ! -L "$attempt_cancelled" || exit 75',
-          ': > "$attempt_active"',
-          'chmod 600 -- "$attempt_lock" "$attempt_active"',
+          'chmod 600 -- "$attempt_lock"',
         ]
-      : []),
+      : secureFileShellPrelude("$(id -u)")),
     cleanupFunction,
     "trap cleanup_secret_env_files EXIT",
     "trap 'exit 1' HUP INT TERM",
-    'cat > "$env_file"',
+    'secure_reset_file "$env_file"',
+    'exec 8>>"$env_file"',
+    "cat >&8",
+    "exec 8>&-",
+    'secure_private_regular_file_proof "$env_file"',
+    'secure_private_regular_file_proof "$env_file"',
     `test "$(tail -n 1 "$env_file")" = ${shellQuote(CONTAINER_SECRET_ENV_STDIN_SENTINEL)}`,
-    'sed \'$d\' "$env_file" > "$env_body_file"',
+    'secure_reset_file "$env_body_file"',
+    'exec 8>>"$env_body_file"',
+    'secure_private_regular_file_proof "$env_file"',
+    "sed '$d' \"$env_file\" >&8",
+    "exec 8>&-",
+    'secure_private_regular_file_proof "$env_body_file"',
     'mv "$env_body_file" "$env_file"',
+    'secure_private_regular_file_proof "$env_file"',
     'truncate -s -1 "$env_file"',
-    `cat ${vaultFile} >> "$env_file"`,
-    "printf '\\n' >> \"$env_file\"",
-    'chmod 600 "$env_file"',
-    options.dockerCreateCommand,
+    'secure_private_regular_file_proof "$env_file"',
+    'secure_private_regular_file_proof "$vault_file"',
+    'exec 7<"$vault_file"',
+    'exec 8>>"$env_file"',
+    "cat <&7 >&8",
+    "printf '\\n' >&8",
+    "exec 7<&-",
+    "exec 8>&-",
+    'secure_private_regular_file_proof "$env_file"',
+    ...(replacementAttemptId
+      ? [
+          'secure_reset_control_file "$attempt_docker_error"',
+          'secure_reset_control_file "$attempt_active"',
+        ]
+      : []),
+    dockerCreateCommand,
   ].join("; ");
 }
 

--- a/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
@@ -1,6 +1,29 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { DockerSSHClient } from "./docker-ssh";
+
+let connectingSession: FakeConnectingSshClient | undefined;
+
+class FakeConnectingSshClient extends EventEmitter {
+  connectCalls = 0;
+  destroyCalls = 0;
+
+  constructor() {
+    super();
+    connectingSession = this;
+  }
+
+  connect(): void {
+    this.connectCalls += 1;
+  }
+
+  destroy(): this {
+    this.destroyCalls += 1;
+    return this;
+  }
+}
+
+mock.module("ssh2", () => ({ Client: FakeConnectingSshClient }));
 
 class FakeClientChannel extends EventEmitter {
   readonly stderr = new EventEmitter();
@@ -55,8 +78,58 @@ async function requireError(promise: Promise<unknown>): Promise<Error> {
   throw new Error("Expected promise to reject");
 }
 
+function makeCallerAbortReason(message: string): Error {
+  const reason = new Error(message);
+  reason.name = "AbortError";
+  return reason;
+}
+
+describe("DockerSSHClient.connect cancellation", () => {
+  test("preserves the exact reason of a pre-aborted signal", async () => {
+    const client = new DockerSSHClient({
+      hostname: "restore-node.example.test",
+      privateKey: Buffer.from("unused"),
+      hostKeyFingerprint: "test-host-key-fingerprint",
+    });
+    const controller = new AbortController();
+    const reason = makeCallerAbortReason("cancelled before SSH connect");
+    controller.abort(reason);
+
+    const error = await requireError(client.connect(controller.signal));
+
+    expect(error).toBe(reason);
+    expect(client.isConnected).toBe(false);
+  });
+
+  test("preserves the exact reason when aborted while connect is in flight", async () => {
+    connectingSession = undefined;
+    const client = new DockerSSHClient({
+      hostname: "restore-node.example.test",
+      privateKey: Buffer.from("unused"),
+      hostKeyFingerprint: "test-host-key-fingerprint",
+    });
+    const controller = new AbortController();
+    const reason = makeCallerAbortReason("cancelled during SSH connect");
+
+    const promise = client.connect(controller.signal);
+
+    for (let attempt = 0; attempt < 100 && !connectingSession; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    if (!connectingSession) throw new Error("Expected SSH connection attempt to start");
+    expect(connectingSession.connectCalls).toBe(1);
+
+    controller.abort(reason);
+    const error = await requireError(promise);
+
+    expect(error).toBe(reason);
+    expect(connectingSession.destroyCalls).toBe(1);
+    expect(client.isConnected).toBe(false);
+  });
+});
+
 describe("DockerSSHClient.execStdinAbortable", () => {
-  test("rejects a pre-aborted signal before opening an SSH exec channel", async () => {
+  test("preserves a pre-aborted signal reason before opening an SSH exec channel", async () => {
     const channel = new FakeClientChannel();
     const session: FakeSshSession = {
       execCalls: 0,
@@ -71,7 +144,8 @@ describe("DockerSSHClient.execStdinAbortable", () => {
     };
     const client = makeConnectedClient(session);
     const controller = new AbortController();
-    controller.abort();
+    const reason = makeCallerAbortReason("cancelled before stdin transfer");
+    controller.abort(reason);
 
     const error = await requireError(
       client.execStdinAbortable(
@@ -81,6 +155,7 @@ describe("DockerSSHClient.execStdinAbortable", () => {
       ),
     );
 
+    expect(error).toBe(reason);
     expect(error.name).toBe("AbortError");
     expect(error.message).not.toContain("secret-command");
     expect(error.message).not.toContain("secret");
@@ -103,6 +178,7 @@ describe("DockerSSHClient.execStdinAbortable", () => {
     };
     const client = makeConnectedClient(session);
     const controller = new AbortController();
+    const reason = makeCallerAbortReason("cancelled during stdin transfer");
     const input = Buffer.from("vault-passphrase-frame");
     let outcome = "pending";
 
@@ -121,7 +197,7 @@ describe("DockerSSHClient.execStdinAbortable", () => {
     );
 
     expect(channel.endedWith).toBe(input);
-    controller.abort();
+    controller.abort(reason);
     await Promise.resolve();
 
     expect(channel.closeCalls).toBe(1);
@@ -130,6 +206,7 @@ describe("DockerSSHClient.execStdinAbortable", () => {
 
     channel.emit("close", 0);
     const error = await requireError(promise);
+    expect(error).toBe(reason);
     expect(error.name).toBe("AbortError");
     expect(outcome).toBe("rejected");
     expect(session.destroyCalls).toBe(0);

--- a/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { DockerSSHClient } from "./docker-ssh";
+
+class FakeClientChannel extends EventEmitter {
+  readonly stderr = new EventEmitter();
+  closeCalls = 0;
+  destroyCalls = 0;
+  endedWith: Buffer | undefined;
+
+  close(): void {
+    this.closeCalls += 1;
+  }
+
+  destroy(): this {
+    this.destroyCalls += 1;
+    return this;
+  }
+
+  end(input: Buffer): void {
+    this.endedWith = input;
+  }
+}
+
+interface FakeSshSession {
+  execCalls: number;
+  destroyCalls: number;
+  exec(
+    command: string,
+    callback: (error: Error | undefined, channel: FakeClientChannel) => void,
+  ): void;
+  destroy(): void;
+}
+
+function makeConnectedClient(session: FakeSshSession): DockerSSHClient {
+  const client = new DockerSSHClient({
+    hostname: "restore-node.example.test",
+    privateKey: Buffer.from("unused"),
+    hostKeyFingerprint: "test-host-key-fingerprint",
+  });
+  Object.defineProperties(client, {
+    connected: { configurable: true, value: true, writable: true },
+    client: { configurable: true, value: session, writable: true },
+  });
+  return client;
+}
+
+async function requireError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw new Error("Expected an Error rejection");
+  }
+  throw new Error("Expected promise to reject");
+}
+
+describe("DockerSSHClient.execStdinAbortable", () => {
+  test("rejects a pre-aborted signal before opening an SSH exec channel", async () => {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    controller.abort();
+
+    const error = await requireError(
+      client.execStdinAbortable(
+        "secret-command --redacted",
+        Buffer.from("secret"),
+        controller.signal,
+      ),
+    );
+
+    expect(error.name).toBe("AbortError");
+    expect(error.message).not.toContain("secret-command");
+    expect(error.message).not.toContain("secret");
+    expect(session.execCalls).toBe(0);
+    expect(channel.endedWith).toBeUndefined();
+  });
+
+  test("does not settle an in-flight abort until the SSH channel is closed", async () => {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    const input = Buffer.from("vault-passphrase-frame");
+    let outcome = "pending";
+
+    const promise = client.execStdinAbortable(
+      "secret-command --redacted",
+      input,
+      controller.signal,
+    );
+    void promise.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+
+    expect(channel.endedWith).toBe(input);
+    controller.abort();
+    await Promise.resolve();
+
+    expect(channel.closeCalls).toBe(1);
+    expect(channel.destroyCalls).toBe(1);
+    expect(outcome).toBe("pending");
+
+    channel.emit("close", 0);
+    const error = await requireError(promise);
+    expect(error.name).toBe("AbortError");
+    expect(outcome).toBe("rejected");
+    expect(session.destroyCalls).toBe(0);
+  });
+
+  test("does not destroy the session when channel cancellation closes synchronously", async () => {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    channel.close = () => {
+      channel.closeCalls += 1;
+      channel.emit("close", null);
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    const promise = client.execStdinAbortable(
+      "secret-command --redacted",
+      Buffer.from("secret"),
+      controller.signal,
+    );
+
+    controller.abort();
+    const error = await requireError(promise);
+    expect(error.name).toBe("AbortError");
+    await Bun.sleep(1_100);
+    expect(session.destroyCalls).toBe(0);
+  });
+
+  test("destroys the dedicated SSH session when an aborted channel never closes", async () => {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    const promise = client.execStdinAbortable(
+      "secret-command --redacted",
+      Buffer.from("secret"),
+      controller.signal,
+    );
+
+    controller.abort();
+    const error = await requireError(promise);
+
+    expect(error.name).toBe("AbortError");
+    expect(channel.closeCalls).toBe(1);
+    expect(channel.destroyCalls).toBe(1);
+    expect(session.destroyCalls).toBe(1);
+    expect(client.isConnected).toBe(false);
+  });
+
+  test("destroys a late channel without ever handing it stdin after abort", async () => {
+    const lateChannel = new FakeClientChannel();
+    let openCallback: ((error: Error | undefined, channel: FakeClientChannel) => void) | undefined;
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        openCallback = callback;
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    const promise = client.execStdinAbortable(
+      "secret-command --redacted",
+      Buffer.from("secret"),
+      controller.signal,
+    );
+
+    controller.abort();
+    const error = await requireError(promise);
+    expect(error.name).toBe("AbortError");
+    expect(session.destroyCalls).toBe(1);
+
+    if (!openCallback) throw new Error("Expected SSH exec callback to be captured");
+    openCallback(undefined, lateChannel);
+    expect(lateChannel.destroyCalls).toBe(1);
+    expect(lateChannel.endedWith).toBeUndefined();
+  });
+
+  test("discards bounded remote output on a successful close", async () => {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    const promise = client.execStdinAbortable(
+      "receipt-command",
+      Buffer.from("frame"),
+      controller.signal,
+    );
+
+    channel.emit("data", Buffer.from("receipt-ok\n"));
+    channel.emit("close", 0);
+
+    expect(await promise).toBeUndefined();
+    expect(session.destroyCalls).toBe(0);
+  });
+
+  test("never reflects remote output in a non-zero exit error", async () => {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const client = makeConnectedClient(session);
+    const controller = new AbortController();
+    const promise = client.execStdinAbortable(
+      "secret-command --redacted",
+      Buffer.from("secret"),
+      controller.signal,
+    );
+
+    const reflectedOutput = Buffer.from("reflected-secret");
+    channel.stderr.emit("data", reflectedOutput);
+    channel.emit("close", 17);
+
+    const error = await requireError(promise);
+    expect(reflectedOutput.every((byte) => byte === 0)).toBe(true);
+    expect(error.message).toContain("exited with code 17");
+    expect(error.message).not.toContain("reflected-secret");
+    expect(error.message).not.toContain("secret-command");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-ssh.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh.ts
@@ -91,7 +91,7 @@ function getDockerSshAbortReason(signal: AbortSignal, hostname: string): unknown
     const reason = signal.reason;
     if (reason !== undefined) return reason;
   } catch {
-    /* fall through to the compatibility error */
+    // error-policy:J3 an incomplete AbortSignal becomes an explicit redacted AbortError.
   }
   return createDockerSshAbortError(hostname);
 }
@@ -419,7 +419,7 @@ export class DockerSSHClient {
         try {
           conn.destroy();
         } catch {
-          /* best-effort; rejection still fences this client instance */
+          // error-policy:J6 rejection still fences this failed connection instance.
         }
         this.connected = false;
         if (this.client === conn) this.client = null;
@@ -450,7 +450,7 @@ export class DockerSSHClient {
           try {
             conn.destroy();
           } catch {
-            /* best-effort */
+            // error-policy:J6 the late connection is already fenced from callers.
           }
           return;
         }
@@ -811,7 +811,7 @@ export class DockerSSHClient {
         try {
           client.destroy();
         } catch {
-          /* best-effort; the local channel was already destroyed */
+          // error-policy:J6 the local channel was already destroyed before session teardown.
         }
         if (this.client === client) {
           this.client = null;
@@ -823,12 +823,12 @@ export class DockerSSHClient {
         try {
           stream?.close();
         } catch {
-          /* best-effort */
+          // error-policy:J6 destroy below remains the authoritative channel teardown.
         }
         try {
           stream?.destroy();
         } catch {
-          /* best-effort */
+          // error-policy:J6 the grace timer destroys the dedicated session if close never arrives.
         }
       };
 
@@ -882,7 +882,7 @@ export class DockerSSHClient {
           try {
             openedStream?.destroy();
           } catch {
-            /* best-effort */
+            // error-policy:J6 the parent SSH session was already fenced before this late callback.
           }
           return;
         }
@@ -945,6 +945,7 @@ export class DockerSSHClient {
         try {
           stream.end(input);
         } catch {
+          // error-policy:J1 translate a synchronous SSH writable failure after teardown starts.
           cancel(new Error(`[docker-ssh] stdin write failed on ${this.hostname}`));
         }
       });

--- a/packages/cloud/shared/src/lib/services/docker-ssh.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh.ts
@@ -83,6 +83,19 @@ function createDockerSshAbortError(hostname: string): Error {
   return error;
 }
 
+function getDockerSshAbortReason(signal: AbortSignal, hostname: string): unknown {
+  // Abort reasons are part of the caller's cancellation contract. Preserve the
+  // exact value (including non-Error values) when the runtime exposes one, and
+  // synthesize a redacted AbortError only for older/incomplete implementations.
+  try {
+    const reason = signal.reason;
+    if (reason !== undefined) return reason;
+  } catch {
+    /* fall through to the compatibility error */
+  }
+  return createDockerSshAbortError(hostname);
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -377,7 +390,7 @@ export class DockerSSHClient {
    */
   async connect(signal?: AbortSignal): Promise<void> {
     if (signal?.aborted) {
-      throw createDockerSshAbortError(this.hostname);
+      throw getDockerSshAbortReason(signal, this.hostname);
     }
     if (this.connected && this.client) {
       return;
@@ -386,7 +399,7 @@ export class DockerSSHClient {
     const SSHClientCtor = await loadSSHClientCtor();
 
     if (signal?.aborted) {
-      throw createDockerSshAbortError(this.hostname);
+      throw getDockerSshAbortReason(signal, this.hostname);
     }
 
     return new Promise<void>((resolve, reject) => {
@@ -399,7 +412,7 @@ export class DockerSSHClient {
         signal?.removeEventListener("abort", onAbort);
       };
 
-      const failPendingConnection = (error: Error) => {
+      const failPendingConnection = (error: unknown) => {
         if (settled) return;
         settled = true;
         cleanupPendingConnection();
@@ -414,7 +427,8 @@ export class DockerSSHClient {
       };
 
       const onAbort = () => {
-        failPendingConnection(createDockerSshAbortError(this.hostname));
+        if (!signal) return;
+        failPendingConnection(getDockerSshAbortReason(signal, this.hostname));
       };
 
       const timeout = setTimeout(() => {
@@ -758,13 +772,13 @@ export class DockerSSHClient {
     timeoutMs?: number,
   ): Promise<void> {
     if (signal.aborted) {
-      throw createDockerSshAbortError(this.hostname);
+      throw getDockerSshAbortReason(signal, this.hostname);
     }
     if (!this.connected || !this.client) {
       await this.connect(signal);
     }
     if (signal.aborted) {
-      throw createDockerSshAbortError(this.hostname);
+      throw getDockerSshAbortReason(signal, this.hostname);
     }
 
     this.lastActivityMs = Date.now();
@@ -774,7 +788,8 @@ export class DockerSSHClient {
     return new Promise<void>((resolve, reject) => {
       let outputBytes = 0;
       let settled = false;
-      let terminalError: Error | undefined;
+      let terminalError: unknown;
+      let hasTerminalError = false;
       let stream: ClientChannel | undefined;
       let closeGraceTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -784,11 +799,11 @@ export class DockerSSHClient {
         signal.removeEventListener("abort", onAbort);
       };
 
-      const finish = (error?: Error) => {
+      const finish = (error?: unknown) => {
         if (settled) return;
         settled = true;
         cleanup();
-        if (error) reject(error);
+        if (error !== undefined) reject(error);
         else resolve();
       };
 
@@ -817,9 +832,10 @@ export class DockerSSHClient {
         }
       };
 
-      const cancel = (error: Error) => {
-        if (settled || terminalError) return;
+      const cancel = (error: unknown) => {
+        if (settled || hasTerminalError) return;
         terminalError = error;
+        hasTerminalError = true;
         clearTimeout(commandTimer);
 
         if (!stream) {
@@ -844,7 +860,7 @@ export class DockerSSHClient {
       };
 
       const onAbort = () => {
-        cancel(createDockerSshAbortError(this.hostname));
+        cancel(getDockerSshAbortReason(signal, this.hostname));
       };
 
       const commandTimer = setTimeout(() => {
@@ -879,7 +895,7 @@ export class DockerSSHClient {
 
         const observeBoundedOutput = (data: Buffer) => {
           try {
-            if (terminalError || settled) return;
+            if (hasTerminalError || settled) return;
             outputBytes += data.byteLength;
             if (outputBytes > ABORTABLE_STDIN_MAX_OUTPUT_BYTES) {
               cancel(
@@ -903,7 +919,7 @@ export class DockerSSHClient {
           observeBoundedOutput(data);
         });
         stream.on("close", (code: number) => {
-          if (terminalError) {
+          if (hasTerminalError) {
             finish(terminalError);
             return;
           }
@@ -918,7 +934,7 @@ export class DockerSSHClient {
           }
         });
         stream.on("error", () => {
-          if (terminalError) return;
+          if (hasTerminalError) return;
           cancel(new Error(`[docker-ssh] stdin channel failed on ${this.hostname}`));
         });
 

--- a/packages/cloud/shared/src/lib/services/docker-ssh.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh.ts
@@ -66,6 +66,23 @@ const CONNECTION_TIMEOUT_MS = 10_000;
 /** Default timeout for a single command execution (ms). */
 const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
 
+/**
+ * A cancelled stdin command gets a short grace period to observe the SSH
+ * channel's authoritative `close` event. If the peer never closes the
+ * channel, the whole dedicated SSH session is destroyed before the promise
+ * settles so the remote command cannot keep consuming buffered secret bytes.
+ */
+const ABORTABLE_STDIN_CLOSE_GRACE_MS = 1_000;
+
+/** Remote output is drained and discarded, with a hard bound against flooding. */
+const ABORTABLE_STDIN_MAX_OUTPUT_BYTES = 64 * 1024;
+
+function createDockerSshAbortError(hostname: string): Error {
+  const error = new Error(`[docker-ssh] stdin command aborted on ${hostname}`);
+  error.name = "AbortError";
+  return error;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -253,6 +270,24 @@ export class DockerSSHClient {
     return client;
   }
 
+  /**
+   * Create an unpooled client for one cancellation-sensitive operation.
+   * Destroying this session can never interrupt another caller's command.
+   */
+  static createDedicated(
+    hostname: string,
+    port?: number,
+    hostKeyFingerprint?: string,
+    username?: string,
+  ): DockerSSHClient {
+    return new DockerSSHClient({
+      hostname,
+      port: port ?? DEFAULT_SSH_PORT,
+      username: username ?? DEFAULT_SSH_USERNAME,
+      hostKeyFingerprint,
+    });
+  }
+
   /** Disconnect and remove every pooled client. */
   static async disconnectAll(): Promise<void> {
     const promises: Promise<void>[] = [];
@@ -340,27 +375,73 @@ export class DockerSSHClient {
    * Establish the SSH connection.  Resolves once the `ready` event fires.
    * If the client is already connected this is a no-op.
    */
-  async connect(): Promise<void> {
+  async connect(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw createDockerSshAbortError(this.hostname);
+    }
     if (this.connected && this.client) {
       return;
     }
 
     const SSHClientCtor = await loadSSHClientCtor();
 
+    if (signal?.aborted) {
+      throw createDockerSshAbortError(this.hostname);
+    }
+
     return new Promise<void>((resolve, reject) => {
       const conn = new SSHClientCtor();
 
+      let settled = false;
+
+      const cleanupPendingConnection = () => {
+        clearTimeout(timeout);
+        signal?.removeEventListener("abort", onAbort);
+      };
+
+      const failPendingConnection = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanupPendingConnection();
+        try {
+          conn.destroy();
+        } catch {
+          /* best-effort; rejection still fences this client instance */
+        }
+        this.connected = false;
+        if (this.client === conn) this.client = null;
+        reject(error);
+      };
+
+      const onAbort = () => {
+        failPendingConnection(createDockerSshAbortError(this.hostname));
+      };
+
       const timeout = setTimeout(() => {
-        conn.end();
-        reject(
+        failPendingConnection(
           new Error(
             `[docker-ssh] Connection to ${this.hostname}:${this.port} timed out after ${CONNECTION_TIMEOUT_MS}ms`,
           ),
         );
       }, CONNECTION_TIMEOUT_MS);
 
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+
       conn.on("ready", () => {
-        clearTimeout(timeout);
+        if (settled) {
+          try {
+            conn.destroy();
+          } catch {
+            /* best-effort */
+          }
+          return;
+        }
+        settled = true;
+        cleanupPendingConnection();
         this.client = conn;
         this.connected = true;
         logger.info(`[docker-ssh] Connected to ${this.hostname}:${this.port}`);
@@ -383,15 +464,17 @@ export class DockerSSHClient {
       });
 
       conn.on("error", (err) => {
-        clearTimeout(timeout);
-        this.connected = false;
-        this.client = null;
-        reject(new Error(`[docker-ssh] Connection error for ${this.hostname}: ${err.message}`));
+        failPendingConnection(
+          new Error(`[docker-ssh] Connection error for ${this.hostname}: ${err.message}`),
+        );
       });
 
       conn.on("close", () => {
         this.connected = false;
         this.client = null;
+        failPendingConnection(
+          new Error(`[docker-ssh] Connection closed before ready for ${this.hostname}`),
+        );
       });
 
       conn.connect({
@@ -649,6 +732,205 @@ export class DockerSSHClient {
         });
 
         stream.end(inputBuffer);
+      });
+    });
+  }
+
+  /**
+   * Execute a secret-bearing command with byte-native stdin and mandatory
+   * cancellation.
+   *
+   * Unlike the legacy `execStdin`, cancellation and timeout do not reject
+   * while the SSH channel may still be reading. The method first closes and
+   * destroys the channel, waits for the peer-confirmed `close` event, and
+   * destroys the entire SSH session if that event does not arrive within a
+   * bounded grace period. Callers may therefore zeroize `input` as soon as the
+   * returned promise settles.
+   *
+   * Use a dedicated `DockerSSHClient` for this operation: the fail-closed
+   * fallback deliberately destroys the SSH session and would interrupt other
+   * commands sharing a pooled client.
+   */
+  async execStdinAbortable(
+    command: string,
+    input: Buffer,
+    signal: AbortSignal,
+    timeoutMs?: number,
+  ): Promise<void> {
+    if (signal.aborted) {
+      throw createDockerSshAbortError(this.hostname);
+    }
+    if (!this.connected || !this.client) {
+      await this.connect(signal);
+    }
+    if (signal.aborted) {
+      throw createDockerSshAbortError(this.hostname);
+    }
+
+    this.lastActivityMs = Date.now();
+    const effectiveTimeout = timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+    const client = this.client!;
+
+    return new Promise<void>((resolve, reject) => {
+      let outputBytes = 0;
+      let settled = false;
+      let terminalError: Error | undefined;
+      let stream: ClientChannel | undefined;
+      let closeGraceTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const cleanup = () => {
+        clearTimeout(commandTimer);
+        if (closeGraceTimer) clearTimeout(closeGraceTimer);
+        signal.removeEventListener("abort", onAbort);
+      };
+
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (error) reject(error);
+        else resolve();
+      };
+
+      const destroyDedicatedSession = () => {
+        try {
+          client.destroy();
+        } catch {
+          /* best-effort; the local channel was already destroyed */
+        }
+        if (this.client === client) {
+          this.client = null;
+          this.connected = false;
+        }
+      };
+
+      const stopChannel = () => {
+        try {
+          stream?.close();
+        } catch {
+          /* best-effort */
+        }
+        try {
+          stream?.destroy();
+        } catch {
+          /* best-effort */
+        }
+      };
+
+      const cancel = (error: Error) => {
+        if (settled || terminalError) return;
+        terminalError = error;
+        clearTimeout(commandTimer);
+
+        if (!stream) {
+          // No channel means stdin was never handed to ssh2. Destroy the
+          // pending session so a late exec callback cannot revive the effect.
+          destroyDedicatedSession();
+          finish(error);
+          return;
+        }
+
+        closeGraceTimer = setTimeout(() => {
+          // `Client.destroy()` synchronously destroys the underlying socket.
+          // Only then may the caller zeroize its stdin buffer.
+          destroyDedicatedSession();
+          finish(error);
+        }, ABORTABLE_STDIN_CLOSE_GRACE_MS);
+        // Install the grace timer before closing: ssh2 (and test doubles) may
+        // emit `close` synchronously from `close()`/`destroy()`. The close
+        // handler then clears this timer instead of leaving a late callback
+        // that would destroy an already-quiescent dedicated session.
+        stopChannel();
+      };
+
+      const onAbort = () => {
+        cancel(createDockerSshAbortError(this.hostname));
+      };
+
+      const commandTimer = setTimeout(() => {
+        cancel(
+          new Error(
+            `[docker-ssh] stdin command timed out after ${effectiveTimeout}ms on ${this.hostname}`,
+          ),
+        );
+      }, effectiveTimeout);
+
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+
+      client.exec(command, (err, openedStream) => {
+        if (settled) {
+          try {
+            openedStream?.destroy();
+          } catch {
+            /* best-effort */
+          }
+          return;
+        }
+        if (err) {
+          finish(new Error(`[docker-ssh] stdin exec channel failed on ${this.hostname}`));
+          return;
+        }
+
+        stream = openedStream;
+
+        const observeBoundedOutput = (data: Buffer) => {
+          try {
+            if (terminalError || settled) return;
+            outputBytes += data.byteLength;
+            if (outputBytes > ABORTABLE_STDIN_MAX_OUTPUT_BYTES) {
+              cancel(
+                new Error(
+                  `[docker-ssh] stdin command output exceeded ${ABORTABLE_STDIN_MAX_OUTPUT_BYTES} bytes on ${this.hostname}`,
+                ),
+              );
+            }
+          } finally {
+            // A hostile remote command can reflect secret stdin. Discarding
+            // the chunk is not enough: ssh2 handed us mutable bytes that would
+            // otherwise remain readable until the Buffer storage is reused.
+            data.fill(0);
+          }
+        };
+
+        stream.on("data", (data: Buffer) => {
+          observeBoundedOutput(data);
+        });
+        stream.stderr.on("data", (data: Buffer) => {
+          observeBoundedOutput(data);
+        });
+        stream.on("close", (code: number) => {
+          if (terminalError) {
+            finish(terminalError);
+            return;
+          }
+          if (code !== 0) {
+            // Output is intentionally discarded: a compromised remote command
+            // must not reflect secret stdin into immutable strings or errors.
+            finish(
+              new Error(`[docker-ssh] stdin command exited with code ${code} on ${this.hostname}`),
+            );
+          } else {
+            finish();
+          }
+        });
+        stream.on("error", () => {
+          if (terminalError) return;
+          cancel(new Error(`[docker-ssh] stdin channel failed on ${this.hostname}`));
+        });
+
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
+        try {
+          stream.end(input);
+        } catch {
+          cancel(new Error(`[docker-ssh] stdin write failed on ${this.hostname}`));
+        }
       });
     });
   }


### PR DESCRIPTION
## Scope
- Move exact replacement env and vault artifacts into a root-only attempt control directory.
- Reject symlink and hardlink substitution with exclusive creation and file identity proofs.
- Bind durable vault reads to an opened file descriptor and make SSH stdin abortable and zeroized.
- Publish first-use vault keys through a same-filesystem candidate so separate /var/lib and /data mounts cannot fail with EXDEV.
- Preserve the exact caller cancellation reason through SSH connect and stdin teardown.

## Validation
- exact head f29d332568b: cloud-shared typecheck
- 140 targeted utils, vault-seed, SSH, and replacement-cleanup tests pass locally; 1 Linux-only cross-filesystem case is skipped on macOS
- the Linux suite executes the real /tmp to /dev/shm cross-filesystem path: docker-sandbox-utils 60/60
- Biome and git diff --check pass
- adversarial security review is clean; lifecycle findings for cross-filesystem publication and abort-reason propagation are fixed and covered

## Stack
First follow-up on Draft #29870. Part of #20726. It remains Draft until its parent stack is restacked and its hosted evidence is current.