### PR TITLE
test(core): pin manage-server authorization gate contract

### DIFF
--- a/packages/core/src/messaging/manage-server-authorization.test.ts
+++ b/packages/core/src/messaging/manage-server-authorization.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Exercises the structural manage-server authorization boundary with a
+ * deterministic mock runtime, the real identity turn memo, and no database or
+ * model. It owns revocation freshness and exact durable destination binding.
+ */
+
+import { describe, expect, it } from "vitest";
+import { getVerifiedRelatedEntityIds } from "../identity-clusters.ts";
+import { runWithTrajectoryContext } from "../trajectory-context.ts";
+import type {
+	IAgentRuntime,
+	MessageConnectorManageServerDestination,
+	Room,
+	UUID,
+	World,
+} from "../types/index.ts";
+import { authorizeManageServerDestination } from "./manage-server-authorization.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const REQUESTER_ID = "00000000-0000-0000-0000-000000000002" as UUID;
+const LINKED_ADMIN_ID = "00000000-0000-0000-0000-000000000003" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-000000000004" as UUID;
+const MESSAGE_SERVER_ID = "00000000-0000-0000-0000-000000000005" as UUID;
+const OTHER_MESSAGE_SERVER_ID = "00000000-0000-0000-0000-000000000006" as UUID;
+const BINDING_ROOM_A = "00000000-0000-0000-0000-000000000007" as UUID;
+const BINDING_ROOM_B = "00000000-0000-0000-0000-000000000008" as UUID;
+const AGENT_ONLY_ROOM = "00000000-0000-0000-0000-000000000009" as UUID;
+const WRONG_SERVER_ROOM = "00000000-0000-0000-0000-000000000010" as UUID;
+
+const destination: MessageConnectorManageServerDestination = {
+	source: "discord",
+	accountId: "primary",
+	serverId: "guild-a",
+	messageServerId: MESSAGE_SERVER_ID,
+	destinationWorldId: WORLD_ID,
+	target: {
+		source: "discord",
+		accountId: "primary",
+		serverId: "guild-a",
+	},
+};
+
+function room(id: UUID, overrides: Partial<Room> = {}): Room {
+	return {
+		id,
+		agentId: AGENT_ID,
+		worldId: WORLD_ID,
+		source: destination.source,
+		type: "GROUP",
+		serverId: destination.serverId,
+		messageServerId: MESSAGE_SERVER_ID,
+		...overrides,
+	};
+}
+
+function harness(options?: {
+	world?: Partial<World>;
+	rooms?: Room[];
+	linked?: boolean;
+	requesterRooms?: UUID[];
+	agentRooms?: UUID[];
+}) {
+	let linked = options?.linked ?? true;
+	let resolverCalls = 0;
+	const world: World = {
+		id: WORLD_ID,
+		agentId: AGENT_ID,
+		messageServerId: MESSAGE_SERVER_ID,
+		metadata: {
+			roles: { [LINKED_ADMIN_ID]: "ADMIN" },
+			roleSources: { [LINKED_ADMIN_ID]: "manual" },
+		},
+		...options?.world,
+	};
+	const rooms = options?.rooms ?? [room(BINDING_ROOM_A)];
+	const runtime = {
+		agentId: AGENT_ID,
+		getWorld: async (worldId: UUID) => (worldId === WORLD_ID ? world : null),
+		getRooms: async (worldId: UUID) => (worldId === WORLD_ID ? rooms : []),
+		getRoomsForParticipant: async (entityId: UUID) => {
+			if (entityId === AGENT_ID) {
+				return options?.agentRooms ?? [BINDING_ROOM_A];
+			}
+			if (entityId === LINKED_ADMIN_ID) {
+				return options?.requesterRooms ?? [BINDING_ROOM_A];
+			}
+			return [];
+		},
+		getService: (name: string) =>
+			name === "relationships"
+				? {
+						getVerifiedMemberEntityIds: async () => {
+							resolverCalls += 1;
+							return linked ? [LINKED_ADMIN_ID] : [];
+						},
+					}
+				: null,
+		getSetting: () => undefined,
+	} as unknown as IAgentRuntime;
+
+	return {
+		runtime,
+		revokeLink: () => {
+			linked = false;
+		},
+		resolverCalls: () => resolverCalls,
+	};
+}
+
+describe("authorizeManageServerDestination", () => {
+	it("re-resolves a primed identity memo and denies a revoked linked admin", async () => {
+		const { runtime, revokeLink, resolverCalls } = harness();
+
+		await runWithTrajectoryContext({ turnMemo: new Map() }, async () => {
+			expect(await getVerifiedRelatedEntityIds(runtime, REQUESTER_ID)).toEqual([
+				REQUESTER_ID,
+				LINKED_ADMIN_ID,
+			]);
+			revokeLink();
+
+			await expect(
+				authorizeManageServerDestination(runtime, REQUESTER_ID, destination),
+			).rejects.toMatchObject({
+				code: "MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED",
+			});
+		});
+
+		expect(resolverCalls()).toBe(2);
+	});
+
+	it.each([
+		["agent", { agentId: REQUESTER_ID }],
+		["message server", { messageServerId: OTHER_MESSAGE_SERVER_ID }],
+	])("denies a world bound to a different %s", async (_label, world) => {
+		const { runtime } = harness({ world });
+
+		await expect(
+			authorizeManageServerDestination(runtime, REQUESTER_ID, destination),
+		).rejects.toMatchObject({
+			code: "MANAGE_SERVER_DESTINATION_UNBOUND",
+		});
+	});
+
+	it("does not accept a same-world room bound to a different server", async () => {
+		const { runtime } = harness({
+			rooms: [room(WRONG_SERVER_ROOM, { serverId: "guild-b" })],
+		});
+
+		await expect(
+			authorizeManageServerDestination(runtime, REQUESTER_ID, destination),
+		).rejects.toMatchObject({
+			code: "MANAGE_SERVER_DESTINATION_UNBOUND",
+		});
+	});
+
+	it("returns the ADMIN identity and only its agent-shared binding rooms", async () => {
+		const { runtime } = harness({
+			rooms: [
+				room(BINDING_ROOM_A),
+				room(BINDING_ROOM_B),
+				room(AGENT_ONLY_ROOM),
+				room(WRONG_SERVER_ROOM, { serverId: "guild-b" }),
+			],
+			requesterRooms: [
+				BINDING_ROOM_B,
+				WRONG_SERVER_ROOM,
+				BINDING_ROOM_A,
+				BINDING_ROOM_B,
+			],
+			agentRooms: [
+				BINDING_ROOM_A,
+				BINDING_ROOM_B,
+				AGENT_ONLY_ROOM,
+				WRONG_SERVER_ROOM,
+			],
+		});
+
+		await expect(
+			authorizeManageServerDestination(runtime, REQUESTER_ID, destination),
+		).resolves.toMatchObject({
+			authorizedEntityId: LINKED_ADMIN_ID,
+			role: "ADMIN",
+			bindingRoomIds: [BINDING_ROOM_B, BINDING_ROOM_A],
+		});
+	});
+});


