### PR TITLE
fix(core): retain stored role-write audit history in mergeWorldMetadataForLegacyWrite

### DIFF
--- a/packages/core/src/database/world-metadata-cas.test.ts
+++ b/packages/core/src/database/world-metadata-cas.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Owns the legacy-write authority-retention contract of world-metadata-cas:
+ * a possibly-stale caller snapshot passed to mergeWorldMetadataForLegacyWrite
+ * must never erase adapter-owned authority state (roles, roleSources, the
+ * optimistic revision, and the role-write audit history) from the stored
+ * world. Harness is real and deterministic: the exported helpers are executed
+ * directly with real metadata objects, no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import type { Metadata } from "../types/primitives";
+import {
+	appendWorldMetadataRoleAudit,
+	mergeWorldMetadataForLegacyWrite,
+	WORLD_METADATA_REVISION_KEY,
+	WORLD_METADATA_ROLE_AUDIT_KEY,
+} from "./world-metadata-cas";
+
+function storedWorldWithAudit(): Metadata {
+	let stored: Metadata = {
+		[WORLD_METADATA_REVISION_KEY]: 5,
+		theme: "dark",
+	};
+	stored = appendWorldMetadataRoleAudit(stored, {
+		actorEntityId: "a1",
+		newRole: "admin",
+	});
+	stored = appendWorldMetadataRoleAudit(stored, {
+		actorEntityId: "a2",
+		newRole: "moderator",
+	});
+	return stored;
+}
+
+describe("mergeWorldMetadataForLegacyWrite audit retention", () => {
+	it("retains the stored audit history when the caller snapshot carries a stale shorter audit", () => {
+		const stored = storedWorldWithAudit();
+		const staleIncoming: Metadata = {
+			[WORLD_METADATA_REVISION_KEY]: 5,
+			theme: "dark",
+			[WORLD_METADATA_ROLE_AUDIT_KEY]: [
+				{ actorEntityId: "a1", newRole: "admin" },
+			],
+		};
+
+		const merged = mergeWorldMetadataForLegacyWrite(
+			stored,
+			staleIncoming,
+			"world-1",
+		);
+
+		const rows = merged[WORLD_METADATA_ROLE_AUDIT_KEY] as unknown[];
+		// The stored history (a1, a2) survives; the stale single-row snapshot
+		// must not replace it.
+		expect(rows).toHaveLength(2);
+		expect(rows).toEqual(stored[WORLD_METADATA_ROLE_AUDIT_KEY]);
+	});
+
+	it("retains the stored audit history when the caller snapshot has no audit key at all", () => {
+		const stored = storedWorldWithAudit();
+		const incoming: Metadata = {
+			[WORLD_METADATA_REVISION_KEY]: 5,
+			theme: "light",
+		};
+
+		const merged = mergeWorldMetadataForLegacyWrite(
+			stored,
+			incoming,
+			"world-1",
+		);
+
+		expect(merged[WORLD_METADATA_ROLE_AUDIT_KEY]).toEqual(
+			stored[WORLD_METADATA_ROLE_AUDIT_KEY],
+		);
+		// Ordinary observations still merge through.
+		expect(merged.theme).toBe("light");
+	});
+
+	it("drops a caller-supplied audit when the stored world has no audit history", () => {
+		// Mirrors the roles/roleSources semantics: the audit key is
+		// adapter-owned authority state, so a caller-supplied value never
+		// passes through even when the stored world has nothing to protect.
+		const stored: Metadata = { [WORLD_METADATA_REVISION_KEY]: 2 };
+		const incoming: Metadata = {
+			[WORLD_METADATA_REVISION_KEY]: 2,
+			[WORLD_METADATA_ROLE_AUDIT_KEY]: [
+				{ actorEntityId: "a9", newRole: "admin" },
+			],
+		};
+
+		const merged = mergeWorldMetadataForLegacyWrite(
+			stored,
+			incoming,
+			"world-1",
+		);
+
+		expect(Object.hasOwn(merged, WORLD_METADATA_ROLE_AUDIT_KEY)).toBe(false);
+	});
+
+	it("still pins the revision and role maps while retaining the audit", () => {
+		const storedRoles = { admin: ["a1"] };
+		const stored: Metadata = {
+			...storedWorldWithAudit(),
+			roles: storedRoles,
+			roleSources: { admin: "authority" },
+		};
+		const incoming: Metadata = {
+			[WORLD_METADATA_REVISION_KEY]: 999,
+			roles: {},
+			roleSources: {},
+			[WORLD_METADATA_ROLE_AUDIT_KEY]: [],
+		};
+
+		const merged = mergeWorldMetadataForLegacyWrite(
+			stored,
+			incoming,
+			"world-1",
+		);
+
+		expect(merged.roles).toEqual(storedRoles);
+		expect(merged.roleSources).toEqual({ admin: "authority" });
+		expect(merged[WORLD_METADATA_REVISION_KEY]).toBe(5);
+		expect(merged[WORLD_METADATA_ROLE_AUDIT_KEY]).toEqual(
+			stored[WORLD_METADATA_ROLE_AUDIT_KEY],
+		);
+	});
+
+	it("never mutates the caller or stored metadata objects", () => {
+		const stored = storedWorldWithAudit();
+		const storedSnapshot = structuredClone(stored);
+		const staleIncoming: Metadata = {
+			[WORLD_METADATA_REVISION_KEY]: 5,
+			[WORLD_METADATA_ROLE_AUDIT_KEY]: [
+				{ actorEntityId: "a1", newRole: "admin" },
+			],
+		};
+		const incomingSnapshot = structuredClone(staleIncoming);
+
+		const merged = mergeWorldMetadataForLegacyWrite(
+			stored,
+			staleIncoming,
+			"world-1",
+		);
+
+		expect(stored).toEqual(storedSnapshot);
+		expect(staleIncoming).toEqual(incomingSnapshot);
+		// The merged audit array is a detached copy, not the stored reference:
+		// mutating the merged result never rewrites stored history.
+		(merged[WORLD_METADATA_ROLE_AUDIT_KEY] as unknown[]).pop();
+		expect(stored[WORLD_METADATA_ROLE_AUDIT_KEY]).toHaveLength(2);
+	});
+});

