### PR TITLE
fix(plugin-tests): align failing shard contracts with current runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2112,6 +2112,7 @@
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
+        "vitest": "^4.1.10",
       },
     },
     "plugins/plugin-instagram": {
@@ -3419,7 +3420,13 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
+        "jsdom": "^29.0.0",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10",

--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -757,10 +757,14 @@ describe("google plugin", () => {
               set: async (key: string, value: string) => {
                 vault.set(key, value);
               },
+              remove: async (key: string) => {
+                vault.delete(key);
+              },
             }
           : null,
     } as never;
     const manager = createOAuthCallbackManager("google", "acct_google_durable_1", setCredentialRef);
+    Object.assign(runtime, { adapter: manager.getStorage() });
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string | URL | Request) => {
@@ -781,6 +785,9 @@ describe("google plugin", () => {
             }),
             { status: 200, headers: { "content-type": "application/json" } }
           );
+        }
+        if (href.includes("oauth2.googleapis.com/revoke")) {
+          return new Response(null, { status: 200 });
         }
         throw new Error(`Unexpected fetch ${href}`);
       })
@@ -812,20 +819,24 @@ describe("google plugin", () => {
     expect(account.role).toBe("AGENT");
     expect(JSON.stringify(metadata)).not.toContain("google-access-token");
     expect(JSON.stringify(metadata)).not.toContain("google-refresh-token");
+    const [credentialRef] = metadata.credentialRefs as Array<{
+      credentialType: string;
+      vaultRef: string;
+    }>;
     expect(metadata.credentialRefs).toEqual([
       expect.objectContaining({
         credentialType: "oauth.tokens",
-        vaultRef: `connector.agent-1.google.${account.id}.oauth_tokens`,
+        vaultRef: expect.stringMatching(
+          new RegExp(`^connector\\.agent-1\\.google\\.${account.id}-[a-f0-9]+\\.oauth_tokens$`, "u")
+        ),
       }),
     ]);
-    expect(vault.get(`connector.agent-1.google.${account.id}.oauth_tokens`)).toContain(
-      "google-access-token"
-    );
+    expect(vault.get(credentialRef?.vaultRef ?? "")).toContain("google-access-token");
     expect(setCredentialRef).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: account.id,
         credentialType: "oauth.tokens",
-        vaultRef: `connector.agent-1.google.${account.id}.oauth_tokens`,
+        vaultRef: credentialRef?.vaultRef,
       })
     );
   });
@@ -846,6 +857,9 @@ describe("google plugin", () => {
               set: async (key: string, value: string) => {
                 vault.set(key, value);
               },
+              remove: async (key: string) => {
+                vault.delete(key);
+              },
             }
           : null,
     } as never;
@@ -854,6 +868,7 @@ describe("google plugin", () => {
       "acct_google_incremental_grant",
       vi.fn(async () => undefined)
     );
+    Object.assign(runtime, { adapter: manager.getStorage() });
     const provider = createGoogleConnectorAccountProvider(runtime);
     const providerAddedScope = "https://www.googleapis.com/auth/legacy.provider-added";
     const returnedScopes = [
@@ -881,6 +896,9 @@ describe("google plugin", () => {
             }),
             { status: 200, headers: { "content-type": "application/json" } }
           );
+        }
+        if (href.includes("oauth2.googleapis.com/revoke")) {
+          return new Response(null, { status: 200 });
         }
         throw new Error(`Unexpected fetch ${href}`);
       })
