### PR TITLE
test(cloud): retain safe Dedicated activation failure diagnostics

### DIFF
--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -250,6 +250,8 @@ describe("forbidden Cloud agent mutations", () => {
       parsedDedicatedActivationResponseBodyCount: 0,
       decodedDedicatedActivationReceiptCount: 0,
       uninspectableDedicatedActivationResponseBodyCount: 0,
+      dedicatedActivationResponseStatus: null,
+      dedicatedActivationResponseCode: null,
       dedicatedCutoverPostRequestCount: 0,
       successfulDedicatedCutoverPostResponseCount: 0,
       clientErrorDedicatedCutoverPostResponseCount: 0,
@@ -388,6 +390,8 @@ describe("forbidden Cloud agent mutations", () => {
       parsedDedicatedActivationResponseBodyCount: 1,
       decodedDedicatedActivationReceiptCount: 1,
       uninspectableDedicatedActivationResponseBodyCount: 0,
+      dedicatedActivationResponseStatus: 202,
+      dedicatedActivationResponseCode: null,
       dedicatedCutoverPostRequestCount: 2,
       successfulDedicatedCutoverPostResponseCount: 1,
       clientErrorDedicatedCutoverPostResponseCount: 1,
@@ -406,6 +410,34 @@ describe("forbidden Cloud agent mutations", () => {
       dedicatedLifecycleBindingMismatchCount: 4,
     });
     expect(JSON.stringify(snapshot)).not.toMatch(/api\.test|private|timeout/);
+  });
+
+  it("retains only the bounded Dedicated activation status and error code", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const upgrade =
+      "https://api.test/api/v1/eliza/agents/private-target/upgrade-tier";
+    audit.observeRequest(
+      "POST",
+      upgrade,
+      JSON.stringify({ quoteId: "private-quote" }),
+    );
+    audit.observeResponse(
+      "POST",
+      upgrade,
+      409,
+      boundedJsonBody({
+        success: false,
+        code: "dedicated_quote_changed",
+        message: "private user detail",
+      }).responseBody,
+    );
+
+    const snapshot = await audit.snapshot();
+    expect(snapshot.dedicatedActivationResponseStatus).toBe(409);
+    expect(snapshot.dedicatedActivationResponseCode).toBe(
+      "dedicated_quote_changed",
+    );
+    expect(JSON.stringify(snapshot)).not.toMatch(/private user detail|quoteId/);
   });
 
   it("fails closed when an approved quote is followed by another agent target", async () => {

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -95,6 +95,8 @@ export interface CloudLiveNetworkAuditSnapshot {
   parsedDedicatedActivationResponseBodyCount: number;
   decodedDedicatedActivationReceiptCount: number;
   uninspectableDedicatedActivationResponseBodyCount: number;
+  dedicatedActivationResponseStatus: number | null;
+  dedicatedActivationResponseCode: string | null;
   dedicatedCutoverPostRequestCount: number;
   successfulDedicatedCutoverPostResponseCount: number;
   clientErrorDedicatedCutoverPostResponseCount: number;
@@ -694,6 +696,12 @@ interface DedicatedControlPlaneResponseInspection {
   code: string | null;
 }
 
+function boundedDedicatedResponseCode(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const code = value.trim();
+  return /^[a-z][a-z0-9_]{0,79}$/.test(code) ? code : null;
+}
+
 async function inspectDedicatedControlPlaneResponse(
   phase: DedicatedControlPlaneRequest,
   status: number,
@@ -732,8 +740,7 @@ async function inspectDedicatedControlPlaneResponse(
       };
     }
     const root = parsed as Record<string, unknown>;
-    const code =
-      typeof root.code === "string" ? root.code.trim() || null : null;
+    const code = boundedDedicatedResponseCode(root.code);
     const data = root.data;
     const dataRecord =
       data && typeof data === "object" && !Array.isArray(data)
@@ -1455,6 +1462,13 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
     },
     snapshot: async () => {
       await drainResponseHandlers();
+      const latestDedicatedActivationResponse = dedicatedLifecycleRequests
+        .slice()
+        .reverse()
+        .find(
+          (request) =>
+            request.phase === "activation" && request.responseStatus !== null,
+        );
       const approvedTargetId =
         dedicatedApprovalBinding?.dedicatedAgentId ??
         (dedicatedApprovalBinding?.confirmationKind === "activation"
@@ -1581,6 +1595,10 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
           dedicatedControlPlane.activation.decoded,
         uninspectableDedicatedActivationResponseBodyCount:
           dedicatedControlPlane.activation.uninspectableBody,
+        dedicatedActivationResponseStatus:
+          latestDedicatedActivationResponse?.responseStatus ?? null,
+        dedicatedActivationResponseCode:
+          latestDedicatedActivationResponse?.responseCode ?? null,
         dedicatedCutoverPostRequestCount: dedicatedControlPlane.cutover.request,
         successfulDedicatedCutoverPostResponseCount:
           dedicatedControlPlane.cutover.success,

--- a/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
@@ -35,6 +35,8 @@ const ZERO_DEDICATED_CONTROL_PLANE_COUNTERS = {
   parsedDedicatedActivationResponseBodyCount: 0,
   decodedDedicatedActivationReceiptCount: 0,
   uninspectableDedicatedActivationResponseBodyCount: 0,
+  dedicatedActivationResponseStatus: null,
+  dedicatedActivationResponseCode: null,
   dedicatedCutoverPostRequestCount: 0,
   successfulDedicatedCutoverPostResponseCount: 0,
   clientErrorDedicatedCutoverPostResponseCount: 0,
@@ -177,6 +179,41 @@ describe("Cloud live trajectory diagnostic", () => {
         counters,
       ),
     ).toThrow("pre-identity counters must be non-negative integers");
+  });
+
+  it("retains only a bounded Dedicated activation status and machine code", () => {
+    const counters = {
+      runtimeCloudActionAttemptCount: 1,
+      runtimeCloudActionSuccessCount: 0,
+      runtimeCloudActionTimeoutCount: 0,
+      ...ZERO_PERSONAL_BODY_AND_RECOVERY_COUNTERS,
+      personalIdentityGetRequestCount: 1,
+      successfulPersonalIdentityGetResponseCount: 1,
+      clientErrorPersonalIdentityGetResponseCount: 0,
+      serverErrorPersonalIdentityGetResponseCount: 0,
+      otherPersonalIdentityGetResponseCount: 0,
+      failedPersonalIdentityGetRequestCount: 0,
+      pendingPersonalIdentityGetRequestCount: 0,
+      ...ZERO_DEDICATED_CONTROL_PLANE_COUNTERS,
+      dedicatedActivationResponseStatus: 409,
+      dedicatedActivationResponseCode: "dedicated_quote_changed",
+    };
+
+    const diagnostic = createCloudLiveTrajectoryDiagnostic(
+      "personal-identity",
+      456,
+      counters,
+    );
+    expect(diagnostic.preIdentity).toMatchObject({
+      dedicatedActivationResponseStatus: 409,
+      dedicatedActivationResponseCode: "dedicated_quote_changed",
+    });
+    expect(() =>
+      createCloudLiveTrajectoryDiagnostic("personal-identity", 456, {
+        ...counters,
+        dedicatedActivationResponseCode: "private message: user@example.com",
+      }),
+    ).toThrow("bounded machine code");
   });
 
   it("overwrites one private receipt with restrictive permissions", async () => {

--- a/packages/app/test/cloud-live-trajectory-diagnostic.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.ts
@@ -6,7 +6,7 @@ import { dirname } from "node:path";
 export const CLOUD_LIVE_TRAJECTORY_TIMEOUT_MS = 35 * 60 * 1_000;
 export const CLOUD_LIVE_NAVIGATION_TIMEOUT_MS = 2 * 60 * 1_000;
 export const CLOUD_LIVE_TRAJECTORY_DIAGNOSTIC_SCHEMA =
-  "elizaos.cloud.trajectory-progress/v1";
+  "elizaos.cloud.trajectory-progress/v2";
 
 export const CLOUD_LIVE_TRAJECTORY_PHASES = [
   "protected-cloud-boot",
@@ -77,6 +77,8 @@ export interface CloudLivePreIdentityDiagnostic {
   parsedDedicatedActivationResponseBodyCount: number;
   decodedDedicatedActivationReceiptCount: number;
   uninspectableDedicatedActivationResponseBodyCount: number;
+  dedicatedActivationResponseStatus: number | null;
+  dedicatedActivationResponseCode: string | null;
   dedicatedCutoverPostRequestCount: number;
   successfulDedicatedCutoverPostResponseCount: number;
   clientErrorDedicatedCutoverPostResponseCount: number;
@@ -191,6 +193,25 @@ export function createCloudLiveTrajectoryDiagnostic(
       }
       closedCounters[key] = value;
     }
+    const responseStatus = preIdentity.dedicatedActivationResponseStatus;
+    if (
+      responseStatus !== null &&
+      (!Number.isSafeInteger(responseStatus) ||
+        responseStatus < 100 ||
+        responseStatus > 599)
+    ) {
+      throw new Error(
+        "[cloud-live] Dedicated activation response status must be an HTTP status or null",
+      );
+    }
+    const responseCode = preIdentity.dedicatedActivationResponseCode;
+    if (responseCode !== null && !/^[a-z][a-z0-9_]{0,79}$/.test(responseCode)) {
+      throw new Error(
+        "[cloud-live] Dedicated activation response code must be a bounded machine code or null",
+      );
+    }
+    closedCounters.dedicatedActivationResponseStatus = responseStatus;
+    closedCounters.dedicatedActivationResponseCode = responseCode;
     diagnostic.preIdentity = closedCounters;
   }
   return diagnostic;

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -838,6 +838,10 @@ test.describe("real cloud login + personal identity + chat", () => {
             audit.decodedDedicatedActivationReceiptCount,
           uninspectableDedicatedActivationResponseBodyCount:
             audit.uninspectableDedicatedActivationResponseBodyCount,
+          dedicatedActivationResponseStatus:
+            audit.dedicatedActivationResponseStatus,
+          dedicatedActivationResponseCode:
+            audit.dedicatedActivationResponseCode,
           dedicatedCutoverPostRequestCount:
             audit.dedicatedCutoverPostRequestCount,
           successfulDedicatedCutoverPostResponseCount:


### PR DESCRIPTION
## Summary

- upgrade the privacy-safe Cloud live trajectory receipt to v2
- retain only the latest Dedicated activation HTTP status and a strict bounded machine error code
- continue discarding URLs, headers, request bodies, user messages, IDs, tokens, and arbitrary response text
- make the next staging certification failure distinguish 402/409 and exact safe server code instead of collapsing every activation 4xx into one counter

Refs #29967.

## Evidence

The failed staging run `33280946964` proved identity GET and quote decode succeeded, then recorded one parsed activation 4xx but omitted its status/code. The old artifact therefore cannot distinguish `dedicated_quote_changed`, insufficient credit, selection, or quota errors. This change closes that diagnostic gap without guessing at the old response.

## Verification

- `bunx vitest run test/cloud-live-trajectory-diagnostic.test.ts test/cloud-live-continuity-contract.test.ts` (50 pass)
- Biome passes on all five changed files
- `git diff --check` passes
- package typecheck reached only unrelated missing built workspace exports in this fresh worktree; no changed-file errors

No rendered product surface changes; this modifies only the credentialed live-test audit and its private mode-0600 diagnostic artifact.