### PR TITLE
fix(plugin-native-swabble): gate web wake word on token boundaries (#30151)

### DIFF
--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -508,6 +508,56 @@ describe("SwabbleWeb fallback", () => {
     );
   });
 
+  it("fires a configured trigger whose lowercase form expands the case fold (construction)", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({
+      config: { triggers: ["\u0130pek"], locale: "tr-TR" },
+    });
+
+    // "\u0130pek".toLowerCase() is "i" + U+0307 + "pek", a two-code-point sequence
+    // that /iu/ does not equate back to the single-code-point "\u0130". A matcher
+    // built from the lowercased trigger never fires on a verbatim "\u0130pek ..."
+    // transcript; building it from the original spelling keeps the gate open.
+    FakeRecognition.latest?.onresult?.(speechEvent("\u0130pek open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "open calendar", postGap: -1 }),
+    );
+  });
+
+  it("fires a case-fold-expanding trigger applied through updateConfig", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // Swapping the trigger at runtime must rebuild the matcher from the original
+    // spelling too, so the expanding case fold does not silently disable the
+    // wake word after an updateConfig.
+    await plugin.updateConfig({ config: { triggers: ["\u0130pek"] } });
+    FakeRecognition.latest?.onresult?.(speechEvent("\u0130pek open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "open calendar", postGap: -1 }),
+    );
+  });
+
   it("does not fire the wake word when the trigger is only a substring of a larger word", async () => {
     setWindow({ SpeechRecognition: FakeRecognition });
     setNavigator({

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -558,6 +558,68 @@ describe("SwabbleWeb fallback", () => {
     );
   });
 
+  // The settings UI lowercases a manually entered trigger before forwarding it
+  // to Swabble (VoiceConfigView `addTrigger`: raw.trim().toLowerCase()...), so
+  // the plugin never receives the original spelling for a case such as Turkish
+  // "\u0130pek". `settingsNormalizedTrigger` reproduces that exact caller
+  // transform, and the transcript keeps the spoken original spelling.
+  const settingsNormalizedTrigger = "\u0130pek".trim().toLowerCase();
+
+  it("fires a settings-normalized case-fold-expanding trigger from the real caller value (construction)", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+
+    // The caller already lowercased "\u0130pek" to "i" + U+0307 + "pek". A matcher
+    // that required the original spelling (or ran an /iu/ regex against the raw
+    // transcript) would never equate that two-code-point sequence with the
+    // single "\u0130" in the transcript, so the gate would stay shut for the
+    // shipped product path. Folding both sides re-opens it.
+    expect([...settingsNormalizedTrigger].map((c) => c.codePointAt(0))).toEqual(
+      [0x69, 0x307, 0x70, 0x65, 0x6b],
+    );
+    await plugin.start({
+      config: { triggers: [settingsNormalizedTrigger], locale: "tr-TR" },
+    });
+    FakeRecognition.latest?.onresult?.(speechEvent("\u0130pek open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "open calendar", postGap: -1 }),
+    );
+  });
+
+  it("fires a settings-normalized case-fold-expanding trigger applied through updateConfig", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // The runtime rebuild path must also fold the caller-normalized trigger,
+    // otherwise changing the wake word from the settings UI silently disables it.
+    await plugin.updateConfig({
+      config: { triggers: [settingsNormalizedTrigger] },
+    });
+    FakeRecognition.latest?.onresult?.(speechEvent("\u0130pek open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "open calendar", postGap: -1 }),
+    );
+  });
+
   it("does not fire the wake word when the trigger is only a substring of a larger word", async () => {
     setWindow({ SpeechRecognition: FakeRecognition });
     setNavigator({

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -383,6 +383,131 @@ describe("SwabbleWeb fallback", () => {
     },
   );
 
+  it.each([
+    {
+      lang: "ja-JP",
+      trigger: "エリザ",
+      said: "エリザカレンダーを開いて",
+      command: "カレンダーを開いて",
+    },
+    {
+      lang: "zh-CN",
+      trigger: "你好",
+      said: "你好打开日历",
+      command: "打开日历",
+    },
+    {
+      lang: "th-TH",
+      trigger: "สวัสดี",
+      said: "สวัสดีเปิดปฏิทิน",
+      command: "เปิดปฏิทิน",
+    },
+  ])(
+    "fires in continuous scripts where the command follows the trigger with no space ($lang)",
+    async ({ lang, trigger, said, command }) => {
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: {
+          getUserMedia: vi.fn(async () => null),
+        } as unknown as MediaDevices,
+      });
+      const plugin = new SwabbleWeb();
+      const wakeWords = vi.fn();
+      await plugin.addListener("wakeWord", wakeWords);
+      await plugin.start({ config: { triggers: [trigger], locale: lang } });
+
+      // Real Web Speech transcripts for Japanese/Chinese/Thai are not
+      // space-delimited, so the command abuts the trigger. A boundary rule that
+      // demanded a non-letter after the trigger would make the wake word
+      // unfireable in these scripts (a strictly worse failure than the
+      // substring over-firing this PR fixes for space-delimited scripts).
+      FakeRecognition.latest?.onresult?.(speechEvent(said));
+
+      expect(wakeWords).toHaveBeenCalledWith(
+        expect.objectContaining({ wakeWord: trigger, command }),
+      );
+    },
+  );
+
+  it("pins the command to the standalone trigger, not an earlier substring occurrence", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // "elizabeth" contains "eliza" and precedes the standalone "eliza". The
+    // command must be sliced at the boundary-delimited match index, not the
+    // first raw substring occurrence: a plain indexOf would anchor inside
+    // "elizabeth" and dispatch "beth and eliza open calendar".
+    FakeRecognition.latest?.onresult?.(
+      speechEvent("elizabeth and eliza open calendar"),
+    );
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ wakeWord: "eliza", command: "open calendar" }),
+    );
+  });
+
+  it("treats a trigger containing regex metacharacters as a literal token", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+
+    // A trigger with an unescaped regex metacharacter ("hey(") would make
+    // `new RegExp` throw a SyntaxError at gate construction if the trigger were
+    // not escaped. Construction must succeed and the trigger must match only
+    // as a literal token.
+    await expect(
+      plugin.start({ config: { triggers: ["hey("], locale: "en-US" } }),
+    ).resolves.toEqual({ started: true });
+
+    FakeRecognition.latest?.onresult?.(speechEvent("hey( open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ wakeWord: "hey(", command: "open calendar" }),
+    );
+  });
+
+  it("slices the command at the true index when case folding changes length", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // U+0130 (LATIN CAPITAL I WITH DOT ABOVE) lowercases to two code units, so
+    // a match index measured on a lowercased copy would skew the slice against
+    // the original string (yielding "pen calendar"). Matching the original
+    // transcript case-insensitively keeps the index aligned.
+    FakeRecognition.latest?.onresult?.(
+      speechEvent("\u0130\u0130 eliza open calendar"),
+    );
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ wakeWord: "eliza", command: "open calendar" }),
+    );
+  });
+
   it("does not fire the wake word when the trigger is only a substring of a larger word", async () => {
     setWindow({ SpeechRecognition: FakeRecognition });
     setNavigator({

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -383,6 +383,121 @@ describe("SwabbleWeb fallback", () => {
     },
   );
 
+  it("does not fire the wake word when the trigger is only a substring of a larger word", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // "elizabeth" contains "eliza" but the user never spoke the trigger as a
+    // distinct token, so the gate must stay closed. A bare substring match
+    // would fire { wakeWord: "eliza", command: "beth opened the door" } and
+    // dispatch a garbled command the user never issued (issue #30151).
+    FakeRecognition.latest?.onresult?.(
+      speechEvent("elizabeth opened the door"),
+    );
+
+    expect(wakeWords).not.toHaveBeenCalled();
+  });
+
+  it("still fires the wake word when the trigger is a standalone token", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    FakeRecognition.latest?.onresult?.(speechEvent("eliza open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({ wakeWord: "eliza", command: "open calendar" }),
+    );
+  });
+
+  it("does not fire on common words that merely start with the trigger", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    // "hey" is a prefix of "they"; ambient speech must not trip the gate.
+    await plugin.start({ config: { triggers: ["hey"], locale: "en-US" } });
+
+    FakeRecognition.latest?.onresult?.(speechEvent("they left the room"));
+
+    expect(wakeWords).not.toHaveBeenCalled();
+  });
+
+  it("fires when the trigger token is delimited by punctuation, not whitespace", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // A comma after the trigger is a boundary, so the gate still opens. The
+    // command slice begins right after the trigger token; leading punctuation
+    // is preserved (whitespace-only trim), matching the pre-existing contract.
+    FakeRecognition.latest?.onresult?.(speechEvent("eliza, open calendar"));
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wakeWord: "eliza",
+        command: ", open calendar",
+      }),
+    );
+  });
+
+  it("drops the carry-over buffer when a triggerless substring word finalizes", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+    await plugin.start({ config: { triggers: ["eliza"], locale: "en-US" } });
+
+    // "elizabeth" is not a trigger, so it must not be retained as a
+    // trigger-awaiting-command buffer. A following unrelated final must not
+    // become a command dispatched under the substring "eliza".
+    FakeRecognition.latest?.onresult?.(
+      accumulatedEvent([{ transcript: "elizabeth spoke" }], 0),
+    );
+    FakeRecognition.latest?.onresult?.(
+      accumulatedEvent(
+        [{ transcript: "elizabeth spoke" }, { transcript: "open calendar" }],
+        1,
+      ),
+    );
+
+    expect(wakeWords).not.toHaveBeenCalled();
+  });
+
   it("ignores malformed speech result payloads without emitting transcripts", async () => {
     setWindow({ SpeechRecognition: FakeRecognition });
     setNavigator({

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -426,6 +426,36 @@ describe("SwabbleWeb fallback", () => {
     );
   });
 
+  it.each([
+    { trigger: "e", note: "combining mark follows the trigger" },
+    { trigger: "clair", note: "combining mark precedes the trigger" },
+  ])(
+    "does not fire when a decomposed accent keeps the trigger inside a word ($note)",
+    async ({ trigger }) => {
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: {
+          getUserMedia: vi.fn(async () => null),
+        } as unknown as MediaDevices,
+      });
+      const plugin = new SwabbleWeb();
+      const wakeWords = vi.fn();
+      await plugin.addListener("wakeWord", wakeWords);
+      await plugin.start({ config: { triggers: [trigger], locale: "en-US" } });
+
+      // "éclair" in NFD decomposes to "e" + U+0301 (combining acute) + "clair".
+      // A boundary class that excluded combining marks would treat the mark as
+      // a token boundary, so trigger "e" (mark on its right) and trigger
+      // "clair" (mark on its left) would each false-fire inside the single word
+      // "éclair", dispatching a command the user never issued.
+      FakeRecognition.latest?.onresult?.(
+        speechEvent("e\u0301clair recipe please"),
+      );
+
+      expect(wakeWords).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not fire on common words that merely start with the trigger", async () => {
     setWindow({ SpeechRecognition: FakeRecognition });
     setNavigator({

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -620,6 +620,44 @@ describe("SwabbleWeb fallback", () => {
     );
   });
 
+  it("fires a Greek trigger whose case-folding is contextual (final vs medial sigma)", async () => {
+    setWindow({ SpeechRecognition: FakeRecognition });
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => null),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new SwabbleWeb();
+    const wakeWords = vi.fn();
+    await plugin.addListener("wakeWord", wakeWords);
+
+    // The settings UI whole-string-lowercases a manual entry, so "\u039f\u0394\u039f\u03a3"
+    // reaches the plugin as "\u03bf\u03b4\u03bf\u03c2" with word-final sigma "\u03c2" (U+03C2).
+    // toLowerCase() is context-sensitive for Greek capital sigma, so a
+    // per-code-point fold of a capitalized transcript yields medial "\u03c3"
+    // (U+03C3); without canonicalizing final sigma the two folds disagree and
+    // the gate never opens for a legitimately spoken wake word (regression vs
+    // develop, which whole-string-lowercased both sides).
+    const settingsGreekTrigger = "\u039f\u0394\u039f\u03a3".toLowerCase();
+    expect(settingsGreekTrigger).toBe("\u03bf\u03b4\u03bf\u03c2");
+    await plugin.start({
+      config: { triggers: [settingsGreekTrigger], locale: "el-GR" },
+    });
+    FakeRecognition.latest?.onresult?.(
+      speechEvent(
+        "\u039f\u0394\u039f\u03a3 \u03b1\u03bd\u03bf\u03b9\u03be\u03b5",
+      ),
+    );
+
+    expect(wakeWords).toHaveBeenCalledTimes(1);
+    expect(wakeWords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "\u03b1\u03bd\u03bf\u03b9\u03be\u03b5",
+        postGap: -1,
+      }),
+    );
+  });
+
   it("does not fire the wake word when the trigger is only a substring of a larger word", async () => {
     setWindow({ SpeechRecognition: FakeRecognition });
     setNavigator({

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -90,9 +90,14 @@ const CONTINUOUS_SCRIPTS =
   "\\p{sc=Han}\\p{sc=Hiragana}\\p{sc=Katakana}\\p{sc=Thai}\\p{sc=Lao}\\p{sc=Khmer}\\p{sc=Myanmar}";
 
 /**
- * Build a word-boundary matcher for a lowercased trigger, case-insensitive so
- * it runs against the original (un-lowercased) transcript and its match index
- * lines up with the string that is later sliced for the command.
+ * Build a word-boundary matcher for the trigger's original spelling,
+ * case-insensitive (`iu`) so it runs against the original (un-lowercased)
+ * transcript and its match index lines up with the string that is later sliced
+ * for the command. The trigger must keep its original spelling here: lowercasing
+ * an expanding case-fold such as Turkish "\u0130" (U+0130) produces two code
+ * points ("i" + U+0307) that `/iu/` does not equate back to the original
+ * "\u0130", so a matcher built from the lowercased form would never fire on a
+ * verbatim "\u0130pek ..." transcript.
  *
  * In space-delimited scripts the trigger must be a standalone token: a letter,
  * number, or combining mark on either side rejects the match, so "elizabeth"
@@ -110,6 +115,10 @@ const CONTINUOUS_SCRIPTS =
  * alone cannot segment those words, so this is not a regression.
  */
 function buildTriggerMatcher(trigger: string): RegExp {
+  // Build from the trigger's original spelling; the `iu` flag below supplies
+  // case-insensitivity via Unicode simple case folding, which (unlike a
+  // pre-lowercased trigger) keeps an expanding case-fold like U+0130 matchable.
+
   const before = `(?:(?<![\\p{L}\\p{N}\\p{M}])|(?<=[${CONTINUOUS_SCRIPTS}]))`;
   const after = `(?:(?![\\p{L}\\p{N}\\p{M}])|(?=[${CONTINUOUS_SCRIPTS}]))`;
   return new RegExp(`${before}${escapeRegExp(trigger)}${after}`, "iu");
@@ -171,18 +180,21 @@ function normalizeConfig(config: SwabbleConfig): SwabbleConfig {
  * Detection is purely text-based: trigger phrase + subsequent command text.
  */
 class WakeWordGate {
-  // Each matcher pairs a lowercased trigger with its word-boundary regex so a
+  // Each matcher pairs a trigger label with its word-boundary regex so a
   // trigger only fires as a standalone token, never as a bare substring of a
-  // larger word ("elizabeth" must not fire the trigger "eliza").
+  // larger word ("elizabeth" must not fire the trigger "eliza"). The regex is
+  // built from the trigger's original spelling and is case-insensitive (so an
+  // expanding case-fold like U+0130 still matches); `trigger` is the lowercased
+  // label reported as the fired wake word.
   private matchers: Array<{ trigger: string; regex: RegExp }>;
   private minCommandLength: number;
 
   constructor(config: SwabbleConfig) {
     const normalized = normalizeConfig(config);
-    this.matchers = normalized.triggers.map((t) => {
-      const trigger = t.toLowerCase();
-      return { trigger, regex: buildTriggerMatcher(trigger) };
-    });
+    this.matchers = normalized.triggers.map((t) => ({
+      trigger: t.toLowerCase(),
+      regex: buildTriggerMatcher(t),
+    }));
     this.minCommandLength = config.minCommandLength ?? 1;
     // Note: minPostTriggerGap cannot be enforced - Web Speech API lacks timing data
   }
@@ -191,10 +203,10 @@ class WakeWordGate {
     if (config.triggers) {
       this.matchers = normalizeConfig({
         triggers: config.triggers,
-      }).triggers.map((t) => {
-        const trigger = t.toLowerCase();
-        return { trigger, regex: buildTriggerMatcher(trigger) };
-      });
+      }).triggers.map((t) => ({
+        trigger: t.toLowerCase(),
+        regex: buildTriggerMatcher(t),
+      }));
     }
     if (
       typeof config.minCommandLength === "number" &&

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -90,14 +90,46 @@ const CONTINUOUS_SCRIPTS =
   "\\p{sc=Han}\\p{sc=Hiragana}\\p{sc=Katakana}\\p{sc=Thai}\\p{sc=Lao}\\p{sc=Khmer}\\p{sc=Myanmar}";
 
 /**
- * Build a word-boundary matcher for the trigger's original spelling,
- * case-insensitive (`iu`) so it runs against the original (un-lowercased)
- * transcript and its match index lines up with the string that is later sliced
- * for the command. The trigger must keep its original spelling here: lowercasing
- * an expanding case-fold such as Turkish "\u0130" (U+0130) produces two code
- * points ("i" + U+0307) that `/iu/` does not equate back to the original
- * "\u0130", so a matcher built from the lowercased form would never fire on a
- * verbatim "\u0130pek ..." transcript.
+ * Case-fold a string with `toLowerCase()` while recording, for every code unit
+ * of the folded result, the index in the original string it came from. The
+ * returned `map` has one entry per folded code unit plus a trailing sentinel
+ * (`map[folded.length] === value.length`), so a match offset measured in the
+ * folded string can be translated back to a slice offset in the original
+ * string even when folding changes length. This is what keeps the command
+ * slice correct for an expanding case fold such as Turkish "\u0130" (U+0130),
+ * whose lowercase form is the two code points "i" + U+0307.
+ *
+ * `toLowerCase()` is context-free (unlike locale-aware `toLocaleLowerCase()`),
+ * so folding per code point here matches folding the whole string at once,
+ * which is why the folded trigger and the folded transcript stay comparable.
+ */
+function foldForMatch(value: string): { folded: string; map: number[] } {
+  let folded = "";
+  const map: number[] = [];
+  let originalIndex = 0;
+  for (const codePoint of value) {
+    const lowered = codePoint.toLowerCase();
+    for (let i = 0; i < lowered.length; i++) {
+      map.push(originalIndex);
+    }
+    folded += lowered;
+    originalIndex += codePoint.length;
+  }
+  map.push(value.length);
+  return { folded, map };
+}
+
+/**
+ * Build a word-boundary matcher for the case-folded trigger, to run against a
+ * case-folded transcript (see `foldForMatch`). Folding both sides with the same
+ * `toLowerCase()` — rather than an `/i/` regex against an un-folded transcript —
+ * is what makes an expanding case fold matchable no matter how the caller
+ * spelled the trigger: the settings UI lowercases a manual entry before it
+ * reaches this plugin, so Turkish "\u0130pek" arrives as "i" + U+0307 + "pek",
+ * which `/iu/` does not equate back to the single-code-point "\u0130" in the
+ * transcript. Folding the transcript the same way reduces both to "i" + U+0307,
+ * so the gate opens regardless of whether the trigger kept its original
+ * spelling.
  *
  * In space-delimited scripts the trigger must be a standalone token: a letter,
  * number, or combining mark on either side rejects the match, so "elizabeth"
@@ -115,13 +147,10 @@ const CONTINUOUS_SCRIPTS =
  * alone cannot segment those words, so this is not a regression.
  */
 function buildTriggerMatcher(trigger: string): RegExp {
-  // Build from the trigger's original spelling; the `iu` flag below supplies
-  // case-insensitivity via Unicode simple case folding, which (unlike a
-  // pre-lowercased trigger) keeps an expanding case-fold like U+0130 matchable.
-
   const before = `(?:(?<![\\p{L}\\p{N}\\p{M}])|(?<=[${CONTINUOUS_SCRIPTS}]))`;
   const after = `(?:(?![\\p{L}\\p{N}\\p{M}])|(?=[${CONTINUOUS_SCRIPTS}]))`;
-  return new RegExp(`${before}${escapeRegExp(trigger)}${after}`, "iu");
+  const { folded } = foldForMatch(trigger);
+  return new RegExp(`${before}${escapeRegExp(folded)}${after}`, "u");
 }
 
 const getSpeechRecognition = (): SpeechRecognitionCtor | null =>
@@ -183,9 +212,10 @@ class WakeWordGate {
   // Each matcher pairs a trigger label with its word-boundary regex so a
   // trigger only fires as a standalone token, never as a bare substring of a
   // larger word ("elizabeth" must not fire the trigger "eliza"). The regex is
-  // built from the trigger's original spelling and is case-insensitive (so an
-  // expanding case-fold like U+0130 still matches); `trigger` is the lowercased
-  // label reported as the fired wake word.
+  // built from the case-folded trigger and is matched against a case-folded
+  // transcript (see `foldForMatch`), so a caller-lowercased or original-spelling
+  // trigger both match, including an expanding case-fold like U+0130; `trigger`
+  // is the lowercased label reported as the fired wake word.
   private matchers: Array<{ trigger: string; regex: RegExp }>;
   private minCommandLength: number;
 
@@ -224,9 +254,10 @@ class WakeWordGate {
    * (a trigger awaiting its command) versus safe to discard.
    */
   hasTrigger(transcript: string): boolean {
-    // Matchers are case-insensitive, so they run against the original
-    // transcript directly (no separate lowercasing that could shift offsets).
-    return this.matchers.some(({ regex }) => regex.test(transcript));
+    // Matchers are built from the case-folded trigger, so they run against the
+    // case-folded transcript; presence detection needs no offset mapping.
+    const { folded } = foldForMatch(transcript);
+    return this.matchers.some(({ regex }) => regex.test(folded));
   }
 
   /**
@@ -236,19 +267,21 @@ class WakeWordGate {
   match(
     transcript: string,
   ): { wakeWord: string; command: string; postGap: number } | null {
+    // Fold the transcript once and match against the folded form, then map the
+    // folded match-end offset back into the original transcript so the command
+    // is sliced from the untouched text (case folding may change length, e.g.
+    // U+0130, so a folded offset must not index the original directly).
+    const { folded, map } = foldForMatch(transcript);
     for (const { trigger, regex } of this.matchers) {
-      // The matcher is case-insensitive and runs against the original
-      // transcript, so its index and matched length are measured in the same
-      // string that is sliced below. Lowercasing first could change length
-      // (e.g. U+0130) and skew the offset.
-      const found = regex.exec(transcript);
+      const found = regex.exec(folded);
       if (!found) continue;
 
-      // Extract command after the standalone trigger token. Using the match
-      // index and matched length (not raw indexOf) keeps the boundary contract:
-      // only a boundary-delimited trigger reaches this point, so "elizabeth"
-      // never yields a command.
-      const commandStart = found.index + found[0].length;
+      // Extract command after the standalone trigger token. Using the
+      // boundary-delimited match end (mapped back to the original transcript),
+      // not a raw indexOf, keeps the boundary contract: only a boundary-
+      // delimited trigger reaches this point, so "elizabeth" never yields a
+      // command.
+      const commandStart = map[found.index + found[0].length];
       const command = transcript.slice(commandStart).trim();
 
       if (command.length < this.minCommandLength) continue;

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -82,15 +82,19 @@ function escapeRegExp(value: string): string {
 }
 
 /**
- * Build a word-boundary matcher for a lowercased trigger. Unicode letter/number
- * lookarounds require the trigger to be a standalone token rather than a bare
- * substring, so "elizabeth" no longer matches the trigger "eliza" and "they"
- * no longer matches "hey". Punctuation and whitespace count as boundaries, so
+ * Build a word-boundary matcher for a lowercased trigger. Unicode
+ * letter/number/mark lookarounds require the trigger to be a standalone token
+ * rather than a bare substring, so "elizabeth" no longer matches the trigger
+ * "eliza" and "they" no longer matches "hey". Combining marks (`\p{M}`) are
+ * token constituents on both sides, so a decomposed accent adjacent to the
+ * trigger keeps it inside its host word: trigger "e" does not match the
+ * decomposed "e\u0301clair" ("éclair") and trigger "clair" does not match it
+ * either. Punctuation and whitespace still count as boundaries, so
  * "eliza, open calendar" and "eliza open calendar" both match.
  */
 function buildTriggerMatcher(trigger: string): RegExp {
   return new RegExp(
-    `(?<![\\p{L}\\p{N}])${escapeRegExp(trigger)}(?![\\p{L}\\p{N}])`,
+    `(?<![\\p{L}\\p{N}\\p{M}])${escapeRegExp(trigger)}(?![\\p{L}\\p{N}\\p{M}])`,
     "u",
   );
 }
@@ -137,7 +141,9 @@ function normalizeConfig(config: SwabbleConfig): SwabbleConfig {
  * A trigger only fires when it appears as a standalone token, delimited by
  * Unicode word boundaries (whitespace, punctuation, or string edges). A bare
  * substring never fires: "elizabeth" does not trigger "eliza" and "they" does
- * not trigger "hey". TRADEOFF: for scriptless languages that write commands
+ * not trigger "hey". Combining marks are treated as part of the surrounding
+ * token, so a decomposed accent adjacent to the trigger (e.g. "e\u0301clair")
+ * does not open the gate on the trigger "e". TRADEOFF: for scriptless languages that write commands
  * with no whitespace after the trigger (e.g. continuous CJK), the following
  * text is not a separate token, so the current whitespace/punctuation-delimited
  * contract does not split it; every existing locale test delimits the trigger

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -77,6 +77,24 @@ function subscribeDesktopBridgeEvent(options: {
   return () => {};
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Build a word-boundary matcher for a lowercased trigger. Unicode letter/number
+ * lookarounds require the trigger to be a standalone token rather than a bare
+ * substring, so "elizabeth" no longer matches the trigger "eliza" and "they"
+ * no longer matches "hey". Punctuation and whitespace count as boundaries, so
+ * "eliza, open calendar" and "eliza open calendar" both match.
+ */
+function buildTriggerMatcher(trigger: string): RegExp {
+  return new RegExp(
+    `(?<![\\p{L}\\p{N}])${escapeRegExp(trigger)}(?![\\p{L}\\p{N}])`,
+    "u",
+  );
+}
+
 const getSpeechRecognition = (): SpeechRecognitionCtor | null =>
   (window as SpeechRecognitionWindow).SpeechRecognition ||
   (window as SpeechRecognitionWindow).webkitSpeechRecognition ||
@@ -116,27 +134,45 @@ function normalizeConfig(config: SwabbleConfig): SwabbleConfig {
 /**
  * WakeWordGate detects trigger phrases in transcripts.
  *
+ * A trigger only fires when it appears as a standalone token, delimited by
+ * Unicode word boundaries (whitespace, punctuation, or string edges). A bare
+ * substring never fires: "elizabeth" does not trigger "eliza" and "they" does
+ * not trigger "hey". TRADEOFF: for scriptless languages that write commands
+ * with no whitespace after the trigger (e.g. continuous CJK), the following
+ * text is not a separate token, so the current whitespace/punctuation-delimited
+ * contract does not split it; every existing locale test delimits the trigger
+ * from its command with a space.
+ *
  * LIMITATION: Web Speech API does not provide word-level timing data.
  * Unlike native implementations, we cannot measure post-trigger gaps.
  * The `postGap` returned is always -1 (unavailable), and minPostTriggerGap is ignored.
  * Detection is purely text-based: trigger phrase + subsequent command text.
  */
 class WakeWordGate {
-  private triggers: string[];
+  // Each matcher pairs a lowercased trigger with its word-boundary regex so a
+  // trigger only fires as a standalone token, never as a bare substring of a
+  // larger word ("elizabeth" must not fire the trigger "eliza").
+  private matchers: Array<{ trigger: string; regex: RegExp }>;
   private minCommandLength: number;
 
   constructor(config: SwabbleConfig) {
     const normalized = normalizeConfig(config);
-    this.triggers = normalized.triggers.map((t) => t.toLowerCase());
+    this.matchers = normalized.triggers.map((t) => {
+      const trigger = t.toLowerCase();
+      return { trigger, regex: buildTriggerMatcher(trigger) };
+    });
     this.minCommandLength = config.minCommandLength ?? 1;
     // Note: minPostTriggerGap cannot be enforced - Web Speech API lacks timing data
   }
 
   updateConfig(config: Partial<SwabbleConfig>): void {
     if (config.triggers) {
-      this.triggers = normalizeConfig({
+      this.matchers = normalizeConfig({
         triggers: config.triggers,
-      }).triggers.map((t) => t.toLowerCase());
+      }).triggers.map((t) => {
+        const trigger = t.toLowerCase();
+        return { trigger, regex: buildTriggerMatcher(trigger) };
+      });
     }
     if (
       typeof config.minCommandLength === "number" &&
@@ -155,9 +191,7 @@ class WakeWordGate {
    */
   hasTrigger(transcript: string): boolean {
     const normalizedTranscript = transcript.toLowerCase();
-    return this.triggers.some(
-      (trigger) => normalizedTranscript.indexOf(trigger) !== -1,
-    );
+    return this.matchers.some(({ regex }) => regex.test(normalizedTranscript));
   }
 
   /**
@@ -169,12 +203,14 @@ class WakeWordGate {
   ): { wakeWord: string; command: string; postGap: number } | null {
     const normalizedTranscript = transcript.toLowerCase();
 
-    for (const trigger of this.triggers) {
-      const triggerIndex = normalizedTranscript.indexOf(trigger);
-      if (triggerIndex === -1) continue;
+    for (const { trigger, regex } of this.matchers) {
+      const found = regex.exec(normalizedTranscript);
+      if (!found) continue;
 
-      // Extract command after the trigger phrase
-      const commandStart = triggerIndex + trigger.length;
+      // Extract command after the standalone trigger token. Using the match
+      // index (not raw indexOf) keeps the boundary contract: only a whole-word
+      // trigger reaches this point, so "elizabeth" never yields a command.
+      const commandStart = found.index + trigger.length;
       const command = transcript.slice(commandStart).trim();
 
       if (command.length < this.minCommandLength) continue;

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -81,22 +81,38 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Scripts that do not delimit words with whitespace. A word boundary is not
+// textually observable inside them, so requiring a non-letter neighbor there
+// would make the wake word unfireable (the command follows the trigger with no
+// space). For these scripts the boundary is satisfied by an adjacent letter,
+// which restores the substring behavior a continuous-script user depends on.
+const CONTINUOUS_SCRIPTS =
+  "\\p{sc=Han}\\p{sc=Hiragana}\\p{sc=Katakana}\\p{sc=Thai}\\p{sc=Lao}\\p{sc=Khmer}\\p{sc=Myanmar}";
+
 /**
- * Build a word-boundary matcher for a lowercased trigger. Unicode
- * letter/number/mark lookarounds require the trigger to be a standalone token
- * rather than a bare substring, so "elizabeth" no longer matches the trigger
- * "eliza" and "they" no longer matches "hey". Combining marks (`\p{M}`) are
- * token constituents on both sides, so a decomposed accent adjacent to the
- * trigger keeps it inside its host word: trigger "e" does not match the
- * decomposed "e\u0301clair" ("éclair") and trigger "clair" does not match it
- * either. Punctuation and whitespace still count as boundaries, so
- * "eliza, open calendar" and "eliza open calendar" both match.
+ * Build a word-boundary matcher for a lowercased trigger, case-insensitive so
+ * it runs against the original (un-lowercased) transcript and its match index
+ * lines up with the string that is later sliced for the command.
+ *
+ * In space-delimited scripts the trigger must be a standalone token: a letter,
+ * number, or combining mark on either side rejects the match, so "elizabeth"
+ * does not fire "eliza", "they" does not fire "hey", and a decomposed accent
+ * keeps the trigger inside its host word (trigger "e" does not match the NFD
+ * "e\u0301clair"). Whitespace, punctuation, and string edges are boundaries, so
+ * "eliza, open calendar" and "eliza open calendar" both fire.
+ *
+ * A neighbor in a continuous script (`CONTINUOUS_SCRIPTS`) also satisfies the
+ * boundary, because such scripts write the command directly after the trigger
+ * with no delimiter; without this relaxation the wake word could never fire in
+ * Japanese, Chinese, Thai, and similar scripts. The residual cost is that a
+ * trigger which is a prefix of a longer continuous-script word (e.g. "エリザ"
+ * inside "エリザベス") still fires, matching the prior substring behavior; text
+ * alone cannot segment those words, so this is not a regression.
  */
 function buildTriggerMatcher(trigger: string): RegExp {
-  return new RegExp(
-    `(?<![\\p{L}\\p{N}\\p{M}])${escapeRegExp(trigger)}(?![\\p{L}\\p{N}\\p{M}])`,
-    "u",
-  );
+  const before = `(?:(?<![\\p{L}\\p{N}\\p{M}])|(?<=[${CONTINUOUS_SCRIPTS}]))`;
+  const after = `(?:(?![\\p{L}\\p{N}\\p{M}])|(?=[${CONTINUOUS_SCRIPTS}]))`;
+  return new RegExp(`${before}${escapeRegExp(trigger)}${after}`, "iu");
 }
 
 const getSpeechRecognition = (): SpeechRecognitionCtor | null =>
@@ -138,16 +154,16 @@ function normalizeConfig(config: SwabbleConfig): SwabbleConfig {
 /**
  * WakeWordGate detects trigger phrases in transcripts.
  *
- * A trigger only fires when it appears as a standalone token, delimited by
- * Unicode word boundaries (whitespace, punctuation, or string edges). A bare
- * substring never fires: "elizabeth" does not trigger "eliza" and "they" does
- * not trigger "hey". Combining marks are treated as part of the surrounding
- * token, so a decomposed accent adjacent to the trigger (e.g. "e\u0301clair")
- * does not open the gate on the trigger "e". TRADEOFF: for scriptless languages that write commands
- * with no whitespace after the trigger (e.g. continuous CJK), the following
- * text is not a separate token, so the current whitespace/punctuation-delimited
- * contract does not split it; every existing locale test delimits the trigger
- * from its command with a space.
+ * In space-delimited scripts a trigger only fires as a standalone token,
+ * delimited by Unicode word boundaries (whitespace, punctuation, or string
+ * edges). A bare substring never fires: "elizabeth" does not trigger "eliza"
+ * and "they" does not trigger "hey". Combining marks are treated as part of the
+ * surrounding token, so a decomposed accent adjacent to the trigger (e.g.
+ * "e\u0301clair") does not open the gate on the trigger "e". In continuous
+ * scripts (Japanese, Chinese, Thai, and similar) the command follows the
+ * trigger with no whitespace, so an adjacent letter also satisfies the
+ * boundary; without this the wake word could never fire there. See
+ * `buildTriggerMatcher` for the exact rule and its residual prefix-word cost.
  *
  * LIMITATION: Web Speech API does not provide word-level timing data.
  * Unlike native implementations, we cannot measure post-trigger gaps.
@@ -196,8 +212,9 @@ class WakeWordGate {
    * (a trigger awaiting its command) versus safe to discard.
    */
   hasTrigger(transcript: string): boolean {
-    const normalizedTranscript = transcript.toLowerCase();
-    return this.matchers.some(({ regex }) => regex.test(normalizedTranscript));
+    // Matchers are case-insensitive, so they run against the original
+    // transcript directly (no separate lowercasing that could shift offsets).
+    return this.matchers.some(({ regex }) => regex.test(transcript));
   }
 
   /**
@@ -207,16 +224,19 @@ class WakeWordGate {
   match(
     transcript: string,
   ): { wakeWord: string; command: string; postGap: number } | null {
-    const normalizedTranscript = transcript.toLowerCase();
-
     for (const { trigger, regex } of this.matchers) {
-      const found = regex.exec(normalizedTranscript);
+      // The matcher is case-insensitive and runs against the original
+      // transcript, so its index and matched length are measured in the same
+      // string that is sliced below. Lowercasing first could change length
+      // (e.g. U+0130) and skew the offset.
+      const found = regex.exec(transcript);
       if (!found) continue;
 
       // Extract command after the standalone trigger token. Using the match
-      // index (not raw indexOf) keeps the boundary contract: only a whole-word
-      // trigger reaches this point, so "elizabeth" never yields a command.
-      const commandStart = found.index + trigger.length;
+      // index and matched length (not raw indexOf) keeps the boundary contract:
+      // only a boundary-delimited trigger reaches this point, so "elizabeth"
+      // never yields a command.
+      const commandStart = found.index + found[0].length;
       const command = transcript.slice(commandStart).trim();
 
       if (command.length < this.minCommandLength) continue;

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -99,16 +99,25 @@ const CONTINUOUS_SCRIPTS =
  * slice correct for an expanding case fold such as Turkish "\u0130" (U+0130),
  * whose lowercase form is the two code points "i" + U+0307.
  *
- * `toLowerCase()` is context-free (unlike locale-aware `toLocaleLowerCase()`),
- * so folding per code point here matches folding the whole string at once,
- * which is why the folded trigger and the folded transcript stay comparable.
+ * `toLowerCase()` folds each code point independently EXCEPT for Greek capital
+ * sigma, whose whole-string lowercase is context-sensitive: word-final it is
+ * "\u03c2" (U+03C2, final sigma) and medial it is "\u03c3" (U+03C3). A
+ * per-code-point fold cannot observe word position and always yields "\u03c3",
+ * so per-code-point and whole-string folds would disagree whenever a trigger
+ * and transcript spell the same word in different case (e.g. "\u039f\u0394\u039f\u03a3"
+ * vs "\u03bf\u03b4\u03bf\u03c2"), silently shutting the gate. To keep the two folds
+ * equal on both sides, final sigma is canonicalized to "\u03c3"; that swap is
+ * length-preserving (one code point for one), so the offset `map` stays exact.
  */
 function foldForMatch(value: string): { folded: string; map: number[] } {
   let folded = "";
   const map: number[] = [];
   let originalIndex = 0;
   for (const codePoint of value) {
-    const lowered = codePoint.toLowerCase();
+    // Canonicalize Greek final sigma to medial sigma so this per-code-point
+    // fold equals a whole-string toLowerCase() (length-preserving, so `map`
+    // is unaffected).
+    const lowered = codePoint.toLowerCase().replace(/\u03c2/g, "\u03c3");
     for (let i = 0; i < lowered.length; i++) {
       map.push(originalIndex);
     }


### PR DESCRIPTION
# Relates to

Closes #30151

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Package-scoped gates (test/typecheck/lint/build/format) pass; see logs below. Full `bun run verify` is a repo-wide gate not run here (see Known gaps).
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction and test evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (0 commits behind at push).
- [ ] `bun run verify` passes post-sync — the repo-wide gate was not executed on this constrained machine; the owning package's full gate suite passed (see **Known gaps / failures**).

# Risks

Low. The change is confined to `WakeWordGate` in the Web Speech fallback of a single opt-in Capacitor plugin (`plugins/plugin-native-swabble`). It has no elizaOS runtime integration and ships no `Plugin` object. The word-boundary rule is strictly more conservative than the previous substring rule: it can only *reject* firings that previously fired; every previously-valid whitespace/punctuation-delimited command still fires (proved by the 11 pre-existing tests, including the three non-Latin locales, remaining green).

# Background

## What does this PR do?

The Web Speech fallback's wake-word gate (`WakeWordGate.match` / `hasTrigger` in `plugins/plugin-native-swabble/src/web.ts`) located the trigger with a bare `normalizedTranscript.indexOf(trigger)` and accepted the match with no word-boundary check. Any transcript that merely *contained* the trigger as a substring fired a `wakeWord` event and dispatched the trailing text as a command.

- Speaking **"elizabeth opened the door"** (trigger `"eliza"`) emitted `{ wakeWord: "eliza", command: "beth opened the door" }` — the assistant activated and executed a garbled command the user never issued.
- Common English words tripped it too: **"they"** fired trigger `"hey"`; any word starting with the trigger fired.

This defeated the purpose of a wake-word gate: it must not act unless the wake word is actually spoken as a distinct token.

**Fix:** `WakeWordGate` now builds a per-trigger Unicode word-boundary matcher — `(?<![\p{L}\p{N}\p{M}])<escaped-trigger>(?![\p{L}\p{N}\p{M}])` with the `u` flag — and uses the regex match index as the trigger position. Combining marks (`\p{M}`) are token constituents on both sides, so a decomposed accent adjacent to the trigger keeps it inside its host word (e.g. trigger `"e"` does not fire inside the NFD form of `"éclair"`). The existing command slice and `minCommandLength` check are preserved unchanged, so the command still begins immediately after the standalone trigger token. `hasTrigger` uses the same boundary rule so a triggerless substring word (e.g. "elizabeth") is no longer retained in the carry-over buffer.

**Script-aware boundary (documented in the `WakeWordGate` header):** in space-delimited scripts the trigger must be a standalone token, so `"elizabeth"` never fires `"eliza"`. Continuous scripts (Japanese, Chinese, Thai, …) write the command directly after the trigger with no whitespace, so an adjacent letter also satisfies the boundary there; without this relaxation the wake word could never fire in those scripts — a strictly worse failure than the substring over-firing this PR fixes. The residual cost is that a trigger which is a prefix of a longer continuous-script word (e.g. `"エリザ"` inside `"エリザベス"`) still fires, matching the prior substring behavior, because text alone cannot segment those words.

**Case-fold-expanding triggers, matched independent of caller spelling (review, @lalalune, @fid1699):** the matcher and the transcript are now **both** case-folded with the same `toLowerCase()`, matched folded-against-folded, and the folded match-end offset is mapped back into the original transcript so the command slice stays correct even when folding changes length (U+0130). This replaces the earlier `/iu/`-against-raw-transcript approach, which only worked when the caller preserved the trigger's original spelling. The shipped settings UI (`VoiceConfigView.addTrigger`) lowercases a manual entry before it reaches this plugin, so Turkish `İpek` arrives as `"i"` + U+0307 + `"pek"`; an `/iu/` matcher cannot equate that two-code-point sequence with the single-code-point `İ` in the transcript, and the gate stayed shut for the real product path. Folding both sides reduces the caller-normalized trigger, the original-spelling trigger, and the transcript to the identical form, so the gate opens for every spelling; the returned `wakeWord` label stays lowercased, so no other observable behavior changes. Construction and `updateConfig` are covered by new regressions that start from both the original spelling and the exact value the settings caller produces.

**Greek contextual case fold — final sigma (review, @attentionhead):** `toLowerCase()` is context-*sensitive* for Greek capital sigma — word-final it yields `ς` (U+03C2), medial `σ` (U+03C3) — so the earlier claim that a per-code-point fold equals a whole-string fold was false. When a trigger and transcript spelled the same Greek word in different case (the exact scenario folding exists to support, since `VoiceConfigView.addTrigger` whole-string-lowercases a manual entry to a final `ς`), the two folds disagreed and the gate stayed shut — a regression versus `develop`, whose whole-string `indexOf` fired. `foldForMatch` now canonicalizes final sigma to medial (`ς` → `σ`) in its per-code-point step; the swap is length-preserving, so the offset `map` is unaffected and the U+0130 slice stays exact. The misleading "context-free" comment was corrected to describe this.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

The `WakeWordGate` in-code header was updated to document the boundary contract and the CJK tradeoff. No external docs describe the substring behavior, so no other doc change is required.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-swabble/src/web.test.ts` — new cases exercise the corrected contract against the real `SwabbleWeb` state machine with deterministic browser-API doubles (no mocking of the system under test):

1. **substring non-fire** — "elizabeth opened the door" emits no `wakeWord` (the exact reproduction from the issue);
2. **standalone fire** — "eliza open calendar" still emits `{ wakeWord: "eliza", command: "open calendar" }`;
3. **prefix-word non-fire** — trigger "hey" does not fire on "they left the room";
4. **punctuation-delimited fire** — "eliza, open calendar" still fires (command retains the leading comma — pre-existing whitespace-only trim behavior, asserted honestly);
5. **carry-over buffer drop** — a triggerless substring word ("elizabeth spoke") followed by an unrelated final ("open calendar") emits no `wakeWord`;
6. **continuous-script fire (review)** — `ja-JP`/`zh-CN`/`th-TH` transcripts where the command abuts the trigger with no space (`"エリザカレンダーを開いて"`, `"你好打开日历"`, `"สวัสดีเปิดปฏิทิน"`) still fire, guarding the false-negative that a strict boundary would introduce;
7. **match-index pin (review)** — `"elizabeth and eliza open calendar"` yields command `"open calendar"`, pinning the boundary match index against a raw `indexOf` that would anchor inside `"elizabeth"`;
8. **metacharacter trigger (review)** — a trigger `"hey("` constructs and matches as a literal, guarding the `escapeRegExp` call from a `new RegExp` `SyntaxError`;
9. **case-fold index (review)** — `"İİ eliza open calendar"` slices `"open calendar"`, proving the match index stays aligned when case folding changes length;
10. **case-fold-expanding trigger, construction (review)** — a configured trigger `"İpek"` fires on a verbatim `"İpek open calendar"`, which the pre-fix lowercased matcher rejected outright;
11. **case-fold-expanding trigger, updateConfig (review)** — swapping to `"İpek"` at runtime rebuilds the matcher so the same transcript fires after an `updateConfig`;
12. **settings-normalized case-fold trigger, construction (review, @fid1699)** — a trigger equal to the exact value the settings UI produces (`"İpek".toLowerCase()` = `"i"` + U+0307 + `"pek"`) fires on a verbatim `"İpek open calendar"`, guarding the real caller-to-plugin path that the raw-spelling test bypassed;
13. **settings-normalized case-fold trigger, updateConfig (review, @fid1699)** — the same caller-normalized value applied through `updateConfig` fires, so changing the wake word from the settings UI does not silently disable it.
14. **Greek contextual case fold (review, @attentionhead)** — a trigger equal to the settings-UI value `"ΟΔΟΣ".toLowerCase()` (final sigma `ς`) fires on a capitalized transcript `"ΟΔΟΣ ανοιξε"` and slices command `"ανοιξε"`; without canonicalizing final sigma the per-code-point fold yields medial `σ` on the transcript side, the folds disagree, and the gate never opens.

The pre-existing non-Latin space-delimited cases and the other suite tests remain unchanged and green (37 total).

## Detailed testing steps

```bash
node_modules/.bin/vitest run --root plugins/plugin-native-swabble
bun run --cwd plugins/plugin-native-swabble typecheck
bun run --cwd plugins/plugin-native-swabble lint:check
bun run --cwd plugins/plugin-native-swabble build
```

# Evidence Gate

<!-- evidence-head:a8f2843c7346f32a8f6f5a7aea68367a61beb486 -->

<!-- evidence-row:before-screenshots -->
- [ ] `N/A - no rendered UI surface; this is a Capacitor plugin's text-only WakeWordGate logic with no visual output.`
<!-- evidence-row:after-screenshots -->
- [ ] `N/A - no rendered UI surface; see before-screenshots row.`
<!-- evidence-row:walkthrough-video -->
- [ ] `N/A - no user-visible flow; the change is a pure text-matching predicate exercised by the reproduction test.`
<!-- evidence-row:backend-logs -->
- [ ] `N/A - no server/runtime path; the plugin is a browser/desktop Capacitor surface with no backend logger lines. The failing-then-passing vitest reproduction is the code-path proof (attached below).`
<!-- evidence-row:frontend-logs -->
- [ ] `N/A - no request/response cycle; WakeWordGate.match is a synchronous in-process predicate. Test output showing the event fire/non-fire is attached below.`
<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent/action/provider/prompt/model change; this plugin has no elizaOS runtime integration and dispatches no model calls.`
<!-- evidence-row:domain-artifacts -->
- [x] Failing-then-passing WakeWordGate reproductions embedded below, regenerated on the current head `a8f2843c` by driving the real `WakeWordGate` from each source (no mock of the system under test) against both the unmodified `origin/develop` source and this head: (a) the original #30151 substring false-fire (develop fires a garbled command, head rejects), (b) @fid1699's settings-caller Turkish case fold (both develop and head fire), and (c) @attentionhead's Greek final-sigma case: `develop` fires `"ανοιξε"`, the previous head `ae2e58df` returned `null` (regression), and this head fires `"ανοιξε"` again — plus the full 37-test package suite on the PR head. A fork contributor has no push access to the `elizaOS/eliza` pr-evidence release and cannot mint a `user-attachments/files` URL from a headless host, so the artifact is pasted inline per CONTRIBUTING.md § Evidence.

<details><summary>domain artifact — WakeWordGate develop-vs-head reproduction (#30151 substring / Turkish caller case fold / Greek final sigma) + 37-test suite, head `a8f2843c`</summary>

```
=== #30151 substring — trigger 'eliza', transcript 'elizabeth opened the door' ===
  develop: {"wakeWord":"eliza","command":"beth opened the door","postGap":-1}
  head:    null
=== settings-caller Turkish — trigger 'İpek'.toLowerCase(), transcript 'İpek open calendar' ===
  develop: {"wakeWord":"i̇pek","command":"open calendar","postGap":-1}
  head:    {"wakeWord":"i̇pek","command":"open calendar","postGap":-1}
=== Greek final sigma — trigger 'ΟΔΟΣ'.toLowerCase() (final ς), transcript 'ΟΔΟΣ ανοιξε' ===
  develop: {"wakeWord":"οδος","command":"ανοιξε","postGap":-1}
  head:    {"wakeWord":"οδος","command":"ανοιξε","postGap":-1}
=== Greek medial control — trigger 'ΟΔΟΣ' (raw), transcript 'ΟΔΟΣ ανοιξε' ===
  develop: {"wakeWord":"οδος","command":"ανοιξε","postGap":-1}
  head:    {"wakeWord":"οδος","command":"ανοιξε","postGap":-1}

=== Full package suite on head a8f2843c — node_modules/.bin/vitest run src/web.test.ts ===
 Test Files  1 passed (1)
      Tests  37 passed (37)
```

The Greek row is the key evidence for @attentionhead's finding: the head now matches `develop`'s firing behavior (regression closed) while the #30151 substring rejection is preserved. The previous head `ae2e58df` returned `null` for the final-sigma trigger; the mutation test in the suite (dropping the `ς → σ` canonicalization) reproduces that `null` and fails.

</details>
<!-- evidence-row:ocr-review -->
- [ ] `N/A - no rendered visual surface to OCR.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no backend or network path.` The relevant domain artifact is the wake-word gate decision, captured as failing-then-passing vitest reproductions below.

### Before — unpatched source false-fires (reproduction of #30151)

Ran a probe against the unmodified `develop` source (`git show origin/develop:.../web.ts`), delivering final transcript `"elizabeth opened the door"` with trigger `"eliza"`:

<details><summary>probe-before-FAIL.txt (excerpt)</summary>

```
=== BEFORE (unpatched source) ===
Received:
    [
      {
        "command": "beth opened the door",
        "confidence": 0.8,
        "postGap": -1,
        "transcript": "elizabeth opened the door",
        "wakeWord": "eliza",
      },
    ]
Number of calls: 1
 ❯ src/__probe.test.ts:24:27
     expect(wakeWords).not.toHaveBeenCalled();
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

</details>

### After — patched source rejects the substring

<details><summary>probe-after-PASS.txt</summary>

```
=== AFTER (patched source) ===
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

</details>

### Full package suite (37 passed — 11 pre-existing + 26 with new regression cases, incl. the decomposed-accent, continuous-script, match-index, metacharacter, case-fold-index, case-fold-expanding-trigger, settings-normalized-caller, and Greek final-sigma regressions added in review)

<details><summary>swabble-tests-after.txt</summary>

```
 Test Files  1 passed (1)
      Tests  37 passed (37)
```

</details>

Focused gate output on this head:

```
$ bun run --cwd plugins/plugin-native-swabble typecheck
$ tsc --noEmit -p tsconfig.json         # exit 0, no errors

$ bun run --cwd plugins/plugin-native-swabble lint:check
$ bunx @biomejs/biome check .
Checked 7 files in 55ms. No fixes applied.

$ bun run --cwd plugins/plugin-native-swabble format:check
Checked 7 files in 31ms. No fixes applied.

$ bun run --cwd plugins/plugin-native-swabble build
created dist/plugin.js, dist/plugin.cjs.js in 203ms
```

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface. No `.tsx`/`.css`/`.svg` under `packages/app`, `packages/ui`, or `apps/app` is touched; the diff is confined to `plugins/plugin-native-swabble/src/web.ts` and its test.`

### Before

`N/A - see above.`

### After

`N/A - see above.`

### Walkthrough video

`N/A - no user-visible flow.`

## Audio / voice walkthrough

`N/A - this changes text-matching logic on already-transcribed strings, not audio capture, STT, or TTS. The Web Speech / Whisper transcription path is unchanged; only how a finalized transcript string is gated is corrected. Deterministic transcript reproductions above cover the changed contract.`

## Known gaps / failures

- Repo-wide `bun run verify` was **not** executed on this constrained Raspberry Pi worktree; it is a heavy monorepo-wide gate. The owning package's full gate suite (test, typecheck, lint:check, format:check, build) passed on the exact PR head, and the change is isolated to one plugin with no cross-package exports. This is not a blocker for a self-contained fix in an opt-in plugin.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@411e7c699be42e3162998666edc262e30e2fa875:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@411e7c699be42e3162998666edc262e30e2fa875:packages/skills/skills/contribute-to-eliza"} -->



