### PR TITLE
fix(cloud): consume cold auth hydration inline

### DIFF
--- a/packages/cloud/api/__tests__/generative-route-warming-await.test.ts
+++ b/packages/cloud/api/__tests__/generative-route-warming-await.test.ts
@@ -1,15 +1,12 @@
 /**
- * Covers the voice-only bounded hydration await on the generative auth gate:
- * warming converts to authorized inside the budget, budget expiry stays a
- * retryable 503, and the default unset option keeps chat's fast-fail path.
+ * Covers bounded continuation-deadline forwarding to the shared auth resolver
+ * and fail-closed handling of its authorized, denied, and warming outcomes.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const resolveInferenceAuthContext = mock();
-const observeInferenceApiKeyUsage = mock();
 mock.module("@/lib/services/inference-auth-context", () => ({
-  observeInferenceApiKeyUsage,
   resolveInferenceAuthContext,
 }));
 
@@ -70,22 +67,15 @@ const authorized = {
 describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
   beforeEach(() => {
     resolveInferenceAuthContext.mockReset();
-    observeInferenceApiKeyUsage.mockReset();
   });
 
   afterEach(() => {
     resolveInferenceAuthContext.mockReset();
-    observeInferenceApiKeyUsage.mockReset();
   });
 
-  test("consumes an authorized continuation without a second cache read", async () => {
+  test("accepts the resolver's authorized inline continuation result", async () => {
     const { c } = workerContext();
-    const continuation = Promise.resolve(authorized);
-    resolveInferenceAuthContext.mockResolvedValueOnce({
-      kind: "warming",
-      hydration: continuation,
-      continuation,
-    });
+    resolveInferenceAuthContext.mockResolvedValueOnce(authorized);
 
     const caller = await requireGenerativeRouteCaller(c as never, {
       awaitWarmingMs: 1500,
@@ -96,7 +86,9 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
       user: { id: "user-1", organization_id: "org-1" },
     });
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
-    expect(observeInferenceApiKeyUsage).toHaveBeenCalledTimes(1);
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      inlineContinuationDeadlineMs: 1500,
+    });
   });
 
   test("returns the retryable warming 503 when the budget expires", async () => {
@@ -118,7 +110,9 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
       code: "service_unavailable",
     });
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
-    expect(observeInferenceApiKeyUsage).not.toHaveBeenCalled();
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      inlineContinuationDeadlineMs: 20,
+    });
     release?.();
   });
 
@@ -134,15 +128,11 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
 
   test("definitive rejection after hydration is surfaced, not swallowed", async () => {
     const { c } = workerContext();
-    const continuation = Promise.resolve({
+    const rejection = {
       kind: "rejected" as const,
       status: 401 as const,
-    });
-    resolveInferenceAuthContext.mockResolvedValueOnce({
-      kind: "warming",
-      hydration: continuation,
-      continuation,
-    });
+    };
+    resolveInferenceAuthContext.mockResolvedValueOnce(rejection);
 
     await expect(
       requireGenerativeRouteCaller(c as never, { awaitWarmingMs: 1500 }),
@@ -151,10 +141,9 @@ describe("requireGenerativeRouteCaller awaitWarmingMs", () => {
       code: "authentication_required",
     });
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
-    expect(observeInferenceApiKeyUsage).not.toHaveBeenCalled();
   });
 
-  test("default unset budget keeps the original warming 503", async () => {
+  test("a shared-resolver timeout remains a retryable warming 503", async () => {
     const { c } = workerContext();
     resolveInferenceAuthContext.mockResolvedValueOnce({
       kind: "warming",

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -114,11 +114,18 @@ cannot safely be replayed as asynchronous hydration.
 
 On a Worker cache miss:
 
-- the request receives a retryable warming response;
-- the authoritative lookup is registered with `waitUntil`;
-- concurrent hydration is single-flight by identity; and
-- no provider request starts until a later request observes the populated
-  cache.
+- the authoritative lookup is registered with `waitUntil` and consumed directly
+  under a 2.5-second request deadline;
+- the origin decision is used without a second KV read, while its projection
+  write remains asynchronous behind a standalone strong-check barrier;
+- concurrent request and refresh hydration is single-flight by identity until
+  that projection settles; and
+- request-consumed decisions carry their credential into the atomic admission
+  lease. The route then calls the real rate limiter exactly once.
+
+An authoritative denial is returned directly and blocks admission. A deadline,
+dependency failure, or cache outage retains the retryable warming response; the
+retained continuation may still populate the projection for a later request.
 
 When the gate is enabled, cache errors never fabricate authorization and never
 join a Postgres fallback to the request promise. Invalidation is only cache
@@ -180,8 +187,9 @@ Residual exposure bound: an authorization-relevant mutation that evicts no
 cache entry (none is currently known for the session path; for the API-key
 path a user-level ban does not revoke the key or its validation entry) is
 bounded by the 30s idle TTL and the 5-minute sliding-refresh cap, after which
-the entry must re-hydrate through the authoritative gate. Cache-only misses
-never authorize — they warm under `waitUntil` and return a retryable 503.
+the entry must re-hydrate through the authoritative gate. A combined-cache miss
+can authorize only from its bounded, strong-boundary-checked origin
+continuation; it cannot authorize from missing or unavailable cache state.
 
 ## Organization admission protocol
 

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -40,7 +40,6 @@ class AiPricingCacheUnavailableError extends Error {
 }
 
 const resolveInferenceAuthContext = vi.fn();
-const observeInferenceApiKeyUsage = vi.fn();
 const requireAuthOrApiKeyWithOrg = vi.fn();
 const requireUserOrApiKeyWithOrg = vi.fn();
 const reserveFlatUsageCredits = vi.fn();
@@ -55,7 +54,6 @@ vi.mock("@/lib/services/ai-pricing/cache", () => ({
   AiPricingCacheUnavailableError,
 }));
 vi.mock("@/lib/services/inference-auth-context", () => ({
-  observeInferenceApiKeyUsage,
   resolveInferenceAuthContext,
 }));
 vi.mock("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
@@ -82,7 +80,6 @@ if (typeof Bun !== "undefined") {
     AiPricingCacheUnavailableError,
   }));
   bunTest.mock.module("@/lib/services/inference-auth-context", () => ({
-    observeInferenceApiKeyUsage,
     resolveInferenceAuthContext,
   }));
   bunTest.mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
@@ -670,7 +667,6 @@ describe("resolveInferenceAuthStandingDenial", () => {
 describe("requireGenerativeRouteCaller", () => {
   beforeEach(() => {
     resolveInferenceAuthContext.mockReset();
-    observeInferenceApiKeyUsage.mockReset();
     requireAuthOrApiKeyWithOrg.mockReset();
     requireUserOrApiKeyWithOrg.mockReset();
     enforceOrgRateLimit.mockReset();
@@ -692,7 +688,6 @@ describe("requireGenerativeRouteCaller", () => {
 
   afterEach(() => {
     resolveInferenceAuthContext.mockReset();
-    observeInferenceApiKeyUsage.mockReset();
     requireAuthOrApiKeyWithOrg.mockReset();
     requireUserOrApiKeyWithOrg.mockReset();
     enforceOrgRateLimit.mockReset();
@@ -874,7 +869,7 @@ describe("requireGenerativeRouteCaller", () => {
     });
   });
 
-  test("fails closed on warming without awaiting when the budget is unset", async () => {
+  test("fails closed when warming has no one-shot continuation", async () => {
     const { c } = workerContext();
     resolveInferenceAuthContext.mockResolvedValueOnce({
       kind: "warming",
@@ -900,6 +895,9 @@ describe("requireGenerativeRouteCaller", () => {
       requireGenerativeRouteCaller(c as never, { awaitWarmingMs: 0 }),
     ).rejects.toMatchObject({ status: 503 });
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      inlineContinuationDeadlineMs: 0,
+    });
   });
 
   test("fails fast when warming has no hydration promise even with a budget", async () => {
@@ -911,22 +909,35 @@ describe("requireGenerativeRouteCaller", () => {
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
   });
 
-  test("consumes the one-shot continuation without a second cache read", async () => {
-    const { c, executionCtx } = workerContext();
-    resolveInferenceAuthContext.mockResolvedValueOnce({
-      kind: "warming",
-      hydration: Promise.resolve(sessionAuthorized),
-      continuation: Promise.resolve(sessionAuthorized),
-    });
+  test("uses the inline origin result returned by the shared resolver", async () => {
+    const { c } = workerContext();
+    resolveInferenceAuthContext.mockResolvedValueOnce(sessionAuthorized);
     const caller = await requireGenerativeRouteCaller(c as never, {
-      awaitWarmingMs: 1500,
+      rateLimitEndpoint: "strict",
     });
     expect(caller.authSource).toBe("combined_cache");
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
-    expect(observeInferenceApiKeyUsage).toHaveBeenCalledWith(
-      sessionAuthorized,
-      executionCtx,
-    );
+    expect(enforceOrgRateLimit).toHaveBeenCalledTimes(1);
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      inlineContinuationDeadlineMs: undefined,
+    });
+  });
+
+  test("surfaces a definitive continuation denial before rate limit admission", async () => {
+    const { c } = workerContext();
+    const denial = {
+      kind: "rejected" as const,
+      status: 403 as const,
+      reason: "organization_inactive" as const,
+    };
+    resolveInferenceAuthContext.mockResolvedValueOnce(denial);
+
+    await expect(
+      requireGenerativeRouteCaller(c as never, { rateLimitEndpoint: "strict" }),
+    ).rejects.toMatchObject({ status: 403, code: "access_denied" });
+
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(enforceOrgRateLimit).not.toHaveBeenCalled();
   });
 
   test("still 503s when the warming budget expires", async () => {
@@ -947,7 +958,10 @@ describe("requireGenerativeRouteCaller", () => {
       code: "service_unavailable",
     });
     expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
-    expect(observeInferenceApiKeyUsage).not.toHaveBeenCalled();
+    expect(enforceOrgRateLimit).not.toHaveBeenCalled();
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      inlineContinuationDeadlineMs: 20,
+    });
     release?.();
   });
 

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -328,11 +328,11 @@ export async function admitFlatGenerativeOperation(params: {
 }
 
 /**
- * Cache misses fail closed with a retryable response while authoritative
- * hydration runs under the Worker lifetime. Wallet proof remains on the
- * compatibility path because replay-protected signatures cannot be cached.
- * Voice routes may opt into one bounded await of the already-coalesced
- * hydration so a 60s idle cache miss does not 503 the first utterance.
+ * Cache misses consume the already-coalesced authoritative continuation under
+ * one bounded deadline. The continuation does not re-read the combined cache;
+ * it returns the origin decision directly. The route invokes the real limiter
+ * once after authorization. Wallet proof remains on the compatibility path
+ * because replay-protected signatures cannot be cached.
  */
 export async function requireGenerativeRouteCaller(
   c: AppContext,
@@ -340,9 +340,8 @@ export async function requireGenerativeRouteCaller(
     compatibility?: "hono" | "raw";
     rateLimitEndpoint?: EndpointType;
     /**
-     * When set, a cache-only warming resolution awaits the coalesced
-     * hydration for at most this many milliseconds and then re-resolves.
-     * Chat and every other generative route leave this unset.
+     * Override the default bounded wait for the one-shot origin continuation.
+     * Zero preserves an immediate retryable warming response.
      */
     awaitWarmingMs?: number;
   } = {},
@@ -369,44 +368,17 @@ export async function requireGenerativeRouteCaller(
       appScopeId: null,
     };
   }
