### PR TITLE
fix(cloud): fail closed when the hosted logout marker is not persisted

### DIFF
--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -308,4 +308,66 @@ describe("POST /api/auth/logout cookie clearing", () => {
     expect(getCurrentUserMock).not.toHaveBeenCalled();
     expect(endAllUserSessionsMock).not.toHaveBeenCalled();
   });
+
+  test("REGRESSION (#29935): unconfirmed SSO marker after both write attempts → 503, not a 200 success", async () => {
+    // Fail closed: if both markSsoBridgeLogout attempts fail, the cross-host
+    // logout barrier is not persisted and a paired-origin refresh could
+    // re-plant the signed-out session. The route must not report success the
+    // client would treat as permission to navigate to /login.
+    readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
+    markSsoBridgeLogoutMock.mockRejectedValue(new Error("store unavailable"));
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer header.payload.signature",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(503);
+    expect((await res.json()) as unknown).toEqual({
+      error: "Cross-host logout is not yet persisted; retry sign-out",
+      code: "logout_marker_unavailable",
+    });
+    // Cookies are still cleared (this origin IS logged out) and the bounded
+    // retry actually ran: exactly two write attempts.
+    expect(deletedCookieNames(res)).toContain("steward-token-staging");
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("REGRESSION (#29935): a transient marker failure recovers on the bounded retry → 200", async () => {
+    readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
+    // Reset the persistent rejection the previous test installed, then fail
+    // exactly the first write: the bounded retry must recover to a 200.
+    markSsoBridgeLogoutMock.mockResolvedValue(undefined);
+    markSsoBridgeLogoutMock.mockRejectedValueOnce(
+      new Error("transient store blip"),
+    );
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer header.payload.signature",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledTimes(2);
+    expect((await res.json()) as unknown).toEqual({
+      success: true,
+      message: "Logged out successfully",
+    });
+  });
 });

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -370,4 +370,96 @@ describe("POST /api/auth/logout cookie clearing", () => {
       message: "Logged out successfully",
     });
   });
