### PR TITLE
fix(agent): fail closed on unusable provider credentials

### DIFF
--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -31,7 +31,10 @@ interface HarnessOptions {
   config?: ElizaConfig;
   processEnv?: NodeJS.ProcessEnv;
   managerStart?: ReturnType<typeof vi.fn>;
-  runtime?: { getModelRegistrations: () => unknown[] } | null;
+  runtime?: {
+    getModelRegistrations: () => unknown[];
+    getSetting?: (key: string) => string | null;
+  } | null;
 }
 
 function makeHarness(
@@ -661,6 +664,23 @@ describe("GET /api/models/config activeChat", () => {
     };
   }
 
+  function runtimeWithDirectHandler(
+    provider: "openai" | "anthropic",
+    settings: Record<string, string> = {},
+  ) {
+    return {
+      getModelRegistrations: () => [
+        {
+          modelType: ModelType.TEXT_SMALL,
+          provider,
+          priority: 0,
+          registrationOrder: 1,
+        },
+      ],
+      getSetting: (key: string) => settings[key] ?? null,
+    };
+  }
+
   it("names the cloud brain + its endpoint under cloud-proxy routing", async () => {
     const { ctx, json } = makeHarness("GET", null, {
       config: cloudRoutedConfig,
@@ -705,7 +725,11 @@ describe("GET /api/models/config activeChat", () => {
           },
         },
       } as never,
-      processEnv: { OPENAI_BASE_URL: "https://api.cerebras.ai/v1" },
+      processEnv: {
+        CEREBRAS_API_KEY: "test-cerebras-key",
+        OPENAI_BASE_URL: "https://api.cerebras.ai/v1",
+      },
+      runtime: runtimeWithDirectHandler("openai"),
     });
     await handleModelConfigRoutes(ctx as never);
     const { body } = responseOf(json);
@@ -733,7 +757,8 @@ describe("GET /api/models/config activeChat", () => {
           },
         },
       } as never,
-      processEnv: {},
+      processEnv: { CEREBRAS_API_KEY: "test-cerebras-key" },
+      runtime: runtimeWithDirectHandler("openai"),
     });
     await handleModelConfigRoutes(ctx as never);
     expect(responseOf(json).body.activeChat).toEqual({
@@ -748,18 +773,10 @@ describe("GET /api/models/config activeChat", () => {
       config: {} as never,
       processEnv: {
         ELIZA_PROVIDER: "cerebras",
+        CEREBRAS_API_KEY: "test-cerebras-key",
         CEREBRAS_BASE_URL: "https://api.cerebras.ai/v1",
       },
-      runtime: {
-        getModelRegistrations: () => [
-          {
-            modelType: ModelType.TEXT_SMALL,
-            provider: "openai",
-            priority: 0,
-            registrationOrder: 1,
-          },
-        ],
-      },
+      runtime: runtimeWithDirectHandler("openai"),
     });
     await handleModelConfigRoutes(ctx as never);
     expect(responseOf(json).body.activeChat).toEqual({
@@ -782,7 +799,7 @@ describe("GET /api/models/config activeChat", () => {
     expect(responseOf(json).body).not.toHaveProperty("activeChat");
   });
 
-  it("uses Cerebras base URL unless the shared OpenAI override is configured", async () => {
+  it("uses the Cerebras base URL and fails closed for a non-Cerebras OpenAI override", async () => {
     const config = {
       serviceRouting: {
         llmText: {
@@ -794,7 +811,11 @@ describe("GET /api/models/config activeChat", () => {
     } as never;
     const cerebras = makeHarness("GET", null, {
       config,
-      processEnv: { CEREBRAS_BASE_URL: "https://inference.example/v1" },
+      processEnv: {
+        CEREBRAS_API_KEY: "test-cerebras-key",
+        CEREBRAS_BASE_URL: "https://inference.example/v1",
+      },
+      runtime: runtimeWithDirectHandler("openai"),
     });
     await handleModelConfigRoutes(cerebras.ctx as never);
     expect(responseOf(cerebras.json).body.activeChat).toMatchObject({
@@ -804,14 +825,16 @@ describe("GET /api/models/config activeChat", () => {
     const openAiOverride = makeHarness("GET", null, {
       config,
       processEnv: {
+        CEREBRAS_API_KEY: "test-cerebras-key",
         CEREBRAS_BASE_URL: "https://inference.example/v1",
         OPENAI_BASE_URL: "https://gateway.example/v1",
       },
+      runtime: runtimeWithDirectHandler("openai"),
     });
     await handleModelConfigRoutes(openAiOverride.ctx as never);
-    expect(responseOf(openAiOverride.json).body.activeChat).toMatchObject({
-      endpoint: "gateway.example",
-    });
+    expect(responseOf(openAiOverride.json).body).not.toHaveProperty(
+      "activeChat",
+    );
   });
 
   it("matches provider endpoint precedence across config and process env", async () => {
@@ -830,7 +853,11 @@ describe("GET /api/models/config activeChat", () => {
             vars: { OPENAI_BASE_URL: " https://nested.openai.example/v1 " },
           },
         },
-        processEnv: { OPENAI_BASE_URL: "https://process.openai.example/v1" },
+        processEnv: {
+          OPENAI_API_KEY: "test-openai-key",
+          OPENAI_BASE_URL: "https://process.openai.example/v1",
+        },
+        runtime: runtimeWithDirectHandler("openai"),
         endpoint: "nested.openai.example",
       },
       {
@@ -851,8 +878,10 @@ describe("GET /api/models/config activeChat", () => {
           },
         },
         processEnv: {
+          ANTHROPIC_API_KEY: "test-anthropic-key",
           ANTHROPIC_BASE_URL: " https://process.anthropic.example/v1 ",
         },
+        runtime: runtimeWithDirectHandler("anthropic"),
         endpoint: "process.anthropic.example",
       },
       {
@@ -900,8 +929,10 @@ describe("GET /api/models/config activeChat", () => {
           env: { vars: { OPENAI_BASE_URL: " " } },
         },
         processEnv: {
+          CEREBRAS_API_KEY: "test-cerebras-key",
           CEREBRAS_BASE_URL: "https://process.cerebras.example/v1",
         },
+        runtime: runtimeWithDirectHandler("openai"),
         endpoint: "process.cerebras.example",
       },
     ] as const;
@@ -910,7 +941,7 @@ describe("GET /api/models/config activeChat", () => {
       const harness = makeHarness("GET", null, {
         config: testCase.config as never,
         processEnv: { ...testCase.processEnv },
-        runtime: "runtime" in testCase ? testCase.runtime : undefined,
+        runtime: testCase.runtime,
       });
       await handleModelConfigRoutes(harness.ctx as never);
       expect(

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -24,9 +24,9 @@
  *
  * `GET /api/models/config` reports the current effective value for every key
  * this route owns, with the source that won (`config.env` → `config.env.vars`
- * → `process.env`). `activeChat` names the serving provider only when the
- * runtime actually registered that handler — cloud-proxy without a signed-in
- * elizaOSCloud TEXT_SMALL handler omits the field (#20045).
+ * → `process.env`). `activeChat` names the serving provider only when its
+ * runtime handler and direct-provider credential are usable. Unresolved vault
+ * references and configured-but-unservable providers omit the field.
  */
 import {
   type AgentRuntime,
@@ -37,7 +37,10 @@ import {
   type RouteRequestMeta,
 } from "@elizaos/core";
 import { resolveElizaCloudBaseURL } from "@elizaos/plugin-elizacloud/endpoint-config";
-import { resolveOpenAIBaseURL } from "@elizaos/plugin-openai/endpoint-config";
+import {
+  isCerebrasMode,
+  resolveOpenAIBaseURL,
+} from "@elizaos/plugin-openai/endpoint-config";
 import {
   DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
@@ -49,6 +52,7 @@ import {
   resolveDevCloudEnvAuthority,
 } from "../config/dev-cloud-env-authority.ts";
 import type { RuntimeOperationManager } from "../runtime/operations/index.ts";
+import { isVaultRef } from "../runtime/operations/vault-bridge.ts";
 import { hasCloudTextHandlerRegistered } from "./agent-model.ts";
 import {
   buildModelCatalog,
@@ -554,9 +558,9 @@ function resolveEffective(
  * canonical serviceRouting topology — the same signal the plugin-collector
  * uses to decide which model plugin loads. Cloud-proxy only reports
  * `elizacloud` when the runtime has a registered elizaOSCloud TEXT_SMALL
- * handler; a configured-but-unsigned-in cloud account falls through to
- * local inference and must not advertise Cloud as the active brain
- * (#20045). `endpoint` is the host that answers, so operator surfaces
+ * handler. Direct providers additionally require a matching text handler and
+ * usable credential; an unresolved vault reference is never serving evidence.
+ * `endpoint` is the host that answers, so operator surfaces
  * (/model show, the settings panel) can name what ACTUALLY serves instead
  * of guessing from OPENAI_BASE_URL, which stays pinned in the environment
  * even when cloud-proxy routing makes it inert.
@@ -578,18 +582,111 @@ function hostOf(value: string | undefined): string | null {
   }
 }
 
-function hasOpenAiTextHandlerRegistered(runtime: AgentRuntime): boolean {
+function hasTextHandlerRegistered(
+  runtime: AgentRuntime,
+  provider: string,
+): boolean {
   try {
     return (runtime.getModelRegistrations?.() ?? []).some(
       (entry) =>
         (entry.modelType === ModelType.TEXT_SMALL ||
           entry.modelType === ModelType.TEXT_LARGE) &&
-        entry.provider === "openai",
+        entry.provider === provider,
     );
-  } catch {
-    // error-policy:J7 diagnostics must not kill the serving-truth resolver.
+  } catch (error) {
+    // error-policy:J7 Report diagnostics failure while withholding serving proof.
+    runtime.reportError("model-config.serving-truth", error);
     return false;
   }
+}
+
+const DIRECT_CHAT_SERVING_REQUIREMENTS: Readonly<
+  Record<string, { credentialKeys: readonly string[]; runtimeProvider: string }>
+> = {
+  cerebras: {
+    credentialKeys: ["CEREBRAS_API_KEY", "OPENAI_API_KEY"],
+    runtimeProvider: "openai",
+  },
+  openai: {
+    credentialKeys: ["OPENAI_API_KEY"],
+    runtimeProvider: "openai",
+  },
+  "claude-chat": {
+    credentialKeys: ["ANTHROPIC_API_KEY"],
+    runtimeProvider: "anthropic",
+  },
+};
+
+function isUsableProviderCredential(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    value.trim().length > 0 &&
+    !isVaultRef(value.trim())
+  );
+}
+
+function isConfiguredCerebrasMode(
+  runtime: AgentRuntime,
+  processEnv: NodeJS.ProcessEnv,
+): boolean {
+  try {
+    const settingsRuntime = new Proxy(runtime, {
+      get(target, property, receiver) {
+        if (property !== "getSetting") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (key: string) => {
+          const runtimeValue = runtime.getSetting(key);
+          if (runtimeValue !== null && runtimeValue !== undefined) {
+            return runtimeValue;
+          }
+          return processEnv[key] ?? "";
+        };
+      },
+    });
+    return isCerebrasMode(settingsRuntime);
+  } catch (error) {
+    // error-policy:J7 Report diagnostics failure while withholding serving proof.
+    runtime.reportError("model-config.serving-truth", error);
+    return false;
+  }
+}
+
+function hasDirectProviderServingEvidence(
+  provider: string,
+  processEnv: NodeJS.ProcessEnv,
+  runtime: AgentRuntime,
+): boolean {
+  const requirement = DIRECT_CHAT_SERVING_REQUIREMENTS[provider];
+  if (
+    !requirement ||
+    !hasTextHandlerRegistered(runtime, requirement.runtimeProvider) ||
+    (provider === "cerebras" && !isConfiguredCerebrasMode(runtime, processEnv))
+  ) {
+    return false;
+  }
+  for (const credentialKey of requirement.credentialKeys) {
+    let runtimeCredential: unknown;
+    try {
+      runtimeCredential = runtime.getSetting(credentialKey);
+    } catch (error) {
+      // error-policy:J7 Report credential lookup failure without claiming readiness.
+      runtime.reportError("model-config.serving-truth", error, {
+        credentialKey,
+      });
+      return false;
+    }
+    if (isUsableProviderCredential(runtimeCredential)) return true;
+    if (runtimeCredential !== null && runtimeCredential !== undefined) {
+      if (String(runtimeCredential).trim().length > 0) return false;
+      continue;
+    }
+    const environmentCredential = processEnv[credentialKey];
+    if (isUsableProviderCredential(environmentCredential)) return true;
+    if (environmentCredential?.trim()) return false;
+  }
+  return false;
 }
 
 export function resolveActiveChat(
@@ -612,7 +709,19 @@ export function resolveActiveChat(
         ? "elizacloud"
         : undefined;
   } else if (llmText?.transport === "direct" && backend !== undefined) {
-    provider = LLM_BACKEND_TO_CHAT_PROVIDER[backend];
+    const candidate = LLM_BACKEND_TO_CHAT_PROVIDER[backend];
+    if (candidate === "elizacloud") {
+      provider =
+        runtime && hasCloudTextHandlerRegistered(runtime)
+          ? candidate
+          : undefined;
+    } else if (
+      runtime &&
+      candidate &&
+      hasDirectProviderServingEvidence(candidate, processEnv, runtime)
+    ) {
+      provider = candidate;
+    }
   } else if (routing === null) {
     // Legacy/local launches may configure plugin-openai directly from the
     // environment without persisting a serviceRouting block. ELIZA_PROVIDER is
@@ -628,7 +737,7 @@ export function resolveActiveChat(
     if (
       explicitProvider === "cerebras" &&
       runtime &&
-      hasOpenAiTextHandlerRegistered(runtime)
+      hasDirectProviderServingEvidence("cerebras", processEnv, runtime)
     ) {
       provider = "cerebras";
     }
@@ -741,7 +850,7 @@ export async function handleModelConfigRoutes(
     const activeChat = resolveActiveChat(
       state.config,
       processEnv,
-      state.runtime,
+      state.runtime ?? null,
     );
     json(res, {
       targets: buildEffectiveConfig(state.config, processEnv, activeChat),
@@ -789,7 +898,8 @@ export async function handleModelConfigRoutes(
     const writes = resolveChatWrites(
       catalog,
       body,
-      resolveActiveChat(state.config, processEnv, state.runtime)?.provider,
+      resolveActiveChat(state.config, processEnv, state.runtime ?? null)
+        ?.provider,
     );
     if (
       devCloudAuthority &&

--- a/packages/agent/src/api/provider-serving-truth.test.ts
+++ b/packages/agent/src/api/provider-serving-truth.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Deterministic serving-truth coverage for provider credentials at the boot,
+ * runtime-settings, and model-config boundaries. No provider or network is
+ * contacted; fake registrations model only whether a runtime can serve text.
+ */
+import { type AgentRuntime, ModelType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  buildRuntimeSettingsProjection,
+  hydrateConfigEnvForBoot,
+} from "../runtime/runtime-settings.ts";
+import {
+  handleModelConfigRoutes,
+  resolveActiveChat,
+} from "./model-config-routes.ts";
+
+const VAULT_REF = "vault://providers.cerebras.api-key";
+
+function cerebrasConfig(credential?: string): ElizaConfig {
+  return {
+    serviceRouting: {
+      llmText: { transport: "direct", backend: "cerebras" },
+    },
+    ...(credential ? { env: { vars: { CEREBRAS_API_KEY: credential } } } : {}),
+  } as unknown as ElizaConfig;
+}
+
+function runtimeWith(options: {
+  credential?: string | null;
+  openAiCredential?: string | null;
+  baseUrl?: string | null;
+  explicitProvider?: string | null;
+  provider?: string;
+  throwOnSetting?: string;
+}): AgentRuntime {
+  return {
+    reportError: vi.fn(),
+    getSetting: (key: string) => {
+      if (key === options.throwOnSetting) throw new Error("lookup unavailable");
+      if (key === "CEREBRAS_API_KEY") return options.credential ?? null;
+      if (key === "OPENAI_API_KEY") return options.openAiCredential ?? null;
+      if (key === "OPENAI_BASE_URL") return options.baseUrl ?? null;
+      if (key === "ELIZA_PROVIDER") return options.explicitProvider ?? null;
+      return null;
+    },
+    getModelRegistrations: () => [
+      {
+        modelType: ModelType.TEXT_SMALL,
+        provider: options.provider ?? "openai",
+      },
+    ],
+  } as unknown as AgentRuntime;
+}
+
+describe("provider serving truth", () => {
+  it.each([
+    ["canonical", VAULT_REF],
+    ["whitespace-padded", ` ${VAULT_REF} `],
+  ])(
+    "does not hydrate or project an unresolved provider vault reference (%s)",
+    (_label, credential) => {
+      const config = cerebrasConfig(credential);
+      const env: NodeJS.ProcessEnv = {};
+
+      hydrateConfigEnvForBoot(config, env);
+      const settings = buildRuntimeSettingsProjection(config, { env });
+
+      expect(env.CEREBRAS_API_KEY).toBeUndefined();
+      expect(settings.CEREBRAS_API_KEY).toBeUndefined();
+      expect(resolveActiveChat(config, env, runtimeWith({}))).toBeNull();
+    },
+  );
+
+  it("does not report a registered provider without a usable credential", () => {
+    expect(resolveActiveChat(cerebrasConfig(), {}, runtimeWith({}))).toBeNull();
+  });
+
+  it("omits activeChat from the HTTP response before runtime serving is ready", async () => {
+    const json = vi.fn();
+    await handleModelConfigRoutes({
+      req: {} as never,
+      res: {} as never,
+      method: "GET",
+      pathname: "/api/models/config",
+      json,
+      readJsonBody: vi.fn(),
+      state: { config: cerebrasConfig(VAULT_REF) },
+      saveElizaConfig: vi.fn(),
+      runtimeOperationManager: {} as never,
+      processEnv: {},
+    });
+
+    expect(json).toHaveBeenCalledOnce();
+    expect(json.mock.calls[0]?.[1]).not.toHaveProperty("activeChat");
+  });
+
+  it("reports a provider only when its runtime handler and credential are usable", () => {
+    expect(
+      resolveActiveChat(
+        cerebrasConfig(VAULT_REF),
+        {},
+        runtimeWith({ credential: "deterministic-test-credential" }),
+      ),
+    ).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "api.cerebras.ai",
+    });
+  });
+
+  it("accepts plugin-openai's usable Cerebras-mode OpenAI key fallback", () => {
+    expect(
+      resolveActiveChat(
+        cerebrasConfig(),
+        {},
+        runtimeWith({
+          openAiCredential: "deterministic-fallback-credential",
+          explicitProvider: "cerebras",
+        }),
+      ),
+    ).toMatchObject({ provider: "cerebras", family: "OPENAI" });
+  });
+
+  it("does not report Cerebras when plugin-openai resolves a non-Cerebras endpoint", () => {
+    expect(
+      resolveActiveChat(
+        cerebrasConfig(),
+        {},
+        runtimeWith({
+          credential: "deterministic-cerebras-credential",
+          openAiCredential: "deterministic-openai-credential",
+          baseUrl: "https://gateway.example/v1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("reports failed runtime credential lookup without falling back to an env key", () => {
+    const runtime = runtimeWith({ throwOnSetting: "CEREBRAS_API_KEY" });
+    expect(
+      resolveActiveChat(
+        cerebrasConfig(),
+        { CEREBRAS_API_KEY: "deterministic-env-credential" },
+        runtime,
+      ),
+    ).toBeNull();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "model-config.serving-truth",
+      expect.objectContaining({ message: "lookup unavailable" }),
+    );
+  });
+
+  it("does not let an env key override an authoritative runtime vault sentinel", () => {
+    expect(
+      resolveActiveChat(
+        cerebrasConfig(),
+        { CEREBRAS_API_KEY: "deterministic-env-credential" },
+        runtimeWith({ credential: VAULT_REF }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not report a usable credential without the matching handler", () => {
+    expect(
+      resolveActiveChat(
+        cerebrasConfig(),
+        {},
+        runtimeWith({
+          credential: "deterministic-test-credential",
+          provider: "anthropic",
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -83,6 +83,7 @@ import { registerFallbackActionIfAbsent } from "./runtime-action-ownership.ts";
 import { runRuntimeStartupMaintenance } from "./runtime-maintenance.ts";
 import {
   buildRuntimeSettingsProjection,
+  hydrateConfigEnvForBoot,
   type RuntimeSettingsProjectionOptions,
 } from "./runtime-settings.ts";
 import {
@@ -97,7 +98,10 @@ export {
   OPTIONAL_PLUGIN_MAP,
   PROVIDER_PLUGIN_MAP,
 } from "./plugin-collector.ts";
-export { isEnvKeyAllowedForForwarding } from "./runtime-settings.ts";
+export {
+  hydrateConfigEnvForBoot,
+  isEnvKeyAllowedForForwarding,
+} from "./runtime-settings.ts";
 
 import { PROVIDER_PLUGIN_MAP } from "./plugin-collector.ts";
 import { STATIC_ELIZA_PLUGIN_LOADERS } from "./plugin-types.ts";
@@ -294,7 +298,6 @@ import {
   createDevCloudConfigAuthorityView,
   createDevCloudRuntimeSettingsAuthorityOverlay,
   isDevCloudEnvOwnedKey,
-  isDevCloudInternalEnvKey,
   restoreDevCloudEnvAuthority,
 } from "../config/dev-cloud-env-authority.ts";
 import {
@@ -1946,40 +1949,6 @@ function assertPersistentDatabaseRequired(
     throw new Error(
       `Eliza requires persistent database storage and does not permit ALLOW_NO_DATABASE (agent ${runtime.agentId}). Remove ALLOW_NO_DATABASE from config/env and use @elizaos/plugin-sql.`,
     );
-  }
-}
-
-function isElizaCloudManagedProcessEnvKey(key: string): boolean {
-  const upper = key.toUpperCase();
-  return isDevCloudEnvOwnedKey(upper) || isDevCloudInternalEnvKey(upper);
-}
-
-/**
- * Hydrate user-owned config environment values without allowing persisted
- * state to forge launcher authority or repopulate launcher-owned Cloud keys.
- * @internal Exported for regression tests.
- */
-export function hydrateConfigEnvForBoot(
-  config: Pick<ElizaConfig, "env">,
-  env: NodeJS.ProcessEnv = process.env,
-): void {
-  if (
-    !config.env ||
-    typeof config.env !== "object" ||
-    Array.isArray(config.env)
-  ) {
-    return;
-  }
-  const hydrateEntries = (values: Record<string, unknown>): void => {
-    for (const [key, value] of Object.entries(values)) {
-      if (isElizaCloudManagedProcessEnvKey(key)) continue;
-      if (typeof value === "string" && !env[key]) env[key] = value;
-    }
-  };
-  hydrateEntries(config.env as Record<string, unknown>);
-  const vars = (config.env as Record<string, unknown>).vars;
-  if (vars && typeof vars === "object" && !Array.isArray(vars)) {
-    hydrateEntries(vars as Record<string, unknown>);
   }
 }
 

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -6,6 +6,10 @@
 import { resolveServiceRoutingInConfig } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import {
+  isDevCloudEnvOwnedKey,
+  isDevCloudInternalEnvKey,
+} from "../config/dev-cloud-env-authority.ts";
+import {
   collectConfigEnvVars,
   collectConnectorEnvVars,
 } from "../config/env-vars.ts";
@@ -67,6 +71,49 @@ export function isEnvKeyAllowedForForwarding(key: string): boolean {
   return true;
 }
 
+function isElizaCloudManagedProcessEnvKey(key: string): boolean {
+  const upper = key.toUpperCase();
+  return isDevCloudEnvOwnedKey(upper) || isDevCloudInternalEnvKey(upper);
+}
+
+function isUnresolvedVaultRef(value: unknown): boolean {
+  return typeof value === "string" && isVaultRef(value.trim());
+}
+
+/**
+ * Hydrate plain user-owned config values for boot without copying unresolved
+ * vault references or launcher-owned Cloud settings into process authority.
+ */
+export function hydrateConfigEnvForBoot(
+  config: Pick<ElizaConfig, "env">,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (
+    !config.env ||
+    typeof config.env !== "object" ||
+    Array.isArray(config.env)
+  ) {
+    return;
+  }
+  const hydrateEntries = (values: Record<string, unknown>): void => {
+    for (const [key, value] of Object.entries(values)) {
+      if (isElizaCloudManagedProcessEnvKey(key)) continue;
+      if (
+        typeof value === "string" &&
+        !isUnresolvedVaultRef(value) &&
+        !env[key]
+      ) {
+        env[key] = value;
+      }
+    }
+  };
+  hydrateEntries(config.env as Record<string, unknown>);
+  const vars = (config.env as Record<string, unknown>).vars;
+  if (vars && typeof vars === "object" && !Array.isArray(vars)) {
+    hydrateEntries(vars as Record<string, unknown>);
+  }
+}
+
 export function buildRuntimeSettingsProjection(
   config: ElizaConfig,
   options: RuntimeSettingsProjectionOptions = {},
@@ -80,8 +127,9 @@ export function buildRuntimeSettingsProjection(
     VALIDATION_LEVEL: "fast",
     ...(env.SECRET_SALT ? { ENCRYPTION_SALT: env.SECRET_SALT } : {}),
     ...Object.fromEntries(
-      Object.entries(collectConfigEnvVars(config)).filter(([key]) =>
-        isEnvKeyAllowedForForwarding(key),
+      Object.entries(collectConfigEnvVars(config)).filter(
+        ([key, value]) =>
+          isEnvKeyAllowedForForwarding(key) && !isUnresolvedVaultRef(value),
       ),
     ),
     ...(typeof env.EMBEDDING_PROVIDER === "string" &&
@@ -93,7 +141,7 @@ export function buildRuntimeSettingsProjection(
     // value for refs the vault could serve (fail-closed for the rest).
     ...Object.fromEntries(
       Object.entries(collectConnectorEnvVars(config)).filter(
-        ([, value]) => !isVaultRef(value),
+        ([, value]) => !isUnresolvedVaultRef(value),
       ),
     ),
     ...(options.connectorSecretsOverlay ?? {}),

--- a/plugins/plugin-openai/build.ts
+++ b/plugins/plugin-openai/build.ts
@@ -7,7 +7,9 @@ import { buildPlugin } from "../plugin-build";
 
 // Single-quoted re-export to keep the emitted .d.ts byte-stable.
 const reexport = "export * from '../index';\nexport { default } from '../index';\n";
-const endpointDeclaration = `export type EndpointSettingReader = (key: string) => string | undefined;
+const endpointDeclaration = `import type { IAgentRuntime } from "@elizaos/core";
+export type EndpointSettingReader = (key: string) => string | undefined;
+export declare function isCerebrasMode(runtime: IAgentRuntime): boolean;
 export declare function resolveOpenAIBaseURL(
   readSetting: EndpointSettingReader,
   options?: { browser?: boolean; mockBaseURL?: string },


### PR DESCRIPTION
Provider diagnostics now resolve credentials through the same runtime/vault settings boundary used at boot, so configured-but-unavailable credentials are not reported as serving. Startup projects resolved provider settings consistently, and diagnostic failures are reported through runtime.reportError instead of disappearing into logs. The OpenAI build also preserves its existing isCerebrasMode export.

Validation for 63ae93812b3f6ac39086a62c19e3e5be2d2d6c73:

- Rebased on develop and completed normal installation.
- Full root verification passed: 376 tasks plus repository audits.
- Prior focused model-config/provider tests: 55 passed; runtime-settings tests: 4 passed.
- Full agent package runner completed all 759 batches; one batch failed only during temporary-directory teardown (ENOTEMPTY). That exact classify-ordering suite passed its isolated rerun, 2/2 tests. All five required hosted checks passed on this revision.
- This changes credential projection and diagnostic reporting; no live provider inference success is claimed.
