### PR TITLE
fix(plugin-wallet): return deployed vault from receipt VaultCreated event, not a post-mine re-simulation

### DIFF
--- a/plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.create.test.ts
+++ b/plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.create.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression coverage for `MutualStakeEscrow.create()` vault-address
+ * resolution. The system under test is the real SDK class; only the viem
+ * public/wallet clients are stubbed at the RPC boundary. VaultCreated logs are
+ * built with viem's real `encodeEventLog` so the class must genuinely decode
+ * them. Guards the money-path invariant that `create()` returns the vault the
+ * mined transaction actually deployed (the receipt's VaultCreated event),
+ * never a post-mine re-simulation that describes a different, hypothetical
+ * deployment.
+ */
+
+import {
+  type Address,
+  encodeAbiParameters,
+  encodeEventTopics,
+  type Hash,
+  type Log,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MutualStakeEscrow } from "./MutualStakeEscrow.js";
+import type { CreateEscrowParams } from "./types.js";
+
+vi.mock("@elizaos/core", async () => {
+  return await import("../../__tests__/core-vitest-mock.js");
+});
+
+const VaultCreatedEventAbi = [
+  {
+    name: "VaultCreated",
+    type: "event",
+    inputs: [
+      { name: "vault", type: "address", indexed: true },
+      { name: "buyer", type: "address", indexed: true },
+      { name: "seller", type: "address", indexed: true },
+      { name: "token", type: "address", indexed: false },
+      { name: "paymentAmount", type: "uint256", indexed: false },
+      { name: "buyerStake", type: "uint256", indexed: false },
+      { name: "sellerStake", type: "uint256", indexed: false },
+      { name: "verifier", type: "address", indexed: false },
+      { name: "deadline", type: "uint256", indexed: false },
+    ],
+  },
+] as const;
+
+const FACTORY_ADDRESS: Address = "0xFAc00000000000000000000000000000000Face1";
+const BUYER: Address = "0x1111111111111111111111111111111111111111";
+const SELLER: Address = "0x2222222222222222222222222222222222222222";
+const TOKEN: Address = "0x3333333333333333333333333333333333333333";
+const VERIFIER: Address = "0x4444444444444444444444444444444444444444";
+const UNRELATED_CONTRACT: Address =
+  "0x9999999999999999999999999999999999999999";
+
+// The vault the mined transaction actually deployed.
+const DEPLOYED_VAULT: Address = "0xAAaA000000000000000000000000000000000001";
+// The address a post-mine re-simulation (eth_call against advanced state)
+// would return — a DIFFERENT, hypothetical next deployment.
+const RESIMULATED_VAULT: Address = "0xBbbb000000000000000000000000000000000002";
+
+const TX_HASH: Hash =
+  "0xdead00000000000000000000000000000000000000000000000000000000beef";
+
+const CREATE_PARAMS: CreateEscrowParams = {
+  seller: SELLER,
+  paymentAmount: 1_000_000n,
+  buyerStake: 100_000n,
+  sellerStake: 100_000n,
+  verifier: VERIFIER,
+  challengeWindow: 86_400,
+  deadline: 1_900_000_000,
+  token: TOKEN,
+};
+
+function vaultCreatedLog(vault: Address, emitter: Address): Log {
+  const topics = encodeEventTopics({
+    abi: VaultCreatedEventAbi,
+    eventName: "VaultCreated",
+    args: { vault, buyer: BUYER, seller: SELLER },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: "token", type: "address" },
+      { name: "paymentAmount", type: "uint256" },
+      { name: "buyerStake", type: "uint256" },
+      { name: "sellerStake", type: "uint256" },
+      { name: "verifier", type: "address" },
+      { name: "deadline", type: "uint256" },
+    ],
+    [
+      TOKEN,
+      CREATE_PARAMS.paymentAmount,
+      CREATE_PARAMS.buyerStake,
+      CREATE_PARAMS.sellerStake,
+      VERIFIER,
+      BigInt(CREATE_PARAMS.deadline),
+    ],
+  );
+  return {
+    address: emitter,
+    topics,
+    data,
+    blockNumber: 100n,
+    blockHash: `0x${"1".repeat(64)}` as Hash,
+    logIndex: 0,
+    transactionHash: TX_HASH,
+    transactionIndex: 0,
+    removed: false,
+  };
+}
+
+function makeEscrow(logs: Log[]): {
+  escrow: MutualStakeEscrow;
+  readContract: ReturnType<typeof vi.fn>;
+  writeContract: ReturnType<typeof vi.fn>;
+} {
+  const writeContract = vi.fn().mockResolvedValue(TX_HASH);
+  // If create() ever re-simulates via eth_call it returns the WRONG address.
+  const readContract = vi.fn().mockResolvedValue(RESIMULATED_VAULT);
+  const waitForTransactionReceipt = vi
+    .fn()
+    .mockResolvedValue({ logs, transactionHash: TX_HASH, status: "success" });
+
+  const publicClient = {
+    waitForTransactionReceipt,
+    readContract,
+  } as unknown as PublicClient;
+
+  const walletClient = {
+    account: { address: BUYER },
+    chain: undefined,
+    writeContract,
+  } as unknown as WalletClient;
+
+  const escrow = new MutualStakeEscrow({
+    publicClient,
+    walletClient,
+    factoryAddress: FACTORY_ADDRESS,
+    chainId: 8453,
+  });
+
+  return { escrow, readContract, writeContract };
+}
+
+describe("MutualStakeEscrow.create vault-address resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the vault from the receipt's VaultCreated event, not the re-simulated address", async () => {
+    const { escrow, readContract } = makeEscrow([
+      vaultCreatedLog(DEPLOYED_VAULT, FACTORY_ADDRESS),
+    ]);
+
+    const result = await escrow.create(CREATE_PARAMS);
+
+    expect(result.address).toBe(DEPLOYED_VAULT);
+    expect(result.address).not.toBe(RESIMULATED_VAULT);
+    // The fragile post-mine createEscrow re-simulation must be gone.
+    expect(readContract).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the factory transaction hash in the result", async () => {
+    const { escrow } = makeEscrow([
+      vaultCreatedLog(DEPLOYED_VAULT, FACTORY_ADDRESS),
+    ]);
+
+    const result = await escrow.create(CREATE_PARAMS);
+
+    expect(result.txHash).toBe(TX_HASH);
+  });
+
+  it("throws a typed error when the receipt carries no VaultCreated event instead of fabricating an address", async () => {
+    const { escrow, readContract } = makeEscrow([]);
+
+    await expect(escrow.create(CREATE_PARAMS)).rejects.toMatchObject({
+      code: "ESCROW_VAULT_CREATED_EVENT_MISSING",
+    });
+    expect(readContract).not.toHaveBeenCalled();
+  });
+
+  it("ignores VaultCreated logs emitted by an unrelated contract address", async () => {
+    // Only an impostor VaultCreated (from another contract) is present.
+    const { escrow } = makeEscrow([
+      vaultCreatedLog(RESIMULATED_VAULT, UNRELATED_CONTRACT),
+    ]);
+
+    await expect(escrow.create(CREATE_PARAMS)).rejects.toMatchObject({
+      code: "ESCROW_VAULT_CREATED_EVENT_MISSING",
+    });
+  });
+
+  it("selects only the factory's VaultCreated log when impostor logs are interleaved", async () => {
+    const { escrow } = makeEscrow([
+      vaultCreatedLog(RESIMULATED_VAULT, UNRELATED_CONTRACT),
+      vaultCreatedLog(DEPLOYED_VAULT, FACTORY_ADDRESS),
+    ]);
+
+    const result = await escrow.create(CREATE_PARAMS);
+
+    expect(result.address).toBe(DEPLOYED_VAULT);
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.ts
+++ b/plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.ts
@@ -5,7 +5,9 @@
  * resolve) keyed by `TaskStatus`. Verifier addresses and encoding are
  * delegated to `verifiers.ts`.
  */
-import type { Address, Hex, PublicClient, WalletClient } from "viem";
+import { ElizaError } from "@elizaos/core";
+import type { Address, Hash, Hex, Log, PublicClient, WalletClient } from "viem";
+import { parseEventLogs } from "viem";
 import type {
   CreateEscrowParams,
   EscrowCreated,
@@ -225,28 +227,57 @@ export class MutualStakeEscrow {
       chain: this.walletClient.chain,
     });
 
-    await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    const receipt = await this.publicClient.waitForTransactionReceipt({
+      hash: txHash,
+    });
 
-    // Read vault address from return data via simulation.
-    const vaultAddress = (await this.publicClient.readContract({
-      address: this.factoryAddress,
-      abi: StakeVaultFactoryAbi,
-      functionName: "createEscrow",
-      args: [
-        account.address,
-        params.seller,
-        token,
-        params.paymentAmount,
-        params.buyerStake,
-        params.sellerStake,
-        verifierAddress,
-        verifierData,
-        BigInt(params.deadline),
-        BigInt(params.challengeWindow),
-      ],
-    })) as Address;
+    // The authoritative vault address is emitted by the factory's VaultCreated
+    // event on the mined transaction. Decode it from the receipt logs rather
+    // than re-running createEscrow via eth_call: a post-mine simulation runs
+    // against the ALREADY-advanced factory state and returns the address the
+    // NEXT deployment would produce, not the vault this transaction created.
+    // Restrict decoding to logs emitted by this factory so an unrelated
+    // contract cannot spoof a VaultCreated event into the result.
+    const vaultAddress = this.extractVaultAddress(receipt.logs, txHash);
 
     return { address: vaultAddress, txHash };
+  }
+
+  /**
+   * Decode the deployed vault address from a factory transaction's receipt
+   * logs. Only `VaultCreated` events emitted by this factory are considered.
+   * Throws a typed error when no such event is present instead of falling
+   * back to a misleading re-simulation.
+   */
+  private extractVaultAddress(logs: Log[], txHash: Hash): Address {
+    const factoryAddress = this.factoryAddress.toLowerCase();
+    const factoryLogs = logs.filter(
+      (log) => log.address.toLowerCase() === factoryAddress,
+    );
+
+    const events = parseEventLogs({
+      abi: StakeVaultFactoryAbi,
+      eventName: "VaultCreated",
+      logs: factoryLogs,
+    });
+
+    const created = events[0];
+    if (!created?.args.vault) {
+      throw new ElizaError(
+        "Factory transaction mined without a VaultCreated event; the deployed vault address is unknown",
+        {
+          code: "ESCROW_VAULT_CREATED_EVENT_MISSING",
+          context: {
+            factoryAddress: this.factoryAddress,
+            txHash,
+            factoryLogCount: factoryLogs.length,
+          },
+          severity: "fatal",
+        },
+      );
+    }
+
+    return created.args.vault;
   }
 
   /**


### PR DESCRIPTION
# Relates to

Closes #30153

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package checks (owning-package test, typecheck, lint) were run; the one pre-existing unrelated typecheck blocker is recorded under **Known gaps**.
- [x] A reviewer can confirm the change works from the failing-then-passing evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`git rev-list --count HEAD..origin/develop` = 0).
- [ ] `bun run verify` full-repo gate not run to completion on this constrained machine; owning-package test/lint/typecheck were run and the only failure is a pre-existing unrelated module-resolution error documented in **Known gaps**.

# Risks

Low. The change is confined to `MutualStakeEscrow.create()` vault-address resolution in `plugins/plugin-wallet`. It replaces a post-mine `eth_call` re-simulation with decoding the authoritative `VaultCreated` event from the mined receipt. No public type or signature changes: `EscrowCreated { address, txHash }` is unchanged. Behavior change: `create()` now **throws** a typed `ElizaError` when the factory transaction mines without a `VaultCreated` event instead of silently returning a fabricated/wrong address — a strictly safer failure on a money path.

# Background

## What does this PR do?

`MutualStakeEscrow.create()` (public SDK, exported from `plugins/plugin-wallet/src/sdk/index.ts`) sent the factory `createEscrow` transaction, awaited the receipt, then **discarded the receipt** and obtained the vault address by re-running `createEscrow` through `publicClient.readContract` (an `eth_call`). Because the state-changing tx had already mined, that `eth_call` simulated a **second, hypothetical** deployment against the advanced factory state and returned the address the *next* `createEscrow` would produce — not the vault that was actually created. The authoritative `VaultCreated` event (whose ABI was already defined in the same file but never decoded) was ignored.

**User-facing impact:** consumers received a wrong `StakeVault` address. Subsequent `fund()`/`accept()` then approve and deposit real payment + stake collateral to a contract that does not hold this escrow (or revert), directing buyer/seller funds at the wrong address — a data-integrity/contract break on a money path.

**The fix:**
- Capture the mined receipt and decode the `VaultCreated` event from `receipt.logs` with viem's `parseEventLogs`, filtered to logs whose `address === factoryAddress` so an unrelated contract cannot spoof the result. Return that log's `vault` as the deployed address.
- Throw a typed `ElizaError` (`code: ESCROW_VAULT_CREATED_EVENT_MISSING`, severity `fatal`, with `factoryAddress`/`txHash`/`factoryLogCount` context) when no `VaultCreated` log is present — no fallback to the misleading re-simulation.
- Remove the post-mine `readContract("createEscrow")` call entirely.

## What kind of change is this?

Bug fix (non-breaking data-integrity fix on a money path).

## Scope boundary

Only `plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.ts` (the `create()` path) and a new focused regression test. No other escrow lifecycle methods, no type/signature changes, no other packages touched.

# Documentation changes needed?

My changes do not require a change to the project documentation. The public `EscrowCreated` shape and `create()` signature are unchanged; only the correctness of the returned `address` and a new typed failure mode change.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.create.test.ts`. It stubs the viem public/wallet clients at the RPC boundary and builds genuine `VaultCreated` logs with viem's real `encodeEventTopics`/`encodeAbiParameters`, so the SDK must actually decode them.

## Detailed testing steps

```bash
cd plugins/plugin-wallet
./node_modules/.bin/vitest run src/sdk/escrow/MutualStakeEscrow.create.test.ts
```

The suite is **red on the pre-fix code** (the re-simulation returns `0xBbbb…` instead of the deployed `0xAAaA…`) and **green after** decoding the receipt. Cases:
1. `create()` returns the vault from the receipt's `VaultCreated` event even when a hypothetical re-simulation would differ, and asserts the removed `readContract` path is never called.
2. `create()` throws `ESCROW_VAULT_CREATED_EVENT_MISSING` when the receipt has no `VaultCreated` event, rather than fabricating an address.
3. `create()` ignores a `VaultCreated` log emitted by an unrelated contract address.
4. `create()` selects only the factory's `VaultCreated` log when impostor logs are interleaved.
5. `create()` still surfaces the factory `txHash` in the result.

# Evidence Gate

<!-- evidence-head:d1ef49e76b5b1a4d9014996388b4a9dfc44d6fb6 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - SDK/on-chain library change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - SDK/on-chain library change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; the exercised path is a unit-level SDK contract.`
<!-- evidence-row:backend-logs -->
- [x] [30155-backend-logs.txt](https://github.com/agent-cortex/eliza/releases/download/pr-30155-evidence/30155-backend-logs.txt)

```text
# RED — pre-fix code (post-mine re-simulation returns the WRONG vault)
 FAIL  src/sdk/escrow/MutualStakeEscrow.create.test.ts > returns the vault from the receipt's VaultCreated event, not the re-simulated address
AssertionError: expected '0xBbbb0000000000000000000000000000000002' to be '0xAAaA0000000000000000000000000000000001' // Object.is equality
 FAIL  > throws a typed error when the receipt carries no VaultCreated event
AssertionError: promise resolved "{ address, txHash }" instead of rejecting
 FAIL  > ignores VaultCreated logs emitted by an unrelated contract address
AssertionError: promise resolved "{ address, txHash }" instead of rejecting
 FAIL  > selects only the factory's VaultCreated log when impostor logs are interleaved
AssertionError: expected '0xBbbb0000000000000000000000000000000002' to be '0xAAaA0000000000000000000000000000000001'
 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)

# GREEN — after fix (create() returns the deployed VaultCreated vault)
 Test Files  1 passed (1)
      Tests  5 passed (5)

# Owning-package SDK suite still green
 Test Files  7 passed (7)
      Tests  41 passed (41)
```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; pure SDK data-path fix.`
<!-- evidence-row:domain-artifacts -->
- [x] [30155-domain-artifacts.txt](https://github.com/agent-cortex/eliza/releases/download/pr-30155-evidence/30155-domain-artifacts.txt)

```diff
-    await this.publicClient.waitForTransactionReceipt({ hash: txHash });
-    // Read vault address from return data via simulation.
-    const vaultAddress = (await this.publicClient.readContract({
-      address: this.factoryAddress,
-      abi: StakeVaultFactoryAbi,
-      functionName: "createEscrow",
-      args: [ ...same createEscrow args... ],
-    })) as Address;
+    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    // Decode the authoritative VaultCreated event from the mined receipt,
+    // restricted to logs emitted by this factory. Throws ElizaError
+    // (ESCROW_VAULT_CREATED_EVENT_MISSING) when the event is absent.
+    const vaultAddress = this.extractVaultAddress(receipt.logs, txHash);
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Focused Vitest output — **RED on pre-fix code** (re-simulation returns the wrong vault):

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/sdk/escrow/MutualStakeEscrow.create.test.ts > MutualStakeEscrow.create vault-address resolution > returns the vault from the receipt's VaultCreated event, not the re-simulated address
AssertionError: expected '0xBbbb0000000000000000000000000000000…' to be '0xAAaA0000000000000000000000000000000…' // Object.is equality
 FAIL  src/sdk/escrow/MutualStakeEscrow.create.test.ts > MutualStakeEscrow.create vault-address resolution > throws a typed error when the receipt carries no VaultCreated event instead of fabricating an address
AssertionError: promise resolved "{ …(2) }" instead of rejecting
 FAIL  src/sdk/escrow/MutualStakeEscrow.create.test.ts > MutualStakeEscrow.create vault-address resolution > ignores VaultCreated logs emitted by an unrelated contract address
AssertionError: promise resolved "{ …(2) }" instead of rejecting
 FAIL  src/sdk/escrow/MutualStakeEscrow.create.test.ts > MutualStakeEscrow.create vault-address resolution > selects only the factory's VaultCreated log when impostor logs are interleaved
AssertionError: expected '0xBbbb0000000000000000000000000000000…' to be '0xAAaA0000000000000000000000000000000…' // Object.is equality
      Tests  4 failed | 1 passed (5)
```

**GREEN after the fix** (`src/sdk/escrow/MutualStakeEscrow.create.test.ts`):

```

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  12:03:56
   Duration  834ms (transform 174ms, setup 0ms, import 536ms, tests 39ms, environment 0ms)
```

Full owning-package SDK suite still green:

```

 Test Files  7 passed (7)
      Tests  41 passed (41)
   Start at  12:03:57
   Duration  3.08s (transform 949ms, setup 0ms, import 4.25s, tests 772ms, environment 1ms)
```

Frontend: N/A - no frontend involved.

## Screenshots (before / after) + video walkthrough

N/A - SDK/on-chain data-path change with no rendered surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- `bun run --cwd plugins/plugin-wallet typecheck` reports one **pre-existing, unrelated** error: `src/api/wallet-routes.ts(96,5): error TS2307: Cannot find module '@elizaos/plugin-elizacloud'`. It reproduces on the unmodified base (verified by stashing the escrow changes and re-running `tsc`) and is a workspace module-resolution issue in a file this PR does not touch. `tsc` reports **no** escrow-related type errors.
- Full-repo `bun run verify` was not run to completion on this constrained machine; the owning package's focused test/lint/typecheck were run instead.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@d1ef49e76b5b1a4d9014996388b4a9dfc44d6fb6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@d1ef49e76b5b1a4d9014996388b4a9dfc44d6fb6:packages/skills/skills/contribute-to-eliza"} -->

