### PR TITLE
test(cloud): restore voice WebSocket deploy gate

### DIFF
--- a/packages/cloud/api/test/e2e/run-e2e-batches.mjs
+++ b/packages/cloud/api/test/e2e/run-e2e-batches.mjs
@@ -76,6 +76,12 @@ const e2eEnv = {
   // the wrapper still gets a working KMS.
   NODE_ENV: process.env.NODE_ENV || "test",
   CLOUD_E2E: process.env.CLOUD_E2E || "1",
+  // Paid voice-provider admission requires an atomic Redis implementation.
+  // The local workerd lane has no external Redis binding, so opt it into the
+  // repository's explicit Lua-capable in-memory test backend. Without this,
+  // the real WebSocket route correctly fails closed with HTTP 503 before the
+  // binary-first middleware contract can exercise the 101 upgrade.
+  MOCK_REDIS: process.env.MOCK_REDIS || "1",
   ...(e2eRunReceipt ? { CLOUD_E2E_RUN_RECEIPT: e2eRunReceipt } : {}),
   ELIZA_KMS_BACKEND: process.env.ELIZA_KMS_BACKEND || "memory",
   // Keep the real voice upgrade route reachable in the pinned-Workerd lane.


### PR DESCRIPTION
Links #29339

## Problem

The staging Cloud CF release at run 33291885922 stopped before mutation because the real-workerd Group D voice WebSocket probe received HTTP 503 instead of 101. The paid-provider admission hardening correctly requires atomic Redis, but the local E2E Worker was not opted into the repository test Redis backend.

## Fix

Pass explicit `MOCK_REDIS=1` to the locally owned Worker through the central E2E environment. Caller overrides remain authoritative. Production bindings and fail-closed behavior are unchanged.

## Regression prevented

Cloud CF deploys exercise this real middleware boundary before mutation. Without the fixture binding, every deploy fails before Worker or Pages release, even though the test is intended to certify the connected 101 upgrade through pinned workerd.

## Verification

- `E2E_ONLY=group-d-ai-media bun run --cwd packages/cloud/api test:e2e`: 26 pass, 1 intentional live-provider skip, 0 fail; exact WebSocket probe returned 101.
- `bun run --cwd packages/cloud/api typecheck`: passed, including production Worker dry-run bundle.
- package Biome check: passed.
- `bun run verify` at exact head `7722368f67d3bceb2352f2cf7c96dcf45f7f2f88`: 375/375 workspace tasks and final audits passed; 11,253 test files scanned with 0 focused and 0 orphaned skips.

Screenshots/video are N/A: this changes only the local API E2E harness environment and does not alter UI pixels.