### PR TITLE
fix(plugin-vision): null silence timer on re-arm so end-of-utterance detection survives intra-utterance pauses

### DIFF
--- a/plugins/plugin-vision/src/audio-capture-stream.ts
+++ b/plugins/plugin-vision/src/audio-capture-stream.ts
@@ -194,9 +194,13 @@ export class StreamingAudioCaptureService extends EventEmitter {
       // Add to buffer
       this.audioBuffer.push(audioChunk);
 
-      // Reset silence timer
+      // Reset silence timer. Null the handle after clearing so the
+      // `if (!this.silenceTimer)` re-arm guard below can schedule a fresh
+      // end-of-speech countdown once the user pauses again; a stale truthy
+      // handle would permanently block re-arming and drop the utterance.
       if (this.silenceTimer) {
         clearTimeout(this.silenceTimer);
+        this.silenceTimer = null;
       }
 
       // Start streaming transcription if not already running

--- a/plugins/plugin-vision/src/audio-capture-stream.vad.test.ts
+++ b/plugins/plugin-vision/src/audio-capture-stream.vad.test.ts
@@ -1,0 +1,152 @@
+/**
+ * End-of-utterance detection for the streaming-audio VAD state machine.
+ *
+ * `StreamingAudioCaptureService` uses `silenceTimer` both as a live handle and
+ * as the "is a silence countdown armed?" flag through the `if (!this.silenceTimer)`
+ * re-arm guard. This deterministic harness drives the private `processAudioChunk`
+ * with synthetic PCM buffers under fake timers — no microphone — to prove that a
+ * speech -> pause -> speech -> pause sequence still schedules `endSpeech()`, so
+ * `speechEnd` fires and `processFinalTranscription()` reaches the model. The
+ * regression: the reset branch cleared the timer without nulling it, leaving a
+ * stale truthy handle that permanently blocked re-arming after the first
+ * intra-utterance pause and silently dropped the whole utterance.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  StreamingAudioCaptureService,
+  type StreamingAudioConfig,
+} from "./audio-capture-stream";
+
+const CHUNK_BYTES = 200;
+const SILENCE_TIMEOUT = 1000;
+
+/** A 200-byte S16LE buffer whose every sample is `value`. */
+function pcmChunk(value: number): Buffer {
+  const buffer = Buffer.alloc(CHUNK_BYTES);
+  for (let i = 0; i < CHUNK_BYTES; i += 2) {
+    buffer.writeInt16LE(value, i);
+  }
+  return buffer;
+}
+
+/** High-energy speech (RMS well above the VAD threshold). */
+const SPEECH = () => pcmChunk(30000);
+/** Silence (zero energy, below the VAD threshold). */
+const SILENCE = () => pcmChunk(0);
+
+type Harness = {
+  service: StreamingAudioCaptureService;
+  useModel: ReturnType<typeof vi.fn>;
+  feed: (chunk: Buffer) => void;
+  silenceTimerHandle: () => NodeJS.Timeout | null;
+};
+
+function makeHarness(overrides: Partial<StreamingAudioConfig> = {}): Harness {
+  const useModel = vi.fn().mockResolvedValue("final transcription");
+  const runtime = {
+    agentId: "test-agent",
+    getService: () => null,
+    reportError: () => {},
+    useModel,
+  } as unknown as ConstructorParameters<typeof StreamingAudioCaptureService>[0];
+
+  const service = new StreamingAudioCaptureService(runtime, {
+    enabled: true,
+    silenceTimeout: SILENCE_TIMEOUT,
+    vadThreshold: 0.01,
+    ...overrides,
+  });
+
+  const internals = service as unknown as {
+    processAudioChunk: (chunk: Buffer) => void;
+    transcriptionInProgress: boolean;
+    silenceTimer: NodeJS.Timeout | null;
+  };
+  // Force transcription "in progress" so the streaming-transcription path is
+  // inert and the test isolates the pure VAD/silence-timer state machine.
+  internals.transcriptionInProgress = true;
+
+  return {
+    service,
+    useModel,
+    feed: (chunk: Buffer) => internals.processAudioChunk(chunk),
+    silenceTimerHandle: () => internals.silenceTimer,
+  };
+}
+
+describe("StreamingAudioCaptureService end-of-utterance detection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("emits speechEnd once after speech -> pause -> speech -> pause", async () => {
+    const { service, useModel, feed } = makeHarness();
+    const speechEnd = vi.fn();
+    service.on("speechEnd", speechEnd);
+
+    // Utterance with an intra-utterance pause: speak, breathe, keep speaking,
+    // then actually stop. The middle silence must not permanently disarm the
+    // end-of-speech countdown.
+    feed(SPEECH());
+    feed(SILENCE());
+    feed(SPEECH());
+    feed(SILENCE());
+
+    // The trailing silence must have re-armed the end-of-speech countdown.
+    expect(speechEnd).toHaveBeenCalledTimes(0);
+
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 500);
+
+    expect(speechEnd).toHaveBeenCalledTimes(1);
+    // processFinalTranscription() ran and reached the transcription model.
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(service.isSpeechActive()).toBe(false);
+  });
+
+  it("emits speechEnd once for a simple speech -> silence utterance", async () => {
+    const { service, useModel, feed } = makeHarness();
+    const speechEnd = vi.fn();
+    service.on("speechEnd", speechEnd);
+
+    feed(SPEECH());
+    feed(SILENCE());
+
+    expect(speechEnd).toHaveBeenCalledTimes(0);
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 500);
+
+    expect(speechEnd).toHaveBeenCalledTimes(1);
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms rather than double-arms the silence timer across a pause", async () => {
+    const { service, feed, silenceTimerHandle } = makeHarness();
+    const speechEnd = vi.fn();
+    service.on("speechEnd", speechEnd);
+
+    feed(SPEECH());
+    feed(SILENCE());
+    const firstArmed = silenceTimerHandle();
+    expect(firstArmed).not.toBeNull();
+
+    // Resumed speech must clear AND null the pending countdown so the guard can
+    // re-arm on the next pause instead of being permanently blocked.
+    feed(SPEECH());
+    expect(silenceTimerHandle()).toBeNull();
+
+    feed(SILENCE());
+    const secondArmed = silenceTimerHandle();
+    expect(secondArmed).not.toBeNull();
+    // A genuinely re-armed (not stale) handle fires exactly one endSpeech.
+    expect(secondArmed).not.toBe(firstArmed);
+
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 500);
+    expect(speechEnd).toHaveBeenCalledTimes(1);
+    // The fired timer is cleared back to null by endSpeech().
+    expect(silenceTimerHandle()).toBeNull();
+  });
+});

