### PR TITLE
fix(plugin-native-desktop): propagate DesktopWeb.setFullscreen rejection instead of fabricating success

### DIFF
--- a/plugins/plugin-native-desktop/src/web.test.ts
+++ b/plugins/plugin-native-desktop/src/web.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests `DesktopWeb`'s browser-fallback contracts — permission bridging,
- * notifications, window focus/blur listeners, external URL safety, and
- * battery state — against a stubbed `window`/`navigator` and mocked
- * Electrobun RPC, not a real browser or native host.
+ * notifications, window focus/blur listeners, external URL safety, fullscreen
+ * promise propagation, and battery state — against a stubbed
+ * `window`/`navigator`/`document` and mocked Electrobun RPC, not a real browser
+ * or native host.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -24,6 +25,13 @@ function setNavigator(value: Partial<Navigator>): void {
 
 function setWindow(value: Partial<Window> & Record<string, unknown>): void {
   Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value,
+  });
+}
+
+function setDocument(value: Record<string, unknown>): void {
+  Object.defineProperty(globalThis, "document", {
     configurable: true,
     value,
   });
@@ -246,6 +254,87 @@ describe("DesktopWeb browser fallback contracts", () => {
       "_blank",
       "noopener",
     );
+  });
+
+  it("propagates exitFullscreen rejection instead of fabricating success", async () => {
+    // exitFullscreen rejects with a TypeError when the document is not
+    // currently fullscreen; the caller must observe that rejection.
+    const rejection = new TypeError("Document not active");
+    const exitFullscreen = vi.fn(() => Promise.reject(rejection));
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    setDocument({
+      documentElement: { requestFullscreen },
+      exitFullscreen,
+    });
+
+    await expect(new DesktopWeb().setFullscreen({ flag: false })).rejects.toBe(
+      rejection,
+    );
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("propagates requestFullscreen rejection when there is no user gesture", async () => {
+    const rejection = new TypeError(
+      "API can only be initiated by a user gesture.",
+    );
+    const requestFullscreen = vi.fn(() => Promise.reject(rejection));
+    const exitFullscreen = vi.fn(() => Promise.resolve());
+    setDocument({
+      documentElement: { requestFullscreen },
+      exitFullscreen,
+    });
+
+    await expect(new DesktopWeb().setFullscreen({ flag: true })).rejects.toBe(
+      rejection,
+    );
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("resolves when the underlying fullscreen transition succeeds", async () => {
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    const exitFullscreen = vi.fn(() => Promise.resolve());
+    setDocument({
+      documentElement: { requestFullscreen },
+      exitFullscreen,
+    });
+
+    const plugin = new DesktopWeb();
+    await expect(plugin.setFullscreen({ flag: true })).resolves.toBeUndefined();
+    await expect(
+      plugin.setFullscreen({ flag: false }),
+    ).resolves.toBeUndefined();
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits no unhandled rejection when a fullscreen transition fails", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    setDocument({
+      documentElement: {
+        requestFullscreen: () =>
+          Promise.reject(new TypeError("no user gesture")),
+      },
+      exitFullscreen: () => Promise.reject(new TypeError("not fullscreen")),
+    });
+
+    const plugin = new DesktopWeb();
+    // The caller's try/catch owns the rejection for both flag values.
+    await expect(plugin.setFullscreen({ flag: true })).rejects.toThrow(
+      "no user gesture",
+    );
+    await expect(plugin.setFullscreen({ flag: false })).rejects.toThrow(
+      "not fullscreen",
+    );
+    // Flush the microtask/macrotask queue so any stray rejection would surface.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    process.off("unhandledRejection", onUnhandled);
+    expect(unhandled).toEqual([]);
   });
 
   it("clamps valid battery levels and ignores malformed battery fields", async () => {

--- a/plugins/plugin-native-desktop/src/web.ts
+++ b/plugins/plugin-native-desktop/src/web.ts
@@ -294,9 +294,13 @@ export class DesktopWeb extends WebPlugin {
   }
   async setAlwaysOnTop(_options: { flag: boolean }): Promise<void> {}
   async setFullscreen(options: { flag: boolean }): Promise<void> {
-    options.flag
+    // Await the underlying Fullscreen API promise so a rejection
+    // (requestFullscreen without a user gesture, exitFullscreen while not
+    // fullscreen) propagates to the caller instead of resolving with a
+    // fabricated success and escaping as an unhandled rejection.
+    await (options.flag
       ? document.documentElement.requestFullscreen()
-      : document.exitFullscreen();
+      : document.exitFullscreen());
   }
   async setOpacity(_options: { opacity: number }): Promise<void> {}
 


### PR DESCRIPTION
# Relates to

Closes #30090

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused package checks (test, typecheck, lint) were run; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      failing-before / passing-after vitest evidence attached below.

# Sync with develop

- [x] Branched from and rebased onto the latest `origin/develop` (`e4d6e254e7`); zero conflicts.
- [ ] `bun run verify` — not run to completion on this machine (full-repo gate is heavyweight); the owning package's `test`, `typecheck`, and `lint:check` all pass and are attached under **Evidence Details**. See **Known gaps / failures**.

# Risks

Low. This is a one-line correctness fix in the browser/Electrobun fallback of a
Capacitor plugin. The change only makes `DesktopWeb.setFullscreen` `await` the
promise it already invoked, so a previously swallowed rejection now propagates
to the caller (the documented `Promise<void>` contract). No public type, export,
or signature changes. The only behavior difference visible to callers is that a
genuinely failing fullscreen transition now rejects instead of silently
resolving — which is the intended fix.

# Background

## What does this PR do?

`DesktopWeb.setFullscreen({ flag })` is the browser/Electrobun fallback that runs
whenever the native desktop bridge (`__ELIZA_ELECTROBUN_RPC__`) is absent — the
real path for desktop-app fullscreen toggling. It was declared `Promise<void>`
but used a bare ternary-expression-statement:

```ts
async setFullscreen(options: { flag: boolean }): Promise<void> {
  options.flag
    ? document.documentElement.requestFullscreen()
    : document.exitFullscreen();
}
```

Because it neither `await`ed nor `return`ed the underlying Fullscreen API
promise, the method resolved immediately with `undefined` before the transition
completed, and any rejection escaped as an **unhandled promise rejection**
instead of reaching the awaiting caller. Both underlying calls reject in
ordinary conditions:

- `document.exitFullscreen()` rejects with a `TypeError` when the document is
  not currently fullscreen, and
- `document.documentElement.requestFullscreen()` rejects when not invoked from a
  user gesture.

The result was a **fabricated-success contract break** (a caller's `await` /
`try`/`catch` saw success even on failure) plus an unhandled rejection that can
crash strict hosts (Node `--unhandled-rejections=strict`, Electrobun) or spam
error logs.

The fix awaits the underlying promise so rejections propagate to the caller and
resolution waits for the real transition:

```ts
async setFullscreen(options: { flag: boolean }): Promise<void> {
  await (options.flag
    ? document.documentElement.requestFullscreen()
    : document.exitFullscreen());
}
```

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation — the
`setFullscreen` contract (`Promise<void>` that reflects the transition result)
is unchanged; the implementation now honors it.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-desktop/src/web.test.ts` — four new deterministic tests
mock `document.documentElement.requestFullscreen` / `document.exitFullscreen`
and assert the returned promise's behavior. `plugins/plugin-native-desktop/src/web.ts`
holds the one-line fix.

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-native-desktop test
bun run --cwd plugins/plugin-native-desktop typecheck
bun run --cwd plugins/plugin-native-desktop lint:check
```

The added tests cover: (1) `flag:false` propagates the `exitFullscreen`
`TypeError` instead of resolving `undefined`; (2) `flag:true` propagates a
`requestFullscreen` rejection; (3) both flags resolve `undefined` when the
underlying call resolves; (4) a `process.on("unhandledRejection")` probe records
**zero** unhandled rejections across the failing cases, proving the caller's
`try`/`catch` owns the error.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:e5ba092d4996490f232b055f27988d49c531d2cb -->

<!-- evidence-row:before-screenshots -->
- [ ] `N/A - no UI surface. This is the Capacitor web fallback for a desktop-only fullscreen toggle; the fix is a promise-propagation correction with no rendered output.`
<!-- evidence-row:after-screenshots -->
- [ ] `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [ ] `N/A - no UI flow. The domain artifact is the deterministic promise-rejection assertion attached below.`
<!-- evidence-row:backend-logs -->
- [ ] `N/A - no server/runtime code path. This is a Capacitor plugin browser fallback exercised by unit tests, not the agent backend.`
<!-- evidence-row:frontend-logs -->
- [ ] `N/A - no request/response or view state change; the behavior is a promise resolution/rejection, asserted directly in the tests below.`
<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the deterministic failing-before / passing-after vitest run proving reject-propagation for both flag values and zero unhandled rejections. Full immutable re-verified logs (captured at head `e5ba092d`, revision-pinned): [failing-before](https://gist.githubusercontent.com/agent-cortex/0698c46f6874d1ccf8188c3054dbbd1b/raw/7706a9d8451cb0410efc5cc7c2ebe35c9363eae0/30091-vitest-failing-before.log) · [passing-after](https://gist.githubusercontent.com/agent-cortex/0698c46f6874d1ccf8188c3054dbbd1b/raw/7706a9d8451cb0410efc5cc7c2ebe35c9363eae0/30091-vitest-passing-after.log) · [typecheck+lint](https://gist.githubusercontent.com/agent-cortex/0698c46f6874d1ccf8188c3054dbbd1b/raw/7706a9d8451cb0410efc5cc7c2ebe35c9363eae0/30091-typecheck-lint.txt). Release-asset upload to the `pr-evidence` store is unavailable to this fork account, so the full logs are hosted as an immutable revision-pinned gist and the documented inline `<details>` transcripts below remain the primary artifact.

<details><summary>Failing before the fix — unfixed web.ts + new tests (3 failed / 7 passed)</summary>

```
 ❯ src/web.test.ts (10 tests | 3 failed) 73ms
     × propagates exitFullscreen rejection instead of fabricating success 12ms
     × propagates requestFullscreen rejection when there is no user gesture 2ms
     × emits no unhandled rejection when a fullscreen transition fails 2ms

 FAIL  src/web.test.ts > ... > propagates exitFullscreen rejection instead of fabricating success
 AssertionError: promise resolved "undefined" instead of rejecting
 - Expected: Error { "message": "rejected promise" }
 + Received: undefined

 FAIL  src/web.test.ts > ... > propagates requestFullscreen rejection when there is no user gesture
 AssertionError: promise resolved "undefined" instead of rejecting

 FAIL  src/web.test.ts > ... > emits no unhandled rejection when a fullscreen transition fails
 AssertionError: promise resolved "undefined" instead of rejecting

 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

</details>

<details><summary>Passing after the fix (10 passed)</summary>

```
 RUN  v4.1.10 .../plugins/plugin-native-desktop

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  484ms (transform 222ms, setup 0ms, import 259ms, tests 37ms)
```

</details>
<!-- evidence-row:ocr-review -->
- [ ] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no server/runtime or frontend code path.` The verifiable artifact is the
vitest reproduction below.

### Failing before the fix (unfixed `web.ts` from `origin/develop`, new tests present)

<details><summary>vitest run — 3 failed / 7 passed</summary>

```
 ❯ src/web.test.ts (10 tests | 3 failed) 73ms
     × propagates exitFullscreen rejection instead of fabricating success 12ms
     × propagates requestFullscreen rejection when there is no user gesture 2ms
     × emits no unhandled rejection when a fullscreen transition fails 2ms

 FAIL  src/web.test.ts > ... > propagates exitFullscreen rejection instead of fabricating success
AssertionError: promise resolved "undefined" instead of rejecting
- Expected: Error { "message": "rejected promise" }
+ Received: undefined

 FAIL  src/web.test.ts > ... > propagates requestFullscreen rejection when there is no user gesture
AssertionError: promise resolved "undefined" instead of rejecting

 FAIL  src/web.test.ts > ... > emits no unhandled rejection when a fullscreen transition fails
AssertionError: promise resolved "undefined" instead of rejecting

 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

</details>

### Passing after the fix

<details><summary>vitest run — 10 passed</summary>

```
 RUN  v4.1.10 .../plugins/plugin-native-desktop

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

</details>

### typecheck + lint

<details><summary>typecheck + biome check — clean</summary>

```
=== typecheck ===
$ tsc --noEmit -p tsconfig.json
=== lint:check ===
$ bunx @biomejs/biome check .
Checked 7 files in 77ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI surface (Capacitor web fallback; domain artifact is the promise-rejection test).`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun run verify` (full-repo gate) was not run to completion on this machine;
  it is heavyweight and unrelated to this one-line, single-package change. The
  owning package's `test`, `typecheck`, and `lint:check` all pass and are
  attached above. This is not a blocker: the change is confined to
  `plugins/plugin-native-desktop/src/web.ts` and its test file.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Closes #30090

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@e5ba092d4996490f232b055f27988d49c531d2cb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@e5ba092d4996490f232b055f27988d49c531d2cb:packages/skills/skills/contribute-to-eliza"} -->

