### PR TITLE
fix(ci): align provisioning clean contract

### DIFF
--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -154,7 +154,7 @@ describe("provisioning worker deployment contract", () => {
     );
     const clean = workflow.indexOf("git clean -ffdx -q", verify);
     const cleanVerdict = workflow.indexOf(
-      '[ -z "$(git status --porcelain)" ] || {',
+      '[ -z "$(git status --porcelain --ignore-submodules=all)" ] || {',
       verify,
     );
     expect(reset).toBeGreaterThan(exactSourceCheck);


### PR DESCRIPTION
Fixes #30025.

The exact-SHA deployment workflow intentionally ignores submodule dirt when verifying its clean superproject checkout, but its contract test still searched for the pre-change command. This aligns the assertion with the actual fail-closed workflow without weakening reset/clean/order checks.

Verification:
- `bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts` (25 pass)