### PR TITLE
fix(plugin-sql): consolidate stringToUuid onto @elizaos/core (#30056)

### DIFF
--- a/plugins/plugin-sql/src/__tests__/unit/string-to-uuid-parity.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/string-to-uuid-parity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests proving plugin-sql's `stringToUuid` is byte-for-byte the
+ * canonical `@elizaos/core` implementation, not a fork. plugin-sql previously
+ * shipped a local FNV-1a derivation that diverged from core's SHA-1 derivation
+ * for every non-UUID input, so the RLS `server_id` production computes from
+ * `ELIZA_SERVER_ID` differed from the id core derives for the same key — a
+ * data-isolation hazard. These tests fail against the old FNV implementation
+ * and pass once the utility is consolidated onto core. They exercise the pure
+ * functions and the real `createDatabaseAdapter` RLS-id derivation path; no
+ * live Postgres is required (pg's Pool connects lazily).
+ */
+import { stringToUuid as coreStringToUuid } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatabaseAdapter } from "../../index.node.ts";
+import { stringToUuid as sqlStringToUuid } from "../../utils/string-to-uuid.ts";
+
+const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
+
+interface ManagerLike {
+  close: () => Promise<void>;
+}
+
+function globalManagers(): Map<string, ManagerLike> | undefined {
+  const store = (
+    globalThis as Record<symbol, { postgresConnectionManagers?: Map<string, ManagerLike> }>
+  )[GLOBAL_SINGLETONS];
+  return store?.postgresConnectionManagers;
+}
+
+describe("plugin-sql stringToUuid canonical parity", () => {
+  const cases: Array<string | number> = [
+    "server-123",
+    "advanced-memory:world:00000000-0000-0000-0000-000000000abc",
+    "advanced-memory:long-term:agent:entity",
+    "12345",
+    12345,
+    "",
+    "550e8400-e29b-41d4-a716-446655440000",
+  ];
+
+  it("agrees with @elizaos/core across a table of natural keys", () => {
+    for (const input of cases) {
+      expect(sqlStringToUuid(input)).toBe(coreStringToUuid(input));
+    }
+  });
+
+  it("passes an already-valid UUID through unchanged, matching core", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(sqlStringToUuid(uuid)).toBe(uuid);
+    expect(sqlStringToUuid(uuid)).toBe(coreStringToUuid(uuid));
+  });
+
+  it("produces the documented core SHA-1 UUID for a known key (not the old FNV value)", () => {
+    // core SHA-1 derivation; the retired FNV impl produced 9460a9f3-... here.
+    expect(sqlStringToUuid("server-123")).toBe("f569c7d7-11c9-01e8-bdd4-c6235a8a9af7");
+  });
+
+  it("throws TypeError on non-string, non-number input, like core", () => {
+    // @ts-expect-error exercising the adversarial runtime path
+    expect(() => sqlStringToUuid({})).toThrow(TypeError);
+  });
+});
+
+describe("createDatabaseAdapter RLS server-id derivation", () => {
+  const previousEnv = {
+    ENABLE_DATA_ISOLATION: process.env.ENABLE_DATA_ISOLATION,
+    ELIZA_SERVER_ID: process.env.ELIZA_SERVER_ID,
+  };
+
+  afterEach(async () => {
+    process.env.ENABLE_DATA_ISOLATION = previousEnv.ENABLE_DATA_ISOLATION;
+    process.env.ELIZA_SERVER_ID = previousEnv.ELIZA_SERVER_ID;
+    const managers = globalManagers();
+    if (managers) {
+      for (const manager of managers.values()) {
+        await manager.close().catch(() => undefined);
+      }
+      managers.clear();
+    }
+  });
+
+  it("keys the RLS connection pool by core.stringToUuid(ELIZA_SERVER_ID)", () => {
+    process.env.ENABLE_DATA_ISOLATION = "true";
+    process.env.ELIZA_SERVER_ID = "parity-regression-server";
+    const agentId = "00000000-0000-0000-0000-0000000000aa" as const;
+
+    createDatabaseAdapter(
+      { postgresUrl: "postgresql://eliza:eliza@127.0.0.1:1/eliza_parity" },
+      agentId
+    );
+
+    const expectedRlsId = coreStringToUuid("parity-regression-server");
+    const managers = globalManagers();
+    expect(managers).toBeDefined();
+    expect(managers?.has(expectedRlsId)).toBe(true);
+  });
+});

