### PR TITLE
fix(cloud-e2e): bind mock ports atomically

### DIFF
--- a/packages/cloud/e2e/src/fixtures/stack.ts
+++ b/packages/cloud/e2e/src/fixtures/stack.ts
@@ -331,19 +331,19 @@ export async function startCloudStack(
   const pgDataDir = join(dataDir, "pgdata");
   await mkdir(pgDataDir, { recursive: true });
 
-  const hetznerPort = await pickFreePort();
-  const controlPlanePort = await pickFreePort();
   const pglitePort = await pickFreePort();
   const apiPort = opts.apiPort ?? (await pickFreePort());
   const frontendPort = opts.frontendPort ?? (await pickFreePort());
 
   // 1. In-process mocks
   const hetzner = await startHetznerMock({
-    port: hetznerPort,
+    // Let the listening server claim its ephemeral port atomically. Probing a
+    // free port and closing the probe first leaves a race with parallel CI.
+    port: 0,
     actionMs: Number(process.env.MOCK_HETZNER_ACTION_MS ?? "30"),
   });
   const controlPlane = await startControlPlaneMock({
-    port: controlPlanePort,
+    port: 0,
     hetznerUrl: hetzner.url,
     tickMs: Number(process.env.CONTROL_PLANE_TICK_MS ?? "50"),
   });


### PR DESCRIPTION
## Problem

The current `develop` full-stack cloud lane failed during the onboarding reprovision spec with:

```
Error: listen EADDRINUSE: address already in use 127.0.0.1:45213
```

The stack selected the Hetzner and control-plane mock ports by opening and closing probe sockets before either real mock server bound. That creates a check-then-bind race (and permits the same released ephemeral port to be selected twice).

Run: https://github.com/elizaOS/eliza/actions/runs/33329081779/job/99306076298

## Fix

Let each in-process Node HTTP mock bind `port: 0` directly. The kernel assigns and reserves the ephemeral port as part of the real `listen` operation, and each mock already returns its actual bound URL to downstream configuration.

The subprocess-backed PGlite/API/frontend ports are unchanged.

## Verification

- Started and stopped the real Hetzner + control-plane HTTP servers for 50 consecutive cycles under Node, asserting that both bound ports differed: passed.
- `git diff --check`: passed.
- Package typecheck was attempted but is not a valid focused signal in the sparse isolated checkout: it resolves the older shared dependency tree and reports existing missing-package/current-`develop` errors unrelated to this four-line change.
- Whole-file Biome check reports an unrelated pre-existing formatter delta at the frontend argument list; this change introduces no formatting delta in the edited hunk.

## Duplication

No open PR matched the observed `EADDRINUSE`, onboarding-reprovision collision, port `45213`, or cloud stack port repair. Existing PRs for the transcript and plugin-test failures are separate and intentionally untouched.

## Provenance

Provider: OpenAI  
Model: GPT-5  
Client: Codex  
Skill: `contribute-to-eliza` revision `00228518e70b79b91480a1d21e4420365ed4f607`  
Policy: `2026-08-18.1`
