### PR TITLE
fix(plugin-mcp): CALL_MCP_TOOL honors CallToolResult.isError instead of fabricating success

### DIFF
--- a/plugins/plugin-mcp/src/actions/__tests__/mcp-call-tool-error.test.ts
+++ b/plugins/plugin-mcp/src/actions/__tests__/mcp-call-tool-error.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression coverage for the MCP call_tool action's handling of a
+ * spec-compliant errored CallToolResult (#30037). Exercises the real exported
+ * `mcpAction.handler` against a stub runtime and a stub `McpService` whose
+ * `callTool` returns `{ isError: true }`. Guards the contract that a tool that
+ * reports execution failure yields a distinct `ActionResult` with
+ * `success:false` — never the fabricated "Successfully called tool" / success
+ * result the planner previously recorded — while the success path still reports
+ * success. The harness is deterministic; no live MCP server or model is used.
+ */
+
+import type { HandlerCallback, IAgentRuntime, Memory, State } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { mcpAction } from "../mcp";
+
+type ToolResult = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+function makeRuntime(callToolResult: ToolResult) {
+  const callTool = vi.fn(async () => callToolResult);
+  const providerData = {
+    values: { mcp: {} },
+    data: { mcp: {} },
+    text: "MCP servers: srv",
+  };
+  const mcpService = {
+    getProviderData: () => providerData,
+    callTool,
+  };
+
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    composeState: vi.fn(async (): Promise<State> => ({ values: {}, data: {}, text: "" })),
+    getService: vi.fn(() => mcpService),
+    getModel: vi.fn(() => undefined),
+    addEmbeddingToMemory: vi.fn(async (m: Memory) => m),
+    createMemory: vi.fn(async () => "mem-id"),
+    useModel: vi.fn(async () => "A reasoned, user-facing sentence about the outcome."),
+  } as unknown as IAgentRuntime;
+
+  return { runtime, callTool };
+}
+
+const message = {
+  entityId: "00000000-0000-0000-0000-0000000000bb",
+  roomId: "00000000-0000-0000-0000-0000000000cc",
+  content: { text: "call the flaky tool", source: "test" },
+} as unknown as Memory;
+
+const options = {
+  action: "call_tool",
+  serverName: "srv",
+  toolName: "toolX",
+  arguments: { q: "hi" },
+};
+
+describe("MCP call_tool action — errored CallToolResult (#30037)", () => {
+  it("returns success:false and drops the success narration when isError:true", async () => {
+    const { runtime, callTool } = makeRuntime({
+      content: [{ type: "text", text: "Error: upstream API returned 500" }],
+      isError: true,
+    });
+    const callback = vi.fn(async () => {}) as unknown as HandlerCallback;
+
+    const result = await mcpAction.handler(runtime, message, undefined, options, callback);
+
+    expect(callTool).toHaveBeenCalledWith("srv", "toolX", { q: "hi" });
+    expect(result.success).toBe(false);
+    expect(result.values?.success).toBe(false);
+    expect(result.values?.toolErrored).toBe(true);
+    expect(result.error).toBeInstanceOf(Error);
+    // The planner must not be told the call succeeded.
+    expect(result.text).not.toMatch(/Successfully called tool/i);
+    expect(result.text).toMatch(/reported an error/i);
+    // The error detail is still preserved for downstream inspection.
+    expect(result.data?.isError).toBe(true);
+    expect(result.data?.output).toContain("upstream API returned 500");
+    // The user was still informed via the reasoning reply.
+    expect(runtime.useModel).toHaveBeenCalledWith(ModelType.TEXT_SMALL, expect.anything());
+  });
+
+  it("still reports success:true for a normal successful CallToolResult", async () => {
+    const { runtime } = makeRuntime({
+      content: [{ type: "text", text: "the answer is 42" }],
+    });
+
+    const result = await mcpAction.handler(runtime, message, undefined, options, undefined);
+
+    expect(result.success).toBe(true);
+    expect(result.values?.success).toBe(true);
+    expect(result.values?.toolExecuted).toBe(true);
+    expect(result.data?.isError).toBe(false);
+    expect(result.text).toMatch(/Successfully called tool/i);
+  });
+
+  it("frames the reasoning prompt as a failure when the tool errored", async () => {
+    const { runtime } = makeRuntime({
+      content: [{ type: "text", text: "Error: invalid API key" }],
+      isError: true,
+    });
+
+    await mcpAction.handler(runtime, message, undefined, options, undefined);
+
+    const reasoningCall = (runtime.useModel as unknown as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([, arg]) => typeof arg?.prompt === "string" && arg.prompt.includes("Synthesize the result")
+    );
+    expect(reasoningCall).toBeDefined();
+    expect(reasoningCall?.[1].prompt).toMatch(/reported an ERROR/);
+  });
+});

