### PR TITLE
fix(cloud): await durable hosted logout

### DIFF
--- a/packages/app/test/ui-smoke/hosted-logout-retry.spec.ts
+++ b/packages/app/test/ui-smoke/hosted-logout-retry.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Exercises hosted logout through the real account menu and session teardown.
+ * The hosted document is served from the local build and cloud HTTP responses
+ * are deterministic fixtures, so the test never ends a live account session.
+ */
+import { writeFile } from "node:fs/promises";
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { expect, test } from "@playwright/test";
+import {
+  installCloudApiStubs,
+  seedStewardToken,
+} from "./helpers/cloud-audit-fixtures";
+import { saveBrowserVideoArtifact } from "./helpers/video-artifacts";
+
+for (const viewport of [
+  { name: "desktop", width: 1280, height: 800 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`Hosted logout retains retry authority after a failure on ${viewport.name}`, async ({
+    page,
+    baseURL,
+  }, testInfo) => {
+    if (!baseURL) throw new Error("The local renderer server URL is required");
+    const origin = "https://cloud.eliza.app";
+    const logs: string[] = [];
+    page.on("console", (message) =>
+      logs.push(`[console:${message.type()}] ${message.text()}`),
+    );
+    page.on("response", (response) =>
+      logs.push(`[response] ${response.status()} ${response.url()}`),
+    );
+    page.on("pageerror", (error) => logs.push(`[pageerror] ${error.message}`));
+    await page.setViewportSize(viewport);
+    await page.route(`${origin}/**`, async (route) => {
+      const response = await route.fetch({
+        url: route.request().url().replace(origin, baseURL),
+      });
+      await route.fulfill({ response });
+    });
+    await seedStewardToken(page);
+    await installCloudApiStubs(page);
+    let failLogout = true;
+    let requests = 0;
+    await page.route("**/api/auth/logout", async (route) => {
+      expect(route.request().method()).toBe("POST");
+      expect(route.request().headers().authorization).toMatch(/^Bearer /);
+      requests += 1;
+      await route.fulfill(
+        failLogout
+          ? { status: 503, json: { error: "Logout temporarily unavailable" } }
+          : { json: { ok: true } },
+      );
+    });
+    await page.goto(`${origin}/cloud/agents`);
+    const menu = page.getByRole("button", { name: /^Account menu/ });
+    await expect(menu).toBeVisible({ timeout: 60_000 });
+    await menu.click();
+    const signOut = page.getByRole("menuitem", {
+      name: "Sign out",
+      exact: true,
+    });
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-logout-rest.jpg`),
+      fullPage: true,
+    });
+    await signOut.hover();
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-logout-hover.jpg`),
+      fullPage: true,
+    });
+    await signOut.click();
+    await expect(
+      page.getByText("Could not sign out safely. Please try again.", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(`${origin}/cloud/agents`);
+    expect(
+      await page.evaluate(
+        (key) => Boolean(localStorage.getItem(key)),
+        STEWARD_TOKEN_KEY,
+      ),
+    ).toBe(true);
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-logout-error.jpg`),
+      fullPage: true,
+    });
+    failLogout = false;
+    await page.getByRole("menuitem", { name: "Sign out", exact: true }).click();
+    await expect(page).toHaveURL(/\/login(?:[?#].*)?$/);
+    expect(
+      await page.evaluate(
+        (key) => localStorage.getItem(key),
+        STEWARD_TOKEN_KEY,
+      ),
+    ).toBeNull();
+    expect(requests).toBe(2);
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-logout-complete.jpg`),
+      fullPage: true,
+    });
+    const logPath = testInfo.outputPath(`${viewport.name}-console-network.log`);
+    await writeFile(logPath, logs.join("\n"));
+    await testInfo.attach("console and network", {
+      path: logPath,
+      contentType: "text/plain",
+    });
+    const video = page.video();
+    await page.context().close();
+    if (video) {
+      const artifact = await saveBrowserVideoArtifact({
+        video,
+        testInfo,
+        basename: `${viewport.name}-logout-retry`,
+      });
+      await testInfo.attach("logout retry walkthrough", {
+        path: artifact.path,
+        contentType: artifact.contentType,
+      });
+    }
+  });
+}

--- a/packages/app/test/ui-smoke/hosted-logout-retry.spec.ts
+++ b/packages/app/test/ui-smoke/hosted-logout-retry.spec.ts
@@ -95,6 +95,10 @@ for (const viewport of [
       ),
     ).toBeNull();
     expect(requests).toBe(2);
