### PR TITLE
fix(ui): restore frontend hosting browser fixture

### DIFF
--- a/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
+++ b/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
@@ -207,7 +207,20 @@ export const Buffer = {
   alloc: () => ({}),
   byteLength: () => 0,
 };
-export const promises = {};
+export const promises = {
+  access: anyfn,
+  cp: anyfn,
+  mkdir: anyfn,
+  readFile: anyfn,
+  readdir: () => [],
+  rename: anyfn,
+  rm: anyfn,
+  rmdir: anyfn,
+  stat: anyfn,
+  symlink: anyfn,
+  unlink: anyfn,
+  writeFile: anyfn,
+};
 export const existsSync = () => false;
 export const readFileSync = anyfn;
 export const writeFileSync = anyfn;


### PR DESCRIPTION
## Summary

Restore the real frontend-hosting Chromium E2E on `develop` by making its `node:fs/promises` browser stub internally consistent.

The current `Develop Full` run reaches the fixture bundle, throws during module evaluation, renders a blank page, and times out waiting for `No deployments yet`. The bundled core browser graph now initializes `fs-extra-lite`, which binds methods from `fs.promises`; the harness exported that object as `{}` even though it already exported the corresponding named inert functions.

This change supplies those same inert functions through the stub's `promises` object. No production package or product behavior changes.

## Reproduction and proof

Base: `d8c5b3124d97fac8189ad49afc14363ba56764f6`

Before this change, the exact repository/Chromium flow fails:

```text
TypeError: Cannot read properties of undefined (reading 'bind')
TimeoutError: waitFor: Timeout 30000ms exceeded.
- waiting for getByText('No deployments yet') to be visible
```

The generated bundle resolves the exception to `promises.readFile.bind(promises)` while the harness stub initializes `promises = {}`.

After this change:

```text
bun run --cwd packages/ui test:frontend-hosting-e2e
...
✓ v1 row shows the live badge after publish
✓ older version's action is labeled Roll back
✓ owner preview serves the rolled-back v1 bytes
✓ Retry recovers from cloud-inactive once the API is back
ALL GREEN
```

The final synchronized run exercised the real PGlite migration, local Cloud API, SIWE signup, application creation, Chromium UI, publish/activate/rollback/delete lifecycle, desktop and mobile layouts, simulated 502 outage, and recovery. It produced 13 inspected screenshots plus the recorded walkthrough video.

Additional hygiene:

```text
node --check packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
git diff --check
```

Both pass. Biome intentionally ignores this E2E `.mjs` path.

## Evidence Gate

<!-- evidence-head:623f9e2bd7cc62c029b2cca526e44cfdaff119a4 -->

- [x] Before screenshots — N/A: the regression aborts during bundle module evaluation and leaves an empty body; the exact base failure log above is the useful pre-fix artifact.
- [x] After screenshots — 13 screenshots were generated and inspected by the passing real-browser run, covering desktop/mobile empty, selection, live versions, rollback, deletion, outage, and recovery states.
- [x] Walkthrough video — generated by the Playwright context for the complete passing lifecycle.
- [x] Backend logs — local Cloud API listened successfully, completed SIWE signup and app creation, and served the hosting lifecycle.
- [x] Frontend logs — the only expected console error is the deliberate 502 outage; retry then restores the UI and the run ends `ALL GREEN`.
- [x] Real LLM trajectory — N/A: deterministic Cloud/UI browser fixture; no model or agent behavior is involved.
- [x] Domain artifacts — real deployment versions were published, activated, rolled back, deleted, previewed, and reloaded through the live local Cloud API/PGlite stack.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
