### PR TITLE
fix(cloud): explicitly re-review stale Dedicated selections

### DIFF
--- a/packages/cloud/api/__tests__/admin-personal-dedicated-adoption-selection.pglite.test.ts
+++ b/packages/cloud/api/__tests__/admin-personal-dedicated-adoption-selection.pglite.test.ts
@@ -1,6 +1,7 @@
 /**
- * Real admin route + PGlite coverage for selecting one retained existing
- * personal Dedicated row without provisioning or touching duplicate inventory.
+ * Real admin route + PGlite coverage for selecting and explicitly re-reviewing
+ * one retained personal Dedicated row without provisioning or touching
+ * duplicate compute inventory.
  */
 
 import {
@@ -177,6 +178,89 @@ async function previewFingerprint(): Promise<string> {
     data: { inventoryFingerprint: string };
   };
   return body.data.inventoryFingerprint;
+}
+
+function rereviewRequestBody(
+  retainedAgentId: string,
+  dryRun: true,
+): Record<string, unknown>;
+function rereviewRequestBody(
+  retainedAgentId: string,
+  dryRun: false,
+  preview: {
+    receiptFingerprint: string;
+    inventoryFingerprint: string;
+    stateDisposition:
+      | "verified_backup_present"
+      | "fresh_boot_no_verified_backup";
+  },
+): Record<string, unknown>;
+function rereviewRequestBody(
+  retainedAgentId: string,
+  dryRun: boolean,
+  preview?: {
+    receiptFingerprint: string;
+    inventoryFingerprint: string;
+    stateDisposition:
+      | "verified_backup_present"
+      | "fresh_boot_no_verified_backup";
+  },
+) {
+  return {
+    action: "rereview_existing_personal_dedicated",
+    targetOwnerOrganizationId: ORG_A,
+    targetOwnerUserId: USER_A,
+    retainedAgentId,
+    reason: "duplicate_owned_dedicated_inventory",
+    dryRun,
+    ...(dryRun
+      ? {}
+      : {
+          receiptFingerprint: preview?.receiptFingerprint,
+          inventoryFingerprint: preview?.inventoryFingerprint,
+          stateDisposition: preview?.stateDisposition,
+          confirmation: "rereview_without_provisioning_or_deleting",
+        }),
+  };
+}
+
+async function seedStaleSelection() {
+  await seedAmbiguousInventory();
+  const inventoryFingerprint = await previewFingerprint();
+  await personalDedicatedAdoptionSelectionService.execute({
+    organizationId: ORG_A,
+    userId: USER_A,
+    sourceAgentId: SOURCE_A,
+    retainedAgentId: RETAINED,
+    selectedByUserId: ADMIN,
+    reason: "duplicate_owned_dedicated_inventory",
+    expectedInventoryFingerprint: inventoryFingerprint,
+    expectedStateDisposition: "fresh_boot_no_verified_backup",
+  });
+  const [selection] = await dbWrite
+    .select()
+    .from(personalDedicatedAdoptionSelections);
+  if (!selection) throw new Error("selection fixture was not persisted");
+  return selection;
+}
+
+async function rereviewPreview(retainedAgentId = RETAINED) {
+  const response = await post(rereviewRequestBody(retainedAgentId, true));
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    data: {
+      receiptFingerprint: string;
+      inventoryFingerprint: string;
+      stateDisposition:
+        | "verified_backup_present"
+        | "fresh_boot_no_verified_backup";
+      candidateCount: number;
+      previousRetainedAgentId: string;
+      retainedAgentId: string;
+      replacesTarget: boolean;
+    };
+  };
+  return body.data;
 }
 
 beforeAll(async () => {
@@ -684,6 +768,166 @@ describe("admin personal Dedicated adoption selection", () => {
         sourceAgentId: SOURCE_A,
       }),
     ).toEqual({ state: "unavailable" });
+  });
+
+  test("explicitly re-reviews fingerprint drift without changing original audit identity", async () => {
+    const original = await seedStaleSelection();
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ lifecycle_revision: 5750 })
+      .where(eq(agentSandboxes.id, RETAINED));
+
+    const preview = await rereviewPreview();
+    expect(preview).toMatchObject({
+      receiptFingerprint: original.inventory_fingerprint,
+      previousRetainedAgentId: RETAINED,
+      retainedAgentId: RETAINED,
+      candidateCount: 2,
+      replacesTarget: false,
+    });
+    expect(preview.inventoryFingerprint).not.toBe(
+      original.inventory_fingerprint,
+    );
+
+    const response = await post(rereviewRequestBody(RETAINED, false, preview));
+    expect(response.status).toBe(200);
+    const [refreshed] = await dbWrite
+      .select()
+      .from(personalDedicatedAdoptionSelections);
+    expect(refreshed).toMatchObject({
+      id: original.id,
+      selected_by_user_id: original.selected_by_user_id,
+      selected_at: original.selected_at,
+      created_at: original.created_at,
+      dedicated_agent_id: RETAINED,
+      inventory_fingerprint: preview.inventoryFingerprint,
+      candidate_count: 2,
+    });
+    expect(
+      await resolvePersonalDedicatedAdoption({
+        organizationId: ORG_A,
+        userId: USER_A,
+        sourceAgentId: SOURCE_A,
+      }),
+    ).toMatchObject({ state: "available", agent: { id: RETAINED } });
+    expect(await dbWrite.select().from(jobs)).toHaveLength(0);
+  });
+
+  test("re-reviews candidate-count drift and can explicitly replace the retained target", async () => {
+    const original = await seedStaleSelection();
+    const third = "cccccccc-3333-4333-8333-333333333333";
+    await seedCandidate({ id: third, status: "stopped" });
+
+    const preview = await rereviewPreview(STALE);
+    expect(preview).toMatchObject({
+      receiptFingerprint: original.inventory_fingerprint,
+      previousRetainedAgentId: RETAINED,
+      retainedAgentId: STALE,
+      candidateCount: 3,
+      replacesTarget: true,
+    });
+    const response = await post(rereviewRequestBody(STALE, false, preview));
+    expect(response.status).toBe(200);
+    const [replaced] = await dbWrite
+      .select()
+      .from(personalDedicatedAdoptionSelections);
+    expect(replaced).toMatchObject({
+      id: original.id,
+      selected_by_user_id: original.selected_by_user_id,
+      dedicated_agent_id: STALE,
+      candidate_count: 3,
+      inventory_fingerprint: preview.inventoryFingerprint,
+    });
+    expect(
+      await resolvePersonalDedicatedAdoption({
+        organizationId: ORG_A,
+        userId: USER_A,
+        sourceAgentId: SOURCE_A,
+      }),
+    ).toMatchObject({ state: "available", agent: { id: STALE } });
+    expect(await dbWrite.select().from(agentSandboxes)).toHaveLength(3);
+    expect(await dbWrite.select().from(jobs)).toHaveLength(0);
+  });
+
+  test("rejects re-review when the named target is deleted or ineligible", async () => {
+    const original = await seedStaleSelection();
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ status: "disconnected" })
+      .where(eq(agentSandboxes.id, RETAINED));
+
+    const response = await post(rereviewRequestBody(RETAINED, true));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      code: "personal_dedicated_selection_not_found",
+    });
+    expect(
+      await dbWrite.select().from(personalDedicatedAdoptionSelections),
+    ).toEqual([original]);
+    expect(await dbWrite.select().from(jobs)).toHaveLength(0);
+  });
+
+  test("rejects re-review when activation authority already owns the source", async () => {
+    const original = await seedStaleSelection();
+    await dbWrite.insert(personalDedicatedUpgradeAuthorities).values({
+      organization_id: ORG_A,
+      user_id: USER_A,
+      source_agent_id: SOURCE_A,
+      dedicated_agent_id: RETAINED,
+    });
+
+    const response = await post(rereviewRequestBody(RETAINED, true));
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      code: "personal_dedicated_selection_conflict",
+    });
+    expect(
+      await dbWrite.select().from(personalDedicatedAdoptionSelections),
+    ).toEqual([original]);
+    expect(await dbWrite.select().from(jobs)).toHaveLength(0);
+  });
+
+  test("serializes concurrent stale-receipt refreshes with an exact receipt CAS", async () => {
+    await seedStaleSelection();
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ lifecycle_revision: 5750 })
+      .where(eq(agentSandboxes.id, RETAINED));
+    const preview = await rereviewPreview();
+    const input = {
+      organizationId: ORG_A,
+      userId: USER_A,
+      sourceAgentId: SOURCE_A,
+      retainedAgentId: RETAINED,
+      selectedByUserId: ADMIN,
+      reason: "duplicate_owned_dedicated_inventory" as const,
+      expectedReceiptFingerprint: preview.receiptFingerprint,
+      expectedInventoryFingerprint: preview.inventoryFingerprint,
+      expectedStateDisposition: preview.stateDisposition,
+    };
+
+    const results = await Promise.allSettled([
+      personalDedicatedAdoptionSelectionService.executeRereview(input),
+      personalDedicatedAdoptionSelectionService.executeRereview(input),
+    ]);
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: {
+        code: "PERSONAL_DEDICATED_SELECTION_INVENTORY_CHANGED",
+      },
+    });
+    expect(
+      await resolvePersonalDedicatedAdoption({
+        organizationId: ORG_A,
+        userId: USER_A,
+        sourceAgentId: SOURCE_A,
+      }),
+    ).toMatchObject({ state: "available", agent: { id: RETAINED } });
+    expect(await dbWrite.select().from(jobs)).toHaveLength(0);
   });
 
   test("target deletion preserves selection and authority tombstones and fails closed", async () => {

--- a/packages/cloud/api/v1/admin/personal-dedicated-adoption-selection/route.ts
+++ b/packages/cloud/api/v1/admin/personal-dedicated-adoption-selection/route.ts
@@ -1,6 +1,7 @@
 /**
- * Super-admin boundary for resolving duplicate existing personal Dedicated
- * inventory without provisioning, billing, cutover, or deleting any row.
+ * Super-admin boundary for selecting or explicitly re-reviewing duplicate
+ * personal Dedicated inventory without provisioning, billing, cutover, or
+ * deleting any compute row.
  */
 
 import { Hono } from "hono";
@@ -16,7 +17,6 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const commonRequest = {
-  action: z.literal("select_existing_personal_dedicated"),
   targetOwnerOrganizationId: z.string().uuid(),
   targetOwnerUserId: z.string().uuid(),
   retainedAgentId: z.string().uuid(),
@@ -26,6 +26,7 @@ const commonRequest = {
 const previewRequestSchema = z
   .object({
     ...commonRequest,
+    action: z.literal("select_existing_personal_dedicated"),
     dryRun: z.literal(true),
   })
   .strict();
@@ -33,6 +34,7 @@ const previewRequestSchema = z
 const executeRequestSchema = z
   .object({
     ...commonRequest,
+    action: z.literal("select_existing_personal_dedicated"),
     dryRun: z.literal(false),
     inventoryFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
     stateDisposition: z.enum([
@@ -43,7 +45,35 @@ const executeRequestSchema = z
   })
   .strict();
 
-const requestSchema = z.union([previewRequestSchema, executeRequestSchema]);
+const rereviewPreviewRequestSchema = z
+  .object({
+    ...commonRequest,
+    action: z.literal("rereview_existing_personal_dedicated"),
+    dryRun: z.literal(true),
+  })
+  .strict();
+
+const rereviewExecuteRequestSchema = z
+  .object({
+    ...commonRequest,
+    action: z.literal("rereview_existing_personal_dedicated"),
+    dryRun: z.literal(false),
+    receiptFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    inventoryFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    stateDisposition: z.enum([
+      "verified_backup_present",
+      "fresh_boot_no_verified_backup",
+    ]),
+    confirmation: z.literal("rereview_without_provisioning_or_deleting"),
+  })
+  .strict();
+
+const requestSchema = z.union([
+  previewRequestSchema,
+  executeRequestSchema,
+  rereviewPreviewRequestSchema,
+  rereviewExecuteRequestSchema,
+]);
 const LOCAL_DEV_ADMIN_USER_ID = "00000000-0000-4000-8000-000000000001";
 const LOCAL_DEV_ADMIN_EMAIL = "local-dev-admin@localhost";
 
@@ -51,7 +81,7 @@ interface AdminPersonalDedicatedSelectionRouteDependencies {
   requireAdmin: typeof requireAdmin;
   selectionService: Pick<
     typeof personalDedicatedAdoptionSelectionService,
-    "preview" | "execute"
+    "preview" | "execute" | "previewRereview" | "executeRereview"
   >;
   logger: Pick<typeof logger, "info">;
 }
@@ -135,13 +165,23 @@ export function createAdminPersonalDedicatedSelectionRoute(
             : user.id,
         reason: input.reason,
       };
-      const result = input.dryRun
-        ? await dependencies.selectionService.preview(common)
-        : await dependencies.selectionService.execute({
-            ...common,
-            expectedInventoryFingerprint: input.inventoryFingerprint,
-            expectedStateDisposition: input.stateDisposition,
-          });
+      const rereview = input.action === "rereview_existing_personal_dedicated";
+      const result = rereview
+        ? input.dryRun
+          ? await dependencies.selectionService.previewRereview(common)
+          : await dependencies.selectionService.executeRereview({
+              ...common,
+              expectedReceiptFingerprint: input.receiptFingerprint,
+              expectedInventoryFingerprint: input.inventoryFingerprint,
+              expectedStateDisposition: input.stateDisposition,
+            })
+        : input.dryRun
+          ? await dependencies.selectionService.preview(common)
+          : await dependencies.selectionService.execute({
+              ...common,
+              expectedInventoryFingerprint: input.inventoryFingerprint,
+              expectedStateDisposition: input.stateDisposition,
+            });
 
       dependencies.logger.info(
         "[admin-personal-dedicated-selection] Selection decision accepted",
@@ -153,6 +193,7 @@ export function createAdminPersonalDedicatedSelectionRoute(
           dryRun: input.dryRun,
           alreadySelected: result.alreadySelected,
           candidateCount: result.candidateCount,
+          operation: rereview ? "rereview" : "select",
         },
       );
 

--- a/packages/cloud/shared/src/lib/services/personal-dedicated-adoption-selection.ts
+++ b/packages/cloud/shared/src/lib/services/personal-dedicated-adoption-selection.ts
@@ -1,13 +1,16 @@
 /**
- * Admin-reviewed selection of one existing personal Dedicated candidate.
+ * Admin-reviewed selection and explicit re-review of one existing personal
+ * Dedicated candidate.
  *
  * This boundary is deliberately non-billable: it writes only a durable
- * selection receipt. It never changes the agent row, creates a lifecycle job,
- * starts compute, finalizes personal cutover, or removes another candidate.
+ * selection receipt. Re-review replaces only a stale receipt after a fresh
+ * fingerprint-bound operator decision. Neither path changes an agent row,
+ * creates a lifecycle job, starts compute, finalizes personal cutover, or
+ * removes another candidate.
  */
 
 import { ElizaError } from "@elizaos/core";
-import { and, asc, eq, inArray, notExists, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, ne, notExists, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { dbWrite } from "../../db/helpers";
 import type { AgentSandbox, AgentSandboxStatus } from "../../db/repositories/agent-sandboxes";
@@ -71,6 +74,22 @@ export interface PersonalDedicatedSelectionExecuteInput extends PersonalDedicate
   expectedStateDisposition: PersonalDedicatedStateDisposition;
 }
 
+export type PersonalDedicatedSelectionRereviewInput = PersonalDedicatedSelectionInput;
+
+export interface PersonalDedicatedSelectionRereviewExecuteInput
+  extends PersonalDedicatedSelectionRereviewInput {
+  expectedReceiptFingerprint: string;
+  expectedInventoryFingerprint: string;
+  expectedStateDisposition: PersonalDedicatedStateDisposition;
+}
+
+export interface PersonalDedicatedSelectionRereviewPreview
+  extends PersonalDedicatedSelectionPreview {
+  receiptFingerprint: string;
+  previousRetainedAgentId: string;
+  replacesTarget: boolean;
+}
+
 function selectionError(
   code:
     | "PERSONAL_DEDICATED_SELECTION_NOT_FOUND"
@@ -103,6 +122,23 @@ function unselectedCandidateWhere(organizationId: string, userId: string) {
         .select({ id: personalDedicatedAdoptionSelections.id })
         .from(personalDedicatedAdoptionSelections)
         .where(eq(personalDedicatedAdoptionSelections.dedicated_agent_id, agentSandboxes.id)),
+    ),
+  );
+}
+
+function rereviewCandidateWhere(organizationId: string, userId: string, selectionId: string) {
+  return and(
+    adoptableUnmarkedTargetWhere(organizationId, userId),
+    notExists(
+      dbWrite
+        .select({ id: personalDedicatedAdoptionSelections.id })
+        .from(personalDedicatedAdoptionSelections)
+        .where(
+          and(
+            eq(personalDedicatedAdoptionSelections.dedicated_agent_id, agentSandboxes.id),
+            ne(personalDedicatedAdoptionSelections.id, selectionId),
+          ),
+        ),
     ),
   );
 }
@@ -674,7 +710,294 @@ export async function executePersonalDedicatedSelection(
   }
 }
 
+function rereviewPreviewFromCurrent(params: {
+  input: PersonalDedicatedSelectionRereviewInput;
+  receipt: typeof personalDedicatedAdoptionSelections.$inferSelect;
+  retained: AgentSandbox;
+  candidates: AgentSandbox[];
+  inventoryFingerprint: string;
+  stateDisposition: PersonalDedicatedStateDisposition;
+}): PersonalDedicatedSelectionRereviewPreview {
+  return {
+    inventoryFingerprint: params.inventoryFingerprint,
+    receiptFingerprint: params.receipt.inventory_fingerprint,
+    previousRetainedAgentId: params.receipt.dedicated_agent_id,
+    retainedAgentId: params.retained.id,
+    retainedStatus: params.retained.status,
+    retainedLifecycleRevision: params.retained.lifecycle_revision,
+    stateDisposition: params.stateDisposition,
+    candidateCount: params.candidates.length,
+    alreadySelected: true,
+    replacesTarget: params.receipt.dedicated_agent_id !== params.input.retainedAgentId,
+    startsCompute: false,
+    createsJob: false,
+    deletesRows: false,
+    changesCutover: false,
+  };
+}
+
+function assertReceiptCanBeRereviewed(
+  params: PersonalDedicatedSelectionRereviewInput,
+  receipt: typeof personalDedicatedAdoptionSelections.$inferSelect,
+): void {
+  if (receipt.restore_fence_hash || receipt.restore_fence_started_at) {
+    throw selectionError(
+      "PERSONAL_DEDICATED_SELECTION_CONFLICT",
+      "The Dedicated selection has active restore authority",
+      params,
+    );
+  }
+}
+
+function assertRereviewChangesReceipt(
+  params: PersonalDedicatedSelectionRereviewInput,
+  receipt: typeof personalDedicatedAdoptionSelections.$inferSelect,
+  preview: PersonalDedicatedSelectionRereviewPreview,
+  activationAuthority: ReturnType<typeof personalDedicatedActivationAuthority>,
+): void {
+  const receiptAuthority = personalDedicatedActivationAuthorityFromReceipt(
+    receipt.activation_kind,
+    receipt.activation_backup_id,
+    receipt.activation_backup_hash,
+    receipt.activation_backup_chain,
+  );
+  if (
+    !preview.replacesTarget &&
+    receipt.inventory_fingerprint === preview.inventoryFingerprint &&
+    receipt.candidate_count === preview.candidateCount &&
+    receipt.state_disposition === preview.stateDisposition &&
+    personalDedicatedActivationAuthorityKey(receiptAuthority) ===
+      personalDedicatedActivationAuthorityKey(activationAuthority)
+  ) {
+    throw selectionError(
+      "PERSONAL_DEDICATED_SELECTION_CONFLICT",
+      "The Dedicated selection is already current",
+      params,
+    );
+  }
+}
+
+/**
+ * Recompute the current owner inventory for an explicit operator re-review.
+ * This is read-only and never treats the stale receipt itself as authority.
+ */
+export async function previewPersonalDedicatedSelectionRereview(
+  params: PersonalDedicatedSelectionRereviewInput,
+): Promise<PersonalDedicatedSelectionRereviewPreview> {
+  const receipt = await findSelection(params);
+  if (!receipt) {
+    throw selectionError(
+      "PERSONAL_DEDICATED_SELECTION_NOT_FOUND",
+      "The stale Dedicated selection was not found",
+      params,
+    );
+  }
+  assertReceiptCanBeRereviewed(params, receipt);
+  if (await findAuthority(params)) {
+    throw selectionError(
+      "PERSONAL_DEDICATED_SELECTION_CONFLICT",
+      "This personal Dedicated source already has activation authority",
+      params,
+    );
+  }
+
+  const candidates = await dbWrite
+    .select()
+    .from(agentSandboxes)
+    .where(rereviewCandidateWhere(params.organizationId, params.userId, receipt.id))
+    .orderBy(asc(agentSandboxes.id))
+    .limit(MAX_REVIEWABLE_CANDIDATES + 1);
+  const retained = assertStableAmbiguousInventory(params, candidates);
+  const activeJob = await findActiveCandidateLifecycleJob(
+    dbWrite,
+    params.organizationId,
+    candidates.map((candidate) => candidate.id),
+  );
+  if (activeJob) {
+    throw selectionError(
+      "PERSONAL_DEDICATED_SELECTION_ACTIVE_JOB",
+      "The reviewed Dedicated inventory has active lifecycle work",
+      params,
+    );
+  }
+  const backups = await readBackupProvenance(candidates.map((candidate) => candidate.id));
+  const inventoryFingerprint = await personalDedicatedInventoryFingerprint({
+    ...params,
+    candidates,
+    backups,
+  });
+  const activationAuthority = personalDedicatedActivationAuthority(
+    params.organizationId,
+    retained.id,
+    backups,
+  );
+  const stateDisposition = personalDedicatedStateDisposition(
+    params.organizationId,
+    retained.id,
+    backups,
+  );
+  const preview = rereviewPreviewFromCurrent({
+    input: params,
+    receipt,
+    retained,
+    candidates,
+    inventoryFingerprint,
+    stateDisposition,
+  });
+  assertRereviewChangesReceipt(params, receipt, preview, activationAuthority);
+  return preview;
+}
+
+/**
+ * Replace one stale selection only after a fresh explicit operator review.
+ * The transaction changes only the receipt; no agent, job, billing, or
+ * cutover state is written.
+ */
+export async function executePersonalDedicatedSelectionRereview(
+  params: PersonalDedicatedSelectionRereviewExecuteInput,
+): Promise<PersonalDedicatedSelectionRereviewPreview> {
+  return await dbWrite.transaction(async (tx) => {
+    await configureElizaLifecycleTransaction(tx);
+    await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
+    await tx.execute(
+      elizaAgentTierUpgradeAdvisoryLockSql(params.organizationId, params.sourceAgentId),
+    );
+
+    const [receipt] = await tx
+      .select()
+      .from(personalDedicatedAdoptionSelections)
+      .where(
+        and(
+          eq(personalDedicatedAdoptionSelections.organization_id, params.organizationId),
+          eq(personalDedicatedAdoptionSelections.user_id, params.userId),
+          eq(personalDedicatedAdoptionSelections.source_agent_id, params.sourceAgentId),
+          eq(personalDedicatedAdoptionSelections.schema_version, 1),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!receipt) {
+      throw selectionError(
+        "PERSONAL_DEDICATED_SELECTION_NOT_FOUND",
+        "The stale Dedicated selection was not found",
+        params,
+      );
+    }
+    assertReceiptCanBeRereviewed(params, receipt);
+    if (receipt.inventory_fingerprint !== params.expectedReceiptFingerprint) {
+      throw selectionError(
+        "PERSONAL_DEDICATED_SELECTION_INVENTORY_CHANGED",
+        "The stale Dedicated receipt changed after preview",
+        params,
+      );
+    }
+    const [authority] = await tx
+      .select({ id: personalDedicatedUpgradeAuthorities.id })
+      .from(personalDedicatedUpgradeAuthorities)
+      .where(
+        and(
+          eq(personalDedicatedUpgradeAuthorities.organization_id, params.organizationId),
+          eq(personalDedicatedUpgradeAuthorities.user_id, params.userId),
+          eq(personalDedicatedUpgradeAuthorities.source_agent_id, params.sourceAgentId),
+          eq(personalDedicatedUpgradeAuthorities.schema_version, 1),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (authority) {
+      throw selectionError(
+        "PERSONAL_DEDICATED_SELECTION_CONFLICT",
+        "This personal Dedicated source already has activation authority",
+        params,
+      );
+    }
+
+    const unlockedCandidates = await tx
+      .select({ id: agentSandboxes.id })
+      .from(agentSandboxes)
+      .where(rereviewCandidateWhere(params.organizationId, params.userId, receipt.id))
+      .orderBy(asc(agentSandboxes.id))
+      .limit(MAX_REVIEWABLE_CANDIDATES + 1);
+    for (const candidate of unlockedCandidates) {
+      await tx.execute(elizaProvisionAdvisoryLockSql(params.organizationId, candidate.id));
+    }
+    const candidates = await tx
+      .select()
+      .from(agentSandboxes)
+      .where(rereviewCandidateWhere(params.organizationId, params.userId, receipt.id))
+      .orderBy(asc(agentSandboxes.id))
+      .limit(MAX_REVIEWABLE_CANDIDATES + 1)
+      .for("update");
+    const retained = assertStableAmbiguousInventory(params, candidates);
+    const backups = await readBackupProvenanceInTx(
+      tx,
+      candidates.map((candidate) => candidate.id),
+    );
+    const inventoryFingerprint = await personalDedicatedInventoryFingerprint({
+      ...params,
+      candidates,
+      backups,
+    });
+    const activationAuthority = personalDedicatedActivationAuthority(
+      params.organizationId,
+      retained.id,
+      backups,
+    );
+    const stateDisposition = personalDedicatedStateDisposition(
+      params.organizationId,
+      retained.id,
+      backups,
+    );
+    const preview = rereviewPreviewFromCurrent({
+      input: params,
+      receipt,
+      retained,
+      candidates,
+      inventoryFingerprint,
+      stateDisposition,
+    });
+    assertRereviewChangesReceipt(params, receipt, preview, activationAuthority);
+    if (
+      inventoryFingerprint !== params.expectedInventoryFingerprint ||
+      stateDisposition !== params.expectedStateDisposition
+    ) {
+      throw selectionError(
+        "PERSONAL_DEDICATED_SELECTION_INVENTORY_CHANGED",
+        "The Dedicated inventory changed after re-review",
+        params,
+      );
+    }
+    const activeJob = await findActiveCandidateLifecycleJob(
+      tx,
+      params.organizationId,
+      candidates.map((candidate) => candidate.id),
+    );
+    if (activeJob) {
+      throw selectionError(
+        "PERSONAL_DEDICATED_SELECTION_ACTIVE_JOB",
+        "The reviewed Dedicated inventory has active lifecycle work",
+        params,
+      );
+    }
+
+    await tx
+      .update(personalDedicatedAdoptionSelections)
+      .set({
+        dedicated_agent_id: retained.id,
+        state_disposition: stateDisposition,
+        ...personalDedicatedActivationAuthorityReceiptColumns(activationAuthority),
+        inventory_fingerprint: inventoryFingerprint,
+        candidate_count: candidates.length,
+        updated_at: new Date(),
+      })
+      .where(eq(personalDedicatedAdoptionSelections.id, receipt.id));
+    return preview;
+  });
+}
+
 export const personalDedicatedAdoptionSelectionService = {
   preview: previewPersonalDedicatedSelection,
   execute: executePersonalDedicatedSelection,
+  previewRereview: previewPersonalDedicatedSelectionRereview,
+  executeRereview: executePersonalDedicatedSelectionRereview,
 };


### PR DESCRIPTION
Fixes #30042

## Cause

Generic activation intentionally stops when any owner/source selection receipt exists. Owner adoption intentionally revalidates that receipt against the current eligible inventory, fingerprint, backup disposition, and activation authority. Because the fingerprint includes mutable lifecycle state, a reviewed receipt can become stale; the existing admin boundary rejects that receipt but has no explicit reconciliation operation. The account then remains trapped between `dedicated_adoption_selection_required` and `dedicated_adoption_unavailable`.

## Change

Adds a separate `rereview_existing_personal_dedicated` super-admin operation to the existing selection boundary:

- dry-run recomputes the complete current eligible inventory, fingerprint, backup disposition, and activation authority;
- execute requires the reviewed target, reason, previous receipt fingerprint, current inventory fingerprint/disposition, and exact non-mutating confirmation;
- organization/source and candidate lifecycle locks serialize the transaction;
- the previous receipt fingerprint is an exact CAS, so a concurrent stale preview cannot overwrite a completed review;
- only the existing same-owner/source receipt is updated;
- original receipt id, creator attribution, selected timestamp, and created timestamp are preserved;
- another receipt's target, an ineligible/deleted target, source authority, active restore fence, active lifecycle job, unchanged receipt, and changed preview all fail closed;
- no agent row, lifecycle job, billing, provisioning, activation, adoption, cutover, or deletion is performed.

## Tests

Focused real route + PGlite regression:

```text
bun test --coverage-reporter=lcov --coverage-dir=<temp> packages/cloud/api/__tests__/admin-personal-dedicated-adoption-selection.pglite.test.ts --test-name-pattern "re-review|re-reviews|serializes concurrent stale"
5 pass, 20 filtered, 0 fail, 32 assertions
```

Covers fingerprint drift, candidate-count drift, explicit target replacement, deleted/ineligible target, authority conflict, concurrent receipt CAS, original audit preservation, no job/compute mutation, and subsequent `resolvePersonalDedicatedAdoption` availability.

Additional checks:

- `bun run --cwd packages/cloud/shared typecheck` — passed
- exact changed-file Biome check — passed
- `git diff --check` — passed

## Baseline blockers

- The unfiltered pre-existing PGlite suite currently fails in backup cases because `TIER_UPGRADE_TEST_TABLES` lacks the current `agent_sandbox_backups.source_node_history_id` schema column. All five new focused cases pass.
- `bun run --cwd packages/cloud/api typecheck` reaches a pre-existing unresolved workspace export: `@elizaos/plugin-doordash` from `cloud/shared/src/lib/eliza/runtime/initializer.ts`.

No staging/production state was read or mutated, and this PR does not deploy or perform the operator re-review.
