### PR TITLE
fix(plugin-zai): guard MODEL_USED emission against unhandled rejection (#30115)

### DIFF
--- a/plugins/plugin-zai/__tests__/events.test.ts
+++ b/plugins/plugin-zai/__tests__/events.test.ts
@@ -1,7 +1,16 @@
-/** Unit tests for `emitModelUsageEvent` token normalization, asserting the `MODEL_USED` payload against a mocked `runtime.emitEvent`. */
+/**
+ * Unit tests for `emitModelUsageEvent`: token normalization asserted against a
+ * mocked `runtime.emitEvent`, plus a real-runtime regression that a rejecting
+ * MODEL_USED handler is captured (error-policy J7) and never leaks an unhandled
+ * rejection after a successful model call. The rejecting `emitEvent` is a plain
+ * function returning `Promise.reject(...)`, not a vitest mock — vitest mocks
+ * internally attach a `.catch` to their result promise and would mask the leak.
+ */
 import { EventType } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { emitModelUsageEvent } from "../utils/events";
+
+const flushMacrotask = () => new Promise((resolve) => setTimeout(resolve, 50));
 
 describe("z.ai usage events", () => {
   it("emits normalized token usage from prompt/completion fields", () => {
@@ -46,6 +55,61 @@ describe("z.ai usage events", () => {
         completion: 8,
         total: 13,
       },
+    });
+  });
+
+  describe("when a MODEL_USED handler rejects", () => {
+    let unhandled: unknown[];
+    let onUnhandled: (reason: unknown) => void;
+
+    beforeEach(() => {
+      unhandled = [];
+      onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+    });
+
+    afterEach(() => {
+      process.off("unhandledRejection", onUnhandled);
+    });
+
+    it("captures the emission rejection and reports it without leaking (J7)", async () => {
+      const boom = new Error("metering handler boom");
+      const reportError = vi.fn();
+      // A plain rejecting function models AgentRuntime.emitEvent faithfully:
+      // it does `await Promise.all(handlers.map(...))`, so a throwing MODEL_USED
+      // handler surfaces as a rejected promise from emitEvent itself.
+      const runtime = {
+        emitEvent: () => Promise.reject(boom),
+        reportError,
+      };
+
+      expect(() =>
+        emitModelUsageEvent(runtime as never, "TEXT_SMALL", {
+          promptTokens: 3,
+          completionTokens: 4,
+          totalTokens: 7,
+        })
+      ).not.toThrow();
+
+      // Control: an unguarded rejection in this same test must be collected,
+      // proving the unhandledRejection listener is live.
+      const control = new Error("control unguarded rejection");
+      Promise.reject(control);
+
+      await flushMacrotask();
+
+      // (a) the guarded emission did NOT leak an unhandled rejection.
+      expect(unhandled).not.toContain(boom);
+      // The live control WAS collected.
+      expect(unhandled).toContain(control);
+      // (b) the failure was routed to runtime diagnostics.
+      expect(reportError).toHaveBeenCalledWith(
+        "plugin-zai.model-usage",
+        boom,
+        expect.objectContaining({ type: "TEXT_SMALL" })
+      );
     });
   });
 });

--- a/plugins/plugin-zai/utils/events.ts
+++ b/plugins/plugin-zai/utils/events.ts
@@ -1,9 +1,15 @@
 /**
  * Normalizes AI SDK token usage (prompt/completion or input/output naming) and
  * emits `EventType.MODEL_USED` so the runtime can meter each z.ai call.
+ *
+ * The emission is fire-and-forget but its rejection is captured: a faulty
+ * MODEL_USED handler (metering/billing) must not convert an already-successful
+ * model call into an unhandled rejection that terminates the process under
+ * Node's default policy. Failures are warned and forwarded to
+ * `runtime.reportError` (error-policy J7), matching the sibling zerollama guard.
  */
 import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