--- a/plugins/plugin-mcp/src/actions/mcp.ts
+++ b/plugins/plugin-mcp/src/actions/mcp.ts
@@ -21,7 +21,7 @@ import {
 import type { McpService } from "../service";
 import { resourceSelectionTemplate } from "../templates/resourceSelectionTemplate";
 import { MCP_SERVICE_NAME, type McpServer, type McpServerInfo } from "../types";
-import { handleMcpError } from "../utils/error";
+import { handleMcpError, McpError } from "../utils/error";
 import { handleNoToolAvailable } from "../utils/handler";
 import {
   handleResourceAnalysis,
@@ -237,7 +237,7 @@ async function handleCallTool(
 
     const result = await mcpService.callTool(serverName, toolName, toolArguments);
 
-    const { toolOutput, hasAttachments, attachments } = processToolResult(
+    const { toolOutput, hasAttachments, attachments, isError } = processToolResult(
       result,
       serverName,
       toolName,
@@ -256,8 +256,46 @@ async function handleCallTool(
       attachments,
       composedState,
       mcpProvider,
-      callback
+      callback,
+      isError
     );
+
+    const data = {
+      actionName: "MCP",
+      op: "call_tool" as const,
+      serverName,
+      toolName,
+      toolArgumentsJson: JSON.stringify(toolArguments),
+      reasoning: selection.reasoning,
+      output: toolOutput,
+      attachmentCount: attachments?.length ?? 0,
+      isError,
+    };
+
+    if (isError) {
+      // The MCP server returned a structured failure (CallToolResult.isError).
+      // The user was still informed via handleToolResponse, but the planner must
+      // see a distinct failure rather than a fabricated success (repo error
+      // policy: "Do not catch and continue with fabricated success").
+      return {
+        text: `Tool ${serverName}/${toolName} reported an error. Reasoned response: ${replyMemory.content.text}`,
+        values: {
+          success: false,
+          toolExecuted: true,
+          toolErrored: true,
+          serverName,
+          toolName,
+          hasAttachments,
+          output: toolOutput,
+        },
+        data,
+        success: false,
+        error: new McpError(
+          `MCP tool '${serverName}/${toolName}' returned an error result: ${toolOutput}`,
+          "TOOL_EXECUTION_ERROR"
+        ),
+      };
+    }
 
     return {
       text: `Successfully called tool: ${serverName}/${toolName}. Reasoned response: ${replyMemory.content.text}`,
@@ -269,16 +307,7 @@ async function handleCallTool(
         hasAttachments,
         output: toolOutput,
       },
-      data: {
-        actionName: "MCP",
-        op: "call_tool",
-        serverName,
-        toolName,
-        toolArgumentsJson: JSON.stringify(toolArguments),
-        reasoning: selection.reasoning,
-        output: toolOutput,
-        attachmentCount: attachments?.length ?? 0,
-      },
+      data,
       success: true,
     };
   } catch (error) {

--- a/plugins/plugin-mcp/src/prompts.ts
+++ b/plugins/plugin-mcp/src/prompts.ts
@@ -162,6 +162,9 @@ Original user request: "{{{userMessage}}}"
 Tool response:
 {{{toolOutput}}}
 
+{{#if toolErrored}}
+IMPORTANT: The tool reported an ERROR — the call did NOT succeed. The "Tool response" above is the error detail, not requested data. Tell the user plainly that the operation failed, explain what went wrong when the error text is actionable, and do not present the error content as if it were a successful result.
+{{/if}}
 {{#if hasAttachments}}
 The tool also returned images or other media that will be shared with the user.
 {{/if}}

--- a/plugins/plugin-mcp/src/utils/__tests__/processing.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/processing.test.ts
@@ -104,3 +104,46 @@ describe("processToolResult attachment ids", () => {
     expect(toolOutput).toBe("hello");
   });
 });
+
+describe("processToolResult error signal (#30037)", () => {
+  it("surfaces isError=true from a spec-compliant errored CallToolResult", () => {
+    const out = processToolResult(
+      { content: [{ type: "text", text: "Error: upstream API returned 500" }], isError: true },
+      "srv",
+      "toolX",
+      runtime,
+      messageEntityId
+    );
+
+    // The error detail is still carried, but the failure flag must no longer be
+    // dropped: the caller needs it to avoid fabricating success on the planner.
+    expect(out.toolOutput).toBe("Error: upstream API returned 500");
+    expect(out.isError).toBe(true);
+    expect(Object.keys(out)).toContain("isError");
+  });
+
+  it("reports isError=false for a normal successful result", () => {
+    const out = processToolResult(
+      { content: [{ type: "text", text: "the answer is 42" }] },
+      "srv",
+      "toolX",
+      runtime,
+      messageEntityId
+    );
+
+    expect(out.toolOutput).toBe("the answer is 42");
+    expect(out.isError).toBe(false);
+  });
+
+  it("treats an explicit isError=false the same as an absent flag", () => {
+    const out = processToolResult(
+      { content: [{ type: "text", text: "ok" }], isError: false },
+      "srv",
+      "toolX",
+      runtime,
+      messageEntityId
+    );
+
+    expect(out.isError).toBe(false);
+  });
+});

--- a/plugins/plugin-mcp/src/utils/processing.ts
+++ b/plugins/plugin-mcp/src/utils/processing.ts
@@ -82,7 +82,7 @@ export function processToolResult(
   toolName: string,
   runtime: IAgentRuntime,
   messageEntityId: string
-): { toolOutput: string; hasAttachments: boolean; attachments: Media[] } {
+): { toolOutput: string; hasAttachments: boolean; attachments: Media[]; isError: boolean } {
   let toolOutput = "";
   let hasAttachments = false;
   const attachments: Media[] = [];
@@ -122,7 +122,11 @@ export function processToolResult(
     }
   }
 
-  return { toolOutput, hasAttachments, attachments };
+  // Propagate the spec-mandated failure signal. MCP tools report execution
+  // failures via CallToolResult.isError=true with the error detail carried in
+  // `content`; without surfacing this the caller cannot distinguish a failed
+  // call from a successful one and would fabricate success on the planner path.
+  return { toolOutput, hasAttachments, attachments, isError: result.isError === true };
 }
 
 export async function handleResourceAnalysis(
@@ -175,7 +179,8 @@ export async function handleToolResponse(
   attachments: readonly Media[],
   state: State,
   mcpProvider: McpProviderArg,
-  callback?: HandlerCallback
+  callback?: HandlerCallback,
+  isError = false
 ): Promise<Memory> {
   await createMcpMemory(runtime, message, "tool", serverName, toolOutput, {
     toolName,
@@ -190,7 +195,8 @@ export async function handleToolResponse(
     serverName,
     message.content.text ?? "",
     toolOutput,
-    hasAttachments
+    hasAttachments,
+    isError
   );
 
   const reasonedResponse = (await runtime.useModel(ModelType.TEXT_SMALL, {
@@ -262,7 +268,8 @@ function createReasoningPrompt(
   serverName: string,
   userMessage: string,
   toolOutput: string,
-  hasAttachments: boolean
+  hasAttachments: boolean,
+  toolErrored: boolean
 ): string {
   const enhancedState: State = {
     ...state,
@@ -274,6 +281,7 @@ function createReasoningPrompt(
       userMessage,
       toolOutput,
       hasAttachments,
+      toolErrored,
     },
   };
 


### PR DESCRIPTION
# Relates to

Closes #30037

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` is a full-repo gate; the owning-package focused gates (typecheck, focused tests, lint) were run and are recorded below. See **Known gaps** for the full-`verify` note.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Owning-package focused checks pass post-sync; see **Known gaps** for the repo-wide `verify` note.

# Risks

Low. Change is bounded to `plugins/plugin-mcp` (`utils/processing.ts`, `actions/mcp.ts`, `prompts.ts`). The only behavior change is on the MCP `call_tool` path when the server returns a spec-compliant errored `CallToolResult` (`isError: true`): that call now returns `ActionResult.success:false` instead of a fabricated success. The success path is unchanged (regression-tested). No public type is removed — `isError` was already declared in `types.ts` and `processing.ts`; this PR makes it actually consumed.

# Background

## What does this PR do?

`CALL_MCP_TOOL` never read the SDK's `CallToolResult.isError` flag. When an MCP server returned a structured error result (`isError: true` with the error text in `content` — the spec-mandated way tools report execution failures), `processToolResult()` merged the error text into `toolOutput` indistinguishably from a success payload, and the action returned:

```
{ text: "Successfully called tool: <server>/<tool>", values: { success: true, toolExecuted: true, ... }, success: true }
```

So a tool that failed (upstream 500, invalid API key, …) was recorded as a **successful** tool execution and the agent narrated the error content to the user as if it were data. This violates the repo error policy ("Do not catch and continue with fabricated success"; "Action/tool failures already return to the planner path"). `isError` was declared in `types.ts` and `processing.ts` but read nowhere in the package.

The fix:

- `processToolResult()` now returns `isError: result.isError === true` alongside `toolOutput`/attachments.
- `handleCallTool()` branches on `isError`: an errored result returns a distinct `ActionResult` with `success:false`, `values.toolErrored:true`, `data.isError:true`, a typed `McpError("…TOOL_EXECUTION_ERROR")`, and text `"Tool <server>/<tool> reported an error…"` — never `"Successfully called tool"`.
- The user is still informed: `handleToolResponse()` threads a `toolErrored` hint into the reasoning template so the model frames the outcome as a failure rather than presenting the error content as requested data.

## What kind of change is this?

Bug fix (non-breaking; fixes fabricated success on the planner path).

# Documentation changes needed?

No. Behavior is corrected to match the MCP spec and the repo error policy; no user-facing docs describe the previous (incorrect) behavior.

# Testing

## Where should a reviewer start?

`plugins/plugin-mcp/src/utils/__tests__/processing.test.ts` (pure `processToolResult` error-signal cases) and the new `plugins/plugin-mcp/src/actions/__tests__/mcp-call-tool-error.test.ts` (real `mcpAction.handler` with a stub `McpService.callTool` returning `isError:true`).

## Detailed testing steps

```bash
cd plugins/plugin-mcp
npx vitest run --config vitest.config.ts \
  src/utils/__tests__/processing.test.ts \
  src/actions/__tests__/mcp-call-tool-error.test.ts
```

The action test asserts: errored result → `result.success === false`, `values.toolErrored === true`, `result.error instanceof Error`, text no longer matches `/Successfully called tool/`; success result → `result.success === true`, text still claims success; and that the reasoning prompt for an errored call contains the failure framing.

# Evidence Gate

<!-- evidence-head:1005fef1286c0dc15eda57fdb91020709bde5858 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; change is in the plugin-mcp action/util layer (no rendered component).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; change is in the plugin-mcp action/util layer (no rendered component).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-UI backend action-result change; proven by focused unit tests below.`
<!-- evidence-row:backend-logs -->
- [x] Focused vitest run against live package source. Workspace deps were rebuilt at this exact head (`node packages/scripts/run-turbo.mjs run build --filter="@elizaos/plugin-mcp^..."`, 88/88 tasks) before `../../node_modules/.bin/vitest run --config ./vitest.config.ts src/utils/__tests__/processing.test.ts src/actions/__tests__/mcp-call-tool-error.test.ts`. Immutable release/user-attachment hosting is unavailable to this fork identity (HTTP 404 — no write access to the elizaOS/eliza `pr-evidence` release), so the run is inlined verbatim per CONTRIBUTING.md § Evidence ("long logs in a `<details>` block").
<details><summary>backend logs — focused vitest 11/11 GREEN (verbatim)</summary>

```

 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-30039/plugins/plugin-mcp

 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > assigns a distinct id to each image in a multi-image tool result 7ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > still yields a single well-formed id for a single-image tool result 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > does not reuse an id across separate tool calls with different image bytes 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > distinguishes two images that share identical bytes within one call 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > emits no attachments and no id churn for a text-only result 1ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > surfaces isError=true from a spec-compliant errored CallToolResult 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > reports isError=false for a normal successful result 1ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > treats an explicit isError=false the same as an absent flag 1ms
 ✓ src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > returns success:false and drops the success narration when isError:true 21ms
 ✓ src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > still reports success:true for a normal successful CallToolResult 2ms
 ✓ src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > frames the reasoning prompt as a failure when the tool errored 1ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  08:20:10
   Duration  17.07s (transform 25.49s, setup 0ms, import 33.48s, tests 46ms, environment 0ms)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no live-model behavior change. The reasoning model call is unchanged except for a deterministic template hint (toolErrored) whose presence is asserted in test; no new prompt/model contract requires a live trajectory. The model call is stubbed deterministically in the handler test.`
<!-- evidence-row:domain-artifacts -->
- [x] RED control at this head: reverting all three production files to `origin/develop` while keeping the new tests fails exactly the 6 new assertions (both directions — errored result must report `success:false`, successful result must still report `success:true`), then restoring HEAD returns 11/11 GREEN. Grep proof confirms `isError` is now consumed on the call-tool path (was declaration-only on develop). Inlined verbatim (fork identity cannot mint an immutable release asset — HTTP 404).
<details><summary>domain artifacts — RED control (6 failed) + grep proof (verbatim)</summary>

```
## RED: git checkout origin/develop -- src/utils/processing.ts src/actions/mcp.ts src/prompts.ts (tests kept)
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > assigns a distinct id to each image in a multi-image tool result 8ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > still yields a single well-formed id for a single-image tool result 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > does not reuse an id across separate tool calls with different image bytes 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > distinguishes two images that share identical bytes within one call 2ms
 ✓ src/utils/__tests__/processing.test.ts > processToolResult attachment ids > emits no attachments and no id churn for a text-only result 1ms
 × src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > surfaces isError=true from a spec-compliant errored CallToolResult 9ms
 × src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > reports isError=false for a normal successful result 5ms
 × src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > treats an explicit isError=false the same as an absent flag 2ms
 × src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > returns success:false and drops the success narration when isError:true 28ms
 × src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > still reports success:true for a normal successful CallToolResult 4ms
 × src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > frames the reasoning prompt as a failure when the tool errored 2ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
 Test Files  2 failed (2)
      Tests  6 failed | 5 passed (11)

## GREP: isError now consumed on the call-tool path at HEAD
plugins/plugin-mcp/src/actions/mcp.ts:240:    const { toolOutput, hasAttachments, attachments, isError } = processToolResult(
plugins/plugin-mcp/src/actions/mcp.ts:260:      isError
plugins/plugin-mcp/src/actions/mcp.ts:272:      isError,
plugins/plugin-mcp/src/actions/mcp.ts:275:    if (isError) {
plugins/plugin-mcp/src/actions/mcp.ts:276:      // The MCP server returned a structured failure (CallToolResult.isError).
plugins/plugin-mcp/src/utils/processing.ts:76:  readonly isError?: boolean;
plugins/plugin-mcp/src/utils/processing.ts:85:): { toolOutput: string; hasAttachments: boolean; attachments: Media[]; isError: boolean } {
plugins/plugin-mcp/src/utils/processing.ts:126:  // failures via CallToolResult.isError=true with the error detail carried in
plugins/plugin-mcp/src/utils/processing.ts:129:  return { toolOutput, hasAttachments, attachments, isError: result.isError === true };
plugins/plugin-mcp/src/utils/processing.ts:183:  isError = false
plugins/plugin-mcp/src/utils/processing.ts:199:    isError
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see llm-trajectory row above. No live-model contract change.`

## Backend + frontend logs

Focused test run (11 passed) against live package source via the plugin vitest config:

<details><summary>vitest — processing.test.ts + mcp-call-tool-error.test.ts (verbose)</summary>

```
 ✓ src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > surfaces isError=true from a spec-compliant errored CallToolResult
 ✓ src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > reports isError=false for a normal successful result
 ✓ src/utils/__tests__/processing.test.ts > processToolResult error signal (#30037) > treats an explicit isError=false the same as an absent flag
 ✓ src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > returns success:false and drops the success narration when isError:true
 ✓ src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > still reports success:true for a normal successful CallToolResult
 ✓ src/actions/__tests__/mcp-call-tool-error.test.ts > MCP call_tool action — errored CallToolResult (#30037) > frames the reasoning prompt as a failure when the tool errored

 Test Files  2 passed (2)
      Tests  11 passed (11)
```
</details>

<details><summary>typecheck (tsc --noEmit) — clean</summary>

```
$ tsc --noEmit
(no errors)
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - non-UI change.`

### Before / After (reproduction artifact)

<details><summary>isError dropped → surfaced + grep proof isError is now consumed</summary>

```
## BEFORE (origin/develop) — isError silently dropped
plugins/plugin-mcp/src/utils/processing.ts:125:
  return { toolOutput, hasAttachments, attachments };
=> Object.keys(out) === ['toolOutput','hasAttachments','attachments']; out.isError === undefined
=> actions/mcp.ts returned success:true / toolExecuted:true / "Successfully called tool"
   even when the server set isError:true.

## AFTER (this branch) — isError surfaced and honored
plugins/plugin-mcp/src/utils/processing.ts:129:
  return { toolOutput, hasAttachments, attachments, isError: result.isError === true };
=> actions/mcp.ts branches on isError → success:false / toolErrored:true / typed McpError.

## grep — isError now consumed on the call-tool path (was declaration-only before)
src/actions/mcp.ts:240:    const { toolOutput, hasAttachments, attachments, isError } = processToolResult(
src/actions/mcp.ts:260:      isError
src/actions/mcp.ts:272:      isError,
src/actions/mcp.ts:275:    if (isError) {
src/utils/processing.ts:129:  return { toolOutput, hasAttachments, attachments, isError: result.isError === true };
src/utils/processing.ts:199:    isError
```
</details>

### Walkthrough video

`N/A - non-UI change.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface.`

## Known gaps / failures

- **Repo-wide `bun run verify`**: not run to completion on this constrained machine (Raspberry Pi); it drives the full Turbo graph across all workspaces and is disproportionate to a bounded three-file plugin fix. The owning-package gates were run: `tsc --noEmit` clean, focused vitest 11/11, and `biome check --write` clean on the touched files.
- **Full `plugin-mcp` vitest suite**: the parallel run shows a pre-existing, ordering/isolation flake in `__tests__/validation.test.ts` (`validateToolSelectionArgument` empty-string coercion) that reproduces on a clean `origin/develop` checkout **without** this change (3 failures on clean vs. 1 with this branch), and the file passes in isolation (10/10). It is unrelated to this PR (touches `utils/validation.ts` / `utils/schemas.ts`, none of which this PR modifies).
- **Immutable attachment URLs**: the evidence-attachment uploader could not authenticate in this environment, so artifacts are inlined as verbatim log/`<details>` blocks above rather than minted attachment links.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@1005fef1286c0dc15eda57fdb91020709bde5858:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@1005fef1286c0dc15eda57fdb91020709bde5858:packages/skills/skills/contribute-to-eliza"} -->

