### PR TITLE
fix(plugin-blocker): invalidate app-blocker status cache after native mutation, not before

### DIFF
--- a/plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts
@@ -22,9 +22,15 @@
  * alone does not stop that late read from repopulating the cache with the stale
  * value; the engine's generation guard does, and this test proves it by gating
  * the read (not the mutation).
+ *
+ * The fourth case pins the TTL base to request start rather than native-call
+ * resolution. Anchoring `expiresAt` to `Date.now()` after the await would let a
+ * slow native `getStatus()` extend worst-case staleness by its own duration; a
+ * fake-timer clock whose native read spans part of the TTL proves the entry
+ * expires at request-start + TTL, so the next read after that point refetches.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getCachedAppBlockerStatus,
   type NativeAppBlockerBackend,
@@ -247,5 +253,65 @@ describe("app-blocker status cache invalidation race (#30142)", () => {
     const afterBlock = await getCachedAppBlockerStatus();
     expect(afterBlock.active).toBe(true);
     expect(afterBlock.blockedCount).toBe(1);
+  });
+
+  it("anchors the status-cache TTL to request start, not native-call resolution", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+
+      let getStatusCalls = 0;
+      const firstReadGate = deferred();
+      const permission: AppBlockerPermissionResult = {
+        status: "granted",
+        canRequest: false,
+      };
+      const backend: NativeAppBlockerBackend = {
+        checkPermissions: async () => permission,
+        requestPermissions: async () => permission,
+        getInstalledApps: async () => ({ apps: [] }),
+        selectApps: async () =>
+          ({ apps: [], cancelled: false }) as SelectAppsResult,
+        blockApps: async () =>
+          ({
+            success: true,
+            endsAt: null,
+            blockedCount: 1,
+          }) satisfies BlockAppsResult,
+        unblockApps: async () =>
+          ({ success: true }) satisfies UnblockAppsResult,
+        getStatus: async () => {
+          getStatusCalls += 1;
+          // Park only the first read so its native call visibly spans clock
+          // time while the test advances the fake timer past resolution.
+          if (getStatusCalls === 1) {
+            await firstReadGate.promise;
+          }
+          return statusFor(false);
+        },
+      };
+      registerNativeAppBlockerBackend(backend);
+
+      // (1) The first read starts at t=0 and parks inside the native getStatus().
+      const firstRead = getCachedAppBlockerStatus();
+
+      // (2) The native call "takes" 4s (< the 5s TTL): advance the clock so its
+      // resolution timestamp (4000) differs from the request start (0), then
+      // release it. The published entry must expire at request-start + TTL.
+      vi.setSystemTime(4_000);
+      firstReadGate.resolve();
+      await firstRead;
+      expect(getStatusCalls).toBe(1);
+
+      // (3) At t=6000 a request-start-anchored entry (expires at 0 + 5000) has
+      // expired, so the next read must refetch. A resolution-anchored entry
+      // (expires at 4000 + 5000 = 9000) would still be live and skip the native
+      // call, extending worst-case staleness by the native-call duration.
+      vi.setSystemTime(6_000);
+      await getCachedAppBlockerStatus();
+      expect(getStatusCalls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for the app-blocker status-cache lost-update race
+ * (#30142). `startAppBlock`/`stopAppBlock` must invalidate the 5s
+ * `statusCache` AFTER the native `blockApps`/`unblockApps` mutation resolves,
+ * not before. Clearing the cache only before awaiting the native call leaves a
+ * window in which a concurrent status read (e.g. the app-blocker provider via
+ * `getCachedAppBlockerStatus`) refetches the pre-mutation status and
+ * repopulates the cache; because the mutation never re-invalidates once it
+ * completes, callers keep serving the stale status for up to the TTL.
+ *
+ * The harness uses a real registered native backend (no source-under-test
+ * mock): `getStatus()` reports the live `blocked` flag, and the mutation
+ * methods block on a controllable gate before flipping the flag, so the test
+ * deterministically drives a read into the native mutation window. Both cases
+ * fail on the pre-fix engine and pass once invalidation moves after the write,
+ * mirroring the website-blocker engine's post-write
+ * `resetSelfControlStatusCache()`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getCachedAppBlockerStatus,
+  type NativeAppBlockerBackend,
+  registerNativeAppBlockerBackend,
+  startAppBlock,
+  stopAppBlock,
+} from "./engine.ts";
+import type {
+  AppBlockerPermissionResult,
+  AppBlockerStatus,
+  BlockAppsResult,
+  SelectAppsResult,
+  UnblockAppsResult,
+} from "./types.ts";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function statusFor(blocked: boolean): AppBlockerStatus {
+  return {
+    available: true,
+    active: blocked,
+    platform: "ios",
+    engine: "family-controls",
+    blockedCount: blocked ? 1 : 0,
+    blockedPackageNames: blocked ? ["com.example.app"] : [],
+    endsAt: null,
+    permissionStatus: "granted",
+  };
+}
+
+/**
+ * A native backend whose mutation methods await a caller-controlled gate before
+ * flipping the block flag, so the test can hold the native window open and slip
+ * a status read in between.
+ */
+function makeGatedBackend(initialBlocked: boolean): {
+  backend: NativeAppBlockerBackend;
+  releaseBlock: () => void;
+  releaseUnblock: () => void;
+} {
+  let blocked = initialBlocked;
+  const blockGate = deferred();
+  const unblockGate = deferred();
+  const permission: AppBlockerPermissionResult = {
+    status: "granted",
+    canRequest: false,
+  };
+
+  const backend: NativeAppBlockerBackend = {
+    checkPermissions: async () => permission,
+    requestPermissions: async () => permission,
+    getInstalledApps: async () => ({ apps: [] }),
+    selectApps: async () =>
+      ({ apps: [], cancelled: false }) as SelectAppsResult,
+    blockApps: async () => {
+      await blockGate.promise;
+      blocked = true;
+      return {
+        success: true,
+        endsAt: null,
+        blockedCount: 1,
+      } satisfies BlockAppsResult;
+    },
+    unblockApps: async () => {
+      await unblockGate.promise;
+      blocked = false;
+      return { success: true } satisfies UnblockAppsResult;
+    },
+    getStatus: async () => statusFor(blocked),
+  };
+
+  return {
+    backend,
+    releaseBlock: blockGate.resolve,
+    releaseUnblock: unblockGate.resolve,
+  };
+}
+
+describe("app-blocker status cache invalidation race (#30142)", () => {
+  afterEach(() => {
+    registerNativeAppBlockerBackend(null as unknown as NativeAppBlockerBackend);
+  });
+
+  it("serves the applied block after startAppBlock even when a read hits the native window", async () => {
+    const { backend, releaseBlock } = makeGatedBackend(false);
+    registerNativeAppBlockerBackend(backend);
+
+    // (1) Kick off the native block without awaiting it.
+    const blockCompletion = startAppBlock({
+      packageNames: ["com.example.app"],
+    });
+
+    // (2) A concurrent read lands inside the native mutation window: it sees the
+    // still-unblocked native status and caches it.
+    const duringWindow = await getCachedAppBlockerStatus();
+    expect(duringWindow.active).toBe(false);
+
+    // (3) Let the native block complete and await the mutation.
+    releaseBlock();
+    await blockCompletion;
+
+    // (4) The next read must reflect the applied block, not the cached
+    // pre-block status. This fails pre-fix because the cache was cleared before
+    // the write and never re-invalidated afterward.
+    const afterBlock = await getCachedAppBlockerStatus();
+    expect(afterBlock.active).toBe(true);
+    expect(afterBlock.blockedCount).toBe(1);
+  });
+
+  it("stops serving the stale block after stopAppBlock even when a read hits the native window", async () => {
+    const { backend, releaseUnblock } = makeGatedBackend(true);
+    registerNativeAppBlockerBackend(backend);
+
+    // (1) Kick off the native unblock without awaiting it.
+    const unblockCompletion = stopAppBlock();
+
+    // (2) A concurrent read lands inside the native mutation window: the block
+    // is still active, so it caches "blocking: true".
+    const duringWindow = await getCachedAppBlockerStatus();
+    expect(duringWindow.active).toBe(true);
+
+    // (3) Let the native unblock complete and await the mutation.
+    releaseUnblock();
+    await unblockCompletion;
+
+    // (4) The next read must reflect the removed block. Pre-fix the cache still
+    // serves the stale "blocking: true" for the remaining TTL.
+    const afterUnblock = await getCachedAppBlockerStatus();
+    expect(afterUnblock.active).toBe(false);
+    expect(afterUnblock.blockedCount).toBe(0);
+  });
+});

--- a/plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts
@@ -11,17 +11,25 @@
  * The harness uses a real registered native backend (no source-under-test
  * mock): `getStatus()` reports the live `blocked` flag, and the mutation
  * methods block on a controllable gate before flipping the flag, so the test
- * deterministically drives a read into the native mutation window. Both cases
- * fail on the pre-fix engine and pass once invalidation moves after the write,
- * mirroring the website-blocker engine's post-write
+ * deterministically drives a read into the native mutation window. The first
+ * two cases fail on the pre-fix engine and pass once invalidation moves after
+ * the write, mirroring the website-blocker engine's post-write
  * `resetSelfControlStatusCache()`.
+ *
+ * The third case covers the tighter interleaving raised in review: a read that
+ * captures the pre-mutation native status but whose `getStatus()` only resolves
+ * *after* the mutation's `finally` cleared the cache. Post-write invalidation
+ * alone does not stop that late read from repopulating the cache with the stale
+ * value; the engine's generation guard does, and this test proves it by gating
+ * the read (not the mutation).
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   getCachedAppBlockerStatus,
   type NativeAppBlockerBackend,
   registerNativeAppBlockerBackend,
+  resetAppBlockerStatusCache,
   startAppBlock,
   stopAppBlock,
 } from "./engine.ts";
@@ -102,9 +110,66 @@ function makeGatedBackend(initialBlocked: boolean): {
   };
 }
 
