### PR TITLE
fix(ui): reconcile tab after history navigation

### DIFF
--- a/packages/ui/src/state/useAppProviderEffects.ts
+++ b/packages/ui/src/state/useAppProviderEffects.ts
@@ -56,23 +56,33 @@ export function useNavigationPathSync({
     // `tabFromPath` consults the live registry, so a version bump must re-run
     // this effect to reconcile a deep link that booted before its page landed.
     void appShellRegistryVersion;
-    let navPath = getWindowNavigationPath();
-    const legacyRoute = resolveLegacyBuiltinRoute(navPath);
-    if (legacyRoute && typeof window !== "undefined") {
-      const nextUrl = shouldUseHashNavigation()
-        ? `${window.location.pathname}${window.location.search}#${legacyRoute.canonicalPath}`
-        : `${legacyRoute.canonicalPath}${window.location.search}${window.location.hash}`;
-      shellHistory.replaceState(window.history.state, "", nextUrl);
-      window.dispatchEvent(new PopStateEvent("popstate"));
-      navPath = legacyRoute.canonicalPath;
-    }
-    if (isRouteRootPath(navPath)) {
-      return;
-    }
-    const routeTab = tabFromPath(navPath);
-    if (routeTab && routeTab !== tab) {
-      setTabRaw(routeTab);
-    }
+    if (typeof window === "undefined") return;
+
+    const reconcileNavigationPath = () => {
+      const navPath = getWindowNavigationPath();
+      const legacyRoute = resolveLegacyBuiltinRoute(navPath);
+      if (legacyRoute) {
+        const nextUrl = shouldUseHashNavigation()
+          ? `${window.location.pathname}${window.location.search}#${legacyRoute.canonicalPath}`
+          : `${legacyRoute.canonicalPath}${window.location.search}${window.location.hash}`;
+        shellHistory.replaceState(window.history.state, "", nextUrl);
+        window.dispatchEvent(new PopStateEvent("popstate"));
+        return;
+      }
+      if (isRouteRootPath(navPath)) return;
+      const routeTab = tabFromPath(navPath);
+      if (routeTab && routeTab !== tab) {
+        setTabRaw(routeTab);
+      }
+    };
+
+    window.addEventListener("hashchange", reconcileNavigationPath);
+    window.addEventListener("popstate", reconcileNavigationPath);
+    reconcileNavigationPath();
+    return () => {
+      window.removeEventListener("hashchange", reconcileNavigationPath);
+      window.removeEventListener("popstate", reconcileNavigationPath);
+    };
   }, [tab, setTabRaw, appShellRegistryVersion]);
 }
 

--- a/packages/ui/src/state/useNavigationPathSync.test.tsx
+++ b/packages/ui/src/state/useNavigationPathSync.test.tsx
@@ -6,7 +6,7 @@
  * preserving the browser path that names the exact owning page.
  */
 
-import { act, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerAppShellPage } from "../app-shell-registry";
 import type { Tab } from "../navigation";
@@ -14,6 +14,7 @@ import { resetUiRegistryHostForTests } from "../registry-host";
 import { useNavigationPathSync } from "./useAppProviderEffects";
 
 afterEach(() => {
+  cleanup();
   resetUiRegistryHostForTests();
   window.history.replaceState(null, "", "/");
 });
@@ -90,6 +91,51 @@ describe("useNavigationPathSync — app-shell registry reactivity", () => {
     );
 
     // routeTab === tab, so no redundant reconciliation is dispatched.
+    expect(setTabRaw).not.toHaveBeenCalled();
+  });
+
+  it("reconciles the active tab when browser history changes", () => {
+    window.history.replaceState(null, "", "/settings");
+    const setTabRaw = vi.fn();
+
+    renderHook(() =>
+      useNavigationPathSync({ tab: "settings" as Tab, setTabRaw }),
+    );
+
+    act(() => {
+      window.history.pushState(null, "", "/views");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(setTabRaw).toHaveBeenCalledTimes(1);
+    expect(setTabRaw).toHaveBeenCalledWith("views");
+  });
+
+  it("reconciles app-window hash navigation", () => {
+    window.history.replaceState(null, "", "/index.html?appWindow=1#/settings");
+    const setTabRaw = vi.fn();
+    renderHook(() =>
+      useNavigationPathSync({ tab: "settings" as Tab, setTabRaw }),
+    );
+    act(() => {
+      window.history.replaceState(null, "", "/index.html?appWindow=1#/views");
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+    expect(setTabRaw).toHaveBeenCalledWith("views");
+  });
+
+  it("stops reconciling browser events after unmount", () => {
+    window.history.replaceState(null, "", "/settings");
+    const setTabRaw = vi.fn();
+    const view = renderHook(() =>
+      useNavigationPathSync({ tab: "settings" as Tab, setTabRaw }),
+    );
+    view.unmount();
+    act(() => {
+      window.history.replaceState(null, "", "/views");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
     expect(setTabRaw).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Browser Back/Forward navigation and app-window hash changes now reconcile the active tab while AppProvider stays mounted. The hook subscribes to both history event types, handles legacy-route canonicalization, and removes both subscriptions when it unmounts.

Validation for `231d546d31ab3efca517b338bf2968dc45b7c8ae`:

- All 11 focused navigation tests passed, including hash navigation and listener cleanup.
- Full repository verification and formatting passed in [qualification CI](https://github.com/elizaOS/eliza/actions/runs/33952748595).
- The app visual audit passed all 219 cases with no broken or needs-work verdicts; OCR completed with no broken views; desktop/mobile Settings and Views captures and the scoped rest/hover behavior were inspected.
- Chromium exercised the actual navigation hook and real browser Back/Forward in desktop/mobile path and app-window hash modes. All four repaired cases returned to Settings correctly, then forward to Views. The original hook remained on Views after Back. This is an isolated hook harness with real route registries, not a full backend-connected app session.
- Full UI package qualification passed 13,511 executed tests with zero failures/errors (7 existing skips), and all required original PR checks passed. [Before/after screenshots, MP4 recordings, and reproducible results](https://github.com/elizaOS/eliza/pull/30070#issuecomment-5552222980) are attached inline. The optional broader workflow includes cancelled server and unrelated failed lanes; it is not claimed fully green.
