### PR TITLE
docs(app-core): document the Node 24+ requirement for the supervised Vite proxy

### DIFF
--- a/packages/app-core/README.md
+++ b/packages/app-core/README.md
@@ -53,11 +53,11 @@ existing transport contracts.
 > combined dev supervisor pins that Vite proxy child to a Node 24+ executable
 > (the generic `resolveViteCommand` still resolves Bun when appropriate) because
 > Vite's dev-server WebSocket proxy depends on Node HTTP-upgrade semantics that
-> the repo-pinned Bun (`bun@1.3.14`) does not fully implement: under a Bun-hosted
-> Vite the dashboard's `/ws` upgrade
-> stays in `CONNECTING` and fails while ordinary `/api` HTTP proxying still
-> succeeds. A Bun-only checkout without a compliant Node fails at supervisor
-> start. This incompatibility was measured on the pinned Bun 1.3.x; later Bun
+> the repo-pinned Bun (`bun@1.3.14`) does not fully implement: under a
+> Bun-hosted Vite the dashboard's `/ws` upgrade stays in `CONNECTING` and fails
+> while ordinary `/api` HTTP proxying still succeeds. A checkout without a
+> compliant Node (the pinned `engines.node`) fails at supervisor start. This
+> incompatibility was measured on the pinned Bun 1.3.x; later Bun
 > releases may complete the upgrade, so re-verify before removing the Node pin.
 > See
 > [`scripts/README.md`](scripts/README.md#node-runtime-for-the-supervised-vite-proxy).

--- a/packages/app-core/README.md
+++ b/packages/app-core/README.md
@@ -49,6 +49,19 @@ connection. Broad cloud or wildcard-bind CORS reachability does not grant
 cookie access. Explicit bearer and paired-device authentication retain their
 existing transport contracts.
 
+> **`bun run dev`'s supervised Vite proxy child requires Node 24+.** The
+> combined dev supervisor pins that Vite proxy child to a Node 24+ executable
+> (the generic `resolveViteCommand` still resolves Bun when appropriate) because
+> Vite's dev-server WebSocket proxy depends on Node HTTP-upgrade semantics that
+> the repo-pinned Bun (`bun@1.3.14`) does not fully implement: under a Bun-hosted
+> Vite the dashboard's `/ws` upgrade
+> stays in `CONNECTING` and fails while ordinary `/api` HTTP proxying still
+> succeeds. A Bun-only checkout without a compliant Node fails at supervisor
+> start. This incompatibility was measured on the pinned Bun 1.3.x; later Bun
+> releases may complete the upgrade, so re-verify before removing the Node pin.
+> See
+> [`scripts/README.md`](scripts/README.md#node-runtime-for-the-supervised-vite-proxy).
+
 ## Isolated local development
 
 Give each concurrent instance distinct `ELIZA_UI_PORT`, `ELIZA_API_PORT`,

--- a/packages/app-core/scripts/README.md
+++ b/packages/app-core/scripts/README.md
@@ -32,6 +32,22 @@ the matching staging API and authenticated Cloud app hosts.
 - Recommended: **Bun 1.3.x stable** for `dev:win` flows.
 - Canary builds can change ESM/CJS interop behavior. `dev-ui.mjs` prints a startup advisory when it detects canary or non-1.3 Bun.
 
+### Node runtime for the supervised Vite proxy
+
+`bun run dev` proxies the dashboard's `/api` and `/ws` traffic through Vite,
+whose dev-server WebSocket proxy depends on Node HTTP-upgrade semantics that the
+repo-pinned Bun (`bun@1.3.14`) does not fully implement: under a Bun-hosted Vite
+the `/ws` upgrade stays in `CONNECTING` and fails (silently dropping live
+notifications and chat events) while ordinary `/api` HTTP proxying still
+succeeds. `dev-ui.mjs` therefore pins its **Vite child** to a Node 24+
+executable even when the orchestrator itself runs under Bun; the API runtime is
+resolved independently and may stay Bun-backed. A checkout without a compliant
+Node (the pinned `engines.node`) fails at supervisor start with an actionable
+`No usable Node.js 24+ executable found` message. Install Node 24+, or set
+`ELIZA_NODE_PATH=/absolute/path/to/node` if a compliant Node is not on `PATH`.
+The incompatibility was observed on the pinned Bun 1.3.x; later Bun releases may
+complete the `/ws` upgrade, so re-verify before removing the Node pin.
+
 ### Supporting modules (`eliza/packages/app-core/scripts/lib/`)
 
 | Module | Why it exists |


### PR DESCRIPTION
# Relates to

Closes #30073

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-surface check (`node scripts/check-markdown-links.mjs`) passes and is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`867f0909ea`); zero conflicts.
- [x] Focused check passes post-sync (see **Testing**).

# Scope change after the code fix landed on develop

**This PR is now documentation-only.** The code fix it originally proposed —
pinning the supervised `bun run dev` Vite child to Node so the dashboard's
`/ws` proxy works — landed on `develop` first via a parallel PR
(`7a32688ff7 fix(app-core): keep supervised Vite proxy on Node (#30073)`). That
commit added `resolveSupervisedViteCommand(...)` to
`packages/app-core/scripts/lib/dev-ui-vite.mjs`, wired `startVite()` to it, and
defined `resolveNodeRuntimePath(...)` in `dev-ui.mjs`, with a matching contract
test. The behavior this PR set out to deliver is therefore already present on
`develop`.

Rather than reintroduce a competing, duplicate implementation of the same
function, this PR was reduced during conflict resolution to the one thing
`develop` still lacked: **documentation of the resulting Node 24+ requirement**,
which reviewer @attentionhead explicitly requested. The keep-vs-close decision
is deferred to maintainers; if a standalone docs PR is not wanted, it can be
closed with no loss, since the code fix is already merged.

# Risks

Very low. Documentation only. No source, script, test, manifest, lockfile, or CI
file changes.

# Background

The combined `bun run dev` supervisor proxies the dashboard's `/api` and `/ws`
traffic through Vite. Vite's dev-server WebSocket proxy depends on Node
HTTP-upgrade semantics that the repo-pinned Bun (`bun@1.3.14`) does not fully
implement: under a Bun-hosted Vite the `/ws` upgrade stays in `CONNECTING` and
fails (silently dropping live notifications and chat events) while ordinary
`/api` HTTP proxying still succeeds. The merged fix pins the supervised Vite
child to a Node 24+ executable; the API runtime is resolved independently and may
stay Bun-backed. A checkout without a compliant Node fails at supervisor start
with an actionable `No usable Node.js 24+ executable found` message.

## What does this PR add?

- `packages/app-core/README.md` — a callout next to the existing "targets Node
  `>=24`" line stating that `bun run dev` requires Node 24+ and pointing at the
  scripts README section, so the requirement is discoverable from the package
  root.
- `packages/app-core/scripts/README.md` — a new **"Node runtime for the
  supervised Vite proxy"** subsection under the dev-orchestration notes covering
  the Bun `/ws`-proxy incompatibility, the actionable supervisor-start error, and
  the `ELIZA_NODE_PATH=/absolute/path/to/node` override.

## What kind of change is this?

Documentation only.

# Documentation changes needed?

This PR is the documentation change.

# Testing

## Where should a reviewer start?

The two changed Markdown files, and the relative-link/anchor check below.

## Detailed testing steps

```
$ node scripts/check-markdown-links.mjs
[check-markdown-links] PASS: relative Markdown links resolve.
```

The anchor `scripts/README.md#node-runtime-for-the-supervised-vite-proxy`
referenced from `packages/app-core/README.md` resolves to the new heading.

# Evidence Gate

<!-- evidence-head:b4c2cf1c0f92c842c76799c208eba799bd3806b0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - documentation-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - documentation-only change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - documentation-only change; no user-facing UI flow.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - documentation-only change; the markdown link/anchor check output is pasted inline under Detailed testing steps.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - documentation-only change; no browser/frontend code path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - documentation-only change; the only artifact is the edited Markdown file in the diff.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

```
$ node scripts/check-markdown-links.mjs
[check-markdown-links] PASS: relative Markdown links resolve.
```

## Known gaps / failures

- The code behavior these docs describe is verified by the already-merged fix
  (`7a32688ff7`) and its contract test on `develop`, not by this PR. This PR
  changes no executable code, so there is no runtime behavior to reproduce here.

## Maintainer CI exception record

`N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@6457f26ceae6e90c55b11559010e6f8946671ff2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@6457f26ceae6e90c55b11559010e6f8946671ff2:packages/skills/skills/contribute-to-eliza"} -->




