### PR TITLE
fix(cloud): add staging latency certification

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1106,6 +1106,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          INFERENCE_AUTH_PROBE_TOKEN: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.INFERENCE_AUTH_PROBE_TOKEN || '' }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           FAL_KEY: ${{ secrets.FAL_KEY }}
           # fal key under its alternate name: the video provider registry reads
@@ -1595,6 +1596,13 @@ jobs:
           for name in "${managed_worker_provisioning_secrets[@]}"; do
             queue_secret "$name" || exit 1
           done
+
+          # Controlled cache-miss certification exists only on staging. A blank
+          # protected value preserves the current binding; the opt-in live
+          # certification workflow independently fails closed when requested.
+          if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+            queue_secret INFERENCE_AUTH_PROBE_TOKEN || exit 1
+          fi
 
           for name in \
             ELIZA_APP_BLOOIO_API_KEY \

--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -1,0 +1,139 @@
+name: Cloud Latency Certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_deploy_sha:
+        description: Exact 40-character develop SHA that staging must serve.
+        required: true
+        type: string
+      run_auth:
+        description: Also run protected inference-auth hit, miss, guard, and sanitized Worker Tail proof.
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloud-latency-certification-staging
+  cancel-in-progress: false
+
+jobs:
+  certify-staging:
+    name: Certify staging gateway and auth latency
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment: staging
+    env:
+      BUN_VERSION: "1.3.14"
+      NODE_VERSION: "24.15.0"
+      EXPECTED_DEPLOY_SHA: ${{ inputs.expected_deploy_sha }}
+      RUN_AUTH: ${{ inputs.run_auth }}
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+      ELIZA_STAGING_SUSPENDED_API_KEY: ${{ secrets.ELIZA_STAGING_SUSPENDED_API_KEY }}
+      INFERENCE_AUTH_PROBE_TOKEN: ${{ secrets.INFERENCE_AUTH_PROBE_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Validate trusted exact-SHA dispatch and protected credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$EXPECTED_DEPLOY_SHA" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "::error::expected_deploy_sha must be a lowercase 40-character commit."
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/heads/develop" ]]; then
+            echo "::error::Cloud latency certification must dispatch the trusted develop workflow definition."
+            exit 1
+          fi
+          if [[ "$EXPECTED_DEPLOY_SHA" != "$GITHUB_SHA" ]]; then
+            echo "::error::Dispatch must select develop at the exact expected_deploy_sha; refusing arbitrary checkout bytes."
+            exit 1
+          fi
+          required=(CEREBRAS_API_KEY ELIZAOS_CLOUD_API_KEY)
+          if [[ "$RUN_AUTH" == "true" ]]; then
+            required+=(
+              ELIZA_STAGING_SUSPENDED_API_KEY
+              INFERENCE_AUTH_PROBE_TOKEN
+              CLOUDFLARE_API_TOKEN
+              CLOUDFLARE_ACCOUNT_ID
+            )
+          fi
+          missing=()
+          for name in "${required[@]}"; do
+            value_without_whitespace="${!name:-}"
+            value_without_whitespace="${value_without_whitespace//[[:space:]]/}"
+            [[ -n "$value_without_whitespace" ]] || missing+=("$name")
+          done
+          unset value_without_whitespace
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing required protected staging secret: %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "Protected staging credential names are configured; values were not printed."
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Run exact-SHA privacy-safe latency certification
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="$GITHUB_WORKSPACE/artifacts/cloud-latency-certification"
+          args=(
+            --deploy-sha "$EXPECTED_DEPLOY_SHA"
+            --output-dir "$output_dir"
+          )
+          if [[ "$RUN_AUTH" == "true" ]]; then
+            args+=(--auth)
+          fi
+          node packages/cloud/scripts/cloud-latency-certification.mjs "${args[@]}"
+
+      - name: Remove private Worker Tail material
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          private_tail_directories=("$RUNNER_TEMP"/eliza-inference-auth-tail-*)
+          for directory in "${private_tail_directories[@]}"; do
+            if [[ ! -d "$directory" || -L "$directory" ]]; then
+              echo "::error::Refusing unexpected private Tail cleanup target."
+              exit 1
+            fi
+            rm -rf -- "$directory"
+          done
+
+      - name: Upload sanitized certification evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cloud-latency-certification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/cloud-latency-certification/deployment.json
+            artifacts/cloud-latency-certification/paired.jsonl
+            artifacts/cloud-latency-certification/inference-auth.jsonl
+            artifacts/cloud-latency-certification/inference-auth-worker.jsonl
+            artifacts/cloud-latency-certification/summary.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -1,0 +1,559 @@
+#!/usr/bin/env node
+/**
+ * Runs exact-SHA staging latency certification while retaining only bounded,
+ * privacy-safe evidence. Raw Worker Tail bytes remain in a private temporary
+ * directory that is removed on every success or failure path.
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import {
+  sanitizeInferenceAuthTail,
+  summarizeDeferredCacheWrites,
+  waitForInferenceAuthTail,
+} from "./inference-auth-latency.mjs";
+
+const STAGING_BASE_URL = "https://api-staging.eliza.app";
+const CEREBRAS_BASE_URL = "https://api.cerebras.ai";
+const STAGING_WORKER = "eliza-cloud-api-staging";
+const EXPECTED_PAIRED_RECORDS = 44;
+const EXPECTED_AUTH_RECORDS = 45;
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function sleep(durationMs) {
+  return new Promise((resolvePromise) =>
+    setTimeout(resolvePromise, durationMs),
+  );
+}
+
+function parseJsonLines(text, label) {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  return lines.map((line, index) => {
+    try {
+      const value = JSON.parse(line);
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("record is not an object");
+      }
+      return value;
+    } catch (cause) {
+      // error-policy:J2 certification evidence must be complete JSONL; retain
+      // the parser cause locally without echoing arbitrary record contents.
+      throw new Error(`${label} record ${index + 1} is invalid JSON`, {
+        cause,
+      });
+    }
+  });
+}
+
+export function parseCertificationArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      "deploy-sha": { type: "string" },
+      "output-dir": { type: "string" },
+      auth: { type: "boolean", default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  const deploySha = values["deploy-sha"]?.trim() ?? "";
+  if (!SHA_PATTERN.test(deploySha)) {
+    throw new Error("--deploy-sha must be a lowercase 40-character commit");
+  }
+  const outputDir = values["output-dir"]?.trim() ?? "";
+  if (!outputDir) throw new Error("--output-dir is required");
+  return { deploySha, outputDir: resolve(outputDir), runAuth: values.auth };
+}
+
+function requireSecret(env, name) {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`Required protected secret is missing: ${name}`);
+  return value;
+}
+
+export function requirePairedSecrets(env) {
+  return {
+    directApiKey: requireSecret(env, "CEREBRAS_API_KEY"),
+    gatewayApiKey: requireSecret(env, "ELIZAOS_CLOUD_API_KEY"),
+  };
+}
+
+export function requireAuthSecrets(env) {
+  return {
+    apiKey: requireSecret(env, "ELIZAOS_CLOUD_API_KEY"),
+    suspendedApiKey: requireSecret(env, "ELIZA_STAGING_SUSPENDED_API_KEY"),
+    probeToken: requireSecret(env, "INFERENCE_AUTH_PROBE_TOKEN"),
+    cloudflareApiToken: requireSecret(env, "CLOUDFLARE_API_TOKEN"),
+    cloudflareAccountId: requireSecret(env, "CLOUDFLARE_ACCOUNT_ID"),
+  };
+}
+
+export async function verifyExactDeployment(deploySha, fetchImpl = fetch) {
+  let response;
+  try {
+    response = await fetchImpl(`${STAGING_BASE_URL}/api/health`, {
+      headers: { "user-agent": "eliza-cloud-latency-certification/1.0" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (cause) {
+    // error-policy:J2 keep network details out of the workflow boundary while
+    // preserving the local cause for a debugger.
+    throw new Error("Staging health request failed", { cause });
+  }
+  if (!response.ok) {
+    throw new Error(`Staging health returned HTTP ${response.status}`);
+  }
+  const body = await response.json();
+  if (body?.commit !== deploySha) {
+    throw new Error("Staging Worker did not serve the expected commit");
+  }
+  if (body?.environment !== "staging") {
+    throw new Error("Staging health returned the wrong environment");
+  }
+  return { kind: "deployment", deploySha, environment: "staging" };
+}
+
+export function validatePairedEvidence(text, deploySha) {
+  const records = parseJsonLines(text, "Paired latency evidence");
+  if (records.length !== EXPECTED_PAIRED_RECORDS) {
+    throw new Error(
+      `Paired latency evidence must contain ${EXPECTED_PAIRED_RECORDS} records`,
+    );
+  }
+  const counts = { direct: 0, gateway: 0 };
+  for (const record of records) {
+    if (record.target !== "direct" && record.target !== "gateway") {
+      throw new Error("Paired latency evidence contains an unexpected target");
+    }
+    counts[record.target]++;
+    if (
+      record.ok !== true ||
+      record.transportOk !== true ||
+      record.proofMatched !== true
+    ) {
+      throw new Error("Paired latency evidence contains a failed proof");
+    }
+    if (record.ci?.sha !== deploySha) {
+      throw new Error(
+        "Paired latency evidence is not bound to the dispatch SHA",
+      );
+    }
+  }
+  if (counts.direct !== 22 || counts.gateway !== 22) {
+    throw new Error("Paired latency evidence is not a balanced 20-run matrix");
+  }
+  return { records, counts };
+}
+
+export function validateAuthEvidence(text, deploySha) {
+  const records = parseJsonLines(text, "Inference auth evidence");
+  if (records.length !== EXPECTED_AUTH_RECORDS) {
+    throw new Error(
+      `Inference auth evidence must contain ${EXPECTED_AUTH_RECORDS} records`,
+    );
+  }
+  const deployment = records.filter((record) => record.kind === "deployment");
+  const samples = records.filter((record) => record.kind === "sample");
+  const guards = records.filter((record) => record.kind === "guard");
+  const summaries = records.filter((record) => record.kind === "summary");
+  if (
+    deployment.length !== 1 ||
+    samples.length !== 40 ||
+    guards.length !== 3 ||
+    summaries.length !== 1
+  ) {
+    throw new Error("Inference auth evidence has an invalid record matrix");
+  }
+  if (
+    deployment[0].deploySha !== deploySha ||
+    deployment[0].environment !== "staging"
+  ) {
+    throw new Error("Inference auth deployment evidence is not exact staging");
+  }
+  const hits = samples.filter((record) => record.phase === "hit");
+  const misses = samples.filter((record) => record.phase === "miss");
+  if (hits.length !== 30 || misses.length !== 10) {
+    throw new Error("Inference auth evidence has an invalid hit/miss count");
+  }
+  for (const record of records.filter((value) => value.kind !== "deployment")) {
+    if (record.deploySha !== deploySha) {
+      throw new Error(
+        "Inference auth evidence contains a different deploy SHA",
+      );
+    }
+  }
+  for (const record of hits) {
+    if (
+      record.status !== 400 ||
+      record.auth?.read !== "hit" ||
+      record.auth?.result !== "authorized_cache"
+    ) {
+      throw new Error(
+        "Inference auth hit evidence is not a cache authorization",
+      );
+    }
+  }
+  for (const record of misses) {
+    if (
+      record.status !== 400 ||
+      record.auth?.read !== "miss" ||
+      record.auth?.authoritative !== "authorized" ||
+      record.auth?.write !== "deferred" ||
+      record.auth?.result !== "authorized_origin"
+    ) {
+      throw new Error("Inference auth miss evidence is not authoritative");
+    }
+  }
+  const guardByName = new Map(guards.map((record) => [record.guard, record]));
+  if (
+    guardByName.get("invalid_key")?.status !== 401 ||
+    guardByName.get("suspended_key")?.status !== 403 ||
+    guardByName.get("forged_probe")?.status !== 400
+  ) {
+    throw new Error("Inference auth guard evidence is incomplete");
+  }
+  const traceIds = [...samples, ...guards].map((record) => record.traceId);
+  if (
+    traceIds.length !== 43 ||
+    new Set(traceIds).size !== traceIds.length ||
+    traceIds.some((traceId) => !UUID_PATTERN.test(traceId))
+  ) {
+    throw new Error("Inference auth evidence has invalid trace correlation");
+  }
+  return { records, traceIds };
+}
+
+export async function withPrivateTailDirectory(task, root = tmpdir()) {
+  const directory = await mkdtemp(join(root, "eliza-inference-auth-tail-"));
+  await chmod(directory, 0o700);
+  let result;
+  let failure;
+  try {
+    result = await task(directory);
+  } catch (error) {
+    // error-policy:J5 the same failure is rethrown immediately after the raw
+    // Tail directory has been removed.
+    failure = error;
+  }
+  try {
+    await rm(directory, { recursive: true, force: true });
+  } catch (cause) {
+    // error-policy:J2 raw Tail cleanup is a security boundary and therefore
+    // cannot degrade to a warning or a successful certification.
+    throw new Error("Private Worker Tail cleanup failed", { cause });
+  }
+  if (failure) throw failure;
+  return result;
+}
+
+async function runCommandToFile({
+  command,
+  args,
+  stdoutPath,
+  stderrPath,
+  env,
+  label,
+}) {
+  const stdout = await open(stdoutPath, "wx", 0o600);
+  const stderr = await open(stderrPath, "wx", 0o600);
+  try {
+    const child = spawn(command, args, {
+      env,
+      stdio: ["ignore", stdout.fd, stderr.fd],
+    });
+    const exitCode = await new Promise((resolvePromise, rejectPromise) => {
+      child.once("error", (cause) => {
+        rejectPromise(new Error(`${label} could not start`, { cause }));
+      });
+      child.once("exit", (code, signal) => {
+        if (signal) {
+          rejectPromise(new Error(`${label} exited from signal ${signal}`));
+          return;
+        }
+        resolvePromise(code ?? 1);
+      });
+    });
+    if (exitCode !== 0)
+      throw new Error(`${label} failed with exit ${exitCode}`);
+  } finally {
+    await Promise.all([stdout.close(), stderr.close()]);
+  }
+}
+
+async function startPrivateTail(directory, env) {
+  const rawPath = join(directory, "wrangler-tail.raw.json");
+  const stderrPath = join(directory, "wrangler-tail.stderr");
+  const stdout = await open(rawPath, "wx", 0o600);
+  const stderr = await open(stderrPath, "wx", 0o600);
+  const child = spawn(
+    "bunx",
+    ["wrangler@4.116.0", "tail", STAGING_WORKER, "--format", "json"],
+    { env, stdio: ["ignore", stdout.fd, stderr.fd] },
+  );
+  await Promise.all([stdout.close(), stderr.close()]);
+  return { child, rawPath };
+}
+
+async function raceTailLifetime(child, operation) {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const cleanup = () => {
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+    const onError = (cause) => {
+      cleanup();
+      rejectPromise(new Error("Worker Tail could not start", { cause }));
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      rejectPromise(
+        new Error(
+          `Worker Tail stopped before evidence capture (${signal ?? code ?? "unknown"})`,
+        ),
+      );
+    };
+    child.once("error", onError);
+    child.once("exit", onExit);
+    operation.then(
+      (value) => {
+        cleanup();
+        resolvePromise(value);
+      },
+      (error) => {
+        cleanup();
+        rejectPromise(error);
+      },
+    );
+  });
+}
+
+async function stopTail(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolvePromise) => {
+    child.once("exit", () => resolvePromise(true));
+  });
+  child.kill("SIGINT");
+  const stopped = await Promise.race([exited, sleep(5_000).then(() => false)]);
+  if (!stopped && child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+async function waitForSanitizedTail(rawPath, traceIds, deploySha) {
+  let lastFailure;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    if (attempt > 0) await sleep(250);
+    try {
+      const rawText = await readFile(rawPath, "utf8");
+      return sanitizeInferenceAuthTail(rawText, traceIds, deploySha);
+    } catch (error) {
+      // error-policy:J3 a live JSON stream can be incomplete between writes;
+      // only a fully sanitized fixed-schema result leaves this retry boundary.
+      lastFailure = error;
+    }
+  }
+  throw new Error(
+    "Worker Tail did not yield complete sanitized auth evidence",
+    {
+      cause: lastFailure,
+    },
+  );
+}
+
+async function runPaired({ deploySha, outputDir, env }) {
+  requirePairedSecrets(env);
+  const outputPath = join(outputDir, "paired.jsonl");
+  const stderrPath = join(outputDir, ".paired.stderr");
+  const scriptPath = new URL("./chat-latency.mjs", import.meta.url);
+  try {
+    await runCommandToFile({
+      command: process.execPath,
+      args: [
+        scriptPath.pathname,
+        "--target",
+        "paired",
+        "--gateway-base-url",
+        STAGING_BASE_URL,
+        "--direct-base-url",
+        CEREBRAS_BASE_URL,
+        "--gateway-api-key-env",
+        "ELIZAOS_CLOUD_API_KEY",
+        "--direct-api-key-env",
+        "CEREBRAS_API_KEY",
+        "--case",
+        "gemma-4-31b@omit@512",
+        "--repeat",
+        "20",
+        "--idle-ms",
+        "500",
+        "--pair-interval-ms",
+        "250",
+        "--seed",
+        `staging-${deploySha}`,
+      ],
+      stdoutPath: outputPath,
+      stderrPath,
+      env: { ...env, ELIZA_GATEWAY_DEPLOY_SHA: deploySha },
+      label: "Paired latency probe",
+    });
+    return validatePairedEvidence(
+      await readFile(outputPath, "utf8"),
+      deploySha,
+    );
+  } finally {
+    await rm(stderrPath, { force: true });
+  }
+}
+
+async function runAuth({ deploySha, outputDir, env }) {
+  const secrets = requireAuthSecrets(env);
+  const privateRoot = env.RUNNER_TEMP?.trim() || tmpdir();
+  return await withPrivateTailDirectory(async (directory) => {
+    const { child, rawPath } = await startPrivateTail(directory, env);
+    let failure;
+    let result;
+    try {
+      await raceTailLifetime(
+        child,
+        waitForInferenceAuthTail({
+          baseUrl: STAGING_BASE_URL,
+          apiKey: secrets.apiKey,
+          probeToken: secrets.probeToken,
+          deploySha,
+          timeoutMs: 30_000,
+          readTail: () => readFileSync(rawPath, "utf8"),
+        }),
+      );
+      const outputPath = join(outputDir, "inference-auth.jsonl");
+      const stderrPath = join(directory, "inference-auth.stderr");
+      const scriptPath = new URL(
+        "./inference-auth-latency.mjs",
+        import.meta.url,
+      );
+      await raceTailLifetime(
+        child,
+        runCommandToFile({
+          command: process.execPath,
+          args: [
+            scriptPath.pathname,
+            "--base-url",
+            STAGING_BASE_URL,
+            "--api-key-env",
+            "ELIZAOS_CLOUD_API_KEY",
+            "--suspended-api-key-env",
+            "ELIZA_STAGING_SUSPENDED_API_KEY",
+            "--probe-token-env",
+            "INFERENCE_AUTH_PROBE_TOKEN",
+            "--deploy-sha",
+            deploySha,
+            "--hit-count",
+            "30",
+            "--miss-count",
+            "10",
+            "--timeout-ms",
+            "30000",
+            "--interval-ms",
+            "250",
+          ],
+          stdoutPath: outputPath,
+          stderrPath,
+          env,
+          label: "Inference auth probe",
+        }),
+      );
+      const validation = validateAuthEvidence(
+        await readFile(outputPath, "utf8"),
+        deploySha,
+      );
+      const workerRecords = await raceTailLifetime(
+        child,
+        waitForSanitizedTail(rawPath, validation.traceIds, deploySha),
+      );
+      const workerPath = join(outputDir, "inference-auth-worker.jsonl");
+      await writeFile(
+        workerPath,
+        `${workerRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+        { mode: 0o600, flag: "wx" },
+      );
+      result = {
+        records: validation.records.length,
+        workerRecords: workerRecords.length,
+        deferredCacheWriteMs: summarizeDeferredCacheWrites(workerRecords),
+      };
+    } catch (error) {
+      // error-policy:J5 the same failure is rethrown after the Tail subprocess
+      // is stopped and withPrivateTailDirectory removes every raw byte.
+      failure = error;
+    } finally {
+      try {
+        await stopTail(child);
+      } catch (cause) {
+        // error-policy:J2 a Tail process that cannot be terminated invalidates
+        // the certification rather than leaving credentialed observation alive.
+        failure = new Error("Worker Tail teardown failed", { cause });
+      }
+    }
+    if (failure) throw failure;
+    return result;
+  }, privateRoot);
+}
+
+export async function runCertification(
+  options,
+  { env = process.env, fetchImpl = fetch } = {},
+) {
+  await mkdir(options.outputDir, { recursive: true, mode: 0o700 });
+  const deployment = await verifyExactDeployment(options.deploySha, fetchImpl);
+  await writeFile(
+    join(options.outputDir, "deployment.json"),
+    `${JSON.stringify(deployment)}\n`,
+    { mode: 0o600, flag: "wx" },
+  );
+  const paired = await runPaired({ ...options, env });
+  const auth = options.runAuth
+    ? await runAuth({ ...options, env })
+    : { skipped: true, reason: "not_requested" };
+  const summary = {
+    kind: "cloud_latency_certification",
+    deploySha: options.deploySha,
+    environment: "staging",
+    paired: { records: paired.records.length, counts: paired.counts },
+    auth,
+  };
+  await writeFile(
+    join(options.outputDir, "summary.json"),
+    `${JSON.stringify(summary)}\n`,
+    { mode: 0o600, flag: "wx" },
+  );
+  return summary;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  runCertification(parseCertificationArgs(process.argv.slice(2))).catch(
+    (error) => {
+      // error-policy:J1 the CLI emits one bounded category; child stderr, raw
+      // Tail bytes, request headers, and nested causes never reach Actions logs.
+      process.stderr.write(
+        `[cloud-latency-certification] ${error instanceof Error ? error.message : "unknown failure"}\n`,
+      );
+      process.exitCode = 1;
+    },
+  );
+}

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -1,0 +1,260 @@
+/**
+ * Deterministic contract tests for exact-SHA latency evidence validation and
+ * private raw Worker Tail lifecycle; no network or provider calls are made.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  parseCertificationArgs,
+  requireAuthSecrets,
+  requirePairedSecrets,
+  validateAuthEvidence,
+  validatePairedEvidence,
+  verifyExactDeployment,
+  withPrivateTailDirectory,
+} from "./cloud-latency-certification.mjs";
+
+const SHA = "a".repeat(40);
+
+function pairedRecord(index, overrides = {}) {
+  return {
+    schemaVersion: 1,
+    target: index % 2 === 0 ? "direct" : "gateway",
+    ok: true,
+    transportOk: true,
+    proofMatched: true,
+    ci: { sha: SHA },
+    ...overrides,
+  };
+}
+
+function authTrace(index) {
+  const suffix = index.toString(16).padStart(12, "0");
+  return `11111111-1111-4111-8111-${suffix}`;
+}
+
+function authEvidence() {
+  const records = [
+    { kind: "deployment", deploySha: SHA, environment: "staging" },
+  ];
+  for (let index = 0; index < 30; index++) {
+    records.push({
+      kind: "sample",
+      deploySha: SHA,
+      phase: "hit",
+      sequence: index,
+      traceId: authTrace(index),
+      status: 400,
+      auth: { read: "hit", result: "authorized_cache" },
+    });
+  }
+  for (let index = 0; index < 10; index++) {
+    records.push({
+      kind: "sample",
+      deploySha: SHA,
+      phase: "miss",
+      sequence: index,
+      traceId: authTrace(30 + index),
+      status: 400,
+      auth: {
+        read: "miss",
+        authoritative: "authorized",
+        write: "deferred",
+        result: "authorized_origin",
+      },
+    });
+  }
+  records.push(
+    {
+      kind: "guard",
+      deploySha: SHA,
+      guard: "invalid_key",
+      traceId: authTrace(40),
+      status: 401,
+    },
+    {
+      kind: "guard",
+      deploySha: SHA,
+      guard: "suspended_key",
+      traceId: authTrace(41),
+      status: 403,
+    },
+    {
+      kind: "guard",
+      deploySha: SHA,
+      guard: "forged_probe",
+      traceId: authTrace(42),
+      status: 400,
+    },
+    {
+      kind: "summary",
+      deploySha: SHA,
+      counts: { hit: 30, miss: 10 },
+    },
+  );
+  return records;
+}
+
+function jsonl(records) {
+  return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+}
+
+test("parseCertificationArgs requires an exact SHA and explicit output directory", () => {
+  assert.deepEqual(
+    parseCertificationArgs([
+      "--deploy-sha",
+      SHA,
+      "--output-dir",
+      "artifacts/cert",
+      "--auth",
+    ]),
+    {
+      deploySha: SHA,
+      outputDir: join(process.cwd(), "artifacts/cert"),
+      runAuth: true,
+    },
+  );
+  assert.throws(
+    () =>
+      parseCertificationArgs([
+        "--deploy-sha",
+        "develop",
+        "--output-dir",
+        "artifacts/cert",
+      ]),
+    /lowercase 40-character commit/,
+  );
+});
+
+test("protected secret gates fail closed without exposing values", () => {
+  const configured = {
+    CEREBRAS_API_KEY: "direct-private",
+    ELIZAOS_CLOUD_API_KEY: "gateway-private",
+    ELIZA_STAGING_SUSPENDED_API_KEY: "suspended-private",
+    INFERENCE_AUTH_PROBE_TOKEN: "probe-private",
+    CLOUDFLARE_API_TOKEN: "cloudflare-private",
+    CLOUDFLARE_ACCOUNT_ID: "account-private",
+  };
+  assert.equal(requirePairedSecrets(configured).directApiKey, "direct-private");
+  assert.equal(requireAuthSecrets(configured).probeToken, "probe-private");
+  const failure = (() => {
+    try {
+      requireAuthSecrets({ ...configured, INFERENCE_AUTH_PROBE_TOKEN: " " });
+      return null;
+    } catch (error) {
+      return error;
+    }
+  })();
+  assert.match(failure.message, /INFERENCE_AUTH_PROBE_TOKEN/);
+  assert.equal(failure.message.includes("probe-private"), false);
+});
+
+test("verifyExactDeployment accepts only the requested staging commit", async () => {
+  assert.deepEqual(
+    await verifyExactDeployment(SHA, async () =>
+      Response.json({ status: "ok", environment: "staging", commit: SHA }),
+    ),
+    { kind: "deployment", deploySha: SHA, environment: "staging" },
+  );
+  await assert.rejects(
+    verifyExactDeployment(SHA, async () =>
+      Response.json({
+        status: "ok",
+        environment: "staging",
+        commit: "b".repeat(40),
+      }),
+    ),
+    /expected commit/,
+  );
+  await assert.rejects(
+    verifyExactDeployment(SHA, async () =>
+      Response.json({ status: "ok", environment: "production", commit: SHA }),
+    ),
+    /wrong environment/,
+  );
+});
+
+test("paired certification requires exactly 44 balanced successful proofs", () => {
+  const records = Array.from({ length: 44 }, (_, index) => pairedRecord(index));
+  assert.deepEqual(validatePairedEvidence(jsonl(records), SHA).counts, {
+    direct: 22,
+    gateway: 22,
+  });
+  assert.throws(
+    () =>
+      validatePairedEvidence(
+        jsonl(
+          records.map((record, index) =>
+            index === 7 ? { ...record, proofMatched: false } : record,
+          ),
+        ),
+        SHA,
+      ),
+    /failed proof/,
+  );
+  assert.throws(
+    () => validatePairedEvidence(jsonl(records.slice(1)), SHA),
+    /44 records/,
+  );
+});
+
+test("auth certification requires the complete hit, miss, and guard matrix", () => {
+  const records = authEvidence();
+  const result = validateAuthEvidence(jsonl(records), SHA);
+  assert.equal(result.records.length, 45);
+  assert.equal(result.traceIds.length, 43);
+  assert.throws(
+    () =>
+      validateAuthEvidence(
+        jsonl(
+          records.map((record) =>
+            record.guard === "suspended_key"
+              ? { ...record, status: 401 }
+              : record,
+          ),
+        ),
+        SHA,
+      ),
+    /guard evidence/,
+  );
+});
+
+test("private Tail directory is mode 0700 and deleted after success", async () => {
+  const root = await mkdtemp(join(tmpdir(), "eliza-tail-test-root-"));
+  let observedDirectory = "";
+  try {
+    const value = await withPrivateTailDirectory(async (directory) => {
+      observedDirectory = directory;
+      const metadata = await stat(directory);
+      assert.equal(metadata.mode & 0o777, 0o700);
+      return "done";
+    }, root);
+    assert.equal(value, "done");
+    assert.equal(existsSync(observedDirectory), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("private Tail directory is deleted when capture fails", async () => {
+  const root = await mkdtemp(join(tmpdir(), "eliza-tail-test-root-"));
+  let observedDirectory = "";
+  try {
+    await assert.rejects(
+      withPrivateTailDirectory(async (directory) => {
+        observedDirectory = directory;
+        throw new Error("capture failed");
+      }, root),
+      /capture failed/,
+    );
+    assert.equal(existsSync(observedDirectory), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -102,6 +102,20 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     expect(verify.run).toContain('"VOICE_REALTIME_ELIZA_AUTHORIZATION"');
   });
 
+  test("publishes the controlled inference-auth probe token only in staging", () => {
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    expect(prepare.env?.INFERENCE_AUTH_PROBE_TOKEN).toBe(
+      "$" +
+        "{{ steps.env.outputs.deploy_environment == 'staging' && secrets.INFERENCE_AUTH_PROBE_TOKEN || '' }}",
+    );
+    expect(prepare.run).toContain(
+      'if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then\n  queue_secret INFERENCE_AUTH_PROBE_TOKEN || exit 1\nfi',
+    );
+    expect(prepare.run).not.toContain(
+      "queue_toggle_secret INFERENCE_AUTH_PROBE_TOKEN",
+    );
+  });
+
   test("preflights and atomically verifies protected mobile App Auth bindings", () => {
     const preflight = step("Validate protected mobile App Auth registration");
     const prepare = step("Prepare Worker secrets for atomic deploy");

--- a/packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Fail-closed workflow contract for exact-SHA staging latency certification
+ * and sanitized-only Worker Tail evidence retention.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const source = readFileSync(
+  new URL(".github/workflows/cloud-latency-certification.yml", repoRoot),
+  "utf8",
+);
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, string | boolean | number>;
+}
+
+interface Job {
+  environment?: string;
+  env?: Record<string, string>;
+  steps?: Step[];
+}
+
+interface Workflow {
+  on?: Record<
+    string,
+    {
+      inputs?: Record<
+        string,
+        { required?: boolean; type?: string; default?: boolean }
+      >;
+    }
+  >;
+  permissions?: Record<string, string>;
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  jobs?: Record<string, Job>;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const job = workflow.jobs?.["certify-staging"];
+
+function step(name: string): Step {
+  const found = job?.steps?.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing workflow step: ${name}`);
+  return found;
+}
+
+describe("Cloud latency certification workflow", () => {
+  test("is manual-only, staging-scoped, read-only, and serialized", () => {
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_dispatch"]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.concurrency).toEqual({
+      group: "cloud-latency-certification-staging",
+      "cancel-in-progress": false,
+    });
+    expect(job?.environment).toBe("staging");
+    expect(source).not.toContain("environment: production");
+  });
+
+  test("requires an exact SHA and keeps the auth lane explicitly optional", () => {
+    const inputs = workflow.on?.workflow_dispatch?.inputs;
+    expect(inputs?.expected_deploy_sha).toMatchObject({
+      required: true,
+      type: "string",
+    });
+    expect(inputs?.run_auth).toEqual({
+      description:
+        "Also run protected inference-auth hit, miss, guard, and sanitized Worker Tail proof.",
+      required: true,
+      default: false,
+      type: "boolean",
+    });
+    const preflight = step(
+      "Validate trusted exact-SHA dispatch and protected credentials",
+    ).run;
+    expect(preflight).toContain('"$EXPECTED_DEPLOY_SHA" != "$GITHUB_SHA"');
+    expect(preflight).toContain('"$GITHUB_REF" != "refs/heads/develop"');
+    expect(preflight).toContain("^[a-f0-9]{40}$");
+    expect(preflight).toContain('if [[ "$RUN_AUTH" == "true" ]]');
+  });
+
+  test("fails closed on paired and optional auth credentials before checkout", () => {
+    const preflight = step(
+      "Validate trusted exact-SHA dispatch and protected credentials",
+    );
+    const preflightIndex = job?.steps?.indexOf(preflight) ?? -1;
+    const checkoutIndex =
+      job?.steps?.findIndex((candidate) =>
+        candidate.uses?.startsWith("actions/checkout@"),
+      ) ?? -1;
+    expect(preflightIndex).toBe(0);
+    expect(checkoutIndex).toBeGreaterThan(preflightIndex);
+    for (const name of [
+      "CEREBRAS_API_KEY",
+      "ELIZAOS_CLOUD_API_KEY",
+      "ELIZA_STAGING_SUSPENDED_API_KEY",
+      "INFERENCE_AUTH_PROBE_TOKEN",
+      "CLOUDFLARE_API_TOKEN",
+      "CLOUDFLARE_ACCOUNT_ID",
+    ]) {
+      expect(preflight.run).toContain(name);
+      expect(job?.env?.[name]).toContain(`secrets.${name}`);
+    }
+  });
+
+  test("runs the bounded orchestrator and never selects arbitrary checkout bytes", () => {
+    const checkout = job?.steps?.find((candidate) =>
+      candidate.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout?.with?.["persist-credentials"]).toBe(false);
+    expect(checkout?.with?.ref).toBeUndefined();
+    const run = step("Run exact-SHA privacy-safe latency certification").run;
+    expect(run).toContain(
+      "node packages/cloud/scripts/cloud-latency-certification.mjs",
+    );
+    expect(run).toContain('--deploy-sha "$EXPECTED_DEPLOY_SHA"');
+    expect(run).toContain("args+=(--auth)");
+    expect(run).not.toContain("wrangler tail");
+  });
+
+  test("uploads only explicitly sanitized evidence and never raw Tail material", () => {
+    const cleanup = step("Remove private Worker Tail material");
+    expect(cleanup.run).toContain(
+      'private_tail_directories=("$RUNNER_TEMP"/eliza-inference-auth-tail-*)',
+    );
+    expect(cleanup.run).toContain('rm -rf -- "$directory"');
+    expect(job?.steps?.indexOf(cleanup)).toBeLessThan(
+      job?.steps?.indexOf(step("Upload sanitized certification evidence")) ??
+        -1,
+    );
+    const upload = step("Upload sanitized certification evidence");
+    expect(upload.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    const paths = String(upload.with?.path ?? "");
+    expect(paths).toContain("paired.jsonl");
+    expect(paths).toContain("inference-auth.jsonl");
+    expect(paths).toContain("inference-auth-worker.jsonl");
+    expect(paths).toContain("summary.json");
+    expect(paths).not.toContain("raw");
+    expect(paths).not.toContain("stderr");
+    expect(paths).not.toContain("RUNNER_TEMP");
+    expect(source).not.toContain("tee ");
+  });
+});


### PR DESCRIPTION
Closes #30041

## Summary

- add a manual-only, protected-staging latency certification workflow pinned to the exact deployed `develop` commit
- require 44 paired direct-Cerebras/gateway records with successful transport and matching deployment proof
- optionally certify inference-auth cache hit, miss, and bad-standing behavior, failing closed unless every protected credential is present
- keep raw Cloudflare Tail data in a mode-0600 temporary directory, upload only sanitized correlation evidence, and guarantee teardown/deletion
- publish `INFERENCE_AUTH_PROBE_TOKEN` to the Worker only for staging, preserving the existing binding when the protected value is absent

## Verification

- `bun run verify` (375/375 Turbo tasks plus repository audits)
- `bun run verify:cloud` (84/84)
- `node --test packages/cloud/scripts/cloud-latency-certification.test.mjs packages/cloud/scripts/inference-auth-latency.test.mjs packages/cloud/scripts/chat-latency.test.mjs` (36/36)
- `bun test packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts` (11/11)
- related workflow/action-pin/Bun-version contract suite (93/93)
- pinned `actionlint` on both touched workflows
- `node packages/scripts/workflow-trigger-policy.mjs`
- `bun run check:agents-claude`
- `bun run audit:tee-secret-leak`
- Biome on all changed code/test files
- `git diff --check`

## Operational boundary

The auth lane intentionally cannot run until environment owners add both `INFERENCE_AUTH_PROBE_TOKEN` and `ELIZA_STAGING_SUSPENDED_API_KEY` to the protected `staging` GitHub environment. This PR does not set secrets, create or suspend QA users, deploy, or merge.