-  const { observeInferenceApiKeyUsage, resolveInferenceAuthContext } =
-    await import("@/lib/services/inference-auth-context");
+  const { resolveInferenceAuthContext } = await import(
+    "@/lib/services/inference-auth-context"
+  );
   const resolveCallerAuth = () =>
     resolveInferenceAuthContext(c.req.raw, {
       traceId: c.get("traceId") ?? c.get("requestId"),
       cacheOnly: Boolean(executionCtx),
       executionCtx,
+      inlineContinuationDeadlineMs: options.awaitWarmingMs,
     });
-  let resolution = await resolveCallerAuth();
-
-  if (
-    resolution.kind === "warming" &&
-    typeof options.awaitWarmingMs === "number" &&
-    options.awaitWarmingMs > 0 &&
-    resolution.continuation
-  ) {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const timedOut = Symbol("inference-auth-continuation-timeout");
-    try {
-      const continued = await Promise.race([
-        resolution.continuation,
-        new Promise<typeof timedOut>((resolve) => {
-          timeoutId = setTimeout(
-            () => resolve(timedOut),
-            options.awaitWarmingMs,
-          );
-        }),
-      ]);
-      if (continued !== timedOut && continued) {
-        if (continued.kind === "authorized") {
-          observeInferenceApiKeyUsage(continued, executionCtx);
-        }
-        resolution = continued;
-      }
-    } finally {
-      if (timeoutId !== undefined) clearTimeout(timeoutId);
-    }
-  }
+  const resolution = await resolveCallerAuth();
 
   if (resolution.kind === "authorized") {
     const user = {

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1215,9 +1215,9 @@ export async function handleChatCompletionsPOST(
 
   try {
     // 1. Authenticate (+ moderation). API-key and Steward-session requests
-    // resolve auth + org + moderation from a combined cache decision. Cold
-    // Workers schedule authoritative hydration and return a retryable response;
-    // only non-Worker callers may join that hydration inline.
+    // resolve auth + org + moderation from a combined cache decision. On one
+    // true cold miss, Workers may consume the retained authoritative decision
+    // under a bounded deadline; its cache projection remains off-path.
     let user: { id: string; organization_id: string };
     let apiKey: { id: string } | null;
     let moderationAlreadyChecked = false;

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -114,7 +114,6 @@ mock.module("./inference-credential-revocation", () => ({
 
 const {
   __clearInferenceApiKeyHydrations,
-  observeInferenceApiKeyUsage,
   resolveInferenceAuthContext,
   extractApiKeyCredential,
   resolveInferenceAuthHydrationDeadlineMs,
@@ -309,7 +308,7 @@ describe("resolveInferenceAuthContext", () => {
     expect(serialized).not.toContain("org-1");
   });
 
-  test("cache-only miss returns warming and hydrates authoritatively off path", async () => {
+  test("cache-only miss consumes the authoritative continuation after one cache read", async () => {
     let chainCalls = 0;
     authImpl = async () => {
       chainCalls++;
@@ -320,25 +319,53 @@ describe("resolveInferenceAuthContext", () => {
     };
     const waited: Promise<unknown>[] = [];
     const cacheRead = spyOn(cache, "getWithOutcome");
-    const result = await resolveInferenceAuthContext(reqWithApiKey(), {
-      cacheOnly: true,
-      executionCtx: { waitUntil: (promise) => waited.push(promise) },
-    });
-    expect(result).toMatchObject({ kind: "warming" });
-    expect(result.kind === "warming" && result.hydration).toBeTruthy();
-    expect(result.kind === "warming" && result.continuation).toBeTruthy();
-    expect(waited.length).toBeGreaterThan(0);
-    if (result.kind !== "warming" || !result.continuation) throw new Error("unreachable");
-    const continued = await result.continuation;
-    await Promise.all(waited);
-    expect(chainCalls).toBe(1);
-    expect(continued).toMatchObject({ kind: "authorized", source: "origin" });
-    expect(cacheRead).toHaveBeenCalledTimes(1);
-    expect(incrementUsageCalls).toEqual([]);
-    if (continued) observeInferenceApiKeyUsage(continued, { waitUntil: (p) => waited.push(p) });
-    await Promise.all(waited);
-    expect(incrementUsageCalls).toEqual(["key-1"]);
-    cacheRead.mockRestore();
+    let finishWrite = (): void => {};
+    const cacheWrite = spyOn(cache, "setWithOutcome").mockImplementation(
+      async () =>
+        await new Promise((resolve) => {
+          finishWrite = () => resolve({ kind: "written" as const, backend: "memory" as const });
+        }),
+    );
+    try {
+      const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+        deferStrongCredentialCheck: true,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+      expect(result).toMatchObject({
+        kind: "authorized",
+        source: "origin",
+        credential: {
+          kind: "api_key",
+          credentialId: "key-1",
+          userId: "user-1",
+        },
+      });
+      expect(waited.length).toBeGreaterThan(0);
+      expect(chainCalls).toBe(1);
+      expect(cacheRead).toHaveBeenCalledTimes(1);
+      expect(cacheWrite).toHaveBeenCalledTimes(1);
+      expect(incrementUsageCalls).toEqual(["key-1"]);
+
+      const retryBeforeProjection = await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+        inlineContinuationDeadlineMs: 0,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+      expect(retryBeforeProjection).toMatchObject({ kind: "warming" });
+      expect(chainCalls).toBe(1);
+      expect(cacheRead).toHaveBeenCalledTimes(2);
+      expect(cacheWrite).toHaveBeenCalledTimes(1);
+      expect(waited.length).toBeGreaterThanOrEqual(2);
+      expect(waited[0]).toBe(waited.at(-1));
+
+      finishWrite();
+      await Promise.all(waited);
+    } finally {
+      finishWrite();
+      cacheRead.mockRestore();
+      cacheWrite.mockRestore();
+    }
   });
 
   test("concurrent cache-only misses share one authoritative hydration", async () => {
@@ -360,10 +387,12 @@ describe("resolveInferenceAuthContext", () => {
     const [first, second] = await Promise.all([
       resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,
+        inlineContinuationDeadlineMs: 0,
         executionCtx,
       }),
       resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,
+        inlineContinuationDeadlineMs: 0,
         executionCtx,
       }),
     ]);
@@ -379,6 +408,88 @@ describe("resolveInferenceAuthContext", () => {
     expect(await readInferenceAuthContext(hashApiKey(KEY))).not.toBeNull();
   });
 
+  test("a cold consumer without an admission credential awaits its standalone strong check", async () => {
+    const strongGate = Promise.withResolvers<void>();
+    let strongChecks = 0;
+    assertCredentialActive = async () => {
+      strongChecks++;
+      await strongGate.promise;
+    };
+    const waited: Promise<unknown>[] = [];
+    let settled = false;
+    const resolution = resolveInferenceAuthContext(reqWithApiKey(), {
+      cacheOnly: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    strongGate.resolve();
+    const result = await resolution;
+    expect(result).toMatchObject({ kind: "authorized", source: "origin" });
+    expect(result).not.toHaveProperty("credential");
+    await Promise.all(waited);
+    expect(strongChecks).toBe(2);
+  });
+
+  test("a cold request safely joins a refresh-created flight and retains its lease credential", async () => {
+    await writeInferenceAuthContext({
+      v: 2,
+      cachedAt: 1,
+      userId: "user-1",
+      orgId: "org-1",
+      apiKeyId: "key-1",
+      keyHash: hashApiKey(KEY),
+      appScopeId: null,
+      admission: ADMISSION,
+    });
+    const originGate = Promise.withResolvers<void>();
+    let chainCalls = 0;
+    let strongChecks = 0;
+    authImpl = async () => {
+      chainCalls++;
+      await originGate.promise;
+      return {
+        user: { id: "user-1", organization_id: "org-1" },
+        apiKey: { id: "key-1" },
+      };
+    };
+    assertCredentialActive = async () => {
+      strongChecks++;
+    };
+    const waited: Promise<unknown>[] = [];
+    const executionCtx = { waitUntil: (promise: Promise<unknown>) => waited.push(promise) };
+
+    const warm = await resolveInferenceAuthContext(reqWithApiKey(), {
+      cacheOnly: true,
+      executionCtx,
+    });
+    expect(warm).toMatchObject({ kind: "authorized", source: "cache" });
+    await invalidateInferenceAuthContextByKeyHash(hashApiKey(KEY));
+    const coldPromise = resolveInferenceAuthContext(reqWithApiKey(), {
+      cacheOnly: true,
+      deferStrongCredentialCheck: true,
+      executionCtx,
+    });
+    originGate.resolve();
+    const cold = await coldPromise;
+
+    expect(cold).toMatchObject({
+      kind: "authorized",
+      source: "origin",
+      credential: { kind: "api_key", credentialId: "key-1", userId: "user-1" },
+    });
+    await Promise.all(waited);
+    expect(chainCalls).toBe(1);
+    // One check serves the warm cached request; the projection performs its
+    // own check, while the cold request carries its proof to admission.
+    expect(strongChecks).toBe(2);
+  });
+
   test("definitive API-key rejection converges to cached 401 without another database lookup", async () => {
     let chainCalls = 0;
     authImpl = async () => {
@@ -391,6 +502,7 @@ describe("resolveInferenceAuthContext", () => {
 
     const cold = await resolveInferenceAuthContext(reqWithApiKey(), {
       cacheOnly: true,
+      inlineContinuationDeadlineMs: 0,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
     expect(cold).toMatchObject({ kind: "warming" });
@@ -422,6 +534,32 @@ describe("resolveInferenceAuthContext", () => {
     errorSpy.mockRestore();
   });
 
+  test("inline continuation returns an authoritative rejection after one cache read", async () => {
+    authImpl = async () => {
+      const error = new Error("Invalid or expired API key");
+      error.name = "AuthenticationError";
+      throw error;
+    };
+    const waited: Promise<unknown>[] = [];
+    const cacheRead = spyOn(cache, "getWithOutcome");
+    try {
+      const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+
+      expect(result).toEqual({
+        kind: "rejected",
+        status: 401,
+        reason: "credential_invalid",
+      });
+      expect(cacheRead).toHaveBeenCalledTimes(1);
+      await Promise.all(waited);
+    } finally {
+      cacheRead.mockRestore();
+    }
+  });
+
   test("authoritative suspension converges to a cached fail-closed decision", async () => {
     let moderationCalls = 0;
     shouldBlock = async () => {
@@ -434,7 +572,11 @@ describe("resolveInferenceAuthContext", () => {
       cacheOnly: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
-    expect(cold).toMatchObject({ kind: "warming" });
+    expect(cold).toEqual({
+      kind: "suspended",
+      userId: "user-1",
+      reason: "moderation_blocked",
+    });
     await Promise.all(waited);
     expect(moderationCalls).toBe(1);
 
@@ -443,6 +585,43 @@ describe("resolveInferenceAuthContext", () => {
     });
     expect(retry).toEqual({ kind: "suspended", reason: "moderation_blocked" });
     expect(moderationCalls).toBe(1);
+  });
+
+  test("inline continuation deadline returns warming after one cache read", async () => {
+    const gate = Promise.withResolvers<void>();
+    authImpl = async () => {
+      await gate.promise;
+      return {
+        user: { id: "user-1", organization_id: "org-1" },
+        apiKey: { id: "key-1" },
+      };
+    };
+    const waited: Promise<unknown>[] = [];
+    const cacheRead = spyOn(cache, "getWithOutcome");
+    const warning = spyOn(logger, "warn").mockImplementation(() => undefined);
+    try {
+      const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+        inlineContinuationDeadlineMs: 10,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+
+      expect(result).toMatchObject({ kind: "warming" });
+      expect(cacheRead).toHaveBeenCalledTimes(1);
+      expect(warning).toHaveBeenCalledWith(
+        "[InferenceAuth] inline continuation exceeded deadline",
+        expect.objectContaining({
+          traceId: "unavailable",
+          authSource: "x_api_key",
+          deadlineMs: 10,
+        }),
+      );
+    } finally {
+      gate.resolve();
+      await Promise.all(waited);
+      cacheRead.mockRestore();
+      warning.mockRestore();
+    }
   });
 
   test("Worker execution context defers positive cache population and observes its outcome", async () => {
@@ -496,6 +675,30 @@ describe("resolveInferenceAuthContext", () => {
       finishWrite();
       readSpy.mockRestore();
       writeSpy.mockRestore();
+    }
+  });
+
+  test("a rejected deferred cache write is structured and does not reject waitUntil", async () => {
+    const writeSpy = spyOn(cache, "setWithOutcome").mockRejectedValue(
+      new TypeError("sensitive backend detail"),
+    );
+    const warning = spyOn(logger, "warn").mockImplementation(() => undefined);
+    const waited: Promise<unknown>[] = [];
+    try {
+      const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+        traceId: "0190f2f1-8b5a-7000-8000-000000000003",
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+      expect(result).toMatchObject({ kind: "authorized", source: "origin" });
+      await expect(Promise.all(waited)).resolves.toBeArray();
+      expect(warning).toHaveBeenCalledWith("[InferenceAuth] deferred cache write rejected", {
+        traceId: "0190f2f1-8b5a-7000-8000-000000000003",
+        errorName: "TypeError",
+      });
+      expect(JSON.stringify(warning.mock.calls)).not.toContain("sensitive backend detail");
+    } finally {
+      writeSpy.mockRestore();
+      warning.mockRestore();
     }
   });
 
@@ -829,6 +1032,7 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     for (let i = 0; i < 3; i++) {
       const res = await resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,
+        inlineContinuationDeadlineMs: 0,
         executionCtx: workerCtx(hydrations),
       });
       expect(res.kind).toBe("warming");
@@ -859,6 +1063,7 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     for (let i = 0; i < 2; i++) {
       await resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,
+        inlineContinuationDeadlineMs: 0,
         executionCtx: workerCtx(hydrations),
       });
       await Promise.all(hydrations.splice(0));
@@ -871,6 +1076,7 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     // now answers directly.
     await resolveInferenceAuthContext(reqWithApiKey(), {
       cacheOnly: true,
+      inlineContinuationDeadlineMs: 0,
       executionCtx: workerCtx(hydrations),
     });
     await Promise.all(hydrations.splice(0));
@@ -895,6 +1101,7 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     for (let i = 0; i < 3; i++) {
       const res = await resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,
+        inlineContinuationDeadlineMs: 0,
         executionCtx: workerCtx(hydrations),
       });
       expect(res.kind).toBe("warming");

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -3,9 +3,9 @@
  *
  * `resolveInferenceAuthContext(req)` collapses the pre-forward auth + org +
  * moderation chain into one cache decision for API-key and Steward-session
- * inference. A cold Worker request returns a retryable warming result and
- * hydrates the authoritative decision under `waitUntil`; non-Worker callers may
- * still await the same operation inline for deterministic tools and tests.
+ * inference. A cold Worker request consumes its coalesced authoritative
+ * continuation under a bounded deadline while retaining it under `waitUntil`;
+ * timeout or dependency failure stays an explicit retryable warming result.
  *
  * API keys are keyed by their full hash and Steward sessions by a hash of the
  * verified subject. The cache-backed mode is independently default-off:
@@ -19,8 +19,9 @@
  *   - A positive IAC entry is written ONLY for a fully-authorized credential.
  *   - Auth failures (invalid/inactive/no-org) throw from the authoritative chain
  *     and propagate unchanged -> the route maps them to the exact 401/403.
- *   - A Worker cache failure returns an explicit unavailable/warming result;
- *     it never authorizes by joining a database fallback to model dispatch.
+ *   - A Worker cache failure returns an explicit unavailable/warming result.
+ *     Only an actual combined-cache miss may join the already-retained origin
+ *     continuation, and it never performs a second cache read.
  */
 
 import { createHash, timingSafeEqual } from "node:crypto";
@@ -139,7 +140,7 @@ export interface ResolveInferenceAuthOptions {
   onTelemetry?(telemetry: InferenceAuthTelemetry): void;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   onCacheWriteTelemetry?(telemetry: InferenceAuthCacheWriteTelemetry): void;
-  /** Never join a Postgres hydration to the inference response promise. */
+  /** Use the combined cache and its bounded one-shot miss continuation. */
   cacheOnly?: boolean;
   /** Internal background refresh: bypass the combined decision and revalidate. */
   forceAuthoritative?: boolean;
@@ -147,6 +148,8 @@ export interface ResolveInferenceAuthOptions {
   onAuthoritativeRejection?(reason: InferenceAuthRejectionReason): void;
   /** The caller will fuse this strong check into its atomic admission lease. */
   deferStrongCredentialCheck?: boolean;
+  /** Override the Worker miss deadline; zero retains an immediate warming result. */
+  inlineContinuationDeadlineMs?: number;
 }
 
 interface MutableInferenceAuthTrace {
@@ -171,9 +174,16 @@ interface MutableInferenceAuthTrace {
 
 type InferenceStandingDecisionSource = "authoritative" | "cache" | "session_resolution";
 
-const apiKeyHydrations = new Map<string, Promise<InferenceAuthResolution | undefined>>();
+interface ApiKeyHydration {
+  readonly decision: Promise<InferenceAuthResolution | undefined>;
+  readonly projection: Promise<void>;
+}
+
+const apiKeyHydrations = new Map<string, ApiKeyHydration>();
+const SKIP_CACHE_PROJECTION_WRITE = Symbol("skip-cache-projection-write");
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
 const DEFAULT_HYDRATION_DEADLINE_MS = 10_000;
+const DEFAULT_INLINE_CONTINUATION_DEADLINE_MS = 2_500;
 const MAX_HYDRATION_DEADLINE_MS = 2_147_483_647;
 
 const OPAQUE_TRACE_ID =
@@ -260,7 +270,7 @@ export type InferenceAuthResolution =
   | {
       kind: "warming";
       hydration?: Promise<unknown>;
-      /** One-shot cold-auth result for bounded voice warming without a second cache read. */
+      /** One-shot cold-auth result for bounded request use without a second cache read. */
       continuation?: Promise<InferenceAuthResolution | undefined>;
     }
   | { kind: "slow_path"; reason: "mobile_api_key" | "non_api_key" };
@@ -362,53 +372,45 @@ function hydrationEscapeActive(keyHash: string): boolean {
 function getOrCreateApiKeyHydration(
   req: Request,
   keyHash: string,
-  traceId: string | undefined,
-): Promise<InferenceAuthResolution | undefined> {
+  options: ResolveInferenceAuthOptions & {
+    executionCtx: { waitUntil(promise: Promise<unknown>): void };
+  },
+): ApiKeyHydration {
   const existing = apiKeyHydrations.get(keyHash);
-  if (existing) return existing;
+  if (existing) {
+    options.executionCtx.waitUntil(existing.projection);
+    return existing;
+  }
 
   let authoritativeRejectionReason: InferenceAuthRejectionReason | undefined;
 
-  // The outer Worker waitUntil retains this whole operation, so the
-  // authoritative resolver intentionally runs without an execution context:
-  // it must finish the cache write before releasing the single-flight slot.
-  const attempt = resolveInferenceAuthContext(req, {
-    traceId,
+  // The authoritative decision and its cache projection are separate promises.
+  // A request may consume the decision immediately and carry its credential to
+  // the atomic admission lease, while refresh-only callers retain the
+  // projection barrier, including its standalone strong credential check.
+  const hydrationOptions: ResolveInferenceAuthOptions & {
+    [SKIP_CACHE_PROJECTION_WRITE]: true;
+  } = {
+    traceId: options.traceId,
     cacheOnly: false,
     forceAuthoritative: true,
+    deferStrongCredentialCheck: true,
+    [SKIP_CACHE_PROJECTION_WRITE]: true,
     onAuthoritativeRejection: (reason) => {
       authoritativeRejectionReason = reason;
     },
-  })
-    .then(async (result): Promise<InferenceAuthResolution> => {
-      if (result.kind === "suspended") {
-        const write = await writeInferenceApiKeyAuthRejection(
-          keyHash,
-          "suspended",
-          403,
-          result.reason ?? "moderation_blocked",
-        );
-        if (write.kind !== "written") {
-          throw new Error(`Suspended inference-auth decision cache write failed: ${write.kind}`);
-        }
-      }
+  };
+  const attempt = resolveInferenceAuthContext(req, hydrationOptions)
+    .then((result): InferenceAuthResolution => {
       apiKeyHydrationFailures.delete(keyHash);
       return result;
     })
-    .catch(async (error): Promise<InferenceAuthResolution | undefined> => {
+    .catch((error): InferenceAuthResolution | undefined => {
       const status = getErrorStatusCode(error);
       if (status === 401 || status === 403) {
         const reason = authoritativeRejectionReason ?? "credential_invalid";
-        const write = await writeInferenceApiKeyAuthRejection(keyHash, "rejected", status, reason);
-        if (write.kind !== "written") {
-          logger.warn("[InferenceAuth] rejected decision cache write failed", {
-            traceId: boundedTraceId(traceId),
-            status,
-            cacheWrite: write.kind,
-          });
-        }
-        // A definitive rejection is a successful decision, not a failed
-        // hydration — the cache now answers; no escape pressure needed.
+        // A definitive rejection is a successful decision. The projection
+        // barrier below owns its negative cache write.
         apiKeyHydrationFailures.delete(keyHash);
         return { kind: "rejected", status, reason };
       } else {
@@ -417,9 +419,9 @@ function getOrCreateApiKeyHydration(
       // error-policy:J7 the current request already returned an explicit
       // warming state; preserve the failure in logs and allow a later retry.
       logger.warn("[InferenceAuth] background hydration failed", {
-        traceId: boundedTraceId(traceId),
+        traceId: boundedTraceId(options.traceId),
         failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
-        error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : "UnknownError",
       });
       return undefined;
     });
@@ -427,13 +429,13 @@ function getOrCreateApiKeyHydration(
   // The timed-out promise resolves (never rejects), counts as a failure, and
   // frees the slot for a fresh attempt on the next request.
   let deadline: ReturnType<typeof setTimeout> | undefined;
-  const hydration = Promise.race([
+  const decision = Promise.race([
     attempt,
     new Promise<undefined>((resolve) => {
       deadline = setTimeout(() => {
         noteHydrationFailure(keyHash);
         logger.warn("[InferenceAuth] background hydration exceeded deadline", {
-          traceId: boundedTraceId(traceId),
+          traceId: boundedTraceId(options.traceId),
           deadlineMs: HYDRATION_DEADLINE_MS,
           failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
         });
@@ -442,15 +444,145 @@ function getOrCreateApiKeyHydration(
       if (typeof deadline.unref === "function") deadline.unref();
     }),
   ]);
+
+  const projection = decision
+    .then(async (result) => {
+      if (!result) return;
+      if (result.kind === "authorized" && "keyHash" in result.ctx) {
+        await assertInferenceCredentialActive(result.ctx.orgId, {
+          kind: "api_key",
+          credentialId: result.ctx.apiKeyId,
+          userId: result.ctx.userId,
+        });
+        const startedAt = performance.now();
+        const write = await writeInferenceAuthContext(result.ctx);
+        const telemetry = freezeCacheWriteTrace(options.traceId, write, startedAt);
+        logger.info("[InferenceAuth] trace", telemetry);
+        options.onCacheWriteTelemetry?.(telemetry);
+        if (write.kind !== "written") {
+          logger.warn("[InferenceAuth] positive decision cache write failed", {
+            traceId: boundedTraceId(options.traceId),
+            cacheWrite: write.kind,
+          });
+        }
+        return;
+      }
+      if (result.kind !== "suspended" && result.kind !== "rejected") return;
+      const status = result.kind === "suspended" ? 403 : result.status;
+      const decision = result.kind === "suspended" ? "suspended" : "rejected";
+      const reason =
+        result.reason ??
+        (result.kind === "suspended" ? "moderation_blocked" : "credential_invalid");
+      const write = await writeInferenceApiKeyAuthRejection(keyHash, decision, status, reason);
+      if (write.kind !== "written") {
+        logger.warn("[InferenceAuth] negative decision cache write failed", {
+          traceId: boundedTraceId(options.traceId),
+          status,
+          cacheWrite: write.kind,
+        });
+      }
+    })
+    .catch((error) => {
+      // error-policy:J7 the authoritative decision is independently observed;
+      // a failed projection remains fail-closed and must not reject waitUntil.
+      logger.warn("[InferenceAuth] deferred cache projection failed", {
+        traceId: boundedTraceId(options.traceId),
+        errorName: error instanceof Error ? error.name : "UnknownError",
+      });
+    });
+
+  const hydration: ApiKeyHydration = { decision, projection };
   apiKeyHydrations.set(keyHash, hydration);
-  const clear = () => {
+  options.executionCtx.waitUntil(projection);
+  const clearDeadline = () => {
     if (deadline !== undefined) clearTimeout(deadline);
+  };
+  decision.then(clearDeadline, clearDeadline);
+  const clearProjection = () => {
     if (apiKeyHydrations.get(keyHash) === hydration) {
       apiKeyHydrations.delete(keyHash);
     }
   };
-  hydration.then(clear, clear);
+  projection.then(clearProjection, clearProjection);
   return hydration;
+}
+
+async function consumeInlineAuthContinuation(
+  continuation: Promise<InferenceAuthResolution | undefined>,
+  options: Pick<
+    ResolveInferenceAuthOptions,
+    "executionCtx" | "inlineContinuationDeadlineMs" | "traceId"
+  >,
+  authSource: InferenceAuthCredentialSource,
+): Promise<InferenceAuthResolution | undefined> {
+  const deadlineMs =
+    options.inlineContinuationDeadlineMs ?? DEFAULT_INLINE_CONTINUATION_DEADLINE_MS;
+  if (!Number.isFinite(deadlineMs) || deadlineMs <= 0 || !options.executionCtx) {
+    return undefined;
+  }
+
+  const startedAt = performance.now();
+  const failed = Symbol("inference-auth-inline-continuation-failed");
+  const timedOut = Symbol("inference-auth-inline-continuation-timeout");
+  const operation = continuation;
+  const observed = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+  options.executionCtx.waitUntil(observed);
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const outcome = await Promise.race([
+      operation.then(
+        (resolution) => ({ resolution }),
+        (error) => ({ error, failed }),
+      ),
+      new Promise<{ timedOut: typeof timedOut }>((resolve) => {
+        timeoutId = setTimeout(() => resolve({ timedOut }), Math.floor(deadlineMs));
+        if (typeof timeoutId.unref === "function") timeoutId.unref();
+      }),
+    ]);
+
+    if ("timedOut" in outcome) {
+      logger.warn("[InferenceAuth] inline continuation exceeded deadline", {
+        traceId: boundedTraceId(options.traceId),
+        authSource,
+        deadlineMs: Math.floor(deadlineMs),
+        durationMs: durationSince(startedAt),
+      });
+      return undefined;
+    }
+    if ("failed" in outcome) {
+      logger.warn("[InferenceAuth] inline continuation failed", {
+        traceId: boundedTraceId(options.traceId),
+        authSource,
+        deadlineMs: Math.floor(deadlineMs),
+        durationMs: durationSince(startedAt),
+        errorName: outcome.error instanceof Error ? outcome.error.name : "UnknownError",
+      });
+      return undefined;
+    }
+    if (!outcome.resolution) {
+      logger.warn("[InferenceAuth] inline continuation was unavailable", {
+        traceId: boundedTraceId(options.traceId),
+        authSource,
+        deadlineMs: Math.floor(deadlineMs),
+        durationMs: durationSince(startedAt),
+      });
+      return undefined;
+    }
+    logger.info("[InferenceAuth] inline continuation completed", {
+      traceId: boundedTraceId(options.traceId),
+      authSource,
+      result: outcome.resolution.kind,
+      deadlineMs: Math.floor(deadlineMs),
+      durationMs: durationSince(startedAt),
+    });
+    return outcome.resolution;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
 }
 
 /** Test hook: reset the hydration-failure escape counters. */
@@ -536,7 +668,9 @@ export async function resolveInferenceAuthContext(
   try {
     const authCacheEnabled = isInferenceAuthCacheEnabled();
     const deferStrongCredentialCheck =
-      options.deferStrongCredentialCheck === true && isInferenceStrongRevocationEnabled();
+      authCacheEnabled &&
+      options.deferStrongCredentialCheck === true &&
+      isInferenceStrongRevocationEnabled();
     const extractStartedAt = performance.now();
     const credential = extractApiKeyCredentialWithSource(req);
     trace.timings.extractMs = durationSince(extractStartedAt);
@@ -563,6 +697,38 @@ export async function resolveInferenceAuthContext(
       if (session.kind === "warming") {
         trace.cacheRead = cache.isAvailable() ? "miss" : "unavailable";
         trace.result = "warming";
+        if (session.continuation) {
+          const continued = await consumeInlineAuthContinuation(
+            session.continuation,
+            options,
+            trace.authSource,
+          );
+          if (continued?.kind === "authorized") {
+            trace.authoritative = "authorized";
+            trace.result = "authorized_origin";
+            return continued;
+          }
+          if (continued?.kind === "suspended") {
+            trace.authoritative = "suspended";
+            trace.result = "suspended";
+            logStandingDenial({
+              status: 403,
+              reason: continued.reason,
+              source: "session_resolution",
+            });
+            return continued;
+          }
+          if (continued?.kind === "rejected") {
+            trace.authoritative = "rejected";
+            trace.result = "rejected";
+            logStandingDenial({
+              status: continued.status,
+              reason: continued.reason,
+              source: "session_resolution",
+            });
+            return continued;
+          }
+        }
         return session;
       }
       if (session.kind === "suspended") {
@@ -651,9 +817,10 @@ export async function resolveInferenceAuthContext(
         );
         if (options.executionCtx) {
           if (Date.now() - cached.ctx.cachedAt >= AUTH_CONTEXT_REFRESH_AFTER_MS) {
-            options.executionCtx.waitUntil(
-              getOrCreateApiKeyHydration(req, keyHash, options.traceId),
-            );
+            getOrCreateApiKeyHydration(req, keyHash, {
+              ...options,
+              executionCtx: options.executionCtx,
+            });
           }
         }
         trace.result = "authorized_cache";
@@ -678,9 +845,71 @@ export async function resolveInferenceAuthContext(
       trace.authoritative = "not_run";
       trace.result = "warming";
       if (cacheAvailable && options.executionCtx) {
-        const hydration = getOrCreateApiKeyHydration(req, keyHash, options.traceId);
-        options.executionCtx.waitUntil(hydration);
-        return { kind: "warming", hydration, continuation: hydration };
+        const hydration = getOrCreateApiKeyHydration(req, keyHash, {
+          ...options,
+          executionCtx: options.executionCtx,
+        });
+        const continued = await consumeInlineAuthContinuation(
+          hydration.decision,
+          options,
+          trace.authSource,
+        );
+        if (continued?.kind === "authorized") {
+          if (!deferStrongCredentialCheck && "keyHash" in continued.ctx) {
+            try {
+              await assertInferenceCredentialActive(continued.ctx.orgId, {
+                kind: "api_key",
+                credentialId: continued.ctx.apiKeyId,
+                userId: continued.ctx.userId,
+              });
+            } catch (error) {
+              if (error instanceof InferenceCredentialRevokedError) {
+                trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
+                const reason = inferenceCredentialRevocationReason(error.reason);
+                logStandingDenial({
+                  status: error.reason === "credential_revoked" ? 401 : 403,
+                  reason,
+                  source: "authoritative",
+                });
+                return error.reason === "credential_revoked"
+                  ? { kind: "rejected", status: 401, reason }
+                  : { kind: "suspended", userId: continued.ctx.userId, reason };
+              }
+              throw error;
+            }
+          }
+          trace.authoritative = "authorized";
+          trace.result = "authorized_origin";
+          observeInferenceApiKeyUsage(continued, options.executionCtx);
+          return deferStrongCredentialCheck
+            ? continued
+            : { kind: "authorized", ctx: continued.ctx, source: continued.source };
+        }
+        if (continued?.kind === "suspended") {
+          trace.authoritative = "suspended";
+          trace.result = "suspended";
+          logStandingDenial({
+            status: 403,
+            reason: continued.reason,
+            source: "authoritative",
+          });
+          return continued;
+        }
+        if (continued?.kind === "rejected") {
+          trace.authoritative = "rejected";
+          trace.result = "rejected";
+          logStandingDenial({
+            status: continued.status,
+            reason: continued.reason,
+            source: "authoritative",
+          });
+          return continued;
+        }
+        return {
+          kind: "warming",
+          hydration: hydration.projection,
+          continuation: hydration.decision,
+        };
       }
       return { kind: "warming" };
     }
@@ -796,14 +1025,47 @@ export async function resolveInferenceAuthContext(
           : {}),
       };
     }
+    if (
+      (
+        options as ResolveInferenceAuthOptions & {
+          [SKIP_CACHE_PROJECTION_WRITE]?: true;
+        }
+      )[SKIP_CACHE_PROJECTION_WRITE]
+    ) {
+      trace.cacheWrite = "deferred";
+      return {
+        kind: "authorized",
+        ctx,
+        source: "origin",
+        ...(deferStrongCredentialCheck
+          ? {
+              credential: {
+                kind: "api_key" as const,
+                credentialId: ctx.apiKeyId,
+                userId: ctx.userId,
+              },
+            }
+          : {}),
+      };
+    }
     const cacheWrite = writeInferenceAuthContext(ctx);
     if (cacheAvailable && typeof options.executionCtx?.waitUntil === "function") {
       trace.cacheWrite = "deferred";
-      const observedWrite = cacheWrite.then((write) => {
-        const telemetry = freezeCacheWriteTrace(options.traceId, write, cacheWriteStartedAt);
-        logger.info("[InferenceAuth] trace", telemetry);
-        options.onCacheWriteTelemetry?.(telemetry);
-      });
+      const observedWrite = cacheWrite.then(
+        (write) => {
+          const telemetry = freezeCacheWriteTrace(options.traceId, write, cacheWriteStartedAt);
+          logger.info("[InferenceAuth] trace", telemetry);
+          options.onCacheWriteTelemetry?.(telemetry);
+        },
+        (error) => {
+          // error-policy:J7 authorization is complete; projection failure is
+          // structured and observed without rejecting the Worker lifetime.
+          logger.warn("[InferenceAuth] deferred cache write rejected", {
+            traceId: boundedTraceId(options.traceId),
+            errorName: error instanceof Error ? error.name : "UnknownError",
+          });
+        },
+      );
       // Authorization is already authoritative; waitUntil preserves cache
       // population and its observed outcome without holding the response path.
       options.executionCtx.waitUntil(observedWrite);

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -100,6 +100,7 @@ const { invalidateInferenceSessionAuthContext, readInferenceSessionAuthDecision 
   "./inference-auth-cache"
 );
 const { cache } = await import("../cache/client");
+const { logger } = await import("../utils/logger");
 
 function request(): Request {
   return new Request("https://api.example/api/v1/chat/completions", {
@@ -148,6 +149,7 @@ describe("resolveInferenceSessionAuthContext", () => {
     const result = await resolveInferenceSessionAuthContext(request(), {
       cacheOnly: true,
       useAuthCache: true,
+      deferStrongCredentialCheck: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
 
@@ -163,9 +165,16 @@ describe("resolveInferenceSessionAuthContext", () => {
     await expect(result.continuation).resolves.toMatchObject({
       kind: "authorized",
       source: "origin",
+      credential: {
+        kind: "steward_session",
+        userId: "user-1",
+        stewardUserId: "steward-1",
+        issuedAt: claims?.issuedAt,
+      },
     });
     await Promise.all(waited);
     expect(moderationReads).toBe(1);
+    expect(strongCredentialChecks).toHaveLength(1);
     expect(cacheRead).toHaveBeenCalledTimes(1);
     cacheRead.mockRestore();
   });
@@ -343,10 +352,50 @@ describe("resolveInferenceSessionAuthContext", () => {
     expect(moderationReads).toBe(1);
   });
 
+  test("the session projection barrier prevents rehydration while its write is pending", async () => {
+    let finishWrite = (): void => {};
+    const writeSpy = spyOn(cache, "setWithOutcome").mockImplementation(
+      async () =>
+        await new Promise((resolve) => {
+          finishWrite = () => resolve({ kind: "written" as const, backend: "memory" as const });
+        }),
+    );
+    const firstWaited: Promise<unknown>[] = [];
+    const secondWaited: Promise<unknown>[] = [];
+    try {
+      const first = await resolveInferenceSessionAuthContext(request(), {
+        cacheOnly: true,
+        useAuthCache: true,
+        executionCtx: { waitUntil: (promise) => firstWaited.push(promise) },
+      });
+      if (first.kind !== "warming" || !first.continuation) throw new Error("unreachable");
+      await expect(first.continuation).resolves.toMatchObject({ kind: "authorized" });
+
+      const second = await resolveInferenceSessionAuthContext(request(), {
+        cacheOnly: true,
+        useAuthCache: true,
+        executionCtx: { waitUntil: (promise) => secondWaited.push(promise) },
+      });
+      if (second.kind !== "warming" || !second.continuation) throw new Error("unreachable");
+      await expect(second.continuation).resolves.toMatchObject({ kind: "authorized" });
+      expect(userReads).toBe(1);
+      expect(firstWaited).toHaveLength(1);
+      expect(secondWaited).toHaveLength(1);
+      expect(firstWaited[0]).toBe(secondWaited[0]);
+
+      finishWrite();
+      await Promise.all([...firstWaited, ...secondWaited]);
+    } finally {
+      finishWrite();
+      writeSpy.mockRestore();
+    }
+  });
+
   test("flag-off origin resolution performs no session-auth cache write", async () => {
     const result = await resolveInferenceSessionAuthContext(request(), {
       cacheOnly: false,
       useAuthCache: false,
+      deferStrongCredentialCheck: true,
     });
 
     expect(result).toMatchObject({
@@ -354,6 +403,7 @@ describe("resolveInferenceSessionAuthContext", () => {
       source: "origin",
       ctx: { userId: "user-1", orgId: "org-1", stewardUserId: "steward-1" },
     });
+    expect(result).not.toHaveProperty("credential");
     expect(userReads).toBe(1);
     // The authoritative decision must NOT have been persisted: the real cache
     // stays cold for the subject, so nothing exists for a later flag flip to
@@ -373,6 +423,31 @@ describe("resolveInferenceSessionAuthContext", () => {
       orgId: "org-1",
       stewardUserId: "steward-1",
     });
+  });
+
+  test("a rejected deferred session write is structured and does not reject waitUntil", async () => {
+    const writeSpy = spyOn(cache, "setWithOutcome").mockRejectedValue(
+      new TypeError("sensitive session backend detail"),
+    );
+    const warning = spyOn(logger, "warn").mockImplementation(() => undefined);
+    const waited: Promise<unknown>[] = [];
+    try {
+      const result = await resolveInferenceSessionAuthContext(request(), {
+        cacheOnly: true,
+        useAuthCache: true,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+      expect(result).toMatchObject({ kind: "warming" });
+      await expect(Promise.all(waited)).resolves.toBeArray();
+      expect(warning).toHaveBeenCalledWith(
+        "[InferenceSessionAuth] Deferred cache projection failed",
+        { errorName: "TypeError" },
+      );
+      expect(JSON.stringify(warning.mock.calls)).not.toContain("sensitive session backend detail");
+    } finally {
+      writeSpy.mockRestore();
+      warning.mockRestore();
+    }
   });
 
   test("invalid session is rejected without authoritative hydration", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -39,7 +39,12 @@ import {
   isInferenceStrongRevocationEnabled,
 } from "./inference-credential-revocation";
 
-const sessionHydrations = new Map<string, Promise<InferenceSessionAuthDecision>>();
+interface SessionHydration {
+  readonly decision: Promise<InferenceSessionAuthDecision>;
+  readonly projection: Promise<void>;
+}
+
+const sessionHydrations = new Map<string, SessionHydration>();
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
 
 export interface ResolveInferenceSessionAuthOptions {
@@ -188,7 +193,7 @@ async function enforceStrongSessionBoundary(
   }
 }
 
-async function hydrateAndCache(
+async function hydrateDecision(
   params: {
     stewardUserId: string;
     email?: string;
@@ -198,15 +203,12 @@ async function hydrateAndCache(
   persistDecision: boolean,
 ): Promise<InferenceSessionAuthDecision> {
   const authoritative = await hydrateAuthoritativeDecision(params);
-  const decision =
-    persistDecision && "apiKeyId" in authoritative
-      ? {
-          ...authoritative,
-          admission: await loadInferenceAdmissionSnapshot(authoritative.orgId),
-        }
-      : authoritative;
-  if (persistDecision) await writeInferenceSessionAuthDecision(decision);
-  return decision;
+  return persistDecision && "apiKeyId" in authoritative
+    ? {
+        ...authoritative,
+        admission: await loadInferenceAdmissionSnapshot(authoritative.orgId),
+      }
+    : authoritative;
 }
 
 // Coalesced by subject only: `persistDecision` derives from the env flag, which
@@ -219,18 +221,52 @@ function getOrCreateHydration(
     walletChain?: "ethereum" | "solana";
   },
   persistDecision: boolean,
-): Promise<InferenceSessionAuthDecision> {
+  issuedAt: number,
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+): SessionHydration {
   const existing = sessionHydrations.get(params.stewardUserId);
-  if (existing) return existing;
+  if (existing) {
+    executionCtx?.waitUntil(existing.projection);
+    return existing;
+  }
 
-  const hydration = hydrateAndCache(params, persistDecision);
+  const decision = hydrateDecision(params, persistDecision);
+  const projection = decision
+    .then(async (resolvedDecision) => {
+      if (!persistDecision) return;
+      if ("apiKeyId" in resolvedDecision) {
+        const strong = await enforceStrongSessionBoundary(
+          resolvedDecision,
+          params.stewardUserId,
+          issuedAt,
+          "origin",
+          false,
+        );
+        if (strong.kind !== "authorized") return;
+      }
+      const outcome = await writeInferenceSessionAuthDecision(resolvedDecision);
+      if (outcome.kind !== "written") {
+        logger.warn("[InferenceSessionAuth] Decision cache write failed", {
+          cacheWrite: outcome.kind,
+        });
+      }
+    })
+    .catch((error) => {
+      // error-policy:J7 the authoritative decision is consumed separately;
+      // projection rejection stays fail-closed and cannot reject waitUntil.
+      logger.warn("[InferenceSessionAuth] Deferred cache projection failed", {
+        errorName: error instanceof Error ? error.name : "UnknownError",
+      });
+    });
+  const hydration: SessionHydration = { decision, projection };
   sessionHydrations.set(params.stewardUserId, hydration);
+  executionCtx?.waitUntil(projection);
   const clear = () => {
     if (sessionHydrations.get(params.stewardUserId) === hydration) {
       sessionHydrations.delete(params.stewardUserId);
     }
   };
-  hydration.then(clear, clear);
+  projection.then(clear, clear);
   return hydration;
 }
 
@@ -253,7 +289,9 @@ export async function resolveInferenceSessionAuthContext(
 
   const env = getCloudAwareEnv();
   const deferStrongCredentialCheck =
-    options.deferStrongCredentialCheck === true && isInferenceStrongRevocationEnabled(env);
+    options.useAuthCache === true &&
+    options.deferStrongCredentialCheck === true &&
+    isInferenceStrongRevocationEnabled(env);
   const claims = await verifyStewardTokenCached(
     {
       NODE_ENV: env.NODE_ENV,
@@ -324,7 +362,7 @@ export async function resolveInferenceSessionAuthContext(
     });
     if (cached) {
       if (options.executionCtx && Date.now() - cached.cachedAt >= AUTH_CONTEXT_REFRESH_AFTER_MS) {
-        const refresh = getOrCreateHydration(
+        getOrCreateHydration(
           {
             stewardUserId: claims.userId,
             email: claims.email,
@@ -332,16 +370,9 @@ export async function resolveInferenceSessionAuthContext(
             walletChain: claims.walletChain,
           },
           true,
-        )
-          .then(() => undefined)
-          .catch((error) => {
-            // error-policy:J7 the cached decision already resolved this request;
-            // authoritative refresh failure is observed without adding latency.
-            logger.warn("[InferenceSessionAuth] Background refresh failed", {
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
-        options.executionCtx.waitUntil(refresh);
+          claims.issuedAt,
+          options.executionCtx,
+        );
       }
       return await enforceStrongSessionBoundary(
         cached,
@@ -355,7 +386,7 @@ export async function resolveInferenceSessionAuthContext(
 
   if (options.useAuthCache && options.cacheOnly) {
     if (cache.isAvailable() && options.executionCtx) {
-      const hydrationDecision = getOrCreateHydration(
+      const hydration = getOrCreateHydration(
         {
           stewardUserId: claims.userId,
           email: claims.email,
@@ -363,31 +394,16 @@ export async function resolveInferenceSessionAuthContext(
           walletChain: claims.walletChain,
         },
         true,
+        claims.issuedAt,
+        options.executionCtx,
       );
-      const observed = hydrationDecision
-        .then(() => undefined)
-        .catch((error) => {
-          // error-policy:J7 authoritative hydration is observed by waitUntil;
-          // the current request already returned an explicit warming state.
-          logger.warn("[InferenceSessionAuth] Background hydration failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      options.executionCtx.waitUntil(observed);
       return {
         kind: "warming",
-        hydration: hydrationDecision.then(
-          (decision) => decision,
-          (error) => {
-            // error-policy:J7 a failed hydration stays a retryable warming
-            // outcome for cache-only callers instead of becoming an opaque 500.
-            logger.warn("[InferenceSessionAuth] Inline hydration await failed", {
-              error: error instanceof Error ? error.message : String(error),
-            });
-            return undefined;
-          },
+        hydration: hydration.projection.then(
+          () => undefined,
+          () => undefined,
         ),
-        continuation: hydrationDecision.then(
+        continuation: hydration.decision.then(
           (decision) =>
             enforceStrongSessionBoundary(
               decision,
@@ -398,9 +414,9 @@ export async function resolveInferenceSessionAuthContext(
             ),
           (error) => {
             // error-policy:J7 the retained hydration above owns failure logging;
-            // a voice continuation keeps the original warming outcome.
+            // a request continuation keeps the original warming outcome.
             logger.warn("[InferenceSessionAuth] Continuation hydration failed", {
-              error: error instanceof Error ? error.message : String(error),
+              errorName: error instanceof Error ? error.name : "UnknownError",
             });
             return undefined;
           },
@@ -413,7 +429,7 @@ export async function resolveInferenceSessionAuthContext(
   // Origin path: persist the decision only when the auth cache is enabled —
   // a disabled cache must not be pre-populated with positive identities
   // (mirrors the API-key path's flag-gated positive write).
-  const decision = await getOrCreateHydration(
+  const hydration = getOrCreateHydration(
     {
       stewardUserId: claims.userId,
       email: claims.email,
@@ -421,7 +437,11 @@ export async function resolveInferenceSessionAuthContext(
       walletChain: claims.walletChain,
     },
     options.useAuthCache === true,
+    claims.issuedAt,
+    options.executionCtx,
   );
+  const decision = await hydration.decision;
+  if (!options.executionCtx) await hydration.projection;
   const resolved = await enforceStrongSessionBoundary(
     decision,
     claims.userId,


### PR DESCRIPTION
## Summary

- consume a cold API-key or Steward-session auth continuation inline under a default 2.5s deadline without re-reading the combined cache
- split each identity single-flight into an early authoritative decision and a retained projection barrier, so request consumers can carry credentials into atomic admission while refresh-only hydration completes a standalone strong check
- keep positive/negative projection writes asynchronous with no readback, structured J7 rejection handling, and single-flight retention until the write settles
- invoke the real route rate limiter once after authorization; auth no longer awaits or duplicates rate-limit prewarming, and pricing remains scoped to #30097

Closes #30098.
Related: #30097.

## Safety contract

- exactly one combined auth-cache read per cold request and no projection readback
- request-consumed API-key and Steward decisions defer strong standing only when the credential is threaded into the atomic admission lease
- refresh-only and generic consumers retain a standalone strong credential check; both cache and strong-revocation flags must be enabled before deferral
- mixed request/refresh callers share one authoritative lookup, and the projection barrier prevents a second hydration while the asynchronous write is pending
- authoritative denial, timeout, unavailable cache, dependency failure, and rejected projection writes remain fail-closed
- no provider dispatch occurs before authorization, the real rate limiter, and credential-fused admission

## Validation

Exact PR head: `d1e9ac0c7b628c605f8794cff05a88e6fc4a9b7d`
Rebased parent: `6afeec3f3f255de89f710542396d6b91bfe29f19` (contains #30096 squash)

- `bun --config=/tmp/bunfig-auth-inline.toml test packages/cloud/shared/src/lib/services/inference-auth-context.test.ts` — 52 pass
- `bun --config=/tmp/bunfig-auth-inline.toml test packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts` — 12 pass
- `bun --config=/tmp/bunfig-auth-inline.toml test packages/cloud/api/__tests__/generative-route-warming-await.test.ts` — 5 pass
- `bunx vitest run packages/cloud/api/src/lib/generative-route-auth.test.ts --coverage.enabled=false` — 56 pass
- `bun --config=/tmp/bunfig-auth-inline.toml test packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts` — 16 pass
- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bun run --cwd packages/cloud/api typecheck` — pass, including router contract and production Worker dry-run bundle
- `bunx biome check <eight touched TypeScript files>` — pass
- `git diff --check` — pass

## Evidence boundary

Source-level and dry-run validation only. This PR does not claim protected staging deployment or live exact-SHA cold/warm acceptance. Before merge, staging should prove the first controlled combined-cache miss reaches authorization/admission without repeated `auth_cache_warming`, while denial and timeout probes still block provider dispatch.
