### PR TITLE
fix(cloud): securely shred read-only recovery evidence

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -496,7 +496,7 @@ jobs:
           cleanup() {
             set +e
             if [ -d "$evidence_dir" ]; then
-              find "$evidence_dir" -type f -exec shred -u -- {} +
+              find "$evidence_dir" -type f -exec shred -f -u -- {} +
               find "$evidence_dir" -depth -type d -empty -delete
             fi
           }

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -418,6 +418,7 @@ describe("Cloud CF workflow staging certification gate", () => {
       "Protected recovery authority settings are incomplete",
     );
     expect(migrate).toContain("trap cleanup EXIT");
+    expect(migrate).toContain("shred -f -u --");
     expect(migrate).toContain("production_migration_ledger_not_current");
     expect(migrate).toContain('DATABASE_IDENTITY_GATE_MODE" = "enforce');
   });


### PR DESCRIPTION
Fix the bounded production Hyperdrive recovery cleanup so GNU shred can securely delete the trusted admission script after it is intentionally chmod 0500.

The live bounded-recovery run passed policy, database identity, and migration-ledger admission, then failed before mutation because `shred -u` could not open that read-only evidence file. `shred -f -u` changes permissions as needed before overwriting and unlinking.

Validation:
- `bun test packages/cloud/scripts/staging-release-certification.test.mjs` (34 pass)
- `actionlint .github/workflows/cloud-cf-release.yml`
- `git diff --check`