### PR TITLE
fix(ui): cancel replaced settings bootstrap reads

### DIFF
--- a/packages/ui/src/api/client-agent-accounts.test.ts
+++ b/packages/ui/src/api/client-agent-accounts.test.ts
@@ -20,6 +20,21 @@ function accountsClient(body: unknown): ElizaClient {
 }
 
 describe("ElizaClient account replacement transport", () => {
+  it("forwards a caller's abort signal to the inventory transport", async () => {
+    const request = vi.fn(async () => jsonResponse({ providers: [] }));
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+    const controller = new AbortController();
+
+    await client.listAccounts({ signal: controller.signal });
+
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:31337/api/accounts",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      { timeoutMs: 10_000 },
+    );
+  });
+
   it("accepts the canonical providers response and preserves server metadata", async () => {
     const body = {
       providers: [

--- a/packages/ui/src/api/client-agent-accounts.ts
+++ b/packages/ui/src/api/client-agent-accounts.ts
@@ -58,7 +58,7 @@ export interface AccountOAuthStartResult {
 
 declare module "./client-base" {
   interface ElizaClient {
-    listAccounts(): Promise<AccountsListResponse>;
+    listAccounts(init?: RequestInit): Promise<AccountsListResponse>;
     createApiKeyAccount(
       providerId: LinkedAccountProviderId,
       body: { label: string; apiKey: string },
@@ -102,11 +102,14 @@ declare module "./client-base" {
   }
 }
 
-ElizaClient.prototype.listAccounts = async function (this: ElizaClient) {
+ElizaClient.prototype.listAccounts = async function (this: ElizaClient, init) {
   // The agent is a separate process on an operator-controlled host, so its
   // reply is untrusted input: validate the shape once here rather than letting
   // a malformed provider list surface as undefined fields in the panel.
-  const response = await this.fetch<unknown>("/api/accounts");
+  const response =
+    init === undefined
+      ? await this.fetch<unknown>("/api/accounts")
+      : await this.fetch<unknown>("/api/accounts", init);
   return parseAccountsListResponse(response);
 };
 

--- a/packages/ui/src/api/client-agent-consumer-keys.test.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys.test.ts
@@ -48,7 +48,7 @@ describe("ElizaClient.listConsumerKeys", () => {
     const result = await client.listConsumerKeys();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/accounts/consumer-keys",
-      undefined,
+      { signal: undefined },
       { timeoutMs: CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS },
     );
     expect(result).toEqual([summary]);
@@ -59,8 +59,19 @@ describe("ElizaClient.listConsumerKeys", () => {
     await client.listConsumerKeys(1234);
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/accounts/consumer-keys",
-      undefined,
+      { signal: undefined },
       { timeoutMs: 1234 },
+    );
+  });
+
+  it("forwards a caller cancellation signal without changing the timeout", async () => {
+    const { client, fetchMock } = clientWithBody({ keys: [] });
+    const controller = new AbortController();
+    await client.listConsumerKeys(undefined, controller.signal);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/accounts/consumer-keys",
+      { signal: controller.signal },
+      { timeoutMs: CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS },
     );
   });
 

--- a/packages/ui/src/api/client-agent-consumer-keys.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys.ts
@@ -76,7 +76,10 @@ function parseCreated(value: unknown): ConsumerKeyCreated {
 
 declare module "./client-base" {
   interface ElizaClient {
-    listConsumerKeys(timeoutMs?: number): Promise<ConsumerKeySummary[]>;
+    listConsumerKeys(
+      timeoutMs?: number,
+      signal?: AbortSignal,
+    ): Promise<ConsumerKeySummary[]>;
     createConsumerKey(body: ConsumerKeyPatch): Promise<ConsumerKeyCreated>;
     updateConsumerKey(
       id: string,
@@ -89,10 +92,11 @@ declare module "./client-base" {
 ElizaClient.prototype.listConsumerKeys = async function (
   this: ElizaClient,
   timeoutMs: number = CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS,
+  signal?: AbortSignal,
 ) {
   const response = await this.fetch<unknown>(
     "/api/accounts/consumer-keys",
-    undefined,
+    { signal },
     { timeoutMs },
   );
   if (!isRecord(response) || !Array.isArray(response.keys)) {

--- a/packages/ui/src/api/client-agent-models-config.test.ts
+++ b/packages/ui/src/api/client-agent-models-config.test.ts
@@ -55,6 +55,19 @@ describe("ElizaClient.getModelsConfig", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/models/config");
     expect(result.targets).toBeDefined();
   });
+
+  it("forwards a caller's abort signal to the transport", async () => {
+    const { client, fetchMock } = clientWithBody({
+      targets: { small: {}, large: {}, coding: {} },
+    });
+    const controller = new AbortController();
+
+    await client.getModelsConfig({ signal: controller.signal });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/models/config", {
+      signal: controller.signal,
+    });
+  });
 });
 
 describe("ElizaClient.updateModelsConfig", () => {

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -524,7 +524,7 @@ declare module "./client-base" {
       providers: Record<string, ProviderModelRecord[]>;
       catalog: ModelCatalog;
     }>;
-    getModelsConfig(): Promise<ModelsConfigResponse>;
+    getModelsConfig(init?: RequestInit): Promise<ModelsConfigResponse>;
     updateModelsConfig(
       request: ModelsConfigWriteRequest,
     ): Promise<ModelsConfigWriteResult>;
@@ -2108,8 +2108,13 @@ ElizaClient.prototype.getModelsCatalog = async function (
     : this.fetch("/api/models?catalogOnly=1", init);
 };
 
-ElizaClient.prototype.getModelsConfig = async function (this: ElizaClient) {
-  return this.fetch("/api/models/config");
+ElizaClient.prototype.getModelsConfig = async function (
+  this: ElizaClient,
+  init,
+) {
+  return init === undefined
+    ? this.fetch("/api/models/config")
+    : this.fetch("/api/models/config", init);
 };
 
 ElizaClient.prototype.updateModelsConfig = async function (

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
@@ -16,6 +16,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ConsumerKeyCreated,
@@ -104,6 +105,47 @@ describe("list states", () => {
     });
     render(<ConsumerKeyPanelBody api={api} />);
     expect(screen.getByTestId("consumer-keys-loading")).toBeTruthy();
+  });
+
+  it("cancels the replaced StrictMode list read and renders its successor", async () => {
+    const signals: AbortSignal[] = [];
+    const list = vi.fn(
+      (_timeoutMs?: number, signal?: AbortSignal) =>
+        new Promise<ConsumerKeySummary[]>((resolve, reject) => {
+          if (!signal) throw new Error("missing cancellation signal");
+          signals.push(signal);
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+          if (signals.length === 2) resolve([key()]);
+        }),
+    );
+    render(
+      <StrictMode>
+        <ConsumerKeyPanelBody api={makeApi({ listConsumerKeys: list })} />
+      </StrictMode>,
+    );
+    await waitFor(() => expect(screen.getByText("proxy-a")).toBeTruthy());
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+    expect(screen.queryByTestId("consumer-keys-error")).toBeNull();
+  });
+
+  it("cancels the active list read when the panel unmounts", () => {
+    let signal: AbortSignal | undefined;
+    const list = vi.fn((_timeoutMs?: number, nextSignal?: AbortSignal) => {
+      signal = nextSignal;
+      return new Promise<ConsumerKeySummary[]>(() => {});
+    });
+    const view = render(
+      <ConsumerKeyPanelBody api={makeApi({ listConsumerKeys: list })} />,
+    );
+    expect(signal?.aborted).toBe(false);
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
   });
 
   it("renders an explicit error state and retries into data", async () => {

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
@@ -17,7 +17,7 @@ import {
   RotateCw,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../api";
 import type {
   ConsumerKeyCreated,
@@ -32,7 +32,10 @@ import { Input } from "../ui/input";
 import { Skeleton } from "../ui/skeleton";
 
 export interface ConsumerKeyPanelApi {
-  listConsumerKeys(): Promise<ConsumerKeySummary[]>;
+  listConsumerKeys(
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<ConsumerKeySummary[]>;
   createConsumerKey(body: ConsumerKeyPatch): Promise<ConsumerKeyCreated>;
   updateConsumerKey(
     id: string,
@@ -154,24 +157,49 @@ export function ConsumerKeyPanelBody({
     value: string;
   } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const activeLoadAbortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
+    activeLoadAbortRef.current?.abort();
+    const abortController = new AbortController();
+    activeLoadAbortRef.current = abortController;
     setLoading(true);
     setError(null);
     try {
-      setKeys(await api.listConsumerKeys());
+      const nextKeys = await api.listConsumerKeys(
+        undefined,
+        abortController.signal,
+      );
+      if (
+        abortController.signal.aborted ||
+        activeLoadAbortRef.current !== abortController
+      )
+        return;
+      setKeys(nextKeys);
     } catch (loadError) {
       // error-policy:J4 the list read failing renders the explicit error+retry
       // state; an empty-looking healthy panel would misreport the store.
+      if (
+        abortController.signal.aborted ||
+        activeLoadAbortRef.current !== abortController
+      )
+        return;
       setError(errorText(loadError));
       setKeys(null);
     } finally {
-      setLoading(false);
+      if (activeLoadAbortRef.current === abortController) {
+        activeLoadAbortRef.current = null;
+        setLoading(false);
+      }
     }
   }, [api]);
 
   useEffect(() => {
     void load();
+    return () => {
+      activeLoadAbortRef.current?.abort();
+      activeLoadAbortRef.current = null;
+    };
   }, [load]);
 
   const withBusy = useCallback(

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -265,6 +265,46 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("catalog load states", () => {
+  it.each(["catalog", "config"] as const)(
+    "cancels the pending sibling when the %s request fails and can retry",
+    async (failedRequest) => {
+      const failed = deferred<never>();
+      let siblingCancelled = false;
+      const pending = (init: RequestInit) =>
+        new Promise<never>((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              siblingCancelled = true;
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        });
+      const failing =
+        failedRequest === "catalog"
+          ? clientMock.getModelsCatalog
+          : clientMock.getModelsConfig;
+      const sibling =
+        failedRequest === "catalog"
+          ? clientMock.getModelsConfig
+          : clientMock.getModelsCatalog;
+      failing.mockImplementationOnce(() => failed.promise);
+      sibling.mockImplementationOnce(pending);
+      render(<ModelConfigurationPanel />);
+      await act(async () => failed.reject(new Error("bootstrap unavailable")));
+      await waitFor(() =>
+        expect(screen.getByText(/bootstrap unavailable/)).toBeTruthy(),
+      );
+      expect(siblingCancelled).toBe(true);
+      act(() => agentButton("models-retry").click());
+      await waitFor(() =>
+        expect(agentElements.has("models-small-provider")).toBe(true),
+      );
+      expect(screen.queryByText(/bootstrap unavailable/)).toBeNull();
+    },
+  );
+
   it("reaches ready after the StrictMode effect lifecycle replay", async () => {
     render(
       <StrictMode>
@@ -276,6 +316,18 @@ describe("catalog load states", () => {
       expect(agentElements.has("models-small-provider")).toBe(true),
     );
     expect(screen.queryByText("Loading model catalog…")).toBeNull();
+    const firstCatalogSignal = clientMock.getModelsCatalog.mock.calls[0]?.[0]
+      ?.signal as AbortSignal | undefined;
+    const currentCatalogSignal = clientMock.getModelsCatalog.mock.calls[1]?.[0]
+      ?.signal as AbortSignal | undefined;
+    const firstConfigSignal = clientMock.getModelsConfig.mock.calls[0]?.[0]
+      ?.signal as AbortSignal | undefined;
+    const currentConfigSignal = clientMock.getModelsConfig.mock.calls[1]?.[0]
+      ?.signal as AbortSignal | undefined;
+    expect(firstCatalogSignal?.aborted).toBe(true);
+    expect(firstConfigSignal?.aborted).toBe(true);
+    expect(currentCatalogSignal?.aborted).toBe(false);
+    expect(currentConfigSignal?.aborted).toBe(false);
   });
 
   it("keeps the current StrictMode load when the stale load succeeds later", async () => {
@@ -368,9 +420,15 @@ describe("catalog load states", () => {
     clientMock.getModelsCatalog.mockReset().mockReturnValue(catalog.promise);
     clientMock.getModelsConfig.mockReset().mockReturnValue(config.promise);
     const view = render(<ModelConfigurationPanel />);
+    const catalogSignal = clientMock.getModelsCatalog.mock.calls[0]?.[0]
+      ?.signal as AbortSignal | undefined;
+    const configSignal = clientMock.getModelsConfig.mock.calls[0]?.[0]
+      ?.signal as AbortSignal | undefined;
     expect(screen.getByText("Loading model catalog…")).toBeTruthy();
 
     view.unmount();
+    expect(catalogSignal?.aborted).toBe(true);
+    expect(configSignal?.aborted).toBe(true);
     await act(async () => {
       catalog.resolve({ providers: {}, catalog: fixtureCatalog() });
       config.resolve(fixtureConfig());

--- a/packages/ui/src/components/settings/useModelConfiguration.ts
+++ b/packages/ui/src/components/settings/useModelConfiguration.ts
@@ -456,6 +456,7 @@ export function useModelConfiguration(
   const lifecycleGenerationRef = useRef(0);
   const activeLifecycleRef = useRef(0);
   const loadGenerationRef = useRef(0);
+  const activeLoadAbortRef = useRef<AbortController | null>(null);
   useEffect(() => {
     lifecycleGenerationRef.current += 1;
     const lifecycleGeneration = lifecycleGenerationRef.current;
@@ -497,6 +498,10 @@ export function useModelConfiguration(
 
   const loadAll = useCallback(async () => {
     const lifecycleGeneration = activeLifecycleRef.current;
+    if (lifecycleGeneration === 0 || disposedRef.current) return;
+    activeLoadAbortRef.current?.abort();
+    const abortController = new AbortController();
+    activeLoadAbortRef.current = abortController;
     loadGenerationRef.current += 1;
     const loadGeneration = loadGenerationRef.current;
     // A mounted boolean alone cannot distinguish StrictMode's replaced setup
@@ -506,13 +511,15 @@ export function useModelConfiguration(
       lifecycleGeneration !== 0 &&
       activeLifecycleRef.current === lifecycleGeneration &&
       loadGenerationRef.current === loadGeneration &&
+      activeLoadAbortRef.current === abortController &&
+      !abortController.signal.aborted &&
       !disposedRef.current;
     if (!ownsLoad()) return;
     setLoad({ phase: "loading" });
     try {
       const [modelsResponse, configResponse] = await Promise.all([
-        client.getModelsCatalog(),
-        client.getModelsConfig(),
+        client.getModelsCatalog({ signal: abortController.signal }),
+        client.getModelsConfig({ signal: abortController.signal }),
       ]);
       if (!ownsLoad()) return;
       const data: ReadyData = {
@@ -526,12 +533,23 @@ export function useModelConfiguration(
       // error-policy:J4 catalog/config fetch failure renders the panel's
       // designed error state (with retry) instead of a healthy-empty panel.
       if (!ownsLoad()) return;
+      // Promise.all rejects before its other request settles; cancel that
+      // sibling before releasing this load's controller.
+      abortController.abort();
       setLoad({ phase: "error", message: failureMessage(err) });
+    } finally {
+      if (activeLoadAbortRef.current === abortController) {
+        activeLoadAbortRef.current = null;
+      }
     }
   }, [initializeDrafts]);
 
   useEffect(() => {
     void loadAll();
+    return () => {
+      activeLoadAbortRef.current?.abort();
+      activeLoadAbortRef.current = null;
+    };
   }, [loadAll]);
 
   /**

--- a/packages/ui/src/hooks/useAccounts.test.tsx
+++ b/packages/ui/src/hooks/useAccounts.test.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const client = vi.hoisted(() => ({
@@ -43,6 +44,19 @@ vi.mock("./useDocumentVisibility", () => ({
 import type { AccountsListResponse } from "../api/client-agent";
 import { AccountCard } from "../components/accounts/AccountCard";
 import { useAccounts } from "./useAccounts";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 const initial: AccountsListResponse = {
   providers: [
@@ -96,6 +110,26 @@ beforeEach(() => {
 });
 
 describe("useAccounts", () => {
+  it("coalesces the replaced StrictMode lifecycle before inventory transport", async () => {
+    const current = deferred<AccountsListResponse>();
+    client.listAccounts.mockReset().mockReturnValue(current.promise);
+
+    const { result } = renderHook(() => useAccounts({ pollMs: 0 }), {
+      wrapper: StrictMode,
+    });
+    await waitFor(() => expect(client.listAccounts).toHaveBeenCalledTimes(1));
+
+    const currentSignal = client.listAccounts.mock.calls[0]?.[0]?.signal as
+      | AbortSignal
+      | undefined;
+    expect(currentSignal?.aborted).toBe(false);
+
+    await act(async () => current.resolve(initial));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(initial);
+    expect(result.current.error).toBeNull();
+  });
+
   it("adopts a dialog-created account before the inventory refresh settles", async () => {
     let resolveRefresh: ((value: AccountsListResponse) => void) | undefined;
     const pendingRefresh = new Promise<AccountsListResponse>((resolve) => {

--- a/packages/ui/src/hooks/useAccounts.ts
+++ b/packages/ui/src/hooks/useAccounts.ts
@@ -129,6 +129,7 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
   const accountVersionRef = useRef(new Map<string, number>());
   const stateVersionRef = useRef(0);
   const listRequestIdRef = useRef(0);
+  const activeListAbortRef = useRef<AbortController | null>(null);
   const dataRef = useRef(data);
   dataRef.current = data;
 
@@ -160,10 +161,27 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
           replaceAccount(previous, created.providerId, created.account),
         );
       }
+      activeListAbortRef.current?.abort();
+      const abortController = new AbortController();
+      activeListAbortRef.current = abortController;
       const requestId = ++listRequestIdRef.current;
       const stateVersion = stateVersionRef.current;
       try {
-        const next = await client.listAccounts();
+        // StrictMode replaces an effect before the next microtask. Defer the
+        // inventory GET until then so the discarded lifecycle can be aborted
+        // before it reaches the account store; canceling after dispatch still
+        // leaves that server-side read competing with its successor.
+        await Promise.resolve();
+        if (
+          abortController.signal.aborted ||
+          activeListAbortRef.current !== abortController ||
+          !mountedRef.current ||
+          listRequestIdRef.current !== requestId
+        )
+          return;
+        const next = await client.listAccounts({
+          signal: abortController.signal,
+        });
         if (
           !mountedRef.current ||
           listRequestIdRef.current !== requestId ||
@@ -173,6 +191,7 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
         setData(next);
         setError(null);
       } catch (err) {
+        if (abortController.signal.aborted) return;
         if (
           !mountedRef.current ||
           listRequestIdRef.current !== requestId ||
@@ -182,7 +201,10 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
         setError(describeError("Failed to load accounts", err));
         notify("Failed to load accounts", err);
       } finally {
-        if (mountedRef.current) setLoading(false);
+        if (activeListAbortRef.current === abortController) {
+          activeListAbortRef.current = null;
+          if (mountedRef.current) setLoading(false);
+        }
       }
     },
     [notify],
@@ -420,6 +442,8 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
     void refresh();
     return () => {
       mountedRef.current = false;
+      activeListAbortRef.current?.abort();
+      activeListAbortRef.current = null;
     };
   }, [refresh]);
 


### PR DESCRIPTION
Settings bootstrap reads now carry cancellation through the API client. Replaced or unmounted account, consumer-key, and model-settings loads abort their outstanding requests and cannot publish stale state. Review fixes also abort sibling requests when a parallel bootstrap fails, while preserving the distinction between cancellation and a visible load error.

Validation for `234cd3a0c0d988df88b3e42a2f5116167770544a`:

- All 92 focused tests passed across six API/hook/component suites after rebase.
- Normal installation and full repository verification passed, including all 376 tasks and final audits.
- Full UI package run: 13,518 passed, six failed, seven skipped. All six failed suites then passed targeted reruns; protected-storage teardown needed a 20-second budget for dynamic module loading, with unchanged assertions.
- App audit: 219 passed; all four settings viewport captures inspected.
- Real HTTP cancellation passed for all three client methods. Actual component Chromium capture proved desktop/mobile cancellation and server disconnect versus the pre-change component.
- Screenshots, MP4 recordings, harness source, audit reports and test logs: https://github.com/elizaOS/eliza/pull/30063#issuecomment-5552474492
- All five required original PR checks passed on this exact revision. No live-model or production account mutation is involved.
