### PR TITLE
perf(cloud): add SHA-locked placement A/B certification

### DIFF
--- a/.github/workflows/cloud-placement-ab.yml
+++ b/.github/workflows/cloud-placement-ab.yml
@@ -1,0 +1,109 @@
+name: Cloud Placement A/B
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_deploy_sha:
+        description: Exact 40-character develop SHA served by both staging arms.
+        required: true
+        type: string
+      smart_base_url:
+        description: Credential-free HTTPS origin for the Smart Placement staging arm.
+        required: true
+        type: string
+      control_base_url:
+        description: Credential-free HTTPS workers.dev origin for the default-placement staging arm.
+        required: true
+        type: string
+      smart_worker:
+        description: Cloudflare service name for the Smart Placement staging arm.
+        required: true
+        type: string
+      control_worker:
+        description: Cloudflare service name for the default-placement staging arm.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloud-placement-ab-staging
+  cancel-in-progress: false
+
+jobs:
+  certify-placement:
+    name: Certify staging Smart Placement against default placement
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    environment: staging
+    env:
+      NODE_VERSION: "24.15.0"
+      EXPECTED_DEPLOY_SHA: ${{ inputs.expected_deploy_sha }}
+      SMART_BASE_URL: ${{ inputs.smart_base_url }}
+      CONTROL_BASE_URL: ${{ inputs.control_base_url }}
+      SMART_WORKER: ${{ inputs.smart_worker }}
+      CONTROL_WORKER: ${{ inputs.control_worker }}
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      ELIZA_GATEWAY_DEPLOY_SHA: ${{ inputs.expected_deploy_sha }}
+    steps:
+      - name: Validate trusted exact-SHA staging dispatch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$EXPECTED_DEPLOY_SHA" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "::error::expected_deploy_sha must be a lowercase 40-character commit."
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/heads/develop" || "$GITHUB_SHA" != "$EXPECTED_DEPLOY_SHA" ]]; then
+            echo "::error::Dispatch develop at the exact SHA served by both staging arms."
+            exit 1
+          fi
+          required=(ELIZAOS_CLOUD_API_KEY CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID)
+          for name in "${required[@]}"; do
+            value_without_whitespace="${!name:-}"
+            value_without_whitespace="${value_without_whitespace//[[:space:]]/}"
+            if [[ -z "$value_without_whitespace" ]]; then
+              echo "::error::Missing protected staging secret: $name"
+              exit 1
+            fi
+          done
+          unset value_without_whitespace
+          echo "Protected staging credential names are configured; values were not printed."
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Run exact-SHA privacy-safe placement A/B
+        shell: bash
+        run: |
+          set -euo pipefail
+          node packages/cloud/scripts/cloud-placement-ab.mjs \
+            --deploy-sha "$EXPECTED_DEPLOY_SHA" \
+            --smart-base-url "$SMART_BASE_URL" \
+            --control-base-url "$CONTROL_BASE_URL" \
+            --smart-worker "$SMART_WORKER" \
+            --control-worker "$CONTROL_WORKER" \
+            --success-pairs 30 \
+            --max-attempts 45 \
+            --output-dir "$GITHUB_WORKSPACE/artifacts/cloud-placement-ab"
+
+      - name: Upload sanitized placement evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cloud-placement-ab-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/cloud-placement-ab/placement-ab.jsonl
+            artifacts/cloud-placement-ab/summary.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -199,6 +199,8 @@
     "cloud:reconcile-steward-email-callback": "bun packages/cloud/scripts/reconcile-steward-email-callback-config.mjs",
     "cloud:chat-latency": "node packages/cloud/scripts/chat-latency.mjs",
     "test:chat-latency": "node --test packages/cloud/scripts/chat-latency.test.mjs",
+    "cloud:placement-ab": "node packages/cloud/scripts/cloud-placement-ab.mjs",
+    "test:placement-ab": "node --test packages/cloud/scripts/cloud-placement-ab.test.mjs",
     "cloud:inference-auth-latency": "node packages/cloud/scripts/inference-auth-latency.mjs",
     "test:inference-auth-latency": "node --test packages/cloud/scripts/inference-auth-latency.test.mjs",
     "cloud:group-room-sim": "bun packages/cloud/scripts/group-room-sim/run-room-sim.ts",