--- a/packages/core/src/database/world-metadata-cas.ts
+++ b/packages/core/src/database/world-metadata-cas.ts
@@ -114,6 +114,10 @@ export function mergeWorldMetadataForLegacyWrite(
 	// newly constructed owner-only projection during message ingestion.
 	delete incoming.roles;
 	delete incoming.roleSources;
+	// The role-write audit trail is the same authority state: caller metadata
+	// is a possibly-stale round-tripped snapshot, so its shorter audit array
+	// must never erase appended rows on the stored world.
+	delete incoming[WORLD_METADATA_ROLE_AUDIT_KEY];
 	return {
 		...stored,
 		...incoming,
@@ -121,6 +125,12 @@ export function mergeWorldMetadataForLegacyWrite(
 		...(stored.roleSources === undefined
 			? {}
 			: { roleSources: stored.roleSources }),
+		...(stored[WORLD_METADATA_ROLE_AUDIT_KEY] === undefined
+			? {}
+			: {
+					[WORLD_METADATA_ROLE_AUDIT_KEY]:
+						stored[WORLD_METADATA_ROLE_AUDIT_KEY],
+				}),
 		[WORLD_METADATA_REVISION_KEY]: storedRevision,
 	};
 }


### PR DESCRIPTION
Closes #30132

# Relates to

- Closes #30132
- Consumer: `AgentRuntime.ensureWorldExists` (packages/core/src/runtime.ts ~L4910) — every legacy whole-world write funnels through `mergeWorldMetadataForLegacyWrite`; connectors pass round-tripped `world.metadata` snapshots back in.
- Authority surface: `__eliza_role_audit` is the role-write audit trail introduced with the #23100 CAS work; `appendWorldMetadataRoleAudit`'s header promises to "Preserve authority history even when connector-owned log rows are deleted."

# What broke

`mergeWorldMetadataForLegacyWrite` re-pinned `roles`, `roleSources`, and the optimistic revision against stale caller metadata, but not `WORLD_METADATA_ROLE_AUDIT_KEY`. A connector snapshot older than the latest role write carries a shorter audit array; the next `ensureWorldExists` silently erased the appended audit rows from the persisted world — no error, no failing test anywhere.

Executed reproduction at `origin/develop` `d8c5b3124d` (direct module import):

```ts
stored = { revision: 5, audit: [a1, a2] }        // via appendWorldMetadataRoleAudit
incoming = { revision: 5, audit: [a1] }          // stale round-tripped snapshot
mergeWorldMetadataForLegacyWrite(stored, incoming) // -> audit: [a1] — a2 erased
```

# The fix

Mirrors the existing `roles`/`roleSources` retention in the same function: the cloned incoming metadata's audit key is deleted, and the stored audit is re-added when present. 10 lines in `packages/core/src/database/world-metadata-cas.ts`.

# Verification

- **Red control**: with the develop version of the module restored at the same tree, the new suite fails 3/5 (stale-shorter-audit retention, caller-audit drop, and the combined authority-pinning test); with the fix, 5/5 pass — the tests pin the behavior the fix introduces.
- **New suite** (`packages/core/src/database/world-metadata-cas.test.ts`, 5 tests): stale-shorter-audit retention, absent-audit retention + ordinary-key passthrough, caller-audit drop when stored has none (symmetric with `roles`), combined roles/roleSources/revision/audit pinning, and input non-mutation + detached-output clone isolation.
- **Neighbors at head**: `roles.role-write-cas` (12), `roles.resolution`, `roles.owner-for-message`, `trust/actions/roles.cas`, `trust/actions/roles` (62 total), `dm-world-metadata` (4) — all green.
- `bun run --cwd packages/core typecheck`: 0 errors. `biome check` on both files: clean.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `d8c5b3124d` with zero conflicts.
- [x] `bun install` not needed (no dependency change); package typecheck and focused suites pass as listed above.
- [x] A reviewer can confirm the defect and fix from the reproduction, red control, and suite above without reading anything else.

# Sync with develop

- [x] Branched from `origin/develop` tip `d8c5b3124d`; zero conflicts.
- [x] Focused verification rerun after commit at the final head.

# Risks

Low. One function's merge semantics narrow: caller-supplied `__eliza_role_audit` values were previously (incorrectly) passed through; now the stored history always wins, matching the documented invariant and the sibling `roles`/`roleSources` behavior in the same function. No adapter, wire, or migration surface changes.

<!-- evidence-head:087430c206e0c317c1ac0cf17c5f3887394e03ed -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only head move 6394bbb3a7 (no behavior change); verified at new head: vitest world-metadata-cas.test.ts 5/5 pass, packages/core typecheck rc=0, clean rebase onto develop 3a7f438a9e

$ bun run --cwd packages/core typecheck   # rc=0
Done!

$ bunx biome check packages/core/src/database/world-metadata-cas.ts packages/core/src/database/world-metadata-cas.test.ts
Checked 2 files in 65ms. No fixes applied.
```

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change; pure packages/core module fix

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI/UX change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/trajectory surface change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser surface change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - defect reproduction is the inline bun probe transcript in the PR body

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@3e2749ee1cf340314f9dc2b36e0c4333c18ea760:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@3e2749ee1cf340314f9dc2b36e0c4333c18ea760:packages/skills/skills/contribute-to-eliza"} -->




