### PR TITLE
fix(cloud): restore latency certification contracts

### DIFF
--- a/packages/app/test/cloud-live-dedicated-adoption-consent.ts
+++ b/packages/app/test/cloud-live-dedicated-adoption-consent.ts
@@ -193,15 +193,17 @@ export function installDedicatedAdoptionConsentProof(
         }
         const copyMatches = await consentTurn.evaluate(
           (element, expectedLines) => {
-            const normalize = (line: string) =>
-              line.replace(/\s+/g, " ").trim();
-            const visibleLines = (element as HTMLElement).innerText
-              .split("\n")
-              .map(normalize)
-              .filter(Boolean);
-            return expectedLines
-              .map(normalize)
-              .every((line) => visibleLines.includes(line));
+            const normalize = (text: string) =>
+              text.replace(/\s+/g, " ").trim();
+            const visibleCopy = normalize((element as HTMLElement).innerText);
+            let cursor = 0;
+            for (const expectedLine of expectedLines) {
+              const expected = normalize(expectedLine);
+              const index = visibleCopy.indexOf(expected, cursor);
+              if (index < 0) return false;
+              cursor = index + expected.length;
+            }
+            return true;
           },
           exactVisibleConsentLines(quote),
         );

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -604,11 +604,7 @@ test.describe("Cloud live optional action boundary", () => {
     await page.goto("/");
     await page.setContent(`
       <article data-testid="thread-line">
-        <p>Use your existing Dedicated agent?</p>
-        <p>Current status: stopped.</p>
-        <p>Hosting: $0.01/hour ($0.24/day).</p>
-        <p>Balance: $115.54; minimum required: $0.72 (3 days of runway); deficit: $0.00.</p>
-        <p>This action starts Dedicated compute and will restore its reviewed backup.</p>
+        <p>Use your existing Dedicated agent? Current status: stopped. Hosting: $0.01/hour ($0.24/day). Balance: $115.54; minimum required: $0.72 (3 days of runway); deficit: $0.00. This action starts Dedicated compute and will restore its reviewed backup.</p>
         <button data-testid="dedicated-adoption-confirm">Confirm and continue</button>
         <button data-testid="dedicated-adoption-cancel">Not now</button>
       </article>
@@ -677,7 +673,7 @@ test.describe("Cloud live optional action boundary", () => {
               return "adoption";
             },
           },
-          timeoutMs: 500,
+          timeoutMs: 2_000,
           runtimeCloudGraceMs: 50,
           pollIntervalMs: 5,
         }),

--- a/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
@@ -19,6 +19,7 @@ import { expect, type Page, test } from "@playwright/test";
 import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   expectNoPageDiagnostics,
+  expectOnlyAllowedPageDiagnostics,
   installPageDiagnosticsGuard,
   seedAppStorage,
 } from "./helpers";
@@ -60,6 +61,13 @@ test.describe("cloud-only onboarding (production default)", () => {
   });
 
   test.afterEach(async ({ page }, testInfo) => {
+    if (testInfo.title.includes("activation redirect")) {
+      await expectOnlyAllowedPageDiagnostics(page, testInfo.title, [
+        /^http\.409: POST .*\/upgrade-tier$/,
+        /^console\.error: Failed to load resource: the server responded with a status of 409 \(Conflict\)$/,
+      ]);
+      return;
+    }
     await expectNoPageDiagnostics(page, testInfo.title);
   });
 
@@ -262,6 +270,181 @@ test.describe("cloud-only onboarding (production default)", () => {
 
       await dedicatedAdoptionProof.confirmVisibleConsent(confirm);
       await expect.poll(() => adoptionPosts).toBe(1);
+      await expect(page.getByTestId("home-screen")).toBeVisible({
+        timeout: 20_000,
+      });
+      await settleHomeEntrance(page);
+    } finally {
+      dedicatedAdoptionProof.dispose();
+    }
+  });
+
+  test("an activation redirect surfaces existing Dedicated adoption and completes cutover", async ({
+    page,
+  }) => {
+    await injectCloudAuthToken(page);
+    await installHomeRoutes(page);
+    await installCloudRoutes(page);
+    const dedicatedAgentId = "22222222-2222-4222-8222-222222222222";
+    const adoptionQuoteId = "b".repeat(64);
+    let activationPosts = 0;
+    let adoptionQuoteGets = 0;
+    let adoptionPosts = 0;
+    let cutoverPosts = 0;
+    await page.route("**/api/auth/cli-session", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessionId: "dedicated-adoption-session" }),
+      });
+    });
+    await page.route("**/api/auth/cli-session/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "authenticated",
+          apiKey: "ui-smoke-onboarding-cloud-token",
+          organizationId: "ui-smoke-onboarding-org",
+          userId: "ui-smoke-onboarding-user",
+        }),
+      });
+    });
+    await page.unroute("**/api/v1/eliza/personal");
+    await page.route("**/api/v1/eliza/personal", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            identity: {
+              id: PERSONAL_ELIZA_ID,
+              displayName: CLOUD_AGENT_NAME,
+              runtime: "shared",
+            },
+          },
+        }),
+      });
+    });
+    await page.route("**/upgrade-tier/adopt-existing", async (route) => {
+      if (route.request().method() === "GET") {
+        adoptionQuoteGets += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              quoteId: adoptionQuoteId,
+              dedicatedAgentId,
+              adoptionState: "available",
+              status: "stopped",
+              startsCompute: true,
+              hourlyRateUsd: 0.01,
+              dailyRateUsd: 0.24,
+              minimumBalanceUsd: 0.72,
+              minimumRunwayDays: 3,
+              balanceUsd: 115.54059,
+              deficitUsd: 0,
+              stateDisposition: "verified_backup_present",
+              canAdopt: true,
+              requiresCatalogRestore: false,
+              requiresConfirmation: true,
+              action: "adopt_existing_dedicated",
+            },
+          }),
+        });
+        return;
+      }
+      adoptionPosts += 1;
+      expect(JSON.parse(route.request().postData() ?? "{}")).toEqual({
+        action: "adopt_existing_dedicated",
+        quoteId: adoptionQuoteId,
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            dedicatedAgentId,
+            runtime: "dedicated_pending_cutover",
+            status: "running",
+          },
+        }),
+      });
+    });
+    await page.route("**/upgrade-tier/cutover", async (route) => {
+      cutoverPosts += 1;
+      expect(JSON.parse(route.request().postData() ?? "{}")).toEqual({
+        dedicatedAgentId,
+      });
+      const origin = new URL(page.url()).origin;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            personalElizaId: PERSONAL_ELIZA_ID,
+            activeAgentId: dedicatedAgentId,
+            runtime: "dedicated",
+            apiBase: origin,
+            importedMessages: 0,
+          },
+        }),
+      });
+    });
+    await page.route("**/upgrade-tier", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              quoteId: "a".repeat(64),
+              canActivate: true,
+              activation: { state: "available" },
+            },
+          }),
+        });
+        return;
+      }
+      activationPosts += 1;
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          code: "dedicated_adoption_selection_required",
+          error: "Continue with same-row adoption.",
+        }),
+      });
+    });
+    await seedAppStorage(page, {
+      "eliza:first-run-complete": "",
+      "eliza:enable-runtime-chooser": "0",
+      steward_session_token: "ui-smoke-onboarding-cloud-token",
+      steward_session_token_scope: "eliza-cloud:production",
+      steward_session_active_scope: "eliza-cloud:production",
+    });
+
+    const dedicatedAdoptionProof = installDedicatedAdoptionConsentProof(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    const confirm = page.getByTestId(
+      "choice-__first_run__:dedicated-adoption:confirm",
+    );
+    try {
+      await expect(confirm).toBeVisible({ timeout: 20_000 });
+      expect(activationPosts).toBe(1);
+      expect(adoptionQuoteGets).toBe(1);
+      expect(adoptionPosts).toBe(0);
+
+      await dedicatedAdoptionProof.confirmVisibleConsent(confirm);
+      await expect.poll(() => adoptionPosts).toBe(1);
+      await expect.poll(() => cutoverPosts).toBe(1);
       await expect(page.getByTestId("home-screen")).toBeVisible({
         timeout: 20_000,
       });

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
@@ -75,6 +75,21 @@ function server(
   };
 }
 
+function action(
+  id: number,
+  command: string,
+  resourceId: number,
+): Record<string, unknown> {
+  return {
+    id,
+    command,
+    status: "success",
+    progress: 100,
+    resources: [{ id: resourceId, type: "server" }],
+    error: null,
+  };
+}
+
 function serverListResponse(servers: Array<Record<string, unknown>>): Response {
   return Response.json({
     servers,
@@ -140,9 +155,22 @@ describe("Hetzner E2E provision HTTP boundary", () => {
         }),
       ]),
       new Response(null, { status: 204 }),
+      Response.json(
+        { error: { code: "not_found", message: "server missing" } },
+        { status: 404 },
+      ),
+      Response.json({
+        server: server({
+          id: 99,
+          status: "initializing",
+          created: new Date().toISOString(),
+        }),
+        action: action(99, "create_server", 99),
+        next_actions: [],
+        root_password: null,
+      }),
       Response.json({
         server: server({ id: 99, created: new Date().toISOString() }),
-        root_password: null,
       }),
     );
 
@@ -173,8 +201,17 @@ describe("Hetzner E2E provision HTTP boundary", () => {
         server({ id: 45, created: null, name: "invalid-created" }),
       ]),
       Response.json({
-        server: server({ id: 99, created: new Date().toISOString() }),
+        server: server({
+          id: 99,
+          status: "initializing",
+          created: new Date().toISOString(),
+        }),
+        action: action(99, "create_server", 99),
+        next_actions: [],
         root_password: null,
+      }),
+      Response.json({
+        server: server({ id: 99, created: new Date().toISOString() }),
       }),
     );
 

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
@@ -87,12 +87,16 @@ describe("Hetzner E2E reaper credential boundary", () => {
         },
       ]),
       new Response(null, { status: 204 }),
+      Response.json(
+        { error: { code: "not_found", message: "server missing" } },
+        { status: 404 },
+      ),
     );
 
     await expect(
       runHetznerE2eReaper("valid-ci-token"),
     ).resolves.toBeUndefined();
-    expect(requestedMethods).toEqual(["GET", "DELETE"]);
+    expect(requestedMethods).toEqual(["GET", "DELETE", "GET"]);
     expect(requestedUrls[1]).toBe("https://api.hetzner.cloud/v1/servers/42");
   });
 
@@ -107,13 +111,17 @@ describe("Hetzner E2E reaper credential boundary", () => {
         { status: 409 },
       ),
       new Response(null, { status: 204 }),
+      Response.json(
+        { error: { code: "not_found", message: "server missing" } },
+        { status: 404 },
+      ),
     );
 
     await expect(runHetznerE2eReaper("valid-ci-token")).rejects.toMatchObject({
       name: "AggregateError",
       message: "Hetzner E2E reaper failed to delete 1 stale server(s)",
     });
-    expect(requestedMethods).toEqual(["GET", "DELETE", "DELETE"]);
+    expect(requestedMethods).toEqual(["GET", "DELETE", "DELETE", "GET"]);
     expect(requestedUrls[2]).toBe("https://api.hetzner.cloud/v1/servers/43");
   });
 });

--- a/packages/cloud/scripts/chat-latency.mjs
+++ b/packages/cloud/scripts/chat-latency.mjs
@@ -15,6 +15,9 @@ import { parseArgs } from "node:util";
 
 const TARGETS = new Set(["direct", "gateway", "paired", "dedicated"]);
 const REASONING_EFFORTS = new Set(["omit", "none", "low", "medium", "high"]);
+const DELTA_STREAM_PROTOCOL = "delta-v2";
+const SHARED_TURN_CORRELATION_HEADER = "X-ElizaOS-Turn-Correlation";
+const SHARED_TURN_ATTEMPT_HEADER = "X-ElizaOS-Turn-Attempt";
 const SAFE_RESPONSE_HEADERS = [
   "cf-placement",
   "cf-ray",
@@ -589,6 +592,34 @@ async function createConversation(
   return id;
 }
 
+/** Build the first-attempt conversation stream wire used by the frontend client. */
+export function buildDedicatedStreamRequest({
+  apiKey,
+  prompt,
+  clientMessageId,
+  turnCorrelation,
+  traceId,
+}) {
+  return {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      "X-Eliza-Trace-Id": traceId,
+      "X-Eliza-Telemetry": "full",
+      [SHARED_TURN_CORRELATION_HEADER]: turnCorrelation,
+      [SHARED_TURN_ATTEMPT_HEADER]: "1",
+      "User-Agent": "eliza-chat-latency/1.0",
+    },
+    body: JSON.stringify({
+      text: prompt,
+      channelType: "DM",
+      clientMessageId,
+      streamProtocol: DELTA_STREAM_PROTOCOL,
+    }),
+  };
+}
+
 export async function probeDedicated({
   agentId,
   baseUrl,
@@ -615,6 +646,13 @@ export async function probeDedicated({
       fetchImpl,
     );
     const startedAt = performance.now();
+    const streamRequest = buildDedicatedStreamRequest({
+      apiKey,
+      prompt,
+      clientMessageId: randomUUID(),
+      turnCorrelation: randomUUID(),
+      traceId,
+    });
     const response = await fetchImpl(
       baseUrl +
         "/api/conversations/" +
@@ -622,19 +660,7 @@ export async function probeDedicated({
         "/messages/stream",
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          Accept: "text/event-stream",
-          "X-Eliza-Trace-Id": traceId,
-          "X-Eliza-Telemetry": "full",
-          "User-Agent": "eliza-chat-latency/1.0",
-        },
-        body: JSON.stringify({
-          text: prompt,
-          channelType: "DM",
-          clientMessageId: randomUUID(),
-        }),
+        ...streamRequest,
         signal: requestSignal(timeoutMs),
       },
     );

--- a/packages/cloud/scripts/chat-latency.test.mjs
+++ b/packages/cloud/scripts/chat-latency.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildDedicatedStreamRequest,
   buildOpenAiRequestBody,
   buildProofPrompt,
   consumeOpenAiEvent,
@@ -223,6 +224,33 @@ test("buildProofPrompt preserves a custom prompt and always adds the nonce", () 
   assert.match(buildProofPrompt(undefined, "proof-456"), /proof-456/);
 });
 
+test("buildDedicatedStreamRequest matches the frontend delta stream contract", () => {
+  const request = buildDedicatedStreamRequest({
+    apiKey: "secret",
+    prompt: "private prompt",
+    clientMessageId: "message-1",
+    turnCorrelation: "11111111-1111-4111-8111-111111111111",
+    traceId: "22222222-2222-4222-8222-222222222222",
+  });
+
+  assert.deepEqual(JSON.parse(request.body), {
+    text: "private prompt",
+    channelType: "DM",
+    clientMessageId: "message-1",
+    streamProtocol: "delta-v2",
+  });
+  assert.deepEqual(request.headers, {
+    Authorization: "Bearer secret",
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+    "X-Eliza-Trace-Id": "22222222-2222-4222-8222-222222222222",
+    "X-Eliza-Telemetry": "full",
+    "X-ElizaOS-Turn-Correlation": "11111111-1111-4111-8111-111111111111",
+    "X-ElizaOS-Turn-Attempt": "1",
+    "User-Agent": "eliza-chat-latency/1.0",
+  });
+});
+
 test("probeOpenAi requires a clean terminal frame and never records prompt text", async () => {
   let requestBody = null;
   const result = await probeOpenAi({
@@ -393,7 +421,12 @@ test("safeTerminalTelemetry uses exact numeric paths and drops arbitrary strings
 test("probeDedicated requires a done terminal and sanitizes telemetry", async () => {
   const calls = [];
   const fetchImpl = async (url, init = {}) => {
-    calls.push({ url, method: init.method });
+    calls.push({
+      url,
+      method: init.method,
+      headers: init.headers,
+      body: init.body,
+    });
     if (calls.length === 1) {
       return Response.json({ conversation: { id: "conversation-1" } });
     }
@@ -426,6 +459,12 @@ test("probeDedicated requires a done terminal and sanitizes telemetry", async ()
     runtime: { totalMs: 20, provider: "cerebras" },
   });
   assert.equal(calls.length, 3);
+  assert.match(
+    calls[1].headers["X-ElizaOS-Turn-Correlation"],
+    /^[0-9a-f-]{36}$/,
+  );
+  assert.equal(calls[1].headers["X-ElizaOS-Turn-Attempt"], "1");
+  assert.equal(JSON.parse(calls[1].body).streamProtocol, "delta-v2");
   assert.equal(calls[2].method, "DELETE");
 
   const errorResult = await probeDedicated({

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
@@ -404,6 +404,21 @@ describe("Hetzner lifecycle deadlines and absence", () => {
     expect(requests).toEqual([{ method: "DELETE", path: "/v1/servers/41" }]);
   });
 
+  test("server deletion accepts 204 only after exact absence readback", async () => {
+    empty();
+    json({ server: server(41) });
+    await expect(client().deleteServer(41)).rejects.toMatchObject({
+      code: "server_error",
+    });
+
+    responses = [];
+    requests = [];
+    empty();
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
+    await expect(client().deleteServer(41)).resolves.toBeUndefined();
+    expect(requests.map(({ path }) => path)).toEqual(["/v1/servers/41", "/v1/servers/41"]);
+  });
+
   test("volume delete requires exact post-delete absence", async () => {
     empty();
     json({ volume: volume(51) });

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -430,11 +430,14 @@ export class HetznerCloudClient implements ComputeProvider {
   async deleteServer(serverId: number): Promise<void> {
     validateResourceId(serverId, "serverId");
     const deadline = deadlineAfter(this.lifecycleTimeoutMs);
-    let data: Record<string, unknown>;
+    let deleteResponse: unknown | typeof NO_CONTENT;
     try {
-      data = requireEnvelope(
-        await this.request<unknown>("DELETE", `/servers/${serverId}`, undefined, deadline),
-        "delete server",
+      deleteResponse = await this.request<unknown>(
+        "DELETE",
+        `/servers/${serverId}`,
+        undefined,
+        deadline,
+        true,
       );
     } catch (error) {
       // error-policy:J4 an exact target 404 is the provider's explicit
@@ -442,13 +445,16 @@ export class HetznerCloudClient implements ComputeProvider {
       if (error instanceof HetznerCloudError && error.code === "not_found") return;
       throw error;
     }
-    await this.settleReturnedActions(
-      data.action,
-      Object.hasOwn(data, "next_actions") ? data.next_actions : [],
-      deadline,
-      { id: serverId, type: "server" },
-      true,
-    );
+    if (deleteResponse !== NO_CONTENT) {
+      const data = requireEnvelope(deleteResponse, "delete server");
+      await this.settleReturnedActions(
+        data.action,
+        Object.hasOwn(data, "next_actions") ? data.next_actions : [],
+        deadline,
+        { id: serverId, type: "server" },
+        true,
+      );
+    }
     if ((await this.getServerWithin(serverId, deadline)) !== null) {
       throw new HetznerCloudError(
         "server_error",

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -1,6 +1,7 @@
-// Pins the fail-closed contract of the connection-enforcement gate: an internal cache/oauth
-// failure must PROPAGATE (throw), and stay distinguishable from a legitimately-negative
-// "no required connection" result. Deterministic fixtures — no live cache or oauth.
+/**
+ * Pins the fail-closed connection-enforcement contract with deterministic cache
+ * and OAuth fixtures, including the disabled nudge-generation boundary.
+ */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const cacheGet = mock();
@@ -23,17 +24,8 @@ mock.module("../oauth", () => ({
   },
 }));
 
-mock.module("../../providers/language-model", () => ({
-  getLanguageModel: mock(() => "mock-model"),
-  hasLanguageModelProviderConfigured: mock(() => true),
-}));
-
 mock.module("../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
-}));
-
-mock.module("ai", () => ({
-  generateText: mock(async () => ({ text: "unused in this suite" })),
 }));
 
 const { connectionEnforcementService } = await import(

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
@@ -2,8 +2,8 @@
  * Connection enforcement for Eliza App messaging channels.
  *
  * WHY: Eliza needs at least one connected data source before agent workflows
- * are useful. When no supported connection exists, we respond in-character and
- * steer the user toward connecting Google, Microsoft, or X.
+ * are useful. Connection-status checks remain active, while nudge generation
+ * fails closed until it is routed through the admitted generative boundary.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -23,50 +23,6 @@ interface NudgeParams {
   userId: string;
 }
 
-interface ConversationMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
-interface ConversationState {
-  messageCount: number;
-  messages: ConversationMessage[];
-}
-
-interface ElizaCharacter {
-  name: string;
-  system: string;
-  bio: string[];
-  adjectives: string[];
-  style: { all: string[]; chat: string[] };
-}
-
-const DEFAULT_ELIZA_CHARACTER: ElizaCharacter = {
-  name: "Eliza",
-  system:
-    "You are Eliza. A presence, not an assistant. You say less and mean more. You never use exclamation points. You use lowercase naturally.",
-  bio: [
-    "pays attention to what people care about",
-    "warm through what she notices, not what she announces",
-    "comfortable in ambiguity, allergic to false certainty",
-    "genuinely interested in the texture of someone's day",
-    "quietly direct when something matters",
-  ],
-  adjectives: ["perceptive", "present", "warm but restrained", "curious", "ungeneric"],
-  style: {
-    all: [
-      "say less. mean more.",
-      "never use exclamation points",
-      "use lowercase naturally",
-      "short sentences. fragments are fine.",
-    ],
-    chat: [
-      "you are a presence, not an assistant",
-      "help as yourself. don't shift into service mode.",
-    ],
-  },
-};
-
 const PROVIDER_ALIAS_ENTRIES = [
   ["google calendar", "google"],
   ["google", "google"],
@@ -82,34 +38,8 @@ const PROVIDER_ALIAS_ENTRIES = [
 ] as Array<[string, RequiredPlatform]>;
 PROVIDER_ALIAS_ENTRIES.sort((left, right) => right[0].length - left[0].length);
 
-const PLATFORM_DISPLAY_NAMES: Record<RequiredPlatform, string> = {
-  google: "Google",
-  microsoft: "Microsoft",
-  twitter: "X",
-};
-
-const CLAIM_CONNECTED_PATTERNS = [
-  "connected",
-  "i connected",
-  "done",
-  "i did it",
-  "finished",
-  "completed",
-  "linked",
-  "authorized",
-  "signed in",
-  "logged in",
-  "all set",
-  "it's done",
-  "its done",
-  "did it",
-  "went through",
-];
-
 const NUDGE_INTERVAL = 3;
 const CONNECTION_STATUS_TTL_SECONDS = 30;
-const CONVERSATION_TTL_SECONDS = 3600;
-const NUDGE_MODEL = "openai/gpt-5-mini";
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -119,210 +49,12 @@ function compileAliasRegex(alias: string): RegExp {
   return new RegExp(`(^|[^a-z0-9])${escapeRegex(alias)}(?=$|[^a-z0-9])`, "i");
 }
 
-function sample<T>(items: T[], count: number): T[] {
-  const shuffled = [...items];
-  for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const nextIndex = Math.floor(Math.random() * (index + 1));
-    [shuffled[index], shuffled[nextIndex]] = [shuffled[nextIndex], shuffled[index]];
-  }
-  return shuffled.slice(0, Math.min(count, shuffled.length));
-}
-
-function formatConversationHistory(messages: ConversationMessage[]): string {
-  if (messages.length === 0) return "";
-
-  return `\n\nRecent conversation:\n${messages
-    .map((message) => `${message.role === "user" ? "User" : "Eliza"}: ${message.content}`)
-    .join("\n")}\n`;
-}
-
 function getConversationKey(organizationId: string, userId: string): string {
   return `connection-enforcement:conversation:${organizationId}:${userId}`;
 }
 
 function getConnectionStatusKey(organizationId: string, userId: string): string {
   return `connection-enforcement:required-connection:${organizationId}:${userId}`;
-}
-
-async function loadConversationState(
-  organizationId: string,
-  userId: string,
-): Promise<ConversationState> {
-  // A cache MISS legitimately yields no history (`?? { empty }`, designed-empty). A cache
-  // read ERROR must propagate — masking it as an empty conversation would silently reset the
-  // nudge cadence and drop history, conflating a broken cache with a brand-new conversation.
-  return (
-    (await cache.get<ConversationState>(getConversationKey(organizationId, userId))) ?? {
-      messageCount: 0,
-      messages: [],
-    }
-  );
-}
-
-async function saveConversationState(
-  organizationId: string,
-  userId: string,
-  state: ConversationState,
-): Promise<void> {
-  try {
-    await cache.set(getConversationKey(organizationId, userId), state, CONVERSATION_TTL_SECONDS);
-  } catch (error) {
-    // error-policy:J7 auxiliary continuity write — runs after the user-facing reply is already
-    // produced; a cache write blip must not turn a successful reply into a user error. Warns so
-    // the failure stays observable; the only fallout is a degraded nudge cadence next turn.
-    logger.warn("[ConnectionEnforcement] Failed to persist conversation state", {
-      organizationId,
-      userId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-function getBaseUrl(): string {
-  const configuredBaseUrl = process.env.NEXT_PUBLIC_APP_URL;
-  if (configuredBaseUrl) return configuredBaseUrl;
-
-  logger.warn(
-    "[ConnectionEnforcement] NEXT_PUBLIC_APP_URL missing, falling back to production URL",
-  );
-  return "https://cloud.eliza.app";
-}
-
-function isClaimingConnected(message: string): boolean {
-  const lower = message.toLowerCase().trim();
-  return CLAIM_CONNECTED_PATTERNS.some((pattern) => lower.includes(pattern));
-}
-
-function shouldNudge(messageCount: number): boolean {
-  return messageCount % NUDGE_INTERVAL === 0;
-}
-
-function formatLinks(
-  links: { platform: RequiredPlatform; url: string }[],
-  messagingPlatform: MessagingPlatform,
-): string {
-  if (messagingPlatform === "telegram") {
-    return links
-      .map((link) => `[Connect ${PLATFORM_DISPLAY_NAMES[link.platform]}](${link.url})`)
-      .join("\n");
-  }
-
-  return links.map((link) => `${PLATFORM_DISPLAY_NAMES[link.platform]}: ${link.url}`).join("\n");
-}
-
-function buildNudgePrompt(
-  platform: MessagingPlatform,
-  conversationHistory: string,
-  isFirstInteraction: boolean,
-): string {
-  const bioSample = sample(DEFAULT_ELIZA_CHARACTER.bio, 4).join(" ");
-  const adjectiveSample = sample(DEFAULT_ELIZA_CHARACTER.adjectives, 4).join(", ");
-  const styleSample = sample(
-    [...DEFAULT_ELIZA_CHARACTER.style.all, ...DEFAULT_ELIZA_CHARACTER.style.chat],
-    5,
-  ).join("; ");
-
-  const firstInteractionContext = isFirstInteraction
-    ? `\n\nIMPORTANT: This is the user's first message after connecting ${platform}. If they say they just connected or signed up, they mean ${platform} itself unless they explicitly mention Google, Microsoft, or X.`
-    : "";
-
-  return `${DEFAULT_ELIZA_CHARACTER.system}
-
-About you: ${bioSample}
-Your personality: ${adjectiveSample}
-Your writing style: ${styleSample}
-
-CONTEXT: The user is messaging you on ${platform}. They do not have a required data connection yet. They need Google, Microsoft, or X connected before you can use their inbox, calendar, contacts, or social feed.${firstInteractionContext}
-
-RESPONSE RULES:
-1. Keep it to 2-3 sentences. Never use exclamation points.
-2. Respond directly to what they said. Do not sound like a support bot.
-3. Briefly explain that you need one data connection before you can help properly.
-4. If they mention a provider, acknowledge that choice briefly. Do not list the other options again.
-5. Do not include any URLs. Links are appended separately when needed.
-6. If they say they already connected something and you still do not see it, say you still do not see the connection yet and suggest trying again.${conversationHistory}`;
-}
-
-function buildChatPrompt(platform: MessagingPlatform, conversationHistory: string): string {
-  const bioSample = sample(DEFAULT_ELIZA_CHARACTER.bio, 4).join(" ");
-  const adjectiveSample = sample(DEFAULT_ELIZA_CHARACTER.adjectives, 4).join(", ");
-  const styleSample = sample(
-    [...DEFAULT_ELIZA_CHARACTER.style.all, ...DEFAULT_ELIZA_CHARACTER.style.chat],
-    5,
-  ).join("; ");
-
-  return `${DEFAULT_ELIZA_CHARACTER.system}
-
-About you: ${bioSample}
-Your personality: ${adjectiveSample}
-Your writing style: ${styleSample}
-
-CONTEXT: The user is messaging you on ${platform}. They still have no required data connection, but you already reminded them recently. Chat naturally without bringing it up again unless they ask.${conversationHistory}`;
-}
-
-const FALLBACK_RESPONSES = [
-  "i'd like to help, but i need one connection first so i can actually see your world. google, microsoft, or x?",
-  "i'm missing the context that makes me useful. connect google, microsoft, or x and we can do something real.",
-  "i can talk, but i can't actually work with your day until one account is connected. google, microsoft, or x?",
-];
-
-function getFallbackResponse(message: string): string {
-  const lower = message.toLowerCase();
-  if (lower.includes("why") || lower.includes("what for")) {
-    return "because without a connection i'm guessing. one inbox, calendar, or feed changes that. google, microsoft, or x?";
-  }
-
-  if (
-    lower.includes("none") ||
-    lower.includes("skip") ||
-    lower.includes("don't want") ||
-    lower.includes("without")
-  ) {
-    return "fair. i just can't do much without context. if you were going to pick one, which would it be: google, microsoft, or x?";
-  }
-
-  return FALLBACK_RESPONSES[Math.floor(Math.random() * FALLBACK_RESPONSES.length)];
-}
-
-async function generateOAuthLinks(
-  organizationId: string,
-  userId: string,
-  platform: MessagingPlatform,
-  specificProvider?: RequiredPlatform | null,
-): Promise<{ platform: RequiredPlatform; url: string }[]> {
-  const redirectUrl = `${getBaseUrl()}/api/eliza-app/auth/connection-success?platform=${platform}`;
-  const providers = specificProvider ? [specificProvider] : [...REQUIRED_PLATFORMS];
-
-  const results = await Promise.allSettled(
-    providers.map(async (provider) => {
-      const result = await oauthService.initiateAuth({
-        organizationId,
-        userId,
-        platform: provider,
-        redirectUrl,
-      });
-
-      return result.authUrl ? { platform: provider, url: result.authUrl } : null;
-    }),
-  );
-
-  // error-policy:J4 designed degrade — fan out per provider and return whichever links
-  // succeeded; one provider's auth-init failure must not deny the user the others. Failures
-  // are warned, and the caller renders whatever links come back (or none if all failed).
-  return results.flatMap((result) => {
-    if (result.status === "fulfilled" && result.value) {
-      return [result.value];
-    }
-
-    if (result.status === "rejected") {
-      logger.warn("[ConnectionEnforcement] Failed to generate OAuth link", {
-        organizationId,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      });
-    }
-
-    return [];
-  });
 }
 
 function detectProviderFromMessage(message: string): RequiredPlatform | null {

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -81,8 +81,6 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts":
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
-	"packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts":
-		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/app-promotion-assets.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
@@ -95,9 +93,6 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 	"packages/cloud/shared/src/lib/services/provisioning-agent-chat.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
-	"packages/cloud/shared/src/lib/services/room-title.ts": [
-		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
-	],
 	"packages/cloud/shared/src/lib/services/seo.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
@@ -105,13 +100,40 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts":
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
-	"packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts":
-		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts":
 		[/isModelOutputLimitFinishReason\(completion\.finishReason\)/],
 	"plugins/plugin-anthropic/models/image.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}response\.finishReason/,
 	],
+};
+
+const directModelDispatchPatterns = [
+	/from\s+["']ai["']|import\(["']ai["']\)/,
+	/from\s+["'][^"']*providers\/language-model["']|import\(["'][^"']*providers\/language-model["']\)/,
+	/\bgenerateText\s*\(/,
+	/\bstreamText\s*\(/,
+] as const;
+
+const nonDirectModelDispatchBoundaries: Record<
+	string,
+	{
+		readonly requiredPatterns: readonly RegExp[];
+	}
+> = {
+	"packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts":
+		{
+			requiredPatterns: [/code:\s*"CONNECTION_ENFORCEMENT_LLM_DISABLED"/],
+		},
+	"packages/cloud/shared/src/lib/services/room-title.ts": {
+		requiredPatterns: [/const title = generateFallbackTitle\(text\)/],
+	},
+	"packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts":
+		{
+			requiredPatterns: [
+				/await runSharedAgentTurn\(\{/,
+				/runSharedAgentTurnStream\(\{/,
+			],
+		},
 };
 
 const guardedSources: Record<string, readonly RegExp[]> = {
@@ -1291,6 +1313,27 @@ describe("prompt integrity policy", () => {
 			);
 			for (const pattern of requiredPatterns) {
 				expect(source, `${relativePath} must match ${pattern}`).toMatch(
+					pattern,
+				);
+			}
+		}
+	});
+
+	it("keeps disabled, deterministic, and delegated paths free of direct model dispatches", () => {
+		for (const [relativePath, policy] of Object.entries(
+			nonDirectModelDispatchBoundaries,
+		)) {
+			const source = readFileSync(
+				resolve(repositoryRoot, relativePath),
+				"utf8",
+			);
+			for (const pattern of policy.requiredPatterns) {
+				expect(source, `${relativePath} must match ${pattern}`).toMatch(
+					pattern,
+				);
+			}
+			for (const pattern of directModelDispatchPatterns) {
+				expect(source, `${relativePath} must not match ${pattern}`).not.toMatch(
 					pattern,
 				);
 			}

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -154,7 +154,7 @@ describe("provisioning worker deployment contract", () => {
     );
     const clean = workflow.indexOf("git clean -ffdx -q", verify);
     const cleanVerdict = workflow.indexOf(
-      '[ -z "$(git status --porcelain)" ] || {',
+      '[ -z "$(git status --porcelain --ignore-submodules=all)" ] || {',
       verify,
     );
     expect(reset).toBeGreaterThan(exactSourceCheck);


### PR DESCRIPTION
## Summary

- accept Hetzner 204 deletion only provisionally and prove exact by-id absence
- align provisioning clean-tree verification with submodule-aware deployment behavior
- remove unreachable connection-enforcement model/history work and keep active prompt-integrity enforcement fail-closed
- make the latency probe exactly mirror the frontend delta-v2 streaming request and correlation headers
- certify wrapped responsive adoption consent text while preserving exact safe-sentence ordering and no-pre-consent mutation

This consolidates the exact fixes from #30018, #30027, #30030, #30031, and #30032 so the latency-certification path can be deployed and measured from one exact head.

Fixes #30017
Fixes #30023
Fixes #30024
Fixes #30025
Fixes #30026

## Verification

- bun run verify (375/375 workspace tasks plus repository audits)
- prompt-integrity and connection-enforcement focused tests: 15 pass
- chat-latency request contract: 18 pass
- Hetzner provision/reaper/lifecycle: 31 pass
- provisioning workflow contract: 25 pass
- responsive adoption browser contracts: focused suites pass
- git diff --check

## Live acceptance after merge

Deploy the immutable merged SHA to staging, verify both public health routes report that SHA, run the deployed renderer certification, then run paired frontend-mirroring gateway and direct Cerebras probes with one unique turn-correlation ID per request. Only after staging passes will production be considered.