### PR TITLE
fix(ci): manual staging dispatch with renderer=false skips deployed-renderer job

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -2897,7 +2897,7 @@ jobs:
   deployed-renderer-staging:
     name: Verify deployed staging renderer (Pages alias)
     needs: [deploy-app, verify-routing]
-    if: ${{ !cancelled() && inputs.target_environment == 'staging' && ((vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)) }}
+    if: ${{ !cancelled() && inputs.target_environment == 'staging' && ((github.event_name != 'workflow_dispatch' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)) }}
     runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 45

--- a/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
@@ -241,7 +241,7 @@ describe("Cloudflare deployed browser workflow contract", () => {
       "inputs.run_deployed_renderer_staging == true",
     );
     expect(deployedJob.if).toContain(
-      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success'",
+      "github.event_name != 'workflow_dispatch' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success'",
     );
     expect(deployedJob.if).toContain(
       "|| (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)",


### PR DESCRIPTION
## Summary
A manual staging Cloud CF dispatch with `run_deployed_renderer_staging=false` still ran `deployed-renderer-staging` because the job-level condition's automatic live-ready arm (`ELIZA_CLOUD_STAGING_LIVE_READY == '1'`) did not exclude `workflow_dispatch` events. The job spent 13 minutes building the browser proof and failed on the Personal identity deadline (#30065).

## Fix
Gate the automatic live-ready arm on `github.event_name != 'workflow_dispatch'` so only digest-bound automatic reconciliations use it; the manual arm still requires `run_deployed_renderer_staging == true`.

## Verification
Workflow contract test updated to assert the event/input truth table: manual dispatch + `false` skips the job even with the live-ready variable enabled; manual + `true` still runs the one-shot proof.

Closes #30065.