### PR TITLE
fix(cloud): trim latency certification setup

### DIFF
--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -98,14 +98,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup workspace dependencies
-        uses: ./.github/actions/setup-bun-workspace
+      - name: Setup Bun for pinned Wrangler
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: ${{ env.BUN_VERSION }}
-          install-command: bun install --frozen-lockfile
-          install-native-deps: "false"
-          skip-avatar-clone: "true"
-          no-vision-deps: "true"
 
       - name: Run exact-SHA privacy-safe latency certification
         shell: bash

--- a/packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts
@@ -11,6 +11,10 @@ const source = readFileSync(
   new URL(".github/workflows/cloud-latency-certification.yml", repoRoot),
   "utf8",
 );
+const orchestratorSource = readFileSync(
+  new URL("packages/cloud/scripts/cloud-latency-certification.mjs", repoRoot),
+  "utf8",
+);
 
 interface Step {
   name?: string;
@@ -135,6 +139,31 @@ describe("Cloud latency certification workflow", () => {
     expect(run).toContain("args+=(--auth)");
     expect(run).toContain("args+=(--suspended)");
     expect(run).not.toContain("wrangler tail");
+  });
+
+  test("installs only pinned Bun for the pinned Wrangler Tail client", () => {
+    expect(job?.env?.BUN_VERSION).toBe("1.3.14");
+    const setupBun = step("Setup Bun for pinned Wrangler");
+    expect(setupBun.uses).toBe(
+      "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+    );
+    expect(setupBun.with).toEqual({
+      "bun-version": `\${{ env.BUN_VERSION }}`,
+    });
+    expect(source).not.toContain("setup-bun-workspace");
+    expect(source).not.toContain("bun install");
+    expect(orchestratorSource).toContain('"wrangler@4.116.0"');
+
+    const importSpecifiers = [
+      ...orchestratorSource.matchAll(/from\s+["']([^"']+)["']/g),
+    ].map((match) => match[1]);
+    expect(importSpecifiers.length).toBeGreaterThan(0);
+    expect(
+      importSpecifiers.every(
+        (specifier) =>
+          specifier?.startsWith("node:") || specifier?.startsWith("./"),
+      ),
+    ).toBe(true);
   });
 
   test("uploads only explicitly sanitized evidence and never raw Tail material", () => {


### PR DESCRIPTION
Closes #30093.

## What changed

- replace the full `setup-bun-workspace` path with the pinned `oven-sh/setup-bun` action
- retain exact Node 24.15.0, Bun 1.3.14, and Wrangler 4.116.0 pins
- add a fail-closed workflow contract rejecting `bun install`/workspace setup and external runtime imports

The orchestrator imports only Node built-ins and its adjacent inference-auth helper. Bun is used only by the pinned `bunx wrangler@4.116.0 tail` subprocess, so Python, protoc, Turbo cache restore, monorepo dependencies, postinstall builds, and native submodules are not runtime dependencies of this job.

## Measured evidence

- run 33324197420 setup: 17:04:36Z–17:09:43Z = **5m07s**
- same run benchmark step: 17:09:43Z–17:10:00Z = **17s**
- clean worktree had no `node_modules`; orchestrator dynamic import passed
- cold local `bunx wrangler@4.116.0 --version`: **5.93s**
- repository `bun install --frozen-lockfile`: **430.91s**, 6,885 packages

The hosted savings must be measured by the first workflow run on this head; local timing is directional because runner/network caches differ.

## Validation

- `bun run verify` — 375/375 Turbo tasks plus all repository audits passed on the pre-rebase exact parent; branch then rebased cleanly onto current `origin/develop`
- post-rebase focused suite: 30 passed (workflow contract, certification script, action pinning)
- `actionlint .github/workflows/cloud-latency-certification.yml`
- `bunx @biomejs/biome@2.5.8 check packages/scripts/__tests__/cloud-latency-certification-workflow.test.ts`
- `git diff --check origin/develop...HEAD`

## Risk boundary

`bunx` still downloads Wrangler on a cold runner, but the package version is exact and the Bun setup action is commit-pinned. The existing Tail teardown, sanitized artifact allowlist, exact-SHA gate, protected secret preflight, benchmark counts, and provider/auth logic are unchanged.
