### PR TITLE
fix(app-test): isolate mobile smoke module configuration

### DIFF
--- a/packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs
@@ -11,7 +11,7 @@ process.argv = [
   "--platform",
   "unit-test",
 ];
-const smoke = await import("./mobile-local-chat-smoke.mjs");
+const smoke = await import("./mobile-local-chat-smoke.mjs?port-policy");
 process.argv = originalArgv;
 
 afterAll(() => {

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -42,7 +42,7 @@ process.argv = [
   "--platform",
   "unit-test",
 ];
-const smoke = await import("./mobile-local-chat-smoke.mjs");
+const smoke = await import("./mobile-local-chat-smoke.mjs?full-contract");
 process.argv = originalArgv;
 
 let server;


### PR DESCRIPTION
## Summary

- evaluate the stateful mobile smoke CLI independently in each Bun test file
- prevent aggregate test order from freezing another file's model-size and timing environment
- retain fail-closed production model size/hash verification

## Verification

- both mobile smoke test files together: 36 passed
- aggregate app Bun script lane advances past the prior model fixture failure

Fixes #29979