### PR TITLE
fix(cloud): add safe staging selection re-review operator

### DIFF
--- a/.github/workflows/database-identity-staging-report.yml
+++ b/.github/workflows/database-identity-staging-report.yml
@@ -32,10 +32,14 @@ jobs:
           submodules: false
           persist-credentials: false
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: 1.3.14
+          setup-python: "false"
+          install-protoc: "false"
+          install-native-deps: "false"
+          run-postinstall: "false"
 
       - name: Require exact develop commit
         env:
@@ -51,8 +55,10 @@ jobs:
             if (expected !== checkedOut) process.exit(1);
           '
 
-      - name: Install deterministic dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build required linked runtime
+        run: |
+          bun run --cwd packages/prompts build:package
+          bun run --cwd packages/shared build
 
       - name: Validate identity reporter contracts
         run: bun test packages/cloud/scripts/admin/preflight-database-identity.test.ts packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts

--- a/.github/workflows/personal-dedicated-rereview-staging.yml
+++ b/.github/workflows/personal-dedicated-rereview-staging.yml
@@ -1,0 +1,117 @@
+name: Personal Dedicated stale selection re-review
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Preview first; execute only with its approval digest
+        required: true
+        type: choice
+        options:
+          - preview
+          - execute
+      expected_cloud_commit:
+        description: Exact 40-character commit currently served by staging
+        required: true
+        type: string
+      expected_cluster_sha256:
+        description: Reviewed staging PostgreSQL cluster receipt
+        required: true
+        type: string
+      expected_authority_sha256:
+        description: Reviewed staging PostgreSQL authority receipt
+        required: true
+        type: string
+      approval_digest:
+        description: Identifier-free digest emitted by the prior preview run
+        required: false
+        type: string
+      reviewed_reason:
+        description: Type retain_current_receipt_target_after_duplicate_inventory_review
+        required: false
+        type: string
+      confirmation:
+        description: Type REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  rereview:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: staging
+    concurrency:
+      group: personal-dedicated-rereview-staging
+      cancel-in-progress: false
+    env:
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_STAGING: "1"
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_MODE: ${{ inputs.mode }}
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_EXPECTED_CLOUD_COMMIT: ${{ inputs.expected_cloud_commit }}
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_APPROVAL_DIGEST: ${{ inputs.approval_digest }}
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_REVIEWED_REASON: ${{ inputs.reviewed_reason }}
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_CONFIRMATION: ${{ inputs.confirmation }}
+      DATABASE_IDENTITY_GATE_MODE: enforce
+      DATABASE_IDENTITY_ENVIRONMENT: staging
+      DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ inputs.expected_cluster_sha256 }}
+      DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ inputs.expected_authority_sha256 }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
+
+    steps:
+      - name: Checkout exact workflow commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Require exact develop deployment authority
+        env:
+          EXPECTED_COMMIT: ${{ inputs.expected_cloud_commit }}
+          CHECKED_OUT_COMMIT: ${{ github.sha }}
+          REF_NAME: ${{ github.ref }}
+          MODE: ${{ inputs.mode }}
+          APPROVAL_DIGEST: ${{ inputs.approval_digest }}
+          REVIEWED_REASON: ${{ inputs.reviewed_reason }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          bun -e '
+            const expected = process.env.EXPECTED_COMMIT ?? "";
+            if (process.env.REF_NAME !== "refs/heads/develop") process.exit(1);
+            if (!/^[0-9a-f]{40}$/.test(expected) || expected !== process.env.CHECKED_OUT_COMMIT) process.exit(1);
+            if (process.env.MODE === "execute") {
+              if (!/^[0-9a-f]{64}$/.test(process.env.APPROVAL_DIGEST ?? "")) process.exit(1);
+              if (process.env.REVIEWED_REASON !== "retain_current_receipt_target_after_duplicate_inventory_review") process.exit(1);
+              if (process.env.CONFIRMATION !== "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION") process.exit(1);
+            }
+          '
+
+      - name: Require protected staging authorities
+        run: |
+          bun -e '
+            const required = ["DATABASE_URL", "ELIZAOS_CLOUD_API_KEY", "DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256", "DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256"];
+            if (required.some((name) => !(process.env[name] ?? "").trim())) process.exit(1);
+          '
+
+      - name: Install deterministic dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate operator contracts
+        run: >-
+          bun test
+          packages/cloud/scripts/admin/preflight-database-identity.test.ts
+          packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
+          packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
+
+      - name: Verify protected staging database identity
+        run: bun run packages/cloud/scripts/admin/preflight-database-identity.ts
+
+      - name: Preview or execute exact re-review
+        run: bun run packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts

--- a/.github/workflows/personal-dedicated-rereview-staging.yml
+++ b/.github/workflows/personal-dedicated-rereview-staging.yml
@@ -67,10 +67,14 @@ jobs:
           fetch-depth: 1
           submodules: false
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: 1.3.14
+          setup-python: "false"
+          install-protoc: "false"
+          install-native-deps: "false"
+          run-postinstall: "false"
 
       - name: Require exact develop deployment authority
         env:
@@ -100,8 +104,10 @@ jobs:
             if (required.some((name) => !(process.env[name] ?? "").trim())) process.exit(1);
           '
 
-      - name: Install deterministic dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build required linked runtime
+        run: |
+          bun run --cwd packages/prompts build:package
+          bun run --cwd packages/shared build
 
       - name: Validate operator contracts
         run: >-

--- a/packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts
+++ b/packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts
@@ -78,7 +78,7 @@ describe("database identity staging report workflow", () => {
 
   test("requires the exact develop commit", () => {
     const guard = step("Require exact develop commit");
-    expect(job.steps.indexOf(step("Setup Bun"))).toBeLessThan(
+    expect(job.steps.indexOf(step("Setup Bun workspace"))).toBeLessThan(
       job.steps.indexOf(guard),
     );
     expect(guard.env?.EXPECTED_COMMIT).toBe(
@@ -91,10 +91,20 @@ describe("database identity staging report workflow", () => {
   });
 
   test("runs only contract checks and the read-only reporter", () => {
-    expect(step("Setup Bun").with?.["bun-version"]).toBe("1.3.14");
-    expect(step("Install deterministic dependencies").run).toBe(
-      "bun install --frozen-lockfile --ignore-scripts",
+    const setup = step("Setup Bun workspace");
+    expect(setup.uses).toBe("./.github/actions/setup-bun-workspace");
+    expect(setup.with).toMatchObject({
+      "bun-version": "1.3.14",
+      "setup-python": "false",
+      "install-protoc": "false",
+      "install-native-deps": "false",
+      "run-postinstall": "false",
+    });
+    const linkedBuild = step("Build required linked runtime").run;
+    expect(linkedBuild).toContain(
+      "bun run --cwd packages/prompts build:package",
     );
+    expect(linkedBuild).toContain("bun run --cwd packages/shared build");
     expect(step("Validate identity reporter contracts").run).toContain(
       "preflight-database-identity.test.ts",
     );

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
@@ -79,4 +79,16 @@ describe("personal Dedicated staging re-review workflow", () => {
       job.steps.some((candidate) => candidate.run?.includes("upload-artifact")),
     ).toBe(false);
   });
+
+  test("uses primary database authority for identity and mutation proofs", () => {
+    const command = readFileSync(
+      resolve(
+        repoRoot,
+        "packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts",
+      ),
+      "utf8",
+    );
+    expect(command).not.toContain("dbRead");
+    expect(command.match(/dbWrite/g)?.length).toBeGreaterThanOrEqual(7);
+  });
 });

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
@@ -1,0 +1,82 @@
+/** Verifies the manual workflow that owns the protected staging re-review boundary. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+type Step = {
+  name?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+};
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const workflow = parse(
+  readFileSync(
+    resolve(
+      repoRoot,
+      ".github/workflows/personal-dedicated-rereview-staging.yml",
+    ),
+    "utf8",
+  ),
+) as {
+  on: { workflow_dispatch: { inputs: Record<string, { required: boolean }> } };
+  permissions: Record<string, string>;
+  jobs: {
+    rereview: {
+      environment: string;
+      concurrency: Record<string, unknown>;
+      env: Record<string, string>;
+      steps: Step[];
+    };
+  };
+};
+const job = workflow.jobs.rereview;
+const step = (name: string) => {
+  const found = job.steps.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing workflow step: ${name}`);
+  return found;
+};
+
+describe("personal Dedicated staging re-review workflow", () => {
+  test("is manual, staging protected, serialized, and GitHub read-only", () => {
+    expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(job.environment).toBe("staging");
+    expect(job.concurrency).toEqual({
+      group: "personal-dedicated-rereview-staging",
+      "cancel-in-progress": false,
+    });
+  });
+
+  test("requires exact develop SHA, prior digest, reviewed reason, and confirmation", () => {
+    const guard = step("Require exact develop deployment authority");
+    expect(guard.run).toContain(
+      'process.env.REF_NAME !== "refs/heads/develop"',
+    );
+    expect(guard.run).toContain("expected !== process.env.CHECKED_OUT_COMMIT");
+    expect(guard.run).toContain("APPROVAL_DIGEST");
+    expect(guard.run).toContain(
+      "retain_current_receipt_target_after_duplicate_inventory_review",
+    );
+    expect(guard.run).toContain(
+      "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
+    );
+  });
+
+  test("binds protected identity and smoke account authorities without artifacts", () => {
+    expect(job.env.DATABASE_IDENTITY_GATE_MODE).toBe("enforce");
+    expect(job.env.DATABASE_IDENTITY_ENVIRONMENT).toBe("staging");
+    expect(job.env.DATABASE_URL).toContain("secrets.DATABASE_URL");
+    expect(job.env.ELIZAOS_CLOUD_API_KEY).toContain(
+      "secrets.ELIZAOS_CLOUD_API_KEY",
+    );
+    expect(step("Verify protected staging database identity").run).toContain(
+      "preflight-database-identity.ts",
+    );
+    expect(
+      job.steps.some((candidate) => candidate.run?.includes("upload-artifact")),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
@@ -80,6 +80,23 @@ describe("personal Dedicated staging re-review workflow", () => {
     ).toBe(false);
   });
 
+  test("materializes the linked runtime required by fresh-checkout imports", () => {
+    const setup = step("Setup Bun workspace");
+    expect(setup.uses).toBe("./.github/actions/setup-bun-workspace");
+    expect(setup.with).toMatchObject({
+      "bun-version": "1.3.14",
+      "setup-python": "false",
+      "install-protoc": "false",
+      "install-native-deps": "false",
+      "run-postinstall": "false",
+    });
+    const linkedBuild = step("Build required linked runtime").run;
+    expect(linkedBuild).toContain(
+      "bun run --cwd packages/prompts build:package",
+    );
+    expect(linkedBuild).toContain("bun run --cwd packages/shared build");
+  });
+
   test("uses primary database authority for identity and mutation proofs", () => {
     const command = readFileSync(
       resolve(

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
@@ -1,0 +1,180 @@
+/** Exercises the privacy and execution gates of the staging re-review operator with deterministic dependencies. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  PersonalDedicatedRereviewOperatorError,
+  type RereviewOperatorConfig,
+  type RereviewOperatorDependencies,
+  readRereviewOperatorConfig,
+  runRereviewOperator,
+} from "./personal-dedicated-rereview-staging";
+
+const resolved = {
+  organizationId: "10000000-0000-4000-8000-000000000001",
+  userId: "20000000-0000-4000-8000-000000000002",
+  sourceAgentId: "personal-shared-private-source",
+  retainedAgentId: "30000000-0000-4000-8000-000000000003",
+};
+const preview = {
+  receiptFingerprint: "a".repeat(64),
+  inventoryFingerprint: "b".repeat(64),
+  stateDisposition: "fresh_boot_no_verified_backup" as const,
+  candidateCount: 2,
+  replacesTarget: false,
+};
+const snapshot = {
+  agentCount: 2,
+  agentDigest: "c".repeat(64),
+  jobCount: 0,
+  jobDigest: "d".repeat(64),
+};
+
+function config(mode: "preview" | "execute"): RereviewOperatorConfig {
+  return {
+    mode,
+    apiKey: "eliza_private_smoke_key",
+    expectedCloudCommit: "e".repeat(40),
+  };
+}
+
+function dependencies(overrides: Partial<RereviewOperatorDependencies> = {}) {
+  let executeCalls = 0;
+  const value: RereviewOperatorDependencies = {
+    verifyDeployment: async () => {},
+    resolveSelection: async () => resolved,
+    preview: async () => preview,
+    execute: async () => {
+      executeCalls += 1;
+    },
+    snapshot: async () => snapshot,
+    ...overrides,
+  };
+  return { value, executeCalls: () => executeCalls };
+}
+
+describe("personal Dedicated staging re-review operator", () => {
+  test("returns identifier-free preview evidence and does not execute", async () => {
+    const deps = dependencies();
+    const result = await runRereviewOperator(config("preview"), deps.value);
+    const serialized = JSON.stringify(result);
+
+    expect(result).toMatchObject({
+      mode: "preview",
+      identityResolved: true,
+      candidateCount: 2,
+      computeMutation: false,
+      executed: false,
+    });
+    expect(result.approvalDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(deps.executeCalls()).toBe(0);
+    for (const privateValue of [
+      ...Object.values(resolved),
+      preview.receiptFingerprint,
+      preview.inventoryFingerprint,
+      config("preview").apiKey,
+    ]) {
+      expect(serialized).not.toContain(privateValue);
+    }
+  });
+
+  test("requires the prior exact preview digest and reviewed confirmation", async () => {
+    const deps = dependencies();
+    const prior = await runRereviewOperator(config("preview"), deps.value);
+    const executeConfig = {
+      ...config("execute"),
+      approvalDigest: prior.approvalDigest,
+      confirmation: "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
+      reviewedReason:
+        "retain_current_receipt_target_after_duplicate_inventory_review",
+    };
+
+    const result = await runRereviewOperator(executeConfig, deps.value);
+    expect(result.executed).toBe(true);
+    expect(deps.executeCalls()).toBe(1);
+
+    await expect(
+      runRereviewOperator(
+        { ...executeConfig, approvalDigest: "f".repeat(64) },
+        deps.value,
+      ),
+    ).rejects.toMatchObject({ code: "stale_or_wrong_approval_digest" });
+    await expect(
+      runRereviewOperator(
+        { ...executeConfig, confirmation: "yes" },
+        deps.value,
+      ),
+    ).rejects.toMatchObject({ code: "exact_confirmation_required" });
+  });
+
+  test("binds approval to current inventory and refuses compute or job drift", async () => {
+    const first = dependencies();
+    const prior = await runRereviewOperator(config("preview"), first.value);
+    const driftedPreview = dependencies({
+      preview: async () => ({ ...preview, candidateCount: 3 }),
+    });
+    await expect(
+      runRereviewOperator(
+        {
+          ...config("execute"),
+          approvalDigest: prior.approvalDigest,
+          confirmation: "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
+          reviewedReason:
+            "retain_current_receipt_target_after_duplicate_inventory_review",
+        },
+        driftedPreview.value,
+      ),
+    ).rejects.toMatchObject({ code: "stale_or_wrong_approval_digest" });
+
+    let snapshots = 0;
+    const mutation = dependencies({
+      snapshot: async () => {
+        snapshots += 1;
+        return snapshots === 1 ? snapshot : { ...snapshot, jobCount: 1 };
+      },
+    });
+    await expect(
+      runRereviewOperator(config("preview"), mutation.value),
+    ).rejects.toMatchObject({
+      code: "compute_or_job_state_changed",
+    });
+  });
+
+  test("rejects deployment mismatch before resolving account identity", async () => {
+    let resolvedAccount = false;
+    const deps = dependencies({
+      verifyDeployment: async () => {
+        throw new PersonalDedicatedRereviewOperatorError(
+          "staging_deploy_commit_mismatch",
+        );
+      },
+      resolveSelection: async () => {
+        resolvedAccount = true;
+        return resolved;
+      },
+    });
+    await expect(
+      runRereviewOperator(config("preview"), deps.value),
+    ).rejects.toMatchObject({
+      code: "staging_deploy_commit_mismatch",
+    });
+    expect(resolvedAccount).toBe(false);
+  });
+
+  test("requires explicit staging opt-in and validates execute authority inputs", () => {
+    expect(() => readRereviewOperatorConfig({})).toThrow(
+      "explicit_staging_opt_in_required",
+    );
+    const parsed = readRereviewOperatorConfig({
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_STAGING: "1",
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_MODE: "execute",
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_EXPECTED_CLOUD_COMMIT: "e".repeat(40),
+      ELIZAOS_CLOUD_API_KEY: "private",
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_APPROVAL_DIGEST: "a".repeat(64),
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_CONFIRMATION:
+        "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
+      ELIZA_PERSONAL_DEDICATED_REREVIEW_REVIEWED_REASON:
+        "retain_current_receipt_target_after_duplicate_inventory_review",
+    });
+    expect(parsed.mode).toBe("execute");
+  });
+});

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
@@ -264,7 +264,7 @@ async function defaultResolveSelection(
 ): Promise<ResolvedSelection> {
   const [
     { and, eq, isNull },
-    { dbRead },
+    { dbWrite },
     { apiKeys },
     { users },
     selectionSchema,
@@ -284,7 +284,9 @@ async function defaultResolveSelection(
   const { personalDedicatedAdoptionSelections } = selectionSchema;
   const { personalSharedAgentId } = shared;
   const keyHash = createHash("sha256").update(apiKey).digest("hex");
-  const keyRows = await dbRead
+  // Identity and receipt resolution are execution authority. A replica can
+  // lag key revocation or receipt replacement, so every read uses primary.
+  const keyRows = await dbWrite
     .select()
     .from(apiKeys)
     .where(
@@ -301,7 +303,7 @@ async function defaultResolveSelection(
   if (key.expires_at && key.expires_at <= new Date()) {
     throw new PersonalDedicatedRereviewOperatorError("smoke_key_expired");
   }
-  const ownerRows = await dbRead
+  const ownerRows = await dbWrite
     .select({ id: users.id, organizationId: users.organization_id })
     .from(users)
     .where(
@@ -324,7 +326,7 @@ async function defaultResolveSelection(
     organizationId: owner.organizationId,
     userId: owner.id,
   });
-  const receipts = await dbRead
+  const receipts = await dbWrite
     .select({
       retainedAgentId: personalDedicatedAdoptionSelections.dedicated_agent_id,
     })
@@ -357,7 +359,7 @@ async function defaultResolveSelection(
 async function defaultSnapshot(
   input: ResolvedSelection,
 ): Promise<MutationSnapshot> {
-  const [{ and, eq }, { dbRead }, sandboxSchema, jobsSchema] =
+  const [{ and, eq }, { dbWrite }, sandboxSchema, jobsSchema] =
     await Promise.all([
       import("drizzle-orm"),
       import("@elizaos/cloud-shared/db/client"),
@@ -366,7 +368,9 @@ async function defaultSnapshot(
     ]);
   const { agentSandboxes } = sandboxSchema;
   const { jobs } = jobsSchema;
-  const agentRows = await dbRead
+  // These digests claim exact pre/post mutation proof, so replica freshness is
+  // not an acceptable authority even though both queries are read-only.
+  const agentRows = await dbWrite
     .select()
     .from(agentSandboxes)
     .where(
@@ -376,7 +380,7 @@ async function defaultSnapshot(
       ),
     )
     .orderBy(agentSandboxes.id);
-  const jobRows = await dbRead
+  const jobRows = await dbWrite
     .select()
     .from(jobs)
     .where(

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
@@ -1,0 +1,447 @@
+#!/usr/bin/env bun
+/**
+ * Runs the staging-only, privacy-safe operator boundary for re-reviewing the
+ * existing personal Dedicated selection owned by the deployed smoke account.
+ * It resolves identifiers internally, binds execution to a prior redacted
+ * preview, and proves that agent and job rows did not change.
+ */
+
+import { createHash, createHmac } from "node:crypto";
+
+const STAGING_API_BASE_URL = "https://api-staging.eliza.app";
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const EXECUTE_CONFIRMATION =
+  "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION";
+const REVIEWED_REASON =
+  "retain_current_receipt_target_after_duplicate_inventory_review";
+
+type Mode = "preview" | "execute";
+type JsonRecord = Record<string, unknown>;
+
+export class PersonalDedicatedRereviewOperatorError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+    this.name = "PersonalDedicatedRereviewOperatorError";
+  }
+}
+
+interface ResolvedSelection {
+  organizationId: string;
+  userId: string;
+  sourceAgentId: string;
+  retainedAgentId: string;
+}
+
+interface MutationSnapshot {
+  agentCount: number;
+  agentDigest: string;
+  jobCount: number;
+  jobDigest: string;
+}
+
+export interface RereviewOperatorConfig {
+  mode: Mode;
+  apiKey: string;
+  expectedCloudCommit: string;
+  approvalDigest?: string;
+  confirmation?: string;
+  reviewedReason?: string;
+}
+
+export interface RereviewOperatorEvidence {
+  schemaVersion: 1;
+  mode: Mode;
+  deployedCommitVerified: true;
+  identityResolved: true;
+  candidateCount: number;
+  stateDisposition: "verified_backup_present" | "fresh_boot_no_verified_backup";
+  replacesTarget: boolean;
+  approvalDigest: string;
+  computeMutation: false;
+  agentCount: number;
+  jobCount: number;
+  executed: boolean;
+}
+
+export interface RereviewOperatorDependencies {
+  verifyDeployment(expectedCommit: string): Promise<void>;
+  resolveSelection(apiKey: string): Promise<ResolvedSelection>;
+  preview(input: ResolvedSelection): Promise<{
+    receiptFingerprint: string;
+    inventoryFingerprint: string;
+    stateDisposition: RereviewOperatorEvidence["stateDisposition"];
+    candidateCount: number;
+    replacesTarget: boolean;
+  }>;
+  execute(
+    input: ResolvedSelection & {
+      expectedReceiptFingerprint: string;
+      expectedInventoryFingerprint: string;
+      expectedStateDisposition: RereviewOperatorEvidence["stateDisposition"];
+    },
+  ): Promise<void>;
+  snapshot(input: ResolvedSelection): Promise<MutationSnapshot>;
+}
+
+function required(
+  environment: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string {
+  const value = environment[name]?.trim();
+  if (!value)
+    throw new PersonalDedicatedRereviewOperatorError(
+      `missing_${name.toLowerCase()}`,
+    );
+  return value;
+}
+
+/** Reads explicit operator authority without logging any secret or identifier. */
+export function readRereviewOperatorConfig(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): RereviewOperatorConfig {
+  if (environment.ELIZA_PERSONAL_DEDICATED_REREVIEW_STAGING !== "1") {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "explicit_staging_opt_in_required",
+    );
+  }
+  const mode = required(environment, "ELIZA_PERSONAL_DEDICATED_REREVIEW_MODE");
+  if (mode !== "preview" && mode !== "execute") {
+    throw new PersonalDedicatedRereviewOperatorError("invalid_mode");
+  }
+  const expectedCloudCommit = required(
+    environment,
+    "ELIZA_PERSONAL_DEDICATED_REREVIEW_EXPECTED_CLOUD_COMMIT",
+  ).toLowerCase();
+  if (!COMMIT_PATTERN.test(expectedCloudCommit)) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "invalid_expected_cloud_commit",
+    );
+  }
+  return {
+    mode,
+    apiKey: required(environment, "ELIZAOS_CLOUD_API_KEY"),
+    expectedCloudCommit,
+    approvalDigest:
+      environment.ELIZA_PERSONAL_DEDICATED_REREVIEW_APPROVAL_DIGEST?.trim(),
+    confirmation:
+      environment.ELIZA_PERSONAL_DEDICATED_REREVIEW_CONFIRMATION?.trim(),
+    reviewedReason:
+      environment.ELIZA_PERSONAL_DEDICATED_REREVIEW_REVIEWED_REASON?.trim(),
+  };
+}
+
+function normalized(value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(normalized);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as JsonRecord)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalized(entry)]),
+    );
+  }
+  return value;
+}
+
+function digestRows(rows: unknown[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify(normalized(rows)))
+    .digest("hex");
+}
+
+function approvalDigest(
+  apiKey: string,
+  resolved: ResolvedSelection,
+  preview: Awaited<ReturnType<RereviewOperatorDependencies["preview"]>>,
+): string {
+  return createHmac("sha256", apiKey)
+    .update(
+      JSON.stringify({
+        schemaVersion: 1,
+        ...resolved,
+        receiptFingerprint: preview.receiptFingerprint,
+        inventoryFingerprint: preview.inventoryFingerprint,
+        stateDisposition: preview.stateDisposition,
+        candidateCount: preview.candidateCount,
+        replacesTarget: preview.replacesTarget,
+      }),
+    )
+    .digest("hex");
+}
+
+function assertNoComputeMutation(
+  before: MutationSnapshot,
+  after: MutationSnapshot,
+): void {
+  if (
+    before.agentCount !== after.agentCount ||
+    before.agentDigest !== after.agentDigest ||
+    before.jobCount !== after.jobCount ||
+    before.jobDigest !== after.jobDigest
+  ) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "compute_or_job_state_changed",
+    );
+  }
+}
+
+export async function runRereviewOperator(
+  config: RereviewOperatorConfig,
+  dependencies: RereviewOperatorDependencies,
+): Promise<RereviewOperatorEvidence> {
+  await dependencies.verifyDeployment(config.expectedCloudCommit);
+  const resolved = await dependencies.resolveSelection(config.apiKey);
+  const preview = await dependencies.preview(resolved);
+  const digest = approvalDigest(config.apiKey, resolved, preview);
+  const before = await dependencies.snapshot(resolved);
+
+  if (config.mode === "execute") {
+    if (!config.approvalDigest || !DIGEST_PATTERN.test(config.approvalDigest)) {
+      throw new PersonalDedicatedRereviewOperatorError(
+        "invalid_approval_digest",
+      );
+    }
+    if (config.approvalDigest !== digest) {
+      throw new PersonalDedicatedRereviewOperatorError(
+        "stale_or_wrong_approval_digest",
+      );
+    }
+    if (config.confirmation !== EXECUTE_CONFIRMATION) {
+      throw new PersonalDedicatedRereviewOperatorError(
+        "exact_confirmation_required",
+      );
+    }
+    if (config.reviewedReason !== REVIEWED_REASON) {
+      throw new PersonalDedicatedRereviewOperatorError(
+        "reviewed_reason_required",
+      );
+    }
+    await dependencies.execute({
+      ...resolved,
+      expectedReceiptFingerprint: preview.receiptFingerprint,
+      expectedInventoryFingerprint: preview.inventoryFingerprint,
+      expectedStateDisposition: preview.stateDisposition,
+    });
+  }
+
+  const after = await dependencies.snapshot(resolved);
+  assertNoComputeMutation(before, after);
+  return {
+    schemaVersion: 1,
+    mode: config.mode,
+    deployedCommitVerified: true,
+    identityResolved: true,
+    candidateCount: preview.candidateCount,
+    stateDisposition: preview.stateDisposition,
+    replacesTarget: preview.replacesTarget,
+    approvalDigest: digest,
+    computeMutation: false,
+    agentCount: after.agentCount,
+    jobCount: after.jobCount,
+    executed: config.mode === "execute",
+  };
+}
+
+async function defaultVerifyDeployment(expectedCommit: string): Promise<void> {
+  const response = await fetch(`${STAGING_API_BASE_URL}/api/health`, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok)
+    throw new PersonalDedicatedRereviewOperatorError("staging_health_failed");
+  const body = (await response.json()) as JsonRecord;
+  if (body.commit !== expectedCommit) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "staging_deploy_commit_mismatch",
+    );
+  }
+}
+
+async function defaultResolveSelection(
+  apiKey: string,
+): Promise<ResolvedSelection> {
+  const [
+    { and, eq, isNull },
+    { dbRead },
+    { apiKeys },
+    { users },
+    selectionSchema,
+    shared,
+  ] = await Promise.all([
+    import("drizzle-orm"),
+    import("@elizaos/cloud-shared/db/client"),
+    import("@elizaos/cloud-shared/db/schemas/api-keys"),
+    import("@elizaos/cloud-shared/db/schemas/users"),
+    import(
+      "@elizaos/cloud-shared/db/schemas/personal-dedicated-adoption-selections"
+    ),
+    import(
+      "@elizaos/cloud-shared/lib/services/shared-runtime/personal-shared-agent"
+    ),
+  ]);
+  const { personalDedicatedAdoptionSelections } = selectionSchema;
+  const { personalSharedAgentId } = shared;
+  const keyHash = createHash("sha256").update(apiKey).digest("hex");
+  const keyRows = await dbRead
+    .select()
+    .from(apiKeys)
+    .where(
+      and(
+        eq(apiKeys.key_hash, keyHash),
+        eq(apiKeys.is_active, true),
+        isNull(apiKeys.deleted_at),
+      ),
+    )
+    .limit(2);
+  if (keyRows.length !== 1)
+    throw new PersonalDedicatedRereviewOperatorError("smoke_key_not_active");
+  const key = keyRows[0];
+  if (key.expires_at && key.expires_at <= new Date()) {
+    throw new PersonalDedicatedRereviewOperatorError("smoke_key_expired");
+  }
+  const ownerRows = await dbRead
+    .select({ id: users.id, organizationId: users.organization_id })
+    .from(users)
+    .where(
+      and(
+        eq(users.id, key.user_id),
+        eq(users.is_active, true),
+        isNull(users.deleted_at),
+      ),
+    )
+    .limit(2);
+  const owner = ownerRows[0];
+  if (
+    ownerRows.length !== 1 ||
+    !owner?.organizationId ||
+    owner.organizationId !== key.organization_id
+  ) {
+    throw new PersonalDedicatedRereviewOperatorError("smoke_owner_not_active");
+  }
+  const sourceAgentId = personalSharedAgentId({
+    organizationId: owner.organizationId,
+    userId: owner.id,
+  });
+  const receipts = await dbRead
+    .select({
+      retainedAgentId: personalDedicatedAdoptionSelections.dedicated_agent_id,
+    })
+    .from(personalDedicatedAdoptionSelections)
+    .where(
+      and(
+        eq(
+          personalDedicatedAdoptionSelections.organization_id,
+          owner.organizationId,
+        ),
+        eq(personalDedicatedAdoptionSelections.user_id, owner.id),
+        eq(personalDedicatedAdoptionSelections.source_agent_id, sourceAgentId),
+        eq(personalDedicatedAdoptionSelections.schema_version, 1),
+      ),
+    )
+    .limit(2);
+  if (receipts.length !== 1) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_receipt_not_unique",
+    );
+  }
+  return {
+    organizationId: owner.organizationId,
+    userId: owner.id,
+    sourceAgentId,
+    retainedAgentId: receipts[0].retainedAgentId,
+  };
+}
+
+async function defaultSnapshot(
+  input: ResolvedSelection,
+): Promise<MutationSnapshot> {
+  const [{ and, eq }, { dbRead }, sandboxSchema, jobsSchema] =
+    await Promise.all([
+      import("drizzle-orm"),
+      import("@elizaos/cloud-shared/db/client"),
+      import("@elizaos/cloud-shared/db/schemas/agent-sandboxes"),
+      import("@elizaos/cloud-shared/db/schemas/jobs"),
+    ]);
+  const { agentSandboxes } = sandboxSchema;
+  const { jobs } = jobsSchema;
+  const agentRows = await dbRead
+    .select()
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.organization_id, input.organizationId),
+        eq(agentSandboxes.user_id, input.userId),
+      ),
+    )
+    .orderBy(agentSandboxes.id);
+  const jobRows = await dbRead
+    .select()
+    .from(jobs)
+    .where(
+      and(
+        eq(jobs.organization_id, input.organizationId),
+        eq(jobs.user_id, input.userId),
+      ),
+    )
+    .orderBy(jobs.id);
+  return {
+    agentCount: agentRows.length,
+    agentDigest: digestRows(agentRows),
+    jobCount: jobRows.length,
+    jobDigest: digestRows(jobRows),
+  };
+}
+
+const defaultDependencies: RereviewOperatorDependencies = {
+  verifyDeployment: defaultVerifyDeployment,
+  resolveSelection: defaultResolveSelection,
+  preview: async (input) => {
+    const { personalDedicatedAdoptionSelectionService } = await import(
+      "@elizaos/cloud-shared/lib/services/personal-dedicated-adoption-selection"
+    );
+    return personalDedicatedAdoptionSelectionService.previewRereview({
+      ...input,
+      selectedByUserId: null,
+      reason: "duplicate_owned_dedicated_inventory",
+    });
+  },
+  execute: async (input) => {
+    const { personalDedicatedAdoptionSelectionService } = await import(
+      "@elizaos/cloud-shared/lib/services/personal-dedicated-adoption-selection"
+    );
+    await personalDedicatedAdoptionSelectionService.executeRereview({
+      ...input,
+      selectedByUserId: null,
+      reason: "duplicate_owned_dedicated_inventory",
+    });
+  },
+  snapshot: defaultSnapshot,
+};
+
+if (import.meta.main) {
+  try {
+    const evidence = await runRereviewOperator(
+      readRereviewOperatorConfig(),
+      defaultDependencies,
+    );
+    const { logger } = await import("@elizaos/cloud-shared/lib/utils/logger");
+    logger.info(
+      "[personal-dedicated-rereview-staging] Operator result",
+      evidence,
+    );
+  } catch (error) {
+    // error-policy:J1 the command boundary emits only a typed diagnostic code;
+    // sensitive resolved identifiers and credentials never reach logs.
+    const code =
+      error instanceof PersonalDedicatedRereviewOperatorError
+        ? error.code
+        : "personal_dedicated_rereview_failed";
+    const { logger } = await import("@elizaos/cloud-shared/lib/utils/logger");
+    logger.error("[personal-dedicated-rereview-staging] Operator failed", {
+      code,
+    });
+    process.exitCode = 1;
+  }
+}

