### PR TITLE
fix(cloud): make suspended auth certification optional

### DIFF
--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -8,7 +8,12 @@ on:
         required: true
         type: string
       run_auth:
-        description: Also run protected inference-auth hit, miss, guard, and sanitized Worker Tail proof.
+        description: Also run protected inference-auth hit, miss, non-standing guards, and sanitized Worker Tail proof.
+        required: true
+        default: false
+        type: boolean
+      run_suspended:
+        description: Also prove the optional suspended-standing 403 guard (requires run_auth).
         required: true
         default: false
         type: boolean
@@ -31,6 +36,7 @@ jobs:
       NODE_VERSION: "24.15.0"
       EXPECTED_DEPLOY_SHA: ${{ inputs.expected_deploy_sha }}
       RUN_AUTH: ${{ inputs.run_auth }}
+      RUN_SUSPENDED: ${{ inputs.run_suspended }}
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
       ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
       ELIZA_STAGING_SUSPENDED_API_KEY: ${{ secrets.ELIZA_STAGING_SUSPENDED_API_KEY }}
@@ -54,14 +60,20 @@ jobs:
             echo "::error::Dispatch must select develop at the exact expected_deploy_sha; refusing arbitrary checkout bytes."
             exit 1
           fi
+          if [[ "$RUN_SUSPENDED" == "true" && "$RUN_AUTH" != "true" ]]; then
+            echo "::error::run_suspended is valid only when run_auth=true."
+            exit 1
+          fi
           required=(CEREBRAS_API_KEY ELIZAOS_CLOUD_API_KEY)
           if [[ "$RUN_AUTH" == "true" ]]; then
             required+=(
-              ELIZA_STAGING_SUSPENDED_API_KEY
               INFERENCE_AUTH_PROBE_TOKEN
               CLOUDFLARE_API_TOKEN
               CLOUDFLARE_ACCOUNT_ID
             )
+          fi
+          if [[ "$RUN_SUSPENDED" == "true" ]]; then
+            required+=(ELIZA_STAGING_SUSPENDED_API_KEY)
           fi
           missing=()
           for name in "${required[@]}"; do
@@ -106,6 +118,9 @@ jobs:
           )
           if [[ "$RUN_AUTH" == "true" ]]; then
             args+=(--auth)
+          fi
+          if [[ "$RUN_SUSPENDED" == "true" ]]; then
+            args+=(--suspended)
           fi
           node packages/cloud/scripts/cloud-latency-certification.mjs "${args[@]}"
 

--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -31,7 +31,6 @@ const STAGING_BASE_URL = "https://api-staging.eliza.app";
 const CEREBRAS_BASE_URL = "https://api.cerebras.ai";
 const STAGING_WORKER = "eliza-cloud-api-staging";
 const EXPECTED_PAIRED_RECORDS = 44;
-const EXPECTED_AUTH_RECORDS = 45;
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -68,6 +67,7 @@ export function parseCertificationArgs(argv) {
       "deploy-sha": { type: "string" },
       "output-dir": { type: "string" },
       auth: { type: "boolean", default: false },
+      suspended: { type: "boolean", default: false },
     },
     strict: true,
     allowPositionals: false,
@@ -78,7 +78,15 @@ export function parseCertificationArgs(argv) {
   }
   const outputDir = values["output-dir"]?.trim() ?? "";
   if (!outputDir) throw new Error("--output-dir is required");
-  return { deploySha, outputDir: resolve(outputDir), runAuth: values.auth };
+  if (values.suspended && !values.auth) {
+    throw new Error("--suspended requires --auth");
+  }
+  return {
+    deploySha,
+    outputDir: resolve(outputDir),
+    runAuth: values.auth,
+    runSuspended: values.suspended,
+  };
 }
 
 function requireSecret(env, name) {
@@ -94,14 +102,19 @@ export function requirePairedSecrets(env) {
   };
 }
 