@@ -915,9 +933,8 @@ describe("google plugin", () => {
     expect(account.purpose).toEqual(["messaging"]);
     expect(metadata.grantedCapabilities).toEqual(["gmail.read"]);
     expect(metadata.grantedScopes).toEqual(returnedScopes);
-    expect(vault.get(`connector.agent-1.google.${account.id}.oauth_tokens`)).toContain(
-      providerAddedScope
-    );
+    const [credentialRef] = metadata.credentialRefs as Array<{ vaultRef: string }>;
+    expect(vault.get(credentialRef?.vaultRef ?? "")).toContain(providerAddedScope);
   });
 
   it("does not record or re-request a compound capability from a partial provider grant", async () => {
@@ -936,6 +953,9 @@ describe("google plugin", () => {
               set: async (key: string, value: string) => {
                 vault.set(key, value);
               },
+              remove: async (key: string) => {
+                vault.delete(key);
+              },
             }
           : null,
     } as never;
@@ -944,6 +964,7 @@ describe("google plugin", () => {
       "acct_google_partial_compound",
       vi.fn(async () => undefined)
     );
+    Object.assign(runtime, { adapter: manager.getStorage() });
     const provider = createGoogleConnectorAccountProvider(runtime);
     const returnedScopes = [
       GOOGLE_OAUTH_SCOPES.profile.openid,
@@ -970,6 +991,9 @@ describe("google plugin", () => {
             }),
             { status: 200, headers: { "content-type": "application/json" } }
           );
+        }
+        if (href.includes("oauth2.googleapis.com/revoke")) {
+          return new Response(null, { status: 200 });
         }
         throw new Error(`Unexpected fetch ${href}`);
       })
@@ -1046,6 +1070,7 @@ describe("google plugin", () => {
       "acct_google_identity_only",
       vi.fn(async () => undefined)
     );
+    Object.assign(runtime, { adapter: manager.getStorage() });
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string | URL | Request) => {
@@ -1066,6 +1091,9 @@ describe("google plugin", () => {
             }),
             { status: 200, headers: { "content-type": "application/json" } }
           );
+        }
+        if (href.includes("oauth2.googleapis.com/revoke")) {
+          return new Response(null, { status: 200 });
         }
         throw new Error(`Unexpected fetch ${href}`);
       })
@@ -1134,6 +1162,7 @@ describe("google plugin", () => {
       "acct_google_invalid_scope",
       vi.fn(async () => undefined)
     );
+    Object.assign(runtime, { adapter: manager.getStorage() });
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string | URL | Request) => {
@@ -1148,6 +1177,9 @@ describe("google plugin", () => {
             }),
             { status: 200, headers: { "content-type": "application/json" } }
           );
+        }
+        if (href.includes("oauth2.googleapis.com/revoke")) {
+          return new Response(null, { status: 200 });
         }
         throw new Error(`Unexpected fetch ${href}`);
       })
@@ -1208,6 +1240,9 @@ describe("google plugin", () => {
             { status: 200, headers: { "content-type": "application/json" } }
           );
         }
+        if (href.includes("oauth2.googleapis.com/revoke")) {
+          return new Response(null, { status: 200 });
+        }
         throw new Error(`Unexpected fetch ${href}`);
       })
     );
@@ -1218,6 +1253,7 @@ describe("google plugin", () => {
       "acct_google_durable_1",
       vi.fn(async () => undefined)
     );
+    Object.assign(runtime, { adapter: manager.getStorage() });
     await expect(
       provider.completeOAuth?.(
         {
@@ -1237,7 +1273,13 @@ describe("google plugin", () => {
         },
         manager as never
       )
-    ).rejects.toThrow(/durable connector credential store|vault writer/i);
+    ).rejects.toMatchObject({
+      code: "GOOGLE_OAUTH_COMPLETION_COMPENSATION_FAILED",
+      context: expect.objectContaining({
+        revocationAttempted: true,
+        grantRevoked: true,
+      }),
+    });
   });
 
   it("uses a fake Gmail client with selected Gmail read/send scopes", async () => {
@@ -1447,7 +1489,7 @@ describe("google plugin", () => {
     });
   });
 
