### PR TITLE
fix(cloud): classify staging selection bootstrap blockers

### DIFF
--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
@@ -96,7 +96,7 @@ describe("personal Dedicated staging re-review operator", () => {
         })),
         (candidate) => candidate.authority,
       ),
-    ).toThrow("selection_bootstrap_decision_required");
+    ).toThrow("selection_bootstrap_no_restore_authority");
     expect(() =>
       resolveBootstrapCandidate(
         candidates.map((candidate) => ({
@@ -105,13 +105,25 @@ describe("personal Dedicated staging re-review operator", () => {
         })),
         (candidate) => candidate.authority,
       ),
-    ).toThrow("selection_bootstrap_decision_required");
+    ).toThrow("selection_bootstrap_multiple_restore_authorities");
     expect(() =>
       resolveBootstrapCandidate(
         [candidates[1]],
         (candidate) => candidate.authority,
       ),
-    ).toThrow("selection_bootstrap_decision_required");
+    ).toThrow("selection_bootstrap_single_candidate");
+    expect(() => resolveBootstrapCandidate([], () => "fresh-boot")).toThrow(
+      "selection_bootstrap_zero_candidates",
+    );
+    expect(() =>
+      resolveBootstrapCandidate(
+        Array.from({ length: 101 }, (_, index) => ({
+          id: String(index),
+          authority: index === 0 ? "from-legacy-backup" : "fresh-boot",
+        })),
+        (candidate) => candidate.authority,
+      ),
+    ).toThrow("selection_bootstrap_inventory_over_limit");
   });
 
   test("returns identifier-free preview evidence and does not execute", async () => {

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
@@ -137,17 +137,32 @@ export function resolveBootstrapCandidate<T>(
   candidates: readonly T[],
   activationKind: (candidate: T) => "fresh-boot" | string,
 ): T {
-  if (candidates.length < 2 || candidates.length > 100) {
+  if (candidates.length === 0) {
     throw new PersonalDedicatedRereviewOperatorError(
-      "selection_bootstrap_decision_required",
+      "selection_bootstrap_zero_candidates",
+    );
+  }
+  if (candidates.length === 1) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_bootstrap_single_candidate",
+    );
+  }
+  if (candidates.length > 100) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_bootstrap_inventory_over_limit",
     );
   }
   const restorable = candidates.filter(
     (candidate) => activationKind(candidate) !== "fresh-boot",
   );
-  if (restorable.length !== 1) {
+  if (restorable.length === 0) {
     throw new PersonalDedicatedRereviewOperatorError(
-      "selection_bootstrap_decision_required",
+      "selection_bootstrap_no_restore_authority",
+    );
+  }
+  if (restorable.length > 1) {
+    throw new PersonalDedicatedRereviewOperatorError(
+      "selection_bootstrap_multiple_restore_authorities",
     );
   }
   return restorable[0];
@@ -486,11 +501,6 @@ async function defaultResolveSelection(
       )
       .orderBy(asc(agentSandboxes.id))
       .limit(101);
-    if (candidates.length < 2 || candidates.length > 100) {
-      throw new PersonalDedicatedRereviewOperatorError(
-        "selection_bootstrap_decision_required",
-      );
-    }
     const storedBackups = await dbWrite
       .select()
       .from(agentSandboxBackups)


### PR DESCRIPTION
## Summary
- split the privacy-safe staging bootstrap stop into zero, single, over-limit, no-restore-authority, and multiple-restore-authority codes
- preserve identifier-free logs and the existing fail-closed behavior
- remove the duplicate coarse cardinality guard so all cases use the tested classifier

Closes #30040

## Verification
- `bun install --frozen-lockfile`
- `bun test packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts` (15 pass)
- `bunx biome check packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts`

## Live context
- exact merged/deployed staging SHA before this diagnostic: `be86906a83d633587078ecc3cceca6d453463101`
- deployment/certification run: https://github.com/elizaOS/eliza/actions/runs/33325070965
- protected identity report: https://github.com/elizaOS/eliza/actions/runs/33326096278
- read-only preview safely stopped at the previously coarse bootstrap boundary: https://github.com/elizaOS/eliza/actions/runs/33326205262
- no compute, job, billing, cutover, deletion, or selection mutation occurred