### PR DESCRIPTION
Closes #29969.

# Relates to

- Closes #29969
- Consumer: `MESSAGE op=manage_server` and the Discord, Telegram, and WhatsApp connector mutation boundaries that re-check this gate.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `e7b7e7c90595cd419460ef7871ba2407569e0d3b` with zero conflicts.
- [ ] `bun install` and `bun run verify` passed after sync. `bun install --frozen-lockfile` was attempted only after the preinstalled tree proved incomplete, but concurrent installer contention prevented completion. `bun run verify` fails identically in the untouched control because `mammoth` is absent; see Known gaps / failures.
- [x] A reviewer can confirm the authorization contract from the full-path before/after and mutation outputs below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It fails on the same missing `mammoth` dependency in the issue branch and untouched control.

# Risks

Low. This is one deterministic owning-boundary test file and makes no production change. The suite directly executes the real authorization gate and real turn-memo implementation with a mock runtime around persistence/service collaborators.

# Background

## What does this PR do?

Adds `packages/core/src/messaging/manage-server-authorization.test.ts` to pin the security contract that was previously only documented at the gate:

- revocation forces a fresh verified-identity lookup even inside a primed turn memo;
- foreign agent/world bindings and foreign message-server bindings fail closed;
- a same-world room for a different server is not a durable destination binding; and
- success returns the ADMIN identity and only the exact rooms shared by the ADMIN, agent, and destination binding.

## Acceptance checklist