--- a/plugins/plugin-vision/src/audio-capture-stream.vad.test.ts
+++ b/plugins/plugin-vision/src/audio-capture-stream.vad.test.ts
@@ -100,7 +100,9 @@ describe("StreamingAudioCaptureService end-of-utterance detection", () => {
     // The trailing silence must have re-armed the end-of-speech countdown.
     expect(speechEnd).toHaveBeenCalledTimes(0);
 
-    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 500);
+    // Advance just past the configured timeout (not the hardcoded 1500 default),
+    // so a build that ignored `config.silenceTimeout` would not fire here.
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 100);
 
     expect(speechEnd).toHaveBeenCalledTimes(1);
     // processFinalTranscription() ran and reached the transcription model.
@@ -117,7 +119,7 @@ describe("StreamingAudioCaptureService end-of-utterance detection", () => {
     feed(SILENCE());
 
     expect(speechEnd).toHaveBeenCalledTimes(0);
-    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 500);
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 100);
 
     expect(speechEnd).toHaveBeenCalledTimes(1);
     expect(useModel).toHaveBeenCalledTimes(1);
@@ -144,9 +146,30 @@ describe("StreamingAudioCaptureService end-of-utterance detection", () => {
     // A genuinely re-armed (not stale) handle fires exactly one endSpeech.
     expect(secondArmed).not.toBe(firstArmed);
 
-    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 500);
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 100);
     expect(speechEnd).toHaveBeenCalledTimes(1);
     // The fired timer is cleared back to null by endSpeech().
     expect(silenceTimerHandle()).toBeNull();