+
+  test("combined failure: revocation 503 takes precedence and the marker failure is not double-reported", async () => {
+    // Pin the documented precedence: when both fail-closed flags are set the
+    // response is the revocation 503; the marker failure stays visible in the
+    // error log and the audit metadata, not the transport body.
+    readStewardSessionTokenMock.mockReturnValue("prod-token");
+    getCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    markSsoBridgeLogoutMock.mockRejectedValue(new Error("store unavailable"));
+    revokeInferenceSessionsThroughMock.mockRejectedValue(
+      new Error("boundary unavailable"),
+    );
+    // Calls accumulate across tests (beforeEach clears only the marker mock).
+    revokeInferenceSessionsThroughMock.mockClear();
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api.elizacloud.ai",
+          origin: "https://eliza.app",
+          cookie: "steward-token=prod-token",
+        },
+      },
+      {
+        ENVIRONMENT: "production",
+        NODE_ENV: "production",
+        INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+      },
+    );
+
+    expect(res.status).toBe(503);
+    expect((await res.json()) as unknown).toEqual({
+      error: "Logout revocation is temporarily unavailable",
+      code: "logout_revocation_unavailable",
+    });
+    // Both failure paths still ran their bounded work before the response.
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledTimes(2);
+    expect(revokeInferenceSessionsThroughMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("characterization (#29935 review): a credential-less retry after a failed first attempt returns success with zero marker writes", async () => {
+    // Documents the pre-client-reorder gap: the first attempt 503s, but the
+    // develop client has already scrubbed the bearer/cookie by then, so the
+    // retry presents no credentials, the marker block is skipped entirely,
+    // and the route answers success while the barrier is still unstamped.
+    // This is why the client reorder (elizaOS/eliza#29936) is load-bearing —
+    // keep this test until that lands; if it ever fails, the sequencing
+    // changed and deserves a fresh look.
+    readStewardSessionTokenMock.mockReturnValue("header.payload.signature");
+    markSsoBridgeLogoutMock.mockRejectedValue(new Error("store unavailable"));
+
+    const first = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+          authorization: "Bearer header.payload.signature",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+    expect(first.status).toBe(503);
+    expect(markSsoBridgeLogoutMock).toHaveBeenCalledTimes(2);
+
+    // Retry presents neither Authorization header nor cookie — the token
+    // reader is request-mocked, so reflect the absent credentials here.
+    markSsoBridgeLogoutMock.mockClear();
+    readStewardSessionTokenMock.mockReturnValue(null);
+    const second = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          origin: "https://cloud-staging.eliza.app",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+    expect(second.status).toBe(200);
+    expect(markSsoBridgeLogoutMock).not.toHaveBeenCalled();
+    expect((await second.json()) as unknown).toEqual({
+      success: true,
+      message: "Logged out successfully",
+    });
+  });
 });

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -125,12 +125,13 @@ app.post("/", async (c) => {
         logger.debug("[Logout] Stamped SSO bridge logout marker");
       }
     } catch (error) {
-      // error-policy:J6 best-effort teardown — cookies are already cleared, so
-      // THIS origin is logged out; but the cross-host logout barrier did not
-      // land, which is a security-relevant condition worth an alert, not a
-      // debug line. The bridge's own store reads fail closed while the store
-      // is down, narrowing the exposure to a post-recovery window bounded by
-      // the access-token TTL.
+      // error-policy:J1 boundary translation — this catch now determines the
+      // transport response (flag → structured 503 below) as well as logging a
+      // security-relevant condition at error level, not a teardown-only J6.
+      // Cookies are already cleared, so THIS origin is logged out; but the
+      // cross-host logout barrier did not land. The bridge's own store reads
+      // fail closed while the store is down, narrowing the exposure to a
+      // post-recovery window bounded by the access-token TTL.
       logger.error(
         "[Logout] FAILED to stamp SSO bridge logout marker — cross-host logout barrier not persisted",
         {
@@ -167,7 +168,23 @@ app.post("/", async (c) => {
             ip: getRequestIp(c),
             user_agent: c.req.header("user-agent") ?? undefined,
             request_id: c.get("requestId"),
-            metadata: { method: "steward_session" },
+            // result stays "success" (this origin's cookies/sessions are
+            // torn down either way), but the marker flag must be visible to
+            // an auditor reading a success event next to an HTTP 503.
+            metadata: {
+              method: "steward_session",
+              ...(ssoMarkerUnconfirmed || strongRevocationFailed
+                ? {
+                    incomplete_logout: true,
+                    ...(ssoMarkerUnconfirmed
+                      ? { sso_marker_unconfirmed: true }
+                      : {}),
+                    ...(strongRevocationFailed
+                      ? { strong_revocation_unconfirmed: true }
+                      : {}),
+                  }
+                : {}),
+            },
           })
           // error-policy:J7 audit write is diagnostic; logout already succeeded via
           // the cookie clear above, so a dropped audit event is logged, not fatal.

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -76,6 +76,7 @@ app.post("/", async (c) => {
   deleteCookie(c, "eliza-anon-session", { path: "/" });
 
   let strongRevocationFailed = false;
+  let ssoMarkerUnconfirmed = false;
   if (stewardToken && isInferenceStrongRevocationEnabled(c.env)) {
     try {
       const [claims, user] = await Promise.all([
@@ -136,6 +137,11 @@ app.post("/", async (c) => {
           error: error instanceof Error ? error.message : String(error),
         },
       );
+      // Fail closed (#29935): an unconfirmed marker means a refresh of the
+      // paired origin can re-plant the signed-out session, so the response
+      // must not claim a globally complete logout. The client treats only a
+      // 2xx as permission to navigate away from the authenticated surface.
+      ssoMarkerUnconfirmed = true;
     }
   }
 
@@ -189,6 +195,16 @@ app.post("/", async (c) => {
       {
         error: "Logout revocation is temporarily unavailable",
         code: "logout_revocation_unavailable" as const,
+      },
+      503,
+    );
+  }
+
+  if (ssoMarkerUnconfirmed) {
+    return c.json(
+      {
+        error: "Cross-host logout is not yet persisted; retry sign-out",
+        code: "logout_marker_unavailable" as const,
       },
       503,
     );


### PR DESCRIPTION
# Relates to

Closes #29935

**Dependency note (per review, must-fix 1):** this PR is the server half
only. On develop, the hosted client scrubs its credential BEFORE awaiting
the logout response, so this 503 alone produces "cookies deleted,
credential gone, error shown, barrier unstamped" — and a credential-less
retry returns success with zero marker writes (pinned by the
characterization test below). Do not merge standalone as a complete fix:
either land it coupled with #29936's client reorder, or treat it as the
server prerequisite that PR sits on. The two conflict in `app.post("/")`;
only one server change should merge.

- [x] This PR targets `develop` and is built directly on develop@4b017df0 (Git data API), zero conflicts.
- [x] Focused tests pass (exact command and output below), RED→GREEN verified.
- [x] A reviewer can confirm the change works from the regressions below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. The change mirrors the route's existing `strongRevocationFailed`
fail-closed shape one block later: a flag set in the marker catch, and a
structured 503 before the success return. Cookie clearing (which happens
earlier in the handler) and the single bounded retry are untouched, so a
transient write failure still recovers to 200 — pinned by a regression.
The only new behavior is that an unconfirmed marker no longer reports
success. Client caveat (per review): on develop, `signOutFromSsoBridgedHost`
scrubs the local credential BEFORE awaiting the logout response, so this
status is surfaced as an error but the retry arrives without credentials —
the client-side reorder in #29936 is what lets a caller actually act on
this status. The two changes are complementary; this PR stays server-only.

# Background

## What does this PR do?

`POST /api/auth/logout` stamps the cross-host SSO logout marker
(`markSsoBridgeLogout`) with one bounded retry. When both writes failed it
logged at error level and still returned HTTP 200 — and the hosted client
treats a 2xx as permission to navigate to `/login`, so sign-out completed
visually while the barrier that stops the paired origin from re-planting
the session was never persisted. An immediate refresh could restore the
old authenticated `/join` session (#29935's live staging reproduction).

The route already had the exact fail-closed precedent for the strong
inference revocation: flag in the catch, structured 503
(`logout_revocation_unavailable`) before the success return. This PR adds
the twin for the marker: `ssoMarkerUnconfirmed` → 503
`logout_marker_unavailable`, cookies still cleared (this origin IS logged
out — the response tells the client to retry sign-out, not that logout
half-happened).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/auth/logout/route.ts` — the `ssoMarkerUnconfirmed`
flag (search `#29935`) and the new 503 block before the success return —
then the two REGRESSION tests at the end of `route.test.ts`.

## Detailed testing steps

- `cd packages/cloud/api && bun test auth/logout/route.test.ts`
  - 12 pass / 0 fail (8 pre-existing + 4 new: fail-closed regression,
    transient-recovery regression, combined-failure precedence,
    second-attempt characterization).
- RED check: with `route.ts` reverted to develop and the tests kept, the
  503 regression fails (develop returns 200 for an unconfirmed marker;
  9 pass / 1 fail); restoring the fix returns to 10/10.
- Regression 1 (fail closed): `markSsoBridgeLogout` rejects on both
  attempts → 503 with `{ error: "Cross-host logout is not yet persisted;
  retry sign-out", code: "logout_marker_unavailable" }`, staging cookies
  still cleared, exactly 2 write attempts (the bounded retry ran).
- Regression 2 (transient recovery): first write rejects, retry lands →
  200 `{ success: true, message: "Logged out successfully" }`.
- Cross-check: `__tests__/auth-audit-ip-attribution.test.ts` also drives
  the logout route; its 5 failures in this sandbox are pre-existing and
  environmental (IP-attribution assertions about cf-connecting-ip vs
  x-forwarded-for and login-audit events, failing identically with the
  develop route — verified by reverting `route.ts` and re-running), and
  its logout test's marker mock succeeds, so the 200 it asserts is
  unchanged. CI runs it on a fully built workspace.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:eb7f0213c0a813d70d0b429b356748792e36873a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface in this PR; a server-side fail-closed
      status change covered by deterministic route tests against the
      mocked collaborators.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable effect (503 instead of 200 when the marker
      write fails) is asserted directly by the regression; the client's
      stay-on-surface behavior already exists for non-2xx.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no logging change; the existing error-level log for the
      failed stamp is retained and the defect/fix is value-level.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched in this PR.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB schema change; the marker store is mocked at the
      service boundary in the focused suite.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
(pass) POST /api/auth/logout cookie clearing > REGRESSION (#29935): unconfirmed SSO marker after both write attempts → 503, not a 200 success
(pass) POST /api/auth/logout cookie clearing > REGRESSION (#29935): a transient marker failure recovers on the bounded retry → 200
(pass) POST /api/auth/logout cookie clearing > combined failure: revocation 503 takes precedence and the marker failure is not double-reported
(pass) POST /api/auth/logout cookie clearing > characterization (#29935 review): a credential-less retry after a failed first attempt returns success with zero marker writes
 12 pass
 0 fail
 53 expect() calls
Ran 12 tests across 1 file.
```

## Known gaps / failures

`auth-audit-ip-attribution.test.ts` (5 tests) failed in this sandbox with
the develop route and this branch alike — the reviewer's clean
frozen-lockfile worktree reports 5/5 pass at head and base, so the local
failures are stale-workspace artifacts unrelated to the marker path.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->
