### PR TITLE
fix(plugin-mcp): process union/nullable-typed nodes in tool-schema compatibility

### DIFF
--- a/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
+++ b/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
@@ -8,7 +8,10 @@
 import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { GoogleMcpCompatibility } from "../src/tool-compatibility/providers/google.ts";
-import { OpenAIMcpCompatibility } from "../src/tool-compatibility/providers/openai.ts";
+import {
+  OpenAIMcpCompatibility,
+  OpenAIReasoningMcpCompatibility,
+} from "../src/tool-compatibility/providers/openai.ts";
 import {
   MAX_MCP_SCHEMA_DEPTH,
   MAX_MCP_SCHEMA_NODES,
@@ -119,6 +122,139 @@ describe("MCP tool compatibility", () => {
         properties,
       })
     ).toThrowError(ElizaError);
+  });
+
+  // A JSON Schema `type` array such as ["string","null"] is the standard
+  // nullable/optional encoding emitted by Zod .nullable() and many MCP
+  // servers. The dispatch switch never matched these nodes, so provider-
+  // unsupported keywords survived on every nullable field and everything
+  // nested under a nullable object/array, then 400ed at strict function-
+  // calling providers (Gemini/OpenAI). These cases pin the fixed contract.
+  describe("nullable (union) typed nodes", () => {
+    const google = new GoogleMcpCompatibility({
+      provider: "google",
+      modelId: "gemini-1.5-pro",
+    });
+    const reasoning = new OpenAIReasoningMcpCompatibility({
+      provider: "openai",
+      modelId: "o3-mini",
+      isReasoningModel: true,
+    });
+
+    it("strips format/pattern/minLength on a nullable string and folds them into the description (Google)", () => {
+      const out = google.transformToolSchema({
+        type: "object",
+        properties: {
+          email: {
+            type: ["string", "null"],
+            format: "email",
+            pattern: "^x@",
+            minLength: 3,
+          },
+        },
+      } as never);
+      const email = out.properties?.email as Record<string, unknown>;
+      // The nullable `type` array is preserved so the field stays optional.
+      expect(email.type).toEqual(["string", "null"]);
+      expect(email.format).toBeUndefined();
+      expect(email.pattern).toBeUndefined();
+      expect(email.minLength).toBeUndefined();
+      expect(email.description).toContain("at least 3 characters");
+      expect(email.description).toContain("valid email");
+    });
+
+    it("strips minimum/maximum on a nullable integer (Google)", () => {
+      const out = google.transformToolSchema({
+        type: "object",
+        properties: {
+          age: { type: ["integer", "null"], minimum: 0, maximum: 120 },
+        },
+      } as never);
+      const age = out.properties?.age as Record<string, unknown>;
+      expect(age.type).toEqual(["integer", "null"]);
+      expect(age.minimum).toBeUndefined();
+      expect(age.maximum).toBeUndefined();
+      expect(age.description).toContain("at least 0");
+      expect(age.description).toContain("no more than 120");
+    });
+
+    it("recurses into items of a nullable array and strips child keywords (Google)", () => {
+      const out = google.transformToolSchema({
+        type: "object",
+        properties: {
+          tags: {
+            type: ["array", "null"],
+            minItems: 1,
+            items: { type: "string", maxLength: 8 },
+          },
+        },
+      } as never);
+      const tags = out.properties?.tags as Record<string, unknown>;
+      expect(tags.type).toEqual(["array", "null"]);
+      expect(tags.minItems).toBeUndefined();
+      const items = tags.items as Record<string, unknown>;
+      expect(items.maxLength).toBeUndefined();
+      expect(items.description).toContain("no more than 8");
+    });
+
+    it("recurses into a nullable object's nested properties (Google)", () => {
+      const out = google.transformToolSchema({
+        type: "object",
+        properties: {
+          profile: {
+            type: ["object", "null"],
+            properties: { name: { type: "string", maxLength: 5 } },
+          },
+        },
+      } as never);
+      const profile = out.properties?.profile as Record<string, unknown>;
+      expect(profile.type).toEqual(["object", "null"]);
+      const props = profile.properties as Record<string, Record<string, unknown>>;
+      expect(props.name.maxLength).toBeUndefined();
+      expect(props.name.description).toContain("no more than 5");
+    });
+
+    it("strips format/pattern on a nullable string for OpenAI reasoning models", () => {
+      const out = reasoning.transformToolSchema({
+        type: "object",
+        properties: {
+          email: {
+            type: ["string", "null"],
+            format: "email",
+            pattern: "^x@",
+            minLength: 2,
+          },
+        },
+      } as never);
+      const email = out.properties?.email as Record<string, unknown>;
+      expect(email.type).toEqual(["string", "null"]);
+      expect(email.format).toBeUndefined();
+      expect(email.pattern).toBeUndefined();
+      expect(email.minLength).toBeUndefined();
+      expect(String(email.description)).toContain("IMPORTANT");
+    });
+
+    it("leaves a plain (non-union) typed schema behavior-identical (regression guard)", () => {
+      const unionOut = google.transformToolSchema({
+        type: "object",
+        properties: {
+          email: { type: ["string"], format: "email", pattern: "^x@" },
+        },
+      } as never);
+      const scalarOut = google.transformToolSchema({
+        type: "object",
+        properties: {
+          email: { type: "string", format: "email", pattern: "^x@" },
+        },
+      } as never);
+      const unionEmail = unionOut.properties?.email as Record<string, unknown>;
+      const scalarEmail = scalarOut.properties?.email as Record<string, unknown>;
+      // A single-member union carries the same stripped keywords and folded
+      // description as its scalar equivalent; only `type` differs in shape.
+      expect(unionEmail.format).toBeUndefined();
+      expect(scalarEmail.format).toBeUndefined();
+      expect(unionEmail.description).toEqual(scalarEmail.description);
+    });
   });
 
   it("throws MCP_TOOL_SCHEMA_UNBOUNDED on a cyclic items graph, not RangeError", () => {

--- a/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
+++ b/plugins/plugin-mcp/__tests__/tool-compatibility.test.ts
@@ -255,6 +255,42 @@ describe("MCP tool compatibility", () => {
       expect(scalarEmail.format).toBeUndefined();
       expect(unionEmail.description).toEqual(scalarEmail.description);
     });
+
+    it("still runs combinator handling under a nullable node (cleans anyOf children)", () => {
+      // The nullable branch ends in processGenericSchema so oneOf/anyOf/allOf
+      // members carried alongside an array `type` are still recursed and
+      // cleaned. Without that final call the child keywords leak to strict
+      // providers exactly as they did for the top-level nullable node.
+      const out = google.transformToolSchema({
+        type: "object",
+        properties: {
+          child: {
+            type: ["object", "null"],
+            anyOf: [{ type: "string", format: "email", pattern: "^x$", description: "child" }],
+          },
+        },
+      } as never);
+      const child = out.properties?.child as Record<string, unknown>;
+      const anyOf = child.anyOf as Array<Record<string, unknown>>;
+      expect(anyOf[0].format).toBeUndefined();
+      expect(anyOf[0].pattern).toBeUndefined();
+      expect(String(anyOf[0].description)).toContain("valid email");
+    });
+
+    it("folds a multi-concrete union canonically regardless of member order", () => {
+      // JSON Schema `type` arrays are unordered sets, so semantically identical
+      // schemas that differ only in member order must transform identically.
+      const build = (types: string[]) =>
+        google.transformToolSchema({
+          type: "object",
+          properties: {
+            id: { type: types, pattern: "^a+$", minimum: 3, maximum: 9 },
+          },
+        } as never);
+      const forward = build(["string", "integer"]).properties?.id as Record<string, unknown>;
+      const reversed = build(["integer", "string"]).properties?.id as Record<string, unknown>;
+      expect(reversed.description).toEqual(forward.description);
+    });
   });
 
   it("throws MCP_TOOL_SCHEMA_UNBOUNDED on a cyclic items graph, not RangeError", () => {


### PR DESCRIPTION
# Relates to

Closes #30075

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks pass. Repo-wide `bun run verify` was not run to completion on this constrained host — see **Known gaps** for the exact scope and the pre-existing unrelated flaky test.
- [x] A reviewer can confirm the change works from the failing-then-passing test run and the before/after schema dump below, without reading the code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`90bb56ea38`); zero conflicts.
- [x] Focused package `test`, `typecheck`, and `lint:check` pass post-sync. See **Known gaps** for the pre-existing, unrelated `validation.test.ts` flakiness.

# Risks

Low. The change is confined to `McpToolCompatibility.processSchema` dispatch in `plugins/plugin-mcp/src/tool-compatibility/base.ts`. Scalar-typed schema nodes take the identical code path as before; only array-valued `type` nodes (previously unhandled) gain per-type cleaning. No public surface, export, or type changed.

# Background

## What does this PR do?

`McpToolCompatibility.processSchema` dispatched on a string `type` switch (`"string"/"number"/"integer"/"array"/"object"`). JSON Schema also permits `type` to be an **array** of types — e.g. `type: ["string","null"]`, the standard nullable/optional encoding emitted by Zod `.nullable()` and by many MCP servers. Such nodes matched no case and fell through to `processGenericSchema`, which only walks `oneOf/anyOf/allOf`: it stripped **no** per-type validation keywords and never recursed into `properties`/`items`.

The whole purpose of this layer is to remove keywords that strict provider function-calling schemas reject. So for any nullable field — and everything nested under a nullable object/array — provider-unsupported keywords (`format`, `pattern`, `minLength/maxLength`, `minimum/maximum`, `minItems`, …) survived. On Google/Gemini (a strict OpenAPI subset that 400s on unsupported `format` and keywords) and OpenAI strict/reasoning modes, `callTool` then failed at the provider boundary even though the compatibility fixup had run.

The fix routes array-typed nodes through a new `processUnionTypeSchema`, which applies each concrete per-type processor the node declares — stripping the matching keywords, folding them into the `description` (preserving existing description-folding behavior), and recursing into `properties`/`items` — while preserving the original nullable `type` array on the output. It then runs the combinator handling so `oneOf/anyOf/allOf` behavior stays identical to the scalar path. `"null"` and `"boolean"` members carry no strippable keywords and are skipped.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is corrected to match the layer's documented purpose (strip provider-unsupported keywords); no public API or documented contract changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-mcp/__tests__/tool-compatibility.test.ts` → the new `nullable (union) typed nodes` describe block. Each case asserts the fixed contract against a real `GoogleMcpCompatibility` / `OpenAIReasoningMcpCompatibility` instance with deterministic JSON Schema input and no external MCP server.

## Detailed testing steps

```bash
bun install
cd plugins/plugin-mcp
bunx vitest run __tests__/tool-compatibility.test.ts   # 17 passed
bun run typecheck                                       # clean
bun run lint:check                                      # clean
```

# Evidence Gate

<!-- evidence-head:c39c35baca1acf2728d872e60ccbee331b17378b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. This changes a JSON-Schema transformation function; there is no rendered view.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface (schema-transformation function).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the fix is a pure schema transform verified by unit tests and a before/after JSON dump.`
<!-- evidence-row:backend-logs -->
- [x] Failing-then-passing run of the real `processSchema` path. **Before** (new tests vs pre-fix `base.ts`) the union-type cases fail because the forbidden keywords survive; **after** the fix the full suite is green (17 passed). Two review-requested tests were added and are load-bearing: reverting the member `.sort()` fails "folds a multi-concrete union canonically…", and replacing the loop's final `processGenericSchema` with `return current` fails "still runs combinator handling under a nullable node…". Durable GitHub-hosted copy of this exact run (regenerated at head `c39c35b`): [30076-backend-logs.txt](https://gist.githubusercontent.com/agent-cortex/178746fb22bea1e51251115ab96f1ffd/raw/7fc35520bdce108a5fccfe0f63e6ec8003376e7f/30076-backend-logs.txt).

<details><summary>Backend log — failing (pre-fix) then passing (fixed)</summary>

```text
 × __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips format/pattern/minLength on a nullable string and folds them into the description (Google) 9ms
   → expected 'email' to be undefined
 × __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips minimum/maximum on a nullable integer (Google) 2ms
   → expected +0 to be undefined
 × __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > recurses into items of a nullable array and strips child keywords (Google) 1ms
   → expected 1 to be undefined
 × __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > recurses into a nullable object's nested properties (Google) 2ms
   → expected 5 to be undefined
 × __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips format/pattern on a nullable string for OpenAI reasoning models 1ms
   → expected 'email' to be undefined
 × __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > leaves a plain (non-union) typed schema behavior-identical (regression guard) 1ms
   → expected 'email' to be undefined
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips format/pattern/minLength on a nullable string and folds them into the description (Google)
AssertionError: expected 'email' to be undefined
 FAIL  __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips minimum/maximum on a nullable integer (Google)
AssertionError: expected +0 to be undefined
 FAIL  __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > recurses into items of a nullable array and strips child keywords (Google)
AssertionError: expected 1 to be undefined
 FAIL  __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > recurses into a nullable object's nested properties (Google)
AssertionError: expected 5 to be undefined
 FAIL  __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips format/pattern on a nullable string for OpenAI reasoning models
AssertionError: expected 'email' to be undefined
 FAIL  __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > leaves a plain (non-union) typed schema behavior-identical (regression guard)
AssertionError: expected 'email' to be undefined
      Tests  6 failed | 9 passed (15)

========== AFTER FIX (full tool-compatibility suite) ==========

 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > preserves zero upper bounds in Google descriptions 4ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > still rewrites an honest nested object/array schema 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > throws MCP_TOOL_SCHEMA_UNBOUNDED one past depth 32 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > accepts a 31-deep items nest 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > throws MCP_TOOL_SCHEMA_UNBOUNDED past 2048 nodes 6ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips format/pattern/minLength on a nullable string and folds them into the description (Google) 2ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips minimum/maximum on a nullable integer (Google) 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > recurses into items of a nullable array and strips child keywords (Google) 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > recurses into a nullable object's nested properties (Google) 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > strips format/pattern on a nullable string for OpenAI reasoning models 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > leaves a plain (non-union) typed schema behavior-identical (regression guard) 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > still runs combinator handling under a nullable node (cleans anyOf children) 0ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > nullable (union) typed nodes > folds a multi-concrete union canonically regardless of member order 0ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > throws MCP_TOOL_SCHEMA_UNBOUNDED on a cyclic items graph, not RangeError 0ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > does not RangeError a 20k items nest 1ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > enforces the budget when the provider does not apply fixup 0ms
 ✓ __tests__/tool-compatibility.test.ts > MCP tool compatibility > rejects a provider rewrite that expands beyond the retained-schema byte cap 3ms
      Tests  17 passed (17)

========== MUTATION CHECK (review-requested tests kill surviving mutants) ==========

revert member .sort()                 -> FAIL folds a multi-concrete union canonically regardless of member order
loop returns `current` (skip generic) -> FAIL still runs combinator handling under a nullable node (cleans anyOf children)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response; the change is server-side schema fixup with no browser interaction.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - deterministic schema transformation with no model call. A real Gemini/OpenAI function-calling endpoint is not reachable from this build host; the provider-boundary rejection this fixes is reproduced deterministically by the before/after schema dump (forbidden keywords present before, removed after).`
<!-- evidence-row:domain-artifacts -->
- [x] Before/after JSON dump of a representative nullable-field tool `inputSchema` transformed by `GoogleMcpCompatibility`: `format/pattern/min*/max*` are present on nullable string/integer/array/object fields before, and after the fix are removed and re-expressed in `description` while the nullable `type` array is preserved and `items`/nested `properties` are reached. Durable GitHub-hosted copy of this dump (regenerated at head `c39c35b` via the real `GoogleMcpCompatibility.transformToolSchema`): [30076-domain-artifact.txt](https://gist.githubusercontent.com/agent-cortex/178746fb22bea1e51251115ab96f1ffd/raw/64336016223d9a711412db05f2a7a5a21dfa407f/30076-domain-artifact.txt).

<details><summary>Domain artifact — before/after tool schema JSON</summary>

```json
=== BEFORE ===
{
  "type": "object",
  "properties": {
    "email": {
      "type": [
        "string",
        "null"
      ],
      "format": "email",
      "pattern": "^x@",
      "minLength": 3
    },
    "age": {
      "type": [
        "integer",
        "null"
      ],
      "minimum": 0,
      "maximum": 120
    },
    "tags": {
      "type": [
        "array",
        "null"
      ],
      "minItems": 1,
      "items": {
        "type": "string",
        "maxLength": 8
      }
    },
    "profile": {
      "type": [
        "object",
        "null"
      ],
      "properties": {
        "name": {
          "type": "string",
          "maxLength": 5
        }
      }
    }
  }
}
=== AFTER ===
{
  "type": "object",
  "properties": {
    "email": {
      "type": [
        "string",
        "null"
      ],
      "description": "Constraints: text must be at least 3 characters long; must be a valid email address; must match the regular expression pattern: ^x@"
    },
    "age": {
      "type": [
        "integer",
        "null"
      ],
      "description": "Constraints: number must be at least 0; number must be no more than 120"
    },
    "tags": {
      "type": [
        "array",
        "null"
      ],
      "items": {
        "type": "string",
        "description": "Constraints: text must be no more than 8 characters long"
      },
      "description": "Constraints: array must contain at least 1 items"
    },
    "profile": {
      "type": [
        "object",
        "null"
      ],
      "properties": {
        "name": {
          "type": "string",
          "description": "Constraints: text must be no more than 5 characters long"
        }
      }
    }
  }
}
```
</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic schema transformation; no live-model call is part of the changed code path. The provider-boundary 400 this fixes is caused by forbidden JSON-Schema keywords, shown present-before / absent-after in the Domain artifact above.`

## Backend + frontend logs

Backend proof is inline on the **backend-logs** evidence row above (failing-then-passing vitest run). Frontend: `N/A - server-side schema fixup, no browser path.`

## Screenshots (before / after) + video walkthrough

### Before
`N/A - no UI.`
### After
`N/A - no UI.`
### Walkthrough video
`N/A - no UI flow.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- `plugins/plugin-mcp/__tests__/validation.test.ts` is a **pre-existing flaky test** unrelated to this change. It exercises `validateToolSelectionArgument` (Ajv worker/timeout), not the tool-compatibility layer. It passes 3/3 in isolation with this change applied, and it also flakes (1 failed) on the clean `origin/develop` tree with this change stashed. This PR does not touch that file or its code path.
- Repo-wide `bun run verify` was not run to completion on this constrained ARM build host. The owning package's `test` (tool-compatibility suite), `typecheck`, and `lint:check` were run and pass.
- Evidence artifacts are embedded inline in `<details>` blocks (per CONTRIBUTING.md § Evidence) because hosted attachment upload is unavailable from this headless environment for a fork contributor.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c39c35baca1acf2728d872e60ccbee331b17378b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c39c35baca1acf2728d872e60ccbee331b17378b:packages/skills/skills/contribute-to-eliza"} -->

