### PR TITLE
fix(plugin-sql): populate entity agentId in getEntitiesByNames/searchEntitiesByName

### DIFF
--- a/plugins/plugin-sql/src/__tests__/integration/entity-methods.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/entity-methods.real.test.ts
@@ -816,4 +816,101 @@ describe("Entity Methods Integration Tests", () => {
       expect(results).toHaveLength(1);
     });
   });
+
+  /**
+   * Regression coverage for #30010.
+   *
+   * `getEntitiesByNames` and the non-empty-query branch of
+   * `searchEntitiesByName` previously ran `SELECT * FROM entities` through
+   * `db.execute()`, which returns driver-native snake_case column names
+   * (`agent_id`). The result mapping read `row.agentId`, which was always
+   * `undefined`, so every returned Entity silently dropped its required
+   * `agentId` field. That violated the Entity DTO contract (`agentId` is
+   * required) and diverged from both the reference `InMemoryAdapter` and the
+   * empty-query branch of `searchEntitiesByName`, which uses the Drizzle query
+   * builder and returns a populated `agentId`.
+   *
+   * These assertions pin the corrected contract: the required `agentId` key is
+   * present, is the queried agent, and the two branches of `searchEntitiesByName`
+   * agree. They fail before the alias fix and pass after it.
+   */
+  describe("agentId population (regression #30010)", () => {
+    it("getEntitiesByNames returns entities with the required agentId field", async () => {
+      const entity: Entity = {
+        id: uuidv4() as UUID,
+        agentId: testAgentId,
+        names: ["Probe Person GEBN"],
+        metadata: { type: "person" },
+      };
+      await adapter.createEntities([entity]);
+
+      const byName = await adapter.getEntitiesByNames({
+        names: ["Probe Person GEBN"],
+        agentId: testAgentId,
+      });
+
+      const found = byName.find((e) => e.id === entity.id);
+      if (!found) throw new Error("getEntitiesByNames should return the probe entity");
+      // The row must actually carry the agentId key, not merely be undefined.
+      expect(Object.keys(found)).toContain("agentId");
+      expect(found.agentId).toBe(testAgentId);
+      expect(found.agentId).not.toBeUndefined();
+    });
+
+    it("searchEntitiesByName (non-empty query) returns entities with the required agentId field", async () => {
+      const entity: Entity = {
+        id: uuidv4() as UUID,
+        agentId: testAgentId,
+        names: ["Probe Person SEBN"],
+        metadata: { type: "person" },
+      };
+      await adapter.createEntities([entity]);
+
+      const searched = await adapter.searchEntitiesByName({
+        query: "Probe Person SEBN",
+        agentId: testAgentId,
+        limit: 1000,
+      });
+
+      const found = searched.find((e) => e.id === entity.id);
+      if (!found) throw new Error("searchEntitiesByName should return the probe entity");
+      expect(Object.keys(found)).toContain("agentId");
+      expect(found.agentId).toBe(testAgentId);
+      expect(found.agentId).not.toBeUndefined();
+    });
+
+    it("both searchEntitiesByName branches (empty vs non-empty query) populate the same agentId", async () => {
+      const entity: Entity = {
+        id: uuidv4() as UUID,
+        agentId: testAgentId,
+        names: ["Parity Probe Person"],
+        metadata: { type: "person" },
+      };
+      await adapter.createEntities([entity]);
+
+      // Non-empty-query branch: raw SELECT with aliased columns.
+      const nonEmptyBranch = await adapter.searchEntitiesByName({
+        query: "Parity Probe Person",
+        agentId: testAgentId,
+        limit: 1000,
+      });
+      // Empty-query branch: Drizzle query builder (already correct pre-fix).
+      const emptyBranch = await adapter.searchEntitiesByName({
+        query: "",
+        agentId: testAgentId,
+        limit: 1000,
+      });
+
+      const fromNonEmpty = nonEmptyBranch.find((e) => e.id === entity.id);
+      const fromEmpty = emptyBranch.find((e) => e.id === entity.id);
+
+      if (!fromNonEmpty) throw new Error("Non-empty-query branch should return the probe entity");
+      if (!fromEmpty) throw new Error("Empty-query branch should return the probe entity");
+
+      // Both branches of the same method must agree on the populated agentId.
+      expect(fromNonEmpty.agentId).toBe(testAgentId);
+      expect(fromEmpty.agentId).toBe(testAgentId);
+      expect(fromNonEmpty.agentId).toBe(fromEmpty.agentId);
+    });
+  });
 });

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1716,8 +1716,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       // Build a condition to match any of the names
       const nameConditions = names.map((name) => sql`${name} = ANY(${entityTable.names})`);
 