-export function requireAuthSecrets(env) {
-  return {
+export function requireAuthSecrets(env, runSuspended = false) {
+  const secrets = {
     apiKey: requireSecret(env, "ELIZAOS_CLOUD_API_KEY"),
-    suspendedApiKey: requireSecret(env, "ELIZA_STAGING_SUSPENDED_API_KEY"),
     probeToken: requireSecret(env, "INFERENCE_AUTH_PROBE_TOKEN"),
     cloudflareApiToken: requireSecret(env, "CLOUDFLARE_API_TOKEN"),
     cloudflareAccountId: requireSecret(env, "CLOUDFLARE_ACCOUNT_ID"),
   };
+  return runSuspended
+    ? {
+        ...secrets,
+        suspendedApiKey: requireSecret(env, "ELIZA_STAGING_SUSPENDED_API_KEY"),
+      }
+    : secrets;
 }
 
 export async function verifyExactDeployment(deploySha, fetchImpl = fetch) {
@@ -161,11 +174,12 @@ export function validatePairedEvidence(text, deploySha) {
   return { records, counts };
 }
 
-export function validateAuthEvidence(text, deploySha) {
+export function validateAuthEvidence(text, deploySha, runSuspended = false) {
   const records = parseJsonLines(text, "Inference auth evidence");
-  if (records.length !== EXPECTED_AUTH_RECORDS) {
+  const expectedRecordCount = runSuspended ? 45 : 44;
+  if (records.length !== expectedRecordCount) {
     throw new Error(
-      `Inference auth evidence must contain ${EXPECTED_AUTH_RECORDS} records`,
+      `Inference auth evidence must contain ${expectedRecordCount} records`,
     );
   }
   const deployment = records.filter((record) => record.kind === "deployment");
@@ -175,7 +189,7 @@ export function validateAuthEvidence(text, deploySha) {
   if (
     deployment.length !== 1 ||
     samples.length !== 40 ||
-    guards.length !== 3 ||
+    guards.length !== (runSuspended ? 3 : 2) ||
     summaries.length !== 1
   ) {
     throw new Error("Inference auth evidence has an invalid record matrix");
@@ -223,14 +237,24 @@ export function validateAuthEvidence(text, deploySha) {
   const guardByName = new Map(guards.map((record) => [record.guard, record]));
   if (
     guardByName.get("invalid_key")?.status !== 401 ||
-    guardByName.get("suspended_key")?.status !== 403 ||
     guardByName.get("forged_probe")?.status !== 400
   ) {
     throw new Error("Inference auth guard evidence is incomplete");
   }
+  const suspendedGuard = guardByName.get("suspended_key");
+  if (
+    (runSuspended && suspendedGuard?.status !== 403) ||
+    (!runSuspended && suspendedGuard !== undefined)
+  ) {
+    throw new Error("Inference auth suspended guard evidence is inconsistent");
+  }
+  const expectedSuspendedStatus = runSuspended ? "observed" : "not_requested";
+  if (summaries[0]?.suspendedGuard !== expectedSuspendedStatus) {
+    throw new Error("Inference auth summary misstates the suspended guard");
+  }
   const traceIds = [...samples, ...guards].map((record) => record.traceId);
   if (
-    traceIds.length !== 43 ||
+    traceIds.length !== (runSuspended ? 43 : 42) ||
     new Set(traceIds).size !== traceIds.length ||
     traceIds.some((traceId) => !UUID_PATTERN.test(traceId))
   ) {
@@ -422,8 +446,8 @@ async function runPaired({ deploySha, outputDir, env }) {
   }
 }
 
-async function runAuth({ deploySha, outputDir, env }) {
-  const secrets = requireAuthSecrets(env);
+async function runAuth({ deploySha, outputDir, env, runSuspended }) {
+  const secrets = requireAuthSecrets(env, runSuspended);
   const privateRoot = env.RUNNER_TEMP?.trim() || tmpdir();
   return await withPrivateTailDirectory(async (directory) => {
     const { child, rawPath } = await startPrivateTail(directory, env);
@@ -457,8 +481,6 @@ async function runAuth({ deploySha, outputDir, env }) {
             STAGING_BASE_URL,
             "--api-key-env",
             "ELIZAOS_CLOUD_API_KEY",
-            "--suspended-api-key-env",
-            "ELIZA_STAGING_SUSPENDED_API_KEY",
             "--probe-token-env",
             "INFERENCE_AUTH_PROBE_TOKEN",
             "--deploy-sha",
@@ -471,6 +493,9 @@ async function runAuth({ deploySha, outputDir, env }) {
             "30000",
             "--interval-ms",
             "250",
+            ...(runSuspended
+              ? ["--suspended-api-key-env", "ELIZA_STAGING_SUSPENDED_API_KEY"]
+              : []),
           ],
           stdoutPath: outputPath,
           stderrPath,
@@ -481,6 +506,7 @@ async function runAuth({ deploySha, outputDir, env }) {
       const validation = validateAuthEvidence(
         await readFile(outputPath, "utf8"),
         deploySha,
+        runSuspended,
       );
       const workerRecords = await raceTailLifetime(
         child,
@@ -495,6 +521,7 @@ async function runAuth({ deploySha, outputDir, env }) {
       result = {
         records: validation.records.length,
         workerRecords: workerRecords.length,
+        suspendedGuard: runSuspended ? "observed" : "not_requested",
         deferredCacheWriteMs: summarizeDeferredCacheWrites(workerRecords),
       };
     } catch (error) {
@@ -529,7 +556,11 @@ export async function runCertification(
   const paired = await runPaired({ ...options, env });
   const auth = options.runAuth
     ? await runAuth({ ...options, env })
-    : { skipped: true, reason: "not_requested" };
+    : {
+        skipped: true,
+        reason: "not_requested",
+        suspendedGuard: "not_requested",
+      };
   const summary = {
     kind: "cloud_latency_certification",
     deploySha: options.deploySha,

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -39,7 +39,7 @@ function authTrace(index) {
   return `11111111-1111-4111-8111-${suffix}`;
 }
 
-function authEvidence() {
+function authEvidence(runSuspended = false) {
   const records = [
     { kind: "deployment", deploySha: SHA, environment: "staging" },
   ];
@@ -81,21 +81,26 @@ function authEvidence() {
     {
       kind: "guard",
       deploySha: SHA,
-      guard: "suspended_key",
-      traceId: authTrace(41),
-      status: 403,
-    },
-    {
-      kind: "guard",
-      deploySha: SHA,
       guard: "forged_probe",
-      traceId: authTrace(42),
+      traceId: authTrace(41),
       status: 400,
     },
+    ...(runSuspended
+      ? [
+          {
+            kind: "guard",
+            deploySha: SHA,
+            guard: "suspended_key",
+            traceId: authTrace(42),
+            status: 403,
+          },
+        ]
+      : []),
     {
       kind: "summary",
       deploySha: SHA,
       counts: { hit: 30, miss: 10 },
+      suspendedGuard: runSuspended ? "observed" : "not_requested",
     },
   );
   return records;
@@ -118,6 +123,7 @@ test("parseCertificationArgs requires an exact SHA and explicit output directory
       deploySha: SHA,
       outputDir: join(process.cwd(), "artifacts/cert"),
       runAuth: true,
+      runSuspended: false,
     },
   );
   assert.throws(
@@ -129,6 +135,17 @@ test("parseCertificationArgs requires an exact SHA and explicit output directory
         "artifacts/cert",
       ]),
     /lowercase 40-character commit/,
+  );
+  assert.throws(
+    () =>
+      parseCertificationArgs([
+        "--deploy-sha",
+        SHA,
+        "--output-dir",
+        "artifacts/cert",
+        "--suspended",
+      ]),
+    /requires --auth/,
   );
 });
 
@@ -143,6 +160,21 @@ test("protected secret gates fail closed without exposing values", () => {
   };
   assert.equal(requirePairedSecrets(configured).directApiKey, "direct-private");
   assert.equal(requireAuthSecrets(configured).probeToken, "probe-private");
+  assert.equal(
+    requireAuthSecrets(
+      { ...configured, ELIZA_STAGING_SUSPENDED_API_KEY: " " },
+      false,
+    ).probeToken,
+    "probe-private",
+  );
+  assert.throws(
+    () =>
+      requireAuthSecrets(
+        { ...configured, ELIZA_STAGING_SUSPENDED_API_KEY: " " },
+        true,
+      ),
+    /ELIZA_STAGING_SUSPENDED_API_KEY/,
+  );
   const failure = (() => {
     try {
       requireAuthSecrets({ ...configured, INFERENCE_AUTH_PROBE_TOKEN: " " });
@@ -204,24 +236,49 @@ test("paired certification requires exactly 44 balanced successful proofs", () =
   );
 });
 
-test("auth certification requires the complete hit, miss, and guard matrix", () => {
-  const records = authEvidence();
+test("auth certification separates required guards from optional suspended standing", () => {
+  const records = authEvidence(false);
   const result = validateAuthEvidence(jsonl(records), SHA);
-  assert.equal(result.records.length, 45);
-  assert.equal(result.traceIds.length, 43);
+  assert.equal(result.records.length, 44);
+  assert.equal(result.traceIds.length, 42);
+  assert.throws(
+    () => validateAuthEvidence(jsonl(records), SHA, true),
+    /45 records/,
+  );
+
+  const suspendedRecords = authEvidence(true);
+  const suspended = validateAuthEvidence(jsonl(suspendedRecords), SHA, true);
+  assert.equal(suspended.records.length, 45);
+  assert.equal(suspended.traceIds.length, 43);
   assert.throws(
     () =>
       validateAuthEvidence(
         jsonl(
-          records.map((record) =>
+          suspendedRecords.map((record) =>
             record.guard === "suspended_key"
               ? { ...record, status: 401 }
               : record,
           ),
         ),
         SHA,
+        true,
       ),
-    /guard evidence/,
+    /suspended guard evidence/,
+  );
+  assert.throws(
+    () =>
+      validateAuthEvidence(
+        jsonl(
+          records.map((record) =>
+            record.kind === "summary"
+              ? { ...record, suspendedGuard: "observed" }
+              : record,
+          ),
+        ),
+        SHA,
+        false,
+      ),
+    /misstates the suspended guard/,
   );
 });
 

--- a/packages/cloud/scripts/inference-auth-latency.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.mjs
@@ -395,7 +395,10 @@ export function parseArgs(args) {
   if (!/^[A-Z][A-Z0-9_]+$/.test(options.apiKeyEnv)) {
     throw new Error("--api-key-env must name an environment variable");
   }
-  if (!/^[A-Z][A-Z0-9_]+$/.test(options.suspendedApiKeyEnv)) {
+  if (
+    options.suspendedApiKeyEnv &&
+    !/^[A-Z][A-Z0-9_]+$/.test(options.suspendedApiKeyEnv)
+  ) {
     throw new Error(
       "--suspended-api-key-env must name an environment variable",
     );
@@ -843,13 +846,21 @@ export function summarizeDeferredCacheWrites(workerLogs) {
   );
 }
 
-export function summarizeAuthSamples(records, deploySha) {
+export function summarizeAuthSamples(
+  records,
+  deploySha,
+  suspendedGuard = "not_requested",
+) {
+  if (suspendedGuard !== "observed" && suspendedGuard !== "not_requested") {
+    throw new Error("Invalid suspended guard summary status");
+  }
   const hits = records.filter((record) => record.phase === "hit");
   const misses = records.filter((record) => record.phase === "miss");
   return {
     kind: "summary",
     deploySha,
     counts: { hit: hits.length, miss: misses.length },
+    suspendedGuard,
     hitAuthResolveMs: metricSummary(
       hits,
       (record) => record.timings.auth_resolve,
@@ -888,11 +899,14 @@ function sleep(durationMs) {
 export async function runAuthProbes(options, dependencies = {}) {
   const env = dependencies.env ?? process.env;
   const apiKey = env[options.apiKeyEnv];
-  const suspendedApiKey = env[options.suspendedApiKeyEnv];
+  const runSuspended = Boolean(options.suspendedApiKeyEnv);
+  const suspendedApiKey = runSuspended
+    ? env[options.suspendedApiKeyEnv]
+    : undefined;
   const probeToken = env[options.probeTokenEnv];
   if (!apiKey)
     throw new Error("Auth probe API key environment variable is missing");
-  if (!suspendedApiKey)
+  if (runSuspended && !suspendedApiKey)
     throw new Error(
       "Suspended auth probe API key environment variable is missing",
     );
@@ -965,7 +979,12 @@ export async function runAuthProbes(options, dependencies = {}) {
   }
 
   const guards = [];
-  for (const guard of ["invalid_key", "suspended_key", "forged_probe"]) {
+  const requestedGuards = [
+    "invalid_key",
+    "forged_probe",
+    ...(runSuspended ? ["suspended_key"] : []),
+  ];
+  for (const guard of requestedGuards) {
     const record = await probeAuthGuardSample({
       baseUrl: options.baseUrl,
       apiKey: guard === "suspended_key" ? suspendedApiKey : apiKey,
@@ -994,7 +1013,11 @@ export async function runAuthProbes(options, dependencies = {}) {
     if (options.intervalMs > 0) await wait(options.intervalMs);
   }
 
-  const summary = summarizeAuthSamples(records, options.deploySha);
+  const summary = summarizeAuthSamples(
+    records,
+    options.deploySha,
+    runSuspended ? "observed" : "not_requested",
+  );
   emit(summary);
   return { deployment, records, guards, summary };
 }

--- a/packages/cloud/scripts/inference-auth-latency.test.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.test.mjs
@@ -9,6 +9,7 @@ import {
   parseAuthTrace,
   probeAuthGuardSample,
   probeAuthSample,
+  runAuthProbes,
   sanitizeInferenceAuthTail,
   sanitizeInferenceAuthTelemetry,
   summarizeAuthSamples,
@@ -77,6 +78,75 @@ test("parseArgs requires exact HTTPS deployment provenance and sample counts", (
       ]),
     /HTTPS/,
   );
+  const withoutSuspended = parseArgs([
+    "--base-url",
+    "https://preview.example",
+    "--api-key-env",
+    "AUTH_KEY",
+    "--probe-token-env",
+    "PROBE_TOKEN",
+    "--deploy-sha",
+    SHA,
+  ]);
+  assert.equal(withoutSuspended.suspendedApiKeyEnv, "");
+});
+
+test("auth probe omits suspended credentials and records not_requested explicitly", async () => {
+  const emitted = [];
+  const fetchImpl = async (url, init) => {
+    if (url.endsWith("/api/health")) {
+      return Response.json({ commit: SHA, environment: "staging" });
+    }
+    const key = init.headers["X-API-Key"];
+    const traceId = init.headers["X-Eliza-Trace-Id"];
+    const probe = init.headers["X-Eliza-Auth-Probe"];
+    const invalid = key !== "eliza_valid";
+    const forcedMiss =
+      typeof probe === "string" && !probe.startsWith("invalid-control:");
+    const auth = invalid
+      ? "v=1;credential=x_api_key;probe=off;available=available;backend=cloudflare_kv;read=miss;authoritative=rejected;write=not_run;result=rejected"
+      : forcedMiss
+        ? authHeader("miss")
+        : authHeader("hit");
+    const timings = invalid
+      ? "auth_extract;dur=0.1, auth_cache_available;dur=0.1, auth_cache_read;dur=1, auth_key_lookup;dur=3, auth_resolve;dur=5"
+      : timingHeader(forcedMiss ? "miss" : "hit");
+    return new Response(null, {
+      status: invalid ? 401 : 400,
+      headers: {
+        "X-Eliza-Trace-Id": traceId,
+        "X-Eliza-Auth-Trace": auth,
+        "Server-Timing": timings,
+      },
+    });
+  };
+
+  const result = await runAuthProbes(
+    {
+      baseUrl: "https://preview.example",
+      apiKeyEnv: "AUTH_KEY",
+      suspendedApiKeyEnv: "",
+      probeTokenEnv: "PROBE_TOKEN",
+      deploySha: SHA,
+      hitCount: 1,
+      missCount: 1,
+      timeoutMs: 1_000,
+      intervalMs: 0,
+    },
+    {
+      env: { AUTH_KEY: "eliza_valid", PROBE_TOKEN: "private-probe" },
+      fetchImpl,
+      emit: (record) => emitted.push(record),
+      sleep: async () => {},
+    },
+  );
+
+  assert.deepEqual(
+    result.guards.map((record) => record.guard),
+    ["invalid_key", "forged_probe"],
+  );
+  assert.equal(result.summary.suspendedGuard, "not_requested");
+  assert.equal(JSON.stringify(emitted).includes("private-probe"), false);
 });
 
 test("auth parsers accept only bounded enums and finite auth durations", () => {
@@ -503,6 +573,7 @@ test("summary reports sample volume and latency distributions without thresholds
   ];
   const summary = summarizeAuthSamples(passing, SHA);
   assert.deepEqual(summary.counts, { hit: 30, miss: 10 });
+  assert.equal(summary.suspendedGuard, "not_requested");
   assert.deepEqual(summary.hitAuthResolveMs, {
     p50: 10,
     p90: 10,

--- a/packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts
@@ -69,7 +69,14 @@ describe("Cloud latency certification workflow", () => {
     });
     expect(inputs?.run_auth).toEqual({
       description:
-        "Also run protected inference-auth hit, miss, guard, and sanitized Worker Tail proof.",
+        "Also run protected inference-auth hit, miss, non-standing guards, and sanitized Worker Tail proof.",
+      required: true,
+      default: false,
+      type: "boolean",
+    });
+    expect(inputs?.run_suspended).toEqual({
+      description:
+        "Also prove the optional suspended-standing 403 guard (requires run_auth).",
       required: true,
       default: false,
       type: "boolean",
@@ -81,6 +88,9 @@ describe("Cloud latency certification workflow", () => {
     expect(preflight).toContain('"$GITHUB_REF" != "refs/heads/develop"');
     expect(preflight).toContain("^[a-f0-9]{40}$");
     expect(preflight).toContain('if [[ "$RUN_AUTH" == "true" ]]');
+    expect(preflight).toContain(
+      'if [[ "$RUN_SUSPENDED" == "true" && "$RUN_AUTH" != "true" ]]',
+    );
   });
 
   test("fails closed on paired and optional auth credentials before checkout", () => {
@@ -105,6 +115,10 @@ describe("Cloud latency certification workflow", () => {
       expect(preflight.run).toContain(name);
       expect(job?.env?.[name]).toContain(`secrets.${name}`);
     }
+    expect(preflight.run).toContain('if [[ "$RUN_SUSPENDED" == "true" ]]');
+    expect(preflight.run).toContain(
+      "required+=(ELIZA_STAGING_SUSPENDED_API_KEY)",
+    );
   });
 
   test("runs the bounded orchestrator and never selects arbitrary checkout bytes", () => {
@@ -119,6 +133,7 @@ describe("Cloud latency certification workflow", () => {
     );
     expect(run).toContain('--deploy-sha "$EXPECTED_DEPLOY_SHA"');
     expect(run).toContain("args+=(--auth)");
+    expect(run).toContain("args+=(--suspended)");
     expect(run).not.toContain("wrangler tail");
   });
 


### PR DESCRIPTION
Closes #30054

## What changed

- adds manual `run_suspended` input, default off and valid only with `run_auth=true`
- keeps auth-only certification independent of `ELIZA_STAGING_SUSPENDED_API_KEY`
- always proves 30 cache hits, 10 forced authoritative misses with deferred writes, invalid-key and forged-probe guards, plus sanitized correlated Worker Tail evidence
- requires and probes the suspended credential only when requested
- records `suspendedGuard: observed` or `not_requested` in sanitized inference evidence and the certification summary
- validates exact 44-record/42-trace auth-only and 45-record/43-trace suspended matrices

## Verification

- `node --test packages/cloud/scripts/cloud-latency-certification.test.mjs packages/cloud/scripts/inference-auth-latency.test.mjs packages/cloud/scripts/chat-latency.test.mjs` — 37/37 passed
- `bun test packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts` — 11/11 passed
- `bunx @biomejs/biome check <six touched files>` — passed
- `bun run verify:cloud` — 84/84 tasks passed
- `git diff --check` — passed

## Evidence

- Live staging run: N/A — deployment and live certification were explicitly out of scope.
- UI screenshots/video: N/A — no rendered UI changed.
- Raw Worker Tail: N/A — intentionally prohibited from logs and artifacts.