--- a/packages/cloud/api/docs/placement-ab.md
+++ b/packages/cloud/api/docs/placement-ab.md
@@ -1,0 +1,60 @@
+# Staging placement A/B
+
+The API Worker mixes latency-sensitive Durable Object calls, Hyperdrive access,
+and external model-provider requests. Smart Placement optimizes the whole fetch
+handler, so a remote execution decision can help one origin while adding a
+cross-region round trip to another. Do not infer a Durable Object's location
+from `cf-placement`: that header identifies Worker fetch-handler execution.
+
+Use `.github/workflows/cloud-placement-ab.yml` only after an operator has
+provisioned a temporary default-placement staging control Worker. The workflow
+does not deploy, edit, or delete Workers. It rejects production origins and
+names, verifies that both health endpoints serve the requested develop SHA,
+confirms the treatment reports Smart Placement and the control reports no
+placement mode, and compares a privacy-safe fingerprint of their binding
+topology before sending probes.
+
+## Control-arm requirements
+
+- Deploy the exact same source SHA as `eliza-cloud-api-staging` under a Worker
+  name containing `staging`, with a `workers.dev` origin and no placement stanza.
+- Bind the canonical staging Durable Object namespaces externally. Do not let
+  the control Worker create fresh namespaces: existing Objects retain their
+  original locations, and divergent state would invalidate the comparison.
+- Reuse the staging Hyperdrive, KV, R2, rate-limit, and service resources. The
+  workflow compares resource identifiers and binding names/types through the
+  Workers settings API and fails if the structural fingerprint differs.
+- Copy the same protected staging secrets through the account's approved secret
+  process. Cloudflare exposes secret binding names, not values, so value parity
+  remains an operator-controlled prerequisite that the workflow cannot prove.
+- Keep the control unrouted from production and canonical staging domains. The
+  workflow accepts only `api-staging.eliza.app` or a staging-named
+  `workers.dev` origin.
+
+Provisioning and cleanup are Cloudflare account mutations and require explicit
+operator authorization. Record the control Worker name, source SHA, binding
+readback, secret-copy procedure, and deletion readback in issue #30099. Do not
+run the A/B while the control is missing or while either arm has a different
+binding fingerprint.
+
+## Evidence contract
+
+Each pair sends the same generated proof request to both arms concurrently.
+The runner continues until it has 30 successful warm pairs or reaches 45
+attempts, with separate cold and post-idle controls. Artifacts retain only
+bounded placement/colo headers, trace identifiers, phase timings, status/error
+tokens, usage counts, output length, and whether the proof matched. Prompts,
+generated text, keys, response bodies, and secret values are never written.
+
+The summary reports success/failure counts and p50/p90/p95 for response headers,
+first visible token, total time, upstream headers, and each gateway preforward
+phase, stratified by arm and observed `cf-placement`. It also captures placement
+status before and after the window. A result is evidence for the tested SHA and
+traffic window only; it is not authorization to change production placement.
+
+Cloudflare references:
+
+- [Workers Placement](https://developers.cloudflare.com/workers/configuration/placement/)
+- [Durable Objects data location](https://developers.cloudflare.com/durable-objects/reference/data-location/)
+- [Durable Object environments](https://developers.cloudflare.com/durable-objects/reference/environments/)
+- [Hyperdrive architecture](https://developers.cloudflare.com/hyperdrive/concepts/how-hyperdrive-works/)

--- a/packages/cloud/scripts/cloud-placement-ab.mjs
+++ b/packages/cloud/scripts/cloud-placement-ab.mjs
@@ -1,0 +1,477 @@
+#!/usr/bin/env node
+/**
+ * Certifies a staging-only Smart Placement A/B against two pre-provisioned
+ * Workers while retaining bounded timing and placement metadata only.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import { parseProbeCase, probeOpenAi } from "./chat-latency.mjs";
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const WORKER_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const DEFAULT_SUCCESS_PAIRS = 30;
+const DEFAULT_MAX_ATTEMPTS = 45;
+
+function boundedInteger(value, label, minimum, maximum) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(
+      `${label} must be an integer between ${minimum} and ${maximum}`,
+    );
+  }
+  return parsed;
+}
+
+function boundedToken(value, fallback = "unknown") {
+  return typeof value === "string" && /^[A-Za-z0-9_.:-]{1,100}$/.test(value)
+    ? value
+    : fallback;
+}
+
+export function validateStagingArmUrl(raw, label) {
+  let url;
+  try {
+    url = new URL(raw);
+  } catch (cause) {
+    throw new Error(`${label} must be an absolute URL`, { cause });
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error(`${label} must be a credential-free HTTPS origin`);
+  }
+  const hostname = url.hostname.toLowerCase();
+  const allowed =
+    hostname === "api-staging.eliza.app" ||
+    (hostname.endsWith(".workers.dev") && hostname.includes("staging"));
+  if (!allowed || hostname.includes("prod")) {
+    throw new Error(`${label} must identify a staging Worker origin`);
+  }
+  return url.origin;
+}
+
+export function validateStagingWorkerName(value, label) {
+  const name = value.trim();
+  if (
+    !WORKER_PATTERN.test(name) ||
+    !name.includes("staging") ||
+    name.includes("prod")
+  ) {
+    throw new Error(`${label} must be a staging-only Worker name`);
+  }
+  return name;
+}
+
+export function parsePlacementAbArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      "deploy-sha": { type: "string" },
+      "smart-base-url": { type: "string" },
+      "control-base-url": { type: "string" },
+      "smart-worker": { type: "string" },
+      "control-worker": { type: "string" },
+      "output-dir": { type: "string" },
+      "success-pairs": {
+        type: "string",
+        default: String(DEFAULT_SUCCESS_PAIRS),
+      },
+      "max-attempts": {
+        type: "string",
+        default: String(DEFAULT_MAX_ATTEMPTS),
+      },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  const deploySha = values["deploy-sha"]?.trim() ?? "";
+  if (!SHA_PATTERN.test(deploySha)) {
+    throw new Error("--deploy-sha must be a lowercase 40-character commit");
+  }
+  const outputDir = values["output-dir"]?.trim();
+  if (!outputDir) throw new Error("--output-dir is required");
+  const successPairs = boundedInteger(
+    values["success-pairs"],
+    "success-pairs",
+    30,
+    100,
+  );
+  const maxAttempts = boundedInteger(
+    values["max-attempts"],
+    "max-attempts",
+    successPairs,
+    150,
+  );
+  const smartBaseUrl = validateStagingArmUrl(
+    values["smart-base-url"] ?? "",
+    "--smart-base-url",
+  );
+  const controlBaseUrl = validateStagingArmUrl(
+    values["control-base-url"] ?? "",
+    "--control-base-url",
+  );
+  const smartWorker = validateStagingWorkerName(
+    values["smart-worker"] ?? "",
+    "--smart-worker",
+  );
+  const controlWorker = validateStagingWorkerName(
+    values["control-worker"] ?? "",
+    "--control-worker",
+  );
+  if (smartBaseUrl === controlBaseUrl || smartWorker === controlWorker) {
+    throw new Error("Smart and control arms must be distinct Workers");
+  }
+  return {
+    deploySha,
+    smartBaseUrl,
+    controlBaseUrl,
+    smartWorker,
+    controlWorker,
+    outputDir: resolve(outputDir),
+    successPairs,
+    maxAttempts,
+  };
+}
+
+export async function verifyArmDeployment(
+  { arm, baseUrl, deploySha },
+  fetchImpl = fetch,
+) {
+  let response;
+  try {
+    response = await fetchImpl(`${baseUrl}/api/health`, {
+      headers: { "user-agent": "eliza-cloud-placement-ab/1.0" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (cause) {
+    throw new Error(`${arm} health request failed`, { cause });
+  }
+  if (!response.ok) throw new Error(`${arm} health returned HTTP ${response.status}`);
+  const body = await response.json();
+  if (body?.commit !== deploySha || body?.environment !== "staging") {
+    throw new Error(`${arm} did not serve the exact staging commit`);
+  }
+  return {
+    arm,
+    deploySha,
+    environment: "staging",
+    placement: boundedToken(response.headers.get("cf-placement"), "absent"),
+    colo: boundedToken(response.headers.get("cf-ray")?.split("-").at(-1)),
+  };
+}
+
+export function sanitizePlacementServiceResult(worker, payload) {
+  if (payload?.success !== true) {
+    throw new Error(`Cloudflare placement status failed for ${worker}`);
+  }
+  const script = payload.result?.default_environment?.script ?? payload.result?.script;
+  const placement = script?.placement;
+  return {
+    worker,
+    mode: boundedToken(placement?.mode ?? script?.placement_mode, "absent"),
+    status: boundedToken(
+      placement?.status ?? script?.placement_status,
+      "absent",
+    ),
+    lastAnalyzedAt:
+      typeof placement?.last_analyzed_at === "string"
+        ? placement.last_analyzed_at
+        : null,
+  };
+}
+
+export async function readPlacementStatus(
+  { worker, accountId, apiToken },
+  fetchImpl = fetch,
+) {
+  let response;
+  try {
+    response = await fetchImpl(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/workers/services/${encodeURIComponent(worker)}`,
+      {
+        headers: {
+          authorization: `Bearer ${apiToken}`,
+          "content-type": "application/json",
+        },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch (cause) {
+    throw new Error(`Cloudflare placement status request failed for ${worker}`, {
+      cause,
+    });
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Cloudflare placement status returned HTTP ${response.status} for ${worker}`,
+    );
+  }
+  return sanitizePlacementServiceResult(worker, await response.json());
+}
+
+export function fingerprintWorkerBindings(worker, payload) {
+  if (payload?.success !== true || !Array.isArray(payload.result?.bindings)) {
+    throw new Error(`Cloudflare binding readback failed for ${worker}`);
+  }
+  const bindings = payload.result.bindings
+    .map((binding) => ({
+      name: boundedToken(binding?.name),
+      type: boundedToken(binding?.type),
+      namespaceId: boundedToken(binding?.namespace_id, "absent"),
+      id: boundedToken(binding?.id, "absent"),
+      bucketName: boundedToken(binding?.bucket_name, "absent"),
+      className: boundedToken(binding?.class_name, "absent"),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const types = Object.fromEntries(
+    [...Map.groupBy(bindings, (binding) => binding.type).entries()]
+      .map(([type, group]) => [type, group.length])
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return {
+    worker,
+    bindingCount: bindings.length,
+    types,
+    fingerprint: createHash("sha256")
+      .update(JSON.stringify(bindings))
+      .digest("hex"),
+  };
+}
+
+export async function readWorkerBindingContract(
+  { worker, accountId, apiToken },
+  fetchImpl = fetch,
+) {
+  let response;
+  try {
+    response = await fetchImpl(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/workers/scripts/${encodeURIComponent(worker)}/settings`,
+      {
+        headers: { authorization: `Bearer ${apiToken}` },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch (cause) {
+    throw new Error(`Cloudflare binding readback failed for ${worker}`, { cause });
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Cloudflare binding readback returned HTTP ${response.status} for ${worker}`,
+    );
+  }
+  return fingerprintWorkerBindings(worker, await response.json());
+}
+
+function percentile(values, quantile) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = (sorted.length - 1) * quantile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const value =
+    lower === upper
+      ? sorted[lower]
+      : sorted[lower] * (1 - (index - lower)) + sorted[upper] * (index - lower);
+  return Math.round(value * 100) / 100;
+}
+
+function metric(records, selector) {
+  const values = records.map(selector).filter(Number.isFinite);
+  return {
+    p50: percentile(values, 0.5),
+    p90: percentile(values, 0.9),
+    p95: percentile(values, 0.95),
+  };
+}
+
+export function summarizePlacementRecords(records) {
+  const groups = Map.groupBy(
+    records.filter((record) => record.phase === "warm"),
+    (record) => `${record.arm}:${record.headers?.["cf-placement"] ?? "absent"}`,
+  );
+  return [...groups.entries()]
+    .map(([key, group]) => {
+      const successful = group.filter((record) => record.ok === true);
+      const [arm, placement] = key.split(":", 2);
+      return {
+        arm,
+        placement,
+        attempts: group.length,
+        successes: successful.length,
+        failures: group.length - successful.length,
+        responseHeadersMs: metric(successful, (record) => record.responseHeadersMs),
+        firstTokenMs: metric(successful, (record) => record.firstTokenMs),
+        totalMs: metric(successful, (record) => record.totalMs),
+        preforwardTotalMs: metric(successful, (record) => record.preforward?.total),
+        preforwardAuthMs: metric(successful, (record) => record.preforward?.auth),
+        preforwardMiddleMs: metric(successful, (record) => record.preforward?.mid),
+        preforwardReserveMs: metric(successful, (record) => record.preforward?.reserve),
+        preforwardSetupMs: metric(successful, (record) => record.preforward?.setup),
+        upstreamHeadersMs: metric(
+          successful,
+          (record) => record.serverTiming?.upstream_headers,
+        ),
+      };
+    })
+    .sort((left, right) => left.arm.localeCompare(right.arm));
+}
+
+function requiredSecret(env, name) {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`Required protected secret is missing: ${name}`);
+  return value;
+}
+
+async function sleep(durationMs) {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, durationMs));
+}
+
+async function runProbePair({ options, apiKey, phase, sequence, fetchImpl }) {
+  const proof = `placement-proof-${randomUUID()}`;
+  const pairId = randomUUID();
+  const probeCase = parseProbeCase("gemma-4-31b@omit@512");
+  return await Promise.all(
+    [
+      ["smart", options.smartBaseUrl],
+      ["control", options.controlBaseUrl],
+    ].map(async ([arm, baseUrl]) =>
+      probeOpenAi({
+        target: arm,
+        probeCase,
+        baseUrl,
+        apiKey,
+        proof,
+        timeoutMs: 30_000,
+        sequence,
+        promptCacheKey: `placement-ab-${options.deploySha}`,
+        metadata: { arm, phase, pairId, deploySha: options.deploySha },
+        fetchImpl,
+      }),
+    ),
+  );
+}
+
+export async function runPlacementAb(
+  options,
+  { env = process.env, fetchImpl = fetch } = {},
+) {
+  const apiKey = requiredSecret(env, "ELIZAOS_CLOUD_API_KEY");
+  const apiToken = requiredSecret(env, "CLOUDFLARE_API_TOKEN");
+  const accountId = requiredSecret(env, "CLOUDFLARE_ACCOUNT_ID");
+  await mkdir(options.outputDir, { recursive: true, mode: 0o700 });
+
+  const arms = [
+    { arm: "smart", baseUrl: options.smartBaseUrl, worker: options.smartWorker },
+    {
+      arm: "control",
+      baseUrl: options.controlBaseUrl,
+      worker: options.controlWorker,
+    },
+  ];
+  const deployments = await Promise.all(
+    arms.map((arm) => verifyArmDeployment({ ...arm, deploySha: options.deploySha }, fetchImpl)),
+  );
+  const placementBefore = await Promise.all(
+    arms.map(({ worker }) =>
+      readPlacementStatus({ worker, accountId, apiToken }, fetchImpl),
+    ),
+  );
+  if (placementBefore[0]?.mode !== "smart") {
+    throw new Error("Smart arm is not configured for Smart Placement");
+  }
+  if (placementBefore[1]?.mode !== "absent") {
+    throw new Error("Control arm must use default placement");
+  }
+  const bindingContracts = await Promise.all(
+    arms.map(({ worker }) =>
+      readWorkerBindingContract({ worker, accountId, apiToken }, fetchImpl),
+    ),
+  );
+  if (bindingContracts[0]?.fingerprint !== bindingContracts[1]?.fingerprint) {
+    throw new Error("Placement arms do not have identical binding topology");
+  }
+
+  const records = [];
+  records.push(
+    ...(await runProbePair({ options, apiKey, phase: "cold", sequence: 1, fetchImpl })),
+  );
+  let successfulPairs = 0;
+  for (
+    let attempt = 1;
+    attempt <= options.maxAttempts && successfulPairs < options.successPairs;
+    attempt += 1
+  ) {
+    await sleep(250);
+    const pair = await runProbePair({
+      options,
+      apiKey,
+      phase: "warm",
+      sequence: attempt,
+      fetchImpl,
+    });
+    records.push(...pair);
+    if (pair.every((record) => record.ok && record.proofMatched)) successfulPairs++;
+  }
+  await sleep(500);
+  records.push(
+    ...(await runProbePair({
+      options,
+      apiKey,
+      phase: "post-idle",
+      sequence: 1,
+      fetchImpl,
+    })),
+  );
+  const placementAfter = await Promise.all(
+    arms.map(({ worker }) =>
+      readPlacementStatus({ worker, accountId, apiToken }, fetchImpl),
+    ),
+  );
+
+  await writeFile(
+    resolve(options.outputDir, "placement-ab.jsonl"),
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    { mode: 0o600, flag: "wx" },
+  );
+  const summary = {
+    kind: "cloud_placement_ab",
+    deploySha: options.deploySha,
+    successfulPairs,
+    requiredSuccessfulPairs: options.successPairs,
+    deployments,
+    bindingContracts,
+    placementBefore,
+    placementAfter,
+    warm: summarizePlacementRecords(records),
+  };
+  await writeFile(
+    resolve(options.outputDir, "summary.json"),
+    `${JSON.stringify(summary)}\n`,
+    { mode: 0o600, flag: "wx" },
+  );
+  if (successfulPairs < options.successPairs) {
+    throw new Error("Placement A/B did not collect enough successful warm pairs");
+  }
+  return summary;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  runPlacementAb(parsePlacementAbArgs(process.argv.slice(2))).catch((error) => {
+    // error-policy:J1 workflow boundary emits only bounded categories and
+    // never prints response bodies, prompts, generated text, or credentials.
+    process.stderr.write(
+      `[cloud-placement-ab] ${error instanceof Error ? error.message : "unknown failure"}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/scripts/cloud-placement-ab.mjs
+++ b/packages/cloud/scripts/cloud-placement-ab.mjs
@@ -224,6 +224,38 @@ export async function readPlacementStatus(
   return sanitizePlacementServiceResult(worker, await response.json());
 }
 
+/** Reject a placement window unless its two arms retain their intended modes. */
+export function assertExpectedPlacementModes(placements, phase) {
+  const [smart, control] = placements;
+  if (smart?.mode !== "smart") {
+    throw new Error(`${phase} Smart arm is not configured for Smart Placement`);
+  }
+  if (control?.mode !== "absent") {
+    throw new Error(`${phase} control arm must use default placement`);
+  }
+}
+
+/**
+ * Reattests both staging arms before or after a probe window. Health readback
+ * binds the observation to the requested SHA, while service metadata verifies
+ * the Smart Placement/default-placement comparison did not change mid-run.
+ */
+export async function verifyPlacementWindow(
+  { arms, deploySha, accountId, apiToken, phase },
+  fetchImpl = fetch,
+) {
+  const deployments = await Promise.all(
+    arms.map((arm) => verifyArmDeployment({ ...arm, deploySha }, fetchImpl)),
+  );
+  const placements = await Promise.all(
+    arms.map(({ worker }) =>
+      readPlacementStatus({ worker, accountId, apiToken }, fetchImpl),
+    ),
+  );
+  assertExpectedPlacementModes(placements, phase);
+  return { deployments, placements };
+}
+
 export function fingerprintWorkerBindings(worker, payload) {
   if (payload?.success !== true || !Array.isArray(payload.result?.bindings)) {
     throw new Error(`Cloudflare binding readback failed for ${worker}`);
@@ -236,6 +268,10 @@ export function fingerprintWorkerBindings(worker, payload) {
       id: boundedToken(binding?.id, "absent"),
       bucketName: boundedToken(binding?.bucket_name, "absent"),
       className: boundedToken(binding?.class_name, "absent"),
+      scriptName: boundedToken(binding?.script_name, "absent"),
+      service: boundedToken(binding?.service, "absent"),
+      environment: boundedToken(binding?.environment, "absent"),
+      entrypoint: boundedToken(binding?.entrypoint, "absent"),
     }))
     .sort((left, right) => left.name.localeCompare(right.name));
   const types = Object.fromEntries(
@@ -407,22 +443,17 @@ export async function runPlacementAb(
       worker: options.controlWorker,
     },
   ];
-  const deployments = await Promise.all(
-    arms.map((arm) =>
-      verifyArmDeployment({ ...arm, deploySha: options.deploySha }, fetchImpl),
-    ),
-  );
-  const placementBefore = await Promise.all(
-    arms.map(({ worker }) =>
-      readPlacementStatus({ worker, accountId, apiToken }, fetchImpl),
-    ),
-  );
-  if (placementBefore[0]?.mode !== "smart") {
-    throw new Error("Smart arm is not configured for Smart Placement");
-  }
-  if (placementBefore[1]?.mode !== "absent") {
-    throw new Error("Control arm must use default placement");
-  }
+  const { deployments, placements: placementBefore } =
+    await verifyPlacementWindow(
+      {
+        arms,
+        deploySha: options.deploySha,
+        accountId,
+        apiToken,
+        phase: "Pre-window",
+      },
+      fetchImpl,
+    );
   const bindingContracts = await Promise.all(
     arms.map(({ worker }) =>
       readWorkerBindingContract({ worker, accountId, apiToken }, fetchImpl),
@@ -470,11 +501,17 @@ export async function runPlacementAb(
       fetchImpl,
     })),
   );
-  const placementAfter = await Promise.all(
-    arms.map(({ worker }) =>
-      readPlacementStatus({ worker, accountId, apiToken }, fetchImpl),
-    ),
-  );
+  const { deployments: deploymentsAfter, placements: placementAfter } =
+    await verifyPlacementWindow(
+      {
+        arms,
+        deploySha: options.deploySha,
+        accountId,
+        apiToken,
+        phase: "Post-window",
+      },
+      fetchImpl,
+    );
 
   await writeFile(
     resolve(options.outputDir, "placement-ab.jsonl"),
@@ -487,6 +524,7 @@ export async function runPlacementAb(
     successfulPairs,
     requiredSuccessfulPairs: options.successPairs,
     deployments,
+    deploymentsAfter,
     bindingContracts,
     placementBefore,
     placementAfter,

--- a/packages/cloud/scripts/cloud-placement-ab.mjs
+++ b/packages/cloud/scripts/cloud-placement-ab.mjs
@@ -156,7 +156,8 @@ export async function verifyArmDeployment(
   } catch (cause) {
     throw new Error(`${arm} health request failed`, { cause });
   }
-  if (!response.ok) throw new Error(`${arm} health returned HTTP ${response.status}`);
+  if (!response.ok)
+    throw new Error(`${arm} health returned HTTP ${response.status}`);
   const body = await response.json();
   if (body?.commit !== deploySha || body?.environment !== "staging") {
     throw new Error(`${arm} did not serve the exact staging commit`);
@@ -174,7 +175,8 @@ export function sanitizePlacementServiceResult(worker, payload) {
   if (payload?.success !== true) {
     throw new Error(`Cloudflare placement status failed for ${worker}`);
   }
-  const script = payload.result?.default_environment?.script ?? payload.result?.script;
+  const script =
+    payload.result?.default_environment?.script ?? payload.result?.script;
   const placement = script?.placement;
   return {
     worker,
@@ -207,9 +209,12 @@ export async function readPlacementStatus(
       },
     );
   } catch (cause) {
-    throw new Error(`Cloudflare placement status request failed for ${worker}`, {
-      cause,
-    });
+    throw new Error(
+      `Cloudflare placement status request failed for ${worker}`,
+      {
+        cause,
+      },
+    );
   }
   if (!response.ok) {
     throw new Error(
@@ -262,7 +267,9 @@ export async function readWorkerBindingContract(
       },
     );
   } catch (cause) {
-    throw new Error(`Cloudflare binding readback failed for ${worker}`, { cause });
+    throw new Error(`Cloudflare binding readback failed for ${worker}`, {
+      cause,
+    });
   }
   if (!response.ok) {
     throw new Error(
@@ -309,14 +316,32 @@ export function summarizePlacementRecords(records) {
         attempts: group.length,
         successes: successful.length,
         failures: group.length - successful.length,
-        responseHeadersMs: metric(successful, (record) => record.responseHeadersMs),
+        responseHeadersMs: metric(
+          successful,
+          (record) => record.responseHeadersMs,
+        ),
         firstTokenMs: metric(successful, (record) => record.firstTokenMs),
         totalMs: metric(successful, (record) => record.totalMs),
-        preforwardTotalMs: metric(successful, (record) => record.preforward?.total),
-        preforwardAuthMs: metric(successful, (record) => record.preforward?.auth),
-        preforwardMiddleMs: metric(successful, (record) => record.preforward?.mid),
-        preforwardReserveMs: metric(successful, (record) => record.preforward?.reserve),
-        preforwardSetupMs: metric(successful, (record) => record.preforward?.setup),
+        preforwardTotalMs: metric(
+          successful,
+          (record) => record.preforward?.total,
+        ),
+        preforwardAuthMs: metric(
+          successful,
+          (record) => record.preforward?.auth,
+        ),
+        preforwardMiddleMs: metric(
+          successful,
+          (record) => record.preforward?.mid,
+        ),
+        preforwardReserveMs: metric(
+          successful,
+          (record) => record.preforward?.reserve,
+        ),
+        preforwardSetupMs: metric(
+          successful,
+          (record) => record.preforward?.setup,
+        ),
         upstreamHeadersMs: metric(
           successful,
           (record) => record.serverTiming?.upstream_headers,
@@ -371,7 +396,11 @@ export async function runPlacementAb(
   await mkdir(options.outputDir, { recursive: true, mode: 0o700 });
 
   const arms = [
-    { arm: "smart", baseUrl: options.smartBaseUrl, worker: options.smartWorker },
+    {
+      arm: "smart",
+      baseUrl: options.smartBaseUrl,
+      worker: options.smartWorker,
+    },
     {
       arm: "control",
       baseUrl: options.controlBaseUrl,
@@ -379,7 +408,9 @@ export async function runPlacementAb(
     },
   ];
   const deployments = await Promise.all(
-    arms.map((arm) => verifyArmDeployment({ ...arm, deploySha: options.deploySha }, fetchImpl)),
+    arms.map((arm) =>
+      verifyArmDeployment({ ...arm, deploySha: options.deploySha }, fetchImpl),
+    ),
   );
   const placementBefore = await Promise.all(
     arms.map(({ worker }) =>
@@ -403,7 +434,13 @@ export async function runPlacementAb(
 
   const records = [];
   records.push(
-    ...(await runProbePair({ options, apiKey, phase: "cold", sequence: 1, fetchImpl })),
+    ...(await runProbePair({
+      options,
+      apiKey,
+      phase: "cold",
+      sequence: 1,
+      fetchImpl,
+    })),
   );
   let successfulPairs = 0;
   for (
@@ -420,7 +457,8 @@ export async function runPlacementAb(
       fetchImpl,
     });
     records.push(...pair);
-    if (pair.every((record) => record.ok && record.proofMatched)) successfulPairs++;
+    if (pair.every((record) => record.ok && record.proofMatched))
+      successfulPairs++;
   }
   await sleep(500);
   records.push(
@@ -460,7 +498,9 @@ export async function runPlacementAb(
     { mode: 0o600, flag: "wx" },
   );
   if (successfulPairs < options.successPairs) {
-    throw new Error("Placement A/B did not collect enough successful warm pairs");
+    throw new Error(
+      "Placement A/B did not collect enough successful warm pairs",
+    );
   }
   return summary;
 }

--- a/packages/cloud/scripts/cloud-placement-ab.test.mjs
+++ b/packages/cloud/scripts/cloud-placement-ab.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * Deterministic contract tests for staging-only placement arm validation,
+ * exact-SHA health checks, Cloudflare metadata sanitizing, and summaries.
+ */
+
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  fingerprintWorkerBindings,
+  parsePlacementAbArgs,
+  sanitizePlacementServiceResult,
+  summarizePlacementRecords,
+  validateStagingArmUrl,
+  verifyArmDeployment,
+} from "./cloud-placement-ab.mjs";
+
+const SHA = "a".repeat(40);
+
+test("placement A/B args require two staging origins and an exact SHA", () => {
+  assert.deepEqual(
+    parsePlacementAbArgs([
+      "--deploy-sha",
+      SHA,
+      "--smart-base-url",
+      "https://api-staging.eliza.app",
+      "--control-base-url",
+      "https://eliza-cloud-api-staging-placement-control.example.workers.dev",
+      "--smart-worker",
+      "eliza-cloud-api-staging",
+      "--control-worker",
+      "eliza-cloud-api-staging-placement-control",
+      "--output-dir",
+      "artifacts/placement",
+    ]),
+    {
+      deploySha: SHA,
+      smartBaseUrl: "https://api-staging.eliza.app",
+      controlBaseUrl:
+        "https://eliza-cloud-api-staging-placement-control.example.workers.dev",
+      smartWorker: "eliza-cloud-api-staging",
+      controlWorker: "eliza-cloud-api-staging-placement-control",
+      outputDir: join(process.cwd(), "artifacts/placement"),
+      successPairs: 30,
+      maxAttempts: 45,
+    },
+  );
+  assert.throws(
+    () => validateStagingArmUrl("https://api.eliza.app", "arm"),
+    /staging Worker origin/,
+  );
+  assert.throws(
+    () => validateStagingArmUrl("https://127.0.0.1", "arm"),
+    /staging Worker origin/,
+  );
+  assert.throws(
+    () =>
+      parsePlacementAbArgs([
+        "--deploy-sha",
+        SHA,
+        "--smart-base-url",
+        "https://api-staging.eliza.app",
+        "--control-base-url",
+        "https://api-staging.eliza.app",
+        "--smart-worker",
+        "eliza-cloud-api-staging",
+        "--control-worker",
+        "eliza-cloud-api-staging",
+        "--output-dir",
+        "artifacts/placement",
+      ]),
+    /distinct Workers/,
+  );
+});
+
+test("exact-SHA arm health retains only bounded placement metadata", async () => {
+  const result = await verifyArmDeployment(
+    { arm: "smart", baseUrl: "https://api-staging.eliza.app", deploySha: SHA },
+    async () =>
+      Response.json(
+        { environment: "staging", commit: SHA, private: "not-retained" },
+        { headers: { "cf-placement": "remote-LAX", "cf-ray": "trace-ORD" } },
+      ),
+  );
+  assert.deepEqual(result, {
+    arm: "smart",
+    deploySha: SHA,
+    environment: "staging",
+    placement: "remote-LAX",
+    colo: "ORD",
+  });
+  assert.equal(JSON.stringify(result).includes("not-retained"), false);
+  await assert.rejects(
+    verifyArmDeployment(
+      { arm: "smart", baseUrl: "https://api-staging.eliza.app", deploySha: SHA },
+      async () => Response.json({ environment: "staging", commit: "b".repeat(40) }),
+    ),
+    /exact staging commit/,
+  );
+});
+
+test("Cloudflare placement response is reduced to non-secret decision metadata", () => {
+  const result = sanitizePlacementServiceResult("worker-staging", {
+    success: true,
+    result: {
+      default_environment: {
+        script: {
+          placement: {
+            mode: "smart",
+            status: "SUCCESS",
+            last_analyzed_at: "2026-08-30T17:40:08Z",
+          },
+          bindings: [{ secret_text: "private" }],
+        },
+      },
+    },
+  });
+  assert.deepEqual(result, {
+    worker: "worker-staging",
+    mode: "smart",
+    status: "SUCCESS",
+    lastAnalyzedAt: "2026-08-30T17:40:08Z",
+  });
+  assert.equal(JSON.stringify(result).includes("private"), false);
+});
+
+test("binding readback emits only a structural fingerprint and type counts", () => {
+  const result = fingerprintWorkerBindings("worker-staging", {
+    success: true,
+    result: {
+      bindings: [
+        { name: "API_KEY", type: "secret_text", text: "private" },
+        {
+          name: "GATE",
+          type: "durable_object_namespace",
+          namespace_id: "namespace-1",
+          class_name: "Gate",
+          script_name: "canonical-worker",
+          environment: "staging",
+        },
+      ],
+    },
+  });
+  assert.equal(result.bindingCount, 2);
+  assert.deepEqual(result.types, {
+    durable_object_namespace: 1,
+    secret_text: 1,
+  });
+  assert.match(result.fingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(JSON.stringify(result).includes("private"), false);
+});
+
+test("warm summary stratifies arms by observed placement and reports phase percentiles", () => {
+  const records = [10, 20, 30].flatMap((duration) => [
+    {
+      arm: "smart",
+      phase: "warm",
+      ok: true,
+      headers: { "cf-placement": "remote-LAX" },
+      responseHeadersMs: duration,
+      firstTokenMs: duration + 1,
+      totalMs: duration + 2,
+      preforward: {
+        total: duration,
+        auth: duration,
+        mid: duration,
+        reserve: duration,
+        setup: duration,
+      },
+      serverTiming: { upstream_headers: duration },
+    },
+    {
+      arm: "control",
+      phase: "warm",
+      ok: true,
+      headers: {},
+      responseHeadersMs: duration / 2,
+      firstTokenMs: duration / 2 + 1,
+      totalMs: duration / 2 + 2,
+      preforward: { total: duration / 2 },
+      serverTiming: { upstream_headers: duration / 2 },
+    },
+  ]);
+  const summary = summarizePlacementRecords(records);
+  assert.equal(summary.length, 2);
+  assert.deepEqual(
+    summary.find((group) => group.arm === "smart")?.preforwardTotalMs,
+    { p50: 20, p90: 28, p95: 29 },
+  );
+  assert.equal(
+    summary.find((group) => group.arm === "control")?.placement,
+    "absent",
+  );
+});

--- a/packages/cloud/scripts/cloud-placement-ab.test.mjs
+++ b/packages/cloud/scripts/cloud-placement-ab.test.mjs
@@ -93,8 +93,13 @@ test("exact-SHA arm health retains only bounded placement metadata", async () =>
   assert.equal(JSON.stringify(result).includes("not-retained"), false);
   await assert.rejects(
     verifyArmDeployment(
-      { arm: "smart", baseUrl: "https://api-staging.eliza.app", deploySha: SHA },
-      async () => Response.json({ environment: "staging", commit: "b".repeat(40) }),
+      {
+        arm: "smart",
+        baseUrl: "https://api-staging.eliza.app",
+        deploySha: SHA,
+      },
+      async () =>
+        Response.json({ environment: "staging", commit: "b".repeat(40) }),
     ),
     /exact staging commit/,
   );

--- a/packages/cloud/scripts/cloud-placement-ab.test.mjs
+++ b/packages/cloud/scripts/cloud-placement-ab.test.mjs
@@ -14,9 +14,48 @@ import {
   summarizePlacementRecords,
   validateStagingArmUrl,
   verifyArmDeployment,
+  verifyPlacementWindow,
 } from "./cloud-placement-ab.mjs";
 
 const SHA = "a".repeat(40);
+const ARMS = [
+  {
+    arm: "smart",
+    baseUrl: "https://api-staging.eliza.app",
+    worker: "smart-worker-staging",
+  },
+  {
+    arm: "control",
+    baseUrl: "https://control-staging.example.workers.dev",
+    worker: "control-worker-staging",
+  },
+];
+
+function placementWindowFetch({
+  controlMode = "absent",
+  controlCommit = SHA,
+  controlEnvironment = "staging",
+} = {}) {
+  return async (url) => {
+    const target = String(url);
+    if (target.endsWith("/api/health")) {
+      const control = target.includes("control-staging");
+      return Response.json({
+        environment: control ? controlEnvironment : "staging",
+        commit: control ? controlCommit : SHA,
+      });
+    }
+    const control = target.includes("control-worker-staging");
+    return Response.json({
+      success: true,
+      result: {
+        default_environment: {
+          script: { placement: { mode: control ? controlMode : "smart" } },
+        },
+      },
+    });
+  };
+}
 
 test("placement A/B args require two staging origins and an exact SHA", () => {
   assert.deepEqual(
@@ -105,6 +144,37 @@ test("exact-SHA arm health retains only bounded placement metadata", async () =>
   );
 });
 
+test("post-window attestation stubs reject placement, SHA, and environment drift", async () => {
+  const options = {
+    arms: ARMS,
+    deploySha: SHA,
+    accountId: "private-account",
+    apiToken: "private-token",
+    phase: "Post-window",
+  };
+  await assert.rejects(
+    verifyPlacementWindow(
+      options,
+      placementWindowFetch({ controlMode: "smart" }),
+    ),
+    /Post-window control arm must use default placement/,
+  );
+  await assert.rejects(
+    verifyPlacementWindow(
+      options,
+      placementWindowFetch({ controlCommit: "b".repeat(40) }),
+    ),
+    /control did not serve the exact staging commit/,
+  );
+  await assert.rejects(
+    verifyPlacementWindow(
+      options,
+      placementWindowFetch({ controlEnvironment: "production" }),
+    ),
+    /control did not serve the exact staging commit/,
+  );
+});
+
 test("Cloudflare placement response is reduced to non-secret decision metadata", () => {
   const result = sanitizePlacementServiceResult("worker-staging", {
     success: true,
@@ -131,7 +201,7 @@ test("Cloudflare placement response is reduced to non-secret decision metadata",
 });
 
 test("binding readback emits only a structural fingerprint and type counts", () => {
-  const result = fingerprintWorkerBindings("worker-staging", {
+  const payload = {
     success: true,
     result: {
       bindings: [
@@ -144,16 +214,31 @@ test("binding readback emits only a structural fingerprint and type counts", () 
           script_name: "canonical-worker",
           environment: "staging",
         },
+        {
+          name: "UPSTREAM",
+          type: "service",
+          service: "canonical-worker",
+          environment: "staging",
+          entrypoint: "fetch",
+        },
       ],
     },
-  });
-  assert.equal(result.bindingCount, 2);
+  };
+  const result = fingerprintWorkerBindings("worker-staging", payload);
+  assert.equal(result.bindingCount, 3);
   assert.deepEqual(result.types, {
     durable_object_namespace: 1,
     secret_text: 1,
+    service: 1,
   });
   assert.match(result.fingerprint, /^[a-f0-9]{64}$/);
   assert.equal(JSON.stringify(result).includes("private"), false);
+  const changedTarget = structuredClone(payload);
+  changedTarget.result.bindings[2].service = "different-worker";
+  assert.notEqual(
+    result.fingerprint,
+    fingerprintWorkerBindings("worker-staging", changedTarget).fingerprint,
+  );
 });
 
 test("warm summary stratifies arms by observed placement and reports phase percentiles", () => {

--- a/packages/scripts/__tests__/cloud-placement-ab-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-placement-ab-workflow.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Fail-closed workflow contract for manual staging-only placement comparison;
+ * the workflow reads two existing Workers and cannot deploy either arm.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const source = readFileSync(
+  new URL(".github/workflows/cloud-placement-ab.yml", repoRoot),
+  "utf8",
+);
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, string | boolean | number>;
+}
+
+interface Workflow {
+  on?: Record<string, { inputs?: Record<string, { required?: boolean; type?: string }> }>;
+  permissions?: Record<string, string>;
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  jobs?: Record<
+    string,
+    { environment?: string; env?: Record<string, string>; steps?: Step[] }
+  >;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const job = workflow.jobs?.["certify-placement"];
+
+function step(name: string): Step {
+  const found = job?.steps?.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing workflow step: ${name}`);
+  return found;
+}
+
+describe("Cloud placement A/B workflow", () => {
+  test("is manual, staging-only, read-only, serialized, and non-deploying", () => {
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_dispatch"]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.concurrency).toEqual({
+      group: "cloud-placement-ab-staging",
+      "cancel-in-progress": false,
+    });
+    expect(job?.environment).toBe("staging");
+    expect(source).not.toContain("environment: production");
+    expect(source).not.toMatch(/wrangler\s+(?:deploy|delete|versions deploy)/);
+  });
+
+  test("requires exact-SHA arm coordinates and protected read credentials", () => {
+    const inputs = workflow.on?.workflow_dispatch?.inputs ?? {};
+    for (const name of [
+      "expected_deploy_sha",
+      "smart_base_url",
+      "control_base_url",
+      "smart_worker",
+      "control_worker",
+    ]) {
+      expect(inputs[name]).toMatchObject({ required: true, type: "string" });
+    }
+    const preflight = step("Validate trusted exact-SHA staging dispatch").run;
+    expect(preflight).toContain('"$GITHUB_REF" != "refs/heads/develop"');
+    expect(preflight).toContain('"$GITHUB_SHA" != "$EXPECTED_DEPLOY_SHA"');
+    expect(preflight).toContain("^[a-f0-9]{40}$");
+    for (const name of [
+      "ELIZAOS_CLOUD_API_KEY",
+      "CLOUDFLARE_API_TOKEN",
+      "CLOUDFLARE_ACCOUNT_ID",
+    ]) {
+      expect(job?.env?.[name]).toContain(`secrets.${name}`);
+      expect(preflight).toContain(name);
+    }
+  });
+
+  test("runs thirty successful paired probes and uploads only bounded outputs", () => {
+    const run = step("Run exact-SHA privacy-safe placement A/B").run;
+    expect(run).toContain("packages/cloud/scripts/cloud-placement-ab.mjs");
+    expect(run).toContain('--deploy-sha "$EXPECTED_DEPLOY_SHA"');
+    expect(run).toContain("--success-pairs 30");
+    expect(run).toContain("--max-attempts 45");
+    const upload = step("Upload sanitized placement evidence");
+    expect(upload.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    const paths = String(upload.with?.path ?? "");
+    expect(paths).toContain("placement-ab.jsonl");
+    expect(paths).toContain("summary.json");
+    expect(paths).not.toContain("stderr");
+    expect(paths).not.toContain("secret");
+  });
+});

--- a/packages/scripts/__tests__/cloud-placement-ab-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-placement-ab-workflow.test.ts
@@ -20,7 +20,10 @@ interface Step {
 }
 
 interface Workflow {
-  on?: Record<string, { inputs?: Record<string, { required?: boolean; type?: string }> }>;
+  on?: Record<
+    string,
+    { inputs?: Record<string, { required?: boolean; type?: string }> }
+  >;
   permissions?: Record<string, string>;
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
   jobs?: Record<


### PR DESCRIPTION
## Summary

- add a manual, staging-only Smart Placement vs default-placement certification workflow
- require both pre-provisioned arms to serve one exact develop SHA
- read Cloudflare placement status before and after the window and fail if the treatment is not `smart` or the control is not default
- hash the arms' sanitized binding topology so a control with divergent Durable Object, Hyperdrive, KV, R2, rate-limit, variable, or secret-binding structure cannot be compared
- collect at least 30 successful concurrent warm pairs plus cold/post-idle controls, with p50/p90/p95 stratified by observed `cf-placement`
- retain no prompts, generated text, keys, response bodies, or secret values
- document the operator-owned control-arm provisioning and cleanup prerequisites

Refs #30099.

## Why no direct placement change

The exact-SHA staging certification at `be86906a83d633587078ecc3cceca6d453463101` ([run 33326096912](https://github.com/elizaOS/eliza/actions/runs/33326096912)) recorded 22/22 gateway responses as `cf-placement=remote-LAX` from ORD ingress. Eleven successful warm samples had gateway preforward p50 322 ms and p90 571 ms; the phase p50s were auth 71 ms, middle 85 ms, reserve 83 ms, and setup 77 ms.

A read-only Workers service query reported staging Smart Placement `SUCCESS`, confirming LAX is the active fetch-handler placement decision. It does not reveal Durable Object location. Cloudflare documents that existing Durable Objects do not relocate, while this monolithic Worker also uses Hyperdrive and external inference providers. Disabling placement without a same-SHA control would trade one unknown against another.

## Safety boundary

This PR does not deploy, create, edit, route, or delete a Worker. It rejects production origins and Worker names. The account currently has no placement-control Worker, so the workflow cannot run until an operator explicitly authorizes and provisions a staging-only control with external bindings to the canonical Durable Object namespaces and identical staging resources/secrets.

## Verification

- `bun run test:placement-ab` — 5 pass
- `bun test packages/scripts/__tests__/cloud-placement-ab-workflow.test.ts` — 3 pass
- `bun run check:agents-claude` — pass, 160 pairs
- `git diff --check origin/develop...HEAD` — pass
- `bun run verify:cloud` — 84/84 tasks passed on exact head `1115a68207dfc388a766f82acffd15e82dc7e52b`

## Evidence

- Generated artifact: N/A — the required control Worker does not exist and this PR is deliberately non-provisioning.
- UI screenshots/video: N/A — no UI is changed.
- Live production evidence: N/A — production access and placement are unchanged.
- Staging mutation evidence: N/A — no Cloudflare mutation was authorized or performed.
