### PR TITLE
test(ui): give the navigate-view auth mock its full authenticated state

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -44,6 +44,15 @@ const appState = vi.hoisted(() => ({
   }>,
 }));
 
+/** The full authenticated `AuthStatusState`, shared so the hook and the
+ * out-of-React snapshot cannot drift apart again. */
+const AUTHENTICATED_AUTH_STATUS = vi.hoisted(() => ({
+  phase: "authenticated" as const,
+  identity: { id: "test-user" },
+  session: { id: "test-session" },
+  access: {},
+}));
+
 const authStatusMock = vi.hoisted(() => ({
   phase: "authenticated" as
     | "authenticated"
@@ -313,7 +322,14 @@ vi.mock("./hooks/useAuthStatus", () => ({
   useAuthStatus: (options: { skip?: boolean } = {}) => {
     authStatusMock.use(options);
     return {
-      state: { phase: authStatusMock.phase },
+      // AuthStatusState is a discriminated union: `phase: "authenticated"`
+      // carries identity/session/access. Returning the bare phase left
+      // consumers that read `authStatus.identity.id` dereferencing undefined,
+      // which is what getAuthStatusSnapshot below already models correctly.
+      state:
+        authStatusMock.phase === "authenticated"
+          ? AUTHENTICATED_AUTH_STATUS
+          : { phase: authStatusMock.phase },
       refetch: authStatusMock.refetch,
     };
   },
@@ -331,12 +347,7 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // same static phase in AuthStatusState shape.
   getAuthStatusSnapshot: () =>
     authStatusMock.phase === "authenticated"
-      ? {
-          phase: "authenticated",
-          identity: { id: "test-user" },
-          session: { id: "test-session" },
-          access: {},
-        }
+      ? AUTHENTICATED_AUTH_STATUS
       : { phase: "unauthenticated" },
   subscribeAuthStatus: () => vi.fn(),
 }));


### PR DESCRIPTION
# Relates to

Closes #30058.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Repairs a lane that is red on `develop` right now.
- [x] Changes no runtime source — the diff is one test's auth double.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] One file differs: `+18/-7`.

# Risks

None to runtime. No production file is touched, and non-authenticated phases keep their
existing behaviour in both mocked seams — only the authenticated shape changes, and only
to match the type it was already claiming to model.

# Background

## What is broken

`tests / Zero-Key unit + UI coverage` is red. `App.navigate-view-wiring.test.tsx` fails
4 of 39 and reproduces locally at the current tip:

```
TypeError: Cannot read properties of undefined (reading 'id')
 ❯ usePendingActions src/components/shell/pending-action-notifications.ts:496:29
 ❯ NotificationsHomeCenter src/components/shell/NotificationsHomeCenter.tsx:723:7
Tests  4 failed | 35 passed (39)
```

The fourth failure is downstream of the same crash — the subtree never renders, so the
assertion reports `Unable to find an element by: [data-testid="launcher-surface"]`.

## Root cause

`AuthStatusState` (`packages/ui/src/hooks/useAuthStatus.ts:37`) is a discriminated union
whose authenticated arm carries `identity`, `session`, and `access`. Production is
therefore right to read `authStatus.identity.id` behind a `phase === "authenticated"`
check — the type guarantees the field.

The test mocks that module with two seams that disagree. `getAuthStatusSnapshot` returns
the complete shape, and its comment says as much ("the same static phase in
AuthStatusState shape"). The hook returns only the discriminant:

```ts
state: { phase: authStatusMock.phase },
```

`usePendingActions` consumes the **hook**, so it sees `phase: "authenticated"` with no
`identity`.

## Why it started failing

`2f213f3caa` ("fix(ui): persist resolved approval notification fences", 2026-08-28T21:24)
introduced the `authStatus.identity.id` read. Verified by counting that expression across
the file's history: 0 at `a6bd0d97fc` and every earlier commit, 1 from `2f213f3caa`
onward. The mock has been incomplete all along — that commit is just the first consumer to
reach for the missing field.

## What is the fix?

Give the hook the same authenticated state the snapshot already returns, and share one
constant so the two seams cannot drift apart again:

```diff
+/** The full authenticated `AuthStatusState`, shared so the hook and the
+ * out-of-React snapshot cannot drift apart again. */
+const AUTHENTICATED_AUTH_STATUS = vi.hoisted(() => ({
+  phase: "authenticated" as const,
+  identity: { id: "test-user" },
+  session: { id: "test-session" },
+  access: {},
+}));
...
-      state: { phase: authStatusMock.phase },
+      state:
+        authStatusMock.phase === "authenticated"
+          ? AUTHENTICATED_AUTH_STATUS
+          : { phase: authStatusMock.phase },
```

No production guard is added, deliberately: the union already makes `identity` mandatory
on that arm, so the runtime code is correct and adding a defensive check would weaken a
contract the type system is enforcing. The defect is entirely in the double.

# Documentation changes needed?

No. Test only.

# Testing

## Where should a reviewer start?

The mutation block.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `vitest run packages/ui/src/App.navigate-view-wiring.test.tsx` | **39 passed (39)** — was `4 failed | 35 passed` |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| diff vs `develop` | `+18/-7`, one test file, zero runtime files |

Mutation resistance — restoring **only** develop's version of the mock:

```
TypeError: Cannot read properties of undefined (reading 'id')
 Warn [ViewLifecycle] view "apps" crashed: Cannot read properties of undefined (reading 'id')
```

That is the same crash the hosted `Zero-Key unit + UI coverage` job fails with, so the
local reproduction and the CI failure are the same failure.

# Evidence Gate

<!-- evidence-head:fbf3c2ecc2b1111ec3ee138116405b1fe7d3ed61 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test double repair; this diff touches no rendering code`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test double repair; this diff touches no rendering code`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable result is the suite's pass/fail, quoted above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; this is a client-side render test`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - the relevant console output is the crash trace, quoted above`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in auth-status wiring`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the suite result and crash trace, quoted above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface changes`.

# Attribution

- Identified and fixed by Claude Code (`claude-opus-5`): `Zero-Key unit + UI coverage` log triage, local reproduction at the exact `develop` tip, reading the `AuthStatusState` union to establish that the runtime code is correct and the double is not, the expression-count history isolating the first consumer to `2f213f3caa`, and the mutation proof.

Attribution status: self-reported