-  it("normalizes hostile Gmail limits before listing messages", async () => {
+  it("rejects hostile Gmail limits with the typed public error", async () => {
     const fakeGmail = {
       users: {
         messages: {
@@ -1467,20 +1509,21 @@ describe("google plugin", () => {
         query: "in:inbox",
         maxResults: Number.POSITIVE_INFINITY,
       })
-    ).resolves.toEqual([]);
-    fakeGmail.users.messages.list.mockClear();
+    ).rejects.toMatchObject({
+      code: "GOOGLE_GMAIL_LIMIT_INVALID",
+      context: { field: "maxResults", value: Number.POSITIVE_INFINITY },
+    });
     await expect(
       client.listGmailUnrespondedThreads({
         accountId: "acct_google_1",
         olderThanDays: -4,
         maxResults: Number.NaN,
       })
-    ).resolves.toEqual([]);
-
-    expect(fakeGmail.users.messages.list).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ q: "in:sent older_than:3d", maxResults: 100 })
-    );
+    ).rejects.toMatchObject({
+      code: "GOOGLE_GMAIL_LIMIT_INVALID",
+      context: { field: "maxResults", value: Number.NaN },
+    });
+    expect(fakeGmail.users.messages.list).not.toHaveBeenCalled();
   });
 
   it("escapes Drive folder IDs and preserves explicit trashed predicates", async () => {
@@ -2041,10 +2084,15 @@ function createOAuthCallbackManager(
   durableAccountId: string,
   setCredentialRef: ReturnType<typeof vi.fn>
 ) {
+  const storage = {
+    setConnectorAccountCredentialRef: setCredentialRef,
+    deleteConnectorAccountCredentialRefs: vi.fn(async () => 0),
+    listConnectorAccountCredentialRefs: vi.fn(async () => []),
+    deleteAccount: vi.fn(async () => true),
+    upsertAccount: vi.fn(async (account: ConnectorAccount) => account),
+  };
   return {
-    getStorage: () => ({
-      setConnectorAccountCredentialRef: setCredentialRef,
-    }),
+    getStorage: () => storage,
     upsertAccount: vi.fn(
       async (
         providerId: string,

--- a/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
@@ -80,20 +80,15 @@ describe("x_dm unread derivation", () => {
     expect(inbox.messages[0]?.unread).toBe(true);
   });
 
-  it("maintains strict total ordering in thread groups when timestamp is NaN", () => {
-    const inbox = build([
-      xDm({
-        id: "dm-invalid",
-        threadId: "conv-mixed",
-        timestamp: Number.NaN,
-      }),
-      xDm({
-        id: "dm-valid",
-        threadId: "conv-mixed",
-        timestamp: NOW,
-      }),
-    ]);
-    expect(inbox.threadGroups).toHaveLength(1);
-    expect(inbox.threadGroups?.[0]?.latestMessage.id).toBe("x_dm:dm-valid");
+  it("rejects a non-finite provider timestamp at the inbox boundary", () => {
+    expect(() =>
+      build([
+        xDm({
+          id: "dm-invalid",
+          threadId: "conv-mixed",
+          timestamp: Number.NaN,
+        }),
+      ]),
+    ).toThrow(RangeError);
   });
 });

--- a/plugins/plugin-inbox/src/inbox/reflection.test.ts
+++ b/plugins/plugin-inbox/src/inbox/reflection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { reflectOnAutoReply } from "./reflection.ts";
 
 describe("reflectOnAutoReply", () => {
-  it("truncates unparseable reflection text with surrogate safety", async () => {
+  it("preserves complete unparseable reflection text with valid Unicode", async () => {
     const rawUnparseable = `${"a".repeat(99)}😀${"b".repeat(20)}`;
     const runtime = {
       useModel: vi.fn().mockResolvedValue(rawUnparseable),
@@ -17,18 +17,9 @@ describe("reflectOnAutoReply", () => {
     });
 
     expect(result.approved).toBe(false);
-    expect(result.reasoning.startsWith("Could not parse reflection: ")).toBe(
-      true,
+    expect(result.reasoning).toBe(
+      `Could not parse reflection: ${rawUnparseable}`,
     );
-    expect(result.reasoning.includes("😀")).toBe(false);
-    expect(result.reasoning.length).toBeLessThanOrEqual(
-      "Could not parse reflection: ".length + 100,
-    );
-    // The invariant the fix is actually about: the old raw.slice(0, 100) cut
-    // between the two code units of the astral char and left an unpaired high
-    // surrogate. Length and emoji-absence alone hold for the old code too, so
-    // assert the absence of unpaired surrogate code units explicitly or this
-    // test cannot fail on develop.
     expect(
       /[\uD800-\uDFFF]/.test(
         result.reasoning.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, ""),

--- a/plugins/plugin-inmemorydb/package.json
+++ b/plugins/plugin-inmemorydb/package.json
@@ -53,7 +53,8 @@
     "@biomejs/biome": "2.5.8",
     "@types/node": "^25.0.3",
     "@typescript/native": "npm:typescript@^7.0.2",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "dev": "bun run build.ts --watch",

--- a/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
+++ b/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
@@ -7,11 +7,11 @@
  */
 import {
   ROLE_WRITE_AUDIT_LOG_TYPE,
+  stringToUuid,
   type UUID,
   WORLD_METADATA_REVISION_KEY,
   type World,
 } from "@elizaos/core";
-import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
 import { MemoryStorage } from "./storage-memory";
@@ -20,8 +20,8 @@ import { COLLECTIONS } from "./types";
 const AGENT_ID = "70000000-0000-0000-0000-000000000001" as UUID;
 const ACTOR_ID = "70000000-0000-0000-0000-000000000002" as UUID;
 const TARGET_ID = "70000000-0000-0000-0000-000000000003" as UUID;
-const ROOM_ID = v4() as UUID;
-const WORLD_ID = v4() as UUID;
+const ROOM_ID = stringToUuid("inmemorydb-world-cas-room");
+const WORLD_ID = stringToUuid("inmemorydb-world-cas-world");
 
 const BASE_METADATA = {
   ownership: { ownerId: String(ACTOR_ID) },
@@ -156,7 +156,7 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
   it("reports not_found for an unknown world", async () => {
     const adapter = await buildAdapter();
     const result = await adapter.compareAndSwapWorldMetadata({
-      worldId: v4() as UUID,
+      worldId: stringToUuid("inmemorydb-world-cas-missing-world"),
       expectedMetadata: {} as never,
       replacementMetadata: {} as never,
     });

--- a/plugins/plugin-native-llama/src/generate-stream.test.ts
+++ b/plugins/plugin-native-llama/src/generate-stream.test.ts
@@ -138,7 +138,11 @@ describe("CapacitorLlamaAdapter.generateStream", () => {
       timings: { predicted_ms: 50 },
     });
 
-    await expect(generation).rejects.toThrow(/partial text/);
+    await expect(generation).rejects.toMatchObject({
+      code: "MODEL_OUTPUT_INCOMPLETE",
+      message:
+        "[capacitor-llama] native generation reached maxTokens=3 before a stop condition; no partial response was returned",
+    });
   });
 
   it("ends with an error+done pair when the native call rejects", async () => {

--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -368,14 +368,15 @@ describe("Telegram message connector adapter", () => {
     expect(runtime.getMemories).toHaveBeenCalledWith({
       tableName: "messages",
       roomId,
-      limit: 200,
+      limit: 500,
+      offset: 0,
       orderBy: "createdAt",
       orderDirection: "desc",
     });
     expect(result).toEqual([acctAMemory, legacyMemory]);
   });
 
-  it("searches fetched connector messages case-insensitively with a sane fallback limit", async () => {
+  it("rejects an invalid search limit before reading connector messages", async () => {
     const roomId = "room-1" as never;
     const runtime = {
       ...createRuntime(),
@@ -410,19 +411,20 @@ describe("Telegram message connector adapter", () => {
       accountStates: new Map([["acct-a", { accountId: "acct-a" }]]),
     });
 
-    const result = await service.searchConnectorMessages(
-      { runtime, accountId: "acct-a" } as never,
-      {
-        target: { source: "telegram", accountId: "acct-a", roomId },
-        query: "deploy",
-        limit: -5,
-      },
-    );
-
-    expect(runtime.getMemories).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 100 }),
-    );
-    expect(result.map((memory) => memory.id)).toEqual(["memory-1", "memory-3"]);
+    await expect(
+      service.searchConnectorMessages(
+        { runtime, accountId: "acct-a" } as never,
+        {
+          target: { source: "telegram", accountId: "acct-a", roomId },
+          query: "deploy",
+          limit: -5,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "TELEGRAM_MESSAGE_LIMIT_INVALID",
+      context: { limit: -5 },
+    });
+    expect(runtime.getMemories).not.toHaveBeenCalled();
   });
 
   it("starts non-default accounts when the default account has no token", async () => {

--- a/plugins/plugin-wifi/package.json
+++ b/plugins/plugin-wifi/package.json
@@ -64,6 +64,12 @@
     "dist"
   ],
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "jsdom": "^29.0.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "tsup": "^8.5.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",

--- a/plugins/plugin-wifi/src/components/WifiAppView.test.ts
+++ b/plugins/plugin-wifi/src/components/WifiAppView.test.ts
@@ -32,6 +32,8 @@ vi.mock("@elizaos/capacitor-system", () => ({
 }));
 
 vi.mock("@elizaos/ui", () => ({
+  Badge: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) =>
+    React.createElement("span", props, children),
   Button: ({
     children,
     type = "button",

--- a/plugins/plugin-x/src/services/PostService.test.ts
+++ b/plugins/plugin-x/src/services/PostService.test.ts
@@ -64,10 +64,12 @@ describe("TwitterPostService", () => {
   it("reports and rejects getPosts provider failures", async () => {
     const providerError = new Error("twitter 429 rate limited");
     const reportError = vi.fn();
-    const getUserTweets = vi.fn().mockRejectedValue(providerError);
+    const getUserTweetsIterator = vi.fn(() => {
+      throw providerError;
+    });
     const failing = new TwitterPostService({
       runtime: { reportError },
-      twitterClient: { getUserTweets },
+      twitterClient: { getUserTweetsIterator },
     } as unknown as ClientBase);
 
     await expect(
@@ -85,10 +87,14 @@ describe("TwitterPostService", () => {
 
   it("keeps a legitimate empty provider result distinct from failure", async () => {
     const reportError = vi.fn();
-    const getUserTweets = vi.fn(async () => ({ tweets: [] }));
+    const getUserTweetsIterator = vi.fn(() =>
+      (async function* () {
+        yield* [];
+      })(),
+    );
     const empty = new TwitterPostService({
       runtime: { reportError },
-      twitterClient: { getUserTweets },
+      twitterClient: { getUserTweetsIterator },
     } as unknown as ClientBase);
 
     await expect(
@@ -282,7 +288,7 @@ describe("TwitterPostService", () => {
 
     expect(fetchSearchTweets).toHaveBeenCalledWith(
       "@current-b",
-      20,
+      100,
       expect.anything(),
       undefined,
     );

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -361,7 +361,7 @@ describe("XService trusted account routing", () => {
     expect(getClient).toHaveBeenCalledWith("secondary");
     expect(fetchSearchTweets).toHaveBeenCalledWith(
       "multi-account routing",
-      20,
+      100,
       expect.anything(),
       undefined,
     );

--- a/plugins/plugin-zai/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-zai/__tests__/error-policy.shape.test.ts
@@ -104,7 +104,7 @@ describe("z.ai failure surfaces (real ai + @ai-sdk/openai-compatible, stubbed tr
     const runtime = createRuntime(fetchMock as unknown as typeof fetch);
 
     await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
-      code: "MODEL_INCOMPLETE_OUTPUT",
+      code: "MODEL_OUTPUT_INCOMPLETE",
     });
     expect(emitEventOf(runtime)).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -128,7 +128,7 @@ describe("z.ai text parameter resolution", () => {
     const explicitCall = generateTextMock.mock.calls[1]?.[0] as Record<string, unknown>;
     expect(defaultCall).not.toHaveProperty("maxOutputTokens");
     expect(defaultCall).not.toHaveProperty("maxTokens");
-    expect(explicitCall.maxOutputTokens).toBe(123);
+    expect(explicitCall.maxTokens).toBe(123);
   });
 
   it("uses deprecated CoT budget settings to enable z.ai thinking mode", async () => {


### PR DESCRIPTION
Closes #30006.

## Summary

Aligns the eight failing plugin-shard test packages with current runtime contracts. The changes update OAuth compensation fakes, typed-error assertions, lossless reflection expectations, pagination calls, async X iterators, model-output codes, and the Wi-Fi UI mock. The in-memory adapter test no longer imports undeclared `uuid`; in-memory and Wi-Fi test dependencies are now declared at their owning package boundaries.

## Acceptance criteria

- [x] Every listed package passes its focused package test command. Exact commands, statuses, elapsed time, and peak RSS are recorded below.
- [x] Tests assert the current consumer-visible contract rather than retired internal wording. Assertions now cover `GOOGLE_GMAIL_LIMIT_INVALID`, `TELEGRAM_MESSAGE_LIMIT_INVALID`, `MODEL_OUTPUT_INCOMPLETE`, complete reflection content, the 500-row Telegram pagination request, current X pagination/iterator behavior, and attempt-scoped Google credential refs.
- [x] Missing dependencies are removed or declared at the owning package boundary. `plugin-inmemorydb` uses core `stringToUuid` instead of undeclared `uuid` and declares Vitest; `plugin-wifi` declares its React/jsdom/testing-library harness dependencies.
- [ ] The hosted plugin shard completes successfully on exact PR head `4fc46a21fcaaf6eac4301b5948a1f9d41d8ead46`. This remains pending until the PR-triggered hosted check runs; the exact local shard command is green below.

## Before: reproduced failures

The reported hosted run was inspected first:

```text
Develop Full run 33283695532, job 99183350084
FAIL  world-metadata-cas.test.ts
Error: Cannot find package 'uuid' imported from '/home/runner/work/eliza/eliza/plugins/plugin-inmemorydb/world-metadata-cas.test.ts'
Error: [vitest] No "Badge" export is defined on the "@elizaos/ui" mock. Did you forget to return it from "vi.mock"?
```

The exact focused package commands then reproduced the stale contracts locally. Output excerpts and `/usr/bin/time -lp` measurements:

```text
$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-google-workspace test
Test Files  1 failed | 36 passed (37)
Tests  8 failed | 385 passed (393)
error: script "test" exited with code 1
real 10.85
1448345600  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-inbox test
Test Files  2 failed | 25 passed | 1 skipped (28)
Tests  2 failed | 236 passed | 2 skipped (240)
error: script "test" exited with code 1
real 17.17
1574305792  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-inmemorydb test
Test Files  18 passed (18)
Tests  98 passed (98)
real 6.13
2315796480  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-native-llama test
expected [Function] to throw error matching /partial text/ but got '[capacitor-llama] native generation reached maxTokens=3 before a stop condition; no partial response was returned'
error: script "test" exited with code 1
real 0.40
121683968  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-telegram test
AssertionError: expected "spy" to be called with arguments: [ { tableName: 'messages', …(4) } ]
error: script "test" exited with code 1
real 7.18
393691136  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-wifi test
Error: Failed to resolve entry for package "@elizaos/ui". The package may have incorrect main/module/exports specified in its package.json.
error: script "test" exited with code 1
real 0.83
193806336  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-x test
TypeError: this.client.twitterClient.getUserTweetsIterator(...) is not a function or its return value is not async iterable
error: script "test" exited with code 1
real 9.06
422051840  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-zai test
AssertionError: expected { code: 'MODEL_OUTPUT_INCOMPLETE' } to match object { code: 'MODEL_INCOMPLETE_OUTPUT' }
error: script "test" exited with code 1
real 3.36
2110423040  maximum resident set size
```

`plugin-inmemorydb` passed locally only because the monorepo root supplied transitive `uuid`; the hosted isolated package run above proves the owning-boundary failure. Wi-Fi's initial local failure was the unbuilt `@elizaos/ui` workspace entry; after building that workspace package, its reported hosted `Badge` mock failure reproduced.

## After: focused package commands

All commands below ran after `bunx biome check --write` on every touched source/manifest file:

```text
$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-google-workspace test
Test Files  37 passed (37)
Tests  393 passed (393)
real 15.29
1237663744  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-inbox test
Test Files  27 passed | 1 skipped (28)
Tests  238 passed | 2 skipped (240)
real 20.20
1581645824  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-inmemorydb test
Test Files  18 passed (18)
Tests  98 passed (98)
real 11.53
1648558080  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-native-llama test
Test Files  4 passed (4)
Tests  45 passed (45)
real 2.27
122306560  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-telegram test
Test Files  28 passed (28)
Tests  277 passed (277)
real 9.62
406044672  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-wifi test
Test Files  3 passed (3)
Tests  38 passed (38)
real 1.45
240467968  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-x test
Test Files  41 passed | 1 skipped (42)
Tests  403 passed | 13 skipped (416)
real 10.46
473645056  maximum resident set size

$ bun run --cwd /Users/sailesh/Developer/worktrees/issue-30006/plugins/plugin-zai test
Test Files  7 passed (7)
Tests  60 passed (60)
real 5.03
2106195968  maximum resident set size
```

## Exact shard and repository verification

```text
$ CI=true TEST_SHARD=1/4 /usr/bin/time -lp bun run test:plugins
[eliza-test] RESULTS tasks=32 pass=32 fail=0 skip=0 not-run=0 excluded=1 unobserved=0
[eliza-test] EVIDENCE reports=32 tests=4403 executed=4381 skipped=22 unobserved-tasks=0
real 188.07
2336735232  maximum resident set size
```

```text
$ bunx biome check --write <13 touched source and manifest paths>
Checked 13 files in 40ms. No fixes applied.

$ bunx tsc --noEmit -p <owning-package>/tsconfig.json
plugin-google-workspace exit_code=0
plugin-inbox exit_code=0
plugin-inmemorydb exit_code=0
plugin-native-llama exit_code=0
plugin-telegram exit_code=0
plugin-wifi exit_code=0
plugin-x exit_code=0
plugin-zai exit_code=0

$ bun run verify
Tasks:    375 successful, 375 total
Cached:    2 cached, 375 total
[anti-larp] clean — no focused tests, no untracked skips.
```

Because every owning-package typecheck returned zero total errors, the change introduces zero errors relative to the untouched `origin/develop` control.

## Risk

Low. Production code is unchanged. The only manifest changes declare dependencies already used by the package tests. The main risk is future contract drift, which these assertions now expose at the consumer boundary.

## Documentation

No documentation change is needed; this corrects tests and package dependency ownership.

## Known gaps / failures

- Hosted shard status is pending until GitHub runs it on the exact PR head. This criterion is deliberately left unchecked above and will be updated only from measured hosted output.
- No signed identity.slop.cash trace is attached because this unattended session cannot finalize the interactive OAuth trace. Command output is included inline instead.
- Screenshots, video, frontend/backend logs, OCR, domain artifacts, and live-LLM trajectory are N/A because this change touches only deterministic tests and dev dependency declarations; it does not change a rendered UI, backend runtime path, prompt, provider behavior, or model call.
- Maintainer CI exception: N/A - no exception requested.

## Evidence Gate

<!-- evidence-head:4fc46a21fcaaf6eac4301b5948a1f9d41d8ead46 -->
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI behavior changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI behavior changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - deterministic package-test contract alignment only.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend runtime path changed; exact test and shard output is inline above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: N/A - no prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain state changed.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openrouter/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenRouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza"} -->
