### PR TITLE
perf(cloud): fuse revocation with inference lease

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -17,6 +17,7 @@ import * as inferenceAuthContextActual from "@/lib/services/inference-auth-conte
 import * as billingDeferredActual from "@/lib/services/inference-billing-deferred";
 import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
 import * as billingLedgerActual from "@/lib/services/inference-billing-ledger";
+import * as inferenceCredentialRevocationActual from "@/lib/services/inference-credential-revocation";
 import * as modelCatalogActual from "@/lib/services/model-catalog";
 import * as organizationAdmissionActual from "@/lib/services/organization-inference-admission";
 import * as teamPoolActual from "@/lib/services/team-credential-pool";
@@ -43,6 +44,8 @@ let deferredEnabled = false;
 let ledgerAdmits = true;
 let reserveCreditsThrows: Error | null = null;
 let organizationAdmissionError: Error | null = null;
+let strongRevocationEnabled = true;
+const callOrder: string[] = [];
 
 // Direct storage operations are deliberately observable but must remain unused.
 const writePendingInferenceCharge = mock(async () => backstopPersists);
@@ -66,11 +69,15 @@ const createLedgerDebitSettler = mock(() => ledgerInnerSettler);
 const createCreditReservationSettler = mock(() => async () => null);
 const organizationSettler = mock(async (_actualCostUsd: number) => null);
 const organizationUnknownSettler = mock(async () => null);
