### PR TITLE
fix(ui): skip Cloud billing polls for remote runtimes

### DIFF
--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -24,6 +24,7 @@ import {
   prepareDesktopCloudLoginSession,
 } from "./cloud-login-launch";
 import { registerStewardLoginLauncher } from "./cloud-steward-login";
+import { savePersistedActiveServer } from "./persistence";
 import { useCloudState } from "./useCloudState";
 
 const DEVICE_CODE_SENTINEL = "device-code-flow-reached";
@@ -1208,6 +1209,37 @@ describe("useCloudState — pollCloudCredits status snapshot", () => {
     delete globalWithPlatform.Capacitor;
     restorePinnedRemote();
     vi.restoreAllMocks();
+  });
+
+  it("does not poll a selected remote runtime's unrelated Cloud billing state", async () => {
+    expect(
+      savePersistedActiveServer({
+        id: "remote:browser-preview",
+        kind: "remote",
+        label: "Eliza VPS",
+        apiBase: "http://127.0.0.1:12487",
+      }),
+    ).toBe(true);
+    getCloudStatusSpy.mockResolvedValue({
+      enabled: true,
+      connected: true,
+      hasApiKey: true,
+      cloudVoiceProxyAvailable: false,
+    });
+    getCloudCreditsSpy.mockResolvedValue({ authRejected: true });
+
+    const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+    let connected = true;
+    await act(async () => {
+      connected = await result.current.pollCloudCredits();
+    });
+
+    expect(connected).toBe(false);
+    expect(getCloudStatusSpy).not.toHaveBeenCalled();
+    expect(getCloudCreditsSpy).not.toHaveBeenCalled();
+    expect(result.current.elizaCloudAuthRejected).toBe(false);
+    expect(result.current.elizaCloudPollInterval.current).toBeNull();
+    unmount();
   });
 
   it("applies a connected snapshot: enabled, credits balance, low/critical flags, and status reason", async () => {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -94,6 +94,7 @@ import {
 } from "./cloud-steward-login";
 
 import {
+  loadPersistedActiveServer,
   savePersistedFirstRunComplete,
   scrubPersistedActiveServerToken,
 } from "./persistence";
@@ -427,10 +428,16 @@ function hasCloudLoginBackend(): boolean {
 }
 
 function canPollCloudStatus(): boolean {
-  // A dedicated remote build gets models and voice from its paired runtime.
-  // Polling that runtime's optional Cloud billing integration misclassifies an
-  // unrelated server credential as the mobile app's own authentication state.
-  if (getBuildConfiguredRemoteApiBaseUrl()) return false;
+  // A remote client gets models and voice from its paired runtime, whether the
+  // target is immutable at build time or selected during first run. Polling
+  // that runtime's optional Cloud billing integration misclassifies an
+  // unrelated server credential as the client's own authentication state.
+  if (
+    getBuildConfiguredRemoteApiBaseUrl() ||
+    loadPersistedActiveServer()?.kind === "remote"
+  ) {
+    return false;
+  }
 
   const explicitBase =
     typeof client.getBaseUrl === "function" ? client.getBaseUrl().trim() : "";


### PR DESCRIPTION
Closes #29944.

## What changed
- Treat a user-selected persisted remote runtime like an immutable build-pinned remote for ambient Cloud polling.
- Preserve explicit Cloud login/session verification.
- Add the exact remote runtime + rejected server Cloud credential regression.

## Evidence
- Focused Vitest: 26/26 pass.
- `packages/ui` typecheck: pass after generating the existing `@elizaos/cloud-routing` package output required by this worktree.
- Biome (2 changed files): pass.
- `git diff --check`: pass.
- Real browser: exact-current local renderer paired through an SSH loopback tunnel to `bot.nubs.site`; Home loaded, existing VPS history persisted, and after HMR + cold navigation the bogus Cloud rejection notice was absent.

## Not part of this PR
- Existing launcher partial-catalog alert is owned by #29789.
- The currently observed slow/hung real model reply is being diagnosed separately; this PR does not mask provider/runtime failures.
- No phone install, VPS restart/deploy/edit, Cloud production action, or credential exposure.