### PR TITLE
fix(cloud): reuse bounded recovery evidence directory

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -664,7 +664,7 @@ jobs:
           set -euo pipefail
           umask 077
           evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
-          mkdir -m 0700 "$evidence_dir"
+          install -d -m 0700 "$evidence_dir"
           candidate_id="$(
             bun -e '
               const source = await Bun.file("packages/cloud/api/wrangler.toml").text();
@@ -728,7 +728,7 @@ jobs:
           set -euo pipefail
           umask 077
           evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
-          mkdir -m 0700 "$evidence_dir"
+          install -d -m 0700 "$evidence_dir"
           capture() {
             local label="$1"
             local output="$2"

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -439,6 +439,9 @@ describe("Cloud CF workflow staging certification gate", () => {
     expect(authorize).toContain(
       "audit-production-railway-database-authority.ts",
     );
+    expect(
+      authorize.match(/install -d -m 0700 "\$evidence_dir"/g),
+    ).toHaveLength(2);
     expect(authorize).toContain("--canonical-ref refs/heads/main");
     expect(authorize).toContain("bun run build:core");
     expect(authorize).toContain("wrangler deploy --env production --dry-run");


### PR DESCRIPTION
## Summary

Makes the bounded production Hyperdrive recovery authority directory idempotent across its sequential Cloudflare and Railway evidence steps. The Railway step currently fails before any mutation because the prior step already created the shared private directory.

Refs #30130.

## Evidence

- Reproduced in protected recovery run `33357391241`: Cloudflare authority passed; Railway capture failed on `mkdir: File exists`.
- Both authority steps now use `install -d -m 0700`, preserving private permissions while allowing the second step to reuse the directory.
- Regression assertion requires both idempotent directory initializations.
- Focused certification/admission suites: 63/63 PASS.
- actionlint: PASS.
- Biome: PASS.
- `git diff --check`: PASS.

After merge, the exact develop tree will be deployed to staging to obtain the immutable recovery-policy certificate before byte-identical promotion to `main`.