+const markProviderDispatched = mock(async () => {
+  callOrder.push("dispatch");
+});
 type OrganizationAdmissionParams = Parameters<
   typeof organizationAdmissionActual.admitOrganizationInference
 >[0];
 const admitOrganizationInference = mock(
   async (params: OrganizationAdmissionParams) => {
+    callOrder.push("combined-admission");
     if (organizationAdmissionError) throw organizationAdmissionError;
     return {
       mode: params.executionCtx
@@ -78,10 +85,13 @@ const admitOrganizationInference = mock(
         : ("synchronous_reservation" as const),
       settle: organizationSettler,
       settleUnknown: organizationUnknownSettler,
+      markProviderDispatched,
     };
   },
 );
-const enforceOrgRateLimit = mock(async () => null);
+const enforceOrgRateLimit = mock(async () => {
+  callOrder.push("rate-limit");
+});
 
 // Auth: resolve straight to an authorized org user via the hot-path resolver so
 // the org-credits branch (not app-credits) is taken and moderation is skipped.
@@ -103,6 +113,7 @@ const ADMISSION = {
 };
 const resolveInferenceAuthContext = mock(
   async (_request: Request, options: AuthResolveOptions = {}) => {
+    callOrder.push("auth");
     authResolveOptions.push(options);
     options.onTelemetry?.({
       v: 1,
@@ -139,6 +150,15 @@ const resolveInferenceAuthContext = mock(
         appScopeId: null,
         admission: ADMISSION,
       },
+      ...(options.deferStrongCredentialCheck
+        ? {
+            credential: {
+              kind: "api_key" as const,
+              credentialId: API_KEY_ID,
+              userId: USER,
+            },
+          }
+        : {}),
     };
   },
 );
@@ -146,6 +166,10 @@ mock.module("@/lib/services/inference-auth-context", () => ({
   ...inferenceAuthContextActual,
   isInferenceHotPathCacheEnabled: () => true,
   resolveInferenceAuthContext,
+}));
+mock.module("@/lib/services/inference-credential-revocation", () => ({
+  ...inferenceCredentialRevocationActual,
+  isInferenceStrongRevocationEnabled: () => strongRevocationEnabled,
 }));
 
 // Provider config: pretend a provider is configured; the model object is unused
@@ -256,6 +280,7 @@ mock.module("@/lib/utils/credit-reservation", () => ({
 // Keep spies so reasoning-effort tests can also assert the exact configuration
 // that survives the full route pipeline.
 const generateText = mock((_config: Record<string, unknown>) => {
+  callOrder.push("provider");
   throw new Error("model-call-stub");
 });
 const streamText = mock((_config: Record<string, unknown>) => {
@@ -279,6 +304,10 @@ afterAll(() => {
   mock.module(
     "@/lib/services/inference-auth-context",
     () => inferenceAuthContextActual,
+  );
+  mock.module(
+    "@/lib/services/inference-credential-revocation",
+    () => inferenceCredentialRevocationActual,
   );
   mock.module("@/lib/providers/language-model", () => languageModelActual);
   mock.module("@/lib/pricing", () => pricingActual);
@@ -363,6 +392,8 @@ describe("chat/completions cache-only organization admission", () => {
     ledgerAdmits = true;
     reserveCreditsThrows = null;
     organizationAdmissionError = null;
+    strongRevocationEnabled = true;
+    callOrder.length = 0;
     billingDeferredActual.__clearDeferredAdmissionState();
     writePendingInferenceCharge.mockClear();
     reserveCredits.mockClear();
@@ -377,6 +408,7 @@ describe("chat/completions cache-only organization admission", () => {
     admitOrganizationInference.mockClear();
     organizationSettler.mockClear();
     organizationUnknownSettler.mockClear();
+    markProviderDispatched.mockClear();
     enforceOrgRateLimit.mockClear();
     generateText.mockClear();
     streamText.mockClear();
@@ -477,6 +509,7 @@ describe("chat/completions cache-only organization admission", () => {
     expect(authResolveOptions).toHaveLength(1);
     expect(authResolveOptions[0]?.executionCtx).toBeDefined();
     expect(authResolveOptions[0]?.cacheOnly).toBe(true);
+    expect(authResolveOptions[0]?.deferStrongCredentialCheck).toBe(true);
     expect(enforceOrgRateLimit).toHaveBeenCalledWith(
       ORG,
       "completions",
@@ -496,6 +529,13 @@ describe("chat/completions cache-only organization admission", () => {
       "auth_resolve;dur=1.2",
     );
     expect(generateText).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual([
+      "auth",
+      "rate-limit",
+      "combined-admission",
+      "dispatch",
+      "provider",
+    ]);
     await Promise.all(waitUntilPromises);
     expect(admitOrganizationInference).toHaveBeenCalledTimes(1);
     const admission = (
@@ -504,9 +544,38 @@ describe("chat/completions cache-only organization admission", () => {
       >
     )[0]?.[0];
     expect(admission?.executionCtx).toBeDefined();
+    expect(admission?.credential).toEqual({
+      kind: "api_key",
+      credentialId: API_KEY_ID,
+      userId: USER,
+    });
     expect(organizationUnknownSettler).toHaveBeenCalled();
     expect(reserveCredits).not.toHaveBeenCalled();
     expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+  });
+
+  test("a flag-off Worker preserves legacy admission without credential fusion", async () => {
+    strongRevocationEnabled = false;
+    const captured: Promise<unknown>[] = [];
+
+    const response = await driveWithCtx(captured);
+
+    expect(response.status).toBe(500);
+    expect(authResolveOptions).toHaveLength(1);
+    expect(authResolveOptions[0]?.deferStrongCredentialCheck).toBe(false);
+    const admission = (
+      admitOrganizationInference.mock.calls as unknown as Array<
+        [OrganizationAdmissionParams]
+      >
+    )[0]?.[0];
+    expect(admission?.credential).toBeUndefined();
+    expect(callOrder).toEqual([
+      "auth",
+      "combined-admission",
+      "dispatch",
+      "provider",
+    ]);
+    await Promise.all(captured);
   });
 
   test("billing requestId is server-generated, not copied from x-request-id", async () => {

--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -315,6 +315,77 @@ describe("Miniflare Durable Object integration", () => {
     );
   });
 
+  test("authorized lease checks revocation and balance in one Durable Object request", async () => {
+    const organizationId = "org-miniflare-authorized-lease";
+    const credential = {
+      organizationId,
+      kind: "api_key",
+      credentialId: "00000000-0000-0000-0000-000000000106",
+      userId: "00000000-0000-0000-0000-000000000206",
+    };
+    expect(
+      (
+        await post(
+          "/hydrate",
+          { balanceUsd: 1, balanceRevision: "1" },
+          organizationId,
+        )
+      ).status,
+    ).toBe(200);
+    const leaseBody = (requestId: string) => ({
+      organizationId,
+      requestId,
+      balanceUsd: 1,
+      balanceRevision: "1",
+      estimatedCostUsd: 1,
+      credential,
+      recovery: {
+        version: 1,
+        kind: "organization",
+        organizationId,
+        userId: credential.userId,
+        requestId,
+        model: "test-model",
+        provider: "test-provider",
+        billingSource: "test",
+        description: "authorized Miniflare admission test",
+        accounting: { kind: "direct_debit" },
+      },
+    });
+    expect(
+      (
+        await post(
+          "/lease-authorized",
+          leaseBody("authorized-before-revocation"),
+          organizationId,
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await post(
+          "/credential/revoke",
+          {
+            organizationId,
+            kind: credential.kind,
+            credentialId: credential.credentialId,
+          },
+          organizationId,
+        )
+      ).status,
+    ).toBe(200);
+    const denied = await post(
+      "/lease-authorized",
+      leaseBody("authorized-after-revocation"),
+      organizationId,
+    );
+    expect(denied.status).toBe(403);
+    expect(JSON.parse(await denied.text())).toEqual({
+      allowed: false,
+      reason: "credential_revoked",
+    });
+  });
+
   test("session cutoff revokes old tokens without rejecting a later login", async () => {
     const base = {
       organizationId: "org-miniflare",

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -17,6 +17,7 @@ import {
   warmInferenceRateLimitGate,
 } from "@/lib/services/inference-admission-gate";
 import * as admissionRecovery from "@/lib/services/inference-admission-recovery";
+import { InferenceCredentialRevokedError } from "@/lib/services/inference-credential-revocation";
 import { InferenceAdmissionGate } from "../src/inference-admission-gate";
 
 const recoverExpiredLease = spyOn(
@@ -246,6 +247,7 @@ function post(
   path:
     | "/hydrate"
     | "/lease"
+    | "/lease-authorized"
     | "/dispatch"
     | "/release"
     | "/settle"
@@ -262,7 +264,8 @@ function post(
   body: Record<string, unknown>,
 ): Promise<Response> {
   const payload =
-    path === "/lease" && body.recovery === undefined
+    (path === "/lease" || path === "/lease-authorized") &&
+    body.recovery === undefined
       ? {
           ...body,
           organizationId: body.organizationId ?? "org-a",
@@ -279,7 +282,7 @@ function post(
             accounting: { kind: "direct_debit" },
           },
         }
-      : path === "/lease"
+      : path === "/lease" || path === "/lease-authorized"
         ? { ...body, organizationId: body.organizationId ?? "org-a" }
         : body;
   return gate.fetch(
@@ -799,6 +802,150 @@ describe("InferenceAdmissionGate", () => {
     ]);
   });
 
+  test("authorized leases reject revoked and disabled standing before reserving balance", async () => {
+    const cases = [
+      {
+        mutationPath: "/credential/revoke" as const,
+        mutation: {
+          organizationId: "org-a",
+          kind: "api_key",
+          credentialId: "key-a",
+        },
+        reason: "credential_revoked",
+      },
+      {
+        mutationPath: "/subject/set-active" as const,
+        mutation: {
+          organizationId: "org-a",
+          userId: "user-a",
+          active: false,
+          reason: "account",
+        },
+        reason: "subject_account_disabled",
+      },
+      {
+        mutationPath: "/organization/set-active" as const,
+        mutation: { organizationId: "org-a", active: false },
+        reason: "organization_disabled",
+      },
+    ];
+
+    for (const [index, candidate] of cases.entries()) {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 5);
+      expect(
+        (await post(gate, candidate.mutationPath, candidate.mutation)).status,
+      ).toBe(200);
+      const response = await post(gate, "/lease-authorized", {
+        requestId: `denied-${index}`,
+        balanceUsd: 5,
+        balanceRevision: "1",
+        estimatedCostUsd: 1,
+        credential: {
+          organizationId: "org-a",
+          kind: "api_key",
+          credentialId: "key-a",
+          userId: "user-a",
+        },
+      });
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        allowed: false,
+        reason: candidate.reason,
+      });
+      expect(
+        storage.read<{ activeLeaseCount: number }>("ledger"),
+      ).toMatchObject({ activeLeaseCount: 0 });
+    }
+  });
+
+  test("authorized leases preserve insufficient, duplicate, and concurrent accounting", async () => {
+    const gate = createGate();
+    await hydrateGate(gate, 2);
+    const credential = {
+      organizationId: "org-a",
+      kind: "api_key",
+      credentialId: "key-a",
+      userId: "user-a",
+    } as const;
+    const first = await post(gate, "/lease-authorized", {
+      requestId: "authorized-a",
+      balanceUsd: 2,
+      balanceRevision: "1",
+      estimatedCostUsd: 1,
+      credential,
+    });
+    expect(first.status).toBe(200);
+    expect(
+      (
+        await post(gate, "/lease-authorized", {
+          requestId: "authorized-a",
+          balanceUsd: 2,
+          balanceRevision: "1",
+          estimatedCostUsd: 1,
+          credential,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await post(gate, "/lease-authorized", {
+          requestId: "authorized-insufficient",
+          balanceUsd: 2,
+          balanceRevision: "1",
+          estimatedCostUsd: 2,
+          credential,
+        })
+      ).status,
+    ).toBe(402);
+
+    const concurrentGate = createGate();
+    await hydrateGate(concurrentGate, 1);
+    const statuses = await Promise.all(
+      ["concurrent-a", "concurrent-b"].map(
+        async (requestId) =>
+          (
+            await post(concurrentGate, "/lease-authorized", {
+              requestId,
+              balanceUsd: 1,
+              balanceRevision: "1",
+              estimatedCostUsd: 1,
+              credential,
+            })
+          ).status,
+      ),
+    );
+    expect(statuses.sort()).toEqual([200, 402]);
+  });
+
+  test("authorized lease persistence failures publish neither admission nor balance hold", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 2);
+    storage.failNextPut = true;
+    await expect(
+      post(gate, "/lease-authorized", {
+        requestId: "authorized-storage-failure",
+        balanceUsd: 2,
+        balanceRevision: "1",
+        estimatedCostUsd: 1,
+        credential: {
+          organizationId: "org-a",
+          kind: "api_key",
+          credentialId: "key-a",
+          userId: "user-a",
+        },
+      }),
+    ).rejects.toThrow("injected storage failure");
+    expect(storage.read<{ activeLeaseCount: number }>("ledger")).toMatchObject({
+      activeLeaseCount: 0,
+    });
+    expect(
+      storage.read(storedLeaseKey("authorized-storage-failure")),
+    ).toBeUndefined();
+  });
+
   test("bounds each alarm batch and drains every lease at maximum capacity", async () => {
     const clock = spyOn(Date, "now").mockReturnValue(1_000);
     try {
@@ -1048,6 +1195,34 @@ describe("InferenceAdmissionGate", () => {
       ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
       await markInferenceAdmissionLeaseDispatched(lease);
       await settleInferenceAdmissionLease(lease, 2);
+
+      expect(
+        (
+          await post(gate, "/credential/revoke", {
+            organizationId: "org-a",
+            kind: "api_key",
+            credentialId: "key-a",
+          })
+        ).status,
+      ).toBe(200);
+      await expect(
+        acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "request-revoked",
+          balanceUsd: 2,
+          balanceRevision: "1",
+          estimatedCostUsd: 1,
+          recovery: organizationRecovery("request-revoked"),
+          credential: {
+            kind: "api_key",
+            credentialId: "key-a",
+            userId: "user-a",
+          },
+        }),
+      ).rejects.toMatchObject({
+        name: InferenceCredentialRevokedError.name,
+        reason: "credential_revoked",
+      });
     });
 
     await expect(

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -62,6 +62,10 @@ interface LeaseRequest {
   recovery: InferenceAdmissionRecoveryContext;
 }
 
+interface AuthorizedLeaseRequest extends LeaseRequest {
+  credential: CredentialCheckRequest;
+}
+
 interface HydrateRequest {
   balanceUsd: number;
   balanceRevision: string;
@@ -831,6 +835,20 @@ export class InferenceAdmissionGate {
     });
   }
 
+  private async authorizedLease(
+    request: AuthorizedLeaseRequest,
+  ): Promise<Response> {
+    if (
+      !request.credential ||
+      request.credential.organizationId !== request.organizationId
+    ) {
+      return jsonError("Invalid authorized inference admission lease", 400);
+    }
+    const denial = await this.credentialDenial(request.credential);
+    if (denial) return denial;
+    return await this.lease(request);
+  }
+
   private async hydrate(request: HydrateRequest): Promise<Response> {
     if (
       !nonNegativeFinite(request.balanceUsd) ||
@@ -1077,9 +1095,9 @@ export class InferenceAdmissionGate {
     );
   }
 
-  private async credentialCheck(
+  private async credentialDenial(
     request: CredentialCheckRequest,
-  ): Promise<Response> {
+  ): Promise<Response | null> {
     if (
       !validTrimmedId(request.organizationId) ||
       !validTrimmedId(request.userId) ||
@@ -1131,7 +1149,7 @@ export class InferenceAdmissionGate {
             { allowed: false, reason: "credential_revoked" },
             { status: 403 },
           )
-        : Response.json({ allowed: true });
+        : null;
     }
 
     if (revocations.get(credentialKeys[0] ?? "") === true) {
@@ -1148,7 +1166,15 @@ export class InferenceAdmissionGate {
           { allowed: false, reason: "session_revoked" },
           { status: 403 },
         )
-      : Response.json({ allowed: true });
+      : null;
+  }
+
+  private async credentialCheck(
+    request: CredentialCheckRequest,
+  ): Promise<Response> {
+    return (
+      (await this.credentialDenial(request)) ?? Response.json({ allowed: true })
+    );
   }
 
   private async revokeCredential(
@@ -1245,6 +1271,7 @@ export class InferenceAdmissionGate {
     }
     let body:
       | LeaseRequest
+      | AuthorizedLeaseRequest
       | HydrateRequest
       | SettleRequest
       | LeaseIdentityRequest
@@ -1259,6 +1286,7 @@ export class InferenceAdmissionGate {
     try {
       body = (await request.json()) as
         | LeaseRequest
+        | AuthorizedLeaseRequest
         | HydrateRequest
         | SettleRequest
         | LeaseIdentityRequest
@@ -1278,6 +1306,13 @@ export class InferenceAdmissionGate {
     const path = new URL(request.url).pathname;
     if (path === "/lease") {
       return await this.serialize(() => this.lease(body as LeaseRequest));
+    }
+    if (path === "/lease-authorized") {
+      return await this.serializeRevocation(() =>
+        this.serialize(() =>
+          this.authorizedLease(body as AuthorizedLeaseRequest),
+        ),
+      );
     }
     if (path === "/hydrate") {
       return await this.serialize(() => this.hydrate(body as HydrateRequest));

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -105,6 +105,13 @@ import {
 } from "@/lib/services/inference-auth-context";
 import { InferenceBalanceCacheWarmingError } from "@/lib/services/inference-billing-fast-path";
 import {
+  assertInferenceCredentialActive,
+  type InferenceCredentialCheck,
+  InferenceCredentialRevokedError,
+  inferenceCredentialRevocationReason,
+  isInferenceStrongRevocationEnabled,
+} from "@/lib/services/inference-credential-revocation";
+import {
   createPassthroughStreamMeter,
   isPassthroughStreamingEnabled,
   type PassthroughStreamTail,
@@ -1215,12 +1222,16 @@ export async function handleChatCompletionsPOST(
     let apiKey: { id: string } | null;
     let moderationAlreadyChecked = false;
     let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
+    let admissionCredential: InferenceCredentialCheck | undefined;
     let appScopeId: string | null = null;
 
+    const deferStrongCredentialCheck =
+      Boolean(options.executionCtx) && isInferenceStrongRevocationEnabled();
     const resolution = await resolveInferenceAuthContext(req, {
       traceId,
       executionCtx: options.executionCtx,
       cacheOnly: Boolean(options.executionCtx),
+      deferStrongCredentialCheck,
       onTelemetry: (telemetry) => {
         authTelemetry = telemetry;
       },
@@ -1295,6 +1306,7 @@ export async function handleChatCompletionsPOST(
       };
       apiKey = resolution.ctx.apiKeyId ? { id: resolution.ctx.apiKeyId } : null;
       admissionSnapshot = resolution.ctx.admission;
+      admissionCredential = resolution.credential;
       appScopeId =
         "appScopeId" in resolution.ctx ? resolution.ctx.appScopeId : null;
       // The resolver already verified not-suspended (cache hit = at populate;
@@ -1708,9 +1720,21 @@ export async function handleChatCompletionsPOST(
           useMonetizedAppBilling,
         })
       ) {
+        if (admissionCredential) {
+          await assertInferenceCredentialActive(
+            user.organization_id,
+            admissionCredential,
+          );
+        }
         settleReservation = async () => null;
         settleUnknown = async () => null;
       } else if (useAppCredits && appId && monetizedApp) {
+        if (admissionCredential) {
+          await assertInferenceCredentialActive(
+            user.organization_id,
+            admissionCredential,
+          );
+        }
         assertInferenceAppAffiliateSupported(appId, affiliateCode);
         const { totalCost } = await calculateCost(
           normalizedModel,
@@ -1785,6 +1809,7 @@ export async function handleChatCompletionsPOST(
           affiliateCode,
           executionCtx: options.executionCtx,
           admissionSnapshot,
+          credential: admissionCredential,
         });
         settleReservation = admission.settle;
         settleUnknown = admission.settleUnknown;
@@ -1792,6 +1817,33 @@ export async function handleChatCompletionsPOST(
         billingReservation = admission.reservation;
       }
     } catch (error) {
+      if (error instanceof InferenceCredentialRevokedError) {
+        const reason = inferenceCredentialRevocationReason(error.reason);
+        const denial = resolveInferenceAuthStandingDenial(
+          reason === "moderation_blocked" ||
+            reason === "organization_inactive" ||
+            reason === "account_inactive" ||
+            reason === "membership_missing"
+            ? { kind: "suspended", reason }
+            : { kind: "rejected", status: 401, reason },
+          { route: "chat_completions", traceId },
+        );
+        return attachPreforwardTelemetry(
+          addCorsHeaders(
+            Response.json(
+              {
+                error: {
+                  message: denial.message,
+                  type: denial.type,
+                  code: denial.code,
+                  details: { reason: denial.reason },
+                },
+              },
+              { status: denial.status },
+            ),
+          ),
+        );
+      }
       if (error instanceof InferenceAppAffiliateUnsupportedError) {
         return addCorsHeaders(
           Response.json(

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -19,6 +19,10 @@ import { getCloudBinding } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { type CreditReconciliationResult, creditsService } from "./credits";
 import type { InferenceAdmissionRecoveryContext } from "./inference-admission-recovery";
+import {
+  type InferenceCredentialCheck,
+  InferenceCredentialRevokedError,
+} from "./inference-credential-revocation";
 import type { EndpointType } from "./org-rate-limits";
 
 const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
@@ -529,6 +533,8 @@ export async function acquireInferenceAdmissionLease(params: {
   balanceRevision: string;
   estimatedCostUsd: number;
   recovery: InferenceAdmissionRecoveryContext;
+  /** Strong standing proof fused into the lease transaction when supplied. */
+  credential?: InferenceCredentialCheck;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }): Promise<InferenceAdmissionLease> {
   const balanceUsd = finiteNonNegative(params.balanceUsd, "balanceUsd");
@@ -547,7 +553,7 @@ export async function acquireInferenceAdmissionLease(params: {
   const stub = gateStub(params.organizationId);
   const response = await gateFetch(
     params.organizationId,
-    "/lease",
+    params.credential ? "/lease-authorized" : "/lease",
     {
       organizationId: params.organizationId,
       requestId: params.requestId,
@@ -555,10 +561,28 @@ export async function acquireInferenceAdmissionLease(params: {
       balanceRevision: params.balanceRevision,
       estimatedCostUsd,
       recovery: params.recovery,
+      ...(params.credential
+        ? {
+            credential: {
+              organizationId: params.organizationId,
+              ...params.credential,
+            },
+          }
+        : {}),
     },
     stub,
     AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
   );
+  if (response.status === 403 && params.credential) {
+    let reason = "revoked";
+    try {
+      const payload = (await response.json()) as { reason?: unknown };
+      if (typeof payload.reason === "string") reason = payload.reason;
+    } catch {
+      // error-policy:J3 malformed denial output remains a fail-closed generic revocation.
+    }
+    throw new InferenceCredentialRevokedError(reason);
+  }
   if (response.status === 503) {
     const code = await readGateErrorCode(response);
     if (code === "inference_admission_gate_uninitialized" && params.executionCtx) {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -96,7 +96,15 @@ mock.module("./inference-credential-revocation", () => ({
   assertInferenceCredentialActive: (
     organizationId: string,
     credential: { kind: string; credentialId?: string; userId: string },
-  ) => assertCredentialActive(organizationId, credential),
+  ) =>
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED === "true"
+      ? assertCredentialActive(organizationId, credential)
+      : Promise.resolve(),
+  inferenceCredentialRevocationReason: (reason: string) => {
+    if (reason === "credential_revoked") return "credential_inactive";
+    if (reason === "organization_disabled") return "organization_inactive";
+    return "credential_invalid";
+  },
   revokeInferenceApiKey: async () => undefined,
   setInferenceSessionBindingActive: async () => undefined,
   revokeInferenceSessionsThrough: async () => undefined,
@@ -133,6 +141,7 @@ function reqWithApiKey(key = KEY): Request {
 }
 
 beforeEach(async () => {
+  process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "true";
   authImpl = async () => ({
     user: { id: "user-1", organization_id: "org-1" },
     apiKey: { id: "key-1" },
@@ -503,6 +512,51 @@ describe("resolveInferenceAuthContext", () => {
     expect(res.source).toBe("cache");
     expect(chainCalls).toBe(0); // zero auth/moderation DB work on warm hit
     expect(incrementUsageCalls).toContain("key-1"); // usage tracking preserved
+  });
+
+  test("warm hit can carry its strong credential into admission after one cache read", async () => {
+    await resolveInferenceAuthContext(reqWithApiKey());
+    let strongChecks = 0;
+    assertCredentialActive = async () => {
+      strongChecks++;
+    };
+    const cacheRead = spyOn(cache, "getWithOutcome");
+
+    const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+      deferStrongCredentialCheck: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "authorized",
+      source: "cache",
+      credential: {
+        kind: "api_key",
+        credentialId: "key-1",
+        userId: "user-1",
+      },
+    });
+    expect(cacheRead).toHaveBeenCalledTimes(1);
+    expect(strongChecks).toBe(0);
+  });
+
+  test("flag-off origin auth never defers a credential into admission", async () => {
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "false";
+    let strongChecks = 0;
+    assertCredentialActive = async () => {
+      strongChecks++;
+    };
+
+    const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+      forceAuthoritative: true,
+      deferStrongCredentialCheck: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "authorized",
+      source: "origin",
+    });
+    expect(result).not.toHaveProperty("credential");
+    expect(strongChecks).toBe(0);
   });
 
   test("warm positive is denied immediately when the strong boundary revokes it", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -47,7 +47,10 @@ import {
 } from "./inference-auth-cache";
 import {
   assertInferenceCredentialActive,
+  type InferenceCredentialCheck,
   InferenceCredentialRevokedError,
+  inferenceCredentialRevocationReason,
+  isInferenceStrongRevocationEnabled,
 } from "./inference-credential-revocation";
 import { isInferenceAuthCacheEnabled } from "./inference-hot-path-caches";
 import { resolveInferenceSessionAuthContext } from "./inference-session-auth-context";
@@ -142,6 +145,8 @@ export interface ResolveInferenceAuthOptions {
   forceAuthoritative?: boolean;
   /** Internal hook preserving a bounded authoritative standing reason. */
   onAuthoritativeRejection?(reason: InferenceAuthRejectionReason): void;
+  /** The caller will fuse this strong check into its atomic admission lease. */
+  deferStrongCredentialCheck?: boolean;
 }
 
 interface MutableInferenceAuthTrace {
@@ -181,23 +186,6 @@ function boundedTraceId(traceId: string | undefined): string {
 
 function durationSince(startedAt: number): number {
   return Math.round((performance.now() - startedAt) * 100) / 100;
-}
-
-function rejectionReasonForRevocation(reason: string): InferenceAuthRejectionReason {
-  switch (reason) {
-    case "organization_disabled":
-      return "organization_inactive";
-    case "subject_account_disabled":
-      return "account_inactive";
-    case "subject_membership_disabled":
-      return "membership_missing";
-    case "subject_moderation_disabled":
-      return "moderation_blocked";
-    case "credential_revoked":
-      return "credential_inactive";
-    default:
-      return "credential_invalid";
-  }
 }
 
 function controlledProbeDiscriminator(req: Request): string | null {
@@ -265,6 +253,7 @@ export type InferenceAuthResolution =
       kind: "authorized";
       ctx: ResolvedInferenceAuthContext;
       source: "cache" | "origin";
+      credential?: InferenceCredentialCheck;
     }
   | { kind: "suspended"; userId?: string; reason?: InferenceAuthRejectionReason }
   | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason }
@@ -546,6 +535,8 @@ export async function resolveInferenceAuthContext(
 
   try {
     const authCacheEnabled = isInferenceAuthCacheEnabled();
+    const deferStrongCredentialCheck =
+      options.deferStrongCredentialCheck === true && isInferenceStrongRevocationEnabled();
     const extractStartedAt = performance.now();
     const credential = extractApiKeyCredentialWithSource(req);
     trace.timings.extractMs = durationSince(extractStartedAt);
@@ -554,6 +545,7 @@ export async function resolveInferenceAuthContext(
         cacheOnly: authCacheEnabled && options.cacheOnly,
         useAuthCache: authCacheEnabled,
         executionCtx: options.executionCtx,
+        deferStrongCredentialCheck,
       });
       if (session.kind === "not_session") {
         return { kind: "slow_path", reason: "non_api_key" };
@@ -618,16 +610,30 @@ export async function resolveInferenceAuthContext(
       trace.cacheRead = cached.kind;
       trace.cacheBackend = cached.backend;
       if (cached.kind === "hit") {
+        const credential: InferenceCredentialCheck = {
+          kind: "api_key",
+          credentialId: cached.ctx.apiKeyId,
+          userId: cached.ctx.userId,
+        };
+        if (deferStrongCredentialCheck) {
+          observeInferenceApiKeyUsage(
+            { kind: "authorized", ctx: cached.ctx, source: "cache" },
+            options.executionCtx,
+          );
+          trace.result = "authorized_cache";
+          return {
+            kind: "authorized",
+            ctx: cached.ctx,
+            source: "cache",
+            credential,
+          };
+        }
         try {
-          await assertInferenceCredentialActive(cached.ctx.orgId, {
-            kind: "api_key",
-            credentialId: cached.ctx.apiKeyId,
-            userId: cached.ctx.userId,
-          });
+          await assertInferenceCredentialActive(cached.ctx.orgId, credential);
         } catch (error) {
           if (error instanceof InferenceCredentialRevokedError) {
             trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
-            const reason = rejectionReasonForRevocation(error.reason);
+            const reason = inferenceCredentialRevocationReason(error.reason);
             logStandingDenial({
               status: error.reason === "credential_revoked" ? 401 : 403,
               reason,
@@ -749,15 +755,17 @@ export async function resolveInferenceAuthContext(
       ...(admission ? { admission } : {}),
     };
     try {
-      await assertInferenceCredentialActive(ctx.orgId, {
-        kind: "api_key",
-        credentialId: ctx.apiKeyId,
-        userId: ctx.userId,
-      });
+      if (!deferStrongCredentialCheck) {
+        await assertInferenceCredentialActive(ctx.orgId, {
+          kind: "api_key",
+          credentialId: ctx.apiKeyId,
+          userId: ctx.userId,
+        });
+      }
     } catch (error) {
       if (error instanceof InferenceCredentialRevokedError) {
         trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
-        const reason = rejectionReasonForRevocation(error.reason);
+        const reason = inferenceCredentialRevocationReason(error.reason);
         logStandingDenial({
           status: error.reason === "credential_revoked" ? 401 : 403,
           reason,
@@ -773,7 +781,20 @@ export async function resolveInferenceAuthContext(
     trace.result = "authorized_origin";
     const cacheWriteStartedAt = performance.now();
     if (!authCacheEnabled) {
-      return { kind: "authorized", ctx, source: "origin" };
+      return {
+        kind: "authorized",
+        ctx,
+        source: "origin",
+        ...(deferStrongCredentialCheck
+          ? {
+              credential: {
+                kind: "api_key" as const,
+                credentialId: ctx.apiKeyId,
+                userId: ctx.userId,
+              },
+            }
+          : {}),
+      };
     }
     const cacheWrite = writeInferenceAuthContext(ctx);
     if (cacheAvailable && typeof options.executionCtx?.waitUntil === "function") {
@@ -792,7 +813,20 @@ export async function resolveInferenceAuthContext(
       trace.cacheWrite = write.kind;
       trace.cacheBackend = write.backend;
     }
-    return { kind: "authorized", ctx, source: "origin" };
+    return {
+      kind: "authorized",
+      ctx,
+      source: "origin",
+      ...(deferStrongCredentialCheck
+        ? {
+            credential: {
+              kind: "api_key" as const,
+              credentialId: ctx.apiKeyId,
+              userId: ctx.userId,
+            },
+          }
+        : {}),
+    };
   } catch (error) {
     if (authoritativeStandingReason && !standingDenialLogged) {
       const status = getErrorStatusCode(error);

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -13,12 +13,13 @@ import type {
   RuntimeDurableObjectStub,
 } from "../../types/cloud-worker-env";
 import { getCloudAwareEnv, getCloudBinding } from "../runtime/cloud-bindings";
+import type { InferenceAuthRejectionReason } from "./inference-auth-cache";
 
 const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
 const OPERATION_TIMEOUT_MS = 1_500;
 
-type CredentialCheck =
+export type InferenceCredentialCheck =
   | { kind: "api_key"; credentialId: string; userId: string }
   | { kind: "steward_session"; userId: string; stewardUserId: string; issuedAt: number };
 
@@ -51,6 +52,24 @@ export class InferenceCredentialRevokedError extends ElizaError {
       code: "INFERENCE_CREDENTIAL_REVOKED",
       context: { reason },
     });
+  }
+}
+
+/** Map the strong-boundary reason onto the bounded public standing taxonomy. */
+export function inferenceCredentialRevocationReason(reason: string): InferenceAuthRejectionReason {
+  switch (reason) {
+    case "organization_disabled":
+      return "organization_inactive";
+    case "subject_account_disabled":
+      return "account_inactive";
+    case "subject_membership_disabled":
+      return "membership_missing";
+    case "subject_moderation_disabled":
+      return "moderation_blocked";
+    case "credential_revoked":
+      return "credential_inactive";
+    default:
+      return "credential_invalid";
   }
 }
 
@@ -131,7 +150,7 @@ async function gateRequest(
 /** Fail closed unless the strong boundary confirms this credential is active. */
 export async function assertInferenceCredentialActive(
   organizationId: string,
-  credential: CredentialCheck,
+  credential: InferenceCredentialCheck,
 ): Promise<void> {
   if (!isInferenceStrongRevocationEnabled()) return;
   const result = await gateRequest(organizationId, "/credential/check", credential, true);

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -80,6 +80,9 @@ mock.module("./inference-credential-revocation", () => ({
     _organizationId: string,
     credential: Record<string, unknown>,
   ) => {
+    if (process.env.INFERENCE_STRONG_REVOCATION_ENABLED !== "true") {
+      return Promise.resolve();
+    }
     strongCredentialChecks.push(credential);
     return assertSessionActive();
   },
@@ -105,6 +108,7 @@ function request(): Request {
 }
 
 beforeEach(async () => {
+  process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "true";
   __clearInferenceSessionAuthHydrations();
   claims = {
     userId: "steward-1",
@@ -200,6 +204,59 @@ describe("resolveInferenceSessionAuthContext", () => {
       stewardUserId: "steward-1",
       issuedAt: claims?.issuedAt,
     });
+  });
+
+  test("warm verified session carries its signed credential into admission without a standalone check", async () => {
+    const waited: Promise<unknown>[] = [];
+    await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    });
+    await Promise.all(waited);
+    strongCredentialChecks.length = 0;
+    const cacheRead = spyOn(cache, "getWithOutcome");
+
+    const result = await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      deferStrongCredentialCheck: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "authorized",
+      source: "cache",
+      credential: {
+        kind: "steward_session",
+        userId: "user-1",
+        stewardUserId: "steward-1",
+        issuedAt: claims?.issuedAt,
+      },
+    });
+    expect(cacheRead).toHaveBeenCalledTimes(1);
+    expect(strongCredentialChecks).toHaveLength(0);
+  });
+
+  test("flag-off Steward auth never defers its signed credential into admission", async () => {
+    const waited: Promise<unknown>[] = [];
+    await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    });
+    await Promise.all(waited);
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "false";
+    strongCredentialChecks.length = 0;
+
+    const result = await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      deferStrongCredentialCheck: true,
+    });
+
+    expect(result).toMatchObject({ kind: "authorized", source: "cache" });
+    expect(result).not.toHaveProperty("credential");
+    expect(strongCredentialChecks).toHaveLength(0);
   });
 
   test("warm verified session is denied when its issued-at cutoff is revoked", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -34,7 +34,9 @@ import {
 } from "./inference-auth-cache";
 import {
   assertInferenceCredentialActive,
+  type InferenceCredentialCheck,
   InferenceCredentialRevokedError,
+  isInferenceStrongRevocationEnabled,
 } from "./inference-credential-revocation";
 
 const sessionHydrations = new Map<string, Promise<InferenceSessionAuthDecision>>();
@@ -44,6 +46,8 @@ export interface ResolveInferenceSessionAuthOptions {
   cacheOnly?: boolean;
   useAuthCache?: boolean;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+  /** The caller will fuse this strong check into its admission lease. */
+  deferStrongCredentialCheck?: boolean;
 }
 
 export type InferenceSessionContinuationResolution =
@@ -51,6 +55,7 @@ export type InferenceSessionContinuationResolution =
       kind: "authorized";
       ctx: InferenceSessionAuthContext;
       source: "cache" | "origin";
+      credential?: InferenceCredentialCheck;
     }
   | { kind: "suspended"; userId?: string; reason?: InferenceAuthRejectionReason }
   | { kind: "rejected"; status: 401 | 403; reason?: InferenceAuthRejectionReason };
@@ -159,16 +164,19 @@ async function enforceStrongSessionBoundary(
   stewardUserId: string,
   issuedAt: number,
   source: "cache" | "origin",
+  deferStrongCredentialCheck = false,
 ): Promise<InferenceSessionContinuationResolution> {
   const resolved = toResolution(decision, source);
   if (resolved.kind !== "authorized") return resolved;
+  const credential: InferenceCredentialCheck = {
+    kind: "steward_session",
+    userId: resolved.ctx.userId,
+    stewardUserId,
+    issuedAt,
+  };
+  if (deferStrongCredentialCheck) return { ...resolved, credential };
   try {
-    await assertInferenceCredentialActive(resolved.ctx.orgId, {
-      kind: "steward_session",
-      userId: resolved.ctx.userId,
-      stewardUserId,
-      issuedAt,
-    });
+    await assertInferenceCredentialActive(resolved.ctx.orgId, credential);
     return resolved;
   } catch (error) {
     if (error instanceof InferenceCredentialRevokedError) {
@@ -244,6 +252,8 @@ export async function resolveInferenceSessionAuthContext(
   if (!token) return { kind: "not_session" };
 
   const env = getCloudAwareEnv();
+  const deferStrongCredentialCheck =
+    options.deferStrongCredentialCheck === true && isInferenceStrongRevocationEnabled(env);
   const claims = await verifyStewardTokenCached(
     {
       NODE_ENV: env.NODE_ENV,
@@ -296,6 +306,7 @@ export async function resolveInferenceSessionAuthContext(
       claims.userId,
       claims.issuedAt,
       "origin",
+      deferStrongCredentialCheck,
     );
   }
 
@@ -332,7 +343,13 @@ export async function resolveInferenceSessionAuthContext(
           });
         options.executionCtx.waitUntil(refresh);
       }
-      return await enforceStrongSessionBoundary(cached, claims.userId, claims.issuedAt, "cache");
+      return await enforceStrongSessionBoundary(
+        cached,
+        claims.userId,
+        claims.issuedAt,
+        "cache",
+        deferStrongCredentialCheck,
+      );
     }
   }
 
@@ -372,7 +389,13 @@ export async function resolveInferenceSessionAuthContext(
         ),
         continuation: hydrationDecision.then(
           (decision) =>
-            enforceStrongSessionBoundary(decision, claims.userId, claims.issuedAt, "origin"),
+            enforceStrongSessionBoundary(
+              decision,
+              claims.userId,
+              claims.issuedAt,
+              "origin",
+              deferStrongCredentialCheck,
+            ),
           (error) => {
             // error-policy:J7 the retained hydration above owns failure logging;
             // a voice continuation keeps the original warming outcome.
@@ -404,6 +427,7 @@ export async function resolveInferenceSessionAuthContext(
     claims.userId,
     claims.issuedAt,
     "origin",
+    deferStrongCredentialCheck,
   );
   if (resolved.kind === "rejected") {
     if (resolved.status === 401) throw AuthenticationError();

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -363,10 +363,19 @@ test("warm Worker admission writes only the Durable Object lease before provider
   fetchEntriesForSource.mockClear();
 
   const background: Promise<unknown>[] = [];
-  const admission = await admitOrganizationInference(admissionParams(model, background));
+  const credential = {
+    kind: "api_key" as const,
+    credentialId: "key-1",
+    userId: "user-1",
+  };
+  const admission = await admitOrganizationInference({
+    ...admissionParams(model, background),
+    credential,
+  });
   const leaseParams = acquireInferenceAdmissionLease.mock.calls.at(-1)?.[0] as
     | {
         requestId: string;
+        credential?: typeof credential;
         recovery: {
           version: number;
           kind: string;
@@ -380,6 +389,7 @@ test("warm Worker admission writes only the Durable Object lease before provider
   if (!leaseParams) throw new Error("expected inference admission lease");
 
   expect(admission.mode).toBe("durable_object_debit");
+  expect(leaseParams.credential).toEqual(credential);
   expect(leaseParams.recovery).toMatchObject({
     version: 1,
     kind: "organization",

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -60,6 +60,7 @@ import {
   createLedgerDebitSettler,
   resolveInferenceBillingLedger,
 } from "./inference-billing-ledger";
+import type { InferenceCredentialCheck } from "./inference-credential-revocation";
 
 export type InferenceAdmissionMode =
   | "durable_object_debit"
@@ -100,6 +101,8 @@ export interface OrganizationInferenceAdmissionParams {
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   /** Combined auth-cache projection; skips the separate balance KV read. */
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  /** Strong standing proof consumed atomically by the primary admission gate. */
+  credential?: InferenceCredentialCheck;
 }
 
 /** Retryable signal preserving route compatibility while identifying pricing hydration. */
@@ -384,6 +387,7 @@ export async function admitOrganizationInference(
               }
             : { kind: "direct_debit" },
         },
+        credential: params.credential,
         executionCtx: params.executionCtx,
       });
     } catch (error) {


### PR DESCRIPTION
Fixes #30094

## Summary

- carry the API-key or Steward-session identity from the single combined inference-auth KV read into organization admission when strong revocation rollout is enabled
- validate credential, subject, and organization standing inside the same primary organization Durable Object RPC/ordered critical section that acquires the exact balance lease
- preserve `INFERENCE_STRONG_REVOCATION_ENABLED`: flag-off Worker requests retain authoritative-origin auth and the legacy `/lease` path; resolver-level guards prevent accidental deferred credentials
- retain the isolated rate-limit Durable Object, fail-closed errors, durable provider-dispatch acknowledgement, idempotent recovery, and asynchronous settlement with no readback
- retain standalone strong checks for pooled-noop and app-credit paths that do not acquire an organization lease
- map fused standing denials back to the existing bounded 401/403 contract and structured route-boundary log

## Required order proved

`auth cache -> isolated rate limit -> combined standing + balance lease -> dispatch ack -> provider`

## Validation

- `bunx biome check <13 touched files>`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun test packages/cloud/api/__tests__/inference-admission-gate.test.ts` — 42 pass
- `bun test packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts` — 17 pass
- `bun test packages/cloud/shared/src/lib/services/inference-auth-context.test.ts` — 47 pass
- `bun test packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts` — 10 pass
- `bun test packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts` — 14 pass
- `bun test packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts` — 16 pass

The focused suites were run as separate Bun processes because `mock.module` is process-wide. Total: 146 pass, 0 fail.

## Known repository gate

`bun run --cwd packages/cloud/api typecheck` currently stops in untouched shared code at `packages/cloud/shared/src/lib/eliza/runtime/initializer.ts:14` with TS2307 for `@elizaos/plugin-doordash`. Shared typecheck is green and no touched-file diagnostic is emitted before that unrelated resolution failure.

## Evidence

- UI screenshots/video: N/A — Worker/DO backend path only
- Live provider request: N/A for this PR; provider dispatch remains mocked so tests can prove it is unreachable before durable acknowledgement
- Real Durable Object behavior: covered by Miniflare serialization and revocation integration tests