### PR TITLE
fix(cloud): gate remaining app and MCP provider calls

### DIFF
--- a/packages/cloud/api/__tests__/elevenlabs-voice-verify-fail-closed.test.ts
+++ b/packages/cloud/api/__tests__/elevenlabs-voice-verify-fail-closed.test.ts
@@ -21,20 +21,11 @@
  * `global.fetch` (the TTS probe) are stubbed.
  */
 
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   ElevenLabsError,
   ElevenLabsTimeoutError,
 } from "@elevenlabs/elevenlabs-js";
-import * as authActual from "@/lib/auth";
 
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.ELEVENLABS_API_KEY ||= "test-elevenlabs-key";
@@ -54,13 +45,36 @@ let getVoiceByIdImpl: () => Promise<unknown> = async () => ({
   samples: [{}, {}],
   fineTuning: { state: { model_a: "fine_tuned" } },
 });
+const getVoiceById = mock(() => getVoiceByIdImpl());
+const requireGenerativeRouteCaller = mock(async () => ({
+  user: { id: USER, organization_id: ORG },
+  apiKeyId: "api-key-id",
+  authSource: "combined_cache" as const,
+  appScopeId: null,
+}));
+const operationContext = {
+  organizationId: ORG,
+  userId: USER,
+  apiKeyId: "api-key-id",
+  requestId: "voice-verify-request",
+  executionCtx: { waitUntil: (_promise: Promise<unknown>) => undefined },
+};
+const runFlatProviderOperation = mock(
+  async (
+    _context: unknown,
+    _operation: unknown,
+    dispatch: () => Promise<unknown>,
+  ) => dispatch(),
+);
 
