### PR TITLE
fix(imessage): add Blooio transport and durable CLI auth handoff

### DIFF
--- a/packages/app/test/ui-smoke/cli-auth-completion.spec.ts
+++ b/packages/app/test/ui-smoke/cli-auth-completion.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Real-browser coverage for CLI authentication completion across ordinary tabs,
+ * orphaned login tabs, and named popup handoffs. The renderer and router are
+ * exact-head local bytes; Steward authentication and the completion endpoint
+ * use the repository's documented browser-test seams.
+ */
+
+import { type BrowserContext, expect, type Page, test } from "@playwright/test";
+import { seedStewardSession } from "./helpers/test-auth";
+
+const PROVIDERS = {
+  passkey: false,
+  email: true,
+  sms: false,
+  siwe: false,
+  siws: false,
+  google: false,
+  discord: false,
+  github: false,
+  twitter: false,
+  oauth: [],
+};
+
+const TEST_AUTH_ENABLED =
+  process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
+  process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
+
+async function installManagedOriginProxy(
+  context: BrowserContext,
+  localBaseUrl: string,
+  onComplete: (sessionId: string) => void,
+): Promise<string> {
+  const local = new URL(localBaseUrl);
+  const managed = new URL(localBaseUrl);
+  managed.hostname = "cloud.eliza.app";
+
+  await context.route(`${managed.origin}/**`, async (route) => {
+    const target = new URL(route.request().url());
+    target.protocol = local.protocol;
+    target.hostname = local.hostname;
+    target.port = local.port;
+    const response = await route.fetch({ url: target.toString() });
+    await route.fulfill({ response });
+  });
+  await context.route("**/auth/providers", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PROVIDERS),
+    });
+  });
+  await context.route("**/api/auth/cli-session/*/complete", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const sessionId = path.split("/").at(-2);
+    if (!sessionId) throw new Error(`Missing CLI session id in ${path}`);
+    onComplete(sessionId);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ keyPrefix: "ek_test_browser" }),
+    });
+  });
+
+  return managed.origin;
+}
+
+async function armAuthenticatedCloudPage(
+  page: Page,
+  managedOrigin: string,
+): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: "eliza-test-auth",
+      value: "1",
+      domain: "cloud.eliza.app",
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+  await seedStewardSession(page, {
+    jwt: true,
+    userId: "22222222-2222-4222-8222-222222222222",
+    email: "cli-auth-browser@test.local",
+  });
+  await page.goto(`${managedOrigin}/terms-of-service`);
+}
+
+test.describe("CLI auth completion handoff", () => {
+  test.skip(
+    !TEST_AUTH_ENABLED,
+    "requires VITE_PLAYWRIGHT_TEST_AUTH=true in the renderer build",
+  );
+
+  test("ordinary success replays into an orphaned login tab", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("Playwright baseURL is required");
+    const completed: string[] = [];
+    const managedOrigin = await installManagedOriginProxy(
+      page.context(),
+      baseURL,
+      (sessionId) => completed.push(sessionId),
+    );
+    await armAuthenticatedCloudPage(page, managedOrigin);
+
+    await page.goto(`${managedOrigin}/auth/cli-login?session=sess-browser-tab`);
+    await expect(
+      page.getByRole("heading", { name: "Authorize CLI Sign-In?" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Authorize" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Authentication Complete!" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Return to App" }),
+    ).toHaveAttribute("href", "/");
+    await expect(
+      page.getByRole("button", { name: "Close window" }),
+    ).toHaveCount(0);
+    expect(completed).toEqual(["sess-browser-tab"]);
+
+    const orphan = await page.context().newPage();
+    const returnTo = encodeURIComponent(
+      `/auth/cli-login?session=sess-browser-tab`,
+    );
+    await orphan.goto(`${managedOrigin}/login?returnTo=${returnTo}`);
+    await expect(
+      orphan.getByRole("heading", { name: "You're signed in" }),
+    ).toBeVisible();
+    await expect(
+      orphan.getByRole("link", { name: "Return to App" }),
+    ).toHaveAttribute("href", "/");
+    await expect(
+      orphan.getByRole("button", { name: "Close window" }),
+    ).toHaveCount(0);
+    expect(completed).toEqual(["sess-browser-tab"]);
+  });
+
+  test("named popup completes once, closes, and leaves replayable terminal state", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("Playwright baseURL is required");
+    const completed: string[] = [];
+    const managedOrigin = await installManagedOriginProxy(
+      page.context(),
+      baseURL,
+      (sessionId) => completed.push(sessionId),
+    );
+    await armAuthenticatedCloudPage(page, managedOrigin);
+
+    const popupPromise = page.waitForEvent("popup");
+    await page.evaluate((url) => {
+      window.open(url, "eliza-cloud-auth", "popup,width=520,height=720");
+    }, `${managedOrigin}/auth/cli-login?session=sess-browser-popup`);
+    const popup = await popupPromise;
+    await expect(
+      popup.getByRole("heading", { name: "Authorize CLI Sign-In?" }),
+    ).toBeVisible();
+    await popup.getByRole("button", { name: "Authorize" }).click();
+    await popup.waitForEvent("close");
+    expect(completed).toEqual(["sess-browser-popup"]);
+
+    const replay = await page.context().newPage();
+    await replay.goto(
+      `${managedOrigin}/auth/cli-login?session=sess-browser-popup`,
+    );
+    await expect(
+      replay.getByRole("heading", { name: "Authentication Complete!" }),
+    ).toBeVisible();
+    await expect(
+      replay.getByRole("link", { name: "Return to App" }),
+    ).toHaveAttribute("href", "/");
+    expect(completed).toEqual(["sess-browser-popup"]);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -205,6 +205,7 @@ import {
   clearCloudAuthFirstScreenGreeting,
   markCloudAuthFirstScreenGreeting,
 } from "./state/cloud-auth-first-screen";
+import { cloudAuthFirstScreenOwnsHost } from "./state/cloud-auth-first-screen-policy";
 import { hasUsableStoredStewardToken } from "./state/cloud-steward-login";
 import { isAuthoritativeFirstRunOpen } from "./state/first-run-chat-release";
 import {
@@ -3258,9 +3259,15 @@ function AppContent() {
     !isPopout &&
     !isAuxiliaryAppWindow &&
     !cloudPairToken &&
-    (branding.cloudOnly === true ||
-      (isAndroidCloudBuild() && branding.cloudOnly !== false) ||
-      isElizaCloudRuntimeLocked());
+    (cloudAuthFirstScreenOwnsHost({
+      cloudOnlyBranding: branding.cloudOnly === true,
+      isAgentlessCloudOrigin,
+      isNative,
+      isDesktopShell: isElectrobunRuntime(),
+    }) ||
+      (isNative &&
+        ((isAndroidCloudBuild() && branding.cloudOnly !== false) ||
+          isElizaCloudRuntimeLocked())));
   const hasUsableCloudSession =
     elizaCloudConnected ||
     hasUsableStoredStewardToken() ||

--- a/packages/ui/src/api/csrf-client.test.ts
+++ b/packages/ui/src/api/csrf-client.test.ts
@@ -7,6 +7,7 @@
  */
 import { setBootConfig as setSharedBootConfig } from "@elizaos/shared/config/boot-config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearElizaApiToken, setElizaApiToken } from "../utils/eliza-globals";
 
 const bootConfigMock = vi.hoisted(() => ({
   getBootConfig: vi.fn(),
@@ -97,6 +98,7 @@ describe("fetchWithCsrf", () => {
     clearCookie("eliza_csrf");
     clearCookie("other");
     setSharedBootConfig({ branding: {} });
+    clearElizaApiToken();
     vi.clearAllMocks();
   });
 
@@ -165,6 +167,16 @@ describe("fetchWithCsrf", () => {
     expect(
       localAgentTokenMock.hydrateAndroidLocalAgentTokenForUrl,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches the paired runtime bearer when boot config has no token", async () => {
+    setElizaApiToken("  paired-runtime-token  ");
+
+    await fetchWithCsrf("/api/apps/favorites");
+
+    const headers = fetchTransportMock.fetchAgentTransport.request.mock
+      .calls[0]?.[1].headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer paired-runtime-token");
   });
 
   it("routes external desktop HTTP auth requests through the desktop transport", async () => {

--- a/packages/ui/src/api/csrf-client.ts
+++ b/packages/ui/src/api/csrf-client.ts
@@ -17,6 +17,7 @@ import { getBootConfig } from "../config/boot-config";
 import { hydrateAndroidLocalAgentTokenForUrl } from "../first-run/local-agent-token";
 import { resolveApiUrl } from "../utils/asset-url";
 import { isDedicatedCloudAgentBase } from "../utils/cloud-agent-base";
+import { getElizaApiToken } from "../utils/eliza-globals";
 import { androidNativeAgentTransportForUrl } from "./android-native-agent-transport";
 import { readCsrfTokenForUrl } from "./auth/csrf-cookie";
 import { CSRF_HEADER_NAME } from "./auth/sessions";
@@ -36,6 +37,7 @@ export async function fetchWithCsrf(
   init: RequestInit = {},
   context: AgentRequestContext = {},
 ): Promise<Response> {
+  init.signal?.throwIfAborted();
   // Resolve relative API paths against the configured API base. On Capacitor
   // remote mode the page origin is the bundle's asset server, which answers
   // ANY path with index.html and HTTP 200 — a relative "/api/..." fetch
@@ -58,7 +60,9 @@ export async function fetchWithCsrf(
 
   if (!headers.has("Authorization")) {
     await hydrateAndroidLocalAgentTokenForUrl(url);
-    const apiToken = getBootConfig().apiToken?.trim();
+    init.signal?.throwIfAborted();
+    const apiToken =
+      getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim();
     if (apiToken) {
       headers.set("Authorization", `Bearer ${apiToken}`);
     }

--- a/packages/ui/src/auth-status.ts
+++ b/packages/ui/src/auth-status.ts
@@ -4,6 +4,7 @@
  */
 export {
   type AuthStatusState,
+  getAuthStatusSnapshot,
   isAuthenticatedNow,
   subscribeAuthStatus,
 } from "./hooks/useAuthStatus";

--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.test.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  hasCloudAuthCompleted,
   isCloudAuthCompleteMessage,
   isCloudAuthHandoffSurface,
   publishCloudAuthComplete,
@@ -15,6 +16,7 @@ let originalOpener: PropertyDescriptor | undefined;
 beforeEach(() => {
   originalName = window.name;
   originalOpener = Object.getOwnPropertyDescriptor(window, "opener");
+  window.localStorage.clear();
 });
 
 afterEach(() => {
@@ -81,6 +83,12 @@ describe("publish / subscribe", () => {
   it("publish and subscribe are safe no-ops or callable without throw", () => {
     const unsub = subscribeCloudAuthComplete(() => {});
     expect(() => publishCloudAuthComplete("sess-bc")).not.toThrow();
+    expect(hasCloudAuthCompleted("sess-bc")).toBe(true);
     expect(() => unsub()).not.toThrow();
+  });
+
+  it("does not replay a different session", () => {
+    publishCloudAuthComplete("sess-one");
+    expect(hasCloudAuthCompleted("sess-two")).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.test.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.test.ts
@@ -91,4 +91,17 @@ describe("publish / subscribe", () => {
     publishCloudAuthComplete("sess-one");
     expect(hasCloudAuthCompleted("sess-two")).toBe(false);
   });
+
+  it("removes a completion marker dated in the future", () => {
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    window.localStorage.setItem(
+      "eliza-cloud-auth-complete:sess-future",
+      String(now + 1),
+    );
+    expect(hasCloudAuthCompleted("sess-future")).toBe(false);
+    expect(
+      window.localStorage.getItem("eliza-cloud-auth-complete:sess-future"),
+    ).toBeNull();
+  });
 });

--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
@@ -16,6 +16,8 @@
 export const CLOUD_AUTH_COMPLETE_MESSAGE_TYPE = "eliza-cloud-auth-complete";
 
 export const CLOUD_AUTH_COMPLETE_CHANNEL = "eliza-cloud-auth-complete";
+const CLOUD_AUTH_COMPLETE_STORAGE_PREFIX = "eliza-cloud-auth-complete:";
+const CLOUD_AUTH_COMPLETE_TTL_MS = 10 * 60 * 1000;
 
 export type CloudAuthCompleteMessage = {
   type: typeof CLOUD_AUTH_COMPLETE_MESSAGE_TYPE;
@@ -44,6 +46,15 @@ export function publishCloudAuthComplete(sessionId: string): void {
     sessionId: trimmed,
   };
   try {
+    window.localStorage.setItem(
+      `${CLOUD_AUTH_COMPLETE_STORAGE_PREFIX}${trimmed}`,
+      String(Date.now()),
+    );
+  } catch (error) {
+    void error;
+    // error-policy:J6 durable cross-tab replay is best-effort; live signaling remains available.
+  }
+  try {
     if (typeof BroadcastChannel === "undefined") return;
     const channel = new BroadcastChannel(CLOUD_AUTH_COMPLETE_CHANNEL);
     channel.postMessage(payload);
@@ -51,6 +62,28 @@ export function publishCloudAuthComplete(sessionId: string): void {
   } catch (error) {
     void error;
     // error-policy:J6 broadcast is best-effort; opener poll still completes login.
+  }
+}
+
+/** True when this browser recently completed the exact CLI session. */
+export function hasCloudAuthCompleted(sessionId: string): boolean {
+  const trimmed = sessionId.trim();
+  if (!trimmed || typeof window === "undefined") return false;
+  const key = `${CLOUD_AUTH_COMPLETE_STORAGE_PREFIX}${trimmed}`;
+  try {
+    const completedAt = Number(window.localStorage.getItem(key));
+    if (
+      !Number.isFinite(completedAt) ||
+      Date.now() - completedAt > CLOUD_AUTH_COMPLETE_TTL_MS
+    ) {
+      window.localStorage.removeItem(key);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    void error;
+    // error-policy:J4 storage-denied browsers retain the live BroadcastChannel path.
+    return false;
   }
 }
 

--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
@@ -74,6 +74,7 @@ export function hasCloudAuthCompleted(sessionId: string): boolean {
     const completedAt = Number(window.localStorage.getItem(key));
     if (
       !Number.isFinite(completedAt) ||
+      completedAt > Date.now() ||
       Date.now() - completedAt > CLOUD_AUTH_COMPLETE_TTL_MS
     ) {
       window.localStorage.removeItem(key);

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -133,6 +133,7 @@ beforeEach(() => {
   searchParamsRef.current = new URLSearchParams("session=sess-1");
   resetSessionAuth();
   testSessionStorage.clear();
+  localStorage.clear();
   currentDocumentReferrer = "";
   vi.spyOn(document, "referrer", "get").mockImplementation(
     () => currentDocumentReferrer,
@@ -329,14 +330,11 @@ describe("CliLoginPage", () => {
     rerender(<CliLoginPage />);
     await waitFor(() =>
       expect(
-        screen.getByRole("heading", { name: "Authorize CLI Sign-In?" }),
+        screen.getByRole("heading", { name: "Authentication Complete!" }),
       ).toBeTruthy(),
     );
     await Promise.resolve();
     expect(apiFetchMock).toHaveBeenCalledTimes(1);
-
-    await user.click(screen.getByRole("button", { name: "Authorize" }));
-    await waitFor(() => expect(apiFetchMock).toHaveBeenCalledTimes(2));
   });
 
   it("Cancel abandons the flow with no POST and a distinct cancelled state", async () => {
@@ -378,10 +376,12 @@ describe("CliLoginPage", () => {
     );
     expect(apiFetchMock).toHaveBeenCalledTimes(1);
     expect(postMessage).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "Close window" })).toBeTruthy();
     expect(
-      screen.queryByRole("link", { name: "Continue to dashboard" }),
-    ).toBeNull();
+      screen
+        .getByRole("link", { name: "Return to Eliza" })
+        .getAttribute("href"),
+    ).toBe("/");
+    expect(screen.queryByRole("button", { name: "Close window" })).toBeNull();
     expect(screen.queryByText("API Key Details")).toBeNull();
     expect(screen.queryByText("ek_live_abc")).toBeNull();
     expect(navigateMock).not.toHaveBeenCalled();

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -377,9 +377,7 @@ describe("CliLoginPage", () => {
     expect(apiFetchMock).toHaveBeenCalledTimes(1);
     expect(postMessage).not.toHaveBeenCalled();
     expect(
-      screen
-        .getByRole("link", { name: "Return to Eliza" })
-        .getAttribute("href"),
+      screen.getByRole("link", { name: "Return to App" }).getAttribute("href"),
     ).toBe("/");
     expect(screen.queryByRole("button", { name: "Close window" })).toBeNull();
     expect(screen.queryByText("API Key Details")).toBeNull();

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
 import {
+  hasCloudAuthCompleted,
   isCloudAuthHandoffSurface,
   publishCloudAuthComplete,
   subscribeCloudAuthComplete,
@@ -352,12 +353,18 @@ export default function CliLoginPage() {
   // self-echo double-close).
   useEffect(() => {
     if (!sessionId) return;
+    if (hasCloudAuthCompleted(sessionId)) {
+      completionFiredRef.current = true;
+      setCompletion({ status: "success", apiKeyPrefix: "" });
+      if (isCloudAuthHandoffSurface()) tryCloseAuthWindow();
+      return;
+    }
     return subscribeCloudAuthComplete((message) => {
       if (message.sessionId !== sessionId) return;
       if (completionFiredRef.current) return;
       completionFiredRef.current = true;
       setCompletion({ status: "success", apiKeyPrefix: "" });
-      tryCloseAuthWindow();
+      if (isCloudAuthHandoffSurface()) tryCloseAuthWindow();
     });
   }, [sessionId]);
 
@@ -673,17 +680,31 @@ export default function CliLoginPage() {
   }
 
   if (pageState.status === "success") {
+    const canClose = isCloudAuthHandoffSurface();
     return (
       <CliLoginPanel
         actions={
-          <Button
-            className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
-            onClick={() => window.close()}
-          >
-            {t("cloud.cliLogin.closeWindow", {
-              defaultValue: "Close window",
-            })}
-          </Button>
+          canClose ? (
+            <Button
+              className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+              onClick={tryCloseAuthWindow}
+            >
+              {t("cloud.cliLogin.closeWindow", {
+                defaultValue: "Close window",
+              })}
+            </Button>
+          ) : (
+            <Button
+              asChild
+              className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+            >
+              <a href="/">
+                {t("cloud.cliLogin.returnToEliza", {
+                  defaultValue: "Return to Eliza",
+                })}
+              </a>
+            </Button>
+          )
         }
         description={t("cloud.cliLogin.successDescription", {
           defaultValue:

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -699,8 +699,8 @@ export default function CliLoginPage() {
               className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
             >
               <a href="/">
-                {t("cloud.cliLogin.returnToEliza", {
-                  defaultValue: "Return to Eliza",
+                {t("cloud.authSuccess.returnToAppCta", {
+                  defaultValue: "Return to App",
                 })}
               </a>
             </Button>

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -152,8 +152,8 @@ function PublicLoginPage(): React.JSX.Element {
               className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
             >
               <Link to="/">
-                {t("cloud.login.returnToEliza", {
-                  defaultValue: "Return to Eliza",
+                {t("cloud.authSuccess.returnToAppCta", {
+                  defaultValue: "Return to App",
                 })}
               </Link>
             </Button>

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -17,7 +17,11 @@ import { CheckCircle2 } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
-import { subscribeCloudAuthComplete } from "../../../auth/cloud-auth-complete-signal";
+import {
+  hasCloudAuthCompleted,
+  isCloudAuthHandoffSurface,
+  subscribeCloudAuthComplete,
+} from "../../../auth/cloud-auth-complete-signal";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import { usePageTitle } from "../../lib/use-page-title";
 import { LoginOptionsSkeleton } from "./login-section-skeleton";
@@ -104,18 +108,20 @@ function PublicLoginPage(): React.JSX.Element {
 
   useEffect(() => {
     if (!handoffSessionId) return;
+    if (hasCloudAuthCompleted(handoffSessionId)) {
+      setHandoffComplete(true);
+      if (isCloudAuthHandoffSurface()) window.close();
+      return;
+    }
     return subscribeCloudAuthComplete((message) => {
       if (message.sessionId !== handoffSessionId) return;
       setHandoffComplete(true);
-      try {
-        window.close();
-      } catch (error) {
-        void error;
-      }
+      if (isCloudAuthHandoffSurface()) window.close();
     });
   }, [handoffSessionId]);
 
   if (handoffComplete) {
+    const canClose = isCloudAuthHandoffSurface();
     return (
       <LoginBackground>
         <div className="space-y-6 text-center">
@@ -133,18 +139,25 @@ function PublicLoginPage(): React.JSX.Element {
               })}
             </p>
           </div>
-          <Button
-            className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
-            onClick={() => {
-              try {
-                window.close();
-              } catch (error) {
-                void error;
-              }
-            }}
-          >
-            {t("cloud.login.closeWindow", { defaultValue: "Close window" })}
-          </Button>
+          {canClose ? (
+            <Button
+              className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+              onClick={() => window.close()}
+            >
+              {t("cloud.login.closeWindow", { defaultValue: "Close window" })}
+            </Button>
+          ) : (
+            <Button
+              asChild
+              className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+            >
+              <Link to="/">
+                {t("cloud.login.returnToEliza", {
+                  defaultValue: "Return to Eliza",
+                })}
+              </Link>
+            </Button>
+          )}
         </div>
       </LoginBackground>
     );

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -22,6 +22,9 @@ const { authMock } = vi.hoisted(() => ({
 vi.mock("../../../hooks/useAuthStatus", () => ({
   useIsAuthenticated: () => authMock.authenticated,
 }));
+vi.mock("../../../hooks/useRole", () => ({
+  useRole: () => ({ isOwner: true }),
+}));
 
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -19,6 +19,7 @@ import {
   useIntervalWhenDocumentVisible,
 } from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useRole } from "../../../hooks/useRole";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -210,6 +211,7 @@ export function CalendarUpcomingWidget({
   // (the loading tile behind the sign-in overlay); the probe re-fires when the
   // phase flips because it participates in the callback deps below.
   const authenticated = useIsAuthenticated();
+  const { isOwner } = useRole();
 
   const probeConnection = useCallback(
     async (signal?: AbortSignal) => {
@@ -219,7 +221,7 @@ export function CalendarUpcomingWidget({
         setEvents([]);
         return false;
       }
-      if (!authenticated) return false;
+      if (!authenticated || !isOwner) return false;
 
       try {
         const res = await client.listConnectorAccounts(
@@ -247,7 +249,7 @@ export function CalendarUpcomingWidget({
         return false;
       }
     },
-    [authenticated],
+    [authenticated, isOwner],
   );
 
   const loadEvents = useCallback(async (signal?: AbortSignal) => {

--- a/packages/ui/src/components/chat/widgets/goals-attention-data.ts
+++ b/packages/ui/src/components/chat/widgets/goals-attention-data.ts
@@ -21,6 +21,7 @@
 
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
+import { fetchWithCsrf } from "../../../api/csrf-client";
 
 /** How often a home surface refreshes goals - matches GoalsView's 20s poll. */
 export const GOALS_REFRESH_INTERVAL_MS = 20_000;
@@ -101,10 +102,15 @@ export async function fetchGoals(
   callerSignal?: AbortSignal,
 ): Promise<AttentionGoal[]> {
   const deadline = AbortSignal.timeout(GOALS_REQUEST_TIMEOUT_MS);
-  const response = await fetch(`${client.getBaseUrl()}/api/lifeops/goals`, {
-    method: "GET",
-    signal: callerSignal ? AbortSignal.any([callerSignal, deadline]) : deadline,
-  });
+  const response = await fetchWithCsrf(
+    `${client.getBaseUrl()}/api/lifeops/goals`,
+    {
+      method: "GET",
+      signal: callerSignal
+        ? AbortSignal.any([callerSignal, deadline])
+        : deadline,
+    },
+  );
   if (!response.ok) {
     throw new Error(`Goals request failed (${response.status})`);
   }

--- a/packages/ui/src/components/chat/widgets/goals-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.test.tsx
@@ -18,6 +18,9 @@ const { authMock, intervalMock } = vi.hoisted(() => ({
 vi.mock("../../../hooks/useAuthStatus", () => ({
   useIsAuthenticated: () => authMock.authenticated,
 }));
+vi.mock("../../../hooks/useRole", () => ({
+  useRole: () => ({ isOwner: true }),
+}));
 
 vi.mock("../../../hooks", () => ({
   useIntervalWhenDocumentVisible: (callback: () => void) => {

--- a/packages/ui/src/components/chat/widgets/goals-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.tsx
@@ -13,6 +13,7 @@ import type { ComponentType } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useRole } from "../../../hooks/useRole";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -47,13 +48,14 @@ export function GoalsAttentionWidget({
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
   // the 20s goals poll must stay dormant until the session is authenticated.
   const authenticated = useIsAuthenticated();
+  const { isOwner } = useRole();
 
   const load = useCallback(
     (background = false) => {
       activeLoadRef.current?.abort();
       const controller = new AbortController();
       activeLoadRef.current = controller;
-      void loadGoalsForGlance(authenticated, controller.signal)
+      void loadGoalsForGlance(authenticated && isOwner, controller.signal)
         .then((next) => {
           if (controller.signal.aborted) return;
           if (next == null) {
@@ -68,7 +70,7 @@ export function GoalsAttentionWidget({
           }
         });
     },
-    [authenticated],
+    [authenticated, isOwner],
   );
 
   useEffect(() => {

--- a/packages/ui/src/components/chat/widgets/model-download.test.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.test.tsx
@@ -40,16 +40,23 @@ import type {
 // The widget reads routing, hub readiness, and retry through the typed client.
 // Routing + hub responses vary per test; the download spy proves retry owns the
 // assigned model rather than reconstructing one from display text.
-const { getBaseUrlMock, getModelsConfigMock, getHubMock, startDownloadMock } =
-  vi.hoisted(() => ({
-    getBaseUrlMock: vi.fn(() => "http://localhost:31337"),
-    getModelsConfigMock: vi.fn(),
-    getHubMock: vi.fn(),
-    startDownloadMock: vi.fn(),
-  }));
+const {
+  getBaseUrlMock,
+  getRestAuthTokenMock,
+  getModelsConfigMock,
+  getHubMock,
+  startDownloadMock,
+} = vi.hoisted(() => ({
+  getBaseUrlMock: vi.fn(() => "http://localhost:31337"),
+  getRestAuthTokenMock: vi.fn((): string | null => null),
+  getModelsConfigMock: vi.fn(),
+  getHubMock: vi.fn(),
+  startDownloadMock: vi.fn(),
+}));
 vi.mock("../../../api", () => ({
   client: {
     getBaseUrl: getBaseUrlMock,
+    getRestAuthToken: getRestAuthTokenMock,
     getModelsConfig: getModelsConfigMock,
     getLocalInferenceHub: getHubMock,
     startLocalInferenceDownload: startDownloadMock,
@@ -65,8 +72,11 @@ vi.mock("../../../chat/useSlashCommandController", () => ({
 // EventSource cannot open in jsdom; the widget already tolerates a null
 // EventSource (native-IPC fallback). Force the null path so the test drives off
 // the single initial hub fetch.
+const { openEventSourceMock } = vi.hoisted(() => ({
+  openEventSourceMock: vi.fn(() => null),
+}));
 vi.mock("../../../utils/event-source", () => ({
-  openEventSource: () => null,
+  openEventSource: openEventSourceMock,
 }));
 
 import { ModelDownloadWidget } from "./model-download";
@@ -144,6 +154,9 @@ describe("ModelDownloadWidget", () => {
     runtimeModeMock.refetch.mockClear();
     getBaseUrlMock.mockReset();
     getBaseUrlMock.mockReturnValue("http://localhost:31337");
+    getRestAuthTokenMock.mockReset();
+    getRestAuthTokenMock.mockReturnValue(null);
+    openEventSourceMock.mockClear();
     getModelsConfigMock.mockReset();
     getModelsConfigMock.mockResolvedValue({});
     getHubMock.mockReset();
@@ -369,6 +382,19 @@ describe("ModelDownloadWidget", () => {
     expect(
       container.querySelector('[data-testid="chat-widget-model-download"]'),
     ).toBeNull();
+  });
+
+  it("does not open an unauthenticated download stream for a paired bearer session", async () => {
+    getRestAuthTokenMock.mockReturnValue("paired-machine-session");
+    getHubMock.mockResolvedValue(
+      hub({ TEXT_LARGE: slot({ state: "downloading" }) }),
+    );
+
+    render(<ModelDownloadWidget />);
+
+    await screen.findByTestId("chat-widget-model-download");
+    expect(getHubMock).toHaveBeenCalled();
+    expect(openEventSourceMock).not.toHaveBeenCalled();
   });
 
   it("starts the hub fetch once the session flips to authenticated", async () => {

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -208,7 +208,13 @@ export function useLocalModelDownloads(): LocalModelDownloads {
     const url = appendTokenParam(
       resolveApiUrl("/api/local-inference/downloads/stream"),
     );
-    const es = openEventSource(url, { withCredentials: false });
+    // Paired/self-hosted sessions authenticate with a bearer token that
+    // EventSource cannot attach. Keep the authenticated one-shot hub fetch and
+    // skip the stream instead of leaking the session token through the URL or
+    // entering EventSource's unauthenticated reconnect loop.
+    const es = client.getRestAuthToken()
+      ? null
+      : openEventSource(url, { withCredentials: false });
     if (es) {
       es.onmessage = () => {
         if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);

--- a/packages/ui/src/components/chat/widgets/today-todos-data.test.ts
+++ b/packages/ui/src/components/chat/widgets/today-todos-data.test.ts
@@ -192,6 +192,7 @@ describe("fetchTodayTodos", () => {
     );
 
     const pending = fetchTodayTodos(caller.signal);
+    await vi.waitFor(() => expect(requestSignal).toBeDefined());
     caller.abort();
 
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });

--- a/packages/ui/src/components/chat/widgets/today-todos-data.ts
+++ b/packages/ui/src/components/chat/widgets/today-todos-data.ts
@@ -18,6 +18,7 @@
 
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
+import { fetchWithCsrf } from "../../../api/csrf-client";
 
 /** Home-card poll cadence — matches the TodosView 15s background refresh. */
 export const TODAY_TODOS_REFRESH_INTERVAL_MS = 15_000;
@@ -118,10 +119,15 @@ export async function fetchTodayTodos(
   callerSignal?: AbortSignal,
 ): Promise<TodayTodo[]> {
   const deadline = AbortSignal.timeout(TODAY_TODOS_REQUEST_TIMEOUT_MS);
-  const response = await fetch(`${client.getBaseUrl()}/api/lifeops/todos`, {
-    method: "GET",
-    signal: callerSignal ? AbortSignal.any([callerSignal, deadline]) : deadline,
-  });
+  const response = await fetchWithCsrf(
+    `${client.getBaseUrl()}/api/lifeops/todos`,
+    {
+      method: "GET",
+      signal: callerSignal
+        ? AbortSignal.any([callerSignal, deadline])
+        : deadline,
+    },
+  );
   if (!response.ok) {
     throw new Error(`Todos request failed (${response.status})`);
   }
@@ -134,7 +140,7 @@ export async function fetchTodayTodos(
  * caller roll the optimistic completion back.
  */
 export async function completeTodayTodo(id: string): Promise<void> {
-  const response = await fetch(
+  const response = await fetchWithCsrf(
     `${client.getBaseUrl()}/api/lifeops/occurrences/${encodeURIComponent(id)}/complete`,
     {
       method: "POST",

--- a/packages/ui/src/components/chat/widgets/todo.test.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.test.tsx
@@ -105,6 +105,9 @@ vi.mock("../../../hooks", () => ({
 vi.mock("../../../hooks/useAuthStatus", () => ({
   useIsAuthenticated: () => authMock.authenticated,
 }));
+vi.mock("../../../hooks/useRole", () => ({
+  useRole: () => ({ isOwner: true }),
+}));
 
 vi.mock("../../../state", () => ({
   useAppSelectorShallow: <T,>(selector: (state: typeof mockState) => T): T =>

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -24,6 +24,7 @@ import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities"
 import type { WorkbenchTodo } from "../../../api/client-types-config";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useRole } from "../../../hooks/useRole";
 import { useAppSelectorShallow } from "../../../state";
 import type { TranslateFn } from "../../../types";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
@@ -309,6 +310,7 @@ function WorkbenchTodoItems({
  */
 function useAtRiskGoal(): AttentionGoal | null {
   const authenticated = useIsAuthenticated();
+  const { isOwner } = useRole();
   const [goals, setGoals] = useState<AttentionGoal[] | null>(null);
   const activeLoadRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
@@ -325,7 +327,7 @@ function useAtRiskGoal(): AttentionGoal | null {
       activeLoadRef.current?.abort();
       const controller = new AbortController();
       activeLoadRef.current = controller;
-      void loadGoalsForGlance(authenticated, controller.signal)
+      void loadGoalsForGlance(authenticated && isOwner, controller.signal)
         .then((next) => {
           if (controller.signal.aborted || !mountedRef.current) return;
           if (next == null) {
@@ -340,7 +342,7 @@ function useAtRiskGoal(): AttentionGoal | null {
           }
         });
     },
-    [authenticated],
+    [authenticated, isOwner],
   );
 
   useEffect(() => {
@@ -371,6 +373,7 @@ function useTodayTodos(): {
   complete: (id: string) => void;
 } {
   const authenticated = useIsAuthenticated();
+  const { isOwner } = useRole();
   const [todos, setTodos] = useState<TodayTodo[] | null>(null);
   const [now, setNow] = useState(0);
   const [completingIds, setCompletingIds] = useState<ReadonlySet<string>>(
@@ -391,7 +394,7 @@ function useTodayTodos(): {
       activeLoadRef.current?.abort();
       const controller = new AbortController();
       activeLoadRef.current = controller;
-      void loadTodayTodosForGlance(authenticated, controller.signal)
+      void loadTodayTodosForGlance(authenticated && isOwner, controller.signal)
         .then((next) => {
           if (controller.signal.aborted || !mountedRef.current) return;
           setNow(Date.now());
@@ -407,7 +410,7 @@ function useTodayTodos(): {
           }
         });
     },
-    [authenticated],
+    [authenticated, isOwner],
   );
 
   useEffect(() => {

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -60,6 +60,7 @@ vi.mock("../../hooks/useRuntimeMode", () => ({
 }));
 
 vi.mock("../../first-run/mobile-runtime-mode", () => ({
+  MOBILE_RUNTIME_MODE_STORAGE_KEY: "eliza:mobile-runtime-mode",
   readPersistedMobileRuntimeMode: () => mobileRuntimeModeMock.value,
 }));
 

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.ts
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.ts
@@ -196,7 +196,9 @@ export function useHomeModelStatus(): HomeModelStatus {
       );
       // On-device runtimes are addressed via the native IPC base, which
       // EventSource cannot open — fall back to the one-shot `refresh()` above.
-      eventSource = openEventSource(url, { withCredentials: false });
+      eventSource = getElizaApiToken()
+        ? null
+        : openEventSource(url, { withCredentials: false });
       if (eventSource) {
         eventSource.onmessage = () => {
           // The stream carries download/active deltas but not recomputed

--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
@@ -32,6 +32,9 @@ const FOCUSABLE_SELECTOR =
 function approvalStreamUrl(): string | null {
   const baseUrl = client.getBaseUrl();
   const restToken = client.getRestAuthToken();
+  // Browser EventSource cannot attach the bearer header used by paired
+  // machine sessions. Those sessions use the authenticated polling fallback.
+  if (restToken) return null;
   let url: URL;
   try {
     url = new URL(

--- a/packages/ui/src/state/active-server-credential.durability.test.ts
+++ b/packages/ui/src/state/active-server-credential.durability.test.ts
@@ -8,11 +8,13 @@ const mocks = vi.hoisted(() => ({
   savePersistedActiveServer: vi.fn(),
   setStorageValue: vi.fn(),
   updateAgentProfile: vi.fn(),
+  upsertAndActivateAgentProfile: vi.fn(),
 }));
 
 vi.mock("./agent-profiles", () => ({
   getActiveProfile: mocks.getActiveProfile,
   updateAgentProfile: mocks.updateAgentProfile,
+  upsertAndActivateAgentProfile: mocks.upsertAndActivateAgentProfile,
 }));
 
 vi.mock("./persistence", () => ({

--- a/packages/ui/src/state/active-server-credential.test.ts
+++ b/packages/ui/src/state/active-server-credential.test.ts
@@ -54,6 +54,20 @@ describe("persistActiveServerCredential", () => {
     });
   });
 
+  it("pins a same-origin browser pairing before its first reload", async () => {
+    savePersistedActiveServer(createPersistedActiveServer({ kind: "local" }));
+
+    await persistActiveServerCredential("paired-token");
+
+    expect(loadPersistedActiveServer()).toEqual({
+      id: `remote:${window.location.origin}`,
+      kind: "remote",
+      label: window.location.hostname,
+      apiBase: window.location.origin,
+      accessToken: "paired-token",
+    });
+  });
+
   it("does not copy a remote pairing bearer into a stale Cloud profile", async () => {
     savePersistedActiveServer(
       createPersistedActiveServer({

--- a/packages/ui/src/state/active-server-credential.test.ts
+++ b/packages/ui/src/state/active-server-credential.test.ts
@@ -62,7 +62,7 @@ describe("persistActiveServerCredential", () => {
     expect(loadPersistedActiveServer()).toEqual({
       id: `remote:${window.location.origin}`,
       kind: "remote",
-      label: window.location.hostname,
+      label: window.location.host,
       apiBase: window.location.origin,
       accessToken: "paired-token",
     });

--- a/packages/ui/src/state/active-server-credential.ts
+++ b/packages/ui/src/state/active-server-credential.ts
@@ -23,10 +23,19 @@ export async function persistActiveServerCredential(
   pairedApiBase?: string,
 ): Promise<void> {
   const activeServer = loadPersistedActiveServer();
-  const fallbackRemote = pairedApiBase?.trim()
+  const explicitPairingBase = pairedApiBase?.trim() || null;
+  const sameOriginPairingBase =
+    (!activeServer || activeServer.kind === "local") &&
+    typeof window !== "undefined" &&
+    (window.location.protocol === "http:" ||
+      window.location.protocol === "https:")
+      ? window.location.origin
+      : null;
+  const pairingBase = explicitPairingBase ?? sameOriginPairingBase;
+  const fallbackRemote = pairingBase
     ? createPersistedActiveServer({
         kind: "remote",
-        apiBase: pairedApiBase,
+        apiBase: pairingBase,
         accessToken: token,
       })
     : null;

--- a/packages/ui/src/state/cloud-auth-first-screen-policy.test.ts
+++ b/packages/ui/src/state/cloud-auth-first-screen-policy.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Verifies that Cloud account login owns only Cloud-controlled browser origins
+ * or cloud-only native/desktop clients, never a standalone agent pairing page.
+ */
+
+import { describe, expect, it } from "vitest";
+import { cloudAuthFirstScreenOwnsHost } from "./cloud-auth-first-screen-policy";
+
+describe("cloudAuthFirstScreenOwnsHost", () => {
+  it("keeps a self-hosted browser on the standalone agent pairing surface", () => {
+    expect(
+      cloudAuthFirstScreenOwnsHost({
+        cloudOnlyBranding: true,
+        isAgentlessCloudOrigin: false,
+        isNative: false,
+        isDesktopShell: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("lets the Cloud control plane own hosted browser sign-in", () => {
+    expect(
+      cloudAuthFirstScreenOwnsHost({
+        cloudOnlyBranding: true,
+        isAgentlessCloudOrigin: true,
+        isNative: false,
+        isDesktopShell: false,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { isNative: true, isDesktopShell: false },
+    { isNative: false, isDesktopShell: true },
+  ])(
+    "retains cloud-only client login for $isNative/$isDesktopShell",
+    (host) => {
+      expect(
+        cloudAuthFirstScreenOwnsHost({
+          cloudOnlyBranding: true,
+          isAgentlessCloudOrigin: false,
+          ...host,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it("does not claim any host when cloud-only branding is disabled", () => {
+    expect(
+      cloudAuthFirstScreenOwnsHost({
+        cloudOnlyBranding: false,
+        isAgentlessCloudOrigin: true,
+        isNative: true,
+        isDesktopShell: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/state/cloud-auth-first-screen-policy.ts
+++ b/packages/ui/src/state/cloud-auth-first-screen-policy.ts
@@ -1,0 +1,24 @@
+/**
+ * Decides whether Cloud account authentication may replace the app's primary
+ * startup surface. Browser-hosted standalone and dedicated agents retain their
+ * own pairing gate even when the production renderer uses cloud-only branding.
+ */
+
+export interface CloudAuthFirstScreenHost {
+  cloudOnlyBranding: boolean;
+  isAgentlessCloudOrigin: boolean;
+  isNative: boolean;
+  isDesktopShell: boolean;
+}
+
+/**
+ * Cloud-only branding identifies product capabilities, not necessarily the
+ * authority serving the page. Only the Cloud control plane owns browser login;
+ * native and desktop cloud-only clients may also initiate that login directly.
+ */
+export function cloudAuthFirstScreenOwnsHost(
+  host: CloudAuthFirstScreenHost,
+): boolean {
+  if (!host.cloudOnlyBranding) return false;
+  return host.isAgentlessCloudOrigin || host.isNative || host.isDesktopShell;
+}

--- a/packages/ui/src/state/first-run-bootstrap.test.ts
+++ b/packages/ui/src/state/first-run-bootstrap.test.ts
@@ -222,15 +222,28 @@ describe("detectExistingFirstRunConnection — wait-for-boot retry", () => {
 });
 
 describe("detectExistingFirstRunConnection — fresh-install single shot", () => {
-  it("does not wait: any failure resolves to null immediately (fast onboarding)", async () => {
-    // Even an auth error is "no install here" for a fresh install — the single
-    // shot never throws and never retries, so onboarding is instant.
+  it("treats same-origin auth as an existing install so pairing owns startup", async () => {
     const client = scriptedClient([{ throw: apiError("http", 401) }]);
 
     const result = await detectExistingFirstRunConnection({
       client,
       timeoutMs: 3_500,
       // waitForBootingAgent omitted → fresh-install path
+    });
+
+    expect(result).toEqual({
+      activeServer: expect.objectContaining({ kind: "local" }),
+      detectedExistingInstall: true,
+    });
+    expect(client.calls()).toBe(1);
+  });
+
+  it("does not wait for a transport failure on a genuinely fresh install", async () => {
+    const client = scriptedClient([{ throw: apiError("network") }]);
+
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 3_500,
     });
 
     expect(result).toBeNull();

--- a/packages/ui/src/state/first-run-bootstrap.ts
+++ b/packages/ui/src/state/first-run-bootstrap.ts
@@ -173,8 +173,19 @@ export async function detectExistingFirstRunConnection(args: {
         status = await args.client.getFirstRunStatus();
       } catch (err) {
         if (!args.waitForBootingAgent) {
-          // error-policy:J4 fresh-install probe — an unreachable agent means
-          // "no existing install detected" and first-run proceeds normally.
+          const api = asApiLikeError(err);
+          if (api?.status === 401 || api?.status === 403) {
+            // error-policy:J4 an auth-gated same-origin response proves that a
+            // standalone agent exists. Restore that authority so the normal
+            // backend poll can render pairing instead of misclassifying a
+            // fresh browser as a new Cloud install.
+            return {
+              activeServer: LOCAL_ACTIVE_SERVER,
+              detectedExistingInstall: true,
+            } satisfies ExistingFirstRunProbeResult;
+          }
+          // error-policy:J4 a transport failure on a genuinely fresh install
+          // means "no existing install detected" and first-run proceeds.
           return null;
         }
         // The committed on-device agent is still booting only when the probe

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -133,6 +133,8 @@ async function flushDelivery(): Promise<void> {
 describe("notification-store", () => {
   beforeEach(() => {
     __resetNotificationStoreForTests();
+    __resetAuthStatusForTests();
+    __setAuthStatusForTests({ phase: "unauthenticated" });
     listNotifications.mockReset().mockResolvedValue({
       notifications: [],
       unreadCount: 0,
@@ -160,6 +162,7 @@ describe("notification-store", () => {
   });
 
   afterEach(() => {
+    __resetAuthStatusForTests();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -998,9 +1001,45 @@ describe("notification-store — protected hydrate gate (#16242)", () => {
     });
   });
 
-  it("hydrates on mount on a non-Cloud origin regardless of auth (unchanged)", async () => {
+  it("holds a non-Cloud inbox until the auth probe resolves", async () => {
     setOrigin("http://localhost:2138/");
     initNotifications();
+    await Promise.resolve();
+    expect(listNotifications).not.toHaveBeenCalled();
+
+    __setAuthStatusForTests({ phase: "unauthenticated" });
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps a pairing-gated remote inbox disabled until authentication", async () => {
+    setOrigin("https://agent.example.com/");
+    __setAuthStatusForTests({
+      phase: "unauthenticated",
+      reason: "remote_auth_required",
+      access: {
+        mode: "remote",
+        passwordConfigured: false,
+        ownerConfigured: false,
+      },
+    });
+
+    initNotifications();
+    await Promise.resolve();
+    expect(listNotifications).not.toHaveBeenCalled();
+    expect(__getStateForTests().hydrationStatus).toBe("disabled");
+
+    __setAuthStatusForTests({
+      phase: "authenticated",
+      identity: { id: "u-1", displayName: "Owner", kind: "owner" },
+      session: { id: "s-1", kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: false,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    });
+
     await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
   });
 });
@@ -1031,6 +1070,7 @@ describe("notification-store — authority isolation (#18391)", () => {
   beforeEach(() => {
     __resetNotificationStoreForTests();
     __resetAuthStatusForTests();
+    __setAuthStatusForTests({ phase: "unauthenticated" });
     listNotifications
       .mockReset()
       .mockResolvedValue({ notifications: [], unreadCount: 0 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -38,7 +38,6 @@ import {
 import {
   type AuthStatusState,
   getAuthStatusSnapshot,
-  isAuthenticatedNow,
   subscribeAuthStatus,
 } from "../../hooks/useAuthStatus";
 import { protectedAgentProbesEnabled } from "../../hooks/useProtectedAgentProbesEnabled";
@@ -125,10 +124,21 @@ let notificationEventUnsub: (() => void) | null = null;
  * module-scope hydrate path can re-evaluate on auth/base changes.
  */
 function notificationProbesEnabled(): boolean {
+  const authStatus = getAuthStatusSnapshot();
+  if (
+    authStatus.phase === "loading" ||
+    authStatus.phase === "server_unavailable" ||
+    (authStatus.phase === "unauthenticated" &&
+      (authStatus.reason === "remote_auth_required" ||
+        authStatus.reason === "remote_password_not_configured" ||
+        authStatus.access?.mode === "remote"))
+  ) {
+    return false;
+  }
   const origin = typeof window !== "undefined" ? window.location.origin : null;
   if (
     !protectedAgentProbesEnabled(
-      isAuthenticatedNow(),
+      authStatus.phase === "authenticated",
       origin,
       undefined,
       Capacitor.isNativePlatform() && !client.getBaseUrl().trim(),
@@ -484,7 +494,14 @@ function clearForAuthorityChange(): void {
 function reconcileAuthority(authStatus: AuthStatusState): void {
   const baseUrl = client.getBaseUrl();
   const nextKey = computeAuthorityKey(authStatus, baseUrl);
-  if (nextKey === currentAuthorityKey) return;
+  if (nextKey === currentAuthorityKey) {
+    // The boot-time loading snapshot and a resolved anonymous session share
+    // the same authority key. Re-evaluate a hydrate that was deliberately
+    // held while auth was unknown without refetching an already-ready inbox
+    // on ordinary same-session auth refreshes.
+    if (state.hydrationStatus === "disabled") void requestHydration();
+    return;
+  }
   // Only rotate when the authority being LEFT had a real, hydration-worthy
   // identity — not the boot-time "anon" seed or placeholder, which never
   // held anything worth protecting — and the base is unchanged (a base

--- a/packages/ui/src/state/useAppShellState.favorites-retry.test.tsx
+++ b/packages/ui/src/state/useAppShellState.favorites-retry.test.tsx
@@ -29,6 +29,9 @@ vi.mock("../api", () => ({
 vi.mock("../api/app-shell-capabilities", () => ({
   supportsFullAppShellRoutes: () => true,
 }));
+vi.mock("../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => true,
+}));
 
 import { AGENT_READY_EVENT } from "../events";
 import { useAppShellState } from "./useAppShellState";

--- a/packages/ui/src/state/useAppShellState.ts
+++ b/packages/ui/src/state/useAppShellState.ts
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useState } from "react";
 import { client } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import { AGENT_READY_EVENT } from "../events";
+import { useIsAuthenticated } from "../hooks/useAuthStatus";
 import {
   fetchServerFavoriteApps,
   loadFavoriteApps,
@@ -35,6 +36,7 @@ interface UseAppShellStateOptions {
 export function useAppShellState({
   syncServerFavorites = true,
 }: UseAppShellStateOptions = {}) {
+  const authenticated = useIsAuthenticated();
   const [ownerName, setOwnerNameState] = useState<string | null>(null);
   const [appsSubTab, setAppsSubTabRaw] = useState<
     "browse" | "running" | "games"
@@ -85,7 +87,7 @@ export function useAppShellState({
   }, []);
 
   useEffect(() => {
-    if (!syncServerFavorites) return;
+    if (!syncServerFavorites || !authenticated) return;
     if (!supportsFullAppShellRoutes(client.getBaseUrl())) return;
     let cancelled = false;
     let hydrated = false;
@@ -122,7 +124,7 @@ export function useAppShellState({
       cancelled = true;
       document.removeEventListener(AGENT_READY_EVENT, onAgentReady);
     };
-  }, [syncServerFavorites]);
+  }, [authenticated, syncServerFavorites]);
 
   const setRecentApps = useCallback((apps: string[]) => {
     setRecentAppsRaw(apps);

--- a/plugins/plugin-imessage/AGENTS.md
+++ b/plugins/plugin-imessage/AGENTS.md
@@ -1,15 +1,16 @@
 # @elizaos/plugin-imessage
 
-iMessage connector for Eliza agents on macOS — local inbound reads from chat.db and outbound delivery through Apple's Messages automation surface.
+iMessage connector for Eliza agents using native macOS Messages or a channel-isolated Blooio webhook and API transport.
 
 ## Purpose / role
 
-Adds iMessage send/receive capability to an Eliza agent running on macOS without BlueBubbles, a third-party daemon, a network service, or an auxiliary CLI. The plugin registers `IMessageService`, which polls `~/Library/Messages/chat.db` for inbound messages and delivers outbound messages through the built-in `osascript` interface to Messages.app. It also registers the service as a `MessageConnector` so the standard `MESSAGE` operation routes through it. Auto-enabled when `config.connectors.imessage` is present and not explicitly disabled; opt-in otherwise.
+Adds iMessage send/receive capability through either local macOS Messages or Blooio. `IMessageService` polls `~/Library/Messages/chat.db` and uses `osascript` in native mode; in Blooio mode it verifies signed webhook deliveries, requires an exact configured channel id, and sends through the v4 message API. It registers the same `MessageConnector` in both modes.
 
 ## Plugin surface
 
 **Services**
 - `IMessageService` (`src/service.ts`) — core service; polls chat.db, dispatches inbound messages through `runtime.messageService.handleMessage`, sends through Messages.app via AppleScript, and registers the `MessageConnector` with `resolveTargets`, `listRecentTargets`, `listRooms`, `fetchMessages`, `searchMessages`, `getChatContext`, `getUserContext`. Static `serviceType = "imessage"`.
+- `src/blooio-transport.ts` — Blooio v4 payload parsing, signature verification, channel isolation, and outbound delivery receipts.
 
 **Actions** — none registered. Sending goes through the `MessageConnector` path (`MESSAGE` / `operation=send`).
 
@@ -25,6 +26,7 @@ Adds iMessage send/receive capability to an Eliza agent running on macOS without
 *Data routes* (`src/data-routes.ts`):
 - `GET    /api/imessage/messages` — recent messages (`?chatId=&limit=`)
 - `POST   /api/imessage/messages` — send a message (`{ to|chatId, text, mediaUrl? }`)
+- `POST   /api/imessage/webhook/blooio` — signed Blooio `message.received` delivery
 - `GET    /api/imessage/chats` — list chats (DMs + groups) from chat.db
 - `GET    /api/imessage/contacts` — list Apple Contacts (full detail)
 - `POST   /api/imessage/contacts` — create a contact (CNContactStore)
@@ -93,6 +95,11 @@ All read via `runtime.getSetting(key)` with `process.env[key]` fallback. None re
 | `IMESSAGE_ALLOW_FROM` | `""` | Comma-separated E.164 phones or iCloud emails for allowlist |
 | `IMESSAGE_ENABLED` | `"true"` | Set to `"false"` to disable |
 | `IMESSAGE_BACKFILL` | `0` | Number of rows before the current DB tip to replay on startup |
+| `IMESSAGE_TRANSPORT` | `"native"` | `native` or `blooio` |
+| `IMESSAGE_BLOOIO_API_KEY` | fallback `BLOOIO_API_KEY` | Required in Blooio mode |
+| `IMESSAGE_BLOOIO_WEBHOOK_SECRET` | fallback `BLOOIO_WEBHOOK_SECRET` | Required in Blooio mode |
+| `IMESSAGE_BLOOIO_FROM_NUMBER` | fallback `BLOOIO_FROM_NUMBER` | Required in Blooio mode |
+| `IMESSAGE_BLOOIO_CHANNEL_ID` | none | Required exact channel accepted in Blooio mode |
 | `ELIZA_NATIVE_PERMISSIONS_DYLIB` | `""` | Path to the native permissions dylib used for CNContactStore access |
 
 Config block in character settings:
@@ -132,7 +139,7 @@ Config block in character settings:
 
 ## Conventions / gotchas
 
-- **macOS only.** `IMessageService.start()` throws `IMessageNotSupportedError` on non-darwin platforms. The plugin still loads on other platforms but the service never starts; all route handlers return 503.
+- **Transport gate.** Native mode throws `IMessageNotSupportedError` on non-darwin platforms. Blooio mode runs on Linux but fails startup unless all Blooio settings are present.
 - **chat.db requires Full Disk Access.** Without it, `openChatDb` returns `null` and the service runs send-only. Guide the user to `System Settings > Privacy & Security > Full Disk Access`. The `createFullDiskAccessAction()` helper in `chatdb-reader.ts` builds the structured action object the UI needs.
 - **Sending requires Automation permission.** The first user-triggered send may produce macOS's Automation prompt for Messages. Service startup does not probe Messages.app, so enabling inbound reads cannot launch Messages or create unrelated permission pressure.
 - **Contacts permission is lazy.** `loadContacts()` is NOT called at service start — it fires on the first inbound message that needs handle→name resolution. This avoids a macOS TCC dialog at app launch.
@@ -142,7 +149,7 @@ Config block in character settings:
 - **Attachment ownership.** Downloaded inbound files are copied from the Messages attachment directory into `IFileStorageService` before Memory creation, so only canonical `/api/media/<sha256>.<ext>` handles enter runtime state. Outbound media-store handles use `runtime.fetch`; remote URLs use the core SSRF-guarded connector resolver; both paths are byte-capped and staged only for the duration of the Messages send.
 - **DM `pairing` uses the core PairingService.** The connector has no pairing handshake of its own; unknown DM senders are held until the owner approves their pairing code. The pairing-code reply is an autonomous outbound text, so it is only sent when `IMESSAGE_AUTO_REPLY=true` (the same consent gate as agent-generated replies); pending requests are always visible in the pairing UI.
 - **Message chunking.** Messages over 4000 chars (`MAX_IMESSAGE_MESSAGE_LENGTH`) are split at newlines or spaces and sent as sequential AppleScript calls. A supplied attachment is sent exactly once after all text chunks succeed.
-- **Transport ownership.** This plugin is the only supported iMessage connector. It has no external bridge, daemon, relay, or auxiliary-CLI configuration.
+- **Transport ownership.** This plugin owns native and Blooio iMessage transport. BlueBubbles remains separate. A Blooio webhook must be channel-scoped; the plugin also enforces the configured channel id after signature verification.
 - **No npm build deps.** Only `@elizaos/core` and `zod` at runtime. The build uses `build.ts` (not a tsdown config file) invoked via `bun run build.ts`.
 
 ## Verification

--- a/plugins/plugin-imessage/CLAUDE.md
+++ b/plugins/plugin-imessage/CLAUDE.md
@@ -1,15 +1,16 @@
 # @elizaos/plugin-imessage
 
-iMessage connector for Eliza agents on macOS — local inbound reads from chat.db and outbound delivery through Apple's Messages automation surface.
+iMessage connector for Eliza agents using native macOS Messages or a channel-isolated Blooio webhook and API transport.
 
 ## Purpose / role
 
-Adds iMessage send/receive capability to an Eliza agent running on macOS without BlueBubbles, a third-party daemon, a network service, or an auxiliary CLI. The plugin registers `IMessageService`, which polls `~/Library/Messages/chat.db` for inbound messages and delivers outbound messages through the built-in `osascript` interface to Messages.app. It also registers the service as a `MessageConnector` so the standard `MESSAGE` operation routes through it. Auto-enabled when `config.connectors.imessage` is present and not explicitly disabled; opt-in otherwise.
+Adds iMessage send/receive capability through either local macOS Messages or Blooio. `IMessageService` polls `~/Library/Messages/chat.db` and uses `osascript` in native mode; in Blooio mode it verifies signed webhook deliveries, requires an exact configured channel id, and sends through the v4 message API. It registers the same `MessageConnector` in both modes.
 
 ## Plugin surface
 
 **Services**
 - `IMessageService` (`src/service.ts`) — core service; polls chat.db, dispatches inbound messages through `runtime.messageService.handleMessage`, sends through Messages.app via AppleScript, and registers the `MessageConnector` with `resolveTargets`, `listRecentTargets`, `listRooms`, `fetchMessages`, `searchMessages`, `getChatContext`, `getUserContext`. Static `serviceType = "imessage"`.
+- `src/blooio-transport.ts` — Blooio v4 payload parsing, signature verification, channel isolation, and outbound delivery receipts.
 
 **Actions** — none registered. Sending goes through the `MessageConnector` path (`MESSAGE` / `operation=send`).
 
@@ -25,6 +26,7 @@ Adds iMessage send/receive capability to an Eliza agent running on macOS without
 *Data routes* (`src/data-routes.ts`):
 - `GET    /api/imessage/messages` — recent messages (`?chatId=&limit=`)
 - `POST   /api/imessage/messages` — send a message (`{ to|chatId, text, mediaUrl? }`)
+- `POST   /api/imessage/webhook/blooio` — signed Blooio `message.received` delivery
 - `GET    /api/imessage/chats` — list chats (DMs + groups) from chat.db
 - `GET    /api/imessage/contacts` — list Apple Contacts (full detail)
 - `POST   /api/imessage/contacts` — create a contact (CNContactStore)
@@ -93,6 +95,11 @@ All read via `runtime.getSetting(key)` with `process.env[key]` fallback. None re
 | `IMESSAGE_ALLOW_FROM` | `""` | Comma-separated E.164 phones or iCloud emails for allowlist |
 | `IMESSAGE_ENABLED` | `"true"` | Set to `"false"` to disable |
 | `IMESSAGE_BACKFILL` | `0` | Number of rows before the current DB tip to replay on startup |
+| `IMESSAGE_TRANSPORT` | `"native"` | `native` or `blooio` |
+| `IMESSAGE_BLOOIO_API_KEY` | fallback `BLOOIO_API_KEY` | Required in Blooio mode |
+| `IMESSAGE_BLOOIO_WEBHOOK_SECRET` | fallback `BLOOIO_WEBHOOK_SECRET` | Required in Blooio mode |
+| `IMESSAGE_BLOOIO_FROM_NUMBER` | fallback `BLOOIO_FROM_NUMBER` | Required in Blooio mode |
+| `IMESSAGE_BLOOIO_CHANNEL_ID` | none | Required exact channel accepted in Blooio mode |
 | `ELIZA_NATIVE_PERMISSIONS_DYLIB` | `""` | Path to the native permissions dylib used for CNContactStore access |
 
 Config block in character settings:
@@ -132,7 +139,7 @@ Config block in character settings:
 
 ## Conventions / gotchas
 
-- **macOS only.** `IMessageService.start()` throws `IMessageNotSupportedError` on non-darwin platforms. The plugin still loads on other platforms but the service never starts; all route handlers return 503.
+- **Transport gate.** Native mode throws `IMessageNotSupportedError` on non-darwin platforms. Blooio mode runs on Linux but fails startup unless all Blooio settings are present.
 - **chat.db requires Full Disk Access.** Without it, `openChatDb` returns `null` and the service runs send-only. Guide the user to `System Settings > Privacy & Security > Full Disk Access`. The `createFullDiskAccessAction()` helper in `chatdb-reader.ts` builds the structured action object the UI needs.
 - **Sending requires Automation permission.** The first user-triggered send may produce macOS's Automation prompt for Messages. Service startup does not probe Messages.app, so enabling inbound reads cannot launch Messages or create unrelated permission pressure.
 - **Contacts permission is lazy.** `loadContacts()` is NOT called at service start — it fires on the first inbound message that needs handle→name resolution. This avoids a macOS TCC dialog at app launch.
@@ -142,7 +149,7 @@ Config block in character settings:
 - **Attachment ownership.** Downloaded inbound files are copied from the Messages attachment directory into `IFileStorageService` before Memory creation, so only canonical `/api/media/<sha256>.<ext>` handles enter runtime state. Outbound media-store handles use `runtime.fetch`; remote URLs use the core SSRF-guarded connector resolver; both paths are byte-capped and staged only for the duration of the Messages send.
 - **DM `pairing` uses the core PairingService.** The connector has no pairing handshake of its own; unknown DM senders are held until the owner approves their pairing code. The pairing-code reply is an autonomous outbound text, so it is only sent when `IMESSAGE_AUTO_REPLY=true` (the same consent gate as agent-generated replies); pending requests are always visible in the pairing UI.
 - **Message chunking.** Messages over 4000 chars (`MAX_IMESSAGE_MESSAGE_LENGTH`) are split at newlines or spaces and sent as sequential AppleScript calls. A supplied attachment is sent exactly once after all text chunks succeed.
-- **Transport ownership.** This plugin is the only supported iMessage connector. It has no external bridge, daemon, relay, or auxiliary-CLI configuration.
+- **Transport ownership.** This plugin owns native and Blooio iMessage transport. BlueBubbles remains separate. A Blooio webhook must be channel-scoped; the plugin also enforces the configured channel id after signature verification.
 - **No npm build deps.** Only `@elizaos/core` and `zod` at runtime. The build uses `build.ts` (not a tsdown config file) invoked via `bun run build.ts`.
 
 ## Verification

--- a/plugins/plugin-imessage/README.md
+++ b/plugins/plugin-imessage/README.md
@@ -1,8 +1,9 @@
 # @elizaos/plugin-imessage
 
-iMessage plugin for elizaOS agents. Enables chat integration with Apple's iMessage on macOS.
+iMessage plugin for elizaOS agents. Uses Apple's Messages app on macOS or a
+Blooio channel on any supported server platform.
 
-**Note: This plugin only works on macOS systems.**
+Native mode requires macOS. Blooio mode supports Linux servers.
 
 ## Features
 
@@ -11,6 +12,8 @@ iMessage plugin for elizaOS agents. Enables chat integration with Apple's iMessa
 - **Attachments**: Rehost inbound Messages files into the canonical media store and send bounded local or SSRF-guarded remote media through Messages.app
 - **Message Polling**: Receive incoming messages via polling
 - **Policy Controls**: Configure DM and group policies
+- **Blooio Webhook**: Receive signed events at `/api/imessage/webhook/blooio`
+- **Channel Isolation**: Dispatch only the configured Blooio channel
 
 ## Requirements
 
@@ -42,6 +45,11 @@ bun add @elizaos/plugin-imessage
 | `IMESSAGE_ALLOW_FROM` | Comma-separated handles for allowlist | No |
 | `IMESSAGE_ENABLED` | Enable/disable the plugin | No |
 | `IMESSAGE_BACKFILL` | Rows before current DB tip to replay on startup | No |
+| `IMESSAGE_TRANSPORT` | `native` (default) or `blooio` | No |
+| `IMESSAGE_BLOOIO_API_KEY` | Blooio API key; falls back to `BLOOIO_API_KEY` | Blooio |
+| `IMESSAGE_BLOOIO_WEBHOOK_SECRET` | Webhook signing secret; falls back to `BLOOIO_WEBHOOK_SECRET` | Blooio |
+| `IMESSAGE_BLOOIO_FROM_NUMBER` | E.164 sender number; falls back to `BLOOIO_FROM_NUMBER` | Blooio |
+| `IMESSAGE_BLOOIO_CHANNEL_ID` | Exact Blooio channel accepted by this agent | Blooio |
 
 ### Agent Configuration
 
@@ -57,6 +65,18 @@ bun add @elizaos/plugin-imessage
 ```
 
 ## Setup
+
+### Blooio on Linux
+
+Set `IMESSAGE_TRANSPORT=blooio` and all four Blooio settings above. Create a
+channel-scoped Blooio webhook for the configured channel pointing to:
+
+```text
+https://YOUR_AGENT_HOST/api/imessage/webhook/blooio
+```
+
+Subscribe to `message.received`. The route verifies `X-Blooio-Signature`
+against the unmodified request body and silently ignores other channel IDs.
 
 ### Permissions
 
@@ -127,7 +147,7 @@ iMessage supports multiple target types:
 
 ## Limitations
 
-- **macOS Only**: iMessage doesn't have an official API and only works on macOS
+- **Native mode is macOS-only**: Blooio mode is the supported server transport
 - **No Official API**: Sending uses Messages.app's supported AppleScript dictionary
 - **Permissions**: Message history requires Full Disk Access, sending through
   Messages requires Automation, and contact resolution/editing requires

--- a/plugins/plugin-imessage/auto-enable.ts
+++ b/plugins/plugin-imessage/auto-enable.ts
@@ -6,8 +6,16 @@
 // auto-enable engine loads dozens of these per boot.
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
-/** Enable when an `imessage` connector block is present and not explicitly disabled. */
+function isFalse(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "no";
+}
+
+/** Enable from connector config or an explicit environment-backed transport. */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
+  if (isFalse(ctx.env.IMESSAGE_ENABLED)) return false;
+  if (ctx.env.IMESSAGE_TRANSPORT?.trim().toLowerCase() === "blooio") return true;
+  if (ctx.env.IMESSAGE_ENABLED?.trim()) return true;
   const c = (ctx.config.connectors as Record<string, unknown> | undefined)
     ?.imessage;
   if (!c || typeof c !== "object") return false;

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -75,6 +75,36 @@
   },
   "agentConfig": {
     "pluginParameters": {
+      "IMESSAGE_TRANSPORT": {
+        "type": "string",
+        "description": "Transport: native or blooio",
+        "required": false,
+        "sensitive": false
+      },
+      "IMESSAGE_BLOOIO_API_KEY": {
+        "type": "string",
+        "description": "Blooio API key",
+        "required": false,
+        "sensitive": true
+      },
+      "IMESSAGE_BLOOIO_WEBHOOK_SECRET": {
+        "type": "string",
+        "description": "Blooio webhook signing secret",
+        "required": false,
+        "sensitive": true
+      },
+      "IMESSAGE_BLOOIO_FROM_NUMBER": {
+        "type": "string",
+        "description": "Blooio sender phone number",
+        "required": false,
+        "sensitive": false
+      },
+      "IMESSAGE_BLOOIO_CHANNEL_ID": {
+        "type": "string",
+        "description": "Blooio channel accepted by this agent",
+        "required": false,
+        "sensitive": false
+      },
       "IMESSAGE_DB_PATH": {
         "type": "string",
         "description": "Path to database file",
@@ -119,6 +149,31 @@
       }
     },
     "configUiHints": {
+      "IMESSAGE_TRANSPORT": {
+        "label": "Transport",
+        "order": 1,
+        "group": "connection"
+      },
+      "IMESSAGE_BLOOIO_API_KEY": {
+        "label": "Blooio API key",
+        "order": 2,
+        "group": "connection"
+      },
+      "IMESSAGE_BLOOIO_WEBHOOK_SECRET": {
+        "label": "Webhook secret",
+        "order": 3,
+        "group": "connection"
+      },
+      "IMESSAGE_BLOOIO_FROM_NUMBER": {
+        "label": "Sender number",
+        "order": 4,
+        "group": "connection"
+      },
+      "IMESSAGE_BLOOIO_CHANNEL_ID": {
+        "label": "Channel ID",
+        "order": 5,
+        "group": "connection"
+      },
       "IMESSAGE_DB_PATH": {
         "label": "Database path",
         "order": 2,

--- a/plugins/plugin-imessage/src/auto-enable.test.ts
+++ b/plugins/plugin-imessage/src/auto-enable.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Verifies environment and connector-config activation for the iMessage plugin.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "../auto-enable.js";
+
+function context(env: Record<string, string | undefined>, connectors?: Record<string, unknown>) {
+  return { env, config: connectors ? { connectors } : {} } as Parameters<typeof shouldEnable>[0];
+}
+
+describe("plugin-imessage auto enable", () => {
+  it("enables a Blooio transport configured entirely through environment variables", () => {
+    expect(shouldEnable(context({ IMESSAGE_TRANSPORT: "blooio" }))).toBe(true);
+  });
+
+  it("honors an explicit disable over transport configuration", () => {
+    expect(shouldEnable(context({ IMESSAGE_TRANSPORT: "blooio", IMESSAGE_ENABLED: "false" }))).toBe(
+      false
+    );
+  });
+
+  it("preserves connector-block activation", () => {
+    expect(shouldEnable(context({}, { imessage: { enabled: true } }))).toBe(true);
+    expect(shouldEnable(context({}, { imessage: { enabled: false } }))).toBe(false);
+  });
+});

--- a/plugins/plugin-imessage/src/blooio-transport.test.ts
+++ b/plugins/plugin-imessage/src/blooio-transport.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Exercises Blooio signature, channel-isolation, parsing, and outbound receipt contracts.
+ */
+
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseBlooioInbound,
+  sendBlooioMessage,
+  verifyBlooioSignature,
+} from "./blooio-transport.js";
+
+const SECRET = "whsec_test";
+const NOW = 1_800_000_000;
+
+function envelope(channelId = "ch_bettina"): string {
+  return JSON.stringify({
+    id: "evt_1",
+    type: "message.received",
+    created_at: NOW * 1000,
+    data: {
+      id: "msg_1",
+      chat_id: "chat_1",
+      channel_id: channelId,
+      channel_type: "blooio",
+      sender: "+15551234567",
+      recipient: "+12692921765",
+      text: "hello",
+      attachments: ["https://media.blooio.com/a.jpg", "https://evil.example/a.jpg"],
+    },
+  });
+}
+
+function sign(body: string, timestamp = NOW): string {
+  const digest = crypto.createHmac("sha256", SECRET).update(`${timestamp}.${body}`).digest("hex");
+  return `t=${timestamp},v1=${digest}`;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Blooio iMessage transport", () => {
+  it("accepts a fresh authentic signature and rejects tampering or replay", () => {
+    const body = envelope();
+    expect(verifyBlooioSignature(SECRET, sign(body), body, NOW)).toBe(true);
+    expect(verifyBlooioSignature(SECRET, sign(body), `${body} `, NOW)).toBe(false);
+    expect(verifyBlooioSignature(SECRET, sign(body, NOW - 301), body, NOW)).toBe(false);
+  });
+
+  it("dispatches only the configured channel and retains trusted Blooio media", () => {
+    expect(parseBlooioInbound(envelope("ch_shared"), "ch_bettina")).toBeNull();
+    expect(parseBlooioInbound(envelope(), "ch_bettina")).toMatchObject({
+      messageId: "msg_1",
+      sender: "+15551234567",
+      channelId: "ch_bettina",
+      mediaUrls: ["https://media.blooio.com/a.jpg"],
+    });
+  });
+
+  it("sends through v4 with the selected channel and requires a receipt", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "msg_out" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      sendBlooioMessage({
+        apiKey: "api_test",
+        from: "ch_bettina",
+        to: "+15551234567",
+        text: "reply",
+        idempotencyKey: "reply-msg-1",
+      })
+    ).resolves.toEqual({ success: true, messageId: "msg_out", chatId: "+15551234567" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.blooio.com/v4/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ to: "+15551234567", from: "ch_bettina", text: "reply" }),
+      })
+    );
+  });
+
+  it("replies to v4 groups through their chat resource", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ message_id: "msg_group_out" }), { status: 200 })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      sendBlooioMessage({
+        apiKey: "api_test",
+        from: "ch_bettina",
+        to: "chat_id:chat_group",
+        text: "group reply",
+        idempotencyKey: "reply-group-1",
+      })
+    ).resolves.toEqual({ success: true, messageId: "msg_group_out", chatId: "chat_group" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.blooio.com/v4/chats/chat_group/messages",
+      expect.objectContaining({ body: JSON.stringify({ text: "group reply" }) })
+    );
+  });
+});

--- a/plugins/plugin-imessage/src/blooio-transport.test.ts
+++ b/plugins/plugin-imessage/src/blooio-transport.test.ts
@@ -42,6 +42,7 @@ describe("Blooio iMessage transport", () => {
   it("accepts a fresh authentic signature and rejects tampering or replay", () => {
     const body = envelope();
     expect(verifyBlooioSignature(SECRET, sign(body), body, NOW)).toBe(true);
+    expect(verifyBlooioSignature(SECRET, sign(body).replace(",", ", "), body, NOW)).toBe(true);
     expect(verifyBlooioSignature(SECRET, sign(body), `${body} `, NOW)).toBe(false);
     expect(verifyBlooioSignature(SECRET, sign(body, NOW - 301), body, NOW)).toBe(false);
   });

--- a/plugins/plugin-imessage/src/blooio-transport.test.ts
+++ b/plugins/plugin-imessage/src/blooio-transport.test.ts
@@ -45,6 +45,11 @@ describe("Blooio iMessage transport", () => {
     expect(verifyBlooioSignature(SECRET, sign(body).replace(",", ", "), body, NOW)).toBe(true);
     expect(verifyBlooioSignature(SECRET, sign(body), `${body} `, NOW)).toBe(false);
     expect(verifyBlooioSignature(SECRET, sign(body, NOW - 301), body, NOW)).toBe(false);
+    expect(verifyBlooioSignature(SECRET, sign(body, NOW + 301), body, NOW)).toBe(false);
+    expect(verifyBlooioSignature(SECRET, `t=not-a-number,v1=${"a".repeat(64)}`, body, NOW)).toBe(
+      false
+    );
+    expect(verifyBlooioSignature(SECRET, `t=${NOW},v1=abc`, body, NOW)).toBe(false);
   });
 
   it("dispatches only the configured channel and retains trusted Blooio media", () => {
@@ -55,6 +60,20 @@ describe("Blooio iMessage transport", () => {
       channelId: "ch_bettina",
       mediaUrls: ["https://media.blooio.com/a.jpg"],
     });
+  });
+
+  it("rejects insecure and suffix-confusable media origins", () => {
+    const body = JSON.parse(envelope()) as {
+      data: { attachments: string[] };
+    };
+    body.data.attachments = [
+      "http://media.blooio.com/insecure.jpg",
+      "https://notblooio.com/confusable.jpg",
+      "https://media.blooio.com/trusted.jpg",
+    ];
+    expect(parseBlooioInbound(JSON.stringify(body), "ch_bettina")?.mediaUrls).toEqual([
+      "https://media.blooio.com/trusted.jpg",
+    ]);
   });
 
   it("sends through v4 with the selected channel and requires a receipt", async () => {
@@ -81,6 +100,29 @@ describe("Blooio iMessage transport", () => {
         body: JSON.stringify({ to: "+15551234567", from: "ch_bettina", text: "reply" }),
       })
     );
+  });
+
+  it("rejects provider errors and successful responses without a message receipt", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("provider unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const input = {
+      apiKey: "api_test",
+      from: "ch_bettina",
+      to: "+15551234567",
+      text: "reply",
+      idempotencyKey: "reply-msg-1",
+    };
+    await expect(sendBlooioMessage(input)).resolves.toEqual({
+      success: false,
+      error: "Blooio rejected delivery (503)",
+    });
+    await expect(sendBlooioMessage(input)).resolves.toEqual({
+      success: false,
+      error: "Blooio accepted delivery without a message id",
+    });
   });
 
   it("replies to v4 groups through their chat resource", async () => {

--- a/plugins/plugin-imessage/src/blooio-transport.ts
+++ b/plugins/plugin-imessage/src/blooio-transport.ts
@@ -1,0 +1,193 @@
+/**
+ * Blooio's signed webhook and message API boundary for the iMessage connector.
+ */
+
+import crypto from "node:crypto";
+import { z } from "zod";
+import type { IMessageSendResult } from "./types.js";
+
+const BLOOIO_MESSAGES_URL = "https://api.blooio.com/v4/messages";
+const BLOOIO_CHATS_URL = "https://api.blooio.com/v4/chats";
+const SIGNATURE_TOLERANCE_SECONDS = 300;
+const BLOOIO_MEDIA_DOMAINS = [
+  "blooio.com",
+  "backend.blooio.com",
+  "api.blooio.com",
+  "media.blooio.com",
+];
+
+function isAllowedBlooioMediaUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      BLOOIO_MEDIA_DOMAINS.some(
+        (domain) => url.hostname === domain || url.hostname.endsWith(`.${domain}`)
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+const AttachmentSchema = z.union([
+  z.string().url(),
+  z.object({ url: z.string().url(), name: z.string().nullish() }).passthrough(),
+]);
+
+const MessageSchema = z
+  .object({
+    id: z.string().trim().min(1).nullish(),
+    message_id: z.string().trim().min(1).nullish(),
+    chat_id: z.string().trim().min(1).nullish(),
+    channel_id: z.string().trim().min(1),
+    channel_type: z.string().trim().min(1).nullish(),
+    sender: z.string().trim().min(1),
+    recipient: z.string().trim().min(1).nullish(),
+    channel_address: z.string().trim().min(1).nullish(),
+    text: z.string().nullish(),
+    reply_to_message_id: z.string().trim().min(1).nullish(),
+    attachments: z.array(AttachmentSchema).nullish(),
+    protocol: z.string().nullish(),
+    is_group: z.boolean().nullish(),
+    group: z.unknown().nullish(),
+  })
+  .passthrough();
+
+const EnvelopeSchema = z.object({
+  id: z.string().trim().min(1),
+  type: z.string().trim().min(1),
+  created_at: z.number(),
+  data: MessageSchema,
+});
+
+export interface BlooioInboundMessage {
+  messageId: string;
+  sender: string;
+  chatId: string;
+  channelId: string;
+  text: string;
+  timestamp: number;
+  isGroup: boolean;
+  replyToMessageId?: string;
+  mediaUrls: string[];
+}
+
+export function verifyBlooioSignature(
+  secret: string,
+  signatureHeader: string | undefined,
+  rawBody: string,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): boolean {
+  if (!secret || !signatureHeader) return false;
+  const parts = signatureHeader.split(",");
+  const timestampPart = parts.find((part) => part.startsWith("t="));
+  const signaturePart = parts.find((part) => part.startsWith("v1="));
+  if (!timestampPart || !signaturePart) return false;
+  const rawTimestamp = timestampPart.slice(2);
+  if (!/^\d+$/.test(rawTimestamp)) return false;
+  const timestamp = Number(rawTimestamp);
+  if (!Number.isSafeInteger(timestamp)) return false;
+  if (Math.abs(nowSeconds - timestamp) > SIGNATURE_TOLERANCE_SECONDS) return false;
+
+  const provided = signaturePart.slice(3);
+  if (!/^[0-9a-f]{64}$/i.test(provided)) return false;
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest("hex");
+  return crypto.timingSafeEqual(Buffer.from(provided, "hex"), Buffer.from(expected, "hex"));
+}
+
+export function parseBlooioInbound(
+  rawBody: string,
+  expectedChannelId: string
+): BlooioInboundMessage | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    // error-policy:J3 malformed webhook JSON is rejected at the route boundary.
+    return null;
+  }
+  const envelope = EnvelopeSchema.safeParse(parsed);
+  if (!envelope.success || envelope.data.type !== "message.received") return null;
+  const message = envelope.data.data;
+  if (message.channel_id !== expectedChannelId) return null;
+  const messageId = message.message_id ?? message.id;
+  if (!messageId) return null;
+  const mediaUrls = (message.attachments ?? [])
+    .map((attachment) => (typeof attachment === "string" ? attachment : attachment.url))
+    .filter(isAllowedBlooioMediaUrl);
+  if (!(message.text ?? "").trim() && mediaUrls.length === 0) return null;
+  const rawTimestamp = envelope.data.created_at;
+  const timestamp = rawTimestamp < 100_000_000_000 ? rawTimestamp * 1000 : rawTimestamp;
+  return {
+    messageId,
+    sender: message.sender,
+    chatId: message.chat_id ?? message.sender,
+    channelId: message.channel_id,
+    text: message.text ?? "",
+    timestamp,
+    isGroup: message.is_group ?? message.group != null,
+    ...(message.reply_to_message_id ? { replyToMessageId: message.reply_to_message_id } : {}),
+    mediaUrls,
+  };
+}
+
+export async function sendBlooioMessage(input: {
+  apiKey: string;
+  from: string;
+  to: string;
+  text: string;
+  idempotencyKey: string;
+}): Promise<IMessageSendResult> {
+  const chatId = input.to.startsWith("chat_id:") ? input.to.slice("chat_id:".length) : null;
+  const url = chatId
+    ? `${BLOOIO_CHATS_URL}/${encodeURIComponent(chatId)}/messages`
+    : BLOOIO_MESSAGES_URL;
+  const requestBody = chatId
+    ? { text: input.text }
+    : { to: input.to, from: input.from, text: input.text };
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiKey}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": input.idempotencyKey,
+      },
+      body: JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    // error-policy:J1 provider transport failures become explicit delivery failures.
+    return {
+      success: false,
+      error: `Blooio request failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const body = await response.text();
+  if (!response.ok) {
+    return { success: false, error: `Blooio rejected delivery (${response.status})` };
+  }
+  let receipt: unknown;
+  try {
+    receipt = JSON.parse(body);
+  } catch {
+    // error-policy:J3 an accepted response without a stable receipt is uncertain, not success.
+    return { success: false, error: "Blooio accepted delivery without a valid receipt" };
+  }
+  const record = receipt && typeof receipt === "object" ? (receipt as Record<string, unknown>) : {};
+  const messageId =
+    typeof record.id === "string"
+      ? record.id
+      : typeof record.message_id === "string"
+        ? record.message_id
+        : undefined;
+  if (!messageId?.trim()) {
+    return { success: false, error: "Blooio accepted delivery without a message id" };
+  }
+  return { success: true, messageId: messageId.trim(), chatId: chatId ?? input.to };
+}

--- a/plugins/plugin-imessage/src/blooio-transport.ts
+++ b/plugins/plugin-imessage/src/blooio-transport.ts
@@ -80,7 +80,7 @@ export function verifyBlooioSignature(
   nowSeconds = Math.floor(Date.now() / 1000)
 ): boolean {
   if (!secret || !signatureHeader) return false;
-  const parts = signatureHeader.split(",");
+  const parts = signatureHeader.split(",").map((part) => part.trim());
   const timestampPart = parts.find((part) => part.startsWith("t="));
   const signaturePart = parts.find((part) => part.startsWith("v1="));
   if (!timestampPart || !signaturePart) return false;

--- a/plugins/plugin-imessage/src/blooio-webhook-dedupe.test.ts
+++ b/plugins/plugin-imessage/src/blooio-webhook-dedupe.test.ts
@@ -6,10 +6,10 @@
  */
 
 import crypto from "node:crypto";
-import type { IAgentRuntime, Media } from "@elizaos/core";
+import type { IAgentRuntime, Media, Task, TaskWorker } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { ChatDbMessage } from "./chatdb-reader.js";
-import { IMessageService } from "./service.js";
+import { BLOOIO_RECEIPT_RETENTION_MS, IMessageService } from "./service.js";
 import type { IMessageSettings } from "./types.js";
 
 const SECRET = "whsec_dedupe_test";
@@ -43,10 +43,16 @@ interface CacheHarness {
   runtime: IAgentRuntime;
   store: Map<string, unknown>;
   reportError: ReturnType<typeof vi.fn>;
+  deleteCache: ReturnType<typeof vi.fn>;
+  tasks: Task[];
+  workers: Map<string, TaskWorker>;
 }
 
 function makeRuntime(store = new Map<string, unknown>()): CacheHarness {
   const reportError = vi.fn();
+  const tasks: Task[] = [];
+  const workers = new Map<string, TaskWorker>();
+  const deleteCache = vi.fn(async (key: string) => store.delete(key));
   const runtime = {
     agentId: "00000000-0000-0000-0000-000000000001",
     getSetting: vi.fn(() => undefined),
@@ -55,9 +61,21 @@ function makeRuntime(store = new Map<string, unknown>()): CacheHarness {
       store.set(key, value);
       return true;
     }),
+    deleteCache,
+    registerTaskWorker: vi.fn((worker: TaskWorker) => workers.set(worker.name, worker)),
+    getTaskWorker: vi.fn((name: string) => workers.get(name)),
+    createTask: vi.fn(async (task: Task) => {
+      const id = `00000000-0000-0000-0000-${String(tasks.length + 1).padStart(12, "0")}`;
+      tasks.push({ ...task, id: id as Task["id"] });
+      return id;
+    }),
+    deleteTask: vi.fn(async (id: string) => {
+      const index = tasks.findIndex((task) => task.id === id);
+      if (index >= 0) tasks.splice(index, 1);
+    }),
     reportError,
   } as unknown as IAgentRuntime;
-  return { runtime, store, reportError };
+  return { runtime, store, reportError, deleteCache, tasks, workers };
 }
 
 type InboundDispatch = (row: ChatDbMessage, media?: Media[]) => Promise<void>;
@@ -156,6 +174,202 @@ describe("Blooio webhook durable dispatch receipts", () => {
     await expect(restartedService.handleBlooioWebhook(body, signature)).resolves.toBe("ignored");
     expect(firstDispatch).toHaveBeenCalledTimes(1);
     expect(restartedDispatch).not.toHaveBeenCalled();
+  });
+
+  it("schedules a bounded cleanup task that deletes the matching durable receipt", async () => {
+    const { runtime, store, tasks, workers } = makeRuntime();
+    const dispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    const service = makeService(runtime, dispatch);
+    const body = envelope();
+
+    await expect(service.handleBlooioWebhook(body, sign(body))).resolves.toBe("accepted");
+    expect(tasks).toHaveLength(1);
+    const [task] = tasks;
+    expect(task.tags).toContain("repeat");
+    expect(task.metadata?.maxFailures).toBe(0);
+    const acceptedAt = task.metadata?.acceptedAt;
+    expect(typeof acceptedAt).toBe("number");
+    expect(Number(task.dueAt) - Number(acceptedAt)).toBe(BLOOIO_RECEIPT_RETENTION_MS);
+    const receiptKey = task.metadata?.receiptKey;
+    expect(typeof receiptKey).toBe("string");
+    expect(store.get(String(receiptKey))).toMatchObject({
+      version: 1,
+      acceptedAt,
+      cleanupTaskId: task.id,
+    });
+
+    const worker = workers.get(task.name);
+    expect(worker).toBeDefined();
+    await worker?.execute(runtime, task.metadata ?? {}, task);
+    expect(store.has(String(receiptKey))).toBe(false);
+  });
+
+  it("keeps the scheduled cleanup task retryable when durable deletion fails", async () => {
+    const harness = makeRuntime();
+    const service = makeService(
+      harness.runtime,
+      vi.fn<InboundDispatch>().mockResolvedValue(undefined)
+    );
+    const body = envelope();
+    await service.handleBlooioWebhook(body, sign(body));
+    const [task] = harness.tasks;
+    const worker = harness.workers.get(task.name);
+    harness.deleteCache.mockRejectedValueOnce(new Error("cache delete unavailable"));
+
+    await expect(worker?.execute(harness.runtime, task.metadata ?? {}, task)).rejects.toMatchObject(
+      {
+        code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_FAILED",
+      }
+    );
+    expect(harness.tasks).toContain(task);
+    expect(harness.store.has(String(task.metadata?.receiptKey))).toBe(true);
+    expect(harness.reportError).toHaveBeenCalledWith(
+      "IMessageService.blooioReceiptCleanup",
+      expect.objectContaining({ code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_FAILED" }),
+      expect.objectContaining({ receiptDigest: expect.any(String) })
+    );
+  });
+
+  it("repairs a receipt whose cleanup scheduling initially failed without redispatching", async () => {
+    const harness = makeRuntime();
+    vi.mocked(harness.runtime.createTask).mockRejectedValueOnce(
+      new Error("task storage temporarily unavailable")
+    );
+    const dispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    const service = makeService(harness.runtime, dispatch);
+    const body = envelope();
+    const signature = sign(body);
+
+    await expect(service.handleBlooioWebhook(body, signature)).rejects.toMatchObject({
+      code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_SCHEDULE_FAILED",
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [receiptKey] = harness.store.keys();
+    expect(harness.store.get(receiptKey)).toMatchObject({ version: 1 });
+    expect(harness.store.get(receiptKey)).not.toHaveProperty("cleanupTaskId");
+
+    await expect(service.handleBlooioWebhook(body, signature)).resolves.toBe("ignored");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(harness.store.get(receiptKey)).toMatchObject({
+      version: 1,
+      cleanupTaskId: expect.any(String),
+    });
+    expect(harness.tasks).toHaveLength(1);
+  });
+
+  it("cleans an expired receipt and allows the delivery to dispatch again", async () => {
+    const sharedStore = new Map<string, unknown>();
+    const firstHarness = makeRuntime(sharedStore);
+    const firstService = makeService(
+      firstHarness.runtime,
+      vi.fn<InboundDispatch>().mockResolvedValue(undefined)
+    );
+    const body = envelope();
+    const signature = sign(body);
+    await firstService.handleBlooioWebhook(body, signature);
+    const [receiptKey] = sharedStore.keys();
+    sharedStore.set(receiptKey, {
+      version: 1,
+      acceptedAt: Date.now() - BLOOIO_RECEIPT_RETENTION_MS - 1,
+      cleanupTaskId: "old-cleanup-task",
+    });
+
+    const retryHarness = makeRuntime(sharedStore);
+    const retryDispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    const retryService = makeService(retryHarness.runtime, retryDispatch);
+    await expect(retryService.handleBlooioWebhook(body, signature)).resolves.toBe("accepted");
+    expect(retryHarness.deleteCache).toHaveBeenCalledWith(receiptKey);
+    expect(retryDispatch).toHaveBeenCalledTimes(1);
+    expect(sharedStore.get(receiptKey)).toMatchObject({ version: 1 });
+  });
+
+  it.each([
+    ["primitive", "poison"],
+    ["invalid current timestamp", { version: 1, acceptedAt: "yesterday" }],
+    ["invalid version zero", { version: 0, acceptedAt: Date.now() }],
+    ["far-future current timestamp", { version: 1, acceptedAt: Date.now() + 10 * 60 * 1000 }],
+    ["invalid cleanup task id", { version: 1, acceptedAt: Date.now(), cleanupTaskId: "" }],
+  ])(
+    "removes malformed receipt state (%s) and self-heals through dispatch",
+    async (_name, value) => {
+      const sharedStore = new Map<string, unknown>();
+      const seedHarness = makeRuntime(sharedStore);
+      const body = envelope();
+      const signature = sign(body);
+      await makeService(
+        seedHarness.runtime,
+        vi.fn<InboundDispatch>().mockResolvedValue(undefined)
+      ).handleBlooioWebhook(body, signature);
+      const [receiptKey] = sharedStore.keys();
+      sharedStore.set(receiptKey, value);
+
+      const retryHarness = makeRuntime(sharedStore);
+      const retryDispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+      await expect(
+        makeService(retryHarness.runtime, retryDispatch).handleBlooioWebhook(body, signature)
+      ).resolves.toBe("accepted");
+      expect(retryHarness.deleteCache).toHaveBeenCalledWith(receiptKey);
+      expect(retryDispatch).toHaveBeenCalledTimes(1);
+      expect(retryHarness.reportError).toHaveBeenCalledWith(
+        "IMessageService.blooioWebhook",
+        expect.objectContaining({ code: "IMESSAGE_BLOOIO_RECEIPT_INVALID" }),
+        expect.objectContaining({ receiptDigest: expect.any(String) })
+      );
+    }
+  );
+
+  it("treats a future receipt version as processed during rolling deploys", async () => {
+    const sharedStore = new Map<string, unknown>();
+    const seedHarness = makeRuntime(sharedStore);
+    const body = envelope();
+    const signature = sign(body);
+    await makeService(
+      seedHarness.runtime,
+      vi.fn<InboundDispatch>().mockResolvedValue(undefined)
+    ).handleBlooioWebhook(body, signature);
+    const [receiptKey] = sharedStore.keys();
+    const futureReceipt = { version: 2, lifecycle: "owned-by-newer-node" };
+    sharedStore.set(receiptKey, futureReceipt);
+
+    const olderHarness = makeRuntime(sharedStore);
+    const olderDispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    await expect(
+      makeService(olderHarness.runtime, olderDispatch).handleBlooioWebhook(body, signature)
+    ).resolves.toBe("ignored");
+    expect(olderDispatch).not.toHaveBeenCalled();
+    expect(olderHarness.deleteCache).not.toHaveBeenCalled();
+    expect(sharedStore.get(receiptKey)).toBe(futureReceipt);
+  });
+
+  it("fails without dispatch when expired receipt cleanup cannot complete", async () => {
+    const sharedStore = new Map<string, unknown>();
+    const seedHarness = makeRuntime(sharedStore);
+    const body = envelope();
+    const signature = sign(body);
+    await makeService(
+      seedHarness.runtime,
+      vi.fn<InboundDispatch>().mockResolvedValue(undefined)
+    ).handleBlooioWebhook(body, signature);
+    const [receiptKey] = sharedStore.keys();
+    sharedStore.set(receiptKey, {
+      version: 1,
+      acceptedAt: Date.now() - BLOOIO_RECEIPT_RETENTION_MS - 1,
+      cleanupTaskId: "old-cleanup-task",
+    });
+
+    const retryHarness = makeRuntime(sharedStore);
+    retryHarness.deleteCache.mockRejectedValueOnce(new Error("cache delete unavailable"));
+    const retryDispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    await expect(
+      makeService(retryHarness.runtime, retryDispatch).handleBlooioWebhook(body, signature)
+    ).rejects.toMatchObject({ code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_FAILED" });
+    expect(retryDispatch).not.toHaveBeenCalled();
+    expect(sharedStore.has(receiptKey)).toBe(true);
+    expect(retryHarness.reportError).toHaveBeenCalledWith(
+      "IMessageService.blooioWebhook",
+      expect.objectContaining({ code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_FAILED" }),
+      expect.objectContaining({ receiptDigest: expect.any(String) })
+    );
   });
 
   it("reports and fails before dispatch when durable receipt storage is unavailable", async () => {

--- a/plugins/plugin-imessage/src/blooio-webhook-dedupe.test.ts
+++ b/plugins/plugin-imessage/src/blooio-webhook-dedupe.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Exercises Blooio webhook idempotency through the public service boundary with
+ * a durable runtime cache and a controlled inbound dispatcher. The harness
+ * proves failed dispatches remain retryable, concurrent deliveries cannot both
+ * dispatch, and completed receipts survive a new service instance.
+ */
+
+import crypto from "node:crypto";
+import type { IAgentRuntime, Media } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatDbMessage } from "./chatdb-reader.js";
+import { IMessageService } from "./service.js";
+import type { IMessageSettings } from "./types.js";
+
+const SECRET = "whsec_dedupe_test";
+const CHANNEL_ID = "ch_bettina";
+const MESSAGE_ID = "msg_retry_1";
+
+function envelope(): string {
+  return JSON.stringify({
+    id: "evt_retry_1",
+    type: "message.received",
+    created_at: Date.now(),
+    data: {
+      id: MESSAGE_ID,
+      chat_id: "chat_retry_1",
+      channel_id: CHANNEL_ID,
+      channel_type: "blooio",
+      sender: "+15551234567",
+      recipient: "+12692921765",
+      text: "retry me safely",
+    },
+  });
+}
+
+function sign(body: string): string {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const digest = crypto.createHmac("sha256", SECRET).update(`${timestamp}.${body}`).digest("hex");
+  return `t=${timestamp},v1=${digest}`;
+}
+
+interface CacheHarness {
+  runtime: IAgentRuntime;
+  store: Map<string, unknown>;
+  reportError: ReturnType<typeof vi.fn>;
+}
+
+function makeRuntime(store = new Map<string, unknown>()): CacheHarness {
+  const reportError = vi.fn();
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    getSetting: vi.fn(() => undefined),
+    getCache: vi.fn(async (key: string) => store.get(key)),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+      return true;
+    }),
+    reportError,
+  } as unknown as IAgentRuntime;
+  return { runtime, store, reportError };
+}
+
+type InboundDispatch = (row: ChatDbMessage, media?: Media[]) => Promise<void>;
+
+function makeService(runtime: IAgentRuntime, dispatch: InboundDispatch): IMessageService {
+  const service = new IMessageService(runtime);
+  const internal = service as unknown as {
+    settings: IMessageSettings;
+    dispatchInboundMessage: InboundDispatch;
+  };
+  internal.settings = {
+    transport: "blooio",
+    pollIntervalMs: 0,
+    heartbeatIntervalMs: 60_000,
+    dmPolicy: "open",
+    groupPolicy: "allowlist",
+    allowFrom: [],
+    enabled: true,
+    blooioApiKey: "api_test",
+    blooioWebhookSecret: SECRET,
+    blooioFromNumber: "+12692921765",
+    blooioChannelId: CHANNEL_ID,
+  };
+  internal.dispatchInboundMessage = dispatch;
+  return service;
+}
+
+describe("Blooio webhook durable dispatch receipts", () => {
+  it("leaves no receipt after dispatch failure so a provider retry can succeed", async () => {
+    const { runtime, store } = makeRuntime();
+    const dispatch = vi
+      .fn<InboundDispatch>()
+      .mockRejectedValueOnce(new Error("runtime temporarily unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const service = makeService(runtime, dispatch);
+    const body = envelope();
+    const signature = sign(body);
+
+    await expect(service.handleBlooioWebhook(body, signature)).rejects.toThrow(
+      "runtime temporarily unavailable"
+    );
+    expect(store.size).toBe(0);
+
+    await expect(service.handleBlooioWebhook(body, signature)).resolves.toBe("accepted");
+    await expect(service.handleBlooioWebhook(body, signature)).resolves.toBe("ignored");
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(store.size).toBe(1);
+    const [receiptKey] = store.keys();
+    expect(receiptKey).toMatch(/^imessage:blooio-receipt:v1:[a-f0-9]{64}$/);
+    expect(receiptKey).not.toContain(CHANNEL_ID);
+    expect(receiptKey).not.toContain(MESSAGE_ID);
+  });
+
+  it("rejects a concurrent duplicate without dispatching it twice", async () => {
+    const { runtime, reportError } = makeRuntime();
+    let releaseDispatch: (() => void) | undefined;
+    const dispatchBlocked = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const dispatch = vi.fn<InboundDispatch>(() => dispatchBlocked);
+    const service = makeService(runtime, dispatch);
+    const body = envelope();
+    const signature = sign(body);
+
+    const first = service.handleBlooioWebhook(body, signature);
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+    await expect(service.handleBlooioWebhook(body, signature)).rejects.toMatchObject({
+      code: "IMESSAGE_BLOOIO_DISPATCH_IN_FLIGHT",
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(
+      "IMessageService.blooioWebhook",
+      expect.objectContaining({ code: "IMESSAGE_BLOOIO_DISPATCH_IN_FLIGHT" }),
+      expect.objectContaining({ receiptDigest: expect.any(String) })
+    );
+
+    releaseDispatch?.();
+    await expect(first).resolves.toBe("accepted");
+    await expect(service.handleBlooioWebhook(body, signature)).resolves.toBe("ignored");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the durable receipt to suppress replay after a new service instance starts", async () => {
+    const sharedStore = new Map<string, unknown>();
+    const firstHarness = makeRuntime(sharedStore);
+    const firstDispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    const firstService = makeService(firstHarness.runtime, firstDispatch);
+    const body = envelope();
+    const signature = sign(body);
+
+    await expect(firstService.handleBlooioWebhook(body, signature)).resolves.toBe("accepted");
+
+    const restartedHarness = makeRuntime(sharedStore);
+    const restartedDispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    const restartedService = makeService(restartedHarness.runtime, restartedDispatch);
+    await expect(restartedService.handleBlooioWebhook(body, signature)).resolves.toBe("ignored");
+    expect(firstDispatch).toHaveBeenCalledTimes(1);
+    expect(restartedDispatch).not.toHaveBeenCalled();
+  });
+
+  it("reports and fails before dispatch when durable receipt storage is unavailable", async () => {
+    const { runtime, reportError } = makeRuntime();
+    vi.mocked(runtime.getCache).mockRejectedValueOnce(new Error("cache offline"));
+    const dispatch = vi.fn<InboundDispatch>().mockResolvedValue(undefined);
+    const service = makeService(runtime, dispatch);
+    const body = envelope();
+
+    await expect(service.handleBlooioWebhook(body, sign(body))).rejects.toMatchObject({
+      code: "IMESSAGE_BLOOIO_RECEIPT_READ_FAILED",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledWith(
+      "IMessageService.blooioWebhook",
+      expect.objectContaining({ code: "IMESSAGE_BLOOIO_RECEIPT_READ_FAILED" }),
+      expect.objectContaining({ receiptDigest: expect.any(String) })
+    );
+  });
+});

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -34,6 +34,10 @@ const IMESSAGE_SERVICE_NAME = "imessage";
  * module so the route file stays loosely coupled.
  */
 interface IMessageServiceLike {
+  handleBlooioWebhook?(
+    rawBody: string,
+    signature: string | undefined
+  ): Promise<"accepted" | "ignored" | "unauthorized">;
   getRecentMessages(limit?: number): Promise<
     Array<{
       id: string;
@@ -107,6 +111,38 @@ interface IMessageServiceLike {
     }
   ): Promise<boolean>;
   deleteContact(personId: string): Promise<boolean>;
+}
+
+function readHeader(req: RouteRequest, name: string): string | undefined {
+  const value = req.headers?.[name.toLowerCase()] ?? req.headers?.[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function handleBlooioWebhook(
+  req: RouteRequest,
+  res: RouteResponse,
+  runtime: IAgentRuntime
+): Promise<void> {
+  const service = resolveService(runtime);
+  if (!service?.handleBlooioWebhook) {
+    res
+      .status(503)
+      .json(buildSetupError("service_unavailable", "imessage Blooio transport is unavailable"));
+    return;
+  }
+  if (typeof req.rawBody !== "string" || req.rawBody.length === 0) {
+    res.status(400).json(buildSetupError("bad_request", "raw webhook body is required"));
+    return;
+  }
+  const result = await service.handleBlooioWebhook(
+    req.rawBody,
+    readHeader(req, "x-blooio-signature")
+  );
+  if (result === "unauthorized") {
+    res.status(401).json(buildSetupError("unauthorized", "invalid Blooio webhook signature"));
+    return;
+  }
+  res.status(200).json({ received: true, dispatched: result === "accepted" });
 }
 
 function isIMessageServiceLike(service: unknown): service is IMessageServiceLike {
@@ -475,6 +511,12 @@ async function handleDeleteContact(
 }
 
 export const imessageDataRoutes: Route[] = [
+  {
+    type: "POST",
+    path: "/api/imessage/webhook/blooio",
+    handler: handleBlooioWebhook,
+    rawPath: true,
+  },
   {
     type: "GET",
     path: "/api/imessage/messages",

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -512,10 +512,15 @@ async function handleDeleteContact(
 
 export const imessageDataRoutes: Route[] = [
   {
+    name: "imessage-blooio-webhook",
     type: "POST",
     path: "/api/imessage/webhook/blooio",
     handler: handleBlooioWebhook,
     rawPath: true,
+    public: true,
+    publicReason: "Blooio webhook delivery is authenticated by its HMAC signature.",
+    publicWrite:
+      "Inbound Blooio webhook POST authenticated by the X-Blooio-Signature header, not the local gate.",
   },
   {
     type: "GET",

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -1,9 +1,7 @@
 /**
  * iMessage Plugin for elizaOS
  *
- * Provides iMessage integration for Eliza agents on macOS. Inbound messages
- * come from the local Messages database and outbound messages use Messages.app
- * automation, without an auxiliary CLI, relay, or network service.
+ * Provides iMessage integration through native macOS Messages or Blooio.
  */
 
 import { platform } from "node:os";
@@ -85,7 +83,7 @@ export {
  */
 const imessagePlugin: Plugin = {
   name: "imessage",
-  description: "iMessage plugin for Eliza agents (macOS only)",
+  description: "iMessage plugin for Eliza agents using native Messages or Blooio",
   connectorSources: [
     {
       source: "imessage",
@@ -132,16 +130,23 @@ const imessagePlugin: Plugin = {
     registerIMessageDmSensitiveRequestAdapter(runtime);
 
     const isMacOS = platform() === "darwin";
+    const transport = (
+      config.IMESSAGE_TRANSPORT ||
+      process.env.IMESSAGE_TRANSPORT ||
+      "native"
+    ).toLowerCase();
 
     logger.info("iMessage plugin configuration:");
     logger.info(`  - Platform: ${platform()}`);
     logger.info(`  - macOS: ${isMacOS ? "Yes" : "No"}`);
-    logger.info("  - Bridge: native macOS Messages (chat.db + Apple Automation)");
+    logger.info(
+      `  - Bridge: ${transport === "blooio" ? "Blooio webhook + API" : "native macOS Messages (chat.db + Apple Automation)"}`
+    );
     logger.info(
       `  - DM policy: ${config.IMESSAGE_DM_POLICY || process.env.IMESSAGE_DM_POLICY || "pairing"}`
     );
 
-    if (!isMacOS) {
+    if (!isMacOS && transport !== "blooio") {
       logger.warn(
         "iMessage plugin is only supported on macOS. The plugin will be inactive on this platform."
       );

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -103,6 +103,7 @@ const imessagePlugin: Plugin = {
   // configured under config.connectors. The hardcoded CONNECTOR_PLUGINS map
   // in plugin-auto-enable-engine.ts still serves as a fallback.
   autoEnable: {
+    envKeys: ["IMESSAGE_TRANSPORT", "IMESSAGE_ENABLED"],
     connectorKeys: ["imessage"],
   },
 

--- a/plugins/plugin-imessage/src/routes-e2e.test.ts
+++ b/plugins/plugin-imessage/src/routes-e2e.test.ts
@@ -309,6 +309,16 @@ describe("plugin-imessage setup routes (real dispatch)", () => {
 // ── Data routes ───────────────────────────────────────────────────────
 
 describe("plugin-imessage data routes (real dispatch)", () => {
+  it("allows the signed Blooio webhook route to reach its handler without local auth", async () => {
+    const base = await startServer(makeRuntime({ imessage: null }), () => false);
+    const res = await sendJson(base, "POST", "/api/imessage/webhook/blooio", {
+      type: "message.delivered",
+    });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("service_unavailable");
+  });
+
   it("GET /api/imessage/messages returns the service's messages and count", async () => {
     const base = await startServer(
       makeRuntime({

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -1159,6 +1159,18 @@ export class IMessageService extends Service implements IIMessageService {
       return "ignored";
     }
     if (!verifyBlooioSignature(settings.blooioWebhookSecret, signature, rawBody)) {
+      logger.warn(
+        {
+          src: "plugin:imessage:blooio",
+          rawBodyBytes: Buffer.byteLength(rawBody),
+          rawBodySha256: crypto.createHash("sha256").update(rawBody).digest("hex"),
+          signaturePresent: Boolean(signature),
+          signatureLength: signature?.length ?? 0,
+          signatureSegmentCount: signature?.split(",").length ?? 0,
+          signatureContainsWhitespace: /\s/.test(signature ?? ""),
+        },
+        "[imessage] Rejected a Blooio webhook with an invalid signature"
+      );
       return "unauthorized";
     }
     const inbound = parseBlooioInbound(rawBody, settings.blooioChannelId);

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -3,6 +3,7 @@
  */
 
 import { execFile } from "node:child_process";
+import crypto from "node:crypto";
 import { mkdtemp, open, rm, writeFile } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
 import { extname, isAbsolute, join } from "node:path";
@@ -44,6 +45,11 @@ import {
   DEFAULT_ACCOUNT_ID as IMESSAGE_LOCAL_ACCOUNT_ID,
   normalizeAccountId as normalizeIMessageAccountId,
 } from "./accounts.js";
+import {
+  parseBlooioInbound,
+  sendBlooioMessage,
+  verifyBlooioSignature,
+} from "./blooio-transport.js";
 import {
   type ChatDbMessage,
   type ChatDbReader,
@@ -309,6 +315,7 @@ function firstAttachmentUrl(content: Content): string | undefined {
 
 function statusMetadata(status: IMessageServiceStatus): Record<string, string | boolean | null> {
   return {
+    transport: status.transport,
     available: status.available,
     connected: status.connected,
     chatDbAvailable: status.chatDbAvailable,
@@ -316,6 +323,8 @@ function statusMetadata(status: IMessageServiceStatus): Record<string, string | 
     chatDbPath: status.chatDbPath,
     reason: status.reason,
     permissionAction: status.permissionAction?.label ?? null,
+    webhookPath: status.webhookPath,
+    channelId: status.channelId,
   };
 }
 
@@ -547,7 +556,7 @@ async function resolveIMessageChatId(
 export class IMessageService extends Service implements IIMessageService {
   static serviceType: string = IMESSAGE_SERVICE_NAME;
 
-  capabilityDescription = "iMessage service for sending and receiving messages on macOS";
+  capabilityDescription = "iMessage service using native Messages or a Blooio gateway";
 
   private settings: IMessageSettings | null = null;
   private connected: boolean = false;
@@ -606,6 +615,8 @@ export class IMessageService extends Service implements IIMessageService {
   private contacts: ContactsMap = new Map();
   /** Whether the lazy contact load has been attempted this session. */
   private contactsLoadAttempted = false;
+  /** Webhook message ids accepted during this process lifetime. */
+  private blooioMessageIds = new Set<string>();
 
   /**
    * Start the iMessage service.
@@ -615,13 +626,11 @@ export class IMessageService extends Service implements IIMessageService {
 
     const service = new IMessageService(runtime);
 
-    // Check if running on macOS
-    if (!service.isMacOS()) {
-      throw new IMessageNotSupportedError();
-    }
-
     // Load settings
     service.settings = service.loadSettings();
+    if (service.settings.transport === "native" && !service.isMacOS()) {
+      throw new IMessageNotSupportedError();
+    }
     const settingFromRuntime =
       typeof service.runtime.getSetting === "function"
         ? service.runtime.getSetting("IMESSAGE_BACKFILL")
@@ -640,7 +649,8 @@ export class IMessageService extends Service implements IIMessageService {
     // the polling cursor from the current tip of the database so a freshly
     // started agent doesn't re-process its entire message backlog.
     service.chatDbPath = service.settings.dbPath || DEFAULT_CHAT_DB_PATH;
-    service.chatDb = await openChatDb(service.chatDbPath);
+    service.chatDb =
+      service.settings.transport === "native" ? await openChatDb(service.chatDbPath) : null;
     if (service.chatDb) {
       const tip = service.chatDb.getLatestRowId();
 
@@ -687,23 +697,30 @@ export class IMessageService extends Service implements IIMessageService {
   }
 
   static registerSendHandlers(runtime: IAgentRuntime, service: IMessageService): void {
+    const status = service.getStatus();
+    const isBlooio = status.transport === "blooio";
     const registration = {
       source: IMESSAGE_SERVICE_NAME,
       label: "iMessage",
-      capabilities: ["send_message", "attachments", "contact_resolution", "chat_context"],
+      capabilities: isBlooio
+        ? ["send_message", "chat_context"]
+        : ["send_message", "attachments", "contact_resolution", "chat_context"],
       supportedTargetKinds: ["phone", "email", "contact", "user", "group", "room"],
       contexts: ["phone", "social", "connectors"],
-      description:
-        "Send SMS/iMessage through macOS Messages using phone numbers, emails, contacts, or chat ids.",
+      description: isBlooio
+        ? "Send and receive iMessage through the configured Blooio channel."
+        : "Send SMS/iMessage through macOS Messages using phone numbers, emails, contacts, or chat ids.",
       metadata: {
         // `sms` is the canonical source owned by the Android Messages plugin.
         // Keeping the local bridge on its iMessage/Messages names makes source
         // selection deterministic when both first-party plugins are loaded.
         aliases: ["imessage", "messages"],
         accountId: IMESSAGE_LOCAL_ACCOUNT_ID,
-        bridge: "macos-messages",
-        accountSemantics: "local-macos-messages-single-account",
-        status: statusMetadata(service.getStatus()),
+        bridge: isBlooio ? "blooio" : "macos-messages",
+        accountSemantics: isBlooio
+          ? "blooio-channel-single-account"
+          : "local-macos-messages-single-account",
+        status: statusMetadata(status),
       },
       sendHandler: async (_runtime: IAgentRuntime, target: TargetInfo, content: Content) => {
         const accountId = assertLocalIMessageAccount(readTargetAccountId(target));
@@ -993,17 +1010,25 @@ export class IMessageService extends Service implements IIMessageService {
   }
 
   getStatus(): IMessageServiceStatus {
+    const transport = this.settings?.transport ?? "native";
     const chatDbAvailable = this.chatDb !== null;
-    const accessIssue = chatDbAvailable ? null : getLastChatDbAccessIssue(this.chatDbPath);
+    const accessIssue =
+      transport === "native" && !chatDbAvailable ? getLastChatDbAccessIssue(this.chatDbPath) : null;
 
     return {
+      transport,
       available: true,
       connected: this.connected,
       chatDbAvailable,
-      sendOnly: this.connected && !chatDbAvailable,
+      sendOnly: transport === "native" && this.connected && !chatDbAvailable,
       chatDbPath: this.chatDbPath,
-      reason: accessIssue?.reason ?? (chatDbAvailable ? null : "chat.db reader not available"),
+      reason:
+        transport === "blooio"
+          ? null
+          : (accessIssue?.reason ?? (chatDbAvailable ? null : "chat.db reader not available")),
       permissionAction: accessIssue?.permissionAction ?? null,
+      webhookPath: transport === "blooio" ? "/api/imessage/webhook/blooio" : null,
+      channelId: transport === "blooio" ? (this.settings?.blooioChannelId ?? null) : null,
     };
   }
 
@@ -1025,6 +1050,14 @@ export class IMessageService extends Service implements IIMessageService {
     const accountId = assertLocalIMessageAccount(options?.accountId);
     if (!this.settings) {
       return { success: false, error: "Service not initialized" };
+    }
+
+    if (this.settings.transport === "blooio" && options?.mediaUrl) {
+      return {
+        success: false,
+        error:
+          "Blooio media sends require a public attachment URL and are not supported by this endpoint yet",
+      };
     }
 
     // Format phone number if needed
@@ -1111,6 +1144,73 @@ export class IMessageService extends Service implements IIMessageService {
       messageId: Date.now().toString(),
       chatId: target,
     };
+  }
+
+  async handleBlooioWebhook(
+    rawBody: string,
+    signature: string | undefined
+  ): Promise<"accepted" | "ignored" | "unauthorized"> {
+    const settings = this.settings;
+    if (
+      settings?.transport !== "blooio" ||
+      !settings.blooioWebhookSecret ||
+      !settings.blooioChannelId
+    ) {
+      return "ignored";
+    }
+    if (!verifyBlooioSignature(settings.blooioWebhookSecret, signature, rawBody)) {
+      return "unauthorized";
+    }
+    const inbound = parseBlooioInbound(rawBody, settings.blooioChannelId);
+    if (!inbound || this.blooioMessageIds.has(inbound.messageId)) return "ignored";
+
+    const access: { allowed: boolean; pairingReplyMessage?: string } = inbound.isGroup
+      ? this.checkGroupAccess(inbound.sender)
+      : await this.checkDmAccess(inbound.sender);
+    if (!access.allowed) {
+      if (access.pairingReplyMessage && this.isAutoReplyEnabled()) {
+        await this.sendSingleMessage(inbound.sender, access.pairingReplyMessage);
+      }
+      return "ignored";
+    }
+
+    this.blooioMessageIds.add(inbound.messageId);
+    if (this.blooioMessageIds.size > 2_000) {
+      const oldest = this.blooioMessageIds.values().next().value;
+      if (typeof oldest === "string") this.blooioMessageIds.delete(oldest);
+    }
+
+    const media: Media[] = inbound.mediaUrls.map((url, index) => ({
+      id: `${inbound.messageId}-${index}`,
+      url,
+      source: "imessage",
+      title: "Blooio attachment",
+      description: "Inbound Blooio attachment",
+    }));
+    const row: ChatDbMessage = {
+      rowId: inbound.timestamp,
+      guid: inbound.messageId,
+      text: inbound.text,
+      kind: "text",
+      handle: inbound.sender,
+      chatId: inbound.chatId,
+      chatType: inbound.isGroup ? "group" : "direct",
+      displayName: null,
+      timestamp: inbound.timestamp,
+      isFromMe: false,
+      service: "iMessage",
+      isSent: false,
+      isDelivered: true,
+      isRead: false,
+      dateRead: 0,
+      dateEdited: 0,
+      dateRetracted: 0,
+      replyToGuid: inbound.replyToMessageId ?? null,
+      reaction: null,
+      attachments: [],
+    };
+    await this.dispatchInboundMessage(row, media);
+    return "accepted";
   }
 
   /**
@@ -1205,6 +1305,7 @@ export class IMessageService extends Service implements IIMessageService {
       return;
     }
     this.contactsLoadAttempted = true;
+    if (this.settings?.transport === "blooio") return;
     try {
       this.contacts = await loadContacts();
       this.recordContactsPermissionBlock("contacts.resolve");
@@ -1301,6 +1402,15 @@ export class IMessageService extends Service implements IIMessageService {
     };
 
     const dbPath = getStringSetting("IMESSAGE_DB_PATH", "IMESSAGE_DB_PATH") || undefined;
+    const transportRaw = getStringSetting("IMESSAGE_TRANSPORT", "IMESSAGE_TRANSPORT", "native")
+      .trim()
+      .toLowerCase();
+    if (transportRaw !== "native" && transportRaw !== "blooio") {
+      throw new IMessageConfigurationError(
+        "IMESSAGE_TRANSPORT must be native or blooio",
+        "IMESSAGE_TRANSPORT"
+      );
+    }
 
     const pollIntervalRaw = getStringSetting(
       "IMESSAGE_POLL_INTERVAL_MS",
@@ -1343,6 +1453,7 @@ export class IMessageService extends Service implements IIMessageService {
     const enabled = enabledRaw !== "false";
 
     return {
+      transport: transportRaw,
       dbPath,
       pollIntervalMs,
       heartbeatIntervalMs,
@@ -1350,12 +1461,41 @@ export class IMessageService extends Service implements IIMessageService {
       groupPolicy,
       allowFrom,
       enabled,
+      blooioApiKey:
+        getStringSetting("IMESSAGE_BLOOIO_API_KEY", "IMESSAGE_BLOOIO_API_KEY") ||
+        getStringSetting("BLOOIO_API_KEY", "BLOOIO_API_KEY") ||
+        undefined,
+      blooioWebhookSecret:
+        getStringSetting("IMESSAGE_BLOOIO_WEBHOOK_SECRET", "IMESSAGE_BLOOIO_WEBHOOK_SECRET") ||
+        getStringSetting("BLOOIO_WEBHOOK_SECRET", "BLOOIO_WEBHOOK_SECRET") ||
+        undefined,
+      blooioFromNumber:
+        getStringSetting("IMESSAGE_BLOOIO_FROM_NUMBER", "IMESSAGE_BLOOIO_FROM_NUMBER") ||
+        getStringSetting("BLOOIO_FROM_NUMBER", "BLOOIO_FROM_NUMBER") ||
+        undefined,
+      blooioChannelId:
+        getStringSetting("IMESSAGE_BLOOIO_CHANNEL_ID", "IMESSAGE_BLOOIO_CHANNEL_ID") || undefined,
     };
   }
 
   private async validateSettings(): Promise<void> {
     if (!this.settings) {
       throw new IMessageConfigurationError("Settings not loaded");
+    }
+
+    if (this.settings.transport === "blooio") {
+      for (const [setting, value] of [
+        ["IMESSAGE_BLOOIO_API_KEY", this.settings.blooioApiKey],
+        ["IMESSAGE_BLOOIO_WEBHOOK_SECRET", this.settings.blooioWebhookSecret],
+        ["IMESSAGE_BLOOIO_FROM_NUMBER", this.settings.blooioFromNumber],
+        ["IMESSAGE_BLOOIO_CHANNEL_ID", this.settings.blooioChannelId],
+      ] as const) {
+        if (!value)
+          throw new IMessageConfigurationError(
+            `${setting} is required for the Blooio transport`,
+            setting
+          );
+      }
     }
 
     // Do not probe Messages.app during service startup. Sending is gated by
@@ -1365,6 +1505,15 @@ export class IMessageService extends Service implements IIMessageService {
   }
 
   private async sendSingleMessage(to: string, text: string): Promise<IMessageSendResult> {
+    if (this.settings?.transport === "blooio") {
+      return await sendBlooioMessage({
+        apiKey: this.settings.blooioApiKey as string,
+        from: this.settings.blooioChannelId ?? (this.settings.blooioFromNumber as string),
+        to,
+        text,
+        idempotencyKey: `imessage-${crypto.randomUUID()}`,
+      });
+    }
     // Outbound delivery stays on Apple's local Messages automation surface.
     // No third-party CLI, daemon, network service, or fallback transport is
     // invoked from the native connector.
@@ -1600,7 +1749,7 @@ export class IMessageService extends Service implements IIMessageService {
         // follows the same IMESSAGE_AUTO_REPLY consent gate as agent replies.
         // Only the DM pairing path produces one; group denials never do.
         if (access.pairingReplyMessage && this.isAutoReplyEnabled()) {
-          const sendResult = await this.sendViaAppleScript(row.handle, access.pairingReplyMessage);
+          const sendResult = await this.sendSingleMessage(row.handle, access.pairingReplyMessage);
           if (!sendResult.success) {
             logger.warn(
               `[imessage] Pairing reply send failed for handle=${row.handle}: ${sendResult.error}`
@@ -1719,7 +1868,10 @@ export class IMessageService extends Service implements IIMessageService {
    * `source: "imessage"` tag on content, same HandlerCallback signature
    * for the reply path.
    */
-  private async dispatchInboundMessage(row: ChatDbMessage): Promise<void> {
+  private async dispatchInboundMessage(
+    row: ChatDbMessage,
+    externalMedia: Media[] = []
+  ): Promise<void> {
     if (!this.runtime) return;
     const accountId = IMESSAGE_LOCAL_ACCOUNT_ID;
 
@@ -1860,7 +2012,10 @@ export class IMessageService extends Service implements IIMessageService {
       ? createUniqueUuid(this.runtime, `imessage-guid-${row.replyToGuid}`)
       : undefined;
 
-    const rehostedAttachments = await this.rehostInboundAttachments(row.attachments);
+    const rehostedAttachments = [
+      ...(await this.rehostInboundAttachments(row.attachments)),
+      ...externalMedia,
+    ];
     const memoryContent: Content = {
       text: row.text,
       source: "imessage",
@@ -1942,7 +2097,7 @@ export class IMessageService extends Service implements IIMessageService {
         return [];
       }
 
-      const sendResult = await this.sendViaAppleScript(replyTarget, replyText);
+      const sendResult = await this.sendSingleMessage(replyTarget, replyText);
       if (!sendResult.success) {
         logger.error(`[imessage] Reply send failed for ROWID=${row.rowId}: ${sendResult.error}`);
         return [];
@@ -2228,7 +2383,10 @@ export class IMessageService extends Service implements IIMessageService {
         let tip = 0;
         let contactsCount = 0;
         try {
-          if (!this.chatDb) {
+          if (this.settings?.transport === "blooio") {
+            ok = this.connected;
+            reason = ok ? "" : "Blooio transport disconnected";
+          } else if (!this.chatDb) {
             ok = false;
             reason = "chat.db reader not available (send-only mode)";
           } else {
@@ -2288,8 +2446,7 @@ export class IMessageService extends Service implements IIMessageService {
       try {
         await this.runtime.createTask({
           name: "IMESSAGE_HEARTBEAT",
-          description:
-            "Periodic health probe for the iMessage connector (chat.db reader, contacts, polling cursor).",
+          description: "Periodic health probe for the active iMessage connector transport.",
           metadata: {
             updatedAt: Date.now(),
             updateInterval: heartbeatIntervalMs,

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -102,11 +102,22 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
 // with a JavaScript timer, even though current TaskService compares timestamps.
 const MAX_HEARTBEAT_INTERVAL_MS = 2_147_483_647;
 const BLOOIO_RECEIPT_CACHE_NAMESPACE = "imessage:blooio-receipt:v1";
+const BLOOIO_RECEIPT_CLEANUP_TASK_NAME = "IMESSAGE_BLOOIO_RECEIPT_CLEANUP";
+export const BLOOIO_RECEIPT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const BLOOIO_RECEIPT_MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 interface BlooioDispatchReceipt {
   version: 1;
   acceptedAt: number;
+  cleanupTaskId?: string;
 }
+
+type BlooioReceiptState =
+  | { kind: "absent" }
+  | { kind: "processed"; receipt: BlooioDispatchReceipt }
+  | { kind: "expired"; receipt: BlooioDispatchReceipt }
+  | { kind: "future-version"; version: number }
+  | { kind: "malformed" };
 
 function blooioReceiptCacheKey(channelId: string, messageId: string): string {
   const digest = crypto
@@ -118,15 +129,38 @@ function blooioReceiptCacheKey(channelId: string, messageId: string): string {
   return `${BLOOIO_RECEIPT_CACHE_NAMESPACE}:${digest}`;
 }
 
-function isBlooioDispatchReceipt(value: unknown): value is BlooioDispatchReceipt {
-  if (!value || typeof value !== "object") return false;
+function classifyBlooioDispatchReceipt(value: unknown, now: number): BlooioReceiptState {
+  if (value === undefined) return { kind: "absent" };
+  if (!value || typeof value !== "object") return { kind: "malformed" };
   const candidate = value as Partial<BlooioDispatchReceipt>;
-  return (
-    candidate.version === 1 &&
-    typeof candidate.acceptedAt === "number" &&
-    Number.isSafeInteger(candidate.acceptedAt) &&
-    candidate.acceptedAt > 0
-  );
+  if (
+    typeof candidate.version === "number" &&
+    Number.isSafeInteger(candidate.version) &&
+    candidate.version > 1
+  ) {
+    // A newer node owns the receipt schema and its lifecycle. Older nodes in a
+    // rolling deploy must treat it as processed without rewriting or deleting it.
+    return { kind: "future-version", version: candidate.version };
+  }
+  if (
+    candidate.version !== 1 ||
+    typeof candidate.acceptedAt !== "number" ||
+    !Number.isSafeInteger(candidate.acceptedAt) ||
+    candidate.acceptedAt <= 0 ||
+    candidate.acceptedAt > now + BLOOIO_RECEIPT_MAX_FUTURE_SKEW_MS ||
+    (candidate.cleanupTaskId !== undefined &&
+      (typeof candidate.cleanupTaskId !== "string" || !candidate.cleanupTaskId.trim()))
+  ) {
+    return { kind: "malformed" };
+  }
+  const receipt: BlooioDispatchReceipt = {
+    version: 1,
+    acceptedAt: candidate.acceptedAt,
+    ...(candidate.cleanupTaskId ? { cleanupTaskId: candidate.cleanupTaskId } : {}),
+  };
+  return now - receipt.acceptedAt >= BLOOIO_RECEIPT_RETENTION_MS
+    ? { kind: "expired", receipt }
+    : { kind: "processed", receipt };
 }
 
 export function resolveHeartbeatIntervalMs(raw: string | undefined): number {
@@ -645,6 +679,8 @@ export class IMessageService extends Service implements IIMessageService {
   private contactsLoadAttempted = false;
   /** Message ids currently dispatching, preventing concurrent webhook re-entry. */
   private blooioMessagesInFlight = new Set<string>();
+  /** Whether this service has installed the durable receipt cleanup worker. */
+  private blooioCleanupWorkerRegistered = false;
 
   /**
    * Start the iMessage service.
@@ -671,6 +707,9 @@ export class IMessageService extends Service implements IIMessageService {
     // external resource. A typo must fail startup, not silently alter replay.
     const backfill = resolveBackfillRows(resolvedBackfillRaw);
     await service.validateSettings();
+    if (service.settings.transport === "blooio") {
+      service.registerBlooioReceiptCleanupWorker();
+    }
 
     // Open chat.db for inbound polling. A null return here is non-fatal —
     // the service degrades to send-only and logs its own warning. We seed
@@ -1174,6 +1213,185 @@ export class IMessageService extends Service implements IIMessageService {
     };
   }
 
+  private registerBlooioReceiptCleanupWorker(): void {
+    if (this.blooioCleanupWorkerRegistered) return;
+    if (
+      typeof this.runtime.registerTaskWorker !== "function" ||
+      typeof this.runtime.createTask !== "function"
+    ) {
+      const error = new ElizaError(
+        "Blooio durable receipt cleanup requires the runtime task system",
+        {
+          code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_UNAVAILABLE",
+          severity: "fatal",
+        }
+      );
+      this.runtime.reportError("IMessageService.blooioReceiptCleanup", error);
+      throw error;
+    }
+    const existing =
+      typeof this.runtime.getTaskWorker === "function"
+        ? this.runtime.getTaskWorker(BLOOIO_RECEIPT_CLEANUP_TASK_NAME)
+        : undefined;
+    if (!existing) {
+      this.runtime.registerTaskWorker({
+        name: BLOOIO_RECEIPT_CLEANUP_TASK_NAME,
+        execute: async (runtime, options, task) => {
+          const completeCleanupTask = async (): Promise<void> => {
+            if (task.id) await runtime.deleteTask(task.id);
+          };
+          const receiptKey = options.receiptKey;
+          const acceptedAt = options.acceptedAt;
+          if (
+            typeof receiptKey !== "string" ||
+            !receiptKey.startsWith(`${BLOOIO_RECEIPT_CACHE_NAMESPACE}:`) ||
+            typeof acceptedAt !== "number" ||
+            !Number.isSafeInteger(acceptedAt) ||
+            acceptedAt <= 0
+          ) {
+            throw new ElizaError("Blooio receipt cleanup task metadata is invalid", {
+              code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_TASK_INVALID",
+              severity: "fatal",
+            });
+          }
+          const receiptDigest = receiptKey.slice(receiptKey.lastIndexOf(":") + 1);
+          let storedReceipt: unknown;
+          try {
+            storedReceipt = await runtime.getCache<unknown>(receiptKey);
+          } catch (cause) {
+            // error-policy:J2 TaskService owns retry/backoff for durable cleanup failures.
+            const error = new ElizaError("Blooio receipt cleanup could not read durable state", {
+              code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_READ_FAILED",
+              cause,
+              context: { receiptDigest },
+              severity: "ephemeral",
+            });
+            runtime.reportError("IMessageService.blooioReceiptCleanup", error, {
+              receiptDigest,
+            });
+            throw error;
+          }
+          const state = classifyBlooioDispatchReceipt(storedReceipt, Date.now());
+          if (state.kind === "absent" || state.kind === "future-version") {
+            await completeCleanupTask();
+            return undefined;
+          }
+          if (
+            (state.kind === "processed" || state.kind === "expired") &&
+            state.receipt.acceptedAt !== acceptedAt
+          ) {
+            await completeCleanupTask();
+            return undefined;
+          }
+          try {
+            const deleted = await runtime.deleteCache(receiptKey);
+            if (!deleted && (await runtime.getCache<unknown>(receiptKey)) !== undefined) {
+              throw new Error("runtime rejected receipt cleanup");
+            }
+          } catch (cause) {
+            // error-policy:J2 TaskService owns retry/backoff for durable cleanup failures.
+            const error = new ElizaError("Blooio durable dispatch receipt cleanup failed", {
+              code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_FAILED",
+              cause,
+              context: { receiptDigest },
+              severity: "ephemeral",
+            });
+            runtime.reportError("IMessageService.blooioReceiptCleanup", error, {
+              receiptDigest,
+            });
+            throw error;
+          }
+          await completeCleanupTask();
+          return undefined;
+        },
+      });
+    }
+    this.blooioCleanupWorkerRegistered = true;
+  }
+
+  private async deleteBlooioReceipt(receiptKey: string, receiptDigest: string): Promise<void> {
+    try {
+      const deleted = await this.runtime.deleteCache(receiptKey);
+      if (!deleted && (await this.runtime.getCache<unknown>(receiptKey)) !== undefined) {
+        throw new Error("runtime rejected receipt cleanup");
+      }
+    } catch (cause) {
+      // error-policy:J2 Do not dispatch while stale or malformed dedupe state remains durable.
+      const error = new ElizaError("Blooio durable dispatch receipt cleanup failed", {
+        code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_FAILED",
+        cause,
+        context: { receiptDigest },
+        severity: "ephemeral",
+      });
+      this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+      throw error;
+    }
+  }
+
+  private async scheduleBlooioReceiptCleanup(
+    receiptKey: string,
+    receiptDigest: string,
+    acceptedAt: number
+  ): Promise<string> {
+    this.registerBlooioReceiptCleanupWorker();
+    let taskId: UUID;
+    try {
+      taskId = await this.runtime.createTask({
+        name: BLOOIO_RECEIPT_CLEANUP_TASK_NAME,
+        description: "Delete one expired durable Blooio inbound-dispatch receipt.",
+        agentId: this.runtime.agentId,
+        tags: ["queue", "repeat", "imessage", "blooio", "receipt-cleanup"],
+        metadata: {
+          receiptKey,
+          acceptedAt,
+          updateInterval: 60 * 60 * 1000,
+          maxFailures: 0,
+          blocking: true,
+        },
+        dueAt: acceptedAt + BLOOIO_RECEIPT_RETENTION_MS,
+      });
+    } catch (cause) {
+      // error-policy:J2 The webhook must retry until the durable receipt has bounded cleanup.
+      const error = new ElizaError("Blooio receipt cleanup task could not be scheduled", {
+        code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_SCHEDULE_FAILED",
+        cause,
+        context: { receiptDigest },
+        severity: "ephemeral",
+      });
+      this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+      throw error;
+    }
+    const receipt: BlooioDispatchReceipt = {
+      version: 1,
+      acceptedAt,
+      cleanupTaskId: taskId,
+    };
+    let updated: boolean;
+    try {
+      updated = await this.runtime.setCache(receiptKey, receipt);
+    } catch (cause) {
+      // error-policy:J2 The scheduled task remains safe, but the receipt update must be retried.
+      const error = new ElizaError("Blooio cleanup task receipt could not be recorded", {
+        code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_RECORD_FAILED",
+        cause,
+        context: { receiptDigest },
+        severity: "ephemeral",
+      });
+      this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+      throw error;
+    }
+    if (!updated) {
+      const error = new ElizaError("Blooio cleanup task receipt was not recorded", {
+        code: "IMESSAGE_BLOOIO_RECEIPT_CLEANUP_RECORD_REJECTED",
+        context: { receiptDigest },
+        severity: "ephemeral",
+      });
+      this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+      throw error;
+    }
+    return taskId;
+  }
+
   async handleBlooioWebhook(
     rawBody: string,
     signature: string | undefined
@@ -1232,15 +1450,30 @@ export class IMessageService extends Service implements IIMessageService {
         this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
         throw error;
       }
-      if (storedReceipt !== undefined) {
-        if (isBlooioDispatchReceipt(storedReceipt)) return "ignored";
-        const error = new ElizaError("Blooio durable dispatch receipt is invalid", {
+      const receiptState = classifyBlooioDispatchReceipt(storedReceipt, Date.now());
+      if (receiptState.kind === "future-version") {
+        return "ignored";
+      }
+      if (receiptState.kind === "processed") {
+        if (!receiptState.receipt.cleanupTaskId) {
+          await this.scheduleBlooioReceiptCleanup(
+            receiptKey,
+            receiptDigest,
+            receiptState.receipt.acceptedAt
+          );
+        }
+        return "ignored";
+      }
+      if (receiptState.kind === "expired") {
+        await this.deleteBlooioReceipt(receiptKey, receiptDigest);
+      } else if (receiptState.kind === "malformed") {
+        const error = new ElizaError("Blooio durable dispatch receipt was malformed", {
           code: "IMESSAGE_BLOOIO_RECEIPT_INVALID",
           context: { receiptDigest },
-          severity: "fatal",
+          severity: "ephemeral",
         });
         this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
-        throw error;
+        await this.deleteBlooioReceipt(receiptKey, receiptDigest);
       }
 
       const access: { allowed: boolean; pairingReplyMessage?: string } = inbound.isGroup
@@ -1284,11 +1517,12 @@ export class IMessageService extends Service implements IIMessageService {
       };
       await this.dispatchInboundMessage(row, media);
 
+      const acceptedAt = Date.now();
       let receiptStored: boolean;
       try {
         receiptStored = await this.runtime.setCache<BlooioDispatchReceipt>(receiptKey, {
           version: 1,
-          acceptedAt: Date.now(),
+          acceptedAt,
         });
       } catch (cause) {
         // error-policy:J2 Dispatch succeeded, but fail the webhook because dedupe was not durable.
@@ -1310,6 +1544,7 @@ export class IMessageService extends Service implements IIMessageService {
         this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
         throw error;
       }
+      await this.scheduleBlooioReceiptCleanup(receiptKey, receiptDigest, acceptedAt);
       return "accepted";
     } finally {
       this.blooioMessagesInFlight.delete(inbound.messageId);

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -16,6 +16,7 @@ import {
   checkPairingAllowed,
   createUniqueUuid,
   DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+  ElizaError,
   type Entity,
   type EventPayload,
   EventType,
@@ -100,6 +101,33 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
 // Keep the recurring-task value portable to runtimes that ultimately schedule
 // with a JavaScript timer, even though current TaskService compares timestamps.
 const MAX_HEARTBEAT_INTERVAL_MS = 2_147_483_647;
+const BLOOIO_RECEIPT_CACHE_NAMESPACE = "imessage:blooio-receipt:v1";
+
+interface BlooioDispatchReceipt {
+  version: 1;
+  acceptedAt: number;
+}
+
+function blooioReceiptCacheKey(channelId: string, messageId: string): string {
+  const digest = crypto
+    .createHash("sha256")
+    .update(channelId)
+    .update("\0")
+    .update(messageId)
+    .digest("hex");
+  return `${BLOOIO_RECEIPT_CACHE_NAMESPACE}:${digest}`;
+}
+
+function isBlooioDispatchReceipt(value: unknown): value is BlooioDispatchReceipt {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<BlooioDispatchReceipt>;
+  return (
+    candidate.version === 1 &&
+    typeof candidate.acceptedAt === "number" &&
+    Number.isSafeInteger(candidate.acceptedAt) &&
+    candidate.acceptedAt > 0
+  );
+}
 
 export function resolveHeartbeatIntervalMs(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") return DEFAULT_HEARTBEAT_INTERVAL_MS;
@@ -615,8 +643,8 @@ export class IMessageService extends Service implements IIMessageService {
   private contacts: ContactsMap = new Map();
   /** Whether the lazy contact load has been attempted this session. */
   private contactsLoadAttempted = false;
-  /** Webhook message ids accepted during this process lifetime. */
-  private blooioMessageIds = new Set<string>();
+  /** Message ids currently dispatching, preventing concurrent webhook re-entry. */
+  private blooioMessagesInFlight = new Set<string>();
 
   /**
    * Start the iMessage service.
@@ -1174,55 +1202,118 @@ export class IMessageService extends Service implements IIMessageService {
       return "unauthorized";
     }
     const inbound = parseBlooioInbound(rawBody, settings.blooioChannelId);
-    if (!inbound || this.blooioMessageIds.has(inbound.messageId)) return "ignored";
+    if (!inbound) return "ignored";
 
-    const access: { allowed: boolean; pairingReplyMessage?: string } = inbound.isGroup
-      ? this.checkGroupAccess(inbound.sender)
-      : await this.checkDmAccess(inbound.sender);
-    if (!access.allowed) {
-      if (access.pairingReplyMessage && this.isAutoReplyEnabled()) {
-        await this.sendSingleMessage(inbound.sender, access.pairingReplyMessage);
+    const receiptKey = blooioReceiptCacheKey(settings.blooioChannelId, inbound.messageId);
+    const receiptDigest = receiptKey.slice(receiptKey.lastIndexOf(":") + 1);
+    if (this.blooioMessagesInFlight.has(inbound.messageId)) {
+      const error = new ElizaError("Blooio message dispatch is already in progress", {
+        code: "IMESSAGE_BLOOIO_DISPATCH_IN_FLIGHT",
+        context: { receiptDigest },
+        severity: "ephemeral",
+      });
+      this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+      throw error;
+    }
+
+    this.blooioMessagesInFlight.add(inbound.messageId);
+    try {
+      let storedReceipt: unknown;
+      try {
+        storedReceipt = await this.runtime.getCache<unknown>(receiptKey);
+      } catch (cause) {
+        // error-policy:J2 The webhook must fail so Blooio retries when durable dedupe is unavailable.
+        const error = new ElizaError("Blooio durable dispatch receipt could not be read", {
+          code: "IMESSAGE_BLOOIO_RECEIPT_READ_FAILED",
+          cause,
+          context: { receiptDigest },
+          severity: "ephemeral",
+        });
+        this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+        throw error;
       }
-      return "ignored";
-    }
+      if (storedReceipt !== undefined) {
+        if (isBlooioDispatchReceipt(storedReceipt)) return "ignored";
+        const error = new ElizaError("Blooio durable dispatch receipt is invalid", {
+          code: "IMESSAGE_BLOOIO_RECEIPT_INVALID",
+          context: { receiptDigest },
+          severity: "fatal",
+        });
+        this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+        throw error;
+      }
 
-    this.blooioMessageIds.add(inbound.messageId);
-    if (this.blooioMessageIds.size > 2_000) {
-      const oldest = this.blooioMessageIds.values().next().value;
-      if (typeof oldest === "string") this.blooioMessageIds.delete(oldest);
-    }
+      const access: { allowed: boolean; pairingReplyMessage?: string } = inbound.isGroup
+        ? this.checkGroupAccess(inbound.sender)
+        : await this.checkDmAccess(inbound.sender);
+      if (!access.allowed) {
+        if (access.pairingReplyMessage && this.isAutoReplyEnabled()) {
+          await this.sendSingleMessage(inbound.sender, access.pairingReplyMessage);
+        }
+        return "ignored";
+      }
 
-    const media: Media[] = inbound.mediaUrls.map((url, index) => ({
-      id: `${inbound.messageId}-${index}`,
-      url,
-      source: "imessage",
-      title: "Blooio attachment",
-      description: "Inbound Blooio attachment",
-    }));
-    const row: ChatDbMessage = {
-      rowId: inbound.timestamp,
-      guid: inbound.messageId,
-      text: inbound.text,
-      kind: "text",
-      handle: inbound.sender,
-      chatId: inbound.chatId,
-      chatType: inbound.isGroup ? "group" : "direct",
-      displayName: null,
-      timestamp: inbound.timestamp,
-      isFromMe: false,
-      service: "iMessage",
-      isSent: false,
-      isDelivered: true,
-      isRead: false,
-      dateRead: 0,
-      dateEdited: 0,
-      dateRetracted: 0,
-      replyToGuid: inbound.replyToMessageId ?? null,
-      reaction: null,
-      attachments: [],
-    };
-    await this.dispatchInboundMessage(row, media);
-    return "accepted";
+      const media: Media[] = inbound.mediaUrls.map((url, index) => ({
+        id: `${inbound.messageId}-${index}`,
+        url,
+        source: "imessage",
+        title: "Blooio attachment",
+        description: "Inbound Blooio attachment",
+      }));
+      const row: ChatDbMessage = {
+        rowId: inbound.timestamp,
+        guid: inbound.messageId,
+        text: inbound.text,
+        kind: "text",
+        handle: inbound.sender,
+        chatId: inbound.chatId,
+        chatType: inbound.isGroup ? "group" : "direct",
+        displayName: null,
+        timestamp: inbound.timestamp,
+        isFromMe: false,
+        service: "iMessage",
+        isSent: false,
+        isDelivered: true,
+        isRead: false,
+        dateRead: 0,
+        dateEdited: 0,
+        dateRetracted: 0,
+        replyToGuid: inbound.replyToMessageId ?? null,
+        reaction: null,
+        attachments: [],
+      };
+      await this.dispatchInboundMessage(row, media);
+
+      let receiptStored: boolean;
+      try {
+        receiptStored = await this.runtime.setCache<BlooioDispatchReceipt>(receiptKey, {
+          version: 1,
+          acceptedAt: Date.now(),
+        });
+      } catch (cause) {
+        // error-policy:J2 Dispatch succeeded, but fail the webhook because dedupe was not durable.
+        const error = new ElizaError("Blooio durable dispatch receipt could not be written", {
+          code: "IMESSAGE_BLOOIO_RECEIPT_WRITE_FAILED",
+          cause,
+          context: { receiptDigest },
+          severity: "ephemeral",
+        });
+        this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+        throw error;
+      }
+      if (!receiptStored) {
+        const error = new ElizaError("Blooio durable dispatch receipt was not stored", {
+          code: "IMESSAGE_BLOOIO_RECEIPT_WRITE_REJECTED",
+          context: { receiptDigest },
+          severity: "ephemeral",
+        });
+        this.runtime.reportError("IMessageService.blooioWebhook", error, { receiptDigest });
+        throw error;
+      }
+      return "accepted";
+    } finally {
+      this.blooioMessagesInFlight.delete(inbound.messageId);
+    }
   }
 
   /**

--- a/plugins/plugin-imessage/src/setup-routes.ts
+++ b/plugins/plugin-imessage/src/setup-routes.ts
@@ -8,11 +8,9 @@
  *   POST /api/setup/imessage/start    mark iMessage as enabled in connector config
  *   POST /api/setup/imessage/cancel   clear stored iMessage connector config
  *
- * iMessage on macOS does not have a credential/pairing flow — it reads chat.db
- * directly and sends through Messages.app via osascript. "Setup" is just the
- * permission gate (Full Disk Access) plus marking the connector enabled in
- * config so the service spins up. The status endpoint exposes the permission
- * state so the UI can guide the user.
+ * Native iMessage setup is a macOS permission gate. The Blooio transport uses
+ * an API credential, webhook secret, sender number, and channel id supplied as
+ * settings; status reports which transport owns the service.
  *
  * Post-setup data routes (messages, chats, contacts) live in
  * `./data-routes.ts` under `/api/imessage/` since they are CRUD against a
@@ -42,6 +40,7 @@ const IMESSAGE_SERVICE_NAME = "imessage";
 interface IMessageServiceLike {
   isConnected(): boolean;
   getStatus?(): {
+    transport: "native" | "blooio";
     available: boolean;
     connected: boolean;
     chatDbAvailable: boolean;
@@ -54,6 +53,8 @@ interface IMessageServiceLike {
       url: string;
       instructions: string[];
     } | null;
+    webhookPath: string | null;
+    channelId: string | null;
   };
 }
 
@@ -88,6 +89,7 @@ function resolveService(runtime: IAgentRuntime): IMessageServiceLike | null {
 }
 
 interface IMessageSetupDetail {
+  transport?: "native" | "blooio";
   available: boolean;
   connected: boolean;
   chatDbAvailable?: boolean;
@@ -100,6 +102,8 @@ interface IMessageSetupDetail {
     url: string;
     instructions: string[];
   } | null;
+  webhookPath?: string | null;
+  channelId?: string | null;
 }
 
 function buildStatusResponse(runtime: IAgentRuntime): SetupStatusResponse<IMessageSetupDetail> {
@@ -126,11 +130,14 @@ function buildStatusResponse(runtime: IAgentRuntime): SetupStatusResponse<IMessa
       connected,
       ...(status
         ? {
+            transport: status.transport,
             chatDbAvailable: status.chatDbAvailable,
             sendOnly: status.sendOnly,
             chatDbPath: status.chatDbPath,
             reason: status.reason,
             permissionAction: status.permissionAction,
+            webhookPath: status.webhookPath,
+            channelId: status.channelId,
           }
         : {}),
     },

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -36,6 +36,8 @@ export type IMessageChatType = "direct" | "group";
  * Configuration settings for the iMessage plugin
  */
 export interface IMessageSettings {
+  /** Delivery bridge used by the connector. */
+  transport: "native" | "blooio";
   /** Path to iMessage database */
   dbPath?: string;
   /** Polling interval in ms */
@@ -50,6 +52,14 @@ export interface IMessageSettings {
   allowFrom: string[];
   /** Enable/disable the plugin */
   enabled: boolean;
+  /** Blooio API credential, required by the Blooio transport. */
+  blooioApiKey?: string;
+  /** Secret used to authenticate Blooio webhook deliveries. */
+  blooioWebhookSecret?: string;
+  /** Blooio sender phone number. */
+  blooioFromNumber?: string;
+  /** Provider channel allowed to deliver into this agent. */
+  blooioChannelId?: string;
 }
 
 /**
@@ -137,6 +147,7 @@ export interface IMessagePermissionAction {
 }
 
 export interface IMessageServiceStatus {
+  transport: "native" | "blooio";
   available: boolean;
   connected: boolean;
   chatDbAvailable: boolean;
@@ -144,6 +155,8 @@ export interface IMessageServiceStatus {
   chatDbPath: string;
   reason: string | null;
   permissionAction: IMessagePermissionAction | null;
+  webhookPath: string | null;
+  channelId: string | null;
 }
 
 /**
@@ -170,6 +183,12 @@ export interface IIMessageService extends Service {
 
   /** Get chats */
   getChats(): Promise<IMessageChat[]>;
+
+  /** Authenticate and dispatch one Blooio webhook delivery. */
+  handleBlooioWebhook(
+    rawBody: string,
+    signature: string | undefined
+  ): Promise<"accepted" | "ignored" | "unauthorized">;
 }
 
 /**

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -76,7 +76,10 @@ const h = vi.hoisted(() => {
     }),
     isElectrobunRuntime: vi.fn(() => false),
     loadDesktopWorkspaceSnapshot: vi.fn(async () => ({ supported: false })),
-    authState: { phase: "authenticated" } as { phase: string },
+    authState: { phase: "authenticated", access: { role: "OWNER" } } as {
+      phase: string;
+      access?: { role: string };
+    },
     authSubscribers: new Set<(state: { phase: string }) => void>(),
     dispatchStatus: vi.fn(),
     capacitorGetPlatform: vi.fn(() => "web"),
@@ -102,6 +105,7 @@ vi.mock("@elizaos/ui/api", () => ({
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
+  getAuthStatusSnapshot: () => h.authState,
   isAuthenticatedNow: () => h.authState.phase === "authenticated",
   subscribeAuthStatus: (listener: (state: { phase: string }) => void) => {
     h.authSubscribers.add(listener);
@@ -110,6 +114,14 @@ vi.mock("@elizaos/ui/api", () => ({
   client: {
     getStatus: h.getStatus,
     captureLifeOpsActivitySignal: h.captureLifeOpsActivitySignal,
+  },
+}));
+vi.mock("@elizaos/ui/auth-status", () => ({
+  getAuthStatusSnapshot: () => h.authState,
+  isAuthenticatedNow: () => h.authState.phase === "authenticated",
+  subscribeAuthStatus: (listener: (state: typeof h.authState) => void) => {
+    h.authSubscribers.add(listener);
+    return () => h.authSubscribers.delete(listener);
   },
 }));
 vi.mock("@elizaos/ui/bridge", () => ({
@@ -124,6 +136,7 @@ vi.mock("@elizaos/ui/bridge", () => ({
   isCloudAgentGoneError: h.isCloudAgentGoneError,
   ElizaClient: h.ElizaClient,
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
+  getAuthStatusSnapshot: () => h.authState,
   isAuthenticatedNow: () => h.authState.phase === "authenticated",
   subscribeAuthStatus: (listener: (state: { phase: string }) => void) => {
     h.authSubscribers.add(listener);
@@ -142,6 +155,7 @@ vi.mock("@elizaos/ui/events", () => ({
   isCloudAgentGoneError: h.isCloudAgentGoneError,
   ElizaClient: h.ElizaClient,
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
+  getAuthStatusSnapshot: () => h.authState,
   isAuthenticatedNow: () => h.authState.phase === "authenticated",
   subscribeAuthStatus: (listener: (state: { phase: string }) => void) => {
     h.authSubscribers.add(listener);
@@ -156,6 +170,7 @@ vi.mock("@elizaos/ui/browser", () => ({
   ElizaClient: h.ElizaClient,
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
+  getAuthStatusSnapshot: () => h.authState,
   isAuthenticatedNow: () => h.authState.phase === "authenticated",
   subscribeAuthStatus: (listener: (state: { phase: string }) => void) => {
     h.authSubscribers.add(listener);
@@ -249,7 +264,10 @@ function mockNativeMobile(): void {
 }
 
 function publishAuthStatus(phase: string): void {
-  h.authState = { phase };
+  h.authState =
+    phase === "authenticated"
+      ? { phase, access: { role: "OWNER" } }
+      : { phase };
   for (const subscriber of h.authSubscribers) {
     subscriber(h.authState);
   }
@@ -267,7 +285,7 @@ describe("startLifeOpsActivitySignalCapture", () => {
     h.isApiError.mockReturnValue(false);
     h.isElectrobunRuntime.mockReturnValue(false);
     h.loadDesktopWorkspaceSnapshot.mockResolvedValue({ supported: false });
-    h.authState = { phase: "authenticated" };
+    h.authState = { phase: "authenticated", access: { role: "OWNER" } };
     h.authSubscribers.clear();
     h.capacitorGetPlatform.mockReturnValue("web");
     h.capacitorIsNative.mockReturnValue(false);

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -87,6 +87,7 @@ import {
 } from "@elizaos/ui/api";
 import {
   type AuthStatusState,
+  getAuthStatusSnapshot,
   isAuthenticatedNow,
   subscribeAuthStatus,
 } from "@elizaos/ui/auth-status";
@@ -791,13 +792,21 @@ export function startLifeOpsActivitySignalCapture(
   };
 
   const handleAuthStatus = (state: AuthStatusState): void => {
-    updateSessionAvailability(state.phase === "authenticated", "runtime-ready");
+    updateSessionAvailability(
+      state.phase === "authenticated" && state.access.role === "OWNER",
+      "runtime-ready",
+    );
   };
 
   // Subscribe before reading the snapshot so an auth publication racing this
   // startup cannot be missed. A duplicate authenticated publication is a no-op.
   const unsubscribeAuthStatus = subscribeAuthStatus(handleAuthStatus);
-  if (isAuthenticatedNow()) {
+  const initialAuth = getAuthStatusSnapshot();
+  if (
+    isAuthenticatedNow() &&
+    initialAuth.phase === "authenticated" &&
+    initialAuth.access.role === "OWNER"
+  ) {
     updateSessionAvailability(true, "mount");
   }
 


### PR DESCRIPTION
# Relates to

Refs #22787
Refs #30014

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and is rebased on the exact base recorded below.
- [x] Exact-head install, focused tests, browser E2E, app audit, and full repository verification completed locally.
- [ ] Hosted exact-head checks must finish successfully.
- [ ] Required review and inline UI attachments remain before merge.

# Exact revision

- Base: `d8c5b3124d97fac8189ad49afc14363ba56764f6`
- Head: `a1d4e3f2e4d52eb21e9c1f158ad3b7e9b4fc9235`

# What changed

- Adds a Blooio v4 transport to `plugin-imessage` while preserving the native macOS transport.
- Verifies `X-Blooio-Signature` over the exact raw body with a two-sided five-minute window, exact configured-channel filtering, HTTPS media-origin allowlisting, and receipt-required outbound delivery.
- Exposes the signed webhook route through the real plugin route dispatcher and supports direct and group replies.
- Enables environment-only Blooio setup on Linux and exposes transport-aware setup/status metadata.
- Persists CLI auth completion briefly so orphaned login tabs can recover a missed handoff, rejects future-dated markers, and preserves pairing credentials for same-origin dashboard requests.
- Keeps self-hosted pairing ahead of Cloud login and fixes paired-session API/model-stream authorization.

# Risk

Medium. This adds a public signed webhook and an outbound provider transport. HMAC verification, timestamp bounds, exact-channel isolation, HTTPS hostname allowlisting, provider receipt enforcement, auth gating, and adversarial tests bound the exposed surface. Provider balance and recipient consent remain live-send prerequisites.

# Verification

- `plugin-imessage`: 21 files / 243 tests passed, including durable post-dispatch receipts, seven-day physical cleanup, malformed/expired recovery, rolling-deploy-safe future versions, cleanup failure, restart replay, concurrency, and retry-after-dispatch-failure; focused lifecycle suite 15/15 passed; package typecheck, lint, format, and build passed.
- Cloud auth focused final suite: 9/9 passed; UI typecheck passed.
- Real Chromium CLI-auth completion: 2/2 passed for ordinary-tab replay and named-popup close/replay; completion observed once per session.
- App audit at the immediate parent head: 215/215 captures, 0 broken, 0 needs-work, 0 hover/density/color violations; the final diff changes only non-rendered TTL validation and tests.
- Full exact-head `bun run verify`: 375/375 Turbo tasks and every repository audit passed.
- Hosted exact-head checks: running.

# Live redacted evidence

- Runtime health reported ready with 34 plugins loaded, 0 failed, 98 services registered, 0 failed, and zero service restarts.
- iMessage setup reported paired and connected with `transport=blooio` and the configured webhook path.
- Valid signed public ingress returned HTTP 200 and dispatched.
- Exact replay returned HTTP 200 without duplicate dispatch; tampered body returned HTTP 401.
- Deployed connector source hashes matched the tested transport, route, and service files.
- The VPS Cloud credential authenticated successfully. Its balance was zero, so no model-generated message to a real recipient is claimed.

# Evidence gate

<!-- evidence-head:a1d4e3f2e4d52eb21e9c1f158ad3b7e9b4fc9235 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: local evidence exists; inline attachment pending.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: local ordinary-tab and popup completion captures inspected; inline attachment pending.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: real Chromium recordings inspected; inline attachment pending.
<!-- evidence-row:backend-logs -->
- [x] Backend evidence is summarized above without secrets or private identifiers.
<!-- evidence-row:frontend-logs -->
- [x] E2E network behavior confirmed one completion request per session with no terminal browser errors.
<!-- evidence-row:llm-trajectory -->
- [x] N/A: no prompt, action-planning, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Provider receipts and runtime transport status inspected live.
<!-- evidence-row:ocr-review -->
- [x] App audit OCR: 200 verified, 12 eyeball, 0 broken.

# Reviewer entry points

- `plugins/plugin-imessage/src/blooio-transport.ts`
- `plugins/plugin-imessage/src/service.ts`
- `plugins/plugin-imessage/src/data-routes.ts`
- `packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts`
- `packages/ui/src/state/active-server-credential.ts`

# Known live gates

- A real outbound iMessage requires provider balance and an explicitly consented recipient.
- The broader multi-tier staging isolation acceptance in #22787 is outside this connector/auth fix.
- No maintainer CI exception is requested.
