### PR TITLE
fix(cloud): await authoritative pricing on cold cache miss

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
@@ -404,6 +404,39 @@ test("rejected or invalid flat hydration fails closed without a durable write", 
   expect(write).not.toHaveBeenCalled();
 });
 
+test("flat pricing rejects non-finite durable timestamps instead of serving them forever", async () => {
+  for (const [label, cachedAt] of [
+    ["infinity", Number.POSITIVE_INFINITY],
+    ["nan", Number.NaN],
+  ] as const) {
+    __clearPersistedPricingCache();
+    const read = spyOn(cache, "getWithOutcome").mockResolvedValueOnce({
+      kind: "hit",
+      backend: "memory",
+      value: { v: 1, cachedAt, entry: FLAT_ENTRY },
+    });
+    const write = spyOn(cache, "setWithOutcome").mockResolvedValue({
+      kind: "written",
+      backend: "memory",
+    });
+    const loader = mock(async () => FLAT_ENTRY);
+    const background: Promise<unknown>[] = [];
+
+    await expect(
+      getCachedFlatPricingEntry(
+        `flat-corrupt-timestamp-${label}`,
+        loader,
+        workerOptions(background),
+      ),
+    ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+    await Promise.all(background);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledTimes(1);
+    mock.restore();
+  }
+});
+
 test("timed-out flat hydration fails closed, then finishes its background write without readback", async () => {
   __clearPersistedPricingCache();
   const { read, write } = stubColdDurableCache();

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
@@ -1,11 +1,13 @@
 /**
- * getCachedExternalEntries negative-caching: a failing external-catalog fetch
- * (e.g. Cerebras retiring its public catalog → permanent 404) must NOT be
- * re-run on every hot-path pricing lookup. Regression guard for the prod
- * latency issue where the failing fetch ran 2x per chat request.
+ * Pricing cache tests drive real coalescing, validation, and Worker cold-miss
+ * behavior behind injected authoritative loaders and durable-cache spies.
+ * They prove that dependency failures remain distinct from empty results and
+ * that admission never waits for or reads back a background persistence write.
  */
-import { expect, mock, test } from "bun:test";
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
 import type { AiPricingEntry } from "../../../db/schemas/ai-pricing";
+import { cache } from "../../cache/client";
+import { logger } from "../../utils/logger";
 import {
   __clearPersistedPricingCache,
   AiPricingCacheUnavailableError,
@@ -15,6 +17,48 @@ import {
   getCachedTextPricingRates,
 } from "./cache";
 import type { PreparedPricingEntry } from "./types";
+
+const TOKEN_RATES = {
+  inputUnitPrice: 0.000001,
+  outputUnitPrice: 0.000004,
+};
+
+const FLAT_ENTRY = {
+  billingSource: "fal",
+  provider: "fal",
+  model: "fal-ai/test",
+  productFamily: "image",
+  chargeType: "generation",
+  unit: "image",
+  unitPrice: 0.01,
+} as PreparedPricingEntry;
+
+function workerOptions(background: Promise<unknown>[], coldHydrationDeadlineMs = 1_000) {
+  return {
+    cacheOnly: true,
+    coldHydrationDeadlineMs,
+    executionCtx: {
+      waitUntil: (promise: Promise<unknown>) => background.push(promise),
+    },
+  };
+}
+
+function stubColdDurableCache() {
+  const read = spyOn(cache, "getWithOutcome").mockResolvedValue({
+    kind: "miss",
+    backend: "memory",
+  });
+  const write = spyOn(cache, "setWithOutcome").mockResolvedValue({
+    kind: "written",
+    backend: "memory",
+  });
+  return { read, write };
+}
+
+afterEach(() => {
+  __clearPersistedPricingCache();
+  mock.restore();
+});
 
 test("negative-caches a failing loader — subsequent lookups skip the re-fetch", async () => {
   let calls = 0;
@@ -172,47 +216,213 @@ test("cache-only token pricing without a Worker lifetime is explicitly unavailab
   expect(loader).not.toHaveBeenCalled();
 });
 
-test("cold flat pricing warms outside the Worker request and serves the retry", async () => {
-  const previousBackend = process.env.CACHE_BACKEND;
-  const previousEnabled = process.env.CACHE_ENABLED;
-  process.env.CACHE_BACKEND = "memory";
-  process.env.CACHE_ENABLED = "true";
-  try {
-    __clearPersistedPricingCache();
-    const entry = {
-      billingSource: "fal",
-      provider: "fal",
-      model: "fal-ai/test",
-      productFamily: "image",
-      chargeType: "generation",
-      unit: "image",
-      unitPrice: 0.01,
-    } as PreparedPricingEntry;
-    const loader = mock(async () => entry);
-    const background: Promise<unknown>[] = [];
-    const options = {
-      cacheOnly: true,
-      executionCtx: {
-        waitUntil: (promise: Promise<unknown>) => background.push(promise),
+test("cold token pricing consumes one authoritative hydration while KV persistence stays background", async () => {
+  __clearPersistedPricingCache();
+  const { read, write } = stubColdDurableCache();
+  const writeGate = Promise.withResolvers<{
+    kind: "written";
+    backend: "memory";
+  }>();
+  write.mockImplementation(() => writeGate.promise);
+  const loader = mock(async () => TOKEN_RATES);
+  const background: Promise<unknown>[] = [];
+
+  await expect(
+    getCachedTextPricingRates(
+      "token-cold-success",
+      { input: true, output: true },
+      loader,
+      workerOptions(background),
+    ),
+  ).resolves.toEqual(TOKEN_RATES);
+  expect(background).toHaveLength(1);
+  expect(write).toHaveBeenCalledTimes(1);
+  writeGate.resolve({ kind: "written", backend: "memory" });
+  await Promise.all(background);
+  expect(read).toHaveBeenCalledTimes(1);
+  expect(loader).toHaveBeenCalledTimes(1);
+  expect(write).toHaveBeenCalledTimes(1);
+});
+
+test("concurrent token cold misses share one authoritative load and one background write", async () => {
+  __clearPersistedPricingCache();
+  const { read, write } = stubColdDurableCache();
+  const gate = Promise.withResolvers<typeof TOKEN_RATES>();
+  const loader = mock(() => gate.promise);
+  const background: Promise<unknown>[] = [];
+  const options = workerOptions(background);
+
+  const first = getCachedTextPricingRates(
+    "token-cold-concurrent",
+    { input: true, output: true },
+    loader,
+    options,
+  );
+  const second = getCachedTextPricingRates(
+    "token-cold-concurrent",
+    { input: true, output: true },
+    loader,
+    options,
+  );
+  gate.resolve(TOKEN_RATES);
+
+  await expect(Promise.all([first, second])).resolves.toEqual([TOKEN_RATES, TOKEN_RATES]);
+  await Promise.all(background);
+  expect(read).toHaveBeenCalledTimes(2);
+  expect(loader).toHaveBeenCalledTimes(1);
+  expect(write).toHaveBeenCalledTimes(1);
+});
+
+test("rejected token hydration fails closed with sanitized telemetry", async () => {
+  __clearPersistedPricingCache();
+  const { write } = stubColdDurableCache();
+  const warn = spyOn(logger, "warn").mockImplementation(() => undefined);
+  const loader = mock(async () => {
+    throw new Error("secret-account-123 database rejected");
+  });
+  const background: Promise<unknown>[] = [];
+
+  await expect(
+    getCachedTextPricingRates(
+      "secret-model-key",
+      { input: true, output: true },
+      loader,
+      workerOptions(background),
+    ),
+  ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+  await Promise.all(background);
+  expect(write).not.toHaveBeenCalled();
+  const telemetry = JSON.stringify(warn.mock.calls);
+  expect(telemetry).not.toContain("secret-account-123");
+  expect(telemetry).not.toContain("secret-model-key");
+});
+
+test("invalid token hydration fails closed without a durable write", async () => {
+  __clearPersistedPricingCache();
+  const { write } = stubColdDurableCache();
+  const background: Promise<unknown>[] = [];
+
+  await expect(
+    getCachedTextPricingRates(
+      "token-cold-invalid",
+      { input: true, output: true },
+      async () => ({ inputUnitPrice: TOKEN_RATES.inputUnitPrice, outputUnitPrice: null }),
+      workerOptions(background),
+    ),
+  ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+  await Promise.all(background);
+  expect(write).not.toHaveBeenCalled();
+});
+
+test("timed-out token hydration fails closed, then finishes its background write without readback", async () => {
+  __clearPersistedPricingCache();
+  const { read, write } = stubColdDurableCache();
+  const gate = Promise.withResolvers<typeof TOKEN_RATES>();
+  const loader = mock(() => gate.promise);
+  const background: Promise<unknown>[] = [];
+  const options = workerOptions(background, 5);
+
+  await expect(
+    getCachedTextPricingRates("token-cold-timeout", { input: true, output: true }, loader, options),
+  ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+  expect(read).toHaveBeenCalledTimes(1);
+  gate.resolve(TOKEN_RATES);
+  await Promise.all(background);
+  expect(write).toHaveBeenCalledTimes(1);
+  await expect(
+    getCachedTextPricingRates("token-cold-timeout", { input: true, output: true }, loader, options),
+  ).resolves.toEqual(TOKEN_RATES);
+  expect(read).toHaveBeenCalledTimes(1);
+});
+
+test("cold flat pricing consumes one authoritative hydration while KV persistence stays background", async () => {
+  __clearPersistedPricingCache();
+  const { read, write } = stubColdDurableCache();
+  const writeGate = Promise.withResolvers<{
+    kind: "written";
+    backend: "memory";
+  }>();
+  write.mockImplementation(() => writeGate.promise);
+  const loader = mock(async () => FLAT_ENTRY);
+  const background: Promise<unknown>[] = [];
+
+  await expect(
+    getCachedFlatPricingEntry("flat-cold-success", loader, workerOptions(background)),
+  ).resolves.toEqual(FLAT_ENTRY);
+  expect(write).toHaveBeenCalledTimes(1);
+  writeGate.resolve({ kind: "written", backend: "memory" });
+  await Promise.all(background);
+  expect(read).toHaveBeenCalledTimes(1);
+  expect(loader).toHaveBeenCalledTimes(1);
+  expect(write).toHaveBeenCalledTimes(1);
+});
+
+test("concurrent flat cold misses share one authoritative load and one background write", async () => {
+  __clearPersistedPricingCache();
+  const { read, write } = stubColdDurableCache();
+  const gate = Promise.withResolvers<PreparedPricingEntry>();
+  const loader = mock(() => gate.promise);
+  const background: Promise<unknown>[] = [];
+  const options = workerOptions(background);
+
+  const first = getCachedFlatPricingEntry("flat-cold-concurrent", loader, options);
+  const second = getCachedFlatPricingEntry("flat-cold-concurrent", loader, options);
+  gate.resolve(FLAT_ENTRY);
+
+  await expect(Promise.all([first, second])).resolves.toEqual([FLAT_ENTRY, FLAT_ENTRY]);
+  await Promise.all(background);
+  expect(read).toHaveBeenCalledTimes(2);
+  expect(loader).toHaveBeenCalledTimes(1);
+  expect(write).toHaveBeenCalledTimes(1);
+});
+
+test("rejected or invalid flat hydration fails closed without a durable write", async () => {
+  __clearPersistedPricingCache();
+  const { write } = stubColdDurableCache();
+  const rejectedBackground: Promise<unknown>[] = [];
+  await expect(
+    getCachedFlatPricingEntry(
+      "flat-cold-rejected",
+      async () => {
+        throw new Error("catalog dependency rejected");
       },
-    };
+      workerOptions(rejectedBackground),
+    ),
+  ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+  await Promise.all(rejectedBackground);
 
-    await expect(getCachedFlatPricingEntry("flat-worker-warm", loader, options)).rejects.toThrow(
-      "warming",
-    );
-    expect(background).toHaveLength(1);
-    await background[0];
+  __clearPersistedPricingCache();
+  const invalidBackground: Promise<unknown>[] = [];
+  await expect(
+    getCachedFlatPricingEntry(
+      "flat-cold-invalid",
+      async () => ({ ...FLAT_ENTRY, unitPrice: -1 }),
+      workerOptions(invalidBackground),
+    ),
+  ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+  await Promise.all(invalidBackground);
+  expect(write).not.toHaveBeenCalled();
+});
 
-    await expect(getCachedFlatPricingEntry("flat-worker-warm", loader, options)).resolves.toEqual(
-      entry,
-    );
-    expect(loader).toHaveBeenCalledTimes(1);
-  } finally {
-    if (previousBackend === undefined) delete process.env.CACHE_BACKEND;
-    else process.env.CACHE_BACKEND = previousBackend;
-    if (previousEnabled === undefined) delete process.env.CACHE_ENABLED;
-    else process.env.CACHE_ENABLED = previousEnabled;
-  }
+test("timed-out flat hydration fails closed, then finishes its background write without readback", async () => {
+  __clearPersistedPricingCache();
+  const { read, write } = stubColdDurableCache();
+  const gate = Promise.withResolvers<PreparedPricingEntry>();
+  const loader = mock(() => gate.promise);
+  const background: Promise<unknown>[] = [];
+  const options = workerOptions(background, 5);
+
+  await expect(
+    getCachedFlatPricingEntry("flat-cold-timeout", loader, options),
+  ).rejects.toBeInstanceOf(AiPricingCacheUnavailableError);
+  expect(read).toHaveBeenCalledTimes(1);
+  gate.resolve(FLAT_ENTRY);
+  await Promise.all(background);
+  expect(write).toHaveBeenCalledTimes(1);
+  await expect(getCachedFlatPricingEntry("flat-cold-timeout", loader, options)).resolves.toEqual(
+    FLAT_ENTRY,
+  );
+  expect(read).toHaveBeenCalledTimes(1);
 });
 
 test("cache-only flat pricing without a Worker lifetime is explicitly unavailable", async () => {

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
@@ -2,9 +2,10 @@
  * Coalesces canonical pricing reads and owns the Worker-safe rate cache.
  *
  * Catalog rows remain short-lived process caches for non-Worker billing work.
- * Cache-only inference admission reads canonical token rates from an L1 plus
- * the configured Worker cache; misses hydrate from authoritative catalogs only
- * under `waitUntil`, so Postgres and provider HTTP never join model dispatch.
+ * Cache-only inference admission reads canonical rates from an L1 plus the
+ * configured Worker cache. A normal cold miss may join the same coalesced
+ * authoritative catalog load under a bounded deadline, while durable writes
+ * and stale refreshes remain under `waitUntil` without a cache readback.
  */
 import type { AiPricingEntry } from "../../../db/schemas/ai-pricing";
 import { cache } from "../../cache/client";
@@ -465,7 +466,9 @@ export async function getCachedTextPricingRates(
 function isCachedFlatPricingEntry(value: unknown): value is CachedFlatPricingEntry {
   if (!value || typeof value !== "object") return false;
   const record = value as Record<string, unknown>;
-  if (record.v !== 1 || typeof record.cachedAt !== "number") return false;
+  if (record.v !== 1 || typeof record.cachedAt !== "number" || !Number.isFinite(record.cachedAt)) {
+    return false;
+  }
   if (!record.entry || typeof record.entry !== "object") return false;
   const entry = record.entry as Record<string, unknown>;
   return (

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
@@ -20,6 +20,8 @@ import {
 export interface PricingCacheReadOptions {
   cacheOnly?: boolean;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+  /** Internal deterministic-test override for the normal cold-miss join. */
+  coldHydrationDeadlineMs?: number;
 }
 
 export class AiPricingCacheWarmingError extends Error {
@@ -159,6 +161,7 @@ const TEXT_PRICING_HARD_TTL_SECONDS = 15 * 60;
 const TEXT_PRICING_HARD_TTL_MS = TEXT_PRICING_HARD_TTL_SECONDS * 1000;
 const TEXT_PRICING_FAILURE_TTL_MS = 15 * 1000;
 const TEXT_PRICING_CACHE_VERSION = 1;
+const DEFAULT_COLD_HYDRATION_DEADLINE_MS = 5_000;
 
 interface CachedTextPricingRates {
   v: typeof TEXT_PRICING_CACHE_VERSION;
@@ -178,8 +181,58 @@ interface CachedFlatPricingEntry {
 }
 
 const flatPricingCache = new Map<string, CachedFlatPricingEntry>();
+const flatPricingInFlight = new Map<string, Promise<PreparedPricingEntry>>();
 const flatPricingPersistenceInFlight = new Map<string, Promise<PreparedPricingEntry>>();
 const flatPricingFailures = new Map<string, number>();
+
+type PricingHydrationKind = "token" | "flat";
+
+function coldHydrationDeadlineMs(options: PricingCacheReadOptions): number {
+  const configured = options.coldHydrationDeadlineMs;
+  return configured !== undefined && Number.isSafeInteger(configured) && configured > 0
+    ? configured
+    : DEFAULT_COLD_HYDRATION_DEADLINE_MS;
+}
+
+async function awaitColdHydration<T>(
+  pricingKind: PricingHydrationKind,
+  hydration: Promise<T>,
+  options: PricingCacheReadOptions,
+): Promise<T> {
+  const startedAt = Date.now();
+  const deadlineMs = coldHydrationDeadlineMs(options);
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  const outcome = await Promise.race([
+    hydration.then(
+      (value) => ({ kind: "ready" as const, value }),
+      () => ({ kind: "rejected" as const }),
+    ),
+    new Promise<{ kind: "timeout" }>((resolve) => {
+      deadline = setTimeout(() => resolve({ kind: "timeout" }), deadlineMs);
+      if (typeof deadline.unref === "function") deadline.unref();
+    }),
+  ]);
+  if (deadline !== undefined) clearTimeout(deadline);
+
+  const durationMs = Date.now() - startedAt;
+  if (outcome.kind === "ready") {
+    logger.info("[AI Pricing] cold authoritative hydration completed", {
+      pricingKind,
+      result: "ready",
+      durationMs,
+      deadlineMs,
+    });
+    return outcome.value;
+  }
+
+  logger.warn("[AI Pricing] cold authoritative hydration unavailable", {
+    pricingKind,
+    result: outcome.kind,
+    durationMs,
+    deadlineMs,
+  });
+  throw new AiPricingCacheUnavailableError();
+}
 
 function durableTextPricingKey(cacheKey: string): string {
   return `iac:pricing:${cacheKey}:v1`;
@@ -314,21 +367,23 @@ function scheduleTextPricingHydration(
   required: { input: boolean; output: boolean },
   loader: () => Promise<TokenPricingRates>,
   executionCtx: { waitUntil(promise: Promise<unknown>): void },
-): void {
+): Promise<TokenPricingRates> {
   const hydration = persistTextPricingRates(cacheKey, required, loader);
+  const authoritative = loadTextPricingRates(cacheKey, required, loader);
   const observed = hydration.then(
     () => undefined,
-    (error) => {
+    () => {
       textPricingFailures.set(cacheKey, Date.now() + TEXT_PRICING_FAILURE_TTL_MS);
       // error-policy:J7 pricing hydration is intentionally outside model
       // dispatch; retain a typed unavailable state and surface the failure.
       logger.warn("[AI Pricing] canonical rate cache hydration failed", {
-        cacheKey,
-        error: error instanceof Error ? error.message : String(error),
+        pricingKind: "token",
+        result: "rejected",
       });
     },
   );
   executionCtx.waitUntil(observed);
+  return authoritative;
 }
 
 function readLocalTextPricingRates(
@@ -349,10 +404,10 @@ function readLocalTextPricingRates(
 }
 
 /**
- * Resolve canonical token rates without allowing authoritative I/O to leak
- * into a Worker request. A cold cache returns a typed retryable state after
- * registering hydration; a stale-but-bounded rate serves immediately and
- * refreshes in the background.
+ * Resolve canonical token rates while keeping durable persistence off the
+ * Worker response. A normal cold miss may consume the coalesced authoritative
+ * load under a bounded deadline; stale-but-bounded rates still refresh in the
+ * background.
  */
 export async function getCachedTextPricingRates(
   cacheKey: string,
@@ -394,10 +449,16 @@ export async function getCachedTextPricingRates(
     throw new AiPricingCacheUnavailableError();
   }
   textPricingFailures.delete(cacheKey);
-  scheduleTextPricingHydration(cacheKey, required, loader, options.executionCtx);
   if (outcome.kind === "miss") {
-    throw new AiPricingCacheWarmingError();
+    const hydration = scheduleTextPricingHydration(
+      cacheKey,
+      required,
+      loader,
+      options.executionCtx,
+    );
+    return await awaitColdHydration("token", hydration, options);
   }
+  scheduleTextPricingHydration(cacheKey, required, loader, options.executionCtx);
   throw new AiPricingCacheUnavailableError();
 }
 
@@ -414,9 +475,40 @@ function isCachedFlatPricingEntry(value: unknown): value is CachedFlatPricingEnt
     typeof entry.productFamily === "string" &&
     typeof entry.chargeType === "string" &&
     typeof entry.unit === "string" &&
-    typeof entry.unitPrice === "number" &&
-    Number.isFinite(entry.unitPrice)
+    isPositiveRate(entry.unitPrice)
   );
+}
+
+function assertLoadedFlatPricingEntry(entry: PreparedPricingEntry): void {
+  const record: CachedFlatPricingEntry = { v: 1, cachedAt: Date.now(), entry };
+  if (!isCachedFlatPricingEntry(record)) {
+    throw new Error("AI pricing loader returned an invalid flat-rate entry");
+  }
+}
+
+function loadFlatPricingEntry(
+  cacheKey: string,
+  loader: () => Promise<PreparedPricingEntry>,
+): Promise<PreparedPricingEntry> {
+  const existing = flatPricingInFlight.get(cacheKey);
+  if (existing) return existing;
+
+  const started = Promise.resolve()
+    .then(loader)
+    .then((entry) => {
+      assertLoadedFlatPricingEntry(entry);
+      flatPricingCache.set(cacheKey, { v: 1, cachedAt: Date.now(), entry });
+      flatPricingFailures.delete(cacheKey);
+      return entry;
+    });
+  flatPricingInFlight.set(cacheKey, started);
+  const cleanup = () => {
+    if (flatPricingInFlight.get(cacheKey) === started) {
+      flatPricingInFlight.delete(cacheKey);
+    }
+  };
+  started.then(cleanup, cleanup);
+  return started;
 }
 
 function persistFlatPricingEntry(
@@ -426,13 +518,11 @@ function persistFlatPricingEntry(
   const existing = flatPricingPersistenceInFlight.get(cacheKey);
   if (existing) return existing;
 
-  const persistence = loader().then(async (entry) => {
-    const record: CachedFlatPricingEntry = {
-      v: 1,
-      cachedAt: Date.now(),
-      entry,
-    };
-    flatPricingCache.set(cacheKey, record);
+  const persistence = loadFlatPricingEntry(cacheKey, loader).then(async (entry) => {
+    const record = flatPricingCache.get(cacheKey);
+    if (!record) {
+      throw new Error("AI flat-rate pricing hydration completed without a cache record");
+    }
     const outcome = await cache.setWithOutcome(
       durableFlatPricingKey(cacheKey),
       record,
@@ -454,41 +544,34 @@ function persistFlatPricingEntry(
   return persistence;
 }
 
-async function loadFlatPricingEntry(
-  cacheKey: string,
-  loader: () => Promise<PreparedPricingEntry>,
-): Promise<PreparedPricingEntry> {
-  const entry = await loader();
-  flatPricingCache.set(cacheKey, { v: 1, cachedAt: Date.now(), entry });
-  flatPricingFailures.delete(cacheKey);
-  return entry;
-}
-
 function scheduleFlatPricingHydration(
   cacheKey: string,
   loader: () => Promise<PreparedPricingEntry>,
   executionCtx: { waitUntil(promise: Promise<unknown>): void },
-): void {
+): Promise<PreparedPricingEntry> {
+  const hydration = persistFlatPricingEntry(cacheKey, loader);
+  const authoritative = loadFlatPricingEntry(cacheKey, loader);
   executionCtx.waitUntil(
-    persistFlatPricingEntry(cacheKey, loader).then(
+    hydration.then(
       () => undefined,
-      (error) => {
+      () => {
         flatPricingFailures.set(cacheKey, Date.now() + TEXT_PRICING_FAILURE_TTL_MS);
         // error-policy:J7 flat-rate hydration is intentionally outside model
         // dispatch; retain a typed unavailable state and surface the failure.
         logger.warn("[AI Pricing] flat-rate cache hydration failed", {
-          cacheKey,
-          error: error instanceof Error ? error.message : String(error),
+          pricingKind: "flat",
+          result: "rejected",
         });
       },
     ),
   );
+  return authoritative;
 }
 
 /**
- * Resolve a fixed-operation pricing entry without authoritative I/O in a
- * Worker request. Bounded stale values serve immediately while refresh runs
- * under `waitUntil`; a cold miss returns a retryable warming state.
+ * Resolve a fixed-operation pricing entry while keeping durable persistence
+ * off the Worker response. Bounded stale values serve immediately; a normal
+ * cold miss may consume the coalesced authoritative load under a deadline.
  */
 export async function getCachedFlatPricingEntry(
   cacheKey: string,
@@ -525,8 +608,11 @@ export async function getCachedFlatPricingEntry(
     throw new AiPricingCacheUnavailableError();
   }
   flatPricingFailures.delete(cacheKey);
+  if (outcome.kind === "miss") {
+    const hydration = scheduleFlatPricingHydration(cacheKey, loader, options.executionCtx);
+    return await awaitColdHydration("flat", hydration, options);
+  }
   scheduleFlatPricingHydration(cacheKey, loader, options.executionCtx);
-  if (outcome.kind === "miss") throw new AiPricingCacheWarmingError();
   throw new AiPricingCacheUnavailableError();
 }
 
@@ -539,6 +625,7 @@ export function __clearPersistedPricingCache(): void {
   textPricingPersistenceInFlight.clear();
   textPricingFailures.clear();
   flatPricingCache.clear();
+  flatPricingInFlight.clear();
   flatPricingPersistenceInFlight.clear();
   flatPricingFailures.clear();
 }

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -2,9 +2,10 @@
  * Proves Worker organization admission reads caches and writes only its
  * Durable Object lease before provider dispatch.
  *
- * The real pricing lookup runs against repository/catalog tripwires: a cold
- * request must reject before those reads finish, while the retry after its
- * `waitUntil` hydration performs zero authoritative pricing calls.
+ * The real pricing lookup runs against repository/catalog tripwires: a normal
+ * cold request consumes its coalesced authoritative rates before admission,
+ * while persistence remains under `waitUntil` and later requests perform zero
+ * authoritative pricing calls.
  */
 
 process.env.MOCK_REDIS = "1";
@@ -235,11 +236,7 @@ mock.module("./inference-billing-deferred", () => ({
   },
 }));
 
-const {
-  admitOrganizationInference,
-  InferencePricingCacheWarmingError,
-  InferencePricingCacheUnavailableError,
-} = await import("./organization-inference-admission");
+const { admitOrganizationInference } = await import("./organization-inference-admission");
 const { __clearPersistedPricingCache } = await import("./ai-pricing/cache");
 const { __clearInferenceAffiliateCacheState } = await import("./inference-affiliate-cache");
 
@@ -274,16 +271,11 @@ function admissionParams(
 
 async function hydratePricing(model: string): Promise<void> {
   const background: Promise<unknown>[] = [];
-  const error = await admitOrganizationInference(admissionParams(model, background)).then(
-    () => null,
-    (reason: unknown) => reason,
-  );
-  expect(
-    error instanceof InferencePricingCacheWarmingError ||
-      error instanceof InferencePricingCacheUnavailableError,
-  ).toBe(true);
+  const admission = await admitOrganizationInference(admissionParams(model, background));
+  expect(admission.mode).toBe("durable_object_debit");
   expect(background).toHaveLength(1);
   await background[0];
+  acquireInferenceAdmissionLease.mockClear();
 }
 
 beforeEach(() => {
@@ -320,33 +312,29 @@ afterEach(() => {
   setSystemTime();
 });
 
-test("cold pricing rejects immediately and owns authoritative hydration under waitUntil", async () => {
+test("cold pricing joins authoritative hydration before admission while persistence stays background", async () => {
   const model = nextModel();
   const releaseRepository = Promise.withResolvers<void>();
   repositoryBlock = releaseRepository.promise;
   const background: Promise<unknown>[] = [];
 
-  const outcome = await Promise.race([
-    admitOrganizationInference(admissionParams(model, background)).then(
-      () => ({ kind: "resolved" as const }),
-      (error: unknown) => ({ kind: "rejected" as const, error }),
-    ),
+  const pending = admitOrganizationInference(admissionParams(model, background));
+  const early = await Promise.race([
+    pending.then(() => ({ kind: "resolved" as const })),
     new Promise<{ kind: "timeout" }>((resolve) =>
       setTimeout(() => resolve({ kind: "timeout" }), 100),
     ),
   ]);
 
-  expect(outcome.kind).toBe("rejected");
-  if (outcome.kind !== "rejected") throw new Error("cold admission joined pricing hydration");
-  expect(
-    outcome.error instanceof InferencePricingCacheWarmingError ||
-      outcome.error instanceof InferencePricingCacheUnavailableError,
-  ).toBe(true);
+  expect(early.kind).toBe("timeout");
   expect(background).toHaveLength(1);
   expect(reserveCredits).not.toHaveBeenCalled();
+  expect(acquireInferenceAdmissionLease).not.toHaveBeenCalled();
 
   releaseRepository.resolve();
-  await background[0];
+  const admission = await pending;
+  expect(admission.mode).toBe("durable_object_debit");
+  await Promise.all(background);
   expect(pairReads).toBe(2);
   expect(fallbackReads).toBe(0);
   expect(catalogReads).toBe(0);


### PR DESCRIPTION
## Summary

- let a normal token or flat pricing KV miss consume the existing coalesced authoritative hydration under a 5-second bounded deadline
- return only validated positive canonical rates/entries before inference admission, while retaining the KV write under `waitUntil` without waiting for or reading it back
- keep durable invalid/error/unavailable states fail-closed, translate loader rejection/invalid data/deadline expiry to the typed unavailable contract, and emit privacy-bounded outcome/timing logs without cache keys or raw dependency errors
- preserve single-flight behavior across concurrent token and flat cold misses

Closes #30101
Refs #30097

## Behavioral proof

The real organization-admission test blocks the authoritative pricing repository and proves that no Durable Object admission lease is acquired while rates are unresolved. Releasing the repository lets that same first request admit successfully; the durable pricing write remains owned by `waitUntil`.

Cache tests additionally prove for both token and flat pricing:

- one durable read per cold request and no readback
- one authoritative loader invocation and one KV write per same-key concurrent group
- request success does not wait for the background KV write
- loader rejection and invalid/non-positive rates fail closed without a write
- deadline expiry fails closed while the already-started hydration may finish and populate L1/KV in the background
- structured failure telemetry contains neither the cache key nor the injected dependency error text

## Exact-head validation

- PR head: `94751141d8e9e0ad87ad01c023f27a1834af077b`
- validated base: `7cd2d742ed9c014736e68877fa52d81188d423a2`
- `bun install` — pass (Bun 1.3.14; linked workspaces/core and pinned inference submodule installed)
- `bun test /private/tmp/eliza-30097-pricing-cold-hydration/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts /private/tmp/eliza-30097-pricing-cold-hydration/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts` from `/private/tmp` — 34 pass, 0 fail, 200 assertions
- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/ai-pricing/cache.ts packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts` — pass
- `git diff --check` — pass
- `git merge-base --is-ancestor 7cd2d742ed9c014736e68877fa52d81188d423a2 94751141d8e9e0ad87ad01c023f27a1834af077b` — pass

## Evidence applicability

- UI screenshots / mobile captures / walkthrough: N/A — backend pricing-cache and admission behavior only
- provider trajectory: N/A — the regression occurs before model-provider dispatch; the test asserts admission remains blocked until exact pricing resolves
- database or ledger artifact: N/A — no schema or settlement mutation; this changes only pre-dispatch cache hydration coordination
- exact-SHA staging certification: not run from this PR branch because staging deploy authority was not part of this change. Post-deploy acceptance remains the 22/22 gateway certification in #30097 with no `billing_cache_warming`; the independent rate-limit cold failure remains out of scope.
