### PR TITLE
fix(cloud): verify no-content server deletion

### DIFF
--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
@@ -75,6 +75,21 @@ function server(
   };
 }
 
+function action(
+  id: number,
+  command: string,
+  resourceId: number,
+): Record<string, unknown> {
+  return {
+    id,
+    command,
+    status: "success",
+    progress: 100,
+    resources: [{ id: resourceId, type: "server" }],
+    error: null,
+  };
+}
+
 function serverListResponse(servers: Array<Record<string, unknown>>): Response {
   return Response.json({
     servers,
@@ -140,9 +155,22 @@ describe("Hetzner E2E provision HTTP boundary", () => {
         }),
       ]),
       new Response(null, { status: 204 }),
+      Response.json(
+        { error: { code: "not_found", message: "server missing" } },
+        { status: 404 },
+      ),
+      Response.json({
+        server: server({
+          id: 99,
+          status: "initializing",
+          created: new Date().toISOString(),
+        }),
+        action: action(99, "create_server", 99),
+        next_actions: [],
+        root_password: null,
+      }),
       Response.json({
         server: server({ id: 99, created: new Date().toISOString() }),
-        root_password: null,
       }),
     );
 
@@ -173,8 +201,17 @@ describe("Hetzner E2E provision HTTP boundary", () => {
         server({ id: 45, created: null, name: "invalid-created" }),
       ]),
       Response.json({
-        server: server({ id: 99, created: new Date().toISOString() }),
+        server: server({
+          id: 99,
+          status: "initializing",
+          created: new Date().toISOString(),
+        }),
+        action: action(99, "create_server", 99),
+        next_actions: [],
         root_password: null,
+      }),
+      Response.json({
+        server: server({ id: 99, created: new Date().toISOString() }),
       }),
     );
 

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
@@ -87,12 +87,16 @@ describe("Hetzner E2E reaper credential boundary", () => {
         },
       ]),
       new Response(null, { status: 204 }),
+      Response.json(
+        { error: { code: "not_found", message: "server missing" } },
+        { status: 404 },
+      ),
     );
 
     await expect(
       runHetznerE2eReaper("valid-ci-token"),
     ).resolves.toBeUndefined();
-    expect(requestedMethods).toEqual(["GET", "DELETE"]);
+    expect(requestedMethods).toEqual(["GET", "DELETE", "GET"]);
     expect(requestedUrls[1]).toBe("https://api.hetzner.cloud/v1/servers/42");
   });
 
@@ -107,13 +111,17 @@ describe("Hetzner E2E reaper credential boundary", () => {
         { status: 409 },
       ),
       new Response(null, { status: 204 }),
+      Response.json(
+        { error: { code: "not_found", message: "server missing" } },
+        { status: 404 },
+      ),
     );
 
     await expect(runHetznerE2eReaper("valid-ci-token")).rejects.toMatchObject({
       name: "AggregateError",
       message: "Hetzner E2E reaper failed to delete 1 stale server(s)",
     });
-    expect(requestedMethods).toEqual(["GET", "DELETE", "DELETE"]);
+    expect(requestedMethods).toEqual(["GET", "DELETE", "DELETE", "GET"]);
     expect(requestedUrls[2]).toBe("https://api.hetzner.cloud/v1/servers/43");
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
@@ -404,6 +404,21 @@ describe("Hetzner lifecycle deadlines and absence", () => {
     expect(requests).toEqual([{ method: "DELETE", path: "/v1/servers/41" }]);
   });
 
