### PR TITLE
fix(cloud): probe identity operator dependencies

### DIFF
--- a/.github/workflows/database-identity-staging-report.yml
+++ b/.github/workflows/database-identity-staging-report.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           bun run --cwd packages/prompts build:package
           bun run --cwd packages/shared build
+          bun run --cwd packages/core build
+
+      - name: Probe fixed runtime dependencies
+        run: bun run packages/cloud/scripts/admin/preflight-database-identity.ts --probe-dependencies
 
       - name: Validate identity reporter contracts
         run: bun test packages/cloud/scripts/admin/preflight-database-identity.test.ts packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts

--- a/.github/workflows/personal-dedicated-rereview-staging.yml
+++ b/.github/workflows/personal-dedicated-rereview-staging.yml
@@ -108,6 +108,10 @@ jobs:
         run: |
           bun run --cwd packages/prompts build:package
           bun run --cwd packages/shared build
+          bun run --cwd packages/core build
+
+      - name: Probe fixed runtime dependencies
+        run: bun run packages/cloud/scripts/admin/preflight-database-identity.ts --probe-dependencies
 
       - name: Validate operator contracts
         run: >-

--- a/packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts
+++ b/packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts
@@ -105,6 +105,10 @@ describe("database identity staging report workflow", () => {
       "bun run --cwd packages/prompts build:package",
     );
     expect(linkedBuild).toContain("bun run --cwd packages/shared build");
+    expect(linkedBuild).toContain("bun run --cwd packages/core build");
+    expect(step("Probe fixed runtime dependencies").run).toBe(
+      "bun run packages/cloud/scripts/admin/preflight-database-identity.ts --probe-dependencies",
+    );
     expect(step("Validate identity reporter contracts").run).toContain(
       "preflight-database-identity.test.ts",
     );

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
@@ -95,6 +95,10 @@ describe("personal Dedicated staging re-review workflow", () => {
       "bun run --cwd packages/prompts build:package",
     );
     expect(linkedBuild).toContain("bun run --cwd packages/shared build");
+    expect(linkedBuild).toContain("bun run --cwd packages/core build");
+    expect(step("Probe fixed runtime dependencies").run).toBe(
+      "bun run packages/cloud/scripts/admin/preflight-database-identity.ts --probe-dependencies",
+    );
   });
 
   test("uses primary database authority for identity and mutation proofs", () => {

--- a/packages/cloud/scripts/admin/preflight-database-identity.test.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.test.ts
@@ -3,6 +3,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   classifyDatabaseIdentityFailure,
+  DatabaseIdentityDependencyError,
+  databaseIdentityFailureDiagnostic,
+  probeDatabaseIdentityDependencies,
   readDatabaseIdentityConfig,
   readDatabaseIdentityReceipt,
   runDatabaseIdentityPreflight,
@@ -169,6 +172,40 @@ describe("database identity preflight", () => {
         classifyDatabaseIdentityFailure(new Error("secret")),
       ]),
     ).not.toContain("secret");
+  });
+
+  test("probes fixed dependencies in order and reports only the failed label", async () => {
+    const observed: string[] = [];
+    await probeDatabaseIdentityDependencies(async (specifier) => {
+      observed.push(specifier);
+      return {};
+    });
+    expect(observed).toEqual([
+      "pg",
+      "@elizaos/core/edge",
+      "@elizaos/cloud-shared/db/client",
+    ]);
+
+    const privateLoaderMessage =
+      "Cannot find /private/runner/packages/core/dist/edge/index.edge.js";
+    let failure: unknown;
+    try {
+      await probeDatabaseIdentityDependencies(async (specifier) => {
+        if (specifier === "@elizaos/core/edge") {
+          throw new Error(privateLoaderMessage);
+        }
+        return {};
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(DatabaseIdentityDependencyError);
+    expect(databaseIdentityFailureDiagnostic(failure)).toBe(
+      "category=dependency_unavailable; dependency=core_edge",
+    );
+    expect(databaseIdentityFailureDiagnostic(failure)).not.toContain(
+      privateLoaderMessage,
+    );
   });
 
   test("enforce mode requires both authorities and fails closed on mismatch", async () => {

--- a/packages/cloud/scripts/admin/preflight-database-identity.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.ts
@@ -5,7 +5,6 @@
  */
 
 import { appendFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import {
   type DatabaseIdentityReceipt,
   type IdentityQueryClient,
@@ -32,9 +31,6 @@ interface RuntimePgClient extends IdentityQueryClient {
   end(): Promise<void>;
 }
 
-const { Client } = createRequire(import.meta.url)("pg") as {
-  Client: new (config: ClientConfig) => RuntimePgClient;
-};
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 
 export type DatabaseIdentityGateMode = "off" | "report" | "enforce";
@@ -60,6 +56,39 @@ export type DatabaseIdentityFailureCategory =
   | "database_query_failed"
   | "operator_setup_failed";
 
+export type DatabaseIdentityDependencyLabel = "pg" | "core_edge" | "db_client";
+
+export class DatabaseIdentityDependencyError extends Error {
+  constructor(readonly dependency: DatabaseIdentityDependencyLabel) {
+    super(`database_identity_dependency_${dependency}_unavailable`);
+    this.name = "DatabaseIdentityDependencyError";
+  }
+}
+
+const DEPENDENCY_PROBES = [
+  ["pg", "pg"],
+  ["core_edge", "@elizaos/core/edge"],
+  ["db_client", "@elizaos/cloud-shared/db/client"],
+] as const satisfies ReadonlyArray<
+  readonly [DatabaseIdentityDependencyLabel, string]
+>;
+
+/** Probes the fixed runtime chain in order and discards every import exception. */
+export async function probeDatabaseIdentityDependencies(
+  importer: (specifier: string) => Promise<unknown> = (specifier) =>
+    import(specifier),
+): Promise<void> {
+  for (const [label, specifier] of DEPENDENCY_PROBES) {
+    try {
+      await importer(specifier);
+    } catch {
+      // error-policy:J1 only the fixed probe label crosses the CLI boundary;
+      // loader messages and paths are deliberately discarded.
+      throw new DatabaseIdentityDependencyError(label);
+    }
+  }
+}
+
 const DEPENDENCY_ERROR_CODES = new Set([
   "MODULE_NOT_FOUND",
   "ERR_MODULE_NOT_FOUND",
@@ -80,6 +109,9 @@ const CONNECTION_ERROR_CODES = new Set([
 export function classifyDatabaseIdentityFailure(
   error: unknown,
 ): Exclude<DatabaseIdentityFailureCategory, "database_query_failed"> {
+  if (error instanceof DatabaseIdentityDependencyError) {
+    return "dependency_unavailable";
+  }
   if (typeof error === "object" && error !== null) {
     const code = Reflect.get(error, "code");
     if (typeof code === "string") {
@@ -88,6 +120,16 @@ export function classifyDatabaseIdentityFailure(
     }
   }
   return "operator_setup_failed";
+}
+
+/** Formats only bounded diagnostics suitable for public workflow logs. */
+export function databaseIdentityFailureDiagnostic(error: unknown): string {
+  const category = classifyDatabaseIdentityFailure(error);
+  const dependency =
+    error instanceof DatabaseIdentityDependencyError
+      ? `; dependency=${error.dependency}`
+      : "";
+  return `category=${category}${dependency}`;
 }
 
 function readMode(value: string | undefined): DatabaseIdentityGateMode {
@@ -250,6 +292,13 @@ async function clientConfig(databaseUrl: string): Promise<ClientConfig> {
   };
 }
 
+async function createRuntimePgClient(
+  databaseUrl: string,
+): Promise<RuntimePgClient> {
+  const { Client } = await import("pg");
+  return new Client(await clientConfig(databaseUrl));
+}
+
 /** Formats a redacted receipt for operator logs and GitHub step summaries. */
 function formatDatabaseIdentitySummary(
   result: IdentityPreflightResult,
@@ -302,6 +351,13 @@ export async function publishDatabaseIdentityResult(
 }
 
 async function main(): Promise<void> {
+  if (process.argv.includes("--probe-dependencies")) {
+    await probeDatabaseIdentityDependencies();
+    process.stdout.write(
+      "[database-identity] dependency probes passed: pg,core_edge,db_client\n",
+    );
+    return;
+  }
   const environment: Readonly<Record<string, string | undefined>> = process.env;
   const config = readDatabaseIdentityConfig(environment);
   if (config.mode === "off") {
@@ -324,7 +380,8 @@ async function main(): Promise<void> {
   }
   let client: RuntimePgClient | undefined;
   try {
-    client = new Client(await clientConfig(databaseUrl));
+    await probeDatabaseIdentityDependencies();
+    client = await createRuntimePgClient(databaseUrl);
     await client.connect();
     const result = await runDatabaseIdentityPreflight(config, client);
     await publishDatabaseIdentityResult(config, result, environment);
@@ -332,9 +389,8 @@ async function main(): Promise<void> {
     // error-policy:J1 the CLI boundary emits only a generic class so provider
     // errors cannot leak connection strings, hosts, roles, or database names.
     if (config.mode === "report") {
-      const failureCategory = classifyDatabaseIdentityFailure(error);
       process.stdout.write(
-        `::warning::database identity report unavailable; category=${failureCategory}\n`,
+        `::warning::database identity report unavailable; ${databaseIdentityFailureDiagnostic(error)}\n`,
       );
       return;
     }
@@ -350,9 +406,9 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch(() => {
+  main().catch((error) => {
     process.stderr.write(
-      "[database-identity] fatal: identity enforcement failed\n",
+      `[database-identity] fatal: ${databaseIdentityFailureDiagnostic(error)}\n`,
     );
     process.exit(1);
   });


### PR DESCRIPTION
Closes #30052

## Outcome

Repairs the remaining fresh-checkout runtime failure observed in staging database identity report run 33296821799 after #30048. Both protected workflows now build the full `@elizaos/core` package after the existing prompts/shared linked builds. This materializes both `@elizaos/core/edge` and the root core export required transitively by cloud-shared DB schemas.

Before any database operation, the reporter now probes a fixed ordered dependency set:

1. `pg`
2. `core_edge`
3. `db_client`

A failed probe discards the loader exception and emits only `category=dependency_unavailable; dependency=<fixed-label>`. The standalone workflow probe exits nonzero, preventing another green-but-unavailable bootstrap failure. The normal reporter repeats the probes so direct invocations retain the same safety boundary.

## Fresh-checkout proof

Starting from a new worktree at `02b7ccd24daac44f79634435fc1d708a7e945882` with no existing dist artifacts:

- install + prompts/shared builds reproduced `pg` pass followed by `core_edge` failure;
- after `bun run --cwd packages/core build`, the command emitted `dependency probes passed: pg,core_edge,db_client`;
- an intentionally unreachable local PostgreSQL endpoint then emitted only `category=database_connection_failed`.

No filesystem path, URL, credential, role, database name, module-loader message, or raw exception was printed by the repaired reporter.

## Checks

- Focused reporter/workflow/operator suite: 25 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck`: pass
- Changed-file Biome and `git diff --check`: pass

## Live evidence

- Staging workflow dispatch: N/A — explicitly not performed in this PR.
- Deployment/live mutation: N/A — prohibited; workflow and diagnostics only.
- UI evidence: N/A — no rendered UI change.

No merge, deployment, staging access, or live data mutation was performed.