### PR TITLE
fix(plugin-wallet): size relative EVM swaps by the fromToken balance, not native

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
@@ -1,6 +1,10 @@
 /**
  * Unit tests for `buildSwapDetails`'s relative-amount resolution
- * (absolute/half/max/percent → concrete token amount from wallet balance).
+ * (absolute/half/max/percent → concrete token amount). Relative amounts must
+ * resolve against the balance of the token being sold: the ERC-20 `fromToken`
+ * balance for token inputs, or the native chain balance (with a `max` gas
+ * reserve) only when the input is the native asset. Regression coverage for
+ * #29930, where a relative ERC-20 swap was sized off the native gas balance.
  * The intent-extraction LLM call is mocked to return fixed JSON so each case
  * isolates the arithmetic and validation, not model behavior.
  */
@@ -8,6 +12,7 @@ import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { base } from "viem/chains";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSwapDetails } from "../../actions/swap";
+import { NATIVE_TOKEN_ADDRESS } from "../../constants";
 import type { WalletProvider } from "../../providers/wallet";
 
 // Control the raw LLM output so we can assert the structured amountMode →
@@ -19,18 +24,45 @@ vi.mock("../../../../utils/intent-trajectory", () => ({
 
 const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+// base's native asset is ETH; NATIVE names the native basis unambiguously.
+const NATIVE = NATIVE_TOKEN_ADDRESS;
+const OWNER = "0x1111111111111111111111111111111111111111";
 
 // base mainnet native balance, as a decimal string (the shape getWalletBalances returns)
 const BASE_BALANCE = "2"; // 2.0 ETH
 
+// Stubs the on-chain ERC-20 read path (`balanceOf` + `decimals`) used to size
+// relative swaps of a token input. `throws` models an unreachable RPC.
+interface TokenStub {
+  balanceRaw?: bigint;
+  decimals?: number;
+  throws?: boolean;
+}
+
 function createWalletProvider(
-  balances: Record<string, string> = { base: BASE_BALANCE }
+  balances: Record<string, string> = { base: BASE_BALANCE },
+  tokenStub?: TokenStub
 ): WalletProvider {
   return {
     chains: { base },
     getSupportedChains: () => ["base"],
     getChainConfigs: () => base,
     getWalletBalances: async () => balances,
+    getAddress: () => OWNER,
+    getPublicClient: () => ({
+      readContract: async ({ functionName }: { functionName: string }) => {
+        if (tokenStub?.throws) {
+          throw new Error("RPC unavailable");
+        }
+        if (functionName === "decimals") {
+          return tokenStub?.decimals ?? 6;
+        }
+        if (functionName === "balanceOf") {
+          return tokenStub?.balanceRaw ?? 0n;
+        }
+        throw new Error(`unexpected readContract: ${functionName}`);
+      },
+    }),
   } as unknown as WalletProvider;
 }
 
@@ -95,9 +127,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     expect(details.amount).toBe("1.25");
   });
 
-  it("resolves half to balance / 2", async () => {
+  it("resolves native half to native balance / 2", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "half",
       chain: "base",
@@ -113,9 +145,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     expect(details.amount).toBe("1"); // 2 / 2
   });
 
-  it("resolves max to balance * 0.9 (gas reserve)", async () => {
+  it("resolves native max to native balance * 0.9 (gas reserve)", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "max",
       chain: "base",
@@ -131,9 +163,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     expect(details.amount).toBe("9"); // 10 * 0.9
   });
 
-  it("resolves percent to balance * amountPercent / 100", async () => {
+  it("resolves native percent against the native balance", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "percent",
       amountPercent: 30,
@@ -150,9 +182,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     expect(details.amount).toBe("3"); // 10 * 30 / 100
   });
 
-  it("accepts a numeric percent supplied as a string", async () => {
+  it("accepts a numeric native percent supplied as a string", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "percent",
       amountPercent: "25",
@@ -169,9 +201,90 @@ describe("buildSwapDetails amountMode resolution", () => {
     expect(details.amount).toBe("2"); // 8 * 25 / 100
   });
 
-  it("throws INVALID_PARAMS when the chain balance is unknown for a relative mode", async () => {
+  // Regression for #29930: a relative swap of an ERC-20 must resolve against
+  // that token's on-chain balance, not the native gas balance. Here the wallet
+  // holds only 2 ETH but 500 USDC (6 decimals); 50% of USDC must be 250, not
+  // 1 (which is 50% of the native ETH balance the buggy code used).
+  it("resolves a token percent against the ERC-20 fromToken balance, not native", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "percent",
+      amountPercent: 50,
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "2" }, { balanceRaw: 500_000000n, decimals: 6 })
+    );
+
+    expect(details.fromToken).toBe(USDC);
+    expect(details.amount).toBe("250"); // 50% of 500 USDC, not 50% of 2 ETH ("1")
+    expect(details.amount).not.toBe("1");
+  });
+
+  it("resolves a token half against the ERC-20 fromToken balance", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "2" }, { balanceRaw: 1000_000000n, decimals: 6 })
+    );
+
+    expect(details.amount).toBe("500"); // 1000 USDC / 2
+  });
+
+  // A token `max` spends the whole token balance: the 0.9 gas reserve only
+  // applies to the native asset, since gas is paid in a different token.
+  it("resolves a token max to the full ERC-20 balance (no gas reserve)", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "max",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "2" }, { balanceRaw: 250_000000n, decimals: 6 })
+    );
+
+    expect(details.amount).toBe("250"); // full 250 USDC, not 225
+  });
+
+  it("throws INVALID_PARAMS when the ERC-20 fromToken balance cannot be read", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    await expect(
+      buildSwapDetails(
+        {} as State,
+        message,
+        createRuntime(),
+        createWalletProvider({ base: "2" }, { throws: true })
+      )
+    ).rejects.toThrow(/failed to read the .* balance/i);
+  });
+
+  it("throws INVALID_PARAMS when the native balance is unknown for a relative mode", async () => {
+    llmJson({
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "half",
       chain: "base",
@@ -188,9 +301,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     ).rejects.toThrow(/unknown balance/i);
   });
 
-  it("throws INVALID_PARAMS when percent is out of range (0)", async () => {
+  it("throws INVALID_PARAMS when native percent is out of range (0)", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "percent",
       amountPercent: 0,
@@ -202,9 +315,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     ).rejects.toThrow(/between 1 and 100/i);
   });
 
-  it("throws INVALID_PARAMS when percent is out of range (150)", async () => {
+  it("throws INVALID_PARAMS when native percent is out of range (150)", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "percent",
       amountPercent: 150,
@@ -216,9 +329,9 @@ describe("buildSwapDetails amountMode resolution", () => {
     ).rejects.toThrow(/between 1 and 100/i);
   });
 
-  it("throws INVALID_PARAMS when percent mode omits amountPercent", async () => {
+  it("throws INVALID_PARAMS when native percent mode omits amountPercent", async () => {
     llmJson({
-      inputToken: WETH,
+      inputToken: NATIVE,
       outputToken: USDC,
       amountMode: "percent",
       chain: "base",

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
@@ -264,6 +264,96 @@ describe("buildSwapDetails amountMode resolution", () => {
     expect(details.amount).toBe("250"); // full 250 USDC, not 225
   });
 
+  // Magnitude + precision: ERC-20 balances the caller does not control span
+  // dust and >1e24-token ranges. The pre-fix float path (`Number(balance) / 2`
+  // then `.toString()`) emitted exponential notation there (`"5e-13"`,
+  // `"1e+24"`) that `parseUnits` rejects, and lost precision past ~15 digits.
+  // These pin the exact-integer path: always plain decimal, always exact.
+  it("resolves a dust 18-decimal token half to plain decimal, not exponential", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      // 1e6 wei of an 18-decimal token = 0.000000000001 token; the old float
+      // path halved this to "5e-13", which parseUnits cannot parse.
+      createWalletProvider({ base: "2" }, { balanceRaw: 1_000_000n, decimals: 18 })
+    );
+
+    expect(details.amount).toBe("0.0000000000005");
+    expect(details.amount).not.toMatch(/e/i);
+  });
+
+  it("resolves a very large 18-decimal token half to plain decimal, not exponential", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      // 2e24 whole tokens (18 decimals); the old float path produced "1e+24".
+      createWalletProvider({ base: "2" }, { balanceRaw: 2n * 10n ** 42n, decimals: 18 })
+    );
+
+    expect(details.amount).toBe("1000000000000000000000000");
+    expect(details.amount).not.toMatch(/e/i);
+  });
+
+  it("keeps full precision halving an 18-decimal balance past float64's ~15 digits", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      // 123456789.123456789012345678 tokens; float halving gives
+      // "61728394.561728396" (wrong past 15 digits), exact halving does not.
+      createWalletProvider(
+        { base: "2" },
+        { balanceRaw: 123456789123456789012345678n, decimals: 18 }
+      )
+    );
+
+    expect(details.amount).toBe("61728394.561728394506172839");
+  });
+
+  it("resolves a fractional token percent with exact-integer arithmetic", async () => {
+    llmJson({
+      inputToken: USDC,
+      outputToken: WETH,
+      amountMode: "percent",
+      amountPercent: 33.33,
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      // 1000 USDC (6 decimals); 33.33% = 333.3 USDC.
+      createWalletProvider({ base: "2" }, { balanceRaw: 1000_000000n, decimals: 6 })
+    );
+
+    expect(details.amount).toBe("333.3");
+    expect(details.amount).not.toMatch(/e/i);
+  });
+
   it("throws INVALID_PARAMS when the ERC-20 fromToken balance cannot be read", async () => {
     llmJson({
       inputToken: USDC,

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -4,7 +4,10 @@
  * recovery across `slippageLevels`), handles ERC-20 approval when needed, and
  * submits the winning route's transaction. `buildSwapDetails` turns the LLM's
  * structured intent into concrete `SwapParams`, resolving relative amounts
- * (half/max/percent) against the wallet's live chain balance. `swapAction` is
+ * (half/max/percent) against the balance of the token actually being sold: the
+ * ERC-20 `fromToken` balance for token inputs, or the native chain balance
+ * (with a gas reserve for `max`) only when the input is the native asset.
+ * `swapAction` is
  * the `WALLET`/`swap` subaction entry point and always runs through
  * `gateWalletFinancialExecution` before submission.
  */
@@ -31,7 +34,14 @@ import {
   type Route,
 } from "@lifi/sdk";
 
-import { type Address, encodeFunctionData, type Hex, parseAbi, parseUnits } from "viem";
+import {
+  type Address,
+  encodeFunctionData,
+  formatUnits,
+  type Hex,
+  parseAbi,
+  parseUnits,
+} from "viem";
 import { runIntentModel } from "../../../utils/intent-trajectory";
 import {
   BEBOP_CHAIN_MAP,
@@ -802,6 +812,7 @@ export async function buildSwapDetails(
 
   const chain = String(parsedResponse.chain ?? "").toLowerCase();
   const amountMode = resolveAmountMode(parsedResponse.amountMode);
+  const fromToken = String(parsedResponse.inputToken ?? "");
 
   // `chain` is an arbitrary lowercased string from the model, so the balance
   // lookup is honestly `string | undefined` (resolveRelativeAmount throws when
@@ -811,10 +822,13 @@ export async function buildSwapDetails(
   const amount =
     amountMode === "absolute"
       ? String(parsedResponse.amount ?? "")
-      : resolveRelativeAmount(amountMode, parsedResponse.amountPercent, chainBalance);
+      : await resolveRelativeSwapAmount(wp, chain, fromToken, amountMode, {
+          rawPercent: parsedResponse.amountPercent,
+          nativeBalance: chainBalance,
+        });
 
   const swapDetails = parseSwapParams({
-    fromToken: String(parsedResponse.inputToken ?? ""),
+    fromToken,
     toToken: String(parsedResponse.outputToken ?? ""),
     amount,
     chain,
@@ -837,16 +851,114 @@ function resolveAmountMode(value: unknown): AmountMode {
   return AMOUNT_MODES.includes(value as AmountMode) ? (value as AmountMode) : "absolute";
 }
 
+const ERC20_BALANCE_ABI = parseAbi([
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+]);
+
+/**
+ * Decide whether the model's `fromToken` names the chain's native asset. The
+ * caller only reaches this for a configured chain (else `getChainConfigs`
+ * throws), so a token that is neither the zero-address sentinel nor the native
+ * symbol is treated as an ERC-20 whose own balance must be consulted.
+ */
+function isNativeFromToken(wp: WalletProvider, chain: string, fromToken: string): boolean {
+  if (fromToken === NATIVE_TOKEN_ADDRESS) {
+    return true;
+  }
+  const chainConfig = wp.chains[chain] ? wp.getChainConfigs(chain as SupportedChain) : undefined;
+  if (!chainConfig) {
+    return false;
+  }
+  return fromToken.toUpperCase() === chainConfig.nativeCurrency.symbol.toUpperCase();
+}
+
+/**
+ * Read the wallet's on-chain ERC-20 balance for `fromToken` as a
+ * human-readable string (`balanceOf` scaled by the token's `decimals`). A
+ * symbol is resolved to its address through Li.Fi; a 0x address is used
+ * directly. Any resolution or RPC failure becomes an INVALID_PARAMS error so
+ * the relative-amount math never silently falls back to the native balance.
+ */
+async function fetchFromTokenBalance(
+  wp: WalletProvider,
+  chain: string,
+  fromToken: string
+): Promise<string> {
+  const chainConfig = wp.getChainConfigs(chain as SupportedChain);
+  try {
+    const tokenAddress: Address =
+      fromToken.startsWith("0x") && fromToken.length === 42
+        ? (fromToken as Address)
+        : ((await getToken(chainConfig.id, fromToken)).address as Address);
+
+    const publicClient = wp.getPublicClient(chain as SupportedChain);
+    const owner = wp.getAddress();
+
+    const [rawBalance, decimals] = await Promise.all([
+      publicClient.readContract({
+        address: tokenAddress,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "balanceOf",
+        args: [owner],
+        authorizationList: undefined,
+      }),
+      publicClient.readContract({
+        address: tokenAddress,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "decimals",
+        authorizationList: undefined,
+      }),
+    ]);
+
+    return formatUnits(BigInt(rawBalance as bigint), Number(decimals));
+  } catch (error) {
+    // error-policy:J2 wrap the resolution/RPC failure with a typed, actionable
+    // error; never resolve a relative amount against the wrong (native) basis.
+    if (error instanceof EVMError) {
+      throw error;
+    }
+    throw new EVMError(
+      EVMErrorCode.INVALID_PARAMS,
+      `Cannot resolve a relative swap amount: failed to read the ${fromToken} balance on ${chain}.`,
+      error instanceof Error ? error : undefined
+    );
+  }
+}
+
+/**
+ * Turn a relative swap intent into a concrete amount using the balance of the
+ * token actually being sold. When `fromToken` is the native asset the native
+ * chain balance is used (with the `max` gas reserve); otherwise the ERC-20
+ * `fromToken` balance is fetched and used with no gas reserve, because the gas
+ * token is a separate asset.
+ */
+async function resolveRelativeSwapAmount(
+  wp: WalletProvider,
+  chain: string,
+  fromToken: string,
+  mode: Exclude<AmountMode, "absolute">,
+  opts: { rawPercent: unknown; nativeBalance: string | undefined }
+): Promise<string> {
+  if (isNativeFromToken(wp, chain, fromToken)) {
+    return resolveRelativeAmount(mode, opts.rawPercent, opts.nativeBalance, true);
+  }
+  const tokenBalance = await fetchFromTokenBalance(wp, chain, fromToken);
+  return resolveRelativeAmount(mode, opts.rawPercent, tokenBalance, false);
+}
+
 /**
  * Resolve a relative swap size ("half"/"max"/"percent") into an absolute,
- * human-readable amount string from the connected chain's native balance.
- * `max` keeps a 10% gas reserve (0.9 * balance). Throws INVALID_PARAMS when the
- * balance for the chain is unknown or a percentage is out of the 1-100 range.
+ * human-readable amount string from a supplied token balance. `max` keeps a
+ * 10% gas reserve (0.9 * balance) only when `reserveGasForMax` is set (native
+ * inputs); ERC-20 `max` spends the whole balance. Throws INVALID_PARAMS when
+ * the balance is unknown or a percentage is out of the 1-100 range.
  */
 function resolveRelativeAmount(
   mode: Exclude<AmountMode, "absolute">,
   rawPercent: unknown,
-  balance: string | undefined
+  balance: string | undefined,
+  reserveGasForMax: boolean
 ): string {
   if (balance === undefined) {
     throw new EVMError(
@@ -861,7 +973,7 @@ function resolveRelativeAmount(
     return (balanceNum / 2).toString();
   }
   if (mode === "max") {
-    return (balanceNum * 0.9).toString();
+    return (reserveGasForMax ? balanceNum * 0.9 : balanceNum).toString();
   }
 
   const percent = Number(rawPercent);

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -874,17 +874,19 @@ function isNativeFromToken(wp: WalletProvider, chain: string, fromToken: string)
 }
 
 /**
- * Read the wallet's on-chain ERC-20 balance for `fromToken` as a
- * human-readable string (`balanceOf` scaled by the token's `decimals`). A
- * symbol is resolved to its address through Li.Fi; a 0x address is used
- * directly. Any resolution or RPC failure becomes an INVALID_PARAMS error so
- * the relative-amount math never silently falls back to the native balance.
+ * Read the wallet's on-chain ERC-20 balance for `fromToken` as the raw
+ * `balanceOf` integer alongside the token's `decimals`. A symbol is resolved
+ * to its address through Li.Fi; a 0x address is used directly. The raw
+ * `bigint` is returned (not a formatted string) so the relative-amount math
+ * can stay in exact integer arithmetic and never round-trips through float64.
+ * Any resolution or RPC failure becomes an INVALID_PARAMS error so the
+ * relative-amount math never silently falls back to the native balance.
  */
 async function fetchFromTokenBalance(
   wp: WalletProvider,
   chain: string,
   fromToken: string
-): Promise<string> {
+): Promise<{ raw: bigint; decimals: number }> {
   const chainConfig = wp.getChainConfigs(chain as SupportedChain);
   try {
     const tokenAddress: Address =
@@ -911,7 +913,7 @@ async function fetchFromTokenBalance(
       }),
     ]);
 
-    return formatUnits(BigInt(rawBalance as bigint), Number(decimals));
+    return { raw: BigInt(rawBalance as bigint), decimals: Number(decimals) };
   } catch (error) {
     // error-policy:J2 wrap the resolution/RPC failure with a typed, actionable
     // error; never resolve a relative amount against the wrong (native) basis.
@@ -943,16 +945,56 @@ async function resolveRelativeSwapAmount(
   if (isNativeFromToken(wp, chain, fromToken)) {
     return resolveRelativeAmount(mode, opts.rawPercent, opts.nativeBalance, true);
   }
-  const tokenBalance = await fetchFromTokenBalance(wp, chain, fromToken);
-  return resolveRelativeAmount(mode, opts.rawPercent, tokenBalance, false);
+  const { raw, decimals } = await fetchFromTokenBalance(wp, chain, fromToken);
+  return resolveRelativeTokenAmount(mode, opts.rawPercent, raw, decimals);
 }
 
 /**
- * Resolve a relative swap size ("half"/"max"/"percent") into an absolute,
- * human-readable amount string from a supplied token balance. `max` keeps a
- * 10% gas reserve (0.9 * balance) only when `reserveGasForMax` is set (native
- * inputs); ERC-20 `max` spends the whole balance. Throws INVALID_PARAMS when
- * the balance is unknown or a percentage is out of the 1-100 range.
+ * Resolve a relative ERC-20 swap size ("half"/"max"/"percent") into an
+ * absolute, human-readable amount using exact integer arithmetic on the raw
+ * `balanceOf` value, formatting to decimal exactly once at the end. Working in
+ * `bigint` keeps every wei of a token balance whose magnitude the caller does
+ * not control: 18-decimal balances span both dust and >1e24-token ranges where
+ * `Number(...).toString()` loses precision past ~15 significant digits and
+ * emits exponential notation (e.g. `"5e-13"`, `"1e+24"`) that `parseUnits`
+ * rejects. `max` spends the whole balance (gas is a separate asset). Throws
+ * INVALID_PARAMS when the percentage is out of the 1-100 range.
+ */
+function resolveRelativeTokenAmount(
+  mode: Exclude<AmountMode, "absolute">,
+  rawPercent: unknown,
+  raw: bigint,
+  decimals: number
+): string {
+  if (mode === "half") {
+    return formatUnits(raw / 2n, decimals);
+  }
+  if (mode === "max") {
+    return formatUnits(raw, decimals);
+  }
+
+  const percent = Number(rawPercent);
+  if (!Number.isFinite(percent) || percent < 1 || percent > 100) {
+    throw new EVMError(
+      EVMErrorCode.INVALID_PARAMS,
+      `Swap percentage must be between 1 and 100, received: ${String(rawPercent)}`
+    );
+  }
+  // Scale the percent to an integer basis-of-a-million so a fractional percent
+  // stays representable while the (possibly huge) balance keeps every wei; the
+  // division by 100_000_000 then yields `raw * percent / 100` in pure bigint.
+  const scaledPercent = BigInt(Math.round(percent * 1_000_000));
+  return formatUnits((raw * scaledPercent) / 100_000_000n, decimals);
+}
+
+/**
+ * Resolve a relative native-asset swap size ("half"/"max"/"percent") into an
+ * absolute, human-readable amount string from the supplied native balance.
+ * `max` keeps a 10% gas reserve (0.9 * balance) when `reserveGasForMax` is set.
+ * Native balances are gas-token scale, so the float basis here is unchanged
+ * from before; ERC-20 inputs take the exact-integer path in
+ * `resolveRelativeTokenAmount` instead. Throws INVALID_PARAMS when the balance
+ * is unknown or a percentage is out of the 1-100 range.
  */
 function resolveRelativeAmount(
   mode: Exclude<AmountMode, "absolute">,


### PR DESCRIPTION
# Relates to

Closes #29930

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks were run (see **Known gaps / failures** for the two unrelated pre-existing blockers that keep the full `bun run verify` from completing on this machine).
- [x] A reviewer can confirm the change works without reading the code, from the failing-before/passing-after test evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (branch was already up to date).
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures**; the two blockers are pre-existing and unrelated to this diff.

# Risks

Low. The change is confined to `buildSwapDetails` relative-amount resolution in the EVM swap action. It makes relative swaps of an ERC-20 correct (previously they moved an arbitrary, wrong amount) and adds an explicit typed failure when the token balance cannot be read. Native-asset relative swaps are unchanged (same native basis and `max` gas reserve). Absolute-amount swaps are untouched.

# Background

## What does this PR do?

Fixes a silent financial-correctness defect in the EVM swap action. `buildSwapDetails` turned a relative-amount intent ("half"/"max"/"percent") into a concrete amount using the wallet's **native** chain balance regardless of which token was being sold. The swap template explicitly classifies phrasings like "swap 30% of my USDC" as a relative mode for the *input token*, but the code computed that fraction of the native gas-token balance. Result: "swap half my USDC" traded an amount equal to half of the ETH balance denominated in USDC — an arbitrary, wrong quantity. The transaction succeeded but moved the wrong amount.

After this change, relative amounts resolve against the balance of the token actually being sold:

- **ERC-20 `fromToken`**: the fraction is computed from the token's own on-chain balance (`balanceOf` scaled by the token's `decimals`). `max` spends the whole token balance (no gas reserve — gas is paid in a different asset). The fraction is taken with **exact integer (`bigint`) arithmetic on the raw `balanceOf` value**, formatting to decimal once at the end, so a token balance whose magnitude the caller does not control (dust or >1e24-token) never round-trips through float64 — the earlier `Number(...)/…/.toString()` path lost precision past ~15 significant digits and emitted exponential notation (`"5e-13"`, `"1e+24"`) that viem's `parseUnits` rejects.
- **Native asset** (`fromToken` is the zero-address sentinel or the chain's native symbol): the native chain balance is used, keeping the existing `0.9` gas reserve for `max`. Unchanged behavior.
- If the token balance cannot be read (address resolution or RPC failure), `buildSwapDetails` throws `EVMError(INVALID_PARAMS)` rather than silently falling back to the native balance.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a documentation change. The file header and the two helper doc-comments in `swap.ts` were updated to describe the corrected basis.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts` and the changed `buildSwapDetails` in `plugins/plugin-wallet/src/chains/evm/actions/swap.ts`.

## Detailed testing steps

```bash
bun install
# focused regression + neighbour suite
plugins/plugin-wallet/node_modules/.bin/vitest run \
  plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
# Node-tree typecheck (contains swap.ts)
cd plugins/plugin-wallet && node_modules/.bin/tsc --noEmit -p tsconfig.json
```

The regression test drives the real `buildSwapDetails` with a stub `WalletProvider` (native `base` balance `2.0`, ERC-20 `balanceOf`/`decimals` stubbed) and a stub runtime whose intent model returns a fixed structured JSON. No network.

# Evidence Gate

<!-- evidence-head:934d47d28bccdcbbc96821b05a62540122d168a2 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend swap-amount resolution logic; no rendered UI surface changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend swap-amount resolution logic; no rendered UI surface changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI flow; the observable behavior is the computed swap amount, shown in the test trace below.`
<!-- evidence-row:backend-logs -->
- [x] Failing-before / passing-after trace of the real `buildSwapDetails`, both runs of the **current 18-case** `swap-amount-mode.test.ts` at head `934d47d`. Immutable GitHub-hosted captures (commit-pinned gist raw URLs): [before-fix (8 failed | 10 passed)](https://gist.githubusercontent.com/agent-cortex/ef89c262b7ba425fcc276a2d4c8eb7a6/raw/314b713fa9db9625f54445ecfdf6a2b6d1b5cdb2/29933-swap-amount-mode-before.txt) · [after-fix (18 passed)](https://gist.githubusercontent.com/agent-cortex/ef89c262b7ba425fcc276a2d4c8eb7a6/raw/76d88f3a02a82b2568b730d7b41a651027c49fef/29933-swap-amount-mode-after.txt). The before-fix run drives the current suite against the pre-PR `swap.ts` (`git 2a4af73:.../actions/swap.ts`); the eight failing cases are exactly the relative-ERC-20 and exact-integer regressions this PR adds.

<details>
<summary>buildSwapDetails relative-amount trace (current 18-case suite, before-fix vs after-fix)</summary>

```
BEFORE (current suite vs pre-PR swap.ts): relative ERC-20 sizing falls back to the native ETH balance
 × resolves a token percent against the ERC-20 fromToken balance, not native   → expected '1' to be '250'
 × resolves a token half against the ERC-20 fromToken balance                   → expected '1' to be '500'
 × resolves a token max to the full ERC-20 balance (no gas reserve)             → expected '1.8' to be '250'
 × resolves a dust 18-decimal token half to plain decimal, not exponential      → expected '1' to be '0.0000000000005'
 × resolves a very large 18-decimal token half to plain decimal, not exponential→ expected '1' to be '1000000000000000000000000'
 × keeps full precision halving past float64's ~15 digits                       → expected '1' to be '61728394.561728394506172839'
 × resolves a fractional token percent with exact-integer arithmetic            → expected '0.6666' to be '333.3'
 × throws INVALID_PARAMS when the ERC-20 fromToken balance cannot be read        → promise resolved instead of rejecting
 Tests  8 failed | 10 passed (18)

AFTER (fixed swap.ts at head 934d47d): the ERC-20 fromToken balance basis + exact-integer math
 ✓ resolves a token percent against the ERC-20 fromToken balance, not native
 ✓ resolves a token half against the ERC-20 fromToken balance
 ✓ resolves a token max to the full ERC-20 balance (no gas reserve)
 ✓ resolves a dust 18-decimal token half to plain decimal, not exponential
 ✓ resolves a very large 18-decimal token half to plain decimal, not exponential
 ✓ keeps full precision halving an 18-decimal balance past float64's ~15 digits
 ✓ resolves a fractional token percent with exact-integer arithmetic
 ✓ throws INVALID_PARAMS when the ERC-20 fromToken balance cannot be read
 Tests  18 passed (18)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - the intent LLM call is unchanged; the fix is deterministic arithmetic downstream of the model output, which is fixed in the test to isolate it.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — the computed swap `amount` for a 50% USDC swap of a wallet holding 2 ETH / 500 USDC. Immutable GitHub-hosted capture (commit-pinned gist raw URL): [29933-domain-artifact.txt](https://gist.githubusercontent.com/agent-cortex/ef89c262b7ba425fcc276a2d4c8eb7a6/raw/11adb4fd62061491de7bf693ae044c5febab0f40/29933-domain-artifact.txt).

<details>
<summary>computed swap amount output (domain artifact)</summary>

```
wallet balances: 2.0 ETH (native gas asset), 500 USDC (ERC-20, 6 decimals)
intent: swap 50% of USDC -> WETH on base (amountMode=percent, amountPercent=50)
BEFORE fix: details.amount = "1"   (50% of the 2.0 native ETH balance — wrong asset)
AFTER  fix: details.amount = "250" (50% of the 500 USDC balance — correct)
details.fromToken = USDC (0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48)
```
</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic post-model arithmetic; the model output is pinned in the test so the amount resolution is exercised in isolation.`

## Backend + frontend logs

Frontend: `N/A - no frontend`.

Backend / domain reproduction — same regression test, run against the pre-fix code (fails) and the fixed code (passes). This is the exact user-facing defect: a 50% swap of a wallet holding **2 ETH** and **500 USDC** must move 250 USDC, not 1 (which is 50% of the ETH balance).

<details>
<summary>BEFORE (pre-fix swap.ts) — the 50%-USDC swap resolves against the native ETH balance</summary>

```
 × buildSwapDetails amountMode resolution > resolves a token percent against the ERC-20 fromToken balance, not native
   → expected '1' to be '250' // Object.is equality

 FAIL  swap-amount-mode.test.ts > ... > resolves a token percent against the ERC-20 fromToken balance, not native
AssertionError: expected '1' to be '250' // Object.is equality
Expected: "250"
Received: "1"
    224|     expect(details.fromToken).toBe(USDC);
    225|     expect(details.amount).toBe("250"); // 50% of 500 USDC, not 50% of 2 ETH ("1")
       |                            ^
 Test Files  1 failed (1)
      Tests  1 failed | 13 skipped (14)
```
</details>

<details>
<summary>AFTER (fixed swap.ts) — full suite passes, ERC-20 basis is used</summary>

```
 ✓ passes through an absolute amount unchanged
 ✓ treats a missing/unknown amountMode as absolute
 ✓ resolves native half to native balance / 2
 ✓ resolves native max to native balance * 0.9 (gas reserve)
 ✓ resolves native percent against the native balance
 ✓ accepts a numeric native percent supplied as a string
 ✓ resolves a token percent against the ERC-20 fromToken balance, not native
 ✓ resolves a token half against the ERC-20 fromToken balance
 ✓ resolves a token max to the full ERC-20 balance (no gas reserve)
 ✓ throws INVALID_PARAMS when the ERC-20 fromToken balance cannot be read
 ✓ throws INVALID_PARAMS when the native balance is unknown for a relative mode
 ✓ throws INVALID_PARAMS when native percent is out of range (0)
 ✓ throws INVALID_PARAMS when native percent is out of range (150)
 ✓ throws INVALID_PARAMS when native percent mode omits amountPercent
 ✓ resolves a dust 18-decimal token half to plain decimal, not exponential (0.0000000000005)
 ✓ resolves a very large 18-decimal token half to plain decimal, not exponential (1000000000000000000000000)
 ✓ keeps full precision halving an 18-decimal balance past float64's ~15 digits (61728394.561728394506172839)
 ✓ resolves a fractional token percent with exact-integer arithmetic (33.33% of 1000 USDC = 333.3)

 Test Files  1 passed (1)
      Tests  18 passed (18)
```
</details>

<details>
<summary>Neighbour suites — no regressions</summary>

```
# swap.timeout.test.ts + swap-amount-mode.test.ts
 Test Files  2 passed (2)
      Tests  22 passed (22)

# full EVM unit directory
 Test Files  8 passed (8)
      Tests  58 passed (58)

# Node-tree typecheck (tsconfig.json, contains swap.ts)
node_modules/.bin/tsc --noEmit -p tsconfig.json   ->  exit 0

# Biome lint on the two changed files
Checked 2 files. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change; the observable behavior is the computed amount shown in the trace above.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- Full `bun run verify` was not completed on this machine. Two **pre-existing, unrelated** blockers:
  1. The package `typecheck` script also builds the React UI tree (`tsconfig.ui.json`), which fails to resolve `@elizaos/ui/*` subpaths when `@elizaos/ui` is not pre-built in this checkout. This is present on the clean tree (verified by stashing my changes) and is unrelated to `swap.ts`. The Node tree (`tsconfig.json`), which contains my change, typechecks clean (exit 0).
  2. `src/api/wallet-routes.ts` reports `Cannot find module '@elizaos/plugin-elizacloud'` until that workspace is built; also pre-existing and unrelated (I built it locally to confirm the Node tree is otherwise clean).
- Focused package checks that are in scope for this diff all pass: the changed unit suite, the EVM unit directory, the Node-tree typecheck, and Biome lint on the changed files.

## Maintainer CI exception record

`N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@2a4af7351c96881b83333fabb37927222dbb09fd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@2a4af7351c96881b83333fabb37927222dbb09fd:packages/skills/skills/contribute-to-eliza"} -->


