### PR TITLE
fix(app-test): align Vite command and live HMR contracts

### DIFF
--- a/packages/app/playwright.hmr.config.ts
+++ b/packages/app/playwright.hmr.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
       ELIZA_DEV_NO_WATCH: "1",
       ELIZA_DEV_QUIET_LOGS: "1",
       ELIZA_NO_VISION_DEPS: "1",
+      // This lane edits main.tsx and its eager workspace dependencies. Force
+      // the full chat harness so the hosted root cannot select the lightweight
+      // marketing/public entry and leave those modules outside the client graph.
+      ELIZA_CHAT_UI_HARNESS: "1",
       // Vite cold-start of the full raw-source module graph exceeds dev-ui's
       // default 60s health-check window on shared CI runners; widen it so the
       // watchdog doesn't SIGTERM Vite before it can serve the HMR client.

--- a/packages/app/scripts/lib/dev-vite-command.test.mjs
+++ b/packages/app/scripts/lib/dev-vite-command.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Verifies app development entrypoints share one Node-backed Vite command,
+ * Verifies app development entrypoints share one active-runtime Vite command,
  * including dashboard flags, child lifecycle, and dependency diagnostics.
  */
 
@@ -97,15 +97,17 @@ async function runMirroredChildProbe({ childSource, wrapperSignal }) {
 }
 
 describe("development Vite process commands", () => {
-  it("runs the shared server through Node with source import support", () => {
+  it("runs the shared server through Bun without the Node-only loader", () => {
     assert.deepEqual(
-      resolveViteCommand({ appDir, nodePath: "/usr/local/bin/node" }),
+      resolveViteCommand({
+        appDir,
+        runtime: "bun",
+        runtimePath: "/usr/local/bin/bun",
+      }),
       {
-        command: "/usr/local/bin/node",
+        command: "/usr/local/bin/bun",
         args: [
           "--conditions=eliza-source",
-          "--import",
-          "tsx",
           viteCli,
           "--configLoader",
           "bundle",
@@ -119,15 +121,14 @@ describe("development Vite process commands", () => {
       resolveViteCommand({
         appDir,
         force: true,
-        nodePath: "/usr/bin/node",
+        runtime: "bun",
+        runtimePath: "/usr/bin/bun",
         port: 2138,
       }),
       {
-        command: "/usr/bin/node",
+        command: "/usr/bin/bun",
         args: [
           "--conditions=eliza-source",
-          "--import",
-          "tsx",
           viteCli,
           "--configLoader",
           "bundle",
@@ -140,15 +141,14 @@ describe("development Vite process commands", () => {
     assert.deepEqual(
       resolveViteCommand({
         appDir,
-        nodePath: "/usr/bin/node",
+        runtime: "bun",
+        runtimePath: "/usr/bin/bun",
         port: 2138,
       }),
       {
-        command: "/usr/bin/node",
+        command: "/usr/bin/bun",
         args: [
           "--conditions=eliza-source",
-          "--import",
-          "tsx",
           viteCli,
           "--configLoader",
           "bundle",
@@ -162,11 +162,33 @@ describe("development Vite process commands", () => {
   it("forwards direct Vite CLI flags after the canonical dev arguments", () => {
     const resolved = resolveViteCommand({
       appDir,
-      nodePath: "/usr/bin/node",
+      runtime: "bun",
+      runtimePath: "/usr/bin/bun",
       viteArgs: ["--host", "127.0.0.1"],
     });
 
     assert.deepEqual(resolved.args.slice(-2), ["--host", "127.0.0.1"]);
+  });
+
+  it("keeps the explicit Node fallback source-aware", () => {
+    assert.deepEqual(
+      resolveViteCommand({
+        appDir,
+        runtime: "node",
+        runtimePath: "/usr/bin/node",
+      }),
+      {
+        command: "/usr/bin/node",
+        args: [
+          "--conditions=eliza-source",
+          "--import",
+          "tsx",
+          viteCli,
+          "--configLoader",
+          "bundle",
+        ],
+      },
+    );
   });
 
   it("keeps direct package dev commands on Node with source import support", () => {
@@ -241,10 +263,11 @@ describe("development Vite process commands", () => {
     });
   }
 
-  it("loads NodeNext workspace source with the production child argv", () => {
+  it("loads workspace source with the active-runtime child argv", () => {
     const viteCommand = resolveViteCommand({
       appDir,
-      nodePath: "node",
+      runtime: "bun",
+      runtimePath: process.execPath,
     });
     const viteCliIndex = viteCommand.args.indexOf(viteCli);
     assert.notEqual(viteCliIndex, -1);
@@ -265,16 +288,17 @@ describe("development Vite process commands", () => {
     assert.equal(result.status, 0, result.stderr);
   });
 
-  it("fails before spawning when Node or the Vite CLI is unavailable", () => {
+  it("fails before spawning when the runtime or Vite CLI is unavailable", () => {
     assert.throws(
-      () => resolveViteCommand({ appDir, nodePath: null }),
-      /Node.js is required/,
+      () => resolveViteCommand({ appDir, runtimePath: "" }),
+      /JavaScript runtime is required/,
     );
     assert.throws(
       () =>
         resolveViteCommand({
           appDir: path.join(appDir, "missing"),
-          nodePath: "/usr/bin/node",
+          runtime: "bun",
+          runtimePath: "/usr/bin/bun",
         }),
       /Vite CLI not found/,
     );

--- a/packages/app/test/hmr/hmr-dependency-levels.spec.ts
+++ b/packages/app/test/hmr/hmr-dependency-levels.spec.ts
@@ -13,22 +13,27 @@ const repoRoot = path.resolve(
   "../../../..",
 );
 
-// Always-in-the-module-graph source files by dependency depth. The point of the
+// Always-in-the-full-app-module-graph source files by dependency depth. The point of the
 // suite is to prove an edit made at each depth — the app itself, workspace UI,
 // shared code, and every visual-matrix plugin GUI view package — propagates to
 // the running dev client over Vite's HMR channel. That exercises the dev
 // architecture's reliance on `src/` (not `dist/`) resolution plus
 // workspace-source watching.
 const LEVELS = [
-  { name: "app (packages/app)", file: "packages/app/src/main.tsx" },
-  // The app imports @elizaos/ui via subpaths (not the root barrel), so target
-  // the root App component that main.tsx renders — guaranteed in the live graph.
-  { name: "@elizaos/ui", file: "packages/ui/src/App.tsx" },
-  // shared/brand is only reachable via ElizaLogo, which is not eager on the app
-  // "/" route, so Vite never transforms it and an edit emits no HMR event. Target
-  // character-presets instead: main.tsx calls getStylePresets() at module scope,
-  // so this source file is guaranteed in the live graph.
-  { name: "@elizaos/shared", file: "packages/shared/src/character-presets.ts" },
+  { name: "app (packages/app)", file: "packages/app/src/entry.ts" },
+  // The chat harness deliberately skips the full App component. Target an
+  // eager UI provider imported directly by main.tsx so this level is guaranteed
+  // in both harness and normal full-app graphs.
+  {
+    name: "@elizaos/ui",
+    file: "packages/ui/src/components/ShellModalityProvider.tsx",
+  },
+  // entry.ts reaches this shared hostname contract synchronously through
+  // web-entry-policy.ts, so it is present before any renderer branch is chosen.
+  {
+    name: "@elizaos/shared",
+    file: "packages/shared/src/elizacloud/domain-contract.ts",
+  },
   {
     name: "plugin view contacts",
     file: "plugins/plugin-contacts/src/components/ContactsAppView.tsx",
@@ -151,10 +156,10 @@ async function waitForViteClient(page: Page): Promise<void> {
 }
 
 // Most plugin GUI views are NOT reachable in the dev client's module graph from
-// the "/" route: they are served as standalone agent-built bundles loaded by
+// the "/chat" route: they are served as standalone agent-built bundles loaded by
 // DynamicViewLoader (a separate module graph the app's Vite dev server never
 // transforms), or lazy()-split out of an eagerly-loaded register.ts. Vite never
-// transforms their source from "/", so an edit emits no HMR event — the same
+// transforms their source from "/chat", so an edit emits no HMR event — the same
 // limitation the @elizaos/shared note above describes. Eager-loading every view
 // at dev boot to fold them in would regress startup (the app-load-perf work
 // deliberately defers them); they are HMR-validated when the view is actually
@@ -193,26 +198,46 @@ test.describe("HMR propagation across package dependency levels", () => {
         const marker = `HMR_PROBE_${level.name.replace(/[^a-z0-9]/gi, "_")}_${Date.now()}`;
 
         const events = collectViteEvents(page);
-        await page.goto("/");
+        // The hosted root can select the lightweight marketing entry, which
+        // intentionally excludes main.tsx and @elizaos/ui. Use a full-app route
+        // so every asserted dependency is present in the live client graph.
+        await page.goto("/chat");
         await waitForViteClient(page);
 
-        // Sentinel survives an HMR module swap but is wiped by a full reload —
-        // recorded for diagnostics, not asserted (barrels legitimately reload).
+        // Clear the execution marker before editing. The changed module sets it
+        // again when Vite propagates either an HMR update or a full reload.
         await page.evaluate((m) => {
-          (window as unknown as Record<string, unknown>).__hmrSentinel = m;
-        }, marker);
+          (window as unknown as Record<string, unknown>).__elizaHmrProbe = m;
+        }, null);
 
         events.length = 0;
         try {
-          // Appending a comment is always syntactically valid and still forces
-          // Vite to re-process the module and push an update to the client.
-          fs.writeFileSync(abs, `${original}\n// ${marker}\n`);
+          // The probe must survive transformation and execute in the browser.
+          // A comment-only edit can compile to identical output, so observing a
+          // console log would test Vite's diagnostics rather than propagation.
+          fs.writeFileSync(
+            abs,
+            `${original}\n(globalThis as typeof globalThis & { __elizaHmrProbe?: string }).__elizaHmrProbe = ${JSON.stringify(marker)};\n`,
+          );
           await expect
-            .poll(() => events.length, {
-              timeout: 30_000,
-              message: `Expected a Vite HMR/reload event in the browser after editing ${level.file}. Captured: ${JSON.stringify(events)}`,
-            })
-            .toBeGreaterThan(0);
+            .poll(
+              () =>
+                page
+                  .evaluate(
+                    () =>
+                      (
+                        globalThis as typeof globalThis & {
+                          __elizaHmrProbe?: string;
+                        }
+                      ).__elizaHmrProbe,
+                  )
+                  .catch(() => undefined),
+              {
+                timeout: 30_000,
+                message: `Expected the edited module ${level.file} to execute in the browser. Captured Vite events: ${JSON.stringify(events)}`,
+              },
+            )
+            .toBe(marker);
         } finally {
           fs.writeFileSync(abs, original);
         }


### PR DESCRIPTION
## Summary

- update shared-server and dashboard assertions to the Bun-backed Vite contract
- retain explicit coverage for the Node plus `tsx` fallback and fail-fast preflights
- force the HMR lane onto the full chat-harness entry instead of the lightweight hosted root
- target app, UI, and shared modules that are genuinely present in the connected browser graph
- prove propagation by executing an observable marker rather than matching Vite console wording after a comment-only edit

## Verification

- `bun test scripts/lib/dev-vite-command.test.mjs` — 12 passed
- `node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts --retries=0` — 3 passed, 22 intentionally skipped

Fixes #29980