- [x] Revoked linked identity is denied `MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED` after the pre-revocation cluster primes the real turn memo. The focused suite passes, and the mutation run below fails only this case when `invalidateRelatedEntityIds(runtime, requesterEntityId)` is removed.
- [x] `world.agentId` mismatch denies `MANAGE_SERVER_DESTINATION_UNBOUND` (`denies a world bound to a different agent`).
- [x] `world.messageServerId` mismatch denies `MANAGE_SERVER_DESTINATION_UNBOUND` (`denies a world bound to a different message server`).
- [x] Same-world/wrong-server room does not satisfy the binding (`does not accept a same-world room bound to a different server`).
- [x] Success returns `authorizedEntityId`, `role`, and `bindingRoomIds` for the ADMIN+ member's exact intersection (`returns the ADMIN identity and only its agent-shared binding rooms`).
- [x] No production changes: the committed diff adds only the owning-boundary test file.

## What kind of change is this?

Test-only regression ownership for a reachable authorization boundary specified by the maintainer-filed issue.

# Documentation changes needed?

No. The production module already documents the contract; this change gives that contract an executable owner.

# Testing

## Where should a reviewer start?

Run the exact file:

```bash
bun test --coverage-reporter=lcov /Users/sailesh/Developer/worktrees/issue-29969/packages/core/src/messaging/manage-server-authorization.test.ts
```

## Before: untouched `origin/develop`

Command exited 1. Output verbatim:

```text
bun test v1.3.14 (0d9b296a)
Test filter "/Users/sailesh/Developer/worktrees/issue-29969-control/packages/core/src/messaging/manage-server-authorization.test.ts" had no matches
        0.00 real         0.00 user         0.00 sys
            22102016  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                1482  page reclaims
                  52  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   0  voluntary context switches
                  32  involuntary context switches
           142150060  instructions retired
            40312904  cycles elapsed
             9454240  peak memory footprint
```

## After: issue branch at `5855abb4ea0ba20d9063cb8ad14cd6363b030ece`

Command exited 0. Output verbatim:

```text
bun test v1.3.14 (0d9b296a)

packages/core/src/messaging/manage-server-authorization.test.ts:
(pass) authorizeManageServerDestination > re-resolves a primed identity memo and denies a revoked linked admin [0.86ms]
(pass) authorizeManageServerDestination > denies a world bound to a different agent [0.04ms]
(pass) authorizeManageServerDestination > denies a world bound to a different message server [0.01ms]
(pass) authorizeManageServerDestination > does not accept a same-world room bound to a different server [0.04ms]
(pass) authorizeManageServerDestination > returns the ADMIN identity and only its agent-shared binding rooms [0.73ms]

 5 pass
 0 fail
 7 expect() calls
Ran 5 tests across 1 file. [51.00ms]
        0.05 real         0.07 user         0.03 sys
            73564160  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                4606  page reclaims
                  70  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   0  voluntary context switches
                 305  involuntary context switches
          1016358449  instructions retired
           363652094  cycles elapsed
            47825760  peak memory footprint
```

## Invalidation mutation proof

I temporarily removed only `invalidateRelatedEntityIds(runtime, requesterEntityId)`, ran the same full-path command, captured this exit-1 output verbatim, and restored the production line. The committed diff contains no production change.

```text
bun test v1.3.14 (0d9b296a)

packages/core/src/messaging/manage-server-authorization.test.ts:
118 | 			]);
119 | 			revokeLink();
120 |
121 | 			await expect(
122 | 				authorizeManageServerDestination(runtime, REQUESTER_ID, destination),
123 | 			).rejects.toMatchObject({
                   ^
error:

Expected promise that rejects
Received promise that resolved: Promise { <resolved> }

      at <anonymous> (/Users/sailesh/Developer/worktrees/issue-29969/packages/core/src/messaging/manage-server-authorization.test.ts:123:14)
      at async <anonymous> (/Users/sailesh/Developer/worktrees/issue-29969/packages/core/src/messaging/manage-server-authorization.test.ts:114:9)
(fail) authorizeManageServerDestination > re-resolves a primed identity memo and denies a revoked linked admin [1.62ms]
(pass) authorizeManageServerDestination > denies a world bound to a different agent [0.11ms]
(pass) authorizeManageServerDestination > denies a world bound to a different message server [0.01ms]
(pass) authorizeManageServerDestination > does not accept a same-world room bound to a different server [0.05ms]
(pass) authorizeManageServerDestination > returns the ADMIN identity and only its agent-shared binding rooms [0.12ms]

 4 pass
 1 fail
 6 expect() calls
Ran 5 tests across 1 file. [61.00ms]
        0.06 real         0.07 user         0.03 sys
            72171520  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                4522  page reclaims
                  70  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   0  voluntary context switches
                 374  involuntary context switches
          1018255705  instructions retired
           361796867  cycles elapsed
            46170976  peak memory footprint
```

