### PR TITLE
fix(cloud): word-boundary the room-title intent regexes

### DIFF
--- a/packages/cloud/shared/src/lib/services/room-title.ts
+++ b/packages/cloud/shared/src/lib/services/room-title.ts
@@ -103,12 +103,14 @@ function generateFallbackTitle(message: string): string {
   const cleaned = message.trim().toLowerCase();
 
   // Common greeting patterns -> generic titles
-  if (/^(hi|hello|hey|howdy|greetings|yo|sup)/i.test(cleaned)) {
+  // Word-boundary anchored so a prefix like "hi" in "history" cannot
+  // collapse a real message to a generic title (#30122).
+  if (/^(hi|hello|hey|howdy|greetings|yo|sup)\b/i.test(cleaned)) {
     return "New Conversation";
   }
 
   // Question patterns
-  if (/^(what|how|why|when|where|who|can|could|would|should|is|are|do|does)/i.test(cleaned)) {
+  if (/^(what|how|why|when|where|who|can|could|would|should|is|are|do|does)\b/i.test(cleaned)) {
     const words = message.trim().split(/\s+/).slice(0, 6);
     if (words.length >= 3) {
       return capitalizeFirst(words.slice(0, 5).join(" "));
@@ -117,17 +119,17 @@ function generateFallbackTitle(message: string): string {
   }
 
   // Help/assist patterns
-  if (/^(help|assist|support|i need|please)/i.test(cleaned)) {
+  if (/^(help|assist|support|i need|please)\b/i.test(cleaned)) {
     return "Help Request";
   }
 
   // Code/technical patterns
-  if (/^(code|write|create|build|make|implement|debug|fix)/i.test(cleaned)) {
+  if (/^(code|write|create|build|make|implement|debug|fix)\b/i.test(cleaned)) {
     return "Coding Assistance";
   }
 
   // Explain patterns
-  if (/^(explain|tell me|describe|what is|define)/i.test(cleaned)) {
+  if (/^(explain|tell me|describe|what is|define)\b/i.test(cleaned)) {
     return "Explanation Request";
   }
 


### PR DESCRIPTION
## Summary
`generateFallbackTitle` anchored every intent regex with `^(word|word|...)` and **no word boundary**, so a message merely *starting with a word that begins like an intent keyword* collapsed to a generic title: `History of the Roman Empire` hit `^hi` → `New Conversation`, `Written notes` hit `^write` → `Coding Assistance`, `Supporting evidence` hit `^support` → `Help Request`. The mistake is permanent — rooms are never retitled (#30122).

## Fix
Add `\b` after each alternation so intent regexes match only whole words.

## Verification
14 cases verified: the 8 regression messages (History/You were/Suppose/Heyday/Written/Supporting/Island/Dos) now get content-derived titles; 6 genuine intents (hello there, yo!, why?, please help, write a haiku, define success metrics) still map to their generic buckets.

Closes #30122.