### PR TITLE
fix(app-test): serve complete local inference fixtures

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -11,6 +11,7 @@ import {
   installPageDiagnosticsGuard,
   openAppPath,
   seedAppStorage,
+  UI_SMOKE_CPU_ONLY_HARDWARE,
 } from "./helpers";
 import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
@@ -225,7 +226,7 @@ async function installAssistantFlowRoutes(page: Page): Promise<{
         updatedAt: new Date(0).toISOString(),
       },
       downloads: [],
-      hardware: { status: "unsupported" },
+      hardware: UI_SMOKE_CPU_ONLY_HARDWARE,
       assignments: {},
       textReadiness: {
         updatedAt: new Date(0).toISOString(),

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -272,6 +272,18 @@ const SMOKE_AGENT = {
   status: "running",
 } as const;
 
+export const UI_SMOKE_CPU_ONLY_HARDWARE = {
+  totalRamGb: 8,
+  freeRamGb: 4,
+  gpu: null,
+  cpuCores: 4,
+  platform: "linux",
+  arch: "x64",
+  appleSilicon: false,
+  recommendedBucket: "small",
+  source: "os-fallback",
+} as const;
+
 export async function seedAppStorage(
   page: Page,
   overrides: Record<string, string> = {},
@@ -1742,6 +1754,18 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
         startedAt: Date.parse(SMOKE_GENERATED_AT),
         uptime: 60_000,
       }),
+    });
+  });
+
+  await page.route("**/api/local-inference/device/stream**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "",
     });
   });
 

--- a/packages/app/test/ui-smoke/home-widget-priority.spec.ts
+++ b/packages/app/test/ui-smoke/home-widget-priority.spec.ts
@@ -11,6 +11,7 @@ import {
   installPageDiagnosticsGuard,
   openAppPath,
   seedAppStorage,
+  UI_SMOKE_CPU_ONLY_HARDWARE,
 } from "./helpers";
 import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
@@ -349,7 +350,7 @@ async function installHomeWidgetRoutes(page: Page): Promise<void> {
         updatedAt: new Date(0).toISOString(),
       },
       downloads: [],
-      hardware: { status: "unsupported" },
+      hardware: UI_SMOKE_CPU_ONLY_HARDWARE,
       assignments: {},
       textReadiness: {
         updatedAt: new Date(0).toISOString(),

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -5,7 +5,10 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, type Page, type Route } from "@playwright/test";
-import { installDefaultAppRoutes } from "./helpers";
+import {
+  installDefaultAppRoutes,
+  UI_SMOKE_CPU_ONLY_HARDWARE,
+} from "./helpers";
 import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 import {
@@ -443,7 +446,7 @@ export async function installHomeRoutes(
         updatedAt: new Date(0).toISOString(),
       },
       downloads: [],
-      hardware: { status: "unsupported" },
+      hardware: UI_SMOKE_CPU_ONLY_HARDWARE,
       assignments: {},
       textReadiness: {
         updatedAt: new Date(0).toISOString(),

--- a/packages/app/test/ui-smoke/settings-background.spec.ts
+++ b/packages/app/test/ui-smoke/settings-background.spec.ts
@@ -12,6 +12,7 @@ import {
   installPageDiagnosticsGuard,
   openAppPath,
   seedAppStorage,
+  UI_SMOKE_CPU_ONLY_HARDWARE,
 } from "./helpers";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 
@@ -213,7 +214,7 @@ async function installSettingsBackgroundRoutes(page: Page): Promise<void> {
         updatedAt: new Date(0).toISOString(),
       },
       downloads: [],
-      hardware: { status: "unsupported" },
+      hardware: UI_SMOKE_CPU_ONLY_HARDWARE,
       assignments: {},
       textReadiness: {
         updatedAt: new Date(0).toISOString(),


### PR DESCRIPTION
## Summary

- replace invalid `{ status: "unsupported" }` hub payloads with one complete deterministic CPU-only hardware probe
- use that contract in assistant-home, onboarding, settings-background, and home-widget fixtures
- serve the baseline device-status SSE endpoint so Settings does not emit an unrelated 501 diagnostic

## Verification

- `bun run --cwd packages/app test:e2e -- test/ui-smoke/assistant-home-flow.spec.ts --grep "renders the iOS-style home screen and a pinned tile opens its view"` — 1 passed

Fixes #30004