### PR TITLE
fix(ci): classify runtime-conditional skip options in lane evidence

### DIFF
--- a/packages/scripts/audit-focused-skipped-tests.mjs
+++ b/packages/scripts/audit-focused-skipped-tests.mjs
@@ -955,8 +955,10 @@ export function findViolations(filePath, content) {
  * A site is runtime-conditional when whether the test skips is decided at run
  * time, not in the source text: a runner ternary (`cond ? describe :
  * describe.skip`), a `skipIf`/`todoIf` whose condition is not statically
- * decidable, or a `skip`/`fixme` whose first argument is a non-literal,
- * non-function condition. Unconditional skips — even documented ones — are
+ * decidable, a `skip`/`fixme` whose first argument is a non-literal,
+ * non-function condition, or a runner call whose options-object argument
+ * carries a `skip`/`fixme` property whose initializer is not statically
+ * decidable. Unconditional skips — even documented ones — are
  * never returned, and a file with any gate violation yields zero sites, so
  * consumers (the script-lane JUnit evidence gate) cannot bless a file the
  * anti-larp gate itself rejects. Throws on unparseable input.
@@ -1035,6 +1037,35 @@ export function findConditionalSkipSites(filePath, content) {
           staticTruthiness(firstValue) === undefined
         ) {
           record(node, `conditional-${modifier}`);
+        }
+      } else if (
+        isRunnerReference(chain) &&
+        ts.isStringLiteralLike(node.arguments[0]) &&
+        ts.isObjectLiteralExpression(node.arguments[1])
+      ) {
+        const options = node.arguments[1];
+        for (const prop of options.properties) {
+          if (!ts.isPropertyAssignment(prop)) continue;
+          let name;
+          if (ts.isIdentifier(prop.name)) name = prop.name.text;
+          else if (ts.isStringLiteralLike(prop.name)) name = prop.name.text;
+          else continue;
+          if (name !== "skip" && name !== "fixme") continue;
+          const initializer = prop.initializer;
+          if (!initializer) continue;
+          const value = unwrapExpression(initializer);
+          if (
+            !ts.isStringLiteralLike(value) &&
+            !ts.isFunctionLike(value) &&
+            staticTruthiness(value) === undefined
+          ) {
+            record(
+              prop,
+              name === "skip"
+                ? "conditional-skip-option"
+                : "conditional-fixme-option",
+            );
+          }
         }
       }
     }
@@ -1310,6 +1341,21 @@ function selfTest() {
       name: "conditional: non-runner ternary is ignored",
       src: 'const value = cond ? left : right;\nit("a", () => {});',
       expect: [],
+    },
+    {
+      name: "conditional: options-object skip: runtime condition is a site",
+      src: 'test("a", { skip: process.platform !== "win32" ? "reason" : false }, () => {});',
+      expect: ["conditional-skip-option"],
+    },
+    {
+      name: "conditional: options-object skip: statically-true is not runtime-conditional",
+      src: 'test("a", { skip: true }, () => {});',
+      expect: [],
+    },
+    {
+      name: "conditional: options-object fixme: runtime condition is a site",
+      src: 'test("a", { fixme: process.platform !== "win32" ? "reason" : false }, () => {});',
+      expect: ["conditional-fixme-option"],
     },
   ];
 


### PR DESCRIPTION
# Relates to

No issue existed for this defect, and a self-directed run must not create one;
this pull request is the defect report and the repair. It follows the
`contribute-to-eliza` gate order: every PR in the current frozen review epoch
was dispositioned first (`complete: true`, 7/7), and the `mission-ready` issue
queue is empty (zero open issues carry that label), so this is the next
eligible outcome — restoring `develop` workflow health.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts. `origin/develop` was
      `d8c5b3124d97fac8189ad49afc14363ba56764f6` at fetch time and this head is
      that commit plus one, with zero conflicts.
- [x] `bun install` resolved from the pinned `bun@1.3.14` (verified
      `bun --version` = `1.3.14`) and the affected verification was run after
      sync. The aggregate `bun run verify` blocker on this machine is recorded
      verbatim in **Known gaps / failures** below rather than hidden.
- [x] A reviewer can confirm the change works without reading the code: the
      real failing artifact from `develop` is replayed against the patched gate
      in **Evidence Details**.

# Sync with develop

- [x] Rebased onto `origin/develop`
      (`d8c5b3124d97fac8189ad49afc14363ba56764f6`); zero conflicts.
- [x] Post-sync verification re-run on this head: classifier self-test
      `35/35`, affected script tests `32 pass / 0 fail`,
      `node --check` clean, `biome check` clean, and the JUnit evidence gate
      replayed against CI's own artifact returns `status: valid`. The
      repository-wide `bun run verify` blocker is documented below.

# Risks

**Low, and confined to a verification gate.** The change only affects which
skip sites the shared classifier recognizes as runtime-conditional in the
script-test lane.

- It does not touch any product/runtime path, any shipped package, or any test
  outcome. No test is added, removed, skipped, or un-skipped; `bun test` results
  are byte-identical before and after.
