### PR TITLE
fix(plugin-wallet): resolve relative native swap amounts in bigint

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
@@ -5,6 +5,7 @@
  * isolates the arithmetic and validation, not model behavior.
  */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { parseUnits } from "viem";
 import { base } from "viem/chains";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSwapDetails } from "../../actions/swap";
@@ -227,5 +228,94 @@ describe("buildSwapDetails amountMode resolution", () => {
     await expect(
       buildSwapDetails({} as State, message, createRuntime(), createWalletProvider({ base: "5" }))
     ).rejects.toThrow(/between 1 and 100/i);
+  });
+
+  // A dust native balance used to run through `parseFloat` arithmetic and
+  // `Number.prototype.toString`, which switches to exponential notation below
+  // ~1e-6 ("5e-8"). Every downstream `parseUnits(params.amount, decimals)` call
+  // site in this action rejects that form with a raw viem decimal-format error,
+  // so the resolved amount must stay plain decimal.
+  it("resolves half of a dust native balance to plain decimal, not exponential notation", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "0.0000001" })
+    );
+
+    expect(details.amount).toBe("0.00000005"); // 0.0000001 / 2, was "5e-8"
+    expect(details.amount).not.toMatch(/e[+-]/i);
+    expect(() => parseUnits(details.amount, 18)).not.toThrow();
+  });
+
+  it("resolves max of a dust native balance to plain decimal, keeping the 10% gas reserve", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "max",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "0.0000001" })
+    );
+
+    expect(details.amount).toBe("0.00000009"); // 0.0000001 * 0.9, was "9e-8"
+    expect(details.amount).not.toMatch(/e[+-]/i);
+    expect(() => parseUnits(details.amount, 18)).not.toThrow();
+  });
+
+  it("resolves a percent of a dust native balance to plain decimal", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      amountPercent: 30,
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "0.0000005" })
+    );
+
+    expect(details.amount).toBe("0.00000015"); // 30% of 0.0000005, was "1.5e-7"
+    expect(details.amount).not.toMatch(/e[+-]/i);
+    expect(() => parseUnits(details.amount, 18)).not.toThrow();
+  });
+
+  it("drops the float residue a percent of a small balance used to carry", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      amountPercent: 1,
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "0.00001" })
+    );
+
+    // Float math produced "1.0000000000000001e-7" here — both residue and
+    // exponent form in one value.
+    expect(details.amount).toBe("0.0000001");
+    expect(details.amount).not.toMatch(/e[+-]/i);
+    expect(() => parseUnits(details.amount, 18)).not.toThrow();
   });
 });

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -31,7 +31,14 @@ import {
   type Route,
 } from "@lifi/sdk";
 