+      // Alias snake_case driver columns to the camelCase Entity DTO keys.
+      // `db.execute` returns raw driver rows (e.g. `agent_id`), so a bare
+      // `SELECT *` would leave the required `agentId` field undefined. This
+      // mirrors the document-list query's `agent_id AS "agentId"` precedent.
       const query = sql`
-        SELECT * FROM ${entityTable}
+        SELECT
+          ${entityTable.id} AS "id",
+          ${entityTable.agentId} AS "agentId",
+          ${entityTable.names} AS "names",
+          ${entityTable.metadata} AS "metadata"
+        FROM ${entityTable}
         WHERE ${entityTable.agentId} = ${agentId}
         AND (${sql.join(nameConditions, sql` OR `)})
       `;
@@ -1765,9 +1774,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         }));
       }
 
-      // Otherwise, search for entities with names containing the query (case-insensitive)
+      // Otherwise, search for entities with names containing the query (case-insensitive).
+      // Alias snake_case driver columns to the camelCase Entity DTO keys so the
+      // required `agentId` survives `db.execute`, matching the empty-query
+      // Drizzle-builder branch above and the document-list query precedent.
       const searchQuery = sql`
-        SELECT * FROM ${entityTable}
+        SELECT
+          ${entityTable.id} AS "id",
+          ${entityTable.agentId} AS "agentId",
+          ${entityTable.names} AS "names",
+          ${entityTable.metadata} AS "metadata"
+        FROM ${entityTable}
         WHERE ${entityTable.agentId} = ${agentId}
         AND EXISTS (
           SELECT 1 FROM unnest(${entityTable.names}) AS name


### PR DESCRIPTION
# Relates to

Closes #30010

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` (full repo gate) was not run to completion on this constrained machine; the owning-package gates (test, typecheck, lint) all pass — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works from the before/after evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`a437022` is 0/0 vs `origin/develop`); zero conflicts.
- [x] Owning-package `test`, `typecheck`, and `lint` pass post-sync. Full `bun run verify` not completed here — see **Known gaps / failures**.

# Risks

Low. Two SQL read paths in `BaseDrizzleAdapter` are changed from `SELECT *` to an explicit aliased column list over the same table/filters. No schema, migration, or public-type change. The empty-query branch of `searchEntitiesByName` (Drizzle builder) is untouched and already correct; the fix makes the raw-SQL branches agree with it.

# Background

## What does this PR do?

`BaseDrizzleAdapter.getEntitiesByNames()` and the non-empty-query branch of `searchEntitiesByName()` ran `SELECT * FROM entities` through `db.execute()`. `db.execute` returns **driver-native snake_case** column names (`agent_id`), but the result mapping read `row.agentId`, which was therefore **always `undefined`**. Every returned `Entity` silently dropped its required `agentId` field.

This violated the `Entity` DTO contract (`agentId` is required) and diverged from:

- the reference `InMemoryAdapter` (`packages/core/src/database/inMemoryAdapter.ts`), which returns the full stored `Entity` including `agentId`; and
- this same file's own document-list query, which correctly aliases `agent_id AS "agentId"` (`plugins/plugin-sql/src/base.ts`), and the **empty-query** branch of `searchEntitiesByName`, which uses the Drizzle query builder and returns a populated `agentId`. The two branches of one method disagreed.

Any caller that keys/filters/persists by `entity.agentId` (e.g. re-saving a looked-up entity, agent-scoping) silently received `undefined`.

**Fix:** in both raw-SQL branches, select explicit columns aliased to the camelCase Entity keys (`${entityTable.agentId} AS "agentId"`, etc.), mirroring the existing in-file document-list precedent. Minimal, self-contained; no schema/contract change.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation (internal adapter contract fix; no public API or behavior surface documented separately).

# Testing

## Where should a reviewer start?

`plugins/plugin-sql/src/base.ts` (`getEntitiesByNames`, `searchEntitiesByName`) and the new `agentId population (regression #30010)` describe block in `plugins/plugin-sql/src/__tests__/integration/entity-methods.real.test.ts`.

## Detailed testing steps

