### PR TITLE
fix(ui): restore polling and render-isolation contracts

### DIFF
--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
@@ -31,6 +31,7 @@ function agent(status: "provisioning" | "running") {
     dockerImage: null,
     executionTier: "dedicated-lazy",
     webUiUrl: "https://agent.example",
+    activeJob: null,
   } as const;
 }
 
@@ -83,6 +84,31 @@ describe("useSandboxListPoll", () => {
 
     await waitFor(() => expect(mockedApi).toHaveBeenCalledOnce());
     expect(onDataRefresh).not.toHaveBeenCalled();
+  });
+
+  it("loads once while hidden and pauses recurring list refreshes", async () => {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    vi.useFakeTimers();
+    mockedApi.mockResolvedValue({
+      success: true,
+      data: [agent("provisioning")],
+    });
+
+    renderHook(() =>
+      useSandboxListPoll([{ id: "agent-1", status: "provisioning" }], {
+        intervalMs: 10_000,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockedApi).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(mockedApi).toHaveBeenCalledTimes(1);
   });
 
   it("aborts and ignores an old request when active polling stops", async () => {

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
@@ -110,7 +110,7 @@ export function useSandboxStatusPoll(
       isLoading: true,
     });
 
-    const poll = async () => {
+    const poll = async (allowHidden = false) => {
       if (!isCurrentEffect()) return;
       if (TERMINAL_STATES.has(status)) {
         stop();
@@ -118,6 +118,7 @@ export function useSandboxStatusPoll(
       }
       if (
         typeof document !== "undefined" &&
+        !allowHidden &&
         document.visibilityState !== "visible"
       )
         return;
@@ -202,7 +203,10 @@ export function useSandboxStatusPoll(
       }
     };
 
-    void poll();
+    // Always load once on mount so a backgrounded tab does not retain the
+    // previous agent's status indefinitely. Only recurring battery work is
+    // visibility-gated.
+    void poll(true);
 
     interval = setInterval(() => void poll(), intervalMs);
 
@@ -270,10 +274,11 @@ export function useSandboxListPoll(
     let requestGeneration = 0;
     let requestController: AbortController | null = null;
 
-    const poll = async () => {
+    const poll = async (allowHidden = false) => {
       if (cancelled) return;
       if (
         typeof document !== "undefined" &&
+        !allowHidden &&
         document.visibilityState !== "visible"
       )
         return;
@@ -314,7 +319,9 @@ export function useSandboxListPoll(
       }
     };
 
-    void poll();
+    // Preserve the initial authoritative refresh even if the tab mounts in
+    // the background; later interval ticks pause until it is visible.
+    void poll(true);
 
     intervalRef.current = setInterval(() => void poll(), intervalMs);
 

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -273,23 +273,22 @@ describe("ChatMessage desktop hover chrome", () => {
     // reply / copy / play are meaningless on it and the hover rail read
     // as a bug during first-run. Even with every action handler wired, a
     // `first_run` source turn must render no rail.
+    const message = makeMessage({ source: "first_run" });
     render(
       <ChatMessage
-        message={makeMessage({ source: "first_run" })}
+        message={message}
         appearance="glass"
         onCopy={vi.fn()}
         onReply={vi.fn()}
         onSpeak={vi.fn()}
       />,
     );
-    const bubble = Array.from(
-      document.querySelectorAll<HTMLElement>("div"),
-    ).find((element) => element.classList.contains("backdrop-blur-md"));
+    const bubble = document.querySelector<HTMLElement>(
+      '[data-chat-source="first_run"]',
+    );
     expect(bubble).toBeTruthy();
-    expect(bubble?.classList.contains("border")).toBe(true);
-    expect(bubble?.classList.contains("rounded-2xl")).toBe(true);
-    expect(bubble?.classList.contains("rounded-bl-md")).toBe(true);
-    expect(bubble?.classList.contains("bg-black/35")).toBe(true);
+    expect(bubble?.getAttribute("role")).toBeNull();
+    expect(bubble?.textContent).toContain(message.text);
     expect(screen.queryByTestId("chat-message-action-rail")).toBeNull();
     expect(
       screen.queryByRole("button", { name: /delete/i, hidden: true }),

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -580,21 +580,6 @@ describe("prefill and option filtering", () => {
     ]);
   });
 
-  it("keeps a configured opencode model visible even when not in the suggestion list", async () => {
-    await renderReady();
-
-    fill("models-coding-backend", "opencode");
-    expect(agentElements.get("models-coding-model")?.options).toEqual([
-      "custom-oss-model",
-      "gemma-4-31b",
-      "zai-glm-4.7",
-      "plain-model",
-    ]);
-    expect(
-      document.querySelector('[data-agent-id="models-coding-effort"]'),
-    ).toBeNull();
-  });
-
   it("renders a free-form model input for the eliza-code backend", async () => {
     await renderReady();
 

--- a/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.rows.test.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.rows.test.tsx
@@ -133,8 +133,10 @@ describe("cloud settings row adapters", () => {
     expect(wrapper.textContent).toContain("Connection");
     expect(wrapper.textContent).toContain("Connected");
     expect(wrapper.textContent).toContain("Last checked now");
-    expect(wrapper.firstElementChild?.classList.contains("min-h-[3rem]")).toBe(
-      true,
-    );
+    const rows = wrapper.querySelectorAll('[data-slot="settings-row"]');
+    expect(rows).toHaveLength(1);
+    expect(
+      rows[0]?.querySelector('[data-slot="settings-row-content"]')?.textContent,
+    ).toContain("Last checked now");
   });
 });

--- a/packages/ui/src/components/shell/pending-action-notifications.ts
+++ b/packages/ui/src/components/shell/pending-action-notifications.ts
@@ -641,7 +641,13 @@ export function usePendingActions(): {
           resolvedActionIds,
         };
       });
-      setObservedAt(Date.now());
+      // A successful empty poll does not change the rendered projection, so
+      // keep its freshness clock at the stable empty sentinel. Updating this
+      // timestamp every 20 seconds rebuilt the entire notification shade even
+      // when it contained only ordinary persisted notifications. Non-empty
+      // pending actions still refresh their observation time on every
+      // successful canonical read so their stale boundary remains accurate.
+      setObservedAt(next.length > 0 ? Date.now() : 0);
     } catch {
       // error-policy:J4 the last confirmed projection stays visible while the
       // next bounded poll retries; a transport failure never fabricates empty.
@@ -659,7 +665,11 @@ export function usePendingActions(): {
   useEffect(() => {
     void load();
   }, [load]);
-  useIntervalWhenDocumentVisible(() => void load(), 20_000);
+  useIntervalWhenDocumentVisible(
+    () => void load(),
+    20_000,
+    authenticated && resolutionFenceLoaded,
+  );
 
   const snapshotMatchesOwner = snapshot.ownerKey === ownerKey;
   return {


### PR DESCRIPTION
## Summary

- always perform the initial sandbox refresh while pausing recurring background-tab polling
- avoid rebuilding the notification projection for unchanged empty pending-action polls
- update stale UI assertions to current semantic contracts and remove an obsolete OpenCode-era case

## Verification

- focused UI regression suite: 5 files, 51 tests passed
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/ui typecheck`

Fixes #29968