### PR TITLE
fix(ci): recapture unavailable watchdog identity

### DIFF
--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -857,6 +857,66 @@ describe("watchdog configuration", () => {
     expect(signalSource.listenerCount("SIGTERM")).toBe(0);
   });
 
+  it("recaptures an identity that was unavailable immediately after spawn", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let terminationOptions;
+    const resultPromise = runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 1,
+      writeOut: () => {},
+      writeErr: () => {},
+      platform: "win32",
+      signalSource,
+      identityFn: () => undefined,
+      spawnFn: () => child,
+      terminateTree: async (_pid, options) => {
+        terminationOptions = options;
+        child.emit("close", null, "SIGKILL");
+      },
+    });
+
+    const result = await resultPromise;
+
+    expect(result.timedOut).toBe(true);
+    expect(terminationOptions).toMatchObject({
+      expectedIdentity: undefined,
+      identityCaptured: false,
+    });
+  });
+
+  it("preserves a process identity captured immediately after spawn", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let terminationOptions;
+    const resultPromise = runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 1,
+      writeOut: () => {},
+      writeErr: () => {},
+      platform: "win32",
+      signalSource,
+      identityFn: () => "original-process",
+      spawnFn: () => child,
+      terminateTree: async (_pid, options) => {
+        terminationOptions = options;
+        child.emit("close", null, "SIGKILL");
+      },
+    });
+
+    const result = await resultPromise;
+
+    expect(result.timedOut).toBe(true);
+    expect(terminationOptions).toMatchObject({
+      expectedIdentity: "original-process",
+      identityCaptured: true,
+    });
+  });
+
   it("keeps the first termination cause when a parent signal races a timeout", async () => {
     const signalSource = new EventEmitter();
     const child = new EventEmitter();

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -727,7 +727,7 @@ export function runCommandWithWatchdog(
           platform,
           graceMs: terminationGraceMs,
           expectedIdentity: childIdentity,
-          identityCaptured: true,
+          identityCaptured: childIdentity !== undefined,
           identityFn,
         })
           .catch((error) => {


### PR DESCRIPTION
## Summary

- treat an unavailable post-spawn process identity as not yet captured
- let the existing termination boundary capture and pin the live identity before sending any tree-kill signal
- retain the fail-closed PID-reuse contract for identities captured at spawn

## Verification

- `bun test packages/scripts/__tests__/test-cloud-run.test.mjs` — 52 passed, 134 assertions

Fixes #29995