### PR TITLE
fix(cloud): align chat-latency probe with frontend wire contract

### DIFF
--- a/packages/cloud/scripts/chat-latency.mjs
+++ b/packages/cloud/scripts/chat-latency.mjs
@@ -628,12 +628,16 @@ export async function probeDedicated({
           Accept: "text/event-stream",
           "X-Eliza-Trace-Id": traceId,
           "X-Eliza-Telemetry": "full",
+          "X-ElizaOS-Turn-Correlation": randomUUID(),
           "User-Agent": "eliza-chat-latency/1.0",
         },
         body: JSON.stringify({
           text: prompt,
           channelType: "DM",
           clientMessageId: randomUUID(),
+          // Match the first-party frontend wire contract so the measured
+          // path exercises the same negotiated protocol and framing (#30024).
+          streamProtocol: "delta-v2",
         }),
         signal: requestSignal(timeoutMs),
       },


### PR DESCRIPTION
## Summary
The dedicated latency probe POSTed `/api/conversations/:id/messages/stream` without the negotiated `delta-v2` `streamProtocol` or the opaque `X-ElizaOS-Turn-Correlation` UUID the first-party frontend sends, so its streamed latency and framing behavior could differ from the path it is intended to measure (#30024).

## Fix
- Send `streamProtocol: "delta-v2"` in the request body.
- Send an opaque `X-ElizaOS-Turn-Correlation` UUID header.
- Preserve the existing `clientMessageId`, DM channel, SSE accept header, auth, trace, and telemetry.

Closes #30024.