### PR TITLE
fix(plugin-elizacloud): cancel in-flight reconnect loop on ConnectionMonitor.stop()

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
@@ -306,4 +306,119 @@ describe("ConnectionMonitor.stop() cancels in-flight reconnect (#29941)", () => 
 
     monitor.stop();
   });
+
+  it('suppresses provision() when stop() runs synchronously inside onStatusChange("reconnecting")', async () => {
+    // onStatusChange is public and synchronous, exactly like onDisconnect. A
+    // caller may tear the monitor down from inside the "reconnecting" emit.
+    // Without the loop-top token recheck, attemptReconnect() still issues one
+    // provision() request on a stopped monitor.
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const statusChanges: string[] = [];
+    const onReconnect = vi.fn();
+    let monitor!: ConnectionMonitor;
+    const onStatusChange = vi.fn((s: string) => {
+      statusChanges.push(s);
+      if (s === "reconnecting") monitor.stop();
+    });
+    monitor = new ConnectionMonitor(
+      client,
+      "agent-sc-reconnecting",
+      { onDisconnect: vi.fn(), onReconnect, onStatusChange },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    // Failed heartbeat → attemptReconnect → emits "reconnecting" → caller stops.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(monitor.isMonitoring()).toBe(false);
+    expect(statusChanges).toEqual(["reconnecting"]);
+    // A torn-down monitor must issue no provision() request.
+    expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+    expect(onReconnect).not.toHaveBeenCalled();
+  });
+
+  it('suppresses onReconnect() when stop() runs synchronously inside onStatusChange("connected")', async () => {
+    // The success branch emits "connected" then onReconnect(). If the caller
+    // stops from inside the "connected" callback, onReconnect() must not fire
+    // into a torn-down manager.
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const statusChanges: string[] = [];
+    const onReconnect = vi.fn();
+    let monitor!: ConnectionMonitor;
+    const onStatusChange = vi.fn((s: string) => {
+      statusChanges.push(s);
+      if (s === "connected") monitor.stop();
+    });
+    monitor = new ConnectionMonitor(
+      client,
+      "agent-sc-connected",
+      { onDisconnect: vi.fn(), onReconnect, onStatusChange },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    // Failed heartbeat → reconnect → provision() succeeds → emits "connected"
+    // → caller stops before onReconnect() would fire.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(monitor.isMonitoring()).toBe(false);
+    expect(statusChanges).toEqual(["reconnecting", "connected"]);
+    expect(onReconnect).not.toHaveBeenCalled();
+  });
+
+  it('suppresses onReconnectExhausted() when stop() runs synchronously inside onStatusChange("disconnected")', async () => {
+    // The exhaustion branch emits "disconnected" then onReconnectExhausted(). A
+    // caller may stop from inside the "disconnected" callback; the exhaustion
+    // callback must not fire after teardown. maxFailures + a single attempt
+    // budget is not configurable, so drive real exhaustion with a rejecting
+    // provision() and flush all backoff timers.
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockRejectedValue(new Error("provision failed")),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const statusChanges: string[] = [];
+    const onReconnectExhausted = vi.fn();
+    let monitor!: ConnectionMonitor;
+    const onStatusChange = vi.fn((s: string) => {
+      statusChanges.push(s);
+      if (s === "disconnected") monitor.stop();
+    });
+    monitor = new ConnectionMonitor(
+      client,
+      "agent-sc-disconnected",
+      {
+        onDisconnect: vi.fn(),
+        onReconnect: vi.fn(),
+        onStatusChange,
+        onReconnectExhausted,
+      },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    // Flush all 10 attempts and their capped backoff sleeps to reach exhaustion.
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(statusChanges).toContain("disconnected");
+    expect(monitor.isMonitoring()).toBe(false);
+    // stop() ran inside the "disconnected" callback; the exhaustion callback
+    // must not fire after teardown.
+    expect(onReconnectExhausted).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression for #29941: `ConnectionMonitor.stop()` must cancel an in-flight
+ * `attemptReconnect()` loop so no lifecycle callback fires after teardown.
+ *
+ * The monitor runs a detached retry loop that awaits `client.provision()` and
+ * inter-attempt backoff sleeps. Before the fix, `stop()` had no way to signal
+ * that loop: a `provision()` that resolved after `stop()` still emitted
+ * `onStatusChange("connected")` + `onReconnect()`, and an exhausted loop still
+ * emitted `onStatusChange("disconnected")` + `onReconnectExhausted()`. Because
+ * `CloudManager.disconnect()` calls `stop()` and nulls its proxy, those stale
+ * callbacks fire a state-machine transition after teardown. These tests drive
+ * the real `ConnectionMonitor` with a client whose `provision()` is a
+ * test-controlled deferred, so `stop()` can be interleaved with the exact
+ * await points inside the loop. Uses vitest fake timers; the client stub is the
+ * only mock — the monitor under test is real.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectionMonitor } from "../src/cloud/reconnect";
+
+const HEARTBEAT_INTERVAL_MS = 1_000;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("ConnectionMonitor.stop() cancels in-flight reconnect (#29941)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("suppresses onReconnect/onStatusChange when stop() runs during the provision await", async () => {
+    // provision() hangs on a deferred the test controls, so we can call stop()
+    // while the loop is parked inside `await client.provision()`.
+    const provisionGate = deferred<void>();
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockReturnValue(provisionGate.promise),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const onReconnect = vi.fn();
+    const statusChanges: string[] = [];
+    const monitor = new ConnectionMonitor(
+      client,
+      "agent-1",
+      {
+        onDisconnect: vi.fn(),
+        onReconnect,
+        onStatusChange: (s) => statusChanges.push(s),
+      },
+      HEARTBEAT_INTERVAL_MS,
+      1 // maxFailures — a single failed heartbeat enters attemptReconnect
+    );
+
+    monitor.start();
+    // One failed heartbeat → monitor enters attemptReconnect and awaits provision().
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+
+    // The loop is confirmed entered and parked on provision().
+    expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    expect(statusChanges).toEqual(["reconnecting"]);
+
+    // Tear down while the loop is awaiting provision().
+    monitor.stop();
+    expect(monitor.isMonitoring()).toBe(false);
+    const reconnectCallsAtStop = onReconnect.mock.calls.length;
+    const statusesAtStop = [...statusChanges];
+
+    // provision() now resolves *after* stop(). The stale loop must abandon
+    // itself: no "connected" status, no onReconnect().
+    provisionGate.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onReconnect.mock.calls.length).toBe(reconnectCallsAtStop);
+    expect(statusChanges).toEqual(statusesAtStop);
+    expect(statusChanges).not.toContain("connected");
+  });
+
+  it("suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep", async () => {
+    // provision() always rejects, so the loop falls through to the backoff
+    // sleep. We call stop() while that sleep is pending, before exhaustion.
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockRejectedValue(new Error("provision failed")),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const onReconnectExhausted = vi.fn();
+    const statusChanges: string[] = [];
+    const monitor = new ConnectionMonitor(
+      client,
+      "agent-2",
+      {
+        onDisconnect: vi.fn(),
+        onReconnect: vi.fn(),
+        onStatusChange: (s) => statusChanges.push(s),
+        onReconnectExhausted,
+      },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    // Failed heartbeat → reconnect → first provision() rejects → parks on the
+    // 3s backoff sleep before attempt 2.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(statusChanges).toEqual(["reconnecting"]);
+
+    // Stop mid-backoff, then let all possible timers/microtasks flush. A live
+    // loop would run 10 attempts (backoff capped at 60s) and then fire the
+    // exhaustion callbacks; a cancelled one must not.
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(onReconnectExhausted).not.toHaveBeenCalled();
+    expect(statusChanges).not.toContain("disconnected");
+    // provision() must not keep being retried after stop().
+    expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it("regression: an un-stopped monitor still fires onReconnect exactly once on a recovered provision", async () => {
+    // provision() succeeds on the first attempt; with no stop() the loop must
+    // still emit the success path exactly once.
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const onReconnect = vi.fn();
+    const statusChanges: string[] = [];
+    const monitor = new ConnectionMonitor(
+      client,
+      "agent-3",
+      {
+        onDisconnect: vi.fn(),
+        onReconnect,
+        onStatusChange: (s) => statusChanges.push(s),
+      },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    // Flush the resolved provision() microtask.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(statusChanges).toEqual(["reconnecting", "connected"]);
+
+    monitor.stop();
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
@@ -8,11 +8,14 @@
  * `onStatusChange("connected")` + `onReconnect()`, and an exhausted loop still
  * emitted `onStatusChange("disconnected")` + `onReconnectExhausted()`. Because
  * `CloudManager.disconnect()` calls `stop()` and nulls its proxy, those stale
- * callbacks fire a state-machine transition after teardown. These tests drive
- * the real `ConnectionMonitor` with a client whose `provision()` is a
- * test-controlled deferred, so `stop()` can be interleaved with the exact
- * await points inside the loop. Uses vitest fake timers; the client stub is the
- * only mock — the monitor under test is real.
+ * callbacks fire a state-machine transition after teardown. The earliest await
+ * is `tick()`'s own `client.heartbeat()`; a `stop()` there must also abandon
+ * the tick before it reaches `onDisconnect()`/`attemptReconnect()`, since the
+ * loop inherits its lifecycle token from that pre-heartbeat capture. These
+ * tests drive the real `ConnectionMonitor` with a client whose `heartbeat()`
+ * and `provision()` are test-controlled deferreds, so `stop()` can be
+ * interleaved with the exact await points. Uses vitest fake timers; the client
+ * stub is the only mock — the monitor under test is real.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionMonitor } from "../src/cloud/reconnect";
@@ -42,6 +45,57 @@ describe("ConnectionMonitor.stop() cancels in-flight reconnect (#29941)", () => 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await", async () => {
+    // The earliest await in a tick is `client.heartbeat()`. If stop() lands
+    // while a tick is parked there, the stale continuation must not fire
+    // onDisconnect() or enter attemptReconnect() after teardown — and even a
+    // successful provision() that follows must emit nothing. Before threading
+    // the lifecycle token from tick() (captured *before* the heartbeat await)
+    // into attemptReconnect(), the loop captured the already-incremented token
+    // as its own baseline, so this exact interleaving reconnected after stop().
+    const heartbeatGate = deferred<boolean>();
+    const client = {
+      heartbeat: vi.fn().mockReturnValue(heartbeatGate.promise),
+      provision: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const onDisconnect = vi.fn();
+    const onReconnect = vi.fn();
+    const statusChanges: string[] = [];
+    const monitor = new ConnectionMonitor(
+      client,
+      "agent-hb",
+      {
+        onDisconnect,
+        onReconnect,
+        onStatusChange: (s) => statusChanges.push(s),
+      },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    // Fire the interval so tick() runs and parks inside `await heartbeat()`.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect((client.heartbeat as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+
+    // Tear down while the tick is still awaiting the heartbeat.
+    monitor.stop();
+    expect(monitor.isMonitoring()).toBe(false);
+
+    // The heartbeat now resolves "dead" *after* stop(). The stale tick must
+    // abandon itself: no onDisconnect(), no provision(), no onReconnect(), and
+    // no status transition at all.
+    heartbeatGate.resolve(false);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+    expect(onReconnect).not.toHaveBeenCalled();
+    expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+    expect(statusChanges).toEqual([]);
   });
 
   it("suppresses onReconnect/onStatusChange when stop() runs during the provision await", async () => {

--- a/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
@@ -164,4 +164,47 @@ describe("ConnectionMonitor.stop() cancels in-flight reconnect (#29941)", () => 
 
     monitor.stop();
   });
+
+  it("a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag", async () => {
+    // stop() cancelling a loop mid-provision leaves attemptReconnect() to bail
+    // via the post-await token checkpoint, which returns *without* clearing
+    // `reconnecting`. stop()'s own `reconnecting = false` is therefore the only
+    // thing that stops a restarted monitor from wedging on tick()'s
+    // `if (this.reconnecting) return` guard forever. First provision() hangs so
+    // stop() lands mid-await; the second resolves so the restarted monitor must
+    // recover normally.
+    const firstProvision = deferred<void>();
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockReturnValueOnce(firstProvision.promise).mockResolvedValue(undefined),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const onReconnect = vi.fn();
+    const monitor = new ConnectionMonitor(
+      client,
+      "agent-4",
+      { onDisconnect: vi.fn(), onReconnect, onStatusChange: vi.fn() },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    // Enter attemptReconnect, park on the first (hanging) provision(), then
+    // cancel. The stale loop must abandon itself and fire no onReconnect.
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    monitor.stop();
+    firstProvision.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    // Restart: the monitor must not be wedged by a stale `reconnecting` flag.
+    // The next failed heartbeat must re-enter the loop and recover on the
+    // second (resolving) provision().
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+  });
 });

--- a/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts
@@ -219,6 +219,51 @@ describe("ConnectionMonitor.stop() cancels in-flight reconnect (#29941)", () => 
     monitor.stop();
   });
 
+  it("suppresses reconnect work when stop() runs synchronously inside onDisconnect()", async () => {
+    // onDisconnect() is a public synchronous callback that may tear the monitor
+    // down. If it calls stop(), runToken advances synchronously; the reconnect
+    // loop must not start — no "reconnecting" status, no provision(). Before the
+    // token re-check between onDisconnect() and attemptReconnect(), the loop ran
+    // up to its first post-await check, firing both side effects on a stopped
+    // monitor.
+    const client = {
+      heartbeat: vi.fn().mockResolvedValue(false),
+      provision: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+
+    const statusChanges: string[] = [];
+    const onReconnect = vi.fn();
+    let monitor!: ConnectionMonitor;
+    const onDisconnect = vi.fn(() => {
+      // Tear the monitor down from within the disconnect callback.
+      monitor.stop();
+    });
+    monitor = new ConnectionMonitor(
+      client,
+      "agent-sync-stop",
+      {
+        onDisconnect,
+        onReconnect,
+        onStatusChange: (s) => statusChanges.push(s),
+      },
+      HEARTBEAT_INTERVAL_MS,
+      1
+    );
+
+    monitor.start();
+    // One failed heartbeat → tick() calls onDisconnect(), which stops the
+    // monitor synchronously before attemptReconnect() would run.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(monitor.isMonitoring()).toBe(false);
+    // The reconnect loop must never have started.
+    expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+    expect(onReconnect).not.toHaveBeenCalled();
+    expect(statusChanges).toEqual([]);
+  });
+
   it("a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag", async () => {
     // stop() cancelling a loop mid-provision leaves attemptReconnect() to bail
     // via the post-await token checkpoint, which returns *without* clearing

--- a/plugins/plugin-elizacloud/src/cloud/reconnect.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.ts
@@ -29,12 +29,15 @@ export class ConnectionMonitor {
   /**
    * Monotonic lifecycle token. `tick()` captures the current value before its
    * heartbeat await and threads it into `attemptReconnect()`; `stop()`
-   * increments it. After every `await` point the loop compares its captured
-   * token to the live one and early-returns without firing any callback when
-   * they differ — this is the only way to cancel a detached tick/retry loop
-   * that is mid-`heartbeat()`, mid-`provision()`, or mid-backoff-sleep when
-   * `stop()` runs, so no onStatusChange/onReconnect/onReconnectExhausted fires
-   * after teardown and a dead monitor's backoff sleep cannot keep it alive.
+   * increments it. After every `await` point — and after every public
+   * synchronous callback that could re-enter `stop()` (`onDisconnect`, each
+   * `onStatusChange`) — the loop compares its captured token to the live one and
+   * early-returns without firing any further callback when they differ. This is
+   * the only way to cancel a detached tick/retry loop that is mid-`heartbeat()`,
+   * mid-`provision()`, or mid-backoff-sleep, or that a caller tore down from
+   * inside a lifecycle callback, so no onStatusChange/onReconnect/
+   * onReconnectExhausted and no provision() request follows teardown and a dead
+   * monitor's backoff sleep cannot keep it alive.
    */
   private runToken = 0;
 
@@ -138,6 +141,12 @@ export class ConnectionMonitor {
 
     let delay = 3_000;
     for (let attempt = 1; attempt <= 10; attempt++) {
+      // onStatusChange is a public synchronous callback and may tear the
+      // monitor down (e.g. call stop()) — from the "reconnecting" emit above on
+      // the first pass, or from any status callback reachable on a later pass.
+      // Re-check at the loop top before the provision() network call so a
+      // stopped monitor issues no request, on this and every subsequent attempt.
+      if (this.runToken !== token) return;
       logger.info(`[cloud-monitor] Reconnect attempt ${attempt}/10...`);
       const ok = await this.client
         .provision(this.agentId)
@@ -154,6 +163,9 @@ export class ConnectionMonitor {
         this.consecutiveFailures = 0;
         this.reconnecting = false;
         this.callbacks.onStatusChange?.("connected");
+        // A caller may stop() synchronously from inside onStatusChange; don't
+        // fire onReconnect() into a torn-down manager after teardown.
+        if (this.runToken !== token) return;
         this.callbacks.onReconnect();
         return;
       }
@@ -170,6 +182,9 @@ export class ConnectionMonitor {
     logger.error("[cloud-monitor] Failed to reconnect after 10 attempts");
     this.reconnecting = false;
     this.callbacks.onStatusChange?.("disconnected");
+    // Same synchronous-teardown guard: a caller may stop() from inside the
+    // "disconnected" status callback; don't fire the exhaustion callback after.
+    if (this.runToken !== token) return;
     // error-policy:#14415 — the link is now durably down. Report exactly once
     // per exhaustion (not per failed attempt) so this is observable without
     // spamming. A throwing handler must not re-break the monitor.

--- a/plugins/plugin-elizacloud/src/cloud/reconnect.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.ts
@@ -26,6 +26,16 @@ export class ConnectionMonitor {
   private timer: ReturnType<typeof setInterval> | null = null;
   private consecutiveFailures = 0;
   private reconnecting = false;
+  /**
+   * Monotonic lifecycle token. `attemptReconnect()` captures the current value
+   * at entry; `stop()` increments it. After every `await` point the loop
+   * compares its captured token to the live one and early-returns without
+   * firing any callback when they differ — this is the only way to cancel a
+   * detached retry loop that is mid-`provision()` or mid-backoff-sleep when
+   * `stop()` runs, so no onStatusChange/onReconnect/onReconnectExhausted fires
+   * after teardown and a dead monitor's backoff sleep cannot keep it alive.
+   */
+  private runToken = 0;
 
   constructor(
     private client: ElizaCloudClient,
@@ -51,6 +61,9 @@ export class ConnectionMonitor {
       clearInterval(this.timer);
       this.timer = null;
     }
+    // Invalidate any in-flight attemptReconnect() loop: it re-checks this token
+    // after each await and bails without firing callbacks once it changes.
+    this.runToken++;
     this.consecutiveFailures = 0;
     this.reconnecting = false;
     logger.info("[cloud-monitor] Connection monitor stopped");
@@ -89,6 +102,10 @@ export class ConnectionMonitor {
   }
 
   private async attemptReconnect(): Promise<void> {
+    // Capture the lifecycle token for this loop. stop() bumps runToken, which
+    // lets every post-await checkpoint below detect that this loop was
+    // cancelled and abandon it silently.
+    const token = this.runToken;
     this.reconnecting = true;
     this.callbacks.onStatusChange?.("reconnecting");
 
@@ -99,6 +116,11 @@ export class ConnectionMonitor {
         .provision(this.agentId)
         .then(() => true)
         .catch(() => false);
+
+      // provision() may have resolved after stop(): a stopped monitor must fire
+      // no success callback and must not flip a torn-down manager back to
+      // "connected".
+      if (this.runToken !== token) return;
 
       if (ok) {
         logger.info("[cloud-monitor] Reconnection successful");
@@ -111,6 +133,11 @@ export class ConnectionMonitor {
 
       await new Promise((r) => setTimeout(r, delay));
       delay = Math.min(delay * 2, 60_000);
+
+      // The backoff sleep is the other place stop() can land. Abandon the loop
+      // here too so a dead monitor cannot keep retrying for tens of seconds or
+      // reach the exhaustion callbacks below.
+      if (this.runToken !== token) return;
     }
 
     logger.error("[cloud-monitor] Failed to reconnect after 10 attempts");

--- a/plugins/plugin-elizacloud/src/cloud/reconnect.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.ts
@@ -27,11 +27,12 @@ export class ConnectionMonitor {
   private consecutiveFailures = 0;
   private reconnecting = false;
   /**
-   * Monotonic lifecycle token. `attemptReconnect()` captures the current value
-   * at entry; `stop()` increments it. After every `await` point the loop
-   * compares its captured token to the live one and early-returns without
-   * firing any callback when they differ — this is the only way to cancel a
-   * detached retry loop that is mid-`provision()` or mid-backoff-sleep when
+   * Monotonic lifecycle token. `tick()` captures the current value before its
+   * heartbeat await and threads it into `attemptReconnect()`; `stop()`
+   * increments it. After every `await` point the loop compares its captured
+   * token to the live one and early-returns without firing any callback when
+   * they differ — this is the only way to cancel a detached tick/retry loop
+   * that is mid-`heartbeat()`, mid-`provision()`, or mid-backoff-sleep when
    * `stop()` runs, so no onStatusChange/onReconnect/onReconnectExhausted fires
    * after teardown and a dead monitor's backoff sleep cannot keep it alive.
    */
@@ -76,7 +77,18 @@ export class ConnectionMonitor {
   private async tick(): Promise<void> {
     if (this.reconnecting) return;
 
+    // Capture the lifecycle token before the heartbeat await. stop() bumps the
+    // token while a tick is parked here; without this checkpoint the stale
+    // continuation would fire onDisconnect() and enter attemptReconnect() after
+    // teardown, and that loop would capture the already-incremented token as
+    // its own baseline — defeating every downstream checkpoint.
+    const token = this.runToken;
+
     const alive = await this.client.heartbeat(this.agentId).catch(() => false);
+
+    // stop() may have run during the heartbeat await. Abandon this stale tick so
+    // a torn-down monitor fires no callback and starts no reconnect loop.
+    if (this.runToken !== token) return;
 
     if (alive) {
       if (this.consecutiveFailures > 0) {
@@ -97,15 +109,15 @@ export class ConnectionMonitor {
       // retry attempts fail. This avoids a misleading disconnected→
       // reconnecting flicker for callers.
       this.callbacks.onDisconnect();
-      await this.attemptReconnect();
+      await this.attemptReconnect(token);
     }
   }
 
-  private async attemptReconnect(): Promise<void> {
-    // Capture the lifecycle token for this loop. stop() bumps runToken, which
-    // lets every post-await checkpoint below detect that this loop was
-    // cancelled and abandon it silently.
-    const token = this.runToken;
+  private async attemptReconnect(token: number): Promise<void> {
+    // The lifecycle token is captured by tick() before its heartbeat await and
+    // threaded in here, so a stop() during that await is already reflected. stop()
+    // bumps runToken, which lets every post-await checkpoint below detect that
+    // this loop was cancelled and abandon it silently.
     this.reconnecting = true;
     this.callbacks.onStatusChange?.("reconnecting");
 

--- a/plugins/plugin-elizacloud/src/cloud/reconnect.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.ts
@@ -109,6 +109,15 @@ export class ConnectionMonitor {
       // retry attempts fail. This avoids a misleading disconnected→
       // reconnecting flicker for callers.
       this.callbacks.onDisconnect();
+
+      // onDisconnect() is a public synchronous callback and may tear the
+      // monitor down (e.g. call stop()). stop() bumps runToken synchronously,
+      // so re-check before entering attemptReconnect(): a monitor stopped from
+      // inside onDisconnect() must emit no "reconnecting" status and call no
+      // provision(). Without this checkpoint the reconnect loop runs up to its
+      // first post-await check, which is after those side effects.
+      if (this.runToken !== token) return;
+
       await this.attemptReconnect(token);
     }
   }
@@ -118,6 +127,12 @@ export class ConnectionMonitor {
     // threaded in here, so a stop() during that await is already reflected. stop()
     // bumps runToken, which lets every post-await checkpoint below detect that
     // this loop was cancelled and abandon it silently.
+    //
+    // Defensive entry checkpoint: tick() already re-checks the token after
+    // onDisconnect(), but guarding here too means no caller can enter this loop
+    // with a stale token and fire "reconnecting"/provision() on a stopped
+    // monitor before the first post-await check.
+    if (this.runToken !== token) return;
     this.reconnecting = true;
     this.callbacks.onStatusChange?.("reconnecting");
 


### PR DESCRIPTION
# Relates to

Closes #29941

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; focused package checks were run (see Known gaps for the repo-wide `verify` note).
- [x] A reviewer can confirm the change works from the before/after test evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`2a4af7351c`); zero conflicts.
- [ ] `bun run verify` — not run to completion on this constrained machine; focused package `test` + `typecheck` + `lint` were run and pass. See **Known gaps**.

# Risks

Low. The change is confined to `ConnectionMonitor` in `plugins/plugin-elizacloud/src/cloud/reconnect.ts`. It only *adds* early-return checkpoints after existing `await` points and a token bump in `stop()`; the happy-path reconnect behavior (fire `onReconnect`/`onStatusChange` exactly once on recovery, fire `onReconnectExhausted` once on exhaustion) is unchanged for a monitor that is never stopped mid-flight, and is covered by the regression suite.

# Background

## What does this PR do?

`ConnectionMonitor.attemptReconnect()` runs a **detached** async retry loop (up to 10 attempts, backoff capped at 60s) that awaits `client.provision()` and inter-attempt `setTimeout` sleeps. `stop()` cleared the heartbeat interval and set `reconnecting=false`, but had **no way to signal the already-running loop**. So if `stop()` ran while the loop was parked on `provision()` or a backoff sleep:

- on the next successful `provision()` the stale loop still called `onStatusChange("connected")` + `onReconnect()`;
- on exhaustion it still called `onStatusChange("disconnected")` + `onReconnectExhausted()`.

`CloudManager.disconnect()` calls `connectionMonitor.stop()` then `setStatus("disconnected")` and nulls the proxy. A stale reconnect resolving afterward flips the manager back to `"connected"` and invokes `onReconnect` on a torn-down proxy — a state-machine transition **after teardown**, plus a lifecycle leak (the loop could keep retrying for tens of seconds after the monitor was stopped).

**Fix:** add a monotonic `runToken`. `attemptReconnect()` captures it at entry; `stop()` increments it. After each await point (after `provision()` resolves, and after the backoff sleep) the loop early-returns **without firing any callback** when `this.runToken !== token`. This makes `stop()` truly cancel the in-flight loop and stops the dead-monitor backoff leak.

## What kind of change is this?

Bug fix (non-breaking change which fixes a lifecycle/state-machine defect).

# Documentation changes needed?

No. Public API and callback contract are unchanged; only the post-`stop()` cancellation semantics are corrected. Behavior is documented in code comments on `runToken`, `stop()`, and the loop checkpoints.

# Testing

## Where should a reviewer start?

`plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts` drives the **real** `ConnectionMonitor` (only the cloud client is stubbed) with vitest fake timers and a test-controlled deferred `provision()`, so `stop()` can be interleaved with the exact await points inside the loop.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-elizacloud test        # full package suite
bunx vitest run __tests__/reconnect-stop-cancels-inflight.test.ts \
                __tests__/reconnect-exhaustion-report.test.ts   # focused
```

Three cases:
1. `stop()` during the `provision()` await → the later-resolving `provision()` must fire **no** `onReconnect`/`onStatusChange("connected")`.
2. `stop()` during the backoff sleep before exhaustion → **no** `onStatusChange("disconnected")`/`onReconnectExhausted`, and `provision()` is not retried again.
3. Regression: an **un-stopped** monitor still fires `onReconnect` exactly once and emits `["reconnecting","connected"]` on a recovered `provision()`.

Failing-before / passing-after was verified by checking out the base `reconnect.ts` (`git checkout HEAD~1 -- src/cloud/reconnect.ts`) and re-running the same new test file — cases 1 & 2 fail on base, all pass with the fix. Existing `reconnect-exhaustion-report.test.ts` stays green.

# Evidence Gate

<!-- evidence-head:e58c63712232dc6c0d1d4baf93229824c691433e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface. This is a runtime lifecycle fix in a background connection monitor with no rendered component.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the observable behavior is callback suppression, captured via the backend test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Structured `[cloud-monitor]` logger lines from the real `ConnectionMonitor` under test. On base `develop` `reconnect.ts` (no fix) the loop keeps running **after** `Connection monitor stopped` — the heartbeat-await case (a `stop()` while the tick is parked on `client.heartbeat()` still reaches `Reconnect attempt 1/10` → `Reconnection successful` after teardown), the provision case, the backoff case, the restart case, and the newly covered synchronous-teardown case where `stop()` is called from inside `onDisconnect()` and `client.provision()` still runs once. The positive control passes on both revisions. With the fix the whole suite passes.

<details>
<summary>BEFORE — base develop `reconnect.ts` (no fix) + head tests: 5 cases FAIL, positive control passes</summary>

```

 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-29942

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
 Info       [cloud-monitor] Starting connection monitor (interval: 1000ms, maxFailures: 1)

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
 Info       [cloud-monitor] Connection monitor stopped

stderr | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
 Warn       [cloud-monitor] Heartbeat failed (1/1)

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
 Info       [cloud-monitor] Reconnect attempt 1/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
 Info       [cloud-monitor] Reconnection successful

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnect/onStatusChange when stop() runs during the provision await
 Info       [cloud-monitor] Starting connection monitor (interval: 1000ms, maxFailures: 1)

stderr | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnect/onStatusChange when stop() runs during the provision await
 Warn       [cloud-monitor] Heartbeat failed (1/1)

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnect/onStatusChange when stop() runs during the provision await
 Info       [cloud-monitor] Reconnect attempt 1/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnect/onStatusChange when stop() runs during the provision await
 Info       [cloud-monitor] Connection monitor stopped

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnect/onStatusChange when stop() runs during the provision await
 Info       [cloud-monitor] Reconnection successful

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Starting connection monitor (interval: 1000ms, maxFailures: 1)

stderr | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Warn       [cloud-monitor] Heartbeat failed (1/1)

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 1/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Connection monitor stopped

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 2/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 3/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 4/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 5/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 6/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 7/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 8/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 9/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Info       [cloud-monitor] Reconnect attempt 10/10...

stderr | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
 Error      [cloud-monitor] Failed to reconnect after 10 attempts

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses reconnect work when stop() runs synchronously inside onDisconnect()
 Info       [cloud-monitor] Starting connection monitor (interval: 1000ms, maxFailures: 1)

stderr | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses reconnect work when stop() runs synchronously inside onDisconnect()
 Warn       [cloud-monitor] Heartbeat failed (1/1)

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses reconnect work when stop() runs synchronously inside onDisconnect()
 Info       [cloud-monitor] Connection monitor stopped
 Info       [cloud-monitor] Reconnect attempt 1/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses reconnect work when stop() runs synchronously inside onDisconnect()
 Info       [cloud-monitor] Reconnection successful

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
 Info       [cloud-monitor] Starting connection monitor (interval: 1000ms, maxFailures: 1)

stderr | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
 Warn       [cloud-monitor] Heartbeat failed (1/1)

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
 Info       [cloud-monitor] Reconnect attempt 1/10...

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
 Info       [cloud-monitor] Connection monitor stopped

stdout | plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
 Info       [cloud-monitor] Reconnection successful

 ❯ plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts (6 tests | 5 failed) 84ms
     × suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await 33ms
     × suppresses onReconnect/onStatusChange when stop() runs during the provision await 14ms
     × suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep 20ms
     × suppresses reconnect work when stop() runs synchronously inside onDisconnect() 4ms
     × a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag 5ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1

 ❯ plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts:95:30
     93|     await vi.advanceTimersByTimeAsync(0);
     94|
     95|     expect(onDisconnect).not.toHaveBeenCalled();
       |                              ^
     96|     expect(onReconnect).not.toHaveBeenCalled();
     97|     expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.l…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnect/onStatusChange when stop() runs during the provision await
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts:143:43
    141|     await vi.advanceTimersByTimeAsync(0);
    142|
    143|     expect(onReconnect.mock.calls.length).toBe(reconnectCallsAtStop);
       |                                           ^
    144|     expect(statusChanges).toEqual(statusesAtStop);
    145|     expect(statusChanges).not.toContain("connected");

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array [
      Object {
        "attempts": 10,
      },
    ]


Number of calls: 1

 ❯ plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts:183:38
    181|     await vi.advanceTimersByTimeAsync(10 * 60_000);
    182|
    183|     expect(onReconnectExhausted).not.toHaveBeenCalled();
       |                                      ^
    184|     expect(statusChanges).not.toContain("disconnected");
    185|     // provision() must not keep being retried after stop().

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > suppresses reconnect work when stop() runs synchronously inside onDisconnect()
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts:262:78
    260|     expect(monitor.isMonitoring()).toBe(false);
    261|     // The reconnect loop must never have started.
    262|     expect((client.provision as ReturnType<typeof vi.fn>).mock.calls.l…
       |                                                                              ^
    263|     expect(onReconnect).not.toHaveBeenCalled();
    264|     expect(statusChanges).toEqual([]);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

 FAIL  plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts > ConnectionMonitor.stop() cancels in-flight reconnect (#29941) > a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1

 ❯ plugins/plugin-elizacloud/__tests__/reconnect-stop-cancels-inflight.test.ts:297:29
    295|     firstProvision.resolve();
    296|     await vi.advanceTimersByTimeAsync(0);
    297|     expect(onReconnect).not.toHaveBeenCalled();
       |                             ^
    298|
    299|     // Restart: the monitor must not be wedged by a stale `reconnectin…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/5]⎯


 Test Files  1 failed (1)
      Tests  5 failed | 1 passed (6)
   Start at  04:19:13
   Duration  16.39s (transform 12.87s, setup 0ms, import 15.97s, tests 84ms, environment 0ms)
```

</details>

<details>
<summary>AFTER — with fix (head `6452c5939d`): focused suite passes (6 tests)</summary>

```

 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-29942


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  04:19:31
   Duration  16.82s (transform 13.46s, setup 0ms, import 16.58s, tests 55ms, environment 0ms)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response path is exercised by this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a connection-monitor lifecycle fix with no model call.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the failing-then-passing vitest reproduction. On base `develop` `reconnect.ts` (no lifecycle token at all) the eight defect-proving assertions fail — `onDisconnect`/`onReconnect` fire after stop during the heartbeat await; `onReconnect` fires after stop during provision; `onReconnectExhausted` fires after stop during backoff; a `stop()` called synchronously from inside `onDisconnect()` still runs `provision()` once; the restarted monitor sees the stale reconnect fire; and (new this round) a `stop()` called synchronously from inside `onStatusChange("reconnecting")`/`("connected")`/`("disconnected")` still issues a `provision()` request / fires `onReconnect()` / fires `onReconnectExhausted()` after teardown. The lone positive-control assertion passes on both. With the fix all 9 pass.

<details>
<summary>Reproduction — base <code>develop</code> reconnect.ts + head tests: 8 failed / 1 passed; after the fix 9/9 pass</summary>

```
# BEFORE — base develop reconnect.ts (parent 2a4af7351c) + head tests
 ❯ __tests__/reconnect-stop-cancels-inflight.test.ts (9 tests | 8 failed)
     × suppresses onDisconnect/onReconnect when stop() runs during the heartbeat await
       AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
     × suppresses onReconnect/onStatusChange when stop() runs during the provision await
       AssertionError: expected 1 to be +0  // onReconnect fired after stop()
     × suppresses onReconnectExhausted/disconnected when stop() runs during the backoff sleep
       AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
     × suppresses reconnect work when stop() runs synchronously inside onDisconnect()
       AssertionError: expected 1 to be +0  // provision() ran after synchronous stop()
     × a monitor restarted after a cancelled reconnect is not wedged by the reconnecting flag
       AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
     × suppresses provision() when stop() runs synchronously inside onStatusChange("reconnecting")
       AssertionError: expected [ 'reconnecting', 'connected' ] to deeply equal [ 'reconnecting' ]
     × suppresses onReconnect() when stop() runs synchronously inside onStatusChange("connected")
       AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
     × suppresses onReconnectExhausted() when stop() runs synchronously inside onStatusChange("disconnected")
       AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
     ✓ regression: an un-stopped monitor still fires onReconnect exactly once on a recovered provision
      Tests  8 failed | 1 passed (9)

# AFTER — head reconnect.ts + head tests
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Per-guard mutation (head tests held fixed): removing the loop-top recheck fails only the `onStatusChange("reconnecting")` case; removing the post-`"connected"` recheck fails only the `onStatusChange("connected")` case; removing the post-`"disconnected"` recheck fails only the `onStatusChange("disconnected")` case — each new guard is killed by exactly one new test.

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call in this path.`

## Backend + frontend logs

See the inline `<details>` transcripts in the **backend-logs** row above (real `[cloud-monitor]` structured logger lines). Frontend: `N/A - no frontend path.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface; this is a background lifecycle fix. Behavioral before/after is the vitest reproduction above.`

### Before

`N/A - no UI.`

### After

`N/A - no UI.`

### Walkthrough video

`N/A - no UI flow.`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT change.`

## Known gaps / failures

- `bun run verify` (repo-wide gate) was not run to completion on this constrained Raspberry Pi machine. The **owning package** checks were run and pass: `vitest` (635 passed, 5 skipped across the full package; the focused reconnect suite is 6/6), `tsc --noEmit`, and Biome `check` on the touched files.
- One pre-existing package suite, `__tests__/unit/research-retirement.test.ts`, fails to import `@elizaos/plugin-elizacloud/endpoint-config` because it resolves the package's built `dist` export, which is not present without a full build. This failure reproduces on the unmodified base revision (`git checkout HEAD~1`) and is unrelated to this change (it does not touch `reconnect.ts` or endpoint-config).
- GitHub attachment-URL minting was unavailable in this environment (the fork account cannot write to the upstream `pr-evidence` release, and the browser upload flow hit a verification interstitial), so all logs are pasted inline in `<details>` blocks per CONTRIBUTING.md § Evidence.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@8af3a1f5145cf1e9e24a995aa48e0c3f47626d65:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@8af3a1f5145cf1e9e24a995aa48e0c3f47626d65:packages/skills/skills/contribute-to-eliza"} -->