+  });
+
+  it("does not end speech from a stale countdown when the pause is followed by more speech", async () => {
+    const { service, feed } = makeHarness();
+    const speechEnd = vi.fn();
+    service.on("speechEnd", speechEnd);
+
+    // Pin the *cancel* half of the invariant: resuming speech must clear the
+    // pending countdown, not merely null the handle. Time passes during the
+    // pause, then the user resumes and keeps talking past the moment the first
+    // countdown would have expired. A stale-but-live timer (nulled without
+    // clearing) would fire mid-speech and drop the utterance.
+    feed(SPEECH());
+    feed(SILENCE());
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT - 200);
+    feed(SPEECH());
+    await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT);
+    feed(SPEECH());
+
+    expect(speechEnd).toHaveBeenCalledTimes(0);
+    expect(service.isSpeechActive()).toBe(true);
   });
 });


### PR DESCRIPTION
# Relates to

Closes #30103

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks below pass. Repo-wide `bun run verify` note in **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the failing-then-passing test evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`7cd2d742ed`); zero conflicts.
- [ ] `bun run verify` — see **Known gaps / failures** for the single pre-existing, unrelated typecheck blocker.

# Risks

Low. The change is a one-line teardown correction inside `StreamingAudioCaptureService.processAudioChunk`. It only affects the `plugin-vision` streaming-audio VAD state machine and strictly restores the intended re-arm invariant already used by every other timer teardown in the class (`responseTimer`, `endSpeech()`, `stop()`). No public surface, config, type, or export changes.

# Background

## What does this PR do?

`StreamingAudioCaptureService` uses `this.silenceTimer` **both** as a live timer handle **and** as the "is a silence countdown armed?" flag through the re-arm guard `if (!this.silenceTimer)`. When speech resumes after a brief intra-utterance pause, `processAudioChunk` cleared the pending silence timer with `clearTimeout(this.silenceTimer)` but never reset the handle to `null` — unlike the adjacent `responseTimer`, `endSpeech()`, and `stop()`, which all null their handles.

The stale truthy handle then permanently blocked `if (!this.silenceTimer)` from arming a new silence timer. Consequence: after any `speech → pause → speech` sequence, when the user actually stops talking `endSpeech()` is never scheduled — `speechEnd` is never emitted, `processFinalTranscription()` never runs, and the final transcription + response are never produced. Real voice interaction (speak, take a breath, keep speaking, then stop) silently dropped the whole utterance and the agent never responded.

The fix nulls the handle after clearing it, matching every other timer teardown in the class:

```ts
// Reset silence timer.
if (this.silenceTimer) {
  clearTimeout(this.silenceTimer);
  this.silenceTimer = null;   // <-- restores the re-arm invariant
}
```

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior corrected is internal to the VAD state machine and matches the already-documented intent of the surrounding teardown code.

# Testing

## Where should a reviewer start?

`plugins/plugin-vision/src/audio-capture-stream.vad.test.ts` — a deterministic, hardware-free regression test. It drives the private `processAudioChunk` with synthetic 200-byte S16LE PCM buffers (high-energy `30000` = speech, zero = silence) under Vitest fake timers, so no microphone is needed.

## Detailed testing steps

```bash
bun install
bunx vitest run src/audio-capture-stream.vad.test.ts   # from plugins/plugin-vision
```

