### PR TITLE
fix(core): normalize Windows platform contracts

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/currentTime.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/currentTime.test.ts
@@ -109,7 +109,7 @@ describe("currentTimeProvider", () => {
 				userTimeZone: null,
 				timeZoneOrigin: "agent-setting",
 			});
-			if (String(invalid).length > 0) {
+			if (typeof invalid === "string" && invalid.length > 0) {
 				expect(result.text).not.toContain(String(invalid));
 			}
 		},

--- a/packages/core/src/features/plugin-manager/utils/paths.test.ts
+++ b/packages/core/src/features/plugin-manager/utils/paths.test.ts
@@ -1,3 +1,6 @@
+/** Tests config-path overrides against host-native absolute and home paths. */
+
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveConfigPath } from "./paths.ts";
@@ -21,12 +24,10 @@ describe("resolveConfigPath", () => {
 	});
 
 	it("resolves an absolute override verbatim", () => {
-		expect(
-			resolveConfigPath(
-				{ ELIZA_CONFIG_PATH: "/etc/eliza/custom.json" },
-				stateDir,
-			),
-		).toBe("/etc/eliza/custom.json");
+		const absolute = path.resolve(path.sep, "etc", "eliza", "custom.json");
+		expect(resolveConfigPath({ ELIZA_CONFIG_PATH: absolute }, stateDir)).toBe(
+			absolute,
+		);
 	});
 
 	it("expands a tilde override to the home directory", () => {
@@ -35,7 +36,7 @@ describe("resolveConfigPath", () => {
 			stateDir,
 		);
 		expect(path.isAbsolute(out)).toBe(true);
-		expect(out).toBe(path.join(process.env.HOME ?? "/root", "eliza.json"));
+		expect(out).toBe(path.join(os.homedir(), "eliza.json"));
 	});
 
 	it("resolves a relative override against cwd", () => {

--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -47,7 +47,7 @@ async function productionRegistrationSites(): Promise<
 			)?.length;
 			if (registrations) {
 				found.push({
-					site: path.relative(pluginsRoot, file),
+					site: path.relative(pluginsRoot, file).replaceAll(path.sep, "/"),
 					registrations,
 				});
 			}
@@ -71,10 +71,12 @@ describe("first-party interaction capability matrix", () => {
 	});
 
 	it("matches the committed reviewer-readable golden artifact", async () => {
-		const golden = await fs.readFile(
-			path.join(import.meta.dirname, "CAPABILITY_MATRIX.md"),
-			"utf8",
-		);
+		const golden = (
+			await fs.readFile(
+				path.join(import.meta.dirname, "CAPABILITY_MATRIX.md"),
+				"utf8",
+			)
+		).replaceAll("\r\n", "\n");
 		expect(`${renderFirstPartyInteractionCapabilityMatrix()}\n`).toBe(golden);
 	});
 });

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -53,6 +53,7 @@ function normalizeOptions(
 }
 
 let tmpSequenceCounter = 0n;
+const asyncWriteTails = new Map<string, Promise<void>>();
 
 function tmpPathFor(filePath: string): string {
 	tmpSequenceCounter += 1n;
@@ -70,42 +71,65 @@ function assertFilePath(filePath: string): void {
 	}
 }
 
+async function serializeAsyncWrite<T>(
+	filePath: string,
+	write: () => Promise<T>,
+): Promise<T> {
+	const target = path.resolve(filePath);
+	const previous = asyncWriteTails.get(target) ?? Promise.resolve();
+	const pending = previous.then(write);
+	// error-policy:J5 The returned pending promise reports the write failure to
+	// its caller; the non-rejecting tail only keeps later same-target writes live.
+	const tail = pending.then(
+		() => undefined,
+		() => undefined,
+	);
+	asyncWriteTails.set(target, tail);
+	try {
+		return await pending;
+	} finally {
+		if (asyncWriteTails.get(target) === tail) asyncWriteTails.delete(target);
+	}
+}
+
 export async function writeJsonAtomic(
 	filePath: string,
 	value: unknown,
 	opts?: WriteJsonAtomicOptions,
 ): Promise<void> {
 	assertFilePath(filePath);
-	const o = normalizeOptions(opts);
-	if (!o.skipMkdir) {
-		await fsp.mkdir(path.dirname(filePath), {
-			recursive: true,
-			mode: o.dirMode,
-		});
-	}
-	const tmp = tmpPathFor(filePath);
-	try {
-		await fsp.writeFile(tmp, serialize(value, o), {
-			encoding: "utf-8",
-			mode: o.mode,
-			flag: "wx",
-		});
-		await fsp.rename(tmp, filePath);
-	} finally {
-		try {
-			await fsp.rm(tmp, { force: true });
-		} catch (error) {
-			// error-policy:J6 best-effort teardown — a stranded temporary file is
-			// observable but must not mask the original write/rename failure.
-			logger.warn(
-				{
-					file: tmp,
-					error: error instanceof Error ? error.message : String(error),
-				},
-				"[AtomicJson] Failed to remove temporary file",
-			);
+	await serializeAsyncWrite(filePath, async () => {
+		const o = normalizeOptions(opts);
+		if (!o.skipMkdir) {
+			await fsp.mkdir(path.dirname(filePath), {
+				recursive: true,
+				mode: o.dirMode,
+			});
 		}
-	}
+		const tmp = tmpPathFor(filePath);
+		try {
+			await fsp.writeFile(tmp, serialize(value, o), {
+				encoding: "utf-8",
+				mode: o.mode,
+				flag: "wx",
+			});
+			await fsp.rename(tmp, filePath);
+		} finally {
+			try {
+				await fsp.rm(tmp, { force: true });
+			} catch (error) {
+				// error-policy:J6 best-effort teardown — a stranded temporary file is
+				// observable but must not mask the original write/rename failure.
+				logger.warn(
+					{
+						file: tmp,
+						error: error instanceof Error ? error.message : String(error),
+					},
+					"[AtomicJson] Failed to remove temporary file",
+				);
+			}
+		}
+	});
 }
 
 export function writeJsonAtomicSync(


### PR DESCRIPTION
## Summary

- serialize same-target async atomic JSON replacements so Windows does not race `rename` calls into `EPERM`
- normalize host path separators and CRLF in platform-sensitive core tests
- make time-provider invalid-input assertions distinguish numeric values from rendered timestamps
- resolve config overrides against the host-native absolute path and `os.homedir()`

Fixes #30009

## Verification

- focused Windows failure set: 4 files, 26 tests passed
- `bun run --cwd packages/core typecheck`
- Biome check on all changed files
- full core run: 902 files / 11,353 tests passed; four unrelated fixed-budget timeouts under a 68-minute overloaded run
- isolated rerun of those timeout files: 3 files, 33 tests passed in 19.6 seconds
- `git diff --check`