- It **narrows nothing** in the anti-larp gate. `findViolations()` still
  short-circuits a violating file to zero sites, unconditional
  `it.skip("name", fn)` still yields no site, and a statically decidable
  `skip: true` / `skip: false` still yields no site — both behaviors are now
  pinned by self-test cases rather than asserted in prose.
- The one real widening: a file using `test(name, { skip: <runtime condition> }, fn)`
  becomes eligible to report skipped tests in lane evidence. That is the class
  of skip the gate was written to bless (precedent: `01ee615653`
  "permit classifier-blessed conditional skips in script-lane JUnit evidence"),
  and it is decided statically from source, not from a comment or an allowlist.
- Blast radius if wrong: a lane that should fail would pass. The new
  statically-true negative case is specifically there to keep that door shut.

# Background

## What does this PR do?

Teaches the script-test skip classifier one more runtime-conditional skip
shape: the **options-object** form.

`packages/scripts/run-script-tests.mjs` ends the `Script Tests (Linux)` and
`canonical / Tests (scripts)` lanes by validating its JUnit evidence, and it
permits skipped testcases only in files that
`conditionalSkipBearingFiles()` — backed by
`findConditionalSkipSites()` in
`packages/scripts/audit-focused-skipped-tests.mjs` — classifies as carrying
runtime-conditional skips.

The classifier recognized three shapes: a runner ternary
(`cond ? describe : describe.skip`), `skipIf`/`todoIf` with a non-static
condition, and the **call form** `test.skip(cond, reason)`. It did not
recognize the equally runtime-conditional options form that
`packages/scripts/run-with-deadline.test.mjs` uses at 11 sites:

```js
test("safely cleans Windows fixtures with shell-sensitive paths", {
  timeout: 15_000,
  skip: process.platform !== "win32" ? "Windows cleanup contract" : false,
}, async (context) => { ... });
```

This PR adds that fourth shape to the classifier (recording
`conditional-skip-option` / `conditional-fixme-option`), reusing the existing
`unwrapExpression` / `staticTruthiness` predicates so the semantics match the
call form exactly, and adds three self-test cases (positive `skip:`, negative
statically-`true`, positive `fixme:`).

## Why are we doing this?

Because `develop` cannot pass its own script-test lane, and the failure is
invisible in the logs. At
`d8c5b3124d97fac8189ad49afc14363ba56764f6` the CI evidence artifact
(`script-tests-linux` from run `33329081779`) records:

```
status failed  exitCode 1  childExitCode 0  evidenceExitCode 1
junit.status "invalid"
junit.error "JUnit artifact contains skipped test(s) in
  packages/scripts/run-with-deadline.test.mjs; skipped tests are only
  permitted in files whose skips are statically classified as
  runtime-conditional (see packages/scripts/audit-focused-skipped-tests.mjs)"
```

`childExitCode = 0` means all 293 script-test files **passed**; the lane still
exits 1 on evidence policy alone, and because the driver merges JUnit only when
every file passes, the run prints no diagnostic at all — the log ends at
`error: script "test:scripts" exited with code 1`. That fails
`tests / ci-ok`, `canonical / All Tests Passed` and `Complete manifest` on the
integration branch, which is why open pull requests sit at
`mergeStateStatus = BLOCKED` with green tests.

This is a repair at the single canonical boundary — one predicate in the
classifier both gates read — rather than a per-file exception, an allowlist
entry, or a reworded skip comment.

# Documentation changes needed?

- [x] My changes do not require a change to the project documentation. The
  classifier's own doc block is updated in this diff to list the recognized
  shapes; `packages/scripts/audit-focused-skipped-tests.mjs --self-test`
  remains the executable specification.

# Testing

```bash
# 1. classifier self-test (35 cases, incl. 3 new)
node packages/scripts/audit-focused-skipped-tests.mjs --self-test      # 35/35 PASSED

# 2. the real file now classifies its 11 option-form sites
node --input-type=module -e '
import { readFileSync } from "node:fs";
const m = await import("./packages/scripts/audit-focused-skipped-tests.mjs");
const f = "packages/scripts/run-with-deadline.test.mjs";
const s = m.findConditionalSkipSites(f, readFileSync(f, "utf8"));
console.log("SITES:", s.length, "FORMS:", [...new Set(s.map(x => x.form))].join(","));
console.log("LINES:", s.map(x => x.line).join(","));'
#   SITES: 11  FORMS: conditional-skip-option
#   LINES: 230,315,339,382,416,491,505,536,612,694,738

# 3. replay CI's failing artifact through the patched gate
node /tmp/gate2.mjs      # GATE: PASS {"status":"valid","tests":3428,...}

# 4. affected script tests
bun test packages/scripts/__tests__/audit-focused-skipped-tests-discovery.test.ts \
         packages/scripts/__tests__/script-test-inventory.test.ts \
         packages/scripts/__tests__/junit-summary.test.ts                  # 32 pass / 0 fail
```