The suite covers four cases:
1. `speech → pause → speech → pause` asserts `speechEnd` fires **exactly once** and `useModel` (the transcription model, reached via `processFinalTranscription()`) is called once. This is the regression that was silently broken.
2. simple `speech → silence` asserts no regression to the single-utterance path.
3. asserts the silence timer is genuinely **re-armed** across a pause (`clear + null`, new handle `!== firstArmed`), not stale or double-armed, and is nulled again by `endSpeech()`.
4. pins the *cancel* half of the invariant: resuming speech past the moment the first countdown would have expired must **clear** (not merely null) the pending timer, so a stale-but-live countdown cannot fire mid-speech and drop the utterance. The three timer-advance windows also observe the **configured** `silenceTimeout` (advance by `+100`, not the earlier `+500` that coincided with the hardcoded `1500` default), so a build ignoring the configured value no longer passes. Both refinements were adopted from reviewer coverage notes.

# Evidence Gate

<!-- evidence-head:0427deeb1979d11ef64ef48ae774ea1a25ee1ac1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; Node-only VAD/timer state-machine fix in plugin-vision.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface; Node-only VAD/timer state-machine fix in plugin-vision.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered user flow; reproduction is a headless Vitest fake-timer run shown inline below.
<!-- evidence-row:backend-logs -->
- [x] Real `bunx vitest run src/audio-capture-stream.vad.test.ts` output, captured on this PR head (`0427deeb1`). Failing BEFORE the one-line fix (2 of 4 tests), passing AFTER — exactly reproducible with the single command in **Testing**.

<details>
<summary>BEFORE fix (silenceTimer handle left truthy) — real Vitest output, 2 of 4 tests fail</summary>

```
 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-30106/plugins/plugin-vision

 ❯ src/audio-capture-stream.vad.test.ts (4 tests | 2 failed) 34ms
     × emits speechEnd once after speech -> pause -> speech -> pause 14ms
     × re-arms rather than double-arms the silence timer across a pause 7ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/audio-capture-stream.vad.test.ts > StreamingAudioCaptureService end-of-utterance detection > emits speechEnd once after speech -> pause -> speech -> pause
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ src/audio-capture-stream.vad.test.ts:107:23
    105|     await vi.advanceTimersByTimeAsync(SILENCE_TIMEOUT + 100);
    106|
    107|     expect(speechEnd).toHaveBeenCalledTimes(1);
       |                       ^
    108|     // processFinalTranscription() ran and reached the transcription m…
    109|     expect(useModel).toHaveBeenCalledTimes(1);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  src/audio-capture-stream.vad.test.ts > StreamingAudioCaptureService end-of-utterance detection > re-arms rather than double-arms the silence timer across a pause
AssertionError: expected { refed: true, …(4), …(1) } to be null

- Expected:
null

+ Received:
{
  "hasRef": [Function hasRef],
  "ref": [Function ref],
  "refed": true,
  "refresh": [Function refresh],
  "unref": [Function unref],
  Symbol(Symbol.toPrimitive): [Function [Symbol.toPrimitive]],
}

 ❯ src/audio-capture-stream.vad.test.ts:141:34
    139|     // re-arm on the next pause instead of being permanently blocked.
    140|     feed(SPEECH());
    141|     expect(silenceTimerHandle()).toBeNull();
       |                                  ^
    142|
    143|     feed(SILENCE());

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
   Start at  20:41:54
   Duration  14.43s (transform 12.53s, setup 0ms, import 14.19s, tests 34ms, environment 0ms)
```

</details>

<details>
<summary>AFTER fix (this.silenceTimer = null) — real Vitest output, all 4 tests pass</summary>

