### PR TITLE
fix(plugin-agent-skills): parse SKILL.md YAML block scalar descriptions (#30121)

### DIFF
--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -381,28 +381,39 @@ function parseBlockScalarBody(
 	if (header.style === "literal") {
 		core = content.join("\n");
 	} else {
-		// Folded style: single line breaks between equally-indented non-empty
-		// lines fold to a space, but a line that is still indented after the
-		// common indentation is stripped is "more indented" and the breaks on
-		// either side of it are preserved literally (YAML 1.2 §8.1.3).
+		// Folded style: a single line break between two equally-indented,
+		// non-blank lines folds to a space. Every other break is preserved as a
+		// literal newline, per YAML 1.2 §8.1.3: breaks around "more indented"
+		// lines (lines still indented after the common indentation is stripped)
+		// and around blank lines are not folded. A run of blank lines between
+		// two content lines yields that many newlines; leading blank lines each
+		// contribute a literal newline before the first content line.
 		core = "";
+		let started = false;
+		let blankRun = 0;
 		let prevMoreIndented = false;
 		for (let i = 0; i < content.length; i++) {
 			const line = content[i];
-			const isBlank = line === "";
-			const moreIndented = !isBlank && /^[ \t]/.test(line);
-			if (i === 0) {
-				core = line;
-			} else if (isBlank) {
-				core += "\n";
-			} else if (core.endsWith("\n")) {
-				core += line;
-			} else if (moreIndented || prevMoreIndented) {
-				core += `\n${line}`;
+			if (line === "") {
+				blankRun++;
+				continue;
+			}
+			const moreIndented = /^[ \t]/.test(line);
+			if (!started) {
+				core = `${"\n".repeat(blankRun)}${line}`;
+				started = true;
 			} else {
-				core += ` ${line}`;
+				const breaks = blankRun + 1;
+				if (moreIndented || prevMoreIndented) {
+					core += `${"\n".repeat(breaks)}${line}`;
+				} else if (blankRun === 0) {
+					core += ` ${line}`;
+				} else {
+					core += `${"\n".repeat(breaks - 1)}${line}`;
+				}
 			}
 			prevMoreIndented = moreIndented;
+			blankRun = 0;
 		}
 	}
 

--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -328,7 +328,10 @@ function parseBlockScalarHeader(valueStr: string): BlockScalarHeader | null {
  * Consumes every line more indented than `keyIndent` (blank lines included),
  * strips the block's common leading indentation, then joins literal blocks with
  * newlines and folds folded blocks so single line breaks become spaces while
- * blank lines stay newlines. Chomping controls trailing newlines. Returns the
+ * blank lines stay newlines. Per the YAML spec, a folded block preserves the
+ * line breaks around "more indented" lines (lines still indented after the
+ * common indentation is removed) so nested bullets and indented code blocks are
+ * not silently flattened. Chomping controls trailing newlines. Returns the
  * decoded string and the index of the first line the caller has not consumed.
  */
 function parseBlockScalarBody(
@@ -378,17 +381,28 @@ function parseBlockScalarBody(
 	if (header.style === "literal") {
 		core = content.join("\n");
 	} else {
+		// Folded style: single line breaks between equally-indented non-empty
+		// lines fold to a space, but a line that is still indented after the
+		// common indentation is stripped is "more indented" and the breaks on
+		// either side of it are preserved literally (YAML 1.2 §8.1.3).
 		core = "";
-		for (const line of content) {
-			if (core === "") {
+		let prevMoreIndented = false;
+		for (let i = 0; i < content.length; i++) {
+			const line = content[i];
+			const isBlank = line === "";
+			const moreIndented = !isBlank && /^[ \t]/.test(line);
+			if (i === 0) {
 				core = line;
-			} else if (line === "") {
+			} else if (isBlank) {
 				core += "\n";
 			} else if (core.endsWith("\n")) {
 				core += line;
+			} else if (moreIndented || prevMoreIndented) {
+				core += `\n${line}`;
 			} else {
 				core += ` ${line}`;
 			}
+			prevMoreIndented = moreIndented;
 		}
 	}
 

--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -200,7 +200,22 @@ function parseYamlSubset(yaml: string): Record<string, unknown> {
 
 			const parent = stack[stack.length - 1].obj;
 
-			if (valueStr === "" || valueStr === "|" || valueStr === ">") {
+			const blockScalar = parseBlockScalarHeader(valueStr);
+			if (blockScalar) {
+				// YAML block scalar (`|` literal or `>` folded). Consume every
+				// following line indented deeper than the key and assign the
+				// dedented, folded/joined text to the key so a `description: >`
+				// (used by real published skills) becomes a string instead of an
+				// empty object that later resolves the frontmatter to null.
+				const { value, nextIndex } = parseBlockScalarBody(
+					lines,
+					i + 1,
+					indent,
+					blockScalar,
+				);
+				parent[key] = value;
+				i = nextIndex - 1;
+			} else if (valueStr === "") {
 				// Could be object, multiline string, or multiline JSON
 				// Check if next non-empty line starts with { or [
 				let nextLineIdx = i + 1;
@@ -274,6 +289,120 @@ function parseYamlSubset(yaml: string): Record<string, unknown> {
 	}
 
 	return result;
+}
+
+/**
+ * Parsed YAML block-scalar header: literal (`|`) or folded (`>`) style plus a
+ * chomping indicator and an optional explicit indentation offset.
+ */
+interface BlockScalarHeader {
+	style: "literal" | "folded";
+	chomping: "clip" | "strip" | "keep";
+	explicitIndent: number | null;
+}
+
+/**
+ * Recognize a YAML block-scalar header such as `|`, `>`, `|-`, `>+`, or `>2`.
+ *
+ * The indicator character selects literal vs folded style; a trailing `-`/`+`
+ * selects strip/keep chomping (default clip); a single digit selects an
+ * explicit indentation. Returns null for any other value so ordinary scalars
+ * and the empty-value (nested object) case keep their existing handling.
+ */
+function parseBlockScalarHeader(valueStr: string): BlockScalarHeader | null {
+	const match = valueStr.match(/^([|>])([+-]?)([1-9]?)([+-]?)$/);
+	if (!match) return null;
+	const [, indicator, chompA, digit, chompB] = match;
+	if (chompA && chompB) return null; // at most one chomping indicator
+	const chomp = chompA || chompB;
+	return {
+		style: indicator === "|" ? "literal" : "folded",
+		chomping: chomp === "-" ? "strip" : chomp === "+" ? "keep" : "clip",
+		explicitIndent: digit ? parseInt(digit, 10) : null,
+	};
+}
+
+/**
+ * Collect and decode a YAML block-scalar body starting at `startIdx`.
+ *
+ * Consumes every line more indented than `keyIndent` (blank lines included),
+ * strips the block's common leading indentation, then joins literal blocks with
+ * newlines and folds folded blocks so single line breaks become spaces while
+ * blank lines stay newlines. Chomping controls trailing newlines. Returns the
+ * decoded string and the index of the first line the caller has not consumed.
+ */
+function parseBlockScalarBody(
+	lines: string[],
+	startIdx: number,
+	keyIndent: number,
+	header: BlockScalarHeader,
+): { value: string; nextIndex: number } {
+	const raw: string[] = [];
+	let idx = startIdx;
+	for (; idx < lines.length; idx++) {
+		const line = lines[idx];
+		if (line.trim() === "") {
+			raw.push(line);
+			continue;
+		}
+		if (line.search(/\S/) <= keyIndent) break;
+		raw.push(line);
+	}
+
+	// Base indentation: explicit offset from the key, else the first content line.
+	let baseIndent = header.explicitIndent
+		? keyIndent + header.explicitIndent
+		: null;
+	if (baseIndent === null) {
+		for (const line of raw) {
+			if (line.trim() === "") continue;
+			baseIndent = line.search(/\S/);
+			break;
+		}
+	}
+	if (baseIndent === null) baseIndent = keyIndent + 1; // block was all blank
+
+	const base = baseIndent;
+	const content = raw.map((line) =>
+		line.trim() === "" ? "" : line.slice(Math.min(base, line.search(/\S/))),
+	);
+
+	// Separate trailing blank lines so chomping can control final newlines.
+	let trailingBlanks = 0;
+	while (content.length > 0 && content[content.length - 1] === "") {
+		content.pop();
+		trailingBlanks++;
+	}
+
+	let core: string;
+	if (header.style === "literal") {
+		core = content.join("\n");
+	} else {
+		core = "";
+		for (const line of content) {
+			if (core === "") {
+				core = line;
+			} else if (line === "") {
+				core += "\n";
+			} else if (core.endsWith("\n")) {
+				core += line;
+			} else {
+				core += ` ${line}`;
+			}
+		}
+	}
+
+	let value: string;
+	if (header.chomping === "strip") {
+		value = core;
+	} else if (header.chomping === "keep") {
+		value = core === "" && trailingBlanks === 0 ? "" : `${core}${"\n".repeat(trailingBlanks + 1)}`;
+	} else {
+		// clip: exactly one trailing newline when there is any content
+		value = core === "" ? "" : `${core}\n`;
+	}
+
+	return { value, nextIndex: idx };
 }
 
 /**

--- a/plugins/plugin-agent-skills/src/parser.validation.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.validation.test.ts
@@ -207,6 +207,32 @@ describe("YAML block scalar descriptions (issue #30121)", () => {
     );
   });
 
+  it("preserves line breaks around more-indented lines in a `>` description", () => {
+    // Per YAML 1.2 §8.1.3 a folded scalar folds equally-indented lines to
+    // spaces but preserves the breaks around "more indented" lines, so a nested
+    // bullet or indented code block keeps its own lines instead of flattening.
+    const nested = [
+      "---",
+      "name: my-skill",
+      "description: >",
+      "  Use this skill when you need to:",
+      "    - list dependencies",
+      "    - render a report",
+      "  after collecting the inputs.",
+      "---",
+      "Body",
+    ].join("\n");
+    const fm = parseFrontmatter(nested).frontmatter;
+    // The lead-in and trailing line fold to spaces, but the two more-indented
+    // bullet lines keep their own newlines and relative indentation.
+    expect(fm?.description).toBe(
+      "Use this skill when you need to:\n" +
+        "  - list dependencies\n" +
+        "  - render a report\n" +
+        "after collecting the inputs.\n",
+    );
+  });
+
   it("strips the trailing newline for a `>-` chomped description", () => {
     const stripped = [
       "---",

--- a/plugins/plugin-agent-skills/src/parser.validation.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.validation.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { validateFrontmatter, validateSkillDirectory } from "./parser.ts";
+import {
+  parseFrontmatter,
+  validateFrontmatter,
+  validateSkillDirectory,
+} from "./parser.ts";
 import type { SkillFrontmatter } from "./types.ts";
 
 const fm = (over: Partial<SkillFrontmatter> = {}): SkillFrontmatter => ({
@@ -148,5 +152,86 @@ describe("validateSkillDirectory", () => {
     ].join("\n");
     const r = validateSkillDirectory("/x/SKILL.md", content, "my-skill");
     expect(r.valid).toBe(true);
+  });
+});
+
+describe("YAML block scalar descriptions (issue #30121)", () => {
+  // A folded (`>`) description mirroring the real @reduxjs/toolkit skills that
+  // regressed to MISSING_FRONTMATTER before the block-scalar fix.
+  const foldedSkill = [
+    "---",
+    "name: build-modern-redux-apps",
+    "description: >",
+    "  Use this when setting up a new Redux Toolkit app or modernizing an",
+    "  existing React + Redux codebase.",
+    "type: lifecycle",
+    "license: MIT",
+    "---",
+    "",
+    "# Body",
+  ].join("\n");
+
+  it("folds a `>` description into a single space-joined line", () => {
+    const fm = parseFrontmatter(foldedSkill).frontmatter;
+    expect(fm).not.toBeNull();
+    expect(fm?.name).toBe("build-modern-redux-apps");
+    // Single line breaks fold to spaces; clip chomping adds one trailing newline.
+    expect(fm?.description).toBe(
+      "Use this when setting up a new Redux Toolkit app or modernizing an " +
+        "existing React + Redux codebase.\n",
+    );
+    expect(fm?.description).not.toContain("\n  ");
+  });
+
+  it("keeps a same-indent key after the block scalar (no line swallowing)", () => {
+    // `license` sits at the key indent right after the folded block; it must
+    // still be parsed rather than absorbed into the description.
+    const fm = parseFrontmatter(foldedSkill).frontmatter;
+    expect(fm?.license).toBe("MIT");
+  });
+
+  it("preserves internal newlines for a literal `|` description", () => {
+    const literal = [
+      "---",
+      "name: my-skill",
+      "description: |",
+      "  First sentence about when to use this skill.",
+      "  Second sentence on the next line.",
+      "---",
+      "Body",
+    ].join("\n");
+    const fm = parseFrontmatter(literal).frontmatter;
+    expect(fm?.description).toBe(
+      "First sentence about when to use this skill.\n" +
+        "Second sentence on the next line.\n",
+    );
+  });
+
+  it("strips the trailing newline for a `>-` chomped description", () => {
+    const stripped = [
+      "---",
+      "name: my-skill",
+      "description: >-",
+      "  alpha",
+      "  beta",
+      "---",
+      "Body",
+    ].join("\n");
+    expect(parseFrontmatter(stripped).frontmatter?.description).toBe(
+      "alpha beta",
+    );
+  });
+
+  it("treats a folded description directory as valid, not MISSING_FRONTMATTER", () => {
+    const before = validateSkillDirectory(
+      "/x/SKILL.md",
+      // Same content but with the description as an empty value would still be
+      // missing; here we prove the folded form now validates end to end.
+      foldedSkill,
+      "build-modern-redux-apps",
+    );
+    expect(codes(before)).not.toContain("MISSING_FRONTMATTER");
+    expect(codes(before)).not.toContain("MISSING_DESCRIPTION");
+    expect(before.valid).toBe(true);
   });
 });

--- a/plugins/plugin-agent-skills/src/parser.validation.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.validation.test.ts
@@ -252,6 +252,43 @@ describe("YAML block scalar descriptions (issue #30121)", () => {
     );
   });
 
+  it("keeps a blank line after a more-indented folded line as a paragraph break", () => {
+    // A blank line between a more-indented line and the next line must survive
+    // as a paragraph break. Because breaks around a more-indented line are not
+    // folded, the single blank line yields two newlines ("\n\n"), matching the
+    // `yaml` reference; it must not be absorbed into a single separator.
+    const doc = [
+      "---",
+      "name: my-skill",
+      "description: >",
+      "  a",
+      "    x",
+      "",
+      "  b",
+      "---",
+      "Body",
+    ].join("\n");
+    expect(parseFrontmatter(doc).frontmatter?.description).toBe("a\n  x\n\nb\n");
+  });
+
+  it("preserves a leading blank line in a `>` description without adding a space", () => {
+    // A folded block that opens with a blank line keeps that leading newline
+    // and folds the following two plain lines to a single space. The first
+    // content line must not be prefixed with a stray space, matching `yaml`
+    // ("\na b\n").
+    const doc = [
+      "---",
+      "name: my-skill",
+      "description: >",
+      "",
+      "  a",
+      "  b",
+      "---",
+      "Body",
+    ].join("\n");
+    expect(parseFrontmatter(doc).frontmatter?.description).toBe("\na b\n");
+  });
+
   it("strips the trailing newline for a `>-` chomped description", () => {
     const stripped = [
       "---",

--- a/plugins/plugin-agent-skills/src/parser.validation.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.validation.test.ts
@@ -233,6 +233,25 @@ describe("YAML block scalar descriptions (issue #30121)", () => {
     );
   });
 
+  it("honors an explicit indentation indicator (`|2`) for the block base", () => {
+    // The explicit indentation indicator fixes the block base at keyIndent + 2
+    // instead of inferring it from the first content line. Without it, the
+    // first (6-space) line would set a deeper base and its leading spaces would
+    // be stripped; the indicator keeps the 4 extra spaces, matching js-yaml.
+    const explicit = [
+      "---",
+      "name: my-skill",
+      "description: |2",
+      "      deep line",
+      "  base line",
+      "---",
+      "Body",
+    ].join("\n");
+    expect(parseFrontmatter(explicit).frontmatter?.description).toBe(
+      "    deep line\nbase line\n",
+    );
+  });
+
   it("strips the trailing newline for a `>-` chomped description", () => {
     const stripped = [
       "---",


### PR DESCRIPTION
# Relates to

Closes #30121

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`; the branch is currently conflict-free against
      `origin/develop` (GitHub reports `MERGEABLE` / `CLEAN`).
- [x] `bun install` was run; the owning package's test, typecheck, and lint pass
      (see **Testing** and the inlined before/after evidence).
- [x] A reviewer can confirm the change works without reading the code, from the
      failing-before / passing-after vitest output inlined under **Evidence
      Details** and the green **All Tests Passed** CI job at this head.

# Sync with develop

- [x] Branch is mergeable with the latest `origin/develop` (`bc84c05273`); GitHub
      merge state is `CLEAN`, so no rebase was required for this evidence update.
- [x] Owning-package gates pass. Full-repo `bun run verify` was not run on this
      constrained device — see **Known gaps / failures**.

# Risks

Low. The change is confined to the hand-rolled YAML subset parser in
`plugins/plugin-agent-skills/src/parser.ts`. It adds recognition of YAML block
scalar headers (`|` / `>` and their chomping/indent variants) and a decoder for
the block body. No public signature, type, or return value changes; a
`description:` written as an ordinary inline scalar keeps its existing handling.
Worst case for a non-block-scalar document is unchanged behavior, because the
new branch only fires when the value matches a block-scalar header.

# Background

## What does this PR do?

The `plugin-agent-skills` SKILL.md validator parses frontmatter with a small
in-repo YAML subset parser (the plugin intentionally does not pull a full YAML
dependency into this path). That parser treated a bare `|` or `>` value the same
as an empty value, so a real published skill written as:

```yaml
---
name: build-modern-redux-apps
description: >
  Use this skill when building Redux Toolkit apps: modeling slices,
  wiring the store, and testing reducers.
---
```

parsed `description` as an empty object `{}`. The enclosing frontmatter then
resolved to `null`, and validation reported **`MISSING_FRONTMATTER`**, rejecting
a structurally valid skill (issue #30121).

This PR teaches the parser about YAML block scalars:

- **`parseBlockScalarHeader`** recognizes `|` (literal) and `>` (folded) plus a
  chomping indicator (`-` strip / `+` keep / default clip) and an optional
  explicit indentation digit (`|2`, `>2`). Anything else returns `null` and
  falls through to the previous scalar / nested-object handling.
- **`parseBlockScalarBody`** consumes the following lines indented past the key,
  strips the common (or explicit) indentation, and decodes the body:
  - **literal (`|`)** keeps internal newlines verbatim;
  - **folded (`>`)** folds a single break between two equally-indented, non-blank
    lines to one space, but preserves the breaks around **more-indented** lines
    and around **blank** lines per YAML 1.2 §8.1.3 (so nested bullets, indented
    snippets, and paragraph breaks survive instead of being flattened);
  - **chomping** clip/strip/keep is applied to the trailing newline.

The decoded string is assigned to the key, so `description: >` / `description: |`
now yields a real string and the skill validates.

## Review-driven refinements

This fix was hardened across review rounds (all addressed at the current head):

- **@ss251** — folding was not indentation-aware; more-indented lines were
  flattened. Fixed in `3097e2b` with a regression test.
- **@attentionhead** / **@hermesagent270-commits** — two folding shapes still
  deviated from the reference `yaml` package: a blank line *after* a
  more-indented line was swallowed, and a folded block *starting* with a blank
  line emitted a leading space. Fixed in `37efaba` by making the fold loop
  paragraph-aware (blank-run counting, leading-blank preservation), with two new
  differential regression tests that match the `yaml` reference exactly.
- **@attentionhead** M3 mutant (explicit `|2`/`>2` indent had no test) — pinned
  in `a365286`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. This corrects frontmatter parsing for an already-documented SKILL.md format;
no user-facing API or config changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/parser.validation.test.ts` — the
`YAML block scalar descriptions (issue #30121)` block adds nine cases covering
folded space-joining, same-indent key continuation (no line swallowing), literal
`|` newline preservation, more-indented line breaks, explicit `|2` indent,
blank-line-after-more-indented paragraph breaks, leading-blank preservation,
`>-` strip chomping, and the end-to-end "valid, not `MISSING_FRONTMATTER`" case.
Several fixtures were checked against the real `yaml` package as an oracle by the
reviewers.

## Detailed testing steps

```bash
cd plugins/plugin-agent-skills
bunx vitest run src/parser.validation.test.ts   # focused
bun run test                                     # full package suite
bun run typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:37efaba5e4343ba5710a544857b2da7ecfb6e76a -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. Pure YAML-subset parser change in plugins/plugin-agent-skills/src/parser.ts; nothing is rendered.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface. See above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow. Correctness is proven by the failing-before / passing-after vitest output inlined under Evidence Details.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no server/runtime log path. The changed code is a synchronous string parser; its real execution is the vitest output inlined under Evidence Details.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response path.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior change. Only SKILL.md frontmatter parsing is corrected.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain artifact is the vitest before/after reproduction, inlined under Evidence Details. This fork-contributor account lacks elizaOS/eliza push access, so it cannot mint pr-evidence release-asset URLs; logs are inlined per the template inline allowance and the same suite runs green in the All Tests Passed CI job at this head.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior change.`

## Failing-before / passing-after (the domain artifact)

Reverting only `parser.ts` to `origin/develop` and running the validation suite
turns the nine issue-#30121 cases red — including the headline
`MISSING_FRONTMATTER` regression — proving the tests pin this fix rather than
passing alongside it:

<details>
<summary>bunx vitest run src/parser.validation.test.ts — parser.ts reverted to origin/develop (9 failed | 13 passed)</summary>

```
 × YAML block scalar descriptions (issue #30121) > folds a `>` description into a single space-joined line
   → expected null not to be null
 × YAML block scalar descriptions (issue #30121) > keeps a same-indent key after the block scalar (no line swallowing)
   → expected undefined to be 'MIT'
 × YAML block scalar descriptions (issue #30121) > preserves internal newlines for a literal `|` description
   → expected undefined to be 'First sentence about when to use this…'
 × YAML block scalar descriptions (issue #30121) > preserves line breaks around more-indented lines in a `>` description
   → expected undefined to be 'Use this skill when you need to:\n  -…'
 × YAML block scalar descriptions (issue #30121) > honors an explicit indentation indicator (`|2`) for the block base
   → expected '|2' to be '    deep line\nbase line\n'
 × YAML block scalar descriptions (issue #30121) > keeps a blank line after a more-indented folded line as a paragraph break
   → expected undefined to be 'a\n  x\n\nb\n'
 × YAML block scalar descriptions (issue #30121) > preserves a leading blank line in a `>` description without adding a space
   → expected undefined to be '\na b\n'
 × YAML block scalar descriptions (issue #30121) > strips the trailing newline for a `>-` chomped description
   → expected '>-' to be 'alpha beta'
 × YAML block scalar descriptions (issue #30121) > treats a folded description directory as valid, not MISSING_FRONTMATTER
   → expected [ 'MISSING_FRONTMATTER' ] to not include 'MISSING_FRONTMATTER'

 Test Files  1 failed (1)
      Tests  9 failed | 13 passed (22)
```
</details>

With the fix at head `37efaba` the same file is fully green:

<details>
<summary>bunx vitest run src/parser.validation.test.ts — HEAD 37efaba (22 passed)</summary>

```
 ✓ src/parser.validation.test.ts (22 tests) 55ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
```
</details>

Full package suite and typecheck at the same head:

<details>
<summary>bun run test — plugin-agent-skills (406 passed) + typecheck + biome</summary>

```
# bun run --cwd plugins/plugin-agent-skills test
 Test Files  34 passed (34)
      Tests  406 passed (406)

# bun run --cwd plugins/plugin-agent-skills typecheck
$ tsc --noEmit        # exit 0, no output

# bunx biome check plugins/plugin-agent-skills/src/parser.ts \
#     plugins/plugin-agent-skills/src/parser.validation.test.ts
Checked 2 files in 55ms. No fixes applied.   # exit 0
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Full repository `bun run verify` was not run on this constrained device (16 GB
  Raspberry Pi); the owning package's focused gates (vitest suite, typecheck,
  biome) were run and pass, and the repository **All Tests Passed** CI job is
  green at this head. The change is a single-file parser fix with no
  cross-package surface.
- Evidence artifacts could not be uploaded to the shared `pr-evidence` release:
  that requires push access to `elizaOS/eliza`, which this fork-contributor
  account (`agent-cortex`) does not have. Per the template's inline allowance,
  the vitest before/after output is inlined above verbatim.
- One unrelated package test (`skill-package-bytes.test.ts` deadline case) can
  time out under load on this device; it passes in isolation and is independent
  of the parser change.

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@37efaba5e4343ba5710a544857b2da7ecfb6e76a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@37efaba5e4343ba5710a544857b2da7ecfb6e76a:packages/skills/skills/contribute-to-eliza"} -->