Real-PGlite integration tests via `createIsolatedTestDatabase`:

```bash
cd plugins/plugin-sql/src
bunx vitest run --config vitest.real.config.ts entity-methods -t "regression #30010"
```

Three assertions: (1) `getEntitiesByNames` returns an entity carrying `agentId === testAgentId`; (2) `searchEntitiesByName` (non-empty query) returns `agentId === testAgentId`; (3) parity — both the empty-query and non-empty-query branches of `searchEntitiesByName` return the same populated `agentId`. They fail before the fix and pass after it.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a437022f1929d0502d2ef83180b8f00de9637dda -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; this is a database-adapter data-path fix.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; this is a database-adapter data-path fix.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; change is exercised by the real-PGlite integration test below.
<!-- evidence-row:backend-logs -->
- [x] Backend evidence attached: failing-before / passing-after real-PGlite vitest output below (re-run at head `a437022`).

<details><summary>vitest console output — real PGlite (<code>createIsolatedTestDatabase</code>), before vs after fix</summary>

```
# Command (from plugins/plugin-sql/src):
#   bunx vitest run --config vitest.real.config.ts entity-methods -t "regression #30010"

 Info       [PLUGIN:SQL] DatabaseMigrationService initialized
 Info       [PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=226)
 Info       [PLUGIN:SQL] All migrations completed successfully (successCount=1)

# BEFORE FIX — base.ts reverted to `SELECT *` (git checkout HEAD~1 -- base.ts):
 ❯ __tests__/integration/entity-methods.real.test.ts (24 tests | 3 failed | 21 skipped)
       × getEntitiesByNames returns entities with the required agentId field
       × searchEntitiesByName (non-empty query) returns entities with the required agentId field
       × both searchEntitiesByName branches (empty vs non-empty query) populate the same agentId
 AssertionError: expected undefined to be 'df2adcf0-8ace-41f3-8548-807080291dc0' // Object.is equality
   ❯ __tests__/integration/entity-methods.real.test.ts:856:29
      Tests  3 failed | 21 skipped (24)

# AFTER FIX — head a437022 (full entity-methods.real.test.ts suite):
 ✓ __tests__/integration/entity-methods.real.test.ts (24 tests) 10838ms
 Test Files  1 passed (1)
      Tests  24 passed (24)
   Duration  36.57s
```
</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts attached: serialized entity rows from getEntitiesByNames/searchEntitiesByName carrying the required `agentId` after the fix (captured at head `a437022`).

<details><summary>serialized entity rows (output) — agentId present, equals queried agent</summary>

```
# Inserted one entity via createEntities, read back through both methods
# against a real PGlite backend (createIsolatedTestDatabase). Pre-fix the
# agentId key was absent entirely (db.execute returns snake_case agent_id).
EV_QUERIED_AGENT_ID 58906bff-0477-4e9e-aec9-7e899c8dcb43
EV_GET_BY_NAMES_ROW {"id":"4378a861-d6be-468c-a894-550983a8dca1","agentId":"58906bff-0477-4e9e-aec9-7e899c8dcb43","names":["Probe Person"],"metadata":{"type":"person"}}
EV_SEARCH_ROW {"id":"4378a861-d6be-468c-a894-550983a8dca1","agentId":"58906bff-0477-4e9e-aec9-7e899c8dcb43","names":["Probe Person"],"metadata":{"type":"person"}}
```
</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Frontend: N/A - no frontend involved.

Backend: focused real-PGlite vitest run (`vitest.real.config.ts`, `createIsolatedTestDatabase`), before and after the one-line-per-branch alias fix.

<details><summary>BEFORE FIX — base.ts reverted to <code>SELECT *</code> → 3 failing (agentId undefined)</summary>