<!-- evidence-head:714f3293a0faea21328d5ed049f0d58e5182e1c0 -->

# Evidence

The artifact under test is not a local fixture: `junit.xml` is the file the
`develop` run itself published (`gh api
repos/elizaOS/eliza/actions/runs/33329081779/artifacts` → `script-tests-linux`,
1,072,119 bytes, sha256
`2d0cfa205c3f51e991853dc492ba70c50cea3689d07c669fb6594e6b49425022`). Feeding it
to the shipped `validateJunitEvidence` with the `develop` tree reproduces the
lane failure, and the same call against this head returns `status: valid`.

<details>
<summary>before / after / mutation-control transcript</summary>

```text
BEFORE (develop tree, identical 3-arg call):
  GATE RESULT: THROWS -> JUnit artifact contains skipped test(s) in
    packages/scripts/run-with-deadline.test.mjs; skipped tests are only
    permitted in files whose skips are statically classified as
    runtime-conditional (see packages/scripts/audit-focused-skipped-tests.mjs)
  findConditionalSkipSites(run-with-deadline) -> 0 sites
  conditionalSkipBearingFiles(inventory) -> 6 files, target blessed? false

AFTER (this head):
  SITES: 11 FORMS: conditional-skip-option
  LINES: 230,315,339,382,416,491,505,536,612,694,738
  conditionalSkipBearingFiles(inventory) -> 7 files, target blessed: true
  GATE: PASS {"status":"valid","path":"reports/script-tests/junit.xml",
              "bytes":1072119,
              "sha256":"2d0cfa205c3f51e991853dc492ba70c50cea3689d07c669fb6594e6b49425022",
              "tests":3428,"assertions":44221,"failures":0,...}
  self-test PASSED (35/35)
  affected script tests: 32 pass / 0 fail
  biome check: Checked 1 file. No fixes applied.

MUTATION CONTROL (proves the new cases are failure-sensitive, not vacuous):
  rename the recorded form "conditional-skip-option" -> "unused-form-name"
  self-test FAILED (1/35)     # the new option-form case catches it
```

</details>

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface: the diff changes only a static skip classifier in packages/scripts/audit-focused-skipped-tests.mjs (no .tsx/.css/.svg under packages/app, packages/ui or apps/app)
<!-- evidence-row:after-screenshots -->
- [ ] N/A - same as before-screenshots: no visual surface is built or rendered by this change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow exists to walk through; the affected path is the CI script-test lane evidence gate, proved by the artifact replay pasted inline in the Evidence section
<!-- evidence-row:backend-logs -->
- [ ] N/A - the complete before, after and mutation-control transcript is pasted inline in the Evidence section of this body; release-asset upload to the upstream pr-evidence release returns HTTP 404 for a contributor without upstream write access
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path executes; the changed file runs only inside node/bun CI script-test lanes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt or model behavior changes; no model call is made on the affected path
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks or generated product files are involved; the lane's own JUnit artifact replay is pasted inline under Evidence
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual surface to OCR

# Known gaps / failures

Honest limits of this evidence, none of which the diff papers over:

1. **`bun run test:scripts` on a full monorepo lane was not run to green on
   this machine.** Locally, at the `develop` head and again on this head, 11 of
   293 script-test files fail for environment reasons on this WSL Debian box
   (`systemd-analyze`-dependent cases in
   `packages/cloud/scripts/admin/systemd-environment-line.test.ts`,
   network-dependent `packages/scripts/__tests__/release-registry.test.ts`,
   `scripts/lifeops/env-layers.test.mjs` bundle cases, and the
   deployment-contract fixtures in `packages/cloud/scripts/group-room-sim/`,
   `packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts` and
   `packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts`).
   Every one of those tests is `(pass)` in CI at the same head, which is why
   `childExitCode` is 0 there. The authoritative statement about this lane is
   therefore this PR's own CI run, not the local run; the local run is used
   only for the deterministic gate replay above.
2. **No TypeScript project covers the changed file.** `packages/scripts` has no
   `package.json` or `tsconfig.json` (verified), so there is no `typecheck`
   task for `audit-focused-skipped-tests.mjs`. The substitute gates run here are
   `node --check`, `biome check`, and the 35-case self-test.
3. **The driver's silence on failure is a separate, untouched defect.**
   `run-script-test-files.mjs` merges JUnit fragments only when
   `failures.length === 0`, so any real test failure additionally surfaces as
   "evidence invalid: ENOENT junit.xml" and hides the actual failure. It is not
   the cause of the red lane fixed here, and fixing it in the same PR would mix
   two outcomes; it is noted so it is not lost.
4. This PR repairs the evidence-policy rejection of legitimate platform skips.
   It does not claim the rest of the `Develop Full` run is green: the other
   failing lanes at the head above have their own causes, several of which are
   owned by open pull requests already.

---

Run disclosure: this contribution was produced by an automated agent run.
Provider `qwen`, model `Qwen3.8-Flash`, client `qoder-desktop-0.1.2.0`.