```
 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-30106/plugins/plugin-vision


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  20:42:09
   Duration  14.45s (transform 12.50s, setup 0ms, import 14.24s, tests 25ms, environment 0ms)
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend; the change never reaches a browser surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/model/agent behavior change; useModel is only observed to prove processFinalTranscription() is reached.
<!-- evidence-row:domain-artifacts -->
- [x] The reviewed production change is a one-line teardown correction in `StreamingAudioCaptureService.processAudioChunk`; the exact hunk under review (git-verifiable against `0427deeb1`; production code is unchanged from the approved head — this update only strengthens the VAD tests):

```diff
diff --git a/plugins/plugin-vision/src/audio-capture-stream.ts b/plugins/plugin-vision/src/audio-capture-stream.ts
index a526de46be..049338527b 100644
--- a/plugins/plugin-vision/src/audio-capture-stream.ts
+++ b/plugins/plugin-vision/src/audio-capture-stream.ts
@@ -194,9 +194,13 @@ export class StreamingAudioCaptureService extends EventEmitter {
       // Add to buffer
       this.audioBuffer.push(audioChunk);
 
-      // Reset silence timer
+      // Reset silence timer. Null the handle after clearing so the
+      // `if (!this.silenceTimer)` re-arm guard below can schedule a fresh
+      // end-of-speech countdown once the user pauses again; a stale truthy
+      // handle would permanently block re-arming and drop the utterance.
       if (this.silenceTimer) {
         clearTimeout(this.silenceTimer);
+        this.silenceTimer = null;
       }
 
       // Start streaming transcription if not already running
```
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change. The transcription `useModel` call is only observed (via a stub) to prove `processFinalTranscription()` is reached after the fix.

## Backend + frontend logs

Frontend: N/A - no frontend surface.

Backend / test transcript: the real failing-BEFORE / passing-AFTER `bunx vitest run` output is embedded in the **Backend logs** evidence row above, captured on this PR head (`0427deeb1`). Both blocks are verbatim tool output (real durations, real Vitest v4.1.10 banner, real assertion dumps), not a paraphrase, and reproduce with the single command in **Testing**.

The one-line diff under review (also carried inline in the **Domain artifacts** evidence row above):

```diff
       // Add to buffer
       this.audioBuffer.push(audioChunk);

-      // Reset silence timer
+      // Reset silence timer. Null the handle after clearing so the
+      // `if (!this.silenceTimer)` re-arm guard below can schedule a fresh
+      // end-of-speech countdown once the user pauses again; a stale truthy
+      // handle would permanently block re-arming and drop the utterance.
       if (this.silenceTimer) {
         clearTimeout(this.silenceTimer);
+        this.silenceTimer = null;
       }
```

## Screenshots (before / after) + video walkthrough

N/A - no UI change (Node-only `plugin-vision` internal state machine).

### Walkthrough video

N/A - no rendered user flow; the headless fake-timer reproduction above is the complete proof.

## Audio / voice walkthrough

N/A - the change corrects timer teardown in the VAD state machine and does not alter audio capture, transcription, or TTS output. The regression is proven deterministically with synthetic PCM buffers under fake timers; a live microphone would add no signal a reviewer can verify, whereas the fake-timer transcript is exactly reproducible.

## Known gaps / failures

- Full-package `bun run --cwd plugins/plugin-vision typecheck` reports one **pre-existing, unrelated** error in `src/index.ts(122,9)`: `Cannot find module '@elizaos/plugin-computeruse/mobile/ocr-provider'` (an unbuilt optional sibling package). Confirmed present on a clean `origin/develop` checkout (`git stash` + typecheck) before my change, in a file this PR does not touch. `biome lint`/`format` on both touched files are clean; the focused test suite passes.
- Evidence artifacts are embedded inline (per CONTRIBUTING.md § Evidence, "long logs in a `<details>` block") rather than as release-asset URLs: `node scripts/pr-evidence.mjs attach 30106 ...` was re-attempted and returns `HTTP 404` on `uploads.github.com` because this fork account lacks push access to the upstream `pr-evidence` release (`gh api repos/elizaOS/eliza/collaborators/agent-cortex/permission` returns `403 Must have push access`). The `user-attachments` uploader needs an interactive browser session that a headless CLI run cannot mint. All inline proof is verbatim tool output and reproduces with the single `bunx vitest run` command above.

## Maintainer CI exception record

N/A - no exception requested.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@413405be920734c92d760c8cd2f68288014076fa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@413405be920734c92d760c8cd2f68288014076fa:packages/skills/skills/contribute-to-eliza"} -->