-mock.module("@/lib/auth", () => ({
-  ...authActual,
-  requireAuthOrApiKeyWithOrg: async () => ({
-    user: { id: USER, organization_id: ORG },
-    apiKey: { id: "api-key-id" },
-  }),
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: () => null,
+  getGenerativeOperationContext: () => operationContext,
+  requireGenerativeRouteCaller,
+}));
+
+mock.module("@/lib/services/generative-operation", () => ({
+  runFlatProviderOperation,
 }));
 
 mock.module("@/lib/services/voice-cloning", () => ({
@@ -71,7 +85,7 @@ mock.module("@/lib/services/voice-cloning", () => ({
 
 mock.module("@/lib/services/elevenlabs", () => ({
   getElevenLabsService: () => ({
-    getVoiceById: () => getVoiceByIdImpl(),
+    getVoiceById,
   }),
 }));
 
@@ -108,6 +122,15 @@ function stubFetch(impl: () => Promise<Response>): void {
 
 describe("#12787 elevenlabs voices/verify — fail closed on upstream failure", () => {
   beforeEach(() => {
+    getVoiceById.mockClear();
+    requireGenerativeRouteCaller.mockClear();
+    requireGenerativeRouteCaller.mockImplementation(async () => ({
+      user: { id: USER, organization_id: ORG },
+      apiKeyId: "api-key-id",
+      authSource: "combined_cache" as const,
+      appScopeId: null,
+    }));
+    runFlatProviderOperation.mockClear();
     dbVoice = {
       id: "voice-1",
       name: "My Voice",
@@ -127,8 +150,18 @@ describe("#12787 elevenlabs voices/verify — fail closed on upstream failure", 
     globalThis.fetch = realFetch;
   });
 
-  afterAll(() => {
-    mock.module("@/lib/auth", () => authActual);
+  test("standing denial makes zero ElevenLabs provider calls", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new Error("account not in good standing"),
+    );
+
+    const res = await verify();
+
+    expect(res.status).toBe(500);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(runFlatProviderOperation).not.toHaveBeenCalled();
+    expect(getVoiceById).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test("ElevenLabs 5xx surfaces a structured failure, never a fabricated 'still processing' success", async () => {
@@ -262,6 +295,15 @@ describe("#12787 elevenlabs voices/verify — fail closed on upstream failure", 
     expect(json.success).toBe(true);
     expect(json.status.canGenerateTTS).toBe(true);
     expect(json.status.isReady).toBe(true);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(runFlatProviderOperation).toHaveBeenCalledTimes(1);
+    expect(runFlatProviderOperation.mock.calls[0]?.[1]).toMatchObject({
+      provider: "elevenlabs",
+      operation: "voice_verify",
+      cost: 0,
+    });
+    expect(getVoiceById).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
   test("voice missing from DB is a 404, unaffected by the fix", async () => {

--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -21,6 +21,7 @@ import {
 } from "bun:test";
 import { Hono } from "hono";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
+import { resetHfProxyEgressQuotaForTests } from "@/lib/services/hf-proxy-egress-quota";
 import * as loggerActual from "@/lib/utils/logger";
 
 const requireGenerativeRouteCaller =
@@ -37,6 +38,7 @@ const loggerError = mock<(...args: unknown[]) => void>();
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   requireGenerativeRouteCaller,
+  getGenerativeExecutionContext: () => undefined,
   asGenerativeCacheApiError: () => null,
 }));
 
@@ -68,6 +70,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  resetHfProxyEgressQuotaForTests();
   loggerInfo.mockClear();
   loggerWarn.mockClear();
   loggerError.mockClear();
@@ -92,23 +95,6 @@ afterAll(() => {
 });
 
 const RESOLVE_PATH = "elizaos/eliza-1/resolve/main/model.gguf";
-
-function fakeKv() {
-  const map = new Map<string, string>();
-  return {
-    get: async (key: string) => map.get(key) ?? null,
-    put: async (key: string, value: string) => {
-      map.set(key, value);
-    },
-    delete: async (key: string) => {
-      map.delete(key);
-    },
-    list: async () => ({
-      keys: [...map.keys()].map((name) => ({ name })),
-      list_complete: true,
-    }),
-  };
-}
 
 function makeRequest(
   path: string,
@@ -299,7 +285,6 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
   test("enforces per-org monthly egress budget before streaming the next response", async () => {
     setSystemTime(new Date("2026-02-28T23:59:58.250Z"));
-    const kv = fakeKv();
     globalThis.fetch = mock(
       async () =>
         new Response("12345678", {
@@ -313,7 +298,7 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const env = {
       HF_TOKEN: "hf-secret",
-      CACHE_KV: kv,
+      MOCK_REDIS: "1",
       HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "12",
     };
     const first = await app.fetch(makeRequest(RESOLVE_PATH), env);
@@ -336,47 +321,40 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
   test("pre-check exhaustion advertises the next UTC month and admits its fresh bucket", async () => {
     setSystemTime(new Date("2026-01-31T23:59:59.999Z"));
-    const kv = fakeKv();
-    await kv.put(
-      "hf-proxy:egress:org-1:2026-01",
-      JSON.stringify({ bytes: 12 }),
-    );
-
     let fetchCalls = 0;
     globalThis.fetch = mock(async () => {
       fetchCalls += 1;
-      return new Response("NEXT", {
+      const body = fetchCalls === 1 ? "123456789012" : "NEXT";
+      return new Response(body, {
         status: 200,
         headers: {
           "content-type": "application/octet-stream",
-          "content-length": "4",
+          "content-length": String(body.length),
         },
       });
     }) as unknown as typeof fetch;
 
     const env = {
       HF_TOKEN: "hf-secret",
-      CACHE_KV: kv,
+      MOCK_REDIS: "1",
       HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "12",
     };
+    const january = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(january.status).toBe(200);
+    expect(await january.text()).toBe("123456789012");
     const blocked = await app.fetch(makeRequest(RESOLVE_PATH), env);
     expect(blocked.status).toBe(429);
     expect(blocked.headers.get("Retry-After")).toBe("1");
     expect(((await blocked.json()) as { code?: string }).code).toBe(
       "HF_PROXY_EGRESS_LIMIT",
     );
-    expect(fetchCalls).toBe(0);
+    expect(fetchCalls).toBe(1);
 
     setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
     const admitted = await app.fetch(makeRequest(RESOLVE_PATH), env);
     expect(admitted.status).toBe(200);
     expect(await admitted.text()).toBe("NEXT");
-    expect(fetchCalls).toBe(1);
-
-    const februaryCounter = JSON.parse(
-      (await kv.get("hf-proxy:egress:org-1:2026-02")) ?? "{}",
-    ) as { bytes?: number };
-    expect(februaryCounter.bytes).toBe(4);
+    expect(fetchCalls).toBe(2);
   });
 });
 

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -1,24 +1,23 @@
 /**
- * Regression (#11637): the MCP metered proxy debits the caller upfront, so
- * EVERY post-debit failure must refund — not only a non-ok HTTP status. Before
- * the fix an unreachable upstream / unsafe endpoint / down container returned
- * 502/400/503 while keeping the money = a silent over-charge.
+ * Exercises MCP proxy standing, flat admission, dispatch ordering, and retained
+ * settlement through the real Hono route with deterministic boundary mocks.
  *
- * Drives the real route handler with mocked deps and asserts `refundCredits` is
- * called on each failure branch and NOT on success. Red on develop tip (only
- * the non-ok branch refunded); green after the fix.
+ * Failures before upstream dispatch release admission; uncertain failures after
+ * dispatch settle conservatively instead of fabricating a zero-cost call.
  */
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 import { __mcpProxyHopTestHooks } from "../mcp/proxy/[mcpId]/proxy-body-budget";
 
-// mock.module is process-global — spread the real auth module so only
-// requireUserOrApiKeyWithOrg is overridden (mirrors agent-mcp-billing.test.ts).
-const requireUserOrApiKeyWithOrg = mock();
-const realAuth = await import("@/lib/auth/workers-hono-auth");
-mock.module("@/lib/auth/workers-hono-auth", () => ({
-  ...realAuth,
-  requireUserOrApiKeyWithOrg,
+const requireGenerativeRouteCaller = mock();
+const admitFlatGenerativeOperation = mock();
+let executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined;
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  admitFlatGenerativeOperation,
+  asGenerativeCacheApiError: () => null,
+  getGenerativeExecutionContext: () => executionCtx,
+  requireGenerativeRouteCaller,
 }));
 
 const assertSafeOutboundUrl = mock();
@@ -37,11 +36,21 @@ mock.module("@/lib/services/containers", () => ({
   containersService: { getById: containersGetById },
 }));
 
-const reserveAndDeductCredits = mock();
-const refundCredits = mock();
+class InsufficientCreditsError extends Error {
+  constructor(
+    public readonly required: number,
+    public readonly available: number,
+  ) {
+    super("Insufficient credits");
+  }
+}
 mock.module("@/lib/services/credits", () => ({
-  creditsService: { reserveAndDeductCredits, refundCredits },
+  InsufficientCreditsError,
 }));
+
+const settle = mock(async () => null);
+const settleUnknown = mock(async () => null);
+const markProviderDispatched = mock(async () => undefined);
 
 const getById = mock();
 const recordUsageWithoutDeduction = mock(async () => {});
@@ -52,8 +61,10 @@ mock.module("@/lib/services/user-mcps", () => ({
   },
 }));
 
+const loggerError = mock();
+const loggerWarn = mock();
 mock.module("@/lib/utils/logger", () => ({
-  logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
+  logger: { error: loggerError, info: mock(), warn: loggerWarn, debug: mock() },
 }));
 
 const mcpRoute = (await import("../mcp/proxy/[mcpId]/route")).default;
@@ -81,39 +92,119 @@ const EXTERNAL_MCP = {
 };
 
 beforeEach(() => {
-  requireUserOrApiKeyWithOrg.mockResolvedValue({
-    id: "u1",
-    organization_id: "org1",
+  executionCtx = undefined;
+  requireGenerativeRouteCaller.mockReset();
+  requireGenerativeRouteCaller.mockResolvedValue({
+    user: { id: "u1", organization_id: "org1" },
+    apiKeyId: "key1",
+    authSource: "combined_cache",
+    admissionSnapshot: { standing: "active" },
+    appScopeId: null,
+  });
+  settle.mockReset();
+  settle.mockResolvedValue(null);
+  settleUnknown.mockReset();
+  settleUnknown.mockResolvedValue(null);
+  markProviderDispatched.mockReset();
+  markProviderDispatched.mockResolvedValue(undefined);
+  admitFlatGenerativeOperation.mockReset();
+  admitFlatGenerativeOperation.mockResolvedValue({
+    settle,
+    settleUnknown,
+    markProviderDispatched,
+    reservation: { reservationTransactionId: "reservation-1" },
   });
   getById.mockResolvedValue({ ...EXTERNAL_MCP });
   getReferrer.mockReset();
   getReferrer.mockResolvedValue(null);
   recordUsageWithoutDeduction.mockClear();
-  reserveAndDeductCredits.mockClear();
-  reserveAndDeductCredits.mockResolvedValue({
-    success: true,
-    transaction: { id: "tx1" },
-    newBalance: 95,
-  });
-  refundCredits.mockReset();
-  refundCredits.mockResolvedValue({ newBalance: 100 });
   assertSafeOutboundUrl.mockResolvedValue(
     new URL("https://mcp.example.test/rpc"),
   );
   safeFetch.mockReset();
   containersGetById.mockReset();
+  loggerError.mockClear();
+  loggerWarn.mockClear();
 });
 
 afterEach(() => {
   __mcpProxyHopTestHooks.resetHopTimeoutMs();
 });
 
-test("unreachable upstream (502) refunds the upfront debit (#11637)", async () => {
+test("cached standing denial preserves its reason and skips admission", async () => {
+  requireGenerativeRouteCaller.mockRejectedValue(
+    new ApiError(403, "access_denied", "Organization is inactive", {
+      reason: "organization_inactive",
+    }),
+  );
+
+  const res = await post();
+  const body = (await res.json()) as {
+    details?: { reason?: string };
+  };
+
+  expect(res.status).toBe(403);
+  expect(body.details?.reason).toBe("organization_inactive");
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(loggerWarn).toHaveBeenCalledWith(
+    "[MCP Proxy] Caller admission denied",
+    expect.objectContaining({
+      mcpId: "test-mcp",
+      reason: "organization_inactive",
+      errorName: "ApiError",
+    }),
+  );
+});
+
+test("admits before marking dispatch and marks immediately before fetch", async () => {
+  safeFetch.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 200 }),
+  );
+
+  const res = await post();
+
+  expect(res.status).toBe(200);
+  expect(requireGenerativeRouteCaller.mock.invocationCallOrder[0]).toBeLessThan(
+    assertSafeOutboundUrl.mock.invocationCallOrder[0],
+  );
+  expect(assertSafeOutboundUrl.mock.invocationCallOrder[0]).toBeLessThan(
+    admitFlatGenerativeOperation.mock.invocationCallOrder[0],
+  );
+  expect(admitFlatGenerativeOperation.mock.invocationCallOrder[0]).toBeLessThan(
+    markProviderDispatched.mock.invocationCallOrder[0],
+  );
+  expect(markProviderDispatched.mock.invocationCallOrder[0]).toBeLessThan(
+    safeFetch.mock.invocationCallOrder[0],
+  );
+});
+
+test("retains successful settlement and usage under waitUntil", async () => {
+  const retained: Promise<unknown>[] = [];
+  const waitUntil = mock((promise: Promise<unknown>) => {
+    retained.push(promise);
+  });
+  executionCtx = { waitUntil };
+  safeFetch.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 200 }),
+  );
+
+  const res = await post();
+
+  expect(res.status).toBe(200);
+  expect(waitUntil).toHaveBeenCalledTimes(1);
+  await Promise.all(retained);
+  expect(settle).toHaveBeenCalledWith(0.05);
+  expect(recordUsageWithoutDeduction).toHaveBeenCalledTimes(1);
+});
+
+test("unreachable upstream settles unknown after dispatch", async () => {
   safeFetch.mockRejectedValue(new Error("ECONNREFUSED"));
   const res = await post();
   expect(res.status).toBe(502);
-  expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(admitFlatGenerativeOperation).toHaveBeenCalledTimes(1);
+  expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
 });
 
 test("non-owner org CANNOT invoke another org's PRIVATE MCP — 404, no billing (#11838)", async () => {
@@ -125,7 +216,7 @@ test("non-owner org CANNOT invoke another org's PRIVATE MCP — 404, no billing 
   });
   const res = await post();
   expect(res.status).toBe(404);
-  expect(reserveAndDeductCredits).not.toHaveBeenCalled();
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
   expect(safeFetch).not.toHaveBeenCalled();
 });
 
@@ -140,17 +231,19 @@ test("non-owner org CAN invoke a PUBLIC MCP — monetization model preserved (#1
   );
   const res = await post();
   expect(res.status).toBe(200);
-  expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
+  expect(admitFlatGenerativeOperation).toHaveBeenCalledTimes(1);
 });
 
-test("unsafe/blocked external endpoint (400) refunds (#11637)", async () => {
+test("unsafe/blocked external endpoint is rejected before admission", async () => {
   assertSafeOutboundUrl.mockRejectedValue(new Error("SSRF blocked"));
   const res = await post();
   expect(res.status).toBe(400);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
+  expect(markProviderDispatched).not.toHaveBeenCalled();
 });
 
-test("container-unavailable (503) refunds (#11637)", async () => {
+test("container-unavailable is rejected before admission", async () => {
   getById.mockResolvedValue({
     id: "test-mcp",
     name: "Container MCP",
@@ -163,10 +256,11 @@ test("container-unavailable (503) refunds (#11637)", async () => {
   containersGetById.mockResolvedValue(null); // no load_balancer_url
   const res = await post();
   expect(res.status).toBe(503);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
 });
 
-test("container lookup failure (502) refunds after upfront debit (#11637)", async () => {
+test("container lookup failure is rejected before admission", async () => {
   getById.mockResolvedValue({
     id: "test-mcp",
     name: "Container MCP",
@@ -179,34 +273,31 @@ test("container lookup failure (502) refunds after upfront debit (#11637)", asyn
   containersGetById.mockRejectedValue(new Error("container DB down"));
   const res = await post();
   expect(res.status).toBe(502);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
 });
 
-test("invalid JSON body (400) refunds after the upfront debit (#11637)", async () => {
+test("invalid JSON body is rejected before admission", async () => {
   const res = await post("{not json");
   expect(res.status).toBe(400);
-  expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
 });
 
-test("oversized request body returns 413, refunds exact receipt, and skips upstream", async () => {
+test("oversized request body returns 413 before admission and skips upstream", async () => {
   const res = await post(`{"payload":"${"x".repeat(1_000_001)}"}`);
   expect(res.status).toBe(413);
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({ reason: "request_body_too_large" }),
-    }),
-  );
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
   expect(safeFetch).not.toHaveBeenCalled();
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
-test("non-ok upstream status refunds (existing behavior preserved)", async () => {
+test("non-ok upstream status settles unknown after dispatch", async () => {
   safeFetch.mockResolvedValue(new Response("upstream error", { status: 500 }));
   const res = await post();
   expect(res.status).toBe(500);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
 });
 
 test("upstream response body read failure refunds before usage is recorded", async () => {
@@ -220,12 +311,7 @@ test("upstream response body read failure refunds before usage is recorded", asy
   } as unknown as Response);
   const res = await post();
   expect(res.status).toBe(502);
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({ reason: "mcp_response_read_failed" }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
@@ -241,12 +327,7 @@ test("declared oversized upstream body returns 502 and refunds exact receipt", a
   );
   const res = await post();
   expect(res.status).toBe(502);
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({ reason: "mcp_response_too_large" }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
@@ -270,14 +351,7 @@ test("headers-resolve body-never-resolves returns 504, refunds exact receipt, an
   expect(res.status).toBe(504);
   const timedOut = (await res.json()) as { error: string };
   expect(timedOut).toEqual({ error: "MCP endpoint timed out" });
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "upstream_deadline_exceeded",
-      }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
@@ -303,12 +377,7 @@ test("streamed oversized upstream body returns 502 and refunds exact receipt", a
   );
   const res = await post();
   expect(res.status).toBe(502);
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({ reason: "mcp_response_too_large" }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
@@ -345,14 +414,7 @@ test("container hop headers-resolve body-never-resolves returns 504 and refunds"
   try {
     const res = await post();
     expect(res.status).toBe(504);
-    expect(refundCredits).toHaveBeenCalledWith(
-      expect.objectContaining({
-        amount: 0.05,
-        metadata: expect.objectContaining({
-          reason: "upstream_deadline_exceeded",
-        }),
-      }),
-    );
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
     expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
     expect(safeFetch).not.toHaveBeenCalled();
   } finally {
@@ -380,27 +442,22 @@ test("headers-never-resolve fetch abort refunds exact receipt and skips usage", 
   });
   const res = await post();
   expect(res.status).toBe(504);
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "upstream_deadline_exceeded",
-      }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
-test("successful call does NOT refund", async () => {
+test("successful call settles exact cost and records usage", async () => {
   safeFetch.mockResolvedValue(
     new Response(JSON.stringify({ ok: true }), { status: 200 }),
   );
   const res = await post();
   expect(res.status).toBe(200);
-  expect(refundCredits).not.toHaveBeenCalled();
+  expect(settle).toHaveBeenCalledWith(0.05);
+  expect(settleUnknown).not.toHaveBeenCalled();
+  expect(recordUsageWithoutDeduction).toHaveBeenCalledTimes(1);
 });
 
-test("stalled endpoint prevalidation returns 504, refunds exact receipt, and skips usage", async () => {
+test("stalled endpoint prevalidation returns 504 before admission", async () => {
   __mcpProxyHopTestHooks.setHopTimeoutMs(20);
   assertSafeOutboundUrl.mockReturnValue(
     new Promise(() => {
@@ -417,14 +474,8 @@ test("stalled endpoint prevalidation returns 504, refunds exact receipt, and ski
   expect(res.status).toBe(504);
   const prevalidationTimedOut = (await res.json()) as { error: string };
   expect(prevalidationTimedOut).toEqual({ error: "MCP endpoint timed out" });
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "upstream_deadline_exceeded",
-      }),
-    }),
-  );
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
   expect(safeFetch).not.toHaveBeenCalled();
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
@@ -446,18 +497,11 @@ test("stalled pre-socket DNS in safeFetch returns 504, refunds exact receipt, an
   expect(res.status).toBe(504);
   const dnsTimedOut = (await res.json()) as { error: string };
   expect(dnsTimedOut).toEqual({ error: "MCP endpoint timed out" });
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "upstream_deadline_exceeded",
-      }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
-test("caller-aborted inbound JSON read returns 504, refunds exact receipt, and skips usage", async () => {
+test("caller-aborted inbound JSON read returns 504 before admission", async () => {
   const caller = new AbortController();
   const body = new ReadableStream<Uint8Array>({
     pull() {
@@ -483,14 +527,8 @@ test("caller-aborted inbound JSON read returns 504, refunds exact receipt, and s
   expect(res.status).toBe(504);
   const inboundTimedOut = (await res.json()) as { error: string };
   expect(inboundTimedOut).toEqual({ error: "MCP endpoint timed out" });
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "upstream_deadline_exceeded",
-      }),
-    }),
-  );
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
   expect(safeFetch).not.toHaveBeenCalled();
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
@@ -506,7 +544,11 @@ test("affiliate surcharge uses one exact debit, persisted receipt, and refund au
   );
   const success = await post();
   expect(success.status).toBe(200);
-  expect(reserveAndDeductCredits.mock.calls[0]?.[0].amount).toBe(0.065);
+  expect(admitFlatGenerativeOperation.mock.calls[0]?.[0].cost).toEqual({
+    baseTotalCost: 0.05,
+    platformMarkup: 0.015,
+    totalCost: 0.065,
+  });
   expect(recordUsageWithoutDeduction).toHaveBeenCalledWith(
     expect.objectContaining({
       creditsCharged: 5,
@@ -526,10 +568,10 @@ test("affiliate surcharge uses one exact debit, persisted receipt, and refund au
   safeFetch.mockRejectedValue(new Error("offline"));
   const failure = await post();
   expect(failure.status).toBe(502);
-  expect(refundCredits.mock.calls[0]?.[0].amount).toBe(0.065);
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
 });
 
-test("malformed UTF-8 request body returns 400, refunds exact receipt, and skips upstream (#24768)", async () => {
+test("malformed UTF-8 request body returns 400 before admission (#24768)", async () => {
   const malformed = new Uint8Array([
     0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
   ]);
@@ -542,14 +584,8 @@ test("malformed UTF-8 request body returns 400, refunds exact receipt, and skips
   expect((await res.json()) as { error: string }).toEqual({
     error: "MCP request body is not valid UTF-8",
   });
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "request_body_malformed_utf8",
-      }),
-    }),
-  );
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+  expect(settle).not.toHaveBeenCalled();
   expect(safeFetch).not.toHaveBeenCalled();
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
@@ -575,13 +611,6 @@ test("malformed UTF-8 upstream response returns 502, refunds exact receipt, and 
   expect((await res.json()) as { error: string }).toEqual({
     error: "MCP response is not valid UTF-8",
   });
-  expect(refundCredits).toHaveBeenCalledWith(
-    expect.objectContaining({
-      amount: 0.05,
-      metadata: expect.objectContaining({
-        reason: "mcp_response_malformed_utf8",
-      }),
-    }),
-  );
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });

--- a/packages/cloud/api/__tests__/paid-boundary-route-test-mocks.ts
+++ b/packages/cloud/api/__tests__/paid-boundary-route-test-mocks.ts
@@ -1,0 +1,49 @@
+/** Shares deterministic generative-route mocks across mounted boundary suites. */
+
+import { mock } from "bun:test";
+
+export const paidBoundaryState: {
+  routeError: Error | null;
+  knownIdentityError: Error | null;
+} = {
+  routeError: null,
+  knownIdentityError: null,
+};
+
+export const requireGenerativeRouteCaller = mock(async () => {
+  if (paidBoundaryState.routeError) throw paidBoundaryState.routeError;
+  return {
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    authSource: "combined_cache" as const,
+    appScopeId: null,
+  };
+});
+
+export const requireGenerativeKnownIdentity = mock(async () => {
+  if (paidBoundaryState.knownIdentityError)
+    throw paidBoundaryState.knownIdentityError;
+  return {
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    authSource: "compatibility" as const,
+    appScopeId: null,
+  };
+});
+
+export const getGenerativeOperationContext = mock(
+  (_context: unknown, caller: { apiKeyId: string | null }) => ({
+    organizationId: "org-1",
+    userId: "user-1",
+    apiKeyId: caller.apiKeyId,
+    requestId: "request-1",
+  }),
+);
+
+export function resetPaidBoundaryRouteMocks(): void {
+  paidBoundaryState.routeError = null;
+  paidBoundaryState.knownIdentityError = null;
+  requireGenerativeRouteCaller.mockClear();
+  requireGenerativeKnownIdentity.mockClear();
+  getGenerativeOperationContext.mockClear();
+}

--- a/packages/cloud/api/cron/social-automation/route.standing.test.ts
+++ b/packages/cloud/api/cron/social-automation/route.standing.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Mounts the scheduled social-automation route and proves due jobs without a
+ * delegated standing snapshot fail closed before provider-capable services.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const discordPost = mock(async () => ({ success: true }));
+const telegramPost = mock(async () => ({ success: true }));
+const twitterPost = mock(async () => ({ success: true }));
+
+const appRow = {
+  id: "app-1",
+  organization_id: "org-1",
+  created_by_user_id: "user-1",
+  api_key_id: "key-1",
+  name: "Scheduled App",
+};
+const configRow = {
+  app_id: "app-1",
+  discord_automation: { enabled: true, autoAnnounce: true },
+  telegram_automation: { enabled: true, autoAnnounce: true },
+  twitter_automation: { enabled: true, autoPost: true },
+};
+
+mock.module("drizzle-orm", () => ({
+  eq: () => ({}),
+  or: () => ({}),
+  sql: () => ({}),
+}));
+mock.module("@/db/client", () => ({
+  dbRead: {
+    select: () => ({
+      from: () => ({ where: async () => [configRow] }),
+    }),
+    query: { apps: { findFirst: async () => appRow } },
+  },
+}));
+mock.module("@/db/schemas", () => ({ apps: { id: {} } }));
+mock.module("@/db/schemas/app-config", () => ({
+  appConfig: {
+    discord_automation: {},
+    telegram_automation: {},
+    twitter_automation: {},
+  },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireCronSecret: () => undefined,
+}));
+mock.module("@/lib/services/discord-automation/app-automation", () => ({
+  discordAppAutomationService: { postAnnouncement: discordPost },
+}));
+mock.module("@/lib/services/telegram-automation/app-automation", () => ({
+  telegramAppAutomationService: { postAnnouncement: telegramPost },
+}));
+mock.module("@/lib/services/twitter-automation/app-automation", () => ({
+  twitterAppAutomationService: { postAppTweet: twitterPost },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/cron/social-automation", route);
+
+beforeEach(() => {
+  discordPost.mockClear();
+  telegramPost.mockClear();
+  twitterPost.mockClear();
+});
+
+describe("social automation cron standing boundary", () => {
+  test("reports due jobs as blocked without dispatching any provider-capable service", async () => {
+    const response = await app.request("/cron/social-automation", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      stats: { postsAttempted: 3, successful: 0, failed: 3 },
+    });
+    expect(discordPost).not.toHaveBeenCalled();
+    expect(telegramPost).not.toHaveBeenCalled();
+    expect(twitterPost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/cron/social-automation/route.ts
+++ b/packages/cloud/api/cron/social-automation/route.ts
@@ -18,9 +18,6 @@ import { apps } from "@/db/schemas";
 import { type AppConfig, appConfig } from "@/db/schemas/app-config";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
-import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
-import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
-import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -53,6 +50,30 @@ interface ProcessResult {
   success: boolean;
   messageId?: string;
   error?: string;
+}
+
+const MISSING_SCHEDULED_ADMISSION =
+  "Scheduled AI generation requires a persisted delegated admission context";
+
+function rejectUntrustedScheduledGeneration(
+  app: App,
+  platform: ProcessResult["platform"],
+): ProcessResult {
+  logger.warn("[SocialAutomation Cron] Blocked scheduled provider generation", {
+    appId: app.id,
+    organizationId: app.organization_id,
+    createdByUserId: app.created_by_user_id,
+    apiKeyId: app.api_key_id,
+    platform,
+    reason: "missing_delegated_admission_snapshot",
+  });
+  return {
+    appId: app.id,
+    appName: app.name,
+    platform,
+    success: false,
+    error: MISSING_SCHEDULED_ADMISSION,
+  };
 }
 
 /**
@@ -145,19 +166,9 @@ async function processDiscordAutomation({
   const isDue = isAnnouncementDue(automationConfig, "announcement", app.id);
   if (!isDue) return null;
 
-  const result = await discordAppAutomationService.postAnnouncement(
-    app.organization_id,
-    app.id,
-  );
-
-  return {
-    appId: app.id,
-    appName: app.name,
-    platform: "discord",
-    success: result.success,
-    messageId: result.messageId,
-    error: result.error,
-  };
+  // App ownership columns identify a candidate principal, but do not prove
+  // current standing or carry the combined cache snapshot required to admit.
+  return rejectUntrustedScheduledGeneration(app, "discord");
 }
 
 async function processTelegramAutomation({
@@ -171,19 +182,7 @@ async function processTelegramAutomation({
   const isDue = isAnnouncementDue(automationConfig, "announcement", app.id);
   if (!isDue) return null;
 
-  const result = await telegramAppAutomationService.postAnnouncement(
-    app.organization_id,
-    app.id,
-  );
-
-  return {
-    appId: app.id,
-    appName: app.name,
-    platform: "telegram",
-    success: result.success,
-    messageId: result.messageId?.toString(),
-    error: result.error,
-  };
+  return rejectUntrustedScheduledGeneration(app, "telegram");
 }
 
 async function processTwitterAutomation({
@@ -196,19 +195,7 @@ async function processTwitterAutomation({
   const isDue = isAnnouncementDue(automationConfig, "post", app.id);
   if (!isDue) return null;
 
-  const result = await twitterAppAutomationService.postAppTweet(
-    app.organization_id,
-    app.id,
-  );
-
-  return {
-    appId: app.id,
-    appName: app.name,
-    platform: "twitter",
-    success: result.success,
-    messageId: result.tweetId,
-    error: result.error,
-  };
+  return rejectUntrustedScheduledGeneration(app, "twitter");
 }
 
 /**

--- a/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
@@ -1,6 +1,10 @@
-// Handles cloud API elevenlabs voices verify id route traffic with route-local auth expectations.
-//
-// Verification reports whether a cloned voice is usable. It distinguishes THREE
+/**
+ * Verifies cloned ElevenLabs voices behind the combined account-standing and
+ * provider-admission boundary. The upstream lookup and synthesis probe share
+ * one admitted operation, so verification performs one identity-cache read
+ * and one asynchronous zero-cost settlement without a cache readback.
+ *
+ * Verification reports whether a cloned voice is usable. It distinguishes THREE
 // outcomes so callers never conflate "voice legitimately not ready yet" with
 // "ElevenLabs is broken" (#12787 / #12182):
 //   - voice missing FROM ElevenLabs (upstream 404) => a real "still processing /
@@ -13,20 +17,26 @@
 //     poll forever against a broken service believing the voice just wasn't done.
 //   - the TTS smoke call is a best-effort readiness probe: its result feeds
 //     `canGenerateTTS`, but a NON-2xx HTTP response or a thrown fetch must read
-//     as "cannot generate" (observably), never silently count as success.
+ *     as "cannot generate" (observably), never silently count as success.
+ */
 
 import {
   ElevenLabsError,
   ElevenLabsTimeoutError,
 } from "@elevenlabs/elevenlabs-js";
 import { Hono } from "hono";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
 import { getErrorStatusCode, nextJsonFromCaughtError } from "@/lib/api/errors";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
+import { runFlatProviderOperation } from "@/lib/services/generative-operation";
 import { voiceCloningService } from "@/lib/services/voice-cloning";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * An ElevenLabs lookup that 404s means the voice row exists in our DB but the
@@ -136,14 +146,13 @@ async function probeTtsReadiness(
  * @param context - Route context containing the voice ID parameter.
  * @returns Voice verification status including readiness, TTS capability, and fine-tuning information.
  */
-async function __hono_GET(
-  request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
+async function __hono_GET(c: AppContext) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
-    const params = await context.params;
-    const voiceId = params.id;
+    const caller = await requireGenerativeRouteCaller(c, {
+      compatibility: "raw",
+    });
+    const { user } = caller;
+    const voiceId = c.req.param("id")!;
 
     logger.info(`[Voice Verify API] Verifying voice ${voiceId}`);
 
@@ -166,39 +175,62 @@ async function __hono_GET(
       throw new Error("ELEVENLABS_API_KEY environment variable is required");
     }
 
-    let elevenLabsVoice: Awaited<ReturnType<typeof elevenlabs.getVoiceById>>;
-    try {
-      elevenLabsVoice = await elevenlabs.getVoiceById(voice.elevenlabsVoiceId);
-    } catch (error) {
-      if (isUpstreamVoiceAbsent(error)) {
-        // error-policy:J4 upstream 404 is an EXPECTED not-ready state for a
-        // freshly-created professional voice — degrade to a distinct
-        // "still processing" verdict (not a synthesis failure, not a 500).
-        logger.info("[Voice Verify API] Voice not yet present in ElevenLabs", {
-          voiceId: voice.id,
+    const verification = await runFlatProviderOperation(
+      getGenerativeOperationContext(c, caller),
+      {
+        provider: "elevenlabs",
+        billingSource: "gateway",
+        model: "elevenlabs/voice-verification",
+        operation: "voice_verify",
+        cost: 0,
+      },
+      async () => {
+        let elevenLabsVoice: Awaited<
+          ReturnType<typeof elevenlabs.getVoiceById>
+        >;
+        try {
+          elevenLabsVoice = await elevenlabs.getVoiceById(
+            voice.elevenlabsVoiceId,
+          );
+        } catch (error) {
+          if (isUpstreamVoiceAbsent(error)) return { kind: "absent" } as const;
+          throw toUpstreamBoundaryError(error);
+        }
+        return {
+          kind: "ready" as const,
+          elevenLabsVoice,
+          canGenerateTTS: await probeTtsReadiness(
+            voice.elevenlabsVoiceId,
+            apiKey,
+          ),
+        };
+      },
+    );
+
+    if (verification.kind === "absent") {
+      // error-policy:J4 upstream 404 is an EXPECTED not-ready state for a
+      // freshly-created professional voice — degrade to a distinct verdict.
+      logger.info("[Voice Verify API] Voice not yet present in ElevenLabs", {
+        voiceId: voice.id,
+        elevenlabsVoiceId: voice.elevenlabsVoiceId,
+      });
+      return Response.json({
+        success: true,
+        voice: {
+          id: voice.id,
+          name: voice.name,
           elevenlabsVoiceId: voice.elevenlabsVoiceId,
-        });
-        return Response.json({
-          success: true,
-          voice: {
-            id: voice.id,
-            name: voice.name,
-            elevenlabsVoiceId: voice.elevenlabsVoiceId,
-            cloneType: voice.cloneType,
-          },
-          status: {
-            isReady: false,
-            canGenerateTTS: false,
-            message: "Voice is still being processed. Please wait.",
-          },
-        });
-      }
-      // A real upstream failure (transport / 401 / 429 / 5xx) is NOT a
-      // "still processing" state. Rethrow to the J1 boundary (carrying the
-      // real upstream status) so the caller gets a structured failure and
-      // stops polling a broken service.
-      throw toUpstreamBoundaryError(error);
+          cloneType: voice.cloneType,
+        },
+        status: {
+          isReady: false,
+          canGenerateTTS: false,
+          message: "Voice is still being processed. Please wait.",
+        },
+      });
     }
+
+    const { elevenLabsVoice, canGenerateTTS } = verification;
 
     // For professional voices, check fine-tuning status
     const isProfessional = voice.cloneType === "professional";
@@ -211,11 +243,6 @@ async function __hono_GET(
 
     // Probe a one-word synthesis to confirm the voice actually generates. A
     // non-2xx or thrown fetch reads observably as canGenerateTTS=false.
-    const canGenerateTTS = await probeTtsReadiness(
-      voice.elevenlabsVoiceId,
-      apiKey,
-    );
-
     return Response.json({
       success: true,
       voice: {
@@ -245,14 +272,10 @@ async function __hono_GET(
     if (getErrorStatusCode(error) >= 500) {
       logger.error("[Voice Verify API] Error:", error);
     }
-    return nextJsonFromCaughtError(error);
+    return nextJsonFromCaughtError(asGenerativeCacheApiError(error) ?? error);
   }
 }
 
 const __hono_app = new Hono<AppEnv>();
-__hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
-    params: Promise.resolve({ id: c.req.param("id")! }),
-  }),
-);
+__hono_app.get("/", __hono_GET);
 export default __hono_app;

--- a/packages/cloud/api/eliza-app/provisioning-agent/chat/route.billing.test.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/chat/route.billing.test.ts
@@ -1,0 +1,104 @@
+/** Verifies provisioning chat standing denial before the paid service boundary. */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  getGenerativeOperationContext,
+  paidBoundaryState,
+  requireGenerativeKnownIdentity,
+  requireGenerativeRouteCaller,
+  resetPaidBoundaryRouteMocks,
+} from "../../../__tests__/paid-boundary-route-test-mocks";
+
+const validateAuthHeader = mock(async () => ({
+  userId: "user-1",
+  organizationId: "org-1",
+}));
+const provisioningAgentChat = mock(async (_params: unknown) => ({
+  reply: "ready",
+  containerStatus: "none" as const,
+  bridgeUrl: null,
+  agentId: null,
+  history: [],
+}));
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppSessionService: { validateAuthHeader },
+}));
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  getGenerativeOperationContext,
+  requireGenerativeKnownIdentity,
+  requireGenerativeRouteCaller,
+}));
+mock.module("@/lib/services/provisioning-agent-chat", () => ({
+  provisioningAgentChat,
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: () => undefined, info: () => undefined },
+}));
+
+const { default: app } = await import("./route");
+
+beforeEach(() => {
+  validateAuthHeader.mockClear();
+  requireGenerativeKnownIdentity.mockClear();
+  getGenerativeOperationContext.mockClear();
+  provisioningAgentChat.mockClear();
+  resetPaidBoundaryRouteMocks();
+});
+
+describe("POST /api/eliza-app/provisioning-agent/chat billing boundary", () => {
+  test("revalidates standing once and passes one operation context to the service", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer signed-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(validateAuthHeader).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeKnownIdentity).toHaveBeenCalledTimes(1);
+    expect(getGenerativeOperationContext).toHaveBeenCalledTimes(1);
+    expect(provisioningAgentChat).toHaveBeenCalledTimes(1);
+    expect(provisioningAgentChat.mock.calls[0]?.[0]).toMatchObject({
+      userId: "user-1",
+      organizationId: "org-1",
+      operationContext: { requestId: "request-1" },
+    });
+  });
+
+  test("standing denial never crosses the paid service boundary", async () => {
+    paidBoundaryState.knownIdentityError = new Error("account inactive");
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer signed-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(validateAuthHeader).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeKnownIdentity).toHaveBeenCalledTimes(1);
+    expect(getGenerativeOperationContext).not.toHaveBeenCalled();
+    expect(provisioningAgentChat).not.toHaveBeenCalled();
+  });
+
+  test("invalid input performs no standing read and no paid service call", async () => {
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer signed-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ message: "" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(requireGenerativeKnownIdentity).not.toHaveBeenCalled();
+    expect(provisioningAgentChat).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/eliza-app/provisioning-agent/chat/route.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/chat/route.ts
@@ -7,6 +7,11 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  getGenerativeOperationContext,
+  requireGenerativeKnownIdentity,
+} from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
 import { provisioningAgentChat } from "@/lib/services/provisioning-agent-chat";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
@@ -53,12 +58,14 @@ app.post("/", async (c) => {
   }
 
   try {
-    const result = await provisioningAgentChat(
-      session.userId,
-      session.organizationId,
-      parsed.data.message,
-      parsed.data.agentId,
-    );
+    const caller = await requireGenerativeKnownIdentity(c, session);
+    const result = await provisioningAgentChat({
+      userId: session.userId,
+      organizationId: session.organizationId,
+      userMessage: parsed.data.message,
+      agentId: parsed.data.agentId,
+      operationContext: getGenerativeOperationContext(c, caller),
+    });
 
     const bridgeUrl = result.bridgeUrl ?? undefined;
 
@@ -73,7 +80,7 @@ app.post("/", async (c) => {
     });
   } catch (err) {
     logger.error("[eliza-app provisioning-agent/chat] Error", { error: err });
-    return c.json({ success: false, error: "Chat failed" }, 500);
+    return failureResponse(c, err);
   }
 });
 

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.ledger.pglite.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.ledger.pglite.test.ts
@@ -62,8 +62,11 @@ const sharedRestMessageSend = mock(async (..._args: unknown[]) => ({
 const namespace = {
   getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
 };
+const retainedTasks: Promise<unknown>[] = [];
 const runtimeExecutionCtx = {
-  waitUntil: mock((_promise: Promise<unknown>) => undefined),
+  waitUntil: mock((promise: Promise<unknown>) => {
+    retainedTasks.push(promise);
+  }),
 };
 
 // Network edges of the describe helper: the SSRF-guarded fetch and the
@@ -216,7 +219,9 @@ async function deliver(
   expect(response.status).toBe(200);
   expect(response.headers.get("X-Eliza-Failure-Stage")).toBeNull();
   expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
-  return sharedRestMessageSend.mock.calls[0]?.[2] as string;
+  const delivered = sharedRestMessageSend.mock.calls[0]?.[2] as string;
+  await Promise.all(retainedTasks.splice(0));
+  return delivered;
 }
 
 async function ledgerRow(messageId: string) {
@@ -246,13 +251,28 @@ async function quotaRows() {
   return rows;
 }
 
-const ENRICHED = `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n${DESCRIPTION}`;
+const ENRICHED =
+  `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n${DESCRIPTION}` +
+  `\n\n[Attached image URL]\n${MEDIA_URL}`;
 
 beforeAll(async () => {
   const database = getPgliteClientForTests();
   await database.exec(`
-    CREATE TABLE organizations (id uuid PRIMARY KEY);
-    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY,
+      is_active boolean NOT NULL DEFAULT true
+    );
+    CREATE TABLE users (
+      id uuid PRIMARY KEY,
+      organization_id uuid REFERENCES organizations(id),
+      is_active boolean NOT NULL DEFAULT true,
+      deleted_at timestamp
+    );
+    CREATE TABLE user_moderation_status (
+      user_id uuid PRIMARY KEY REFERENCES users(id),
+      status text NOT NULL DEFAULT 'clean',
+      total_violations integer NOT NULL DEFAULT 0
+    );
   `);
   const migration = await Bun.file(
     new URL(
@@ -270,8 +290,10 @@ beforeEach(async () => {
       users,
       organizations CASCADE;
     INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
-    INSERT INTO users (id) VALUES ('${USER_A}'), ('${USER_B}');
+    INSERT INTO users (id, organization_id)
+      VALUES ('${USER_A}', '${ORG_A}'), ('${USER_B}', '${ORG_B}');
   `);
+  retainedTasks.length = 0;
   safeFetch.mockClear();
   safeFetch.mockImplementation(
     async () =>
@@ -416,6 +438,19 @@ describe("inbound media admission ledger through the messaging route", () => {
     expect(safeFetch).not.toHaveBeenCalled();
     expect(generateText).not.toHaveBeenCalled();
     expect(await ledgerRow("message-5")).toBeUndefined();
+  });
+
+  test("one combined standing denial blocks the provider before claim or quota mutation", async () => {
+    await getPgliteClientForTests().query(
+      "UPDATE users SET is_active = false WHERE id = $1",
+      [USER_A],
+    );
+
+    expect(await deliver("message-standing-denied")).toBe(RAW_MEDIA_MESSAGE);
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(await ledgerRow("message-standing-denied")).toBeUndefined();
+    expect(await quotaRows()).toEqual([]);
   });
 
   test("a ledger outage fails closed: raw turn, 200, no spend", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
@@ -232,6 +232,7 @@ describe("blooio inbound media enrichment at the messaging route", () => {
     prewarmPersonalSharedAgentTurnCaches.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
     bridge.mockClear();
+    runtimeExecutionCtx.waitUntil.mockClear();
     ledgerAdmit.mockReset();
     ledgerAdmit.mockResolvedValue({ kind: "claimed", claim: LEDGER_CLAIM });
     ledgerComplete.mockReset();
@@ -394,6 +395,7 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       { kind: "previously_failed", reason: "media_fetch_failed" },
       { kind: "identity_mismatch" },
       { kind: "media_mismatch" },
+      { kind: "standing_denied", reason: "moderation_blocked" },
       { kind: "exhausted", scope: "sender", limit: 20, used: 20, requested: 1 },
       {
         kind: "exhausted",
@@ -415,16 +417,17 @@ describe("blooio inbound media enrichment at the messaging route", () => {
     expect(ledgerFail).not.toHaveBeenCalled();
   });
 
-  test("a lost settlement keeps the raw turn instead of using uncommitted OCR text", async () => {
-    describeInboundImageMedia.mockResolvedValue("must not enter the turn");
+  test("post-dispatch settlement is retained off the mounted response path", async () => {
+    describeInboundImageMedia.mockResolvedValue("described before settlement");
     ledgerComplete.mockResolvedValue(false);
     const response = await request(blooioDelivery());
     expect(response.status).toBe(200);
-    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(deliveredMessage()).toContain("described before settlement");
     expect(ledgerComplete).toHaveBeenCalledWith(
       LEDGER_CLAIM,
-      "must not enter the turn",
+      "described before settlement",
     );
+    expect(runtimeExecutionCtx.waitUntil).toHaveBeenCalled();
   });
 
   test("a missing admission decision fails closed: raw turn, no spend, no 500", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1616,6 +1616,7 @@ app.post("/", async (c) => {
         organizationId: account.organizationId,
         userId: account.userId,
         mediaUrls: parsed.data.mediaUrls,
+        executionCtx: worker.executionCtx,
       });
       if (enrichment.kind === "described") {
         deliveryMessage = `${deliveryMessage}\n\n[Attached image description]\n${enrichment.description}\n\n[Attached image URL]\n${parsed.data.mediaUrls.join("\n")}`;

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -6,10 +6,10 @@
  * POST /api/mcp/proxy/[mcpId] - Proxy MCP request
  * GET /api/mcp/proxy/[mcpId] - Get MCP info
  *
- * After the precharge succeeds, the owned hop deadline starts before endpoint
+ * After admission succeeds, the owned hop deadline starts before endpoint
  * resolution and inbound body parsing. Untrusted waits (SSRF DNS, inbound JSON
  * reads, outbound fetch, response reads) are raced against that signal so a
- * never-settling lookup or caller abort still refunds as a typed 504.
+ * never-settling lookup or caller abort still settles as a typed 504.
  */
 
 import {
@@ -21,13 +21,20 @@ import {
 } from "@elizaos/cloud-shared/billing";
 import { Hono } from "hono";
 
+import {
+  admitFlatGenerativeOperation,
+  asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS } from "@/lib/cors-constants";
 import { assertSafeOutboundUrl } from "@/lib/security/outbound-url";
 import { safeFetch } from "@/lib/security/safe-fetch";
 import { affiliatesService } from "@/lib/services/affiliates";
 import { containersService } from "@/lib/services/containers";
-import { creditsService } from "@/lib/services/credits";
+import { InsufficientCreditsError } from "@/lib/services/credits";
 import { userMcpsService } from "@/lib/services/user-mcps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -269,11 +276,22 @@ app.post("/", async (c) => {
     return c.json({ error: "Missing MCP id" }, 400);
   }
 
-  const user = await requireUserOrApiKeyWithOrg(c).catch(() => null);
-
-  if (!user) {
-    return c.json({ error: "Authentication required" }, 401);
+  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
+  try {
+    caller = await requireGenerativeRouteCaller(c);
+  } catch (error) {
+    logger.warn("[MCP Proxy] Caller admission denied", {
+      mcpId,
+      error: error instanceof Error ? error.message : String(error),
+      errorName: error instanceof Error ? error.name : "unknown",
+      reason:
+        error && typeof error === "object" && "details" in error
+          ? (error as { details?: { reason?: unknown } }).details?.reason
+          : undefined,
+    });
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
+  const user = caller.user;
 
   const mcp = await userMcpsService.getById(mcpId);
 
@@ -334,81 +352,49 @@ app.post("/", async (c) => {
     platformFeePoints: platformFeeCredits,
   });
 
-  const preChargeResult = await creditsService.reserveAndDeductCredits({
-    organizationId: user.organization_id,
-    amount: chargeReceipt.totalAmountUsd,
-    description: `MCP: ${mcp.name}`,
-    metadata: {
-      mcp_id: mcp.id,
-      mcp_name: mcp.name,
-      reserved: true,
-      base_credits: creditsRequired.toFixed(4),
-      affiliate_fee: affiliateFeeCredits.toFixed(4),
-      platform_fee: platformFeeCredits.toFixed(4),
-      total_credits_charged: totalCreditsRequired.toFixed(4),
-      base_amount_usd: formatOrganizationCreditUsd(chargeReceipt.baseAmountUsd),
-      affiliate_fee_usd: formatOrganizationCreditUsd(
-        chargeReceipt.affiliateFeeUsd,
-      ),
-      platform_fee_usd: formatOrganizationCreditUsd(
-        chargeReceipt.platformFeeUsd,
-      ),
-      total_amount_usd: formatOrganizationCreditUsd(
-        chargeReceipt.totalAmountUsd,
-      ),
-      credit_unit: ORGANIZATION_CREDIT_UNIT,
-      ...(affiliateOwnerId && { affiliate_owner_id: affiliateOwnerId }),
-      ...(affiliateCodeId && { affiliate_code_id: affiliateCodeId }),
-    },
-  });
-
-  if (!preChargeResult.success) {
-    return c.json(
-      {
-        error: "Insufficient credits",
-        creditUnit: ORGANIZATION_CREDIT_UNIT,
-        requiredUsd: chargeReceipt.totalAmountUsd,
-        /** @deprecated Legacy MCP pricing points (100 points = $1). */
-        required: totalCreditsRequired,
-        balance: preChargeResult.newBalance,
-      },
-      402,
-    );
-  }
-
-  // The caller was debited upfront; ANY post-debit failure (unsafe/misconfigured
-  // endpoint, unreachable upstream, container down, non-ok status) must return
-  // the money — otherwise a momentarily-down MCP silently over-charges the org
-  // (#11637). Refund on every failure branch, not only a non-ok HTTP status.
-  let refundedPrecharge = false;
-  const refundPrecharge = async (
-    reason: string,
-    metadata: Record<string, string | number | boolean | null | undefined> = {},
+  const requestId = `mcp-proxy:${mcp.id}:${crypto.randomUUID()}`;
+  let admission:
+    | Awaited<ReturnType<typeof admitFlatGenerativeOperation>>
+    | undefined;
+  const executionCtx = getGenerativeExecutionContext(c);
+  let providerDispatchStarted = false;
+  const retainAccounting = async (
+    task: Promise<unknown>,
+    operation: string,
+    metadata: Record<string, unknown> = {},
   ): Promise<void> => {
-    if (refundedPrecharge) return;
-    refundedPrecharge = true;
-    await creditsService
-      .refundCredits({
+    const observed = task.catch((error) => {
+      // error-policy:J7 durable admission keeps the charge recoverable while
+      // operators receive the complete accounting failure context.
+      logger.error("[MCP Proxy] Background accounting failed", {
+        mcpId,
         organizationId: user.organization_id,
-        amount: chargeReceipt.totalAmountUsd,
-        description: `MCP refund: ${mcp.name} (${reason})`,
-        metadata: {
-          mcp_id: mcp.id,
-          reason,
-          ...metadata,
-        },
-      })
-      .catch((refundError: Error | string) => {
-        logger.error("[MCP Proxy] Failed to refund credits", {
-          mcpId,
-          reason,
-          error:
-            typeof refundError === "string" ? refundError : refundError.message,
-        });
+        requestId,
+        operation,
+        ...metadata,
+        error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : "unknown",
       });
+    });
+    if (executionCtx) executionCtx.waitUntil(observed);
+    else await observed;
+  };
+  const settleFailure = async (
+    reason: string,
+    metadata: Record<string, unknown> = {},
+  ): Promise<void> => {
+    const activeAdmission = admission;
+    if (!activeAdmission) return;
+    await retainAccounting(
+      providerDispatchStarted
+        ? activeAdmission.settleUnknown()
+        : activeAdmission.settle(0),
+      providerDispatchStarted ? "settle_unknown" : "release_admission",
+      { reason, ...metadata },
+    );
   };
 
-  // Own the wall-clock bound before every untrusted post-precharge wait.
+  // Own the wall-clock bound before every untrusted post-admission wait.
   // Creating the timer after endpoint DNS or inbound parsing left those
   // awaits able to retain the Worker request and the debit indefinitely.
   const hop = createMcpProxyHopDeadline(c.req.raw.signal);
@@ -417,7 +403,7 @@ app.post("/", async (c) => {
       mcpId,
       timeoutMs: hop.timeoutMs,
     });
-    await refundPrecharge("upstream_deadline_exceeded", {
+    await settleFailure("upstream_deadline_exceeded", {
       timeoutMs: hop.timeoutMs,
     });
     return c.json({ error: "MCP endpoint timed out" }, 504);
@@ -443,7 +429,7 @@ app.post("/", async (c) => {
           hop.signal,
         );
       } catch (error) {
-        // error-policy:J1 hop abort maps to a 504 refund; other failures stay 400.
+        // error-policy:J1 hop abort maps to 504 settlement; other failures stay 400.
         if (hopAborted(error)) {
           return await refundDeadline();
         }
@@ -451,7 +437,7 @@ app.post("/", async (c) => {
           mcpId,
           error: error instanceof Error ? error.message : String(error),
         });
-        await refundPrecharge("unsafe_endpoint");
+        await settleFailure("unsafe_endpoint");
         return c.json({ error: "Unsafe external MCP endpoint" }, 400);
       }
       targetUrl = parsed.toString();
@@ -464,7 +450,7 @@ app.post("/", async (c) => {
           hop.signal,
         );
       } catch (error) {
-        // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
+        // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
         if (hopAborted(error)) {
           return await refundDeadline();
         }
@@ -473,18 +459,18 @@ app.post("/", async (c) => {
           containerId: mcp.container_id,
           error: error instanceof Error ? error.message : String(error),
         });
-        await refundPrecharge("container_lookup_failed", {
+        await settleFailure("container_lookup_failed", {
           error: error instanceof Error ? error.message : String(error),
         });
         return c.json({ error: "MCP container not available" }, 502);
       }
       if (!container?.load_balancer_url) {
-        await refundPrecharge("container_unavailable");
+        await settleFailure("container_unavailable");
         return c.json({ error: "MCP container not available" }, 503);
       }
       targetUrl = `${container.load_balancer_url}${mcp.endpoint_path || "/mcp"}`;
     } else {
-      await refundPrecharge("endpoint_misconfigured");
+      await settleFailure("endpoint_misconfigured");
       return c.json({ error: "MCP endpoint not configured" }, 500);
     }
 
@@ -497,7 +483,7 @@ app.post("/", async (c) => {
         hop.signal,
       );
     } catch (error) {
-      // error-policy:J1 hop abort maps to a 504 refund; overflow stays 413.
+      // error-policy:J1 hop abort maps to 504 settlement; overflow stays 413.
       if (hopAborted(error)) {
         return await refundDeadline();
       }
@@ -507,7 +493,7 @@ app.post("/", async (c) => {
           bytes: error.bytes,
           maxBytes: error.maxBytes,
         });
-        await refundPrecharge("request_body_too_large", {
+        await settleFailure("request_body_too_large", {
           maxBytes: error.maxBytes,
         });
         return c.json({ error: "MCP request body is too large" }, 413);
@@ -517,7 +503,7 @@ app.post("/", async (c) => {
           mcpId,
           bytes: error.bytes,
         });
-        await refundPrecharge("request_body_malformed_utf8", {
+        await settleFailure("request_body_malformed_utf8", {
           bytes: error.bytes,
         });
         return c.json({ error: "MCP request body is not valid UTF-8" }, 400);
@@ -526,7 +512,7 @@ app.post("/", async (c) => {
         mcpId,
         error: error instanceof Error ? error.message : String(error),
       });
-      await refundPrecharge("invalid_json");
+      await settleFailure("invalid_json");
       return c.json({ error: "Invalid MCP request body" }, 400);
     }
     const toolName = toolNameFromRpcBody(proxyBody);
@@ -542,8 +528,80 @@ app.post("/", async (c) => {
       body: JSON.stringify(proxyBody),
     };
 
+    try {
+      admission = await admitFlatGenerativeOperation({
+        c,
+        context: {
+          organizationId: user.organization_id,
+          userId: user.id,
+          apiKeyId: caller.apiKeyId,
+          model: `mcp/${mcp.id}`,
+          provider: "mcp",
+          billingSource: "selfhosted",
+          requestId,
+          description: `MCP: ${mcp.name}`,
+          metadata: {
+            mcp_id: mcp.id,
+            mcp_name: mcp.name,
+            base_credits: creditsRequired.toFixed(4),
+            affiliate_fee: affiliateFeeCredits.toFixed(4),
+            platform_fee: platformFeeCredits.toFixed(4),
+            total_credits_charged: totalCreditsRequired.toFixed(4),
+            base_amount_usd: formatOrganizationCreditUsd(
+              chargeReceipt.baseAmountUsd,
+            ),
+            affiliate_fee_usd: formatOrganizationCreditUsd(
+              chargeReceipt.affiliateFeeUsd,
+            ),
+            platform_fee_usd: formatOrganizationCreditUsd(
+              chargeReceipt.platformFeeUsd,
+            ),
+            total_amount_usd: formatOrganizationCreditUsd(
+              chargeReceipt.totalAmountUsd,
+            ),
+            credit_unit: ORGANIZATION_CREDIT_UNIT,
+            ...(affiliateOwnerId && { affiliate_owner_id: affiliateOwnerId }),
+            ...(affiliateCodeId && { affiliate_code_id: affiliateCodeId }),
+          },
+        },
+        apiKeyId: caller.apiKeyId,
+        admissionSnapshot: caller.admissionSnapshot,
+        cost: {
+          baseTotalCost: chargeReceipt.baseAmountUsd,
+          platformMarkup:
+            chargeReceipt.totalAmountUsd - chargeReceipt.baseAmountUsd,
+          totalCost: chargeReceipt.totalAmountUsd,
+        },
+      });
+    } catch (error) {
+      if (error instanceof InsufficientCreditsError) {
+        return c.json(
+          {
+            error: "Insufficient credits",
+            creditUnit: ORGANIZATION_CREDIT_UNIT,
+            requiredUsd: chargeReceipt.totalAmountUsd,
+            /** @deprecated Legacy MCP pricing points (100 points = $1). */
+            required: totalCreditsRequired,
+            balance: error.available,
+          },
+          402,
+        );
+      }
+      logger.error("[MCP Proxy] Flat admission failed", {
+        mcpId,
+        organizationId: user.organization_id,
+        requestId,
+        error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : "unknown",
+      });
+      return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
+    }
+    const activeAdmission = admission;
+
     let mcpResponse: Response;
     try {
+      await activeAdmission.markProviderDispatched?.();
+      providerDispatchStarted = true;
       if (isExternalEndpoint) {
         // safeFetch validates + IP-pins the request and (redirect: "error")
         // rejects any redirect — the single SSRF guard for outbound-from-user
@@ -573,7 +631,7 @@ app.post("/", async (c) => {
         }
       }
     } catch (error) {
-      // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
+      // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
       if (hopAborted(error)) {
         return await refundDeadline();
       }
@@ -582,7 +640,7 @@ app.post("/", async (c) => {
         targetUrl,
         error: error instanceof Error ? error.message : String(error),
       });
-      await refundPrecharge("upstream_unreachable");
+      await settleFailure("upstream_unreachable");
       return c.json({ error: "Failed to reach MCP endpoint" }, 502);
     }
 
@@ -617,7 +675,7 @@ app.post("/", async (c) => {
             status: mcpResponse.status,
             receivedBytes: budgeted.bytes,
           });
-          await refundPrecharge("mcp_response_malformed_utf8", {
+          await settleFailure("mcp_response_malformed_utf8", {
             status: mcpResponse.status,
           });
           return c.json({ error: "MCP response is not valid UTF-8" }, 502);
@@ -628,7 +686,7 @@ app.post("/", async (c) => {
           receivedBytes: budgeted.bytes,
           maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
         });
-        await refundPrecharge("mcp_response_too_large", {
+        await settleFailure("mcp_response_too_large", {
           status: mcpResponse.status,
           maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
         });
@@ -636,7 +694,7 @@ app.post("/", async (c) => {
       }
       responseBody = budgeted.text;
     } catch (error) {
-      // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
+      // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
       if (hopAborted(error)) {
         return await refundDeadline();
       }
@@ -645,7 +703,7 @@ app.post("/", async (c) => {
         status: mcpResponse.status,
         error: error instanceof Error ? error.message : String(error),
       });
-      await refundPrecharge("mcp_response_read_failed", {
+      await settleFailure("mcp_response_read_failed", {
         status: mcpResponse.status,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -659,8 +717,21 @@ app.post("/", async (c) => {
     // layer). Refund on an explicit JSON-RPC error instead of success-shaping it.
     const rpcErrored = mcpResponse.ok && isJsonRpcErrorResponse(responseBody);
     if (mcpResponse.ok && !rpcErrored) {
-      await userMcpsService
-        .recordUsageWithoutDeduction({
+      const accountingTask = (async () => {
+        const reconciliation = await activeAdmission.settle(
+          chargeReceipt.totalAmountUsd,
+        );
+        if (reconciliation?.adjustmentType === "uncollected_overage") {
+          logger.error("[MCP Proxy] Final charge was not collected", {
+            mcpId,
+            organizationId: user.organization_id,
+            requestId,
+            reserved: reconciliation.reservedAmount,
+            actual: reconciliation.actualCost,
+          });
+          return;
+        }
+        await userMcpsService.recordUsageWithoutDeduction({
           mcpId: mcp.id,
           organizationId: user.organization_id,
           userId: user.id,
@@ -674,21 +745,19 @@ app.post("/", async (c) => {
           metadata: {
             responseTime: Date.now() - startTime,
             success: true,
-            preChargeTransactionId: preChargeResult.transaction?.id,
+            preChargeTransactionId:
+              activeAdmission.reservation?.reservationTransactionId ??
+              requestId,
             totalCreditsCharged: totalCreditsRequired,
             affiliateFeeCredits,
             platformFeeCredits,
           },
-        })
-        // error-policy:J7 usage recording is diagnostic and runs after the proxied
-        // call already succeeded and settled; a failed write is logged, not fatal.
-        .catch((usageError: Error | string) => {
-          logger.error("[MCP Proxy] Failed to record usage", {
-            mcpId,
-            error:
-              typeof usageError === "string" ? usageError : usageError.message,
-          });
         });
+      })();
+      await retainAccounting(accountingTask, "settle_and_record_usage", {
+        toolName,
+        status: mcpResponse.status,
+      });
     } else if (rpcErrored) {
       // Protocol-level failure over a 2xx transport: refund and do not bill. The
       // caller still receives the MCP's error envelope verbatim below.
@@ -700,11 +769,11 @@ app.post("/", async (c) => {
           toolName,
         },
       );
-      await refundPrecharge("mcp_jsonrpc_error", {
+      await settleFailure("mcp_jsonrpc_error", {
         status: mcpResponse.status,
       });
     } else {
-      await refundPrecharge("mcp_call_failed", { status: mcpResponse.status });
+      await settleFailure("mcp_call_failed", { status: mcpResponse.status });
     }
 
     return new Response(responseBody, {

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -168,6 +168,70 @@ export function getGenerativePricingCacheOptions(
   return { cacheOnly: Boolean(executionCtx), executionCtx };
 }
 
+/** Revalidates a signed non-Steward session before paid provider admission. */
+export async function requireGenerativeKnownIdentity(
+  c: AppContext,
+  identity: { userId: string; organizationId: string },
+): Promise<GenerativeRouteCaller> {
+  const [{ usersRepository }, { adminService }] = await Promise.all([
+    import("@/db/repositories/users"),
+    import("@/lib/services/admin"),
+  ]);
+  const user = await usersRepository.findWithOrganization(identity.userId);
+  const reason = !user
+    ? "account_inactive"
+    : user.organization_id !== identity.organizationId || !user.organization
+      ? "membership_missing"
+      : !user.is_active
+        ? "account_inactive"
+        : !user.organization.is_active
+          ? "organization_inactive"
+          : (await adminService.shouldBlockUser(user.id))
+            ? "moderation_blocked"
+            : null;
+  if (reason) {
+    logger.warn(
+      "[InferenceAuth] blocked known identity before provider dispatch",
+      {
+        traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
+        route: "eliza-app/provisioning-agent/chat",
+        reason,
+        status: 403,
+      },
+    );
+    throw new ApiError(
+      403,
+      "access_denied",
+      "Account is not eligible for generative work",
+      {
+        reason,
+      },
+    );
+  }
+
+  const executionCtx = getGenerativeExecutionContext(c);
+  const admissionSnapshot = executionCtx
+    ? await import("@/lib/services/inference-admission-snapshot").then(
+        (module) =>
+          module.getInferenceAdmissionSnapshotCacheOnly(
+            identity.organizationId,
+            executionCtx,
+          ),
+      )
+    : await import("@/lib/services/inference-admission-snapshot").then(
+        (module) =>
+          module.loadInferenceAdmissionSnapshot(identity.organizationId),
+      );
+
+  return {
+    user: { id: identity.userId, organization_id: identity.organizationId },
+    apiKeyId: null,
+    authSource: "compatibility",
+    admissionSnapshot,
+    appScopeId: null,
+  };
+}
+
 export function asGenerativeCacheApiError(error: unknown): ApiError | null {
   if (
     error instanceof AiPricingCacheWarmingError ||

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -19,6 +19,7 @@ import type {
   InferenceAdmissionSnapshot,
   InferenceAuthRejectionReason,
 } from "@/lib/services/inference-auth-cache";
+import type { GenerativeOperationContext } from "@/lib/services/generative-operation";
 import type { EndpointType } from "@/lib/services/org-rate-limits";
 import type { OrganizationInferenceAdmission } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";
@@ -144,6 +145,20 @@ export function getGenerativeExecutionContext(
     // retain the authoritative compatibility path used by tests and tooling.
     return undefined;
   }
+}
+
+export function getGenerativeOperationContext(
+  c: AppContext,
+  caller: GenerativeRouteCaller,
+): GenerativeOperationContext {
+  return {
+    organizationId: caller.user.organization_id,
+    userId: caller.user.id,
+    apiKeyId: caller.apiKeyId,
+    requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
+    admissionSnapshot: caller.admissionSnapshot,
+    executionCtx: getGenerativeExecutionContext(c),
+  };
 }
 
 export function getGenerativePricingCacheOptions(

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -15,11 +15,11 @@ import {
   AiPricingCacheUnavailableError,
   AiPricingCacheWarmingError,
 } from "@/lib/services/ai-pricing/cache";
+import type { GenerativeOperationContext } from "@/lib/services/generative-operation";
 import type {
   InferenceAdmissionSnapshot,
   InferenceAuthRejectionReason,
 } from "@/lib/services/inference-auth-cache";
-import type { GenerativeOperationContext } from "@/lib/services/generative-operation";
 import type { EndpointType } from "@/lib/services/org-rate-limits";
 import type { OrganizationInferenceAdmission } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";

--- a/packages/cloud/api/v1/apps/[id]/automation-post-standing.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/automation-post-standing.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Mounts the three manual app-automation post routes and proves a combined
+ * standing denial stops the service boundary before any provider-capable call.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const discordPost = mock(async () => ({ success: true }));
+const telegramPost = mock(async () => ({ success: true }));
+const twitterPost = mock(async () => ({ success: true }));
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller: mock(async () => {
+    throw new Error("cached standing denied");
+  }),
+  getGenerativeOperationContext: mock(() => {
+    throw new Error("operation context must not be created after denial");
+  }),
+  asGenerativeCacheApiError: () => null,
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) =>
+    Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 403 },
+    ),
+}));
+mock.module("@/lib/services/generative-operation", () => ({
+  isGenerativeOperationAdmissionError: () => false,
+}));
+mock.module("@/lib/services/discord-automation/app-automation", () => ({
+  discordAppAutomationService: { postAnnouncement: discordPost },
+}));
+mock.module("@/lib/services/telegram-automation/app-automation", () => ({
+  telegramAppAutomationService: { postAnnouncement: telegramPost },
+}));
+mock.module("@/lib/services/twitter-automation/app-automation", () => ({
+  twitterAppAutomationService: { postAppTweet: twitterPost },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: mock(() => undefined), error: mock(() => undefined) },
+}));
+
+const { default: discordRoute } = await import(
+  "./discord-automation/post/route"
+);
+const { default: telegramRoute } = await import(
+  "./telegram-automation/post/route"
+);
+const { default: twitterRoute } = await import(
+  "./twitter-automation/post/route"
+);
+
+const app = new Hono()
+  .route("/:id/discord", discordRoute)
+  .route("/:id/telegram", telegramRoute)
+  .route("/:id/twitter", twitterRoute);
+
+beforeEach(() => {
+  discordPost.mockClear();
+  telegramPost.mockClear();
+  twitterPost.mockClear();
+});
+
+describe("manual app automation standing boundary", () => {
+  test.each(["discord", "telegram", "twitter"])(
+    "denies %s before its provider-capable service call",
+    async (platform) => {
+      const response = await app.request(`/app-1/${platform}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: "cached standing denied",
+      });
+      expect(discordPost).not.toHaveBeenCalled();
+      expect(telegramPost).not.toHaveBeenCalled();
+      expect(twitterPost).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -11,9 +11,17 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { z } from "zod";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+} from "@/lib/services/generative-operation";
 import { logger } from "@/lib/utils/logger";
 
 const postSchema = z.object({
@@ -24,6 +32,7 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
+  operationContext: GenerativeOperationContext,
 ): Promise<Response> {
   const { user } = caller;
   const { id: appId } = await params;
@@ -50,6 +59,7 @@ async function __hono_POST(
       user.organization_id,
       appId,
       body.text,
+      operationContext,
     );
 
     if (!result.success) {
@@ -68,6 +78,7 @@ async function __hono_POST(
       channelId: result.channelId,
     });
   } catch (error) {
+    if (isGenerativeOperationAdmissionError(error)) throw error;
     if (error instanceof Error && error.message === "App not found") {
       return Response.json({ error: "App not found" }, { status: 404 });
     }
@@ -92,9 +103,10 @@ __hono_app.post("/", async (c) => {
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
+      getGenerativeOperationContext(c, caller),
     );
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts
@@ -32,7 +32,28 @@ const AD_SIZES = {
   linkedin_post: { width: 1200, height: 627 },
   google_display_leaderboard: { width: 728, height: 90 },
 };
+const generateAssetBundle = mock(async () => ({
+  assets: [],
+  copy: undefined,
+  errors: [],
+}));
+const operationContext = {
+  organizationId: "org-1",
+  userId: "user-1",
+  apiKeyId: null,
+  requestId: "request-1",
+};
 
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller: mock(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  })),
+  getGenerativeOperationContext: () => operationContext,
+  asGenerativeCacheApiError: () => null,
+}));
 mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
 mock.module("@/lib/auth/app-key-scope", () => ({ isAppKeyOutOfScope }));
 mock.module("@/lib/services/apps", () => ({
@@ -42,11 +63,7 @@ mock.module("@/lib/services/app-promotion-assets", () => ({
   AD_SIZES,
   appPromotionAssetsService: {
     getRecommendedSizes,
-    generateAssetBundle: mock(async () => ({
-      assets: [],
-      copy: null,
-      errors: [],
-    })),
+    generateAssetBundle,
   },
 }));
 mock.module("@/lib/promotion-pricing", () => ({
@@ -54,11 +71,8 @@ mock.module("@/lib/promotion-pricing", () => ({
   PROMO_IMAGE_COST: 2,
   estimateAssetGenerationCost: () => ({ total: 5, display: "5" }),
 }));
-mock.module("@/lib/services/credits", () => ({
-  creditsService: {
-    deductCredits: mock(async () => ({ success: true })),
-    refundCredits: mock(async () => undefined),
-  },
+mock.module("@/lib/services/generative-operation", () => ({
+  retainGenerativeTask: mock(async (_context, _operation, task) => await task),
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: { info: mock(() => undefined), error: mock(() => undefined) },
@@ -78,6 +92,32 @@ describe("GET /api/v1/apps/:id/promote/assets platform identity", () => {
       organization_id: "org-1",
       name: "Demo",
     });
+  });
+
+  test("does not report copy credits when only image generation succeeds", async () => {
+    generateAssetBundle.mockResolvedValueOnce({
+      assets: [
+        {
+          type: "social_card",
+          size: { width: 800, height: 418 },
+          url: "https://example.test/asset.png",
+          format: "png",
+          generatedAt: new Date("2026-08-29T00:00:00.000Z"),
+        },
+      ],
+      copy: undefined,
+      errors: ["Failed to generate copy"],
+    });
+
+    const response = await app.request("/app-1/promote/assets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ includeCopy: true }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { creditsUsed: number };
+    expect(body.creditsUsed).toBe(2);
   });
 
   test.each(["", "?platform="])(

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.platform.test.ts
@@ -1,11 +1,13 @@
 /**
- * GET /api/v1/apps/:id/promote/assets `platform` is catalog-platform
- * identity, not leftover my-agents sortBy tax. Stock develop cast the
- * token and `getRecommendedSizes` fell through to Twitter cards, so
- * `platform=META` / `facebook` listed Twitter sizes.
+ * Exercises promotion-asset route billing output and catalog-platform
+ * validation through the real Hono boundary with deterministic service mocks.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import type {
+  AdCopyVariants,
+  GeneratedAsset,
+} from "@/lib/services/app-promotion-assets";
 
 const requireAuthOrApiKeyWithOrg = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
@@ -32,11 +34,17 @@ const AD_SIZES = {
   linkedin_post: { width: 1200, height: 627 },
   google_display_leaderboard: { width: 728, height: 90 },
 };
-const generateAssetBundle = mock(async () => ({
-  assets: [],
-  copy: undefined,
-  errors: [],
-}));
+const generateAssetBundle = mock(
+  async (): Promise<{
+    assets: GeneratedAsset[];
+    copy?: AdCopyVariants;
+    errors: string[];
+  }> => ({
+    assets: [],
+    copy: undefined,
+    errors: [],
+  }),
+);
 const operationContext = {
   organizationId: "org-1",
   userId: "user-1",

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -1,7 +1,11 @@
 // Handles v1 cloud API v1 apps id promote assets route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -17,9 +21,9 @@ import {
   appPromotionAssetsService,
 } from "@/lib/services/app-promotion-assets";
 import { appsService } from "@/lib/services/apps";
-import { creditsService } from "@/lib/services/credits";
+import { retainGenerativeTask } from "@/lib/services/generative-operation";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const GenerateAssetsSchema = z.object({
   sizes: z
@@ -32,11 +36,12 @@ const GenerateAssetsSchema = z.object({
 });
 
 async function __hono_POST(
-  request: Request,
+  c: AppContext,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ) {
   const { user } = caller;
+  const operationContext = getGenerativeOperationContext(c, caller);
   const { id } = await params;
 
   const app = await appsService.getById(id);
@@ -47,7 +52,7 @@ async function __hono_POST(
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const body = await request.json();
+  const body = await c.req.json();
   const parsed = GenerateAssetsSchema.safeParse(body);
 
   if (!parsed.success) {
@@ -57,27 +62,8 @@ async function __hono_POST(
     );
   }
 
-  // Calculate cost - 1 social card always generated + 1 banner (if requested)
   const imageCount = 1; // Social cards always generated (includeSocialCards: true)
   const bannerCount = parsed.data.includeAdBanners ? 1 : 0;
-  const totalImageCost = (imageCount + bannerCount) * PROMO_IMAGE_COST;
-  const copyCost =
-    parsed.data.includeCopy !== false ? AD_COPY_GENERATION_COST : 0;
-  const totalCost = totalImageCost + copyCost;
-
-  const deduction = await creditsService.deductCredits({
-    organizationId: user.organization_id,
-    amount: totalCost,
-    description: `Generate promotional assets for ${app.name}`,
-    metadata: { appId: id, imageCount: imageCount + bannerCount },
-  });
-
-  if (!deduction.success) {
-    return Response.json(
-      { error: "Insufficient credits", required: totalCost },
-      { status: 402 },
-    );
-  }
 
   logger.info("[Promote Assets API] Generating assets", {
     appId: id,
@@ -86,25 +72,19 @@ async function __hono_POST(
   });
 
   try {
-    const result = await appPromotionAssetsService.generateAssetBundle(app, {
-      includeSocialCards: true,
-      includeAdBanners: parsed.data.includeAdBanners,
-      includeCopy: parsed.data.includeCopy,
-      targetAudience: parsed.data.targetAudience,
-      customPrompt: parsed.data.customPrompt,
-    });
+    const result = await appPromotionAssetsService.generateAssetBundle(
+      app,
+      {
+        includeSocialCards: true,
+        includeAdBanners: parsed.data.includeAdBanners,
+        includeCopy: parsed.data.includeCopy,
+        targetAudience: parsed.data.targetAudience,
+        customPrompt: parsed.data.customPrompt,
+      },
+      operationContext,
+    );
 
-    // Refund for failed generations
     const successfulImages = result.assets.length;
-    const failedImages = imageCount + bannerCount - successfulImages;
-    if (failedImages > 0) {
-      await creditsService.refundCredits({
-        organizationId: user.organization_id,
-        amount: failedImages * PROMO_IMAGE_COST,
-        description: "Refund for failed asset generations",
-        metadata: { appId: id, failedCount: failedImages },
-      });
-    }
 
     if (successfulImages > 0) {
       const promotionalAssets = result.assets.map((asset) => ({
@@ -114,9 +94,19 @@ async function __hono_POST(
         generatedAt: asset.generatedAt.toISOString(),
       }));
 
-      await appsService.update(id, {
-        promotional_assets: promotionalAssets,
-      });
+      await retainGenerativeTask(
+        operationContext,
+        {
+          provider: "promotion-assets",
+          billingSource: "gateway",
+          model: "promotion-assets/persistence",
+          operation: "promotion_assets_status_write",
+          cost: 0,
+        },
+        appsService.update(id, {
+          promotional_assets: promotionalAssets,
+        }),
+      );
 
       logger.info("[Promote Assets API] Saved promotional assets to app", {
         appId: id,
@@ -134,26 +124,17 @@ async function __hono_POST(
       })),
       copy: result.copy,
       errors: result.errors,
-      creditsUsed: totalCost - failedImages * PROMO_IMAGE_COST,
+      creditsUsed:
+        successfulImages * PROMO_IMAGE_COST +
+        (result.copy ? AD_COPY_GENERATION_COST : 0),
     });
   } catch (error) {
-    // Full refund on complete failure
-    await creditsService.refundCredits({
-      organizationId: user.organization_id,
-      amount: totalCost,
-      description: "Refund for failed asset generation",
-      metadata: { appId: id, reason: "generation_error" },
-    });
-
     logger.error("[Promote Assets API] Generation failed", {
       appId: id,
       error: error instanceof Error ? error.message : "Unknown error",
     });
 
-    return Response.json(
-      { error: "Failed to generate assets. Credits have been refunded." },
-      { status: 500 },
-    );
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 }
 
@@ -238,12 +219,12 @@ __hono_app.post("/", async (c) => {
       rateLimitEndpoint: "strict",
     });
     return await __hono_POST(
-      c.req.raw,
+      c,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
     );
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.json.test.ts
@@ -5,11 +5,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
-const requireAuthOrApiKeyWithOrg = mock(async () => ({
-  user: { id: "user-1", organization_id: "org-1" },
-  apiKey: null,
-}));
-const isAppKeyOutOfScope = mock(async () => false);
 const getById = mock(async () => ({
   id: "app-1",
   organization_id: "org-1",
@@ -22,17 +17,37 @@ const getById = mock(async () => ({
   discord_automation: {},
   telegram_automation: {},
 }));
-const generateAnnouncement = mock(async () => "preview");
-const generateAppTweet = mock(async () => ({
-  text: "preview",
-  type: "promotional",
-}));
+const generateAnnouncement = mock(
+  async (_organizationId: string, _app: unknown, _operationContext?: unknown) =>
+    "preview",
+);
+const generateAppTweet = mock(
+  async (
+    _organizationId: string,
+    _app: unknown,
+    _type: string,
+    _operationContext?: unknown,
+  ) => ({
+    text: "preview",
+    type: "promotional",
+  }),
+);
+const operationContext = {
+  organizationId: "org-1",
+  userId: "user-1",
+  apiKeyId: null,
+  requestId: "request-1",
+};
 
-mock.module("@/lib/auth", () => ({
-  requireAuthOrApiKeyWithOrg,
-}));
-mock.module("@/lib/auth/app-key-scope", () => ({
-  isAppKeyOutOfScope,
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller: mock(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  })),
+  getGenerativeOperationContext: () => operationContext,
+  asGenerativeCacheApiError: () => null,
 }));
 mock.module("@/lib/services/apps", () => ({
   appsService: { getById },
@@ -50,6 +65,9 @@ mock.module("@/lib/services/telegram-automation/app-automation", () => ({
 }));
 mock.module("@/lib/services/twitter-automation/app-automation", () => ({
   twitterAppAutomationService: { generateAppTweet },
+}));
+mock.module("@/lib/services/generative-operation", () => ({
+  isGenerativeOperationAdmissionError: () => false,
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: { info: () => undefined, error: () => undefined },
@@ -81,5 +99,6 @@ describe("POST /api/v1/apps/:id/promote/preview malformed JSON", () => {
     });
     expect(response.status).toBe(200);
     expect(generateAppTweet).toHaveBeenCalled();
+    expect(generateAppTweet.mock.calls[0]?.[3]).toBe(operationContext);
   });
 });

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -2,7 +2,9 @@
 
 import { Hono } from "hono";
 import {
+  asGenerativeCacheApiError,
   type GenerativeRouteCaller,
+  getGenerativeOperationContext,
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -26,6 +28,10 @@ import {
   getTwitterConfigWithDefaults,
 } from "@/lib/services/automation-constants";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+} from "@/lib/services/generative-operation";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
@@ -47,6 +53,7 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
   caller: GenerativeRouteCaller,
+  operationContext: GenerativeOperationContext,
 ): Promise<Response> {
   const { user } = caller;
   const { id } = await params;
@@ -123,6 +130,7 @@ async function __hono_POST(
             await discordAppAutomationService.generateAnnouncement(
               user.organization_id,
               previewApp,
+              operationContext,
             );
           previews.push({
             platform: "discord",
@@ -132,6 +140,7 @@ async function __hono_POST(
           });
         }
       })().catch((error) => {
+        if (isGenerativeOperationAdmissionError(error)) throw error;
         const errorMessage =
           error instanceof Error ? error.message : "Unknown error";
         logger.error("[Promote Preview API] Discord generation failed", {
@@ -157,6 +166,7 @@ async function __hono_POST(
             await telegramAppAutomationService.generateAnnouncement(
               user.organization_id,
               previewApp,
+              operationContext,
             );
           previews.push({
             platform: "telegram",
@@ -166,6 +176,7 @@ async function __hono_POST(
           });
         }
       })().catch((error) => {
+        if (isGenerativeOperationAdmissionError(error)) throw error;
         const errorMessage =
           error instanceof Error ? error.message : "Unknown error";
         logger.error("[Promote Preview API] Telegram generation failed", {
@@ -191,6 +202,7 @@ async function __hono_POST(
             user.organization_id,
             previewApp,
             tweetTypes[i % tweetTypes.length],
+            operationContext,
           );
           previews.push({
             platform: "twitter",
@@ -200,6 +212,7 @@ async function __hono_POST(
           });
         }
       })().catch((error) => {
+        if (isGenerativeOperationAdmissionError(error)) throw error;
         const errorMessage =
           error instanceof Error ? error.message : "Unknown error";
         logger.error("[Promote Preview API] Twitter generation failed", {
@@ -242,9 +255,10 @@ __hono_app.post("/", async (c) => {
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
+      getGenerativeOperationContext(c, caller),
     );
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -1,7 +1,11 @@
 // Handles v1 cloud API v1 apps id promote route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -11,7 +15,7 @@ import {
   type PromotionConfig,
 } from "@/lib/services/app-promotion";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const SocialPlatformSchema = z.enum([
   "twitter",
@@ -171,7 +175,7 @@ async function __hono_GET(
 }
 
 async function __hono_POST(
-  request: Request,
+  c: AppContext,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
 ) {
@@ -181,7 +185,7 @@ async function __hono_POST(
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const body = await request.json();
+  const body = await c.req.json();
   const parsed = PromotionConfigSchema.safeParse(body);
 
   if (!parsed.success) {
@@ -270,6 +274,7 @@ async function __hono_POST(
     user.id,
     id,
     config,
+    getGenerativeOperationContext(c, caller),
   );
 
   logger.info("[Promote API] Promotion complete", {
@@ -295,12 +300,12 @@ __hono_app.post("/", async (c) => {
       rateLimitEndpoint: "strict",
     });
     return await __hono_POST(
-      c.req.raw,
+      c,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
     );
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/review/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/review/route.ts
@@ -10,7 +10,11 @@
  */
 
 import { Hono } from "hono";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
@@ -50,6 +54,7 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
     const review = await runAppReview({
       app: appRow,
       triggeredByUserId: user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
 
     logger.info("[AppReview API] Submitted app for review", {
@@ -72,7 +77,7 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
     });
   } catch (error) {
     logger.error("[AppReview API] Review submission failed", { error });
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -11,8 +11,16 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { z } from "zod";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+} from "@/lib/services/generative-operation";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -26,6 +34,7 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
+  operationContext: GenerativeOperationContext,
 ): Promise<Response> {
   const { user } = caller;
   const { id: appId } = await params;
@@ -54,6 +63,7 @@ async function __hono_POST(
       appId,
       body.text,
       chatIdOverride,
+      operationContext,
     );
 
     if (!result.success) {
@@ -76,6 +86,7 @@ async function __hono_POST(
       chatId: result.chatId,
     });
   } catch (error) {
+    if (isGenerativeOperationAdmissionError(error)) throw error;
     if (error instanceof Error && error.message === "App not found") {
       return Response.json({ error: "App not found" }, { status: 404 });
     }
@@ -97,9 +108,10 @@ __hono_app.post("/", async (c) => {
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
+      getGenerativeOperationContext(c, caller),
     );
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default __hono_app;

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -1,9 +1,17 @@
 // Handles v1 cloud API v1 apps id twitter automation post route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
-import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+} from "@/lib/services/generative-operation";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -19,6 +27,7 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
+  operationContext: GenerativeOperationContext,
 ): Promise<Response> {
   const { user } = caller;
   const { id } = await params;
@@ -47,6 +56,7 @@ async function __hono_POST(
       user.organization_id,
       id,
       parsed.data.text,
+      operationContext,
     );
 
     if (!result.success) {
@@ -63,14 +73,9 @@ async function __hono_POST(
       tweetUrl: result.tweetUrl,
     });
   } catch (error) {
+    if (isGenerativeOperationAdmissionError(error)) throw error;
     if (error instanceof Error && error.message === "App not found") {
       return Response.json({ error: "App not found" }, { status: 404 });
-    }
-    if (
-      error instanceof Error &&
-      error.message.includes("Insufficient credits")
-    ) {
-      return Response.json({ error: error.message }, { status: 402 });
     }
     logger.error("[Twitter Automation API] Failed to post tweet", {
       appId: id,
@@ -93,9 +98,10 @@ __hono_app.post("/", async (c) => {
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
+      getGenerativeOperationContext(c, caller),
     );
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default __hono_app;

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.json.test.ts
@@ -6,16 +6,25 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
-const requireAuthOrApiKeyWithOrg = mock(async () => ({
+const requireGenerativeRouteCaller = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
-  apiKey: null,
+  apiKeyId: null,
+  authSource: "combined_cache",
+  appScopeId: null,
 }));
 const executeHostedBrowserCommand = mock(async () => ({
   ok: true,
 }));
 
-mock.module("@/lib/auth", () => ({
-  requireAuthOrApiKeyWithOrg,
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: () => null,
+  requireGenerativeRouteCaller,
+  getGenerativeOperationContext: () => ({
+    organizationId: "org-1",
+    userId: "user-1",
+    apiKeyId: null,
+    requestId: "request-1",
+  }),
 }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {} },

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
@@ -2,13 +2,16 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { getErrorStatusCode, getSafeErrorMessage } from "@/lib/api/errors";
 import {
   nextStyleParams,
   type RouteContext,
 } from "@/lib/api/hono-next-style-params";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -18,7 +21,7 @@ import {
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const commandSchema = z.object({
   id: z.string().trim().optional(),
@@ -46,13 +49,13 @@ const commandSchema = z.object({
 });
 
 async function handlePOST(
-  request: Request,
+  c: AppContext,
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const authResult = await requireAuthOrApiKeyWithOrg(request);
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
-    const decodedRawBody = await decodeRequestJson(request);
+    const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -70,19 +73,17 @@ async function handlePOST(
     }
 
     const result = await executeHostedBrowserCommand(id, bodyResult.data, {
-      apiKeyId: authResult.apiKey?.id ?? null,
-      organizationId: authResult.user.organization_id,
+      apiKeyId: caller.apiKeyId,
+      organizationId: caller.user.organization_id,
       requestSource: "api",
-      userId: authResult.user.id,
+      userId: caller.user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
 
     return Response.json(result);
   } catch (error) {
     logHostedBrowserFailure("browser_command", error);
-    return Response.json(
-      { error: getSafeErrorMessage(error) },
-      { status: getErrorStatusCode(error) },
-    );
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 }
 
@@ -90,9 +91,9 @@ const ROUTE_PARAM_SPEC = [{ name: "id", splat: false }] as const;
 const honoRouter = new Hono<AppEnv>();
 honoRouter.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handlePOST(c.req.raw, nextStyleParams(c, ROUTE_PARAM_SPEC));
+    return await handlePOST(c, nextStyleParams(c, ROUTE_PARAM_SPEC));
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default honoRouter;

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.json.test.ts
@@ -6,17 +6,26 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
-const requireAuthOrApiKeyWithOrg = mock(async () => ({
+const requireGenerativeRouteCaller = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
-  apiKey: null,
+  apiKeyId: null,
+  authSource: "combined_cache",
+  appScopeId: null,
 }));
 const navigateHostedBrowserSession = mock(async () => ({
   id: "sess-1",
   url: "https://example.com",
 }));
 
-mock.module("@/lib/auth", () => ({
-  requireAuthOrApiKeyWithOrg,
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: () => null,
+  requireGenerativeRouteCaller,
+  getGenerativeOperationContext: () => ({
+    organizationId: "org-1",
+    userId: "user-1",
+    apiKeyId: null,
+    requestId: "request-1",
+  }),
 }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {} },

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
@@ -2,13 +2,16 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { getErrorStatusCode, getSafeErrorMessage } from "@/lib/api/errors";
 import {
   nextStyleParams,
   type RouteContext,
 } from "@/lib/api/hono-next-style-params";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -18,20 +21,20 @@ import {
   navigateHostedBrowserSession,
 } from "@/lib/services/browser-tools";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const navigateSchema = z.object({
   url: z.string().trim().url().max(2_000),
 });
 
 async function handlePOST(
-  request: Request,
+  c: AppContext,
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const authResult = await requireAuthOrApiKeyWithOrg(request);
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
-    const decodedRawBody = await decodeRequestJson(request);
+    const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -52,20 +55,18 @@ async function handlePOST(
       id,
       bodyResult.data.url,
       {
-        apiKeyId: authResult.apiKey?.id ?? null,
-        organizationId: authResult.user.organization_id,
+        apiKeyId: caller.apiKeyId,
+        organizationId: caller.user.organization_id,
         requestSource: "api",
-        userId: authResult.user.id,
+        userId: caller.user.id,
+        operationContext: getGenerativeOperationContext(c, caller),
       },
     );
 
     return Response.json({ session });
   } catch (error) {
     logHostedBrowserFailure("browser_navigate", error);
-    return Response.json(
-      { error: getSafeErrorMessage(error) },
-      { status: getErrorStatusCode(error) },
-    );
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 }
 
@@ -73,9 +74,9 @@ const ROUTE_PARAM_SPEC = [{ name: "id", splat: false }] as const;
 const honoRouter = new Hono<AppEnv>();
 honoRouter.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handlePOST(c.req.raw, nextStyleParams(c, ROUTE_PARAM_SPEC));
+    return await handlePOST(c, nextStyleParams(c, ROUTE_PARAM_SPEC));
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default honoRouter;

--- a/packages/cloud/api/v1/browser/sessions/[id]/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/route.ts
@@ -1,12 +1,15 @@
 // Handles v1 cloud API v1 browser sessions id route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { getErrorStatusCode, getSafeErrorMessage } from "@/lib/api/errors";
 import {
   nextStyleParams,
   type RouteContext,
 } from "@/lib/api/hono-next-style-params";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -16,43 +19,39 @@ import {
   getHostedBrowserSession,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
-async function handleGET(
-  request: Request,
-  context: RouteContext<{ id: string }>,
-) {
+async function handleGET(c: AppContext, context: RouteContext<{ id: string }>) {
   try {
-    const authResult = await requireAuthOrApiKeyWithOrg(request);
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
     const session = await getHostedBrowserSession(id, {
-      apiKeyId: authResult.apiKey?.id ?? null,
-      organizationId: authResult.user.organization_id,
+      apiKeyId: caller.apiKeyId,
+      organizationId: caller.user.organization_id,
       requestSource: "api",
-      userId: authResult.user.id,
+      userId: caller.user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
     return Response.json({ session });
   } catch (error) {
     logHostedBrowserFailure("browser_get", error);
-    return Response.json(
-      { error: getSafeErrorMessage(error) },
-      { status: getErrorStatusCode(error) },
-    );
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 }
 
 async function handleDELETE(
-  request: Request,
+  c: AppContext,
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const authResult = await requireAuthOrApiKeyWithOrg(request);
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
     const result = await deleteHostedBrowserSession(id, {
-      apiKeyId: authResult.apiKey?.id ?? null,
-      organizationId: authResult.user.organization_id,
+      apiKeyId: caller.apiKeyId,
+      organizationId: caller.user.organization_id,
       requestSource: "api",
-      userId: authResult.user.id,
+      userId: caller.user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
     return Response.json({
       closed: result.success === true,
@@ -61,10 +60,7 @@ async function handleDELETE(
     });
   } catch (error) {
     logHostedBrowserFailure("browser_delete", error);
-    return Response.json(
-      { error: getSafeErrorMessage(error) },
-      { status: getErrorStatusCode(error) },
-    );
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 }
 
@@ -72,16 +68,16 @@ const ROUTE_PARAM_SPEC = [{ name: "id", splat: false }] as const;
 const honoRouter = new Hono<AppEnv>();
 honoRouter.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handleGET(c.req.raw, nextStyleParams(c, ROUTE_PARAM_SPEC));
+    return await handleGET(c, nextStyleParams(c, ROUTE_PARAM_SPEC));
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 honoRouter.delete("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handleDELETE(c.req.raw, nextStyleParams(c, ROUTE_PARAM_SPEC));
+    return await handleDELETE(c, nextStyleParams(c, ROUTE_PARAM_SPEC));
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default honoRouter;

--- a/packages/cloud/api/v1/browser/sessions/[id]/snapshot/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/snapshot/route.ts
@@ -1,12 +1,15 @@
 // Handles v1 cloud API v1 browser sessions id snapshot route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { getErrorStatusCode, getSafeErrorMessage } from "@/lib/api/errors";
 import {
   nextStyleParams,
   type RouteContext,
 } from "@/lib/api/hono-next-style-params";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -15,28 +18,23 @@ import {
   getHostedBrowserSnapshot,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
-async function handleGET(
-  request: Request,
-  context: RouteContext<{ id: string }>,
-) {
+async function handleGET(c: AppContext, context: RouteContext<{ id: string }>) {
   try {
-    const authResult = await requireAuthOrApiKeyWithOrg(request);
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
     const snapshot = await getHostedBrowserSnapshot(id, {
-      apiKeyId: authResult.apiKey?.id ?? null,
-      organizationId: authResult.user.organization_id,
+      apiKeyId: caller.apiKeyId,
+      organizationId: caller.user.organization_id,
       requestSource: "api",
-      userId: authResult.user.id,
+      userId: caller.user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
     return Response.json(snapshot);
   } catch (error) {
     logHostedBrowserFailure("browser_snapshot", error);
-    return Response.json(
-      { error: getSafeErrorMessage(error) },
-      { status: getErrorStatusCode(error) },
-    );
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 }
 
@@ -44,9 +42,9 @@ const ROUTE_PARAM_SPEC = [{ name: "id", splat: false }] as const;
 const honoRouter = new Hono<AppEnv>();
 honoRouter.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handleGET(c.req.raw, nextStyleParams(c, ROUTE_PARAM_SPEC));
+    return await handleGET(c, nextStyleParams(c, ROUTE_PARAM_SPEC));
   } catch (error) {
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 export default honoRouter;

--- a/packages/cloud/api/v1/browser/sessions/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.json.test.ts
@@ -7,10 +7,19 @@ const createHostedBrowserSession = mock(async () => ({
   url: "https://example.com",
 }));
 
-mock.module("@/lib/auth/workers-hono-auth", () => ({
-  requireUserOrApiKeyWithOrg: async () => ({
-    id: "user-1",
-    organization_id: "org-1",
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: () => null,
+  requireGenerativeRouteCaller: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+  getGenerativeOperationContext: () => ({
+    organizationId: "org-1",
+    userId: "user-1",
+    apiKeyId: null,
+    requestId: "request-1",
   }),
 }));
 
@@ -56,10 +65,10 @@ describe("POST /api/v1/browser/sessions malformed JSON", () => {
   });
 
   test("preserves non-syntax request decoding failures as server errors", async () => {
-    const originalJson = HonoRequest.prototype.json;
-    HonoRequest.prototype.json = mock(async () => {
+    const originalText = HonoRequest.prototype.text;
+    HonoRequest.prototype.text = mock(async () => {
       throw new Error("request stream failed");
-    }) as typeof HonoRequest.prototype.json;
+    }) as typeof HonoRequest.prototype.text;
 
     try {
       const response = await app.request("/", {
@@ -70,7 +79,7 @@ describe("POST /api/v1/browser/sessions malformed JSON", () => {
       expect(response.status).toBe(500);
       expect(createHostedBrowserSession).not.toHaveBeenCalled();
     } finally {
-      HonoRequest.prototype.json = originalJson;
+      HonoRequest.prototype.text = originalText;
     }
   });
 });

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -5,8 +5,12 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -33,23 +37,26 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const caller = await requireGenerativeRouteCaller(c);
+    const { user } = caller;
     const sessions = await listHostedBrowserSessions({
       apiKeyId: null,
       organizationId: user.organization_id,
       requestSource: "api",
       userId: user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
     return c.json({ sessions });
   } catch (error) {
     logHostedBrowserFailure("browser_list", error);
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const caller = await requireGenerativeRouteCaller(c);
+    const { user } = caller;
     const decodedBody = await decodeRequestJson(c.req);
     if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
@@ -68,15 +75,16 @@ app.post("/", async (c) => {
     }
 
     const session = await createHostedBrowserSession(bodyResult.data, {
-      apiKeyId: null,
+      apiKeyId: caller.apiKeyId,
       organizationId: user.organization_id,
       requestSource: "api",
       userId: user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
     return c.json({ session });
   } catch (error) {
     logHostedBrowserFailure("browser_create", error);
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 

--- a/packages/cloud/api/v1/extract/route.json.test.ts
+++ b/packages/cloud/api/v1/extract/route.json.test.ts
@@ -13,10 +13,18 @@ import type {
 const USER_ID = "00000000-0000-4000-8000-0000000000aa";
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
 
-const requireUserOrApiKeyWithOrg = mock(async () => ({
-  id: USER_ID,
-  organization_id: ORG_ID,
+const requireGenerativeRouteCaller = mock(async () => ({
+  user: { id: USER_ID, organization_id: ORG_ID },
+  apiKeyId: "key-1",
+  authSource: "combined_cache",
+  appScopeId: null,
 }));
+const operationContext = {
+  organizationId: ORG_ID,
+  userId: USER_ID,
+  apiKeyId: "key-1",
+  requestId: "request-1",
+};
 
 const extractHostedPage = mock(
   async (
@@ -34,8 +42,10 @@ const failureResponse = mock(
     c.json({ success: false, error: "An unexpected error occurred" }, 500),
 );
 
-mock.module("@/lib/auth/workers-hono-auth", () => ({
-  requireUserOrApiKeyWithOrg,
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: () => null,
+  requireGenerativeRouteCaller,
+  getGenerativeOperationContext: () => operationContext,
 }));
 
 mock.module("@/lib/services/browser-tools", () => ({
@@ -71,7 +81,7 @@ function post(raw: string) {
 
 describe("POST /api/v1/extract JSON body", () => {
   beforeEach(() => {
-    requireUserOrApiKeyWithOrg.mockClear();
+    requireGenerativeRouteCaller.mockClear();
     extractHostedPage.mockClear();
     logHostedBrowserFailure.mockClear();
     failureResponse.mockClear();
@@ -90,7 +100,7 @@ describe("POST /api/v1/extract JSON body", () => {
         success: false,
         error: "Invalid JSON body",
       });
-      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalled();
+      expect(requireGenerativeRouteCaller).toHaveBeenCalled();
       expect(extractHostedPage).not.toHaveBeenCalled();
       expect(logHostedBrowserFailure).not.toHaveBeenCalled();
       expect(failureResponse).not.toHaveBeenCalled();
@@ -104,6 +114,19 @@ describe("POST /api/v1/extract JSON body", () => {
     const body = (await res.json()) as { error?: string };
     expect(body.error).toBe("Invalid extract request");
     expect(extractHostedPage).not.toHaveBeenCalled();
+  });
+
+  test("never dispatches extraction when account-standing admission fails", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new Error("account not in good standing"),
+    );
+
+    const res = await post(JSON.stringify({ url: "https://example.com" }));
+
+    expect(res.status).toBe(500);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(extractHostedPage).not.toHaveBeenCalled();
+    expect(failureResponse).toHaveBeenCalledTimes(1);
   });
 
   test("still extracts a canonical object body", async () => {

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -5,8 +5,12 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -35,7 +39,8 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const caller = await requireGenerativeRouteCaller(c);
+    const { user } = caller;
     const decodedBody = await decodeRequestJson(c.req);
     if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
@@ -55,16 +60,17 @@ app.post("/", async (c) => {
     }
 
     const result = await extractHostedPage(bodyResult.data, {
-      apiKeyId: null,
+      apiKeyId: caller.apiKeyId,
       organizationId: user.organization_id,
       requestSource: "api",
       userId: user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
     });
 
     return c.json(result);
   } catch (error) {
     logHostedBrowserFailure("extract_page", error);
-    return failureResponse(c, error);
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -23,15 +23,19 @@
 import { Hono } from "hono";
 import {
   asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import {
+  createHfProxyEgressQuotaStore,
+  type HfProxyEgressQuotaStore,
+} from "@/lib/services/hf-proxy-egress-quota";
 import { logger, redact } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const HF_UPSTREAM_HOST = "https://huggingface.co";
 const DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES = 500 * 1024 ** 3;
-const MONTHLY_EGRESS_TTL_SECONDS = 35 * 24 * 60 * 60;
 
 /**
  * Only repos under this org may be proxied. The curated eliza-1 catalog lives at
@@ -77,13 +81,6 @@ const PASSTHROUGH_RESPONSE_HEADERS = [
 
 const app = new Hono<AppEnv>();
 
-interface EgressCounter {
-  bytes: number;
-  expiresAt: number;
-}
-
-const inMemoryEgressCounters = new Map<string, EgressCounter>();
-
 function monthlyEgressLimitBytes(env: AppEnv["Bindings"]): number {
   const raw = env.HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES;
   const parsed =
@@ -107,63 +104,6 @@ function retryAfterUntilNextUtcMonth(now: Date): string {
     (nextMonthStartedAt - now.getTime()) / 1000,
   );
   return String(Math.max(1, secondsUntilReset));
-}
-
-function egressKey(organizationId: string, now = new Date()): string {
-  return `hf-proxy:egress:${organizationId}:${monthBucket(now)}`;
-}
-
-async function readMonthlyEgress(
-  env: AppEnv["Bindings"],
-  organizationId: string,
-  bucketNow = new Date(),
-): Promise<number> {
-  const key = egressKey(organizationId, bucketNow);
-  const kv = env.CACHE_KV;
-  if (kv) {
-    const raw = await kv.get(key);
-    if (!raw) return 0;
-    try {
-      const parsed = JSON.parse(raw) as { bytes?: unknown };
-      return typeof parsed.bytes === "number" ? parsed.bytes : 0;
-    } catch {
-      return 0;
-    }
-  }
-
-  const now = Date.now();
-  const counter = inMemoryEgressCounters.get(key);
-  if (!counter || counter.expiresAt <= now) {
-    inMemoryEgressCounters.delete(key);
-    return 0;
-  }
-  return counter.bytes;
-}
-
-async function addMonthlyEgress(
-  env: AppEnv["Bindings"],
-  organizationId: string,
-  bytes: number,
-): Promise<number> {
-  if (bytes <= 0) return readMonthlyEgress(env, organizationId);
-
-  const key = egressKey(organizationId);
-  const kv = env.CACHE_KV;
-  const current = await readMonthlyEgress(env, organizationId);
-  const next = current + bytes;
-  const value = JSON.stringify({
-    bytes: next,
-    updatedAt: new Date().toISOString(),
-  });
-  if (kv) {
-    await kv.put(key, value, { expirationTtl: MONTHLY_EGRESS_TTL_SECONDS });
-  } else {
-    inMemoryEgressCounters.set(key, {
-      bytes: next,
-      expiresAt: Date.now() + MONTHLY_EGRESS_TTL_SECONDS * 1000,
-    });
-  }
-  return next;
 }
 
 function parseContentLength(headers: Headers): number | null {
@@ -198,8 +138,11 @@ function egressLimitResponse(
 
 function streamWithEgressAccounting(args: {
   body: ReadableStream<Uint8Array>;
-  env: AppEnv["Bindings"];
+  quota: HfProxyEgressQuotaStore;
   organizationId: string;
+  month: string;
+  limitBytes: number;
+  reservedBytes: number;
   repo: string;
   path: string;
   status: number;
@@ -208,28 +151,39 @@ function streamWithEgressAccounting(args: {
   let bytes = 0;
   return args.body.pipeThrough(
     new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
+      async transform(chunk, controller) {
+        const nextBytes = bytes + chunk.byteLength;
+        if (nextBytes > args.reservedBytes) {
+          const decision = await args.quota.reserve(
+            args.organizationId,
+            args.month,
+            nextBytes - args.reservedBytes,
+            args.limitBytes,
+          );
+          if (!decision.allowed) {
+            throw new Error(
+              "Hugging Face egress quota exhausted while streaming",
+            );
+          }
+          args.reservedBytes = nextBytes;
+        }
         bytes += chunk.byteLength;
         controller.enqueue(chunk);
       },
       async flush() {
-        const record = addMonthlyEgress(
-          args.env,
-          args.organizationId,
+        const excess = args.reservedBytes - bytes;
+        if (excess > 0) {
+          await args.quota.release(args.organizationId, args.month, excess);
+        }
+        logger.info("[hf-proxy] egress metric", {
+          organizationId: args.organizationId,
+          repo: args.repo,
+          path: args.path,
           bytes,
-        ).then((usedBytes) => {
-          logger.info("[hf-proxy] egress metric", {
-            organizationId: args.organizationId,
-            repo: args.repo,
-            path: args.path,
-            bytes,
-            status: args.status,
-            cacheStatus: args.cacheStatus,
-            cacheHit: cacheHit(args.cacheStatus),
-            usedBytes,
-          });
+          status: args.status,
+          cacheStatus: args.cacheStatus,
+          cacheHit: cacheHit(args.cacheStatus),
         });
-        await record;
       },
     }),
   );
@@ -281,14 +235,31 @@ app.get("/*", async (c) => {
     }
 
     const limitBytes = monthlyEgressLimitBytes(c.env);
-    // Pin quota lookup and reset advice to one instant so a request at the UTC
-    // month boundary cannot read one bucket and advertise another reset.
+    const quota = createHfProxyEgressQuotaStore(c.env);
+    if (!quota) {
+      logger.error("[hf-proxy] atomic egress quota store is unavailable");
+      return c.json(
+        { error: "HuggingFace proxy quota service is unavailable." },
+        503,
+        { "Retry-After": "1" },
+      );
+    }
+    // Pin admission and reset advice to one instant so a request at the UTC
+    // month boundary cannot reserve one bucket and advertise another reset.
     const egressNow = new Date();
-    const usedBytes = await readMonthlyEgress(c.env, orgId, egressNow);
-    if (usedBytes >= limitBytes) {
-      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429, {
-        "Retry-After": retryAfterUntilNextUtcMonth(egressNow),
-      });
+    const month = monthBucket(egressNow);
+    // Reserve one byte atomically before the paid provider request. Known
+    // response lengths expand this reservation before any body is delivered;
+    // unknown-length streams reserve each chunk before enqueueing it.
+    const initialAdmission = await quota.reserve(orgId, month, 1, limitBytes);
+    if (!initialAdmission.allowed) {
+      return c.json(
+        egressLimitResponse(orgId, limitBytes, initialAdmission.usedBytes),
+        429,
+        {
+          "Retry-After": retryAfterUntilNextUtcMonth(egressNow),
+        },
+      );
     }
 
     const incomingUrl = new URL(c.req.url);
@@ -302,11 +273,20 @@ app.get("/*", async (c) => {
     const range = c.req.header("range");
     if (range) headers.set("range", range);
 
-    const upstreamResponse = await fetch(upstream, {
-      method: "GET",
-      headers,
-      redirect: "follow",
-    });
+    let upstreamResponse: Response;
+    try {
+      upstreamResponse = await fetch(upstream, {
+        method: "GET",
+        headers,
+        redirect: "follow",
+      });
+    } catch (error) {
+      const release = quota.release(orgId, month, 1);
+      const executionCtx = getGenerativeExecutionContext(c);
+      if (executionCtx) executionCtx.waitUntil(release);
+      else await release;
+      throw error;
+    }
 
     if (upstreamResponse.status >= 400) {
       logger.warn("[hf-proxy] upstream HuggingFace error", {
@@ -338,8 +318,12 @@ app.get("/*", async (c) => {
         status: upstreamResponse.status,
         cacheStatus: upstreamCacheStatus,
         cacheHit: cacheHit(upstreamCacheStatus),
-        usedBytes,
+        usedBytes: initialAdmission.usedBytes - 1,
       });
+      const release = quota.release(orgId, month, 1);
+      const executionCtx = getGenerativeExecutionContext(c);
+      if (executionCtx) executionCtx.waitUntil(release);
+      else await release;
       return c.json(
         {
           error: "HuggingFace repo is gated or unauthorized.",
@@ -350,10 +334,31 @@ app.get("/*", async (c) => {
       );
     }
 
-    if (contentLength !== null && usedBytes + contentLength > limitBytes) {
-      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429, {
-        "Retry-After": retryAfterUntilNextUtcMonth(egressNow),
-      });
+    let reservedBytes = 1;
+    if (contentLength !== null && contentLength > 1) {
+      const expanded = await quota.reserve(
+        orgId,
+        month,
+        contentLength - 1,
+        limitBytes,
+      );
+      if (!expanded.allowed) {
+        await upstreamResponse.body?.cancel();
+        const release = quota.release(orgId, month, 1);
+        const executionCtx = getGenerativeExecutionContext(c);
+        if (executionCtx) executionCtx.waitUntil(release);
+        else await release;
+        return c.json(
+          egressLimitResponse(
+            orgId,
+            limitBytes,
+            Math.max(0, expanded.usedBytes - 1),
+          ),
+          429,
+          { "Retry-After": retryAfterUntilNextUtcMonth(egressNow) },
+        );
+      }
+      reservedBytes = contentLength;
     }
 
     const responseHeaders = new Headers();
@@ -365,8 +370,11 @@ app.get("/*", async (c) => {
     const body = upstreamResponse.body
       ? streamWithEgressAccounting({
           body: upstreamResponse.body,
-          env: c.env,
+          quota,
           organizationId: orgId,
+          month,
+          limitBytes,
+          reservedBytes,
           repo,
           path,
           status: upstreamResponse.status,

--- a/packages/cloud/api/v1/rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/rpc/[chain]/route.ts
@@ -1,5 +1,9 @@
 // Handles v1 cloud API v1 rpc chain route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import {
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { createHandler } from "@/lib/services/proxy/engine";
 import {
@@ -8,7 +12,7 @@ import {
   rpcHandlerForChain,
   SUPPORTED_RPC_CHAINS,
 } from "@/lib/services/proxy/services/rpc";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "POST, OPTIONS";
 
@@ -17,7 +21,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_POST(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string }> },
 ) {
   const { chain } = await params;
@@ -34,14 +38,35 @@ async function __hono_POST(
   }
 
   const config = rpcConfigForChain(normalized);
-  const handler = createHandler(config, rpcHandlerForChain(normalized));
-  return applyCorsHeaders(await handler(request), CORS_METHODS);
+  const caller = await requireGenerativeRouteCaller(c, {
+    rateLimitEndpoint: "standard",
+  });
+  const executionCtx = getGenerativeExecutionContext(c);
+  if (executionCtx && !caller.admissionSnapshot) {
+    return applyCorsHeaders(
+      Response.json(
+        { error: "Provider admission is unavailable; retry shortly" },
+        { status: 503, headers: { "Retry-After": "1" } },
+      ),
+      CORS_METHODS,
+    );
+  }
+  const handler = createHandler(config, rpcHandlerForChain(normalized), {
+    auth: {
+      user: caller.user,
+      ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
+    },
+    admissionSnapshot: caller.admissionSnapshot,
+    executionCtx,
+    requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
+  });
+  return applyCorsHeaders(await handler(c.req.raw), CORS_METHODS);
 }
 
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
+  __hono_POST(c, {
     params: Promise.resolve({ chain: c.req.param("chain")! }),
   }),
 );

--- a/packages/cloud/api/v1/search/route.json.test.ts
+++ b/packages/cloud/api/v1/search/route.json.test.ts
@@ -1,5 +1,12 @@
 /** Verifies the hosted-search JSON boundary with deterministic auth and provider mocks. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  getGenerativeOperationContext,
+  paidBoundaryState,
+  requireGenerativeKnownIdentity,
+  requireGenerativeRouteCaller,
+  resetPaidBoundaryRouteMocks,
+} from "../../__tests__/paid-boundary-route-test-mocks";
 
 const executeHostedGoogleSearch = mock(
   async (
@@ -7,12 +14,11 @@ const executeHostedGoogleSearch = mock(
     _context: unknown,
   ) => ({ results: [] }),
 );
-const requireAuthOrApiKeyWithOrg = mock(async () => ({
-  user: { id: "user-1", organization_id: "org-1" },
-  apiKey: { id: "key-1" },
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  getGenerativeOperationContext,
+  requireGenerativeKnownIdentity,
+  requireGenerativeRouteCaller,
 }));
-
-mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { STANDARD: {}, STRICT: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
@@ -29,6 +35,7 @@ const { default: app } = await import("./route");
 describe("POST /api/v1/search malformed JSON", () => {
   beforeEach(() => {
     executeHostedGoogleSearch.mockClear();
+    resetPaidBoundaryRouteMocks();
   });
 
   test("returns 400 instead of 500 and never searches", async () => {
@@ -71,6 +78,22 @@ describe("POST /api/v1/search malformed JSON", () => {
     });
     expect(response.status).toBe(200);
     expect(executeHostedGoogleSearch).toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(getGenerativeOperationContext).toHaveBeenCalledTimes(1);
+  });
+
+  test("standing denial performs one combined auth read and never dispatches search", async () => {
+    paidBoundaryState.routeError = new Error("cached standing denied");
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "elizaos" }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(getGenerativeOperationContext).not.toHaveBeenCalled();
+    expect(executeHostedGoogleSearch).not.toHaveBeenCalled();
   });
 
   test("passes through an explicit result count above the former hidden cap", async () => {

--- a/packages/cloud/api/v1/search/route.ts
+++ b/packages/cloud/api/v1/search/route.ts
@@ -1,16 +1,19 @@
 // Handles v1 cloud API v1 search route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  getGenerativeOperationContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { getErrorStatusCode, getSafeErrorMessage } from "@/lib/api/errors";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { executeHostedGoogleSearch } from "@/lib/services/google-search";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const searchRequestSchema = z.object({
   query: z.string().trim().min(1).max(2_000),
@@ -25,12 +28,11 @@ const searchRequestSchema = z.object({
   endDate: z.string().trim().min(1).max(32).optional(),
 });
 
-async function handlePOST(req: Request) {
+async function handlePOST(c: AppContext) {
   try {
-    const authResult = await requireAuthOrApiKeyWithOrg(req);
     let raw: unknown;
     try {
-      raw = await req.json();
+      raw = await c.req.raw.json();
     } catch (error) {
       if (!(error instanceof SyntaxError)) throw error;
       // error-policy:J3 malformed JSON is an explicit invalid request.
@@ -49,6 +51,10 @@ async function handlePOST(req: Request) {
     }
 
     const body = bodyResult.data;
+    const caller = await requireGenerativeRouteCaller(c, {
+      compatibility: "raw",
+      rateLimitEndpoint: "standard",
+    });
     const result = await executeHostedGoogleSearch(
       {
         query: body.query,
@@ -61,9 +67,7 @@ async function handlePOST(req: Request) {
         endDate: body.endDate,
       },
       {
-        organizationId: authResult.user.organization_id,
-        userId: authResult.user.id,
-        apiKeyId: authResult.apiKey?.id ?? null,
+        ...getGenerativeOperationContext(c, caller),
         requestSource: "api",
       },
     );
@@ -86,7 +90,7 @@ async function handlePOST(req: Request) {
 const honoRouter = new Hono<AppEnv>();
 honoRouter.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handlePOST(c.req.raw);
+    return await handlePOST(c);
   } catch (error) {
     return failureResponse(c, error);
   }

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
@@ -263,11 +263,18 @@ describe("voice-session ws upgrade (happy path)", () => {
     expect(buildCapturedSession().config.usageStore).toBe(durableStoreValue);
   });
 
-  test("falls back to the in-memory store when no durable store is available", async () => {
+  test("uses the in-memory store only for an explicit mock runtime", async () => {
     durableStoreValue = null;
-    const res = await upgrade();
+    const res = await upgrade({ MOCK_REDIS: "1" });
     expect(res.status).toBe(101);
     expect(buildCapturedSession().config.usageStore).not.toBeNull();
+  });
+
+  test("denies production provider startup when atomic metering is unavailable", async () => {
+    durableStoreValue = null;
+    const res = await upgrade();
+    expect(res.status).toBe(503);
+    expect(attachCalls).toHaveLength(0);
   });
 
   test("still upgrades when the live registry is under the ceiling; admitSession reflects it", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -79,7 +79,7 @@ const HALF_DUPLEX_PLAYBACK_SETTLE_MS = 600;
 /** Accrue metered minutes in whole seconds to keep the store's math simple. */
 const METER_FLUSH_SECONDS = 5;
 /** Nominal minutes charged on admission before ANY audio is forwarded (SEC-15). */
-const ADMISSION_MINUTES = METER_FLUSH_SECONDS / 60;
+export const VOICE_PROVIDER_ADMISSION_MINUTES = METER_FLUSH_SECONDS / 60;
 /** Cap pre-admission buffered frames so an in-flight check can't be flooded. */
 const MAX_PREADMISSION_FRAMES = 64; // ~5s of 80ms frames.
 /** Cover provider WebSocket setup without dropping the user's first words. */
@@ -228,6 +228,8 @@ export interface VoiceSessionConfig {
   // Metering (SEC-15). Server-derived only.
   usageStore: VoiceUsageStore;
   usageLimits: VoiceUsageLimits;
+  /** Initial window already atomically recorded immediately before start(). */
+  initialUsageAdmissionMinutes?: number;
 
   downlink: VoiceSessionDownlink;
   registry?: VoiceSessionRegistry;
@@ -345,6 +347,19 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       organizationId: config.organizationId,
       userId: config.userId,
     };
+    if (config.initialUsageAdmissionMinutes !== undefined) {
+      if (
+        !Number.isFinite(config.initialUsageAdmissionMinutes) ||
+        config.initialUsageAdmissionMinutes <= 0
+      ) {
+        throw new RangeError("initial voice usage admission must be positive");
+      }
+      this.meteringAdmitted = true;
+      this.turnSttMs = Math.round(config.initialUsageAdmissionMinutes * 60_000);
+      this.unmeteredUplinkBytes = -Math.round(
+        config.initialUsageAdmissionMinutes * 60 * PCM16_BYTES_PER_SECOND,
+      );
+    }
     this.cartesiaAdapter = new CartesiaSonicTtsAdapter({
       apiKey: config.cartesiaApiKey,
       voiceId: config.cartesiaVoiceId,
@@ -751,7 +766,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       try {
         const decision = await this.config.usageStore.checkAndRecord(
           this.usageIdentity,
-          ADMISSION_MINUTES,
+          VOICE_PROVIDER_ADMISSION_MINUTES,
           this.config.usageLimits,
         );
         if (this.closed) return;
@@ -762,7 +777,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           return;
         }
         this.meteringAdmitted = true;
-        this.turnSttMs += Math.round(ADMISSION_MINUTES * 60_000);
+        this.turnSttMs += Math.round(VOICE_PROVIDER_ADMISSION_MINUTES * 60_000);
         // Release the buffered frames now that we are admitted.
         const buffered = this.preAdmissionFrames.splice(0);
         for (const frame of buffered) if (!this.forwardSttFrame(frame)) break;

--- a/packages/cloud/api/v1/voice/session/route.ts
+++ b/packages/cloud/api/v1/voice/session/route.ts
@@ -2,10 +2,10 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import { conversationsRepository } from "@/db/repositories/conversations";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { findActivePersonalDedicatedTarget } from "@/lib/services/agent-tier-upgrade-target";
 import {
   isPersonalSharedAgentId,
@@ -78,7 +78,14 @@ app.post("/", async (c) => {
     return c.json({ error: "voice session signing not configured" }, 503);
   }
 
-  const auth = await requireUserOrApiKeyWithOrg(c);
+  // The signed <=120s bootstrap token is the WebSocket's standing proof. Mint
+  // it only from the one combined identity/admission decision so provider
+  // start never joins a stale token to a second auth/cache read.
+  const caller = await requireGenerativeRouteCaller(c, {
+    rateLimitEndpoint: "standard",
+    awaitWarmingMs: 1_500,
+  });
+  const auth = caller.user;
 
   let body: z.infer<typeof MintBody>;
   try {

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -45,7 +45,7 @@ import {
   createWorkerFishAudioFactory,
   isWorkerOutboundWsAvailable,
 } from "../lib/provider-socket-factory";
-import { VoiceSession } from "../lib/session";
+import { VOICE_PROVIDER_ADMISSION_MINUTES, VoiceSession } from "../lib/session";
 
 /**
  * GET /api/v1/voice/session/ws?sessionId=... (contract §7.1/§7.2).
@@ -150,6 +150,24 @@ app.get("/", (c) => {
     return c.json({ error: "voice realtime transport unavailable" }, 503);
   }
 
+  const usageLimits = resolveVoiceUsageLimits(env);
+  // Paid provider admission must be atomic across Worker isolates. The
+  // isolate-local store is an explicit test/local substitute only; production
+  // refuses the upgrade when Redis EVAL is unavailable.
+  const durableStore = createDurableVoiceUsageStore(
+    env as unknown as Parameters<typeof createDurableVoiceUsageStore>[0],
+  );
+  const mockRedis = (c.env as unknown as { MOCK_REDIS?: string }).MOCK_REDIS;
+  const usageStore: VoiceUsageStore | null =
+    durableStore ?? (mockRedis === "1" ? getWorkerFallbackUsageStore() : null);
+  if (!usageStore) {
+    logger.error("[voice-session-ws] atomic usage admission unavailable");
+    return c.json({ error: "voice realtime metering unavailable" }, 503);
+  }
+  const rawRedis = buildRedisClient(
+    env as unknown as Parameters<typeof buildRedisClient>[0],
+  );
+
   const WebSocketPairCtor = (
     globalThis as { WebSocketPair?: new () => [unknown, unknown] }
   ).WebSocketPair;
@@ -187,18 +205,6 @@ app.get("/", (c) => {
 
   server.accept();
 
-  const usageLimits = resolveVoiceUsageLimits(env);
-  // Prefer durable, atomic cross-worker metering whenever the configured Redis
-  // exposes EVAL. SocketRedis and Upstash do; the non-Lua test mock does not.
-  const durableStore = createDurableVoiceUsageStore(
-    env as unknown as Parameters<typeof createDurableVoiceUsageStore>[0],
-  );
-  const usageStore: VoiceUsageStore =
-    durableStore ?? getWorkerFallbackUsageStore();
-  const rawRedis = buildRedisClient(
-    env as unknown as Parameters<typeof buildRedisClient>[0],
-  );
-
   const maxSessions = resolveMaxSessions(env);
   // Capture the request's platform handles while it is live. Late WebSocket
   // turns use the execution context to register cold scope hydration and the
@@ -228,7 +234,47 @@ app.get("/", (c) => {
     // Enforce the per-worker ceiling against the LIVE registry at start time,
     // closing the race where many upgrades pass the earlier route-level check.
     admitSession: () => getVoiceSessionRegistry().size() < maxSessions,
-    buildSession: ({ claims, jti, tokenExpSeconds, downlink }) => {
+    admitProviderSession: async ({ organizationId, userId }) => {
+      let decision: Awaited<ReturnType<VoiceUsageStore["checkAndRecord"]>>;
+      try {
+        decision = await usageStore.checkAndRecord(
+          { organizationId, userId },
+          VOICE_PROVIDER_ADMISSION_MINUTES,
+          usageLimits,
+        );
+      } catch (error) {
+        throw Object.assign(
+          new Error(
+            error instanceof Error ? error.message : "voice quota unavailable",
+          ),
+          { code: "metering_unavailable" },
+        );
+      }
+      if (!decision.allowed) {
+        throw Object.assign(new Error("voice quota exhausted"), {
+          code: "quota_exhausted",
+        });
+      }
+      return {
+        admittedMinutes: VOICE_PROVIDER_ADMISSION_MINUTES,
+        release: () =>
+          usageStore.release(
+            { organizationId, userId },
+            VOICE_PROVIDER_ADMISSION_MINUTES,
+          ),
+      };
+    },
+    defer: (promise) => {
+      if (voiceExecutionCtx) voiceExecutionCtx.waitUntil(promise);
+      else void promise;
+    },
+    buildSession: ({
+      claims,
+      jti,
+      tokenExpSeconds,
+      downlink,
+      initialUsageAdmissionMinutes,
+    }) => {
       logger.info("[voice-sse-context] websocket callback", {
         agentId: claims.agentId,
         cloudBindingsContext: hasCloudBindingsContext(),
@@ -267,6 +313,7 @@ app.get("/", (c) => {
         prewarmElizaContext: elizaFetch.prewarm,
         usageStore,
         usageLimits,
+        initialUsageAdmissionMinutes,
         // The 400ms revocation poll is the highest-frequency store consumer:
         // without the request-scoped client it dialed a fresh Railway TCP
         // connection per tick on Workers — the exact churn #16636 removed

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
@@ -98,8 +98,21 @@ beforeAll(async () => {
   ({ dbWrite } = await import("../helpers"));
   const database = getPgliteClientForTests();
   await database.exec(`
-    CREATE TABLE organizations (id uuid PRIMARY KEY);
-    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY,
+      is_active boolean NOT NULL DEFAULT true
+    );
+    CREATE TABLE users (
+      id uuid PRIMARY KEY,
+      organization_id uuid REFERENCES organizations(id),
+      is_active boolean NOT NULL DEFAULT true,
+      deleted_at timestamp
+    );
+    CREATE TABLE user_moderation_status (
+      user_id uuid PRIMARY KEY REFERENCES users(id),
+      status text NOT NULL DEFAULT 'clean',
+      total_violations integer NOT NULL DEFAULT 0
+    );
   `);
   const migration = await Bun.file(
     new URL("../migrations/0310_personal_shared_inbound_media_admission.sql", import.meta.url),
@@ -114,7 +127,8 @@ beforeEach(async () => {
       users,
       organizations CASCADE;
     INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
-    INSERT INTO users (id) VALUES ('${USER_A}'), ('${USER_B}');
+    INSERT INTO users (id, organization_id)
+      VALUES ('${USER_A}', '${ORG_A}'), ('${USER_B}', '${ORG_B}');
   `);
 });
 
@@ -123,6 +137,66 @@ afterAll(async () => {
 });
 
 describe("personalSharedInboundMediaRepository admission ledger", () => {
+  test("combined account standing denies every bad-standing shape before claim or quota", async () => {
+    const missingUser = "72000000-0000-4000-8000-000000000099";
+    expect(await admission({ sourceMessageId: "standing-missing", userId: missingUser })).toEqual({
+      kind: "standing_denied",
+      reason: "account_missing",
+    });
+
+    await getPgliteClientForTests().query("UPDATE users SET is_active = false WHERE id = $1", [
+      USER_A,
+    ]);
+    expect(await admission({ sourceMessageId: "standing-user" })).toEqual({
+      kind: "standing_denied",
+      reason: "account_inactive",
+    });
+    await getPgliteClientForTests().query("UPDATE users SET is_active = true WHERE id = $1", [
+      USER_A,
+    ]);
+
+    expect(
+      await admission({
+        sourceMessageId: "standing-membership",
+        organizationId: ORG_B,
+      }),
+    ).toEqual({ kind: "standing_denied", reason: "membership_missing" });
+
+    await getPgliteClientForTests().query(
+      "UPDATE organizations SET is_active = false WHERE id = $1",
+      [ORG_A],
+    );
+    expect(await admission({ sourceMessageId: "standing-organization" })).toEqual({
+      kind: "standing_denied",
+      reason: "organization_inactive",
+    });
+    await getPgliteClientForTests().query(
+      "UPDATE organizations SET is_active = true WHERE id = $1",
+      [ORG_A],
+    );
+
+    await getPgliteClientForTests().query(
+      `INSERT INTO user_moderation_status (user_id, status, total_violations)
+       VALUES ($1, 'clean', 5)`,
+      [USER_A],
+    );
+    expect(await admission({ sourceMessageId: "standing-moderation" })).toEqual({
+      kind: "standing_denied",
+      reason: "moderation_blocked",
+    });
+
+    expect(await quotaRows()).toEqual([]);
+    for (const sourceMessageId of [
+      "standing-missing",
+      "standing-user",
+      "standing-membership",
+      "standing-organization",
+      "standing-moderation",
+    ]) {
+      expect(await ledgerRow(sourceMessageId)).toBeUndefined();
+    }
+  });
+
   test("claims a message once and consumes both daily ceilings atomically", async () => {
     const claim = await claimOf("msg-1", { imageCount: 2 });
     expect(claim.attempt).toBe(1);
@@ -212,6 +286,7 @@ describe("personalSharedInboundMediaRepository admission ledger", () => {
     expect(
       await admission({
         sourceMessageId: "msg-identity-pending",
+        organizationId: ORG_B,
         userId: USER_B,
       }),
     ).toEqual({ kind: "identity_mismatch" });

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.postgres.integration.test.ts
@@ -86,8 +86,21 @@ beforeAll(async () => {
   await client.connect();
   try {
     await client.query(`
-      CREATE TABLE organizations (id uuid PRIMARY KEY);
-      CREATE TABLE users (id uuid PRIMARY KEY);
+      CREATE TABLE organizations (
+        id uuid PRIMARY KEY,
+        is_active boolean NOT NULL DEFAULT true
+      );
+      CREATE TABLE users (
+        id uuid PRIMARY KEY,
+        organization_id uuid REFERENCES organizations(id),
+        is_active boolean NOT NULL DEFAULT true,
+        deleted_at timestamp
+      );
+      CREATE TABLE user_moderation_status (
+        user_id uuid PRIMARY KEY REFERENCES users(id),
+        status text NOT NULL DEFAULT 'clean',
+        total_violations integer NOT NULL DEFAULT 0
+      );
     `);
     await client.query(
       readFileSync(
@@ -96,7 +109,10 @@ beforeAll(async () => {
       ),
     );
     await client.query("INSERT INTO organizations (id) VALUES ($1)", [ORG_ID]);
-    await client.query("INSERT INTO users (id) VALUES ($1)", [USER_ID]);
+    await client.query("INSERT INTO users (id, organization_id) VALUES ($1, $2)", [
+      USER_ID,
+      ORG_ID,
+    ]);
   } finally {
     await client.end();
   }

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
@@ -2,22 +2,27 @@
  * Atomic admission and idempotency authority for pooled-key vision descriptions
  * of inbound Personal Shared media. One primary-database transaction claims
  * the connector message id (the enrichment idempotency record) and consumes
- * the sender and connector per-day image ceilings; a denied ceiling rolls the
- * claim back, so a provider call is only ever reachable behind a committed
- * claim plus committed quota. The injectable database keeps the production
- * queries testable against an isolated PostgreSQL-compatible engine.
+ * the sender and connector per-day image ceilings after one combined account-
+ * standing snapshot; a denial rolls the claim back, so a provider call is only
+ * ever reachable behind active user, membership, organization, moderation,
+ * claim, and quota authority. Terminal settlement is one fenced write with no
+ * row readback. The injectable database keeps the production queries testable
+ * against an isolated PostgreSQL-compatible engine.
  */
 import { ElizaError } from "@elizaos/core";
 import { and, eq, sql } from "drizzle-orm";
 import type { Database, DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
 import { dbWrite } from "../helpers";
+import { userModerationStatus } from "../schemas/moderation-violations";
+import { organizations } from "../schemas/organizations";
 import {
   type PersonalSharedInboundMediaPlatform,
   type PersonalSharedInboundMediaQuotaScope,
   personalSharedInboundMediaDescriptions,
   personalSharedInboundMediaQuotas,
 } from "../schemas/personal-shared-inbound-media";
+import { users } from "../schemas/users";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 /**
@@ -64,6 +69,15 @@ export type InboundMediaDescriptionAdmission =
   | { kind: "previously_failed"; reason: string }
   | { kind: "identity_mismatch" }
   | { kind: "media_mismatch" }
+  | {
+      kind: "standing_denied";
+      reason:
+        | "account_missing"
+        | "account_inactive"
+        | "membership_missing"
+        | "organization_inactive"
+        | "moderation_blocked";
+    }
   | {
       kind: "exhausted";
       scope: PersonalSharedInboundMediaQuotaScope;
@@ -144,6 +158,42 @@ export class PersonalSharedInboundMediaRepository {
     try {
       return await this.database.transaction(async (tx) => {
         const transactionStartedAt = await this.readDatabaseNow(tx);
+        // One authoritative row shape owns identity, membership, tenant, and
+        // moderation standing. A denial returns before claim/quota mutation,
+        // so no stale sender projection can reach the pooled vision provider.
+        const [standing] = await tx
+          .select({
+            userId: users.id,
+            userActive: users.is_active,
+            userDeletedAt: users.deleted_at,
+            organizationId: users.organization_id,
+            organizationActive: organizations.is_active,
+            moderationStatus: userModerationStatus.status,
+            moderationViolations: userModerationStatus.totalViolations,
+          })
+          .from(users)
+          .leftJoin(organizations, eq(organizations.id, users.organization_id))
+          .leftJoin(userModerationStatus, eq(userModerationStatus.userId, users.id))
+          .where(eq(users.id, input.userId))
+          .limit(1);
+        if (!standing) {
+          return { kind: "standing_denied", reason: "account_missing" };
+        }
+        if (!standing.userActive || standing.userDeletedAt) {
+          return { kind: "standing_denied", reason: "account_inactive" };
+        }
+        if (!standing.organizationId || standing.organizationId !== input.organizationId) {
+          return { kind: "standing_denied", reason: "membership_missing" };
+        }
+        if (!standing.organizationActive) {
+          return {
+            kind: "standing_denied",
+            reason: "organization_inactive",
+          };
+        }
+        if (standing.moderationStatus === "banned" || (standing.moderationViolations ?? 0) >= 5) {
+          return { kind: "standing_denied", reason: "moderation_blocked" };
+        }
         const claimToken = crypto.randomUUID();
         const preliminaryLeaseExpiresAt = new Date(
           transactionStartedAt.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS,
@@ -347,7 +397,7 @@ export class PersonalSharedInboundMediaRepository {
   ): Promise<boolean> {
     try {
       const now = new Date();
-      const [settled] = await this.database
+      const result = await this.database
         .update(personalSharedInboundMediaDescriptions)
         .set({ ...outcome, completed_at: now, updated_at: now })
         .where(
@@ -356,9 +406,23 @@ export class PersonalSharedInboundMediaRepository {
             eq(personalSharedInboundMediaDescriptions.claim_token, claim.claimToken),
             eq(personalSharedInboundMediaDescriptions.state, "pending"),
           ),
-        )
-        .returning({ id: personalSharedInboundMediaDescriptions.id });
-      return settled !== undefined;
+        );
+      // The command acknowledgement is enough to preserve the claim-token
+      // fence. Do not SELECT/RETURNING the row after a provider dispatch: the
+      // terminal write is the settlement, and a cache/database readback would
+      // put persistence latency back on the response tail.
+      const count =
+        "rowCount" in result && typeof result.rowCount === "number"
+          ? result.rowCount
+          : "affectedRows" in result && typeof result.affectedRows === "number"
+            ? result.affectedRows
+            : null;
+      if (count === null) {
+        throw storageFailure("Inbound media claim settlement returned no write count", {
+          claimId: claim.id,
+        });
+      }
+      return count === 1;
     } catch (error) {
       // error-policy:J2 callers distinguish an unavailable settlement store
       // from an unowned claim token and fail closed on either result.

--- a/packages/cloud/shared/src/lib/api/a2a/skills.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/skills.ts
@@ -227,6 +227,7 @@ export async function executeSkillWebSearch(
       organizationId: ctx.user.organization_id,
       userId: ctx.user.id,
       apiKeyId: ctx.apiKeyId,
+      requestId: `legacy-a2a-search:${ctx.agentIdentifier}:${crypto.randomUUID()}`,
       requestSource: "a2a",
     },
   );

--- a/packages/cloud/shared/src/lib/eliza/message-handler.ts
+++ b/packages/cloud/shared/src/lib/eliza/message-handler.ts
@@ -197,8 +197,7 @@ export class MessageHandler {
       elizaLogger.warn(`[MessageHandler] Discord thread sync failed for room ${roomId}: ${e}`);
     });
 
-    // PERF: Fire-and-forget room title generation -- don't block the response.
-    // Title generation makes a separate LLM call (1-3s) that the user doesn't need to wait for.
+    // Title metadata is deterministic and remains detached from the response.
     generateRoomTitle(roomId).catch((e) => {
       elizaLogger.warn(`[MessageHandler] Room title generation failed for room ${roomId}: ${e}`);
     });

--- a/packages/cloud/shared/src/lib/eliza/plugin-web-search/src/services/searchService.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-web-search/src/services/searchService.ts
@@ -20,6 +20,37 @@ function getGoogleSearchApiKey(runtime: IAgentRuntime): string | null {
   return null;
 }
 
+async function resolveSearchOperationContext(runtime: IAgentRuntime) {
+  const cloudApiKey = runtime.getSetting("ELIZAOS_API_KEY");
+  if (typeof cloudApiKey !== "string" || !cloudApiKey.trim()) {
+    throw new Error("Hosted Google search requires an authenticated Eliza Cloud API key");
+  }
+  const { resolveInferenceAuthContext } = await import(
+    "../../../../services/inference-auth-context"
+  );
+  const resolution = await resolveInferenceAuthContext(
+    new Request("https://cloud.eliza.app/api/v1/search", {
+      headers: { "X-API-Key": cloudApiKey.trim() },
+    }),
+  );
+  if (resolution.kind !== "authorized") {
+    throw new Error(`Hosted Google search standing rejected: ${resolution.kind}`);
+  }
+  const expectedOrganizationId = runtime.getSetting("ORGANIZATION_ID");
+  const expectedUserId = runtime.getSetting("USER_ID");
+  if (resolution.ctx.orgId !== expectedOrganizationId || resolution.ctx.userId !== expectedUserId) {
+    throw new Error("Hosted Google search identity does not match the runtime owner");
+  }
+  return {
+    organizationId: resolution.ctx.orgId,
+    userId: resolution.ctx.userId,
+    apiKeyId: resolution.ctx.apiKeyId,
+    requestId: crypto.randomUUID(),
+    admissionSnapshot: resolution.ctx.admission,
+    requestSource: "action" as const,
+  };
+}
+
 function toSearchResponse(result: HostedSearchResult): SearchResponse {
   return {
     answer: result.answer,
@@ -88,6 +119,7 @@ export class WebSearchService extends Service implements IWebSearchService {
       // Lazy import: the Google-grounded path drags the cloud services/db
       // graph; keyless deployments never pay that module cost.
       const { executeHostedGoogleSearch } = await import("../../../../services/google-search");
+      const operationContext = await resolveSearchOperationContext(this.runtime);
       const result = await executeHostedGoogleSearch(
         {
           query,
@@ -100,13 +132,7 @@ export class WebSearchService extends Service implements IWebSearchService {
           startDate: options?.start_date,
           endDate: options?.end_date,
         },
-        {
-          organizationId:
-            (this.runtime.getSetting("ORGANIZATION_ID") as string | undefined) ?? undefined,
-          userId: (this.runtime.getSetting("USER_ID") as string | undefined) ?? undefined,
-          apiKey: (this.runtime.getSetting("ELIZAOS_API_KEY") as string | undefined) ?? null,
-          requestSource: "action",
-        },
+        operationContext,
       );
 
       return toSearchResponse(result);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-automation-credit-order.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-automation-credit-order.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for the deduct-before-throwable-prep money leak in the
+ * Regression tests for the pre-provider throwable-preparation boundary in the
  * telegram/discord/twitter app-automation generators (#11685).
  *
  * The bug: `generateAnnouncement` / `generateReply` / `generateAppTweet`
@@ -10,9 +10,9 @@
  * schedulers/auto-reply loops, so a transient DB failure leaked a post-cost
  * per invocation.
  *
- * The fix hoists all throwable prep above the deduction, so these tests pin:
- * when the character-context fetch rejects, `deductCredits` is NEVER called
- * (no charge for a generation that never ran). Each test also asserts the
+ * The current contract keeps all throwable prep above paid admission, so these
+ * tests pin that a character-context failure never creates an admission lease.
+ * Each test also asserts the
  * rejection is the context error itself — proving the context fetch (the
  * armed hazard) is what fired, not some earlier failure.
  */
@@ -21,26 +21,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
-interface RecordedCall {
-  organizationId: string;
-  amount: number;
-  description: string;
-  metadata?: Record<string, unknown>;
-}
+const admissionCalls: unknown[] = [];
 
-const deductCalls: RecordedCall[] = [];
-const refundCalls: RecordedCall[] = [];
-
-mock.module("../credits", () => ({
-  creditsService: {
-    deductCredits: async (params: RecordedCall) => {
-      deductCalls.push(params);
-      return { success: true, newBalance: 100, transaction: null };
-    },
-    refundCredits: async (params: RecordedCall) => {
-      refundCalls.push(params);
-      return { transaction: {}, newBalance: 100 };
-    },
+mock.module("../organization-inference-admission", () => ({
+  admitOrganizationInference: async (params: unknown) => {
+    admissionCalls.push(params);
+    throw new Error("admission should not be reached");
   },
 }));
 
@@ -74,21 +60,19 @@ function makeApp(
 }
 
 beforeEach(() => {
-  deductCalls.length = 0;
-  refundCalls.length = 0;
+  admissionCalls.length = 0;
 });
 
-describe("app-automation generators never charge before throwable prep (#11685)", () => {
-  test("telegram generateAnnouncement: context fetch rejects -> no deduction taken", async () => {
+describe("app-automation generators prepare prompts before admission (#11685)", () => {
+  test("telegram generateAnnouncement: context fetch rejects -> no admission", async () => {
     await expect(
       telegramAppAutomationService.generateAnnouncement(ORG_ID, makeApp("telegram_automation")),
     ).rejects.toThrow(CONTEXT_DB_ERROR);
 
-    expect(deductCalls).toHaveLength(0);
-    expect(refundCalls).toHaveLength(0);
+    expect(admissionCalls).toHaveLength(0);
   });
 
-  test("telegram generateReply: context fetch rejects -> no deduction taken", async () => {
+  test("telegram generateReply: context fetch rejects -> no admission", async () => {
     await expect(
       telegramAppAutomationService.generateReply(
         ORG_ID,
@@ -98,20 +82,18 @@ describe("app-automation generators never charge before throwable prep (#11685)"
       ),
     ).rejects.toThrow(CONTEXT_DB_ERROR);
 
-    expect(deductCalls).toHaveLength(0);
-    expect(refundCalls).toHaveLength(0);
+    expect(admissionCalls).toHaveLength(0);
   });
 
-  test("discord generateAnnouncement: context fetch rejects -> no deduction taken", async () => {
+  test("discord generateAnnouncement: context fetch rejects -> no admission", async () => {
     await expect(
       discordAppAutomationService.generateAnnouncement(ORG_ID, makeApp("discord_automation")),
     ).rejects.toThrow(CONTEXT_DB_ERROR);
 
-    expect(deductCalls).toHaveLength(0);
-    expect(refundCalls).toHaveLength(0);
+    expect(admissionCalls).toHaveLength(0);
   });
 
-  test("twitter generateAppTweet: context fetch rejects -> no deduction taken", async () => {
+  test("twitter generateAppTweet: context fetch rejects -> no admission", async () => {
     await expect(
       twitterAppAutomationService.generateAppTweet(
         ORG_ID,
@@ -120,7 +102,6 @@ describe("app-automation generators never charge before throwable prep (#11685)"
       ),
     ).rejects.toThrow(CONTEXT_DB_ERROR);
 
-    expect(deductCalls).toHaveLength(0);
-    expect(refundCalls).toHaveLength(0);
+    expect(admissionCalls).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-automation-provider-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-automation-provider-admission.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Provider-boundary tests for app automation generation using real shared
+ * admission ordering with deterministic provider and lease doubles.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const events: string[] = [];
+let denyAdmission = false;
+let providerFailure = false;
+let settlementGate = Promise.resolve();
+let releaseSettlement: (() => void) | undefined;
+let retainedTask: Promise<unknown> | undefined;
+
+mock.module("../organization-inference-admission", () => ({
+  admitOrganizationInference: async () => {
+    events.push("admit");
+    if (denyAdmission) throw new Error("cached standing denied");
+    return {
+      mode: "cache_admission",
+      affiliateAttribution: null,
+      markProviderDispatched: async () => {
+        events.push("mark");
+      },
+      settle: async () => {
+        events.push("settle");
+        await settlementGate;
+        return null;
+      },
+      settleUnknown: async () => {
+        events.push("settleUnknown");
+        return null;
+      },
+    };
+  },
+}));
+
+mock.module("ai", () => ({
+  generateText: async () => {
+    events.push("provider");
+    if (providerFailure) throw new Error("provider failed");
+    return { text: "A generated announcement", finishReason: "stop" };
+  },
+}));
+
+mock.module("@ai-sdk/openai", () => ({ openai: () => ({ modelId: "gpt-5-mini" }) }));
+mock.module("../../providers/language-model", () => ({
+  getLanguageModel: () => ({ modelId: "claude-sonnet" }),
+}));
+mock.module("../character-prompt-helper", () => ({
+  getCharacterPromptContext: async () => null,
+  buildCharacterSystemPrompt: () => "",
+}));
+
+const { discordAppAutomationService } = await import("../discord-automation/app-automation");
+const { telegramAppAutomationService } = await import("../telegram-automation/app-automation");
+const { twitterAppAutomationService } = await import("../twitter-automation/app-automation");
+
+const organizationId = "00000000-0000-4000-8000-00000000f001";
+const operationContext = {
+  organizationId,
+  userId: "00000000-0000-4000-8000-00000000f002",
+  apiKeyId: null,
+  requestId: "automation-request",
+};
+const app = {
+  id: "00000000-0000-4000-8000-00000000f003",
+  organization_id: organizationId,
+  name: "Admission Test App",
+  description: "Tests paid generation",
+  app_url: "https://example.test/app",
+  website_url: "https://example.test",
+  discord_automation: { enabled: true },
+  telegram_automation: { enabled: true },
+  twitter_automation: { enabled: true },
+} as Parameters<typeof discordAppAutomationService.generateAnnouncement>[1];
+
+beforeEach(() => {
+  events.length = 0;
+  denyAdmission = false;
+  providerFailure = false;
+  settlementGate = Promise.resolve();
+  releaseSettlement = undefined;
+  retainedTask = undefined;
+});
+
+describe("app automation provider admission", () => {
+  test("marks before Discord dispatch and retains settlement asynchronously", async () => {
+    settlementGate = new Promise<void>((resolve) => {
+      releaseSettlement = resolve;
+    });
+    const context = {
+      ...operationContext,
+      executionCtx: {
+        waitUntil(task: Promise<unknown>) {
+          events.push("waitUntil");
+          retainedTask = task;
+        },
+      },
+    };
+
+    await discordAppAutomationService.generateAnnouncement(organizationId, app, context);
+    expect(events).toEqual(["admit", "mark", "provider", "settle", "waitUntil"]);
+    expect(retainedTask).toBeDefined();
+    releaseSettlement?.();
+    await retainedTask;
+  });
+
+  test("cached denial makes zero Telegram provider calls", async () => {
+    denyAdmission = true;
+    await expect(
+      telegramAppAutomationService.generateAnnouncement(organizationId, app, operationContext),
+    ).rejects.toThrow("cached standing denied");
+    expect(events).toEqual(["admit"]);
+  });
+
+  test("post-mark Twitter failure settles unknown", async () => {
+    providerFailure = true;
+    await expect(
+      twitterAppAutomationService.generateAppTweet(
+        organizationId,
+        app,
+        "promotional",
+        operationContext,
+      ),
+    ).rejects.toThrow("provider failed");
+    expect(events).toEqual(["admit", "mark", "provider", "settleUnknown"]);
+  });
+
+  test("cron-style calls without caller context fail closed before providers", async () => {
+    await expect(
+      discordAppAutomationService.generateAnnouncement(organizationId, app),
+    ).rejects.toThrow("trusted generative admission context");
+    await expect(
+      telegramAppAutomationService.generateAnnouncement(organizationId, app),
+    ).rejects.toThrow("trusted generative admission context");
+    await expect(twitterAppAutomationService.generateAppTweet(organizationId, app)).rejects.toThrow(
+      "trusted generative admission context",
+    );
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-promotion-assets.ts
+++ b/packages/cloud/shared/src/lib/services/app-promotion-assets.ts
@@ -4,6 +4,7 @@ import { generateText } from "ai";
 import { z } from "zod";
 import type { App } from "../../db/repositories";
 import { uploadToBlob } from "../blob";
+import { AD_COPY_GENERATION_COST, PROMO_IMAGE_COST } from "../promotion-pricing";
 import { mergeAnthropicCotProviderOptions } from "../providers/anthropic-thinking";
 import { getImageProvider } from "../providers/image/registry";
 import { getLanguageModel } from "../providers/language-model";
@@ -15,6 +16,11 @@ import { extractErrorMessage } from "../utils/error-handling";
 import { logger } from "../utils/logger";
 import { DEFAULT_IMAGE_MODEL_ID, getSupportedImageModelDefinition } from "./ai-pricing-definitions";
 import { contentSafetyService } from "./content-safety";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+  runFlatProviderOperation,
+} from "./generative-operation";
 
 const IMAGE_MODEL = DEFAULT_IMAGE_MODEL_ID;
 
@@ -260,6 +266,7 @@ class AppPromotionAssetsService {
     app: App,
     size: AdSize = "twitter_card",
     customPrompt?: string,
+    operationContext?: GenerativeOperationContext,
   ): Promise<GeneratedAsset | null> {
     const dimensions = AD_SIZES[size];
 
@@ -301,8 +308,6 @@ class AppPromotionAssetsService {
       hasWebsiteContext: Object.keys(websiteContext).length > 0,
     });
 
-    let imageBytes: Uint8Array | null = null;
-
     try {
       // Dispatch through the priced image-provider registry (matching
       // /api/v1/generate-image). The old streamText path resolved the retired
@@ -311,20 +316,69 @@ class AppPromotionAssetsService {
       if (!definition) {
         throw new Error(`Unsupported image model: ${IMAGE_MODEL}`);
       }
+      if (!operationContext) {
+        throw new Error("Promotional image generation requires generative admission");
+      }
       const env = getCloudAwareEnv();
-      const generated = await getImageProvider(definition.billingSource).generate({
-        model: definition.modelId,
-        prompt: `Generate a promotional banner image: ${prompt}`,
-        size: `${dimensions.width}x${dimensions.height}`,
-        apiKeys: {
-          ATLASCLOUD_API_KEY: env.ATLASCLOUD_API_KEY,
-          ATLASCLOUD_BASE_URL: env.ATLASCLOUD_BASE_URL,
-          FAL_KEY: env.FAL_KEY,
-          FAL_API_KEY: env.FAL_API_KEY,
+      return await runFlatProviderOperation(
+        operationContext,
+        {
+          provider: definition.provider,
+          billingSource: definition.billingSource,
+          model: definition.modelId,
+          operation: `promotion_image_${size}`,
+          cost: PROMO_IMAGE_COST,
+          metadata: { appId: app.id, size },
         },
-      });
-      imageBytes = generated.bytes;
+        async () => {
+          const generated = await getImageProvider(definition.billingSource).generate({
+            model: definition.modelId,
+            prompt: `Generate a promotional banner image: ${prompt}`,
+            size: `${dimensions.width}x${dimensions.height}`,
+            apiKeys: {
+              ATLASCLOUD_API_KEY: env.ATLASCLOUD_API_KEY,
+              ATLASCLOUD_BASE_URL: env.ATLASCLOUD_BASE_URL,
+              FAL_KEY: env.FAL_KEY,
+              FAL_API_KEY: env.FAL_API_KEY,
+            },
+          });
+          if (!generated.bytes) {
+            throw new Error("Image provider returned no image bytes");
+          }
+          const buffer = Buffer.from(generated.bytes);
+          logger.info("[PromotionAssets] Uploading to blob storage", {
+            appId: app.id,
+            size,
+            bufferSize: buffer.length,
+          });
+          const blob = await uploadToBlob(buffer, {
+            filename: `${size}-${Date.now()}.png`,
+            contentType: "image/png",
+            folder: `promotion-assets/${app.id}`,
+          });
+          await contentSafetyService.assertSafeForPublicUse({
+            surface: "promotion_asset_output",
+            organizationId: app.organization_id,
+            appId: app.id,
+            imageUrls: [blob.url],
+            metadata: { size, format: "png" },
+          });
+          logger.info("[PromotionAssets] Image generated and uploaded", {
+            appId: app.id,
+            size,
+            url: blob.url,
+          });
+          return {
+            type: "social_card",
+            size: dimensions,
+            url: blob.url,
+            format: "png",
+            generatedAt: new Date(),
+          };
+        },
+      );
     } catch (error) {
+      if (isGenerativeOperationAdmissionError(error)) throw error;
       logger.error("[PromotionAssets] Image generation error", {
         appId: app.id,
         size,
@@ -332,60 +386,19 @@ class AppPromotionAssetsService {
       });
       return null;
     }
-
-    if (!imageBytes) {
-      logger.warn("[PromotionAssets] Failed to generate image - no image returned", {
-        appId: app.id,
-        size,
-      });
-      return null;
-    }
-
-    // Upload to R2 storage
-    const buffer = Buffer.from(imageBytes);
-
-    logger.info("[PromotionAssets] Uploading to blob storage", {
-      appId: app.id,
-      size,
-      bufferSize: buffer.length,
-    });
-
-    const blob = await uploadToBlob(buffer, {
-      filename: `${size}-${Date.now()}.png`,
-      contentType: "image/png",
-      folder: `promotion-assets/${app.id}`,
-    });
-
-    await contentSafetyService.assertSafeForPublicUse({
-      surface: "promotion_asset_output",
-      organizationId: app.organization_id,
-      appId: app.id,
-      imageUrls: [blob.url],
-      metadata: { size, format: "png" },
-    });
-
-    logger.info("[PromotionAssets] Image generated and uploaded", {
-      appId: app.id,
-      size,
-      url: blob.url,
-    });
-
-    return {
-      type: "social_card",
-      size: dimensions,
-      url: blob.url,
-      format: "png",
-      generatedAt: new Date(),
-    };
   }
 
   /**
    * Generate ad banners - runs in parallel for speed
    */
-  async generateAdBanners(app: App, sizes: AdSize[]): Promise<GeneratedAsset[]> {
+  async generateAdBanners(
+    app: App,
+    sizes: AdSize[],
+    operationContext?: GenerativeOperationContext,
+  ): Promise<GeneratedAsset[]> {
     const results = await Promise.all(
       sizes.map(async (size) => {
-        const asset = await this.generateSocialCard(app, size);
+        const asset = await this.generateSocialCard(app, size, undefined, operationContext);
         if (!asset) return null;
         return { ...asset, type: "banner" } as GeneratedAsset;
       }),
@@ -400,6 +413,7 @@ class AppPromotionAssetsService {
     app: App,
     targetAudience?: string,
     tone: "professional" | "casual" | "exciting" | "informative" = "professional",
+    operationContext?: GenerativeOperationContext,
   ): Promise<AdCopyVariants> {
     // Detect app category for better copy
     const description = (app.description || "").toLowerCase();
@@ -475,37 +489,53 @@ Return JSON with these exact fields:
 Return ONLY valid JSON. No markdown, no explanation.`;
 
     const copyModel = "anthropic/claude-sonnet-4.6";
+    if (!operationContext) {
+      throw new Error("Promotional copy generation requires generative admission");
+    }
     // Note: When ANTHROPIC_COT_BUDGET is set, @ai-sdk/anthropic silently strips temperature,
     // topP, and topK when extended thinking is active. We explicitly disable extended thinking
     // (pass budget=0) to preserve temperature control for creative promotional content quality.
-    const result = await generateText({
-      model: getLanguageModel(copyModel),
-      ...mergeAnthropicCotProviderOptions(copyModel, process.env, 0),
-      temperature: 0.8,
-      prompt,
-    });
-    assertModelOutputComplete({
-      finishReason: result.finishReason,
-      provider: "anthropic",
-      model: copyModel,
-    });
+    return await runFlatProviderOperation(
+      operationContext,
+      {
+        provider: "anthropic",
+        billingSource: "anthropic",
+        model: copyModel,
+        operation: "promotion_ad_copy",
+        cost: AD_COPY_GENERATION_COST,
+        metadata: { appId: app.id },
+      },
+      async () => {
+        const result = await generateText({
+          model: getLanguageModel(copyModel),
+          ...mergeAnthropicCotProviderOptions(copyModel, process.env, 0),
+          temperature: 0.8,
+          prompt,
+        });
+        assertModelOutputComplete({
+          finishReason: result.finishReason,
+          provider: "anthropic",
+          model: copyModel,
+        });
 
-    const parsed = parseAiJson(result.text, AdCopyVariantsSchema, "ad copy variants");
+        const parsed = parseAiJson(result.text, AdCopyVariantsSchema, "ad copy variants");
 
-    await contentSafetyService.assertSafeForPublicUse({
-      surface: "promotion_copy",
-      organizationId: app.organization_id,
-      appId: app.id,
-      text: [
-        ...parsed.headlines.map((headline) => `Headline: ${headline}`),
-        ...parsed.descriptions.map((description) => `Description: ${description}`),
-        ...parsed.callToActions.map((callToAction) => `CTA: ${callToAction}`),
-        ...parsed.hashtags.map((hashtag) => `Hashtag: ${hashtag}`),
-      ],
-      metadata: { stage: "output" },
-    });
+        await contentSafetyService.assertSafeForPublicUse({
+          surface: "promotion_copy",
+          organizationId: app.organization_id,
+          appId: app.id,
+          text: [
+            ...parsed.headlines.map((headline) => `Headline: ${headline}`),
+            ...parsed.descriptions.map((description) => `Description: ${description}`),
+            ...parsed.callToActions.map((callToAction) => `CTA: ${callToAction}`),
+            ...parsed.hashtags.map((hashtag) => `Hashtag: ${hashtag}`),
+          ],
+          metadata: { stage: "output" },
+        });
 
-    return parsed;
+        return parsed;
+      },
+    );
   }
 
   /**
@@ -521,6 +551,7 @@ Return ONLY valid JSON. No markdown, no explanation.`;
       targetAudience?: string;
       customPrompt?: string; // Optional user-provided context for image generation
     } = {},
+    operationContext?: GenerativeOperationContext,
   ): Promise<{
     assets: GeneratedAsset[];
     copy?: AdCopyVariants;
@@ -532,19 +563,23 @@ Return ONLY valid JSON. No markdown, no explanation.`;
     // Generate social card (just 1 for speed)
     if (options.includeSocialCards !== false) {
       imagePromises.push(
-        this.generateSocialCard(app, "twitter_card", options.customPrompt).catch((err) => {
-          errors.push(`Failed to generate social card: ${extractErrorMessage(err)}`);
-          return null;
-        }),
+        this.generateSocialCard(app, "twitter_card", options.customPrompt, operationContext).catch(
+          (err) => {
+            if (isGenerativeOperationAdmissionError(err)) throw err;
+            errors.push(`Failed to generate social card: ${extractErrorMessage(err)}`);
+            return null;
+          },
+        ),
       );
     }
 
     // Generate 1 banner (for speed - instagram_square is most versatile)
     if (options.includeAdBanners) {
       imagePromises.push(
-        this.generateSocialCard(app, "instagram_square", options.customPrompt)
+        this.generateSocialCard(app, "instagram_square", options.customPrompt, operationContext)
           .then((asset) => (asset ? ({ ...asset, type: "banner" } as GeneratedAsset) : null))
           .catch((err) => {
+            if (isGenerativeOperationAdmissionError(err)) throw err;
             errors.push(`Failed to generate banner: ${extractErrorMessage(err)}`);
             return null;
           }),
@@ -554,10 +589,13 @@ Return ONLY valid JSON. No markdown, no explanation.`;
     // Generate copy in parallel with images
     const copyPromise =
       options.includeCopy !== false
-        ? this.generateAdCopy(app, options.targetAudience).catch((err) => {
-            errors.push(`Failed to generate copy: ${extractErrorMessage(err)}`);
-            return undefined;
-          })
+        ? this.generateAdCopy(app, options.targetAudience, "professional", operationContext).catch(
+            (err) => {
+              if (isGenerativeOperationAdmissionError(err)) throw err;
+              errors.push(`Failed to generate copy: ${extractErrorMessage(err)}`);
+              return undefined;
+            },
+          )
         : Promise.resolve(undefined);
 
     // Wait for all in parallel

--- a/packages/cloud/shared/src/lib/services/app-promotion.ts
+++ b/packages/cloud/shared/src/lib/services/app-promotion.ts
@@ -25,8 +25,12 @@ import type {
   CampaignOptimizationGoal,
 } from "./advertising/types";
 import { appsService } from "./apps";
-import { creditsService } from "./credits";
 import { discordAppAutomationService } from "./discord-automation/app-automation";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+  runFlatProviderOperation,
+} from "./generative-operation";
 import type { CreateSeoRequestParams } from "./seo";
 import { seoService } from "./seo";
 import { socialMediaService } from "./social-media";
@@ -230,6 +234,7 @@ class AppPromotionService {
   async generatePromotionalContent(
     app: App,
     targetAudience?: string,
+    operationContext?: GenerativeOperationContext,
   ): Promise<GeneratedPromotionalContent> {
     const appDescription = app.description || `${app.name} - An app built on Eliza Cloud`;
     const appUrl = app.app_url;
@@ -261,68 +266,79 @@ Generate the following in JSON format:
 Return ONLY valid JSON, no markdown.`;
 
     const promoModel = "anthropic/claude-sonnet-4.6";
+    if (!operationContext) {
+      throw new Error("Promotional content generation requires generative admission");
+    }
     // Note: When ANTHROPIC_COT_BUDGET is set, temperature is silently dropped by @ai-sdk/anthropic.
     // Promotional content generation is a background service that does not benefit from extended thinking.
     // Pass 0 as thinkingBudget to explicitly disable CoT for these internal service calls.
-    const result = await generateText({
-      model: getLanguageModel(promoModel),
-      temperature: 0.7,
-      prompt,
-      // Note: CoT is explicitly disabled (budget=0) for promotional content generation
-      // because it doesn't benefit from extended thinking and needs temperature control.
-      ...mergeAnthropicCotProviderOptions(promoModel, process.env, 0),
-    });
-    assertModelOutputComplete({
-      finishReason: result.finishReason,
-      provider: "anthropic",
-      model: promoModel,
-    });
-    const { text } = result;
+    return await runFlatProviderOperation(
+      operationContext,
+      {
+        provider: "anthropic",
+        billingSource: "anthropic",
+        model: promoModel,
+        operation: "app_promotional_content",
+        cost: PROMOTION_COSTS.contentGeneration,
+        metadata: { appId: app.id },
+      },
+      async () => {
+        const result = await generateText({
+          model: getLanguageModel(promoModel),
+          temperature: 0.7,
+          prompt,
+          ...mergeAnthropicCotProviderOptions(promoModel, process.env, 0),
+        });
+        assertModelOutputComplete({
+          finishReason: result.finishReason,
+          provider: "anthropic",
+          model: promoModel,
+        });
+        const { text } = result;
 
-    // Parse and validate the AI response
-    const extracted = text.trim();
-    let jsonText = extracted;
+        const extracted = text.trim();
+        let jsonText = extracted;
 
-    // Extract JSON from markdown code blocks if present
-    const fenceMatch = extracted.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (fenceMatch) {
-      jsonText = fenceMatch[1].trim();
-    }
+        // Extract JSON from markdown code blocks if present
+        const fenceMatch = extracted.match(/```(?:json)?\s*([\s\S]*?)```/);
+        if (fenceMatch) jsonText = fenceMatch[1].trim();
 
-    // Find JSON boundaries
-    const jsonStart = jsonText.search(/[{[]/);
-    const lastBrace = jsonText.lastIndexOf("}");
-    const lastBracket = jsonText.lastIndexOf("]");
-    const jsonEnd = Math.max(lastBrace, lastBracket);
+        // Find JSON boundaries
+        const jsonStart = jsonText.search(/[{[]/);
+        const lastBrace = jsonText.lastIndexOf("}");
+        const lastBracket = jsonText.lastIndexOf("]");
+        const jsonEnd = Math.max(lastBrace, lastBracket);
 
-    if (jsonStart === -1 || jsonEnd === -1) {
-      throw new Error("No JSON found in AI response for promotional content");
-    }
+        if (jsonStart === -1 || jsonEnd === -1) {
+          throw new Error("No JSON found in AI response for promotional content");
+        }
 
-    const jsonString = jsonText.slice(jsonStart, jsonEnd + 1);
+        const jsonString = jsonText.slice(jsonStart, jsonEnd + 1);
 
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(jsonString);
-    } catch (parseError) {
-      logger.error("[AppPromotion] Failed to parse AI response JSON", {
-        appId: app.id,
-        error: parseError instanceof Error ? parseError.message : "Unknown error",
-        jsonString: jsonString.substring(0, 500),
-      });
-      throw new Error("Failed to parse promotional content JSON");
-    }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(jsonString);
+        } catch (parseError) {
+          logger.error("[AppPromotion] Failed to parse AI response JSON", {
+            appId: app.id,
+            error: parseError instanceof Error ? parseError.message : "Unknown error",
+            jsonString: jsonString.substring(0, 500),
+          });
+          throw new Error("Failed to parse promotional content JSON");
+        }
 
-    // Validate structure manually (bypasses Zod to avoid Turbopack bundling issues)
-    try {
-      return this.validatePromotionalContent(parsed);
-    } catch (validationError) {
-      logger.error("[AppPromotion] Content validation failed", {
-        appId: app.id,
-        error: validationError instanceof Error ? validationError.message : "Unknown error",
-      });
-      throw new Error("Promotional content validation failed");
-    }
+        // Validate structure manually (bypasses Zod to avoid Turbopack bundling issues)
+        try {
+          return this.validatePromotionalContent(parsed);
+        } catch (validationError) {
+          logger.error("[AppPromotion] Content validation failed", {
+            appId: app.id,
+            error: validationError instanceof Error ? validationError.message : "Unknown error",
+          });
+          throw new Error("Promotional content validation failed");
+        }
+      },
+    );
   }
 
   async promoteApp(
@@ -330,6 +346,7 @@ Return ONLY valid JSON, no markdown.`;
     userId: string,
     appId: string,
     config: PromotionConfig,
+    operationContext?: GenerativeOperationContext,
   ): Promise<PromotionResult> {
     logger.info("[AppPromotion] Starting app promotion", {
       appId,
@@ -357,32 +374,20 @@ Return ONLY valid JSON, no markdown.`;
     // Generate promotional content if needed
     let promotionalContent: GeneratedPromotionalContent | undefined;
     if (config.channels.includes("social") || config.channels.includes("advertising")) {
-      const contentDeduction = await creditsService.deductCredits({
-        organizationId,
-        amount: PROMOTION_COSTS.contentGeneration,
-        description: `Generate promotional content for ${app.name}`,
-        metadata: { appId, type: "content_generation" },
-      });
-
-      if (contentDeduction.success) {
+      try {
+        promotionalContent = await this.generatePromotionalContent(
+          app,
+          undefined,
+          operationContext,
+        );
         result.totalCreditsUsed += PROMOTION_COSTS.contentGeneration;
-        try {
-          promotionalContent = await this.generatePromotionalContent(app);
-        } catch (error) {
-          // Refund credits if content generation fails
-          await creditsService.refundCredits({
-            organizationId,
-            amount: PROMOTION_COSTS.contentGeneration,
-            description: `Refund: Content generation failed for ${app.name}`,
-            metadata: { appId, type: "content_generation_refund" },
-          });
-          result.totalCreditsUsed -= PROMOTION_COSTS.contentGeneration;
-          logger.error("[AppPromotion] Content generation failed, credits refunded", {
-            appId,
-            error: error instanceof Error ? error.message : "Unknown error",
-          });
-          result.errors.push("Content generation failed - credits refunded");
-        }
+      } catch (error) {
+        if (isGenerativeOperationAdmissionError(error)) throw error;
+        logger.error("[AppPromotion] Content generation failed", {
+          appId,
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+        result.errors.push("Content generation failed");
       }
     }
 
@@ -407,6 +412,7 @@ Return ONLY valid JSON, no markdown.`;
         userId,
         app,
         config.seo,
+        operationContext,
       );
       if (!result.channels.seo.success) {
         result.errors.push(`SEO optimization failed: ${result.channels.seo.error}`);
@@ -538,6 +544,7 @@ Return ONLY valid JSON, no markdown.`;
     userId: string,
     app: App,
     config: NonNullable<PromotionConfig["seo"]>,
+    operationContext?: GenerativeOperationContext,
   ): Promise<NonNullable<PromotionResult["channels"]["seo"]>> {
     if (!app.app_url) {
       return {
@@ -555,6 +562,7 @@ Return ONLY valid JSON, no markdown.`;
       pageUrl: app.app_url,
       keywords: [app.name, "ai app", "eliza cloud"],
       promptContext: `App: ${app.name}. ${app.description || ""}`,
+      operationContext,
     });
 
     return {

--- a/packages/cloud/shared/src/lib/services/app-promotion.ts
+++ b/packages/cloud/shared/src/lib/services/app-promotion.ts
@@ -437,6 +437,7 @@ Return ONLY valid JSON, no markdown.`;
         organizationId,
         app,
         config.twitterAutomation,
+        operationContext,
       );
       if (!result.channels.twitterAutomation.success) {
         result.errors.push(`Twitter automation failed: ${result.channels.twitterAutomation.error}`);
@@ -453,6 +454,7 @@ Return ONLY valid JSON, no markdown.`;
         organizationId,
         app,
         config.telegramAutomation,
+        operationContext,
       );
       if (!result.channels.telegramAutomation.success) {
         result.errors.push(
@@ -471,6 +473,7 @@ Return ONLY valid JSON, no markdown.`;
         organizationId,
         app,
         config.discordAutomation,
+        operationContext,
       );
       if (!result.channels.discordAutomation.success) {
         result.errors.push(`Discord automation failed: ${result.channels.discordAutomation.error}`);
@@ -654,6 +657,7 @@ Return ONLY valid JSON, no markdown.`;
     organizationId: string,
     app: App,
     config: NonNullable<PromotionConfig["twitterAutomation"]>,
+    operationContext?: GenerativeOperationContext,
   ): Promise<NonNullable<PromotionResult["channels"]["twitterAutomation"]>> {
     try {
       // Enable automation with the provided config
@@ -675,7 +679,12 @@ Return ONLY valid JSON, no markdown.`;
       let initialTweetUrl: string | undefined;
 
       if (config.autoPost) {
-        const tweetResult = await twitterAppAutomationService.postAppTweet(organizationId, app.id);
+        const tweetResult = await twitterAppAutomationService.postAppTweet(
+          organizationId,
+          app.id,
+          undefined,
+          operationContext,
+        );
 
         if (tweetResult.success) {
           initialTweetId = tweetResult.tweetId;
@@ -696,6 +705,7 @@ Return ONLY valid JSON, no markdown.`;
         initialTweetUrl,
       };
     } catch (error) {
+      if (isGenerativeOperationAdmissionError(error)) throw error;
       logger.error("[AppPromotion] Twitter automation failed", {
         appId: app.id,
         error: extractErrorMessage(error),
@@ -717,6 +727,7 @@ Return ONLY valid JSON, no markdown.`;
     organizationId: string,
     app: App,
     config: NonNullable<PromotionConfig["telegramAutomation"]>,
+    operationContext?: GenerativeOperationContext,
   ): Promise<NonNullable<PromotionResult["channels"]["telegramAutomation"]>> {
     try {
       // If useExisting is true, just post using existing automation config
@@ -729,6 +740,9 @@ Return ONLY valid JSON, no markdown.`;
         const postResult = await telegramAppAutomationService.postAnnouncement(
           organizationId,
           app.id,
+          undefined,
+          undefined,
+          operationContext,
         );
 
         return {
@@ -771,6 +785,9 @@ Return ONLY valid JSON, no markdown.`;
         const postResult = await telegramAppAutomationService.postAnnouncement(
           organizationId,
           app.id,
+          undefined,
+          undefined,
+          operationContext,
         );
 
         if (postResult.success && postResult.messageId) {
@@ -792,6 +809,7 @@ Return ONLY valid JSON, no markdown.`;
         initialMessageId,
       };
     } catch (error) {
+      if (isGenerativeOperationAdmissionError(error)) throw error;
       logger.error("[AppPromotion] Telegram automation failed", {
         appId: app.id,
         error: extractErrorMessage(error),
@@ -813,6 +831,7 @@ Return ONLY valid JSON, no markdown.`;
     organizationId: string,
     app: App,
     config: NonNullable<PromotionConfig["discordAutomation"]>,
+    operationContext?: GenerativeOperationContext,
   ): Promise<NonNullable<PromotionResult["channels"]["discordAutomation"]>> {
     try {
       // If useExisting is true, just post using existing automation config
@@ -825,6 +844,8 @@ Return ONLY valid JSON, no markdown.`;
         const postResult = await discordAppAutomationService.postAnnouncement(
           organizationId,
           app.id,
+          undefined,
+          operationContext,
         );
 
         return {
@@ -865,6 +886,8 @@ Return ONLY valid JSON, no markdown.`;
         const postResult = await discordAppAutomationService.postAnnouncement(
           organizationId,
           app.id,
+          undefined,
+          operationContext,
         );
 
         if (postResult.success) {
@@ -888,6 +911,7 @@ Return ONLY valid JSON, no markdown.`;
         channelId,
       };
     } catch (error) {
+      if (isGenerativeOperationAdmissionError(error)) throw error;
       logger.error("[AppPromotion] Discord automation failed", {
         appId: app.id,
         error: extractErrorMessage(error),

--- a/packages/cloud/shared/src/lib/services/app-review.ts
+++ b/packages/cloud/shared/src/lib/services/app-review.ts
@@ -27,6 +27,11 @@ import { type App, apps } from "../../db/schemas/apps";
 import { getLanguageModel, hasLanguageModelProviderConfigured } from "../providers/language-model";
 import { logger } from "../utils/logger";
 import { appsService } from "./apps";
+import {
+  type GenerativeOperationContext,
+  retainGenerativeTask,
+  runFlatProviderOperation,
+} from "./generative-operation";
 
 /** Bump when the rubric or category taxonomy changes so old rows stay attributable. */
 export const RUBRIC_VERSION = "2026-07-01.1";
@@ -301,7 +306,10 @@ export interface ClassifierResult {
  * Throws if the app needs the LLM (no pre-filter match) but no provider is
  * configured — the caller must treat that as "cannot approve" (fail closed).
  */
-export async function classifyCandidate(document: string): Promise<ClassifierResult> {
+export async function classifyCandidate(
+  document: string,
+  operationContext?: GenerativeOperationContext,
+): Promise<ClassifierResult> {
   const pre = preFilter(document);
   if (pre.matched) {
     return {
@@ -321,14 +329,32 @@ export async function classifyCandidate(document: string): Promise<ClassifierRes
     );
   }
 
-  const { object } = await generateObject({
-    model: getLanguageModel(modelId),
-    schema: ClassifierSchema,
-    system: POLICY_RUBRIC,
-    prompt: `Review this app listing and decide allow or ban.\n\n${document}`,
-    temperature: 0,
-    maxRetries: 2,
-  });
+  if (!operationContext) {
+    throw new Error("[AppReview] Provider-backed classification requires generative admission");
+  }
+
+  const { object } = await runFlatProviderOperation(
+    operationContext,
+    {
+      provider: providerOf(modelId),
+      billingSource:
+        providerOf(modelId) === "unknown"
+          ? "gateway"
+          : (providerOf(modelId) as "anthropic" | "cerebras" | "openai" | "groq"),
+      model: modelId,
+      operation: "app_review_classification",
+      cost: 0.01,
+    },
+    async () =>
+      await generateObject({
+        model: getLanguageModel(modelId),
+        schema: ClassifierSchema,
+        system: POLICY_RUBRIC,
+        prompt: `Review this app listing and decide allow or ban.\n\n${document}`,
+        temperature: 0,
+        maxRetries: 2,
+      }),
+  );
 
   return {
     disposition: object.disposition,
@@ -351,6 +377,7 @@ function providerOf(modelId: string): string {
 
 export interface RunAppReviewParams {
   app: App;
+  operationContext?: GenerativeOperationContext;
   triggeredByUserId?: string | null;
   trajectoryRef?: string | null;
 }
@@ -363,7 +390,7 @@ export interface RunAppReviewParams {
 export async function runAppReview(params: RunAppReviewParams): Promise<AppReview> {
   const { app, triggeredByUserId = null, trajectoryRef = null } = params;
   const candidate = buildReviewCandidate(app);
-  const result = await classifyCandidate(candidate.document);
+  const result = await classifyCandidate(candidate.document, params.operationContext);
 
   const reviewStatus = result.disposition === "allow" ? "approved" : "rejected";
   const now = new Date();
@@ -416,13 +443,32 @@ export async function runAppReview(params: RunAppReviewParams): Promise<AppRevie
   // leaves the payment gate reading a stale "approved" row. Mirrors the
   // invalidate-on-mutation invariant documented at apps.ts:105-111. Best-effort:
   // a cache-eviction failure must not fail the (already-committed) review.
-  try {
-    await appsService.invalidateCache(app.id, app.api_key_id ?? undefined, app.slug ?? undefined);
-  } catch (err) {
-    logger.warn("[AppReview] cache invalidation after review failed", {
-      appId: app.id,
-      error: err instanceof Error ? err.message : String(err),
-    });
+  const cacheInvalidation = appsService.invalidateCache(
+    app.id,
+    app.api_key_id ?? undefined,
+    app.slug ?? undefined,
+  );
+  if (params.operationContext) {
+    await retainGenerativeTask(
+      params.operationContext,
+      {
+        provider: result.modelProvider ?? "local",
+        billingSource: "gateway",
+        model: result.model ?? "deterministic-prefilter",
+        operation: "app_review_cache_invalidation",
+        cost: 0,
+      },
+      cacheInvalidation,
+    );
+  } else {
+    try {
+      await cacheInvalidation;
+    } catch (err) {
+      logger.warn("[AppReview] cache invalidation after review failed", {
+        appId: app.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   logger.info("[AppReview] Completed review", {

--- a/packages/cloud/shared/src/lib/services/browser-tools.cloud-env.test.ts
+++ b/packages/cloud/shared/src/lib/services/browser-tools.cloud-env.test.ts
@@ -5,14 +5,28 @@ import { runWithCloudBindings } from "../runtime/cloud-bindings";
 
 mock.module("../cache/client", () => ({ cache: {} }));
 mock.module("./usage", () => ({ usageService: { create: mock() } }));
+const runFlatProviderOperation = mock(
+  async (_context: unknown, _operation: unknown, dispatch: () => Promise<unknown>) => dispatch(),
+);
+mock.module("./generative-operation", () => ({
+  isGenerativeOperationAdmissionError: () => false,
+  runFlatProviderOperation,
+}));
 
 const { extractHostedPage } = await import("./browser-tools");
 
 const originalFetch = globalThis.fetch;
 const originalFirecrawlKey = process.env.FIRECRAWL_API_KEY;
 const originalFirecrawlUrl = process.env.FIRECRAWL_API_URL;
+const operationContext = {
+  organizationId: "org-1",
+  userId: "user-1",
+  apiKeyId: "key-1",
+  requestId: "request-1",
+};
 
 afterEach(() => {
+  runFlatProviderOperation.mockClear();
   globalThis.fetch = originalFetch;
   if (originalFirecrawlKey === undefined) delete process.env.FIRECRAWL_API_KEY;
   else process.env.FIRECRAWL_API_KEY = originalFirecrawlKey;
@@ -35,9 +49,38 @@ test("uses Firecrawl key and URL from the active Worker binding context", async 
       FIRECRAWL_API_KEY: "worker-secret",
       FIRECRAWL_API_URL: "https://firecrawl.example/",
     },
-    () => extractHostedPage({ url: "https://www.doordash.com/" }),
+    () =>
+      extractHostedPage(
+        { url: "https://www.doordash.com/" },
+        {
+          organizationId: "org-1",
+          userId: "user-1",
+          apiKeyId: "key-1",
+          operationContext,
+        },
+      ),
   );
 
   expect(result.markdown).toBe("Menu");
   expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(runFlatProviderOperation).toHaveBeenCalledTimes(1);
+  expect(runFlatProviderOperation.mock.calls[0]?.[1]).toMatchObject({
+    operation: "extract_page",
+    provider: "firecrawl",
+  });
+});
+
+test("fails closed before Firecrawl when standing context is absent", async () => {
+  const fetchMock = mock(async () => Response.json({ success: true }));
+  globalThis.fetch = fetchMock as typeof fetch;
+
+  await expect(
+    extractHostedPage(
+      { url: "https://example.com" },
+      { organizationId: "org-1", userId: "user-1" },
+    ),
+  ).rejects.toThrow("account-standing context");
+
+  expect(runFlatProviderOperation).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
 });

--- a/packages/cloud/shared/src/lib/services/browser-tools.ts
+++ b/packages/cloud/shared/src/lib/services/browser-tools.ts
@@ -3,6 +3,11 @@ import { cache } from "../cache/client";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { isHostedBrowserSessionOwner } from "./browser-session-ownership";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+  runFlatProviderOperation,
+} from "./generative-operation";
 import { usageService } from "./usage";
 
 export interface HostedBrowserAuthContext {
@@ -11,6 +16,7 @@ export interface HostedBrowserAuthContext {
   organizationId?: string;
   requestSource?: "a2a" | "api" | "mcp";
   userId?: string;
+  operationContext?: GenerativeOperationContext;
 }
 
 export interface HostedBrowserTab {
@@ -167,16 +173,42 @@ function resolveFirecrawlBaseUrl(): string {
   );
 }
 
-async function firecrawlRequest<T>(pathname: string, init: RequestInit): Promise<T> {
-  const response = await fetch(`${resolveFirecrawlBaseUrl()}${pathname}`, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${resolveFirecrawlApiKey()}`,
-      "Content-Type": "application/json",
-      ...(init.headers ?? {}),
+function requireHostedBrowserOperationContext(
+  auth?: HostedBrowserAuthContext,
+): GenerativeOperationContext {
+  if (!auth?.operationContext) {
+    throw new Error("Hosted browser provider dispatch requires account-standing context");
+  }
+  return auth.operationContext;
+}
+
+async function firecrawlRequest<T>(
+  pathname: string,
+  init: RequestInit,
+  auth: HostedBrowserAuthContext | undefined,
+  operation: string,
+): Promise<T> {
+  const response = await runFlatProviderOperation(
+    requireHostedBrowserOperationContext(auth),
+    {
+      provider: "firecrawl",
+      billingSource: "gateway",
+      model: "firecrawl/browser",
+      operation,
+      cost: 0,
+      metadata: { requestSource: auth?.requestSource ?? "api" },
     },
-    signal: AbortSignal.timeout(60_000),
-  });
+    () =>
+      fetch(`${resolveFirecrawlBaseUrl()}${pathname}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${resolveFirecrawlApiKey()}`,
+          "Content-Type": "application/json",
+          ...(init.headers ?? {}),
+        },
+        signal: AbortSignal.timeout(60_000),
+      }),
+  );
 
   const text = await response.text();
   const payload = text.trim().length > 0 ? (JSON.parse(text) as Record<string, unknown>) : {};
@@ -475,6 +507,7 @@ async function logHostedBrowserUsage(
 async function executeFirecrawlBrowserCode(
   sessionId: string,
   code: string,
+  auth?: HostedBrowserAuthContext,
   options?: { language?: "bash" | "node" | "python"; timeoutSeconds?: number },
 ): Promise<FirecrawlBrowserExecuteResponse> {
   return firecrawlRequest<FirecrawlBrowserExecuteResponse>(
@@ -487,11 +520,14 @@ async function executeFirecrawlBrowserCode(
       }),
       method: "POST",
     },
+    auth,
+    "browser_execute",
   );
 }
 
 async function readHostedBrowserPageState(
   sessionId: string,
+  auth?: HostedBrowserAuthContext,
 ): Promise<FirecrawlResolvedPageState | null> {
   const response = await executeFirecrawlBrowserCode(
     sessionId,
@@ -502,6 +538,7 @@ const state = {
 };
 JSON.stringify(state);
     `.trim(),
+    auth,
   );
 
   const payload = parseExecutionPayload(response.result ?? response.stdout);
@@ -516,13 +553,17 @@ JSON.stringify(state);
   };
 }
 
-async function readHostedBrowserSnapshot(sessionId: string): Promise<{ data: string }> {
+async function readHostedBrowserSnapshot(
+  sessionId: string,
+  auth?: HostedBrowserAuthContext,
+): Promise<{ data: string }> {
   const response = await executeFirecrawlBrowserCode(
     sessionId,
     `
 const data = await page.screenshot({ type: "png", encoding: "base64" });
 data;
     `.trim(),
+    auth,
   );
 
   const payload = parseExecutionPayload(response.result ?? response.stdout);
@@ -533,10 +574,17 @@ data;
   return { data: payload };
 }
 
-async function listFirecrawlBrowserSessions(): Promise<FirecrawlBrowserSession[]> {
-  const response = await firecrawlRequest<FirecrawlBrowserListResponse>("/v2/browser", {
-    method: "GET",
-  });
+async function listFirecrawlBrowserSessions(
+  auth?: HostedBrowserAuthContext,
+): Promise<FirecrawlBrowserSession[]> {
+  const response = await firecrawlRequest<FirecrawlBrowserListResponse>(
+    "/v2/browser",
+    {
+      method: "GET",
+    },
+    auth,
+    "browser_list",
+  );
 
   return Array.isArray(response.sessions)
     ? response.sessions.filter(
@@ -554,7 +602,7 @@ async function resolveAuthorizedFirecrawlBrowserSession(
   session: FirecrawlBrowserSession;
 }> {
   const access = await assertHostedBrowserSessionAccess(sessionId, auth);
-  const sessions = await listFirecrawlBrowserSessions();
+  const sessions = await listFirecrawlBrowserSessions(auth);
   const session = sessions.find((entry) => entry.id === sessionId);
 
   if (!session) {
@@ -573,7 +621,7 @@ async function loadAuthorizedHostedBrowserTab(
   tab: HostedBrowserTab;
 }> {
   const { access, session } = await resolveAuthorizedFirecrawlBrowserSession(sessionId, auth);
-  const state = await readHostedBrowserPageState(sessionId).catch((error) => {
+  const state = await readHostedBrowserPageState(sessionId, auth).catch((error) => {
     warnHostedBrowserOptionalReadFailure("page_state", error, { sessionId });
     return null;
   });
@@ -721,13 +769,15 @@ export async function listHostedBrowserSessions(
   auth?: HostedBrowserAuthContext,
 ): Promise<HostedBrowserTab[]> {
   const organizationId = requireHostedBrowserOrganizationId(auth);
+  requireHostedBrowserOperationContext(auth);
   const sessionIds = await getStoredOrganizationSessionIds(organizationId);
   const tabs = await Promise.all(
     sessionIds.map(async (sessionId) => {
       try {
         const { tab } = await loadAuthorizedHostedBrowserTab(sessionId, auth);
         return tab;
-      } catch {
+      } catch (error) {
+        if (isGenerativeOperationAdmissionError(error)) throw error;
         // A same-organization session may belong to another user. Do not delete
         // its access record merely because it is intentionally invisible here.
         return null;
@@ -770,14 +820,19 @@ export async function createHostedBrowserSession(
   auth?: HostedBrowserAuthContext,
 ): Promise<HostedBrowserTab> {
   requireHostedBrowserOrganizationId(auth);
-  const created = await firecrawlRequest<FirecrawlBrowserCreateResponse>("/v2/browser", {
-    body: JSON.stringify({
-      activityTtl: options.activityTtl ?? DEFAULT_BROWSER_ACTIVITY_TTL_SECONDS,
-      streamWebView: true,
-      ttl: options.ttl ?? DEFAULT_BROWSER_TTL_SECONDS,
-    }),
-    method: "POST",
-  });
+  const created = await firecrawlRequest<FirecrawlBrowserCreateResponse>(
+    "/v2/browser",
+    {
+      body: JSON.stringify({
+        activityTtl: options.activityTtl ?? DEFAULT_BROWSER_ACTIVITY_TTL_SECONDS,
+        streamWebView: true,
+        ttl: options.ttl ?? DEFAULT_BROWSER_TTL_SECONDS,
+      }),
+      method: "POST",
+    },
+    auth,
+    "browser_create",
+  );
 
   if (!created.id) {
     throw new Error("Firecrawl returned no browser session id");
@@ -792,6 +847,7 @@ export async function createHostedBrowserSession(
 await page.goto(${JSON.stringify(options.url.trim())}, { waitUntil: "domcontentloaded" });
 JSON.stringify({ title: await page.title(), url: page.url() });
         `.trim(),
+        auth,
       );
     }
 
@@ -838,6 +894,7 @@ export async function navigateHostedBrowserSession(
 await page.goto(${JSON.stringify(url)}, { waitUntil: "domcontentloaded" });
 JSON.stringify({ title: await page.title(), url: page.url() });
     `.trim(),
+    auth,
   );
 
   const tab = await getHostedBrowserSession(sessionId, auth);
@@ -861,6 +918,8 @@ export async function deleteHostedBrowserSession(
     {
       method: "DELETE",
     },
+    auth,
+    "browser_delete",
   );
 
   await removeHostedBrowserSessionAccess(sessionId, access.organizationId);
@@ -882,7 +941,7 @@ export async function getHostedBrowserSnapshot(
   auth?: HostedBrowserAuthContext,
 ): Promise<{ data: string }> {
   await assertHostedBrowserSessionAccess(sessionId, auth);
-  const snapshot = await readHostedBrowserSnapshot(sessionId);
+  const snapshot = await readHostedBrowserSnapshot(sessionId, auth);
   await logHostedBrowserUsage(auth, {
     operation: "browser_snapshot",
     sessionId,
@@ -899,7 +958,7 @@ export async function executeHostedBrowserCommand(
 ): Promise<HostedBrowserCommandResult> {
   await assertHostedBrowserSessionAccess(sessionId, auth);
   const plan = buildCommandCode(command);
-  const executed = await executeFirecrawlBrowserCode(sessionId, plan.code, {
+  const executed = await executeFirecrawlBrowserCode(sessionId, plan.code, auth, {
     language: plan.language,
     timeoutSeconds: plan.timeoutSeconds,
   });
@@ -913,7 +972,7 @@ export async function executeHostedBrowserCommand(
   const snapshot =
     command.subaction === "state" || command.subaction === "get"
       ? undefined
-      : await readHostedBrowserSnapshot(sessionId).catch((error) => {
+      : await readHostedBrowserSnapshot(sessionId, auth).catch((error) => {
           warnHostedBrowserOptionalReadFailure("command_snapshot", error, { sessionId });
           return undefined;
         });
@@ -940,17 +999,22 @@ export async function extractHostedPage(
   options: HostedExtractOptions,
   auth?: HostedBrowserAuthContext,
 ): Promise<HostedExtractResult> {
-  const response = await firecrawlRequest<FirecrawlScrapeResponse>("/v2/scrape", {
-    body: JSON.stringify({
-      formats: options.formats ?? ["markdown"],
-      maxAge: 0,
-      onlyMainContent: options.onlyMainContent ?? true,
-      timeout: options.timeoutMs ?? DEFAULT_EXTRACT_TIMEOUT_MS,
-      url: options.url,
-      waitFor: options.waitFor ?? DEFAULT_EXTRACT_WAIT_FOR_MS,
-    }),
-    method: "POST",
-  });
+  const response = await firecrawlRequest<FirecrawlScrapeResponse>(
+    "/v2/scrape",
+    {
+      body: JSON.stringify({
+        formats: options.formats ?? ["markdown"],
+        maxAge: 0,
+        onlyMainContent: options.onlyMainContent ?? true,
+        timeout: options.timeoutMs ?? DEFAULT_EXTRACT_TIMEOUT_MS,
+        url: options.url,
+        waitFor: options.waitFor ?? DEFAULT_EXTRACT_WAIT_FOR_MS,
+      }),
+      method: "POST",
+    },
+    auth,
+    "extract_page",
+  );
 
   const data = response.data ?? {};
   const result: HostedExtractResult = {

--- a/packages/cloud/shared/src/lib/services/discord-automation/app-automation.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/app-automation.error-policy.test.ts
@@ -67,15 +67,6 @@ mock.module("./index", () => ({
   },
 }));
 
-// Isolate the send path from the credit/LLM generator: postAnnouncement is
-// called with explicit text so generateAnnouncement is never reached.
-mock.module("../credits", () => ({
-  creditsService: {
-    deductCredits: async () => ({ success: true, newBalance: 100, transaction: null }),
-    refundCredits: async () => ({ transaction: {}, newBalance: 100 }),
-  },
-}));
-
 mock.module("../character-prompt-helper", () => ({
   getCharacterPromptContext: async () => null,
   buildCharacterSystemPrompt: () => "",

--- a/packages/cloud/shared/src/lib/services/discord-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/app-automation.ts
@@ -11,7 +11,7 @@ import { createActionRow, createEmbed, DISCORD_BLURPLE } from "../../utils/disco
 import { logger } from "../../utils/logger";
 import { DISCORD_AUTOMATION_DEFAULTS, getDiscordConfigWithDefaults } from "../automation-constants";
 import { buildCharacterSystemPrompt, getCharacterPromptContext } from "../character-prompt-helper";
-import { creditsService } from "../credits";
+import { type GenerativeOperationContext, runFlatProviderOperation } from "../generative-operation";
 import { discordAutomationService } from "./index";
 import type { DiscordAutomationConfig, DiscordAutomationStatus, PostResult } from "./types";
 
@@ -167,10 +167,13 @@ class DiscordAppAutomationService {
     };
   }
 
-  async generateAnnouncement(organizationId: string, app: App): Promise<string> {
-    // All throwable prep (character-context DB fetch, prompt build) runs BEFORE
-    // the deduction: nothing may throw between the charge and the refunding try,
-    // or the user is charged for a generation that never ran (#11685).
+  async generateAnnouncement(
+    organizationId: string,
+    app: App,
+    operationContext?: GenerativeOperationContext,
+  ): Promise<string> {
+    // Complete throwable prompt preparation before admission so validation or
+    // character lookup failures never reserve a provider operation.
     const config = app.discord_automation as DiscordAutomationConfig;
     const vibeStyle = config?.vibeStyle || "professional and engaging";
 
@@ -222,42 +225,35 @@ Write in a ${vibeStyle} style. Keep it concise and engaging.
 Use appropriate emojis sparingly (1-2 max). Do not use excessive formatting.
 Maximum ${MAX_ANNOUNCEMENT_LENGTH} characters. Do not include the URL in your response - it will be added automatically.`;
 
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: DISCORD_POST_COST,
-      description: `Discord AI announcement: ${app.name}`,
-      metadata: { appId: app.id, type: "discord_announcement" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${DISCORD_POST_COST.toFixed(4)}`,
-      );
+    if (!operationContext || operationContext.organizationId !== organizationId) {
+      throw new Error("Discord AI generation requires trusted generative admission context");
     }
 
-    try {
-      const result = await generateText({
-        model: openai("gpt-5-mini"),
-        system: systemPrompt,
-        prompt:
-          "Create a compelling Discord announcement about this app that would engage a community. Focus on what makes it unique and valuable.",
-      });
-      assertModelOutputComplete({
-        finishReason: result.finishReason,
+    return await runFlatProviderOperation(
+      operationContext,
+      {
         provider: "openai",
         model: "gpt-5-mini",
-      });
-
-      return result.text;
-    } catch (error) {
-      await creditsService.refundCredits({
-        organizationId,
-        amount: DISCORD_POST_COST,
-        description: "Refund for failed Discord AI generation",
-        metadata: { appId: app.id, type: "discord_announcement_refund" },
-      });
-      throw error;
-    }
+        billingSource: "openai",
+        operation: "discord_automation_announcement",
+        cost: DISCORD_POST_COST,
+        metadata: { appId: app.id, type: "discord_announcement" },
+      },
+      async () => {
+        const result = await generateText({
+          model: openai("gpt-5-mini"),
+          system: systemPrompt,
+          prompt:
+            "Create a compelling Discord announcement about this app that would engage a community. Focus on what makes it unique and valuable.",
+        });
+        assertModelOutputComplete({
+          finishReason: result.finishReason,
+          provider: "openai",
+          model: "gpt-5-mini",
+        });
+        return result.text;
+      },
+    );
   }
 
   /**
@@ -289,6 +285,7 @@ Maximum ${MAX_ANNOUNCEMENT_LENGTH} characters. Do not include the URL in your re
     organizationId: string,
     appId: string,
     text?: string,
+    operationContext?: GenerativeOperationContext,
   ): Promise<PostResult> {
     const app = await this.getAppForOrg(organizationId, appId);
     const config = app.discord_automation as DiscordAutomationConfig;
@@ -313,7 +310,8 @@ Maximum ${MAX_ANNOUNCEMENT_LENGTH} characters. Do not include the URL in your re
       };
     }
 
-    const messageText = text || (await this.generateAnnouncement(organizationId, app));
+    const messageText =
+      text || (await this.generateAnnouncement(organizationId, app, operationContext));
 
     // Get promotional image if available
     const promotionalImageUrl = this.getPromotionalImage(app);

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -109,4 +109,17 @@ describe("ConnectionEnforcementService.hasRequiredConnection — fail-closed con
     );
     expect(getConnectedPlatforms).not.toHaveBeenCalled();
   });
+
+  test("rejects dormant nudge generation before any LLM dispatch", async () => {
+    await expect(
+      connectionEnforcementService.generateNudgeResponse({
+        userMessage: "hello",
+        platform: "web",
+        organizationId: ORG,
+        userId: USER,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONNECTION_ENFORCEMENT_LLM_DISABLED",
+    });
+  });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
@@ -6,10 +6,8 @@
  * steer the user toward connecting Google, Microsoft, or X.
  */
 
-import { assertModelOutputComplete } from "@elizaos/core";
-import { generateText } from "ai";
+import { ElizaError } from "@elizaos/core";
 import { cache } from "../../cache/client";
-import { getLanguageModel } from "../../providers/language-model";
 import { logger } from "../../utils/logger";
 import { oauthService } from "../oauth";
 
@@ -387,85 +385,17 @@ class ConnectionEnforcementService {
   }
 
   async generateNudgeResponse(params: NudgeParams): Promise<string> {
-    const { userMessage, platform, organizationId, userId } = params;
-    const state = await loadConversationState(organizationId, userId);
-    const conversationHistory = formatConversationHistory(state.messages);
-    const detectedProvider = detectProviderFromMessage(userMessage);
-    const isFirstInteraction = state.messageCount === 0;
-    const mustNudge =
-      Boolean(detectedProvider) ||
-      isClaimingConnected(userMessage) ||
-      shouldNudge(state.messageCount);
-
-    let response: string;
-    let responseForHistory: string;
-    if (mustNudge) {
-      const llmResponse = await this.generateLLMResponse(
-        userMessage,
-        platform,
-        "nudge",
-        conversationHistory,
-        isFirstInteraction,
-      );
-      responseForHistory = llmResponse;
-      const links = await generateOAuthLinks(organizationId, userId, platform, detectedProvider);
-      response =
-        links.length > 0 ? `${llmResponse}\n\n${formatLinks(links, platform)}` : llmResponse;
-    } else {
-      response = await this.generateLLMResponse(
-        userMessage,
-        platform,
-        "chat",
-        conversationHistory,
-        false,
-      );
-      responseForHistory = response;
-    }
-
-    state.messages.push({ role: "user", content: userMessage });
-    state.messages.push({ role: "assistant", content: responseForHistory });
-    state.messageCount += 1;
-    await saveConversationState(organizationId, userId, state);
-
-    return response;
-  }
-
-  private async generateLLMResponse(
-    userMessage: string,
-    platform: MessagingPlatform,
-    mode: "nudge" | "chat",
-    conversationHistory: string,
-    isFirstInteraction: boolean,
-  ): Promise<string> {
-    try {
-      const system =
-        mode === "nudge"
-          ? buildNudgePrompt(platform, conversationHistory, isFirstInteraction)
-          : buildChatPrompt(platform, conversationHistory);
-      const result = await generateText({
-        model: getLanguageModel(NUDGE_MODEL),
-        system,
-        prompt: userMessage || "hey",
-        temperature: mode === "nudge" ? 0.7 : 0.9,
-      });
-      assertModelOutputComplete({
-        finishReason: result.finishReason,
-        provider: "openai",
-        model: NUDGE_MODEL,
-      });
-
-      return result.text;
-    } catch (error) {
-      // error-policy:J4 designed user-facing degrade — on model failure, reply with a canned
-      // in-character nudge that still steers the user to connect a data source. This is a
-      // designed fallback response, not fabricated pipeline data; the failure is logged.
-      logger.error("[ConnectionEnforcement] LLM generation failed", {
-        platform,
-        mode,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return getFallbackResponse(userMessage);
-    }
+    throw new ElizaError(
+      "Connection-enforcement replies are disabled until they use the admitted generative-operation boundary",
+      {
+        code: "CONNECTION_ENFORCEMENT_LLM_DISABLED",
+        context: {
+          organizationId: params.organizationId,
+          platform: params.platform,
+          userId: params.userId,
+        },
+      },
+    );
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
@@ -51,7 +51,10 @@ const describeMedia = mock(
 );
 const deps = { repository, describe: describeMedia };
 
-function enrich(env: InboundMediaEnrichmentEnv = { ELIZA_APP_INBOUND_MEDIA_VISION: "true" }) {
+function enrich(
+  env: InboundMediaEnrichmentEnv = { ELIZA_APP_INBOUND_MEDIA_VISION: "true" },
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+) {
   return enrichInboundImageMedia(
     {
       env,
@@ -62,6 +65,7 @@ function enrich(env: InboundMediaEnrichmentEnv = { ELIZA_APP_INBOUND_MEDIA_VISIO
       organizationId: "00000000-0000-4000-8000-000000000001",
       userId: "00000000-0000-4000-8000-000000000002",
       mediaUrls: [URL_A, URL_B],
+      executionCtx,
     },
     deps,
   );
@@ -213,6 +217,7 @@ describe("enrichInboundImageMedia — ledger decisions", () => {
       [{ kind: "previously_failed", reason: "media_fetch_failed" }, "previously_failed"],
       [{ kind: "identity_mismatch" }, "identity_mismatch"],
       [{ kind: "media_mismatch" }, "media_mismatch"],
+      [{ kind: "standing_denied", reason: "moderation_blocked" }, "standing_denied"],
       [{ kind: "exhausted", scope: "sender", limit: 20, used: 20, requested: 2 }, "exhausted"],
       [
         { kind: "exhausted", scope: "connector", limit: 1000, used: 999, requested: 2 },
@@ -240,6 +245,33 @@ describe("enrichInboundImageMedia — behind a claim", () => {
     expect(describeMedia.mock.calls[0]?.[1]).toEqual([URL_A, URL_B]);
     expect(complete).toHaveBeenCalledWith(CLAIM, "a cat on a keyboard");
     expect(fail).not.toHaveBeenCalled();
+  });
+
+  test("a mounted Worker response does not await post-dispatch settlement", async () => {
+    let releaseSettlement: ((value: boolean) => void) | undefined;
+    complete.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          releaseSettlement = resolve;
+        }),
+    );
+    const retained: Promise<unknown>[] = [];
+    const outcome = await enrich(undefined, {
+      waitUntil(promise) {
+        retained.push(promise);
+      },
+    });
+
+    expect(outcome).toEqual({
+      kind: "described",
+      description: "a cat on a keyboard",
+      reused: false,
+    });
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(retained).toHaveLength(1);
+
+    releaseSettlement?.(true);
+    await Promise.all(retained);
   });
 
   test("a typed enrichment failure is recorded against the claim and skips", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
@@ -4,11 +4,13 @@
  * operator ceilings, then one primary-database transaction that claims the
  * connector message id (the enrichment idempotency record) and consumes the
  * sender and connector per-day image ceilings, and only behind a committed
- * claim the pooled-key vision call. Every outcome other than `described` is a
- * skip the caller answers with the raw media-URL text: a missing or broken
- * admission decision never spends and never fails the turn. A provider
- * redelivery of the same message reuses the stored description, waits out a
- * live claim, and never retries a terminal failure.
+ * claim the pooled-key vision call. Mounted Workers retain the post-dispatch
+ * terminal write under `waitUntil`; it never holds the connector response open
+ * or performs a readback. Every outcome other than `described` is a skip the
+ * caller answers with the raw media-URL text: a missing or broken admission
+ * decision never spends and never fails the turn. A provider redelivery of the
+ * same message reuses the stored description, waits out a live claim, and
+ * never retries a terminal failure.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -49,6 +51,7 @@ export type InboundMediaEnrichmentSkipReason =
   | "previously_failed"
   | "identity_mismatch"
   | "media_mismatch"
+  | "standing_denied"
   | "exhausted"
   | "description_failed"
   | "settlement_failed";
@@ -62,6 +65,7 @@ export interface InboundMediaEnrichmentInput extends InboundMediaDescriptionIden
   organizationId: string;
   userId: string;
   mediaUrls: readonly string[];
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }
 
 export interface InboundMediaEnrichmentDeps {
@@ -129,6 +133,29 @@ async function settleClaim(
     logger.warn(`${LOG_PREFIX} description claim was reclaimed before settlement`, context);
   }
   return settled;
+}
+
+function deferClaimSettlement(
+  input: InboundMediaEnrichmentInput,
+  settlement: Promise<boolean>,
+  context: Record<string, unknown>,
+): boolean {
+  if (!input.executionCtx) return false;
+  input.executionCtx.waitUntil(
+    settlement.then(
+      () => undefined,
+      (error) => {
+        // error-policy:J7 the provider outcome is already fixed; a failed
+        // post-dispatch ledger update is diagnostic and must not reject the
+        // connector response or escape the Worker lifetime task.
+        logger.error(`${LOG_PREFIX} deferred claim settlement failed`, {
+          ...context,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    ),
+  );
+  return true;
 }
 
 export async function enrichInboundImageMedia(
@@ -210,6 +237,12 @@ export async function enrichInboundImageMedia(
         context,
       );
       return { kind: "skipped", reason: "media_mismatch" };
+    case "standing_denied":
+      logger.warn(`${LOG_PREFIX} account standing denied vision`, {
+        ...context,
+        reason: admission.reason,
+      });
+      return { kind: "skipped", reason: "standing_denied" };
     case "exhausted":
       logger.warn(`${LOG_PREFIX} daily image ceiling exhausted; vision denied`, {
         ...context,
@@ -238,7 +271,13 @@ async function describeBehindClaim(
     if (error instanceof InboundMediaVisionDisabledError) {
       // The flag is on but no vision provider is configured: an operator
       // misconfiguration, recorded so a redelivery does not claim again.
-      await settleClaim(() => deps.repository.fail(claim, "vision_disabled"), claimContext);
+      const settlement = settleClaim(
+        () => deps.repository.fail(claim, "vision_disabled"),
+        claimContext,
+      );
+      if (!deferClaimSettlement(input, settlement, claimContext)) {
+        await settlement;
+      }
       logger.error(`${LOG_PREFIX} vision enabled without a configured provider`, claimContext);
       return { kind: "skipped", reason: "vision_disabled" };
     }
@@ -246,7 +285,10 @@ async function describeBehindClaim(
       // error-policy:J4 enrichment is additive: an expected fetch/vision
       // failure degrades to the raw media text instead of dropping the turn.
       // Reported here because the turn still returns success to the connector.
-      await settleClaim(() => deps.repository.fail(claim, error.reason), claimContext);
+      const settlement = settleClaim(() => deps.repository.fail(claim, error.reason), claimContext);
+      if (!deferClaimSettlement(input, settlement, claimContext)) {
+        await settlement;
+      }
       logger.error(`${LOG_PREFIX} inbound media description failed`, {
         ...claimContext,
         reason: error.reason,
@@ -257,10 +299,12 @@ async function describeBehindClaim(
     // An untyped failure is a bug; the pending claim lapses with its lease.
     throw error;
   }
-  const settled = await settleClaim(
-    () => deps.repository.complete(claim, description),
-    claimContext,
-  );
+  const settlement = settleClaim(() => deps.repository.complete(claim, description), claimContext);
+  if (deferClaimSettlement(input, settlement, claimContext)) {
+    logger.info(`${LOG_PREFIX} inbound media described`, claimContext);
+    return { kind: "described", description, reused: false };
+  }
+  const settled = await settlement;
   if (!settled) {
     logger.error(
       `${LOG_PREFIX} description was not committed by the live claim; keeping raw media`,

--- a/packages/cloud/shared/src/lib/services/generative-operation.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.test.ts
@@ -1,0 +1,94 @@
+/** Deterministic unit coverage for paid-provider admission and dispatch ordering. */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const events: string[] = [];
+let admissionError: Error | null = null;
+let settleUnknown = mock(async () => {
+  events.push("settleUnknown");
+  return null;
+});
+
+mock.module("./organization-inference-admission", () => ({
+  admitOrganizationInference: mock(async () => {
+    events.push("admit");
+    if (admissionError) throw admissionError;
+    return {
+      mode: "cache_admission",
+      affiliateAttribution: null,
+      markProviderDispatched: mock(async () => {
+        events.push("mark");
+      }),
+      settle: mock(async () => {
+        events.push("settle");
+        return null;
+      }),
+      settleUnknown,
+    };
+  }),
+}));
+
+const { isGenerativeOperationAdmissionError, runFlatProviderOperation } = await import(
+  "./generative-operation"
+);
+
+const context = {
+  organizationId: "org-1",
+  userId: "user-1",
+  apiKeyId: "key-1",
+  requestId: "request-1",
+};
+const operation = {
+  provider: "anthropic",
+  billingSource: "anthropic" as const,
+  model: "anthropic/test",
+  operation: "test_generation",
+  cost: 0.01,
+};
+
+beforeEach(() => {
+  events.length = 0;
+  admissionError = null;
+  settleUnknown = mock(async () => {
+    events.push("settleUnknown");
+    return null;
+  });
+});
+
+describe("runFlatProviderOperation", () => {
+  test("admits before marking and marks immediately before provider dispatch", async () => {
+    await runFlatProviderOperation(context, operation, async () => {
+      events.push("provider");
+      return "ok";
+    });
+
+    expect(events).toEqual(["admit", "mark", "provider", "settle"]);
+  });
+
+  test("does not dispatch or mark when admission denies", async () => {
+    admissionError = new Error("cached standing denied");
+    const provider = mock(async () => "unexpected");
+
+    let rejection: unknown;
+    try {
+      await runFlatProviderOperation(context, operation, provider);
+    } catch (error) {
+      rejection = error;
+    }
+    expect(rejection).toBe(admissionError);
+    expect(isGenerativeOperationAdmissionError(rejection)).toBe(true);
+    expect(provider).not.toHaveBeenCalled();
+    expect(events).toEqual(["admit"]);
+  });
+
+  test("settles unknown after a marked provider failure", async () => {
+    await expect(
+      runFlatProviderOperation(context, operation, async () => {
+        events.push("provider");
+        throw new Error("provider failed");
+      }),
+    ).rejects.toThrow("provider failed");
+
+    expect(events).toEqual(["admit", "mark", "provider", "settleUnknown"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/generative-operation.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const events: string[] = [];
+const settledCosts: number[] = [];
 let admissionError: Error | null = null;
 let settleUnknown = mock(async () => {
   events.push("settleUnknown");
@@ -19,8 +20,9 @@ mock.module("./organization-inference-admission", () => ({
       markProviderDispatched: mock(async () => {
         events.push("mark");
       }),
-      settle: mock(async () => {
+      settle: mock(async (cost: number) => {
         events.push("settle");
+        settledCosts.push(cost);
         return null;
       }),
       settleUnknown,
@@ -28,9 +30,11 @@ mock.module("./organization-inference-admission", () => ({
   }),
 }));
 
-const { isGenerativeOperationAdmissionError, runFlatProviderOperation } = await import(
-  "./generative-operation"
-);
+const {
+  isGenerativeOperationAdmissionError,
+  runFlatProviderOperation,
+  runMeteredProviderOperation,
+} = await import("./generative-operation");
 
 const context = {
   organizationId: "org-1",
@@ -48,6 +52,7 @@ const operation = {
 
 beforeEach(() => {
   events.length = 0;
+  settledCosts.length = 0;
   admissionError = null;
   settleUnknown = mock(async () => {
     events.push("settleUnknown");
@@ -88,6 +93,60 @@ describe("runFlatProviderOperation", () => {
         throw new Error("provider failed");
       }),
     ).rejects.toThrow("provider failed");
+
+    expect(events).toEqual(["admit", "mark", "provider", "settleUnknown"]);
+  });
+
+  test("settles zero when marking fails before provider dispatch", async () => {
+    const { admitOrganizationInference } = await import("./organization-inference-admission");
+    (admitOrganizationInference as ReturnType<typeof mock>).mockImplementationOnce(async () => ({
+      mode: "cache_admission",
+      affiliateAttribution: null,
+      markProviderDispatched: async () => {
+        events.push("mark");
+        throw new Error("mark failed");
+      },
+      settle: async (cost: number) => {
+        events.push(`settle:${cost}`);
+        return null;
+      },
+      settleUnknown,
+    }));
+
+    await expect(
+      runFlatProviderOperation(context, operation, async () => "unexpected"),
+    ).rejects.toThrow("mark failed");
+    expect(events).toEqual(["mark", "settle:0"]);
+  });
+});
+
+describe("runMeteredProviderOperation", () => {
+  test("marks immediately before dispatch and settles the returned exact cost", async () => {
+    const result = await runMeteredProviderOperation(
+      context,
+      { ...operation, estimatedCost: operation.cost },
+      async () => {
+        events.push("provider");
+        return { value: "ok", actualCost: 0.004 };
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(events).toEqual(["admit", "mark", "provider", "settle"]);
+    expect(settledCosts).toEqual([0.004]);
+  });
+
+  test("settles unknown when output parsing fails after dispatch", async () => {
+    await expect(
+      runMeteredProviderOperation(
+        context,
+        { ...operation, estimatedCost: operation.cost },
+        async () => {
+          events.push("provider");
+          throw new Error("invalid provider output");
+        },
+      ),
+    ).rejects.toThrow("invalid provider output");
 
     expect(events).toEqual(["admit", "mark", "provider", "settleUnknown"]);
   });

--- a/packages/cloud/shared/src/lib/services/generative-operation.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.ts
@@ -26,6 +26,18 @@ export interface FlatProviderOperation {
   metadata?: Record<string, unknown>;
 }
 
+export interface MeteredProviderOperation extends Omit<FlatProviderOperation, "cost"> {
+  estimatedCost: number;
+}
+
+export interface MeteredProviderResult<T> {
+  value: T;
+  actualCost: number;
+}
+
+type ProviderOperationLogContext = Pick<FlatProviderOperation, "provider" | "model" | "operation"> &
+  Partial<Pick<FlatProviderOperation, "billingSource" | "cost" | "metadata">>;
+
 const admissionErrors = new WeakSet<object>();
 
 export function isGenerativeOperationAdmissionError(error: unknown): boolean {
@@ -35,7 +47,7 @@ export function isGenerativeOperationAdmissionError(error: unknown): boolean {
 function observeBackgroundTask(
   task: Promise<unknown>,
   context: GenerativeOperationContext,
-  operation: FlatProviderOperation,
+  operation: ProviderOperationLogContext,
 ): Promise<void> {
   return task.then(
     () => undefined,
@@ -54,7 +66,7 @@ function observeBackgroundTask(
 
 export async function retainGenerativeTask(
   context: GenerativeOperationContext,
-  operation: FlatProviderOperation,
+  operation: ProviderOperationLogContext,
   task: Promise<unknown>,
 ): Promise<void> {
   const observed = observeBackgroundTask(task, context, operation);
@@ -65,15 +77,13 @@ export async function retainGenerativeTask(
   await observed;
 }
 
-/** Admits one priced operation and marks its lease immediately before dispatch. */
-export async function runFlatProviderOperation<T>(
+async function admitFlatCost(
   context: GenerativeOperationContext,
-  operation: FlatProviderOperation,
-  dispatch: () => Promise<T>,
-): Promise<T> {
-  let admission;
+  operation: Omit<FlatProviderOperation, "cost">,
+  cost: number,
+) {
   try {
-    admission = await admitOrganizationInference({
+    return await admitOrganizationInference({
       context: {
         organizationId: context.organizationId,
         userId: context.userId,
@@ -89,8 +99,8 @@ export async function runFlatProviderOperation<T>(
       estimatedInputTokens: 0,
       estimatedOutputTokens: 0,
       flatCost: {
-        totalCost: operation.cost,
-        baseTotalCost: operation.cost,
+        totalCost: cost,
+        baseTotalCost: cost,
         platformMarkup: 0,
       },
       admissionSnapshot: context.admissionSnapshot,
@@ -100,6 +110,15 @@ export async function runFlatProviderOperation<T>(
     if (typeof error === "object" && error !== null) admissionErrors.add(error);
     throw error;
   }
+}
+
+/** Admits one priced operation and marks its lease immediately before dispatch. */
+export async function runFlatProviderOperation<T>(
+  context: GenerativeOperationContext,
+  operation: FlatProviderOperation,
+  dispatch: () => Promise<T>,
+): Promise<T> {
+  const admission = await admitFlatCost(context, operation, operation.cost);
 
   let marked = false;
   try {
@@ -111,8 +130,43 @@ export async function runFlatProviderOperation<T>(
   } catch (error) {
     if (marked) {
       await retainGenerativeTask(context, operation, admission.settleUnknown());
+    } else {
+      await retainGenerativeTask(context, operation, admission.settle(0));
     }
     logger.error("[GenerativeOperation] provider operation failed", {
+      organizationId: context.organizationId,
+      requestId: context.requestId,
+      provider: operation.provider,
+      model: operation.model,
+      operation: operation.operation,
+      providerDispatched: marked,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+/** Admits an estimate, then settles the exact cost returned by provider parsing. */
+export async function runMeteredProviderOperation<T>(
+  context: GenerativeOperationContext,
+  operation: MeteredProviderOperation,
+  dispatch: () => Promise<MeteredProviderResult<T>>,
+): Promise<T> {
+  const admission = await admitFlatCost(context, operation, operation.estimatedCost);
+  let marked = false;
+  try {
+    await admission.markProviderDispatched?.();
+    marked = true;
+    const result = await dispatch();
+    await retainGenerativeTask(context, operation, admission.settle(result.actualCost));
+    return result.value;
+  } catch (error) {
+    if (marked) {
+      await retainGenerativeTask(context, operation, admission.settleUnknown());
+    } else {
+      await retainGenerativeTask(context, operation, admission.settle(0));
+    }
+    logger.error("[GenerativeOperation] metered provider operation failed", {
       organizationId: context.organizationId,
       requestId: context.requestId,
       provider: operation.provider,

--- a/packages/cloud/shared/src/lib/services/generative-operation.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.ts
@@ -1,0 +1,126 @@
+/**
+ * Owns paid-provider admission and durable post-dispatch settlement for shared
+ * cloud services that run outside an inference route handler.
+ */
+
+import { logger } from "../utils/logger";
+import type { PricingBillingSource } from "./ai-pricing-definitions";
+import type { InferenceAdmissionSnapshot } from "./inference-auth-cache";
+import { admitOrganizationInference } from "./organization-inference-admission";
+
+export interface GenerativeOperationContext {
+  organizationId: string;
+  userId: string;
+  apiKeyId: string | null;
+  requestId: string;
+  admissionSnapshot?: InferenceAdmissionSnapshot;
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+}
+
+export interface FlatProviderOperation {
+  provider: string;
+  billingSource: PricingBillingSource;
+  model: string;
+  operation: string;
+  cost: number;
+  metadata?: Record<string, unknown>;
+}
+
+const admissionErrors = new WeakSet<object>();
+
+export function isGenerativeOperationAdmissionError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && admissionErrors.has(error);
+}
+
+function observeBackgroundTask(
+  task: Promise<unknown>,
+  context: GenerativeOperationContext,
+  operation: FlatProviderOperation,
+): Promise<void> {
+  return task.then(
+    () => undefined,
+    (error) => {
+      logger.error("[GenerativeOperation] background task failed", {
+        organizationId: context.organizationId,
+        requestId: context.requestId,
+        provider: operation.provider,
+        model: operation.model,
+        operation: operation.operation,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+}
+
+export async function retainGenerativeTask(
+  context: GenerativeOperationContext,
+  operation: FlatProviderOperation,
+  task: Promise<unknown>,
+): Promise<void> {
+  const observed = observeBackgroundTask(task, context, operation);
+  if (context.executionCtx) {
+    context.executionCtx.waitUntil(observed);
+    return;
+  }
+  await observed;
+}
+
+/** Admits one priced operation and marks its lease immediately before dispatch. */
+export async function runFlatProviderOperation<T>(
+  context: GenerativeOperationContext,
+  operation: FlatProviderOperation,
+  dispatch: () => Promise<T>,
+): Promise<T> {
+  let admission;
+  try {
+    admission = await admitOrganizationInference({
+      context: {
+        organizationId: context.organizationId,
+        userId: context.userId,
+        apiKeyId: context.apiKeyId,
+        requestId: `${context.requestId}:${operation.operation}:${crypto.randomUUID()}`,
+        provider: operation.provider,
+        billingSource: operation.billingSource,
+        model: operation.model,
+        description: operation.operation,
+        metadata: operation.metadata,
+      },
+      apiKeyId: context.apiKeyId,
+      estimatedInputTokens: 0,
+      estimatedOutputTokens: 0,
+      flatCost: {
+        totalCost: operation.cost,
+        baseTotalCost: operation.cost,
+        platformMarkup: 0,
+      },
+      admissionSnapshot: context.admissionSnapshot,
+      executionCtx: context.executionCtx,
+    });
+  } catch (error) {
+    if (typeof error === "object" && error !== null) admissionErrors.add(error);
+    throw error;
+  }
+
+  let marked = false;
+  try {
+    await admission.markProviderDispatched?.();
+    marked = true;
+    const value = await dispatch();
+    await retainGenerativeTask(context, operation, admission.settle(operation.cost));
+    return value;
+  } catch (error) {
+    if (marked) {
+      await retainGenerativeTask(context, operation, admission.settleUnknown());
+    }
+    logger.error("[GenerativeOperation] provider operation failed", {
+      organizationId: context.organizationId,
+      requestId: context.requestId,
+      provider: operation.provider,
+      model: operation.model,
+      operation: operation.operation,
+      providerDispatched: marked,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}

--- a/packages/cloud/shared/src/lib/services/google-search.ts
+++ b/packages/cloud/shared/src/lib/services/google-search.ts
@@ -3,8 +3,11 @@ import { assertModelOutputComplete } from "@elizaos/core";
 import { calculateCost, estimateRequestCost, normalizeModelName } from "../pricing";
 import { PLATFORM_MARKUP_MULTIPLIER } from "../pricing-constants";
 import { logger } from "../utils/logger";
-import { apiKeysService } from "./api-keys";
-import { type CreditReservation, creditsService, InsufficientCreditsError } from "./credits";
+import {
+  type GenerativeOperationContext,
+  retainGenerativeTask,
+  runMeteredProviderOperation,
+} from "./generative-operation";
 import { buildSearchResults } from "./google-search-results";
 import { usageService } from "./usage";
 
@@ -20,11 +23,7 @@ export interface HostedSearchOptions {
   endDate?: string;
 }
 
-export interface HostedSearchAuthContext {
-  organizationId?: string;
-  userId?: string;
-  apiKey?: string | null;
-  apiKeyId?: string | null;
+export interface HostedSearchOperationContext extends GenerativeOperationContext {
   requestSource?: "action" | "api" | "mcp" | "a2a";
 }
 
@@ -181,19 +180,6 @@ function buildSearchQueries(response: GoogleSearchResponse): string[] {
   return [...new Set(queries.map((query) => query.trim()).filter(Boolean))];
 }
 
-async function resolveApiKeyId(auth: HostedSearchAuthContext | undefined): Promise<string | null> {
-  if (auth?.apiKeyId) {
-    return auth.apiKeyId;
-  }
-
-  if (!auth?.apiKey) {
-    return null;
-  }
-
-  const apiKey = await apiKeysService.validateApiKey(auth.apiKey);
-  return apiKey?.id ?? null;
-}
-
 function buildUsage(response: GoogleSearchResponse): HostedSearchUsage {
   const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
   const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
@@ -203,7 +189,7 @@ function buildUsage(response: GoogleSearchResponse): HostedSearchUsage {
 
 export async function executeHostedGoogleSearch(
   options: HostedSearchOptions,
-  auth?: HostedSearchAuthContext,
+  context: HostedSearchOperationContext,
 ): Promise<HostedSearchResult> {
   const apiKey = resolveGoogleSearchApiKey(options.googleApiKey);
   if (!apiKey) {
@@ -222,148 +208,117 @@ export async function executeHostedGoogleSearch(
   const maxResults = resolveExplicitMaxResults(options.maxResults);
   const prompt = buildSearchPrompt({ ...options, query, model });
   const routeStart = Date.now();
-
-  let reservation: CreditReservation | null = null;
-  const requestSource = auth?.requestSource ?? "api";
-
-  if (auth?.organizationId && auth?.userId) {
-    const estimatedCost =
-      (await estimateRequestCost(normalizedModel, [{ role: "user", content: prompt }])) +
-      GOOGLE_GROUNDED_PROMPT_COST;
-
-    try {
-      reservation = await creditsService.reserve({
-        organizationId: auth.organizationId,
-        amount: estimatedCost,
-        userId: auth.userId,
-        description: `Hosted Google search: ${normalizedModel}`,
-      });
-    } catch (error) {
-      if (error instanceof InsufficientCreditsError) {
-        throw new Error(
-          `Insufficient credits: need $${error.required.toFixed(4)}, have $${error.available.toFixed(4)}`,
-        );
-      }
-      throw error;
-    }
-  }
+  const requestSource = context.requestSource ?? "api";
+  const estimatedCost =
+    (await estimateRequestCost(normalizedModel, [{ role: "user", content: prompt }])) +
+    GOOGLE_GROUNDED_PROMPT_COST;
+  const operation = {
+    provider: "google",
+    billingSource: "gateway" as const,
+    model: normalizedModel,
+    operation: "hosted_google_search",
+    estimatedCost,
+    metadata: { requestSource },
+  };
 
   try {
-    const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
-        normalizedModel,
-      )}:generateContent?key=${encodeURIComponent(apiKey)}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          systemInstruction: {
-            parts: [
-              {
-                text: "Answer only with grounded web information. Do not invent unsupported facts.",
-              },
-            ],
-          },
-          contents: [
-            {
-              role: "user",
-              parts: [{ text: prompt }],
+    const result = await runMeteredProviderOperation(context, operation, async () => {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
+          normalizedModel,
+        )}:generateContent?key=${encodeURIComponent(apiKey)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            systemInstruction: {
+              parts: [
+                {
+                  text: "Answer only with grounded web information. Do not invent unsupported facts.",
+                },
+              ],
             },
-          ],
-          tools: [{ google_search: {} }],
-          generationConfig: {
-            temperature: 0.2,
-          },
-        }),
-        signal: AbortSignal.timeout(30_000),
-      },
-    );
-
-    const body = (await response.json()) as GoogleSearchResponse;
-    if (!response.ok) {
-      throw new Error(
-        body.error?.message || `Google Search request failed with ${response.status}`,
+            contents: [{ role: "user", parts: [{ text: prompt }] }],
+            tools: [{ google_search: {} }],
+            generationConfig: { temperature: 0.2 },
+          }),
+          signal: AbortSignal.timeout(30_000),
+        },
       );
-    }
-
-    assertModelOutputComplete({
-      finishReason: body.candidates?.[0]?.finishReason,
-      provider: "google-search",
-      model: normalizedModel,
+      const body = (await response.json()) as GoogleSearchResponse;
+      if (!response.ok) {
+        throw new Error(
+          body.error?.message || `Google Search request failed with ${response.status}`,
+        );
+      }
+      assertModelOutputComplete({
+        finishReason: body.candidates?.[0]?.finishReason,
+        provider: "google-search",
+        model: normalizedModel,
+      });
+      const answer = extractAnswer(body);
+      if (!answer) throw new Error("Google Search returned no grounded answer");
+      const usage = buildUsage(body);
+      const results = buildSearchResults(body, maxResults);
+      const searchQueries = buildSearchQueries(body);
+      const tokenCost = await calculateCost(
+        normalizedModel,
+        "google",
+        usage.inputTokens,
+        usage.outputTokens,
+      );
+      const totalCost = tokenCost.totalCost + GOOGLE_GROUNDED_PROMPT_COST;
+      return {
+        actualCost: totalCost,
+        value: {
+          tokenCost,
+          result: {
+            answer,
+            model: normalizedModel,
+            provider: "google" as const,
+            query,
+            responseTime: Date.now() - routeStart,
+            results,
+            searchQueries,
+            usage,
+            cost: totalCost,
+          },
+        },
+      };
     });
 
-    const answer = extractAnswer(body);
-    if (!answer) {
-      throw new Error("Google Search returned no grounded answer");
-    }
-
-    const usage = buildUsage(body);
-    const results = buildSearchResults(body, maxResults);
-    const searchQueries = buildSearchQueries(body);
-    const tokenCost = await calculateCost(
-      normalizedModel,
-      "google",
-      usage.inputTokens,
-      usage.outputTokens,
-    );
-    const totalCost = tokenCost.totalCost + GOOGLE_GROUNDED_PROMPT_COST;
-
-    if (reservation) {
-      await reservation.reconcile(totalCost);
-    }
-
-    if (auth?.organizationId && auth?.userId) {
-      const apiKeyId = await resolveApiKeyId(auth);
-      await usageService.create({
-        organization_id: auth.organizationId,
-        user_id: auth.userId,
-        api_key_id: apiKeyId,
+    await retainGenerativeTask(
+      context,
+      operation,
+      usageService.create({
+        organization_id: context.organizationId,
+        user_id: context.userId,
+        api_key_id: context.apiKeyId,
         type: "search",
         model: normalizedModel,
         provider: "google",
-        input_tokens: usage.inputTokens,
-        output_tokens: usage.outputTokens,
-        input_cost: String(tokenCost.inputCost + GOOGLE_GROUNDED_PROMPT_COST),
-        output_cost: String(tokenCost.outputCost),
+        input_tokens: result.result.usage.inputTokens,
+        output_tokens: result.result.usage.outputTokens,
+        input_cost: String(result.tokenCost.inputCost + GOOGLE_GROUNDED_PROMPT_COST),
+        output_cost: String(result.tokenCost.outputCost),
         is_successful: true,
         metadata: {
           grounded_search_fee: GOOGLE_GROUNDED_PROMPT_COST,
           request_source: requestSource,
-          search_queries: searchQueries,
-          results_count: results.length,
+          search_queries: result.result.searchQueries,
+          results_count: result.result.results.length,
           source: options.source ?? null,
           topic: options.topic ?? null,
         },
-      });
-    }
-
-    return {
-      answer,
-      model: normalizedModel,
-      provider: "google",
-      query,
-      responseTime: Date.now() - routeStart,
-      results,
-      searchQueries,
-      usage,
-      cost: totalCost,
-    };
+      }),
+    );
+    return result.result;
   } catch (error) {
-    if (reservation) {
-      try {
-        await reservation.reconcile(0);
-      } catch (refundError) {
-        logger.error("[Hosted Google Search] Failed to refund reservation", {
-          error: refundError instanceof Error ? refundError.message : String(refundError),
-        });
-      }
-    }
-
     logger.error("[Hosted Google Search] Request failed", {
+      organizationId: context.organizationId,
+      requestId: context.requestId,
       error: error instanceof Error ? error.message : String(error),
-      query,
+      queryLength: query.length,
       requestSource,
     });
     throw error;

--- a/packages/cloud/shared/src/lib/services/hf-proxy-egress-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/hf-proxy-egress-quota.test.ts
@@ -1,0 +1,22 @@
+/** Tests atomic Hugging Face monthly quota admission and rollback semantics. */
+
+import { expect, test } from "bun:test";
+import { InMemoryHfProxyEgressQuotaStore } from "./hf-proxy-egress-quota";
+
+test("concurrent monthly reservations admit only the request within quota", async () => {
+  const store = new InMemoryHfProxyEgressQuotaStore();
+  const decisions = await Promise.all([
+    store.reserve("org-1", "2026-08", 8, 10),
+    store.reserve("org-1", "2026-08", 8, 10),
+  ]);
+
+  expect(decisions.filter((decision) => decision.allowed)).toHaveLength(1);
+  expect(decisions.filter((decision) => !decision.allowed)).toHaveLength(1);
+});
+
+test("release updates the standing reservation without a readback", async () => {
+  const store = new InMemoryHfProxyEgressQuotaStore();
+  expect((await store.reserve("org-1", "2026-08", 8, 10)).allowed).toBe(true);
+  await store.release("org-1", "2026-08", 3);
+  expect((await store.reserve("org-1", "2026-08", 5, 10)).allowed).toBe(true);
+});

--- a/packages/cloud/shared/src/lib/services/hf-proxy-egress-quota.ts
+++ b/packages/cloud/shared/src/lib/services/hf-proxy-egress-quota.ts
@@ -1,0 +1,142 @@
+/**
+ * Atomically reserves monthly Hugging Face proxy egress before provider work.
+ * Production uses one Redis script per reservation; the isolate-local store is
+ * restricted to explicit mocks and non-Worker development.
+ */
+
+import {
+  buildRedisClient,
+  type EvalCapableRedis,
+  isCloudflareWorkerRuntime,
+  type RedisFactoryEnv,
+  supportsRedisEval,
+} from "../cache/redis-factory";
+
+const MONTHLY_EGRESS_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+export type HfProxyEgressDecision =
+  | { allowed: true; usedBytes: number }
+  | { allowed: false; usedBytes: number };
+
+export interface HfProxyEgressQuotaStore {
+  reserve(
+    organizationId: string,
+    month: string,
+    bytes: number,
+    limitBytes: number,
+  ): Promise<HfProxyEgressDecision>;
+  release(organizationId: string, month: string, bytes: number): Promise<void>;
+}
+
+const RESERVE_LUA = `
+local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+local requested = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
+if current + requested > limit then return {0, current} end
+local next = redis.call('INCRBY', KEYS[1], requested)
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+return {1, next}
+`;
+
+const RELEASE_LUA = `
+local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+local next = math.max(0, current - tonumber(ARGV[1]))
+redis.call('SET', KEYS[1], next, 'EX', ARGV[2])
+return next
+`;
+
+function quotaKey(organizationId: string, month: string): string {
+  return `hf-proxy:egress:${organizationId}:${month}`;
+}
+
+function assertQuotaInput(bytes: number, limitBytes?: number): void {
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) {
+    throw new RangeError("Hugging Face egress bytes must be a positive safe integer");
+  }
+  if (limitBytes !== undefined && (!Number.isSafeInteger(limitBytes) || limitBytes <= 0)) {
+    throw new RangeError("Hugging Face egress limit must be a positive safe integer");
+  }
+}
+
+export class RedisHfProxyEgressQuotaStore implements HfProxyEgressQuotaStore {
+  constructor(private readonly redis: EvalCapableRedis) {}
+
+  async reserve(
+    organizationId: string,
+    month: string,
+    bytes: number,
+    limitBytes: number,
+  ): Promise<HfProxyEgressDecision> {
+    assertQuotaInput(bytes, limitBytes);
+    const raw = await this.redis.eval(
+      RESERVE_LUA,
+      [quotaKey(organizationId, month)],
+      [bytes, limitBytes, MONTHLY_EGRESS_TTL_SECONDS],
+    );
+    if (!Array.isArray(raw) || raw.length !== 2) {
+      throw new Error("Hugging Face egress quota returned an invalid response");
+    }
+    const allowed = Number(raw[0]);
+    const usedBytes = Number(raw[1]);
+    if ((allowed !== 0 && allowed !== 1) || !Number.isSafeInteger(usedBytes) || usedBytes < 0) {
+      throw new Error("Hugging Face egress quota returned an invalid response");
+    }
+    return { allowed: allowed === 1, usedBytes };
+  }
+
+  async release(organizationId: string, month: string, bytes: number): Promise<void> {
+    assertQuotaInput(bytes);
+    await this.redis.eval(
+      RELEASE_LUA,
+      [quotaKey(organizationId, month)],
+      [bytes, MONTHLY_EGRESS_TTL_SECONDS],
+    );
+  }
+}
+
+/** Atomic within one isolate, for deterministic tests and local development. */
+export class InMemoryHfProxyEgressQuotaStore implements HfProxyEgressQuotaStore {
+  private readonly counters = new Map<string, number>();
+
+  async reserve(
+    organizationId: string,
+    month: string,
+    bytes: number,
+    limitBytes: number,
+  ): Promise<HfProxyEgressDecision> {
+    assertQuotaInput(bytes, limitBytes);
+    const key = quotaKey(organizationId, month);
+    const usedBytes = this.counters.get(key) ?? 0;
+    if (usedBytes + bytes > limitBytes) return { allowed: false, usedBytes };
+    const next = usedBytes + bytes;
+    this.counters.set(key, next);
+    return { allowed: true, usedBytes: next };
+  }
+
+  async release(organizationId: string, month: string, bytes: number): Promise<void> {
+    assertQuotaInput(bytes);
+    const key = quotaKey(organizationId, month);
+    this.counters.set(key, Math.max(0, (this.counters.get(key) ?? 0) - bytes));
+  }
+
+  clear(): void {
+    this.counters.clear();
+  }
+}
+
+const localStore = new InMemoryHfProxyEgressQuotaStore();
+
+export function resetHfProxyEgressQuotaForTests(): void {
+  localStore.clear();
+}
+
+export function createHfProxyEgressQuotaStore(
+  env: RedisFactoryEnv,
+): HfProxyEgressQuotaStore | null {
+  const redis = buildRedisClient(env);
+  if (redis && supportsRedisEval(redis)) {
+    return new RedisHfProxyEgressQuotaStore(redis);
+  }
+  if (env.MOCK_REDIS === "1" || !isCloudflareWorkerRuntime()) return localStore;
+  return null;
+}

--- a/packages/cloud/shared/src/lib/services/provisioning-agent-chat.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-agent-chat.ts
@@ -17,14 +17,23 @@ import {
 import type { AgentSandbox } from "../../db/schemas/agent-sandboxes";
 import { cache } from "../cache/client";
 import { CEREBRAS_DEFAULT_TEXT_MODEL } from "../models";
+import { calculateCost, estimateRequestCost } from "../pricing";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { selectElizaAppProvisioningTarget } from "./eliza-app/provisioning";
+import {
+  type GenerativeOperationContext,
+  isGenerativeOperationAdmissionError,
+  retainGenerativeTask,
+  runMeteredProviderOperation,
+} from "./generative-operation";
+import { usageService } from "./usage";
 
 const HISTORY_CACHE_KEY = (userId: string) => `prov-chat:${userId}`;
 const HISTORY_TTL_SECONDS = 604800; // 7 days
 const CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1";
 const CEREBRAS_MODEL = CEREBRAS_DEFAULT_TEXT_MODEL;
+const CEREBRAS_BILLING_MODEL = `cerebras/${CEREBRAS_MODEL}`;
 
 export interface ChatMessage {
   role: "user" | "assistant";
@@ -37,6 +46,14 @@ export interface ProvisioningChatResult {
   bridgeUrl: string | null;
   agentId: string | null;
   history: ChatMessage[];
+}
+
+export interface ProvisioningAgentChatParams {
+  userId: string;
+  organizationId: string;
+  userMessage: string;
+  agentId?: string;
+  operationContext: GenerativeOperationContext;
 }
 
 export type ProvisioningChatContainerStatus = AgentSandboxStatus | "none" | "unknown";
@@ -183,11 +200,9 @@ async function saveHistory(userId: string, history: ChatMessage[]): Promise<void
 }
 
 export async function provisioningAgentChat(
-  userId: string,
-  organizationId: string,
-  userMessage: string,
-  agentId?: string,
+  params: ProvisioningAgentChatParams,
 ): Promise<ProvisioningChatResult> {
+  const { userId, organizationId, userMessage, agentId, operationContext } = params;
   // Resolve container status
   let containerStatus: ProvisioningChatContainerStatus = "none";
   let bridgeUrl: string | null = null;
@@ -220,22 +235,69 @@ export async function provisioningAgentChat(
   try {
     const cerebras = getCerebrasClient();
     const generationInput = buildProvisioningChatGenerationInput(containerStatus, updatedHistory);
-
-    const result = await generateText({
-      model: cerebras.chat(CEREBRAS_MODEL),
-      ...generationInput,
-    });
-    assertModelOutputComplete({
-      finishReason: result.finishReason,
+    const estimatedCost = await estimateRequestCost(CEREBRAS_BILLING_MODEL, [
+      { role: "system", content: generationInput.system },
+      ...updatedHistory,
+    ]);
+    const operation = {
       provider: "cerebras",
-      model: CEREBRAS_MODEL,
+      billingSource: "cerebras" as const,
+      model: CEREBRAS_BILLING_MODEL,
+      operation: "provisioning_agent_chat",
+      estimatedCost,
+      metadata: { historyTurns: updatedHistory.length },
+    };
+    const metered = await runMeteredProviderOperation(operationContext, operation, async () => {
+      const result = await generateText({
+        model: cerebras.chat(CEREBRAS_MODEL),
+        ...generationInput,
+      });
+      assertModelOutputComplete({
+        finishReason: result.finishReason,
+        provider: "cerebras",
+        model: CEREBRAS_MODEL,
+      });
+      if (!result.text.trim()) throw new Error("Cerebras returned an empty provisioning reply");
+      const inputTokens = result.usage.inputTokens ?? 0;
+      const outputTokens = result.usage.outputTokens ?? 0;
+      const cost = await calculateCost(
+        CEREBRAS_BILLING_MODEL,
+        "cerebras",
+        inputTokens,
+        outputTokens,
+        "cerebras",
+      );
+      return {
+        actualCost: cost.totalCost,
+        value: { reply: result.text, inputTokens, outputTokens, cost },
+      };
     });
-
-    reply = result.text;
+    reply = metered.reply;
+    await retainGenerativeTask(
+      operationContext,
+      operation,
+      usageService.create({
+        organization_id: organizationId,
+        user_id: userId,
+        api_key_id: operationContext.apiKeyId,
+        type: "chat",
+        model: CEREBRAS_BILLING_MODEL,
+        provider: "cerebras",
+        input_tokens: metered.inputTokens,
+        output_tokens: metered.outputTokens,
+        input_cost: String(metered.cost.inputCost),
+        output_cost: String(metered.cost.outputCost),
+        is_successful: true,
+        metadata: { request_source: "provisioning_agent_chat" },
+      }),
+    );
   } catch (err) {
+    if (isGenerativeOperationAdmissionError(err)) throw err;
     // error-policy:J4 the chat returns a visible retry response when inference is unavailable.
     logger.error("[ProvisioningAgentChat] generateText failed", {
       userId,
+      organizationId,
+      requestId: operationContext.requestId,
       error: err instanceof Error ? err.message : String(err),
     });
     reply = PROVISIONING_CHAT_INFERENCE_FAILURE_REPLY;

--- a/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Proves the generic RPC proxy consumes one pre-resolved standing/admission
+ * snapshot, marks immediately before provider dispatch, and retains settlement
+ * asynchronously without a second auth or balance-cache read.
+ */
+
+import { afterAll, beforeEach, expect, mock, test } from "bun:test";
+import * as authActual from "../../auth";
+import * as creditsActual from "../credits";
+import * as admissionActual from "../organization-inference-admission";
+import type { ServiceConfig } from "./types";
+
+const realAuth = { ...authActual };
+const realAdmission = { ...admissionActual };
+const legacyAuth = mock(async () => {
+  throw new Error("legacy auth must not run");
+});
+const admit = mock<typeof admissionActual.admitOrganizationInference>();
+
+mock.module("../../auth", () => ({
+  ...realAuth,
+  requireAuth: legacyAuth,
+  requireAuthOrApiKey: legacyAuth,
+  requireAuthOrApiKeyWithOrg: legacyAuth,
+  requireAuthWithOrg: legacyAuth,
+}));
+mock.module("../organization-inference-admission", () => ({
+  ...realAdmission,
+  admitOrganizationInference: admit,
+}));
+
+const { createHandler } = await import("./engine");
+
+const config: ServiceConfig = {
+  id: "evm-rpc",
+  name: "EVM RPC",
+  auth: "apiKeyWithOrg",
+  getCost: async () => 0.25,
+};
+const snapshot = {
+  balance: { balanceUsd: 10, balanceAt: Date.now(), balanceRevision: "7" },
+  rateLimits: {
+    completionsRpm: 10,
+    embeddingsRpm: 10,
+    standardRpm: 10,
+    strictRpm: 10,
+  },
+};
+
+beforeEach(() => {
+  legacyAuth.mockClear();
+  admit.mockReset();
+});
+
+afterAll(() => {
+  mock.module("../../auth", () => realAuth);
+  mock.module("../organization-inference-admission", () => realAdmission);
+});
+
+test("combined RPC admission orders mark before dispatch and defers settlement", async () => {
+  const order: string[] = [];
+  let finishSettlement: (() => void) | undefined;
+  const settlement = new Promise<void>((resolve) => {
+    finishSettlement = resolve;
+  });
+  const settle = mock(async () => {
+    order.push("settle");
+    await settlement;
+    return null;
+  });
+  admit.mockResolvedValue({
+    mode: "durable_object_debit",
+    markProviderDispatched: async () => {
+      order.push("mark");
+    },
+    settle,
+    settleUnknown: settle,
+  });
+  const retained: Promise<unknown>[] = [];
+  const work = mock(async () => {
+    order.push("dispatch");
+    return { response: Response.json({ ok: true }) };
+  });
+  const handler = createHandler(config, work, {
+    auth: {
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKey: { id: "key-1" },
+    },
+    admissionSnapshot: snapshot,
+    executionCtx: { waitUntil: (promise) => retained.push(promise) },
+    requestId: "rpc-1",
+  });
+
+  const response = await handler(
+    new Request("https://api.test/api/v1/rpc/ethereum", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", id: 1 }),
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  expect(order).toEqual(["mark", "dispatch", "settle"]);
+  expect(legacyAuth).not.toHaveBeenCalled();
+  expect(admit).toHaveBeenCalledTimes(1);
+  expect(admit.mock.calls[0]?.[0].admissionSnapshot).toBe(snapshot);
+  expect(retained).toHaveLength(1);
+  finishSettlement?.();
+  await Promise.all(retained);
+});
+
+test("combined RPC admission denial performs zero provider dispatch", async () => {
+  admit.mockRejectedValueOnce(new creditsActual.InsufficientCreditsError(0.25, 0));
+  const work = mock(async () => ({ response: new Response("not reached") }));
+  const handler = createHandler(config, work, {
+    auth: { user: { id: "user-1", organization_id: "org-1" } },
+    admissionSnapshot: snapshot,
+    executionCtx: { waitUntil: () => undefined },
+    requestId: "rpc-denied",
+  });
+
+  const response = await handler(
+    new Request("https://api.test/api/v1/rpc/ethereum", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", id: 1 }),
+    }),
+  );
+
+  expect(response.status).toBe(402);
+  expect(work).not.toHaveBeenCalled();
+  expect(legacyAuth).not.toHaveBeenCalled();
+});

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -11,6 +11,8 @@ import { cache } from "../../cache/client";
 import { withRateLimit } from "../../middleware/rate-limit";
 import { logger } from "../../utils/logger";
 import { creditsService, InsufficientCreditsError } from "../credits";
+import type { InferenceAdmissionSnapshot } from "../inference-auth-cache";
+import { admitOrganizationInference } from "../organization-inference-admission";
 import { usageService } from "../usage";
 import { PricingNotFoundError } from "./pricing";
 import type {
@@ -28,6 +30,43 @@ type CachedProxyResponse = {
   cachedAt: number;
   ttl?: number;
 };
+
+export interface ProxyCombinedAdmission {
+  auth: {
+    user: { id: string; organization_id: string };
+    apiKey?: { id: string };
+  };
+  admissionSnapshot?: InferenceAdmissionSnapshot;
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+  requestId: string;
+}
+
+interface ProxySettlement {
+  settle(actualCostUsd: number): Promise<unknown>;
+  settleUnknown(): Promise<unknown>;
+  markProviderDispatched?(): Promise<void>;
+}
+
+function retainProxySettlement(
+  settlement: Promise<unknown>,
+  executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined,
+  context: { serviceId: string; operation: string },
+): Promise<void> {
+  const observed = settlement.then(
+    () => undefined,
+    (error) => {
+      // error-policy:J7 provider settlement is a detached accounting update;
+      // the response boundary has already committed and the durable admission
+      // lease remains the recovery authority.
+      logger.error("[Proxy Engine] Deferred settlement failed", {
+        ...context,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+  if (executionCtx) executionCtx.waitUntil(observed);
+  return observed;
+}
 
 async function getAuthForLevel(request: Request, level: AuthLevel) {
   switch (level) {
@@ -157,13 +196,14 @@ function isClientErrorMessage(message: string): boolean {
 export function createHandler(
   config: ServiceConfig,
   work: ServiceHandler,
+  combinedAdmission?: ProxyCombinedAdmission,
 ): (request: Request) => Promise<Response> {
   const handler = async (request: Request): Promise<Response> => {
     const startTime = Date.now();
     const searchParams = new URL(request.url).searchParams;
 
     try {
-      const auth = await getAuthForLevel(request, config.auth);
+      const auth = combinedAdmission?.auth ?? (await getAuthForLevel(request, config.auth));
       const { user } = auth;
       const apiKey = "apiKey" in auth ? auth.apiKey : undefined;
       const organizationId = user.organization_id;
@@ -188,12 +228,57 @@ export function createHandler(
       const method = getMethodFromBody(body);
       const cost = await config.getCost(body, searchParams);
 
-      const reservation = await creditsService.reserve({
-        organizationId,
-        userId: user.id,
-        amount: cost,
-        description: config.name,
-      });
+      let settlement: ProxySettlement;
+      if (combinedAdmission?.executionCtx) {
+        if (!combinedAdmission.admissionSnapshot) {
+          throw new Error("Combined proxy admission snapshot is required");
+        }
+        settlement = await admitOrganizationInference({
+          context: {
+            organizationId,
+            userId: user.id,
+            apiKeyId: apiKey?.id ?? null,
+            model: config.id,
+            provider: config.id,
+            billingSource: "gateway",
+            requestId: combinedAdmission.requestId,
+            description: config.name,
+          },
+          apiKeyId: apiKey?.id ?? null,
+          estimatedInputTokens: 0,
+          estimatedOutputTokens: 0,
+          flatCost: {
+            totalCost: cost,
+            baseTotalCost: cost,
+            platformMarkup: 0,
+          },
+          executionCtx: combinedAdmission.executionCtx,
+          admissionSnapshot: combinedAdmission.admissionSnapshot,
+        });
+      } else {
+        const reservation = await creditsService.reserve({
+          organizationId,
+          userId: user.id,
+          amount: cost,
+          description: config.name,
+        });
+        settlement = {
+          settle: (actualCostUsd) => reservation.reconcile(actualCostUsd),
+          settleUnknown: () => reservation.reconcile(cost),
+        };
+      }
+
+      const settle = async (actualCostUsd: number, operation: string) => {
+        const pending = settlement.settle(actualCostUsd);
+        if (combinedAdmission?.executionCtx) {
+          void retainProxySettlement(pending, combinedAdmission.executionCtx, {
+            serviceId: config.id,
+            operation,
+          });
+          return;
+        }
+        await pending;
+      };
 
       const cacheCandidate =
         config.cache && body && !Array.isArray(body)
@@ -226,7 +311,7 @@ export function createHandler(
               const cachedCost = cost * hitMultiplier;
               const remainingMaxAge = Math.max(effectiveMaxAge - age, 0);
 
-              await reservation.reconcile(cachedCost);
+              await settle(cachedCost, "cache_hit");
 
               const response = new Response(cachedResponse.body, {
                 status: cachedResponse.status,
@@ -273,11 +358,25 @@ export function createHandler(
 
       let result: HandlerResult;
       try {
+        // The durable dispatch marker is the last awaited operation before the
+        // provider boundary. Auth, standing, pricing, balance, and the lease
+        // all come from the caller's one combined admission projection.
+        await settlement.markProviderDispatched?.();
         result = await work({ body, auth, searchParams });
       } catch (error) {
-        // error-policy:J2 refund the credit reservation on handler failure, then rethrow
-        // unchanged so the outer boundary surfaces it (never a fabricated success)
-        await reservation.reconcile(0);
+        // error-policy:J2 provider dispatch may have been accepted before the
+        // transport threw, so conservatively settle the marked admission.
+        const pending = combinedAdmission?.executionCtx
+          ? settlement.settleUnknown()
+          : settlement.settle(0);
+        if (combinedAdmission?.executionCtx) {
+          void retainProxySettlement(pending, combinedAdmission.executionCtx, {
+            serviceId: config.id,
+            operation: "provider_error",
+          });
+        } else {
+          await pending;
+        }
         throw error;
       }
 
@@ -286,7 +385,7 @@ export function createHandler(
       // caller got no service, so it refunds the reservation just like the
       // thrown-error path above. See resolveBillableCost.
       const actualCost = resolveBillableCost(result, cost);
-      await reservation.reconcile(actualCost);
+      await settle(actualCost, "provider_result");
 
       if (cacheKey && cacheCandidate && config.cache) {
         const ttl = Math.min(cacheCandidate.clientMaxAge, config.cache.maxTTL);
@@ -405,7 +504,7 @@ export function createHandler(
     }
   };
 
-  if (config.rateLimit) {
+  if (config.rateLimit && !combinedAdmission) {
     return withRateLimit(handler, config.rateLimit);
   }
 

--- a/packages/cloud/shared/src/lib/services/proxy/types.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/types.ts
@@ -1,5 +1,4 @@
 // Coordinates cloud service types behavior behind route handlers.
-import type { UserWithOrganization } from "../../../db/repositories/users";
 import type { ApiKey } from "../../../db/schemas/api-keys";
 
 export type AuthLevel = "session" | "sessionWithOrg" | "apiKey" | "apiKeyWithOrg";
@@ -51,7 +50,10 @@ export interface ServiceConfig {
 
 export interface HandlerContext {
   body: ProxyRequestBody;
-  auth: { user: UserWithOrganization; apiKey?: ApiKey };
+  auth: {
+    user: { id: string; organization_id: string | null };
+    apiKey?: Pick<ApiKey, "id">;
+  };
   searchParams: URLSearchParams;
 }
 

--- a/packages/cloud/shared/src/lib/services/room-title.ts
+++ b/packages/cloud/shared/src/lib/services/room-title.ts
@@ -1,12 +1,13 @@
-// Coordinates cloud service room title behavior behind route handlers.
-import { assertModelOutputComplete } from "@elizaos/core";
-import { generateText } from "ai";
+/**
+ * Assigns deterministic conversation titles without a second model dispatch.
+ * Title generation is best-effort metadata and must not create an unmetered
+ * provider call after the user-visible response has already completed.
+ */
 import { memoriesRepository, roomsRepository } from "../../db/repositories";
-import { getLanguageModel } from "../providers/language-model";
 import { logger } from "../utils/logger";
 
 /**
- * Generate an AI-powered title for a room based on the first user message.
+ * Generate a deterministic title for a room based on the first user message.
  * Only generates if room currently has default title ("New Chat").
  *
  * @param roomId - The room ID to generate title for
@@ -48,46 +49,7 @@ export async function generateRoomTitle(roomId: string): Promise<string | null> 
     return null;
   }
 
-  // Generate AI title
-  let title: string;
-
-  try {
-    const prompt = `Create a brief 3-5 word title summarizing this message topic. Output ONLY the title, no quotes or explanation.
-
-Message: ${text}
-
-Title:`;
-
-    logger.info(`[RoomTitle] Generating AI title for room ${roomId}`);
-
-    const result = await generateText({
-      model: getLanguageModel("openai/gpt-5-mini"),
-      prompt,
-    });
-    assertModelOutputComplete({
-      finishReason: result.finishReason,
-      provider: "openai",
-      model: "gpt-5-mini",
-    });
-
-    // Normalizes the generated title
-    title = result.text
-      .trim()
-      .replace(/^["']|["']$/g, "") // Remove quotes
-      .replace(/^Title:\s*/i, "") // Remove "Title:" prefix if present
-      .replace(/[.!?]$/, ""); // Remove trailing punctuation
-
-    logger.info(`[RoomTitle] AI generated: "${title}"`);
-
-    // Validate title is reasonable
-    if (!title || title.length < 3 || title.length > 50 || title.includes("\n")) {
-      logger.warn(`[RoomTitle] Invalid AI title, using fallback`);
-      title = generateFallbackTitle(text);
-    }
-  } catch (error) {
-    logger.error(`[RoomTitle] AI generation failed:`, error);
-    title = generateFallbackTitle(text);
-  }
+  const title = generateFallbackTitle(text);
 
   await roomsRepository.update(roomId, { name: title });
 

--- a/packages/cloud/shared/src/lib/services/seo.ts
+++ b/packages/cloud/shared/src/lib/services/seo.ts
@@ -19,7 +19,12 @@ import { getLanguageModel } from "../providers/language-model";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
-import { creditsService } from "./credits";
+import {
+  type FlatProviderOperation,
+  type GenerativeOperationContext,
+  retainGenerativeTask,
+  runFlatProviderOperation,
+} from "./generative-operation";
 
 const SEO_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -55,6 +60,7 @@ export type CreateSeoRequestParams = {
   idempotencyKey?: string;
   locationCode?: number;
   query?: string;
+  operationContext?: GenerativeOperationContext;
 };
 
 export type SeoRequestResult = {
@@ -82,24 +88,6 @@ function ensureEnv(variable: string, description: string): string {
 function parseJson<T>(raw: string): T {
   const parsed = JSON.parse(raw) as T;
   return parsed;
-}
-
-async function chargeCredits(
-  organizationId: string,
-  amount: number,
-  description: string,
-  metadata?: Record<string, unknown>,
-): Promise<void> {
-  if (amount <= 0) return;
-  const result = await creditsService.deductCredits({
-    organizationId,
-    amount,
-    description,
-    metadata,
-  });
-  if (!result.success) {
-    throw new Error("Insufficient credits for SEO operation");
-  }
 }
 
 async function callDataForSeoKeywords(
@@ -370,16 +358,6 @@ export class SeoService {
     const providerCalls: SeoProviderCall[] = [];
     let totalCost = 0;
 
-    const charge = async (
-      amount: number,
-      description: string,
-      metadata?: Record<string, unknown>,
-    ) => {
-      if (amount <= 0) return;
-      await chargeCredits(request.organization_id, amount, description, metadata);
-      totalCost += amount;
-    };
-
     const recordCall = async (
       call: Omit<NewSeoProviderCall, "created_at">,
       fn: () => Promise<Record<string, unknown>>,
@@ -390,10 +368,35 @@ export class SeoService {
       });
       let payload: Record<string, unknown>;
       try {
-        payload = await fn();
-        await seoProviderCallsRepository.updateStatus(created.id, "completed", {
+        const cost = Number(call.cost ?? 0);
+        const operation: FlatProviderOperation = {
+          provider: call.provider,
+          billingSource: call.provider === "claude" ? "anthropic" : "gateway",
+          model:
+            call.provider === "claude"
+              ? "anthropic/claude-sonnet-4.6"
+              : `seo/${call.provider}/${call.operation}`,
+          operation: `seo_${call.operation}`,
+          cost,
+          metadata: { requestId: request.id, seoProviderCallId: created.id },
+        };
+        if (cost > 0) {
+          if (!params.operationContext) {
+            throw new Error("Paid SEO provider operation requires generative admission");
+          }
+          payload = await runFlatProviderOperation(params.operationContext, operation, fn);
+          totalCost += cost;
+        } else {
+          payload = await fn();
+        }
+        const statusWrite = seoProviderCallsRepository.updateStatus(created.id, "completed", {
           response_payload: payload,
         });
+        if (params.operationContext) {
+          await retainGenerativeTask(params.operationContext, operation, statusWrite);
+        } else {
+          await statusWrite;
+        }
         providerCalls.push({
           ...created,
           status: "completed",
@@ -402,9 +405,24 @@ export class SeoService {
         return payload;
       } catch (error) {
         const message = error instanceof Error ? error.message : "Provider call failed";
-        await seoProviderCallsRepository.updateStatus(created.id, "failed", {
+        const statusWrite = seoProviderCallsRepository.updateStatus(created.id, "failed", {
           error: message,
         });
+        if (params.operationContext) {
+          await retainGenerativeTask(
+            params.operationContext,
+            {
+              provider: call.provider,
+              billingSource: call.provider === "claude" ? "anthropic" : "gateway",
+              model: `seo/${call.provider}/${call.operation}`,
+              operation: `seo_${call.operation}_status_failed`,
+              cost: 0,
+            },
+            statusWrite,
+          );
+        } else {
+          await statusWrite;
+        }
         throw error;
       }
     };
@@ -430,9 +448,6 @@ export class SeoService {
             request.page_url ?? undefined,
             request.keywords ?? undefined,
           );
-          await charge(SEO_PRICING.claudeGenerationFloor, "SEO meta generation (Claude)", {
-            request_id: request.id,
-          });
           const artifact = await seoArtifactsRepository.create({
             request_id: request.id,
             type: "meta",
@@ -466,9 +481,6 @@ export class SeoService {
             request.page_url ?? undefined,
             request.keywords ?? undefined,
           );
-          await charge(SEO_PRICING.claudeGenerationFloor, "SEO schema generation (Claude)", {
-            request_id: request.id,
-          });
           const artifact = await seoArtifactsRepository.create({
             request_id: request.id,
             type: "schema",
@@ -502,9 +514,6 @@ export class SeoService {
                 request.locale,
                 params.locationCode,
               );
-              await charge(SEO_PRICING.keywordResearch, "SEO keyword research (DataForSEO)", {
-                request_id: request.id,
-              });
               const artifact = await seoArtifactsRepository.create({
                 request_id: request.id,
                 type: "keywords",
@@ -541,9 +550,6 @@ export class SeoService {
                 locale: request.locale,
                 device: request.device,
                 searchEngine: request.search_engine,
-              });
-              await charge(SEO_PRICING.serpSnapshot, "SEO SERP snapshot (SerpApi)", {
-                request_id: request.id,
               });
               const artifact = await seoArtifactsRepository.create({
                 request_id: request.id,
@@ -649,27 +655,62 @@ export class SeoService {
           throw new Error(`Unsupported SEO request type: ${request.type}`);
       }
 
-      await db
+      const completedAt = new Date();
+      const statusWrite = db
         .update(seoRequests)
         .set({
           status: "completed",
           total_cost: String(totalCost),
-          updated_at: new Date(),
-          completed_at: new Date(),
+          updated_at: completedAt,
+          completed_at: completedAt,
         })
         .where(eq(seoRequests.id, request.id));
-
-      const fresh = await seoRequestsRepository.findById(request.id);
+      if (params.operationContext) {
+        await retainGenerativeTask(
+          params.operationContext,
+          {
+            provider: "seo",
+            billingSource: "gateway",
+            model: "seo/request",
+            operation: "seo_request_status_completed",
+            cost: 0,
+          },
+          statusWrite,
+        );
+      } else {
+        await statusWrite;
+      }
       return {
-        request: fresh || request,
+        request: {
+          ...request,
+          status: "completed",
+          total_cost: String(totalCost),
+          updated_at: completedAt,
+          completed_at: completedAt,
+        },
         artifacts,
         providerCalls,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : "SEO request failed";
-      await seoRequestsRepository.updateStatus(request.id, "failed", {
+      const statusWrite = seoRequestsRepository.updateStatus(request.id, "failed", {
         error: message,
       });
+      if (params.operationContext) {
+        await retainGenerativeTask(
+          params.operationContext,
+          {
+            provider: "seo",
+            billingSource: "gateway",
+            model: "seo/request",
+            operation: "seo_request_status_failed",
+            cost: 0,
+          },
+          statusWrite,
+        );
+      } else {
+        await statusWrite;
+      }
       logger.error("[SeoService] request failed", {
         requestId: request.id,
         error: message,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -643,6 +643,24 @@ describe("SharedRuntimeChatService", () => {
     expect(settleCalls).toEqual([0.004]);
   });
 
+  test("does not dispatch a second model call to extract facts after a landed turn", async () => {
+    process.env.SHARED_FACTS_ENABLED = "true";
+    const recordFacts = mock(async () => undefined);
+    sharedMemoryStoreOverride = {
+      listFacts: async () => [],
+      recordFacts,
+      recordTurnPair,
+    };
+    const h = harness();
+
+    const response = await new SharedRuntimeChatService().bridge(agent, rpc, h);
+    expect(response.result?.text).toBe("hello back");
+    await Promise.all(h.background);
+
+    expect(turnCalls).toBe(1);
+    expect(recordFacts).not.toHaveBeenCalled();
+  });
+
   test("samples success, error, and abort terminal receipts exactly once without content", async () => {
     process.env.SHARED_TURN_TRACES_ENABLED = "true";
     process.env.SHARED_TURN_TRACES_SAMPLE = "1";

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -8,7 +8,6 @@
 
 import crypto from "node:crypto";
 import {
-  assertModelOutputComplete,
   ChannelType,
   ElizaError,
   MESSAGE_SOURCE_CLIENT_CHAT,
@@ -88,12 +87,7 @@ import {
 } from "./run-shared-agent-turn";
 import { projectSharedAgentCharacter } from "./shared-agent-character";
 import { capabilityWallActionResult } from "./shared-capability-wall";
-import {
-  buildSharedFactsContext,
-  extractSharedTurnFacts,
-  SHARED_FACTS_EXTRACTION_TIMEOUT_MS,
-  sharedFactsEnabled,
-} from "./shared-facts";
+import { buildSharedFactsContext, sharedFactsEnabled } from "./shared-facts";
 import { createSharedMemoryStore, type SharedMemoryStore } from "./shared-memory-store";
 import {
   buildSharedRecallContext,
@@ -758,68 +752,6 @@ function combinedTurnContext(
     (part): part is string => typeof part === "string" && part.length > 0,
   );
   return parts.length ? parts.join("\n\n") : undefined;
-}
-
-/**
- * P4 post-turn facts extraction, strictly off the response path (same shape as
- * the P5 trace recorder): one small extraction call through the SAME platform
- * model path the turn used, deduped against known facts, written as durable
- * `facts` rows. Runs only for landed user turns while the flag is on; any
- * failure is warned and dropped so knowledge accumulation can never fail or
- * slow a delivered reply.
- */
-function extractSharedTurnFactsOffPath(
-  executionCtx: BridgeExecutionContext | undefined,
-  store: SharedMemoryStore | null,
-  character: SharedAgentCharacter,
-  userMessage: string,
-  assistantReply: string,
-): void {
-  if (!store || !sharedFactsEnabled()) return;
-  const model = resolveSharedAgentTurnModel(character.model);
-  if (!model) return;
-  void settleOffResponsePath(executionCtx, async () => {
-    try {
-      const [{ generateText }, { getInteractiveCerebrasLanguageModel }, knownFacts] =
-        await Promise.all([
-          import("ai"),
-          import("../../providers/language-model"),
-          store.listFacts(),
-        ]);
-      const facts = await extractSharedTurnFacts({
-        agentName: character.name,
-        userMessage,
-        assistantReply,
-        knownFacts,
-        generate: async (prompt) => {
-          const result = await generateText({
-            model: getInteractiveCerebrasLanguageModel(model),
-            prompt,
-            temperature: 0,
-            maxRetries: 0,
-            // A stalled provider request must not pin the waitUntil task open;
-            // the deadline surfaces as a distinct AbortError in the J7 warn.
-            abortSignal: AbortSignal.timeout(SHARED_FACTS_EXTRACTION_TIMEOUT_MS),
-          });
-          assertModelOutputComplete({
-            finishReason: result.finishReason,
-            provider: "cerebras",
-            model,
-          });
-          return result.text;
-        },
-      });
-      if (facts.length) await store.recordFacts(facts);
-    } catch (error) {
-      // error-policy:J7 knowledge extraction is off-path enrichment; its
-      // failure must never surface into the already-delivered turn.
-      logger.warn(
-        `[shared-runtime-chat] facts extraction failed for this turn: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  });
 }
 
 function stableUuid(raw: string): string {
@@ -1521,9 +1453,6 @@ export class SharedRuntimeChatService {
       history,
       options.channel,
     );
-    if (!turn.degraded && turn.responded !== false && messageRole === "user") {
-      extractSharedTurnFactsOffPath(options.executionCtx, memoryStore, character, text, turn.reply);
-    }
     let turnCompleted = false;
     let turnIsProvablyFree = false;
     try {
@@ -1952,15 +1881,6 @@ export class SharedRuntimeChatService {
               });
             }
           });
-        }
-        if (!interrupted && messageRole === "user" && reply.trim()) {
-          extractSharedTurnFactsOffPath(
-            options.executionCtx,
-            streamMemoryStore,
-            character,
-            text,
-            reply,
-          );
         }
         await afterWrite?.();
         finalized = true;

--- a/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.error-policy.test.ts
@@ -74,13 +74,6 @@ mock.module("../../../db/repositories/apps", () => ({
   },
 }));
 
-mock.module("../credits", () => ({
-  creditsService: {
-    deductCredits: async () => ({ success: true, newBalance: 100, transaction: null }),
-    refundCredits: async () => ({ transaction: {}, newBalance: 100 }),
-  },
-}));
-
 mock.module("../character-prompt-helper", () => ({
   getCharacterPromptContext: async () => null,
   buildCharacterSystemPrompt: () => "IN CHARACTER",

--- a/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts
@@ -17,7 +17,7 @@ import {
   TELEGRAM_AUTOMATION_DEFAULTS,
 } from "../automation-constants";
 import { buildCharacterSystemPrompt, getCharacterPromptContext } from "../character-prompt-helper";
-import { creditsService } from "../credits";
+import { type GenerativeOperationContext, runFlatProviderOperation } from "../generative-operation";
 import { telegramAutomationService } from "./index";
 
 export interface TelegramAutomationConfig {
@@ -173,10 +173,13 @@ class TelegramAppAutomationService {
     };
   }
 
-  async generateAnnouncement(organizationId: string, app: App): Promise<string> {
-    // All throwable prep (character-context DB fetch, prompt build) runs BEFORE
-    // the deduction: nothing may throw between the charge and the refunding try,
-    // or the user is charged for a generation that never ran (#11685).
+  async generateAnnouncement(
+    organizationId: string,
+    app: App,
+    operationContext?: GenerativeOperationContext,
+  ): Promise<string> {
+    // Complete throwable prompt preparation before admission so validation or
+    // character lookup failures never reserve a provider operation.
     const config = app.telegram_automation as TelegramAutomationConfig;
     const vibeStyle = config?.vibeStyle || "professional and engaging";
 
@@ -227,42 +230,35 @@ Write in a ${vibeStyle} style. Keep it concise and engaging.
 Use appropriate emojis sparingly. Do not use hashtags excessively.
 Maximum 500 characters.`;
 
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: TELEGRAM_POST_COST,
-      description: `Telegram AI announcement: ${app.name}`,
-      metadata: { appId: app.id, type: "telegram_announcement" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${TELEGRAM_POST_COST.toFixed(4)}`,
-      );
+    if (!operationContext || operationContext.organizationId !== organizationId) {
+      throw new Error("Telegram AI generation requires trusted generative admission context");
     }
 
-    try {
-      const result = await generateText({
-        model: openai("gpt-5-mini"),
-        system: systemPrompt,
-        prompt:
-          "Create a compelling announcement about this app that would engage a Telegram community. Focus on what makes it unique and valuable.",
-      });
-      assertModelOutputComplete({
-        finishReason: result.finishReason,
+    return await runFlatProviderOperation(
+      operationContext,
+      {
         provider: "openai",
         model: "gpt-5-mini",
-      });
-
-      return result.text;
-    } catch (error) {
-      await creditsService.refundCredits({
-        organizationId,
-        amount: TELEGRAM_POST_COST,
-        description: "Refund for failed Telegram AI generation",
-        metadata: { appId: app.id, type: "telegram_announcement_refund" },
-      });
-      throw error;
-    }
+        billingSource: "openai",
+        operation: "telegram_automation_announcement",
+        cost: TELEGRAM_POST_COST,
+        metadata: { appId: app.id, type: "telegram_announcement" },
+      },
+      async () => {
+        const result = await generateText({
+          model: openai("gpt-5-mini"),
+          system: systemPrompt,
+          prompt:
+            "Create a compelling announcement about this app that would engage a Telegram community. Focus on what makes it unique and valuable.",
+        });
+        assertModelOutputComplete({
+          finishReason: result.finishReason,
+          provider: "openai",
+          model: "gpt-5-mini",
+        });
+        return result.text;
+      },
+    );
   }
 
   async generateReply(
@@ -270,8 +266,9 @@ Maximum 500 characters.`;
     app: App,
     userMessage: string,
     userName?: string,
+    operationContext?: GenerativeOperationContext,
   ): Promise<string> {
-    // Throwable prep stays ahead of the deduction — see generateAnnouncement (#11685).
+    // Throwable prompt preparation stays ahead of admission.
     const config = app.telegram_automation as TelegramAutomationConfig;
     const vibeStyle = config?.vibeStyle || "helpful and friendly";
 
@@ -308,43 +305,36 @@ Respond in a ${vibeStyle} style. Be helpful and concise.
 If asked about features not related to the app, politely redirect to the app's purpose.
 Maximum 300 characters.`;
 
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: TELEGRAM_POST_COST,
-      description: `Telegram AI reply: ${app.name}`,
-      metadata: { appId: app.id, type: "telegram_reply" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${TELEGRAM_POST_COST.toFixed(4)}`,
-      );
+    if (!operationContext || operationContext.organizationId !== organizationId) {
+      throw new Error("Telegram AI reply requires trusted generative admission context");
     }
 
-    try {
-      const result = await generateText({
-        model: openai("gpt-5-mini"),
-        system: systemPrompt,
-        prompt: userName
-          ? `User ${userName} says: "${userMessage}"`
-          : `User says: "${userMessage}"`,
-      });
-      assertModelOutputComplete({
-        finishReason: result.finishReason,
+    return await runFlatProviderOperation(
+      operationContext,
+      {
         provider: "openai",
         model: "gpt-5-mini",
-      });
-
-      return result.text;
-    } catch (error) {
-      await creditsService.refundCredits({
-        organizationId,
-        amount: TELEGRAM_POST_COST,
-        description: "Refund for failed Telegram AI reply",
-        metadata: { appId: app.id, type: "telegram_reply_refund" },
-      });
-      throw error;
-    }
+        billingSource: "openai",
+        operation: "telegram_automation_reply",
+        cost: TELEGRAM_POST_COST,
+        metadata: { appId: app.id, type: "telegram_reply" },
+      },
+      async () => {
+        const result = await generateText({
+          model: openai("gpt-5-mini"),
+          system: systemPrompt,
+          prompt: userName
+            ? `User ${userName} says: "${userMessage}"`
+            : `User says: "${userMessage}"`,
+        });
+        assertModelOutputComplete({
+          finishReason: result.finishReason,
+          provider: "openai",
+          model: "gpt-5-mini",
+        });
+        return result.text;
+      },
+    );
   }
 
   /**
@@ -378,6 +368,7 @@ Maximum 300 characters.`;
     appId: string,
     text?: string,
     chatIdOverride?: string,
+    operationContext?: GenerativeOperationContext,
   ): Promise<PostResult> {
     const app = await this.getAppForOrg(organizationId, appId);
     const config = app.telegram_automation;
@@ -391,7 +382,8 @@ Maximum 300 characters.`;
       return { success: false, error: "No channel or group configured" };
     }
 
-    const messageText = text || (await this.generateAnnouncement(organizationId, app));
+    const messageText =
+      text || (await this.generateAnnouncement(organizationId, app, operationContext));
 
     const botToken = await telegramAutomationService.getBotToken(organizationId);
     if (!botToken) {
@@ -506,6 +498,7 @@ Maximum 300 characters.`;
       userName?: string;
       replyToMessageId?: number;
     },
+    operationContext?: GenerativeOperationContext,
   ): Promise<PostResult> {
     const app = await this.getAppForOrg(organizationId, appId);
     const config = app.telegram_automation;
@@ -519,7 +512,13 @@ Maximum 300 characters.`;
       return { success: false, error: "Bot not connected" };
     }
 
-    const replyText = await this.generateReply(organizationId, app, message.text, message.userName);
+    const replyText = await this.generateReply(
+      organizationId,
+      app,
+      message.text,
+      message.userName,
+      operationContext,
+    );
 
     const bot = new Telegraf(botToken);
 

--- a/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.error-policy.test.ts
@@ -66,15 +66,6 @@ mock.module("twitter-api-v2", () => ({
   },
 }));
 
-// Import-safety: these are pulled in at module top but unused on the
-// tweetText-provided path (no generation). Mock to keep the import cheap.
-mock.module("../credits", () => ({
-  creditsService: {
-    deductCredits: async () => ({ success: true, newBalance: 100, transaction: null }),
-    refundCredits: async () => ({ transaction: {}, newBalance: 100 }),
-  },
-}));
-
 const { twitterAppAutomationService } = await import("./app-automation");
 
 const realFetch = globalThis.fetch;

--- a/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.ts
@@ -10,7 +10,7 @@ import { logger } from "../../utils/logger";
 // Note: When ANTHROPIC_COT_BUDGET is set and model is Anthropic, temperature is silently dropped
 // per @ai-sdk/anthropic behavior. This service uses temperature for creative tweet generation.
 import { buildCharacterSystemPrompt, getCharacterPromptContext } from "../character-prompt-helper";
-import { creditsService } from "../credits";
+import { type GenerativeOperationContext, runFlatProviderOperation } from "../generative-operation";
 import { secretsService } from "../secrets";
 
 const TWITTER_API_KEY = process.env.TWITTER_API_KEY;
@@ -143,10 +143,10 @@ class TwitterAppAutomationService {
     organizationId: string,
     app: App,
     type: "promotional" | "engagement" | "educational" | "announcement" = "promotional",
+    operationContext?: GenerativeOperationContext,
   ): Promise<GeneratedTweet> {
-    // All throwable prep (character-context DB fetch, prompt build) runs BEFORE
-    // the deduction: nothing may throw between the charge and the refunding try,
-    // or the user is charged for a generation that never ran (#11685).
+    // Complete throwable prompt preparation before admission so validation or
+    // character lookup failures never reserve a provider operation.
     const config = app.twitter_automation as TwitterAutomationConfig | null;
     const vibeStyle = config?.vibeStyle ?? "professional yet approachable";
     const topics = config?.topics?.join(", ") ?? "";
@@ -223,63 +223,55 @@ Requirements:
 
 Return ONLY the tweet text, nothing else.`;
 
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: TWITTER_POST_COST,
-      description: `Twitter AI tweet: ${app.name}`,
-      metadata: { appId: app.id, type: "twitter_tweet" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${TWITTER_POST_COST.toFixed(4)}`,
-      );
+    if (!operationContext || operationContext.organizationId !== organizationId) {
+      throw new Error("Twitter AI generation requires trusted generative admission context");
     }
 
-    try {
-      const twModel = "anthropic/claude-sonnet-4.6";
-      // Note: Explicitly disable extended thinking (pass 0) for tweet generation.
-      // This is a background service that requires temperature control for creative output,
-      // and enabling CoT would silently drop temperature per @ai-sdk/anthropic behavior.
-      // Temperature 0.8 for varied, creative tweet content.
-      const result = await generateText({
-        model: getLanguageModel(twModel),
-        ...mergeAnthropicCotProviderOptions(twModel, process.env, 0),
-        temperature: 0.8,
-        prompt,
-      });
-      assertModelOutputComplete({
-        finishReason: result.finishReason,
+    const twModel = "anthropic/claude-sonnet-4.6";
+    return await runFlatProviderOperation(
+      operationContext,
+      {
         provider: "anthropic",
+        billingSource: "anthropic",
         model: twModel,
-      });
-      const text = result.text.trim();
-      if (text.length > 280) {
-        throw new ElizaError("[TwitterAutomation] Generated post exceeds Twitter's limit.", {
-          code: "TWITTER_POST_LENGTH_EXCEEDED",
-          context: { appId: app.id, length: text.length, maximumLength: 280 },
+        operation: "twitter_automation_tweet",
+        cost: TWITTER_POST_COST,
+        metadata: { appId: app.id, type: "twitter_tweet" },
+      },
+      async () => {
+        // Note: Explicitly disable extended thinking (pass 0) for tweet generation.
+        // This is a background service that requires temperature control for creative output,
+        // and enabling CoT would silently drop temperature per @ai-sdk/anthropic behavior.
+        // Temperature 0.8 for varied, creative tweet content.
+        const result = await generateText({
+          model: getLanguageModel(twModel),
+          ...mergeAnthropicCotProviderOptions(twModel, process.env, 0),
+          temperature: 0.8,
+          prompt,
         });
-      }
+        assertModelOutputComplete({
+          finishReason: result.finishReason,
+          provider: "anthropic",
+          model: twModel,
+        });
+        const text = result.text.trim();
+        if (text.length > 280) {
+          throw new ElizaError("[TwitterAutomation] Generated post exceeds Twitter's limit.", {
+            code: "TWITTER_POST_LENGTH_EXCEEDED",
+            context: { appId: app.id, length: text.length, maximumLength: 280 },
+          });
+        }
 
-      return {
-        text,
-        type,
-      };
-    } catch (error) {
-      await creditsService.refundCredits({
-        organizationId,
-        amount: TWITTER_POST_COST,
-        description: "Refund for failed Twitter AI generation",
-        metadata: { appId: app.id, type: "twitter_tweet_refund" },
-      });
-      throw error;
-    }
+        return { text, type };
+      },
+    );
   }
 
   async postAppTweet(
     organizationId: string,
     appId: string,
     tweetText?: string,
+    operationContext?: GenerativeOperationContext,
   ): Promise<{
     success: boolean;
     tweetId?: string;
@@ -298,7 +290,12 @@ Return ONLY the tweet text, nothing else.`;
 
     let text = tweetText;
     if (!text) {
-      const generated = await this.generateAppTweet(organizationId, app, "promotional");
+      const generated = await this.generateAppTweet(
+        organizationId,
+        app,
+        "promotional",
+        operationContext,
+      );
       text = generated.text;
     }
 

--- a/packages/cloud/shared/src/lib/voice-session/ws-handler-admission.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/ws-handler-admission.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Exercises the real WebSocket hello boundary around paid voice admission.
+ * The deterministic socket proves denial performs zero session/provider work,
+ * admission precedes start, and failed starts retain asynchronous rollback.
+ */
+
+import { expect, mock, test } from "bun:test";
+import { attachVoiceWsHandler, type ServerWebSocketLike } from "./ws-handler";
+
+class TestSocket implements ServerWebSocketLike {
+  readonly sent: Array<string | ArrayBuffer | Uint8Array> = [];
+  private readonly listeners = new Map<string, Array<(event: { data: unknown }) => void>>();
+
+  send(data: string | ArrayBuffer | Uint8Array): void {
+    this.sent.push(data);
+  }
+  close(): void {}
+  addEventListener(
+    type: "message" | "close" | "error",
+    listener: (event: { data: unknown }) => void,
+  ): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+  message(data: unknown): void {
+    for (const listener of this.listeners.get("message") ?? []) listener({ data });
+  }
+}
+
+const verified = {
+  claims: {
+    sessionId: "session-1",
+    organizationId: "org-1",
+    userId: "user-1",
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+  },
+  jti: "jti-1",
+  expSeconds: Math.floor(Date.now() / 1_000) + 60,
+};
+
+async function flushHello(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const hello = JSON.stringify({
+  t: "hello",
+  protocol: 1,
+  token: "token",
+  uplinkCodec: "pcm16",
+  downlinkCodec: "pcm16",
+  sampleRate: 16_000,
+});
+
+test("voice provider admission denial performs zero provider dispatch", async () => {
+  const socket = new TestSocket();
+  const buildSession = mock(() => {
+    throw new Error("provider must not be constructed");
+  });
+  attachVoiceWsHandler(socket, {
+    requestedSessionId: "session-1",
+    verifyToken: mock(async () => verified),
+    claimToken: mock(async () => true),
+    admitSession: () => true,
+    admitProviderSession: async () => {
+      throw Object.assign(new Error("quota denied"), {
+        code: "quota_exhausted",
+      });
+    },
+    buildSession,
+  });
+
+  socket.message(hello);
+  await flushHello();
+
+  expect(buildSession).not.toHaveBeenCalled();
+  expect(socket.sent.map(String).join("\n")).toContain("quota_exhausted");
+});
+
+test("voice admission is recorded before start and failed start rolls back asynchronously", async () => {
+  const socket = new TestSocket();
+  const order: string[] = [];
+  const release = mock(async () => {
+    order.push("release");
+  });
+  const retained: Promise<unknown>[] = [];
+  attachVoiceWsHandler(socket, {
+    requestedSessionId: "session-1",
+    verifyToken: async () => {
+      order.push("verify");
+      return verified;
+    },
+    claimToken: async () => {
+      order.push("claim");
+      return true;
+    },
+    admitSession: () => true,
+    admitProviderSession: async () => {
+      order.push("admit");
+      return { admittedMinutes: 5 / 60, release };
+    },
+    buildSession: ({ initialUsageAdmissionMinutes }) => {
+      order.push(`build:${initialUsageAdmissionMinutes}`);
+      return {
+        start() {
+          order.push("start");
+          throw new Error("provider open failed");
+        },
+        pushUplinkAudio() {},
+        bargeIn() {},
+        bye() {},
+        sever() {},
+      };
+    },
+    defer: (promise) => retained.push(promise),
+  });
+
+  socket.message(hello);
+  await flushHello();
+  await Promise.all(retained);
+
+  expect(order).toEqual(["verify", "claim", "admit", `build:${5 / 60}`, "start", "release"]);
+  expect(release).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/shared/src/lib/voice-session/ws-handler.ts
+++ b/packages/cloud/shared/src/lib/voice-session/ws-handler.ts
@@ -82,6 +82,7 @@ export interface VoiceWsHandlerDeps {
     jti: string;
     tokenExpSeconds: number;
     downlink: VoiceSessionDownlink;
+    initialUsageAdmissionMinutes?: number;
   }) => VoiceSessionLike;
   /** Verify override for tests; defaults to the real verifier. */
   verifyToken?: typeof verifyVoiceSessionToken;
@@ -99,6 +100,16 @@ export interface VoiceWsHandlerDeps {
    * live registry. Returns true when a new session may start.
    */
   admitSession?: () => boolean;
+  /**
+   * Atomically records the initial paid-provider window after token standing
+   * and capacity checks, immediately before session construction and start.
+   */
+  admitProviderSession?: (identity: { organizationId: string; userId: string }) => Promise<{
+    admittedMinutes: number;
+    release(): Promise<void>;
+  }>;
+  /** Retain detached rollback work under the owning Worker lifetime. */
+  defer?: (promise: Promise<unknown>) => void;
   now?: () => number;
 }
 
@@ -322,23 +333,51 @@ export function attachVoiceWsHandler(socket: ServerWebSocketLike, deps: VoiceWsH
       return;
     }
 
+    let providerAdmission: { admittedMinutes: number; release(): Promise<void> } | undefined;
     try {
+      providerAdmission = await deps.admitProviderSession?.({
+        organizationId: verified.claims.organizationId,
+        userId: verified.claims.userId,
+      });
+      if (state !== "awaiting_hello") {
+        if (providerAdmission) {
+          const release = providerAdmission.release();
+          if (deps.defer) deps.defer(release);
+          else void release;
+        }
+        return;
+      }
       session = deps.buildSession({
         claims: verified.claims,
         jti: verified.jti,
         tokenExpSeconds: verified.expSeconds,
         downlink,
+        initialUsageAdmissionMinutes: providerAdmission?.admittedMinutes,
       });
       state = "active";
       session.start();
-    } catch (ignoredError) {
-      void ignoredError;
+    } catch (error) {
+      if (providerAdmission) {
+        const release = providerAdmission.release();
+        if (deps.defer) deps.defer(release);
+        else void release;
+      }
       // Runtime-config failures (e.g. an invalid Cartesia voiceId rejected by
       // the adapter) must surface as a clean retryable error + close, not a
       // hung socket with a consumed token.
       session = null;
       state = "awaiting_hello";
-      fail("session_start_failed", "could not start voice session", 1011);
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code: unknown }).code)
+          : "session_start_failed";
+      fail(
+        code,
+        code === "quota_exhausted"
+          ? "voice realtime quota exhausted"
+          : "could not start voice session",
+        code === "quota_exhausted" ? 1008 : 1011,
+      );
       return;
     }
     // Replay any audio the client pipelined while verification was in flight,

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -569,7 +569,7 @@ describe("watchdog configuration", () => {
     });
 
     expect(identity).toBe("win-creation:638915887234567890");
-    expect(invocation.command).toBe("powershell.exe");
+    expect(invocation.command).toBe("pwsh.exe");
     expect(invocation.args).toContain("-NoProfile");
     expect(invocation.args.at(-1)).toContain("Get-Process -Id 321");
     expect(invocation.args.at(-1)).not.toContain("Get-CimInstance");
@@ -579,6 +579,25 @@ describe("watchdog configuration", () => {
       timeout: 10_000,
       maxBuffer: 4096,
     });
+  });
+
+  it("falls back to Windows PowerShell when PowerShell 7 is unavailable", () => {
+    const invocations = [];
+    const identity = readProcessIdentity(321, {
+      platform: "win32",
+      spawnSyncFn: (command) => {
+        invocations.push(command);
+        if (command === "pwsh.exe") {
+          return {
+            error: Object.assign(new Error("missing"), { code: "ENOENT" }),
+          };
+        }
+        return { status: 0, stdout: "638915887234567890" };
+      },
+    });
+
+    expect(identity).toBe("win-creation:638915887234567890");
+    expect(invocations).toEqual(["pwsh.exe", "powershell.exe"]);
   });
 
   it("rejects missing or malformed Windows process identities", () => {

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -61,11 +61,11 @@ export const DEFAULT_BATCH_TIMEOUT_MS = 10 * 60 * 1000;
 export const DEFAULT_BATCH_KILL_GRACE_MS = 2000;
 export const MAX_CLASSIFICATION_OUTPUT_CHARS = 1024 * 1024;
 const MAX_TIMER_MS = 2_147_483_647;
-// A cold Windows PowerShell process can take several seconds to initialize on
-// the hosted windows-2025 image. Keep the identity query bounded, but allow the
-// universal powershell.exe path enough time to return the immutable StartTime
-// ticks before any PID-targeted teardown is considered.
+// Prefer the already-provisioned PowerShell 7 host on CI: the legacy Windows
+// PowerShell process can exceed the entire cold-start allowance on windows-2025.
+// Keep the universal powershell.exe path as a bounded local-machine fallback.
 const WINDOWS_PROCESS_IDENTITY_QUERY_TIMEOUT_MS = 10_000;
+const WINDOWS_POWERSHELL_IDENTITY_COMMANDS = ["pwsh.exe", "powershell.exe"];
 const POSIX_PROCESS_GROUP_SUPERVISOR = `
 terminating=0
 trap 'terminating=1' TERM INT
@@ -298,27 +298,31 @@ function readWindowsProcessIdentity(pid, spawnSyncFn) {
     "if ($null -eq $process) { exit 3 }",
     "[Console]::Write($process.StartTime.ToUniversalTime().Ticks)",
   ].join("; ");
-  let result;
-  try {
-    result = spawnSyncFn(
-      "powershell.exe",
-      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
-      {
-        encoding: "utf8",
-        windowsHide: true,
-        timeout: WINDOWS_PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
-        maxBuffer: 4096,
-      },
-    );
-  } catch {
-    // error-policy:J3 An unavailable identity is explicit and makes teardown fail closed.
-    return undefined;
+  for (const executable of WINDOWS_POWERSHELL_IDENTITY_COMMANDS) {
+    let result;
+    try {
+      result = spawnSyncFn(
+        executable,
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+        {
+          encoding: "utf8",
+          windowsHide: true,
+          timeout: WINDOWS_PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
+          maxBuffer: 4096,
+        },
+      );
+    } catch {
+      // error-policy:J3 Try the universal Windows PowerShell fallback before failing closed.
+      continue;
+    }
+    if (result?.status === 3) return undefined;
+    if (result?.error || result?.status !== 0) continue;
+    const creationTicks = result.stdout?.trim();
+    if (/^\d+$/.test(creationTicks ?? "")) {
+      return `win-creation:${creationTicks}`;
+    }
   }
-  if (result?.error || result?.status !== 0) return undefined;
-  const creationTicks = result.stdout?.trim();
-  return /^\d+$/.test(creationTicks ?? "")
-    ? `win-creation:${creationTicks}`
-    : undefined;
+  return undefined;
 }
 
 export function readProcessIdentity(

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
@@ -118,6 +118,23 @@ describe("stubElizaCore", () => {
 
     expect(evaluated).toBe("fixture reply");
   });
+
+  it("exports a concrete fail-closed shortcut matcher for chat fixtures", async () => {
+    const bundle = await bundleWithCoreStub(`
+      import { matchShortcut } from "@elizaos/core";
+      export const observed = {
+        type: typeof matchShortcut,
+        result: matchShortcut([], "send fixture message", { allowNatural: true }),
+      };
+    `);
+
+    const evaluated = new Function(`${bundle}; return fixture.observed;`)() as {
+      type: string;
+      result: unknown;
+    };
+
+    expect(evaluated).toEqual({ type: "function", result: null });
+  });
 });
 
 describe("stubNodeBuiltins", () => {

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
@@ -15,7 +15,7 @@ import type { Plugin } from "esbuild";
 
 /**
  * Replace `@elizaos/core` with a no-op Proxy that answers the render-path symbols
- * the shell reads (`isViewVisible`, `dedupeModalities`,
+ * the shell reads (`isViewVisible`, `dedupeModalities`, `matchShortcut`,
  * `findInteractionRegions`, `stripUnclaimedInteractionMarkup`) and proxies
  * everything else, so core's Node graph is never bundled.
  */
@@ -54,6 +54,10 @@ export function stubElizaCore(): Plugin {
             isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            // Fixture chat messages must fall through to the mocked transport.
+            // Keep this as an own property so esbuild can materialize the named
+            // ESM import reached through slash-menu.ts.
+            matchShortcut: () => null,
             findInteractionRegions: () => [],
             // The stub reports no claimed interaction regions, so preserve the
             // fixture text. This must be a concrete own property: esbuild's ESM


### PR DESCRIPTION
## Summary

- enforce one combined account-standing decision before remaining paid or generative provider dispatches
- preserve safe cached denial reasons and detailed structured error context
- mark dispatch durably immediately before provider work, then settle exact or unknown usage asynchronously without a cache readback
- cover app review/promotion/assets/SEO, automation generators, Firecrawl, provisioning chat, hosted search, voice verification, inbound vision, realtime voice, unified RPC, and Hugging Face egress quota
- remove redundant room-title and secondary fact-extraction LLM calls; fail closed for the dormant unadmitted connection-enforcement model path
- replace Hugging Face KV read-modify-write accounting with atomic Redis reservations
- repair exact-head CI blockers in UI keyboard-shortcut mocking and the Windows watchdog identity probe

Refs #29967.

## Ordering invariant

Every covered path follows validate -> one standing snapshot -> durable admission -> dispatch marker -> provider -> deferred settlement. Malformed, unauthorized, unavailable, or bad-standing requests dispatch nothing. After dispatch, provider uncertainty settles conservatively; status/cache updates run through `waitUntil` and do not read the cache back.

The trusted inbound-vision webhook has no credential key, so its standing check is one synchronous combined SQL decision in the existing claim/quota transaction rather than a credential-keyed KV read. Its completion/failure settlement is one fenced asynchronous UPDATE with no SELECT or RETURNING.

## Verification

Exact head: `6df6de8397ecfa084620c851ce27739a8a50ff9b`

- `bun run verify`: 375/375 workspace tasks passed; all subsequent repository audits passed
- focused Cloud admission/provider suites passed across automation, Firecrawl, provisioning/search, voice verification, inbound vision, realtime/RPC/HF, and connection enforcement
- shared and Cloud API typechecks passed
- production Worker bundle dry-run passed
- UI chat-sheet E2E: 72 screenshots, zero page errors; formerly failing send/dictation/multisend paths passed
- Windows watchdog unit suite: 51 tests / 132 expectations passed; POSIX real self-test passed
- direct Cerebras baseline: 20/20 success, first-token p50 132.77 ms / p95 252.21 ms, total p50 148.77 ms / p95 256.44 ms

Hosted exact-head checks and staging deployment/latency certification remain the merge and production-promotion gates.