### PR TITLE
fix(plugin-x): serialize OAuth2 PKCE token refresh so concurrent loops don't double-spend the single-use refresh token

### DIFF
--- a/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
@@ -53,6 +53,12 @@ export class OAuth2PKCEAuthProvider implements TwitterAuthProvider {
 
   private tokens: StoredOAuth2Tokens | null = null;
   private readonly accountId: string;
+  // Single-flight guard: collapses concurrent expiry-window (or missing-token)
+  // callers onto one refresh/interactive-login so X's single-use, rotating
+  // refresh token is only spent once. Without it, plugin-x's independent loops
+  // (post, interactions, discovery) share this provider instance and can each
+  // refresh the same R0, making the losing caller fail with invalid_grant.
+  private authInFlight: Promise<StoredOAuth2Tokens> | null = null;
 
   constructor(
     private readonly runtime: IAgentRuntime,
@@ -255,33 +261,68 @@ export class OAuth2PKCEAuthProvider implements TwitterAuthProvider {
     return await this.exchangeCodeForToken({ code, codeVerifier: verifier });
   }
 
+  private runInteractiveLogin(): Promise<StoredOAuth2Tokens> {
+    return this.interactiveLoginFn
+      ? this.interactiveLoginFn()
+      : this.interactiveLogin();
+  }
+
+  /**
+   * Resolve a valid token set, serializing refresh/re-auth work through
+   * `authInFlight`. Concurrent callers that observe an expired token join the
+   * same in-flight operation instead of starting a competing refresh, then
+   * re-check the resulting token before returning. `produce` computes fresh
+   * tokens; it runs at most once per burst of contending callers.
+   */
+  private async obtainTokens(
+    produce: () => Promise<StoredOAuth2Tokens>,
+  ): Promise<StoredOAuth2Tokens> {
+    if (this.authInFlight) {
+      const shared = await this.authInFlight;
+      if (!isExpired(shared)) return shared;
+      // The joined operation produced a token that is already expired (or the
+      // caller needed a distinct credential); fall through to start a new one.
+    }
+    if (!this.authInFlight) {
+      this.authInFlight = (async () => {
+        const produced = await produce();
+        await this.saveTokens(produced);
+        return produced;
+      })().finally(() => {
+        this.authInFlight = null;
+      });
+    }
+    return this.authInFlight;
+  }
+
   async getAccessToken(): Promise<string> {
     const tokens = await this.loadTokens();
-    if (!tokens) {
-      const newTokens = this.interactiveLoginFn
-        ? await this.interactiveLoginFn()
-        : await this.interactiveLogin();
-      await this.saveTokens(newTokens);
-      return newTokens.access_token;
-    }
 
-    if (!isExpired(tokens)) {
+    if (tokens && !isExpired(tokens)) {
       return tokens.access_token;
     }
 
-    if (!tokens.refresh_token) {
-      // No refresh token available; must re-auth.
-      await this.tokenStore.clear();
-      this.tokens = null;
-      const newTokens = this.interactiveLoginFn
-        ? await this.interactiveLoginFn()
-        : await this.interactiveLogin();
-      await this.saveTokens(newTokens);
+    if (!tokens) {
+      const newTokens = await this.obtainTokens(() =>
+        this.runInteractiveLogin(),
+      );
       return newTokens.access_token;
     }
 
-    const refreshed = await this.refreshAccessToken(tokens.refresh_token);
-    await this.saveTokens(refreshed);
+    if (!tokens.refresh_token) {
+      // No refresh token available; must re-auth interactively.
+      const newTokens = await this.obtainTokens(async () => {
+        await this.tokenStore.clear();
+        this.tokens = null;
+        return this.runInteractiveLogin();
+      });
+      return newTokens.access_token;
+    }
+
+    const refreshToken = tokens.refresh_token;
+    const refreshed = await this.obtainTokens(() =>
+      this.refreshAccessToken(refreshToken),
+    );
     return refreshed.access_token;
   }
 }

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
@@ -110,7 +110,14 @@ export class OAuth2PKCEAuthProvider implements TwitterAuthProvider {
 
   private async loadTokens(): Promise<StoredOAuth2Tokens | null> {
     if (this.tokens) return this.tokens;
-    this.tokens = await this.tokenStore.load();
+    const loaded = await this.tokenStore.load();
+    // A concurrent single-flight may have refreshed and saved a newer token
+    // while this store read was outstanding (real file/DB stores can have a
+    // read in flight across another loop's write). Never let a pre-write
+    // snapshot clobber the freshly rotated token, or that stale refresh token
+    // gets spent a second time and fails with invalid_grant.
+    if (this.tokens) return this.tokens;
+    this.tokens = loaded;
     return this.tokens;
   }
 

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
@@ -328,7 +328,13 @@ export class OAuth2PKCEAuthProvider implements TwitterAuthProvider {
 
     const refreshToken = tokens.refresh_token;
     const refreshed = await this.obtainTokens(() =>
-      this.refreshAccessToken(refreshToken),
+      // Read the refresh token when `produce` actually runs, not from the
+      // pre-join capture. A joiner whose shared result is already expired falls
+      // through to start a fresh flight; by then the joined flight has rotated
+      // R0 -> R1 and cached it, so the captured R0 is spent. Using the current
+      // cached token spends R1 and avoids re-spending R0 (a rarer invalid_grant
+      // on the same double-spend path this guard exists to prevent).
+      this.refreshAccessToken(this.tokens?.refresh_token ?? refreshToken),
     );
     return refreshed.access_token;
   }

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
@@ -44,7 +44,10 @@ function createStore(initial: StoredOAuth2Tokens | null): TokenStore {
  * rotates it and returns a fresh access/refresh pair; any later use of an
  * already-spent refresh token returns HTTP 400 `invalid_grant`.
  */
-function singleUseRefreshFetch(opts?: { alwaysInvalid?: boolean }) {
+function singleUseRefreshFetch(opts?: {
+  alwaysInvalid?: boolean;
+  expiresIn?: number;
+}) {
   const spent = new Set<string>();
   const refreshCalls: string[] = [];
   let counter = 0;
@@ -63,7 +66,7 @@ function singleUseRefreshFetch(opts?: { alwaysInvalid?: boolean }) {
       JSON.stringify({
         access_token: `A${counter}`,
         refresh_token: `R${counter}`,
-        expires_in: 7200,
+        expires_in: opts?.expiresIn ?? 7200,
         token_type: "bearer",
       }),
       { status: 200 },
@@ -216,6 +219,30 @@ describe("OAuth2PKCEAuthProvider concurrent refresh", () => {
     );
     expect(new Set(values)).toEqual(new Set(["A1"]));
     expect(store.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes again after the rotated token itself expires", async () => {
+    // Each issued token lands inside the 30s expiry skew (expires_in: 1), so the
+    // second sequential call must run a fresh refresh rather than hand back the
+    // still-in-flight promise. This exercises obtainTokens on a *second* expiry
+    // cycle: it only passes when `.finally()` clears `authInFlight` after the
+    // first flight settles and the join branch re-checks the shared token's
+    // expiry. Without the cleanup, `authInFlight` keeps a settled, expired
+    // promise and every later call returns the stale token, never refreshing.
+    const { fetchImpl, refreshCalls } = singleUseRefreshFetch({ expiresIn: 1 });
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      createStore(expiredTokens()),
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    // First cycle spends R0 -> A1/R1; A1 is already inside the skew window.
+    expect(await provider.getAccessToken()).toBe("A1");
+    // Second cycle must observe A1 as expired and spend R1 -> A2/R2.
+    expect(await provider.getAccessToken()).toBe("A2");
+    expect(refreshCalls).toEqual(["R0", "R1"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
   it("serializes concurrent interactive logins when no tokens exist", async () => {

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
@@ -225,10 +225,14 @@ describe("OAuth2PKCEAuthProvider concurrent refresh", () => {
     // Each issued token lands inside the 30s expiry skew (expires_in: 1), so the
     // second sequential call must run a fresh refresh rather than hand back the
     // still-in-flight promise. This exercises obtainTokens on a *second* expiry
-    // cycle: it only passes when `.finally()` clears `authInFlight` after the
-    // first flight settles and the join branch re-checks the shared token's
-    // expiry. Without the cleanup, `authInFlight` keeps a settled, expired
-    // promise and every later call returns the stale token, never refreshing.
+    // cycle. Because the two calls are sequential, the first flight has already
+    // settled and `authInFlight` is null by the time the second call runs, so
+    // this case pins the `.finally()` cleanup alone — not the concurrent join
+    // branch, which it never enters. It only passes when `.finally()` clears
+    // `authInFlight` after the first flight settles; without that cleanup
+    // `authInFlight` keeps a settled, expired promise and every later call
+    // returns the stale token, never refreshing. (A concurrent second-cycle
+    // race that also exercises the join branch's expiry re-check is separate.)
     const { fetchImpl, refreshCalls } = singleUseRefreshFetch({ expiresIn: 1 });
     const provider = new OAuth2PKCEAuthProvider(
       createRuntime(),

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
@@ -164,6 +164,60 @@ describe("OAuth2PKCEAuthProvider concurrent refresh", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("does not let a store read that spans the winner's save re-spend the old refresh token", async () => {
+    // Models a token store backed by real I/O: a read captures its snapshot at
+    // read-start time and can resolve *after* a concurrent save. Caller B's read
+    // starts first and blocks; caller A loads immediately, refreshes R0 -> R1 and
+    // saves; only then does B's read resolve with the pre-write R0 snapshot.
+    let current: StoredOAuth2Tokens | null = expiredTokens();
+    let loadCount = 0;
+    let releaseSecondLoad: () => void = () => {};
+    const secondLoadGate = new Promise<void>((resolve) => {
+      releaseSecondLoad = resolve;
+    });
+    const store: TokenStore = {
+      load: vi.fn(async () => {
+        loadCount += 1;
+        const snapshot = current; // captured at read start, like a DB read tx
+        if (loadCount === 2) await secondLoadGate;
+        return snapshot;
+      }),
+      save: vi.fn(async (t: StoredOAuth2Tokens) => {
+        current = t;
+      }),
+      clear: vi.fn(async () => {
+        current = null;
+      }),
+    };
+    const { fetchImpl, refreshCalls } = singleUseRefreshFetch();
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      store,
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    const settled = Promise.allSettled([
+      provider.getAccessToken(),
+      provider.getAccessToken(),
+    ]);
+    // Let caller A's refresh + save complete (all microtasks) before caller B's
+    // outstanding store read resolves with the now-stale snapshot.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    releaseSecondLoad();
+    const results = await settled;
+
+    // Neither caller re-spends R0; only the original refresh happened.
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    expect(refreshCalls).toEqual(["R0"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const values = results.map((r) =>
+      r.status === "fulfilled" ? r.value : null,
+    );
+    expect(new Set(values)).toEqual(new Set(["A1"]));
+    expect(store.save).toHaveBeenCalledTimes(1);
+  });
+
   it("serializes concurrent interactive logins when no tokens exist", async () => {
     let logins = 0;
     const interactiveLoginFn = vi.fn(async () => {

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression coverage for the OAuth 2.0 PKCE single-use refresh-token race.
+ * plugin-x runs several independent loops (post, interactions, discovery) that
+ * share one `OAuth2PKCEAuthProvider` instance. When the user-context token
+ * expires, multiple loops can observe the expiry window and each call
+ * `refreshAccessToken` with the same rotating (single-use) refresh token, so
+ * X returns HTTP 400 `invalid_grant` to the losing caller. These tests drive
+ * the real provider against a deterministic single-use-refresh `fetchImpl` and
+ * an in-memory `TokenStore`; no live X credentials are required.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { OAuth2PKCEAuthProvider } from "./oauth2-pkce";
+import type { StoredOAuth2Tokens, TokenStore } from "./token-store";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    getSetting: vi.fn(
+      (key: string) =>
+        ({
+          TWITTER_CLIENT_ID: "client-id",
+          TWITTER_REDIRECT_URI: "http://127.0.0.1/callback",
+        })[key],
+    ),
+  } as unknown as IAgentRuntime;
+}
+
+function createStore(initial: StoredOAuth2Tokens | null): TokenStore {
+  let current = initial;
+  return {
+    load: vi.fn(async () => current),
+    save: vi.fn(async (t: StoredOAuth2Tokens) => {
+      current = t;
+    }),
+    clear: vi.fn(async () => {
+      current = null;
+    }),
+  };
+}
+
+/**
+ * Models X's rotating, single-use refresh tokens: the first refresh of a token
+ * rotates it and returns a fresh access/refresh pair; any later use of an
+ * already-spent refresh token returns HTTP 400 `invalid_grant`.
+ */
+function singleUseRefreshFetch(opts?: { alwaysInvalid?: boolean }) {
+  const spent = new Set<string>();
+  const refreshCalls: string[] = [];
+  let counter = 0;
+  const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+    const params = new URLSearchParams(String(init?.body ?? ""));
+    const rt = params.get("refresh_token") ?? "";
+    refreshCalls.push(rt);
+    if (opts?.alwaysInvalid || spent.has(rt)) {
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+      });
+    }
+    spent.add(rt);
+    counter += 1;
+    return new Response(
+      JSON.stringify({
+        access_token: `A${counter}`,
+        refresh_token: `R${counter}`,
+        expires_in: 7200,
+        token_type: "bearer",
+      }),
+      { status: 200 },
+    );
+  });
+  return { fetchImpl, refreshCalls };
+}
+
+function expiredTokens(): StoredOAuth2Tokens {
+  return {
+    access_token: "A0",
+    refresh_token: "R0",
+    expires_at: Date.now() - 1000,
+  };
+}
+
+describe("OAuth2PKCEAuthProvider concurrent refresh", () => {
+  it("collapses concurrent expiry-window callers onto a single refresh", async () => {
+    const { fetchImpl, refreshCalls } = singleUseRefreshFetch();
+    const store = createStore(expiredTokens());
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      store,
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    const results = await Promise.allSettled([
+      provider.getAccessToken(),
+      provider.getAccessToken(),
+      provider.getAccessToken(),
+    ]);
+
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(rejected).toHaveLength(0);
+
+    // Exactly one network refresh happened, spending only the original R0.
+    expect(refreshCalls).toEqual(["R0"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    // All callers share the single rotated access token.
+    const tokens = results.map((r) =>
+      r.status === "fulfilled" ? r.value : null,
+    );
+    expect(new Set(tokens)).toEqual(new Set(["A1"]));
+
+    // The store persisted the rotated credential exactly once.
+    expect(store.save).toHaveBeenCalledTimes(1);
+    expect(store.save).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: "A1", refresh_token: "R1" }),
+    );
+  });
+
+  it("reuses the cached rotated token after the shared refresh without another fetch", async () => {
+    const { fetchImpl, refreshCalls } = singleUseRefreshFetch();
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      createStore(expiredTokens()),
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    await Promise.all([provider.getAccessToken(), provider.getAccessToken()]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    // A later call within the fresh token's validity window hits the cache.
+    const third = await provider.getAccessToken();
+    expect(third).toBe("A1");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(refreshCalls).toEqual(["R0"]);
+  });
+
+  it("surfaces a genuine invalid_grant from the single in-flight refresh to every awaiter", async () => {
+    const { fetchImpl, refreshCalls } = singleUseRefreshFetch({
+      alwaysInvalid: true,
+    });
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      createStore(expiredTokens()),
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    const results = await Promise.allSettled([
+      provider.getAccessToken(),
+      provider.getAccessToken(),
+    ]);
+
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+    for (const r of results) {
+      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+      expect((r as PromiseRejectedResult).reason.message).toContain(
+        "invalid_grant",
+      );
+    }
+    // Only one refresh was attempted even though both callers failed.
+    expect(refreshCalls).toEqual(["R0"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes concurrent interactive logins when no tokens exist", async () => {
+    let logins = 0;
+    const interactiveLoginFn = vi.fn(async () => {
+      logins += 1;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return {
+        access_token: `login-${logins}`,
+        refresh_token: `login-refresh-${logins}`,
+        expires_at: Date.now() + 7200 * 1000,
+      } satisfies StoredOAuth2Tokens;
+    });
+    const store = createStore(null);
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      store,
+      vi.fn() as unknown as typeof fetch,
+      interactiveLoginFn,
+    );
+
+    const [a, b] = await Promise.all([
+      provider.getAccessToken(),
+      provider.getAccessToken(),
+    ]);
+
+    // A single interactive login serves both callers.
+    expect(interactiveLoginFn).toHaveBeenCalledTimes(1);
+    expect(a).toBe("login-1");
+    expect(b).toBe("login-1");
+    expect(store.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts
@@ -249,6 +249,38 @@ describe("OAuth2PKCEAuthProvider concurrent refresh", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("does not re-spend the old refresh token when a concurrent joiner falls through on an already-expired shared result", async () => {
+    // Forces the join branch in `obtainTokens` to return an *expired* token so a
+    // joiner falls through and starts a fresh flight. With expires_in: 1 the
+    // winner's rotated R1 lands inside the 30s skew, so the joiner sees it as
+    // expired and must refresh again. The fix reads the refresh token when
+    // `produce` runs (the cached R1) instead of the pre-join capture (R0):
+    // without it the fall-through would call refreshAccessToken(R0), which the
+    // winner already spent, re-creating the invalid_grant on this rarer path.
+    const { fetchImpl, refreshCalls } = singleUseRefreshFetch({ expiresIn: 1 });
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      createStore(expiredTokens()),
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    const results = await Promise.allSettled([
+      provider.getAccessToken(),
+      provider.getAccessToken(),
+    ]);
+
+    // Both callers succeed: the winner spends R0 -> R1, the joiner sees R1 is
+    // already inside the skew and spends the *current* R1 -> R2, never R0 twice.
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    expect(refreshCalls).toEqual(["R0", "R1"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const values = results.map((r) =>
+      r.status === "fulfilled" ? r.value : null,
+    );
+    expect(new Set(values)).toEqual(new Set(["A1", "A2"]));
+  });
+
   it("serializes concurrent interactive logins when no tokens exist", async () => {
     let logins = 0;
     const interactiveLoginFn = vi.fn(async () => {


### PR DESCRIPTION
# Relates to

Closes #29954

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks pass (see Evidence). `bun run verify` is a full-repo gate not completed on this machine — see **Known gaps**.
- [x] A reviewer can confirm the change works from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`2a4af7351c`); zero conflicts. This branch's parent is exactly the develop head.
- [x] Focused package checks pass post-sync; the full `bun run verify` gate is documented under **Known gaps**.

# Risks

Low. The change is fully local to `plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts` and only affects the OAuth2 PKCE (`TWITTER_AUTH_MODE=oauth`) token path. It serializes the refresh/re-auth work behind a single-flight promise; the non-expired fast path and the token-store contract are unchanged. No public types change.

# Background

## What does this PR do?

`OAuth2PKCEAuthProvider.getAccessToken()` had no mutex around the refresh path. plugin-x runs several independent loops (post, interactions, discovery) that each reach `client.getV2Client()` → `TwitterAuth.ensureClientInitialized()` → `provider.getAccessToken()` on the **shared** provider instance. When the OAuth2 user-context access token expires (~every 2h), two or more loops concurrently observe the expired token and both call `refreshAccessToken(tokens.refresh_token)` with the **same** refresh token.

X OAuth2 refresh tokens rotate and are **single-use**: the first refresh consumes `R0` and rotates to `R1`; the second refresh of `R0` returns HTTP 400 `invalid_grant`. Because that failure throws out of `getAccessToken()` (it is not caught to fall back to re-auth), the losing loop errors out — and on a headless server the interactive re-auth path cannot recover. This is a classic TOCTOU / lost-update race on a persisted credential: `loadTokens()` caches `this.tokens` but there was no in-flight refresh guard, so the check-then-refresh window was unsynchronized.

**Fix:** add a private `authInFlight: Promise<StoredOAuth2Tokens> | null` single-flight guard. In `getAccessToken()`, expired-token callers route through `obtainTokens(produce)`: if a refresh/re-auth is already in flight they **await it and re-check expiry against the result** instead of starting a competing operation; otherwise they start the one operation, `saveTokens`, and clear the guard in `finally`. This collapses concurrent expiry-window callers onto a single refresh, so only `R0` is spent and the rotated `R1` is shared. The same guard covers the missing-token interactive-login branch to prevent two parallel interactive logins. `loadTokens()` also re-checks the in-memory cache after its store read, so a slow `load()` that resolves a pre-write snapshot after the winning refresh can never clobber the rotated token and re-spend the old refresh token through a smaller window.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. Behavior of the public `getAccessToken()` contract is unchanged for callers; only the internal concurrency semantics are corrected. No documented surface changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/client/auth-providers/oauth2-refresh-race.test.ts` — it drives the real `OAuth2PKCEAuthProvider` against a deterministic single-use-refresh `fetchImpl` and an in-memory `TokenStore`. No live X credentials are required.

## Detailed testing steps

```bash
cd plugins/plugin-x
npx vitest run src/client/auth-providers/oauth2-refresh-race.test.ts
npx vitest run src/client/auth-providers/            # full auth-providers dir
bun run --cwd plugins/plugin-x typecheck
bun run --cwd plugins/plugin-x lint
```

Regression coverage added (real system under test):
1. Three concurrent expiry-window callers all succeed with **exactly one** refresh fetch spending only `R0`; the rotated `R1` is persisted once.
2. A later call within the fresh token's validity window reuses the cached rotated token with **no** further fetch.
3. A genuine `invalid_grant` from the single in-flight refresh surfaces to **every** awaiter (still only one refresh attempted).
4. Concurrent interactive logins (no tokens present) collapse to a single interactive login.
5. A store `load()` whose read spans a concurrent winner's save resolves the pre-write snapshot **without** clobbering the freshly rotated token — the slow reader returns the cached `R1` and never re-spends `R0` (real file/DB token stores can have a read in flight across another loop's write).
6. After the rotated token *itself* expires (each token issued inside the 30s skew), a second sequential call runs a fresh refresh (`R0`→`R1`, then `R1`→`R2`) instead of handing back the settled in-flight promise — pins the `authInFlight` cleanup so removing the `.finally()` reset (which would silently return the expired token forever and never refresh again) fails the suite.
7. Two concurrent callers where the joined flight returns an **already-expired** token (`expires_in: 1`): the joiner falls through and starts a fresh flight, and must refresh the **current** rotated `R1` (`refreshCalls == ["R0", "R1"]`), not re-spend the pre-join `R0`. `getAccessToken` now reads the refresh token at flight time (`this.tokens?.refresh_token`) rather than from the pre-join capture, so the fall-through cannot re-create `invalid_grant` on this rarer near-instant-expiry path. Reverting only that read makes the joiner spend `R0` twice and the test fails.

# Evidence Gate

<!-- evidence-head:79c8f53904b503aec5b09ccb5ef5f361acba1b3a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — `N/A - server/runtime credential-refresh race; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — `N/A - server/runtime credential-refresh race; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — `N/A - no UI flow; the exercised path is a provider token-refresh race proven by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end (pre-fix failing reproduction + post-fix passing run):

<details><summary>Backend logs: residual-race reproduction (fix reverted) then full passing run</summary>

```
# Fix reverted (loadTokens re-check removed) — the new regression reproduces the double-spend:
 FAIL  src/client/auth-providers/oauth2-refresh-race.test.ts > OAuth2PKCEAuthProvider concurrent refresh > does not let a store read that spans the winner's save re-spend the old refresh token
 AssertionError: expected false to be true // Object.is equality
 Tests  1 failed | 4 passed (5)

# Fix restored — full auth-providers suite green:
 ✓ concurrent refresh > collapses concurrent expiry-window callers onto a single refresh
 ✓ concurrent refresh > reuses the cached rotated token after the shared refresh without another fetch
 ✓ concurrent refresh > surfaces a genuine invalid_grant from the single in-flight refresh to every awaiter
 ✓ concurrent refresh > does not let a store read that spans the winner's save re-spend the old refresh token
 ✓ concurrent refresh > refreshes again after the rotated token itself expires
 ✓ concurrent refresh > serializes concurrent interactive logins when no tokens exist
 ✓ concurrent refresh > does not re-spend the old refresh token when a concurrent joiner falls through on an already-expired shared result
 Test Files  5 passed (5)
      Tests  54 passed (54)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs — `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider-prompt/model behavior changes; this is an auth token-refresh concurrency fix with no model calls.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — token rotation/persistence artifacts shown inline: exactly one refresh fetch spending `R0`, rotated `R1` saved once, even when a slow store read spans the winning save:

<details><summary>Domain artifacts: refresh-call and save trace for the slow-read case</summary>

```
# Slow load() resolves the pre-write snapshot after the winner's save.
# Without the loadTokens re-check (fix reverted):
  RESULT a="A1"
  RESULT b=rejected  Error: Twitter token refresh failed (400): {"error":"invalid_grant"}
  RESULT refreshCalls=["R0","R0"]  saves=1

# With the loadTokens re-check (this PR):
  RESULT a="A1"
  RESULT b=fulfilled "A1"
  RESULT refreshCalls=["R0"]  saves=1
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes.`

## Backend + frontend logs

**Pre-fix reproduction** (`HEAD~1`, before the single-flight guard) — two concurrent `getAccessToken()` calls against an expired token set (`refresh_token R0`) with a `fetchImpl` modeling X's single-use rotating refresh tokens:

<details><summary>Pre-fix: fulfilled 1 / rejected 1 (invalid_grant)</summary>

```
$ npx vitest run src/client/auth-providers/<probe>   # in plugins/plugin-x

fulfilled: 1 rejected: 1
rejection: Twitter token refresh failed (400): {"error":"invalid_grant"}
AssertionError: expected 1 to be +0 // Object.is equality
 Tests  1 failed (1)
```

One caller loses the race: both loops observed the same expired token and both refreshed `R0`; the first rotated `R0`→`R1`, the second reuse of `R0` returned HTTP 400 `invalid_grant`, which threw out of `getAccessToken()`.
</details>

<details><summary>Post-fix: all callers succeed, single refresh, plus regression suite (5 passed)</summary>

```
$ npx vitest run src/client/auth-providers/oauth2-refresh-race.test.ts --reporter=verbose  # in plugins/plugin-x

 ✓ concurrent refresh > collapses concurrent expiry-window callers onto a single refresh 12ms
 ✓ concurrent refresh > reuses the cached rotated token after the shared refresh without another fetch 2ms
 ✓ concurrent refresh > surfaces a genuine invalid_grant from the single in-flight refresh to every awaiter 2ms
 ✓ concurrent refresh > serializes concurrent interactive logins when no tokens exist 5ms
 ✓ concurrent refresh > does not let a store read that spans the winner's save re-spend the old refresh token 21ms
 ✓ concurrent refresh > refreshes again after the rotated token itself expires 8ms
 ✓ concurrent refresh > does not re-spend the old refresh token when a concurrent joiner falls through on an already-expired shared result 9ms
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ npx vitest run src/client/auth-providers/     # full auth-providers dir (regression safety)
 Test Files  5 passed (5)
      Tests  54 passed (54)

$ bun run --cwd plugins/plugin-x typecheck
$ tsc --noEmit -p tsconfig.json          # exit 0

$ bun run --cwd plugins/plugin-x lint
$ bunx @biomejs/biome check --write --unsafe .
Checked 102 files in 1055ms. No fixes applied.
```
</details>

Frontend logs: `N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - server/runtime concurrency fix; no rendered UI.`

### After

`N/A - server/runtime concurrency fix; no rendered UI.`

### Walkthrough video

`N/A - no UI flow; behavior is proven by the pre-fix-failing / post-fix-passing test logs above.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- **Full `bun run verify`**: not run to completion on this machine (repo-wide multi-package gate). The owning package's focused test, typecheck, and lint all pass on the final synced head (logs above). The change is fully local to one file in `plugins/plugin-x`.
- **Pre-existing unrelated `plugin-x` test failures**: `src/services/PostService.test.ts` and `src/services/x.service.test.ts` fail on a clean `origin/develop` checkout (verified by stashing my change: base had 8 failures, superset of the same files). They are unrelated to the auth-provider path this PR touches; the entire `src/client/auth-providers/` directory is green (54 passed).
- **Immutable evidence-attachment URLs**: the fork's headless attachment-upload session hit a GitHub verification interstitial on this machine and could not mint `user-attachments` URLs. All evidence is therefore pasted inline in `<details>` blocks above rather than as attachment links. Not a blocker: the logs are complete and reproducible offline via the committed test.

## Maintainer CI exception record

`N/A - no exception requested`

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@a3f56262523704e20c9154e19923aa89a266461f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@a3f56262523704e20c9154e19923aa89a266461f:packages/skills/skills/contribute-to-eliza"} -->