+    await expect(
+      page.getByRole("heading", { name: "Sign in", exact: true }),
+    ).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
     await page.screenshot({
       path: testInfo.outputPath(`${viewport.name}-logout-complete.jpg`),
       fullPage: true,

--- a/packages/cloud/api/__tests__/auth-audit-ip-attribution.test.ts
+++ b/packages/cloud/api/__tests__/auth-audit-ip-attribution.test.ts
@@ -76,6 +76,8 @@ const LOGOUT_USER = {
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   ...realAuth,
+  getCurrentUserForStewardToken: async (_context: unknown, token: string) =>
+    token === "logout-token" ? LOGOUT_USER : null,
   getCurrentUser: async (c: {
     req: { header: (n: string) => string | undefined };
   }) =>

--- a/packages/cloud/api/__tests__/sso-bridge.test.ts
+++ b/packages/cloud/api/__tests__/sso-bridge.test.ts
@@ -543,6 +543,69 @@ describe("cache independence — the guarantees may not depend on atomic cache o
 });
 
 describe("logout stays logged out (cross-host)", () => {
+  test("logout retries survive a real marker-store outage and then block the paired host", async () => {
+    const { sql } = await import("drizzle-orm");
+    const { dbWrite } = await import("@/db/client");
+    const { default: logout } = await import("../auth/logout/route");
+    const userId = "logout-retry-cookie-user";
+    const cookieToken = await mintToken(userId, { iatOffsetSec: -10 });
+    const staleBearer = await mintToken(userId, { iatOffsetSec: -7200 });
+    const pair = await makeVerifierPair();
+    const pendingCode = await mintCode(cookieToken, pair.challenge);
+    let cookie = `steward-token-test=${cookieToken}`;
+    const requestLogout = () =>
+      logout.request(
+        "/",
+        {
+          method: "POST",
+          headers: {
+            host: "api.eliza.app",
+            origin: "https://eliza.app",
+            authorization: `Bearer ${staleBearer}`,
+            cookie,
+          },
+        },
+        ENV,
+      );
+
+    // Removing the real table makes both persistence attempts fail without a
+    // mock replacing the route, credential verifier, service or database client.
+    await dbWrite.execute(
+      sql`ALTER TABLE sso_bridge_logout_markers RENAME TO sso_bridge_logout_markers_unavailable`,
+    );
+    try {
+      const failed = await requestLogout();
+      expect(failed.status).toBe(503);
+      if (
+        failed.headers
+          .getSetCookie()
+          .some(
+            (value) =>
+              value.startsWith("steward-token-test=") &&
+              /Max-Age=0/i.test(value),
+          )
+      )
+        cookie = "";
+    } finally {
+      await dbWrite.execute(
+        sql`ALTER TABLE sso_bridge_logout_markers_unavailable RENAME TO sso_bridge_logout_markers`,
+      );
+    }
+    const retried = await requestLogout();
+    expect(retried.status).toBe(200);
+    expect(
+      retried.headers
+        .getSetCookie()
+        .some(
+          (value) =>
+            value.startsWith("steward-token-test=") && /Max-Age=0/i.test(value),
+        ),
+    ).toBe(true);
+    const bridged = await exchange(pendingCode, pair.verifier);
+    expect(bridged.status).toBe(401);
+    expect(await bridged.json()).toMatchObject({ code: "session_ended" });
+  });
+
   test("after an explicit logout, pre-logout tokens can neither mint nor exchange; a fresh login bridges again", async () => {
     const userId = "user-logout";
     const preLogoutToken = await mintToken(userId, { iatOffsetSec: -10 });

--- a/packages/cloud/api/__tests__/sso-bridge.test.ts
+++ b/packages/cloud/api/__tests__/sso-bridge.test.ts
@@ -543,6 +543,40 @@ describe("cache independence — the guarantees may not depend on atomic cache o
 });
 
 describe("logout stays logged out (cross-host)", () => {
+  test("expired credentials finish logout while an unavailable verifier preserves retry authority", async () => {
+    const { default: logout } = await import("../auth/logout/route");
+    const token = await mintToken("expired-logout-user", {
+      iatOffsetSec: -7200,
+    });
+    const request = (env: typeof ENV) =>
+      logout.request(
+        "/",
+        {
+          method: "POST",
+          headers: {
+            host: "api.eliza.app",
+            origin: "https://eliza.app",
+            authorization: `Bearer ${token}`,
+            cookie: `steward-token-test=${token}`,
+          },
+        },
+        env,
+      );
+    const unavailable = await request({ ...ENV, STEWARD_SESSION_SECRET: "" });
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.headers.getSetCookie()).toEqual([]);
+    const completed = await request(ENV);
+    expect(completed.status).toBe(200);
+    expect(
+      completed.headers
+        .getSetCookie()
+        .some(
+          (value) =>
+            value.startsWith("steward-token-test=") && /Max-Age=0/i.test(value),
+        ),
+    ).toBe(true);
+  });
+
   test("logout retries survive a real marker-store outage and then block the paired host", async () => {
     const { sql } = await import("drizzle-orm");
     const { dbWrite } = await import("@/db/client");

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -11,10 +11,12 @@ const getCurrentUserMock = mock(
 );
 const readStewardSessionTokenMock = mock((): string | null => null);
 const endAllUserSessionsMock = mock(async () => undefined);
-const verifyStewardTokenMock = mock(async () => ({
-  userId: "steward-1",
-  issuedAt: 100,
-}));
+const verifyStewardTokenMock = mock(
+  async (): Promise<{ userId: string; issuedAt: number } | null> => ({
+    userId: "steward-1",
+    issuedAt: 100,
+  }),
+);
 const revokeInferenceSessionsThroughMock = mock(async () => undefined);
 const markSsoBridgeLogoutMock = mock(async () => undefined);
 
@@ -23,7 +25,7 @@ mock.module("@/lib/auth", () => ({
 }));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  getCurrentUser: getCurrentUserMock,
+  getCurrentUserForStewardToken: getCurrentUserMock,
   readStewardSessionToken: readStewardSessionTokenMock,
 }));
 mock.module("@/lib/auth/steward-client", () => ({
@@ -76,12 +78,14 @@ function deletedCookieNames(res: Response): string[] {
 beforeEach(() => {
   getCurrentUserMock.mockResolvedValue(null);
   readStewardSessionTokenMock.mockReturnValue(null);
+  verifyStewardTokenMock.mockClear();
   verifyStewardTokenMock.mockResolvedValue({
     userId: "steward-1",
     issuedAt: 100,
   });
   revokeInferenceSessionsThroughMock.mockResolvedValue(undefined);
   markSsoBridgeLogoutMock.mockClear();
+  markSsoBridgeLogoutMock.mockResolvedValue(undefined);
 });
 
 describe("POST /api/auth/logout cookie clearing", () => {
@@ -107,6 +111,109 @@ describe("POST /api/auth/logout cookie clearing", () => {
       "header.payload.signature",
     );
     expect(markSsoBridgeLogoutMock).toHaveBeenCalledWith("steward-1");
+  });
+
+  test("refuses logout success when the cross-host marker cannot be persisted", async () => {
+    readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
+    markSsoBridgeLogoutMock.mockRejectedValue(
+      new Error("logout marker store unavailable"),
+    );
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer header.payload.signature",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(503);
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledTimes(2);
+    expect((await res.json()) as unknown).toEqual({
+      error: "Logout revocation is temporarily unavailable",
+      code: "logout_revocation_unavailable",
+    });
+  });
+
+  test("refuses logout success when the presented token cannot be verified", async () => {
+    readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
+    verifyStewardTokenMock.mockResolvedValue(null);
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer header.payload.signature",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(503);
+    expect(markSsoBridgeLogoutMock).not.toHaveBeenCalled();
+    expect((await res.json()) as unknown).toEqual({
+      error: "Logout revocation is temporarily unavailable",
+      code: "logout_revocation_unavailable",
+    });
+  });
+
+  test("falls back to the scoped cookie when a local bearer is stale", async () => {
+    readStewardSessionTokenMock.mockReturnValue("stale.bearer.signature");
+    getCurrentUserMock.mockResolvedValue({
+      id: "cookie-user",
+      organization_id: "cookie-org",
+    });
+    verifyStewardTokenMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ userId: "cookie-user", issuedAt: 200 });
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer stale.bearer.signature",
+          cookie: "steward-token-staging=valid.cookie.signature",
+        },
+      },
+      {
+        ENVIRONMENT: "staging",
+        NODE_ENV: "production",
+        INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(verifyStewardTokenMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      "stale.bearer.signature",
+    );
+    expect(verifyStewardTokenMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      "valid.cookie.signature",
+    );
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledWith("cookie-user");
+    expect(getCurrentUserMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "valid.cookie.signature",
+    );
+    expect(revokeInferenceSessionsThroughMock).toHaveBeenCalledWith(
+      "cookie-org",
+      "cookie-user",
+      200,
+    );
   });
 
   test("strong rollout commits the session cutoff before reporting logout success", async () => {

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -112,6 +112,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
     expect(verifyStewardTokenMock).toHaveBeenCalledWith(
       expect.anything(),
       "header.payload.signature",
+      { throwOnUnavailable: true },
     );
     expect(markSsoBridgeLogoutMock).toHaveBeenCalledWith("steward-1");
   });
@@ -143,7 +144,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
     });
   });
 
-  test("refuses logout success when the presented token cannot be verified", async () => {
+  test("completes local logout when the presented credential is rejected", async () => {
     readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
     verifyStewardTokenMock.mockResolvedValue(null);
 
@@ -160,11 +161,11 @@ describe("POST /api/auth/logout cookie clearing", () => {
       { ENVIRONMENT: "staging", NODE_ENV: "production" },
     );
 
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(200);
     expect(markSsoBridgeLogoutMock).not.toHaveBeenCalled();
     expect((await res.json()) as unknown).toEqual({
-      error: "Logout revocation is temporarily unavailable",
-      code: "logout_revocation_unavailable",
+      success: true,
+      message: "Logged out successfully",
     });
   });
 
@@ -201,11 +202,13 @@ describe("POST /api/auth/logout cookie clearing", () => {
       1,
       expect.anything(),
       "stale.bearer.signature",
+      { throwOnUnavailable: true },
     );
     expect(verifyStewardTokenMock).toHaveBeenNthCalledWith(
       2,
       expect.anything(),
       "valid.cookie.signature",
+      { throwOnUnavailable: true },
     );
     expect(markSsoBridgeLogoutMock).toHaveBeenCalledWith("cookie-user");
     expect(getCurrentUserMock).toHaveBeenCalledWith(

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -12,7 +12,10 @@ const getCurrentUserMock = mock(
 const readStewardSessionTokenMock = mock((): string | null => null);
 const endAllUserSessionsMock = mock(async () => undefined);
 const verifyStewardTokenMock = mock(
-  async (): Promise<{ userId: string; issuedAt: number } | null> => ({
+  async (
+    _env: unknown,
+    _token: string,
+  ): Promise<{ userId: string; issuedAt: number } | null> => ({
     userId: "steward-1",
     issuedAt: 100,
   }),
@@ -216,6 +219,57 @@ describe("POST /api/auth/logout cookie clearing", () => {
     );
   });
 
+  for (const boundary of ["bridge", "inference"] as const) {
+    test(`retains the cookie needed to retry an unconfirmed ${boundary} logout`, async () => {
+      readStewardSessionTokenMock.mockReturnValue("stale.bearer.signature");
+      verifyStewardTokenMock.mockImplementation(async (_env, token) =>
+        token === "valid.cookie.signature"
+          ? { userId: "cookie-user", issuedAt: 200 }
+          : null,
+      );
+      getCurrentUserMock.mockResolvedValue({
+        id: "cookie-user",
+        organization_id: "cookie-org",
+      });
+      if (boundary === "bridge") {
+        markSsoBridgeLogoutMock
+          .mockRejectedValueOnce(new Error("store unavailable"))
+          .mockRejectedValueOnce(new Error("store unavailable"));
+      } else {
+        revokeInferenceSessionsThroughMock.mockRejectedValueOnce(
+          new Error("store unavailable"),
+        );
+      }
+      let cookie = "steward-token-staging=valid.cookie.signature";
+      const request = () =>
+        app.request(
+          "/",
+          {
+            method: "POST",
+            headers: {
+              host: "api-staging.elizacloud.ai",
+              origin: "https://cloud-staging.eliza.app",
+              authorization: "Bearer stale.bearer.signature",
+              cookie,
+            },
+          },
+          {
+            ENVIRONMENT: "staging",
+            NODE_ENV: "production",
+            INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+          },
+        );
+      const failed = await request();
+      expect(failed.status).toBe(503);
+      // Apply the route's cookie deletion exactly as a browser would before retrying.
+      if (deletedCookieNames(failed).includes("steward-token-staging"))
+        cookie = "";
+      const retried = await request();
+      expect(retried.status).toBe(200);
+      expect(deletedCookieNames(retried)).toContain("steward-token-staging");
+    });
+  }
+
   test("strong rollout commits the session cutoff before reporting logout success", async () => {
     readStewardSessionTokenMock.mockReturnValue("prod-token");
     getCurrentUserMock.mockResolvedValue({
@@ -250,7 +304,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
     );
   });
 
-  test("strong rollout clears cookies but returns 503 when the cutoff is unconfirmed", async () => {
+  test("strong rollout preserves retry credentials when the cutoff is unconfirmed", async () => {
     readStewardSessionTokenMock.mockReturnValue("prod-token");
     getCurrentUserMock.mockResolvedValue({
       id: "user-1",
@@ -278,7 +332,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
     );
 
     expect(res.status).toBe(503);
-    expect(deletedCookieNames(res)).toContain("steward-token");
+    expect(deletedCookieNames(res)).not.toContain("steward-token");
     expect((await res.json()) as unknown).toEqual({
       error: "Logout revocation is temporarily unavailable",
       code: "logout_revocation_unavailable",

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -11,9 +11,12 @@ import { invalidateSessionCaches } from "@/lib/auth";
 import { checkElizaMutatingRequestOrigin } from "@/lib/auth/browser-origin-policy";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import { verifyStewardTokenCached } from "@/lib/auth/steward-client";
-import { stewardCookieNames } from "@/lib/auth/steward-cookies";
 import {
-  getCurrentUser,
+  readStewardAccessCookieFromHeader,
+  stewardCookieNames,
+} from "@/lib/auth/steward-cookies";
+import {
+  getCurrentUserForStewardToken,
   readStewardSessionToken,
 } from "@/lib/auth/workers-hono-auth";
 import {
@@ -55,6 +58,14 @@ app.post("/", async (c) => {
   // through the same JWT-only selection used by getCurrentUser; API-key
   // bearers are deliberately excluded from browser-session teardown.
   const stewardToken = readStewardSessionToken(c);
+  const cookieToken =
+    readStewardAccessCookieFromHeader(
+      c.req.header("cookie") ?? null,
+      c.env.ENVIRONMENT,
+    ) ?? null;
+  let verifiedStewardToken: string | null = null;
+  let verifiedClaims: Awaited<ReturnType<typeof verifyStewardTokenCached>> =
+    null;
 
   // Clear cookies FIRST. Clearing them is what actually logs the user out, and
   // it must happen even if the server-side teardown below fails (a transient DB
@@ -75,32 +86,6 @@ app.post("/", async (c) => {
   deleteCookie(c, cookieNames.authed, stewardOpts);
   deleteCookie(c, "eliza-anon-session", { path: "/" });
 
-  let strongRevocationFailed = false;
-  if (stewardToken && isInferenceStrongRevocationEnabled(c.env)) {
-    try {
-      const [claims, user] = await Promise.all([
-        verifyStewardTokenCached(c.env, stewardToken),
-        getCurrentUser(c),
-      ]);
-      if (!claims || !user?.organization_id) {
-        throw new Error("logout credential identity could not be resolved");
-      }
-      await revokeInferenceSessionsThrough(
-        user.organization_id,
-        user.id,
-        claims.issuedAt,
-      );
-    } catch (error) {
-      // error-policy:J1 cookies are already cleared, but the server must not
-      // claim a globally complete logout until the strong inference boundary
-      // confirms that the presented session generation is denied.
-      logger.error("[Logout] Strong inference-session revocation failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      strongRevocationFailed = true;
-    }
-  }
-
   // Stamp the cross-host SSO logout marker FIRST and in its own guarded block:
   // the sso-bridge legs and the cookie-planting session-sync endpoint refuse
   // tokens issued before this moment, so an explicit logout cannot be silently
@@ -110,45 +95,83 @@ app.post("/", async (c) => {
   // the bridge itself — but a TRANSIENT stamp failure would leave a bridgeable
   // window once the store recovers, hence one retry and an error-level log
   // (never a silent downgrade to debug) when the stamp is unconfirmed.
+  let logoutRevocationFailed = false;
   if (stewardToken) {
     try {
-      const claims = await verifyStewardTokenCached(c.env, stewardToken);
-      if (claims) {
-        try {
-          await markSsoBridgeLogout(claims.userId);
-        } catch {
-          // error-policy:J6 single bounded retry of best-effort teardown; the
-          // definitive failure is handled (loudly) by the outer catch.
-          await markSsoBridgeLogout(claims.userId);
+      const candidates = [stewardToken, cookieToken].filter(
+        (token, index, tokens): token is string =>
+          token !== null && tokens.indexOf(token) === index,
+      );
+      for (const candidate of candidates) {
+        const claims = await verifyStewardTokenCached(c.env, candidate);
+        if (claims) {
+          verifiedStewardToken = candidate;
+          verifiedClaims = claims;
+          break;
         }
-        logger.debug("[Logout] Stamped SSO bridge logout marker");
       }
+      if (!verifiedClaims) {
+        throw new Error("Presented Steward token could not be verified");
+      }
+      try {
+        await markSsoBridgeLogout(verifiedClaims.userId);
+      } catch {
+        // error-policy:J6 single bounded retry of best-effort teardown; the
+        // definitive failure is handled (loudly) by the outer catch.
+        await markSsoBridgeLogout(verifiedClaims.userId);
+      }
+      logger.debug("[Logout] Stamped SSO bridge logout marker");
     } catch (error) {
-      // error-policy:J6 best-effort teardown — cookies are already cleared, so
-      // THIS origin is logged out; but the cross-host logout barrier did not
-      // land, which is a security-relevant condition worth an alert, not a
-      // debug line. The bridge's own store reads fail closed while the store
-      // is down, narrowing the exposure to a post-recovery window bounded by
-      // the access-token TTL.
+      // error-policy:J1 boundary translation — cookies are already cleared,
+      // but without the cross-host barrier a surviving paired-origin session
+      // can immediately restore them. Report a retryable failure instead of
+      // authorizing the client to navigate away as though logout were durable.
       logger.error(
         "[Logout] FAILED to stamp SSO bridge logout marker — cross-host logout barrier not persisted",
         {
           error: error instanceof Error ? error.message : String(error),
         },
       );
+      logoutRevocationFailed = true;
+    }
+  }
+
+  if (
+    verifiedStewardToken &&
+    verifiedClaims &&
+    isInferenceStrongRevocationEnabled(c.env)
+  ) {
+    try {
+      const user = await getCurrentUserForStewardToken(c, verifiedStewardToken);
+      if (!user?.organization_id) {
+        throw new Error("logout credential identity could not be resolved");
+      }
+      await revokeInferenceSessionsThrough(
+        user.organization_id,
+        user.id,
+        verifiedClaims.issuedAt,
+      );
+    } catch (error) {
+      // error-policy:J1 cookies are already cleared, but the server must not
+      // claim a globally complete logout until the strong inference boundary
+      // confirms that the presented session generation is denied.
+      logger.error("[Logout] Strong inference-session revocation failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      logoutRevocationFailed = true;
     }
   }
 
   try {
     // Only tear down caches/sessions when the request presented a Steward JWT
     // through this environment's scoped cookie or Authorization header.
-    if (stewardToken) {
-      await invalidateSessionCaches(stewardToken);
+    if (verifiedStewardToken) {
+      await invalidateSessionCaches(verifiedStewardToken);
       logger.debug("[Logout] Invalidated session caches for token");
     }
 
-    if (stewardToken) {
-      const user = await getCurrentUser(c);
+    if (verifiedStewardToken && !logoutRevocationFailed) {
+      const user = await getCurrentUserForStewardToken(c, verifiedStewardToken);
       if (user) {
         await userSessionsService.endAllUserSessions(user.id);
         await getAuditDispatcher()
@@ -184,7 +207,7 @@ app.post("/", async (c) => {
     );
   }
 
-  if (strongRevocationFailed) {
+  if (logoutRevocationFailed) {
     return c.json(
       {
         error: "Logout revocation is temporarily unavailable",

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -4,7 +4,6 @@
  * Also invalidates Redis caches to ensure immediate token invalidation.
  */
 
-import { ElizaError } from "@elizaos/core";
 import { Hono } from "hono";
 import { deleteCookie } from "hono/cookie";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
@@ -85,26 +84,27 @@ app.post("/", async (c) => {
           token !== null && tokens.indexOf(token) === index,
       );
       for (const candidate of candidates) {
-        const claims = await verifyStewardTokenCached(c.env, candidate);
+        const claims = await verifyStewardTokenCached(c.env, candidate, {
+          throwOnUnavailable: true,
+        });
         if (claims) {
           verifiedStewardToken = candidate;
           verifiedClaims = claims;
           break;
         }
       }
-      if (!verifiedClaims) {
-        throw new ElizaError("Presented Steward token could not be verified", {
-          code: "LOGOUT_CREDENTIAL_UNVERIFIED",
-        });
+      // Rejected credentials have no authenticated identity to revoke. Allow
+      // cookie/local cleanup; only verification infrastructure failures retry.
+      if (verifiedClaims) {
+        try {
+          await markSsoBridgeLogout(verifiedClaims.userId);
+        } catch {
+          // error-policy:J6 one bounded teardown retry; the outer boundary
+          // preserves credentials if persistence remains unavailable.
+          await markSsoBridgeLogout(verifiedClaims.userId);
+        }
+        logger.debug("[Logout] Stamped SSO bridge logout marker");
       }
-      try {
-        await markSsoBridgeLogout(verifiedClaims.userId);
-      } catch {
-        // error-policy:J6 single bounded retry of best-effort teardown; the
-        // definitive failure is handled (loudly) by the outer catch.
-        await markSsoBridgeLogout(verifiedClaims.userId);
-      }
-      logger.debug("[Logout] Stamped SSO bridge logout marker");
     } catch (error) {
       // error-policy:J1 preserve retry credentials and return a failure until
       // the cross-host barrier has been durably confirmed.

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -4,6 +4,7 @@
  * Also invalidates Redis caches to ensure immediate token invalidation.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { Hono } from "hono";
 import { deleteCookie } from "hono/cookie";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
@@ -67,25 +68,6 @@ app.post("/", async (c) => {
   let verifiedClaims: Awaited<ReturnType<typeof verifyStewardTokenCached>> =
     null;
 
-  // Clear cookies FIRST. Clearing them is what actually logs the user out, and
-  // it must happen even if the server-side teardown below fails (a transient DB
-  // error during logout must not leave the session cookies in place — that was
-  // the prior behavior, which left users "still logged in" after a failed
-  // logout). The session-record teardown + cache invalidation are best-effort
-  // hygiene (caches expire on their own TTL).
-  const domain = cookieDomainForHost(c.req.header("host"));
-  const stewardOpts = domain ? { path: "/", domain } : { path: "/" };
-  // Non-production clears only its suffixed pair. The unsuffixed legacy names
-  // are production's live cookies on the shared parent domain; deleting them
-  // from staging/dev signs the user out of production.
-  // In production the scoped names already ARE the historical unsuffixed names,
-  // so a single set of deleteCookie calls covers both eras. The separate legacy
-  // clear block was redundant (#14130).
-  deleteCookie(c, cookieNames.token, stewardOpts);
-  deleteCookie(c, cookieNames.refreshToken, stewardOpts);
-  deleteCookie(c, cookieNames.authed, stewardOpts);
-  deleteCookie(c, "eliza-anon-session", { path: "/" });
-
   // Stamp the cross-host SSO logout marker FIRST and in its own guarded block:
   // the sso-bridge legs and the cookie-planting session-sync endpoint refuse
   // tokens issued before this moment, so an explicit logout cannot be silently
@@ -111,7 +93,9 @@ app.post("/", async (c) => {
         }
       }
       if (!verifiedClaims) {
-        throw new Error("Presented Steward token could not be verified");
+        throw new ElizaError("Presented Steward token could not be verified", {
+          code: "LOGOUT_CREDENTIAL_UNVERIFIED",
+        });
       }
       try {
         await markSsoBridgeLogout(verifiedClaims.userId);
@@ -122,10 +106,8 @@ app.post("/", async (c) => {
       }
       logger.debug("[Logout] Stamped SSO bridge logout marker");
     } catch (error) {
-      // error-policy:J1 boundary translation — cookies are already cleared,
-      // but without the cross-host barrier a surviving paired-origin session
-      // can immediately restore them. Report a retryable failure instead of
-      // authorizing the client to navigate away as though logout were durable.
+      // error-policy:J1 preserve retry credentials and return a failure until
+      // the cross-host barrier has been durably confirmed.
       logger.error(
         "[Logout] FAILED to stamp SSO bridge logout marker — cross-host logout barrier not persisted",
         {
@@ -152,15 +134,39 @@ app.post("/", async (c) => {
         verifiedClaims.issuedAt,
       );
     } catch (error) {
-      // error-policy:J1 cookies are already cleared, but the server must not
-      // claim a globally complete logout until the strong inference boundary
-      // confirms that the presented session generation is denied.
+      // error-policy:J1 preserve retry credentials until the strong inference
+      // boundary confirms that the presented session generation is denied.
       logger.error("[Logout] Strong inference-session revocation failed", {
         error: error instanceof Error ? error.message : String(error),
       });
       logoutRevocationFailed = true;
     }
   }
+
+  if (logoutRevocationFailed) {
+    return c.json(
+      {
+        error: "Logout revocation is temporarily unavailable",
+        code: "logout_revocation_unavailable" as const,
+      },
+      503,
+    );
+  }
+
+  // Clear browser credentials only after durable revocation is confirmed.
+  // A failed attempt must preserve the cookie needed to authenticate its retry.
+  const domain = cookieDomainForHost(c.req.header("host"));
+  const stewardOpts = domain ? { path: "/", domain } : { path: "/" };
+  // Non-production clears only its suffixed pair. The unsuffixed legacy names
+  // are production's live cookies on the shared parent domain; deleting them
+  // from staging/dev signs the user out of production.
+  // In production the scoped names already ARE the historical unsuffixed names,
+  // so a single set of deleteCookie calls covers both eras. The separate legacy
+  // clear block was redundant (#14130).
+  deleteCookie(c, cookieNames.token, stewardOpts);
+  deleteCookie(c, cookieNames.refreshToken, stewardOpts);
+  deleteCookie(c, cookieNames.authed, stewardOpts);
+  deleteCookie(c, "eliza-anon-session", { path: "/" });
 
   try {
     // Only tear down caches/sessions when the request presented a Steward JWT
@@ -204,16 +210,6 @@ app.post("/", async (c) => {
       {
         error: error instanceof Error ? error.message : String(error),
       },
-    );
-  }
-
-  if (logoutRevocationFailed) {
-    return c.json(
-      {
-        error: "Logout revocation is temporarily unavailable",
-        code: "logout_revocation_unavailable" as const,
-      },
-      503,
     );
   }
 

--- a/packages/cloud/shared/src/lib/auth/steward-client.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.test.ts
@@ -16,6 +16,7 @@ const ENV = { STEWARD_JWT_SECRET: SECRET };
 const memoryCache = new Map<string, unknown>();
 let distributedCacheValue: unknown = null;
 let tokenSequence = 0;
+let cacheReadFailure: Error | null = null;
 
 mock.module("../../db/helpers", () => ({
   dbRead: {},
@@ -27,7 +28,10 @@ mock.module("../../db/helpers", () => ({
 
 mock.module("../cache/client", () => ({
   cache: {
-    get: async () => distributedCacheValue,
+    get: async () => {
+      if (cacheReadFailure) throw cacheReadFailure;
+      return distributedCacheValue;
+    },
     set: async () => undefined,
     del: async () => undefined,
   },
@@ -45,6 +49,7 @@ mock.module("../cache/in-memory-lru-cache", () => ({
       memoryCache.delete(key);
     }
     clear() {
+      cacheReadFailure = null;
       memoryCache.clear();
     }
   },
@@ -80,13 +85,33 @@ async function verify(token: string) {
 
 describe("verifyStewardTokenCached — token lifecycle claims", () => {
   beforeEach(() => {
+    cacheReadFailure = null;
     memoryCache.clear();
     distributedCacheValue = null;
   });
 
   afterEach(() => {
+    cacheReadFailure = null;
     memoryCache.clear();
     distributedCacheValue = null;
+  });
+
+  test("strict logout verification distinguishes an unavailable cache from a rejected JWT", async () => {
+    const token = await mint({ exp: Math.floor(Date.now() / 1000) + 600 });
+    cacheReadFailure = new Error("verification cache unavailable");
+    await expect(
+      verifyStewardTokenCached(ENV, token, { throwOnUnavailable: true }),
+    ).rejects.toMatchObject({ code: "STEWARD_VERIFICATION_UNAVAILABLE", cause: cacheReadFailure });
+    expect(await verify(token)).toBeNull();
+    cacheReadFailure = null;
+    expect(await verifyStewardTokenCached(ENV, token, { throwOnUnavailable: true })).toMatchObject({
+      userId: "steward-user-1",
+    });
+    const expired = await mint({
+      iat: Math.floor(Date.now() / 1000) - 7200,
+      exp: Math.floor(Date.now() / 1000) - 3600,
+    });
+    expect(await verifyStewardTokenCached(ENV, expired, { throwOnUnavailable: true })).toBeNull();
   });
 
   test("accepts a token minted at the standard Steward access-token TTL", async () => {

--- a/packages/cloud/shared/src/lib/auth/steward-client.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.ts
@@ -16,6 +16,7 @@
  * - Falls back gracefully on missing secret (logs warning, returns null)
  */
 
+import { ElizaError } from "@elizaos/core";
 import { createHash } from "crypto";
 import { decodeProtectedHeader, type JWTPayload, jwtVerify, SignJWT } from "jose";
 import { cache } from "../cache/client";
@@ -133,6 +134,8 @@ export interface StewardVerifyEnv extends StagingSessionBindingEnv {
 }
 
 export interface StewardVerifyOptions {
+  /** Distinguish unavailable verification from rejected credentials for logout. */
+  throwOnUnavailable?: boolean;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   /**
    * Skip the distributed verification memo after the in-isolate check. Local
@@ -542,7 +545,14 @@ export async function verifyStewardTokenCached(
   const secret = stagingHeader.isCandidate
     ? resolveStagingTokenSecret(env, stagingHeader.keyId)
     : resolveJwtSecret(env);
-  if (!secret) return null;
+  if (!secret) {
+    if (options.throwOnUnavailable) {
+      throw new ElizaError("Session verification key is unavailable", {
+        code: "STEWARD_VERIFICATION_UNAVAILABLE",
+      });
+    }
+    return null;
+  }
 
   const tokenHash = hashToken(token);
   const signingKeyFingerprint = fingerprintSigningKey(secret);
@@ -701,6 +711,8 @@ export async function verifyStewardTokenCached(
 
     return claims;
   } catch (error) {
+    // error-policy:J3 invalid credentials return null; strict callers receive
+    // infrastructure failures separately so they cannot report false logout success.
     const isExpectedFailure =
       error instanceof Error &&
       (error.message.includes("JWSInvalid") ||
@@ -722,6 +734,12 @@ export async function verifyStewardTokenCached(
       return null;
     }
 
+    if (options.throwOnUnavailable) {
+      throw new ElizaError("Session verification is temporarily unavailable", {
+        code: "STEWARD_VERIFICATION_UNAVAILABLE",
+        cause: error,
+      });
+    }
     logger.error(
       "[StewardClient] ✗ Unexpected verification error:",
       error instanceof Error ? error.message : "Unknown error",

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -248,6 +248,14 @@ export async function getCurrentUser(c: AppContext): Promise<AuthedUser | null> 
     return null;
   }
 
+  return getCurrentUserForStewardToken(c, token);
+}
+
+/** Resolves a user from an already-selected Steward session credential. */
+export async function getCurrentUserForStewardToken(
+  c: AppContext,
+  token: string,
+): Promise<AuthedUser | null> {
   const claims = await verifyStewardTokenCached(c.env, token);
   if (!claims) {
     c.set("user", null);

--- a/packages/ui/src/cloud/shell/CloudAccountMenu.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudAccountMenu.test.tsx
@@ -13,14 +13,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudI18nProvider } from "./CloudI18nProvider";
 
 const signOutSession = vi.hoisted(() => vi.fn());
-const toastError = vi.hoisted(() => vi.fn());
 
 vi.mock("../sso-bridge/sso-bridge", () => ({
   signOutFromSsoBridgedHost: signOutSession,
-}));
-
-vi.mock("sonner", () => ({
-  toast: { error: toastError },
 }));
 
 import { CloudAccountMenu } from "./CloudAccountMenu";
@@ -40,7 +35,6 @@ describe("CloudAccountMenu", () => {
   beforeEach(() => {
     signOutSession.mockReset();
     signOutSession.mockResolvedValue(undefined);
-    toastError.mockReset();
   });
 
   afterEach(() => {
@@ -114,13 +108,14 @@ describe("CloudAccountMenu", () => {
     openMenu();
     fireEvent.click(await screen.findByRole("menuitem", { name: "Sign out" }));
 
-    await waitFor(() =>
-      expect(toastError).toHaveBeenCalledWith(
-        "Could not sign out safely. Please try again.",
-      ),
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "Could not sign out safely. Please try again.",
     );
     expect(screen.getByText("Cloud page")).toBeTruthy();
     expect(screen.queryByText("Login page")).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
+    await screen.findByText("Login page");
+    expect(signOutSession).toHaveBeenCalledTimes(2);
   });
 
   it("lets an isolated preview own its local-only teardown", async () => {

--- a/packages/ui/src/cloud/shell/CloudAccountMenu.tsx
+++ b/packages/ui/src/cloud/shell/CloudAccountMenu.tsx
@@ -5,8 +5,8 @@
  */
 
 import { ChevronDown, LogOut, UserRound } from "lucide-react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -29,33 +29,46 @@ export function CloudAccountMenu({
 }: CloudAccountMenuProps): React.JSX.Element {
   const navigate = useNavigate();
   const t = useCloudT();
+  const [open, setOpen] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+  const signOutPending = useRef(false);
   const accountLabel = t("cloud.nav.account", { defaultValue: "Account" });
 
   const signOut = async () => {
-    if (onSignOut) {
-      await onSignOut();
-      return;
-    }
+    if (signOutPending.current) return;
+    signOutPending.current = true;
+    setSigningOut(true);
+    setSignOutError(null);
     try {
+      if (onSignOut) {
+        await onSignOut();
+        return;
+      }
       const { signOutFromSsoBridgedHost } = await import(
         "../sso-bridge/sso-bridge"
       );
       await signOutFromSsoBridgedHost();
       navigate("/login", { replace: true });
     } catch {
-      // error-policy:J4 a failed canonical teardown stays on the authenticated
-      // surface and gives the user a retry instead of claiming sign-out.
-      toast.error(
+      // error-policy:J4 keep the authenticated route and a visible menu retry when teardown fails.
+      setSignOutError(
         t("cloud.userMenu.signOutFailed", {
           defaultValue: "Could not sign out safely. Please try again.",
         }),
       );
+      setOpen(true);
+    } finally {
+      signOutPending.current = false;
+      setSigningOut(false);
     }
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
+        disabled={signingOut}
+        aria-busy={signingOut || undefined}
         aria-label={email ? `Account menu for ${email}` : "Account menu"}
         className="keyboard-focus-surface flex min-h-11 min-w-11 items-center justify-center gap-1.5 rounded-md px-2 text-sm text-txt transition-colors hover:bg-bg-hover"
       >
@@ -69,6 +82,14 @@ export function CloudAccountMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-44">
+        {signOutError && (
+          <p
+            role="alert"
+            className="max-w-64 px-2 py-2 text-sm text-destructive"
+          >
+            {signOutError}
+          </p>
+        )}
         <DropdownMenuItem onSelect={() => navigate("/cloud/account")}>
           {accountLabel}
         </DropdownMenuItem>
@@ -78,6 +99,7 @@ export function CloudAccountMenu({
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="text-destructive"
+          disabled={signingOut}
           onSelect={() => void signOut()}
         >
           <LogOut className="mr-2 size-3.5" aria-hidden />

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -531,6 +531,32 @@ describe("burnSsoBridgeCode", () => {
 });
 
 describe("signOutFromSsoBridgedHost", () => {
+  it("retains local authority until hosted logout is confirmed", async () => {
+    const token = liveToken();
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
+    let resolveLogout: ((response: Response) => void) | undefined;
+    const pendingLogout = new Promise<Response>((resolve) => {
+      resolveLogout = resolve;
+    });
+    const fn = (() => pendingLogout) as typeof fetch;
+
+    const signOut = signOutFromSsoBridgedHost("cloud.eliza.app", fn);
+    await Promise.resolve();
+
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(token);
+    let settled = false;
+    void signOut.finally(() => {
+      settled = true;
+    });
+    expect(settled).toBe(false);
+
+    resolveLogout?.(json(200, { success: true }));
+    await signOut;
+
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(settled).toBe(true);
+  });
+
   it("marks logged-out synchronously, ends the server session, scrubs locally", async () => {
     const token = liveToken();
     localStorage.setItem(STEWARD_TOKEN_KEY, token);
@@ -576,6 +602,8 @@ describe("signOutFromSsoBridgedHost", () => {
   });
 
   it("rejects when the hosted session cannot be ended", async () => {
+    const token = liveToken();
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
     const realFetch = globalThis.fetch;
     globalThis.fetch = (() =>
       Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
@@ -586,12 +614,15 @@ describe("signOutFromSsoBridgedHost", () => {
       await expect(
         signOutFromSsoBridgedHost("cloud.eliza.app", fn),
       ).rejects.toThrow("could not end the browser session (403)");
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(token);
     } finally {
       globalThis.fetch = realFetch;
     }
   });
 
   it("rejects when the hosted logout request cannot reach the server", async () => {
+    const token = liveToken();
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
     const realFetch = globalThis.fetch;
     globalThis.fetch = (() =>
       Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
@@ -601,7 +632,7 @@ describe("signOutFromSsoBridgedHost", () => {
       await expect(
         signOutFromSsoBridgedHost("cloud.eliza.app", fn),
       ).rejects.toBe(networkFailure);
-      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(token);
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -651,12 +651,11 @@ export function burnSsoBridgeCode(
  * marker, and the paired origin's surviving session would silently undo it
  * (re-planting the domain cookies via its background session sync). Order
  * matters: the local logged-out marker lands synchronously first (auto-bridge
- * is suppressed even if the network never answers), the server logout request
- * is ISSUED while the session cookies are still in the jar (it ends the
- * server-side sessions AND stamps the server logout marker that blocks
- * minting, exchanging, and cookie re-planting for pre-logout tokens), and the
- * local scrub stays synchronous so the login page never renders over a
- * half-signed-out session. On hostnames outside the deployed map (local dev)
+ * is suppressed even if the network never answers), and the server logout
+ * request completes while the local token is still available for a retry. A
+ * successful response confirms the server logout marker before the local
+ * credential scrub can move the app to its login route. On hostnames outside
+ * the deployed map (local dev)
  * the server call is skipped and this degrades to the local scrub, exactly
  * the previous local behavior. A hosted non-success response or transport
  * failure rejects so explicit sign-out cannot claim success over a server
@@ -685,13 +684,13 @@ export async function signOutFromSsoBridgedHost(
     : // error-policy:J6 best-effort server teardown — the local marker is
       // already set and the local scrub below always runs.
       Promise.resolve(undefined);
-  await clearStaleStewardSession();
   const response = await serverLogout;
   if (response && !response.ok) {
     throw new Error(
       `Eliza Cloud could not end the browser session (${response.status}).`,
     );
   }
+  await clearStaleStewardSession();
 }
 
 /**

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -45,6 +45,7 @@
  * next sync), and the explicit app-origin logout marker prevents a bounce.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud";
 import {
   readStoredStewardToken,
@@ -686,8 +687,12 @@ export async function signOutFromSsoBridgedHost(
       Promise.resolve(undefined);
   const response = await serverLogout;
   if (response && !response.ok) {
-    throw new Error(
+    throw new ElizaError(
       `Eliza Cloud could not end the browser session (${response.status}).`,
+      {
+        code: "HOSTED_LOGOUT_UNCONFIRMED",
+        context: { status: response.status, hostname },
+      },
     );
   }
   await clearStaleStewardSession();

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -682,9 +682,7 @@ export async function signOutFromSsoBridgedHost(
           ...(stewardToken ? { Authorization: `Bearer ${stewardToken}` } : {}),
         },
       })
-    : // error-policy:J6 best-effort server teardown — the local marker is
-      // already set and the local scrub below always runs.
-      Promise.resolve(undefined);
+    : Promise.resolve(undefined);
   const response = await serverLogout;
   if (response && !response.ok) {
     throw new ElizaError(


### PR DESCRIPTION
Hosted logout now preserves browser and scoped-cookie credentials until durable revocation succeeds. Failed attempts display a retryable error in the account menu; a successful retry clears local authority and reaches sign-in. A stale bearer can fall back to the verified scoped cookie. Expired or rejected credentials can finish local logout, while unavailable verification is kept distinct and still fails closed.

Fixes #29935.

The credential verifier has an additive `throwOnUnavailable` option for logout. Existing callers retain their prior behavior. Both candidate credentials use the same verified identity for revocation and teardown; a failed persistence attempt cannot delete the cookie needed for its retry.

Validation at `7aa65b7a7bd7095740d6fd58b9a9e9f6e1fc33bb`:

- Real HS256/PGlite integration: 22 passed, including storage outage/recovery and expired-credential completion. The new expiry regression fails against the prior route and passes against the repair. Route tests: 13 passed; verifier tests: 22 passed; focused UI tests: 46 passed.
- Full cloud API lane: 593 of 595 files passed in the initial run. Two files collided with root's replacement of the shared build output; both complete files passed afterward (5 tests each).
- Full cloud-shared suite passed: 12,551 passed, 208 skipped. Full UI suite passed: 13,561 tests, 7 skipped.
- Full app suite passed: 948 Bun tests with 2 skips and 1,606 Vitest tests. Full app audit passed 219 cases, with no affected broken/needs-work verdict or hover failure.
- Root `bun run verify` passed all 376 tasks and repository audits after rebase/install. API/shared typechecks and lint also passed.
- Desktop and mobile browser recovery tests passed. Captures exercise the same UI source as the final revision; the last revision only changes the backend verifier/route and their tests. The renderer/router use explicit HTTP fixtures rather than a live account. Backend durability is separately proven by the real-token/database integration.
- All five current-head hosted checks passed.

Live-model and hardware evidence are N/A for this account/HTTP behavior. Browser logs and full-page rest/hover/error/completion screenshots, plus MP4 walkthroughs, follow. The base-revision comparison follows the after captures.

<img width="1740" height="844" alt="rest-desktop-mobile" src="https://github.com/user-attachments/assets/4e4c5de9-7fb0-4aa9-a2f8-1ff9840bd09d" />
<img width="1740" height="844" alt="hover-desktop-mobile" src="https://github.com/user-attachments/assets/fcd8da1f-bf7c-4653-afdd-7ae1147dbfc6" />
<img width="1740" height="844" alt="error-desktop-mobile" src="https://github.com/user-attachments/assets/6c7b47e1-1dc5-4cd2-b852-cbea020cd7b7" />
<img width="1740" height="844" alt="complete-desktop-mobile" src="https://github.com/user-attachments/assets/d99ca070-02fd-44f3-ae04-71b19a461359" />

https://github.com/user-attachments/assets/2c6227fe-e37c-48c4-a24a-4bfce995f9af


https://github.com/user-attachments/assets/205c4223-afc0-42ae-83e7-5ba5ae97ee8a

[desktop-console-network.log](https://github.com/user-attachments/files/31869704/desktop-console-network.log)
[mobile-console-network.log](https://github.com/user-attachments/files/31869705/mobile-console-network.log)


Before comparison, captured and inspected on base revision 1755a9423a226784331a85338e554ec880e82891. Both desktop and mobile runs passed. With the same failed hosted-logout response, the base renderer had already cleared local authority and reached sign-in. The repaired captures above retain the account session, display the failure, and allow a successful retry. The screenshots use the real renderer/router with an explicit HTTP fixture.

<img width="1740" height="844" alt="before-desktop-mobile" src="https://github.com/user-attachments/assets/acf783ec-1f42-4bc7-8a25-35adfe4f28c1" />
