### PR TITLE
test(plugin-anthropic): assert the incomplete-output code on the error itself

### DIFF
--- a/plugins/plugin-anthropic/__tests__/image-description.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/image-description.shape.test.ts
@@ -74,7 +74,9 @@ describe("Anthropic image description plumbing", () => {
 
     await expect(
       handleImageDescription(createRuntime(), "https://example.com/screen.png")
-    ).rejects.toMatchObject({ cause: { code: "MODEL_OUTPUT_INCOMPLETE" } });
+      // formatModelError returns a typed ElizaError unwrapped, so the code is
+      // on the error itself rather than nested under `cause`.
+    ).rejects.toMatchObject({ code: "MODEL_OUTPUT_INCOMPLETE" });
   });
 
   it("rejects empty image URLs before calling the provider", async () => {

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -46,7 +46,10 @@ describe("Anthropic native text plumbing", () => {
     await expect(
       handleTextSmall(createRuntime(), { prompt: "complete this" })
     ).rejects.toMatchObject({
-      cause: expect.objectContaining({ code: "MODEL_OUTPUT_INCOMPLETE" }),
+      // assertModelOutputComplete throws a typed ElizaError, and
+      // formatModelError passes an ElizaError through unwrapped, so the code is
+      // on the error itself rather than nested under `cause`.
+      code: "MODEL_OUTPUT_INCOMPLETE",
     });
   }, 60_000);
 


### PR DESCRIPTION
# Relates to

Closes #30148.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Repairs two suites failing on `develop` right now.
- [x] Changes no runtime source — the diff is two assertions.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Two files differ: `+7/-2` total.

# Risks

None to runtime. No production file is touched, and the assertions become *stricter* in
the useful direction: they now pin the actionable `code` on the error callers actually
receive, rather than a wrapper that no longer exists.

# Background

## What is broken

`@elizaos/plugin-anthropic` fails 3 of 143 on `develop`. Two share one cause:

```
FAIL native-plumbing.shape.test.ts > rejects an output-limited completion instead of returning its text prefix
  expected ElizaError: [anthropic] Model output did … to match object { cause: ObjectContaining{…} }

FAIL image-description.shape.test.ts > rejects a provider length stop instead of parsing the partial description
  expected ElizaError: [anthropic] Model output did … to match object { Object (cause) }
```

## Root cause

`assertModelOutputComplete` (`packages/core/src/utils/model-errors.ts:71`) throws a typed
**origin** error — code on the error, no `cause`:

```
ElizaError {
  message: "[anthropic] Model output did not complete successfully (length).",
  code: "MODEL_OUTPUT_INCOMPLETE",
  context: { finishReason: "length", model: "claude-test-small", provider: "anthropic" },
}
```

Both call sites catch through `formatModelError` (`utils/retry.ts:151`), which returns a
typed error unchanged and wraps only untyped ones:

```ts
if (isElizaError(error)) {
  return error;                              // passthrough — no cause
}
...
return new Error(message, { cause: error }); // only untyped errors get a cause
```

So `cause: { code: ... }` describes a wrapper that is gone. The behaviour is right —
callers get an actionable `code` plus full `context`, and declining to double-wrap an
already-typed domain error is correct.

## Attribution

The passthrough came from **#28112** (`4333300926`, 2026-08-25). Verified by checking for
`isElizaError(error)` inside `formatModelError` across the file's history:

```
2026-08-25 4333300926  present   <-- added here
2026-07-04 9f83ba8752  absent
2026-07-04 d203202c65  absent
2026-06-19 f7a6b0fea5  absent
```

Before it, `formatModelError` wrapped everything with `cause` — exactly what these two
assertions describe. Neither test was updated alongside.

## What is the fix?

Assert the code where it now lives:

```diff
-    ).rejects.toMatchObject({
-      cause: expect.objectContaining({ code: "MODEL_OUTPUT_INCOMPLETE" }),
-    });
+    ).rejects.toMatchObject({
+      code: "MODEL_OUTPUT_INCOMPLETE",
+    });
```

No `src` change: the current shape is the correct one, and loosening the assertion to
accept either shape would stop pinning the contract at all.

# Documentation changes needed?

No. Test only.

# Testing

## Where should a reviewer start?

The mutation block.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| the two changed suites | **21 passed (21)** — was `2 failed | 19 passed` |
| full `plugin-anthropic` package | `1 failed | 142 passed (143)` — was `3 failed | 140 passed` |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| diff vs `develop` | `+7/-2`, two test files, zero runtime files |

Mutation resistance — restoring **only** develop's assertions:

```
AssertionError: expected ElizaError: [anthropic] Model output did … to match object { Object (cause) }
AssertionError: expected ElizaError: [anthropic] Model output did … to match object { cause: ObjectContaining{…} }
 Tests  2 failed | 19 passed (21)
```

**The remaining failure is deliberately not fixed here.**
`error-policy.shape.test.ts > surfaces a failed CLI stream as an error instead of a
healthy-empty completion` fails for an unrelated reason: it expects
`result.finishReason` to resolve to `"error"`, while `createTextStream`
(`utils/claude-cli.ts:484`) throws instead. Both satisfy "not a healthy-empty completion",
so which is intended is a design call for the plugin owner. Recorded in #30148; happy to
follow up once that is decided.

Also worth noting for anyone reproducing: this package runs on **vitest**
(`bunx vitest run --config vitest.config.ts`). Running it with `bun test` fails
misleadingly on `vi.doMock is not a function`.

# Evidence Gate

<!-- evidence-head:55aac605edf72a1da97ae4cfbb095c1104a4440b -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - provider error-shape assertions; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - provider error-shape assertions; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable result is the suites' pass/fail, quoted above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the model handlers are driven directly against a mocked provider`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - the provider is a deterministic double by the suites' design; no live model call`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - the artifact is the thrown ElizaError shape, quoted above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Identified and fixed by Claude Code (`claude-opus-5`): `Plugin Tests` shard triage, local reproduction at the exact `develop` tip, reading `formatModelError` and `assertModelOutputComplete` to establish that the runtime shape is correct and the assertions are not, the `isElizaError`-presence history isolating the change to #28112, and the mutation proof.

Attribution status: self-reported
