### PR TITLE
fix(plugin-elizacloud): guard unguarded JSON.parse of cloud-bridge WebSocket frames

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts
@@ -90,8 +90,18 @@ describe("CloudBridgeService malformed-frame resilience (real undici WebSocket)"
     expect(service.getConnectionState("container-1")).toBe("connected");
   });
 
-  it("drops a valid-JSON but non-object frame without dereferencing method/id", async () => {
+  it("drops a valid-JSON but non-object frame without dispatching it to handlers", async () => {
     await connect("container-2");
+
+    // A registered handler must never see a non-object frame. Pre-fix, `42`
+    // and the array fell through to this dispatch typed as BridgeMessage; the
+    // guard's `typeof !== "object" || null || Array.isArray` branch is what
+    // this assertion locks (the valid response below resolves the pending
+    // request and returns before handler dispatch, so it is never delivered).
+    const received: unknown[] = [];
+    service.onMessage("container-2", (message) => {
+      received.push(message);
+    });
 
     const pending = service.sendRequest("container-2", "status.get", {});
     // `42` and `[...]` are valid JSON but not JSON-RPC objects.
@@ -102,6 +112,7 @@ describe("CloudBridgeService malformed-frame resilience (real undici WebSocket)"
     await expect(pending).resolves.toEqual({ survived: true });
     await new Promise((r) => setTimeout(r, 50));
     expect(uncaughtErrors).toEqual([]);
+    expect(received).toEqual([]);
     expect(service.getConnectionState("container-2")).toBe("connected");
   });
 });

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts
@@ -1,0 +1,107 @@
+/**
+ * End-to-end regression test for CloudBridgeService's inbound-frame handling.
+ *
+ * Harness is integration-backed: a real `ws` WebSocketServer plus the real
+ * undici `WebSocket` client the service actually constructs (no fake socket,
+ * no mocked `@elizaos/core`). undici's `WebSocket` is an `EventTarget`
+ * subclass, so a throw inside the `"message"` listener is re-raised via
+ * `process.nextTick` and surfaces as an `uncaughtException`; the agent host
+ * translates that into `process.exit(1)`. This proves that a single malformed
+ * or non-object frame is dropped without emitting `uncaughtException` and
+ * without disrupting an in-flight JSON-RPC request on the same connection.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import type { IAgentRuntime } from "@elizaos/core";
+import { CloudBridgeService } from "./cloud-bridge";
+
+describe("CloudBridgeService malformed-frame resilience (real undici WebSocket)", () => {
+  let wss: WebSocketServer;
+  let port: number;
+  let service: CloudBridgeService;
+  let serverSocket: import("ws").WebSocket | null;
+  const uncaughtErrors: unknown[] = [];
+  let priorUncaughtListeners: NodeJS.UncaughtExceptionListener[] = [];
+  const onUncaught = (error: unknown): void => {
+    uncaughtErrors.push(error);
+  };
+
+  beforeEach(async () => {
+    uncaughtErrors.length = 0;
+    serverSocket = null;
+    // Take over uncaughtException so a pre-fix re-thrown parse error is
+    // recorded here instead of terminating the vitest worker, then restore
+    // the harness's own listeners afterward.
+    priorUncaughtListeners = process.listeners("uncaughtException");
+    process.removeAllListeners("uncaughtException");
+    process.on("uncaughtException", onUncaught);
+
+    await new Promise<void>((resolve) => {
+      wss = new WebSocketServer({ port: 0 }, () => {
+        port = (wss.address() as { port: number }).port;
+        resolve();
+      });
+    });
+    wss.on("connection", (sock) => {
+      serverSocket = sock;
+    });
+
+    service = new CloudBridgeService({} as IAgentRuntime);
+    Reflect.set(service, "authService", {
+      getApiKey: () => undefined,
+      getClient: () => ({
+        buildWsUrl: (path: string) => `ws://127.0.0.1:${port}${path}`,
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    process.off("uncaughtException", onUncaught);
+    for (const listener of priorUncaughtListeners) process.on("uncaughtException", listener);
+    await service.stop().catch(() => {});
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  async function connect(containerId: string): Promise<void> {
+    await service.connect(containerId);
+    // Wait until the real undici client reports connected.
+    for (let i = 0; i < 200 && service.getConnectionState(containerId) !== "connected"; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(service.getConnectionState(containerId)).toBe("connected");
+    for (let i = 0; i < 200 && !serverSocket; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(serverSocket).not.toBeNull();
+  }
+
+  it("drops a malformed text frame without crashing and still resolves a pending request", async () => {
+    await connect("container-1");
+
+    const pending = service.sendRequest("container-1", "status.get", {});
+    // Server replies with one malformed frame, then the real JSON-RPC response.
+    serverSocket?.send("not json {");
+    serverSocket?.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }));
+
+    await expect(pending).resolves.toEqual({ ok: true });
+    // Give any re-thrown parse error a nextTick/microtask window to surface.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(uncaughtErrors).toEqual([]);
+    expect(service.getConnectionState("container-1")).toBe("connected");
+  });
+
+  it("drops a valid-JSON but non-object frame without dereferencing method/id", async () => {
+    await connect("container-2");
+
+    const pending = service.sendRequest("container-2", "status.get", {});
+    // `42` and `[...]` are valid JSON but not JSON-RPC objects.
+    serverSocket?.send("42");
+    serverSocket?.send(JSON.stringify(["not", "an", "object"]));
+    serverSocket?.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { survived: true } }));
+
+    await expect(pending).resolves.toEqual({ survived: true });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(uncaughtErrors).toEqual([]);
+    expect(service.getConnectionState("container-2")).toBe("connected");
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts
@@ -8,11 +8,14 @@
  * `process.nextTick` and surfaces as an `uncaughtException`; the agent host
  * translates that into `process.exit(1)`. This proves that a single malformed
  * or non-object frame is dropped without emitting `uncaughtException` and
- * without disrupting an in-flight JSON-RPC request on the same connection.
+ * without disrupting an in-flight JSON-RPC request on the same connection. It
+ * also pins the redaction guarantee: the warn arms log a shape/error name plus
+ * a byte count, never the peer-controlled bytes that may carry the `?token=`
+ * API key, and the dropped-shape label stays precise for `null`.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, logger } from "@elizaos/core";
 import { CloudBridgeService } from "./cloud-bridge";
 
 describe("CloudBridgeService malformed-frame resilience (real undici WebSocket)", () => {
@@ -114,5 +117,47 @@ describe("CloudBridgeService malformed-frame resilience (real undici WebSocket)"
     expect(uncaughtErrors).toEqual([]);
     expect(received).toEqual([]);
     expect(service.getConnectionState("container-2")).toBe("connected");
+  });
+
+  it("never logs peer frame bytes and labels the dropped JSON shape precisely", async () => {
+    await connect("container-3");
+
+    // Capture the warn arm. The connect URL carries `?token=<apiKey>`, so a
+    // proxy-injected error page echoing that URL is the frame most likely to be
+    // malformed and to contain the key; the guard must log a shape/name plus a
+    // byte count and never the raw bytes. Without this assertion, restoring the
+    // raw frame into either warn string leaves the suite green (see #30159).
+    const warnings: string[] = [];
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((arg) => String(arg)).join(" "));
+      return logger;
+    });
+
+    const marker = "LEAKMARK-a1b2c3-secret-token";
+    const pending = service.sendRequest("container-3", "status.get", {});
+    // Malformed frame carrying the marker (mirrors a proxy error page whose body
+    // echoes the requested `?token=` URL).
+    serverSocket?.send(`not json ${marker} {`);
+    // Valid JSON that is not a JSON-RPC object: a string carrying the marker, a
+    // literal `null` (the `typeof null === "object"` trap), and an array.
+    serverSocket?.send(JSON.stringify(marker));
+    serverSocket?.send("null");
+    serverSocket?.send(JSON.stringify([marker]));
+    serverSocket?.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }));
+
+    await expect(pending).resolves.toEqual({ ok: true });
+    await new Promise((r) => setTimeout(r, 50));
+    warnSpy.mockRestore();
+
+    const combined = warnings.join("\n");
+    // Security guarantee: no peer-controlled bytes reach the log, from either arm.
+    expect(combined).not.toContain(marker);
+    // Shape-only labels stay precise, including the `null` special-case.
+    expect(warnings).toContainEqual(expect.stringContaining("JSON string"));
+    expect(warnings).toContainEqual(expect.stringContaining("JSON null"));
+    expect(warnings).toContainEqual(expect.stringContaining("JSON array"));
+    expect(warnings).not.toContainEqual(expect.stringContaining("JSON object"));
+    expect(uncaughtErrors).toEqual([]);
+    expect(service.getConnectionState("container-3")).toBe("connected");
   });
 });

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
@@ -155,7 +155,12 @@ export class CloudBridgeService extends Service {
       const raw = event.data;
       const data =
         typeof raw === "string" ? raw : raw instanceof Buffer ? raw.toString("utf-8") : String(raw);
-      const message = JSON.parse(data) as BridgeMessage;
+
+      const message = this.parseBridgeFrame(containerId, data);
+      // A malformed or non-object frame is dropped so one bad frame cannot take
+      // down the connection (or, via the host uncaughtException handler, the
+      // whole process). See parseBridgeFrame.
+      if (!message) return;
 
       // Handle heartbeat responses
       if (message.method === "heartbeat.ack") {
@@ -210,6 +215,48 @@ export class CloudBridgeService extends Service {
       if (this.connections.get(containerId) !== conn) return;
       logger.error(`[CloudBridge] WebSocket error for ${containerId}`);
     });
+  }
+
+  /**
+   * Parse an inbound WebSocket frame into a `BridgeMessage`, returning `null`
+   * for any frame that is not a JSON object.
+   *
+   * undici's `WebSocket` is an `EventTarget` subclass, so a throw inside the
+   * `"message"` listener is re-raised via `process.nextTick` and surfaces as an
+   * `uncaughtException`; the agent host translates that into `process.exit(1)`
+   * (`packages/app-core/src/cli/run-main.ts`). A single non-JSON text frame
+   * (protocol drift, a proxy-injected error page, or a misbehaving peer) would
+   * therefore kill the entire process, not just the bridge. This is the
+   * transport boundary, so an untrusted frame is sanitized here rather than
+   * dereferenced blindly.
+   */
+  private parseBridgeFrame(containerId: string, data: string): BridgeMessage | null {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch (error) {
+      // error-policy:J3 untrusted transport frame; an unparseable body is an
+      // explicit invalid result (dropped), never a fake-valid message.
+      logger.warn(
+        `[CloudBridge] Ignoring malformed frame from ${containerId}: ${
+          error instanceof Error ? error.message : String(error)
+        } (raw preview: ${JSON.stringify(data.slice(0, 200))})`
+      );
+      return null;
+    }
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      // error-policy:J3 valid JSON that is not a JSON-RPC object cannot be
+      // dereferenced for `method`/`id`; treat it as an invalid frame.
+      logger.warn(
+        `[CloudBridge] Ignoring non-object frame from ${containerId}: ${JSON.stringify(
+          data.slice(0, 200)
+        )}`
+      );
+      return null;
+    }
+
+    return parsed as BridgeMessage;
   }
 
   private scheduleReconnect(containerId: string, attempt: number): void {

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
@@ -236,22 +236,27 @@ export class CloudBridgeService extends Service {
       parsed = JSON.parse(data);
     } catch (error) {
       // error-policy:J3 untrusted transport frame; an unparseable body is an
-      // explicit invalid result (dropped), never a fake-valid message.
+      // explicit invalid result (dropped), never a fake-valid message. The
+      // frame is peer-controlled and the connect URL carries `?token=<apiKey>`,
+      // so a proxy-injected error page echoing that URL must not reach a log:
+      // record the error name and byte length, never the raw bytes or the
+      // `SyntaxError` message (which itself quotes a slice of the input).
       logger.warn(
         `[CloudBridge] Ignoring malformed frame from ${containerId}: ${
-          error instanceof Error ? error.message : String(error)
-        } (raw preview: ${JSON.stringify(data.slice(0, 200))})`
+          error instanceof Error ? error.name : "ParseError"
+        } (${data.length} bytes)`
       );
       return null;
     }
 
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       // error-policy:J3 valid JSON that is not a JSON-RPC object cannot be
-      // dereferenced for `method`/`id`; treat it as an invalid frame.
+      // dereferenced for `method`/`id`; treat it as an invalid frame. Log the
+      // JSON shape and byte length only, never the peer-controlled bytes.
       logger.warn(
-        `[CloudBridge] Ignoring non-object frame from ${containerId}: ${JSON.stringify(
-          data.slice(0, 200)
-        )}`
+        `[CloudBridge] Ignoring non-object frame from ${containerId}: JSON ${
+          Array.isArray(parsed) ? "array" : typeof parsed
+        } (${data.length} bytes)`
       );
       return null;
     }

--- a/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bridge.ts
@@ -252,10 +252,12 @@ export class CloudBridgeService extends Service {
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       // error-policy:J3 valid JSON that is not a JSON-RPC object cannot be
       // dereferenced for `method`/`id`; treat it as an invalid frame. Log the
-      // JSON shape and byte length only, never the peer-controlled bytes.
+      // JSON shape and byte length only, never the peer-controlled bytes. The
+      // shape label special-cases `null` because `typeof null === "object"`
+      // would otherwise mislabel a dropped `null` frame as a JSON object.
       logger.warn(
         `[CloudBridge] Ignoring non-object frame from ${containerId}: JSON ${
-          Array.isArray(parsed) ? "array" : typeof parsed
+          parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed
         } (${data.length} bytes)`
       );
       return null;


### PR DESCRIPTION
# Relates to

Closes #30161

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks pass (see Testing). `bun run verify` is a full-repo gate; the affected-surface checks (focused vitest, typecheck, Biome) are recorded below and pass.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`9b93ec4374`); zero conflicts.
- [x] Focused checks pass post-sync (see **Testing** / **Evidence Details**).

# Risks

Low, and strictly risk-reducing. The change is confined to one transport
boundary: the inbound WebSocket `"message"` listener in
`plugins/plugin-elizacloud/src/services/cloud-bridge.ts`. Valid JSON-object
frames stay on the exact same JSON-RPC dispatch path they used before; only
frames that are unparseable or are valid JSON but not an object (numbers,
strings, arrays, `null`) are now dropped with a redacted warn line instead of
either crashing the process or being dispatched to handlers typed as
`BridgeMessage`. No public type, export, or protocol field changes.

# Background

## What does this PR do?

`CloudBridgeService`'s WebSocket `"message"` listener parsed every inbound frame
with an unguarded `JSON.parse(data)` (`cloud-bridge.ts:156`). undici's
`WebSocket` is an `EventTarget` subclass, so a throw inside the listener is
re-raised via `process.nextTick` and surfaces as an `uncaughtException`. The
agent host installs a global `uncaughtException` handler that calls
`process.exit(1)` (`packages/app-core/src/cli/run-main.ts:69`). Net effect: a
**single** non-JSON text frame from the cloud gateway (protocol drift, a
proxy-injected error page, a gateway error delivered as text, or a
misbehaving/compromised peer) took down the **entire agent process**, not just
the bridge.

This PR sanitizes the untrusted frame at the transport boundary:

- Adds `parseBridgeFrame(containerId, data)`, which returns `null` for any frame
  that is not a JSON object. The listener drops a `null` result
  (`if (!message) return;`) before any `message.method` / `message.id` access.
- The malformed-parse arm logs **only** the error name and byte length
  (`SyntaxError (10 bytes)`) — never the raw bytes, and never the `SyntaxError`
  message, which itself quotes a slice of the input. This matters because the
  connect URL carries `?token=<apiKey>`, so a proxy-injected error page echoing
  that URL is exactly the frame most likely to be malformed and to contain the
  key. This mirrors the log-redaction fix in #30159.
- The non-object arm logs **only** the JSON shape and byte length
  (`JSON array (21 bytes)`), never the peer bytes. The shape label special-cases
  `null` because `typeof null === "object"` would otherwise mislabel a dropped
  `null` frame as a JSON object.
- Both handlers carry `// error-policy:J3` (untrusted-input sanitizing): an
  invalid frame becomes an explicit dropped result, never a fake-valid message.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue), with a security-hardening
dimension on the diagnostic log path.

# Documentation changes needed?

No. The behavior is documented in the new `parseBridgeFrame` JSDoc and the
inline `error-policy` rationale.

# Testing

## Where should a reviewer start?

`plugins/plugin-elizacloud/src/services/cloud-bridge.malformed-frame.test.ts` —
three tests that stand up a **real `ws` server and the real undici client**,
temporarily capture `uncaughtException`, and assert the actual failure mode
rather than unit-testing `JSON.parse`.

## Detailed testing steps

```
cd plugins/plugin-elizacloud
bunx vitest run src/services/cloud-bridge.malformed-frame.test.ts --reporter=verbose
```

The three tests are:

1. **drops a malformed text frame without crashing and still resolves a pending
   request** — sends a non-JSON frame, asserts no `uncaughtException` fired, the
   connection stays `connected`, and a subsequent valid JSON-RPC response still
   resolves the pending request. This is the process-kill regression lock.
2. **drops a valid-JSON but non-object frame without dispatching it to
   handlers** — registers a handler and asserts it receives nothing for `42` and
   `["not","an","object"]`, locking the `typeof !== "object" || null ||
   Array.isArray` branch that would otherwise deliver non-objects to
   `BridgeMessage`-typed handlers.
3. **never logs peer frame bytes and labels the dropped JSON shape precisely** —
   feeds a leak marker through all arms, captures `logger.warn`, and asserts the
   combined output omits the marker while emitting `JSON string` / `JSON null` /
   `JSON array` and never `JSON object`. This pins both the redaction and the
   `null`-label fix (same shape as #30159's `not.toContain("LEAKMARK")`).

# Evidence Gate

<!-- evidence-head:f1c43965d10d816326516e56c3f485d72d786e2b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface changed; this is a backend WebSocket transport-boundary parser guard with no view, component, or style diff.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface changed; this is a backend WebSocket transport-boundary parser guard with no view, component, or style diff.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the changed contract is inbound frame handling, verified by the real-undici regression suite and the mutation proof in Evidence Details.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - fork contributor account cannot upload assets to the upstream pr-evidence release (HTTP 404, push access required) and cannot mint GitHub user-attachment URLs headlessly; the real focused-test run, the redacted warn output, and the red/green mutation proof are pasted inline verbatim in Evidence Details below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser/frontend code path changed; the fix is in the Node-side undici WebSocket message listener.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, evaluator, prompt, or model behavior changed; this is a transport parser guard.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the redacted warn output and the three-mutant red/green regression proof, both captured verbatim in Evidence Details; asset upload to the upstream release is not permitted for this fork account (HTTP 404).
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface to OCR.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed.`

## Backend logs — focused tests, typecheck, and lint (head `f1c43965`)

Real undici WebSocket regression suite plus the full `src/services/` suite,
typecheck, and Biome — captured verbatim:

```
$ bunx vitest run src/services/cloud-bridge.malformed-frame.test.ts --reporter=verbose
 Warn  [CloudBridge] Ignoring malformed frame from container-1: SyntaxError (10 bytes)
 ✓ cloud-bridge.malformed-frame.test.ts > drops a malformed text frame without crashing and still resolves a pending request 97ms
 Warn  [CloudBridge] Ignoring non-object frame from container-2: JSON number (2 bytes)
 Warn  [CloudBridge] Ignoring non-object frame from container-2: JSON array (21 bytes)
 ✓ cloud-bridge.malformed-frame.test.ts > drops a valid-JSON but non-object frame without dispatching it to handlers 70ms
 ✓ cloud-bridge.malformed-frame.test.ts > never logs peer frame bytes and labels the dropped JSON shape precisely 73ms
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ bunx vitest run src/services/        # full services suite
 Test Files  2 passed (2)
      Tests  5 passed (5)

$ bun run typecheck                     # tsc --noEmit -p tsconfig.json
(no output — clean)

$ bun run lint:check                    # bunx @biomejs/biome check .
Checked 66 files in 345ms. No fixes applied.
```

The three warn lines above are the complete diagnostic output for dropped
frames: `SyntaxError (10 bytes)`, `JSON number (2 bytes)`, `JSON array (21
bytes)` — an error name or JSON shape plus a byte length, and no peer-controlled
bytes.

## Domain artifact — red/green mutation proof

Each mutant reverts exactly one guarantee in `cloud-bridge.ts`; the suite must
go red. Working tree confirmed clean (`git status --short` empty) after
restoration.

```
== Baseline (unmodified fix) ==
      Tests  3 passed (3)

== Mutant 1: full revert -> const message = JSON.parse(data) as BridgeMessage; ==
AssertionError: expected [ …(1) ] to deeply equal []
AssertionError: expected [ 42, [ 'not', 'an', 'object' ] ] to deeply equal []
AssertionError: expected [] to deep equally contain StringContaining "JSON string"
      Tests  3 failed (3)

== Mutant 2: restore raw peer bytes into the malformed warn (RAW:${data}) ==
AssertionError: expected '[CloudBridge] Ignoring malformed fram…' not to contain 'LEAKMARK-a1b2c3-secret-token'
      Tests  1 failed | 2 passed (3)

== Mutant 3: drop the null special-case in the shape label ==
AssertionError: expected [ …(4) ] to deep equally contain StringContaining "JSON null"
      Tests  1 failed | 2 passed (3)
```

Mutant 1 proves the whole guard is a real process-kill regression lock; mutant 2
proves the redaction is pinned (raw bytes leak → red); mutant 3 proves the
`null` shape-label fix is pinned.

## Severity confirmation (independent of the PR description)

- `plugins/plugin-elizacloud/src/services/cloud-bridge.ts:11` imports
  `WebSocket` from `undici`; its `"message"` listener is `EventTarget`-dispatched
  so an in-listener throw is re-raised out of band.
- `packages/app-core/src/cli/run-main.ts:69` registers
  `process.on("uncaughtException", …)` and ends in `process.exit(1)`.

So one unparseable text frame really did kill the whole process, not just the
bridge.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface changed; the fix is the inbound WebSocket frame parser at the transport boundary.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- **`bun run verify` (full-repo gate) not run to completion**: it is a
  whole-workspace gate unrelated to this localized plugin change; the affected
  package's focused vitest, typecheck, and Biome checks pass (attached above).
- **Immutable artifact upload**: the fork contributor account cannot push assets
  to the upstream `pr-evidence` release (HTTP 404) and cannot mint GitHub
  user-attachment URLs from a headless environment, so the real logs are pasted
  inline verbatim rather than linked. All command output above is copied
  unedited from the local runs at head `f1c43965`.

## Maintainer CI exception record

`N/A - no exception requested`

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@f1c43965d10d816326516e56c3f485d72d786e2b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@f1c43965d10d816326516e56c3f485d72d786e2b:packages/skills/skills/contribute-to-eliza"} -->