--- a/plugins/plugin-sql/src/utils/string-to-uuid.ts
+++ b/plugins/plugin-sql/src/utils/string-to-uuid.ts
@@ -1,49 +1,12 @@
 /**
- * Deterministically derives a v4-shaped UUID from an arbitrary string (or
- * passes an already-valid UUID through unchanged), so the same input always
- * maps to the same synthetic ID — e.g. for deriving stable room/world IDs
- * from a natural key.
+ * Re-exports the canonical `stringToUuid` from `@elizaos/core` so plugin-sql
+ * never forks the natural-key → UUID derivation. This id is security-relevant:
+ * `createDatabaseAdapter` derives the RLS `server_id` (used for row stamping
+ * and tenant filtering) from `ELIZA_SERVER_ID` via this function, and other
+ * code derives ids from natural keys on both sides of the core/plugin-sql
+ * boundary. A local FNV-1a implementation previously diverged byte-for-byte
+ * from core's SHA-1 derivation, so the same key mapped to two different UUIDs.
+ * Delegating to core keeps a single source of truth across every build target
+ * (core's browser bundle exports the same WebCrypto/pure-JS implementation).
  */
-import type { UUID } from "@elizaos/core";
-
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function hashSegment(input: string, seed: number): number {
-  let hash = seed >>> 0;
-  for (let index = 0; index < input.length; index += 1) {
-    hash ^= input.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-export function stringToUuid(target: string | number): UUID {
-  const value = typeof target === "number" ? target.toString() : target;
-
-  if (typeof value !== "string") {
-    throw new TypeError("Value must be string");
-  }
-
-  if (UUID_PATTERN.test(value)) {
-    return value as UUID;
-  }
-
-  const input = encodeURIComponent(value);
-  const hex = [
-    hashSegment(input, 0x811c9dc5),
-    hashSegment(input, 0x9e3779b1),
-    hashSegment(input, 0x85ebca6b),
-    hashSegment(input, 0xc2b2ae35),
-  ]
-    .map((part) => part.toString(16).padStart(8, "0"))
-    .join("")
-    .slice(0, 32)
-    .split("");
-
-  hex[12] = "0";
-  hex[16] = ((Number.parseInt(hex[16] ?? "0", 16) & 0x3) | 0x8).toString(16);
-
-  return `${hex.slice(0, 8).join("")}-${hex.slice(8, 12).join("")}-${hex
-    .slice(12, 16)
-    .join("")}-${hex.slice(16, 20).join("")}-${hex.slice(20, 32).join("")}` as UUID;
-}
+export { stringToUuid } from "@elizaos/core";


### PR DESCRIPTION
# Relates to

Closes #30056

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; owning-package `test`, `typecheck`, and `lint` pass (see logs). Full `bun run verify` not run on this constrained host — see **Known gaps**.
- [x] A reviewer can confirm the change works from the evidence below (pure-function divergence + red→green regression test).

# Sync with develop

- [x] Based on latest `origin/develop` (`b47604274ea56621eaa1bbaa488dba63e37696c9`); zero conflicts.
- [x] Focused package gates pass post-sync; full `bun run verify` blocker documented in **Known gaps**.

# Risks

Low **for the consolidation itself**. The change deletes a divergent local implementation and delegates to the canonical `@elizaos/core` `stringToUuid`. Any code that previously relied on the plugin-sql FNV-1a output for a *non-UUID* natural key will now receive the canonical SHA-1 UUID instead. That is the intended correction: the RLS `server_id` derived from `ELIZA_SERVER_ID` now equals the id core (and the package's own RLS test) already computes for the same key. Already-valid UUID inputs pass through unchanged in both implementations, so callers that pass real UUIDs are unaffected.

## Data continuity / identifier cutover (merge acceptance requirement)

Switching the derivation is a one-time identifier cutover for any data persisted under the retired FNV-1a keys. **Correction (thanks @attentionhead):** an earlier revision of this section claimed the FNV `string-to-uuid.ts` was introduced in `2a4af7351c` (#29910) and was therefore bounded to a recent beta window. That was wrong — it rested on a squashed-history artifact (`git log --diff-filter=A` resolves to `2a4af7351c`, a mega-commit whose subject is actually `fix(cloud): preserve hosted logout authority (#29910)` and which touches thousands of unrelated files, so it is not the real introduction point). Tracing the file properly, `git log --follow -- plugins/plugin-sql/src/utils/string-to-uuid.ts` reaches `f7a6b0fea5` ("elizaOS v2.0.4 — clean baseline"), an ancestor of `develop` with ~19,722 commits to the current head, and the FNV body (offset basis `0x811c9dc5`, prime `16777619`) is already present there. **So the FNV derivation is long-standing, not beta-window scoped.** The affected surface is therefore any natural-key id derived since at least that v2.0.4 baseline, and default deployments can hold real rows keyed under the old ids:

- **advanced-memory (all backends, incl. the default PGlite):** `getMemoryWorldId()` / `getLongTermRoomId()` (`services/advanced-memory-storage.ts`) derive world/room ids from natural keys via this function. After the cutover, reads resolve the new SHA-1 ids and do not discover FNV-keyed worlds/rooms/long-term memories, so pre-cutover long-term memories become unreachable — hidden, not deleted.
- **natural-key RLS Postgres:** for a non-UUID `ELIZA_SERVER_ID`, `createDatabaseAdapter` (`index.node.ts:136`) now stamps and filters rows under a different `server_id`. Rows written under the old tenant id stay isolated under that id (no cross-tenant leak), but they are not visible to the new context, and globally-enforced unique constraints can still collide with the hidden rows. UUID-valued `ELIZA_SERVER_ID` deployments are unaffected (pass-through).

This PR intentionally scopes to the utility consolidation that #30056 requested (which the issue proved with pure functions and required no DB) and does **not** ship a re-keying migration. **Per maintainer direction (@lalalune, coordinating with #30229), this persisted-ID cutover is a merge acceptance requirement, not a risk note the author or a reviewer may wave through.** Utility parity does not prove that existing advanced-memory worlds/rooms or natural-key tenant data remain reachable, so simply accepting the cutover is off the table. Merge is gated on a single deliberate versioned-derivation/upgrade owner — with collision handling, atomic rollback, and restart idempotence — reconciled through one owner coordinated with #30229 (whose canonical-owner work still retains the legacy derivation in these consumers and is not itself a migration for these ids). That owner must land real evidence: pre-upgrade → post-upgrade memory reads on the default PGlite backend plus two-tenant PostgreSQL, proving an existing FNV-keyed row/world/long-term memory survives the cutover. This PR will **not** resolve the overlap by silently re-keying or discarding old records. Blast-radius context for that owner (not a reason to skip the migration): if `ENABLE_DATA_ISOLATION` + a non-UUID `ELIZA_SERVER_ID` is rare in practice, the RLS reach is a *deployment-shape* question and may be small; but if `AdvancedMemoryStorageService` has been live on default PGlite across the window since the v2.0.4 baseline, the migration/dual-read path is strongly required. Raised by @HomunculusLabs, corrected per @attentionhead's history findings, tie-broken by @hermesagent270-commits, and scoped as a merge gate by @lalalune.

# Background

## What does this PR do?

`plugins/plugin-sql` shipped its own `stringToUuid` (`src/utils/string-to-uuid.ts`) that derived the UUID from four FNV-1a hash segments (`Math.imul(hash, 16777619)`), while `@elizaos/core`'s canonical `stringToUuid` derives it from SHA-1 of the same escaped input. The two functions had byte-for-byte identical doc comments and the identical name/signature, yet produced **completely different UUIDs for every non-UUID input**.

This is a security-relevant duplicate-utility drift in data-isolation (RLS):

- `createDatabaseAdapter` (`src/index.node.ts` / `src/index.ts`) computes `rlsServerId = stringToUuid(ELIZA_SERVER_ID)` using the **local FNV** function and installs it as the Postgres tenant id used for row `server_id` stamping/filtering.
- The package's own RLS integration test (`rls-entity.real.test.ts`) computes the same value as `stringToUuid(process.env.ELIZA_SERVER_ID)` imported from `@elizaos/core` (**SHA-1**).

So the tested tenant id was never the id production computes for the same `ELIZA_SERVER_ID`, and any code deriving an id from a natural key on one side of the core/plugin-sql boundary and looking it up on the other got a mismatch.

**Fix:** delete the divergent FNV algorithm and re-export the canonical `stringToUuid` from `@elizaos/core`. Core's browser bundle exports the same WebCrypto/pure-JS implementation, so every build target (node/bun/browser/edge) now agrees. The three importers (`index.ts`, `index.node.ts`, `services/advanced-memory-storage.ts`) keep importing from `./utils/string-to-uuid` unchanged — the module now delegates to core, so there is a single source of truth.

## What kind of change is this?

Bug fix (non-breaking correction of a divergent security-relevant utility).

# Documentation changes needed?

My changes do not require a change to the project documentation. The module header in `string-to-uuid.ts` was rewritten to explain the consolidation and the RLS invariant.

# Testing

## Where should a reviewer start?

`plugins/plugin-sql/src/__tests__/unit/string-to-uuid-parity.test.ts`. It:
1. Imports `stringToUuid` from **both** `@elizaos/core` and `../../utils/string-to-uuid` and asserts equality across a table (`"server-123"`, `"advanced-memory:world:<uuid>"`, numeric, empty string, already-valid UUID pass-through).
2. Pins the known core SHA-1 value for `"server-123"` (`f569c7d7-…`), which the retired FNV impl could never produce (`9460a9f3-…`).
3. Exercises the real `createDatabaseAdapter` RLS path and asserts the connection pool is keyed by `core.stringToUuid(ELIZA_SERVER_ID)` (pg's Pool connects lazily, so no live Postgres is needed).

## Detailed testing steps

```
cd plugins/plugin-sql/src
bunx vitest run __tests__/unit/string-to-uuid-parity.test.ts
```

Red before the fix (FNV impl): 3 of 5 tests fail. Green after: 5/5 pass. Full unit lane (`__tests__/unit` + advanced-memory-storage): 91 pass.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:fdba89f3d121ab18f7b2a454ca2c5a5d07296d79 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; this PR changes a pure utility and its regression test.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the contract is a pure function + RLS id derivation, proven by test output below.
<!-- evidence-row:backend-logs -->
- [x] Focused regression test at head `fdba89f`, captured fresh in this worktree with workspace deps installed (`bun install`), exercising the real `createDatabaseAdapter` RLS server-id derivation (pg Pool connects lazily, so no live Postgres is needed):

<details><summary>plugin-sql string-to-uuid-parity — backend test output (green at head, red mutation control, typecheck)</summary>

```
# cd plugins/plugin-sql/src && bunx vitest run \
#   __tests__/unit/string-to-uuid-parity.test.ts --reporter=verbose
# head fdba89f3d121ab18f7b2a454ca2c5a5d07296d79 — bun 1.3.14 / vitest 4.1.10 (node v22.22.2)

 RUN  v4.1.10 plugins/plugin-sql/src
 ✓ plugin-sql stringToUuid canonical parity > agrees with @elizaos/core across a table of natural keys 53ms
 ✓ plugin-sql stringToUuid canonical parity > passes an already-valid UUID through unchanged, matching core 5ms
 ✓ plugin-sql stringToUuid canonical parity > produces the documented core SHA-1 UUID for a known key (not the old FNV value) 1ms
 ✓ plugin-sql stringToUuid canonical parity > throws TypeError on non-string, non-number input, like core 1ms
 ✓ createDatabaseAdapter RLS server-id derivation > keys the RLS connection pool by core.stringToUuid(ELIZA_SERVER_ID) 16ms
 Test Files  1 passed (1)
      Tests  5 passed (5)

# RED mutation control — restore ONLY the merge-base FNV impl, keep the new test:
#   git show fdba89f~1:plugins/plugin-sql/src/utils/string-to-uuid.ts \
#     > plugins/plugin-sql/src/utils/string-to-uuid.ts

 FAIL  produces the documented core SHA-1 UUID for a known key (not the old FNV value)
AssertionError: expected '9460a9f3-b687-076f-ba6b-01e1e6750083' to be 'f569c7d7-11c9-01e8-bdd4-c6235a8a9af7'
 ❯ __tests__/unit/string-to-uuid-parity.test.ts:55:43
 FAIL  keys the RLS connection pool by core.stringToUuid(ELIZA_SERVER_ID)
AssertionError: expected false to be true // managers.has(coreId)
 ❯ __tests__/unit/string-to-uuid-parity.test.ts:95:42
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
# restored with: git checkout HEAD -- plugins/plugin-sql/src/utils/string-to-uuid.ts

# typecheck at head:  cd plugins/plugin-sql && bun run typecheck
$ tsc --noEmit -p src/tsconfig.typecheck.json
TYPECHECK_EXIT: 0
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact for this UUID-derivation defect is the derived UUID values. Table reconstructed standalone from source at head `fdba89f` (core SHA-1 from `packages/core/src/utils.ts`; retired plugin-sql FNV-1a from `git fdba89f~1:.../string-to-uuid.ts`); the pins match the in-suite assertions and every reviewer reproduction:

<details><summary>stringToUuid divergence / parity table — core (SHA-1) vs retired plugin-sql (FNV-1a)</summary>

```
# node parity-probe.mjs   (node v22.22.2)
input "server-123"
  core (SHA-1):   f569c7d7-11c9-01e8-bdd4-c6235a8a9af7
  fnv  (retired): 9460a9f3-b687-076f-ba6b-01e1e6750083
  match: false
input "advanced-memory:world:agent"
  core (SHA-1):   2df51f61-43cb-0756-8a25-1fb6f9446ba1
  fnv  (retired): 29150750-b9a4-06c4-af9e-0302fd9c2f60
  match: false
input "advanced-memory:long-term:550e8400-...:660e8400-..."
  core (SHA-1):   96adae3a-98a2-0cfa-b9b5-8f2acf9d345a
  fnv  (retired): 2fe89ea1-b95c-09cd-ab0d-0923ce4a2231
  match: false
input 12345
  core (SHA-1):   8cb2237d-0679-0a88-9b64-64eac60da963
  fnv  (retired): 43c2c0d8-630d-028c-8741-b80274a33808
  match: false
input "" (empty)
  core (SHA-1):   da39a3ee-5e6b-0b0d-b255-bfef95601890
  fnv  (retired): 811c9dc5-9e37-09b1-85eb-ca6bc2b2ae35
  match: false
input "550e8400-e29b-41d4-a716-446655440000" (already a UUID)
  core (SHA-1):   550e8400-e29b-41d4-a716-446655440000
  fnv  (retired): 550e8400-e29b-41d4-a716-446655440000
  match: true   (pass-through preserved on both sides)

ANY NON-UUID DIVERGENCE: true
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Standalone bun comparison of the two algorithms (verbatim `core.stringToUuid` vs the plugin-sql impl).

**Before the fix — every non-UUID input diverges:**

```
# Standalone node/bun comparison of the two stringToUuid algorithms BEFORE the fix.
# core (SHA-1) from packages/core/src/utils.ts vs plugin-sql local FNV-1a from
# plugins/plugin-sql/src/utils/string-to-uuid.ts (Math.imul FNV-1a).

input "server-123"
  core: f569c7d7-11c9-01e8-bdd4-c6235a8a9af7
  sql:  9460a9f3-b687-076f-ba6b-01e1e6750083
  match: false
input "advanced-memory:world:agent"
  core: 2df51f61-43cb-0756-8a25-1fb6f9446ba1
  sql:  29150750-b9a4-06c4-af9e-0302fd9c2f60
  match: false
input "12345"
  core: 8cb2237d-0679-0a88-9b64-64eac60da963
  sql:  43c2c0d8-630d-028c-8741-b80274a33808
  match: false
input "550e8400-e29b-41d4-a716-446655440000"
  core: 550e8400-e29b-41d4-a716-446655440000
  sql:  550e8400-e29b-41d4-a716-446655440000
  match: true

ANY DIVERGENCE: true
```

**After the fix — full parity, UUID pass-through preserved:**

```
input "server-123"
  core: f569c7d7-11c9-01e8-bdd4-c6235a8a9af7
  sql:  f569c7d7-11c9-01e8-bdd4-c6235a8a9af7
  match: true
input "advanced-memory:world:agent"
  core: 2df51f61-43cb-0756-8a25-1fb6f9446ba1
  sql:  2df51f61-43cb-0756-8a25-1fb6f9446ba1
  match: true
input "12345"
  core: 8cb2237d-0679-0a88-9b64-64eac60da963
  sql:  8cb2237d-0679-0a88-9b64-64eac60da963
  match: true
input "550e8400-e29b-41d4-a716-446655440000"
  core: 550e8400-e29b-41d4-a716-446655440000
  sql:  550e8400-e29b-41d4-a716-446655440000
  match: true

ANY DIVERGENCE: false
```

**Regression test — RED before the fix (FNV impl restored):**

```
FAIL  __tests__/unit/string-to-uuid-parity.test.ts > createDatabaseAdapter RLS server-id derivation > keys the RLS connection pool by core.stringToUuid(ELIZA_SERVER_ID)
 FAIL  __tests__/unit/string-to-uuid-parity.test.ts > createDatabaseAdapter RLS server-id derivation > keys the RLS connection pool by core.stringToUuid(ELIZA_SERVER_ID)
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ __tests__/unit/string-to-uuid-parity.test.ts:95:42
     93|     const managers = globalManagers();
     94|     expect(managers).toBeDefined();
     95|     expect(managers?.has(expectedRlsId)).toBe(true);
       |                                          ^
     96|   });
     97| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/6]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
   Start at  08:34:10
   Duration  18.25s (transform 14.92s, setup 0ms, import 17.99s, tests 38ms, environment 0ms)
```

**Regression test — GREEN after the fix:**

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-30056/plugins/plugin-sql/src

 ✓ __tests__/unit/string-to-uuid-parity.test.ts (5 tests) 13ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:34:33
   Duration  18.05s (transform 14.79s, setup 0ms, import 17.86s, tests 13ms, environment 0ms)
```

<details><summary>typecheck + lint</summary>

```
$ bun run typecheck
$ tsc --noEmit -p src/tsconfig.typecheck.json

$ bun run lint
$ cd src && bun run lint
$ bunx @biomejs/biome check --write --config-path ./biome.json .
Checked 227 files in 1623ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was not executed on this Raspberry Pi host (16 GB RAM); it drives the whole Turbo workspace and is impractical here. Instead the owning package's `test` (unit lane, 91 pass), `typecheck` (clean), and `lint` (clean) were run and are attached. This is an unrelated environment constraint, not a defect in the change.
- The `rls-entity.real.test.ts` integration test is `describe.skipIf(!POSTGRES_URL)` and requires a live Postgres; it was not run here. The defect is proven purely from the two pure functions and the import cross-reference, which needs no database.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@fdba89f3d121ab18f7b2a454ca2c5a5d07296d79:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@fdba89f3d121ab18f7b2a454ca2c5a5d07296d79:packages/skills/skills/contribute-to-eliza"} -->


