### PR TITLE
fix(shared): single-source and pin the runtime-management owner-approval-exempt operation partition

### DIFF
--- a/packages/agent/src/api/runtime-management-routes.ts
+++ b/packages/agent/src/api/runtime-management-routes.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import type http from "node:http";
 import {
   isRuntimeManagementOperation,
+  RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS,
   type RuntimeManagementRequest,
   type RuntimeManagementResult,
   readJsonBody,
@@ -21,10 +22,9 @@ const PROPOSAL_TIMEOUT_MS = 5 * 60_000;
 const pending = new PendingRequestMap();
 const claims = new Map<string, { token: string | null; expiresAt: number }>();
 let defaultProposalStore: RuntimeManagementProposalStore | undefined;
-const READ_ONLY_OPERATIONS = new Set<RuntimeManagementRequest["op"]>([
-  "list",
-  "inspect_ssh",
-]);
+const READ_ONLY_OPERATIONS = new Set<RuntimeManagementRequest["op"]>(
+  RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS,
+);
 
 export interface RuntimeManagementRouteContext {
   req: http.IncomingMessage;

--- a/packages/shared/src/contracts/runtime-management-partition.test.ts
+++ b/packages/shared/src/contracts/runtime-management-partition.test.ts
@@ -1,0 +1,43 @@
+/** Pins the security partition between owner-approval-exempt and mutating runtime operations. */
+
+import { describe, expect, it } from "vitest";
+import {
+  RUNTIME_MANAGEMENT_OPERATIONS,
+  RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS,
+} from "./runtime-management.ts";
+
+const CONFIRMATION_REQUIRED_OPERATIONS = [
+  "pair",
+  "create_pairing",
+  "claim_pairing",
+  "confirm_pairing",
+  "deny_pairing",
+  "revoke",
+  "remove",
+  "retry",
+  "connect_ssh",
+  "add_direct",
+  "enroll_host",
+  "approve_pairing",
+  "start_host",
+  "stop_host",
+  "revoke_host",
+] as const;
+
+describe("runtime-management owner-approval partition", () => {
+  it("pins the exempt set and its exact confirmation-required complement", () => {
+    const exempt = new Set(RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS);
+
+    expect([...exempt].sort()).toEqual(["inspect_ssh", "list"]);
+    expect(
+      [...exempt].every((operation) =>
+        RUNTIME_MANAGEMENT_OPERATIONS.includes(operation),
+      ),
+    ).toBe(true);
+    expect(
+      RUNTIME_MANAGEMENT_OPERATIONS.filter(
+        (operation) => !exempt.has(operation),
+      ),
+    ).toEqual(CONFIRMATION_REQUIRED_OPERATIONS);
+  });
+});

--- a/packages/shared/src/contracts/runtime-management.ts
+++ b/packages/shared/src/contracts/runtime-management.ts
@@ -23,6 +23,9 @@ export const RUNTIME_MANAGEMENT_OPERATIONS = [
 export type RuntimeManagementOperation =
   (typeof RUNTIME_MANAGEMENT_OPERATIONS)[number];
 
+export const RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS: ReadonlySet<RuntimeManagementOperation> =
+  new Set(["list", "inspect_ssh"]);
+
 export interface RuntimeManagementRequest {
   op: RuntimeManagementOperation;
   targetId?: string;

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -1,11 +1,16 @@
 /** Semantic action coverage for owner-gated Devices & Runtimes operations. */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import {
+	RUNTIME_MANAGEMENT_OPERATIONS,
+	RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS,
+} from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
 	createRuntimeManagementAction,
 	parseRuntimeManagementRequest,
 	type RuntimeManagementFn,
+	runtimeManagementActionInternals,
 } from "./runtime-management.ts";
 
 const runtime = {} as IAgentRuntime;
@@ -16,6 +21,15 @@ function callback(): HandlerCallback {
 }
 
 describe("RUNTIMES action", () => {
+	it("requires confirmation for the exact complement of exempt operations", () => {
+		expect([...runtimeManagementActionInternals.confirmationRequired]).toEqual(
+			RUNTIME_MANAGEMENT_OPERATIONS.filter(
+				(operation) =>
+					!RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS.has(operation),
+			),
+		);
+	});
+
 	it("is owner-gated and exposes no secret parameter", () => {
 		const action = createRuntimeManagementAction();
 		expect(action.roleGate).toEqual({ minRole: "OWNER" });

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -10,7 +10,6 @@ import {
 	createRuntimeManagementAction,
 	parseRuntimeManagementRequest,
 	type RuntimeManagementFn,
-	requiresRuntimeManagementConfirmation,
 } from "./runtime-management.ts";
 
 const runtime = {} as IAgentRuntime;
@@ -21,12 +20,44 @@ function callback(): HandlerCallback {
 }
 
 describe("RUNTIMES action", () => {
-	it("requires confirmation for the exact complement of exempt operations", () => {
-		expect(
-			RUNTIME_MANAGEMENT_OPERATIONS.filter(
-				requiresRuntimeManagementConfirmation,
-			),
-		).toEqual(
+	it("requires confirmation for the exact complement of exempt operations", async () => {
+		const confirmationRequired: Array<
+			(typeof RUNTIME_MANAGEMENT_OPERATIONS)[number]
+		> = [];
+		for (const op of RUNTIME_MANAGEMENT_OPERATIONS) {
+			const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+				ok: true,
+				op: request.op,
+			}));
+			const result = await createRuntimeManagementAction({
+				manageRuntime,
+			}).handler(
+				runtime,
+				message,
+				undefined,
+				{
+					op,
+					targetId: "target-1",
+					runtimeId: "runtime-1",
+					target: "user@example.test",
+					sshPort: 22,
+					remoteApiPort: 2138,
+					expectedFingerprint: "SHA256:verified",
+					identityFile: "/tmp/id_ed25519",
+					apiBase: "http://runtime.example.test",
+					sessionId: "session-1",
+					code: "123456",
+					managedNetwork: false,
+					platform: "linux",
+				},
+				callback(),
+			);
+			if (result?.values?.awaitingConfirmation === true) {
+				confirmationRequired.push(op);
+			}
+		}
+
+		expect(confirmationRequired).toEqual(
 			RUNTIME_MANAGEMENT_OPERATIONS.filter(
 				(operation) =>
 					!RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS.has(operation),

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -10,7 +10,7 @@ import {
 	createRuntimeManagementAction,
 	parseRuntimeManagementRequest,
 	type RuntimeManagementFn,
-	runtimeManagementActionInternals,
+	requiresRuntimeManagementConfirmation,
 } from "./runtime-management.ts";
 
 const runtime = {} as IAgentRuntime;
@@ -22,7 +22,11 @@ function callback(): HandlerCallback {
 
 describe("RUNTIMES action", () => {
 	it("requires confirmation for the exact complement of exempt operations", () => {
-		expect([...runtimeManagementActionInternals.confirmationRequired]).toEqual(
+		expect(
+			RUNTIME_MANAGEMENT_OPERATIONS.filter(
+				requiresRuntimeManagementConfirmation,
+			),
+		).toEqual(
 			RUNTIME_MANAGEMENT_OPERATIONS.filter(
 				(operation) =>
 					!RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS.has(operation),

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -12,6 +12,7 @@ import { logger } from "@elizaos/core";
 import {
 	isRuntimeManagementOperation,
 	RUNTIME_MANAGEMENT_OPERATIONS,
+	RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS,
 	type RuntimeManagementRequest,
 	type RuntimeManagementResult,
 } from "@elizaos/shared";
@@ -41,9 +42,13 @@ const REQUEST_TIMEOUT_MS = 50_000;
 const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 	new Set(
 		RUNTIME_MANAGEMENT_OPERATIONS.filter(
-			(op) => op !== "list" && op !== "inspect_ssh",
+			(op) => !RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS.has(op),
 		),
 	);
+
+export const runtimeManagementActionInternals = {
+	confirmationRequired: CONFIRMATION_REQUIRED,
+};
 
 const SECRET_OPTION_NAMES = new Set([
 	"accesstoken",

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -46,12 +46,6 @@ const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 		),
 	);
 
-export function requiresRuntimeManagementConfirmation(
-	operation: RuntimeManagementRequest["op"],
-): boolean {
-	return CONFIRMATION_REQUIRED.has(operation);
-}
-
 const SECRET_OPTION_NAMES = new Set([
 	"accesstoken",
 	"apikey",
@@ -428,9 +422,7 @@ export function createRuntimeManagementAction(
 				return { success: false, text: reply };
 			}
 			const normalized = normalizeActionOptions(options) ?? {};
-			const requiresConfirmation = requiresRuntimeManagementConfirmation(
-				request.op,
-			);
+			const requiresConfirmation = CONFIRMATION_REQUIRED.has(request.op);
 			const confirmationText = runtimeManagementConfirmationText(request);
 			if (
 				requiresConfirmation &&

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -46,9 +46,11 @@ const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 		),
 	);
 
-export const runtimeManagementActionInternals = {
-	confirmationRequired: CONFIRMATION_REQUIRED,
-};
+export function requiresRuntimeManagementConfirmation(
+	operation: RuntimeManagementRequest["op"],
+): boolean {
+	return CONFIRMATION_REQUIRED.has(operation);
+}
 
 const SECRET_OPTION_NAMES = new Set([
 	"accesstoken",
@@ -426,7 +428,9 @@ export function createRuntimeManagementAction(
 				return { success: false, text: reply };
 			}
 			const normalized = normalizeActionOptions(options) ?? {};
-			const requiresConfirmation = CONFIRMATION_REQUIRED.has(request.op);
+			const requiresConfirmation = requiresRuntimeManagementConfirmation(
+				request.op,
+			);
 			const confirmationText = runtimeManagementConfirmationText(request);
 			if (
 				requiresConfirmation &&


### PR DESCRIPTION
Closes #29986

# Summary

Single-sources the owner-approval-exempt runtime-management operation set in `@elizaos/shared`, derives both the HTTP route and app-control action partitions from it, and pins the security partition against drift.

# Acceptance criteria

- [x] The exempt set is defined and exported exactly once as `RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS` beside `RUNTIME_MANAGEMENT_OPERATIONS` in `packages/shared/src/contracts/runtime-management.ts`.
- [x] `READ_ONLY_OPERATIONS` and `CONFIRMATION_REQUIRED` derive from the shared set. The final source scan shows no partition-member literal in either derivation:

  ```text
  packages/shared/src/contracts/runtime-management.ts:26:export const RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS: ReadonlySet<RuntimeManagementOperation> =
  packages/shared/src/contracts/runtime-management.ts:27:  new Set(["list", "inspect_ssh"]);
  plugins/plugin-app-control/src/actions/runtime-management.ts:42:const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
  plugins/plugin-app-control/src/actions/runtime-management.ts:45:            (op) => !RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS.has(op),
  packages/agent/src/api/runtime-management-routes.ts:25:const READ_ONLY_OPERATIONS = new Set<RuntimeManagementRequest["op"]>(
  packages/agent/src/api/runtime-management-routes.ts:26:  RUNTIME_MANAGEMENT_OWNER_APPROVAL_EXEMPT_OPERATIONS,
  ```
- [x] Contract tests pin the exact exempt set `{list, inspect_ssh}`, subset membership, the explicit confirmation-required complement, and the plugin's actual derived complement.
- [x] Every requested mutation is proven RED: dropping `inspect_ssh`, adding unauthorized exempt member `pair`, and reversing the plugin filter all fail assertions.
- [x] Current behavior is unchanged: on pristine `origin/develop`, agent routes pass 14/14 and plugin action passes 33/33; on this head, agent routes remain 14/14 and the plugin passes 34/34 (the only additional case is the complement assertion).

# Risks

Low. Current partition membership is unchanged. The main compatibility risk is consumers importing the shared root barrel in both browser and server contexts; the new value is a runtime-neutral `Set` with no platform imports.

# Background

The route and action previously encoded the same security partition independently. A future operation addition could weaken action-side confirmation while route-side owner-proposal enforcement remained stricter, or vice versa. This change makes the exempt membership authoritative in one contract and tests both membership and complement semantics.

This is a non-breaking bug fix/refactor plus a focused security-contract pin. No documentation change is needed because externally observable behavior and operation membership do not change.

# Testing

## RED control before production change

Command (full test and config paths):

```text
/usr/bin/time -l bunx vitest run /Users/sailesh/Developer/worktrees/issue-29986/packages/shared/src/contracts/runtime-management-partition.test.ts --config /Users/sailesh/Developer/worktrees/issue-29986/packages/shared/vitest.config.ts --coverage.enabled=false
```

Verbatim output:

```text
 RUN  v4.1.10 /Users/sailesh/Developer/worktrees/issue-29986/packages/shared

(node:40940) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
(Use `node --trace-warnings ...` to show where the warning was created)
 ❯ src/contracts/runtime-management-partition.test.ts (1 test | 1 failed) 5ms
     × pins the exempt set and its exact confirmation-required complement 4ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/contracts/runtime-management-partition.test.ts > runtime-management owner-approval partition > pins the exempt set and its exact confirmation-required complement
AssertionError: expected [] to deeply equal [ 'inspect_ssh', 'list' ]

- Expected
+ Received

- [
-   "inspect_ssh",
-   "list",
- ]
+ []

 ❯ src/contracts/runtime-management-partition.test.ts:33:32
     31|     );
     32|
     33|     expect([...exempt].sort()).toEqual(["inspect_ssh", "list"]);
       |                                ^
     34|     expect(
     35|       [...exempt].every((operation) =>

 Test Files  1 failed (1)
      Tests  1 failed (1)
   Start at  06:08:05
   Duration  155ms (transform 44ms, setup 57ms, import 6ms, tests 5ms, environment 0ms)

        0.49 real         0.44 user         0.08 sys
           131170304  maximum resident set size
EXIT_STATUS=1
```

## GREEN after production change, final rebased head

Same command, verbatim output:

```text
 RUN  v4.1.10 /Users/sailesh/Developer/worktrees/issue-29986/packages/shared

(node:58340) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
(Use `node --trace-warnings ...` to show where the warning was created)

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  06:31:44
   Duration  141ms (transform 42ms, setup 57ms, import 6ms, tests 2ms, environment 0ms)

        0.46 real         0.44 user         0.07 sys
           126386176  maximum resident set size
EXIT_STATUS=0
```

## Mutation battery

Each mutation was applied alone, the named full-path suite was run, and production source was restored afterward.

| Mutation | Exact suite | Actual result |
| --- | --- | --- |
| Drop `inspect_ssh` from shared exempt set | `/Users/sailesh/Developer/worktrees/issue-29986/packages/shared/src/contracts/runtime-management-partition.test.ts` | `expected [ 'list' ] to deeply equal [ 'inspect_ssh', 'list' ]`; 1 failed; exit 1; 0.41s; peak RSS 130,105,344 bytes |
| Add unauthorized exempt member `pair` | same full path | `expected [ 'inspect_ssh', 'list', 'pair' ] to deeply equal [ 'inspect_ssh', 'list' ]`; 1 failed; exit 1; 0.37s; peak RSS 129,466,368 bytes |
| Reverse plugin complement filter | `/Users/sailesh/Developer/worktrees/issue-29986/plugins/plugin-app-control/src/actions/runtime-management.test.ts` | 28 failed / 6 passed; exit 1; 4.13s; peak RSS 488,488,960 bytes |

Verbatim filter-mutation assertion and summary:

```text
 FAIL  src/actions/runtime-management.test.ts > RUNTIMES action > requires confirmation for the exact complement of exempt operations
AssertionError: expected [ 'list', 'inspect_ssh' ] to deeply equal [ 'pair', 'create_pairing', …(13) ]

- Expected
+ Received

  [
-   "pair",
-   "create_pairing",
-   "claim_pairing",
-   "confirm_pairing",
-   "deny_pairing",
-   "revoke",
-   "remove",
-   "retry",
-   "connect_ssh",
-   "add_direct",
-   "enroll_host",
-   "approve_pairing",
-   "start_host",
-   "stop_host",
-   "revoke_host",
+   "list",
+   "inspect_ssh",
  ]

 Test Files  1 failed (1)
      Tests  28 failed | 6 passed (34)
   Duration  3.90s (transform 2.99s, setup 0ms, import 3.79s, tests 23ms, environment 0ms)

        4.13 real         5.59 user         0.92 sys
           488488960  maximum resident set size
EXIT_STATUS=1
```

## Final focused suites and pristine behavior control

All commands used absolute test and config paths and exited 0.

| Suite | Actual result | Elapsed | Peak RSS |
| --- | --- | ---: | ---: |
| shared partition | 1 file, 1 test passed | 0.46s | 126,386,176 bytes |
| agent runtime-management routes | 1 file, 14 tests passed | 3.86s | 368,230,400 bytes |
| plugin runtime-management action | 1 file, 34 tests passed | 3.85s | 488,620,032 bytes |
| pristine control agent routes | 1 file, 14 tests passed | 3.71s | 371,458,048 bytes |
| pristine control plugin action | 1 file, 33 tests passed | 3.86s | 444,022,784 bytes |

## Formatting and typecheck controls

```text
$ bunx biome check --write <five absolute touched-file paths>
Checked 5 files in 15ms. No fixes applied.
```

`tsc --noEmit` was run against the shared, agent, and plugin `tsconfig.json` files on both final head and an untouched detached `origin/develop` control. These preinstalled worktrees do not produce clean package typechecks: generated/optional workspace dependencies are absent. The exact diagnostic-key comparison proves zero new errors; I am not claiming these commands passed.

```text
shared CHANGE_ERRORS=3 CONTROL_ERRORS=3 DIAGNOSTIC_KEY_DIFF_EXIT_STATUS=0
agent CHANGE_ERRORS=725 CONTROL_ERRORS=725 DIAGNOSTIC_KEY_DIFF_EXIT_STATUS=0
plugin CHANGE_ERRORS=15 CONTROL_ERRORS=15 DIAGNOSTIC_KEY_DIFF_EXIT_STATUS=0
```

All six `tsc --noEmit` commands exited 1. The shared failures, identical on control, were:

```text
packages/core/src/cloud-routing.ts(12,8): error TS2307: Cannot find module '@elizaos/cloud-routing' or its corresponding type declarations.
packages/core/src/cloud-routing.ts(19,8): error TS2307: Cannot find module '@elizaos/cloud-routing' or its corresponding type declarations.
packages/shared/src/todo-cutover.ts(8,30): error TS2307: Cannot find module '@elizaos/core/edge' or its corresponding type declarations.
```

## Repository verification

`bun run verify` was run after the final rebase on both this head and pristine `origin/develop`. Both exited 127 at the same unavailable tool:

```text
@elizaos/capacitor-gateway:lint:check: $ node-swiftlint lint
@elizaos/capacitor-gateway:lint:check: /bin/bash: node-swiftlint: command not found
@elizaos/capacitor-gateway:lint:check: error: script "swiftlint" exited with code 127
@elizaos/capacitor-gateway:lint:check: error: script "lint:check" exited with code 127
Failed:    @elizaos/capacitor-gateway#lint:check
ERROR  run failed: command  exited (127)
error: script "verify" exited with code 127
```

Change head: 38.30s elapsed, 1,593,180,160-byte peak RSS. Control: 27.94s elapsed, 1,595,113,472-byte peak RSS.

# Evidence Gate

<!-- evidence-head:2f57f7ca46d6f7f5d7fc95796fa4c7f316335321 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes; this is a runtime-neutral contract refactor.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow or rendered interaction changes.
<!-- evidence-row:backend-logs -->
- [x] Full-path RED/GREEN, mutation, focused route/action, timing, and peak-RSS transcripts are included inline above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, or state surface changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, planner, or model-authored action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the contract refactor intentionally produces no DB, memory, scheduled-task, media, or on-chain artifact.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or rendered UI changes.

# Known gaps / failures

- `bun install` was intentionally not run: the operator required reuse of the already-installed shared checkout to avoid concurrent disk exhaustion.
- Package `tsc --noEmit` commands are not green; exact failure counts and diagnostic keys match the untouched control as documented above.
- `bun run verify` is not green; both change and control fail because `node-swiftlint` is unavailable.
- No signed private trace is attached because this unattended session cannot finalize an interactive `identity.slop.cash` OAuth trace.

# Maintainer CI exception record

N/A - no exception requested.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza"} -->
