### PR TITLE
fix(cloud): finish standing checks and async inference settlement

### DIFF
--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -220,7 +220,8 @@ beforeEach(() => {
   recordCreatorEarnings.mockReset();
   reserve.mockReset();
   admitOrganizationInference.mockClear();
-  markProviderDispatched.mockClear();
+  markProviderDispatched.mockReset();
+  markProviderDispatched.mockResolvedValue(undefined);
   charactersGetById.mockReset();
   requireUserOrApiKeyWithOrg.mockReset();
 
@@ -399,8 +400,8 @@ describe("Agent A2A billing", () => {
     },
   );
 
-  test("missing provider usage fails and refunds instead of fabricating zero metering", async () => {
-    const reconcile = makeReservation({ adjustmentType: "refund" });
+  test("missing provider usage settles the reserved estimate instead of fabricating zero metering", async () => {
+    const reconcile = makeReservation({ adjustmentType: "none" });
     streamText.mockResolvedValue({
       textStream: textStream("unmetered output"),
       usage: Promise.resolve({
@@ -417,7 +418,60 @@ describe("Agent A2A billing", () => {
 
     expect(body.error?.code).toBe(-32000);
     expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("a provider rejection settles the reserved estimate", async () => {
+    const reconcile = makeReservation({ adjustmentType: "none" });
+    streamText.mockRejectedValue(new Error("provider unavailable"));
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32000);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("incomplete provider output settles the reserved estimate", async () => {
+    const reconcile = makeReservation({ adjustmentType: "none" });
+    streamText.mockResolvedValue({
+      textStream: textStream("partial output"),
+      finishReason: Promise.resolve("length"),
+      usage: Promise.resolve({
+        inputTokens: 100,
+        outputTokens: 25,
+        totalTokens: 125,
+      }),
+    });
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32000);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("a dispatch-marker failure refunds before provider dispatch", async () => {
+    const reconcile = makeReservation({ adjustmentType: "refund" });
+    markProviderDispatched.mockRejectedValue(new Error("marker unavailable"));
+
+    const response = await callChat();
+
+    expect(response.status).toBe(200);
+    expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile).toHaveBeenCalledWith(0);
+    expect(streamText).not.toHaveBeenCalled();
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -201,7 +201,8 @@ beforeEach(() => {
   recordCreatorEarnings.mockReset();
   reserve.mockReset();
   admitOrganizationInference.mockClear();
-  markProviderDispatched.mockClear();
+  markProviderDispatched.mockReset();
+  markProviderDispatched.mockResolvedValue(undefined);
 
   estimateRequestCost.mockResolvedValue(0.01);
   calculateCost.mockResolvedValue({ totalCost: 0.01 });
@@ -412,8 +413,8 @@ describe("Agent MCP billing", () => {
     expect(streamText).not.toHaveBeenCalled();
   });
 
-  test("missing provider usage fails and refunds instead of fabricating zero metering", async () => {
-    const reconcile = makeReservation({ adjustmentType: "refund" });
+  test("missing provider usage settles the reserved estimate instead of fabricating zero metering", async () => {
+    const reconcile = makeReservation({ adjustmentType: "none" });
     streamText.mockResolvedValue({
       textStream: textStream("unmetered output"),
       usage: Promise.resolve({
@@ -430,11 +431,12 @@ describe("Agent MCP billing", () => {
 
     expect(body.error?.code).toBe(-32000);
     expect(reconcile).toHaveBeenCalledTimes(1);
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 
-  test("a provider error refunds the reservation and returns -32000", async () => {
+  test("a provider rejection settles the reserved estimate and returns -32000", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
     streamText.mockRejectedValue(new Error("provider unavailable"));
 
@@ -445,8 +447,44 @@ describe("Agent MCP billing", () => {
 
     expect(body.error?.code).toBe(-32000);
     expect(body.error?.message).toBe("provider unavailable");
-    // The whole reservation is refunded (reconcile(0)); no creator earnings.
+    expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("incomplete provider output settles the reserved estimate", async () => {
+    const reconcile = makeReservation({ adjustmentType: "none" });
+    streamText.mockResolvedValue({
+      textStream: textStream("partial output"),
+      finishReason: Promise.resolve("length"),
+      usage: Promise.resolve({
+        inputTokens: 100,
+        outputTokens: 25,
+        totalTokens: 125,
+      }),
+    });
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32000);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("a dispatch-marker failure refunds before provider dispatch", async () => {
+    const reconcile = makeReservation({ adjustmentType: "refund" });
+    markProviderDispatched.mockRejectedValue(new Error("marker unavailable"));
+
+    const response = await callChat();
+
+    expect(response.status).toBe(200);
+    expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile).toHaveBeenCalledWith(0);
+    expect(streamText).not.toHaveBeenCalled();
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
@@ -279,6 +279,79 @@ describe("/v1/chat Worker cache hot path", () => {
     expect(streamText).not.toHaveBeenCalled();
   });
 
+  test("preserves a cached standing 503 before admission or provider dispatch", async () => {
+    authResolutionImpl = async () => ({
+      kind: "rejected" as const,
+      status: 503 as const,
+    });
+    const executionCtx = {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const response = await chatRoute.fetch(
+      new Request("https://api.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer eliza_cached",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      {} as never,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.json()).resolves.toMatchObject({
+      code: "service_unavailable",
+      reason: "authorization_unavailable",
+    });
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("returns a typed cached standing reason before provider dispatch", async () => {
+    authResolutionImpl = async () => ({
+      kind: "rejected" as const,
+      status: 403 as const,
+      reason: "credential_inactive" as const,
+    });
+    const executionCtx = {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const response = await chatRoute.fetch(
+      new Request("https://api.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer eliza_cached",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      {} as never,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "API key is inactive",
+      code: "access_denied",
+      reason: "credential_inactive",
+    });
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
   test("dispatches only after cached admission and defers reservation-aware billing", async () => {
     const waitUntilTasks: Promise<unknown>[] = [];
     const executionCtx = {

--- a/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
@@ -345,6 +345,55 @@ test("warm Worker request reaches provider with authoritative stores tripwired",
   expect(shouldBlockUser).not.toHaveBeenCalled();
 });
 
+test("preserves a cached standing 503 before provider dispatch", async () => {
+  resolveInferenceAuthContext.mockResolvedValueOnce({
+    kind: "rejected",
+    status: 503,
+  } as never);
+  const background: Promise<unknown>[] = [];
+
+  const response = await handleChatCompletionsPOST(request(), {
+    executionCtx: executionCtx(background),
+  });
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("Retry-After")).toBe("1");
+  expect(await response.json()).toMatchObject({
+    error: {
+      type: "service_unavailable",
+      code: "service_unavailable",
+      details: { reason: "authorization_unavailable" },
+    },
+  });
+  expect(enforceOrgRateLimit).not.toHaveBeenCalled();
+  expect(admitAppInferenceCacheOnly).not.toHaveBeenCalled();
+  expect(generateText).not.toHaveBeenCalled();
+});
+
+test("returns a typed cached standing reason before provider dispatch", async () => {
+  resolveInferenceAuthContext.mockResolvedValueOnce({
+    kind: "rejected",
+    status: 403,
+    reason: "organization_inactive",
+  } as never);
+  const background: Promise<unknown>[] = [];
+
+  const response = await handleChatCompletionsPOST(request(), {
+    executionCtx: executionCtx(background),
+  });
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({
+    error: {
+      message: "Organization is inactive",
+      code: "access_denied",
+      details: { reason: "organization_inactive" },
+    },
+  });
+  expect(admitAppInferenceCacheOnly).not.toHaveBeenCalled();
+  expect(generateText).not.toHaveBeenCalled();
+});
+
 test("cold dependency returns 503 before held hydration completes", async () => {
   appCacheState = "warming";
   const hydration = Promise.withResolvers<void>();

--- a/packages/cloud/api/__tests__/embeddings-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-cache-hotpath.test.ts
@@ -329,6 +329,55 @@ describe("POST /api/v1/embeddings Worker cache hot path", () => {
     await scheduled[0];
   });
 
+  test("preserves a cached standing 503 before admission or provider dispatch", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "rejected",
+      status: 503,
+    });
+    const { ctx, scheduled } = makeExecutionCtx();
+
+    const response = await post(ctx);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        type: "service_unavailable",
+        code: "service_unavailable",
+        details: { reason: "authorization_unavailable" },
+      },
+    });
+    expect(enforceOrgRateLimit).not.toHaveBeenCalled();
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(embed).not.toHaveBeenCalled();
+    expect(embedMany).not.toHaveBeenCalled();
+    await Promise.all(scheduled);
+  });
+
+  test("returns a typed cached standing reason before provider dispatch", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "rejected",
+      status: 403,
+      reason: "membership_missing",
+    });
+    const { ctx, scheduled } = makeExecutionCtx();
+
+    const response = await post(ctx);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: "Account is not associated with an active organization",
+        code: "access_denied",
+        details: { reason: "membership_missing" },
+      },
+    });
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(embed).not.toHaveBeenCalled();
+    expect(embedMany).not.toHaveBeenCalled();
+    await Promise.all(scheduled);
+  });
+
   test("cold org-rate policy is an explicit retryable 503 before admission", async () => {
     enforceOrgRateLimit.mockRejectedValueOnce(
       new rateLimitActual.OrgRateLimitCacheNotReadyError("warming", "miss"),

--- a/packages/cloud/api/__tests__/generative-route-warming-await.test.ts
+++ b/packages/cloud/api/__tests__/generative-route-warming-await.test.ts
@@ -7,7 +7,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const resolveInferenceAuthContext = mock();
+const observeInferenceApiKeyUsage = mock();
 mock.module("@/lib/services/inference-auth-context", () => ({
+  observeInferenceApiKeyUsage,
   resolveInferenceAuthContext,
 }));
 
@@ -68,18 +70,22 @@ const authorized = {
 describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
   beforeEach(() => {
     resolveInferenceAuthContext.mockReset();
+    observeInferenceApiKeyUsage.mockReset();
   });
 
   afterEach(() => {
     resolveInferenceAuthContext.mockReset();
+    observeInferenceApiKeyUsage.mockReset();
   });
 
-  test("converts warming to authorized when hydration settles inside the budget", async () => {
+  test("consumes an authorized continuation without a second cache read", async () => {
     const { c } = workerContext();
-    const hydration = Promise.resolve({ kind: "authorized" });
-    resolveInferenceAuthContext
-      .mockResolvedValueOnce({ kind: "warming", hydration })
-      .mockResolvedValueOnce(authorized);
+    const continuation = Promise.resolve(authorized);
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "warming",
+      hydration: continuation,
+      continuation,
+    });
 
     const caller = await requireGenerativeRouteCaller(c as never, {
       awaitWarmingMs: 1500,
@@ -89,7 +95,8 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
       authSource: "combined_cache",
       user: { id: "user-1", organization_id: "org-1" },
     });
-    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(observeInferenceApiKeyUsage).toHaveBeenCalledTimes(1);
   });
 
   test("returns the retryable warming 503 when the budget expires", async () => {
@@ -98,9 +105,11 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
     const hydration = new Promise((resolve) => {
       release = () => resolve({ kind: "authorized" });
     });
-    resolveInferenceAuthContext
-      .mockResolvedValueOnce({ kind: "warming", hydration })
-      .mockResolvedValueOnce({ kind: "warming", hydration });
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "warming",
+      hydration,
+      continuation: hydration,
+    });
 
     await expect(
       requireGenerativeRouteCaller(c as never, { awaitWarmingMs: 20 }),
@@ -108,7 +117,8 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
       status: 503,
       code: "service_unavailable",
     });
-    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(observeInferenceApiKeyUsage).not.toHaveBeenCalled();
     release?.();
   });
 
@@ -124,12 +134,15 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
 
   test("definitive rejection after hydration is surfaced, not swallowed", async () => {
     const { c } = workerContext();
-    resolveInferenceAuthContext
-      .mockResolvedValueOnce({
-        kind: "warming",
-        hydration: Promise.resolve({ kind: "rejected", status: 401 }),
-      })
-      .mockResolvedValueOnce({ kind: "rejected", status: 401 });
+    const continuation = Promise.resolve({
+      kind: "rejected" as const,
+      status: 401 as const,
+    });
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "warming",
+      hydration: continuation,
+      continuation,
+    });
 
     await expect(
       requireGenerativeRouteCaller(c as never, { awaitWarmingMs: 1500 }),
@@ -137,6 +150,8 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
       status: 401,
       code: "authentication_required",
     });
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(observeInferenceApiKeyUsage).not.toHaveBeenCalled();
   });
 
   test("default unset budget keeps the original warming 503", async () => {

--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -20,21 +20,24 @@ import {
   test,
 } from "bun:test";
 import { Hono } from "hono";
-// Spread the real module: bun's `mock.module` replaces the registry entry
-// process-wide, so dropping the other real exports of workers-hono-auth would
-// break every later test file that imports from it.
-import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 import * as loggerActual from "@/lib/utils/logger";
 
-const requireUserOrApiKeyWithOrg =
-  mock<(c: unknown) => Promise<{ id: string; organization_id: string }>>();
+const requireGenerativeRouteCaller =
+  mock<
+    (c: unknown) => Promise<{
+      user: { id: string; organization_id: string };
+      apiKeyId: string | null;
+      appScopeId: string | null;
+    }>
+  >();
 const loggerInfo = mock<(...args: unknown[]) => void>();
 const loggerWarn = mock<(...args: unknown[]) => void>();
 const loggerError = mock<(...args: unknown[]) => void>();
 
-mock.module("@/lib/auth/workers-hono-auth", () => ({
-  ...workersHonoAuthActual,
-  requireUserOrApiKeyWithOrg,
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller,
+  asGenerativeCacheApiError: () => null,
 }));
 
 mock.module("@/lib/utils/logger", () => ({
@@ -68,15 +71,16 @@ beforeEach(() => {
   loggerInfo.mockClear();
   loggerWarn.mockClear();
   loggerError.mockClear();
-  requireUserOrApiKeyWithOrg.mockResolvedValue({
-    id: "user-1",
-    organization_id: "org-1",
+  requireGenerativeRouteCaller.mockResolvedValue({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    appScopeId: null,
   });
 });
 
 afterEach(() => {
   setSystemTime();
-  requireUserOrApiKeyWithOrg.mockReset();
+  requireGenerativeRouteCaller.mockReset();
   loggerInfo.mockReset();
   loggerWarn.mockReset();
   loggerError.mockReset();
@@ -119,7 +123,7 @@ function makeRequest(
 describe("GET /api/v1/hf-proxy/[...path]", () => {
   test("requires authentication", async () => {
     // An unauthenticated request throws from the auth gate before any proxying.
-    requireUserOrApiKeyWithOrg.mockRejectedValueOnce(
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
       Object.assign(new Error("Authentication required"), {
         name: "AuthenticationError",
       }),
@@ -130,7 +134,30 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     });
 
     expect(res.status).toBe(401);
-    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns the cached standing reason without contacting HuggingFace", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new ApiError(403, "access_denied", "Organization is inactive", {
+        reason: "organization_inactive",
+      }),
+    );
+    const upstreamFetch = mock(async () => new Response("not reached"));
+    globalThis.fetch = upstreamFetch as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Organization is inactive",
+      code: "access_denied",
+      details: { reason: "organization_inactive" },
+    });
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(upstreamFetch).not.toHaveBeenCalled();
   });
 
   test("rejects a non-/resolve/ path with 400", async () => {

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -506,6 +506,88 @@ describe("/v1/messages IAC fast path", () => {
     expect(generateText).not.toHaveBeenCalled();
   });
 
+  test("preserves a cached standing 503 before billing or provider work", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "rejected",
+      status: 503,
+    });
+
+    const response = await postMessagesInWorker();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.json()).resolves.toMatchObject({
+      type: "error",
+      error: {
+        type: "service_unavailable",
+        message: "Authorization service is unavailable. Retry shortly.",
+      },
+    });
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("returns a typed cached standing reason before provider work", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "rejected",
+      status: 403,
+      reason: "account_inactive",
+    });
+
+    const response = await postMessagesInWorker();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      type: "error",
+      error: {
+        type: "permission_error",
+        message: "Account is inactive",
+      },
+    });
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("preserves a thrown auth-unavailable 503 instead of collapsing it to 401", async () => {
+    const unavailable = new Error("revocation authority unavailable");
+    unavailable.name = "InferenceCredentialRevocationUnavailableError";
+    resolveInferenceAuthContext.mockRejectedValueOnce(unavailable);
+
+    const response = await postMessagesInWorker();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.json()).resolves.toMatchObject({
+      type: "error",
+      error: { type: "service_unavailable" },
+    });
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("maps an unexpected resolver failure to 500 instead of an auth rejection", async () => {
+    resolveInferenceAuthContext.mockRejectedValueOnce(
+      new Error("database connection reset"),
+    );
+
+    const response = await postMessagesInWorker();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      type: "error",
+      error: {
+        type: "api_error",
+        message: "Authorization could not be completed.",
+      },
+    });
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
   test("monetized X-App-Id messages use app-credit reservation with creator markup", async () => {
     const appReservation = {
       reservedAmount: 0.02,

--- a/packages/cloud/api/__tests__/paid-app-routes-standing-gate.test.ts
+++ b/packages/cloud/api/__tests__/paid-app-routes-standing-gate.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Proves paid app review, promotion, asset, and automation POST routes stop at
+ * the shared standing boundary before any provider-backed service can run.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+
+const requireGenerativeRouteCaller = mock(async () => {
+  throw new ApiError(403, "access_denied", "Organization is inactive", {
+    reason: "organization_inactive",
+  });
+});
+const runAppReview = mock(async () => ({ disposition: "allow" }));
+const promoteApp = mock(async () => ({ totalCreditsUsed: 0, errors: [] }));
+const generateAssetBundle = mock(async () => ({
+  assets: [],
+  copy: null,
+  errors: [],
+}));
+const postAppTweet = mock(async () => ({ success: true }));
+const postTelegramAnnouncement = mock(async () => ({ success: true }));
+const postDiscordAnnouncement = mock(async () => ({ success: true }));
+const generateAppTweet = mock(async () => ({
+  text: "preview",
+  type: "promotional",
+}));
+const generateTelegramAnnouncement = mock(async () => "preview");
+const generateDiscordAnnouncement = mock(async () => "preview");
+const deductCredits = mock(async () => ({ success: true }));
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller,
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { CRITICAL: {}, STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: mock(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKey: null,
+  })),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: mock(async () => false),
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getById: mock(async () => ({
+      id: "app-1",
+      organization_id: "org-1",
+      name: "Demo",
+    })),
+    update: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/app-review", () => ({
+  getLatestAppReview: mock(async () => null),
+  runAppReview,
+}));
+mock.module("@/lib/services/app-promotion", () => ({
+  appPromotionService: {
+    getPromotionHistory: mock(async () => []),
+    getPromotionSuggestions: mock(async () => []),
+    promoteApp,
+  },
+}));
+mock.module("@/lib/services/app-promotion-assets", () => ({
+  AD_SIZES: {
+    twitter_card: { width: 800, height: 418 },
+  },
+  appPromotionAssetsService: {
+    getRecommendedSizes: mock(() => []),
+    generateAssetBundle,
+  },
+}));
+mock.module("@/lib/promotion-pricing", () => ({
+  AD_COPY_GENERATION_COST: 1,
+  PROMO_IMAGE_COST: 2,
+  estimateAssetGenerationCost: () => ({ total: 5 }),
+}));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    deductCredits,
+    refundCredits: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/twitter-automation/app-automation", () => ({
+  twitterAppAutomationService: { postAppTweet, generateAppTweet },
+}));
+mock.module("@/lib/services/telegram-automation/app-automation", () => ({
+  telegramAppAutomationService: {
+    postAnnouncement: postTelegramAnnouncement,
+    generateAnnouncement: generateTelegramAnnouncement,
+  },
+}));
+mock.module("@/lib/services/discord-automation/app-automation", () => ({
+  discordAppAutomationService: {
+    postAnnouncement: postDiscordAnnouncement,
+    generateAnnouncement: generateDiscordAnnouncement,
+  },
+}));
+mock.module("@/lib/services/automation-constants", () => ({
+  getTwitterConfigWithDefaults: (value: unknown) => value ?? {},
+  getTelegramConfigWithDefaults: (value: unknown) => value ?? {},
+  getDiscordConfigWithDefaults: (value: unknown) => value ?? {},
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const [
+  { default: reviewRoute },
+  { default: promoteRoute },
+  { default: assetsRoute },
+  { default: twitterPostRoute },
+  { default: telegramPostRoute },
+  { default: discordPostRoute },
+  { default: promotionPreviewRoute },
+] = await Promise.all([
+  import("../v1/apps/[id]/review/route"),
+  import("../v1/apps/[id]/promote/route"),
+  import("../v1/apps/[id]/promote/assets/route"),
+  import("../v1/apps/[id]/twitter-automation/post/route"),
+  import("../v1/apps/[id]/telegram-automation/post/route"),
+  import("../v1/apps/[id]/discord-automation/post/route"),
+  import("../v1/apps/[id]/promote/preview/route"),
+]);
+
+const app = new Hono()
+  .route("/apps/:id/review", reviewRoute)
+  .route("/apps/:id/promote", promoteRoute)
+  .route("/apps/:id/promote/assets", assetsRoute)
+  .route("/apps/:id/twitter-automation/post", twitterPostRoute)
+  .route("/apps/:id/telegram-automation/post", telegramPostRoute)
+  .route("/apps/:id/discord-automation/post", discordPostRoute)
+  .route("/apps/:id/promote/preview", promotionPreviewRoute);
+
+const providerBackedCalls = [
+  runAppReview,
+  promoteApp,
+  generateAssetBundle,
+  postAppTweet,
+  postTelegramAnnouncement,
+  postDiscordAnnouncement,
+  generateAppTweet,
+  generateTelegramAnnouncement,
+  generateDiscordAnnouncement,
+];
+
+describe("paid app routes standing gate", () => {
+  beforeEach(() => {
+    requireGenerativeRouteCaller.mockClear();
+    deductCredits.mockClear();
+    for (const call of providerBackedCalls) call.mockClear();
+  });
+
+  test.each([
+    ["review", "/apps/app-1/review", {}],
+    ["promotion", "/apps/app-1/promote", { channels: ["social"] }],
+    ["promotion assets", "/apps/app-1/promote/assets", {}],
+    ["Twitter automation", "/apps/app-1/twitter-automation/post", {}],
+    ["Telegram automation", "/apps/app-1/telegram-automation/post", {}],
+    ["Discord automation", "/apps/app-1/discord-automation/post", {}],
+    [
+      "promotion preview",
+      "/apps/app-1/promote/preview",
+      { platforms: ["twitter", "telegram", "discord"], count: 1 },
+    ],
+  ])(
+    "denies %s before credit or provider dispatch",
+    async (_name, path, body) => {
+      const response = await app.request(path, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        code: "access_denied",
+        error: "Organization is inactive",
+        details: { reason: "organization_inactive" },
+      });
+      expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+      expect(deductCredits).not.toHaveBeenCalled();
+      for (const call of providerBackedCalls)
+        expect(call).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -455,8 +455,10 @@ async function handleChat(
     throw error;
   }
 
+  let providerDispatchStarted = false;
   try {
     await admission.markProviderDispatched?.();
+    providerDispatchStarted = true;
     const result = await streamText({
       model: getLanguageModel(model),
       messages: fullMessages,
@@ -555,11 +557,14 @@ async function handleChat(
       id: rpcId,
     });
   } catch (error) {
-    // error-policy:J1 the JSON-RPC boundary refunds a failed generation and
-    // returns a redacted structured failure instead of partial model output.
-    const release = admission.settle(0);
-    if (authUser.executionCtx) authUser.executionCtx.waitUntil(release);
-    else await release;
+    // error-policy:J1 the JSON-RPC boundary conservatively settles dispatches
+    // with unknown usage, while failures before provider dispatch are safe to
+    // refund in full.
+    const terminal = providerDispatchStarted
+      ? admission.settleUnknown()
+      : admission.settle(0);
+    if (authUser.executionCtx) authUser.executionCtx.waitUntil(terminal);
+    else await terminal;
     logger.error("[Agent A2A] Error generating response", {
       error: error instanceof Error ? error.message : "Unknown error",
       agentId: character.id,

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -493,8 +493,10 @@ export async function handleToolCall(
       throw error;
     }
 
+    let providerDispatchStarted = false;
     try {
       await admission.markProviderDispatched?.();
+      providerDispatchStarted = true;
       logger.info("[Agent MCP] Invoking configured provider", {
         agentId: character.id,
         model,
@@ -605,11 +607,14 @@ export async function handleToolCall(
         id: rpcId,
       });
     } catch (error) {
-      // error-policy:J1 the JSON-RPC boundary refunds a failed generation and
-      // returns a structured failure instead of partial model output.
-      const release = admission.settle(0);
-      if (authUser.executionCtx) authUser.executionCtx.waitUntil(release);
-      else await release;
+      // error-policy:J1 the JSON-RPC boundary conservatively settles dispatches
+      // with unknown usage, while failures before provider dispatch are safe to
+      // refund in full.
+      const terminal = providerDispatchStarted
+        ? admission.settleUnknown()
+        : admission.settle(0);
+      if (authUser.executionCtx) authUser.executionCtx.waitUntil(terminal);
+      else await terminal;
       logger.error("[Agent MCP] Error generating response", {
         error: error instanceof Error ? error.message : "Unknown error",
         agentId: character.id,

--- a/packages/cloud/api/fal/proxy/route.standing.test.ts
+++ b/packages/cloud/api/fal/proxy/route.standing.test.ts
@@ -1,0 +1,56 @@
+/** Proves fal.ai mutations stop at the shared standing gate before pricing or dispatch. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+
+const invokeFalProxy = mock(
+  async () => new Response("upstream", { status: 200 }),
+);
+
+mock.module("@fal-ai/server-proxy", () => ({
+  DEFAULT_ALLOWED_URL_PATTERNS: [],
+  TARGET_URL_HEADER: "x-fal-target-url",
+  getEndpoint: (value: string) => value,
+  resolveApiKeyFromEnv: () => "unused",
+}));
+mock.module("@fal-ai/server-proxy/hono", () => ({
+  createRouteHandler: () => invokeFalProxy,
+}));
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  admitFlatGenerativeOperation: mock(async () => {
+    throw new Error("admission must not run after standing denial");
+  }),
+  asGenerativeCacheApiError: () => null,
+  getGenerativeExecutionContext: () => undefined,
+  requireGenerativeRouteCaller: mock(async () => {
+    throw new ApiError(403, "access_denied", "Account is inactive", {
+      reason: "account_inactive",
+    });
+  }),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const { default: falRoute } = await import("./route");
+const app = new Hono().route("/fal/proxy", falRoute);
+
+test("standing denial prevents fal pricing, credit admission, and provider dispatch", async () => {
+  const response = await app.request("/fal/proxy", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "fal-ai/test",
+    },
+    body: "{}",
+  });
+
+  expect(response.status).toBe(403);
+  await expect(response.json()).resolves.toMatchObject({
+    code: "access_denied",
+    error: "Account is inactive",
+    details: { reason: "account_inactive" },
+  });
+  expect(invokeFalProxy).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -16,17 +16,20 @@ import {
 import { createRouteHandler } from "@fal-ai/server-proxy/hono";
 import type { Context, Handler } from "hono";
 import { Hono } from "hono";
+import {
+  admitFlatGenerativeOperation,
+  asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import type { BillingContext } from "@/lib/services/ai-billing";
 import {
   calculateVideoGenerationCostFromCatalog,
   getDefaultVideoBillingDimensions,
 } from "@/lib/services/ai-pricing";
 import { getSupportedVideoModelDefinition } from "@/lib/services/ai-pricing-definitions";
-import {
-  creditsService,
-  InsufficientCreditsError,
-} from "@/lib/services/credits";
+import { InsufficientCreditsError } from "@/lib/services/credits";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -168,26 +171,40 @@ async function priceFalMutation(c: Context<AppEnv>): Promise<{
 
 const handle: Handler<AppEnv> = async (c) => {
   const isMutation = c.req.method === "POST" || c.req.method === "PUT";
-  let reservation: Awaited<ReturnType<typeof creditsService.reserve>> | null =
-    null;
+  let admission: Awaited<
+    ReturnType<typeof admitFlatGenerativeOperation>
+  > | null = null;
   let pricedMutation: Awaited<ReturnType<typeof priceFalMutation>> | null =
     null;
-  let user: Awaited<ReturnType<typeof requireUserOrApiKeyWithOrg>>;
+  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
 
   try {
-    user = await requireUserOrApiKeyWithOrg(c);
+    caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 
   if (isMutation && c.req.header(TARGET_URL_HEADER)) {
     try {
       pricedMutation = await priceFalMutation(c);
-      reservation = await creditsService.reserve({
-        organizationId: user.organization_id,
-        userId: user.id,
-        amount: pricedMutation.cost.totalCost,
+      const billingContext: BillingContext = {
+        organizationId: caller.user.organization_id,
+        userId: caller.user.id,
+        apiKeyId: caller.apiKeyId,
+        model: pricedMutation.model,
+        provider: "fal",
+        billingSource: "fal",
+        requestId: `fal-proxy:${crypto.randomUUID()}`,
         description: `fal.ai ${pricedMutation.model}`,
+      };
+      admission = await admitFlatGenerativeOperation({
+        c,
+        context: billingContext,
+        apiKeyId: caller.apiKeyId,
+        cost: pricedMutation.cost,
+        admissionSnapshot: caller.admissionSnapshot,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
@@ -218,24 +235,42 @@ const handle: Handler<AppEnv> = async (c) => {
   }
 
   try {
+    await admission?.markProviderDispatched?.();
     const response = await invokeFalProxy(c);
 
-    if (reservation && pricedMutation) {
-      if (response.ok) {
-        await reservation.reconcile(pricedMutation.cost.totalCost);
-      } else {
-        await reservation.reconcile(0);
-      }
+    if (admission && pricedMutation) {
+      await retainFalSettlement(
+        c,
+        admission.settle(response.ok ? pricedMutation.cost.totalCost : 0),
+        response.ok ? "settle" : "release",
+      );
     }
 
     return response;
   } catch (error) {
-    if (reservation) {
-      await reservation.reconcile(0);
+    if (admission) {
+      await retainFalSettlement(c, admission.settle(0), "release");
     }
     throw error;
   }
 };
+
+async function retainFalSettlement(
+  c: Context<AppEnv>,
+  settlement: Promise<unknown>,
+  operation: "settle" | "release",
+): Promise<void> {
+  const observed = settlement.catch((error) => {
+    // error-policy:J7 settlement diagnostics must not replace the provider
+    // response; the durable reservation sweep remains the recovery boundary.
+    logger.error(`[fal proxy] Failed to ${operation} inference admission`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  const executionCtx = getGenerativeExecutionContext(c);
+  if (executionCtx) executionCtx.waitUntil(observed);
+  else await observed;
+}
 
 app.get("/", handle);
 app.post("/", handle);

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -40,12 +40,14 @@ class AiPricingCacheUnavailableError extends Error {
 }
 
 const resolveInferenceAuthContext = vi.fn();
+const observeInferenceApiKeyUsage = vi.fn();
 const requireAuthOrApiKeyWithOrg = vi.fn();
 const requireUserOrApiKeyWithOrg = vi.fn();
 const reserveFlatUsageCredits = vi.fn();
 const admitOrganizationInference = vi.fn();
 const enforceOrgRateLimit = vi.fn();
 const inferenceRateLimitConfig = vi.fn();
+const loggerWarn = vi.fn();
 
 vi.mock("@/lib/api/cloud-worker-errors", () => ({ ApiError }));
 vi.mock("@/lib/services/ai-pricing/cache", () => ({
@@ -53,6 +55,7 @@ vi.mock("@/lib/services/ai-pricing/cache", () => ({
   AiPricingCacheUnavailableError,
 }));
 vi.mock("@/lib/services/inference-auth-context", () => ({
+  observeInferenceApiKeyUsage,
   resolveInferenceAuthContext,
 }));
 vi.mock("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
@@ -67,6 +70,9 @@ vi.mock("@/lib/middleware/rate-limit", () => ({ enforceOrgRateLimit }));
 vi.mock("@/lib/services/inference-admission-snapshot", () => ({
   inferenceRateLimitConfig,
 }));
+vi.mock("@/lib/utils/logger", () => ({
+  logger: { warn: loggerWarn },
+}));
 
 if (typeof Bun !== "undefined") {
   const bunTest = await import("bun:test");
@@ -76,6 +82,7 @@ if (typeof Bun !== "undefined") {
     AiPricingCacheUnavailableError,
   }));
   bunTest.mock.module("@/lib/services/inference-auth-context", () => ({
+    observeInferenceApiKeyUsage,
     resolveInferenceAuthContext,
   }));
   bunTest.mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
@@ -97,6 +104,9 @@ if (typeof Bun !== "undefined") {
   bunTest.mock.module("@/lib/services/inference-admission-snapshot", () => ({
     inferenceRateLimitConfig,
   }));
+  bunTest.mock.module("@/lib/utils/logger", () => ({
+    logger: { warn: loggerWarn },
+  }));
 }
 
 const {
@@ -105,6 +115,7 @@ const {
   getGenerativeExecutionContext,
   getGenerativePricingCacheOptions,
   requireGenerativeRouteCaller,
+  resolveInferenceAuthStandingDenial,
 } = await import("./generative-route-auth");
 
 const FLAT_COST = {
@@ -588,9 +599,78 @@ describe("admitFlatGenerativeOperation", () => {
   });
 });
 
+describe("resolveInferenceAuthStandingDenial", () => {
+  beforeEach(() => {
+    loggerWarn.mockReset();
+  });
+
+  test("preserves a retryable resolver 503 and logs only bounded fields", () => {
+    const denial = resolveInferenceAuthStandingDenial(
+      { kind: "rejected", status: 503 },
+      { route: "embeddings", traceId: "trace-1" },
+    );
+
+    expect(denial).toEqual({
+      status: 503,
+      type: "service_unavailable",
+      code: "service_unavailable",
+      message: "Authorization service is unavailable. Retry shortly.",
+      reason: "authorization_unavailable",
+      retryAfterSeconds: 1,
+    });
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[InferenceAuth] blocked provider dispatch at route boundary",
+      {
+        route: "embeddings",
+        traceId: "trace-1",
+        decision: "rejected",
+        status: 503,
+        reason: "authorization_unavailable",
+        retryable: true,
+      },
+    );
+  });
+
+  test("maps every typed standing reason without replacing resolver status", () => {
+    expect(
+      resolveInferenceAuthStandingDenial({
+        kind: "rejected",
+        status: 403,
+        reason: "organization_inactive",
+      }),
+    ).toMatchObject({
+      status: 403,
+      message: "Organization is inactive",
+      reason: "organization_inactive",
+    });
+    expect(
+      resolveInferenceAuthStandingDenial({
+        kind: "rejected",
+        status: 401,
+        reason: "credential_invalid",
+      }),
+    ).toMatchObject({
+      status: 401,
+      message: "Authentication required",
+      reason: "credential_invalid",
+    });
+    expect(
+      resolveInferenceAuthStandingDenial({
+        kind: "suspended",
+        reason: "moderation_blocked",
+      }),
+    ).toMatchObject({
+      status: 403,
+      message: "Account access is blocked by policy moderation",
+      reason: "moderation_blocked",
+    });
+  });
+});
+
 describe("requireGenerativeRouteCaller", () => {
   beforeEach(() => {
     resolveInferenceAuthContext.mockReset();
+    observeInferenceApiKeyUsage.mockReset();
     requireAuthOrApiKeyWithOrg.mockReset();
     requireUserOrApiKeyWithOrg.mockReset();
     enforceOrgRateLimit.mockReset();
@@ -612,6 +692,7 @@ describe("requireGenerativeRouteCaller", () => {
 
   afterEach(() => {
     resolveInferenceAuthContext.mockReset();
+    observeInferenceApiKeyUsage.mockReset();
     requireAuthOrApiKeyWithOrg.mockReset();
     requireUserOrApiKeyWithOrg.mockReset();
     enforceOrgRateLimit.mockReset();
@@ -830,19 +911,22 @@ describe("requireGenerativeRouteCaller", () => {
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
   });
 
-  test("re-resolves after hydration settles inside the budget", async () => {
-    const { c } = workerContext();
-    resolveInferenceAuthContext
-      .mockResolvedValueOnce({
-        kind: "warming",
-        hydration: Promise.resolve(sessionAuthorized),
-      })
-      .mockResolvedValueOnce(sessionAuthorized);
+  test("consumes the one-shot continuation without a second cache read", async () => {
+    const { c, executionCtx } = workerContext();
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "warming",
+      hydration: Promise.resolve(sessionAuthorized),
+      continuation: Promise.resolve(sessionAuthorized),
+    });
     const caller = await requireGenerativeRouteCaller(c as never, {
       awaitWarmingMs: 1500,
     });
     expect(caller.authSource).toBe("combined_cache");
-    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(observeInferenceApiKeyUsage).toHaveBeenCalledWith(
+      sessionAuthorized,
+      executionCtx,
+    );
   });
 
   test("still 503s when the warming budget expires", async () => {
@@ -851,16 +935,19 @@ describe("requireGenerativeRouteCaller", () => {
     const hydration = new Promise((resolve) => {
       release = () => resolve(sessionAuthorized);
     });
-    resolveInferenceAuthContext
-      .mockResolvedValueOnce({ kind: "warming", hydration })
-      .mockResolvedValueOnce({ kind: "warming", hydration });
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "warming",
+      hydration,
+      continuation: hydration,
+    });
     await expect(
       requireGenerativeRouteCaller(c as never, { awaitWarmingMs: 20 }),
     ).rejects.toMatchObject({
       status: 503,
       code: "service_unavailable",
     });
-    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(observeInferenceApiKeyUsage).not.toHaveBeenCalled();
     release?.();
   });
 

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -15,9 +15,13 @@ import {
   AiPricingCacheUnavailableError,
   AiPricingCacheWarmingError,
 } from "@/lib/services/ai-pricing/cache";
-import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
+import type {
+  InferenceAdmissionSnapshot,
+  InferenceAuthRejectionReason,
+} from "@/lib/services/inference-auth-cache";
 import type { EndpointType } from "@/lib/services/org-rate-limits";
 import type { OrganizationInferenceAdmission } from "@/lib/services/organization-inference-admission";
+import { logger } from "@/lib/utils/logger";
 import type { AppContext } from "@/types/cloud-worker-env";
 
 export interface GenerativeRouteCaller {
@@ -29,6 +33,104 @@ export interface GenerativeRouteCaller {
   authSource: "combined_cache" | "compatibility";
   admissionSnapshot?: InferenceAdmissionSnapshot;
   appScopeId: string | null;
+}
+
+export interface InferenceAuthStandingDenial {
+  status: 401 | 403 | 503;
+  type: "authentication_error" | "permission_error" | "service_unavailable";
+  code: "authentication_required" | "access_denied" | "service_unavailable";
+  message: string;
+  reason:
+    | InferenceAuthRejectionReason
+    | "account_suspended"
+    | "authentication_rejected"
+    | "authorization_unavailable";
+  retryAfterSeconds?: number;
+}
+
+type InferenceAuthStandingResolution =
+  | { kind: "suspended"; reason?: InferenceAuthRejectionReason }
+  | {
+      kind: "rejected";
+      status: 401 | 403 | 503;
+      reason?: InferenceAuthRejectionReason;
+    };
+
+function standingMessage(
+  reason: InferenceAuthRejectionReason | undefined,
+  fallback: string,
+): string {
+  switch (reason) {
+    case "moderation_blocked":
+      return "Account access is blocked by policy moderation";
+    case "organization_inactive":
+      return "Organization is inactive";
+    case "account_inactive":
+      return "Account is inactive";
+    case "credential_inactive":
+      return "API key is inactive";
+    case "membership_missing":
+      return "Account is not associated with an active organization";
+    case "credential_invalid":
+      return "Authentication required";
+    default:
+      return fallback;
+  }
+}
+
+/**
+ * Maps cache and authoritative standing decisions to one bounded API contract.
+ * Routes retain their native response envelope, but status, reason, code, and
+ * retry semantics must come from this mapping without another identity read.
+ */
+export function resolveInferenceAuthStandingDenial(
+  resolution: InferenceAuthStandingResolution,
+  logContext?: { route: string; traceId?: string },
+): InferenceAuthStandingDenial {
+  let denial: InferenceAuthStandingDenial;
+  if (resolution.kind === "suspended") {
+    denial = {
+      status: 403,
+      type: "permission_error",
+      code: "access_denied",
+      message: standingMessage(resolution.reason, "Account suspended"),
+      reason: resolution.reason ?? "account_suspended",
+    };
+  } else if (resolution.status === 503) {
+    denial = {
+      status: 503,
+      type: "service_unavailable",
+      code: "service_unavailable",
+      message: "Authorization service is unavailable. Retry shortly.",
+      reason: resolution.reason ?? "authorization_unavailable",
+      retryAfterSeconds: 1,
+    };
+  } else {
+    denial = {
+      status: resolution.status,
+      type:
+        resolution.status === 403 ? "permission_error" : "authentication_error",
+      code:
+        resolution.status === 403 ? "access_denied" : "authentication_required",
+      message: standingMessage(
+        resolution.reason,
+        resolution.status === 403 ? "Forbidden" : "Authentication required",
+      ),
+      reason: resolution.reason ?? "authentication_rejected",
+    };
+  }
+
+  if (logContext) {
+    logger.warn("[InferenceAuth] blocked provider dispatch at route boundary", {
+      route: logContext.route,
+      traceId: logContext.traceId ?? "unavailable",
+      decision: resolution.kind,
+      status: denial.status,
+      reason: denial.reason,
+      retryable: denial.status === 503,
+    });
+  }
+  return denial;
 }
 
 export function getGenerativeExecutionContext(
@@ -188,9 +290,8 @@ export async function requireGenerativeRouteCaller(
       appScopeId: null,
     };
   }
-  const { resolveInferenceAuthContext } = await import(
-    "@/lib/services/inference-auth-context"
-  );
+  const { observeInferenceApiKeyUsage, resolveInferenceAuthContext } =
+    await import("@/lib/services/inference-auth-context");
   const resolveCallerAuth = () =>
     resolveInferenceAuthContext(c.req.raw, {
       traceId: c.get("traceId") ?? c.get("requestId"),
@@ -203,20 +304,29 @@ export async function requireGenerativeRouteCaller(
     resolution.kind === "warming" &&
     typeof options.awaitWarmingMs === "number" &&
     options.awaitWarmingMs > 0 &&
-    resolution.hydration
+    resolution.continuation
   ) {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = Symbol("inference-auth-continuation-timeout");
     try {
-      await Promise.race([
-        resolution.hydration,
-        new Promise<void>((resolve) => {
-          timeoutId = setTimeout(resolve, options.awaitWarmingMs);
+      const continued = await Promise.race([
+        resolution.continuation,
+        new Promise<typeof timedOut>((resolve) => {
+          timeoutId = setTimeout(
+            () => resolve(timedOut),
+            options.awaitWarmingMs,
+          );
         }),
       ]);
+      if (continued !== timedOut && continued) {
+        if (continued.kind === "authorized") {
+          observeInferenceApiKeyUsage(continued, executionCtx);
+        }
+        resolution = continued;
+      }
     } finally {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
     }
-    resolution = await resolveCallerAuth();
   }
 
   if (resolution.kind === "authorized") {
@@ -282,37 +392,25 @@ export async function requireGenerativeRouteCaller(
     );
   }
   if (resolution.kind === "suspended") {
-    const reason = resolution.reason;
-    const message =
-      reason === "moderation_blocked"
-        ? "Account access is blocked by policy moderation"
-        : reason === "organization_inactive"
-          ? "Organization is inactive"
-          : reason === "account_inactive"
-            ? "Account is inactive"
-            : "Account suspended";
-    throw new ApiError(403, "access_denied", message, {
-      reason: reason ?? "account_suspended",
+    const denial = resolveInferenceAuthStandingDenial(resolution, {
+      route: "generative",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    });
+    throw new ApiError(denial.status, denial.code, denial.message, {
+      reason: denial.reason,
     });
   }
   if (resolution.kind === "rejected") {
-    const reason = resolution.reason;
-    throw new ApiError(
-      resolution.status,
-      resolution.status === 403 ? "access_denied" : "authentication_required",
-      reason === "organization_inactive"
-        ? "Organization is inactive"
-        : reason === "account_inactive"
-          ? "Account is inactive"
-          : reason === "credential_inactive"
-            ? "API key is inactive"
-            : reason === "membership_missing"
-              ? "Account is not associated with an active organization"
-              : resolution.status === 403
-                ? "Forbidden"
-                : "Authentication required",
-      { reason: reason ?? "authentication_rejected" },
-    );
+    const denial = resolveInferenceAuthStandingDenial(resolution, {
+      route: "generative",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    });
+    throw new ApiError(denial.status, denial.code, denial.message, {
+      reason: denial.reason,
+      ...(denial.retryAfterSeconds
+        ? { retryAfterSeconds: denial.retryAfterSeconds, retryable: true }
+        : {}),
+    });
   }
 
   // Wallet signatures are timestamped and replay-protected, so they retain the

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -11,8 +11,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { z } from "zod";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -23,10 +23,11 @@ const postSchema = z.object({
 async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
+  caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ): Promise<Response> {
-  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+  const { user } = caller;
   const { id: appId } = await params;
-  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+  if (caller.appScopeId && caller.appScopeId !== appId) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
@@ -82,9 +83,18 @@ async function __hono_POST(
 }
 
 const __hono_app = new Hono<AppEnv>();
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    return await __hono_POST(
+      c.req.raw,
+      { params: Promise.resolve({ id: c.req.param("id")! }) },
+      caller,
+    );
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+});
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -1,6 +1,8 @@
 // Handles v1 cloud API v1 apps id promote assets route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
@@ -32,15 +34,16 @@ const GenerateAssetsSchema = z.object({
 async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
+  caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ) {
-  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+  const { user } = caller;
   const { id } = await params;
 
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
   }
-  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+  if (caller.appScopeId && caller.appScopeId !== id) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
@@ -229,9 +232,18 @@ __hono_app.get("/", async (c) =>
     params: Promise.resolve({ id: c.req.param("id")! }),
   }),
 );
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    return await __hono_POST(
+      c.req.raw,
+      { params: Promise.resolve({ id: c.req.param("id")! }) },
+      caller,
+    );
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+});
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -1,6 +1,11 @@
 /** Generates authenticated promotion previews for cloud applications. */
 
 import { Hono } from "hono";
+import {
+  type GenerativeRouteCaller,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 
@@ -14,8 +19,6 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { z } from "zod";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appsService } from "@/lib/services/apps";
 import {
   getDiscordConfigWithDefaults,
@@ -43,8 +46,9 @@ interface PostPreview {
 async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
+  caller: GenerativeRouteCaller,
 ): Promise<Response> {
-  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+  const { user } = caller;
   const { id } = await params;
 
   const decodedBody = await decodeRequestJson(request);
@@ -68,7 +72,7 @@ async function __hono_POST(
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
   }
-  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+  if (caller.appScopeId && caller.appScopeId !== id) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
@@ -229,9 +233,18 @@ async function __hono_POST(
 }
 
 const __hono_app = new Hono<AppEnv>();
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    return await __hono_POST(
+      c.req.raw,
+      { params: Promise.resolve({ id: c.req.param("id")! }) },
+      caller,
+    );
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+});
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -1,6 +1,8 @@
 // Handles v1 cloud API v1 apps id promote route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
@@ -171,10 +173,11 @@ async function __hono_GET(
 async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
+  caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ) {
-  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+  const { user } = caller;
   const { id } = await params;
-  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+  if (caller.appScopeId && caller.appScopeId !== id) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
@@ -286,9 +289,18 @@ __hono_app.get("/", async (c) =>
     params: Promise.resolve({ id: c.req.param("id")! }),
   }),
 );
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    return await __hono_POST(
+      c.req.raw,
+      { params: Promise.resolve({ id: c.req.param("id")! }) },
+      caller,
+    );
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+});
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/review/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/review/route.ts
@@ -10,6 +10,7 @@
  */
 
 import { Hono } from "hono";
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
@@ -29,7 +30,10 @@ const app = new Hono<AppEnv>();
 // the redemptions POST).
 app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
-    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(c.req.raw);
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    const { user } = caller;
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
 
@@ -39,7 +43,7 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
     // An app-scoped API key may only act on its own app, never a sibling (#10852).
-    if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    if (caller.appScopeId && caller.appScopeId !== appId) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -11,8 +11,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { z } from "zod";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -25,10 +25,11 @@ const postSchema = z.object({
 async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
+  caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ): Promise<Response> {
-  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+  const { user } = caller;
   const { id: appId } = await params;
-  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+  if (caller.appScopeId && caller.appScopeId !== appId) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
@@ -87,9 +88,18 @@ async function __hono_POST(
 }
 
 const __hono_app = new Hono<AppEnv>();
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    return await __hono_POST(
+      c.req.raw,
+      { params: Promise.resolve({ id: c.req.param("id")! }) },
+      caller,
+    );
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+});
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -1,9 +1,9 @@
 // Handles v1 cloud API v1 apps id twitter automation post route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -18,10 +18,11 @@ const PostTweetSchema = z.object({
 async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
+  caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ): Promise<Response> {
-  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+  const { user } = caller;
   const { id } = await params;
-  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+  if (caller.appScopeId && caller.appScopeId !== id) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
@@ -83,9 +84,18 @@ async function __hono_POST(
 }
 
 const __hono_app = new Hono<AppEnv>();
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
+    return await __hono_POST(
+      c.req.raw,
+      { params: Promise.resolve({ id: c.req.param("id")! }) },
+      caller,
+    );
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+});
 export default __hono_app;

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1,5 +1,6 @@
-// app/api/v1/chat/completions/route.ts
+/** Implements the OpenAI-compatible chat-completions boundary and its streaming accounting. */
 import { Hono } from "hono";
+import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -1241,43 +1242,48 @@ export async function handleChatCompletionsPOST(
       );
     }
     if (resolution.kind === "suspended") {
+      const denial = resolveInferenceAuthStandingDenial(resolution, {
+        route: "chat_completions",
+        traceId,
+      });
       return attachPreforwardTelemetry(
         addCorsHeaders(
           Response.json(
             {
               error: {
-                message:
-                  "Your account has been suspended due to policy violations.",
-                type: "account_suspended",
-                code: "moderation_violation",
+                message: denial.message,
+                type: denial.type,
+                code: denial.code,
+                details: { reason: denial.reason },
               },
             },
-            { status: 403 },
+            { status: denial.status },
           ),
         ),
       );
     }
     if (resolution.kind === "rejected") {
+      const denial = resolveInferenceAuthStandingDenial(resolution, {
+        route: "chat_completions",
+        traceId,
+      });
       return attachPreforwardTelemetry(
         addCorsHeaders(
           Response.json(
             {
               error: {
-                message:
-                  resolution.status === 403
-                    ? "Account or organization access is disabled."
-                    : "Authentication required.",
-                type:
-                  resolution.status === 403
-                    ? "permission_error"
-                    : "authentication_error",
-                code:
-                  resolution.status === 403
-                    ? "access_denied"
-                    : "authentication_required",
+                message: denial.message,
+                type: denial.type,
+                code: denial.code,
+                details: { reason: denial.reason },
               },
             },
-            { status: resolution.status },
+            {
+              status: denial.status,
+              headers: denial.retryAfterSeconds
+                ? { "Retry-After": String(denial.retryAfterSeconds) }
+                : undefined,
+            },
           ),
         ),
       );

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -9,6 +9,7 @@
 import { assertModelOutputComplete } from "@elizaos/core";
 import { convertToModelMessages, streamText, type UIMessage } from "ai";
 import { Hono } from "hono";
+import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
 import type { AnonymousSession } from "@/db/repositories/anonymous-sessions";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
@@ -251,23 +252,34 @@ app.post("/", async (c) => {
         return retryableWarmingResponse(c, "Authentication");
       }
       if (authResolution.kind === "suspended") {
+        const denial = resolveInferenceAuthStandingDenial(authResolution, {
+          route: "chat",
+          traceId: c.get("traceId") ?? c.get("requestId"),
+        });
         return c.json(
           {
-            error:
-              "Your account has been suspended due to policy violations. Please contact support.",
+            error: denial.message,
+            code: denial.code,
+            reason: denial.reason,
           },
-          403,
+          denial.status,
         );
       }
       if (authResolution.kind === "rejected") {
+        const denial = resolveInferenceAuthStandingDenial(authResolution, {
+          route: "chat",
+          traceId: c.get("traceId") ?? c.get("requestId"),
+        });
         return c.json(
           {
-            error:
-              authResolution.status === 403
-                ? "Account or organization access is disabled."
-                : "Authentication required",
+            error: denial.message,
+            code: denial.code,
+            reason: denial.reason,
           },
-          authResolution.status,
+          denial.status,
+          denial.retryAfterSeconds
+            ? { "Retry-After": String(denial.retryAfterSeconds) }
+            : undefined,
         );
       }
       if (authResolution.kind === "authorized") {

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -10,6 +10,7 @@
 
 import { APICallError, embed, embedMany, RetryError } from "ai";
 import { Hono } from "hono";
+import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
@@ -124,37 +125,40 @@ app.post("/", async (c) => {
       );
     }
     if (resolution.kind === "suspended") {
+      const denial = resolveInferenceAuthStandingDenial(resolution, {
+        route: "embeddings",
+        traceId: c.get("traceId") ?? c.get("requestId"),
+      });
       return c.json(
         {
           error: {
-            message:
-              "Your account has been suspended due to policy violations.",
-            type: "account_suspended",
-            code: "moderation_violation",
+            message: denial.message,
+            type: denial.type,
+            code: denial.code,
+            details: { reason: denial.reason },
           },
         },
-        403,
+        denial.status,
       );
     }
     if (resolution.kind === "rejected") {
+      const denial = resolveInferenceAuthStandingDenial(resolution, {
+        route: "embeddings",
+        traceId: c.get("traceId") ?? c.get("requestId"),
+      });
       return c.json(
         {
           error: {
-            message:
-              resolution.status === 403
-                ? "Account or organization access is disabled."
-                : "Authentication required.",
-            type:
-              resolution.status === 403
-                ? "permission_error"
-                : "authentication_error",
-            code:
-              resolution.status === 403
-                ? "access_denied"
-                : "authentication_required",
+            message: denial.message,
+            type: denial.type,
+            code: denial.code,
+            details: { reason: denial.reason },
           },
         },
-        resolution.status,
+        denial.status,
+        denial.retryAfterSeconds
+          ? { "Retry-After": String(denial.retryAfterSeconds) }
+          : undefined,
       );
     }
     if (resolution.kind === "authorized") {

--- a/packages/cloud/api/v1/generate-prompts/route.admission.test.ts
+++ b/packages/cloud/api/v1/generate-prompts/route.admission.test.ts
@@ -1,0 +1,124 @@
+/** Proves prompt suggestions complete standing and credit admission before OpenAI dispatch. */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+
+const order: string[] = [];
+const waitUntilTasks: Promise<unknown>[] = [];
+const requireGenerativeRouteCaller = mock(async () => {
+  order.push("standing");
+  return {
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balance: 10, revision: 2 },
+  };
+});
+const markProviderDispatched = mock(async () => {
+  order.push("mark-dispatched");
+});
+const settle = mock(async () => null);
+const settleUnknown = mock(async () => null);
+const admitOrganizationInference = mock(async () => {
+  order.push("admission");
+  return {
+    mode: "durable_object_debit",
+    reservation: { reconcile: async () => undefined },
+    markProviderDispatched,
+    settle,
+    settleUnknown,
+  };
+});
+const streamText = mock(() => {
+  order.push("provider");
+  return {
+    usage: Promise.resolve({ inputTokens: 40, outputTokens: 20 }),
+    toTextStreamResponse: () => new Response("[]", { status: 200 }),
+  };
+});
+const billUsage = mock(async () => ({ totalCost: 0.002 }));
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller,
+  asGenerativeCacheApiError: () => null,
+  getGenerativeExecutionContext: () => ({
+    waitUntil: (promise: Promise<unknown>) => waitUntilTasks.push(promise),
+  }),
+}));
+mock.module("@/lib/services/organization-inference-admission", () => ({
+  admitOrganizationInference,
+}));
+mock.module("@/lib/services/ai-billing", () => ({ billUsage }));
+mock.module("@/lib/pricing", () => ({ estimateTokens: () => 100 }));
+mock.module("@ai-sdk/openai", () => ({ openai: () => ({}) }));
+mock.module("ai", () => ({ streamText }));
+mock.module("@elizaos/core", () => ({
+  assertModelOutputComplete: () => undefined,
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+describe("POST /api/v1/generate-prompts admission ordering", () => {
+  beforeEach(() => {
+    order.length = 0;
+    waitUntilTasks.length = 0;
+    requireGenerativeRouteCaller.mockClear();
+    admitOrganizationInference.mockClear();
+    markProviderDispatched.mockClear();
+    streamText.mockClear();
+    billUsage.mockClear();
+    settle.mockClear();
+    settleUnknown.mockClear();
+  });
+
+  test("admits before provider dispatch and settles off the response path", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ seed: "deterministic" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(order).toEqual([
+      "standing",
+      "admission",
+      "mark-dispatched",
+      "provider",
+    ]);
+    expect(waitUntilTasks).toHaveLength(1);
+    await Promise.all(waitUntilTasks);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(settle).toHaveBeenCalledWith(0.002);
+    expect(settleUnknown).not.toHaveBeenCalled();
+  });
+
+  test("standing denial stops before admission and provider dispatch", async () => {
+    requireGenerativeRouteCaller.mockImplementationOnce(async () => {
+      throw new ApiError(403, "access_denied", "Organization is inactive", {
+        reason: "organization_inactive",
+      });
+    });
+
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "access_denied",
+      error: "Organization is inactive",
+      details: { reason: "organization_inactive" },
+    });
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/generate-prompts/route.ts
+++ b/packages/cloud/api/v1/generate-prompts/route.ts
@@ -10,15 +10,25 @@ import { openai } from "@ai-sdk/openai";
 import { assertModelOutputComplete } from "@elizaos/core";
 import { streamText } from "ai";
 import { Hono } from "hono";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { estimateTokens } from "@/lib/pricing";
 import { billUsage } from "@/lib/services/ai-billing";
+import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
+  let admission:
+    | Awaited<ReturnType<typeof admitOrganizationInference>>
+    | undefined;
+  let providerDispatchStarted = false;
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
@@ -31,13 +41,7 @@ app.post("/", async (c) => {
       typeof body.seed === "string" || typeof body.seed === "number"
         ? String(body.seed)
         : String(Date.now());
-
-    const result = streamText({
-      model: openai("gpt-4o"),
-      messages: [
-        {
-          role: "system",
-          content: `Generate 4 SHORT, USEFUL agent concepts (max 8 words each) that are DIVERSE and practical for real-world utility.
+    const systemPrompt = `Generate 4 SHORT, USEFUL agent concepts (max 8 words each) that are DIVERSE and practical for real-world utility.
 
 CRITICAL: Focus on UTILITY-BASED agents that help with real tasks. Mix different domains:
 - Business & productivity (sales, support, analytics, scheduling)
@@ -68,12 +72,41 @@ BAD prompts (too long, too fantasy):
 
 Return ONLY a JSON array of exactly 4 strings, nothing else. No markdown, no explanation.
 
-Random seed: ${promptSeed}`,
+Random seed: ${promptSeed}`;
+    const userPrompt =
+      "Generate 4 short, practical agent concepts for real-world utility. Keep each under 8 words. Make them diverse across different domains.";
+    const executionCtx = getGenerativeExecutionContext(c);
+    const requestId = `generate-prompts:${crypto.randomUUID()}`;
+    admission = await admitOrganizationInference({
+      context: {
+        organizationId: caller.user.organization_id,
+        userId: caller.user.id,
+        apiKeyId: caller.apiKeyId,
+        model: "gpt-4o",
+        provider: "openai",
+        billingSource: "openai",
+        requestId,
+        description: "generate-prompts agent-concept suggestions",
+      },
+      apiKeyId: caller.apiKeyId,
+      estimatedInputTokens: estimateTokens(`${systemPrompt}\n${userPrompt}`),
+      estimatedOutputTokens: 128,
+      executionCtx,
+      admissionSnapshot: caller.admissionSnapshot,
+    });
+    await admission.markProviderDispatched?.();
+    providerDispatchStarted = true;
+
+    const result = streamText({
+      model: openai("gpt-4o"),
+      messages: [
+        {
+          role: "system",
+          content: systemPrompt,
         },
         {
           role: "user",
-          content:
-            "Generate 4 short, practical agent concepts for real-world utility. Keep each under 8 words. Make them diverse across different domains.",
+          content: userPrompt,
         },
       ],
       temperature: 1.5,
@@ -92,35 +125,59 @@ Random seed: ${promptSeed}`,
     // OpenAI for every call); `result.usage` resolves after the stream
     // finishes, and waitUntil settles the charge without delaying the
     // streamed response.
-    c.executionCtx.waitUntil(
-      (async () => {
-        try {
-          const usage = await result.usage;
-          await billUsage(
-            {
-              organizationId: caller.user.organization_id,
-              userId: caller.user.id,
-              apiKeyId: caller.apiKeyId,
-              model: "gpt-4o",
-              provider: "openai",
-              description: "generate-prompts agent-concept suggestions",
-            },
-            usage,
-          );
-        } catch (error) {
-          // error-policy:J7 billing settlement runs post-response; a failure
-          // must be loud in logs (revenue) but cannot affect the stream.
-          logger.error("[generate-prompts] usage billing failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      })(),
-    );
+    const settlement = (async () => {
+      try {
+        const usage = await result.usage;
+        const billing = await billUsage(
+          {
+            organizationId: caller.user.organization_id,
+            userId: caller.user.id,
+            apiKeyId: caller.apiKeyId,
+            model: "gpt-4o",
+            provider: "openai",
+            billingSource: "openai",
+            requestId,
+            description: "generate-prompts agent-concept suggestions",
+          },
+          usage,
+          admission.reservation,
+        );
+        await admission.settle(billing.totalCost);
+      } catch (error) {
+        await admission.settleUnknown();
+        // error-policy:J7 billing settlement runs post-response; a failure
+        // must be loud in logs (revenue) but cannot affect the stream.
+        logger.error("[generate-prompts] usage billing failed", {
+          requestId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+    if (executionCtx) executionCtx.waitUntil(settlement);
+    else await settlement;
 
     return result.toTextStreamResponse();
   } catch (error) {
-    logger.error("[Generate Prompts] Error:", error);
-    return failureResponse(c, error);
+    if (admission) {
+      const terminal = providerDispatchStarted
+        ? admission.settleUnknown()
+        : admission.settle(0);
+      const executionCtx = getGenerativeExecutionContext(c);
+      const observed = terminal.catch((settlementError) => {
+        logger.error("[generate-prompts] admission release failed", {
+          error:
+            settlementError instanceof Error
+              ? settlementError.message
+              : String(settlementError),
+        });
+      });
+      if (executionCtx) executionCtx.waitUntil(observed);
+      else await observed;
+    }
+    logger.error("[Generate Prompts] Error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -21,8 +21,11 @@
  */
 
 import { Hono } from "hono";
+import {
+  asGenerativeCacheApiError,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { logger, redact } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -236,9 +239,9 @@ app.get("/*", async (c) => {
   try {
     // Auth: a real cloud session or org API key. We require a valid linked
     // account and capture the identity for usage attribution below.
-    const account = await requireUserOrApiKeyWithOrg(c);
-    const userId = account.id;
-    const orgId = account.organization_id;
+    const caller = await requireGenerativeRouteCaller(c);
+    const userId = caller.user.id;
+    const orgId = caller.user.organization_id;
     if (!orgId) {
       return c.json({ error: "Organization is required." }, 403);
     }
@@ -377,7 +380,7 @@ app.get("/*", async (c) => {
       headers: responseHeaders,
     });
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -25,6 +25,8 @@ import {
   type UserModelMessage,
 } from "ai";
 import { Hono } from "hono";
+import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
+import { getErrorStatusCode } from "@/lib/api/errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   enforceOrgRateLimit,
@@ -587,19 +589,24 @@ app.post("/", async (c) => {
       );
     }
     if (resolution.kind === "suspended") {
-      return anthropicError(
-        "permission_error",
-        "Your account has been suspended due to policy violations.",
-        403,
-      );
+      const denial = resolveInferenceAuthStandingDenial(resolution, {
+        route: "messages",
+        traceId,
+      });
+      return anthropicError(denial.type, denial.message, denial.status);
     }
     if (resolution.kind === "rejected") {
+      const denial = resolveInferenceAuthStandingDenial(resolution, {
+        route: "messages",
+        traceId,
+      });
       return anthropicError(
-        resolution.status === 403 ? "permission_error" : "authentication_error",
-        resolution.status === 403
-          ? "Account or organization access is disabled."
-          : "Authentication required.",
-        resolution.status,
+        denial.type,
+        denial.message,
+        denial.status,
+        denial.retryAfterSeconds
+          ? { "Retry-After": String(denial.retryAfterSeconds) }
+          : undefined,
       );
     }
     if (resolution.kind === "authorized") {
@@ -627,8 +634,34 @@ app.post("/", async (c) => {
       apiKey = await getRequestApiKeyId(c);
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return anthropicError("authentication_error", message, 401);
+    // error-policy:J1 resolver infrastructure and typed auth failures retain
+    // their status; an unexpected failure is an Anthropic-shaped 500, never a
+    // fabricated authentication rejection.
+    const status = getErrorStatusCode(error);
+    if (status === 401 || status === 403 || status === 503) {
+      const denial = resolveInferenceAuthStandingDenial(
+        { kind: "rejected", status },
+        { route: "messages", traceId },
+      );
+      return anthropicError(
+        denial.type,
+        denial.message,
+        denial.status,
+        denial.retryAfterSeconds
+          ? { "Retry-After": String(denial.retryAfterSeconds) }
+          : undefined,
+      );
+    }
+    logger.error("[Messages] inference auth resolver failed", {
+      traceId,
+      status,
+      errorName: error instanceof Error ? error.name : "NonErrorThrown",
+    });
+    return anthropicError(
+      "api_error",
+      "Authorization could not be completed.",
+      status >= 400 && status <= 599 ? status : 500,
+    );
   }
   const tAuth = performance.now();
 

--- a/packages/cloud/api/v1/voice/clone/route.standing.test.ts
+++ b/packages/cloud/api/v1/voice/clone/route.standing.test.ts
@@ -1,0 +1,211 @@
+/** Proves voice-clone standing denial stops all priced and irreversible work. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+  }
+}
+
+const requireGenerativeRouteCaller = mock<() => Promise<unknown>>(async () => {
+  throw new ApiError(403, "access_denied", "Account is inactive", {
+    reason: "account_inactive",
+  });
+});
+const admitFlatGenerativeOperation = mock<() => Promise<unknown>>(async () => {
+  throw new Error("admission must not run after standing denial");
+});
+const calculateVoiceCloneCostFromCatalog = mock<() => Promise<unknown>>(
+  async () => {
+    throw new Error("pricing must not run after standing denial");
+  },
+);
+const createCloningJob = mock<() => Promise<unknown>>(async () => {
+  throw new Error("storage must not run after standing denial");
+});
+const createSamples = mock(async () => undefined);
+const createVoice = mock(async () => ({
+  id: "voice-row-1",
+  elevenlabsVoiceId: "eleven-voice-1",
+  name: "Test Voice",
+  description: null,
+  cloneType: "instant",
+  sampleCount: 1,
+  createdAt: new Date("2026-08-29T00:00:00.000Z"),
+}));
+const attachSamplesToVoice = mock(async () => undefined);
+const completeCloningJob = mock(async () => ({
+  id: "job-1",
+  status: "completed",
+  progress: 100,
+}));
+const markProviderDispatched = mock(async () => undefined);
+const settle = mock(async () => null);
+const settleUnknown = mock(async () => null);
+const billFlatUsage = mock(async () => ({
+  totalCost: 1,
+  baseTotalCost: 0.8,
+  platformMarkup: 0.2,
+}));
+const createUsage = mock(async () => undefined);
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  admitFlatGenerativeOperation,
+  asGenerativeCacheApiError: () => null,
+  getGenerativeExecutionContext: () => undefined,
+  requireGenerativeRouteCaller,
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError,
+  ValidationError: (message: string) =>
+    new ApiError(400, "bad_request", message),
+  failureResponse: (
+    c: { json(body: unknown, status: number): Response },
+    error: ApiError,
+  ) =>
+    c.json(
+      { error: error.message, code: error.code, details: error.details },
+      error.status,
+    ),
+  jsonError: (
+    c: { json(body: unknown, status: number): Response },
+    status: number,
+    error: string,
+    code = "internal_error",
+  ) => c.json({ error, code }, status),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/services/ai-pricing", () => ({
+  calculateVoiceCloneCostFromCatalog,
+}));
+mock.module("@/lib/services/ai-billing", () => ({
+  billFlatUsage,
+}));
+mock.module("@/lib/services/credits", () => ({
+  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+}));
+mock.module("@/db/repositories/user-voices", () => ({
+  userVoicesRepository: {
+    createCloningJob,
+    createSamples,
+    createVoice,
+    attachSamplesToVoice,
+    completeCloningJob,
+    deleteSamplesByJobId: mock(async () => undefined),
+    markCloningJobFailed: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/usage", () => ({
+  usageService: { create: createUsage },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+  },
+}));
+
+const { default: voiceCloneRoute } = await import("./route");
+const app = new Hono().route("/v1/voice/clone", voiceCloneRoute);
+
+test("cached bad standing denies before pricing, admission, provider, or storage", async () => {
+  const providerFetch = mock(async () => new Response("provider"));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const blobPut = mock(async () => undefined);
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      { method: "POST" },
+      { ELEVENLABS_API_KEY: "configured", BLOB: { put: blobPut } },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "access_denied",
+      error: "Account is inactive",
+      details: { reason: "account_inactive" },
+    });
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(calculateVoiceCloneCostFromCatalog).not.toHaveBeenCalled();
+    expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+    expect(createCloningJob).not.toHaveBeenCalled();
+    expect(blobPut).not.toHaveBeenCalled();
+    expect(providerFetch).not.toHaveBeenCalled();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("admits before ElevenLabs and settles the flat charge without a readback", async () => {
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balanceUsd: 10, revision: "2" },
+  }));
+  calculateVoiceCloneCostFromCatalog.mockImplementationOnce(async () => ({
+    totalCost: 1,
+    baseTotalCost: 0.8,
+    platformMarkup: 0.2,
+    pricingSource: "catalog",
+  }));
+  admitFlatGenerativeOperation.mockImplementationOnce(async () => ({
+    mode: "synchronous_db_ledger",
+    markProviderDispatched,
+    settle,
+    settleUnknown,
+  }));
+  createCloningJob.mockImplementationOnce(async () => ({
+    id: "job-1",
+    startedAt: new Date(),
+  }));
+  const providerFetch = mock(async () =>
+    Response.json({ voice_id: "eleven-voice-1" }),
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const blobPut = mock(async () => undefined);
+  const form = new FormData();
+  form.set("name", "Test Voice");
+  form.set("cloneType", "instant");
+  form.set(
+    "file0",
+    new File([new Uint8Array([1, 2, 3])], "sample.wav", {
+      type: "audio/wav",
+    }),
+  );
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      { method: "POST", body: form },
+      {
+        ELEVENLABS_API_KEY: "configured",
+        R2_PUBLIC_HOST: "blob.example.test",
+        BLOB: { put: blobPut },
+      },
+    );
+
+    expect(response.status).toBe(201);
+    expect(admitFlatGenerativeOperation).toHaveBeenCalledTimes(1);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+    expect(billFlatUsage).toHaveBeenCalledTimes(1);
+    expect(settle).toHaveBeenCalledWith(1);
+    expect(settleUnknown).not.toHaveBeenCalled();
+    expect(createUsage).toHaveBeenCalledTimes(1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -6,9 +6,9 @@
  * stays free of the SDK's Node-only deps.
  *
  * Credit handling:
- *   1. Reserve credits up-front (prevents overcommitment).
+ *   1. Admit the priced operation up-front (prevents overcommitment).
  *   2. Run upload + ElevenLabs call + DB writes.
- *   3. Reconcile reservation on success; refund (`reconcile(0)`) on failure.
+ *   3. Settle on success; release the admission on pre-commit failure.
  *
  * Request (multipart/form-data):
  *   - name           string (required)
@@ -20,6 +20,12 @@
 
 import { Hono } from "hono";
 import {
+  admitFlatGenerativeOperation,
+  asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
+import {
   type NewUserVoice,
   type NewVoiceCloningJob,
   type NewVoiceSample,
@@ -30,21 +36,13 @@ import {
   jsonError,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import {
-  type BillingContext,
-  billFlatUsage,
-  reserveFlatUsageCredits,
-} from "@/lib/services/ai-billing";
+import { type BillingContext, billFlatUsage } from "@/lib/services/ai-billing";
 import { calculateVoiceCloneCostFromCatalog } from "@/lib/services/ai-pricing";
-import {
-  type CreditReservation,
-  InsufficientCreditsError,
-} from "@/lib/services/credits";
+import { InsufficientCreditsError } from "@/lib/services/credits";
 import { usageService } from "@/lib/services/usage";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -88,12 +86,15 @@ const app = new Hono<AppEnv>();
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
-  let reservation: CreditReservation | undefined;
+  let admission: Awaited<
+    ReturnType<typeof admitFlatGenerativeOperation>
+  > | null = null;
   let jobId: string | undefined;
   let cloneType: CloneType | undefined;
   let cloneCost:
     | Awaited<ReturnType<typeof calculateVoiceCloneCostFromCatalog>>
     | undefined;
+  let billingContext: BillingContext | undefined;
   let user: { id: string; organization_id: string } | undefined;
   let apiKeyId: string | null = null;
   let totalSize = 0;
@@ -107,11 +108,16 @@ app.post("/", async (c) => {
   const uploadedR2Keys: string[] = [];
   let userVoicePersisted = false;
 
+  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
-    const auth = await requireUserOrApiKeyWithOrg(c);
-    user = { id: auth.id, organization_id: auth.organization_id };
-    apiKeyId = await getRequestApiKeyId(c);
+    caller = await requireGenerativeRouteCaller(c);
+  } catch (error) {
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
+  }
+  user = caller.user;
+  apiKeyId = caller.apiKeyId;
 
+  try {
     const apiKey = c.env.ELEVENLABS_API_KEY;
     if (!apiKey) {
       logger.error("[Voice Clone API] ELEVENLABS_API_KEY not configured");
@@ -212,7 +218,7 @@ app.post("/", async (c) => {
     );
 
     cloneCost = await calculateVoiceCloneCostFromCatalog({ cloneType });
-    const billingContext: BillingContext = {
+    billingContext = {
       organizationId: user.organization_id,
       userId: user.id,
       apiKeyId,
@@ -225,7 +231,13 @@ app.post("/", async (c) => {
     };
 
     try {
-      reservation = await reserveFlatUsageCredits(billingContext, cloneCost);
+      admission = await admitFlatGenerativeOperation({
+        c,
+        context: billingContext,
+        apiKeyId,
+        cost: cloneCost,
+        admissionSnapshot: caller.admissionSnapshot,
+      });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
         return c.json(
@@ -310,6 +322,7 @@ app.post("/", async (c) => {
       description,
       language,
       files,
+      markProviderDispatched: admission.markProviderDispatched,
     });
 
     // 3) Persist user_voices row.
@@ -342,11 +355,21 @@ app.post("/", async (c) => {
       elevenlabsVoiceId,
     });
 
-    const billing = await billFlatUsage(billingContext, cloneCost, reservation);
-
-    c.executionCtx.waitUntil(
-      usageService
-        .create({
+    const completedAdmission = admission;
+    const completedCost = cloneCost;
+    const completedBillingContext = billingContext;
+    await retainVoiceCloneTask(
+      c,
+      (async () => {
+        const billing = await billFlatUsage(
+          completedBillingContext,
+          completedCost,
+          completedAdmission.reservation,
+        );
+        if (!completedAdmission.reservation) {
+          await completedAdmission.settle(billing.totalCost);
+        }
+        await usageService.create({
           organization_id: user.organization_id,
           user_id: user.id,
           api_key_id: apiKeyId,
@@ -367,12 +390,23 @@ app.post("/", async (c) => {
             baseTotalCost: billing.baseTotalCost,
             billingSource: "elevenlabs",
           },
-        })
-        .catch((error) => {
-          logger.error("[Voice Clone API] Failed to create usage record", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }),
+        });
+      })().catch(async (error) => {
+        await completedAdmission.settleUnknown().catch((settlementError) => {
+          logger.error(
+            "[Voice Clone API] Failed to conservatively settle inference admission",
+            {
+              error:
+                settlementError instanceof Error
+                  ? settlementError.message
+                  : String(settlementError),
+            },
+          );
+        });
+        logger.error("[Voice Clone API] Failed to create usage record", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }),
     );
 
     logger.info("[Voice Clone API] Voice clone created", {
@@ -463,14 +497,41 @@ app.post("/", async (c) => {
       }
     }
 
-    // Only refund if the voice clone was NOT committed. Once userVoicePersisted
-    // is true the ElevenLabs voice exists and the user_voices row is usable for
-    // TTS, so a later (post-commit) failure — attachSamplesToVoice,
-    // completeCloningJob, or the affiliate lookup inside billFlatUsage — must NOT
-    // refund a delivered clone (the file's own note above). This also prevents a
-    // post-settle double-reconcile (settle happens after the commit).
-    if (reservation && !userVoicePersisted) {
-      await reservation.reconcile(0);
+    // A delivered ElevenLabs voice remains billable even if a later local DB
+    // update fails. Before that commit point, release the full admission.
+    if (admission && userVoicePersisted && cloneCost && billingContext) {
+      const failedAdmission = admission;
+      const failedCost = cloneCost;
+      const failedBillingContext = billingContext;
+      await retainVoiceCloneTask(
+        c,
+        billFlatUsage(
+          failedBillingContext,
+          failedCost,
+          failedAdmission.reservation,
+        )
+          .then(async (billing) => {
+            if (!failedAdmission.reservation) {
+              await failedAdmission.settle(billing.totalCost);
+            }
+          })
+          .catch(async (settlementError) => {
+            await failedAdmission.settleUnknown();
+            logger.error(
+              "[Voice Clone API] Failed to settle committed voice clone",
+              {
+                error:
+                  settlementError instanceof Error
+                    ? settlementError.message
+                    : String(settlementError),
+              },
+            );
+          }),
+      );
+    } else if (admission) {
+      await retainVoiceCloneSettlement(c, admission.settle(0), "release");
+    }
+    if (admission && !userVoicePersisted) {
       logger.info("[Voice Clone API] Credits refunded", {
         organizationId: user?.organization_id,
         amount: cloneCost?.totalCost,
@@ -480,7 +541,8 @@ app.post("/", async (c) => {
     if (user && cloneType) {
       const failedUser = user;
       const failedCloneType = cloneType;
-      c.executionCtx.waitUntil(
+      await retainVoiceCloneTask(
+        c,
         usageService
           .create({
             organization_id: failedUser.organization_id,
@@ -562,20 +624,33 @@ export default app;
 
 // ---------------------------------------------------------------------------
 
-/**
- * Same lookup as `messages/route.ts` — the auth shim doesn't surface the API
- * key row, so we re-derive it from headers. Returns null for session auth.
- */
-async function getRequestApiKeyId(c: AppContext): Promise<string | null> {
-  const apiKeyHeader = c.req.header("X-API-Key") || c.req.header("x-api-key");
-  const auth = c.req.header("authorization");
-  const bearer = auth?.startsWith("Bearer ") ? auth.slice(7).trim() : null;
-  const elizaBearer = bearer?.startsWith("eliza_") ? bearer : null;
-  const apiKey = apiKeyHeader || elizaBearer;
-  if (!apiKey) return null;
-  const { apiKeysService } = await import("@/lib/services/api-keys");
-  const validated = await apiKeysService.validateApiKey(apiKey);
-  return validated ? validated.id : null;
+async function retainVoiceCloneSettlement(
+  c: AppContext,
+  settlement: Promise<unknown>,
+  operation: "settle" | "release",
+): Promise<void> {
+  await retainVoiceCloneTask(
+    c,
+    settlement.catch((error) => {
+      // error-policy:J7 settlement diagnostics must not replace the provider
+      // response; the durable reservation sweep remains the recovery boundary.
+      logger.error(
+        `[Voice Clone API] Failed to ${operation} inference admission`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }),
+  );
+}
+
+async function retainVoiceCloneTask(
+  c: AppContext,
+  task: Promise<unknown>,
+): Promise<void> {
+  const executionCtx = getGenerativeExecutionContext(c);
+  if (executionCtx) executionCtx.waitUntil(task);
+  else await task;
 }
 
 /**
@@ -595,8 +670,17 @@ async function createElevenLabsVoice(params: {
   description: string | undefined;
   language: string;
   files: File[];
+  markProviderDispatched: (() => Promise<void>) | undefined;
 }): Promise<string> {
-  const { apiKey, cloneType, name, description, language, files } = params;
+  const {
+    apiKey,
+    cloneType,
+    name,
+    description,
+    language,
+    files,
+    markProviderDispatched,
+  } = params;
 
   if (cloneType === "instant") {
     const fd = new FormData();
@@ -605,6 +689,7 @@ async function createElevenLabsVoice(params: {
     for (const file of files) {
       fd.append("files", file, file.name);
     }
+    await markProviderDispatched?.();
     const res = await fetch(`${ELEVENLABS_API}/v1/voices/add`, {
       method: "POST",
       headers: { "xi-api-key": apiKey },
@@ -615,6 +700,7 @@ async function createElevenLabsVoice(params: {
   }
 
   // Professional voice cloning is a 3-step operation in ElevenLabs.
+  await markProviderDispatched?.();
   const createRes = await fetch(`${ELEVENLABS_API}/v1/voices/pvc`, {
     method: "POST",
     headers: {

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -569,11 +569,12 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
     "republish failure leaves the debit outcome intact and forces the org off the fast path (#17768)",
     async () => {
       if (!pgliteReady) return;
-      const { creditsService: credits } = await import("../credits");
+      const { cache } = await import("../../cache/client");
       const { isOrgAdmissionRefused } = await import("../inference-admission-refusal");
       const { readOrgBalanceHint } = await import("../inference-auth-cache");
-      const snap = spyOn(credits, "getOrganizationBalanceSnapshot").mockImplementation(async () => {
-        throw new Error("forced snapshot failure for test");
+      const hintWrite = spyOn(cache, "setWithOutcome").mockResolvedValue({
+        kind: "unavailable",
+        backend: "memory",
       });
       try {
         const reqId = nextRequestId();
@@ -592,7 +593,7 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
         expect(isOrgAdmissionRefused(ORG_ID)).toBe(true);
         expect(await readOrgBalanceHint(ORG_ID)).toBeNull();
       } finally {
-        snap.mockRestore();
+        hintWrite.mockRestore();
       }
     },
     PGLITE_TIMEOUT,

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -400,6 +400,7 @@ interface CreditMutationRow {
   org_exists: boolean | string | number | null;
   current_balance: string | number | null;
   new_balance: string | number | null;
+  balance_revision?: string | number | bigint | null;
   id: string | null;
   organization_id: string | null;
   user_id: string | null;
@@ -428,6 +429,14 @@ function parseNumeric(value: string | number | null | undefined, fieldName: stri
     throw new Error(`[CreditsService] Invalid numeric ${fieldName}`);
   }
   return parsed;
+}
+
+function parseBalanceRevision(value: string | number | bigint | null | undefined): string {
+  const revision = String(value ?? "");
+  if (!/^(0|[1-9]\d*)$/.test(revision)) {
+    throw new Error("[CreditsService] Invalid organization balance revision");
+  }
+  return revision;
 }
 
 function parseMetadata(value: CreditMutationRow["metadata"]): Record<string, unknown> {
@@ -768,6 +777,7 @@ export class CreditsService {
   async deductCredits(params: DeductCreditsParams): Promise<{
     success: boolean;
     newBalance: number;
+    balanceRevision: string;
     transaction: CreditTransaction | null;
     reason?: "insufficient_balance" | "below_minimum" | "org_not_found";
   }> {
@@ -785,6 +795,7 @@ export class CreditsService {
   async reserveAndDeductCredits(params: ReserveAndDeductParams): Promise<{
     success: boolean;
     newBalance: number;
+    balanceRevision: string;
     transaction: CreditTransaction | null;
     reason?: "insufficient_balance" | "below_minimum" | "org_not_found";
   }> {
@@ -813,6 +824,7 @@ export class CreditsService {
     const committedKeyedDeduction = async (): Promise<{
       success: true;
       newBalance: number;
+      balanceRevision: string;
       transaction: CreditTransaction;
     } | null> => {
       if (!stripePaymentIntentId) return null;
@@ -824,9 +836,11 @@ export class CreditsService {
           "[CreditsService] Deduction idempotency key belongs to another organization",
         );
       }
+      const snapshot = await this.getOrganizationBalanceSnapshot(organizationId);
       return {
         success: true,
-        newBalance: await this.getOrganizationBalanceUsd(organizationId),
+        newBalance: snapshot.balanceUsd,
+        balanceRevision: snapshot.revision,
         transaction: existing,
       };
     };
@@ -842,7 +856,7 @@ export class CreditsService {
         tx,
         sql`
         WITH org AS (
-          SELECT id, credit_balance::numeric AS current_balance
+          SELECT id, credit_balance::numeric AS current_balance, balance_revision
           FROM organizations
           WHERE id = ${organizationId}
           FOR UPDATE
@@ -895,12 +909,16 @@ export class CreditsService {
           FROM eligible
           WHERE o.id = eligible.id
             AND EXISTS (SELECT 1 FROM inserted)
-          RETURNING eligible.new_balance
+          RETURNING eligible.new_balance, o.balance_revision
         )
         SELECT
           EXISTS(SELECT 1 FROM org) AS org_exists,
           (SELECT current_balance FROM org) AS current_balance,
           (SELECT new_balance FROM updated) AS new_balance,
+          COALESCE(
+            (SELECT balance_revision FROM updated),
+            (SELECT balance_revision FROM org)
+          ) AS balance_revision,
           inserted.id,
           inserted.organization_id,
           inserted.user_id,
@@ -934,11 +952,13 @@ export class CreditsService {
       | {
           success: true;
           newBalance: number;
+          balanceRevision: string;
           transaction: CreditTransaction;
         }
       | {
           success: false;
           newBalance: number;
+          balanceRevision: string;
           transaction: null;
           reason: "insufficient_balance" | "below_minimum" | "org_not_found";
         };
@@ -947,6 +967,7 @@ export class CreditsService {
       result = {
         success: false,
         newBalance: 0,
+        balanceRevision: "0",
         transaction: null,
         reason: "org_not_found",
       };
@@ -955,6 +976,7 @@ export class CreditsService {
       result = {
         success: false,
         newBalance: currentBalance,
+        balanceRevision: parseBalanceRevision(row.balance_revision),
         transaction: null,
         reason:
           minimumBalanceRequired > 0 && currentBalance < minimumBalanceRequired
@@ -965,6 +987,7 @@ export class CreditsService {
       result = {
         success: true,
         newBalance: parseNumeric(row.new_balance, "new_balance"),
+        balanceRevision: parseBalanceRevision(row.balance_revision),
         transaction: toCreditTransaction(row),
       };
     }

--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.test.ts
@@ -89,7 +89,14 @@ describe("session decision validators", () => {
       60,
     );
 
-    await expect(readInferenceSessionAuthDecision(STEWARD_USER_ID)).resolves.toBeNull();
+    const cleanup: Promise<unknown>[] = [];
+    await expect(
+      readInferenceSessionAuthDecision(STEWARD_USER_ID, {
+        waitUntil: (promise) => cleanup.push(promise),
+      }),
+    ).resolves.toBeNull();
+    expect(cleanup).toHaveLength(1);
+    await Promise.all(cleanup);
     // The malformed entry was evicted, not left behind for a later read.
     await expect(cache.get(key)).resolves.toBeNull();
   });
@@ -137,9 +144,14 @@ describe("api-key IAC validators", () => {
       60,
     );
 
-    await expect(readInferenceAuthContextWithOutcome(KEY_HASH)).resolves.toMatchObject({
-      kind: "invalid",
-    });
+    const cleanup: Promise<unknown>[] = [];
+    await expect(
+      readInferenceAuthContextWithOutcome(KEY_HASH, undefined, {
+        waitUntil: (promise) => cleanup.push(promise),
+      }),
+    ).resolves.toMatchObject({ kind: "invalid" });
+    expect(cleanup).toHaveLength(1);
+    await Promise.all(cleanup);
     await expect(cache.get(key)).resolves.toBeNull();
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
@@ -160,6 +160,31 @@ export type InferenceAuthCacheReadOutcome =
       backend: CacheBackendKind;
     };
 
+export interface InferenceCacheCleanupExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+function deferMalformedEntryCleanup(
+  key: string,
+  executionCtx?: InferenceCacheCleanupExecutionContext,
+): void {
+  const cleanup = cache.del(key, { keyClass: "inference_auth" }).then(
+    () => undefined,
+    (error) => {
+      // error-policy:J7 malformed state already failed closed; cleanup remains
+      // observable without adding another remote write to authorization latency.
+      logger.warn("[InferenceAuthCache] Malformed entry cleanup failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+  if (executionCtx) {
+    executionCtx.waitUntil(cleanup);
+  } else {
+    void cleanup;
+  }
+}
+
 /** Org credit-balance snapshot used ONLY as the optimistic-billing fast-path gate hint. */
 export interface OrgBalanceHint {
   v: typeof INFERENCE_AUTH_CONTEXT_VERSION;
@@ -308,6 +333,7 @@ export async function readInferenceAuthContext(
 export async function readInferenceAuthContextWithOutcome(
   keyHash: string,
   probeDiscriminator?: string,
+  executionCtx?: InferenceCacheCleanupExecutionContext,
 ): Promise<InferenceAuthCacheReadOutcome> {
   const canonicalKey = CacheKeys.inference.authContext(keyHash);
   // Authenticated latency probes read a unique, never-written variant so each
@@ -329,7 +355,7 @@ export async function readInferenceAuthContextWithOutcome(
   }
   if (!isInferenceAuthContext(outcome.value) || outcome.value.keyHash !== keyHash) {
     logger.warn("[InferenceAuthCache] Dropping malformed IAC entry");
-    await cache.del(key, { keyClass: "inference_auth" });
+    deferMalformedEntryCleanup(key, executionCtx);
     return { kind: "invalid", backend: outcome.backend };
   }
   return { kind: "hit", ctx: outcome.value, backend: outcome.backend };
@@ -380,6 +406,7 @@ export async function readInferenceSessionAuthContext(
 /** Read the cached positive or fail-closed session decision. */
 export async function readInferenceSessionAuthDecision(
   stewardUserId: string,
+  executionCtx?: InferenceCacheCleanupExecutionContext,
 ): Promise<InferenceSessionAuthDecision | null> {
   const key = CacheKeys.inference.sessionAuthContext(hashStewardUserId(stewardUserId));
   const outcome = await cache.getWithOutcome<unknown>(key, { keyClass: "inference_auth" });
@@ -390,7 +417,7 @@ export async function readInferenceSessionAuthDecision(
     cached.stewardUserId !== stewardUserId
   ) {
     logger.warn("[InferenceAuthCache] Dropping malformed session IAC entry");
-    await cache.del(key, { keyClass: "inference_auth" });
+    deferMalformedEntryCleanup(key, executionCtx);
     return null;
   }
   return cached;

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -106,6 +106,7 @@ mock.module("./inference-credential-revocation", () => ({
 
 const {
   __clearInferenceApiKeyHydrations,
+  observeInferenceApiKeyUsage,
   resolveInferenceAuthContext,
   extractApiKeyCredential,
   resolveInferenceAuthHydrationDeadlineMs,
@@ -309,22 +310,26 @@ describe("resolveInferenceAuthContext", () => {
       };
     };
     const waited: Promise<unknown>[] = [];
+    const cacheRead = spyOn(cache, "getWithOutcome");
     const result = await resolveInferenceAuthContext(reqWithApiKey(), {
       cacheOnly: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
     expect(result).toMatchObject({ kind: "warming" });
     expect(result.kind === "warming" && result.hydration).toBeTruthy();
+    expect(result.kind === "warming" && result.continuation).toBeTruthy();
     expect(waited.length).toBeGreaterThan(0);
-    await waited[0];
+    if (result.kind !== "warming" || !result.continuation) throw new Error("unreachable");
+    const continued = await result.continuation;
     await Promise.all(waited);
     expect(chainCalls).toBe(1);
-
-    const retry = await resolveInferenceAuthContext(reqWithApiKey(), {
-      cacheOnly: true,
-    });
-    expect(retry.kind).toBe("authorized");
-    if (retry.kind === "authorized") expect(retry.source).toBe("cache");
+    expect(continued).toMatchObject({ kind: "authorized", source: "origin" });
+    expect(cacheRead).toHaveBeenCalledTimes(1);
+    expect(incrementUsageCalls).toEqual([]);
+    if (continued) observeInferenceApiKeyUsage(continued, { waitUntil: (p) => waited.push(p) });
+    await Promise.all(waited);
+    expect(incrementUsageCalls).toEqual(["key-1"]);
+    cacheRead.mockRestore();
   });
 
   test("concurrent cache-only misses share one authoritative hydration", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -166,7 +166,7 @@ interface MutableInferenceAuthTrace {
 
 type InferenceStandingDecisionSource = "authoritative" | "cache" | "session_resolution";
 
-const apiKeyHydrations = new Map<string, Promise<void>>();
+const apiKeyHydrations = new Map<string, Promise<InferenceAuthResolution | undefined>>();
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
 const DEFAULT_HYDRATION_DEADLINE_MS = 10_000;
 const MAX_HYDRATION_DEADLINE_MS = 2_147_483_647;
@@ -268,7 +268,12 @@ export type InferenceAuthResolution =
     }
   | { kind: "suspended"; userId?: string; reason?: InferenceAuthRejectionReason }
   | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason }
-  | { kind: "warming"; hydration?: Promise<unknown> }
+  | {
+      kind: "warming";
+      hydration?: Promise<unknown>;
+      /** One-shot cold-auth result for bounded voice warming without a second cache read. */
+      continuation?: Promise<InferenceAuthResolution | undefined>;
+    }
   | { kind: "slow_path"; reason: "mobile_api_key" | "non_api_key" };
 
 /**
@@ -369,7 +374,7 @@ function getOrCreateApiKeyHydration(
   req: Request,
   keyHash: string,
   traceId: string | undefined,
-): Promise<void> {
+): Promise<InferenceAuthResolution | undefined> {
   const existing = apiKeyHydrations.get(keyHash);
   if (existing) return existing;
 
@@ -386,7 +391,7 @@ function getOrCreateApiKeyHydration(
       authoritativeRejectionReason = reason;
     },
   })
-    .then(async (result) => {
+    .then(async (result): Promise<InferenceAuthResolution> => {
       if (result.kind === "suspended") {
         const write = await writeInferenceApiKeyAuthRejection(
           keyHash,
@@ -399,8 +404,9 @@ function getOrCreateApiKeyHydration(
         }
       }
       apiKeyHydrationFailures.delete(keyHash);
+      return result;
     })
-    .catch(async (error) => {
+    .catch(async (error): Promise<InferenceAuthResolution | undefined> => {
       const status = getErrorStatusCode(error);
       if (status === 401 || status === 403) {
         const reason = authoritativeRejectionReason ?? "credential_invalid";
@@ -415,6 +421,7 @@ function getOrCreateApiKeyHydration(
         // A definitive rejection is a successful decision, not a failed
         // hydration — the cache now answers; no escape pressure needed.
         apiKeyHydrationFailures.delete(keyHash);
+        return { kind: "rejected", status, reason };
       } else {
         noteHydrationFailure(keyHash);
       }
@@ -425,6 +432,7 @@ function getOrCreateApiKeyHydration(
         failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
         error: error instanceof Error ? error.message : String(error),
       });
+      return undefined;
     });
   // Deadline: a never-settling attempt must not hold the single-flight slot.
   // The timed-out promise resolves (never rejects), counts as a failure, and
@@ -432,7 +440,7 @@ function getOrCreateApiKeyHydration(
   let deadline: ReturnType<typeof setTimeout> | undefined;
   const hydration = Promise.race([
     attempt,
-    new Promise<void>((resolve) => {
+    new Promise<undefined>((resolve) => {
       deadline = setTimeout(() => {
         noteHydrationFailure(keyHash);
         logger.warn("[InferenceAuth] background hydration exceeded deadline", {
@@ -440,7 +448,7 @@ function getOrCreateApiKeyHydration(
           deadlineMs: HYDRATION_DEADLINE_MS,
           failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
         });
-        resolve();
+        resolve(undefined);
       }, HYDRATION_DEADLINE_MS);
       if (typeof deadline.unref === "function") deadline.unref();
     }),
@@ -464,6 +472,29 @@ export function __clearInferenceApiKeyHydrationFailures(): void {
 /** Test hook for isolating coalesced API-key hydration state. */
 export function __clearInferenceApiKeyHydrations(): void {
   apiKeyHydrations.clear();
+}
+
+/** Retain accepted API-key usage telemetry when a cold-auth continuation is consumed. */
+export function observeInferenceApiKeyUsage(
+  resolution: InferenceAuthResolution,
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+): void {
+  if (resolution.kind !== "authorized" || resolution.ctx.apiKeyId === null) return;
+  const usageUpdate = apiKeysService
+    .incrementUsageDebounced(resolution.ctx.apiKeyId)
+    .catch((error) => {
+      // error-policy:J7 usage telemetry must not add latency or reject an
+      // otherwise authorized inference continuation.
+      logger.warn("[InferenceAuth] API-key usage update failed", {
+        apiKeyId: resolution.ctx.apiKeyId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  if (executionCtx) {
+    executionCtx.waitUntil(usageUpdate);
+  } else {
+    void usageUpdate;
+  }
 }
 
 export async function resolveInferenceAuthContext(
@@ -581,6 +612,7 @@ export async function resolveInferenceAuthContext(
       const cached = await readInferenceAuthContextWithOutcome(
         keyHash,
         probeDiscriminator ?? undefined,
+        options.executionCtx,
       );
       trace.timings.cacheReadMs = durationSince(cacheReadStartedAt);
       trace.cacheRead = cached.kind;
@@ -607,25 +639,16 @@ export async function resolveInferenceAuthContext(
           }
           throw error;
         }
-        const usageUpdate = apiKeysService
-          .incrementUsageDebounced(cached.ctx.apiKeyId)
-          .catch((error) => {
-            // error-policy:J7 usage telemetry must not add latency or create an
-            // unhandled rejection on an otherwise authorized inference.
-            logger.warn("[InferenceAuth] API-key usage update failed", {
-              apiKeyId: cached.ctx.apiKeyId,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
+        observeInferenceApiKeyUsage(
+          { kind: "authorized", ctx: cached.ctx, source: "cache" },
+          options.executionCtx,
+        );
         if (options.executionCtx) {
-          options.executionCtx.waitUntil(usageUpdate);
           if (Date.now() - cached.ctx.cachedAt >= AUTH_CONTEXT_REFRESH_AFTER_MS) {
             options.executionCtx.waitUntil(
               getOrCreateApiKeyHydration(req, keyHash, options.traceId),
             );
           }
-        } else {
-          void usageUpdate;
         }
         trace.result = "authorized_cache";
         return { kind: "authorized", ctx: cached.ctx, source: "cache" };
@@ -651,7 +674,7 @@ export async function resolveInferenceAuthContext(
       if (cacheAvailable && options.executionCtx) {
         const hydration = getOrCreateApiKeyHydration(req, keyHash, options.traceId);
         options.executionCtx.waitUntil(hydration);
-        return { kind: "warming", hydration };
+        return { kind: "warming", hydration, continuation: hydration };
       }
       return { kind: "warming" };
     }

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -9,12 +9,11 @@
  * graph for a single helper (and breaking callers that mock `db/helpers` at
  * its previous, narrower boundary).
  *
- * Its dependencies are exactly the three the ledger already carries or that are
- * leaves: `credits`, `inference-auth-cache`, and the isolate-local
+ * Its dependencies are leaves already used by both settlers:
+ * `inference-auth-cache` and the isolate-local
  * `inference-admission-refusal`.
  */
 
-import { creditsService } from "./credits";
 import { clearOrgAdmissionRefused } from "./inference-admission-refusal";
 import { republishOrgBalanceHint } from "./inference-auth-cache";
 
@@ -35,11 +34,9 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
  * entry exists, so after the delete it is always a no-op.
  *
- * Republishing authoritatively (balance AND revision) costs nothing net: the
- * identical `getOrganizationBalanceSnapshot` read already happened moments
- * later as the 503's background hydration. This only moves that read off the
- * next request's critical path, and it keeps the revision fresh rather than
- * preserving a stale one.
+ * The debit statement returns both the committed balance and trigger-advanced
+ * revision. Passing that atomic result here avoids a post-debit primary read
+ * while keeping the revision fresh rather than preserving a stale one.
  *
  * Republication is one write with no cache readback. The cache is a projection,
  * not the monetary authority: Worker dispatch is fenced by the serialized,
@@ -48,12 +45,12 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * is never allowed to dispatch from this projection. Older snapshots therefore
  * cannot reopen an active gate even if concurrent writers reach Redis out of order.
  */
-export async function republishOrgBalanceHintAfterDebit(organizationId: string): Promise<void> {
-  // Captured BEFORE the authoritative read, matching `refreshOrgBalanceHint`:
-  // the timestamp marks when the read started, so a delayed old query can never
-  // masquerade as fresher than a debit that committed while it was in flight.
+export async function republishOrgBalanceHintAfterDebit(
+  organizationId: string,
+  balanceUsd: number,
+  balanceRevision: string,
+): Promise<void> {
   const balanceAt = Date.now();
-  const snapshot = await creditsService.getOrganizationBalanceSnapshot(organizationId);
-  await republishOrgBalanceHint(organizationId, snapshot.balanceUsd, balanceAt, snapshot.revision);
+  await republishOrgBalanceHint(organizationId, balanceUsd, balanceAt, balanceRevision);
   clearOrgAdmissionRefused(organizationId);
 }

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -70,6 +70,7 @@ mock.module("./credits", () => ({
       if (deductResult.success) {
         return {
           ...deductResult,
+          balanceRevision: "2",
           transaction: {
             organization_id: args.organizationId,
             amount: String(-args.amount),
@@ -395,12 +396,11 @@ describe("createOptimisticDebitSettler", () => {
   test("on debit success republishes the org-balance hint the credit mutation evicted", async () => {
     const input = chargeInput();
     deductResult = { success: true, newBalance: 7.5, transaction: { id: "debit-2" } };
-    // Authoritative post-debit balance the republish must pick up.
-    freshBalanceUsd = 7.5;
     await writeOrgBalanceHint(input.organizationId, 10, Date.now(), "1");
     await writePendingInferenceCharge(input, Date.now());
     await createOptimisticDebitSettler(input)(0.02);
     expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(7.5);
+    expect(freshBalanceCalls).toBe(0);
   });
 
   // REGRESSION (staging 2026-08-05): every settled turn left the gate hint
@@ -412,7 +412,6 @@ describe("createOptimisticDebitSettler", () => {
   test("leaves a warm hint so the NEXT turn does not fail closed on a cacheOnly read", async () => {
     const input = chargeInput();
     deductResult = { success: true, newBalance: 4.25, transaction: { id: "debit-flap" } };
-    freshBalanceUsd = 4.25;
     await writeOrgBalanceHint(input.organizationId, 9, Date.now(), "1");
     await writePendingInferenceCharge(input, Date.now());
 
@@ -449,9 +448,8 @@ describe("createOptimisticDebitSettler", () => {
   test("republished hint carries authoritative balance AND revision, not the stale pre-debit ones", async () => {
     const input = chargeInput();
     deductResult = { success: true, newBalance: 3, transaction: { id: "debit-rev" } };
-    freshBalanceUsd = 3;
-    // Stale entry: higher balance, older revision "1". The credits seam reports
-    // revision "2" as authoritative.
+    // Stale entry: higher balance, older revision "1". The atomic debit result
+    // carries revision "2" alongside its committed balance.
     await writeOrgBalanceHint(input.organizationId, 42, Date.now(), "1");
     await writePendingInferenceCharge(input, Date.now());
 
@@ -670,30 +668,23 @@ describe("#9899 hardening: backstop durability, lower-only hint, claim atomicity
     expect(isOptimisticBackstopAvailable()).toBe(true);
   });
 
-  // The gate must never be raised above authoritative state by an out-of-order
-  // debit (#9899 over-admit bound). The settler no longer trusts the debit's
-  // own `newBalance` for this at all: the committed debit's `onCreditMutation`
-  // evicts the hint, so the settler re-reads AUTHORITATIVE state and republishes
-  // that. A transaction reporting a stale-high balance therefore cannot raise
-  // the gate, because its reported number is never written.
-  test("a stale-high debit report never raises the gate; authoritative state wins", async () => {
+  // The atomic debit statement returns balance + revision from one committed
+  // mutation. Republication must use that pair without a second primary read.
+  test("republishes each atomic debit snapshot without a primary readback", async () => {
     const input = chargeInput();
     await writeOrgBalanceHint(input.organizationId, 10, Date.now(), "1");
-    // Out-of-order: the debit claims 20, but the database says 6.
-    deductResult = { success: true, newBalance: 20, transaction: { id: "debit-high" } };
-    freshBalanceUsd = 6;
+    deductResult = { success: true, newBalance: 6, transaction: { id: "debit-high" } };
     await writePendingInferenceCharge(input, Date.now());
     await createOptimisticDebitSettler(input)(0.01);
-    // The stale-high 20 is never published; the authoritative 6 is.
     expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(6);
 
     // A subsequent debit lowers it further, still from authoritative state.
     const input2 = chargeInput({ organizationId: input.organizationId });
     deductResult = { success: true, newBalance: 4, transaction: { id: "debit-low" } };
-    freshBalanceUsd = 4;
     await writePendingInferenceCharge(input2, Date.now());
     await createOptimisticDebitSettler(input2)(0.01);
     expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(4);
+    expect(freshBalanceCalls).toBe(0);
   });
 
   test("republish issues one direct authoritative write without a cache read", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -443,7 +443,11 @@ export async function debitInferenceCost(
     // Durable Object remains the Worker dispatch authority if concurrent cache
     // writers arrive out of order.
     try {
-      await republishOrgBalanceHintAfterDebit(ctx.organizationId);
+      await republishOrgBalanceHintAfterDebit(
+        ctx.organizationId,
+        result.newBalance,
+        result.balanceRevision,
+      );
     } catch (cause) {
       markOrgAdmissionRefused(ctx.organizationId);
       try {

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -183,6 +183,7 @@ interface SettleOutcome {
   debited: boolean;
   uncollected: boolean;
   newBalance?: number;
+  balanceRevision?: string;
   /** `credit_transactions.id` of the committed debit row, when one was inserted. */
   transactionId?: string;
 }
@@ -193,6 +194,7 @@ interface ClaimRow {
 interface DebitRow {
   debited: boolean | "t" | "f" | null;
   new_balance: string | number | null;
+  balance_revision: string | number | bigint | null;
   transaction_id: string | null;
 }
 
@@ -265,7 +267,7 @@ async function settleLedgerCharge(
             SET credit_balance = o.credit_balance - ${String(amountUsd)}::numeric, updated_at = NOW()
             FROM locked
             WHERE o.id = locked.id AND locked.bal >= ${String(amountUsd)}::numeric
-            RETURNING o.credit_balance AS new_balance
+            RETURNING o.credit_balance AS new_balance, o.balance_revision
           ),
           ins AS (
             INSERT INTO credit_transactions (organization_id, amount, type, description, metadata, created_at)
@@ -277,6 +279,7 @@ async function settleLedgerCharge(
           SELECT
             EXISTS(SELECT 1 FROM upd) AS debited,
             (SELECT new_balance FROM upd) AS new_balance,
+            (SELECT balance_revision FROM upd) AS balance_revision,
             (SELECT id FROM ins) AS transaction_id
         `,
       );
@@ -288,11 +291,16 @@ async function settleLedgerCharge(
         return { claimed: true, debited: false, uncollected: true };
       }
       const nb = debit[0]?.new_balance;
+      const balanceRevision = String(debit[0]?.balance_revision ?? "");
+      if (!/^(0|[1-9]\d*)$/.test(balanceRevision)) {
+        throw new Error("[InferenceLedger] committed debit returned an invalid balance revision");
+      }
       return {
         claimed: true,
         debited: true,
         uncollected: false,
         newBalance: nb === null || nb === undefined ? undefined : Number(nb),
+        balanceRevision,
         ...(debit[0]?.transaction_id && { transactionId: debit[0].transaction_id }),
       };
     });
@@ -330,7 +338,14 @@ async function settleLedgerCharge(
     // guarantee; on failure force the org off the fast path rather than leave a
     // silent absent hint.
     try {
-      await republishOrgBalanceHintAfterDebit(ctx.organizationId);
+      if (outcome.newBalance === undefined || outcome.balanceRevision === undefined) {
+        throw new Error("Committed inference debit did not return its balance snapshot");
+      }
+      await republishOrgBalanceHintAfterDebit(
+        ctx.organizationId,
+        outcome.newBalance,
+        outcome.balanceRevision,
+      );
     } catch (cause) {
       // error-policy:J4 the debit is already committed; convert the post-commit
       // cache failure into an explicit admission refusal instead of presenting

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -149,13 +149,20 @@ describe("resolveInferenceSessionAuthContext", () => {
 
     expect(result).toMatchObject({ kind: "warming" });
     expect(result.kind === "warming" && result.hydration).toBeTruthy();
+    expect(result.kind === "warming" && result.continuation).toBeTruthy();
     expect(waited).toHaveLength(1);
     expect(cacheRead).toHaveBeenCalledTimes(1);
     expect(userReads).toBe(1);
     expect(moderationReads).toBe(0);
     releaseUser();
+    if (result.kind !== "warming" || !result.continuation) throw new Error("unreachable");
+    await expect(result.continuation).resolves.toMatchObject({
+      kind: "authorized",
+      source: "origin",
+    });
     await Promise.all(waited);
     expect(moderationReads).toBe(1);
+    expect(cacheRead).toHaveBeenCalledTimes(1);
     cacheRead.mockRestore();
   });
 

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -46,18 +46,22 @@ export interface ResolveInferenceSessionAuthOptions {
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }
 
-export type InferenceSessionAuthResolution =
-  | { kind: "not_session" }
+export type InferenceSessionContinuationResolution =
   | {
       kind: "authorized";
       ctx: InferenceSessionAuthContext;
       source: "cache" | "origin";
     }
   | { kind: "suspended"; userId?: string; reason?: InferenceAuthRejectionReason }
-  | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason }
+  | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason };
+
+export type InferenceSessionAuthResolution =
+  | { kind: "not_session" }
+  | InferenceSessionContinuationResolution
   | {
       kind: "warming";
       hydration?: Promise<InferenceSessionAuthDecision | undefined>;
+      continuation?: Promise<InferenceSessionContinuationResolution | undefined>;
     };
 
 function looksLikeJwt(token: string): boolean {
@@ -140,7 +144,7 @@ async function hydrateAuthoritativeDecision(params: {
 function toResolution(
   decision: InferenceSessionAuthDecision,
   source: "cache" | "origin",
-): InferenceSessionAuthResolution {
+): InferenceSessionContinuationResolution {
   if ("apiKeyId" in decision) {
     return { kind: "authorized", ctx: decision, source };
   }
@@ -155,7 +159,7 @@ async function enforceStrongSessionBoundary(
   stewardUserId: string,
   issuedAt: number,
   source: "cache" | "origin",
-): Promise<InferenceSessionAuthResolution> {
+): Promise<InferenceSessionContinuationResolution> {
   const resolved = toResolution(decision, source);
   if (resolved.kind !== "authorized") return resolved;
   try {
@@ -296,7 +300,10 @@ export async function resolveInferenceSessionAuthContext(
   }
 
   if (options.useAuthCache && cache.isAvailable()) {
-    const cached = await readInferenceSessionAuthDecision(claims.userId).catch((error) => {
+    const cached = await readInferenceSessionAuthDecision(
+      claims.userId,
+      options.executionCtx,
+    ).catch((error) => {
       // error-policy:J4 inference remains explicitly unavailable on a cache
       // failure; never fall through to an inline database authorization.
       logger.warn("[InferenceSessionAuth] Cache read failed", {
@@ -358,6 +365,18 @@ export async function resolveInferenceSessionAuthContext(
             // error-policy:J7 a failed hydration stays a retryable warming
             // outcome for cache-only callers instead of becoming an opaque 500.
             logger.warn("[InferenceSessionAuth] Inline hydration await failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return undefined;
+          },
+        ),
+        continuation: hydrationDecision.then(
+          (decision) =>
+            enforceStrongSessionBoundary(decision, claims.userId, claims.issuedAt, "origin"),
+          (error) => {
+            // error-policy:J7 the retained hydration above owns failure logging;
+            // a voice continuation keeps the original warming outcome.
+            logger.warn("[InferenceSessionAuth] Continuation hydration failed", {
               error: error instanceof Error ? error.message : String(error),
             });
             return undefined;


### PR DESCRIPTION
## Summary

- enforce one canonical cached account-standing decision across inference and newly gated paid routes
- preserve cached denial reasons in structured client errors and detailed bounded server logs
- move ledger/cache settlement off the response path and publish the committed snapshot without a database readback
- prevent post-dispatch failures from refunding reservations as though no provider work occurred
- add frontend-mimicking latency/auth probes and focused ordering, denial, and no-readback coverage

Refs #29967

This is the core/route correctness slice. The issue intentionally remains open for follow-up migrations inside several legacy paid service implementations, MCP/vendor proxy boundaries, and dedicated runtime dispatch.

## Architecture contract

`frontend -> Cloudflare Worker -> one standing cache read -> admission -> provider -> async ledger/cache settlement`

Cached bad-standing responses stop before provider dispatch and include a safe reason. Railway Postgres is reached through Hyperdrive for authoritative persistence; it is not a serial HTTP hop in the chat path.

## Verification

- `bun test --parallel=4` across 18 changed test files: 291 pass, 0 fail, 1175 expectations
- cloud shared typecheck: pass
- cloud API typecheck: pass
- production Worker dry-run bundle: pass
- Biome across all changed TypeScript files: pass
- `git diff --check`: pass
- `bun run verify`: pass (375/375 Turbo tasks plus repository audits)

## Direct Cerebras baseline

20/20 successful requests:

- response headers: p50 123.16 ms, p95 236.37 ms
- first token: p50 132.77 ms, p95 252.21 ms
- total: p50 148.77 ms, p95 256.44 ms
- provider compute: p50 35.37 ms, p95 79.14 ms

Paired staging gateway certification will be run only after this exact commit, or a containing merge SHA, is deployed.