```
 ❯ __tests__/integration/entity-methods.real.test.ts (24 tests | 3 failed | 21 skipped) 6736ms
       × getEntitiesByNames returns entities with the required agentId field 27ms (retry x1)
       × searchEntitiesByName (non-empty query) returns entities with the required agentId field 11ms (retry x1)
       × both searchEntitiesByName branches (empty vs non-empty query) populate the same agentId 13ms (retry x1)
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests > agentId population (regression #30010) > getEntitiesByNames returns entities with the required agentId field
 FAIL  __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests > agentId population (regression #30010) > getEntitiesByNames returns entities with the required agentId field
AssertionError: expected undefined to be '4930fef7-f817-4ae8-8b8d-e4f1668c93da' // Object.is equality
- Expected:
+ Received:
 ❯ __tests__/integration/entity-methods.real.test.ts:856:29
    854|       // The row must actually carry the agentId key, not merely be un…
    855|       expect(Object.keys(found)).toContain("agentId");
    856|       expect(found.agentId).toBe(testAgentId);
    857|       expect(found.agentId).not.toBeUndefined();
 FAIL  __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests > agentId population (regression #30010) > searchEntitiesByName (non-empty query) returns entities with the required agentId field
 FAIL  __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests > agentId population (regression #30010) > searchEntitiesByName (non-empty query) returns entities with the required agentId field
AssertionError: expected undefined to be '4930fef7-f817-4ae8-8b8d-e4f1668c93da' // Object.is equality
- Expected:
+ Received:
 ❯ __tests__/integration/entity-methods.real.test.ts:878:29
    877|       expect(Object.keys(found)).toContain("agentId");
    878|       expect(found.agentId).toBe(testAgentId);
    879|       expect(found.agentId).not.toBeUndefined();
 FAIL  __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests > agentId population (regression #30010) > both searchEntitiesByName branches (empty vs non-empty query) populate the same agentId
 FAIL  __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests > agentId population (regression #30010) > both searchEntitiesByName branches (empty vs non-empty query) populate the same agentId
AssertionError: expected undefined to be '4930fef7-f817-4ae8-8b8d-e4f1668c93da' // Object.is equality
- Expected:
+ Received:
 ❯ __tests__/integration/entity-methods.real.test.ts:911:36
    911|       expect(fromNonEmpty.agentId).toBe(testAgentId);
    912|       expect(fromEmpty.agentId).toBe(testAgentId);
    913|       expect(fromNonEmpty.agentId).toBe(fromEmpty.agentId);
 Test Files  1 failed (1)
      Tests  3 failed | 21 skipped (24)
```
</details>

<details><summary>AFTER FIX — 3 passing</summary>

```
stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stdout | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

stderr | __tests__/integration/entity-methods.real.test.ts > Entity Methods Integration Tests

 ✓ __tests__/integration/entity-methods.real.test.ts (24 tests | 21 skipped) 6789ms

 Test Files  1 passed (1)
      Tests  3 passed | 21 skipped (24)
   Start at  02:58:05
   Duration  26.83s (transform 16.57s, setup 0ms, import 19.85s, tests 6.79s, environment 0ms)
```
</details>

Full `entity-methods.real.test.ts` suite after the fix: **24 passed (24)**.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Domain artifacts — serialized entity rows after fix

The serialized rows now carry the required `agentId` key equal to the queried agent (previously the key was absent entirely):

<details><summary>JSON row dumps (agentId present, equals queried agent)</summary>

```
EV_QUERIED_AGENT_ID 49cdf83c-6dd9-410f-b0e7-6f917b8e3a42
EV_GET_BY_NAMES_ROW {"id":"b60d1eef-fe9f-4929-9d53-6f1fec307284","agentId":"49cdf83c-6dd9-410f-b0e7-6f917b8e3a42","names":["Probe Person"],"metadata":{"type":"person"}}
EV_SEARCH_ROW {"id":"b60d1eef-fe9f-4929-9d53-6f1fec307284","agentId":"49cdf83c-6dd9-410f-b0e7-6f917b8e3a42","names":["Probe Person"],"metadata":{"type":"person"}}
```
</details>

## Known gaps / failures

- Full `bun run verify` was not run to completion on this constrained machine (Raspberry Pi worktree); it drives the entire Turbo graph. Instead the owning package's gates were run and pass: `bun run --cwd plugins/plugin-sql typecheck` (clean), `bun run --cwd plugins/plugin-sql lint:check` (Checked 226 files, no fixes), and the focused/full `entity-methods.real.test.ts` real-PGlite suite (24 passed). The diff is a two-branch SQL alias change plus a test-only addition, with no cross-package surface.
- Evidence is pasted inline as text (vitest output and JSON row dumps) rather than as attachment URLs; the artifact-upload session was unavailable in this environment. The content matches the reviewed head `a437022f1929d0502d2ef83180b8f00de9637dda`.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@a437022f1929d0502d2ef83180b8f00de9637dda:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@a437022f1929d0502d2ef83180b8f00de9637dda:packages/skills/skills/contribute-to-eliza"} -->