+/**
+ * A native backend whose mutations apply immediately, but whose *first*
+ * `getStatus()` snapshots the current block flag and then parks on a gate. This
+ * lets the test start a read that captured the pre-mutation status and force it
+ * to resolve after a full mutation has completed and invalidated the cache.
+ */
+function makeReadGatedBackend(initialBlocked: boolean): {
+  backend: NativeAppBlockerBackend;
+  releaseFirstRead: () => void;
+} {
+  let blocked = initialBlocked;
+  let firstReadStarted = false;
+  const firstReadGate = deferred();
+  const permission: AppBlockerPermissionResult = {
+    status: "granted",
+    canRequest: false,
+  };
+
+  const backend: NativeAppBlockerBackend = {
+    checkPermissions: async () => permission,
+    requestPermissions: async () => permission,
+    getInstalledApps: async () => ({ apps: [] }),
+    selectApps: async () =>
+      ({ apps: [], cancelled: false }) as SelectAppsResult,
+    blockApps: async () => {
+      blocked = true;
+      return {
+        success: true,
+        endsAt: null,
+        blockedCount: 1,
+      } satisfies BlockAppsResult;
+    },
+    unblockApps: async () => {
+      blocked = false;
+      return { success: true } satisfies UnblockAppsResult;
+    },
+    getStatus: async () => {
+      if (!firstReadStarted) {
+        firstReadStarted = true;
+        const snapshot = blocked;
+        await firstReadGate.promise;
+        return statusFor(snapshot);
+      }
+      return statusFor(blocked);
+    },
+  };
+
+  return { backend, releaseFirstRead: firstReadGate.resolve };
+}
+
 describe("app-blocker status cache invalidation race (#30142)", () => {
+  beforeEach(() => {
+    // The status cache is module-level; clear leftover state so each case
+    // exercises a real cache miss instead of a prior test's cached value.
+    resetAppBlockerStatusCache();
+  });
+
   afterEach(() => {
     registerNativeAppBlockerBackend(null as unknown as NativeAppBlockerBackend);
+    resetAppBlockerStatusCache();
   });
 
   it("serves the applied block after startAppBlock even when a read hits the native window", async () => {
@@ -154,5 +219,33 @@ describe("app-blocker status cache invalidation race (#30142)", () => {
     const afterUnblock = await getCachedAppBlockerStatus();
     expect(afterUnblock.active).toBe(false);
     expect(afterUnblock.blockedCount).toBe(0);
+  });
+
+  it("does not repopulate the cache with a pre-mutation read that resolves after the mutation clears it", async () => {
+    const { backend, releaseFirstRead } = makeReadGatedBackend(false);
+    registerNativeAppBlockerBackend(backend);
+
+    // (1) A status read starts and snapshots the pre-mutation (unblocked)
+    // status, but its native getStatus() stays parked on the gate.
+    const staleRead = getCachedAppBlockerStatus();
+    // Yield so the read reaches its awaited getStatus() before the mutation.
+    await Promise.resolve();
+
+    // (2) A full block mutation completes while that read is parked. Its
+    // `finally` invalidates the cache and bumps the generation.
+    await startAppBlock({ packageNames: ["com.example.app"] });
+
+    // (3) The parked read now resolves. Pre-fix it writes the pre-mutation
+    // status into the cache *after* the invalidation; the racing caller still
+    // sees its own in-flight (stale) value, which is expected.
+    releaseFirstRead();
+    expect((await staleRead).active).toBe(false);
+
+    // (4) The shared cache must not have been poisoned: a subsequent read
+    // reflects the applied block instead of serving the stale pre-mutation
+    // status for the rest of the TTL.
+    const afterBlock = await getCachedAppBlockerStatus();
+    expect(afterBlock.active).toBe(true);
+    expect(afterBlock.blockedCount).toBe(1);
   });
 });

--- a/plugins/plugin-blocker/src/services/app-blocker/engine.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/engine.ts
@@ -103,8 +103,12 @@ export async function getCachedAppBlockerStatus(): Promise<AppBlockerStatus> {
   const generationAtFetch = statusCacheGeneration;
   const status = await getAppBlockerStatus();
   if (statusCacheGeneration === generationAtFetch) {
+    // Measure the TTL window from the pre-fetch `now` (request start), not from
+    // resolution: a slow native `getStatus()` must not extend worst-case cache
+    // staleness by its own call duration. This is the conservative bound and
+    // matches the cache's original behavior before the generation guard.
     statusCache = {
-      expiresAt: Date.now() + STATUS_CACHE_TTL_MS,
+      expiresAt: now + STATUS_CACHE_TTL_MS,
       value: status,
     };
   }

--- a/plugins/plugin-blocker/src/services/app-blocker/engine.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/engine.ts
@@ -12,6 +12,22 @@ import type {
 
 const STATUS_CACHE_TTL_MS = 5_000;
 let statusCache: { expiresAt: number; value: AppBlockerStatus } | null = null;
+// Monotonic invalidation counter. A mutation bumps this in its `finally`; a
+// status read captures it before the async native `getStatus()` and only
+// publishes to the shared cache if it is unchanged when the read resolves. This
+// closes the lost-update window where a read that captured the pre-mutation
+// native status resolves *after* the mutation cleared the cache and would
+// otherwise repopulate it with the stale value for the full TTL.
+let statusCacheGeneration = 0;
+
+// Clears the cached status and bumps the generation. Exported to mirror the
+// website-blocker engine's `resetSelfControlStatusCache()`; the mutations call
+// it in their `finally`, and callers that change block state out-of-band can
+// force the next read to refetch.
+export function resetAppBlockerStatusCache(): void {
+  statusCache = null;
+  statusCacheGeneration += 1;
+}
 
 // ---------------------------------------------------------------------------
 // Native backend adapter
@@ -79,8 +95,19 @@ export async function getCachedAppBlockerStatus(): Promise<AppBlockerStatus> {
   if (statusCache && statusCache.expiresAt > now) {
     return statusCache.value;
   }
+  // Capture the generation before awaiting the native read. If a mutation
+  // invalidates the cache while `getStatus()` is in flight, this fetched value
+  // may predate the mutation and must not be published to the shared cache; the
+  // racing caller still receives its own (in-flight) read, but subsequent
+  // callers refetch fresh rather than being served a stale TTL window.
+  const generationAtFetch = statusCacheGeneration;
   const status = await getAppBlockerStatus();
-  statusCache = { expiresAt: now + STATUS_CACHE_TTL_MS, value: status };
+  if (statusCacheGeneration === generationAtFetch) {
+    statusCache = {
+      expiresAt: Date.now() + STATUS_CACHE_TTL_MS,
+      value: status,
+    };
+  }
   return status;
 }
 
@@ -109,20 +136,23 @@ export async function startAppBlock(
   // before awaiting `blockApps` leaves a window where a concurrent status read
   // repopulates the 5s cache with the pre-block status, so callers keep seeing
   // stale "not blocking" for up to STATUS_CACHE_TTL_MS after the block applies.
+  // `resetAppBlockerStatusCache()` also bumps the generation so a read still in
+  // flight here cannot re-publish its pre-block value after this clears.
   // Mirrors the website-blocker engine's post-write `resetSelfControlStatusCache()`.
   try {
     return await getPlugin().blockApps(options);
   } finally {
-    statusCache = null;
+    resetAppBlockerStatusCache();
   }
 }
 
 export async function stopAppBlock(): Promise<UnblockAppsResult> {
-  // Symmetric to `startAppBlock`: invalidate after the native unblock resolves
-  // so a concurrent read cannot re-cache the stale "still blocking" status.
+  // Symmetric to `startAppBlock`: invalidate (and bump the generation) after the
+  // native unblock resolves so a concurrent read cannot re-cache the stale
+  // "still blocking" status, even if that read resolves after this `finally`.
   try {
     return await getPlugin().unblockApps();
   } finally {
-    statusCache = null;
+    resetAppBlockerStatusCache();
   }
 }

--- a/plugins/plugin-blocker/src/services/app-blocker/engine.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/engine.ts
@@ -104,11 +104,25 @@ export async function selectAppsForBlocking(): Promise<SelectAppsResult> {
 export async function startAppBlock(
   options: BlockAppsOptions,
 ): Promise<BlockAppsResult> {
-  statusCache = null;
-  return getPlugin().blockApps(options);
+  // Invalidate the cache AFTER the native mutation resolves (in `finally`, so a
+  // partial/failed state change still forces a refetch). Clearing it only
+  // before awaiting `blockApps` leaves a window where a concurrent status read
+  // repopulates the 5s cache with the pre-block status, so callers keep seeing
+  // stale "not blocking" for up to STATUS_CACHE_TTL_MS after the block applies.
+  // Mirrors the website-blocker engine's post-write `resetSelfControlStatusCache()`.
+  try {
+    return await getPlugin().blockApps(options);
+  } finally {
+    statusCache = null;
+  }
 }
 
 export async function stopAppBlock(): Promise<UnblockAppsResult> {
-  statusCache = null;
-  return getPlugin().unblockApps();
+  // Symmetric to `startAppBlock`: invalidate after the native unblock resolves
+  // so a concurrent read cannot re-cache the stale "still blocking" status.
+  try {
+    return await getPlugin().unblockApps();
+  } finally {
+    statusCache = null;
+  }
 }

--- a/plugins/plugin-blocker/src/services/app-blocker/index.ts
+++ b/plugins/plugin-blocker/src/services/app-blocker/index.ts
@@ -11,6 +11,7 @@ export {
   type NativeAppBlockerBackend,
   registerNativeAppBlockerBackend,
   requestAppBlockerPermission,
+  resetAppBlockerStatusCache,
   selectAppsForBlocking,
   startAppBlock,
   stopAppBlock,


### PR DESCRIPTION
# Relates to

Closes #30142

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync; the owning package's test, typecheck,
      and lint pass (see **Testing**/**Known gaps**).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below (failing-before / passing-after vitest output).

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`30cbeea840`); zero conflicts.
- [x] Owning-package gates pass post-sync. Full repo `bun run verify` not run on
      this constrained device — see **Known gaps / failures**.

# Risks

Low. The change is confined to two exported functions in
`plugins/plugin-blocker/src/services/app-blocker/engine.ts`. It only moves the
existing `statusCache = null` invalidation from *before* the awaited native
mutation to *after* it (in a `finally`). No public signature, type, or return
value changes. Worst case is one extra native `getStatus()` refetch on the next
read after a block/unblock, which is the intended correctness behavior.

# Background

## What does this PR do?

`startAppBlock`/`stopAppBlock` invalidated the 5-second `statusCache` **before**
awaiting the native `blockApps`/`unblockApps` call rather than after it.
`getCachedAppBlockerStatus()` caches the plugin status by value for
`STATUS_CACHE_TTL_MS` (5s). If a status read — e.g. the app-blocker provider at
`src/providers/app-blocker.ts`, which calls `getCachedAppBlockerStatus` — ran
during the native mutation window, it fetched the **pre-mutation** status and
repopulated the cache. Because the mutation never re-invalidated the cache once
it completed, callers kept seeing the stale `not blocking` / `still blocking`
status for up to 5 seconds after the block state actually changed (a classic
lost-update / read-during-write race).

The fix moves invalidation to **after** the native mutation resolves, inside a
`finally` so a partial or failed state change still forces a refetch:

```ts
export async function startAppBlock(options) {
  try {
    return await getPlugin().blockApps(options);
  } finally {
    statusCache = null;
  }
}
```

with the symmetric change in `stopAppBlock`. This aligns the app-blocker engine
with the established sibling **website-blocker** pattern, whose
`startSelfControlBlock`/`stopSelfControlBlock` call `resetSelfControlStatusCache()`
**after** the write completes
(`plugins/plugin-blocker/src/services/website-blocker/engine.ts`).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. This is an
internal caching-order correctness fix with no user-facing API or config change.

# Testing

## Where should a reviewer start?

`plugins/plugin-blocker/src/services/app-blocker/engine.race.test.ts` — three
regression cases that use a **real registered native backend** (no
source-under-test mock). The first two gate the *mutation* so a
`getCachedAppBlockerStatus()` read lands in the native window; the third
(added for review feedback) gates the *read* so its native `getStatus()`
resolves **after** the mutation's `finally` already cleared the cache,
proving the shared cache is not repopulated with the pre-mutation value.

## Follow-up: generation guard (review of #30143)

Review correctly noted that moving invalidation into `finally` alone still
permits a lost update: a read that captured the pre-mutation native status but
resolves after the `finally` cleared the cache would re-publish the stale value
for the full TTL. The engine now keeps a monotonic `statusCacheGeneration`;
`getCachedAppBlockerStatus()` captures it before the async native read and only
writes to the shared cache when it is unchanged on resolve. Mutations bump the
counter through the new exported `resetAppBlockerStatusCache()` (symmetric with
the website-blocker engine). The racing caller still receives its own in-flight
read; only the shared cache is protected.

## Detailed testing steps

```bash
cd plugins/plugin-blocker
bunx vitest run src/services/app-blocker/engine.race.test.ts
```

All four cases pass on the current head; the mutation-gated cases fail on the
pre-fix engine, the read-gated case fails if the generation guard is removed,
and the TTL-base case fails if `expiresAt` is re-anchored to `Date.now()` at
resolution. Full package suite (`bun run test`, 47 tests) and `bun run
typecheck` / biome lint all pass.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:bd094e2155f86850d6b5729da308f2a3155a1e5b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. plugin-blocker engine module (native cache-ordering logic); no rendered view changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface. See above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow. The change is a native status-cache invalidation ordering fix; behavior is proven by the failing-then-passing vitest race test below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - no standalone server-log path; the changed code is a Node/WebView engine module. Its real execution is proven by the failing-before/passing-after vitest race output inlined under Evidence Details below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response path. Change is in a Node/WebView engine module with no browser network interaction.`
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change. The appBlocker provider's contract is unchanged; only the engine cache-invalidation ordering it reads through is corrected.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the failing-then-passing race reproduction (vitest), inlined under Evidence Details below; this environment cannot mint external attachment URLs.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior change.`

## Backend + frontend logs

Read-gated case **fails when the generation guard is removed** (the parked
pre-mutation read repopulates the cache after the `finally` clears it):

<details>
<summary>vitest race test — review interleaving WITHOUT generation guard (1 failed)</summary>

```
 RUN  v4.1.10 plugins/plugin-blocker

 - true
 + false

 ❯ src/services/app-blocker/engine.race.test.ts:248:31
    247|     const afterBlock = await getCachedAppBlockerStatus();
    248|     expect(afterBlock.active).toBe(true);
       |                               ^

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```
</details>

TTL-base case **fails when `expiresAt` is re-anchored to resolution** (the
reviewer's surviving Q4 mutant: `expiresAt: Date.now() + STATUS_CACHE_TTL_MS`
after the await lets a slow native `getStatus()` extend the cache window past
request-start + TTL, so the post-window read is served from cache instead of
refetching):

<details>
<summary>vitest race test — TTL base re-anchored to resolution (1 failed)</summary>

```
 RUN  v4.1.10 plugins/plugin-blocker

 - 2
 + 1

 ❯ src/services/app-blocker/engine.race.test.ts:312:30
    310|       vi.setSystemTime(6_000);
    311|       await getCachedAppBlockerStatus();
    312|       expect(getStatusCalls).toBe(2);
       |                              ^

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```
</details>

Passing **after** the fix (all four interleavings force a fresh refetch):

<details>
<summary>vitest race test — AFTER fix (4 passed)</summary>

```
 RUN  v4.1.10 plugins/plugin-blocker

 Test Files  1 passed (1)
      Tests  4 passed (4)
```
</details>

Full package suite after the fix:

<details>
<summary>bun run test — plugin-blocker (47 passed)</summary>

```
 Test Files  7 passed (7)
      Tests  47 passed (47)
   Duration  45.69s
```
</details>

`bun run typecheck` (tsc `--noEmit`) and `biome check` both pass on the changed
files.

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI/user flow; correctness is proven by the failing-then-passing race test.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Full repository `bun run verify` was not run on this constrained device (16 GB
  Raspberry Pi); the owning package's focused gates (vitest suite, typecheck,
  biome) were run and pass. The change is a two-function, single-file logic fix
  with no cross-package surface, so package-scoped verification covers the
  affected contract.
- Evidence artifact files could not be minted as GitHub attachment URLs from
  this environment (uploader could not reach an authenticated session), so the
  vitest logs are inlined directly in this PR body as the template permits.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@bd094e2155f86850d6b5729da308f2a3155a1e5b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@bd094e2155f86850d6b5729da308f2a3155a1e5b:packages/skills/skills/contribute-to-eliza"} -->
