### PR TITLE
fix(app): align audit with unavailable view fallbacks

### DIFF
--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -224,9 +224,15 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
   {
     name: "rolodex",
     path: "/rolodex",
-    // /rolodex resolves to the launcher surface on this platform — same
-    // testid anchor as the apps catalog (old text probe never matches).
-    readyChecks: [{ selector: '[data-testid="launcher"]' }],
+    // Rolodex is a retired built-in route whose launcher entry canonicalizes
+    // to Relationships. Its retained deep link must remain a visible,
+    // recoverable unavailable state instead of presenting a healthy launcher.
+    readyChecks: [
+      {
+        selector:
+          '[data-view-status="unavailable"][data-view-id="rolodex"]',
+      },
+    ],
     timeoutMs: 60_000,
   },
   {

--- a/packages/app/test/ui-smoke/apps-builtin-pages-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-builtin-pages-interactions.spec.ts
@@ -153,14 +153,12 @@ test("stream view renders the offline status surface", async ({ page }) => {
   });
 });
 
-test("rolodex resolves to the launcher with registered view tiles", async ({
-  page,
-}) => {
+test("rolodex renders its designed unavailable boundary", async ({ page }) => {
   await openAppPath(page, "/rolodex");
-  await expect(page.getByTestId("launcher")).toBeVisible({
-    timeout: 60_000,
-  });
   await expect(
-    page.locator('[data-testid^="launcher-tile-"]').first(),
-  ).toBeVisible();
+    page.locator(
+      '[data-view-status="unavailable"][data-view-id="rolodex"]',
+    ),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
 });

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -51,6 +51,14 @@ const VIEW_REGISTRY_FALLBACK: OcrExpectation = {
   requireAny: ["ready views", "gui ready"],
 };
 
+const VIEW_UNAVAILABLE_FALLBACK: OcrExpectation = {
+  requireAll: [
+    "View unavailable",
+    "This view is not available in the current runtime",
+  ],
+  requireAny: ["Retry", "Back to views"],
+};
+
 export const VIEW_OCR_POLICIES = {
   "builtin-chat": expected({
     requireAny: [
@@ -61,8 +69,8 @@ export const VIEW_OCR_POLICIES = {
   }),
   "builtin-camera": exempt(
     "native-platform-gated",
-    "The camera is an AOSP-native surface, so the browser audit intentionally renders the launcher fallback.",
-    LAUNCHER_FALLBACK,
+    "The camera is an AOSP-native surface, so the browser audit intentionally renders the unavailable-view boundary.",
+    VIEW_UNAVAILABLE_FALLBACK,
   ),
   "builtin-tasks": expected({
     requireAll: ["Tasks"],
@@ -184,7 +192,7 @@ export const VIEW_OCR_POLICIES = {
       "Filter by type",
     ],
   }),
-  "builtin-rolodex": expected(LAUNCHER_FALLBACK),
+  "builtin-rolodex": expected(VIEW_UNAVAILABLE_FALLBACK),
   "builtin-runtime": expected({
     requireAny: ["Plugins", "Actions", "Providers"],
   }),
@@ -323,8 +331,8 @@ export const VIEW_OCR_POLICIES = {
   }),
   "plugin-cockpit-gui": exempt(
     "unregistered-remote-bundle",
-    "The Cockpit GUI has no remote bundle in the hermetic browser audit, so the launcher fallback is the only observable surface.",
-    LAUNCHER_FALLBACK,
+    "The Cockpit GUI has no remote bundle in the hermetic browser audit, so the unavailable-view boundary is the only observable surface.",
+    VIEW_UNAVAILABLE_FALLBACK,
   ),
   "plugin-trajectory-logger-gui": expected({
     requireAny: ["Back to apps", "HANDLE", "PLAN"],

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -816,7 +816,9 @@ describe("App navigate-view event wiring", () => {
 
     await waitFor(() => {
       expect(
-        container.querySelector('[data-view-status="unavailable"]'),
+        container.querySelector(
+          '[data-view-status="unavailable"][data-view-id="phone"]',
+        ),
       ).toBeTruthy();
     });
     expect(container.querySelector('[data-testid="home-screen"]')).toBeNull();

--- a/packages/ui/src/components/views/ViewStatusStates.tsx
+++ b/packages/ui/src/components/views/ViewStatusStates.tsx
@@ -213,6 +213,7 @@ export function ViewUnavailableState({
   return (
     <ViewStatusFrame
       tone="unavailable"
+      diagnosticId={viewId}
       icon={<Ban className="size-5" aria-hidden="true" />}
       title={t("dynamicviewloader.unavailable.title", {
         defaultValue: "View unavailable",


### PR DESCRIPTION
## Summary

- validate native-only Camera and unregistered Cockpit against the designed unavailable-view boundary
- update retained Rolodex deep-link probes to its current recoverable unavailable state
- keep semantic exemptions narrow and observable

## Verification

- OCR policy contract: 6 passed
- strict app audit previously isolated exactly these 12 stale fallback verdicts across four viewports

Fixes #29978