## Formatting

Command exited 0. Output verbatim:

```text
Checked 1 file in 46ms. Fixed 1 file.
        0.20 real         0.04 user         0.03 sys
            47808512  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                5524  page reclaims
                1268  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                 129  voluntary context switches
                1070  involuntary context switches
           437902321  instructions retired
           151442219  cycles elapsed
            14043080  peak memory footprint
```

## TypeScript comparison

Both full-path raw `tsc --noEmit -p <absolute packages/core/tsconfig.json>` commands exit 1 with the same 10 pre-existing dependency/version diagnostics; the issue branch introduces zero new diagnostics. Shared diagnostics verbatim:

```text
packages/core/src/features/documents/llm.ts(12,31): error TS2305: Module '"ai"' has no exported member 'ModelMessage'.
packages/core/src/features/documents/llm.ts(23,25): error TS2314: Generic type 'EmbeddingModel' requires 1 type argument(s).
packages/core/src/features/documents/llm.ts(118,13): error TS7006: Parameter 'part' implicitly has an 'any' type.
packages/core/src/features/documents/parsers.ts(42,33): error TS2307: Cannot find module 'mammoth' or its corresponding type declarations.
packages/core/src/features/documents/parsers.ts(115,40): error TS2307: Cannot find module 'unpdf' or its corresponding type declarations.
packages/core/src/features/trust/actions/roles.ts(12,20): error TS2307: Cannot find module 'dedent' or its corresponding type declarations.
packages/core/src/markdown/ir.ts(3,24): error TS2307: Cannot find module 'markdown-it' or its corresponding type declarations.
packages/core/src/media/mime-sniffer.ts(19,34): error TS2307: Cannot find module 'file-type' or its corresponding type declarations.
packages/core/src/media/mime-sniffer.ts(20,21): error TS18048: 'fileTypeModule' is possibly 'undefined'.
packages/core/src/utils/crypto-compat.ts(16,26): error TS2307: Cannot find module '@noble/ciphers/aes.js' or its corresponding type declarations.
```

# Evidence Gate

<!-- evidence-head:5855abb4ea0ba20d9063cb8ad14cd6363b030ece -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed; before behavior is the verbatim full-path command failure above.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed; after behavior is the verbatim full-path passing output above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic core authorization test only; no visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server process or production runtime behavior changed; the real gate result and denial codes are shown by the focused command output.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, planner, or action implementation changed; the suite invokes the authorization boundary directly.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database/domain state is written; the observable artifacts are the exact authorization results and denial codes in the command output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model/action implementation changed; this is deterministic authorization-boundary regression ownership.

## Backend + frontend logs

N/A - no live backend or frontend surface changed. Full gate execution output is included above.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice surface changed.

## Known gaps / failures

- `bun install --frozen-lockfile`: started only because the preinstalled dependency tree was genuinely missing `@noble/hashes/sha2.js`; it remained in dependency resolution under concurrent installer contention and was stopped. The exact pinned `@noble/hashes@2.2.0` already in Bun's cache was linked for focused execution.
- `tsc --noEmit`: issue and untouched control both exit 1 with the same 10 diagnostics quoted above; zero new errors.
- `bun run verify`: issue exits 1 after 6.17 s with max RSS 203,587,584 bytes; untouched control exits 1 after 4.73 s with max RSS 181,895,168 bytes. Both stop at the same missing dependency:

```text
[ensure-plugin-test-conventions] failed to resolve 3 vitest config(s):
  - plugins/plugin-personal-assistant/vitest.background-real.config.ts: ResolveMessage: ENOENT while resolving package 'mammoth' from '/Users/sailesh/Developer/worktrees/issue-29969/packages/core/package.json'
  - plugins/plugin-personal-assistant/vitest.config.ts: ResolveMessage: ENOENT while resolving package 'mammoth' from '/Users/sailesh/Developer/worktrees/issue-29969/packages/core/package.json'
  - plugins/plugin-personal-assistant/vitest.src-integration.config.ts: ResolveMessage: ENOENT while resolving package 'mammoth' from '/Users/sailesh/Developer/worktrees/issue-29969/packages/core/package.json'
error: script "ensure-plugin-test-conventions:check" exited with code 1
error: script "verify" exited with code 1
```

The untouched-control paths differ only by the `-control` worktree suffix and report the same missing package. No acceptance criterion is claimed through these unrelated failing gates.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza"} -->
