### PR TITLE
fix(plugin-native-inference): make fused loader auto-load guard role-aware

### DIFF
--- a/plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Regression coverage for the fused loader's cross-role auto-load guard
+ * (issue #30147). Drives the REAL registered TEXT_LARGE / TEXT_EMBEDDING
+ * handlers through `ensureAospLocalInferenceHandlers` over a deterministic
+ * barrier-backed AospLoader and a temp STATE_DIR manifest listing both a chat
+ * and an embedding GGUF. The harness never touches the native FFI boundary; it
+ * asserts which model is resident at generate/embed time, which is exactly the
+ * bug's observable — a chat completion executing against the embedding model
+ * (or vice versa) because both roles shared one in-flight promise.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { AgentRuntime, ModelType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  type AospLoader,
+  ensureAospLocalInferenceHandlers,
+} from "../src/aosp-local-inference-bootstrap";
+
+async function withEnvAsync<T>(
+  overrides: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(overrides)) {
+    previous.set(key, process.env[key]);
+    const value = overrides[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function seedBothModels(stateDir: string): {
+  chatPath: string;
+  embeddingPath: string;
+} {
+  const modelsDir = path.join(stateDir, "local-inference", "models");
+  mkdirSync(modelsDir, { recursive: true });
+  const chatPath = path.join(modelsDir, "eliza-1-chat.gguf");
+  const embeddingPath = path.join(modelsDir, "bge-embedding.gguf");
+  writeFileSync(chatPath, "chat-model-bytes");
+  writeFileSync(embeddingPath, "embedding-model-bytes");
+  writeFileSync(
+    path.join(modelsDir, "manifest.json"),
+    JSON.stringify({
+      models: [
+        { role: "chat", ggufFile: path.basename(chatPath) },
+        { role: "embedding", ggufFile: path.basename(embeddingPath) },
+      ],
+    }),
+  );
+  return { chatPath, embeddingPath };
+}
+
+interface BarrierLoader {
+  loader: AospLoader;
+  loadModelCalls: string[];
+  generateResidentPaths: string[];
+  embedResidentPaths: string[];
+  started(marker: string): Promise<void>;
+  release(marker: string): void;
+}
+
+// Fake AospLoader whose loadModel blocks on a per-marker barrier so a test can
+// pin one role's load in-flight while a request for the OTHER role arrives.
+// `generate`/`embed` record which model is resident at call time — the exact
+// wrong-model observable of the bug. Passed through the real instrumented
+// lifecycle by `ensureAospLocalInferenceHandlers`.
+function makeBarrierLoader(blockOn: string[]): BarrierLoader {
+  const loadModelCalls: string[] = [];
+  const generateResidentPaths: string[] = [];
+  const embedResidentPaths: string[] = [];
+  let currentPath: string | null = null;
+  const gates = new Map<string, Promise<void>>();
+  const releasers = new Map<string, () => void>();
+  const startedFlags = new Map<string, Promise<void>>();
+  const startedSignals = new Map<string, () => void>();
+  for (const marker of blockOn) {
+    gates.set(
+      marker,
+      new Promise<void>((resolve) => releasers.set(marker, resolve)),
+    );
+    startedFlags.set(
+      marker,
+      new Promise<void>((resolve) => startedSignals.set(marker, resolve)),
+    );
+  }
+  const loader: AospLoader = {
+    async loadModel(args) {
+      loadModelCalls.push(args.modelPath);
+      for (const marker of blockOn) {
+        if (args.modelPath.endsWith(marker)) {
+          startedSignals.get(marker)?.();
+          await gates.get(marker);
+        }
+      }
+      currentPath = args.modelPath;
+    },
+    async unloadModel() {
+      currentPath = null;
+    },
+    currentModelPath: () => currentPath,
+    generate: async () => {
+      generateResidentPaths.push(currentPath ?? "<none>");
+      return `gen:${currentPath}`;
+    },
+    embed: async () => {
+      embedResidentPaths.push(currentPath ?? "<none>");
+      return { embedding: [0.1, 0.2], tokens: 1 };
+    },
+  };
+  return {
+    loader,
+    loadModelCalls,
+    generateResidentPaths,
+    embedResidentPaths,
+    started: (marker) => startedFlags.get(marker) ?? Promise.resolve(),
+    release: (marker) => releasers.get(marker)?.(),
+  };
+}
+
+const crossRoleEnv = (stateDir: string) => ({
+  ELIZA_LOCAL_LLAMA: "1",
+  ELIZA_DISABLE_FFI_LLAMA: undefined,
+  ELIZA_LOCAL_EMBEDDING_ENABLED: "1",
+  ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD: "1",
+  ELIZA_DISABLE_VOICE_AUTO_DOWNLOAD: "1",
+  ELIZA_LOCAL_IDLE_UNLOAD_MS: "0",
+  ELIZA_AOSP_TTS_PREWARM: "0",
+  ELIZA_STATE_DIR: stateDir,
+});
+
+describe("AOSP fused loader cross-role in-flight guard (#30147)", () => {
+  it("loads the chat model for a chat request racing an in-flight embedding load (no cross-role piggyback)", async () => {
+    const stateDir = mkdtempSync(
+      path.join(os.tmpdir(), "aosp-crossrole-repro-"),
+    );
+    const { chatPath, embeddingPath } = seedBothModels(stateDir);
+    const barrier = makeBarrierLoader([
+      "bge-embedding.gguf",
+      "eliza-1-chat.gguf",
+    ]);
+
+    await withEnvAsync(crossRoleEnv(stateDir), async () => {
+      const runtime = new AgentRuntime({ logLevel: "fatal" });
+      try {
+        await ensureAospLocalInferenceHandlers(runtime, {
+          buildLoader: async () => barrier.loader,
+          prewarm: false,
+        });
+        const embedHandler = runtime.getModel(ModelType.TEXT_EMBEDDING);
+        const chatHandler = runtime.getModel(ModelType.TEXT_LARGE);
+        if (!embedHandler || !chatHandler) {
+          throw new Error("AOSP cross-role handlers not registered");
+        }
+
+        // (1) Embedding load starts from the nothing-resident state and blocks
+        //     inside loadModel(embedding), holding the in-flight load.
+        const embedPromise = embedHandler(runtime, "index this memory");
+        await barrier.started("bge-embedding.gguf");
+        // (2) A chat request arrives concurrently. Under the shared-inflight bug
+        //     it awaited the embedding load and generated against the embedding
+        //     model; role-aware tracking must load its own chat model instead.
+        const chatPromise = chatHandler(runtime, { prompt: "hello there" });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        // (3) Release the embedding load: the embedding call runs against the
+        //     embedding model; the chat load then proceeds to its own model.
+        barrier.release("bge-embedding.gguf");
+        await expect(embedPromise).resolves.toEqual([0.1, 0.2]);
+        expect(barrier.embedResidentPaths).toEqual([embeddingPath]);
+
+        barrier.release("eliza-1-chat.gguf");
+        await expect(chatPromise).resolves.toBe(`gen:${chatPath}`);
+
+        // The chat model WAS loaded (never true under the bug) and the chat
+        // generate ran against the chat model, not the embedding GGUF.
+        expect(barrier.loadModelCalls).toEqual([embeddingPath, chatPath]);
+        expect(barrier.generateResidentPaths).toEqual([chatPath]);
+      } finally {
+        await runtime.stop({ fast: true });
+      }
+    });
+  });
+
+  it("dedups concurrent same-role embedding loads onto a single native load", async () => {
+    const stateDir = mkdtempSync(
+      path.join(os.tmpdir(), "aosp-crossrole-dedup-"),
+    );
+    const { embeddingPath } = seedBothModels(stateDir);
+    const barrier = makeBarrierLoader(["bge-embedding.gguf"]);
+
+    await withEnvAsync(crossRoleEnv(stateDir), async () => {
+      const runtime = new AgentRuntime({ logLevel: "fatal" });
+      try {
+        await ensureAospLocalInferenceHandlers(runtime, {
+          buildLoader: async () => barrier.loader,
+          prewarm: false,
+        });
+        const embedHandler = runtime.getModel(ModelType.TEXT_EMBEDDING);
+        if (!embedHandler) throw new Error("AOSP embedding handler missing");
+
+        const first = embedHandler(runtime, "memory A");
+        await barrier.started("bge-embedding.gguf");
+        const second = embedHandler(runtime, "memory B");
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        barrier.release("bge-embedding.gguf");
+        await Promise.all([first, second]);
+
+        // Two concurrent same-role requests share ONE load and both embed
+        // against the resident embedding model.
+        expect(barrier.loadModelCalls).toEqual([embeddingPath]);
+        expect(barrier.embedResidentPaths).toEqual([
+          embeddingPath,
+          embeddingPath,
+        ]);
+      } finally {
+        await runtime.stop({ fast: true });
+      }
+    });
+  });
+
+  it("reloads the single native context on every role change, each call running against its own model", async () => {
+    const stateDir = mkdtempSync(
+      path.join(os.tmpdir(), "aosp-crossrole-swap-"),
+    );
+    const { chatPath, embeddingPath } = seedBothModels(stateDir);
+    const barrier = makeBarrierLoader([]);
+
+    await withEnvAsync(crossRoleEnv(stateDir), async () => {
+      const runtime = new AgentRuntime({ logLevel: "fatal" });
+      try {
+        await ensureAospLocalInferenceHandlers(runtime, {
+          buildLoader: async () => barrier.loader,
+          prewarm: false,
+        });
+        const embedHandler = runtime.getModel(ModelType.TEXT_EMBEDDING);
+        const chatHandler = runtime.getModel(ModelType.TEXT_LARGE);
+        if (!embedHandler || !chatHandler) {
+          throw new Error("AOSP cross-role handlers not registered");
+        }
+
+        await expect(chatHandler(runtime, { prompt: "one" })).resolves.toBe(
+          `gen:${chatPath}`,
+        );
+        await expect(embedHandler(runtime, "index")).resolves.toEqual([
+          0.1, 0.2,
+        ]);
+        await expect(chatHandler(runtime, { prompt: "two" })).resolves.toBe(
+          `gen:${chatPath}`,
+        );
+
+        // Each role change reloads the single native context, and every call
+        // runs against its own resident model.
+        expect(barrier.loadModelCalls).toEqual([
+          chatPath,
+          embeddingPath,
+          chatPath,
+        ]);
+        expect(barrier.generateResidentPaths).toEqual([chatPath, chatPath]);
+        expect(barrier.embedResidentPaths).toEqual([embeddingPath]);
+      } finally {
+        await runtime.stop({ fast: true });
+      }
+    });
+  });
+});

--- a/plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts
@@ -7,6 +7,12 @@
  * asserts which model is resident at generate/embed time, which is exactly the
  * bug's observable — a chat completion executing against the embedding model
  * (or vice versa) because both roles shared one in-flight promise.
+ *
+ * The barrier can pin a load in flight AND hold a generate()/embed() call open,
+ * so the atomicity case proves the load-PLUS-use transaction is serialized: an
+ * arriving cross-role request cannot swap the native context while the other
+ * role's inference is still running. The resident model is recorded when each
+ * call RETURNS, so a mid-call swap surfaces as a wrong-model observation.
  */
 
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -69,23 +75,21 @@ interface BarrierLoader {
   embedResidentPaths: string[];
   started(marker: string): Promise<void>;
   release(marker: string): void;
+  startedUse(marker: string): Promise<void>;
+  releaseUse(marker: string): void;
 }
 
-// Fake AospLoader whose loadModel blocks on a per-marker barrier so a test can
-// pin one role's load in-flight while a request for the OTHER role arrives.
-// `generate`/`embed` record which model is resident at call time — the exact
-// wrong-model observable of the bug. Passed through the real instrumented
-// lifecycle by `ensureAospLocalInferenceHandlers`.
-function makeBarrierLoader(blockOn: string[]): BarrierLoader {
-  const loadModelCalls: string[] = [];
-  const generateResidentPaths: string[] = [];
-  const embedResidentPaths: string[] = [];
-  let currentPath: string | null = null;
+function makeGate(markers: string[]): {
+  wait(marker: string): Promise<void> | undefined;
+  release(marker: string): void;
+  started(marker: string): Promise<void>;
+  signalStarted(marker: string): void;
+} {
   const gates = new Map<string, Promise<void>>();
   const releasers = new Map<string, () => void>();
   const startedFlags = new Map<string, Promise<void>>();
   const startedSignals = new Map<string, () => void>();
-  for (const marker of blockOn) {
+  for (const marker of markers) {
     gates.set(
       marker,
       new Promise<void>((resolve) => releasers.set(marker, resolve)),
@@ -95,13 +99,47 @@ function makeBarrierLoader(blockOn: string[]): BarrierLoader {
       new Promise<void>((resolve) => startedSignals.set(marker, resolve)),
     );
   }
+  return {
+    wait: (marker) => gates.get(marker),
+    release: (marker) => releasers.get(marker)?.(),
+    started: (marker) => startedFlags.get(marker) ?? Promise.resolve(),
+    signalStarted: (marker) => startedSignals.get(marker)?.(),
+  };
+}
+
+// Fake AospLoader whose loadModel blocks on a per-marker barrier so a test can
+// pin one role's load in flight while a request for the OTHER role arrives.
+// `holdUseOn` markers additionally block generate()/embed() while that GGUF is
+// resident, so a test can hold one role's inference open and observe whether an
+// arriving cross-role request swaps the context mid-call. `generate`/`embed`
+// record which model is resident when they RETURN — the exact wrong-model
+// observable of the bug. Passed through the real instrumented lifecycle by
+// `ensureAospLocalInferenceHandlers`.
+function makeBarrierLoader(
+  blockLoadOn: string[],
+  holdUseOn: string[] = [],
+): BarrierLoader {
+  const loadModelCalls: string[] = [];
+  const generateResidentPaths: string[] = [];
+  const embedResidentPaths: string[] = [];
+  let currentPath: string | null = null;
+  const loadGate = makeGate(blockLoadOn);
+  const useGate = makeGate(holdUseOn);
+  async function holdUse(resident: string | null): Promise<void> {
+    for (const marker of holdUseOn) {
+      if (resident?.endsWith(marker)) {
+        useGate.signalStarted(marker);
+        await useGate.wait(marker);
+      }
+    }
+  }
   const loader: AospLoader = {
     async loadModel(args) {
       loadModelCalls.push(args.modelPath);
-      for (const marker of blockOn) {
+      for (const marker of blockLoadOn) {
         if (args.modelPath.endsWith(marker)) {
-          startedSignals.get(marker)?.();
-          await gates.get(marker);
+          loadGate.signalStarted(marker);
+          await loadGate.wait(marker);
         }
       }
       currentPath = args.modelPath;
@@ -111,10 +149,12 @@ function makeBarrierLoader(blockOn: string[]): BarrierLoader {
     },
     currentModelPath: () => currentPath,
     generate: async () => {
+      await holdUse(currentPath);
       generateResidentPaths.push(currentPath ?? "<none>");
       return `gen:${currentPath}`;
     },
     embed: async () => {
+      await holdUse(currentPath);
       embedResidentPaths.push(currentPath ?? "<none>");
       return { embedding: [0.1, 0.2], tokens: 1 };
     },
@@ -124,8 +164,10 @@ function makeBarrierLoader(blockOn: string[]): BarrierLoader {
     loadModelCalls,
     generateResidentPaths,
     embedResidentPaths,
-    started: (marker) => startedFlags.get(marker) ?? Promise.resolve(),
-    release: (marker) => releasers.get(marker)?.(),
+    started: (marker) => loadGate.started(marker),
+    release: (marker) => loadGate.release(marker),
+    startedUse: (marker) => useGate.started(marker),
+    releaseUse: (marker) => useGate.release(marker),
   };
 }
 
@@ -184,6 +226,57 @@ describe("AOSP fused loader cross-role in-flight guard (#30147)", () => {
 
         // The chat model WAS loaded (never true under the bug) and the chat
         // generate ran against the chat model, not the embedding GGUF.
+        expect(barrier.loadModelCalls).toEqual([embeddingPath, chatPath]);
+        expect(barrier.generateResidentPaths).toEqual([chatPath]);
+      } finally {
+        await runtime.stop({ fast: true });
+      }
+    });
+  });
+
+  it("keeps load-plus-use atomic: an arriving chat request cannot swap the native context while an embedding call is still running", async () => {
+    const stateDir = mkdtempSync(
+      path.join(os.tmpdir(), "aosp-crossrole-atomic-"),
+    );
+    const { chatPath, embeddingPath } = seedBothModels(stateDir);
+    // Nothing blocks at load time; the embed CALL is held open so a chat
+    // request can try to race the in-flight embedding inference.
+    const barrier = makeBarrierLoader([], ["bge-embedding.gguf"]);
+
+    await withEnvAsync(crossRoleEnv(stateDir), async () => {
+      const runtime = new AgentRuntime({ logLevel: "fatal" });
+      try {
+        await ensureAospLocalInferenceHandlers(runtime, {
+          buildLoader: async () => barrier.loader,
+          prewarm: false,
+        });
+        const embedHandler = runtime.getModel(ModelType.TEXT_EMBEDDING);
+        const chatHandler = runtime.getModel(ModelType.TEXT_LARGE);
+        if (!embedHandler || !chatHandler) {
+          throw new Error("AOSP cross-role handlers not registered");
+        }
+
+        // (1) The embedding model loads and embed() enters, then blocks — the
+        //     embedding transaction is still open on the native context.
+        const embedPromise = embedHandler(runtime, "index this memory");
+        await barrier.startedUse("bge-embedding.gguf");
+        // (2) A chat request arrives while the embedding call is mid-flight.
+        const chatPromise = chatHandler(runtime, { prompt: "hello there" });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        // (3) The chat load MUST NOT have started: swapping the context now
+        //     would unload the embedding model out from under the running
+        //     embed() and persist a vector produced against the chat GGUF.
+        //     Under a load-only guard the chat loadModel already fired here.
+        expect(barrier.loadModelCalls).toEqual([embeddingPath]);
+
+        // (4) Release the embedding call; it ran against the embedding model.
+        barrier.releaseUse("bge-embedding.gguf");
+        await expect(embedPromise).resolves.toEqual([0.1, 0.2]);
+        expect(barrier.embedResidentPaths).toEqual([embeddingPath]);
+
+        // (5) Only now does the chat swap happen, and the generate runs against
+        //     the freshly-resident chat model.
+        await expect(chatPromise).resolves.toBe(`gen:${chatPath}`);
         expect(barrier.loadModelCalls).toEqual([embeddingPath, chatPath]);
         expect(barrier.generateResidentPaths).toEqual([chatPath]);
       } finally {

--- a/plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts
@@ -13,6 +13,11 @@
  * arriving cross-role request cannot swap the native context while the other
  * role's inference is still running. The resident model is recorded when each
  * call RETURNS, so a mid-call swap surfaces as a wrong-model observation.
+ *
+ * The eviction case drives the exported lifecycle's `evict()` (the seam the
+ * voice ASR handler unloads through) directly, proving the out-of-band unload
+ * is serialized on the same executor and so waits behind an in-flight embed
+ * rather than freeing the native context out from under it.
  */
 
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -23,6 +28,7 @@ import { describe, expect, it } from "vitest";
 import {
   type AospLoader,
   ensureAospLocalInferenceHandlers,
+  makeLoaderLifecycle,
 } from "../src/aosp-local-inference-bootstrap";
 
 async function withEnvAsync<T>(
@@ -319,6 +325,69 @@ describe("AOSP fused loader cross-role in-flight guard (#30147)", () => {
       } finally {
         await runtime.stop({ fast: true });
       }
+    });
+  });
+
+  it("routes an out-of-band eviction through the context executor so the unload waits behind an in-flight embed instead of dropping the model mid-call", async () => {
+    const stateDir = mkdtempSync(
+      path.join(os.tmpdir(), "aosp-crossrole-evict-"),
+    );
+    const { embeddingPath } = seedBothModels(stateDir);
+
+    await withEnvAsync(crossRoleEnv(stateDir), async () => {
+      let currentPath: string | null = null;
+      const events: string[] = [];
+      let signalEmbedIn!: () => void;
+      let releaseEmbed!: () => void;
+      const embedIn = new Promise<void>((resolve) => {
+        signalEmbedIn = resolve;
+      });
+      const embedGate = new Promise<void>((resolve) => {
+        releaseEmbed = resolve;
+      });
+      const loader: AospLoader = {
+        loadModel: async (args) => {
+          currentPath = args.modelPath;
+        },
+        unloadModel: async () => {
+          events.push("unload");
+          currentPath = null;
+        },
+        currentModelPath: () => currentPath,
+        generate: async () => "gen",
+        embed: async () => ({ embedding: [0.1, 0.2], tokens: 1 }),
+      };
+      const lifecycle = makeLoaderLifecycle(loader);
+
+      // (1) An embedding transaction loads its model and enters the call, then
+      //     blocks — the embedding model is resident and the context is busy.
+      const embedPromise = lifecycle.withEmbedding(async () => {
+        events.push("embed:start");
+        signalEmbedIn();
+        await embedGate;
+        events.push("embed:end");
+        return [0.1, 0.2];
+      });
+      await embedIn;
+      expect(currentPath).toBe(embeddingPath);
+
+      // (2) A voice eviction fires while the embed is mid-flight. Routed through
+      //     the same serial executor, it MUST queue behind the running embed
+      //     rather than unload the embedding model out from under it — the
+      //     same-class window the load-plus-use serialization closes, reached
+      //     through the unload door. A direct loader.unloadModel() would push
+      //     "unload" into events here, before the embed returns.
+      const evictPromise = lifecycle.evict();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(events).toEqual(["embed:start"]);
+
+      // (3) Release the embed; only now does the queued eviction unload run, and
+      //     the resident role is cleared for the next load.
+      releaseEmbed();
+      await embedPromise;
+      await evictPromise;
+      expect(events).toEqual(["embed:start", "embed:end", "unload"]);
+      expect(currentPath).toBeNull();
     });
   });
 

--- a/plugins/plugin-native-inference/__tests__/inference-priority-lane.test.ts
+++ b/plugins/plugin-native-inference/__tests__/inference-priority-lane.test.ts
@@ -35,6 +35,8 @@ function makeFakeLane(): {
   lifecycle: {
     ensureChatLoaded(): Promise<void>;
     ensureEmbeddingLoaded(): Promise<void>;
+    withChat<T>(use: () => Promise<T>): Promise<T>;
+    withEmbedding<T>(use: () => Promise<T>): Promise<T>;
     markEvicted(): void;
   };
   calls: RecordedGenerate[];
@@ -61,9 +63,17 @@ function makeFakeLane(): {
     },
     embed: async () => ({ embedding: [0], tokens: 1 }),
   };
+  // The fused lifecycle now runs each role's load-swap AND the native call it
+  // guards inside one serial transaction (`withChat`/`withEmbedding`), so
+  // `generateOnPriorityLane` invokes the loader through `withChat` rather than a
+  // bare `ensureChatLoaded`. The double's wrappers just run the call — the fake
+  // loader is single-context and never swaps — so the lane's priority ordering
+  // is what these tests still exercise.
   const lifecycle = {
     ensureChatLoaded: async () => {},
     ensureEmbeddingLoaded: async () => {},
+    withChat: <T>(use: () => Promise<T>) => use(),
+    withEmbedding: <T>(use: () => Promise<T>) => use(),
     markEvicted: () => {},
   };
   return {

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -1597,16 +1597,26 @@ function resolveBundledModelPaths(modelsDir: string): {
  * GGUF. `withChat`/`withEmbedding` keep the load and the call in the same
  * critical section; `ensureChatLoaded`/`ensureEmbeddingLoaded` remain for pure
  * prewarm loads. This is reachable whenever no model is resident — fresh boot
- * or after any `markEvicted()` — and matters because the embedding handler is
+ * or after any `evict()` — and matters because the embedding handler is
  * not behind the process-wide inference priority gate, so a memory-indexing
  * embed and a chat generate genuinely arrive concurrently.
+ *
+ * The one out-of-band way to touch the context is an explicit unload. `evict()`
+ * routes the voice ASR eviction (which frees the chat model's RAM for the cold
+ * ASR load) through the SAME executor, so it too waits behind any in-flight
+ * call instead of unloading the model out from under it. The remaining direct
+ * `loader.unloadModel()` callers are safe by construction rather than through
+ * this executor: the idle unloader defers while a use is in flight
+ * (#11760 in-flight tracking) and teardown runs only after the lifecycle has
+ * quiesced.
  */
 type LoadedRole = "chat" | "embedding" | null;
-function makeLoaderLifecycle(loader: AospLoader): {
+export function makeLoaderLifecycle(loader: AospLoader): {
   ensureChatLoaded(): Promise<void>;
   ensureEmbeddingLoaded(): Promise<void>;
   withChat<T>(use: () => Promise<T>): Promise<T>;
   withEmbedding<T>(use: () => Promise<T>): Promise<T>;
+  evict(): Promise<void>;
   markEvicted(): void;
 } {
   let currentRole: LoadedRole = null;
@@ -1718,9 +1728,11 @@ function makeLoaderLifecycle(loader: AospLoader): {
     });
   }
   // Run `use` (a native generate()/embed()) as one atomic transaction with the
-  // load that guarantees `role` is resident. Nothing else touches the native
-  // context between the load and the call, so the call always runs against its
-  // own model even when the opposite role arrives mid-flight (#30147).
+  // load that guarantees `role` is resident. Because every other context
+  // mutation — a cross-role load and the serialized `evict()` — runs on this
+  // same executor, nothing swaps or unloads the model between this load and its
+  // call, so the call always runs against its own model even when the opposite
+  // role (or a voice eviction) arrives mid-flight (#30147).
   async function withRole<T>(
     role: "chat" | "embedding",
     use: () => Promise<T>,
@@ -1732,19 +1744,35 @@ function makeLoaderLifecycle(loader: AospLoader): {
       return use();
     });
   }
+  // Serialized unload for out-of-band eviction (voice handlers free the chat
+  // model to reclaim RAM for the cold ASR/TTS load). Running it on the same
+  // executor is what keeps the load-plus-use invariant true against the unload
+  // door: the unload waits behind any in-flight generate()/embed() instead of
+  // freeing the native context out from under it (#30147). `currentRole` is
+  // cleared inside the same transaction so the next ensure*/with* actually
+  // reloads; a no-op when nothing is resident.
+  async function evict(): Promise<void> {
+    return runOnContext(async () => {
+      if (loader.currentModelPath() !== null) {
+        await loader.unloadModel();
+      }
+      currentRole = null;
+    });
+  }
   return {
     ensureChatLoaded: () => ensureLoaded("chat"),
     ensureEmbeddingLoaded: () => ensureLoaded("embedding"),
     withChat: (use) => withRole("chat", use),
     withEmbedding: (use) => withRole("embedding", use),
-    // Out-of-band eviction (voice handlers free the chat model directly via
-    // loader.unloadModel() to reclaim RAM for the cold ASR/TTS load). That
-    // bypasses the lifecycle, so `currentRole` would stay stale ("chat") and the
-    // next ensureChatLoaded() would short-circuit and run generate() against a
-    // null ctx. Resetting `currentRole` here forces the next ensure*Loaded()
-    // to actually reload. Safe to call when no load is in flight; if a load is
-    // mid-flight the clear just means the subsequent ensure reloads, which is
-    // the intended post-eviction behaviour anyway.
+    evict,
+    // Reset the resident role after an unload that happened OUTSIDE this
+    // executor — the idle unloader frees the model directly via
+    // loader.unloadModel() (gated by #11760 in-flight tracking, so never during
+    // a call). Without this, `currentRole` would stay stale and the next
+    // ensureChatLoaded() would short-circuit and run generate() against a null
+    // ctx. The voice ASR eviction uses `evict()` instead, which clears the role
+    // inside the serial transaction; this hook is for the idle path that cannot
+    // join the executor.
     markEvicted: () => {
       currentRole = null;
     },
@@ -2882,7 +2910,7 @@ async function transcribeWithAospElizaInference(
   audio: { samples: Float32Array; sampleRate: number },
   signal?: AbortSignal,
   loader?: AospLoader,
-  onEvicted?: () => void,
+  evict?: () => Promise<void>,
 ): Promise<string> {
   assertNotAborted(signal);
   const libPath = resolveElizaInferenceLibPath();
@@ -2899,20 +2927,22 @@ async function transcribeWithAospElizaInference(
   // oom-protect — gets killed mid-load. The chat model auto-reloads on the
   // next TEXT turn (makeGenerateHandler -> lifecycle.ensureChatLoaded), so the
   // eviction is safe; mirrors the cold-TTS eviction in the fused TTS handler.
+  //
+  // The unload is routed through the lifecycle's serial context executor
+  // (`evict`), NOT called on the loader directly: a memory-indexing embed is
+  // not behind the process-wide inference priority gate, so it can be in flight
+  // when a voice turn arrives. Serializing the eviction makes it wait behind
+  // that call instead of unloading the native context out from under it
+  // (#30147). `evict()` also clears the lifecycle's resident role, so the next
+  // text turn reloads instead of short-circuiting on a stale role.
   if (
-    loader &&
+    evict &&
     shouldEvictChatForVoiceLoad() &&
-    typeof loader.currentModelPath === "function" &&
-    loader.currentModelPath() !== null &&
-    typeof loader.unloadModel === "function"
+    typeof loader?.currentModelPath === "function" &&
+    loader.currentModelPath() !== null
   ) {
     try {
-      await loader.unloadModel();
-      // Tell the lifecycle the chat model is gone so the next text turn
-      // actually reloads it (the lifecycle short-circuits on a stale currentRole
-      // otherwise). Done after the unload succeeds so we never mark evicted
-      // when the model is in fact still resident.
-      onEvicted?.();
+      await evict();
       logger.info(
         "[aosp-local-inference] released chat model before fused ASR load to free memory",
       );
@@ -3007,11 +3037,11 @@ async function transcribeWithAospElizaInference(
 
 export function makeAospTranscriptionHandler(
   loader?: AospLoader,
-  onEvicted?: () => void,
+  evict?: () => Promise<void>,
 ): TranscriptionHandler {
   return async (_runtime, params) => {
     const { signal, ...audio } = extractAospTranscriptionAudio(params);
-    return transcribeWithAospElizaInference(audio, signal, loader, onEvicted);
+    return transcribeWithAospElizaInference(audio, signal, loader, evict);
   };
 }
 
@@ -3632,7 +3662,7 @@ export async function ensureAospLocalInferenceHandlers(
         : modelType === ModelType.TEXT_TO_SPEECH
           ? textToSpeechHandler
           : modelType === ModelType.TRANSCRIPTION
-            ? makeAospTranscriptionHandler(textLoader, lifecycle.markEvicted)
+            ? makeAospTranscriptionHandler(textLoader, lifecycle.evict)
             : makeGenerateHandler(textLoader, lifecycle);
     runtimeWithRegistration.registerModel(
       modelType,

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -1588,28 +1588,49 @@ function resolveBundledModelPaths(modelsDir: string): {
  * (and vice versa) on every call.
  *
  * The fused loader owns ONE native context that holds ONE model at a time, so
- * in-flight tracking MUST be role-aware (#30147): a load for role A can never
- * satisfy a request for role B. `inflightByRole` dedups concurrent same-role
- * requests onto one load, while a different-role request waits behind the
- * in-flight swap (`loadChain`) and then loads its own model. A single shared
- * `inflight` promise would let a chat request piggyback on an embedding load
- * (or vice versa) whenever no model was resident — fresh boot or after any
- * `markEvicted()` — and then run its native call against the wrong GGUF.
+ * every load-swap AND the generate()/embed() that consumes it run through one
+ * serial executor (`runOnContext`) as a single load-plus-use transaction
+ * (#30147). Serializing only the loads is not enough: `ensureXLoaded()`
+ * returning proves the model was resident at that instant, but the native call
+ * runs afterwards, so a concurrent other-role load could still swap the context
+ * mid-call and produce a completion — or persist a vector — against the wrong
+ * GGUF. `withChat`/`withEmbedding` keep the load and the call in the same
+ * critical section; `ensureChatLoaded`/`ensureEmbeddingLoaded` remain for pure
+ * prewarm loads. This is reachable whenever no model is resident — fresh boot
+ * or after any `markEvicted()` — and matters because the embedding handler is
+ * not behind the process-wide inference priority gate, so a memory-indexing
+ * embed and a chat generate genuinely arrive concurrently.
  */
 type LoadedRole = "chat" | "embedding" | null;
 function makeLoaderLifecycle(loader: AospLoader): {
   ensureChatLoaded(): Promise<void>;
   ensureEmbeddingLoaded(): Promise<void>;
+  withChat<T>(use: () => Promise<T>): Promise<T>;
+  withEmbedding<T>(use: () => Promise<T>): Promise<T>;
   markEvicted(): void;
 } {
   let currentRole: LoadedRole = null;
-  // In-flight loads keyed by role. A pending entry dedups concurrent requests
-  // for the SAME role; a request for the OTHER role never adopts this promise.
-  const inflightByRole = new Map<"chat" | "embedding", Promise<void>>();
-  // Serializes swaps on the single native context: each load waits for any
-  // currently in-flight load (of either role) to settle before it touches the
-  // loader, so two model swaps never interleave.
-  let loadChain: Promise<void> = Promise.resolve();
+  // Serial executor for the single mutable native context. Every transaction —
+  // a role load-swap and/or the native generate()/embed() that consumes it —
+  // runs to completion before the next starts, so a cross-role swap can never
+  // interleave with another role's in-flight call and make it run against the
+  // wrong resident model (#30147). Serializing the load-PLUS-use (not just the
+  // load) is what closes the window: a bare `ensureXLoaded()` returning only
+  // proves the model was resident at that instant; the actual generate()/
+  // embed() must stay inside the SAME critical section or a concurrent
+  // other-role load swaps the context out from under it mid-call and persists a
+  // completion/vector produced against the wrong GGUF.
+  let contextChain: Promise<unknown> = Promise.resolve();
+  function runOnContext<T>(task: () => Promise<T>): Promise<T> {
+    // Run `task` once the prior transaction settles (its outcome is that
+    // caller's concern), then publish this transaction as the new tail.
+    const run = contextChain.then(task, task);
+    contextChain = run.then(
+      () => {},
+      () => {},
+    );
+    return run;
+  }
   const modelsDir = resolveBundledModelsDir();
   let resolved = resolveBundledModelPaths(modelsDir);
   async function resolveRoleTarget(
@@ -1685,39 +1706,40 @@ function makeLoaderLifecycle(loader: AospLoader): {
     });
     logger.info(`[aosp-local-inference] Loaded ${role} model (path=${target})`);
   }
-  async function loadRole(role: "chat" | "embedding"): Promise<void> {
-    if (currentRole === role) return;
-    const existing = inflightByRole.get(role);
-    if (existing) return existing;
-    // Chain behind any in-flight load so the single native context is swapped
-    // one model at a time. A cross-role request must NOT piggyback on the other
-    // role's promise (#30147) — it waits for that swap, then loads its own
-    // model against the freshly-resident context.
-    const prior = loadChain;
-    const load = (async () => {
-      // Wait for the in-flight load (of either role) to settle. Its failure is
-      // that request's concern; this role still needs its own model, so we do
-      // not adopt the prior error.
-      await prior.catch(() => {});
-      // A concurrent request for THIS role may have completed the load while we
-      // waited behind the other role's swap.
+  // Load `role` into the native context when a different model (or none) is
+  // resident. Runs inside the serial executor so a pure prewarm load never
+  // swaps the context while another role's call is in flight. A concurrent
+  // request for the same role that ran first leaves `currentRole` already set,
+  // so this transaction skips the redundant native load.
+  async function ensureLoaded(role: "chat" | "embedding"): Promise<void> {
+    return runOnContext(async () => {
       if (currentRole === role) return;
       await performRoleLoad(role);
-    })();
-    inflightByRole.set(role, load);
-    loadChain = load.catch(() => {});
-    try {
-      await load;
-    } finally {
-      inflightByRole.delete(role);
-    }
+    });
+  }
+  // Run `use` (a native generate()/embed()) as one atomic transaction with the
+  // load that guarantees `role` is resident. Nothing else touches the native
+  // context between the load and the call, so the call always runs against its
+  // own model even when the opposite role arrives mid-flight (#30147).
+  async function withRole<T>(
+    role: "chat" | "embedding",
+    use: () => Promise<T>,
+  ): Promise<T> {
+    return runOnContext(async () => {
+      if (currentRole !== role) {
+        await performRoleLoad(role);
+      }
+      return use();
+    });
   }
   return {
-    ensureChatLoaded: () => loadRole("chat"),
-    ensureEmbeddingLoaded: () => loadRole("embedding"),
+    ensureChatLoaded: () => ensureLoaded("chat"),
+    ensureEmbeddingLoaded: () => ensureLoaded("embedding"),
+    withChat: (use) => withRole("chat", use),
+    withEmbedding: (use) => withRole("embedding", use),
     // Out-of-band eviction (voice handlers free the chat model directly via
     // loader.unloadModel() to reclaim RAM for the cold ASR/TTS load). That
-    // bypasses loadRole, so `currentRole` would stay stale ("chat") and the
+    // bypasses the lifecycle, so `currentRole` would stay stale ("chat") and the
     // next ensureChatLoaded() would short-circuit and run generate() against a
     // null ctx. Resetting `currentRole` here forces the next ensure*Loaded()
     // to actually reload. Safe to call when no load is in flight; if a load is
@@ -1947,15 +1969,18 @@ export async function generateOnPriorityLane(
         hasGrammar:
           typeof args.grammar === "string" && args.grammar.trim().length > 0,
       });
-      await lifecycle.ensureChatLoaded();
-      writeAospLlamaDebugLog("bootstrap:generate:ensureChat:done");
-      writeAospLlamaDebugLog("bootstrap:generate:start", {
-        promptChars: args.prompt.length,
-        maxTokens: args.maxTokens ?? null,
-        priority,
-        grammarBytes: args.grammar?.trim().length ?? 0,
+      // Keep the chat load and the decode in one native-context transaction so
+      // a concurrent embedding request cannot swap the model mid-generate.
+      return lifecycle.withChat(async () => {
+        writeAospLlamaDebugLog("bootstrap:generate:ensureChat:done");
+        writeAospLlamaDebugLog("bootstrap:generate:start", {
+          promptChars: args.prompt.length,
+          maxTokens: args.maxTokens ?? null,
+          priority,
+          grammarBytes: args.grammar?.trim().length ?? 0,
+        });
+        return loader.generate(args);
       });
-      return loader.generate(args);
     },
   );
 }
@@ -2084,9 +2109,13 @@ function makeEmbeddingHandler(
       }
       return disabledAospEmbeddingVector();
     }
-    await lifecycle.ensureEmbeddingLoaded();
     const text = extractEmbeddingText(params);
-    const result = await loader.embed({ input: text });
+    // Keep the embedding load and the embed() in one native-context transaction
+    // so a concurrent chat generate cannot swap the model mid-embed and persist
+    // a vector produced against the chat GGUF (#30147).
+    const result = await lifecycle.withEmbedding(() =>
+      loader.embed({ input: text }),
+    );
     return result.embedding;
   };
 }
@@ -2880,7 +2909,7 @@ async function transcribeWithAospElizaInference(
     try {
       await loader.unloadModel();
       // Tell the lifecycle the chat model is gone so the next text turn
-      // actually reloads it (loadRole short-circuits on a stale currentRole
+      // actually reloads it (the lifecycle short-circuits on a stale currentRole
       // otherwise). Done after the unload succeeds so we never mark evicted
       // when the model is in fact still resident.
       onEvicted?.();

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -1585,8 +1585,16 @@ function resolveBundledModelPaths(modelsDir: string): {
 /**
  * Per-modelType auto-load gate. We track which model role is currently
  * loaded so a chat handler doesn't try to swap-in the embedding model
- * (and vice versa) on every call. Promise-shaped so two concurrent
- * requests share the single load.
+ * (and vice versa) on every call.
+ *
+ * The fused loader owns ONE native context that holds ONE model at a time, so
+ * in-flight tracking MUST be role-aware (#30147): a load for role A can never
+ * satisfy a request for role B. `inflightByRole` dedups concurrent same-role
+ * requests onto one load, while a different-role request waits behind the
+ * in-flight swap (`loadChain`) and then loads its own model. A single shared
+ * `inflight` promise would let a chat request piggyback on an embedding load
+ * (or vice versa) whenever no model was resident — fresh boot or after any
+ * `markEvicted()` — and then run its native call against the wrong GGUF.
  */
 type LoadedRole = "chat" | "embedding" | null;
 function makeLoaderLifecycle(loader: AospLoader): {
@@ -1595,12 +1603,18 @@ function makeLoaderLifecycle(loader: AospLoader): {
   markEvicted(): void;
 } {
   let currentRole: LoadedRole = null;
-  let inflight: Promise<void> | null = null;
+  // In-flight loads keyed by role. A pending entry dedups concurrent requests
+  // for the SAME role; a request for the OTHER role never adopts this promise.
+  const inflightByRole = new Map<"chat" | "embedding", Promise<void>>();
+  // Serializes swaps on the single native context: each load waits for any
+  // currently in-flight load (of either role) to settle before it touches the
+  // loader, so two model swaps never interleave.
+  let loadChain: Promise<void> = Promise.resolve();
   const modelsDir = resolveBundledModelsDir();
   let resolved = resolveBundledModelPaths(modelsDir);
-  async function loadRole(role: "chat" | "embedding"): Promise<void> {
-    if (currentRole === role) return;
-    if (inflight) return inflight;
+  async function resolveRoleTarget(
+    role: "chat" | "embedding",
+  ): Promise<string> {
     let target = role === "chat" ? resolved.chat : resolved.embedding;
     if (!target) {
       // The models dir is empty at first boot, so the lifecycle's initial
@@ -1630,50 +1644,72 @@ function makeLoaderLifecycle(loader: AospLoader): {
         resolved.embedding = target;
       }
     }
-    inflight = (async () => {
-      writeAospLlamaDebugLog("bootstrap:loadRole:start", {
-        role,
-        model: path.basename(target),
-      });
-      logger.info(
-        `[aosp-local-inference] Loading bundled ${role} model: ${path.basename(target)}`,
-      );
-      try {
-        await loader.loadModel(buildAospLoadModelArgs(role, target));
-        currentRole = role;
-        writeAospActiveModelState({
-          status: "ready",
-          role,
-          provider: PROVIDER,
-          path: target,
-          loadedAt: new Date().toISOString(),
-        });
-      } catch (err) {
-        // error-policy:J2 context-adding rethrow — record the per-role load failure
-        // in the status sidecar (observable), then rethrow; the role is not marked
-        // ready.
-        writeAospActiveModelState({
-          status: "error",
-          role,
-          provider: PROVIDER,
-          path: target,
-          error: err instanceof Error ? err.message : String(err),
-          updatedAt: new Date().toISOString(),
-        });
-        throw err;
-      }
-      writeAospLlamaDebugLog("bootstrap:loadRole:done", {
-        role,
-        model: path.basename(target),
-      });
-      logger.info(
-        `[aosp-local-inference] Loaded ${role} model (path=${target})`,
-      );
-    })();
+    return target;
+  }
+  async function performRoleLoad(role: "chat" | "embedding"): Promise<void> {
+    const target = await resolveRoleTarget(role);
+    writeAospLlamaDebugLog("bootstrap:loadRole:start", {
+      role,
+      model: path.basename(target),
+    });
+    logger.info(
+      `[aosp-local-inference] Loading bundled ${role} model: ${path.basename(target)}`,
+    );
     try {
-      await inflight;
+      await loader.loadModel(buildAospLoadModelArgs(role, target));
+      currentRole = role;
+      writeAospActiveModelState({
+        status: "ready",
+        role,
+        provider: PROVIDER,
+        path: target,
+        loadedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      // error-policy:J2 context-adding rethrow — record the per-role load failure
+      // in the status sidecar (observable), then rethrow; the role is not marked
+      // ready.
+      writeAospActiveModelState({
+        status: "error",
+        role,
+        provider: PROVIDER,
+        path: target,
+        error: err instanceof Error ? err.message : String(err),
+        updatedAt: new Date().toISOString(),
+      });
+      throw err;
+    }
+    writeAospLlamaDebugLog("bootstrap:loadRole:done", {
+      role,
+      model: path.basename(target),
+    });
+    logger.info(`[aosp-local-inference] Loaded ${role} model (path=${target})`);
+  }
+  async function loadRole(role: "chat" | "embedding"): Promise<void> {
+    if (currentRole === role) return;
+    const existing = inflightByRole.get(role);
+    if (existing) return existing;
+    // Chain behind any in-flight load so the single native context is swapped
+    // one model at a time. A cross-role request must NOT piggyback on the other
+    // role's promise (#30147) — it waits for that swap, then loads its own
+    // model against the freshly-resident context.
+    const prior = loadChain;
+    const load = (async () => {
+      // Wait for the in-flight load (of either role) to settle. Its failure is
+      // that request's concern; this role still needs its own model, so we do
+      // not adopt the prior error.
+      await prior.catch(() => {});
+      // A concurrent request for THIS role may have completed the load while we
+      // waited behind the other role's swap.
+      if (currentRole === role) return;
+      await performRoleLoad(role);
+    })();
+    inflightByRole.set(role, load);
+    loadChain = load.catch(() => {});
+    try {
+      await load;
     } finally {
-      inflight = null;
+      inflightByRole.delete(role);
     }
   }
   return {


### PR DESCRIPTION
# Relates to

Closes #30147

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; the owning package's test, typecheck,
      lint, format, and build pass (see **Testing** / **Known gaps**).
- [x] A reviewer can confirm the change works without reading the code, from the
      failing-before / passing-after bun output inlined under **Evidence Details**.

# Sync with develop

- [x] Branched from `origin/develop` at `9b93ec4374`; zero conflicts.
- [x] Owning-package gates pass post-sync. Full repo `bun run verify` not run on
      this constrained device — see **Known gaps / failures**.

# Risks

Low, and confined to `plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts`.
The change replaces the fused loader's shared-across-roles in-flight guard with a
single serial executor that runs each role's load **and** its native
`generate()`/`embed()` as one transaction, and routes the out-of-band voice
eviction through the same executor. No public handler signature, model type, or
registration surface changes. Worst case is that a cross-role request or a voice
eviction now *queues* behind an in-flight native call instead of interleaving
with it — which is the intended correctness behavior.

# Background

## What does this PR do?

The AOSP fused text loader owns **one** native context that holds exactly one
model (chat or embedding) at a time. `makeLoaderLifecycle` originally shared a
single `inflight` promise across **both** roles, so when nothing was resident
(fresh boot, or after any `markEvicted()` from the idle-unloader or a voice
eviction) and two different-role requests arrived concurrently, the second
`loadRole()` hit `if (inflight) return inflight;`, awaited the **other** role's
load, and then ran its native call against the wrong GGUF — a chat completion
executing against the embedding model (garbage text), or a `TEXT_EMBEDDING` call
running against the chat model (semantically wrong vectors persisted into the
memory/vector store). This is reachable in normal operation because the
embedding handler is **not** behind the process-wide inference priority gate, so
a memory-indexing embedding and a chat generate genuinely run concurrently
(#30147).

Review (`@ss251`, `@attentionhead`) then showed that serializing the *loads*
alone was insufficient: `ensureXLoaded()` resolved the instant `loadModel()`
returned, while the native `generate()`/`embed()` ran **outside** any lock, so a
different-role load could still swap the single mutable context **mid-inference**.
`@attentionhead`'s probe captured it directly — a completion that started on
`eliza-1-chat.gguf` finished with `bge-embedding.gguf` swapped in underneath it.

## The fix (final head `c5cd7d03`)

1. **Serialize the whole load-plus-use transaction.** `makeLoaderLifecycle` now
   runs every context mutation through a single serial executor `runOnContext`
   (`contextChain.then(task, task)`). `withChat()` / `withEmbedding()` wrap the
   optional role load-swap **and** the `generate()`/`embed()` that consumes it in
   one critical section (`withRole`); `generateOnPriorityLane` and
   `makeEmbeddingHandler` go through them. `ensureChatLoaded` /
   `ensureEmbeddingLoaded` remain for pure prewarm loads and are serialized on
   the same executor, so a prewarm can't swap mid-call either. A concurrent
   cross-role load can no longer interleave with an in-flight native call.
2. **Serialize the out-of-band voice eviction.** `evict()` runs the
   `loader.unloadModel()` that the voice ASR/TTS path uses to reclaim RAM through
   the **same** executor, so it waits behind any in-flight `generate()`/`embed()`
   instead of freeing the native context out from under it. `markEvicted()` (the
   idle-unloader seam that already gates on #11760 in-flight tracking) is
   preserved for the path that cannot join the executor.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. This is an internal native-context concurrency fix with no user-facing API,
config, or model-registration change.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-inference/__tests__/aosp-crossrole-load-guard.test.ts` —
five regression cases that drive the **real registered** `TEXT_LARGE` /
`TEXT_EMBEDDING` handlers via `ensureAospLocalInferenceHandlers` over a
deterministic barrier-backed `AospLoader` and a temp `STATE_DIR` manifest
listing both a chat and an embedding GGUF (no source-under-test mock). The
barrier can pin a load in flight **and** hold a `generate()`/`embed()` call open,
and each case records the resident model when the call **returns**, so a mid-call
swap surfaces as a wrong-model observation. Coverage: (a) no cross-role
piggyback; (b) load-plus-use stays atomic while an embed is in flight; (c)
same-role concurrent dedup issues one `loadModel`; (d) an out-of-band `evict()`
queues behind an in-flight embed; (e) each role change reloads and runs against
its own model.

## Detailed testing steps

```bash
cd plugins/plugin-native-inference
bun test __tests__/aosp-crossrole-load-guard.test.ts
```

All five cases pass on the current head. Reverting `withRole` to the pre-fix
"load-only" behavior (run the load on the executor but return `use()` **outside**
it) flips the atomicity and eviction cases to fail with a cross-role
`loadModel` firing mid-call (`Received +1`) — see **Evidence Details**.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:c5cd7d03fada0a483fa32a6675bb5f17d8869398 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. plugin-native-inference is a headless Node/native model-loader bootstrap; no rendered view changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface. See above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow. Correctness is a native-context concurrency invariant, proven by the failing-before/passing-after bun test inlined under Evidence Details.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no standalone HTTP server path; the change is in the fused model-loader lifecycle. The real registered-handler lifecycle logs (load / reload / serialized eviction) are inlined under Evidence Details below.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend/browser request path. Headless native-inference loader module.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model/provider contract change; the fix serializes the native model-context load-plus-use lifecycle and the handler input/output contracts are unchanged. The harness drives the real registered handlers with a deterministic barrier-backed loader (no live GGUF is available in this environment), so there is no live model trajectory to record.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the failing-before (load-only mutant) / passing-after bun regression output, inlined under Evidence Details below. A fork contributor cannot mint gate-accepted GitHub attachment URLs from this headless environment: no push access to the pr-evidence release, and the user-attachments upload path requires a browser session.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior change.` The registered
`TEXT_LARGE`/`TEXT_EMBEDDING` handler contracts are unchanged; only the
loader-lifecycle serialization they run through is corrected. The regression
harness drives those real handlers with a deterministic barrier-backed loader
because no live GGUF is available in this environment.

## Domain artifact — failing-before / passing-after regression (bun test)

`aosp-crossrole-load-guard.test.ts` passes on head (5 pass / 0 fail). Reverting
`withRole` to the pre-fix load-only behavior — `await runOnContext(load); return use();`
so the native call runs **outside** the serial transaction — makes the
atomicity and eviction cases fail: a cross-role `loadModel` fires while the embed
is still in flight (`Received +1`), exactly the wrong-model swap the review
raised.

<details>
<summary>AFTER (head c5cd7d03) — 5 pass / 0 fail</summary>

```
(pass) AOSP fused loader cross-role in-flight guard (#30147) > loads the chat model for a chat request racing an in-flight embedding load (no cross-role piggyback)
(pass) AOSP fused loader cross-role in-flight guard (#30147) > keeps load-plus-use atomic: an arriving chat request cannot swap the native context while an embedding call is still running
(pass) AOSP fused loader cross-role in-flight guard (#30147) > dedups concurrent same-role embedding loads onto a single native load
(pass) AOSP fused loader cross-role in-flight guard (#30147) > routes an out-of-band eviction through the context executor so the unload waits behind an in-flight embed instead of dropping the model mid-call
(pass) AOSP fused loader cross-role in-flight guard (#30147) > reloads the single native context on every role change, each call running against its own model
 5 pass
 0 fail
 23 expect() calls
Ran 5 tests across 1 file.
```
</details>

<details>
<summary>BEFORE (load-only mutant: use() outside the serial section) — 3 pass / 2 fail</summary>

```
# Diff applied to withRole():
#   -    return runOnContext(async () => {
#   -      if (currentRole !== role) { await performRoleLoad(role); }
#   -      return use();
#   -    });
#   +    await runOnContext(async () => {
#   +      if (currentRole !== role) { await performRoleLoad(role); }
#   +    });
#   +    return use();

(pass) ... no cross-role piggyback
- Expected  - 0
+ Received  + 1
(fail) ... keeps load-plus-use atomic: an arriving chat request cannot swap the native context while an embedding call is still running
(pass) ... dedups concurrent same-role embedding loads onto a single native load
- Expected  - 0
+ Received  + 1
(fail) ... routes an out-of-band eviction through the context executor so the unload waits behind an in-flight embed instead of dropping the model mid-call
(pass) ... reloads the single native context on every role change, each call running against its own model
 3 pass
 2 fail
Ran 5 tests across 1 file.
```
</details>

## Backend + runtime lifecycle logs

Real registered `eliza-aosp-llama` lifecycle logs emitted during the cross-role
test at head — load / reload ordering on the single native context:

<details>
<summary>[aosp-local-inference] lifecycle logs (excerpt)</summary>

```
[aosp-local-inference] building fused text loader…
[aosp-local-inference] fused text loader ready
[aosp-local-inference] registered eliza-aosp-llama handlers for TEXT_SMALL / TEXT_LARGE / TEXT_EMBEDDING / TEXT_TO_SPEECH (priority 0, text backend fused-libelizainference)
[aosp-local-inference] Loading bundled embedding model: bge-embedding.gguf
[aosp-local-inference] Loaded embedding model (path=.../models/bge-embedding.gguf)
[aosp-local-inference] Loading bundled chat model: eliza-1-chat.gguf
[aosp-local-inference] Loaded chat model (path=.../models/eliza-1-chat.gguf)
```
</details>

## Pre-existing failure isolation

The full package suite is **94 pass / 2 fail**; the only unique failing case,
`generateOnPriorityLane — lock priority (#11914) > rejects an unsupported background output request before the loader`,
fails **identically on the PR base source** (`9b93ec4374`), so it is **not**
introduced by this PR (independently re-confirmed by `@attentionhead` at prior
heads).

<details>
<summary>inference-priority-lane.test.ts — head vs base source (same 3 pass / 1 fail)</summary>

```
-- head source (c5cd7d03) --
(pass) dispatches an interactive turn ahead of an earlier queued background job
(fail) rejects an unsupported background output request before the loader
(pass) never rewrites an interactive turn
(pass) background job that cannot get the lane within its bounded wait fails typed and never reaches the loader
 3 pass / 1 fail

-- base source (9b93ec4374, pre-feature) --
(fail) rejects an unsupported background output request before the loader   ← same failure on base
 3 pass / 1 fail
```
</details>

## Owning-package gates (head c5cd7d03)

```
$ bun run --cwd plugins/plugin-native-inference typecheck   → clean (tsc --noEmit)
$ bun run --cwd plugins/plugin-native-inference lint:check   → clean (biome, 20 files)
$ bun run --cwd plugins/plugin-native-inference format:check → clean (biome, 20 files)
$ bun run --cwd plugins/plugin-native-inference build        → clean
$ bun test __tests__                                          → 94 pass / 2 fail (2 = the pre-existing case above)
```

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface / no user flow; correctness is proven by the
failing-then-passing bun regression test above.`

## Known gaps / failures

- Full repository `bun run verify` was not run on this constrained device (16 GB
  Raspberry Pi); the owning package's focused gates (bun suite, typecheck,
  biome lint + format, build) were run and pass. The change is a single-file
  loader-lifecycle fix with no cross-package surface, so package-scoped
  verification covers the affected contract.
- Evidence artifacts could not be minted as gate-accepted GitHub attachment URLs
  from this headless environment: `agent-cortex` has only `pull` access to
  `elizaOS/eliza` (no push, so the `pr-evidence` release upload returns 404), and
  the `/user-attachments` upload path the evidence gate also accepts requires a
  browser session. Per the gate's own fork-contributor note (#17600), the bun
  outputs are inlined directly above as the template permits.

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c5cd7d03fada0a483fa32a6675bb5f17d8869398:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c5cd7d03fada0a483fa32a6675bb5f17d8869398:packages/skills/skills/contribute-to-eliza"} -->

