### PR TITLE
test(app): classify dedicated adoption quote outcomes

### DIFF
--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -265,6 +265,17 @@ describe("forbidden Cloud agent mutations", () => {
       decodedDedicatedCutoverFinalResponseCount: 0,
       uninspectableDedicatedCutoverResponseBodyCount: 0,
       dedicatedAdoptionQuoteGetRequestCount: 0,
+      successfulDedicatedAdoptionQuoteGetResponseCount: 0,
+      clientErrorDedicatedAdoptionQuoteGetResponseCount: 0,
+      serverErrorDedicatedAdoptionQuoteGetResponseCount: 0,
+      otherDedicatedAdoptionQuoteGetResponseCount: 0,
+      failedDedicatedAdoptionQuoteGetRequestCount: 0,
+      pendingDedicatedAdoptionQuoteGetRequestCount: 0,
+      completedDedicatedAdoptionQuoteResponseBodyCount: 0,
+      parsedDedicatedAdoptionQuoteResponseBodyCount: 0,
+      decodedAdoptableDedicatedAdoptionQuoteCount: 0,
+      decodedUnavailableDedicatedAdoptionQuoteCount: 0,
+      uninspectableDedicatedAdoptionQuoteResponseBodyCount: 0,
       dedicatedAdoptionConfirmationPostRequestCount: 0,
       dedicatedApprovalBindingPresent: false,
       dedicatedLifecycleBindingMismatchCount: 0,
@@ -348,7 +359,40 @@ describe("forbidden Cloud agent mutations", () => {
         data: { runtime: "dedicated", activeAgentId: "private-target" },
       }).responseBody,
     );
-    audit.observeRequest("GET", `${upgrade}/adopt-existing`);
+    const adoption = `${upgrade}/adopt-existing`;
+    audit.observeRequest("GET", adoption);
+    audit.observeResponse(
+      "GET",
+      adoption,
+      200,
+      boundedJsonBody({
+        success: true,
+        data: {
+          requiresConfirmation: true,
+          action: "adopt_existing_dedicated",
+          canAdopt: true,
+          quoteId: "private-adoption-quote",
+          dedicatedAgentId: "private-adoption-target",
+        },
+      }).responseBody,
+    );
+    audit.observeRequest("GET", adoption);
+    audit.observeResponse(
+      "GET",
+      adoption,
+      404,
+      boundedJsonBody({
+        success: false,
+        code: "dedicated_adoption_unavailable",
+      }).responseBody,
+    );
+    audit.observeRequest("GET", adoption);
+    audit.observeResponse("GET", adoption, 503);
+    audit.observeRequest("GET", adoption);
+    audit.observeResponse("GET", adoption, 302);
+    audit.observeRequest("GET", adoption);
+    audit.observeRequestFailure("GET", adoption, "private timeout detail");
+    audit.observeRequest("GET", adoption);
     audit.observeRequest("POST", `${upgrade}/adopt-existing`);
     audit.observeRequest("GET", upgrade);
     audit.observeRequestFailure("GET", upgrade, "private timeout detail");
@@ -404,7 +448,18 @@ describe("forbidden Cloud agent mutations", () => {
       decodedDedicatedCutoverPendingResponseCount: 1,
       decodedDedicatedCutoverFinalResponseCount: 1,
       uninspectableDedicatedCutoverResponseBodyCount: 0,
-      dedicatedAdoptionQuoteGetRequestCount: 1,
+      dedicatedAdoptionQuoteGetRequestCount: 6,
+      successfulDedicatedAdoptionQuoteGetResponseCount: 1,
+      clientErrorDedicatedAdoptionQuoteGetResponseCount: 1,
+      serverErrorDedicatedAdoptionQuoteGetResponseCount: 1,
+      otherDedicatedAdoptionQuoteGetResponseCount: 1,
+      failedDedicatedAdoptionQuoteGetRequestCount: 1,
+      pendingDedicatedAdoptionQuoteGetRequestCount: 1,
+      completedDedicatedAdoptionQuoteResponseBodyCount: 2,
+      parsedDedicatedAdoptionQuoteResponseBodyCount: 2,
+      decodedAdoptableDedicatedAdoptionQuoteCount: 1,
+      decodedUnavailableDedicatedAdoptionQuoteCount: 1,
+      uninspectableDedicatedAdoptionQuoteResponseBodyCount: 2,
       dedicatedAdoptionConfirmationPostRequestCount: 1,
       dedicatedApprovalBindingPresent: false,
       dedicatedLifecycleBindingMismatchCount: 4,

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -110,6 +110,17 @@ export interface CloudLiveNetworkAuditSnapshot {
   decodedDedicatedCutoverFinalResponseCount: number;
   uninspectableDedicatedCutoverResponseBodyCount: number;
   dedicatedAdoptionQuoteGetRequestCount: number;
+  successfulDedicatedAdoptionQuoteGetResponseCount: number;
+  clientErrorDedicatedAdoptionQuoteGetResponseCount: number;
+  serverErrorDedicatedAdoptionQuoteGetResponseCount: number;
+  otherDedicatedAdoptionQuoteGetResponseCount: number;
+  failedDedicatedAdoptionQuoteGetRequestCount: number;
+  pendingDedicatedAdoptionQuoteGetRequestCount: number;
+  completedDedicatedAdoptionQuoteResponseBodyCount: number;
+  parsedDedicatedAdoptionQuoteResponseBodyCount: number;
+  decodedAdoptableDedicatedAdoptionQuoteCount: number;
+  decodedUnavailableDedicatedAdoptionQuoteCount: number;
+  uninspectableDedicatedAdoptionQuoteResponseBodyCount: number;
   dedicatedAdoptionConfirmationPostRequestCount: number;
   dedicatedApprovalBindingPresent: boolean;
   dedicatedLifecycleBindingMismatchCount: number;
@@ -831,6 +842,64 @@ async function inspectDedicatedControlPlaneResponse(
   }
 }
 
+interface DedicatedAdoptionQuoteResponseInspection {
+  bodyCompleted: boolean;
+  parsed: boolean;
+  disposition: "adoptable" | "unavailable" | null;
+}
+
+/** Reduces an adoption quote to outcome counters without retaining its quote or target. */
+async function inspectDedicatedAdoptionQuoteResponse(
+  status: number,
+  responseBody: CloudLiveBoundedResponseBody,
+): Promise<DedicatedAdoptionQuoteResponseInspection> {
+  const unavailable = {
+    bodyCompleted: false,
+    parsed: false,
+    disposition: null,
+  } as const;
+  if (!isJsonContentType(responseBody.contentType)) return unavailable;
+  const bytes = await readCloudLiveBoundedResponseBody(
+    responseBody,
+    MAX_PERSONAL_IDENTITY_RESPONSE_BYTES,
+  );
+  if (!bytes) return unavailable;
+  try {
+    const parsed = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    ) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { bodyCompleted: true, parsed: true, disposition: null };
+    }
+    const root = parsed as Record<string, unknown>;
+    const data = root.data;
+    const quote =
+      data && typeof data === "object" && !Array.isArray(data)
+        ? (data as Record<string, unknown>)
+        : null;
+    const code = typeof root.code === "string" ? root.code : "";
+    const disposition =
+      status >= 200 &&
+      status < 300 &&
+      root.success === true &&
+      quote?.requiresConfirmation === true &&
+      quote.action === "adopt_existing_dedicated" &&
+      quote.canAdopt === true
+        ? "adoptable"
+        : quote?.canAdopt === false ||
+            code === "dedicated_adoption_unavailable" ||
+            code === "dedicated_adoption_ambiguous" ||
+            code === "dedicated_adoption_catalog_restore_required"
+          ? "unavailable"
+          : null;
+    return { bodyCompleted: true, parsed: true, disposition };
+  } catch {
+    // error-policy:J3 malformed/non-UTF-8 bodies remain a closed parsed=false
+    // result; no response content is retained or surfaced.
+    return { bodyCompleted: true, parsed: false, disposition: null };
+  }
+}
+
 interface HistoryAnchorInspection {
   inspected: boolean;
   anchorUserPresent: boolean;
@@ -1131,6 +1200,16 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
   let decodedDedicatedPersonalIdentityResponseCount = 0;
   let uninspectablePersonalIdentityResponseBodyCount = 0;
   let dedicatedAdoptionQuoteGetRequestCount = 0;
+  let successfulDedicatedAdoptionQuoteGetResponseCount = 0;
+  let clientErrorDedicatedAdoptionQuoteGetResponseCount = 0;
+  let serverErrorDedicatedAdoptionQuoteGetResponseCount = 0;
+  let otherDedicatedAdoptionQuoteGetResponseCount = 0;
+  let failedDedicatedAdoptionQuoteGetRequestCount = 0;
+  let completedDedicatedAdoptionQuoteResponseBodyCount = 0;
+  let parsedDedicatedAdoptionQuoteResponseBodyCount = 0;
+  let decodedAdoptableDedicatedAdoptionQuoteCount = 0;
+  let decodedUnavailableDedicatedAdoptionQuoteCount = 0;
+  let uninspectableDedicatedAdoptionQuoteResponseBodyCount = 0;
   let dedicatedAdoptionConfirmationPostRequestCount = 0;
   let dedicatedApprovalBinding: CloudLiveDedicatedApprovalBinding | null = null;
   let latestActivationQuoteBinding: CloudLiveDedicatedApprovalBinding | null =
@@ -1415,6 +1494,39 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
           });
         } else counters.uninspectableBody += 1;
       }
