### PR TITLE
fix(cloud): align latency probe with frontend stream

### DIFF
--- a/packages/cloud/scripts/chat-latency.mjs
+++ b/packages/cloud/scripts/chat-latency.mjs
@@ -15,6 +15,9 @@ import { parseArgs } from "node:util";
 
 const TARGETS = new Set(["direct", "gateway", "paired", "dedicated"]);
 const REASONING_EFFORTS = new Set(["omit", "none", "low", "medium", "high"]);
+const DELTA_STREAM_PROTOCOL = "delta-v2";
+const SHARED_TURN_CORRELATION_HEADER = "X-ElizaOS-Turn-Correlation";
+const SHARED_TURN_ATTEMPT_HEADER = "X-ElizaOS-Turn-Attempt";
 const SAFE_RESPONSE_HEADERS = [
   "cf-placement",
   "cf-ray",
@@ -589,6 +592,34 @@ async function createConversation(
   return id;
 }
 
+/** Build the first-attempt conversation stream wire used by the frontend client. */
+export function buildDedicatedStreamRequest({
+  apiKey,
+  prompt,
+  clientMessageId,
+  turnCorrelation,
+  traceId,
+}) {
+  return {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      "X-Eliza-Trace-Id": traceId,
+      "X-Eliza-Telemetry": "full",
+      [SHARED_TURN_CORRELATION_HEADER]: turnCorrelation,
+      [SHARED_TURN_ATTEMPT_HEADER]: "1",
+      "User-Agent": "eliza-chat-latency/1.0",
+    },
+    body: JSON.stringify({
+      text: prompt,
+      channelType: "DM",
+      clientMessageId,
+      streamProtocol: DELTA_STREAM_PROTOCOL,
+    }),
+  };
+}
+
 export async function probeDedicated({
   agentId,
   baseUrl,
@@ -615,6 +646,13 @@ export async function probeDedicated({
       fetchImpl,
     );
     const startedAt = performance.now();
+    const streamRequest = buildDedicatedStreamRequest({
+      apiKey,
+      prompt,
+      clientMessageId: randomUUID(),
+      turnCorrelation: randomUUID(),
+      traceId,
+    });
     const response = await fetchImpl(
       baseUrl +
         "/api/conversations/" +
@@ -622,19 +660,7 @@ export async function probeDedicated({
         "/messages/stream",
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          Accept: "text/event-stream",
-          "X-Eliza-Trace-Id": traceId,
-          "X-Eliza-Telemetry": "full",
-          "User-Agent": "eliza-chat-latency/1.0",
-        },
-        body: JSON.stringify({
-          text: prompt,
-          channelType: "DM",
-          clientMessageId: randomUUID(),
-        }),
+        ...streamRequest,
         signal: requestSignal(timeoutMs),
       },
     );

--- a/packages/cloud/scripts/chat-latency.test.mjs
+++ b/packages/cloud/scripts/chat-latency.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildDedicatedStreamRequest,
   buildOpenAiRequestBody,
   buildProofPrompt,
   consumeOpenAiEvent,
@@ -223,6 +224,33 @@ test("buildProofPrompt preserves a custom prompt and always adds the nonce", () 
   assert.match(buildProofPrompt(undefined, "proof-456"), /proof-456/);
 });
 
+test("buildDedicatedStreamRequest matches the frontend delta stream contract", () => {
+  const request = buildDedicatedStreamRequest({
+    apiKey: "secret",
+    prompt: "private prompt",
+    clientMessageId: "message-1",
+    turnCorrelation: "11111111-1111-4111-8111-111111111111",
+    traceId: "22222222-2222-4222-8222-222222222222",
+  });
+
+  assert.deepEqual(JSON.parse(request.body), {
+    text: "private prompt",
+    channelType: "DM",
+    clientMessageId: "message-1",
+    streamProtocol: "delta-v2",
+  });
+  assert.deepEqual(request.headers, {
+    Authorization: "Bearer secret",
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+    "X-Eliza-Trace-Id": "22222222-2222-4222-8222-222222222222",
+    "X-Eliza-Telemetry": "full",
+    "X-ElizaOS-Turn-Correlation": "11111111-1111-4111-8111-111111111111",
+    "X-ElizaOS-Turn-Attempt": "1",
+    "User-Agent": "eliza-chat-latency/1.0",
+  });
+});
+
 test("probeOpenAi requires a clean terminal frame and never records prompt text", async () => {
   let requestBody = null;
   const result = await probeOpenAi({
@@ -393,7 +421,12 @@ test("safeTerminalTelemetry uses exact numeric paths and drops arbitrary strings
 test("probeDedicated requires a done terminal and sanitizes telemetry", async () => {
   const calls = [];
   const fetchImpl = async (url, init = {}) => {
-    calls.push({ url, method: init.method });
+    calls.push({
+      url,
+      method: init.method,
+      headers: init.headers,
+      body: init.body,
+    });
     if (calls.length === 1) {
       return Response.json({ conversation: { id: "conversation-1" } });
     }
@@ -426,6 +459,12 @@ test("probeDedicated requires a done terminal and sanitizes telemetry", async ()
     runtime: { totalMs: 20, provider: "cerebras" },
   });
   assert.equal(calls.length, 3);
+  assert.match(
+    calls[1].headers["X-ElizaOS-Turn-Correlation"],
+    /^[0-9a-f-]{36}$/,
+  );
+  assert.equal(calls[1].headers["X-ElizaOS-Turn-Attempt"], "1");
+  assert.equal(JSON.parse(calls[1].body).streamProtocol, "delta-v2");
   assert.equal(calls[2].method, "DELETE");
 
   const errorResult = await probeDedicated({


### PR DESCRIPTION
Closes #30024

## Summary
- make the dedicated conversation latency target advertise the frontend-authoritative `delta-v2` SSE protocol
- send opaque `X-ElizaOS-Turn-Correlation` and first-attempt `X-ElizaOS-Turn-Attempt: 1` headers
- centralize request construction and exercise the actual captured outbound request contract

`delta-v2` is the current source-of-truth frontend protocol at the pinned base; this deliberately does not use the stale requested `delta-v1` value.

## Verification
- `node --test packages/cloud/scripts/chat-latency.test.mjs` (18/18)
- `bunx biome check packages/cloud/scripts/chat-latency.mjs packages/cloud/scripts/chat-latency.test.mjs`
- `git diff --check`
- root `bun run verify`: dependency setup completed and the 375-task Turbo typecheck/lint/build phase passed; the later audit sequence was intentionally interrupted for parent exact-head consolidation