-import { EventType } from "@elizaos/core";
+import { EventType, logger } from "@elizaos/core";
 
 type ModelUsage = {
   promptTokens?: number;
@@ -22,7 +28,7 @@ export function emitModelUsageEvent(
   const completionTokens = usage.completionTokens ?? usage.outputTokens ?? 0;
   const totalTokens = usage.totalTokens ?? promptTokens + completionTokens;
 
-  runtime.emitEvent(EventType.MODEL_USED, {
+  const emission = runtime.emitEvent(EventType.MODEL_USED, {
     runtime,
     source: "zai",
     type,
@@ -31,5 +37,13 @@ export function emitModelUsageEvent(
       completion: completionTokens,
       total: totalTokens,
     },
+  });
+  void Promise.resolve(emission).catch((error) => {
+    // error-policy:J7 usage telemetry must not turn a successful model call
+    // into a failure; report it through the runtime diagnostics channel.
+    logger.warn(
+      `[z.ai] MODEL_USED emission failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    runtime.reportError("plugin-zai.model-usage", error, { type });
   });
 }


### PR DESCRIPTION
# Relates to

Closes #30115

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` ran; owning-package `test`, `typecheck`, and `lint:check` are green (evidence below). `bun run verify` is a repo-wide gate; the focused package gates are attached.
- [x] A reviewer can confirm the change works without reading the code, from the before/after regression output below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (branch was up to date at rebase time).
- [x] Focused package gates pass post-sync; see **Known gaps / failures** for the repo-wide `verify` note.

# Risks

Low. The change is scoped to a single function (`emitModelUsageEvent` in `plugins/plugin-zai/utils/events.ts`). It only adds a `.catch` to an already fire-and-forget emission and forwards the failure to `runtime.reportError`; the success path and the emitted `MODEL_USED` payload are byte-for-byte unchanged (the two existing normalization tests still pass unmodified).

# Background

## What does this PR do?

After a **successful** z.ai text completion, `generateTextWithModel` calls `emitModelUsageEvent`, which invoked `runtime.emitEvent(EventType.MODEL_USED, ...)` **without awaiting and without a `.catch`**. `AgentRuntime.emitEvent` is async and rejects when any registered `MODEL_USED` handler throws/rejects (it does `await Promise.all(handlers.map(...))`). So a faulty or transient metering/billing `MODEL_USED` handler turned a completed, otherwise-successful model call into an **unhandled promise rejection**. Under Node's default unhandled-rejections policy (`throw`, default since Node 15; this repo pins Node 24.15.0), that **terminates the agent process** — a direct violation of repo error policy **J7** ("diagnostics must not kill the loop").

The fix mirrors the already-correct sibling provider `plugin-zerollama` (`utils/modelUsage.ts` → `emitModelUsed`): capture the emission promise, and on rejection warn to the logger and route the failure through `runtime.reportError("plugin-zai.model-usage", ...)`. Usage telemetry can no longer convert a successful model call into a process-killing failure.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. Behavior of the success path is unchanged; this only hardens diagnostic emission. The package AGENTS.md already documents that both handlers emit `MODEL_USED` via `emitModelUsageEvent`.

# Testing

## Where should a reviewer start?

`plugins/plugin-zai/__tests__/events.test.ts` — the new regression `captures the emission rejection and reports it without leaking (J7)`. It installs a live `process.on("unhandledRejection")` collector, calls `emitModelUsageEvent` with a **plain** `emitEvent` returning `Promise.reject(...)` (a vitest mock would mask the bug by attaching its own `.catch`), flushes a macrotask, then asserts (a) the guarded rejection did **not** leak, (b) an unguarded control `Promise.reject` **was** collected (proving the collector is live), and (c) `runtime.reportError` was called with scope `"plugin-zai.model-usage"`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-zai test
bun run --cwd plugins/plugin-zai typecheck
bun run --cwd plugins/plugin-zai lint:check
```

# Evidence Gate

<!-- evidence-head:7d024059672fb3a10c4633a6e8a10068d8d3d8ef -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; provider plugin registers only model handlers (no actions/providers/routes/views).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the change is a background diagnostic-emission guard.`
<!-- evidence-row:backend-logs -->
- [x] AFTER — full `plugin-zai` package suite green (61/61) with the fix applied. Inline transcript below; same file also at the gist link.
<details><summary>backend logs: after (bun run --cwd plugins/plugin-zai test)</summary>

```
$ bunx vitest run --config vitest.config.ts

 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-30115/plugins/plugin-zai


 Test Files  7 passed (7)
      Tests  61 passed (61)
   Start at  01:29:19
   Duration  28.44s (transform 42.42s, setup 0ms, import 60.66s, tests 839ms, environment 1ms)
```

</details>
[zai-30115-after.txt](https://gist.github.com/agent-cortex/fecdeced6e37f2476e217a5c630a03ed/c44a480e87f5942ec957597fe6034dd079709691#file-zai-30115-after-txt)
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model-output behavior changes; only the post-success telemetry emission is guarded. The MODEL_USED payload is unchanged and asserted identical by the two pre-existing normalization tests.`
<!-- evidence-row:domain-artifacts -->
- [x] BEFORE — fix reverted; the regression test captures the leaked `unhandledRejection` ("metering handler boom"). Inline transcript below; same file also at the gist link.
<details><summary>domain artifact: failing reproduction (fix reverted)</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-30115/plugins/plugin-zai

 ❯ __tests__/events.test.ts (3 tests | 1 failed) 68ms
       × captures the emission rejection and reports it without leaking (J7) 59ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  __tests__/events.test.ts > z.ai usage events > when a MODEL_USED handler rejects > captures the emission rejection and reports it without leaking (J7)
AssertionError: expected [ Error: metering handler boom, …(1) ] to not include Error: metering handler boom
 ❯ __tests__/events.test.ts:104:29
    102|
    103|       // (a) the guarded emission did NOT leak an unhandled rejection.
    104|       expect(unhandled).not.toContain(boom);
       |                             ^
    105|       // The live control WAS collected.
    106|       expect(unhandled).toContain(control);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
   Start at  01:29:00
   Duration  13.53s (transform 11.44s, setup 0ms, import 13.25s, tests 68ms, environment 0ms)
```

</details>
[zai-30115-before.txt](https://gist.github.com/agent-cortex/fecdeced6e37f2476e217a5c630a03ed/c44a480e87f5942ec957597fe6034dd079709691#file-zai-30115-before-txt)
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no prompt/model-output behavior changes; the guard runs only after a successful completion and does not alter model I/O.`

## Backend + frontend logs

**BEFORE (fix reverted — the regression test captures the leaked unhandled rejection):**

```
 FAIL  __tests__/events.test.ts > z.ai usage events > when a MODEL_USED handler rejects > captures the emission rejection and reports it without leaking (J7)
AssertionError: expected [ Error: metering handler boom, …(1) ] to not include Error: metering handler boom
 ❯ __tests__/events.test.ts:104:29
    103|       // (a) the guarded emission did NOT leak an unhandled rejection.
    104|       expect(unhandled).not.toContain(boom);
       |                             ^

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

The rejected emit promise surfaces as a real `unhandledRejection` — exactly what kills the process under Node's default policy.

**AFTER (fix applied — full package suite green):**

```
 Test Files  7 passed (7)
      Tests  61 passed (61)
```

The guarded rejection no longer leaks; the live control `Promise.reject` is still collected (proving the probe is real); and `runtime.reportError("plugin-zai.model-usage", ...)` is invoked.

**Parity with the already-correct sibling** `plugin-zerollama/utils/modelUsage.ts` `emitModelUsed` — both now wrap the emission in `void Promise.resolve(emission).catch(...)`, warn to `logger`, and forward to `runtime.reportError` with a `plugin-*.model-usage` scope. The only differences are the source label (`zai` vs `ollama`) and reportError scope/context.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface.`

## Known gaps / failures

- Full repo-wide `bun run verify` was not run to completion on this constrained ARM build host; the owning package's `test` (61 passing), `typecheck`, and `lint:check` (all green) are attached and are the gates that own this contract. The diff is a two-file, single-function change with no cross-package surface.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@7d024059672fb3a10c4633a6e8a10068d8d3d8ef:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@7d024059672fb3a10c4633a6e8a10068d8d3d8ef:packages/skills/skills/contribute-to-eliza"} -->

