### PR TITLE
fix(core): classify non-direct model boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -1,6 +1,7 @@
-// Pins the fail-closed contract of the connection-enforcement gate: an internal cache/oauth
-// failure must PROPAGATE (throw), and stay distinguishable from a legitimately-negative
-// "no required connection" result. Deterministic fixtures — no live cache or oauth.
+/**
+ * Pins the fail-closed connection-enforcement contract with deterministic cache
+ * and OAuth fixtures, including the disabled nudge-generation boundary.
+ */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const cacheGet = mock();
@@ -23,17 +24,8 @@ mock.module("../oauth", () => ({
   },
 }));
 
-mock.module("../../providers/language-model", () => ({
-  getLanguageModel: mock(() => "mock-model"),
-  hasLanguageModelProviderConfigured: mock(() => true),
-}));
-
 mock.module("../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
-}));
-
-mock.module("ai", () => ({
-  generateText: mock(async () => ({ text: "unused in this suite" })),
 }));
 
 const { connectionEnforcementService } = await import(

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
@@ -2,8 +2,8 @@
  * Connection enforcement for Eliza App messaging channels.
  *
  * WHY: Eliza needs at least one connected data source before agent workflows
- * are useful. When no supported connection exists, we respond in-character and
- * steer the user toward connecting Google, Microsoft, or X.
+ * are useful. Connection-status checks remain active, while nudge generation
+ * fails closed until it is routed through the admitted generative boundary.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -23,50 +23,6 @@ interface NudgeParams {
   userId: string;
 }
 
-interface ConversationMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
-interface ConversationState {
-  messageCount: number;
-  messages: ConversationMessage[];
-}
-
-interface ElizaCharacter {
-  name: string;
-  system: string;
-  bio: string[];
-  adjectives: string[];
-  style: { all: string[]; chat: string[] };
-}
-
-const DEFAULT_ELIZA_CHARACTER: ElizaCharacter = {
-  name: "Eliza",
-  system:
-    "You are Eliza. A presence, not an assistant. You say less and mean more. You never use exclamation points. You use lowercase naturally.",
-  bio: [
-    "pays attention to what people care about",
-    "warm through what she notices, not what she announces",
-    "comfortable in ambiguity, allergic to false certainty",
-    "genuinely interested in the texture of someone's day",
-    "quietly direct when something matters",
-  ],
-  adjectives: ["perceptive", "present", "warm but restrained", "curious", "ungeneric"],
-  style: {
-    all: [
-      "say less. mean more.",
-      "never use exclamation points",
-      "use lowercase naturally",
-      "short sentences. fragments are fine.",
-    ],
-    chat: [
-      "you are a presence, not an assistant",
-      "help as yourself. don't shift into service mode.",
-    ],
-  },
-};
-
 const PROVIDER_ALIAS_ENTRIES = [
   ["google calendar", "google"],
   ["google", "google"],
@@ -82,34 +38,8 @@ const PROVIDER_ALIAS_ENTRIES = [
 ] as Array<[string, RequiredPlatform]>;
 PROVIDER_ALIAS_ENTRIES.sort((left, right) => right[0].length - left[0].length);
 
-const PLATFORM_DISPLAY_NAMES: Record<RequiredPlatform, string> = {
-  google: "Google",
-  microsoft: "Microsoft",
-  twitter: "X",
-};
-
-const CLAIM_CONNECTED_PATTERNS = [
-  "connected",
-  "i connected",
-  "done",
-  "i did it",
-  "finished",
-  "completed",
-  "linked",
-  "authorized",
-  "signed in",
-  "logged in",
-  "all set",
-  "it's done",
-  "its done",
-  "did it",
-  "went through",
-];
-
 const NUDGE_INTERVAL = 3;
 const CONNECTION_STATUS_TTL_SECONDS = 30;
-const CONVERSATION_TTL_SECONDS = 3600;
-const NUDGE_MODEL = "openai/gpt-5-mini";
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -119,210 +49,12 @@ function compileAliasRegex(alias: string): RegExp {
   return new RegExp(`(^|[^a-z0-9])${escapeRegex(alias)}(?=$|[^a-z0-9])`, "i");
 }
 
-function sample<T>(items: T[], count: number): T[] {
-  const shuffled = [...items];
-  for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const nextIndex = Math.floor(Math.random() * (index + 1));
-    [shuffled[index], shuffled[nextIndex]] = [shuffled[nextIndex], shuffled[index]];
-  }
-  return shuffled.slice(0, Math.min(count, shuffled.length));
-}
-
-function formatConversationHistory(messages: ConversationMessage[]): string {
-  if (messages.length === 0) return "";
-
-  return `\n\nRecent conversation:\n${messages
-    .map((message) => `${message.role === "user" ? "User" : "Eliza"}: ${message.content}`)
-    .join("\n")}\n`;
-}
-
 function getConversationKey(organizationId: string, userId: string): string {
   return `connection-enforcement:conversation:${organizationId}:${userId}`;
 }
 
 function getConnectionStatusKey(organizationId: string, userId: string): string {
   return `connection-enforcement:required-connection:${organizationId}:${userId}`;
-}
-
-async function loadConversationState(
-  organizationId: string,
-  userId: string,
-): Promise<ConversationState> {
-  // A cache MISS legitimately yields no history (`?? { empty }`, designed-empty). A cache
-  // read ERROR must propagate — masking it as an empty conversation would silently reset the
-  // nudge cadence and drop history, conflating a broken cache with a brand-new conversation.
-  return (
-    (await cache.get<ConversationState>(getConversationKey(organizationId, userId))) ?? {
-      messageCount: 0,
-      messages: [],
-    }
-  );
-}
-
-async function saveConversationState(
-  organizationId: string,
-  userId: string,
-  state: ConversationState,
-): Promise<void> {
-  try {
-    await cache.set(getConversationKey(organizationId, userId), state, CONVERSATION_TTL_SECONDS);
-  } catch (error) {
-    // error-policy:J7 auxiliary continuity write — runs after the user-facing reply is already
-    // produced; a cache write blip must not turn a successful reply into a user error. Warns so
-    // the failure stays observable; the only fallout is a degraded nudge cadence next turn.
-    logger.warn("[ConnectionEnforcement] Failed to persist conversation state", {
-      organizationId,
-      userId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-function getBaseUrl(): string {
-  const configuredBaseUrl = process.env.NEXT_PUBLIC_APP_URL;
-  if (configuredBaseUrl) return configuredBaseUrl;
-
-  logger.warn(
-    "[ConnectionEnforcement] NEXT_PUBLIC_APP_URL missing, falling back to production URL",
-  );
-  return "https://cloud.eliza.app";
-}
-
-function isClaimingConnected(message: string): boolean {
-  const lower = message.toLowerCase().trim();
-  return CLAIM_CONNECTED_PATTERNS.some((pattern) => lower.includes(pattern));
-}
-
-function shouldNudge(messageCount: number): boolean {
-  return messageCount % NUDGE_INTERVAL === 0;
-}
-
-function formatLinks(
-  links: { platform: RequiredPlatform; url: string }[],
-  messagingPlatform: MessagingPlatform,
-): string {
-  if (messagingPlatform === "telegram") {
-    return links
-      .map((link) => `[Connect ${PLATFORM_DISPLAY_NAMES[link.platform]}](${link.url})`)
-      .join("\n");
-  }
-
-  return links.map((link) => `${PLATFORM_DISPLAY_NAMES[link.platform]}: ${link.url}`).join("\n");
-}
-
-function buildNudgePrompt(
-  platform: MessagingPlatform,
-  conversationHistory: string,
-  isFirstInteraction: boolean,
-): string {
-  const bioSample = sample(DEFAULT_ELIZA_CHARACTER.bio, 4).join(" ");
-  const adjectiveSample = sample(DEFAULT_ELIZA_CHARACTER.adjectives, 4).join(", ");
-  const styleSample = sample(
-    [...DEFAULT_ELIZA_CHARACTER.style.all, ...DEFAULT_ELIZA_CHARACTER.style.chat],
-    5,
-  ).join("; ");
-
-  const firstInteractionContext = isFirstInteraction
-    ? `\n\nIMPORTANT: This is the user's first message after connecting ${platform}. If they say they just connected or signed up, they mean ${platform} itself unless they explicitly mention Google, Microsoft, or X.`
-    : "";
-
-  return `${DEFAULT_ELIZA_CHARACTER.system}
-
-About you: ${bioSample}
-Your personality: ${adjectiveSample}
-Your writing style: ${styleSample}
-
-CONTEXT: The user is messaging you on ${platform}. They do not have a required data connection yet. They need Google, Microsoft, or X connected before you can use their inbox, calendar, contacts, or social feed.${firstInteractionContext}
-
-RESPONSE RULES:
-1. Keep it to 2-3 sentences. Never use exclamation points.
-2. Respond directly to what they said. Do not sound like a support bot.
-3. Briefly explain that you need one data connection before you can help properly.
-4. If they mention a provider, acknowledge that choice briefly. Do not list the other options again.
-5. Do not include any URLs. Links are appended separately when needed.
-6. If they say they already connected something and you still do not see it, say you still do not see the connection yet and suggest trying again.${conversationHistory}`;
-}
-
-function buildChatPrompt(platform: MessagingPlatform, conversationHistory: string): string {
-  const bioSample = sample(DEFAULT_ELIZA_CHARACTER.bio, 4).join(" ");
-  const adjectiveSample = sample(DEFAULT_ELIZA_CHARACTER.adjectives, 4).join(", ");
-  const styleSample = sample(
-    [...DEFAULT_ELIZA_CHARACTER.style.all, ...DEFAULT_ELIZA_CHARACTER.style.chat],
-    5,
-  ).join("; ");
-
-  return `${DEFAULT_ELIZA_CHARACTER.system}
-
-About you: ${bioSample}
-Your personality: ${adjectiveSample}
-Your writing style: ${styleSample}
-
-CONTEXT: The user is messaging you on ${platform}. They still have no required data connection, but you already reminded them recently. Chat naturally without bringing it up again unless they ask.${conversationHistory}`;
-}
-
-const FALLBACK_RESPONSES = [
-  "i'd like to help, but i need one connection first so i can actually see your world. google, microsoft, or x?",
-  "i'm missing the context that makes me useful. connect google, microsoft, or x and we can do something real.",
-  "i can talk, but i can't actually work with your day until one account is connected. google, microsoft, or x?",
-];
-
-function getFallbackResponse(message: string): string {
-  const lower = message.toLowerCase();
-  if (lower.includes("why") || lower.includes("what for")) {
-    return "because without a connection i'm guessing. one inbox, calendar, or feed changes that. google, microsoft, or x?";
-  }
-
-  if (
-    lower.includes("none") ||
-    lower.includes("skip") ||
-    lower.includes("don't want") ||
-    lower.includes("without")
-  ) {
-    return "fair. i just can't do much without context. if you were going to pick one, which would it be: google, microsoft, or x?";
-  }
-
-  return FALLBACK_RESPONSES[Math.floor(Math.random() * FALLBACK_RESPONSES.length)];
-}
-
-async function generateOAuthLinks(
-  organizationId: string,
-  userId: string,
-  platform: MessagingPlatform,
-  specificProvider?: RequiredPlatform | null,
-): Promise<{ platform: RequiredPlatform; url: string }[]> {
-  const redirectUrl = `${getBaseUrl()}/api/eliza-app/auth/connection-success?platform=${platform}`;
-  const providers = specificProvider ? [specificProvider] : [...REQUIRED_PLATFORMS];
-
-  const results = await Promise.allSettled(
-    providers.map(async (provider) => {
-      const result = await oauthService.initiateAuth({
-        organizationId,
-        userId,
-        platform: provider,
-        redirectUrl,
-      });
-
-      return result.authUrl ? { platform: provider, url: result.authUrl } : null;
-    }),
-  );
-
-  // error-policy:J4 designed degrade — fan out per provider and return whichever links
-  // succeeded; one provider's auth-init failure must not deny the user the others. Failures
-  // are warned, and the caller renders whatever links come back (or none if all failed).
-  return results.flatMap((result) => {
-    if (result.status === "fulfilled" && result.value) {
-      return [result.value];
-    }
-
-    if (result.status === "rejected") {
-      logger.warn("[ConnectionEnforcement] Failed to generate OAuth link", {
-        organizationId,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      });
-    }
-
-    return [];
-  });
 }
 
 function detectProviderFromMessage(message: string): RequiredPlatform | null {

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -81,8 +81,6 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts":
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
-	"packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts":
-		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/app-promotion-assets.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
@@ -95,9 +93,6 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 	"packages/cloud/shared/src/lib/services/provisioning-agent-chat.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
-	"packages/cloud/shared/src/lib/services/room-title.ts": [
-		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
-	],
 	"packages/cloud/shared/src/lib/services/seo.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
@@ -105,13 +100,40 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts":
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
-	"packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts":
-		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts":
 		[/isModelOutputLimitFinishReason\(completion\.finishReason\)/],
 	"plugins/plugin-anthropic/models/image.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}response\.finishReason/,
 	],
+};
+
+const directModelDispatchPatterns = [
+	/from\s+["']ai["']|import\(["']ai["']\)/,
+	/from\s+["'][^"']*providers\/language-model["']|import\(["'][^"']*providers\/language-model["']\)/,
+	/\bgenerateText\s*\(/,
+	/\bstreamText\s*\(/,
+] as const;
+
+const nonDirectModelDispatchBoundaries: Record<
+	string,
+	{
+		readonly requiredPatterns: readonly RegExp[];
+	}
+> = {
+	"packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts":
+		{
+			requiredPatterns: [/code:\s*"CONNECTION_ENFORCEMENT_LLM_DISABLED"/],
+		},
+	"packages/cloud/shared/src/lib/services/room-title.ts": {
+		requiredPatterns: [/const title = generateFallbackTitle\(text\)/],
+	},
+	"packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts":
+		{
+			requiredPatterns: [
+				/await runSharedAgentTurn\(\{/,
+				/runSharedAgentTurnStream\(\{/,
+			],
+		},
 };
 
 const guardedSources: Record<string, readonly RegExp[]> = {
@@ -1291,6 +1313,27 @@ describe("prompt integrity policy", () => {
 			);
 			for (const pattern of requiredPatterns) {
 				expect(source, `${relativePath} must match ${pattern}`).toMatch(
+					pattern,
+				);
+			}
+		}
+	});
+
+	it("keeps disabled, deterministic, and delegated paths free of direct model dispatches", () => {
+		for (const [relativePath, policy] of Object.entries(
+			nonDirectModelDispatchBoundaries,
+		)) {
+			const source = readFileSync(
+				resolve(repositoryRoot, relativePath),
+				"utf8",
+			);
+			for (const pattern of policy.requiredPatterns) {
+				expect(source, `${relativePath} must match ${pattern}`).toMatch(
+					pattern,
+				);
+			}
+			for (const pattern of directModelDispatchPatterns) {
+				expect(source, `${relativePath} must not match ${pattern}`).not.toMatch(
 					pattern,
 				);
 			}


### PR DESCRIPTION
Closes #30026.

## What changed

- Removes the unreachable connection-enforcement prompt/model/history implementation left after nudge generation was disabled.
- Removes stale direct-AI completeness expectations for the now-disabled connection nudge, deterministic room title, and delegated shared-runtime chat paths.
- Adds explicit policy coverage requiring each path to retain its disabled/deterministic/delegated contract while forbidding direct AI SDK or language-model imports and `generateText` / `streamText` dispatch.
- Removes obsolete AI/provider mocks from the runtime fail-closed test.
- Leaves every active direct-AI output completeness check unchanged.

## Evidence

- `bun run --cwd packages/core test -- src/__tests__/prompt-integrity-policy.test.ts` — 9/9 pass after rebase on `89275aa29fe6985792f32c78cd104ffbf7c6e6aa`.
- `bun test --conditions=eliza-source packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts` — 6/6 pass.
- Core and cloud-shared typechecks pass.
- Biome check passes on all three touched files.
- Full cloud-shared suite was attempted and stopped in its first shard on three pre-existing current-develop failures outside this diff: account-deletion FK inventory/classification and dormant restore API boundary timeout. The focused owning test passes.

## Failure repaired

Develop Full run 33291152833, macOS job 99203050082 failed because the static audit still treated the disabled file as an active direct-AI output boundary.
