### PR TITLE
fix(cloud): bootstrap verified Dedicated selection

### DIFF
--- a/.github/workflows/personal-dedicated-rereview-staging.yml
+++ b/.github/workflows/personal-dedicated-rereview-staging.yml
@@ -1,4 +1,4 @@
-name: Personal Dedicated stale selection re-review
+name: Personal Dedicated selection review
 
 on:
   workflow_dispatch:
@@ -27,11 +27,11 @@ on:
         required: false
         type: string
       reviewed_reason:
-        description: Type retain_current_receipt_target_after_duplicate_inventory_review
+        description: Exact reviewed reason emitted by the selected operation runbook
         required: false
         type: string
       confirmation:
-        description: Type REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION
+        description: Exact non-compute confirmation emitted by the selected operation runbook
         required: false
         type: string
 
@@ -92,8 +92,9 @@ jobs:
             if (!/^[0-9a-f]{40}$/.test(expected) || expected !== process.env.CHECKED_OUT_COMMIT) process.exit(1);
             if (process.env.MODE === "execute") {
               if (!/^[0-9a-f]{64}$/.test(process.env.APPROVAL_DIGEST ?? "")) process.exit(1);
-              if (process.env.REVIEWED_REASON !== "retain_current_receipt_target_after_duplicate_inventory_review") process.exit(1);
-              if (process.env.CONFIRMATION !== "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION") process.exit(1);
+              const rereview = process.env.REVIEWED_REASON === "retain_current_receipt_target_after_duplicate_inventory_review" && process.env.CONFIRMATION === "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION";
+              const bootstrap = process.env.REVIEWED_REASON === "select_unique_verified_backup_after_duplicate_inventory_review" && process.env.CONFIRMATION === "SELECT_UNIQUE_VERIFIED_BACKUP_WITHOUT_COMPUTE_MUTATION";
+              if (!rereview && !bootstrap) process.exit(1);
             }
           '
 

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts
@@ -63,6 +63,12 @@ describe("personal Dedicated staging re-review workflow", () => {
     expect(guard.run).toContain(
       "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
     );
+    expect(guard.run).toContain(
+      "select_unique_verified_backup_after_duplicate_inventory_review",
+    );
+    expect(guard.run).toContain(
+      "SELECT_UNIQUE_VERIFIED_BACKUP_WITHOUT_COMPUTE_MUTATION",
+    );
   });
 
   test("binds protected identity and smoke account authorities without artifacts", () => {

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
@@ -6,6 +6,8 @@ import {
   type RereviewOperatorConfig,
   type RereviewOperatorDependencies,
   readRereviewOperatorConfig,
+  resolveBootstrapCandidate,
+  resolveReceiptRow,
   runRereviewOperator,
 } from "./personal-dedicated-rereview-staging";
 
@@ -14,6 +16,7 @@ const resolved = {
   userId: "20000000-0000-4000-8000-000000000002",
   sourceAgentId: "personal-shared-private-source",
   retainedAgentId: "30000000-0000-4000-8000-000000000003",
+  operation: "rereview" as const,
 };
 const preview = {
   receiptFingerprint: "a".repeat(64),
@@ -39,20 +42,75 @@ function config(mode: "preview" | "execute"): RereviewOperatorConfig {
 
 function dependencies(overrides: Partial<RereviewOperatorDependencies> = {}) {
   let executeCalls = 0;
+  let executedInput:
+    | Parameters<RereviewOperatorDependencies["execute"]>[0]
+    | undefined;
   const value: RereviewOperatorDependencies = {
     verifyDeployment: async () => {},
     resolveSelection: async () => resolved,
     preview: async () => preview,
-    execute: async () => {
+    execute: async (input) => {
       executeCalls += 1;
+      executedInput = input;
     },
     snapshot: async () => snapshot,
     ...overrides,
   };
-  return { value, executeCalls: () => executeCalls };
+  return {
+    value,
+    executeCalls: () => executeCalls,
+    executedInput: () => executedInput,
+  };
 }
 
 describe("personal Dedicated staging re-review operator", () => {
+  test("classifies zero, one, and invariant-breaking receipt counts", () => {
+    expect(resolveReceiptRow([])).toBeNull();
+    expect(resolveReceiptRow([{ retainedAgentId: "retained" }])).toEqual({
+      retainedAgentId: "retained",
+    });
+    expect(() =>
+      resolveReceiptRow([
+        { retainedAgentId: "first" },
+        { retainedAgentId: "second" },
+      ]),
+    ).toThrow("selection_receipt_invariant_violated");
+  });
+
+  test("bootstraps only one canonical restore authority in ambiguous inventory", () => {
+    const candidates = [
+      { id: "fresh", authority: "fresh-boot" },
+      { id: "restorable", authority: "from-legacy-backup" },
+    ];
+    expect(
+      resolveBootstrapCandidate(candidates, (candidate) => candidate.authority),
+    ).toEqual(candidates[1]);
+    expect(() =>
+      resolveBootstrapCandidate(
+        candidates.map((candidate) => ({
+          ...candidate,
+          authority: "fresh-boot",
+        })),
+        (candidate) => candidate.authority,
+      ),
+    ).toThrow("selection_bootstrap_decision_required");
+    expect(() =>
+      resolveBootstrapCandidate(
+        candidates.map((candidate) => ({
+          ...candidate,
+          authority: "catalog-restore-required",
+        })),
+        (candidate) => candidate.authority,
+      ),
+    ).toThrow("selection_bootstrap_decision_required");
+    expect(() =>
+      resolveBootstrapCandidate(
+        [candidates[1]],
+        (candidate) => candidate.authority,
+      ),
+    ).toThrow("selection_bootstrap_decision_required");
+  });
+
   test("returns identifier-free preview evidence and does not execute", async () => {
     const deps = dependencies();
     const result = await runRereviewOperator(config("preview"), deps.value);
@@ -62,13 +120,21 @@ describe("personal Dedicated staging re-review operator", () => {
       mode: "preview",
       identityResolved: true,
       candidateCount: 2,
+      requiredReviewedReason:
+        "retain_current_receipt_target_after_duplicate_inventory_review",
+      requiredConfirmation: "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
       computeMutation: false,
       executed: false,
     });
-    expect(result.approvalDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.approvalDigest).toBe(
+      "86e1e6cfcbf44c955692befd07da569116c9dc04b69703f067aca3c65a36eedd",
+    );
     expect(deps.executeCalls()).toBe(0);
     for (const privateValue of [
-      ...Object.values(resolved),
+      resolved.organizationId,
+      resolved.userId,
+      resolved.sourceAgentId,
+      resolved.retainedAgentId,
       preview.receiptFingerprint,
       preview.inventoryFingerprint,
       config("preview").apiKey,
@@ -91,6 +157,10 @@ describe("personal Dedicated staging re-review operator", () => {
     const result = await runRereviewOperator(executeConfig, deps.value);
     expect(result.executed).toBe(true);
     expect(deps.executeCalls()).toBe(1);
+    expect(deps.executedInput()).toMatchObject({
+      operation: "rereview",
+      expectedReceiptFingerprint: preview.receiptFingerprint,
+    });
 
     await expect(
       runRereviewOperator(
@@ -101,6 +171,55 @@ describe("personal Dedicated staging re-review operator", () => {
     await expect(
       runRereviewOperator(
         { ...executeConfig, confirmation: "yes" },
+        deps.value,
+      ),
+    ).rejects.toMatchObject({ code: "exact_confirmation_required" });
+  });
+
+  test("uses a distinct digest-bound confirmation for missing-receipt bootstrap", async () => {
+    const bootstrapResolved = { ...resolved, operation: "bootstrap" as const };
+    const bootstrapPreview = { ...preview, receiptFingerprint: null };
+    const deps = dependencies({
+      resolveSelection: async () => bootstrapResolved,
+      preview: async () => bootstrapPreview,
+    });
+    const prior = await runRereviewOperator(config("preview"), deps.value);
+    expect(prior).toMatchObject({
+      operation: "bootstrap",
+      requiredReviewedReason:
+        "select_unique_verified_backup_after_duplicate_inventory_review",
+      requiredConfirmation:
+        "SELECT_UNIQUE_VERIFIED_BACKUP_WITHOUT_COMPUTE_MUTATION",
+    });
+
+    const result = await runRereviewOperator(
+      {
+        ...config("execute"),
+        approvalDigest: prior.approvalDigest,
+        confirmation: "SELECT_UNIQUE_VERIFIED_BACKUP_WITHOUT_COMPUTE_MUTATION",
+        reviewedReason:
+          "select_unique_verified_backup_after_duplicate_inventory_review",
+      },
+      deps.value,
+    );
+    expect(result.executed).toBe(true);
+    expect(deps.executeCalls()).toBe(1);
+    expect(deps.executedInput()).toMatchObject({
+      operation: "bootstrap",
+      expectedReceiptFingerprint: null,
+      expectedInventoryFingerprint: preview.inventoryFingerprint,
+      expectedStateDisposition: preview.stateDisposition,
+    });
+
+    await expect(
+      runRereviewOperator(
+        {
+          ...config("execute"),
+          approvalDigest: prior.approvalDigest,
+          confirmation: "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION",
+          reviewedReason:
+            "retain_current_receipt_target_after_duplicate_inventory_review",
+        },
         deps.value,
       ),
     ).rejects.toMatchObject({ code: "exact_confirmation_required" });

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env bun
 /**
- * Runs the staging-only, privacy-safe operator boundary for re-reviewing the
- * existing personal Dedicated selection owned by the deployed smoke account.
- * It resolves identifiers internally, binds execution to a prior redacted
- * preview, and proves that agent and job rows did not change.
+ * Runs the staging-only, privacy-safe operator boundary for the personal
+ * Dedicated selection owned by the deployed smoke account. An existing receipt
+ * is re-reviewed; a missing receipt is bootstrapped only when one candidate has
+ * canonical restore authority. The command resolves identifiers internally,
+ * binds execution to a prior redacted preview, and proves that agent and job
+ * rows did not change.
  */
 
 import { createHash, createHmac } from "node:crypto";
@@ -15,6 +17,10 @@ const EXECUTE_CONFIRMATION =
   "REREVIEW_STALE_SELECTION_WITHOUT_COMPUTE_MUTATION";
 const REVIEWED_REASON =
   "retain_current_receipt_target_after_duplicate_inventory_review";
+const BOOTSTRAP_CONFIRMATION =
+  "SELECT_UNIQUE_VERIFIED_BACKUP_WITHOUT_COMPUTE_MUTATION";
+const BOOTSTRAP_REVIEWED_REASON =
+  "select_unique_verified_backup_after_duplicate_inventory_review";
 
 type Mode = "preview" | "execute";
 type JsonRecord = Record<string, unknown>;
@@ -26,11 +32,14 @@ export class PersonalDedicatedRereviewOperatorError extends Error {
   }
 }
 
+type SelectionOperation = "bootstrap" | "rereview";
+
 interface ResolvedSelection {
   organizationId: string;
   userId: string;
   sourceAgentId: string;
   retainedAgentId: string;
+  operation: SelectionOperation;
 }
 
 interface MutationSnapshot {
@@ -54,10 +63,13 @@ export interface RereviewOperatorEvidence {
   mode: Mode;
   deployedCommitVerified: true;
   identityResolved: true;
+  operation: SelectionOperation;
   candidateCount: number;
   stateDisposition: "verified_backup_present" | "fresh_boot_no_verified_backup";
   replacesTarget: boolean;
   approvalDigest: string;
+  requiredReviewedReason: string;
+  requiredConfirmation: string;
   computeMutation: false;
   agentCount: number;
   jobCount: number;
@@ -68,7 +80,7 @@ export interface RereviewOperatorDependencies {
   verifyDeployment(expectedCommit: string): Promise<void>;
   resolveSelection(apiKey: string): Promise<ResolvedSelection>;
   preview(input: ResolvedSelection): Promise<{
-    receiptFingerprint: string;
+    receiptFingerprint: string | null;
     inventoryFingerprint: string;
     stateDisposition: RereviewOperatorEvidence["stateDisposition"];
     candidateCount: number;
@@ -76,12 +88,41 @@ export interface RereviewOperatorDependencies {
   }>;
   execute(
     input: ResolvedSelection & {
-      expectedReceiptFingerprint: string;
+      expectedReceiptFingerprint: string | null;
       expectedInventoryFingerprint: string;
       expectedStateDisposition: RereviewOperatorEvidence["stateDisposition"];
     },
   ): Promise<void>;
   snapshot(input: ResolvedSelection): Promise<MutationSnapshot>;
+}
+
+export function resolveReceiptRow<T>(receipts: readonly T[]): T | null {
+  if (receipts.length > 1) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_receipt_invariant_violated",
+    );
+  }
+  return receipts[0] ?? null;
+}
+
+export function resolveBootstrapCandidate<T>(
+  candidates: readonly T[],
+  activationKind: (candidate: T) => "fresh-boot" | string,
+): T {
+  if (candidates.length < 2 || candidates.length > 100) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_bootstrap_decision_required",
+    );
+  }
+  const restorable = candidates.filter(
+    (candidate) => activationKind(candidate) !== "fresh-boot",
+  );
+  if (restorable.length !== 1) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_bootstrap_decision_required",
+    );
+  }
+  return restorable[0];
 }
 
 function required(
@@ -196,6 +237,14 @@ export async function runRereviewOperator(
   const preview = await dependencies.preview(resolved);
   const digest = approvalDigest(config.apiKey, resolved, preview);
   const before = await dependencies.snapshot(resolved);
+  const requiredConfirmation =
+    resolved.operation === "rereview"
+      ? EXECUTE_CONFIRMATION
+      : BOOTSTRAP_CONFIRMATION;
+  const requiredReviewedReason =
+    resolved.operation === "rereview"
+      ? REVIEWED_REASON
+      : BOOTSTRAP_REVIEWED_REASON;
 
   if (config.mode === "execute") {
     if (!config.approvalDigest || !DIGEST_PATTERN.test(config.approvalDigest)) {
@@ -208,12 +257,12 @@ export async function runRereviewOperator(
         "stale_or_wrong_approval_digest",
       );
     }
-    if (config.confirmation !== EXECUTE_CONFIRMATION) {
+    if (config.confirmation !== requiredConfirmation) {
       throw new PersonalDedicatedRereviewOperatorError(
         "exact_confirmation_required",
       );
     }
-    if (config.reviewedReason !== REVIEWED_REASON) {
+    if (config.reviewedReason !== requiredReviewedReason) {
       throw new PersonalDedicatedRereviewOperatorError(
         "reviewed_reason_required",
       );
@@ -233,10 +282,13 @@ export async function runRereviewOperator(
     mode: config.mode,
     deployedCommitVerified: true,
     identityResolved: true,
+    operation: resolved.operation,
     candidateCount: preview.candidateCount,
     stateDisposition: preview.stateDisposition,
     replacesTarget: preview.replacesTarget,
     approvalDigest: digest,
+    requiredReviewedReason,
+    requiredConfirmation,
     computeMutation: false,
     agentCount: after.agentCount,
     jobCount: after.jobCount,
@@ -263,12 +315,15 @@ async function defaultResolveSelection(
   apiKey: string,
 ): Promise<ResolvedSelection> {
   const [
-    { and, eq, isNull },
+    { and, asc, eq, inArray, isNull, notExists },
     { dbWrite },
     { apiKeys },
     { users },
     selectionSchema,
+    sandboxSchema,
     shared,
+    targetService,
+    provenance,
   ] = await Promise.all([
     import("drizzle-orm"),
     import("@elizaos/cloud-shared/db/client"),
@@ -277,12 +332,23 @@ async function defaultResolveSelection(
     import(
       "@elizaos/cloud-shared/db/schemas/personal-dedicated-adoption-selections"
     ),
+    import("@elizaos/cloud-shared/db/schemas/agent-sandboxes"),
     import(
       "@elizaos/cloud-shared/lib/services/shared-runtime/personal-shared-agent"
     ),
+    import("@elizaos/cloud-shared/lib/services/agent-tier-upgrade-target"),
+    import(
+      "@elizaos/cloud-shared/lib/services/personal-dedicated-adoption-provenance"
+    ),
   ]);
   const { personalDedicatedAdoptionSelections } = selectionSchema;
+  const { agentSandboxBackups, agentSandboxes } = sandboxSchema;
   const { personalSharedAgentId } = shared;
+  const { adoptableUnmarkedTargetWhere } = targetService;
+  const {
+    personalDedicatedActivationAuthority,
+    personalDedicatedBackupProvenanceFromStored,
+  } = provenance;
   const keyHash = createHash("sha256").update(apiKey).digest("hex");
   // Identity and receipt resolution are execution authority. A replica can
   // lag key revocation or receipt replacement, so every read uses primary.
@@ -343,16 +409,73 @@ async function defaultResolveSelection(
       ),
     )
     .limit(2);
-  if (receipts.length !== 1) {
-    throw new PersonalDedicatedRereviewOperatorError(
-      "selection_receipt_not_unique",
+  const receipt = resolveReceiptRow(receipts);
+  if (!receipt) {
+    const candidates = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          adoptableUnmarkedTargetWhere(owner.organizationId, owner.id),
+          notExists(
+            dbWrite
+              .select({ id: personalDedicatedAdoptionSelections.id })
+              .from(personalDedicatedAdoptionSelections)
+              .where(
+                eq(
+                  personalDedicatedAdoptionSelections.dedicated_agent_id,
+                  agentSandboxes.id,
+                ),
+              ),
+          ),
+        ),
+      )
+      .orderBy(asc(agentSandboxes.id))
+      .limit(101);
+    if (candidates.length < 2 || candidates.length > 100) {
+      throw new PersonalDedicatedRereviewOperatorError(
+        "selection_bootstrap_decision_required",
+      );
+    }
+    const storedBackups = await dbWrite
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        inArray(
+          agentSandboxBackups.sandbox_record_id,
+          candidates.map((candidate) => candidate.id),
+        ),
+      )
+      .orderBy(
+        asc(agentSandboxBackups.sandbox_record_id),
+        asc(agentSandboxBackups.id),
+      );
+    const backups = storedBackups.map(
+      personalDedicatedBackupProvenanceFromStored,
     );
+    const retained = resolveBootstrapCandidate(
+      candidates,
+      (candidate) =>
+        personalDedicatedActivationAuthority(
+          owner.organizationId,
+          candidate.id,
+          backups,
+        ).kind,
+    );
+    return {
+      organizationId: owner.organizationId,
+      userId: owner.id,
+      sourceAgentId,
+      retainedAgentId: retained.id,
+      operation: "bootstrap",
+    };
   }
   return {
     organizationId: owner.organizationId,
     userId: owner.id,
     sourceAgentId,
-    retainedAgentId: receipts[0].retainedAgentId,
+    retainedAgentId: receipt.retainedAgentId,
+    operation: "rereview",
   };
 }
 
@@ -405,20 +528,47 @@ const defaultDependencies: RereviewOperatorDependencies = {
     const { personalDedicatedAdoptionSelectionService } = await import(
       "@elizaos/cloud-shared/lib/services/personal-dedicated-adoption-selection"
     );
-    return personalDedicatedAdoptionSelectionService.previewRereview({
+    const common = {
       ...input,
       selectedByUserId: null,
       reason: "duplicate_owned_dedicated_inventory",
-    });
+    } as const;
+    if (input.operation === "rereview") {
+      return personalDedicatedAdoptionSelectionService.previewRereview(common);
+    }
+    const preview =
+      await personalDedicatedAdoptionSelectionService.preview(common);
+    return {
+      ...preview,
+      receiptFingerprint: null,
+      replacesTarget: false,
+    };
   },
   execute: async (input) => {
     const { personalDedicatedAdoptionSelectionService } = await import(
       "@elizaos/cloud-shared/lib/services/personal-dedicated-adoption-selection"
     );
-    await personalDedicatedAdoptionSelectionService.executeRereview({
+    const common = {
       ...input,
       selectedByUserId: null,
       reason: "duplicate_owned_dedicated_inventory",
+    } as const;
+    if (input.operation === "rereview") {
+      if (!input.expectedReceiptFingerprint) {
+        throw new PersonalDedicatedRereviewOperatorError(
+          "selection_receipt_fingerprint_missing",
+        );
+      }
+      await personalDedicatedAdoptionSelectionService.executeRereview({
+        ...common,
+        expectedReceiptFingerprint: input.expectedReceiptFingerprint,
+      });
+      return;
+    }
+    await personalDedicatedAdoptionSelectionService.execute({
+      ...common,
+      expectedInventoryFingerprint: input.expectedInventoryFingerprint,
+      expectedStateDisposition: input.expectedStateDisposition,
     });
   },
   snapshot: defaultSnapshot,


### PR DESCRIPTION
Fixes #30064

## Cause

The staging selection operator treated both zero matching receipts and more than one receipt as selection_receipt_not_unique. The schema and migration enforce uniqueness for the account/source tuple, so the observed staging failure was the unhandled zero-receipt bootstrap state.

## Repair

- distinguish zero, one, and invariant-breaking multiple receipt rows
- retain the existing one-receipt re-review path
- bootstrap a missing receipt only when the eligible inventory remains deliberately ambiguous (2 to 100 candidates) and exactly one candidate has canonical non-fresh-boot activation authority
- fail with identifier-free selection_bootstrap_decision_required evidence when provenance is absent or ambiguous
- reuse the existing receipt-only preview/execute service; no compute, job, or billing mutation is added
- bind operation, inventory, state disposition, receipt fingerprint, and target to the approval HMAC
- expose the exact identifier-free required reviewed reason and confirmation in preview evidence
- preserve the before/after agent and job snapshot invariant

## Verification

- bun test packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts: 13 pass, 0 fail, 58 assertions
- bun run --cwd packages/cloud/shared typecheck: pass
- Biome on changed workflow/operator/test files: pass
- git diff --check: pass
- bun run verify: running at PR creation; no failures observed yet

## Evidence

- UI screenshots/video: N/A, operator-only staging workflow change
- live staging execution: intentionally not run; this PR does not mutate staging or production
- logs/identifiers: redacted by contract and covered by deterministic tests