### PR TITLE
fix(app): align entrypoint tier expectations with dedicated runtime defaults

### DIFF
--- a/packages/app/src/main.android-entrypoint.test.ts
+++ b/packages/app/src/main.android-entrypoint.test.ts
@@ -173,7 +173,7 @@ describe("renderer Android local composition", () => {
     expect(main.isAndroid).toBe(true);
     expect(main.isNative).toBe(true);
     expect(getBootConfig()).toMatchObject({
-      preferSharedCloudTier: true,
+      preferSharedCloudTier: false,
       autoUpgradeSharedToDedicated: true,
     });
     expect(androidBoot.installAndroidFetch).toHaveBeenCalledOnce();

--- a/packages/app/src/main.web-entrypoint.test.ts
+++ b/packages/app/src/main.web-entrypoint.test.ts
@@ -109,7 +109,7 @@ describe("renderer web composition", () => {
       "https://cloud-staging.eliza.app",
     );
     expect(getBootConfig()).toMatchObject({
-      preferSharedCloudTier: true,
+      preferSharedCloudTier: false,
       autoUpgradeSharedToDedicated: true,
     });
     expect(window.localStorage.getItem(STEWARD_ACTIVE_SCOPE_KEY)).toBe(


### PR DESCRIPTION
# Relates to

Restores the canonical client test lane on `develop` after the dedicated-runtime
contract change in bf642b9836 ("fix(cloud): require dedicated signed-in runtime",
2026-08-26), which updated 23 files but missed the two app entrypoint tests.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only change: two boolean literals in two entrypoint test expectations.
Zero production-code changes; no runtime, API, schema, or UI behavior changes.

# Background

## What does this PR do?

Aligns the web and Android entrypoint composition tests with the dedicated-tier
default that bf642b9836 intentionally introduced: `DEFAULT_BOOT_CONFIG` in
`packages/shared/src/config/boot-config-store.ts` now defaults
`preferSharedCloudTier: false` ("Signed-in app and Cloud sessions require
Dedicated; Shared remains for public and connector ingress").
`buildAppBootConfig()` in `packages/app/src/main.tsx` never overrides
`preferSharedCloudTier`, so both entrypoints inherit the new default, while it
still explicitly seeds `autoUpgradeSharedToDedicated: true` (kept as-is in the
tests).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue) — repairs test expectations
left stale by bf642b9836, which fail the canonical client lane on every develop
run (3/3 attempts red in Develop Full run 33329081779 at head d8c5b3124d).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/src/main.web-entrypoint.test.ts:111` and
`packages/app/src/main.android-entrypoint.test.ts:175` — each changed by one
boolean literal (`preferSharedCloudTier: true` → `false`).

## Detailed testing steps

```bash
bun install
bun run --cwd packages/app vitest run --config vitest.config.ts \
  src/main.web-entrypoint.test.ts src/main.android-entrypoint.test.ts
```

Before (unfixed expectations on the same head): `Test Files 2 failed (2), Tests 2 failed (2)` with `AssertionError: expected ... preferSharedCloudTier: false` at web:111 / android:175 — identical to hosted CI.
After (this branch): `Test Files 2 passed (2), Tests 2 passed (2)`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:655c33794f598d4848f0bd1cca392b2e40e199f1 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes; two boolean literals in test expectations only
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes; two boolean literals in test expectations only
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow changes; deterministic vitest reproduction in PR body
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend path changes
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no runtime frontend behavior changes; vitest console output in PR body
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain state involved
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes.`

## Backend + frontend logs

Vitest lane output on this branch (Bun 1.3.14, repo-pinned):

<details>
<summary>After fix — 2 passed</summary>

```text
 ✓ src/main.web-entrypoint.test.ts (1 test) 5275ms
     ✓ mounts after app config, styles, storage, and platform bridges  5273ms
 ✓ src/main.android-entrypoint.test.ts (1 test) 5285ms
     ✓ connects the native agent and device bridges after mounting  5283ms

 Test Files  2 passed (2)
      Tests  2 passed (2)
```
</details>

<details>
<summary>Before fix — same head, unfixed expectations (matches hosted CI failure)</summary>

```text
 ❯ src/main.web-entrypoint.test.ts:111:29
    expect(getBootConfig()).toMatchObject({
      preferSharedCloudTier: true,   // actual: false
      autoUpgradeSharedToDedicated: true,
    })

 Test Files  2 failed (2)
      Tests  2 failed (2)
```
</details>

Hosted failure reference: Develop Full run 33329081779, job `canonical / Tests (client)` (job id 99304601517), 3/3 attempts failed with the identical assertion diff at `src/main.web-entrypoint.test.ts:111:29` and `src/main.android-entrypoint.test.ts:175:29`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface changes (test-only, two boolean literals).`

### Before

`N/A - no rendered UI surface changes.`

### After

`N/A - no rendered UI surface changes.`

### Walkthrough video

`N/A - no user-visible flow changes; deterministic test reproduction above.`

## Audio / voice walkthrough

`N/A - no voice/audio changes.`

## Known gaps / failures

- Full `bun run verify` was not run end-to-end in the verification environment:
  `bun install` postinstall's fused-inference step requires native build
  prerequisites (cmake, ninja-build, pkg-config, libespeak-ng-dev) that are
  absent in the WSL sandbox; this is unrelated to the diff (native llama.cpp
  tooling) and reproduces identically on pristine `develop`.
- `bun run build` (Turbo) completed 129/131 tasks; `@elizaos/cloud-api#build`
  exited 137 (OOM) in the 16 GB WSL environment — environment-bound, unrelated
  to this diff.
- `packages/app` full `tsc --noEmit -p tsconfig.typecheck.json` passes on this
  branch (exit 0) after the workspace build; Biome check is clean on both
  changed files.
- Hosted Develop Full at the baseline has unrelated concurrent reds (plugin
  lanes, zero-key lanes, stack-e2e, an OCR policy gap in
  `test/audit/ocr-content-rules.test.ts`); those are out of scope for this
  bounded outcome (existing tracking: #20523, #18359, #19181).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

Run disclosure: this contribution was produced by an automated agent run.
Provider `qwen`, model `Qwen3.8-Max`, client `qoder-desktop-0.1.2.0`.