### PR TITLE
fix(app): certify responsive Dedicated adoption consent

### DIFF
--- a/packages/app/test/cloud-live-dedicated-adoption-consent.ts
+++ b/packages/app/test/cloud-live-dedicated-adoption-consent.ts
@@ -193,15 +193,17 @@ export function installDedicatedAdoptionConsentProof(
         }
         const copyMatches = await consentTurn.evaluate(
           (element, expectedLines) => {
-            const normalize = (line: string) =>
-              line.replace(/\s+/g, " ").trim();
-            const visibleLines = (element as HTMLElement).innerText
-              .split("\n")
-              .map(normalize)
-              .filter(Boolean);
-            return expectedLines
-              .map(normalize)
-              .every((line) => visibleLines.includes(line));
+            const normalize = (text: string) =>
+              text.replace(/\s+/g, " ").trim();
+            const visibleCopy = normalize((element as HTMLElement).innerText);
+            let cursor = 0;
+            for (const expectedLine of expectedLines) {
+              const expected = normalize(expectedLine);
+              const index = visibleCopy.indexOf(expected, cursor);
+              if (index < 0) return false;
+              cursor = index + expected.length;
+            }
+            return true;
           },
           exactVisibleConsentLines(quote),
         );

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -604,11 +604,7 @@ test.describe("Cloud live optional action boundary", () => {
     await page.goto("/");
     await page.setContent(`
       <article data-testid="thread-line">
-        <p>Use your existing Dedicated agent?</p>
-        <p>Current status: stopped.</p>
-        <p>Hosting: $0.01/hour ($0.24/day).</p>
-        <p>Balance: $115.54; minimum required: $0.72 (3 days of runway); deficit: $0.00.</p>
-        <p>This action starts Dedicated compute and will restore its reviewed backup.</p>
+        <p>Use your existing Dedicated agent? Current status: stopped. Hosting: $0.01/hour ($0.24/day). Balance: $115.54; minimum required: $0.72 (3 days of runway); deficit: $0.00. This action starts Dedicated compute and will restore its reviewed backup.</p>
         <button data-testid="dedicated-adoption-confirm">Confirm and continue</button>
         <button data-testid="dedicated-adoption-cancel">Not now</button>
       </article>
@@ -677,7 +673,7 @@ test.describe("Cloud live optional action boundary", () => {
               return "adoption";
             },
           },
-          timeoutMs: 500,
+          timeoutMs: 2_000,
           runtimeCloudGraceMs: 50,
           pollIntervalMs: 5,
         }),

--- a/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
@@ -19,6 +19,7 @@ import { expect, type Page, test } from "@playwright/test";
 import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   expectNoPageDiagnostics,
+  expectOnlyAllowedPageDiagnostics,
   installPageDiagnosticsGuard,
   seedAppStorage,
 } from "./helpers";
@@ -60,6 +61,13 @@ test.describe("cloud-only onboarding (production default)", () => {
   });
 
   test.afterEach(async ({ page }, testInfo) => {
+    if (testInfo.title.includes("activation redirect")) {
+      await expectOnlyAllowedPageDiagnostics(page, testInfo.title, [
+        /^http\.409: POST .*\/upgrade-tier$/,
+        /^console\.error: Failed to load resource: the server responded with a status of 409 \(Conflict\)$/,
+      ]);
+      return;
+    }
     await expectNoPageDiagnostics(page, testInfo.title);
   });
 
@@ -262,6 +270,181 @@ test.describe("cloud-only onboarding (production default)", () => {
 
       await dedicatedAdoptionProof.confirmVisibleConsent(confirm);
       await expect.poll(() => adoptionPosts).toBe(1);
+      await expect(page.getByTestId("home-screen")).toBeVisible({
+        timeout: 20_000,
+      });
+      await settleHomeEntrance(page);
+    } finally {
+      dedicatedAdoptionProof.dispose();
+    }
+  });
+
+  test("an activation redirect surfaces existing Dedicated adoption and completes cutover", async ({
+    page,
+  }) => {
+    await injectCloudAuthToken(page);
+    await installHomeRoutes(page);
+    await installCloudRoutes(page);
+    const dedicatedAgentId = "22222222-2222-4222-8222-222222222222";
+    const adoptionQuoteId = "b".repeat(64);
+    let activationPosts = 0;
+    let adoptionQuoteGets = 0;
+    let adoptionPosts = 0;
+    let cutoverPosts = 0;
+    await page.route("**/api/auth/cli-session", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessionId: "dedicated-adoption-session" }),
+      });
+    });
+    await page.route("**/api/auth/cli-session/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "authenticated",
+          apiKey: "ui-smoke-onboarding-cloud-token",
+          organizationId: "ui-smoke-onboarding-org",
+          userId: "ui-smoke-onboarding-user",
+        }),
+      });
+    });
+    await page.unroute("**/api/v1/eliza/personal");
+    await page.route("**/api/v1/eliza/personal", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            identity: {
+              id: PERSONAL_ELIZA_ID,
+              displayName: CLOUD_AGENT_NAME,
+              runtime: "shared",
+            },
+          },
+        }),
+      });
+    });
+    await page.route("**/upgrade-tier/adopt-existing", async (route) => {
+      if (route.request().method() === "GET") {
+        adoptionQuoteGets += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              quoteId: adoptionQuoteId,
+              dedicatedAgentId,
+              adoptionState: "available",
+              status: "stopped",
+              startsCompute: true,
+              hourlyRateUsd: 0.01,
+              dailyRateUsd: 0.24,
+              minimumBalanceUsd: 0.72,
+              minimumRunwayDays: 3,
+              balanceUsd: 115.54059,
+              deficitUsd: 0,
+              stateDisposition: "verified_backup_present",
+              canAdopt: true,
+              requiresCatalogRestore: false,
+              requiresConfirmation: true,
+              action: "adopt_existing_dedicated",
+            },
+          }),
+        });
+        return;
+      }
+      adoptionPosts += 1;
+      expect(JSON.parse(route.request().postData() ?? "{}")).toEqual({
+        action: "adopt_existing_dedicated",
+        quoteId: adoptionQuoteId,
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            dedicatedAgentId,
+            runtime: "dedicated_pending_cutover",
+            status: "running",
+          },
+        }),
+      });
+    });
+    await page.route("**/upgrade-tier/cutover", async (route) => {
+      cutoverPosts += 1;
+      expect(JSON.parse(route.request().postData() ?? "{}")).toEqual({
+        dedicatedAgentId,
+      });
+      const origin = new URL(page.url()).origin;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            personalElizaId: PERSONAL_ELIZA_ID,
+            activeAgentId: dedicatedAgentId,
+            runtime: "dedicated",
+            apiBase: origin,
+            importedMessages: 0,
+          },
+        }),
+      });
+    });
+    await page.route("**/upgrade-tier", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              quoteId: "a".repeat(64),
+              canActivate: true,
+              activation: { state: "available" },
+            },
+          }),
+        });
+        return;
+      }
+      activationPosts += 1;
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          code: "dedicated_adoption_selection_required",
+          error: "Continue with same-row adoption.",
+        }),
+      });
+    });
+    await seedAppStorage(page, {
+      "eliza:first-run-complete": "",
+      "eliza:enable-runtime-chooser": "0",
+      steward_session_token: "ui-smoke-onboarding-cloud-token",
+      steward_session_token_scope: "eliza-cloud:production",
+      steward_session_active_scope: "eliza-cloud:production",
+    });
+
+    const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    const confirm = page.getByTestId(
+      "choice-__first_run__:dedicated-adoption:confirm",
+    );
+    try {
+      await expect(confirm).toBeVisible({ timeout: 20_000 });
+      expect(activationPosts).toBe(1);
+      expect(adoptionQuoteGets).toBe(1);
+      expect(adoptionPosts).toBe(0);
+
+      await dedicatedAdoptionProof.confirmVisibleConsent(confirm);
+      await expect.poll(() => adoptionPosts).toBe(1);
+      await expect.poll(() => cutoverPosts).toBe(1);
       await expect(page.getByTestId("home-screen")).toBeVisible({
         timeout: 20_000,
       });


### PR DESCRIPTION
Fixes #30023

## Cause

The `b3d3e890` deployed renderer path and current source at the investigation base (`3aee813c`) are byte-identical for activation, adoption, first-run orchestration, and certification. The client already recognizes `dedicated_adoption_selection_required`, reads the adoption quote once, renders the explicit confirmation, posts adoption after consent, and cuts over.

The certification proof treated `HTMLElement.innerText` newline boundaries as semantic: it split the rendered card into lines and required each safe sentence to occupy a separate line. The real responsive Chat renderer can combine or wrap those sentences into one text flow, so visible exact consent copy was rejected before the certification click.

## Change

- Match normalized visible consent as exact sentences in order across responsive whitespace and line wrapping.
- Preserve the existing quote binding, target identity, control visibility, exact-copy, and secret-exclusion checks.
- Exercise a single-flow responsive consent card.
- Add a browser regression for the real activation `409` redirect: one quote read, no adoption write before confirmation, one adoption POST, one cutover POST, and home arrival.

## Evidence

- `bunx playwright test --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/cloud-live-optional-action.spec.ts --grep "reuses a Dedicated quote only after explicit staging approval"` — 1 passed
- `bunx playwright test --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/onboarding-cloud-only.spec.ts --grep "activation redirect surfaces existing Dedicated adoption"` — 1 passed
- `bunx biome check packages/app/test/cloud-live-dedicated-adoption-consent.ts packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts` — passed
- `bun run --cwd packages/app lint:check` — passed (one pre-existing informational suggestion outside changed files)

## Broader check note

`bun run --cwd packages/app typecheck` cannot resolve unbuilt workspace exports for `@elizaos/app-core` and `@elizaos/ui` in this fresh worktree. The focused browser paths compile and pass at this exact head.
