### PR TITLE
fix(cloud): restore production Hyperdrive authority

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -1012,7 +1012,7 @@ bucket_name = "eliza-cloud-blob"
 # WebSocket driver in client.ts, which bypasses this binding).
 [[env.production.hyperdrive]]
 binding = "HYPERDRIVE"
-id = "486bdc36737a4ad1b526fc3c08627658"
+id = "9f59e4ec65f048f7b87e29e7b9c5d728"
 
 # KV is the Worker's cache backend (CacheClient). Workers can't reliably open raw
 # TCP to an external Redis (Railway's public proxy hangs under load), so the Worker


### PR DESCRIPTION
## Summary

Restores the production `HYPERDRIVE` binding to the configuration whose origin exactly matches the protected Railway `DATABASE_URL`. The currently deployed binding points to an incomplete database and causes valid production API keys to return `401 Invalid or expired API key`.

Closes #30130.

## Bounded recovery proof

- Served certified base: `8eebf60dc18e1032cb23a3df70a1e76f76af49d7`
- Certified develop policy: `d8c5b3124d97fac8189ad49afc14363ba56764f6`
- Complete source delta: one production Hyperdrive ID token in `packages/cloud/api/wrangler.toml`
- `production-hyperdrive-binding-admission.mjs`: PASS (`changedPathCount: 1`)
- Focused admission suite: 29/29 PASS
- `git diff --check`: PASS

## Deployment and acceptance

After merge, dispatch `.github/workflows/cloud-cf-deploy.yml` on `main` with `environment=production`, `production_binding_only_recovery=true`, and the immutable base/policy SHAs above. The protected job independently checks Hyperdrive origin equality before mutation. Then verify the live API-key balance and chat-completions paths.