--- a/packages/cloud/scripts/admin/preflight-database-identity.test.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  classifyDatabaseIdentityFailure,
   readDatabaseIdentityConfig,
   readDatabaseIdentityReceipt,
   runDatabaseIdentityPreflight,
@@ -137,8 +138,37 @@ describe("database identity preflight", () => {
         );
       },
     });
-    expect(result).toEqual({ status: "unavailable", mismatches: [] });
+    expect(result).toEqual({
+      status: "unavailable",
+      mismatches: [],
+      failureCategory: "database_query_failed",
+    });
     expect(JSON.stringify(result)).not.toContain("raw-");
+  });
+
+  test("classifies setup failures with a bounded non-sensitive category", () => {
+    expect(
+      classifyDatabaseIdentityFailure({
+        code: "ERR_MODULE_NOT_FOUND",
+        message: "missing /private/worktree/packages/prompts/dist/index.js",
+      }),
+    ).toBe("dependency_unavailable");
+    expect(
+      classifyDatabaseIdentityFailure({
+        code: "ECONNREFUSED",
+        message: "connect raw-host as raw-role",
+      }),
+    ).toBe("database_connection_failed");
+    expect(
+      classifyDatabaseIdentityFailure(new Error("DATABASE_URL=secret")),
+    ).toBe("operator_setup_failed");
+    expect(
+      JSON.stringify([
+        classifyDatabaseIdentityFailure({ code: "ERR_MODULE_NOT_FOUND" }),
+        classifyDatabaseIdentityFailure({ code: "ECONNREFUSED" }),
+        classifyDatabaseIdentityFailure(new Error("secret")),
+      ]),
+    ).not.toContain("secret");
   });
 
   test("enforce mode requires both authorities and fails closed on mismatch", async () => {

--- a/packages/cloud/scripts/admin/preflight-database-identity.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.ts
@@ -49,8 +49,45 @@ export interface DatabaseIdentityConfig {
 
 export interface IdentityPreflightResult {
   mismatches: Array<"cluster" | "authority">;
+  failureCategory?: DatabaseIdentityFailureCategory;
   receipt?: DatabaseIdentityReceipt;
   status: "disabled" | "match" | "mismatch" | "reported" | "unavailable";
+}
+
+export type DatabaseIdentityFailureCategory =
+  | "dependency_unavailable"
+  | "database_connection_failed"
+  | "database_query_failed"
+  | "operator_setup_failed";
+
+const DEPENDENCY_ERROR_CODES = new Set([
+  "MODULE_NOT_FOUND",
+  "ERR_MODULE_NOT_FOUND",
+]);
+const CONNECTION_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "28P01",
+  "3D000",
+]);
+
+/** Maps failures to a fixed non-sensitive class without retaining provider text. */
+export function classifyDatabaseIdentityFailure(
+  error: unknown,
+): Exclude<DatabaseIdentityFailureCategory, "database_query_failed"> {
+  if (typeof error === "object" && error !== null) {
+    const code = Reflect.get(error, "code");
+    if (typeof code === "string") {
+      if (DEPENDENCY_ERROR_CODES.has(code)) return "dependency_unavailable";
+      if (CONNECTION_ERROR_CODES.has(code)) return "database_connection_failed";
+    }
+  }
+  return "operator_setup_failed";
 }
 
 function readMode(value: string | undefined): DatabaseIdentityGateMode {
@@ -158,7 +195,11 @@ export async function runDatabaseIdentityPreflight(
     receipt = await readDatabaseIdentityReceipt(client, config.environment);
   } catch (error) {
     if (config.mode === "report") {
-      return { status: "unavailable", mismatches: [] };
+      return {
+        status: "unavailable",
+        mismatches: [],
+        failureCategory: "database_query_failed",
+      };
     }
     throw error;
   }
@@ -250,7 +291,7 @@ export async function publishDatabaseIdentityResult(
   }
   if (result.status === "unavailable") {
     process.stdout.write(
-      "::warning::database identity report unavailable; inspect protected operator logs\n",
+      `::warning::database identity report unavailable; category=${result.failureCategory ?? "operator_setup_failed"}\n`,
     );
   }
   if (config.ignoredExpectedDigests?.length) {
@@ -291,8 +332,9 @@ async function main(): Promise<void> {
     // error-policy:J1 the CLI boundary emits only a generic class so provider
     // errors cannot leak connection strings, hosts, roles, or database names.
     if (config.mode === "report") {
+      const failureCategory = classifyDatabaseIdentityFailure(error);
       process.stdout.write(
-        "::warning::database identity report unavailable; inspect protected operator logs\n",
+        `::warning::database identity report unavailable; category=${failureCategory}\n`,
       );
       return;
     }


### PR DESCRIPTION
Closes #30046

## Outcome

Adds a manual, staging-environment-protected two-step operator workflow for the stale personal Dedicated selection repaired by #30043. The command resolves organization, user, personal-shared source, and current receipt target internally from the protected smoke API key; none are emitted.

Preview returns only counts/enums plus an HMAC approval digest. Execute recomputes the preview, requires that exact digest, the reviewed reason `retain_current_receipt_target_after_duplicate_inventory_review`, and `REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION`. The workflow also requires exact checked-out/deployed commit equality and protected PostgreSQL cluster/authority receipts.

The command snapshots complete owner-scoped `agent_sandboxes` and `jobs` rows before and after and fails if either count or digest changes. It calls only the #30043 receipt re-review service; it does not activate, adopt, provision, delete, bill, or deploy compute.

## Evidence

- `bun test packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts packages/cloud/scripts/admin/preflight-database-identity.test.ts` — 17 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bunx biome check <four changed files>` — pass
- `bun run verify` — reached 145 successful Turbo tasks, then failed outside this diff in `@elizaos/ui#lint:check` because `packages/core/node_modules/@elizaos/prompts/dist/index.js` was absent after the clean `--ignore-scripts` install. Focused changed-surface checks above are green.

## Live evidence

- Staging execution: N/A — explicitly prohibited for this PR.
- Deployment: N/A — this PR only adds the protected workflow and command.
- UI screenshots/video: N/A — no rendered UI change.

## Safe runbook after merge and exact staging deployment

1. Dispatch the workflow from `develop` in `preview` mode with the deployed SHA and reviewed staging DB identity receipts.
2. Review the identifier-free candidate count, disposition, replacement flag, and approval digest in the structured log.
3. Dispatch `execute` from the same exact deployed `develop` SHA, supplying that digest and both exact confirmation phrases.
4. Require `computeMutation: false` and `executed: true`; then rerun the existing staging smoke/certification path.

No live state was read or changed while preparing this PR.