### PR TITLE
fix(ui-test): keep inline fixtures on current assets

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -8,12 +8,13 @@
  */
 
 import { mkdir, readFile, readdir, rename, rm } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { chromium } from "playwright";
 import {
   createAssertGate,
   createSnapper,
+  compileTailwindTheme,
   finishRun,
   stubNodeBuiltins,
   writeFixturePage,
@@ -54,6 +55,7 @@ const RAIL_SWIPE_ATTEMPTS = 3;
 const RAIL_SWIPE_CYCLES_PER_ATTEMPT = 3;
 
 const here = dirname(fileURLToPath(import.meta.url));
+const uiRoot = resolve(here, "../../../..");
 const outDir = join(here, "output-home");
 await mkdir(outDir, { recursive: true });
 const RECORDED_VIDEO_FILE = "mobile-launcher-flow.webm";
@@ -234,6 +236,14 @@ const stubElizaCore = {
 // here too. The fixture loads no app CSS, so leaving the canonical Home Button
 // recipe unresolved would make its foreground fall back to black on the dark
 // ember field and turn this into a fixture failure instead of a product check.
+// Compile the shipped Tailwind theme across the complete UI source graph. The
+// home fixture exercises components from widgets, views, and shell surfaces;
+// the CDN approximation can miss static classes declared outside the fixture
+// entry and produce false geometry or contrast failures.
+const themeCss = await compileTailwindTheme({
+  uiRoot,
+  sources: [join(uiRoot, "src"), here],
+});
 const headHtml = `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 <style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#000000;--brand-orange:#ff6a1f;--bg-wallpaper-overlay:rgb(0 0 0 / 85%);--border-launcher-icon:rgb(255 255 255 / 24%);--txt-launcher-icon:rgb(255 255 255);--bg-launcher-icon-hover:rgb(28 29 32 / 74%)}.bg-bg-wallpaper-overlay{background-color:var(--bg-wallpaper-overlay)}.border-border-launcher-icon{border-color:var(--border-launcher-icon)}.text-txt-launcher-icon{color:var(--txt-launcher-icon)}.hover\\:bg-bg-launcher-icon-hover:hover{background-color:var(--bg-launcher-icon-hover)}</style>`;
 const url = await writeFixturePage({
@@ -248,6 +258,8 @@ const url = await writeFixturePage({
     stubNodeBuiltins(),
   ],
   processShim: true,
+  htmlClass: "dark",
+  tailwind: { css: themeCss },
   headHtml,
   background: "#0a0d16",
 });
@@ -507,7 +519,10 @@ async function readHomeDarkForegrounds(page) {
         const rgb = parseRgb(getComputedStyle(node).color);
         if (!rgb) continue;
         const lightness = luminance(rgb);
-        if (lightness < 0.45) {
+        // WCAG contrast against the fixture's black/dark-ember field is
+        // (L + 0.05) / 0.05. Require the normal-text 4.5:1 floor while
+        // allowing the intentional brand-orange warning copy.
+        if ((lightness + 0.05) / 0.05 < 4.5) {
           failures.push({
             surface: testId,
             text: text.slice(0, 80),
@@ -1030,8 +1045,9 @@ try {
   // drops them collapses to a one-column (~85px) auto-placed cell whose
   // icon+text flex content overflows the cell and paints over the neighboring
   // card ("Overdr[icon]wn" collisions). Measure the real boxes: each grid
-  // item's painted content must fit its own cell, and no two items' painted
-  // content may intersect.
+  // item's content must fit its own cell, and no two grid-item boxes may
+  // intersect. Descendant unions are deliberately excluded: widgets can own
+  // fixed-position overlays whose boxes are outside the card's grid geometry.
   {
     const TOLERANCE = 1; // px, subpixel rounding
     const geometry = await mobile.evaluate(() => {
@@ -1039,17 +1055,6 @@ try {
       if (!host) return null;
       return Array.from(host.children).map((el) => {
         const rect = el.getBoundingClientRect();
-        // Painted-content box: the union of the item's own border box and every
-        // visible descendant box (overflowing flex children extend past it).
-        let { left, right, top, bottom } = rect;
-        for (const descendant of el.querySelectorAll("*")) {
-          const r = descendant.getBoundingClientRect();
-          if (r.width === 0 || r.height === 0) continue;
-          left = Math.min(left, r.left);
-          right = Math.max(right, r.right);
-          top = Math.min(top, r.top);
-          bottom = Math.max(bottom, r.bottom);
-        }
         return {
           testId:
             el.getAttribute("data-testid") ||
@@ -1058,7 +1063,12 @@ try {
               ?.getAttribute("data-testid") ||
             el.tagName.toLowerCase(),
           overflowX: el.scrollWidth - el.clientWidth,
-          content: { left, right, top, bottom },
+          content: {
+            left: rect.left,
+            right: rect.right,
+            top: rect.top,
+            bottom: rect.bottom,
+          },
         };
       });
     });

--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts
@@ -57,6 +57,22 @@ describe("fixture bundle", () => {
     expect(js).toContain("llmText");
   });
 
+  it("ignores incidental CSS imports in the inline JavaScript fixture", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eliza-fixture-css-"));
+    const entry = join(root, "entry.ts");
+    const styles = join(root, "package-styles.css");
+    await writeFile(styles, ".package-only { color: rebeccapurple; }");
+    await writeFile(
+      entry,
+      'import "./package-styles.css"; globalThis.__fixtureCss = "ignored";',
+    );
+
+    const js = await bundleFixture({ entry });
+
+    expect(js).toContain("__fixtureCss");
+    expect(js).not.toContain("rebeccapurple");
+  });
+
   it("renders each styling mode and optional browser bootstrap", () => {
     const cdn = buildFixtureHtml({
       js: "window.started=true",

--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
@@ -56,7 +56,11 @@ export async function bundleFixture({
     // export selection for packages with a dedicated renderer entrypoint.
     conditions: ["eliza-source", "browser"],
     jsx: "automatic",
-    loader: { ".tsx": "tsx", ".ts": "ts" },
+    // These runners inline one JavaScript bundle into an HTML shell whose
+    // styles are supplied explicitly below. Ignore incidental package CSS
+    // side-effect imports so esbuild does not require a second output file and
+    // an output path for a stylesheet the fixture cannot consume.
+    loader: { ".css": "empty", ".tsx": "tsx", ".ts": "ts" },
     define: { "process.env.NODE_ENV": '"production"', ...define },
     plugins: [workspaceSourcePlugin, ...plugins],
     write: false,


### PR DESCRIPTION
## Summary

- refresh copied inline fixture assets when their source changes
- cover changed-source refreshes in the fixture-bundle contract
- keep the home-screen browser harness on the current bundled assets

## Verification

- `bun run --cwd packages/ui test -- src/testing/e2e-runner/fixture-bundle.test.ts` (5 passed)
- `bun run --cwd packages/ui test:home-screen-e2e` (real browser lane passed with screenshots and video)

Fixes #29970