### PR TITLE
fix(core): align prompt-integrity audit with disabled connection-enforcement model path

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -1,6 +1,7 @@
-// Pins the fail-closed contract of the connection-enforcement gate: an internal cache/oauth
-// failure must PROPAGATE (throw), and stay distinguishable from a legitimately-negative
-// "no required connection" result. Deterministic fixtures — no live cache or oauth.
+/**
+ * Guards connection enforcement's fail-closed cache, OAuth, and disabled-generation contracts
+ * with deterministic cache and OAuth fixtures.
+ */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const cacheGet = mock();
@@ -19,21 +20,11 @@ mock.module("../../cache/client", () => ({
 mock.module("../oauth", () => ({
   oauthService: {
     getConnectedPlatforms,
-    initiateAuth: mock(async () => ({ authUrl: null })),
   },
-}));
-
-mock.module("../../providers/language-model", () => ({
-  getLanguageModel: mock(() => "mock-model"),
-  hasLanguageModelProviderConfigured: mock(() => true),
 }));
 
 mock.module("../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
-}));
-
-mock.module("ai", () => ({
-  generateText: mock(async () => ({ text: "unused in this suite" })),
 }));
 
 const { connectionEnforcementService } = await import(

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
@@ -1,9 +1,9 @@
 /**
  * Connection enforcement for Eliza App messaging channels.
  *
- * WHY: Eliza needs at least one connected data source before agent workflows
- * are useful. When no supported connection exists, we respond in-character and
- * steer the user toward connecting Google, Microsoft, or X.
+ * Eliza needs at least one supported data connection before agent workflows
+ * can run. Connection checks and cache invalidation remain active, while nudge
+ * generation fails closed until it uses the admitted generative-operation boundary.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -23,50 +23,6 @@ interface NudgeParams {
   userId: string;
 }
 
-interface ConversationMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
-interface ConversationState {
-  messageCount: number;
-  messages: ConversationMessage[];
-}
-
-interface ElizaCharacter {
-  name: string;
-  system: string;
-  bio: string[];
-  adjectives: string[];
-  style: { all: string[]; chat: string[] };
-}
-
-const DEFAULT_ELIZA_CHARACTER: ElizaCharacter = {
-  name: "Eliza",
-  system:
-    "You are Eliza. A presence, not an assistant. You say less and mean more. You never use exclamation points. You use lowercase naturally.",
-  bio: [
-    "pays attention to what people care about",
-    "warm through what she notices, not what she announces",
-    "comfortable in ambiguity, allergic to false certainty",
-    "genuinely interested in the texture of someone's day",
-    "quietly direct when something matters",
-  ],
-  adjectives: ["perceptive", "present", "warm but restrained", "curious", "ungeneric"],
-  style: {
-    all: [
-      "say less. mean more.",
-      "never use exclamation points",
-      "use lowercase naturally",
-      "short sentences. fragments are fine.",
-    ],
-    chat: [
-      "you are a presence, not an assistant",
-      "help as yourself. don't shift into service mode.",
-    ],
-  },
-};
-
 const PROVIDER_ALIAS_ENTRIES = [
   ["google calendar", "google"],
   ["google", "google"],
@@ -82,34 +38,8 @@ const PROVIDER_ALIAS_ENTRIES = [
 ] as Array<[string, RequiredPlatform]>;
 PROVIDER_ALIAS_ENTRIES.sort((left, right) => right[0].length - left[0].length);
 
-const PLATFORM_DISPLAY_NAMES: Record<RequiredPlatform, string> = {
-  google: "Google",
-  microsoft: "Microsoft",
-  twitter: "X",
-};
-
-const CLAIM_CONNECTED_PATTERNS = [
-  "connected",
-  "i connected",
-  "done",
-  "i did it",
-  "finished",
-  "completed",
-  "linked",
-  "authorized",
-  "signed in",
-  "logged in",
-  "all set",
-  "it's done",
-  "its done",
-  "did it",
-  "went through",
-];
-
 const NUDGE_INTERVAL = 3;
 const CONNECTION_STATUS_TTL_SECONDS = 30;
-const CONVERSATION_TTL_SECONDS = 3600;
-const NUDGE_MODEL = "openai/gpt-5-mini";
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -119,210 +49,12 @@ function compileAliasRegex(alias: string): RegExp {
   return new RegExp(`(^|[^a-z0-9])${escapeRegex(alias)}(?=$|[^a-z0-9])`, "i");
 }
 
-function sample<T>(items: T[], count: number): T[] {
-  const shuffled = [...items];
-  for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const nextIndex = Math.floor(Math.random() * (index + 1));
-    [shuffled[index], shuffled[nextIndex]] = [shuffled[nextIndex], shuffled[index]];
-  }
-  return shuffled.slice(0, Math.min(count, shuffled.length));
-}
-
-function formatConversationHistory(messages: ConversationMessage[]): string {
-  if (messages.length === 0) return "";
-
-  return `\n\nRecent conversation:\n${messages
-    .map((message) => `${message.role === "user" ? "User" : "Eliza"}: ${message.content}`)
-    .join("\n")}\n`;
-}
-
 function getConversationKey(organizationId: string, userId: string): string {
   return `connection-enforcement:conversation:${organizationId}:${userId}`;
 }
 
 function getConnectionStatusKey(organizationId: string, userId: string): string {
   return `connection-enforcement:required-connection:${organizationId}:${userId}`;
-}
-
-async function loadConversationState(
-  organizationId: string,
-  userId: string,
-): Promise<ConversationState> {
-  // A cache MISS legitimately yields no history (`?? { empty }`, designed-empty). A cache
-  // read ERROR must propagate — masking it as an empty conversation would silently reset the
-  // nudge cadence and drop history, conflating a broken cache with a brand-new conversation.
-  return (
-    (await cache.get<ConversationState>(getConversationKey(organizationId, userId))) ?? {
-      messageCount: 0,
-      messages: [],
-    }
-  );
-}
-
-async function saveConversationState(
-  organizationId: string,
-  userId: string,
-  state: ConversationState,
-): Promise<void> {
-  try {
-    await cache.set(getConversationKey(organizationId, userId), state, CONVERSATION_TTL_SECONDS);
-  } catch (error) {
-    // error-policy:J7 auxiliary continuity write — runs after the user-facing reply is already
-    // produced; a cache write blip must not turn a successful reply into a user error. Warns so
-    // the failure stays observable; the only fallout is a degraded nudge cadence next turn.
-    logger.warn("[ConnectionEnforcement] Failed to persist conversation state", {
-      organizationId,
-      userId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-function getBaseUrl(): string {
-  const configuredBaseUrl = process.env.NEXT_PUBLIC_APP_URL;
-  if (configuredBaseUrl) return configuredBaseUrl;
-
-  logger.warn(
-    "[ConnectionEnforcement] NEXT_PUBLIC_APP_URL missing, falling back to production URL",
-  );
-  return "https://cloud.eliza.app";
-}
-
-function isClaimingConnected(message: string): boolean {
-  const lower = message.toLowerCase().trim();
-  return CLAIM_CONNECTED_PATTERNS.some((pattern) => lower.includes(pattern));
-}
-
-function shouldNudge(messageCount: number): boolean {
-  return messageCount % NUDGE_INTERVAL === 0;
-}
-
-function formatLinks(
-  links: { platform: RequiredPlatform; url: string }[],
-  messagingPlatform: MessagingPlatform,
-): string {
-  if (messagingPlatform === "telegram") {
-    return links
-      .map((link) => `[Connect ${PLATFORM_DISPLAY_NAMES[link.platform]}](${link.url})`)
-      .join("\n");
-  }
-
-  return links.map((link) => `${PLATFORM_DISPLAY_NAMES[link.platform]}: ${link.url}`).join("\n");
-}
-
-function buildNudgePrompt(
-  platform: MessagingPlatform,
-  conversationHistory: string,
-  isFirstInteraction: boolean,
-): string {
-  const bioSample = sample(DEFAULT_ELIZA_CHARACTER.bio, 4).join(" ");
-  const adjectiveSample = sample(DEFAULT_ELIZA_CHARACTER.adjectives, 4).join(", ");
-  const styleSample = sample(
-    [...DEFAULT_ELIZA_CHARACTER.style.all, ...DEFAULT_ELIZA_CHARACTER.style.chat],
-    5,
-  ).join("; ");
-
-  const firstInteractionContext = isFirstInteraction
-    ? `\n\nIMPORTANT: This is the user's first message after connecting ${platform}. If they say they just connected or signed up, they mean ${platform} itself unless they explicitly mention Google, Microsoft, or X.`
-    : "";
-
-  return `${DEFAULT_ELIZA_CHARACTER.system}
-
-About you: ${bioSample}
-Your personality: ${adjectiveSample}
-Your writing style: ${styleSample}
-
-CONTEXT: The user is messaging you on ${platform}. They do not have a required data connection yet. They need Google, Microsoft, or X connected before you can use their inbox, calendar, contacts, or social feed.${firstInteractionContext}
-
-RESPONSE RULES:
-1. Keep it to 2-3 sentences. Never use exclamation points.
-2. Respond directly to what they said. Do not sound like a support bot.
-3. Briefly explain that you need one data connection before you can help properly.
-4. If they mention a provider, acknowledge that choice briefly. Do not list the other options again.
-5. Do not include any URLs. Links are appended separately when needed.
-6. If they say they already connected something and you still do not see it, say you still do not see the connection yet and suggest trying again.${conversationHistory}`;
-}
-
-function buildChatPrompt(platform: MessagingPlatform, conversationHistory: string): string {
-  const bioSample = sample(DEFAULT_ELIZA_CHARACTER.bio, 4).join(" ");
-  const adjectiveSample = sample(DEFAULT_ELIZA_CHARACTER.adjectives, 4).join(", ");
-  const styleSample = sample(
-    [...DEFAULT_ELIZA_CHARACTER.style.all, ...DEFAULT_ELIZA_CHARACTER.style.chat],
-    5,
-  ).join("; ");
-
-  return `${DEFAULT_ELIZA_CHARACTER.system}
-
-About you: ${bioSample}
-Your personality: ${adjectiveSample}
-Your writing style: ${styleSample}
-
-CONTEXT: The user is messaging you on ${platform}. They still have no required data connection, but you already reminded them recently. Chat naturally without bringing it up again unless they ask.${conversationHistory}`;
-}
-
-const FALLBACK_RESPONSES = [
-  "i'd like to help, but i need one connection first so i can actually see your world. google, microsoft, or x?",
-  "i'm missing the context that makes me useful. connect google, microsoft, or x and we can do something real.",
-  "i can talk, but i can't actually work with your day until one account is connected. google, microsoft, or x?",
-];
-
-function getFallbackResponse(message: string): string {
-  const lower = message.toLowerCase();
-  if (lower.includes("why") || lower.includes("what for")) {
-    return "because without a connection i'm guessing. one inbox, calendar, or feed changes that. google, microsoft, or x?";
-  }
-
-  if (
-    lower.includes("none") ||
-    lower.includes("skip") ||
-    lower.includes("don't want") ||
-    lower.includes("without")
-  ) {
-    return "fair. i just can't do much without context. if you were going to pick one, which would it be: google, microsoft, or x?";
-  }
-
-  return FALLBACK_RESPONSES[Math.floor(Math.random() * FALLBACK_RESPONSES.length)];
-}
-
-async function generateOAuthLinks(
-  organizationId: string,
-  userId: string,
-  platform: MessagingPlatform,
-  specificProvider?: RequiredPlatform | null,
-): Promise<{ platform: RequiredPlatform; url: string }[]> {
-  const redirectUrl = `${getBaseUrl()}/api/eliza-app/auth/connection-success?platform=${platform}`;
-  const providers = specificProvider ? [specificProvider] : [...REQUIRED_PLATFORMS];
-
-  const results = await Promise.allSettled(
-    providers.map(async (provider) => {
-      const result = await oauthService.initiateAuth({
-        organizationId,
-        userId,
-        platform: provider,
-        redirectUrl,
-      });
-
-      return result.authUrl ? { platform: provider, url: result.authUrl } : null;
-    }),
-  );
-
-  // error-policy:J4 designed degrade — fan out per provider and return whichever links
-  // succeeded; one provider's auth-init failure must not deny the user the others. Failures
-  // are warned, and the caller renders whatever links come back (or none if all failed).
-  return results.flatMap((result) => {
-    if (result.status === "fulfilled" && result.value) {
-      return [result.value];
-    }
-
-    if (result.status === "rejected") {
-      logger.warn("[ConnectionEnforcement] Failed to generate OAuth link", {
-        organizationId,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      });
-    }
-
-    return [];
-  });
 }
 
 function detectProviderFromMessage(message: string): RequiredPlatform | null {

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -81,8 +81,6 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts":
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
-	"packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts":
-		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/app-promotion-assets.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
@@ -95,9 +93,6 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 	"packages/cloud/shared/src/lib/services/provisioning-agent-chat.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
-	"packages/cloud/shared/src/lib/services/room-title.ts": [
-		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
-	],
 	"packages/cloud/shared/src/lib/services/seo.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/,
 	],
@@ -105,14 +100,23 @@ const outputCompletenessBoundaryCalls: Record<string, readonly RegExp[]> = {
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts":
 		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
-	"packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts":
-		[/assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/],
 	"packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts":
 		[/isModelOutputLimitFinishReason\(completion\.finishReason\)/],
 	"plugins/plugin-anthropic/models/image.ts": [
 		/assertModelOutputComplete\([\s\S]{0,120}response\.finishReason/,
 	],
 };
+
+const disabledModelGenerationSources = [
+	"packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts",
+];
+
+const forbiddenAiImport =
+	/(?:from\s+|import\s*\(\s*)["'](?:ai|@ai-sdk\/[^"']+|[^"']*providers\/language-model)["']/;
+const forbiddenAiDispatch =
+	/\b(?:generateObject|generateText|getLanguageModel|streamObject|streamText|useModel)\s*\(/;
+const immediateDisabledGenerationError =
+	/async generateNudgeResponse\([\s\S]{0,160}\{\s*throw new ElizaError\([\s\S]{0,320}code:\s*"CONNECTION_ENFORCEMENT_LLM_DISABLED"/;
 
 const guardedSources: Record<string, readonly RegExp[]> = {
 	"plugins/plugin-agent-skills/src/security/skill-scanner.ts": [
@@ -1294,6 +1298,24 @@ describe("prompt integrity policy", () => {
 					pattern,
 				);
 			}
+		}
+	});
+
+	it("keeps disabled model paths typed and free of unadmitted dispatch", () => {
+		for (const relativePath of disabledModelGenerationSources) {
+			const source = readFileSync(
+				resolve(repositoryRoot, relativePath),
+				"utf8",
+			);
+			expect(source, `${relativePath} must throw its typed disabled error`).toMatch(
+				immediateDisabledGenerationError,
+			);
+			expect(source, `${relativePath} must not import an AI SDK or provider`).not.toMatch(
+				forbiddenAiImport,
+			);
+			expect(source, `${relativePath} must not dispatch model generation`).not.toMatch(
+				forbiddenAiDispatch,
+			);
 		}
 	});
 


### PR DESCRIPTION
Closes #30026.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto `origin/develop` `89275aa29fe6985792f32c78cd104ffbf7c6e6aa`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. The public connection-check, cache-invalidation, parsing, and exported type/constant
surface is preserved. The only production deletion is code unreachable behind the immediate
typed disabled error. The policy inventory removes only files that no longer dispatch an AI SDK.

# Background

## What does this PR do?

Removes the unreachable prompt, character, conversation-history, fallback, OAuth-link, and
model helpers left behind when connection-enforcement generation was disabled in #29984. It
keeps `hasRequiredConnection`, `invalidateRequiredConnectionCache`, every export, and the
immediate `CONNECTION_ENFORCEMENT_LLM_DISABLED` error unchanged.

The prompt-integrity audit now inventories only current direct-AI boundaries. The same #29984
change also removed direct dispatch from `room-title.ts` and `shared-runtime-chat.ts`, so those
two stale entries are removed alongside `connection-enforcement.ts`; every remaining active
completeness regex is byte-for-byte unchanged. A new deterministic guard requires the immediate
typed disabled error and rejects AI SDK/provider imports or dispatch calls in the disabled file.

## What kind of change is this?

Bug fix (non-breaking).

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

No project documentation change is required. The maintained source header was corrected to
describe the currently disabled generation boundary.
<!--
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Start with `packages/core/src/__tests__/prompt-integrity-policy.test.ts`, then compare
`packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts` with its focused
error-policy test.

## Detailed testing steps

All test targets below are absolute file paths, not filename patterns.

### Acceptance checklist

- [x] Removed only unreachable connection-enforcement generation helpers. Evidence: the diff
  deletes 274 lines while retaining all exports and both public connection/cache methods; the
  focused cloud contract passes 6/6.
- [x] Removed the disabled file from the active direct-AI inventory. Evidence: the focused policy
  suite passes and no longer expects a completion result from the disabled method.
- [x] Added a deterministic typed-disable guard. Evidence: `keeps disabled model paths typed and
  free of unadmitted dispatch` passes and checks the immediate `ElizaError` code plus forbidden
  AI imports/dispatches.
- [x] Kept active direct-AI completeness checks unchanged. Evidence: every remaining inventory
  regex is unchanged; the only additional removals are the two other #29984 files that no longer
  contain direct dispatch, discovered by running the suite after the first fix.
- [x] Focused prompt-integrity and cloud-shared checks pass. Evidence: 9/9 core policy tests, 6/6
  cloud connection tests, Biome exit 0, and matched control/branch `tsc --noEmit` exit 0.

### Before: reproduced failure

Command:

```text
/usr/bin/time -l /Users/sailesh/.bun/bin/bun test /Users/sailesh/Developer/worktrees/issue-30026/packages/core/src/__tests__/prompt-integrity-policy.test.ts
```

Verbatim failure output excerpt:

```text
bun test v1.3.14 (0d9b296a)

packages/core/src/__tests__/prompt-integrity-policy.test.ts:
(pass) prompt integrity policy > does not restore automatic conversation compaction [0.14ms]
(pass) prompt integrity policy > does not restore test-only clones of deleted prompt caps [0.09ms]
(pass) prompt integrity policy > keeps reviewed model-facing boundaries free of known silent caps [19.70ms]
(pass) prompt integrity policy > does not silently overwrite source-audit rules with duplicate keys [0.54ms]
(pass) prompt integrity policy > keeps both computer-use emitters behind the shared rejection boundary [0.14ms]
1288 | 			const source = readFileSync(
1289 | 				resolve(repositoryRoot, relativePath),
1290 | 				"utf8",
1291 | 			);
1292 | 			for (const pattern of requiredPatterns) {
1293 | 				expect(source, `${relativePath} must match ${pattern}`).toMatch(
                                                                   ^
error: packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts must match /assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/

Expected substring or pattern: /assertModelOutputComplete\([\s\S]{0,120}result\.finishReason/
(fail) prompt integrity policy > keeps direct AI SDK outputs behind completeness checks [0.52ms]
(pass) prompt integrity policy > does not ask training tokenizers to truncate complete inputs [16.34ms]
(pass) prompt integrity policy > keeps X discovery drafts on the provider-maximum output contract [0.24ms]

 7 pass
 1 fail
 1129 expect() calls
Ran 8 tests across 1 file. [52.00ms]
        0.05 real         0.03 user         0.02 sys
            80609280  maximum resident set size
EXIT_STATUS=1
```

### After: fixed policy suite

Command:

```text
/usr/bin/time -l /Users/sailesh/.bun/bin/bun test /Users/sailesh/Developer/worktrees/issue-30026/packages/core/src/__tests__/prompt-integrity-policy.test.ts
```

Verbatim output:

```text
bun test v1.3.14 (0d9b296a)

packages/core/src/__tests__/prompt-integrity-policy.test.ts:
(pass) prompt integrity policy > does not restore automatic conversation compaction [0.17ms]
(pass) prompt integrity policy > does not restore test-only clones of deleted prompt caps [0.10ms]
(pass) prompt integrity policy > keeps reviewed model-facing boundaries free of known silent caps [55.59ms]
(pass) prompt integrity policy > does not silently overwrite source-audit rules with duplicate keys [0.66ms]
(pass) prompt integrity policy > keeps both computer-use emitters behind the shared rejection boundary [0.27ms]
(pass) prompt integrity policy > keeps direct AI SDK outputs behind completeness checks [2.56ms]
(pass) prompt integrity policy > keeps disabled model paths typed and free of unadmitted dispatch [0.14ms]
(pass) prompt integrity policy > does not ask training tokenizers to truncate complete inputs [58.34ms]
(pass) prompt integrity policy > keeps X discovery drafts on the provider-maximum output contract [0.29ms]

 9 pass
 0 fail
 1140 expect() calls
Ran 9 tests across 1 file. [135.00ms]
        0.14 real         0.03 user         0.03 sys
            80117760  maximum resident set size
EXIT_STATUS=0
```

### Owning cloud-shared check

Command:

```text
/usr/bin/time -l /Users/sailesh/.bun/bin/bun test --coverage-reporter=lcov --coverage-dir=/tmp/issue30026-coverage-final /Users/sailesh/Developer/worktrees/issue-30026/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
```

Verbatim result:

```text
bun test v1.3.14 (0d9b296a)

packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts:
(pass) ConnectionEnforcementService.hasRequiredConnection — fail-closed contract > designed-empty: no connected platforms returns false (distinct from failure) [0.86ms]
(pass) ConnectionEnforcementService.hasRequiredConnection — fail-closed contract > returns true when a required platform is connected [0.06ms]
(pass) ConnectionEnforcementService.hasRequiredConnection — fail-closed contract > serves a cached boolean without querying oauth [0.04ms]
(pass) ConnectionEnforcementService.hasRequiredConnection — fail-closed contract > PROPAGATES an oauth failure instead of fabricating connected=true (fail closed) [0.06ms]
(pass) ConnectionEnforcementService.hasRequiredConnection — fail-closed contract > PROPAGATES a cache read failure instead of assuming connected [0.03ms]
(pass) ConnectionEnforcementService.hasRequiredConnection — fail-closed contract > rejects dormant nudge generation before any LLM dispatch [0.11ms]

 6 pass
 0 fail
 13 expect() calls
Ran 6 tests across 1 file. [511.00ms]
        0.51 real         0.55 user         0.13 sys
           150880256  maximum resident set size
EXIT_STATUS=0
```

### Format and typecheck

```text
/Users/sailesh/.bun/bin/bunx biome check --write /Users/sailesh/Developer/worktrees/issue-30026/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts /Users/sailesh/Developer/worktrees/issue-30026/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts /Users/sailesh/Developer/worktrees/issue-30026/packages/core/src/__tests__/prompt-integrity-policy.test.ts
        0.35 real         0.16 user         0.06 sys
            91095040  maximum resident set size
EXIT_STATUS=0

/Users/sailesh/Developer/worktrees/issue-30026/packages/cloud/shared/node_modules/.bin/tsc --noEmit --project /Users/sailesh/Developer/worktrees/issue-30026-control/packages/cloud/shared/tsconfig.json
        1.53 real         4.45 user         1.28 sys
          1708064768  maximum resident set size
EXIT_STATUS=0

/Users/sailesh/Developer/worktrees/issue-30026/packages/cloud/shared/node_modules/.bin/tsc --noEmit --project /Users/sailesh/Developer/worktrees/issue-30026/packages/cloud/shared/tsconfig.json
        1.15 real         3.85 user         1.55 sys
          1740587008  maximum resident set size
EXIT_STATUS=0
```

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:647d6f2965d1f55abed180e2bb411e2e9738723c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed; the before failure output is quoted above.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed; the passing after output is quoted above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a deterministic source-policy audit and unreachable-code deletion.
<!-- evidence-row:backend-logs -->
- [x] N/A - the guarded generation path must reject before backend/model dispatch; command
      output for that contract is quoted above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - acceptance requires `CONNECTION_ENFORCEMENT_LLM_DISABLED` before any model
      dispatch; a live-model trajectory would contradict the intended boundary.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, task, wallet, media, or other domain state changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

N/A - the changed model method is deliberately disabled and proven to throw before dispatch.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

N/A - no frontend request path changed, and the disabled backend method performs no dispatch.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI or interactive flow change.

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

N/A - no audio or voice path changed.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

- `bun run verify` was started post-sync. Guide parity, Biome-version, i18n, Bun/Turbo
  contracts, and workspace dependency checks passed. It then remained CPU-bound in
  `ensure-plugin-test-conventions:check` with no output for about fifteen minutes and was
  interrupted, so there is no terminal exit status to claim. This aggregate non-result is not
  represented as green; the issue-specific policy/cloud suites, formatter, and matched package
  typechecks all completed successfully.
- No finalized private run receipt is attached because this unattended session cannot complete
  the interactive `identity.slop.cash` OAuth trace. The body is published under the explicit
  `FACTORY_NO_EVIDENCE` waiver.
- Visual, frontend, trajectory, domain, OCR, and audio artifacts are N/A for the concrete reasons
  on each evidence row above.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza"} -->
