### PR TITLE
fix(plugin-app-manager): skip malformed package.json in /api/apps/load-from-directory scan

### DIFF
--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -178,10 +178,13 @@ describe("handleAppsRoutes", () => {
       );
       await mkdir(path.join(dir, "app-bad"));
       // Syntactically malformed manifest: previously threw SyntaxError mid-loop
-      // and aborted the whole scan with HTTP 500.
+      // and aborted the whole scan with HTTP 500. The bareword value also makes
+      // V8 embed a slice of these file bytes in the JSON.parse message, so the
+      // marker below pins that the rejection reason does not persist file
+      // content.
       await writeFile(
         path.join(dir, "app-bad", "package.json"),
-        "{ this is not json ",
+        `{"n": LEAKMARK}`,
       );
 
       const registered: Array<Record<string, unknown>> = [];
@@ -236,6 +239,10 @@ describe("handleAppsRoutes", () => {
       expect(rejected?.directory).toBe(path.join(dir, "app-bad"));
       expect(rejected?.packageName).toBeNull();
       expect(rejected?.reason).toContain("invalid JSON");
+      // Data hygiene: the reason must not carry the malformed file's bytes into
+      // the HTTP response. V8's JSON.parse message would embed them; the reason
+      // is built from the error name instead.
+      expect(rejected?.reason).not.toContain("LEAKMARK");
       expect(rejected?.path).toBe(path.join(dir, "app-bad", "package.json"));
 
       // The rejection is also recorded through the registry service so callers
@@ -249,6 +256,8 @@ describe("handleAppsRoutes", () => {
         requesterRoomId: null,
       });
       expect(String(rejections[0]?.reason)).toContain("invalid JSON");
+      // The persisted rejection record must not carry file bytes either.
+      expect(String(rejections[0]?.reason)).not.toContain("LEAKMARK");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -87,6 +87,7 @@ async function callRoute(args: {
   favoriteApps?: FavoriteAppsStore;
   getPluginManager?: AppsRouteContext["getPluginManager"];
   actorRole?: AppsRouteActorRole | null;
+  runtime?: AppsRouteContext["runtime"];
 }): Promise<{
   handled: boolean;
   res: CapturedResponse;
@@ -105,7 +106,7 @@ async function callRoute(args: {
     appManager,
     favoriteApps: args.favoriteApps,
     actorRole: args.actorRole,
-    runtime: null,
+    runtime: args.runtime ?? null,
     getPluginManager:
       args.getPluginManager ??
       (() =>
@@ -162,6 +163,146 @@ describe("handleAppsRoutes", () => {
       error:
         "Invalid request body at directory: directory must be an absolute path",
     });
+  });
+
+  it("registers every valid sibling app when one package.json is malformed", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "app-manager-load-"));
+    try {
+      await mkdir(path.join(dir, "app-good"));
+      await writeFile(
+        path.join(dir, "app-good", "package.json"),
+        JSON.stringify({
+          name: "@elizaos/app-good",
+          elizaos: { app: { slug: "good", displayName: "Good App" } },
+        }),
+      );
+      await mkdir(path.join(dir, "app-bad"));
+      // Syntactically malformed manifest: previously threw SyntaxError mid-loop
+      // and aborted the whole scan with HTTP 500.
+      await writeFile(
+        path.join(dir, "app-bad", "package.json"),
+        "{ this is not json ",
+      );
+
+      const registered: Array<Record<string, unknown>> = [];
+      const rejections: Array<Record<string, unknown>> = [];
+      const register = vi.fn(async (entry: Record<string, unknown>) => {
+        registered.push(entry);
+      });
+      const recordManifestRejection = vi.fn(
+        async (rejection: Record<string, unknown>) => {
+          rejections.push(rejection);
+        },
+      );
+      const runtime = {
+        getService: (type: string) =>
+          type === "app-registry"
+            ? { register, recordManifestRejection }
+            : null,
+      };
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        body: { directory: dir },
+        runtime: runtime as never,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      const body = result.res.body as {
+        ok: boolean;
+        registered: number;
+        items: Array<{ canonicalName: string }>;
+        rejectedManifests: Array<{
+          directory: string;
+          packageName: string | null;
+          reason: string;
+          path: string;
+        }>;
+      };
+      expect(body.ok).toBe(true);
+      // The valid app registers despite the malformed sibling manifest.
+      expect(body.registered).toBe(1);
+      expect(body.items.map((i) => i.canonicalName)).toEqual([
+        "@elizaos/app-good",
+      ]);
+      expect(register).toHaveBeenCalledTimes(1);
+      expect(registered[0]?.canonicalName).toBe("@elizaos/app-good");
+
+      // The malformed manifest is surfaced as a rejection, not swallowed.
+      expect(body.rejectedManifests).toHaveLength(1);
+      const rejected = body.rejectedManifests[0];
+      expect(rejected?.directory).toBe(path.join(dir, "app-bad"));
+      expect(rejected?.packageName).toBeNull();
+      expect(rejected?.reason).toContain("invalid JSON");
+      expect(rejected?.path).toBe(path.join(dir, "app-bad", "package.json"));
+
+      // The rejection is also recorded through the registry service so callers
+      // that persist rejections still learn which manifest failed.
+      expect(recordManifestRejection).toHaveBeenCalledTimes(1);
+      expect(rejections[0]).toMatchObject({
+        directory: path.join(dir, "app-bad"),
+        packageName: null,
+        path: path.join(dir, "app-bad", "package.json"),
+        requesterEntityId: null,
+        requesterRoomId: null,
+      });
+      expect(String(rejections[0]?.reason)).toContain("invalid JSON");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("registers all apps when every manifest in the directory is valid", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "app-manager-load-ok-"));
+    try {
+      for (const name of ["alpha", "beta", "gamma"]) {
+        await mkdir(path.join(dir, `app-${name}`));
+        await writeFile(
+          path.join(dir, `app-${name}`, "package.json"),
+          JSON.stringify({
+            name: `@elizaos/app-${name}`,
+            elizaos: { app: { slug: name } },
+          }),
+        );
+      }
+
+      const register = vi.fn(async () => {});
+      const recordManifestRejection = vi.fn(async () => {});
+      const runtime = {
+        getService: (type: string) =>
+          type === "app-registry"
+            ? { register, recordManifestRejection }
+            : null,
+      };
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        body: { directory: dir },
+        runtime: runtime as never,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      const body = result.res.body as {
+        registered: number;
+        items: Array<{ canonicalName: string }>;
+        rejectedManifests: unknown[];
+      };
+      expect(body.registered).toBe(3);
+      expect(body.items.map((i) => i.canonicalName).sort()).toEqual([
+        "@elizaos/app-alpha",
+        "@elizaos/app-beta",
+        "@elizaos/app-gamma",
+      ]);
+      expect(body.rejectedManifests).toEqual([]);
+      expect(register).toHaveBeenCalledTimes(3);
+      expect(recordManifestRejection).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("rejects malformed favorite updates before writing the store", async () => {

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -239,6 +239,10 @@ describe("handleAppsRoutes", () => {
       expect(rejected?.directory).toBe(path.join(dir, "app-bad"));
       expect(rejected?.packageName).toBeNull();
       expect(rejected?.reason).toContain("invalid JSON");
+      // The reason is built from the error's name, not a constant: this pins the
+      // positive half of the decision so replacing `parseError.name` with a bare
+      // literal is caught, not just the negative hygiene half below.
+      expect(rejected?.reason).toContain("SyntaxError");
       // Data hygiene: the reason must not carry the malformed file's bytes into
       // the HTTP response. V8's JSON.parse message would embed them; the reason
       // is built from the error name instead.
@@ -256,6 +260,7 @@ describe("handleAppsRoutes", () => {
         requesterRoomId: null,
       });
       expect(String(rejections[0]?.reason)).toContain("invalid JSON");
+      expect(String(rejections[0]?.reason)).toContain("SyntaxError");
       // The persisted rejection record must not carry file bytes either.
       expect(String(rejections[0]?.reason)).not.toContain("LEAKMARK");
     } finally {

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1674,15 +1674,17 @@ export async function handleAppsRoutes(
           parsed = JSON.parse(raw) as Record<string, unknown>;
         } catch (parseError) {
           // error-policy:J3 A syntactically malformed package.json is invalid
-          // on-disk input for this one entry, not a batch failure. Skip it the
-          // same way an unreadable manifest is skipped so every valid sibling
-          // app still registers, and surface which manifest was rejected. Use
-          // the error's name (e.g. "SyntaxError"), not its message: V8 embeds a
-          // slice of the offending file bytes in JSON.parse messages, and this
-          // reason is persisted through recordManifestRejection; `path` already
-          // identifies which manifest failed.
+          // on-disk input for this one entry, not a batch failure. Record it as
+          // a rejection and continue — the same shape as the permissions
+          // rejection below — so every valid sibling app still registers while
+          // the caller still learns which manifest failed. Use the error's name
+          // (e.g. "SyntaxError"), not its message: V8 embeds a slice of the
+          // offending file bytes in JSON.parse messages, and this reason is
+          // persisted through recordManifestRejection; `path` already identifies
+          // which manifest failed. The non-Error arm stays a constant for the
+          // same hygiene reason, though JSON.parse only ever throws SyntaxError.
           const reason = `invalid JSON: ${
-            parseError instanceof Error ? parseError.name : String(parseError)
+            parseError instanceof Error ? parseError.name : "non-Error thrown"
           }`;
           const rejection = {
             directory: subdir,

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1669,7 +1669,33 @@ export async function handleAppsRoutes(
         const pkgPath = path.join(subdir, "package.json");
         const raw = await fs.readFile(pkgPath, "utf8").catch(() => null);
         if (raw === null) continue;
-        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(raw) as Record<string, unknown>;
+        } catch (parseError) {
+          // error-policy:J3 A syntactically malformed package.json is invalid
+          // on-disk input for this one entry, not a batch failure. Skip it the
+          // same way an unreadable manifest is skipped so every valid sibling
+          // app still registers, and surface which manifest was rejected.
+          const reason = `invalid JSON: ${
+            parseError instanceof Error
+              ? parseError.message
+              : String(parseError)
+          }`;
+          const rejection = {
+            directory: subdir,
+            packageName: null,
+            reason,
+            path: pkgPath,
+          };
+          rejectedManifests.push(rejection);
+          await registry.recordManifestRejection?.({
+            ...rejection,
+            requesterEntityId: null,
+            requesterRoomId: null,
+          });
+          continue;
+        }
         const elizaos =
           parsed.elizaos && typeof parsed.elizaos === "object"
             ? (parsed.elizaos as Record<string, unknown>)

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1676,11 +1676,13 @@ export async function handleAppsRoutes(
           // error-policy:J3 A syntactically malformed package.json is invalid
           // on-disk input for this one entry, not a batch failure. Skip it the
           // same way an unreadable manifest is skipped so every valid sibling
-          // app still registers, and surface which manifest was rejected.
+          // app still registers, and surface which manifest was rejected. Use
+          // the error's name (e.g. "SyntaxError"), not its message: V8 embeds a
+          // slice of the offending file bytes in JSON.parse messages, and this
+          // reason is persisted through recordManifestRejection; `path` already
+          // identifies which manifest failed.
           const reason = `invalid JSON: ${
-            parseError instanceof Error
-              ? parseError.message
-              : String(parseError)
+            parseError instanceof Error ? parseError.name : String(parseError)
           }`;
           const rejection = {
             directory: subdir,


### PR DESCRIPTION
# Relates to

Closes #30157

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; owning-package `test`, `typecheck`, and `lint:check` pass (see logs). `bun run verify` is a full-repo gate not run on this machine — the focused package gates are attached below.
- [x] A reviewer can confirm the change works without reading the code, from the failing-before / passing-after test evidence attached below.

# Sync with develop

- [x] Branched from and current with `origin/develop` (`9b93ec4374`); zero conflicts (`git rev-list --count HEAD..origin/develop` = 0).
- [ ] `bun run verify` full-repo gate: not run here (heavy multi-package gate on a Raspberry Pi). Focused package gates (`test` / `typecheck` / `lint:check`) pass and are recorded under **Known gaps / failures**.

# Risks

Low. The change is confined to one loop body in the `POST /api/apps/load-from-directory` handler in `plugins/plugin-app-manager/src/api/apps-routes.ts`. It only adds a `try/catch` around an existing `JSON.parse`, converting an uncaught throw into the same skip-and-continue + `recordManifestRejection` path the loop already uses for missing/invalid manifests. No public type, route, or wire contract changes.

# Background

## What does this PR do?

The `POST /api/apps/load-from-directory` handler scans a directory of app packages and is explicitly designed to **skip bad entries and keep going**: a missing/unreadable `package.json` (`readFile(...).catch(() => null); continue`), a manifest with no `elizaos.app` (`continue`), a manifest with no package `name` (`continue`), and invalid permissions (recorded via `recordManifestRejection` + `continue`).

But the `JSON.parse(raw)` sitting **between** those guards was unguarded. A single sibling directory containing a syntactically malformed `package.json` threw `SyntaxError`, which unwound to the route's outer `catch` and returned **HTTP 500 "Load failed: ..."**. Because the throw happened mid-loop, every valid app package in the same directory that had not yet been reached was silently **NOT registered** — the entire batch was lost to one corrupt manifest.

This PR wraps the parse in a `try/catch` that mirrors the existing bad-entry handling:

- push a `{ directory, packageName: null, reason: "invalid JSON: <message>", path }` entry into `rejectedManifests`,
- forward it through `registry.recordManifestRejection?.(...)` so callers still learn which manifest was rejected,
- `continue` so every valid sibling app still registers.

User-facing impact: an admin loading a directory of apps no longer loses the whole batch (and gets an opaque 500) because one folder has a broken `package.json`. Valid apps register (HTTP 200, `registered: N`) and the malformed manifest is surfaced in `rejectedManifests` — matching the loop's own documented skip-and-continue design and the repository error policy (fail-fast per entry, don't abort the batch).

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity / error-policy defect on a real admin route).

# Documentation changes needed?

No. The route's documented behavior (skip bad entries, continue) is unchanged — this PR makes the implementation match it. No doc edits required.

# Testing

## Where should a reviewer start?

`plugins/plugin-app-manager/src/api/apps-routes.test.ts` — three tests exercise the changed contract against a real temp dir with a stubbed `app-registry` service (no live runtime, no credentials):

1. **registers every valid sibling app when one package.json is malformed** — temp dir with `app-good` (valid `elizaos.app` manifest) + `app-bad` (`"{ this is not json "`). Asserts HTTP **200**, `registered: 1`, `items` = `["@elizaos/app-good"]`, `register` called once with the good app, and `rejectedManifests` contains exactly the bad dir with `packageName: null`, `reason` containing `"invalid JSON"`, and the exact `path`. Also asserts `recordManifestRejection` was called once with the rejection plus `requesterEntityId: null` / `requesterRoomId: null`. This is the direct reproduction from the issue.
2. **registers all apps when every manifest in the directory is valid** — regression: an all-valid directory still registers every app (`registered: 3`, no rejections, `recordManifestRejection` never called).
3. (existing) **rejects relative app directories at the host boundary** — unchanged host-boundary guard.

## Detailed testing steps

```bash
cd plugins/plugin-app-manager
# Full owning-package route suite (18 tests):
node node_modules/vitest/vitest.mjs run src/api/apps-routes.test.ts --config vitest.config.ts
bun run typecheck
bun run lint:check
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:6ea66b37b015a971b5d3ea862f23b068ae35ba34 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend/API-only change (route handler in plugin-app-manager); no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend/API-only change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - backend/API-only change; the user-observable behavior is the HTTP status + JSON body, shown in the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Failing-before focused vitest output showing the buggy handler returns HTTP 500 where the fix returns 200. Captured at PR head `6ea66b37b0` with the parse-guard fix temporarily reverted to the pre-fix bare `JSON.parse`, then the source restored byte-identical. Immutable mirror pinned to gist revision `4f5fb89`: [failing-before.txt](https://gist.githubusercontent.com/agent-cortex/4e8dacd96b63a2e3c2bdff813dcc09b0/raw/4f5fb89df7db58eefc5bde49785ec5d2e00264b9/failing-before.txt):

<details><summary>failing-before logs — vitest -t 'malformed' with the parse-guard fix reverted (head 6ea66b37b0)</summary>

```
 RUN  v4.1.10 .../plugin-app-manager

 ❯ src/api/apps-routes.test.ts (18 tests | 1 failed | 15 skipped) 190ms
     × registers every valid sibling app when one package.json is malformed 135ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/api/apps-routes.test.ts > handleAppsRoutes > registers every valid sibling app when one package.json is malformed
AssertionError: expected 500 to be 200 // Object.is equality

- Expected
+ Received

- 200
+ 500

 ❯ src/api/apps-routes.test.ts:215:33
    213|
    214|       expect(result.handled).toBe(true);
    215|       expect(result.res.status).toBe(200);
       |                                 ^

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed | 15 skipped (18)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved; the endpoint is called by the dashboard/admin surface but this fix is server-side.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is an HTTP route parse-guard fix.`
<!-- evidence-row:domain-artifacts -->
- [x] Passing-after output: full `/api/apps/*` route suite green with the fix at PR head `6ea66b37b0` (the domain artifact is the route's 200 JSON response shape `registered`/`items`/`rejectedManifests` asserted by the new tests). Immutable mirrors pinned to gist revision `4f5fb89`: [full-suite-after.txt](https://gist.githubusercontent.com/agent-cortex/4e8dacd96b63a2e3c2bdff813dcc09b0/raw/4f5fb89df7db58eefc5bde49785ec5d2e00264b9/full-suite-after.txt) and [typecheck-lint.txt](https://gist.githubusercontent.com/agent-cortex/4e8dacd96b63a2e3c2bdff813dcc09b0/raw/4f5fb89df7db58eefc5bde49785ec5d2e00264b9/typecheck-lint.txt):

<details><summary>passing-after logs — vitest run src/api/apps-routes.test.ts --reporter verbose (full route suite, head 6ea66b37b0)</summary>

```
 RUN  v4.1.10 .../plugin-app-manager

 ✓ handleAppsRoutes > rejects relative app directories at the host boundary 47ms
 ✓ handleAppsRoutes > registers every valid sibling app when one package.json is malformed 285ms
 ✓ handleAppsRoutes > registers all apps when every manifest in the directory is valid 8ms
 ✓ handleAppsRoutes > rejects malformed favorite updates before writing the store 4ms
 ✓ handleAppsRoutes > fuzzes favorites replacement through the route sanitizer 773ms
 ✓ handleAppsRoutes > rejects blank run messages without proxying to plugin route handlers 17ms
 ✓ handleAppsRoutes > rejects malformed launch payloads before invoking appManager.launch 2ms
 ✓ handleAppsRoutes > denies undefined actor before invoking appManager.launch 1ms
 ✓ handleAppsRoutes > denies null actor before invoking appManager.launch 2ms
 ✓ handleAppsRoutes > denies USER actor before invoking appManager.launch 1ms
 ✓ handleAppsRoutes > denies GUEST actor before invoking appManager.launch 1ms
 ✓ handleAppsRoutes > allows OWNER actor to launch apps 1ms
 ✓ handleAppsRoutes > allows ADMIN actor to launch apps 1ms
 ✓ handleAppsRoutes > rejects illegal percent-encoding in app path segments before service calls 2ms
 ✓ handleAppsRoutes > still loads a canonically encoded app info slug 3ms
 ✓ handleAppsRoutes > reuses the app hero registry lookup across adjacent image requests 125ms
 ✓ handleAppsRoutes > serves plugin SVG heroes as attachments so they cannot execute on the dashboard origin 36ms
 ✓ handleAppsRoutes > keeps raster hero images inline 35ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Duration  55.66s
```

Owning-package `typecheck` + `lint:check` at the same head (full log in the pinned typecheck-lint.txt mirror above):

```
=== typecheck (tsc --noEmit) ===
$ tsc --noEmit --rootDir ../..
EXIT=0

=== lint:check (biome) ===
$ bunx @biomejs/biome check .
Checked 17 files in 273ms. No fixes applied.
EXIT=0
```
</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend: the real failing-before (HTTP 500) and passing-after (HTTP 200, 18 tests) vitest logs are embedded in the **backend-logs** and **domain-artifacts** evidence rows above, with gist mirrors linked there. The 500→200 transition is the exact user-observable behavior of this route fix.

Frontend: `N/A - server-side route fix; no frontend change.`

## Screenshots (before / after) + video walkthrough

`N/A - backend/API-only change; the observable behavior is the HTTP response, shown in the logs above (500 → 200 with valid apps registered).`

### Before
`N/A - no UI surface.`
### After
`N/A - no UI surface.`
### Walkthrough video
`N/A - no UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun run verify` (full-repo, multi-package gate) was not run on this machine (Raspberry Pi; the gate builds/lints/tests the whole workspace). The **owning package** gates were run and pass:
  - `bun run --cwd plugins/plugin-app-manager test` → 18 passed.
  - `bun run --cwd plugins/plugin-app-manager typecheck` → clean (`tsc --noEmit`).
  - `bun run --cwd plugins/plugin-app-manager lint:check` → clean (Biome, 17 files, no errors).
- Evidence attachment minting (`attach.mjs upload`) could not authenticate in this environment, so the real vitest logs are embedded inline above (the PR template accepts inline artifacts) rather than as GitHub attachment URLs.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@6ea66b37b015a971b5d3ea862f23b068ae35ba34:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@6ea66b37b015a971b5d3ea862f23b068ae35ba34:packages/skills/skills/contribute-to-eliza"} -->

