### PR TITLE
fix(cloud): honor false renderer dispatch input

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -844,7 +844,10 @@ jobs:
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
-      run_deployed_renderer_staging: ${{ github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true }}
+      # Resolve the proof request at the entry workflow boundary. A live-ready
+      # automatic release is a Develop effect reconciliation with a bound
+      # digest; an ordinary manual dispatch must honor its explicit false.
+      run_deployed_renderer_staging: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'staging' && (inputs.run_deployed_renderer_staging == true || (inputs.effect_digest != '' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1')) }}
       production_binding_only_recovery: ${{ github.event_name == 'workflow_dispatch' && inputs.production_binding_only_recovery == true }}
       certified_production_base_sha: ${{ inputs.certified_production_base_sha }}
       certified_recovery_policy_sha: ${{ inputs.certified_recovery_policy_sha }}

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -2911,13 +2911,12 @@ jobs:
   deployed-renderer-staging:
     name: Verify deployed staging renderer (Pages alias)
     needs: [deploy-app, verify-routing]
-    if: ${{ !cancelled() && inputs.target_environment == 'staging' && ((vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)) }}
+    if: ${{ !cancelled() && inputs.target_environment == 'staging' && inputs.run_deployed_renderer_staging == true }}
     runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 45
     steps:
-      - name: Require one-shot staging release prerequisites
-        if: ${{ inputs.run_deployed_renderer_staging == true }}
+      - name: Require deployed-renderer staging release prerequisites
         env:
           DEPLOY_APP_RESULT: ${{ needs.deploy-app.result }}
           PAGES_DEPLOYED: ${{ needs.deploy-app.outputs.pages_deployed }}

--- a/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
@@ -85,9 +85,9 @@ const authorityUpload = requireStep(
   "Publish closed Pages deployment authority",
 );
 const deployedJob = requireJob("deployed-renderer-staging");
-const oneShotPrerequisite = requireStep(
+const rendererPrerequisite = requireStep(
   deployedJob,
-  "Require one-shot staging release prerequisites",
+  "Require deployed-renderer staging release prerequisites",
 );
 const authorityDownload = requireStep(
   deployedJob,
@@ -170,18 +170,13 @@ describe("Cloudflare deployed browser workflow contract", () => {
     expect(freshnessStep.run).toContain("https://develop.eliza-app.pages.dev");
   });
 
-  test("runs only after the staging deploy and public routing gates", () => {
+  test("runs only when the caller requests the staging proof", () => {
     expect(deployedJob.needs).toEqual(["deploy-app", "verify-routing"]);
     expect(deployedJob.environment).toBe("staging");
-    expect(deployedJob.if).toContain("inputs.target_environment == 'staging'");
-    expect(deployedJob.if).toContain(
-      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1'",
-    );
-    expect(deployedJob.if).toContain(
-      "needs.deploy-app.outputs.pages_deployed == 'true'",
-    );
-    expect(deployedJob.if).toContain(
-      "needs.verify-routing.result == 'success'",
+    expect(deployedJob.if).toBe(
+      githubExpression(
+        "!cancelled() && inputs.target_environment == 'staging' && inputs.run_deployed_renderer_staging == true",
+      ),
     );
     expect(deployJob.outputs?.pages_authority_artifact).toBe(
       `pages-deployment-authority-${githubExpression("github.run_id")}-${githubExpression("github.run_attempt")}`,
@@ -215,11 +210,13 @@ describe("Cloudflare deployed browser workflow contract", () => {
     expect(calledInput?.default).toBe(false);
     expect(releaseJob?.with?.[inputName]).toBe(
       githubExpression(
-        "github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true",
+        "github.event_name == 'workflow_dispatch' && inputs.environment == 'staging' && (inputs.run_deployed_renderer_staging == true || (inputs.effect_digest != '' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1'))",
       ),
     );
     expect(admissionStep?.env?.RUN_DEPLOYED_RENDERER_STAGING).toBe(
-      releaseJob?.with?.[inputName],
+      githubExpression(
+        "github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true",
+      ),
     );
     expect(sourceValidationStep?.env?.RUN_DEPLOYED_RENDERER_STAGING).toBe(
       githubExpression("inputs.run_deployed_renderer_staging == true"),
@@ -237,29 +234,23 @@ describe("Cloudflare deployed browser workflow contract", () => {
     expect(admissionStep?.run).toContain(
       '"--run-deployed-renderer-staging=$RUN_DEPLOYED_RENDERER_STAGING"',
     );
-    expect(deployedJob.if).toContain(
-      "inputs.run_deployed_renderer_staging == true",
+    expect(deployedJob.if).toBe(
+      githubExpression(
+        "!cancelled() && inputs.target_environment == 'staging' && inputs.run_deployed_renderer_staging == true",
+      ),
     );
-    expect(deployedJob.if).toContain(
-      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success'",
-    );
-    expect(deployedJob.if).toContain(
-      "|| (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)",
-    );
-    expect(oneShotPrerequisite.if).toBe(
-      githubExpression("inputs.run_deployed_renderer_staging == true"),
-    );
-    expect(oneShotPrerequisite.env).toEqual({
+    expect(rendererPrerequisite.if).toBeUndefined();
+    expect(rendererPrerequisite.env).toEqual({
       DEPLOY_APP_RESULT: githubExpression("needs.deploy-app.result"),
       PAGES_DEPLOYED: githubExpression(
         "needs.deploy-app.outputs.pages_deployed",
       ),
       VERIFY_ROUTING_RESULT: githubExpression("needs.verify-routing.result"),
     });
-    expect(oneShotPrerequisite.run).toContain(
+    expect(rendererPrerequisite.run).toContain(
       '[ "$PAGES_DEPLOYED" != "true" ]',
     );
-    expect(oneShotPrerequisite.run).toContain("exit 1");
+    expect(rendererPrerequisite.run).toContain("exit 1");
     expect(deployWorkflow.on?.schedule).toBeUndefined();
   });
 


### PR DESCRIPTION
Closes #30065.

## What changed

- Resolve the deployed-renderer request once at the entry workflow boundary.
- Honor `run_deployed_renderer_staging=false` for ordinary manual staging deploys even when `ELIZA_CLOUD_STAGING_LIVE_READY=1`.
- Preserve the automatic live-ready proof only for digest-bound Develop effect reconciliations.
- Keep explicit `true` one-shot dispatches and their fail-closed fresh Pages/routing prerequisite gate.
- Tighten the parsed-workflow regression to bind the caller expression and reusable job condition exactly.

## Root cause

The reusable job condition had independent live-ready and explicit-input arms. Run 33299877037 passed the callable input as false, but the repository variable admitted the job anyway, causing a 12m59s browser-proof attempt during an ordinary manual deploy.

## Verification

- `actionlint .github/workflows/cloud-cf-deploy.yml .github/workflows/cloud-cf-release.yml`
- `bun test packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts packages/scripts/__tests__/develop-effect-ledger.test.ts` — 51 pass, 0 fail, 528 assertions
- `bunx biome check packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts .github/workflows/cloud-cf-deploy.yml .github/workflows/cloud-cf-release.yml`
- `git diff --check`

The full repository verify was started after `bun install` but intentionally stopped while it was still traversing unrelated packages; the affected workflow checks above are complete and hosted checks own the exact PR head.

## Evidence

- Workflow incident: https://github.com/elizaOS/eliza/actions/runs/33299877037
- UI screenshots / video: N/A — workflow admission only; no rendered UI changed.
- Live model trajectory: N/A — the fix prevents an unintended expensive model/browser lane and does not change model behavior.
- Data or schema artifact: N/A — no database or runtime data contract changed.
