### PR TITLE
fix(plugin-pty): declare shared build dependency

### DIFF
--- a/plugins/plugin-pty/build.ts
+++ b/plugins/plugin-pty/build.ts
@@ -9,7 +9,7 @@ import { buildPlugin } from "../plugin-build";
 await buildPlugin({
   name: "@elizaos/plugin-pty",
   clean: true,
-  externals: ["@elizaos/core", "@lydell/node-pty"],
+  externals: ["@elizaos/core", "@elizaos/shared", "@lydell/node-pty"],
   targets: [
     {
       label: "Node",


### PR DESCRIPTION
## Summary

- build plugin-pty against the public `@elizaos/shared` package dependency
- remove the workspace-relative source import that fails in isolated hosted builds

## Verification

- `bun run --cwd plugins/plugin-pty build`
- `bun run --cwd plugins/plugin-pty typecheck`
- `bun run --cwd plugins/plugin-pty test` (113 passed)

Fixes #29490