### PR TITLE
fix(plugin-meetings): in-flight throttled flush can clobber the finalized transcript back to "recording" (lost update)

### DIFF
--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts
@@ -336,6 +336,151 @@ describe("MeetingTranscriptWriter — throttling", () => {
   });
 });
 
+/**
+ * Regression: an in-flight throttled incremental flush (status "recording")
+ * must never clobber the finalized "ready" row when both writes are in flight
+ * and complete out of issue order on a pooled SQL adapter / PGlite. The runtime
+ * stub's `updateMemory` parks on a manually-releasable gate and applies the row
+ * mutation only when released, so the test controls write-completion order
+ * deterministically — no DB, no network, no timers. `start()` uses `createMemory`
+ * (ungated), so only the incremental + terminal writes flow through the gate.
+ */
+describe("MeetingTranscriptWriter — finalize vs in-flight flush race", () => {
+  interface GatedWrite {
+    status: unknown;
+    release: () => void;
+  }
+  function makeReleasableRuntime() {
+    const fake = makeFakeRuntime();
+    const applyWrite = fake.runtime.updateMemory.bind(fake.runtime);
+    // `history` records every gated write in issue order (kept after release);
+    // `queue` holds only writes not yet released, so the drainer can release
+    // them newest-first to model out-of-order completion.
+    const history: GatedWrite[] = [];
+    const queue: GatedWrite[] = [];
+    (
+      fake.runtime as { updateMemory: (patch: unknown) => Promise<boolean> }
+    ).updateMemory = (patch) => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const status = (patch as { metadata?: { status?: unknown } }).metadata
+        ?.status;
+      const entry: GatedWrite = { status, release };
+      history.push(entry);
+      queue.push(entry);
+      return gate.then(() =>
+        applyWrite(patch as Parameters<typeof applyWrite>[0]),
+      );
+    };
+    return { ...fake, history, queue };
+  }
+
+  const nextTick = () => new Promise((r) => setTimeout(r, 0));
+
+  /**
+   * Drive `finalize` to completion while releasing whatever writes are pending
+   * newest-issued-first (the adversarial out-of-order order). This exposes the
+   * lost update on the unfixed writer (a late "recording" write reverts the row)
+   * and proves serialization on the fixed writer (the "ready" write lands last).
+   */
+  async function drainReversed(
+    runtime: ReturnType<typeof makeReleasableRuntime>,
+    finalize: Promise<unknown>,
+  ): Promise<void> {
+    let settled = false;
+    void finalize.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    for (let guard = 0; !settled && guard < 50; guard++) {
+      // Yield first so finalize issues every write it can before we release:
+      // on the unfixed writer both the "recording" and "ready" writes park
+      // together, and releasing newest-first lands "recording" last (the bug).
+      await nextTick();
+      if (runtime.queue.length > 0) {
+        const batch = runtime.queue.splice(0).reverse();
+        for (const write of batch) write.release();
+      }
+    }
+    await finalize;
+  }
+
+  it("keeps status ready with the final segments when an in-flight recording flush completes before it", async () => {
+    const runtime = makeReleasableRuntime();
+    let clock = 1_000;
+    const writer = new MeetingTranscriptWriter(
+      runtime.runtime,
+      5_000,
+      () => clock,
+    );
+    await writer.start(START_INPUT);
+
+    // Advance past the throttle window so the next update flushes immediately,
+    // then let that fire-and-forget "recording" flush reach its parked write.
+    clock += 6_000;
+    const s1 = segment("s1", "Jill", "hello", 0, 1_000);
+    const s2 = segment("s2", "Bob", "hi jill", 1_000, 2_000);
+    writer.updateSegments([s1]);
+    await nextTick();
+    expect(runtime.queue.map((w) => w.status)).toEqual(["recording"]);
+
+    // finalize issues the terminal "ready" write; drain releasing newest-first.
+    const finalizePromise = writer.finalize({
+      segments: [s1, s2],
+      endReason: "normal_completion",
+      participants: [{ id: "p1", displayName: "Jill" }],
+      audioWav: null,
+    });
+    await drainReversed(runtime, finalizePromise);
+
+    const row = runtime.memories.get(writer.transcriptId) as Memory;
+    const persisted = transcriptsViewReader(row);
+    expect(persisted?.status).toBe("ready");
+    expect(persisted?.segments).toHaveLength(2);
+    expect(persisted?.endedAt).toBeTypeOf("number");
+    expect(row.metadata).toMatchObject({ status: "ready" });
+  });
+
+  it("suppresses a flush queued immediately before finalize — the only mutating write is status ready", async () => {
+    const runtime = makeReleasableRuntime();
+    let clock = 1_000;
+    const writer = new MeetingTranscriptWriter(
+      runtime.runtime,
+      5_000,
+      () => clock,
+    );
+    await writer.start(START_INPUT);
+
+    clock += 6_000;
+    // Dispatch a flush and call finalize in the SAME synchronous turn: finalize
+    // sets `finalized` before the queued flush's write body runs, so the
+    // "recording" write is never issued.
+    writer.updateSegments([segment("s1", "Jill", "hello", 0, 1_000)]);
+    const finalizePromise = writer.finalize({
+      segments: [
+        segment("s1", "Jill", "hello", 0, 1_000),
+        segment("s2", "Bob", "bye", 1_000, 2_000),
+      ],
+      endReason: "requested_stop",
+      participants: [],
+      audioWav: null,
+    });
+    await drainReversed(runtime, finalizePromise);
+
+    const statuses = runtime.history.map((w) => w.status);
+    expect(statuses).not.toContain("recording");
+    expect(statuses.filter((s) => s === "ready")).toHaveLength(1);
+    const row = runtime.memories.get(writer.transcriptId) as Memory;
+    expect(transcriptsViewReader(row)?.status).toBe("ready");
+  });
+});
+
 describe("persistMeetingAudioWav", () => {
   it("writes content-addressed WAV bytes under the served media dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "meetings-audio-"));

--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
@@ -199,6 +199,13 @@ export class MeetingTranscriptWriter {
   private lastWriteAt = 0;
   private pendingFlush: ReturnType<typeof setTimeout> | null = null;
   private finalized = false;
+  /**
+   * Serializes every store write. `updateMemory` calls chained through this
+   * promise always apply in issue order, so an earlier throttled "recording"
+   * flush can never overtake and clobber the terminal "ready" write when both
+   * are in flight on a pooled SQL adapter / PGlite (out-of-order completion).
+   */
+  private writeChain: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly runtime: MeetingTranscriptRuntime,
@@ -289,13 +296,30 @@ export class MeetingTranscriptWriter {
   }
 
   /**
+   * Append a store write to {@link writeChain} so writes always apply in issue
+   * order. The chain itself absorbs rejections so one failed write never stalls
+   * the queue; the caller observes its own result through the returned promise.
+   */
+  private enqueueWrite(write: () => Promise<void>): Promise<void> {
+    const result = this.writeChain.then(write);
+    this.writeChain = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  /**
    * Incremental store write. Invoked via `void this.flush()` (fire-and-forget)
    * from the throttle path, so it must never reject — a DB hiccup would surface
    * as an unhandled promise rejection. All failures are caught and logged here;
-   * the next update simply retries.
+   * the next update simply retries. The actual `updateMemory` call runs inside
+   * the serialized {@link writeChain}, and re-checks `finalized` at execution
+   * time: once `finalize()` has run, a still-queued incremental write must not
+   * re-issue the stale "recording" row over the finalized "ready" record.
    */
-  private async flush(): Promise<void> {
-    if (this.finalized || !this.transcript) return;
+  private flush(): Promise<void> {
+    if (this.finalized || !this.transcript) return Promise.resolve();
     this.lastWriteAt = this.now();
     const next: Transcript = {
       ...this.transcript,
@@ -305,31 +329,34 @@ export class MeetingTranscriptWriter {
     };
     this.transcript = next;
     const { content, metadata } = transcriptContentAndMetadata(next);
-    try {
-      const ok = await this.runtime.updateMemory({
-        id: this.transcriptId,
-        content,
-        metadata,
-      });
-      if (!ok) {
+    return this.enqueueWrite(async () => {
+      if (this.finalized) return;
+      try {
+        const ok = await this.runtime.updateMemory({
+          id: this.transcriptId,
+          content,
+          metadata,
+        });
+        if (!ok) {
+          logger.warn(
+            {
+              transcriptId: this.transcriptId,
+              sessionId: this.input?.sessionId,
+            },
+            "[MeetingService] incremental transcript update hit a missing row",
+          );
+        }
+      } catch (err) {
         logger.warn(
           {
             transcriptId: this.transcriptId,
             sessionId: this.input?.sessionId,
+            error: err instanceof Error ? err.message : String(err),
           },
-          "[MeetingService] incremental transcript update hit a missing row",
+          "[MeetingService] incremental transcript update failed",
         );
       }
-    } catch (err) {
-      logger.warn(
-        {
-          transcriptId: this.transcriptId,
-          sessionId: this.input?.sessionId,
-          error: err instanceof Error ? err.message : String(err),
-        },
-        "[MeetingService] incremental transcript update failed",
-      );
-    }
+    });
   }
 
   /** Final write: status "ready", timings, participants, audio + knowledge mirror. */
@@ -345,6 +372,12 @@ export class MeetingTranscriptWriter {
       clearTimeout(this.pendingFlush);
       this.pendingFlush = null;
     }
+    // Drain any incremental flush already dispatched (or queued) before this
+    // finalize. `finalized` is now set, so a queued flush skips its write; a
+    // flush already awaiting `updateMemory` settles here first. Either way the
+    // terminal "ready" write below is issued last and cannot be clobbered by a
+    // late "recording" write completing out of order on a pooled adapter.
+    await this.writeChain;
 
     const endedAt = this.now();
     if (input.audioWav && input.retainedAudio) {


### PR DESCRIPTION
# Relates to

Closes #30087

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; focused package `test`, `typecheck`, and `lint` all pass (output inline below). `bun run verify` is a repo-wide gate not runnable within the time/resource budget of this worktree; the owning-package gates are attached instead — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the failing-before / passing-after vitest evidence below.

# Sync with develop

- [x] Branched from and up to date with the latest `origin/develop` (`e4d6e254e7`); zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** (owning-package gates run in its place).

# Risks

Low. The change is confined to `meeting-transcript-writer.ts` (~30 lines of logic). It strictly serializes store writes that were previously concurrent; write payloads and the persisted row shape are unchanged, so the record-shape golden test and the throttle-coalescing test still pass byte-for-byte. No public type, route, event, or export changes.

# Background

## What does this PR do?

Fixes a lost-update data-loss bug in `MeetingTranscriptWriter`. The writer dispatched its throttled incremental store write as fire-and-forget (`void this.flush()`) and never tracked the resulting promise. `finalize()` only cleared the pending **timer** (`clearTimeout(this.pendingFlush)`); it did nothing about a flush already dispatched and awaiting `runtime.updateMemory`. The `finalized` guard inside `flush()` was checked **before** that `await`, so a flush that already passed the guard still issued its stale `"recording"` write.

When the final `"ready"` write and the stale `"recording"` write were both in flight on the same row and completed **out of issue order** (normal under a pooled SQL adapter / PGlite), the `"recording"` write landed last and silently reverted the finalized transcript: `status` went back to `"recording"` and `endedAt`, `participants`, `audioUrl`, `knowledgeDocumentId`, and the final segment set were lost. The Transcripts view then showed the meeting as *still recording forever*, and the knowledge-mirror / audio references were dropped.

This is the exact hand-off point in the real flow: `MeetingPipeline.finalize()` → `notify([])` → the service's `onUpdate` listener → `writer.updateSegments()` (which can dispatch an immediate flush) right before `finishSession()` calls `writer.finalize()` (`service.ts` lines 835 → 868).

**Fix:** every store write is now appended to a single `writeChain` promise, so `updateMemory` calls always apply in issue order and an earlier `"recording"` flush can never overtake the terminal `"ready"` write. The flush body also re-checks `finalized` inside its serialized slot (so a flush queued just before finalize is suppressed), and `finalize()` awaits the chain before issuing its terminal write. Whichever interleaving occurs, the `"ready"` write is applied last.

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-loss issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior for callers is unchanged; only the internal write-ordering invariant is strengthened.

# Testing

## Where should a reviewer start?

`plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts` — the new `describe("MeetingTranscriptWriter — finalize vs in-flight flush race")` block. It uses a runtime stub whose `updateMemory` parks on a manually-releasable gate and applies the row mutation only when released, so write-completion order is controlled deterministically (no DB, no network, no timers; `start()` uses ungated `createMemory`).

## Detailed testing steps

```bash
bun install
cd plugins/plugin-meetings
../../node_modules/.bin/vitest run src/transcripts/meeting-transcript-writer.test.ts
```

- Test 1 (`keeps status ready … when an in-flight recording flush completes before it`) forces the recording flush's write to be in flight, then drives `finalize` and releases writes newest-issued-first (the adversarial out-of-order order). It asserts the persisted row is `status: "ready"` with the final 2 segments and an `endedAt`.
- Test 2 (`suppresses a flush queued immediately before finalize …`) dispatches a flush and calls `finalize` in the same synchronous turn, then asserts no `"recording"` write ever mutated the row and exactly one `"ready"` write did.

Both **fail on the unfixed writer** (`status` reverts to `"recording"`; a stray `"recording"` write is emitted) and **pass with the fix**. The existing record-shape golden test and the throttle-coalescing test remain green.

# Evidence Gate

<!-- evidence-head:4c7720105e66de5f2937d3c4e6a1921aa3006a6e -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface changed; this is an internal persistence-ordering fix in plugin-meetings.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; the change is a runtime write-ordering fix proven by deterministic unit tests.`
<!-- evidence-row:backend-logs -->
- [x] Structured `[MeetingService]` logger lines emitted by the real writer path (record created `recording` → finalized `ready`), captured live from the focused vitest run on head `4c7720105e`.

<details>
<summary>Backend logs — MeetingTranscriptWriter structured logger output (focused vitest run)</summary>

```text
 Info  [MeetingService] meeting transcript record created (recording) (transcriptId=8cbd821c-f7f1-4c46-bca9-4ed90348444a, sessionId=11111111-1111-1111-1111-111111111111)
 Info  [MeetingService] meeting transcript finalized (ready) (transcriptId=8cbd821c-f7f1-4c46-bca9-4ed90348444a, segments=2, durationMs=2000, speakerCount=2, endReason=normal_completion)
 Info  [MeetingService] meeting transcript record created (recording) (transcriptId=808487f7-d52c-414c-9ba4-e0e8c8854d42, sessionId=11111111-1111-1111-1111-111111111111)
 Info  [MeetingService] meeting transcript finalized (ready) (transcriptId=808487f7-d52c-414c-9ba4-e0e8c8854d42, segments=2, durationMs=2000, speakerCount=2, endReason=requested_stop)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; MeetingTranscriptWriter does not call a model.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the persisted transcript memory row loaded by the `/api/transcripts` route + Transcripts view. Before the fix the row reverts to `status: "recording"` (lost update); after the fix it stays `"ready"` with the final 2 segments and an `endedAt`. Live before/after capture below.

<details>
<summary>Domain artifact — persisted transcript memory row (before/after, live capture)</summary>

```text
BEFORE FIX (writer reverted to origin/develop; new regression tests only):
  the terminal "ready" write is overtaken by the stale "recording" flush
  AssertionError: expected 'recording' to be 'ready'   (persisted row.status reverted)
  AssertionError: expected [ 'recording', 'ready' ] to not include 'recording'

AFTER FIX (head 4c7720105e) — live persisted row after the finalize-vs-in-flight-flush race:
  ordered updateMemory write history (status per write): ["recording","ready"]   ("ready" lands last)
  persisted row.metadata.status: ready
  persisted transcript (content.transcript, parsed): { "status": "ready", "endedAt": 7000, "segments": 2 }
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend structured-logger lines fire end-to-end through the real writer in the test runs below (record-created `recording` → finalized `ready`). Frontend: `N/A - no frontend involved`.

<details>
<summary>Failing BEFORE the fix — the lost update reproduced (row reverts to "recording")</summary>

```
 FAIL  src/transcripts/meeting-transcript-writer.test.ts > MeetingTranscriptWriter — finalize vs in-flight flush race > keeps status ready with the final segments when an in-flight recording flush completes before it
AssertionError: expected 'recording' to be 'ready' // Object.is equality

Expected: "ready"
Received: "recording"

 ❯ src/transcripts/meeting-transcript-writer.test.ts:444:31
    442|     const row = runtime.memories.get(writer.transcriptId) as Memory;
    443|     const persisted = transcriptsViewReader(row);
    444|     expect(persisted?.status).toBe("ready");
       |                               ^

 FAIL  src/transcripts/meeting-transcript-writer.test.ts > MeetingTranscriptWriter — finalize vs in-flight flush race > suppresses a flush queued immediately before finalize — the only mutating write is status ready
AssertionError: expected [ 'recording', 'ready' ] to not include 'recording'
 ❯ src/transcripts/meeting-transcript-writer.test.ts:477:26
    477|     expect(statuses).not.toContain("recording");
       |                          ^

 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)
```
(pre-fix source taken from `origin/develop`; the two new regression cases fail, the existing 7 golden/throttle/finalize-edge cases stay green.)

</details>

<details>
<summary>Passing AFTER the fix — focused writer suite (9/9)</summary>

```
 RUN  v4.1.10  plugins/plugin-meetings

stdout | ... > finalize vs in-flight flush race > keeps status ready ...
 Info  [MeetingService] meeting transcript record created (recording) (transcriptId=…, sessionId=…)
 Info  [MeetingService] meeting transcript finalized (ready) (transcriptId=…, segments=2, durationMs=2000, speakerCount=2, endReason=normal_completion)

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

</details>

<details>
<summary>Full plugin-meetings package suite (265/265) + typecheck + lint</summary>

```
$ ../../node_modules/.bin/vitest run
 Test Files  28 passed (28)
      Tests  265 passed (265)

$ bun run --cwd plugins/plugin-meetings typecheck
$ tsc --noEmit          # clean, no errors

$ bun run --cwd plugins/plugin-meetings lint
$ bunx @biomejs/biome check --write --unsafe .
Checked 102 files in 960ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI change; this is an internal runtime persistence-ordering fix.`

### Walkthrough video

`N/A - no UI/user flow.`

## Audio / voice walkthrough

`N/A - no audio/voice/TTS/STT round-trip changed; the transcript-writer change is a store-write ordering fix and does not alter capture, ASR, or audio retention.`

## Known gaps / failures

- `bun run verify` (repo-wide parity/dependency/type/lint/audit aggregate) is not run to completion in this worktree due to time/resource limits on the build host. In its place the **owning package's** `test` (265/265), `typecheck` (clean), and `lint` (clean) gates were run and are attached above, per the "narrowest relevant command … then required package gates" guidance. No repository-wide surface (exports, routes, events, generated data) is touched by this diff.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@4c7720105e66de5f2937d3c4e6a1921aa3006a6e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@4c7720105e66de5f2937d3c4e6a1921aa3006a6e:packages/skills/skills/contribute-to-eliza"} -->