-import { type Address, encodeFunctionData, type Hex, parseAbi, parseUnits } from "viem";
+import {
+  type Address,
+  encodeFunctionData,
+  formatUnits,
+  type Hex,
+  parseAbi,
+  parseUnits,
+} from "viem";
 import { runIntentModel } from "../../../utils/intent-trajectory";
 import {
   BEBOP_CHAIN_MAP,
@@ -811,7 +818,18 @@ export async function buildSwapDetails(
   const amount =
     amountMode === "absolute"
       ? String(parsedResponse.amount ?? "")
-      : resolveRelativeAmount(amountMode, parsedResponse.amountPercent, chainBalance);
+      : resolveRelativeAmount(
+          amountMode,
+          parsedResponse.amountPercent,
+          chainBalance,
+          // Decimals are only meaningful for a balance that exists; when the
+          // balance is undefined resolveRelativeAmount throws before using
+          // them, and the config lookup must not run for a chain the model
+          // may have invented.
+          chainBalance === undefined
+            ? 0
+            : wp.getChainConfigs(chain as SupportedChain).nativeCurrency.decimals
+        );
 
   const swapDetails = parseSwapParams({
     fromToken: String(parsedResponse.inputToken ?? ""),
@@ -838,15 +856,23 @@ function resolveAmountMode(value: unknown): AmountMode {
 }
 
 /**
- * Resolve a relative swap size ("half"/"max"/"percent") into an absolute,
- * human-readable amount string from the connected chain's native balance.
- * `max` keeps a 10% gas reserve (0.9 * balance). Throws INVALID_PARAMS when the
- * balance for the chain is unknown or a percentage is out of the 1-100 range.
+ * Resolve a relative native-asset swap size ("half"/"max"/"percent") into an
+ * absolute, human-readable amount string from the connected chain's native
+ * balance. `max` keeps a 10% gas reserve (0.9 * balance). Throws
+ * INVALID_PARAMS when the balance for the chain is unknown or a percentage is
+ * out of the 1-100 range.
+ *
+ * The arithmetic runs in `bigint` on the parsed wei value so dust balances
+ * never round-trip through `Number.prototype.toString`, which switches to
+ * exponential notation (`"5e-8"`) below ~1e-6 — a form `parseUnits` rejects
+ * with a raw viem decimal-format error. Formatting happens exactly once via
+ * `formatUnits`.
  */
 function resolveRelativeAmount(
   mode: Exclude<AmountMode, "absolute">,
   rawPercent: unknown,
-  balance: string | undefined
+  balance: string | undefined,
+  decimals: number
 ): string {
   if (balance === undefined) {
     throw new EVMError(
@@ -855,13 +881,14 @@ function resolveRelativeAmount(
     );
   }
 
-  const balanceNum = parseFloat(balance);
+  const raw = parseUnits(balance, decimals);
 
   if (mode === "half") {
-    return (balanceNum / 2).toString();
+    return formatUnits(raw / 2n, decimals);
   }
   if (mode === "max") {
-    return (balanceNum * 0.9).toString();
+    // (raw * 9n) / 10n preserves the existing 10% gas reserve exactly.
+    return formatUnits((raw * 9n) / 10n, decimals);
   }
 
   const percent = Number(rawPercent);
@@ -871,7 +898,11 @@ function resolveRelativeAmount(
       `Swap percentage must be between 1 and 100, received: ${String(rawPercent)}`
     );
   }
-  return ((balanceNum * percent) / 100).toString();
+  // Scale the percent to an integer basis-of-a-million so a fractional percent
+  // stays representable while the (possibly huge) balance keeps every wei; the
+  // division by 100_000_000 then yields `raw * percent / 100` in pure bigint.
+  const scaledPercent = BigInt(Math.round(percent * 1_000_000));
+  return formatUnits((raw * scaledPercent) / 100_000_000n, decimals);
 }
 
 export const swapAction = {


### PR DESCRIPTION
## Summary

`resolveRelativeAmount` in `plugins/plugin-wallet/src/chains/evm/actions/swap.ts` sized relative EVM swaps of the **native** asset with `parseFloat` arithmetic and formatted the result via `Number.prototype.toString`. Below roughly `1e-6` that switches to exponential notation, so a dust native balance produced `"5e-8"` and every `parseUnits(params.amount, fromTokenDecimals)` quote site rejected it with a raw `viem` decimal-format error rather than the typed `EVMError(INVALID_PARAMS)` the action raises on its other validated paths (unknown balance, out-of-range percentage).

This is the native branch that #29933 deliberately scoped out when it applied exact-integer arithmetic to the ERC-20 path.

Fixes #29937

## Change

Parse the balance into wei once with `parseUnits`, run the half/max/percent arithmetic in `bigint`, and format exactly once with `formatUnits`.

- `half` -> `raw / 2n`
- `max` -> `(raw * 9n) / 10n`, preserving the existing 10% gas reserve exactly
- `percent` -> percentage scaled to an integer basis-of-a-million so fractional percentages stay representable, then `(raw * scaledPercent) / 100_000_000n`

Native decimals come from `chainConfig.nativeCurrency.decimals`. The lookup is skipped when the balance is `undefined`, so the existing unknown-balance `EVMError` still fires first and a chain the model may have invented never reaches `getChainConfigs`.

## Verification

Executed on this branch at `84b670efc4`, worktree off `origin/develop` at `9b93ec4374`.

**Behaviour, before -> after** (the before column is the failure recorded in the issue):

| case | before | after |
|---|---|---|
| `half` of `0.0000001` | `"5e-8"` -> `parseUnits` throws | `"0.00000005"` |
| `max` of `0.0000001` | `"9e-8"` -> `parseUnits` throws | `"0.00000009"` |
| `30%` of `0.0000005` | `"1.5e-7"` -> `parseUnits` throws | `"0.00000015"` |
| `1%` of `0.00001` | `"1.0000000000000001e-7"` -> `parseUnits` throws | `"0.0000001"` |

**Regression control** — ordinary balances are byte-identical: `half` of `2` -> `"1"`, `max` of `10` -> `"9"`, `30%` of `10` -> `"3"`, `25%` of `8` -> `"2"`. All four are covered by pre-existing tests that still pass unchanged.

**Red/green check.** Stashing only the source change and re-running the suite fails the 4 new tests with exactly the issue's reported values (`Expected: "0.0000001"` / `Received: "1.0000000000000001e-7"`) while the 10 pre-existing tests stay green. Restoring the fix takes the file to 14/14.

**Gates run locally:**

```
bun run --cwd plugins/plugin-wallet test
  -> Test Files  3 failed | 66 passed | 1 skipped (70)
     Tests  415 passed | 1 skipped (416)
```

The 4 added tests account for the delta from the `origin/develop` baseline of 411 passed. The 3 failing files are **pre-existing collection failures**, reproduced identically on a clean `origin/develop` worktree with this change stashed: `src/api/wallet-routes.test.ts` and `src/api/wallet-routes.authority.test.ts` cannot resolve `@elizaos/plugin-elizacloud`, and `src/ui/InventoryView.test.tsx` cannot resolve `@elizaos/ui/spatial` — unbuilt workspace dependencies, not test failures, and untouched by this change.

```
bun run --cwd plugins/plugin-wallet typecheck
  -> src/api/wallet-routes.ts(96,5): error TS2307: Cannot find module '@elizaos/plugin-elizacloud'
```

Same pre-existing error, same file, present on clean `origin/develop` with this change stashed. Both changed files typecheck clean.

```
bunx @biomejs/biome check <the two changed files>
  -> Checked 2 files. No fixes applied.
```

## Files

- `plugins/plugin-wallet/src/chains/evm/actions/swap.ts` — bigint arithmetic in `resolveRelativeAmount`, `decimals` threaded from the caller
- `plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts` — 4 tests: dust `half`, dust `max` (gas reserve preserved), dust `percent`, and the float-residue `1%` case; each asserts the plain-decimal value, absence of exponent notation, and that `parseUnits` accepts the result

<!-- pr-evidence:v1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change; pure arithmetic/formatting fix in an action helper

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change; pure arithmetic/formatting fix in an action helper

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI change; pure arithmetic/formatting fix in an action helper

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic unit tests; vitest output shown in PR checks and quoted under Verification

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no UI change; pure arithmetic/formatting fix in an action helper

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - the intent model is mocked in the affected suite; no LLM execution in the changed path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no migrations, schemas, or generated artifacts; two source files only

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.3

<!-- attribution-row:models -->
z.ai/glm-5.3

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
N/A - direct contribution

<!-- attribution-row:status -->
self-reported

<!-- evidence-head:84b670efc48fed9a1834a176552c8003ff0181d6 -->
