### PR TITLE
fix(cloud): reuse bounded recovery evidence directory

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -664,7 +664,7 @@ jobs:
           set -euo pipefail
           umask 077
           evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
-          mkdir -m 0700 "$evidence_dir"
+          install -d -m 0700 "$evidence_dir"
           candidate_id="$(
             bun -e '
               const source = await Bun.file("packages/cloud/api/wrangler.toml").text();
@@ -728,7 +728,7 @@ jobs:
           set -euo pipefail
           umask 077
           evidence_dir="$RUNNER_TEMP/production-binding-recovery-authority"
-          mkdir -m 0700 "$evidence_dir"
+          install -d -m 0700 "$evidence_dir"
           capture() {
             local label="$1"
             local output="$2"

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -439,6 +439,9 @@ describe("Cloud CF workflow staging certification gate", () => {
     expect(authorize).toContain(
       "audit-production-railway-database-authority.ts",
     );
+    expect(
+      authorize.match(/install -d -m 0700 "\$evidence_dir"/g),
+    ).toHaveLength(2);
     expect(authorize).toContain("--canonical-ref refs/heads/main");
     expect(authorize).toContain("bun run build:core");
     expect(authorize).toContain("wrangler deploy --env production --dry-run");


### PR DESCRIPTION
## Summary

Main-side companion for #30133. It carries byte-identical trusted recovery policy bytes so production can consume only the independently certified develop policy.

Refs #30130.

## Hard ordering gate

**Do not merge until #30133 has a write-access approval, is merged to `develop`, and its exact merged develop tree receives a successful immutable staging release certificate.** The production dispatch must use that exact certified develop policy SHA.

## Verification

- All five trusted policy blob IDs are byte-identical to develop candidate `1e01e1c2adf4ee2cffd4915b71590c6abeac1e20`.
- Focused certification/admission suites: 63/63 PASS.
- actionlint: PASS.
- `git diff --check`: PASS.

No Cloudflare binding, database row, tenant, Worker, billing, or deployment mutation is included.