### PR TITLE
fix(cloud): bound oversized inline job error dumps with a truncation marker

### DIFF
--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -20,6 +20,7 @@ import {
   assertInlinePayloadFits,
   hydrateJsonField,
   hydrateTextField,
+  InlinePayloadTooLargeError,
   offloadJsonField,
   offloadTextField,
 } from "../../lib/storage/object-store";
@@ -398,6 +399,46 @@ export async function hydrateJob(job: Job): Promise<Job> {
   };
 }
 
+/**
+ * Byte-safe UTF-8 prefix of `value` plus an explicit truncation marker, whose
+ * total encoded size never exceeds `capBytes`. The marker names the original
+ * size so a reader can tell the stored summary from the whole dump.
+ */
+export function clampTextToByteCap(value: string, capBytes: number, originalBytes: number): string {
+  const marker = `\n[truncated: ${originalBytes} bytes]`;
+  if (capBytes <= byteLengthOf(marker)) {
+    return marker.slice(0, Math.max(0, capBytes));
+  }
+  const keepBytes = capBytes - byteLengthOf(marker);
+  let output = "";
+  let size = 0;
+  for (const char of value) {
+    const charSize = byteLengthOf(char);
+    if (size + charSize > keepBytes) break;
+    output += char;
+    size += charSize;
+  }
+  return `${output}${marker}`;
+}
+
+function byteLengthOf(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff && index + 1 < value.length) {
+      bytes += 4;
+      index += 1;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
 async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
   data: T,
   context: Pick<Job, "id" | "organization_id" | "created_at">,
@@ -470,6 +511,20 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
             field: "error",
             createdAt,
             value: data.error,
+          }).catch((cause: unknown) => {
+            // A job error dump is operator diagnostics, not a payload that must
+            // stay whole: when it exceeds the SQL inline ceiling and no object
+            // storage exists to offload it, persist a byte-bounded prefix with
+            // an explicit truncation marker instead of failing the insert or
+            // silently writing the whole dump (#22553). Structured fields keep
+            // the strict typed rejection in offloadJsonField, and the explicit
+            // force-inline branch above keeps its strict whole-value contract.
+            if (!(cause instanceof InlinePayloadTooLargeError)) throw cause;
+            return {
+              value: clampTextToByteCap(String(data.error), cause.maxInlineBytes, cause.sizeBytes),
+              storage: "inline" as const,
+              key: null,
+            };
           }),
   ]);
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Repair of an uncovered `Develop Full` red lane listed in #30038 (canonical / Smoke lanes, `prepareJobInsertData` failure). Root motivation for the ceiling: #22553 (quarter-gigabyte failure dumps reaching `jobs.error`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`). Branched at `90bb56ea38663fb1a2d27c88d67683a85a49924a`, the current integration head.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. — `bun install --frozen-lockfile --ignore-scripts` completed; full root `bun run verify` was **not** run in this environment (see Known gaps / failures).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. (Branch cut at current head `90bb56ea38663fb1a2d27c88d67683a85a49924a`.)
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One code path changes behavior: the `error` leg of `prepareJobPayload` when object storage is unavailable (or `SQL_HEAVY_PAYLOAD_STORAGE=inline`) **and** the dump exceeds the inline ceiling. Before: `prepareJobInsertData` threw `InlinePayloadTooLargeError` and the job insert failed. After: a byte-bounded prefix with an explicit `[truncated: N bytes]` marker is stored inline (`error_storage=inline`, `error_key=null`), so the job still records that it failed. Structured (`data`/`result`) fields keep the strict typed rejection; the explicit `error_storage: "inline"` caller branch keeps its strict whole-value contract. Callers that depended on the throw can detect the marker in the stored text; no schema or public API changes.

# Background

## What does this PR do?

Implements the contract the already-merged test `packages/cloud/shared/src/db/repositories/jobs.test.ts > "a failure dump can no longer be written whole into the error column"` asserts: an oversized text error dump is bounded to the `SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES` ceiling with an explicit truncation marker when no object storage is available, instead of throwing. The merged test was red on `develop` (canonical / Smoke lanes job 99233841039 in Develop Full run 33302689243).

## What kind of change is this?

Bug fixes (non-breaking change which fixes a issue) — makes the production code honor the merged test contract.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/repositories/jobs.test.ts` — the last test, `"a failure dump can no longer be written whole into the error column"`, then `prepareJobPayload`'s `error` leg in `packages/cloud/shared/src/db/repositories/jobs.ts` and the new `clampTextToByteCap` helper.

## Detailed testing steps

```bash
bun install --frozen-lockfile --ignore-scripts
cd packages/cloud/shared
BUN_CONFIG_COVERAGE=false bun test src/db/repositories/jobs.test.ts
# expect: 2 pass, 0 fail — including "a failure dump can no longer be written whole into the error column"
```

Red→green against pristine `develop` (same commands, same worktree):

```text
--- pristine (git stash) ---
(fail) prepareJobInsertData > a failure dump can no longer be written whole into the error column [2.54ms]
 1 pass
 1 fail
--- patched ---
 2 pass
 0 fail
```

Neighbors (unchanged behavior, run at this head):

```text
BUN_CONFIG_COVERAGE=false bun test src/lib/services/provisioning-jobs-delete-enqueue.test.ts
 9 pass / 0 fail
```

Hygiene:

```text
bunx biome check packages/cloud/shared/src/db/repositories/jobs.ts   → No errors
bun run --cwd packages/cloud/shared typecheck                        → 0 errors
```

# Known gaps / failures

- Full root `bun run verify` was not executed in this environment: the verification worktree is a fresh `origin/develop` checkout in a disposable location and the full turbo verification (including native/llama builds) was not reproducible here. What was run instead, at this exact head: the focused suite above (red→green), the neighboring deletion-enqueue suite, `biome check` on the changed file, and the owning package `typecheck`. CI (required gates on this exact head) covers the remainder.
- Adjacent pre-existing finding, **not** fixed here to keep the diff bounded: `packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts:168` calls `beforeAll(async () => {...})` in a form bun:test rejects (`beforeAll() expects a function as the second argument`); it fails identically on pristine `develop`, so this is a pre-existing broken harness, not a regression of this PR.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:86fc676e698764b810664594f46ba9d483a0f766 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side storage policy change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side storage policy change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; behavior is asserted by the focused suite shown above.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the red→green focused-suite transcript is inlined in **Detailed testing steps** (pristine throws `InlinePayloadTooLargeError` at `jobs.ts` prepare path; patched returns `error_storage=inline` with a bounded marker and the suite passes).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model path is involved; pure repository storage policy.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the stored-row shape is asserted inline by the test (`error_storage === "inline"`, `error_key === null`, UTF-8 byte length ≤ ceiling, contains `truncated:`, starts with the original dump prefix).
<!-- evidence-row:ocr-review -->
- [x] N/A - the change has no rendered visual surface.

Evidence head captured in the same run via `git rev-parse HEAD`:
`86fc676e698764b810664594f46ba9d483a0f766`