+  test("server deletion accepts 204 only after exact absence readback", async () => {
+    empty();
+    json({ server: server(41) });
+    await expect(client().deleteServer(41)).rejects.toMatchObject({
+      code: "server_error",
+    });
+
+    responses = [];
+    requests = [];
+    empty();
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
+    await expect(client().deleteServer(41)).resolves.toBeUndefined();
+    expect(requests.map(({ path }) => path)).toEqual(["/v1/servers/41", "/v1/servers/41"]);
+  });
+
   test("volume delete requires exact post-delete absence", async () => {
     empty();
     json({ volume: volume(51) });

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -430,11 +430,14 @@ export class HetznerCloudClient implements ComputeProvider {
   async deleteServer(serverId: number): Promise<void> {
     validateResourceId(serverId, "serverId");
     const deadline = deadlineAfter(this.lifecycleTimeoutMs);
-    let data: Record<string, unknown>;
+    let deleteResponse: unknown | typeof NO_CONTENT;
     try {
-      data = requireEnvelope(
-        await this.request<unknown>("DELETE", `/servers/${serverId}`, undefined, deadline),
-        "delete server",
+      deleteResponse = await this.request<unknown>(
+        "DELETE",
+        `/servers/${serverId}`,
+        undefined,
+        deadline,
+        true,
       );
     } catch (error) {
       // error-policy:J4 an exact target 404 is the provider's explicit
@@ -442,13 +445,16 @@ export class HetznerCloudClient implements ComputeProvider {
       if (error instanceof HetznerCloudError && error.code === "not_found") return;
       throw error;
     }
-    await this.settleReturnedActions(
-      data.action,
-      Object.hasOwn(data, "next_actions") ? data.next_actions : [],
-      deadline,
-      { id: serverId, type: "server" },
-      true,
-    );
+    if (deleteResponse !== NO_CONTENT) {
+      const data = requireEnvelope(deleteResponse, "delete server");
+      await this.settleReturnedActions(
+        data.action,
+        Object.hasOwn(data, "next_actions") ? data.next_actions : [],
+        deadline,
+        { id: serverId, type: "server" },
+        true,
+      );
+    }
     if ((await this.getServerWithin(serverId, deadline)) !== null) {
       throw new HetznerCloudError(
         "server_error",


### PR DESCRIPTION
Closes #30017\n\n## What changed\n\n- Accept Hetzner HTTP 204 from server deletion as a provisional no-content response.\n- Preserve the existing exact by-id absence readback before reporting success.\n- Continue settling validated lifecycle action envelopes for non-204 responses.\n- Modernize the E2E fixtures to prove exact absence before replacement provisioning.\n\n## Why\n\nHetzner can return HTTP 204 for DELETE /servers/{id}. The server client previously tried to parse that valid empty response as JSON and failed before its mandatory absence check, breaking Dedicated cleanup and stale-server reaping.\n\n## Safety\n\n- A 204 does not prove deletion by itself.\n- Success still requires the exact target readback to return not-found.\n- A still-present server or readback failure remains fail-closed.\n- No live provider, resource, billing, staging, production, credential, or account action occurred.\n\n## Exact source\n\n- Base: c00f8e23931d758bc99f3dbd7e06d006750d1eaa\n- Head: 0512f61d0e236a9fc4ecb4fbc88c273341de9189\n- Tree: 3fd0703f537bd8ad4e333731fb57dcaa73153ad9\n\n## Verification\n\n- PASS: 31/31 focused real-client lifecycle, reaper, and provisioning tests\n- PASS: packages/cloud/shared typecheck\n- PASS: exact Biome check for all four touched files\n- PASS: git diff --check\n\n## Evidence\n\n- Before/after screenshots: N/A - backend provider lifecycle contract; no rendered UI changes.\n- Walkthrough video: N/A - deterministic HTTP-boundary tests exercise the user-affecting cleanup path.\n- Frontend console/network logs: N/A - no frontend paths changed.\n- Backend logs: N/A - no live provider call was made; focused tests use the real client with only HTTP replaced.\n- Real behavior: the regression proves 204 + still-present rejects, while 204 + exact 404 succeeds; reaper and replacement provisioning then complete.\n\n## Review focus\n\nPlease verify the 204 branch cannot bypass exact absence readback and that non-204 action settlement remains unchanged.