+      if (dedicatedAdoptionRequest(method, rawUrl) === "quote") {
+        if (status >= 200 && status < 300) {
+          successfulDedicatedAdoptionQuoteGetResponseCount += 1;
+        } else if (status >= 400 && status < 500) {
+          clientErrorDedicatedAdoptionQuoteGetResponseCount += 1;
+        } else if (status >= 500 && status < 600) {
+          serverErrorDedicatedAdoptionQuoteGetResponseCount += 1;
+        } else {
+          otherDedicatedAdoptionQuoteGetResponseCount += 1;
+        }
+        if (responseBody) {
+          trackResponseHandler(async () => {
+            const inspection = await inspectDedicatedAdoptionQuoteResponse(
+              status,
+              responseBody,
+            );
+            if (!inspection.bodyCompleted) {
+              uninspectableDedicatedAdoptionQuoteResponseBodyCount += 1;
+              return;
+            }
+            completedDedicatedAdoptionQuoteResponseBodyCount += 1;
+            if (!inspection.parsed) return;
+            parsedDedicatedAdoptionQuoteResponseBodyCount += 1;
+            if (inspection.disposition === "adoptable") {
+              decodedAdoptableDedicatedAdoptionQuoteCount += 1;
+            } else if (inspection.disposition === "unavailable") {
+              decodedUnavailableDedicatedAdoptionQuoteCount += 1;
+            }
+          });
+        } else {
+          uninspectableDedicatedAdoptionQuoteResponseBodyCount += 1;
+        }
+      }
     },
     observeRequestFailure(method, rawUrl, errorText = "") {
       if (isPersonalIdentityGet(method, rawUrl)) {
@@ -1422,6 +1534,9 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
       }
       const dedicatedRequest = dedicatedControlPlaneRequest(method, rawUrl);
       if (dedicatedRequest) dedicatedControlPlane[dedicatedRequest].failed += 1;
+      if (dedicatedAdoptionRequest(method, rawUrl) === "quote") {
+        failedDedicatedAdoptionQuoteGetRequestCount += 1;
+      }
       if (!isHistoryGet(method, rawUrl)) return;
       failedHistoryGetRequestCount += 1;
       if (/tim(?:e|ed)[ _-]?out/i.test(errorText)) {
@@ -1623,6 +1738,25 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
         uninspectableDedicatedCutoverResponseBodyCount:
           dedicatedControlPlane.cutover.uninspectableBody,
         dedicatedAdoptionQuoteGetRequestCount,
+        successfulDedicatedAdoptionQuoteGetResponseCount,
+        clientErrorDedicatedAdoptionQuoteGetResponseCount,
+        serverErrorDedicatedAdoptionQuoteGetResponseCount,
+        otherDedicatedAdoptionQuoteGetResponseCount,
+        failedDedicatedAdoptionQuoteGetRequestCount,
+        pendingDedicatedAdoptionQuoteGetRequestCount: Math.max(
+          0,
+          dedicatedAdoptionQuoteGetRequestCount -
+            successfulDedicatedAdoptionQuoteGetResponseCount -
+            clientErrorDedicatedAdoptionQuoteGetResponseCount -
+            serverErrorDedicatedAdoptionQuoteGetResponseCount -
+            otherDedicatedAdoptionQuoteGetResponseCount -
+            failedDedicatedAdoptionQuoteGetRequestCount,
+        ),
+        completedDedicatedAdoptionQuoteResponseBodyCount,
+        parsedDedicatedAdoptionQuoteResponseBodyCount,
+        decodedAdoptableDedicatedAdoptionQuoteCount,
+        decodedUnavailableDedicatedAdoptionQuoteCount,
+        uninspectableDedicatedAdoptionQuoteResponseBodyCount,
         dedicatedAdoptionConfirmationPostRequestCount,
         dedicatedApprovalBindingPresent: dedicatedApprovalBinding !== null,
         dedicatedLifecycleBindingMismatchCount,

--- a/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.test.ts
@@ -50,6 +50,17 @@ const ZERO_DEDICATED_CONTROL_PLANE_COUNTERS = {
   decodedDedicatedCutoverFinalResponseCount: 0,
   uninspectableDedicatedCutoverResponseBodyCount: 0,
   dedicatedAdoptionQuoteGetRequestCount: 0,
+  successfulDedicatedAdoptionQuoteGetResponseCount: 0,
+  clientErrorDedicatedAdoptionQuoteGetResponseCount: 0,
+  serverErrorDedicatedAdoptionQuoteGetResponseCount: 0,
+  otherDedicatedAdoptionQuoteGetResponseCount: 0,
+  failedDedicatedAdoptionQuoteGetRequestCount: 0,
+  pendingDedicatedAdoptionQuoteGetRequestCount: 0,
+  completedDedicatedAdoptionQuoteResponseBodyCount: 0,
+  parsedDedicatedAdoptionQuoteResponseBodyCount: 0,
+  decodedAdoptableDedicatedAdoptionQuoteCount: 0,
+  decodedUnavailableDedicatedAdoptionQuoteCount: 0,
+  uninspectableDedicatedAdoptionQuoteResponseBodyCount: 0,
   dedicatedAdoptionConfirmationPostRequestCount: 0,
 } as const;
 

--- a/packages/app/test/cloud-live-trajectory-diagnostic.ts
+++ b/packages/app/test/cloud-live-trajectory-diagnostic.ts
@@ -92,6 +92,17 @@ export interface CloudLivePreIdentityDiagnostic {
   decodedDedicatedCutoverFinalResponseCount: number;
   uninspectableDedicatedCutoverResponseBodyCount: number;
   dedicatedAdoptionQuoteGetRequestCount: number;
+  successfulDedicatedAdoptionQuoteGetResponseCount: number;
+  clientErrorDedicatedAdoptionQuoteGetResponseCount: number;
+  serverErrorDedicatedAdoptionQuoteGetResponseCount: number;
+  otherDedicatedAdoptionQuoteGetResponseCount: number;
+  failedDedicatedAdoptionQuoteGetRequestCount: number;
+  pendingDedicatedAdoptionQuoteGetRequestCount: number;
+  completedDedicatedAdoptionQuoteResponseBodyCount: number;
+  parsedDedicatedAdoptionQuoteResponseBodyCount: number;
+  decodedAdoptableDedicatedAdoptionQuoteCount: number;
+  decodedUnavailableDedicatedAdoptionQuoteCount: number;
+  uninspectableDedicatedAdoptionQuoteResponseBodyCount: number;
   dedicatedAdoptionConfirmationPostRequestCount: number;
 }
 
@@ -152,6 +163,17 @@ const CLOUD_LIVE_PRE_IDENTITY_DIAGNOSTIC_KEYS = [
   "decodedDedicatedCutoverFinalResponseCount",
   "uninspectableDedicatedCutoverResponseBodyCount",
   "dedicatedAdoptionQuoteGetRequestCount",
+  "successfulDedicatedAdoptionQuoteGetResponseCount",
+  "clientErrorDedicatedAdoptionQuoteGetResponseCount",
+  "serverErrorDedicatedAdoptionQuoteGetResponseCount",
+  "otherDedicatedAdoptionQuoteGetResponseCount",
+  "failedDedicatedAdoptionQuoteGetRequestCount",
+  "pendingDedicatedAdoptionQuoteGetRequestCount",
+  "completedDedicatedAdoptionQuoteResponseBodyCount",
+  "parsedDedicatedAdoptionQuoteResponseBodyCount",
+  "decodedAdoptableDedicatedAdoptionQuoteCount",
+  "decodedUnavailableDedicatedAdoptionQuoteCount",
+  "uninspectableDedicatedAdoptionQuoteResponseBodyCount",
   "dedicatedAdoptionConfirmationPostRequestCount",
 ] as const satisfies readonly (keyof CloudLivePreIdentityDiagnostic)[];
 

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -868,6 +868,28 @@ test.describe("real cloud login + personal identity + chat", () => {
             audit.uninspectableDedicatedCutoverResponseBodyCount,
           dedicatedAdoptionQuoteGetRequestCount:
             audit.dedicatedAdoptionQuoteGetRequestCount,
+          successfulDedicatedAdoptionQuoteGetResponseCount:
+            audit.successfulDedicatedAdoptionQuoteGetResponseCount,
+          clientErrorDedicatedAdoptionQuoteGetResponseCount:
+            audit.clientErrorDedicatedAdoptionQuoteGetResponseCount,
+          serverErrorDedicatedAdoptionQuoteGetResponseCount:
+            audit.serverErrorDedicatedAdoptionQuoteGetResponseCount,
+          otherDedicatedAdoptionQuoteGetResponseCount:
+            audit.otherDedicatedAdoptionQuoteGetResponseCount,
+          failedDedicatedAdoptionQuoteGetRequestCount:
+            audit.failedDedicatedAdoptionQuoteGetRequestCount,
+          pendingDedicatedAdoptionQuoteGetRequestCount:
+            audit.pendingDedicatedAdoptionQuoteGetRequestCount,
+          completedDedicatedAdoptionQuoteResponseBodyCount:
+            audit.completedDedicatedAdoptionQuoteResponseBodyCount,
+          parsedDedicatedAdoptionQuoteResponseBodyCount:
+            audit.parsedDedicatedAdoptionQuoteResponseBodyCount,
+          decodedAdoptableDedicatedAdoptionQuoteCount:
+            audit.decodedAdoptableDedicatedAdoptionQuoteCount,
+          decodedUnavailableDedicatedAdoptionQuoteCount:
+            audit.decodedUnavailableDedicatedAdoptionQuoteCount,
+          uninspectableDedicatedAdoptionQuoteResponseBodyCount:
+            audit.uninspectableDedicatedAdoptionQuoteResponseBodyCount,
           dedicatedAdoptionConfirmationPostRequestCount:
             audit.dedicatedAdoptionConfirmationPostRequestCount,
           ...dedicatedConsentGate.snapshot(),


### PR DESCRIPTION
## Summary

- classify the deployed renderer adoption-quote response without retaining response bodies, identifiers, or catalog details
- distinguish successful adoptable quotes, explicit unavailable quotes, client/server/other responses, failed requests, pending requests, completed bodies, and uninspectable bodies
- exercise the privacy-safe classifier across adoptable, unavailable, 5xx, redirect, failed, and pending outcomes

Relates to #29339.

## Concrete regression guarded

The signed-in staging renderer can issue the Dedicated adoption quote GET after activation returns `dedicated_adoption_selection_required`, then dead-end until timeout. Existing diagnostics counted only the request, so a backend response failure, an unavailable quote, and a valid adoptable quote that the UI failed to render were observationally identical. The deployed renderer certification is the affected consumer; higher-level coverage did not own the response-disposition contract.

## Exact staging evidence

Full staging run: https://github.com/elizaOS/eliza/actions/runs/33283798487

Exact deployed SHA: `b3d3e890b0e0f4f58f904bce5d56d9bfccfa49f6`

The infrastructure lanes were green. The renderer reached:

- personal identity: shared
- Dedicated activation POST: 409 / `dedicated_adoption_selection_required`
- adoption quote GET requests: 1
- adoption confirmation POSTs: 0
- confirmation offers/clicks: 0
- cutover: 0

This change makes the next exact staging run identify the terminal adoption quote boundary without exposing response data.

## Verification

Exact branch SHA: `e9bfea4e15ab0535020e637289f459288af11f6a`

- `bunx vitest run --config vitest.config.ts test/cloud-live-continuity-contract.test.ts test/cloud-live-trajectory-diagnostic.test.ts` — 2 files, 50 tests passed
- `bunx biome check` on the five touched app test/diagnostic files — passed
- `bun run verify` — passed; 375/375 workspace tasks successful and 11,244 test files clean of focused/orphaned skips

## Evidence applicability

- screenshots/mobile captures/MP4: N/A; diagnostic-only test harness change with no rendered UI output
- live-model trajectory: N/A; no prompt or model behavior changed
- native/device evidence: N/A
- database or billing mutation: none
