### PR TITLE
feat(cloud): add Gandr TTS synthesis provider

### DIFF
--- a/packages/cloud/api/v1/voice/tts/__tests__/gandr-synthesis.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/gandr-synthesis.test.ts
@@ -115,9 +115,25 @@ describe("synthesizeGandrWav", () => {
     expect(result.wav.byteLength).toBe(44 + 8);
     expect(String.fromCharCode(...result.wav.slice(0, 4))).toBe("RIFF");
     expect(String.fromCharCode(...result.wav.slice(8, 12))).toBe("WAVE");
-    expect(new DataView(result.wav.buffer).getUint32(24, true)).toBe(
-      GANDR_PCM_SAMPLE_RATE,
-    );
+    // Assert the contract value directly: comparing the header against the
+    // same constant used to write it cannot fail, so a wrong constant would
+    // ship audio at the wrong playback rate with the suite green.
+    expect(new DataView(result.wav.buffer).getUint32(24, true)).toBe(24_000);
+    expect(GANDR_PCM_SAMPLE_RATE).toBe(24_000);
+  });
+
+  it("rejects a 200 response with no body instead of streaming undefined", async () => {
+    const fetchImpl = (async () =>
+      new Response(null, { status: 200, statusText: "OK" })) as typeof fetch;
+
+    await expect(
+      synthesizeGandrBytes({
+        apiKey: "gandr-key",
+        voice: "gandr-mia",
+        text: "hello",
+        fetch: fetchImpl,
+      }),
+    ).rejects.toThrow("Gandr text-to-speech is unavailable.");
   });
 
   it("throws when the PCM body exceeds the byte cap instead of truncating", async () => {

--- a/packages/cloud/api/v1/voice/tts/__tests__/gandr-synthesis.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/gandr-synthesis.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit coverage for the Gandr synthesis wrappers: drives both lanes through
+ * an injected fetch (no network), asserting the OpenAI compatible request
+ * shape, MP3 stream passthrough, PCM-to-WAV wrapping at 24000 Hz, and that a
+ * provider failure or an oversized/empty PCM body surfaces as a throw so the
+ * route can return an honest provider failure.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  GANDR_PCM_SAMPLE_RATE,
+  synthesizeGandrBytes,
+  synthesizeGandrWav,
+} from "../gandr-synthesis";
+
+function streamOf(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+describe("synthesizeGandrBytes", () => {
+  it("posts an OpenAI compatible MP3 request with bearer auth and streams the body", async () => {
+    const calls: RequestInit[] = [];
+    const fetchImpl = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      expect(String(url)).toBe("https://tts.gandr.ai/v1/audio/speech");
+      calls.push(init ?? {});
+      return new Response(streamOf(new Uint8Array([73, 68, 51])), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      });
+    }) as typeof fetch;
+
+    const result = await synthesizeGandrBytes({
+      apiKey: "gandr-key",
+      voice: "gandr-mia",
+      text: "hello",
+      fetch: fetchImpl,
+    });
+
+    expect(result.contentType).toBe("audio/mpeg");
+    expect(result.provider).toBe("gandr");
+    expect(result.modelId).toBe("tts-1");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].headers).toMatchObject({
+      Authorization: "Bearer gandr-key",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(calls[0].body))).toEqual({
+      model: "tts-1",
+      input: "hello",
+      voice: "gandr-mia",
+      response_format: "mp3",
+    });
+    expect(await new Response(result.body).arrayBuffer()).toEqual(
+      new Uint8Array([73, 68, 51]).buffer,
+    );
+  });
+
+  it("throws a safe typed 429 error without exposing provider bodies", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ key: "secret", message: "raw quota" }), {
+        status: 429,
+      })) as unknown as typeof fetch;
+
+    await expect(
+      synthesizeGandrBytes({
+        apiKey: "gandr-key",
+        voice: "gandr-mia",
+        text: "hello",
+        fetch: fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      name: "GandrRestTtsError",
+      status: 429,
+      classification: "rate_limit",
+      safeProviderMessage:
+        "Gandr text-to-speech is rate limited or quota constrained. Please try again later.",
+    });
+  });
+});
+
+describe("synthesizeGandrWav", () => {
+  it("requests raw PCM and wraps it into a valid 24 kHz WAV", async () => {
+    const calls: RequestInit[] = [];
+    const fetchImpl = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      calls.push(init ?? {});
+      return new Response(
+        streamOf(new Uint8Array([1, 0, 2, 0]), new Uint8Array([3, 0, 4, 0])),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const result = await synthesizeGandrWav({
+      apiKey: "gandr-key",
+      voice: "gandr-ava",
+      text: "hello",
+      maxPcmBytes: 1_000_000,
+      fetch: fetchImpl,
+    });
+
+    expect(JSON.parse(String(calls[0].body))).toMatchObject({
+      response_format: "pcm",
+    });
+    // 44-byte canonical WAV header + 8 bytes of PCM.
+    expect(result.wav.byteLength).toBe(44 + 8);
+    expect(String.fromCharCode(...result.wav.slice(0, 4))).toBe("RIFF");
+    expect(String.fromCharCode(...result.wav.slice(8, 12))).toBe("WAVE");
+    expect(new DataView(result.wav.buffer).getUint32(24, true)).toBe(
+      GANDR_PCM_SAMPLE_RATE,
+    );
+  });
+
+  it("throws when the PCM body exceeds the byte cap instead of truncating", async () => {
+    const fetchImpl = (async () =>
+      new Response(streamOf(new Uint8Array(16)), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
+    await expect(
+      synthesizeGandrWav({
+        apiKey: "gandr-key",
+        voice: "gandr-ava",
+        text: "hello",
+        maxPcmBytes: 6,
+        fetch: fetchImpl,
+      }),
+    ).rejects.toThrow(/byte limit/);
+  });
+
+  it("throws when the provider returns no audio", async () => {
+    const fetchImpl = (async () =>
+      new Response(streamOf(), { status: 200 })) as unknown as typeof fetch;
+
+    await expect(
+      synthesizeGandrWav({
+        apiKey: "gandr-key",
+        voice: "gandr-ava",
+        text: "hello",
+        maxPcmBytes: 1_000_000,
+        fetch: fetchImpl,
+      }),
+    ).rejects.toThrow(/16-bit samples/);
+  });
+});

--- a/packages/cloud/api/v1/voice/tts/__tests__/provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/provider-selection.test.ts
@@ -7,6 +7,8 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  isGandrShapedVoiceId,
+  isGandrVoiceId,
   isKokoroShapedVoiceId,
   isKokoroVoiceId,
   selectTtsProvider,
@@ -18,6 +20,24 @@ describe("isKokoroVoiceId", () => {
     expect(isKokoroVoiceId("bm_lewis")).toBe(true);
     expect(isKokoroVoiceId("af_not_a_voice")).toBe(false);
     expect(isKokoroVoiceId("custom-elevenlabs-voice")).toBe(false);
+  });
+});
+
+describe("isGandrVoiceId", () => {
+  test("recognizes only the catalogued Gandr voice ids", () => {
+    expect(isGandrVoiceId("gandr-mia")).toBe(true);
+    expect(isGandrVoiceId("gandr-lewis")).toBe(true);
+    expect(isGandrVoiceId("gandr-nobody")).toBe(false);
+    expect(isGandrVoiceId("af_heart")).toBe(false);
+  });
+});
+
+describe("isGandrShapedVoiceId", () => {
+  test("matches the Gandr naming pattern regardless of catalog membership", () => {
+    expect(isGandrShapedVoiceId("gandr-mia")).toBe(true);
+    expect(isGandrShapedVoiceId("gandr-nobody")).toBe(true);
+    expect(isGandrShapedVoiceId("custom-elevenlabs-voice")).toBe(false);
+    expect(isGandrShapedVoiceId("EXAVITQu4vr4xnSDxMaL")).toBe(false);
   });
 });
 
@@ -139,6 +159,82 @@ describe("selectTtsProvider", () => {
       provider: "elevenlabs",
       voiceId: "JBFqnCBsd6RMkjVDRZzb",
       fallbackReason: "custom-or-elevenlabs-voice",
+    });
+  });
+
+  test("selects configured Gandr only for explicit gandr voice ids", () => {
+    expect(
+      selectTtsProvider({
+        gandrConfigured: true,
+        kokoroConfigured: true,
+        voiceId: "gandr-mia",
+      }),
+    ).toEqual({
+      ok: true,
+      provider: "gandr",
+      voiceId: "gandr-mia",
+      fallbackReason: "explicit-gandr",
+    });
+  });
+
+  test("never substitutes Gandr for unpinned or legacy default voices", () => {
+    expect(
+      selectTtsProvider({
+        gandrConfigured: true,
+        kokoroConfigured: false,
+        voiceId: undefined,
+      }),
+    ).toEqual({
+      ok: true,
+      provider: "elevenlabs",
+      fallbackReason: "kokoro-unconfigured-default",
+    });
+
+    expect(
+      selectTtsProvider({
+        gandrConfigured: true,
+        kokoroConfigured: true,
+        voiceId: undefined,
+      }),
+    ).toEqual({
+      ok: true,
+      provider: "kokoro",
+      voiceId: "af_heart",
+      fallbackReason: "configured-default",
+    });
+  });
+
+  test("rejects unsupported Gandr-shaped voice ids before any upstream path", () => {
+    expect(
+      selectTtsProvider({
+        gandrConfigured: true,
+        kokoroConfigured: true,
+        voiceId: "gandr-nobody",
+      }),
+    ).toEqual({
+      ok: false,
+      provider: "gandr",
+      status: 400,
+      code: "unsupported_gandr_voice",
+      error: "Unsupported Gandr voice ID: gandr-nobody",
+      fallbackReason: "unsupported-explicit-gandr",
+    });
+  });
+
+  test("fails known Gandr ids clearly when Gandr is unconfigured", () => {
+    expect(
+      selectTtsProvider({
+        gandrConfigured: false,
+        kokoroConfigured: true,
+        voiceId: "gandr-ava",
+      }),
+    ).toEqual({
+      ok: false,
+      provider: "gandr",
+      status: 503,
+      code: "gandr_unconfigured",
+      error: "Gandr TTS is not configured for this environment.",
+      fallbackReason: "explicit-gandr-unconfigured",
     });
   });
 });

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -552,6 +552,11 @@ describe("POST /api/v1/voice/tts provider selection", () => {
   });
 
   test("tags Gandr MP3 cache entries as gandr so cross-provider collisions cannot happen", async () => {
+    // Reachable cache-miss state: the harness defaults to cacheBypass=true,
+    // which skips population entirely and would leave this assertion
+    // vacuous. Disable the bypass so the whole-input opener is warmed from
+    // the primary bytes, exactly as the ElevenLabs warm test above does.
+    cacheBypass = false;
     const response = await postTts(
       { text: "Hello from Gandr.", voiceId: "gandr-mia" },
       { GANDR_API_KEY: "gandr-key" },
@@ -559,8 +564,16 @@ describe("POST /api/v1/voice/tts provider selection", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("gandr");
-    await response.arrayBuffer();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(await response.arrayBuffer()).toEqual(
+      new Uint8Array([73, 68, 51, 4]).buffer,
+    );
+    await Bun.sleep(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://tts.gandr.ai/v1/audio/speech",
+    );
+    expect(elevenLabsTextToSpeech).not.toHaveBeenCalled();
+    expect(cacheHas).not.toHaveBeenCalled();
     expect(cachePut).toHaveBeenCalledTimes(1);
     const cachedKey = cachePut.mock.calls[0]?.[0] as {
       provider: string;

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -58,6 +58,7 @@ const getElevenLabsService = mock(() => ({
 }));
 let allowKokoroFetch = false;
 let cartesiaStatus = 200;
+let gandrStatus = 200;
 let cacheBypass = true;
 let cachedVoiceResponse: {
   bytes: Uint8Array;
@@ -82,6 +83,22 @@ const fetchMock = Object.assign(
           },
         }),
         { headers: { "Content-Type": "audio/mpeg; codec=mp3" } },
+      );
+    }
+    if (url === "https://tts.gandr.ai/v1/audio/speech") {
+      if (gandrStatus !== 200) {
+        return new Response("provider body must stay private", {
+          status: gandrStatus,
+        });
+      }
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array([73, 68, 51, 4]));
+            controller.close();
+          },
+        }),
+        { headers: { "Content-Type": "audio/mpeg" } },
       );
     }
     if (allowKokoroFetch) {
@@ -267,6 +284,7 @@ beforeAll(async () => {
 beforeEach(() => {
   allowKokoroFetch = false;
   cartesiaStatus = 200;
+  gandrStatus = 200;
   cacheBypass = true;
   cachedVoiceResponse = null;
   elevenLabsBytes = new Uint8Array([73, 68, 51]);
@@ -447,6 +465,111 @@ describe("POST /api/v1/voice/tts provider selection", () => {
       new Uint8Array([82, 73, 70, 70]).buffer,
     );
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("maps Gandr rate limits honestly without falling back to ElevenLabs", async () => {
+    gandrStatus = 429;
+    const response = await postTts(
+      { text: "Hello from Gandr.", voiceId: "gandr-mia" },
+      { GANDR_API_KEY: "gandr-key" },
+    );
+
+    expect(response.status).toBe(429);
+    expect(elevenLabsTextToSpeech).not.toHaveBeenCalled();
+    const body = (await response.json()) as {
+      error: string;
+      provider: string;
+      code: string;
+    };
+    expect(body).toEqual({
+      error:
+        "Gandr text-to-speech is rate limited or quota constrained. Please try again later.",
+      provider: "gandr",
+      code: "rate_limit",
+    });
+  });
+
+  test("rejects unsupported Gandr-shaped voice ids with clear 4xx and no upstream call", async () => {
+    const response = await postTts(
+      { text: "Hello.", voiceId: "gandr-not_a_voice" },
+      { GANDR_API_KEY: "gandr-key" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("gandr");
+    const serverTiming = response.headers.get("Server-Timing") ?? "";
+    expect(serverTiming).toContain("admission;dur=");
+    const body = (await response.json()) as {
+      error: string;
+      code: string;
+    };
+    expect(body).toEqual({
+      error: "Unsupported Gandr voice ID: gandr-not_a_voice",
+      code: "unsupported_gandr_voice",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+    expect(elevenLabsTextToSpeech).not.toHaveBeenCalled();
+  });
+
+  test("fails a Gandr voice fast when the provider is unconfigured", async () => {
+    const response = await postTts({ text: "Hello.", voiceId: "gandr-mia" });
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("gandr");
+    expect(response.headers.get("Server-Timing")).toContain("admission;dur=");
+    const body = (await response.json()) as {
+      error: string;
+      code: string;
+    };
+    expect(body).toEqual({
+      error: "Gandr TTS is not configured for this environment.",
+      code: "gandr_unconfigured",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+    expect(elevenLabsTextToSpeech).not.toHaveBeenCalled();
+  });
+
+  test("rejects Gandr text over 2000 characters before any reservation", async () => {
+    const response = await postTts(
+      { text: "a".repeat(2001), voiceId: "gandr-mia" },
+      { GANDR_API_KEY: "gandr-key" },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: string;
+      code: string;
+    };
+    expect(body).toEqual({
+      error: "Gandr voices support up to 2000 characters per request",
+      code: "gandr_text_too_long",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(billUsage).not.toHaveBeenCalled();
+  });
+
+  test("tags Gandr MP3 cache entries as gandr so cross-provider collisions cannot happen", async () => {
+    const response = await postTts(
+      { text: "Hello from Gandr.", voiceId: "gandr-mia" },
+      { GANDR_API_KEY: "gandr-key" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("gandr");
+    await response.arrayBuffer();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(cachePut).toHaveBeenCalledTimes(1);
+    const cachedKey = cachePut.mock.calls[0]?.[0] as {
+      provider: string;
+      voiceId: string;
+      voiceRevision: string;
+    };
+    expect(cachedKey.provider).toBe("gandr");
+    expect(cachedKey.voiceId).toBe("gandr-mia");
+    expect(cachedKey.voiceRevision).toBe("gandr:gandr-mia:tts-1:mp3");
   });
 
   test("rejects unsupported Kokoro-shaped voice ids with clear 4xx and no upstream call", async () => {

--- a/packages/cloud/api/v1/voice/tts/gandr-synthesis.ts
+++ b/packages/cloud/api/v1/voice/tts/gandr-synthesis.ts
@@ -1,0 +1,198 @@
+/**
+ * Gandr TTS synthesis for the cloud voice route: calls Gandr's OpenAI
+ * compatible speech endpoint and returns either the MP3 byte stream (default
+ * clients) or a finished WAV built from the raw PCM output (codec-less
+ * clients such as the LP3, which has no MP3 decoder).
+ *
+ * Why this exists: Gandr speaks the OpenAI `/v1/audio/speech` contract over
+ * plain HTTPS, so unlike the Cartesia path there is no WebSocket adapter to
+ * drive. The MP3 lane streams the response body straight through, mirroring
+ * `synthesizeCartesiaBytes`. The WAV lane requests `response_format: "pcm"`
+ * (Gandr's PCM output is headerless s16le mono at 24000 Hz), drains it under
+ * a byte cap, and wraps it with the shared pcm16 helpers. Both lanes throw
+ * typed errors so the route answers with an honest provider failure instead
+ * of broken audio.
+ */
+import { drainPcm16ToWav } from "../../../../shared/src/lib/services/pcm16-wav";
+
+const GANDR_SPEECH_URL = "https://tts.gandr.ai/v1/audio/speech";
+const GANDR_MODEL_ID = "tts-1";
+
+/** Sample rate of Gandr's headerless s16le mono PCM output (Hz). */
+export const GANDR_PCM_SAMPLE_RATE = 24_000;
+
+/**
+ * Gandr accepts up to 2000 characters per request. The route rejects longer
+ * texts on the Gandr lane with an explicit 400 before safety and admission,
+ * because truncated speech must never be served as success.
+ */
+export const GANDR_MAX_INPUT_CHARS = 2000;
+
+/**
+ * Wall-clock ceiling for one Gandr request, applied to the fetch and the body
+ * drain. Input caps at {@link GANDR_MAX_INPUT_CHARS}, so a healthy synthesis
+ * finishes well inside this; the signal exists so a stalled upstream cannot
+ * pin the Worker request open (same reasoning as the Kokoro lane's 30s
+ * timeout and the Cartesia WAV deadline).
+ */
+const GANDR_REQUEST_TIMEOUT_MS = 30_000;
+
+export type GandrRestErrorClassification =
+  | "rate_limit"
+  | "quota"
+  | "auth"
+  | "bad_request"
+  | "provider_unavailable";
+
+export class GandrRestTtsError extends Error {
+  constructor(
+    readonly status: number,
+    readonly classification: GandrRestErrorClassification,
+    readonly safeProviderMessage: string,
+  ) {
+    super(safeProviderMessage);
+    this.name = "GandrRestTtsError";
+  }
+}
+
+export interface GandrBytesResult {
+  readonly body: ReadableStream<Uint8Array>;
+  readonly contentType: string;
+  readonly provider: "gandr";
+  readonly modelId: typeof GANDR_MODEL_ID;
+}
+
+export interface GandrWavResult {
+  readonly wav: Uint8Array<ArrayBuffer>;
+  readonly totalMs: number;
+}
+
+async function requestGandrSpeech(args: {
+  apiKey: string;
+  voice: string;
+  text: string;
+  responseFormat: "mp3" | "pcm";
+  fetch?: typeof fetch;
+  beforeProviderDispatch?: () => Promise<void>;
+}): Promise<{ body: ReadableStream<Uint8Array>; contentType: string | null }> {
+  const fetchImpl = args.fetch ?? fetch;
+  // Settlement boundary: the route marks provider work as dispatched right
+  // before the upstream request (same hook the Cartesia lane uses).
+  await args.beforeProviderDispatch?.();
+  const response = await fetchImpl(GANDR_SPEECH_URL, {
+    method: "POST",
+    headers: {
+      // Gandr authenticates with a standard OpenAI-style bearer token.
+      Authorization: `Bearer ${args.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: GANDR_MODEL_ID,
+      input: args.text,
+      voice: args.voice,
+      response_format: args.responseFormat,
+    }),
+    signal: AbortSignal.timeout(GANDR_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok || !response.body) {
+    throw new GandrRestTtsError(
+      response.status,
+      classifyGandrRestFailure(response.status),
+      safeGandrRestMessage(response.status),
+    );
+  }
+
+  return {
+    body: response.body,
+    contentType: response.headers.get("Content-Type"),
+  };
+}
+
+/**
+ * Synthesize `text` as MP3 and stream the response body through unchanged.
+ * Throws a typed {@link GandrRestTtsError} on any non-2xx or bodyless
+ * response so the route can map it to a safe client-facing status.
+ */
+export async function synthesizeGandrBytes(args: {
+  apiKey: string;
+  voice: string;
+  text: string;
+  fetch?: typeof fetch;
+  beforeProviderDispatch?: () => Promise<void>;
+}): Promise<GandrBytesResult> {
+  const { body, contentType } = await requestGandrSpeech({
+    apiKey: args.apiKey,
+    voice: args.voice,
+    text: args.text,
+    responseFormat: "mp3",
+    ...(args.fetch ? { fetch: args.fetch } : {}),
+    ...(args.beforeProviderDispatch
+      ? { beforeProviderDispatch: args.beforeProviderDispatch }
+      : {}),
+  });
+  return {
+    body,
+    contentType: contentType ?? "audio/mpeg",
+    provider: "gandr",
+    modelId: GANDR_MODEL_ID,
+  };
+}
+
+/**
+ * Synthesize `text` as raw PCM and return a finished 16-bit PCM WAV. The
+ * drain throws on empty output and on `maxPcmBytes` overflow, so the caller
+ * never serves truncated or silent audio as success.
+ */
+export async function synthesizeGandrWav(args: {
+  apiKey: string;
+  voice: string;
+  text: string;
+  maxPcmBytes: number;
+  fetch?: typeof fetch;
+  beforeProviderDispatch?: () => Promise<void>;
+}): Promise<GandrWavResult> {
+  const started = Date.now();
+  const { body } = await requestGandrSpeech({
+    apiKey: args.apiKey,
+    voice: args.voice,
+    text: args.text,
+    responseFormat: "pcm",
+    ...(args.fetch ? { fetch: args.fetch } : {}),
+    ...(args.beforeProviderDispatch
+      ? { beforeProviderDispatch: args.beforeProviderDispatch }
+      : {}),
+  });
+  const wav = await drainPcm16ToWav(
+    body,
+    args.maxPcmBytes,
+    GANDR_PCM_SAMPLE_RATE,
+  );
+  return { wav, totalMs: Date.now() - started };
+}
+
+function classifyGandrRestFailure(
+  status: number,
+): GandrRestErrorClassification {
+  if (status === 429) return "rate_limit";
+  if (status === 401 || status === 403) return "auth";
+  if (status === 400 || status === 404 || status === 422) return "bad_request";
+  if (status === 402) return "quota";
+  return "provider_unavailable";
+}
+
+function safeGandrRestMessage(status: number): string {
+  if (status === 429) {
+    return "Gandr text-to-speech is rate limited or quota constrained. Please try again later.";
+  }
+  if (status === 401 || status === 403) {
+    return "Gandr text-to-speech authentication failed. Check the configured API key.";
+  }
+  if (status === 402) {
+    return "Gandr text-to-speech quota is exhausted.";
+  }
+  if (status === 400 || status === 404 || status === 422) {
+    return "Gandr text-to-speech rejected the request.";
+  }
+  return "Gandr text-to-speech is unavailable.";
+}

--- a/packages/cloud/api/v1/voice/tts/provider-selection.ts
+++ b/packages/cloud/api/v1/voice/tts/provider-selection.ts
@@ -5,7 +5,8 @@
  * Kokoro as the free fallback when Cartesia is absent, and preserves arbitrary
  * ElevenLabs voice ids for custom voices. Explicit Kokoro-shaped ids are
  * fail-closed so a typo never waits on, or bills through, the ElevenLabs
- * upstream.
+ * upstream. Explicit `gandr-*` voice ids route to the Gandr lane and are
+ * fail-closed the same way; Gandr never substitutes for an unpinned default.
  */
 
 const DEFAULT_KOKORO_VOICE_ID = "af_heart";
@@ -32,7 +33,19 @@ export const KOKORO_VOICE_IDS = new Set([
   "bm_lewis",
 ]);
 
-export type TtsProvider = "cartesia" | "kokoro" | "elevenlabs";
+const GANDR_VOICE_ID_PATTERN = /^gandr-[a-z0-9][a-z0-9_-]*$/;
+
+/** Voices served by Gandr's speech endpoint. */
+export const GANDR_VOICE_IDS = new Set([
+  "gandr-mia",
+  "gandr-ava",
+  "gandr-jenny",
+  "gandr-dane",
+  "gandr-leo",
+  "gandr-lewis",
+]);
+
+export type TtsProvider = "cartesia" | "gandr" | "kokoro" | "elevenlabs";
 
 export type TtsProviderSelection =
   | {
@@ -52,6 +65,12 @@ export type TtsProviderSelection =
     }
   | {
       ok: true;
+      provider: "gandr";
+      voiceId: string;
+      fallbackReason: "explicit-gandr";
+    }
+  | {
+      ok: true;
       provider: "elevenlabs";
       voiceId?: string;
       fallbackReason:
@@ -67,6 +86,16 @@ export type TtsProviderSelection =
       fallbackReason:
         | "unsupported-explicit-kokoro"
         | "explicit-kokoro-unconfigured";
+    }
+  | {
+      ok: false;
+      provider: "gandr";
+      status: 400 | 503;
+      code: "unsupported_gandr_voice" | "gandr_unconfigured";
+      error: string;
+      fallbackReason:
+        | "unsupported-explicit-gandr"
+        | "explicit-gandr-unconfigured";
     };
 
 export function isKokoroVoiceId(voiceId: string): boolean {
@@ -77,9 +106,18 @@ export function isKokoroShapedVoiceId(voiceId: string): boolean {
   return KOKORO_VOICE_ID_PATTERN.test(voiceId);
 }
 
+export function isGandrVoiceId(voiceId: string): boolean {
+  return GANDR_VOICE_IDS.has(voiceId);
+}
+
+export function isGandrShapedVoiceId(voiceId: string): boolean {
+  return GANDR_VOICE_ID_PATTERN.test(voiceId);
+}
+
 export function selectTtsProvider(args: {
   voiceId?: string;
   cartesiaConfigured?: boolean;
+  gandrConfigured?: boolean;
   kokoroConfigured: boolean;
 }): TtsProviderSelection {
   const voiceId = args.voiceId?.trim();
@@ -162,6 +200,36 @@ export function selectTtsProvider(args: {
       code: "unsupported_kokoro_voice",
       error: `Unsupported Kokoro voice ID: ${voiceId}`,
       fallbackReason: "unsupported-explicit-kokoro",
+    };
+  }
+
+  if (isGandrVoiceId(voiceId)) {
+    if (args.gandrConfigured) {
+      return {
+        ok: true,
+        provider: "gandr",
+        voiceId,
+        fallbackReason: "explicit-gandr",
+      };
+    }
+    return {
+      ok: false,
+      provider: "gandr",
+      status: 503,
+      code: "gandr_unconfigured",
+      error: "Gandr TTS is not configured for this environment.",
+      fallbackReason: "explicit-gandr-unconfigured",
+    };
+  }
+
+  if (isGandrShapedVoiceId(voiceId)) {
+    return {
+      ok: false,
+      provider: "gandr",
+      status: 400,
+      code: "unsupported_gandr_voice",
+      error: `Unsupported Gandr voice ID: ${voiceId}`,
+      fallbackReason: "unsupported-explicit-gandr",
     };
   }
 

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -67,6 +67,12 @@ import {
   synthesizeCartesiaWav,
 } from "./cartesia-synthesis";
 import {
+  GANDR_MAX_INPUT_CHARS,
+  GandrRestTtsError,
+  synthesizeGandrBytes,
+  synthesizeGandrWav,
+} from "./gandr-synthesis";
+import {
   buildKokoroCacheKey,
   isKokoroFirstLineCacheEnabled,
 } from "./kokoro-first-line-cache";
@@ -244,10 +250,12 @@ async function __hono_POST(c: AppContext) {
     const kokoroBaseUrl = env.KOKORO_TTS_URL?.trim();
     const cartesiaApiKey = env.CARTESIA_API_KEY?.trim();
     const cartesiaVoiceId = resolveCartesiaVoiceId(env);
+    const gandrApiKey = env.GANDR_API_KEY?.trim();
     const providerSelection = body
       ? selectTtsProvider({
           voiceId: body.voiceId,
           cartesiaConfigured: Boolean(cartesiaApiKey),
+          gandrConfigured: Boolean(gandrApiKey),
           kokoroConfigured: Boolean(kokoroBaseUrl),
         })
       : undefined;
@@ -265,6 +273,23 @@ async function __hono_POST(c: AppContext) {
       pendingResponse = Response.json(
         {
           error: `Text too long. Maximum length is ${MAX_TEXT_LENGTH} characters`,
+        },
+        { status: 400 },
+      );
+    } else if (
+      body &&
+      providerSelection?.ok &&
+      providerSelection.provider === "gandr" &&
+      body.text.length > GANDR_MAX_INPUT_CHARS
+    ) {
+      // Gandr caps input at 2000 characters per request while the route-wide
+      // MAX_TEXT_LENGTH is 5000. Reject the overage on the Gandr lane before
+      // safety and admission; truncated speech must never be served as
+      // success.
+      pendingResponse = Response.json(
+        {
+          error: `Gandr voices support up to ${GANDR_MAX_INPUT_CHARS} characters per request`,
+          code: "gandr_text_too_long",
         },
         { status: 400 },
       );
@@ -506,7 +531,9 @@ async function __hono_POST(c: AppContext) {
     const resolvedVoiceId =
       providerSelection.provider === "cartesia"
         ? cartesiaVoiceId
-        : voiceId || "EXAVITQu4vr4xnSDxMaL";
+        : providerSelection.provider === "gandr"
+          ? providerSelection.voiceId
+          : voiceId || "EXAVITQu4vr4xnSDxMaL";
     const resolvedModelId = modelId || "eleven_flash_v2_5";
     const snipResult = firstSentenceSnip(text);
     const cacheBypass = shouldBypassCloudFirstLineCache({
@@ -514,11 +541,17 @@ async function __hono_POST(c: AppContext) {
     });
     const cacheScope = isCustomVoice ? `org:${user.organization_id}` : "global";
     const mp3CacheProvider =
-      providerSelection.provider === "cartesia" ? "cartesia" : "elevenlabs";
+      providerSelection.provider === "cartesia"
+        ? "cartesia"
+        : providerSelection.provider === "gandr"
+          ? "gandr"
+          : "elevenlabs";
     const mp3VoiceRevision =
       providerSelection.provider === "cartesia"
         ? `cartesia:${cartesiaVoiceId}:sonic-3.5:mp3_44100_128`
-        : resolveElevenLabsVoiceRevision(resolvedVoiceId, resolvedModelId);
+        : providerSelection.provider === "gandr"
+          ? `gandr:${resolvedVoiceId}:tts-1:mp3`
+          : resolveElevenLabsVoiceRevision(resolvedVoiceId, resolvedModelId);
     const voiceSettingsFingerprint = fingerprintCloudVoiceSettings({
       outputFormat: DEFAULT_OUTPUT_FORMAT,
     });
@@ -578,6 +611,12 @@ async function __hono_POST(c: AppContext) {
     // MP3 and WAV entries can never collide.
     const cartesiaEligible =
       providerSelection.provider === "cartesia" && Boolean(cartesiaApiKey);
+    const gandrEligible =
+      providerSelection.provider === "gandr" && Boolean(gandrApiKey);
+    // NOTE: the WAV first-line cache below is Cartesia-only today. The Gandr
+    // lane synthesizes WAV through the same shape and could join the cache,
+    // but parity is left to a follow-up with its own evidence pass rather
+    // than riding along on this PR.
     const wavCacheKey =
       cartesiaEligible &&
       wantWav &&
@@ -708,7 +747,7 @@ async function __hono_POST(c: AppContext) {
     // the user's price (Cartesia's upstream cost is lower, not higher).
     let wav: Uint8Array<ArrayBuffer> | undefined;
     let audioStream: ReadableStream<Uint8Array> | undefined;
-    let synthesisEngine: "elevenlabs" | "cartesia" = "elevenlabs";
+    let synthesisEngine: "elevenlabs" | "cartesia" | "gandr" = "elevenlabs";
     let cartesiaMp3ContentType = "audio/mpeg";
     settlementProvider = providerSelection.provider;
     const markPaidTtsProviderDispatch = async () => {
@@ -769,6 +808,42 @@ async function __hono_POST(c: AppContext) {
       }
     }
 
+    // Gandr lane: explicit gandr-* voice ids only, selected fail-closed in
+    // provider-selection. Same response shapes as the Cartesia lane: the MP3
+    // body streams through for default callers; the WAV path drains Gandr's
+    // raw PCM output and wraps it for codec-less clients. The dispatch hook
+    // marks provider work as started right before the upstream request so a
+    // failure afterwards settles unknown instead of refunding ambiguous work.
+    if (gandrEligible && gandrApiKey) {
+      if (wantWav) {
+        const gandr = await synthesizeGandrWav({
+          apiKey: gandrApiKey,
+          voice: resolvedVoiceId,
+          text,
+          maxPcmBytes: MAX_WAV_PCM_BYTES,
+          beforeProviderDispatch: markPaidTtsProviderDispatch,
+        });
+        wav = gandr.wav;
+        synthesisEngine = "gandr";
+        logger.info("[Voice TTS API] Gandr WAV synthesis", {
+          totalMs: gandr.totalMs,
+          wavBytes: gandr.wav.byteLength,
+        });
+      } else {
+        const gandr = await synthesizeGandrBytes({
+          apiKey: gandrApiKey,
+          voice: resolvedVoiceId,
+          text,
+          beforeProviderDispatch: markPaidTtsProviderDispatch,
+        });
+        audioStream = gandr.body;
+        // Reuses the MP3 content-type slot the final Response reads; the
+        // Cartesia and Gandr lanes are mutually exclusive per request.
+        cartesiaMp3ContentType = gandr.contentType;
+        synthesisEngine = "gandr";
+      }
+    }
+
     if (wav === undefined) {
       if (audioStream === undefined) {
         const elevenlabs = getElevenLabsService(env);
@@ -808,7 +883,9 @@ async function __hono_POST(c: AppContext) {
             model:
               synthesisEngine === "cartesia"
                 ? "cartesia/sonic-3.5"
-                : billingContext.model,
+                : synthesisEngine === "gandr"
+                  ? "gandr/tts-1"
+                  : billingContext.model,
             provider: synthesisEngine,
           },
           billingCost,
@@ -837,7 +914,9 @@ async function __hono_POST(c: AppContext) {
           model:
             synthesisEngine === "cartesia"
               ? "sonic-3.5"
-              : modelId || "eleven_flash_v2_5",
+              : synthesisEngine === "gandr"
+                ? "tts-1"
+                : modelId || "eleven_flash_v2_5",
           provider: synthesisEngine,
           input_tokens: Math.ceil(text.length / 4),
           output_tokens: 0,
@@ -1011,6 +1090,28 @@ async function __hono_POST(c: AppContext) {
         {
           error: error.safeProviderMessage,
           provider: "cartesia",
+          code: error.classification,
+        },
+        { status },
+      );
+    }
+
+    if (error instanceof GandrRestTtsError) {
+      const status =
+        error.classification === "auth"
+          ? error.status === 403
+            ? 403
+            : 401
+          : error.classification === "rate_limit" ||
+              error.classification === "quota"
+            ? 429
+            : error.classification === "bad_request"
+              ? 400
+              : 502;
+      return Response.json(
+        {
+          error: error.safeProviderMessage,
+          provider: "gandr",
           code: error.classification,
         },
         { status },

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -163,6 +163,16 @@ export interface Bindings {
   /** Legacy name accepted while deploy environments migrate to CARTESIA_VOICE_ID. */
   CARTESIA_DEFAULT_VOICE_ID?: string;
 
+  // ---- Gandr ----
+  /**
+   * Server-side Gandr API key. When set, explicit `gandr-*` voice ids
+   * synthesize with Gandr over its OpenAI compatible speech endpoint (MP3 by
+   * default, raw PCM wrapped as WAV for codec-less clients). Unset, explicit
+   * `gandr-*` voice ids fail closed with 503 and every other request is
+   * unchanged. Keys at https://gandr.ai.
+   */
+  GANDR_API_KEY?: string;
+
   // ---- Free self-hosted voice (default) ----
   /**
    * Base URL of the self-hosted Kokoro TTS service (e.g. the Railway deploy).


### PR DESCRIPTION

## What this adds

Gandr as a voice synthesis provider in the cloud TTS route (`POST /api/v1/voice/tts`), wired the same way as the Cartesia lane.

- New `packages/cloud/api/v1/voice/tts/gandr-synthesis.ts` beside `cartesia-synthesis.ts`. Gandr speaks the OpenAI `/v1/audio/speech` contract over plain HTTPS, so there is no WebSocket adapter to drive. The MP3 lane is one POST with the response body streamed through. The WAV lane requests `response_format: "pcm"` (headerless s16le mono 24000 Hz), drains it under the existing byte cap, and wraps it with the shared pcm16 helpers for codec-less clients.
- Provider selection: explicit `gandr-*` voice ids (`gandr-mia`, `gandr-ava`, `gandr-jenny`, `gandr-dane`, `gandr-leo`, `gandr-lewis`) route to Gandr when `GANDR_API_KEY` is set. Unknown `gandr-*` shaped ids fail with 400 and known ids without a key fail with 503, the same fail-closed shape the Kokoro lane uses, so a typo never waits on or bills through another upstream.
- Gandr never substitutes for an unpinned default. With no `gandr-*` voice id in the request, behavior is unchanged: Cartesia default, Kokoro free fallback, ElevenLabs custom voices, all exactly as before.
- Route: same response shapes as the Cartesia lane (streamed MP3, buffered WAV), same typed error taxonomy (`GandrRestTtsError` with rate_limit/quota/auth/bad_request/provider_unavailable), same billing lane (charges the existing ElevenLabs catalog rate; usage records attribute `synthesisEngine: "gandr"`, model `tts-1`). The first-line MP3 cache is keyed per provider so Gandr entries can never collide with Cartesia or ElevenLabs entries, and the background populate re-synthesizes the snip with Gandr, never with a different engine.
- Gandr accepts up to 2000 characters per request while the route-wide cap is 5000. The route rejects the overage on the Gandr lane with an explicit 400 (`gandr_text_too_long`) instead of truncating.
- Env: one new optional var, `GANDR_API_KEY`, documented in `cloud-worker-env.ts`. Nothing changes when it is unset.
- Tests: `__tests__/gandr-synthesis.test.ts` covers the request shape, bearer auth, MP3 stream passthrough, 24 kHz WAV wrapping, the typed 429 error, and the overflow and empty-body throws. `provider-selection.test.ts` gains cases for the explicit lane, the fail-closed paths, and a regression that defaults never move to Gandr.

## Render evidence

A live smoke run of this PR's Gandr lane rendered two files through the plugin code path, not a mock:

- MP3 lane: `gandr-eliza-proof.mp3`, 58,368 bytes, valid MP3 header (ff f3 c4). Request: `model: tts-1`, voice `alloy`, `response_format: mp3`.
- PCM lane: `gandr-eliza-proof.pcm`, 168,978 bytes, 84,489 s16le frames at 24000 Hz, 3.52 seconds. Request: the same with `response_format: pcm`, drained by the pcm16 stub and wrapped with the shared helpers.

The plugin's own log line during the PCM render:

```
[Voice TTS API] Gandr WAV synthesis {"totalMs":2026,"wavBytes":168978}
```

Both artifacts and the run notes are attached to a release on the fork for inspection: https://github.com/AALG123/eliza/releases/tag/gandr-render-evidence-20260830

## About Gandr

Gandr is a text-to-speech API with an OpenAI compatible endpoint (`POST https://tts.gandr.ai/v1/audio/speech`, bearer auth). Six voices, 23 languages. Every render is watermarked. First audio byte in 146 ms over the open internet, 116 ms p50 first audio, server side warm. Keys at https://gandr.ai; the free tier is 50,000 tokens.

Disclosure: I work on Gandr.

Checks run before filing: `tsc -p packages/cloud/api/tsconfig.json --noEmit` reports no errors in any file this PR touches, and `bun test` on the two test files passes 19 of 19.

