### PR TITLE
fix(cloud): restore $5 signup credit

### DIFF
--- a/packages/cloud/api/v1/agents/route.sync.test.ts
+++ b/packages/cloud/api/v1/agents/route.sync.test.ts
@@ -7,8 +7,8 @@ const requireServiceKey = mock(async () => ({
 }));
 const findOrCreateUserByWalletAddress = mock(async (walletAddress: string) => ({
   isNewAccount: true,
-  initialCreditsGranted: false,
-  initialFreeCreditsUsd: 0,
+  initialCreditsGranted: true,
+  initialFreeCreditsUsd: 5,
   user: {
     id: "agent-wallet-user",
     organization_id: "agent-wallet-org",

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -8,8 +8,8 @@ const requireServiceKey = mock(async () => ({
 }));
 const findOrCreateUserByWalletAddress = mock(async (walletAddress: string) => ({
   isNewAccount: true,
-  initialCreditsGranted: false,
-  initialFreeCreditsUsd: 0,
+  initialCreditsGranted: true,
+  initialFreeCreditsUsd: 5,
   user: {
     id: "agent-wallet-user",
     organization_id: "agent-wallet-org",
@@ -179,7 +179,7 @@ describe("service agent provisioning route", () => {
     enqueueAgentProvision.mockClear();
   });
 
-  test("creates a funded wallet-owned cloud agent without minting signup credit", async () => {
+  test("creates a wallet-owned cloud agent with the fixed signup credit", async () => {
     const response = await app.fetch(
       new Request("https://api.example.test/", {
         method: "POST",
@@ -261,8 +261,8 @@ describe("service agent provisioning route", () => {
         organizationId: "agent-wallet-org",
         userId: "agent-wallet-user",
         isNewAccount: true,
-        initialCreditsGranted: false,
-        initialFreeCreditsUsd: 0,
+        initialCreditsGranted: true,
+        initialFreeCreditsUsd: 5,
         welcomeBonusWithheld: false,
       },
     });
@@ -459,7 +459,7 @@ describe("service agent provisioning route", () => {
         agentConfig: expect.objectContaining({
           billing: {
             mode: "owner_credits",
-            initialReserveUsd: 0,
+            initialReserveUsd: 5,
           },
           access: expect.objectContaining({
             guestTokenThreshold: 1000,

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -334,8 +334,8 @@ app.post("/", async (c) => {
       throw error;
     }
 
-    const initialCreditsGranted = false;
-    const initialFreeCreditsUsd = SIGNUP_CREDIT_POLICY.automaticGrantUsd;
+    const initialCreditsGranted = walletAccount?.initialCreditsGranted ?? false;
+    const initialFreeCreditsUsd = walletAccount?.initialFreeCreditsUsd ?? 0;
     const welcomeBonusWithheld = false;
     const welcomeBonusWithheldReason = undefined;
     const welcomeBonusWithheldMessage = undefined;

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
@@ -260,7 +260,7 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
     ).resolves.toEqual({ status: "identity_projection_conflict" });
   });
 
-  test("converges exactly two $0 provisional accounts and retains an idempotent alias receipt", async () => {
+  test("converges two signup accounts without doubling the $5 opening balance", async () => {
     const pair = await createPair();
     const proof = proofFor(pair);
     const inspection = await usersRepository.inspectPhoneTelegramPersonalAccountConvergence(proof);
@@ -289,7 +289,7 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
       phone_number: pair.phoneNumber,
       phone_verified: true,
     });
-    expect(result.organization.credit_balance).toBe("0.000000");
+    expect(result.organization.credit_balance).toBe("5.000000");
     expect(await dbWrite.select().from(users)).toHaveLength(1);
     expect(await dbWrite.select().from(organizations)).toHaveLength(1);
     expect(await dbWrite.select().from(userIdentities)).toHaveLength(1);

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
@@ -368,6 +368,35 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
     });
   });
 
+  test("converges a new $5 phone account into an untouched legacy $0 Telegram account", async () => {
+    const pair = await createPair();
+    await dbWrite
+      .update(organizations)
+      .set({ credit_balance: "0.000000", balance_revision: 0 })
+      .where(eq(organizations.id, pair.telegram.organization.id));
+    const proof = proofFor(pair);
+    const inspection = await usersRepository.inspectPhoneTelegramPersonalAccountConvergence(proof);
+    expect(inspection.status).toBe("eligible");
+    if (inspection.status !== "eligible") return;
+
+    const result = await usersRepository.commitPhoneTelegramPersonalAccountConvergence({
+      ...proof,
+      sourceUserId: pair.phone.user.id,
+      sourceOrganizationId: pair.phone.organization.id,
+      sourceAgentId: "personal:legacy-source",
+      targetUserId: pair.telegram.user.id,
+      targetOrganizationId: pair.telegram.organization.id,
+      targetAgentId: "personal:legacy-target",
+      token: `phone-telegram-legacy:${pair.phone.user.id}:${pair.telegram.user.id}`,
+    });
+
+    expect(result.status).toBe("committed");
+    if (result.status !== "committed") return;
+    expect(result.organization.credit_balance).toBe("5.000000");
+    expect(await dbWrite.select().from(users)).toHaveLength(1);
+    expect(await dbWrite.select().from(organizations)).toHaveLength(1);
+  });
+
   test("moves source Todos and replay authority into the retained Telegram scope", async () => {
     const pair = await createPair();
     const proof = proofFor(pair);

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-link-telegram-phone.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-link-telegram-phone.test.ts
@@ -112,7 +112,7 @@ describe("UsersRepository.linkTelegramAndPhoneIdentity (real PGlite)", () => {
     await closeDatabaseConnectionsForTests();
   });
 
-  test("concurrent trusted first texts create one zero-balance personal account", async () => {
+  test("concurrent trusted first texts create one personal account with $5", async () => {
     const phone = "+14155550100";
     const attempts = await Promise.all(
       Array.from({ length: 8 }, (_, index) =>
@@ -129,7 +129,7 @@ describe("UsersRepository.linkTelegramAndPhoneIdentity (real PGlite)", () => {
       new Set([attempts[0]?.user.id]),
     );
     expect(attempts.filter((result) => result.isNew)).toHaveLength(1);
-    expect(attempts[0]?.organization.credit_balance).toBe("0.000000");
+    expect(attempts[0]?.organization.credit_balance).toBe("5.000000");
     expect(await dbWrite.select().from(users)).toHaveLength(1);
     expect(await dbWrite.select().from(userIdentities)).toHaveLength(1);
     expect(await dbWrite.select().from(organizations)).toHaveLength(1);

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-promote-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-promote-telegram-personal-account.test.ts
@@ -80,7 +80,7 @@ describe("UsersRepository Telegram account promotion (real PGlite)", () => {
     await closeDatabaseConnectionsForTests();
   });
 
-  test("promotes the continuation-bound account without replacing its user, org, or $0 balance", async () => {
+  test("promotes the continuation-bound account without replacing its user, org, or $5 balance", async () => {
     const telegramId = "100000201";
     const provisional = await createTelegramAccount(telegramId);
 
@@ -95,7 +95,7 @@ describe("UsersRepository Telegram account promotion (real PGlite)", () => {
     if (result.status !== "promoted") return;
     expect(result.user.id).toBe(provisional.user.id);
     expect(result.organization.id).toBe(provisional.organization.id);
-    expect(result.organization.credit_balance).toBe("0.000000");
+    expect(result.organization.credit_balance).toBe("5.000000");
     expect(result.user.telegram_id).toBe(telegramId);
 
     const [projection] = await dbWrite

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -9,6 +9,7 @@ import {
   sharedRuntimeWorldId,
   sharedTodoStorageScope,
 } from "../../lib/services/shared-runtime/shared-runtime-storage-identity";
+import { SIGNUP_CREDIT_POLICY } from "../../lib/signup-credits";
 import type { DbTransaction } from "../client";
 import { type SqlExecutor, sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -275,15 +276,15 @@ function hasOnlyEmptySettings(value: unknown): boolean {
   );
 }
 
-function isZeroBalance(value: unknown): boolean {
+function isSignupOpeningBalance(value: unknown): boolean {
   const amount = typeof value === "number" ? value : Number(String(value));
-  return Number.isFinite(amount) && amount === 0;
+  return Number.isFinite(amount) && amount === SIGNUP_CREDIT_POLICY.automaticGrantUsd;
 }
 
 function isPristineProvisionalOrganization(organization: Organization): boolean {
   return (
     organization.is_active &&
-    isZeroBalance(organization.credit_balance) &&
+    isSignupOpeningBalance(organization.credit_balance) &&
     organization.balance_revision === 0 &&
     hasOnlyEmptySettings(organization.settings) &&
     organization.stripe_customer_id === null &&
@@ -1824,7 +1825,7 @@ export class UsersRepository {
         .values({
           name: params.organizationName,
           slug: params.organizationSlug,
-          credit_balance: "0.00",
+          credit_balance: SIGNUP_CREDIT_POLICY.openingBalanceUsd,
         })
         .returning();
       if (!organization) {
@@ -2292,7 +2293,7 @@ export class UsersRepository {
         .values({
           name: params.organizationName,
           slug: params.organizationSlug,
-          credit_balance: "0.00",
+          credit_balance: SIGNUP_CREDIT_POLICY.openingBalanceUsd,
         })
         .returning();
       if (!organization) throw new Error(`Failed to create ${label} personal organization`);

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -9,7 +9,7 @@ import {
   sharedRuntimeWorldId,
   sharedTodoStorageScope,
 } from "../../lib/services/shared-runtime/shared-runtime-storage-identity";
-import { SIGNUP_CREDIT_POLICY } from "../../lib/signup-credits";
+import { isUntouchedSignupOpeningBalance, SIGNUP_CREDIT_POLICY } from "../../lib/signup-credits";
 import type { DbTransaction } from "../client";
 import { type SqlExecutor, sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -276,16 +276,20 @@ function hasOnlyEmptySettings(value: unknown): boolean {
   );
 }
 
-function isSignupOpeningBalance(value: unknown): boolean {
+function signupOpeningBalanceAmount(value: unknown): number | undefined {
   const amount = typeof value === "number" ? value : Number(String(value));
-  return Number.isFinite(amount) && amount === SIGNUP_CREDIT_POLICY.automaticGrantUsd;
+  return Number.isFinite(amount) ? amount : undefined;
 }
 
 function isPristineProvisionalOrganization(organization: Organization): boolean {
+  const balanceUsd = signupOpeningBalanceAmount(organization.credit_balance);
   return (
     organization.is_active &&
-    isSignupOpeningBalance(organization.credit_balance) &&
-    organization.balance_revision === 0 &&
+    balanceUsd !== undefined &&
+    isUntouchedSignupOpeningBalance({
+      balanceUsd,
+      balanceRevision: organization.balance_revision,
+    }) &&
     hasOnlyEmptySettings(organization.settings) &&
     organization.stripe_customer_id === null &&
     organization.billing_email === null &&
@@ -1413,6 +1417,24 @@ export class UsersRepository {
       // deleting the source account would orphan it, so convergence stops.
       if (sourceSchedulingState.has_state) return { status: "phone_account_mature" };
 
+      let retainedOrganization = targetOrganization;
+      const sourceOpeningBalance = signupOpeningBalanceAmount(sourceOrganization.credit_balance);
+      const targetOpeningBalance = signupOpeningBalanceAmount(targetOrganization.credit_balance);
+      if (
+        sourceOpeningBalance === SIGNUP_CREDIT_POLICY.automaticGrantUsd &&
+        targetOpeningBalance === SIGNUP_CREDIT_POLICY.legacyOpeningBalanceUsd
+      ) {
+        const [updatedOrganization] = await tx
+          .update(organizations)
+          .set({ credit_balance: SIGNUP_CREDIT_POLICY.openingBalanceUsd })
+          .where(eq(organizations.id, targetOrganization.id))
+          .returning();
+        if (!updatedOrganization) {
+          throw new Error("Telegram target organization changed during convergence");
+        }
+        retainedOrganization = updatedOrganization;
+      }
+
       const [canonicalStewardOwner] = await tx
         .select({ id: users.id })
         .from(users)
@@ -1533,7 +1555,7 @@ export class UsersRepository {
         status: "committed",
         receipt,
         user: mergedUser,
-        organization: targetOrganization,
+        organization: retainedOrganization,
       };
     });
   }

--- a/packages/cloud/shared/src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts
@@ -56,6 +56,10 @@ let hashInviteToken: typeof import("../../utils/invite-tokens").hashInviteToken;
 let schemas: {
   organizations: typeof import("../../../db/schemas/organizations").organizations;
   users: typeof import("../../../db/schemas/users").users;
+  userIdentities: typeof import("../../../db/schemas/user-identities").userIdentities;
+  personalSharedGroupBindings: typeof import("../../../db/schemas/personal-shared-groups").personalSharedGroupBindings;
+  personalSharedGroupJoinChallenges: typeof import("../../../db/schemas/personal-shared-groups").personalSharedGroupJoinChallenges;
+  personalSharedGroupParticipants: typeof import("../../../db/schemas/personal-shared-groups").personalSharedGroupParticipants;
   organizationInvites: typeof import("../../../db/schemas/organization-invites").organizationInvites;
   userCharacters: typeof import("../../../db/schemas/user-characters").userCharacters;
   conversations: typeof import("../../../db/schemas/conversations").conversations;
@@ -85,6 +89,7 @@ interface SeedResult {
 
 async function seedInviteScenario(options?: {
   inviteeOrgBalance?: string;
+  inviteeOrgBalanceRevision?: number;
   invitedRole?: "admin" | "member";
 }): Promise<SeedResult> {
   const inviterOrgId = uid();
@@ -100,6 +105,7 @@ async function seedInviteScenario(options?: {
       name: "Solo Org",
       slug: `solo-${inviteeOrgId}`,
       credit_balance: options?.inviteeOrgBalance ?? "5.000000",
+      balance_revision: options?.inviteeOrgBalanceRevision ?? 0,
     },
   ]);
   await dbWrite.insert(schemas.users).values([
@@ -160,6 +166,12 @@ beforeAll(async () => {
 
     const { organizations } = await import("../../../db/schemas/organizations");
     const { users } = await import("../../../db/schemas/users");
+    const { userIdentities } = await import("../../../db/schemas/user-identities");
+    const {
+      personalSharedGroupBindings,
+      personalSharedGroupJoinChallenges,
+      personalSharedGroupParticipants,
+    } = await import("../../../db/schemas/personal-shared-groups");
     const { organizationInvites } = await import("../../../db/schemas/organization-invites");
     const { userCharacters } = await import("../../../db/schemas/user-characters");
     const { conversations } = await import("../../../db/schemas/conversations");
@@ -183,6 +195,10 @@ beforeAll(async () => {
     schemas = {
       organizations,
       users,
+      userIdentities,
+      personalSharedGroupBindings,
+      personalSharedGroupJoinChallenges,
+      personalSharedGroupParticipants,
       organizationInvites,
       userCharacters,
       conversations,
@@ -197,6 +213,10 @@ beforeAll(async () => {
       {
         organizations,
         users,
+        userIdentities,
+        personalSharedGroupBindings,
+        personalSharedGroupJoinChallenges,
+        personalSharedGroupParticipants,
         organizationInvites,
         userCharacters,
         conversations,
@@ -262,7 +282,7 @@ describe("acceptInvite solo-org vacate — corrupt credit_balance fails closed (
   );
 
   test(
-    "a healthy zero balance still vacates (no false block)",
+    "an untouched legacy zero balance still vacates (no rollout false block)",
     async () => {
       expect(pgliteReady).toBe(true);
       const seeded = await seedInviteScenario({ inviteeOrgBalance: "0.000000" });
@@ -273,6 +293,60 @@ describe("acceptInvite solo-org vacate — corrupt credit_balance fails closed (
       // Moved into the inviting org; the emptied solo org is deleted as designed.
       expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviterOrgId);
       expect(await orgExists(seeded.inviteeOrgId)).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an untouched current five-dollar signup balance still vacates",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+
+      const accepted = await invitesService.acceptInvite(seeded.token, seeded.inviteeUserId);
+      expect(accepted.status).toBe("accepted");
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviterOrgId);
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a transacted balance below the signup grant blocks vacate and preserves purchased credit",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario({
+        inviteeOrgBalance: "2.000000",
+        inviteeOrgBalanceRevision: 42,
+      });
+
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        SOLO_ORG_CREDITS_BLOCK_MESSAGE,
+      );
+
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
+      expect(await readOrgBalance(seeded.inviteeOrgId)).toBe("2.000000");
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a transacted five-dollar balance blocks vacate even when it matches the signup grant",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario({
+        inviteeOrgBalance: "5.000000",
+        inviteeOrgBalanceRevision: 43,
+      });
+
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        SOLO_ORG_CREDITS_BLOCK_MESSAGE,
+      );
+
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
+      expect(await readOrgBalance(seeded.inviteeOrgId)).toBe("5.000000");
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
@@ -81,17 +81,17 @@ describe("ElizaAppUserService account opening balance", () => {
     addCredits.mockReset();
   });
 
-  test("creates a phone-first personal account at zero without an automatic credit transaction", async () => {
+  test("creates a phone-first personal account with the fixed opening credit", async () => {
     findOrCreatePhonePersonalAccount.mockResolvedValue({
       user: { id: "user-new", phone_number: "+15551234567" },
-      organization: { id: "org-new", credit_balance: "0.00" },
+      organization: { id: "org-new", credit_balance: "5.00" },
       isNew: true,
     });
 
     const result = await elizaAppUserService.findOrCreateByPhone("+15551234567");
 
     expect(result.isNew).toBe(true);
-    expect(result.organization.credit_balance).toBe("0.00");
+    expect(result.organization.credit_balance).toBe("5.00");
     expect(findOrCreatePhonePersonalAccount).toHaveBeenCalledWith(
       expect.objectContaining({ phoneNumber: "+15551234567" }),
     );

--- a/packages/cloud/shared/src/lib/services/eliza-app/x-personal-identity.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/x-personal-identity.integration.test.ts
@@ -70,7 +70,7 @@ async function seedMatureUser(userId: string, suffix: string) {
 }
 
 describe("X personal identity", () => {
-  test("creates one $0 account and reuses it for a retried DM", async () => {
+  test("creates one $5 account and reuses it for a retried DM", async () => {
     const created = await findOrCreateXPersonalAccount({
       twitterUserId: "111",
       username: "alice",
@@ -84,7 +84,7 @@ describe("X personal identity", () => {
     expect(created.isNew).toBe(true);
     expect(replayed.isNew).toBe(false);
     expect(replayed.user.id).toBe(created.user.id);
-    expect(Number(created.organization.credit_balance)).toBe(0);
+    expect(Number(created.organization.credit_balance)).toBe(5);
     expect(created.user.steward_user_id).toBe("x:111");
     const links = await dbWrite
       .select()

--- a/packages/cloud/shared/src/lib/services/eliza-app/x-personal-identity.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/x-personal-identity.ts
@@ -8,6 +8,7 @@ import { dbWrite } from "../../../db/helpers";
 import { identityLinks } from "../../../db/schemas/identity-links";
 import { type Organization, organizations } from "../../../db/schemas/organizations";
 import { type User, users } from "../../../db/schemas/users";
+import { SIGNUP_CREDIT_POLICY } from "../../signup-credits";
 
 const X_PROVIDER = "x";
 
@@ -70,7 +71,7 @@ async function loadAvailableAccount(
   return { user, organization };
 }
 
-/** Resolves a trusted central-bot sender, creating a rowless $0 account once. */
+/** Resolves a trusted central-bot sender, creating one funded personal account. */
 export async function findOrCreateXPersonalAccount(params: {
   twitterUserId: string;
   username?: string;
@@ -110,7 +111,7 @@ export async function findOrCreateXPersonalAccount(params: {
       .values({
         name: `${params.displayName?.trim() || params.username?.trim() || "X user"}'s Workspace`,
         slug: `x-${twitterUserId}`,
-        credit_balance: "0.00",
+        credit_balance: SIGNUP_CREDIT_POLICY.openingBalanceUsd,
       })
       .returning();
     if (!organization) throw new Error("Failed to create X personal organization");

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -13,7 +13,7 @@ import { userCharactersRepository } from "../../db/repositories/characters";
 import { containersRepository } from "../../db/repositories/containers";
 import { conversationsRepository } from "../../db/repositories/conversations";
 import { parseOrganizationCreditBalance } from "../../db/repositories/organizations-credit-balance-numeric";
-import { SIGNUP_CREDIT_POLICY } from "../signup-credits";
+import { isUntouchedSignupOpeningBalance } from "../signup-credits";
 import { generateInviteToken, hashInviteToken } from "../utils/invite-tokens";
 import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
@@ -185,8 +185,8 @@ export class InvitesService {
     // Every self-signup provisions its user as the OWNER of a fresh solo org
     // (steward-sync), so a blanket owner block would dead-end every existing
     // account (#11332). An owner may accept iff their current org is an empty
-    // solo org: no other members, no deployed apps/agents/domains, and no
-    // credits. Anything richer keeps the block with an
+    // solo org: no other members, no deployed apps/agents/domains, and only an
+    // untouched signup opening balance. Anything richer keeps the block with an
     // actionable error — abandoning a real org needs an explicit path.
     const vacatedSoloOrgId = user.role === "owner" ? user.organization_id : null;
     if (vacatedSoloOrgId) {
@@ -231,7 +231,7 @@ export class InvitesService {
 
   /**
    * Gate for an owner accepting an invite: their current org must be an empty
-   * solo org (the auto-provisioned signup artifact), not a real organization.
+   * solo org with an untouched signup balance, not a real organization.
    */
   private async assertOwnerCanVacateSoloOrganization(
     userId: string,
@@ -268,7 +268,9 @@ export class InvitesService {
     if (organization) {
       // Fail closed on a corrupt `credit_balance` (#13415). This guard exists to
       // stop an owner vacating (and thereby auto-deleting) a solo org that still
-      // holds purchased or promotional credits. `credit_balance` is a Postgres
+      // holds purchased or promotional credits. Both the balance amount and its
+      // revision identify an untouched signup grant: a smaller balance can be
+      // purchased credit remaining after spend. `credit_balance` is a Postgres
       // NUMERIC (string at read); the previous bare `Number(...)` failed OPEN on
       // an unreadable value (`'NaN'::numeric` migration artifact / manual edit
       // reads back `"NaN"`): comparing NaN to the policy threshold is FALSE, so the guard
@@ -288,7 +290,12 @@ export class InvitesService {
         // vacate path instead of falling through as a generic storage failure.
         throw new Error(SOLO_ORG_CREDITS_BLOCK_MESSAGE, { cause: error });
       }
-      if (creditBalance > SIGNUP_CREDIT_POLICY.automaticGrantUsd) {
+      if (
+        !isUntouchedSignupOpeningBalance({
+          balanceUsd: creditBalance,
+          balanceRevision: organization.balance_revision,
+        })
+      ) {
         throw new Error(SOLO_ORG_CREDITS_BLOCK_MESSAGE);
       }
     }

--- a/packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts
@@ -104,7 +104,11 @@ describe("wallet-signup fail-closed error policy", () => {
     const racedOrg = { id: "org-raced", slug: "wallet-slug" };
     getByWallet = async () => null;
     findBySlug = async () => racedOrg;
-    orgCreate = async () => null;
+    let organizationInput: unknown;
+    orgCreate = async (input) => {
+      organizationInput = input;
+      return null;
+    };
     userCreate = async (input) => ({
       id: "user-1",
       organization_id: input.organization_id,
@@ -116,8 +120,9 @@ describe("wallet-signup fail-closed error policy", () => {
     expect(res.isNewAccount).toBe(true);
     expect(res.user.organization).toBe(racedOrg as never);
     expect(res.user.organization_id).toBe("org-raced");
-    expect(res.initialCreditsGranted).toBe(false);
-    expect(res.initialFreeCreditsUsd).toBe(0);
+    expect(organizationInput).toEqual(expect.objectContaining({ credit_balance: "5.00" }));
+    expect(res.initialCreditsGranted).toBe(true);
+    expect(res.initialFreeCreditsUsd).toBe(5);
   });
 
   test("internal DB failure during user creation PROPAGATES", async () => {

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -32,6 +32,20 @@ export interface FindOrCreateWalletOptions {
   walletProven?: boolean;
 }
 
+type WalletSignupResult =
+  | {
+      user: UserWithOrganization;
+      isNewAccount: false;
+      initialCreditsGranted: false;
+      initialFreeCreditsUsd: 0;
+    }
+  | {
+      user: UserWithOrganization;
+      isNewAccount: true;
+      initialCreditsGranted: true;
+      initialFreeCreditsUsd: typeof SIGNUP_CREDIT_POLICY.automaticGrantUsd;
+    };
+
 /**
  * Unique-violation detection that survives driver wrapping: drizzle raises
  * `DrizzleQueryError` whose message is the failed SQL, with the Postgres error
@@ -131,8 +145,8 @@ async function raiseWalletProof(
 /**
  * Find user by wallet, or create org + user and return.
  * Address can be any case; stored and slug use lowercase.
- * Used by SIWE, wallet header auth, and x402 topup. Account creation is always
- * $0; purchased top-ups and explicit promotion codes are separate credit paths.
+ * Used by SIWE, wallet header auth, and x402 topup. New personal organizations
+ * receive the fixed signup balance; top-ups and promotion codes stay separate.
  *
  * `walletProven` decides `users.wallet_verified` and defaults to false — see the
  * option's own note for why the caller must say so explicitly.
@@ -140,19 +154,19 @@ async function raiseWalletProof(
 export async function findOrCreateUserByWalletAddress(
   walletAddress: string,
   options?: FindOrCreateWalletOptions,
-): Promise<{
-  user: UserWithOrganization;
-  isNewAccount: boolean;
-  initialCreditsGranted?: false;
-  initialFreeCreditsUsd?: 0;
-}> {
+): Promise<WalletSignupResult> {
   const address = getAddress(walletAddress);
   const normalized = address.toLowerCase();
   const walletProven = options?.walletProven === true;
 
   const existing = await usersService.getByWalletAddressWithOrganization(address);
   if (existing) {
-    return { user: await raiseWalletProof(existing, walletProven), isNewAccount: false };
+    return {
+      user: await raiseWalletProof(existing, walletProven),
+      isNewAccount: false,
+      initialCreditsGranted: false,
+      initialFreeCreditsUsd: 0,
+    };
   }
 
   /* WHY slug wallet-${normalized}: consistent with topup and SIWE; lowercase for unique indexing. */
@@ -161,7 +175,12 @@ export async function findOrCreateUserByWalletAddress(
     return await writeTransaction(async (tx) => {
       const racedExisting = await findEvmUserForWrite(tx, normalized);
       if (racedExisting) {
-        return { user: racedExisting, isNewAccount: false };
+        return {
+          user: racedExisting,
+          isNewAccount: false,
+          initialCreditsGranted: false,
+          initialFreeCreditsUsd: 0,
+        };
       }
 
       const org = await createOrFindWalletOrg({
@@ -191,14 +210,19 @@ export async function findOrCreateUserByWalletAddress(
         if (!raced) {
           throw new Error("User creation conflicted but could not find existing wallet user");
         }
-        return { user: raced, isNewAccount: false };
+        return {
+          user: raced,
+          isNewAccount: false,
+          initialCreditsGranted: false,
+          initialFreeCreditsUsd: 0,
+        };
       }
 
       const user: UserWithOrganization = { ...created, organization: org };
       return {
         user,
         isNewAccount: true,
-        initialCreditsGranted: false,
+        initialCreditsGranted: true,
         initialFreeCreditsUsd: SIGNUP_CREDIT_POLICY.automaticGrantUsd,
       };
     });
@@ -208,7 +232,12 @@ export async function findOrCreateUserByWalletAddress(
     if (!isUniqueViolation(e)) throw e;
     const raced = await usersService.getByWalletAddressWithOrganization(address);
     if (!raced) throw e;
-    return { user: await raiseWalletProof(raced, walletProven), isNewAccount: false };
+    return {
+      user: await raiseWalletProof(raced, walletProven),
+      isNewAccount: false,
+      initialCreditsGranted: false,
+      initialFreeCreditsUsd: 0,
+    };
   }
 }
 
@@ -220,12 +249,7 @@ export async function findOrCreateUserByWalletAddress(
 export async function findOrCreateSolanaUserByWalletAddress(
   walletAddress: string,
   options?: FindOrCreateWalletOptions,
-): Promise<{
-  user: UserWithOrganization;
-  isNewAccount: boolean;
-  initialCreditsGranted?: false;
-  initialFreeCreditsUsd?: 0;
-}> {
+): Promise<WalletSignupResult> {
   const address = walletAddress.trim();
   if (!address) {
     throw new Error("Wallet address is required");
@@ -234,7 +258,12 @@ export async function findOrCreateSolanaUserByWalletAddress(
 
   const existing = await usersRepository.findBySolanaWalletAddressWithOrganization(address);
   if (existing) {
-    return { user: await raiseWalletProof(existing, walletProven), isNewAccount: false };
+    return {
+      user: await raiseWalletProof(existing, walletProven),
+      isNewAccount: false,
+      initialCreditsGranted: false,
+      initialFreeCreditsUsd: 0,
+    };
   }
 
   const slug = `wallet-solana-${address}`;
@@ -242,7 +271,12 @@ export async function findOrCreateSolanaUserByWalletAddress(
     return await writeTransaction(async (tx) => {
       const racedExisting = await findSolanaUserForWrite(tx, address);
       if (racedExisting) {
-        return { user: racedExisting, isNewAccount: false };
+        return {
+          user: racedExisting,
+          isNewAccount: false,
+          initialCreditsGranted: false,
+          initialFreeCreditsUsd: 0,
+        };
       }
 
       const org = await createOrFindWalletOrg({
@@ -269,14 +303,19 @@ export async function findOrCreateSolanaUserByWalletAddress(
         if (!raced) {
           throw new Error("User creation conflicted but could not find existing Solana user");
         }
-        return { user: raced, isNewAccount: false };
+        return {
+          user: raced,
+          isNewAccount: false,
+          initialCreditsGranted: false,
+          initialFreeCreditsUsd: 0,
+        };
       }
 
       const user: UserWithOrganization = { ...created, organization: org };
       return {
         user,
         isNewAccount: true,
-        initialCreditsGranted: false,
+        initialCreditsGranted: true,
         initialFreeCreditsUsd: SIGNUP_CREDIT_POLICY.automaticGrantUsd,
       };
     });
@@ -286,6 +325,11 @@ export async function findOrCreateSolanaUserByWalletAddress(
     if (!isUniqueViolation(e)) throw e;
     const raced = await usersRepository.findBySolanaWalletAddressWithOrganization(address);
     if (!raced) throw e;
-    return { user: await raiseWalletProof(raced, walletProven), isNewAccount: false };
+    return {
+      user: await raiseWalletProof(raced, walletProven),
+      isNewAccount: false,
+      initialCreditsGranted: false,
+      initialFreeCreditsUsd: 0,
+    };
   }
 }

--- a/packages/cloud/shared/src/lib/signup-credits.ts
+++ b/packages/cloud/shared/src/lib/signup-credits.ts
@@ -9,4 +9,21 @@
 export const SIGNUP_CREDIT_POLICY = {
   automaticGrantUsd: 5,
   openingBalanceUsd: "5.00",
+  legacyOpeningBalanceUsd: 0,
 } as const;
+
+/**
+ * Identifies an opening balance that has never been debited or topped up.
+ * The zero-dollar case remains valid only for provisional accounts created
+ * before the five-dollar policy rollout.
+ */
+export function isUntouchedSignupOpeningBalance(input: {
+  balanceUsd: number;
+  balanceRevision: number;
+}): boolean {
+  return (
+    input.balanceRevision === 0 &&
+    (input.balanceUsd === SIGNUP_CREDIT_POLICY.legacyOpeningBalanceUsd ||
+      input.balanceUsd === SIGNUP_CREDIT_POLICY.automaticGrantUsd)
+  );
+}

--- a/packages/cloud/shared/src/lib/signup-credits.ts
+++ b/packages/cloud/shared/src/lib/signup-credits.ts
@@ -1,12 +1,12 @@
 /**
  * Canonical opening-balance policy for every Cloud account-creation path.
  *
- * Shared personal Eliza is platform-funded and does not mint user credits.
- * Purchased top-ups, promotion codes, referrals, and historical balances are
- * separate ledger paths and must never be derived from this policy.
+ * Every newly created personal Cloud organization receives one fixed opening
+ * balance. Purchased top-ups, promotion codes, referrals, historical balances,
+ * and non-signup organization creation remain separate ledger paths.
  */
 
 export const SIGNUP_CREDIT_POLICY = {
-  automaticGrantUsd: 0,
-  openingBalanceUsd: "0.00",
+  automaticGrantUsd: 5,
+  openingBalanceUsd: "5.00",
 } as const;

--- a/packages/cloud/shared/src/lib/signup-grant-amount.test.ts
+++ b/packages/cloud/shared/src/lib/signup-grant-amount.test.ts
@@ -1,5 +1,5 @@
 /**
- * The opening-balance policy stays zero across every runtime environment.
+ * The opening-balance policy stays fixed across every runtime environment.
  * Explicit funding and promotion paths have their own independently tested ledgers.
  */
 
@@ -17,16 +17,16 @@ afterEach(() => {
 });
 
 describe("signup credit policy", () => {
-  test("opens every new organization at zero without an automatic grant", () => {
+  test("opens every new organization with the fixed signup credit", () => {
     expect(SIGNUP_CREDIT_POLICY).toEqual({
-      automaticGrantUsd: 0,
-      openingBalanceUsd: "0.00",
+      automaticGrantUsd: 5,
+      openingBalanceUsd: "5.00",
     });
   });
 
-  test("cannot be re-enabled by the retired environment override", () => {
-    process.env.INITIAL_FREE_CREDITS = "5";
-    expect(SIGNUP_CREDIT_POLICY.automaticGrantUsd).toBe(0);
-    expect(SIGNUP_CREDIT_POLICY.openingBalanceUsd).toBe("0.00");
+  test("cannot be changed by the retired environment override", () => {
+    process.env.INITIAL_FREE_CREDITS = "99";
+    expect(SIGNUP_CREDIT_POLICY.automaticGrantUsd).toBe(5);
+    expect(SIGNUP_CREDIT_POLICY.openingBalanceUsd).toBe("5.00");
   });
 });

--- a/packages/cloud/shared/src/lib/signup-grant-amount.test.ts
+++ b/packages/cloud/shared/src/lib/signup-grant-amount.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { SIGNUP_CREDIT_POLICY } from "./signup-credits";
+import { isUntouchedSignupOpeningBalance, SIGNUP_CREDIT_POLICY } from "./signup-credits";
 
 const originalInitialFreeCredits = process.env.INITIAL_FREE_CREDITS;
 
@@ -21,6 +21,7 @@ describe("signup credit policy", () => {
     expect(SIGNUP_CREDIT_POLICY).toEqual({
       automaticGrantUsd: 5,
       openingBalanceUsd: "5.00",
+      legacyOpeningBalanceUsd: 0,
     });
   });
 
@@ -28,5 +29,13 @@ describe("signup credit policy", () => {
     process.env.INITIAL_FREE_CREDITS = "99";
     expect(SIGNUP_CREDIT_POLICY.automaticGrantUsd).toBe(5);
     expect(SIGNUP_CREDIT_POLICY.openingBalanceUsd).toBe("5.00");
+  });
+
+  test("recognizes only untouched current and legacy opening balances", () => {
+    expect(isUntouchedSignupOpeningBalance({ balanceUsd: 0, balanceRevision: 0 })).toBe(true);
+    expect(isUntouchedSignupOpeningBalance({ balanceUsd: 5, balanceRevision: 0 })).toBe(true);
+    expect(isUntouchedSignupOpeningBalance({ balanceUsd: 2, balanceRevision: 0 })).toBe(false);
+    expect(isUntouchedSignupOpeningBalance({ balanceUsd: 0, balanceRevision: 1 })).toBe(false);
+    expect(isUntouchedSignupOpeningBalance({ balanceUsd: 5, balanceRevision: 1 })).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -1,9 +1,10 @@
-/** Proves Steward account creation starts at $0 without touching the credit ledger. */
+/** Proves Steward account creation receives the fixed opening credit exactly once. */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Mock state captured per test ─────────────────────────────────────────
 const addCreditsCalls: unknown[] = [];
+const orgCreateCalls: unknown[] = [];
 const orgUpdateCalls: Array<{ id: string; data: unknown }> = [];
 const orgDeleteCalls: string[] = [];
 const loggerErrorCalls: Array<{ message: string; context?: unknown }> = [];
@@ -16,7 +17,7 @@ const createdOrg = {
   id: "org-new-1",
   name: "alice's Organization",
   slug: "alice-abc123",
-  credit_balance: "0.00",
+  credit_balance: "5.00",
 };
 const createdUser = {
   id: "user-new-1",
@@ -56,7 +57,10 @@ mock.module("./services/credits", () => ({
 mock.module("./services/organizations", () => ({
   organizationsService: {
     getBySlug: async () => undefined,
-    create: async () => createdOrg,
+    create: async (data: unknown) => {
+      orgCreateCalls.push(data);
+      return createdOrg;
+    },
     update: async (id: string, data: unknown) => {
       orgUpdateCalls.push({ id, data });
       return { ...createdOrg, ...(data as object) };
@@ -161,9 +165,10 @@ const baseParams = {
   name: "alice",
 };
 
-describe("syncUserFromSteward — zero-credit account creation", () => {
+describe("syncUserFromSteward — fixed signup credit", () => {
   beforeEach(() => {
     addCreditsCalls.length = 0;
+    orgCreateCalls.length = 0;
     orgUpdateCalls.length = 0;
     orgDeleteCalls.length = 0;
     loggerErrorCalls.length = 0;
@@ -173,12 +178,13 @@ describe("syncUserFromSteward — zero-credit account creation", () => {
     };
   });
 
-  test("creates the account without a grant, balance write, or withheld state", async () => {
+  test("creates the account with $5 without a second credit transaction", async () => {
     const { syncUserFromSteward } = await import("./steward-sync");
 
     const result = await syncUserFromSteward(baseParams);
 
     expect(addCreditsCalls).toHaveLength(0);
+    expect(orgCreateCalls).toEqual([expect.objectContaining({ credit_balance: "5.00" })]);
     expect(
       orgUpdateCalls.filter((c) => (c.data as { credit_balance?: string }).credit_balance),
     ).toHaveLength(0);
@@ -186,8 +192,8 @@ describe("syncUserFromSteward — zero-credit account creation", () => {
     expect(loggerErrorCalls).toHaveLength(0);
     expect(result).toMatchObject({
       ...finalUserWithOrg,
-      initialCreditsGranted: false,
-      initialFreeCreditsUsd: 0,
+      initialCreditsGranted: true,
+      initialFreeCreditsUsd: 5,
     });
   });
 });

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -1103,9 +1103,9 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     throw new Error(`Failed to create organization for Steward user ${stewardUserId}`);
   }
 
-  // Cloud identity is created at $0. Shared service access is not a credit
-  // grant, and purchased credits remain exclusive to explicit funding paths.
-  const initialCreditsGranted = false;
+  // The organization insert above atomically establishes the fixed signup
+  // balance. Purchased credits remain exclusive to explicit funding paths.
+  const initialCreditsGranted = true;
   const initialFreeCreditsUsd = SIGNUP_CREDIT_POLICY.automaticGrantUsd;
 
   // Create user, handle race conditions


### PR DESCRIPTION
# Relates to

Closes #30137

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; exact unrelated failures are recorded below.
- [x] A reviewer can confirm the change works without reading the code from the focused integration evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is documented in **Known gaps / failures**.

# Risks

Low to medium. This changes the opening balance for every new personal Cloud account from $0 to $5. Existing accounts, ordinary organization creation, and account-detach behavior remain unchanged. Converging phone and Telegram identities retains one $5 balance and does not double it to $10.

# Background

## What does this PR do?

- Restores the fixed initial signup credit to **$5.00** across Steward, wallet, phone, Telegram, Discord, WhatsApp, X, anonymous-promotion, and generic Eliza app signup paths.
- Keeps the policy fixed in code rather than environment-configurable.
- Makes wallet signup metadata distinguish a newly credited account from an existing account or a concurrent-create race.
- Updates phone/Telegram account convergence to recognize the restored untouched opening balance and preserve exactly one $5 balance.

The credit is represented by the new personal organization's opening balance; this does not create a separate credit-ledger transaction.

## What kind of change is this?

Bug fix (non-breaking change that restores the intended signup credit policy).

# Documentation changes needed?

No public documentation change is required. The behavior and its invariants are encoded in the shared signup policy and regression tests.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/signup-credits.ts`, then inspect the real PGlite integration coverage for X signup, phone signup/concurrency, Telegram promotion/convergence, and wallet proof signup.

## Detailed testing steps

Focused checks passed on the exact branch revision:

- Real isolated PGlite X identity signup: 3 passed; created balance is $5 and retry reuses the account.
- Real isolated PGlite phone link/concurrency: 11 passed; concurrent signup produces one organization with $5.
- Real isolated PGlite Telegram promotion: 7 passed; promotion preserves $5.
- Real isolated PGlite phone/Telegram convergence: 13 passed; convergence retains one $5 balance without doubling.
- Invite-vacate credit safety: 5 passed; untouched legacy $0 and current $5 can vacate, while revised $2 and $5 balances are preserved and blocked.n- Wallet proof signup: 4 passed.
- Wallet owner-role signup: 4 passed.
- Wallet error-policy suite: 5 passed.
- API route synchronization suite: 16 passed.
- Focused API signup-response test: 1 passed.
- Signup-policy and Steward grant tests passed.
- `bunx biome check` passed for every touched file.
- `bun run --cwd packages/cloud/shared typecheck` passed.
- `bun run --cwd packages/cloud/api typecheck` passed, including the Wrangler dry-run worker bundle.
- `bun install` passed after rebasing.

# Evidence Gate

<!-- evidence-head:25a8d25e7c63e9f2b2ff51fe17a786de517eb901 -->

- [x] Before full-page screenshots: N/A - backend signup policy change with no rendered UI surface.
- [x] After full-page screenshots: N/A - backend signup policy change with no rendered UI surface.
- [x] Video walkthrough: N/A - no frontend flow or rendered surface changed.
- [x] Backend logs: N/A - no staging or production account was mutated; the paths were exercised against isolated real PGlite databases.
- [x] Frontend logs: N/A - no frontend code or network contract changed.
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
- [x] Domain artifacts: integration assertions verify persisted organization balances, reuse, concurrency, promotion, and convergence behavior in isolated PGlite databases; results are listed under Testing.
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - no deployed environment was mutated. Focused integration suites exercised and inspected the persisted database state directly.

## Screenshots (before / after) + video walkthrough

N/A - backend-only signup policy and persistence change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun run verify` completed 374 of 375 tasks, then failed in the unrelated `@elizaos/ui#lint:check` task because the existing molecular inventory JSON and Markdown artifacts are stale. This branch does not touch `packages/ui` or those artifacts.
- The full `packages/cloud/shared` suite stopped in the first shard on the unrelated pre-existing `agent-backup-restore-api-boundary.test.ts` inventory assertion: it expected one definition-only occurrence of `acquireAgentBackupRestoreLease` and found seven. This branch does not touch agent backup/restore code. All focused signup tests and both affected package typechecks pass.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: N/A - no exception requested
- Validated `origin/develop` SHA: N/A - no exception requested
- Live ruleset readback and named bypass eligibility: N/A - no exception requested
- Queued or failing checks and run URLs: N/A - no exception requested
- Infrastructure-only or unrelated-failure proof: N/A - no exception requested
- Exact-head commands, exit status, and artifacts: N/A - no exception requested
- Exact-head security, secret-scan, and provenance results: N/A - no exception requested
- Conflict-free and affected-path failure attestation: N/A - no exception requested
- Independent approving reviewer: N/A - no exception requested
- Bypass authorizer: N/A - no exception requested
- Merge method: N/A - no exception requested
- Rollback owner: N/A - no exception requested
- Post-merge `develop` validation: N/A - no exception requested