### PR TITLE
fix(app-test): drop retired wallet control assertion

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -920,9 +920,6 @@ test.describe("assistant home app flow", () => {
         .getByRole("tablist", { name: "Wallet asset type" })
         .getByRole("tab", { name: "Tokens", selected: true }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Network settings", exact: true }),
-    ).toBeVisible();
     await screenshot(page, "07-wallet-view-with-pill");
     const personalRequests = [
       ...initialAssistantApi.personalRequests,


### PR DESCRIPTION
## Summary

- keep the assistant-home smoke coverage for opening the wallet route
- retain the selected Tokens-tab assertion that proves the current wallet surface loaded
- remove the stale requirement for the retired `Network settings` control

## Verification

- `bun run --cwd packages/app test:e2e -- test/ui-smoke/assistant-home-flow.spec.ts --grep "captures first-run, assistant home, chat suppression, and view pill states"` — 1 passed

Fixes #30002