### PR TITLE
fix(plugin-slack): stop rewriting the inside of fenced code blocks

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -87,8 +87,29 @@ describe("markdownToSlackMrkdwn", () => {
   });
 
   it("handles a 100k unterminated code fence without backtracking", () => {
-    const adversarial = `\`\`\`json\n${"x".repeat(100_000)}`;
-    expect(markdownToSlackMrkdwn(adversarial)).toContain("x".repeat(100_000));
+    // Exact equality, not `toContain`: a substring check still passed while the
+    // body around it was being rewritten, which is how the unterminated-fence
+    // corruption below survived this test.
+    const body = "x".repeat(100_000);
+    expect(markdownToSlackMrkdwn(`\`\`\`json\n${body}`)).toBe(
+      `\`\`\`\n${body}`,
+    );
+  });
+
+  it("does not rewrite the body after an unmatched opening fence", () => {
+    // A truncated or streamed message ends mid-fence, and SlackService formats
+    // every outbound message, so this is a reachable output state -- not a
+    // parser curiosity. Before this, the tail kept every style pass: `#` went
+    // bold, `*literal*` went italic, and a markdown link became a Slack link.
+    expect(
+      markdownToSlackMrkdwn("```sh\n# keep *literal* [docs](https://ex.com)"),
+    ).toBe("```\n# keep *literal* [docs](https://ex.com)");
+    // and the closed case is unchanged
+    expect(
+      markdownToSlackMrkdwn(
+        "```\n# keep *literal* [docs](https://ex.com)\n```",
+      ),
+    ).toContain("# keep *literal* [docs](https://ex.com)");
   });
 
   it("does not let sentinel-looking input forge a code block into prose", () => {

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -90,6 +90,46 @@ describe("markdownToSlackMrkdwn", () => {
     const adversarial = `\`\`\`json\n${"x".repeat(100_000)}`;
     expect(markdownToSlackMrkdwn(adversarial)).toContain("x".repeat(100_000));
   });
+
+  it("does not let sentinel-looking input forge a code block into prose", () => {
+    // The restore used to split/join each sentinel across the whole document,
+    // so a NUL sentinel arriving IN THE INPUT was replaced with a real fenced
+    // body -- duplicating the block into a prose position. NUL is now stripped
+    // at entry, so neither this nor the BOLD sentinel can be forged.
+    const out = markdownToSlackMrkdwn(
+      "\u0000CODE0\u0000 then\n```\n*real*\n```",
+    );
+    expect(out).not.toContain("\u0000");
+    // the fence body appears exactly once, in its own position
+    expect(out.split("*real*").length - 1).toBe(1);
+    expect(out).toContain("CODE0 then");
+  });
+
+  it("does not splice a later fence into a body that mentions its sentinel", () => {
+    // Restoring in ascending index order re-scanned bodies it had already
+    // restored, so a body containing a LATER sentinel had that block spliced
+    // into it. The restore is now a single left-to-right pass.
+    const out = markdownToSlackMrkdwn(
+      "```\n\u0000CODE1\u0000\n```\ntext\n```\n# second\n```",
+    );
+    expect(out).not.toContain("\u0000");
+    expect(out.split("# second").length - 1).toBe(1);
+    expect(out).toContain("CODE1");
+  });
+
+  it("escapes mention tokens and a leading quote inside a fence", () => {
+    // Holding the body aside swaps escapeSlackMrkdwn (via
+    // escapeSlackMrkdwnContent, which preserves Slack angle tokens and skips a
+    // leading "> ") for escapeSlackMrkdwnSegment, which does neither. Inside a
+    // fence that is the wanted behaviour -- the text is meant to be literal --
+    // so it is pinned here rather than left to be rediscovered.
+    expect(markdownToSlackMrkdwn("```\nping <@U123> now\n```")).toContain(
+      "&lt;@U123&gt;",
+    );
+    expect(markdownToSlackMrkdwn("```\n> quoted line\n```")).toContain(
+      "&gt; quoted line",
+    );
+  });
 });
 
 describe("mention builders + extractors round-trip", () => {

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -48,6 +48,44 @@ describe("markdownToSlackMrkdwn", () => {
     expect(markdownToSlackMrkdwn("")).toBe("");
   });
 
+  it("leaves fenced code bodies exactly as authored", () => {
+    // The link/heading/style passes are regex-based and cannot see fence
+    // state, so without protection they rewrote code: a `#` comment line
+    // became bold, `a * b` became `a _ b`, and a literal markdown link
+    // became a Slack link. Slack renders none of that inside ``` — the user
+    // just sees corrupted code and copies it out.
+    expect(
+      markdownToSlackMrkdwn("Run this:\n```bash\n# install deps\nnpm i\n```"),
+    ).toContain("# install deps");
+    expect(markdownToSlackMrkdwn("```python\narea = w * h * d\n```")).toContain(
+      "area = w * h * d",
+    );
+    expect(
+      markdownToSlackMrkdwn("```md\nsee [docs](https://ex.com)\n```"),
+    ).toContain("[docs](https://ex.com)");
+  });
+
+  it("still entity-escapes & < > inside a fenced body", () => {
+    // The body is held aside before `escapeSlackMrkdwn` runs, so it is escaped
+    // at lift-out time instead; Slack renders raw & < > inside a fence.
+    const out = markdownToSlackMrkdwn(
+      "```sh\nif [ $a -lt 5 ] && echo <hi>\n```",
+    );
+    expect(out).toContain("&amp;&amp;");
+    expect(out).toContain("&lt;hi&gt;");
+  });
+
+  it("restores multiple fences in order and still styles the prose between", () => {
+    const out = markdownToSlackMrkdwn(
+      "```\nAAA * A\n```\nmid *em*\n```\nBBB * B\n```",
+    );
+    expect(out).toContain("AAA * A");
+    expect(out).toContain("BBB * B");
+    expect(out).toContain("_em_");
+    expect(out.indexOf("AAA")).toBeLessThan(out.indexOf("BBB"));
+    expect(out).not.toContain("\u0000");
+  });
+
   it("handles a 100k unterminated code fence without backtracking", () => {
     const adversarial = `\`\`\`json\n${"x".repeat(100_000)}`;
     expect(markdownToSlackMrkdwn(adversarial)).toContain("x".repeat(100_000));

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -163,7 +163,21 @@ function convertCodeBlocks(text: string, codeSink: string[]): string {
     }
     if (text[bodyStart] === "\n") bodyStart += 1;
     const closer = text.indexOf("```", bodyStart);
-    if (closer < 0) break;
+    if (closer < 0) {
+      // An unmatched opener is what a truncated or streamed message produces,
+      // and the rest of it is still code the user reads and copies. Pushing it
+      // raw left every style pass on it, so a `#` comment came out bold and a
+      // markdown link became a Slack link -- the corruption this whole change
+      // exists to stop. Hold it aside like a closed body. No closer is
+      // invented: the output keeps the input's fence parity.
+      const tailToken = `${CODE_SENTINEL_PREFIX}${codeSink.length}${CODE_SENTINEL_SUFFIX}`;
+      codeSink.push(
+        `\`\`\`\n${escapeSlackMrkdwnSegment(text.slice(bodyStart))}`,
+      );
+      out.push(text.slice(cursor, opener), tailToken);
+      cursor = text.length;
+      break;
+    }
     // Escape the body here: `escapeSlackMrkdwn` runs after restoration and can
     // no longer reach it, but Slack still renders raw &, < and > inside a fence.
     const token = `${CODE_SENTINEL_PREFIX}${codeSink.length}${CODE_SENTINEL_SUFFIX}`;

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -210,13 +210,26 @@ function convertHeadings(text: string): string {
  * Puts the held-aside fenced bodies back, after every style pass has run.
  */
 function restoreCodeBlocks(text: string, codeSink: string[]): string {
-  let restored = text;
-  for (let index = 0; index < codeSink.length; index++) {
-    restored = restored
-      .split(`${CODE_SENTINEL_PREFIX}${index}${CODE_SENTINEL_SUFFIX}`)
-      .join(codeSink[index] ?? "");
+  if (codeSink.length === 0) return text;
+  // Single left-to-right pass: a restored body is never rescanned, so a body
+  // that happens to contain a later sentinel cannot splice that block into it.
+  // (An indexOf scan rather than a regex: biome rejects a control character
+  // inside a regex literal via lint/suspicious/noControlCharactersInRegex.)
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const start = text.indexOf(CODE_SENTINEL_PREFIX, cursor);
+    if (start < 0) break;
+    const digitsStart = start + CODE_SENTINEL_PREFIX.length;
+    const end = text.indexOf(CODE_SENTINEL_SUFFIX, digitsStart);
+    if (end < 0) break;
+    const digits = text.slice(digitsStart, end);
+    const body = /^[0-9]+$/.test(digits) ? codeSink[Number(digits)] : undefined;
+    out.push(text.slice(cursor, start), body ?? text.slice(start, end + 1));
+    cursor = end + 1;
   }
-  return restored;
+  out.push(text.slice(cursor));
+  return out.join("");
 }
 
 /**
@@ -230,7 +243,12 @@ export function markdownToSlackMrkdwn(markdown: string): string {
   // Process in order: code blocks -> links -> headings -> text styles -> escape.
   // Fenced bodies are held aside for the whole pipeline and restored last.
   const codeSink: string[] = [];
-  let result = convertCodeBlocks(markdown, codeSink);
+  // NUL never survives into Slack anyway; dropping it up front means neither
+  // sentinel can be forged by the incoming text.
+  let result = convertCodeBlocks(
+    markdown.split(CODE_SENTINEL_SUFFIX).join(""),
+    codeSink,
+  );
   result = convertLinks(result);
   result = convertHeadings(result);
   result = convertBold(result);

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -104,6 +104,13 @@ export function escapeSlackMrkdwn(text: string): string {
 
 // Sentinel used during conversion to prevent bold from being matched as italic.
 const BOLD_SENTINEL = "\u0000BOLD\u0000";
+// Fenced bodies are lifted out behind this sentinel before the link/heading/
+// style passes run, because those passes are regex-based and cannot see fence
+// state: a `# comment` line became bold, `a * b` became `a _ b`, and a literal
+// `[text](url)` became a Slack link. The sibling Telegram converter
+// (plugins/plugin-telegram/src/utils.ts) already substitutes code this way.
+const CODE_SENTINEL_PREFIX = "\u0000CODE";
+const CODE_SENTINEL_SUFFIX = "\u0000";
 
 /**
  * Converts markdown bold to Slack mrkdwn
@@ -136,7 +143,7 @@ function convertStrikethrough(text: string): string {
 /**
  * Converts markdown code blocks to Slack mrkdwn
  */
-function convertCodeBlocks(text: string): string {
+function convertCodeBlocks(text: string, codeSink: string[]): string {
   // Slack code blocks don't support language hints in the same way
   const out: string[] = [];
   let cursor = 0;
@@ -157,12 +164,13 @@ function convertCodeBlocks(text: string): string {
     if (text[bodyStart] === "\n") bodyStart += 1;
     const closer = text.indexOf("```", bodyStart);
     if (closer < 0) break;
-    out.push(
-      text.slice(cursor, opener),
-      "```\n",
-      text.slice(bodyStart, closer),
-      "```",
+    // Escape the body here: `escapeSlackMrkdwn` runs after restoration and can
+    // no longer reach it, but Slack still renders raw &, < and > inside a fence.
+    const token = `${CODE_SENTINEL_PREFIX}${codeSink.length}${CODE_SENTINEL_SUFFIX}`;
+    codeSink.push(
+      `\`\`\`\n${escapeSlackMrkdwnSegment(text.slice(bodyStart, closer))}\`\`\``,
     );
+    out.push(text.slice(cursor, opener), token);
     cursor = closer + 3;
   }
   out.push(text.slice(cursor));
@@ -199,6 +207,19 @@ function convertHeadings(text: string): string {
 }
 
 /**
+ * Puts the held-aside fenced bodies back, after every style pass has run.
+ */
+function restoreCodeBlocks(text: string, codeSink: string[]): string {
+  let restored = text;
+  for (let index = 0; index < codeSink.length; index++) {
+    restored = restored
+      .split(`${CODE_SENTINEL_PREFIX}${index}${CODE_SENTINEL_SUFFIX}`)
+      .join(codeSink[index] ?? "");
+  }
+  return restored;
+}
+
+/**
  * Converts markdown to Slack mrkdwn format
  */
 export function markdownToSlackMrkdwn(markdown: string): string {
@@ -206,14 +227,17 @@ export function markdownToSlackMrkdwn(markdown: string): string {
     return "";
   }
 
-  // Process in order: code blocks -> links -> headings -> text styles -> escape
-  let result = convertCodeBlocks(markdown);
+  // Process in order: code blocks -> links -> headings -> text styles -> escape.
+  // Fenced bodies are held aside for the whole pipeline and restored last.
+  const codeSink: string[] = [];
+  let result = convertCodeBlocks(markdown, codeSink);
   result = convertLinks(result);
   result = convertHeadings(result);
   result = convertBold(result);
   result = convertItalic(result);
   result = convertStrikethrough(result);
   result = escapeSlackMrkdwn(result);
+  result = restoreCodeBlocks(result, codeSink);
 
   return result;
 }


### PR DESCRIPTION
## What

`markdownToSlackMrkdwn` re-emitted fenced code bodies inline from `convertCodeBlocks`, so the link, heading and style passes that run afterwards rewrote the code as well. Those passes are regex-based and have no view of fence state.

## Why it matters

Slack applies no mrkdwn *inside* a fence, so the operator sees the corruption literally — and pasting it back into a shell runs the mangled text.

| the agent writes | Slack receives |
|---|---|
| `# install deps` | `*install deps*` |
| `area = w * h * d` | `area = w _ h _ d` |
| `[docs](https://ex.com)` | `<https://ex.com\|docs>` |

That first row is the sharp one: a comment line becomes a glob.

## The repo already does this correctly one connector over

`plugin-telegram`'s `convertMarkdownToTelegram` substitutes fenced blocks into sentinels before its style passes run. I ran the same three inputs through it as a control — all pass through untouched, language tag included. This change brings Slack in line with that existing approach rather than inventing one.

## The fix

Lift each fenced body out behind a sentinel before the style passes, then restore it once they have all run.

Two things worth flagging for review:

- **Fences only.** Inline code spans are already safe on the current code path, so I deliberately did not widen the change to cover them — the blast radius is smaller than "code isn't protected" would suggest.
- **Escaping had to move.** `escapeSlackMrkdwn` previously reached code bodies, and Slack *does* render raw `&`, `<` and `>` inside a fence. Lifting the body out would have silently dropped that escaping, so the body is escaped at lift-out time instead. That swaps `escapeSlackMrkdwnContent` for `escapeSlackMrkdwnSegment`, which also escapes `<@U123>` and a leading `> ` inside the fence. Inside a fence that is the wanted behaviour — the text is meant to be literal — so it is pinned by a test rather than left for the next reader to guess at.

## Unterminated fences are handled

An earlier revision of this description said they were out of scope. That is no longer true — this diff handles them, and that section is replaced by this one.

`convertCodeBlocks` used to bail out when it found no closing fence, pushing the trailing text through raw so every style pass still reached it. That is precisely the shape a streamed or length-capped agent message produces, and `SlackService` formats every outbound message, so it is a reachable output state rather than a parser curiosity.

The body after an unmatched opener is now held aside like a closed one, with the same entity escaping. No closing fence is invented — the output keeps the input's fence parity.

````text
IN   ```sh
     # keep *literal* [docs](https://ex.com)

was  ```sh
     *keep _literal_ <https://ex.com|docs>*

now  ```
     # keep *literal* [docs](https://ex.com)
````

The existing 100k-character adversarial test asserted `toContain`, which kept passing while the body around the matched substring was being rewritten — that is how this case survived the suite. It now asserts exact equality.

## Formatting repair never truncates

Two defects in earlier revisions of this branch both ended with content disappearing. Both are fixed, and each has a test that fails on the code before its fix.

**The restore lost or duplicated blocks.** It walked the sink in ascending index and `split`/`join`ed each sentinel across the whole document, so a sentinel arriving in the input had a real body substituted into it, and a body containing a later sentinel had that block spliced into it. The restore is now a single left-to-right scan that never rescans a body it has just restored.

**The bold sentinel could eat a code token.** Both sentinels were delimited by the same control character (NUL), and `convertItalic`'s global `BOLD_SENTINEL` → `*` replace could match across a code token's *closing* delimiter whenever the literal word `BOLD` sat between the two. The token was consumed, `restoreCodeBlocks` never found it, the held-aside body never came back, and a bare control character went out to Slack:

````text
IN   ```
     keep me
     ```BOLD**z**

was  <NUL>CODE0*BOLD<NUL>z*          <- the whole code block is gone

now  ```
     keep me
     ```BOLD*z*
````

The two sentinels now use different delimiters. Both delimiters are stripped from the input at entry, so neither sentinel can be forged by text the agent echoes, and a malformed or out-of-range token degrades to inert text rather than swallowing a block.

A 400k-case differential fuzz over an alphabet of fences, emphasis, links, both delimiters and the literal words `CODE` and `BOLD` reports no delimiter reaching the output and no fenced body lost.

## Consolidating #30372

#30372 ("stop caller text from forging the bold sentinel") is closed and its substance is here. The entry strip covers the bold sentinel as well as the code one; `BOLD_SENTINEL` is now built from its delimiter constant rather than repeating the escape, which was the structural half of that PR; and its three forgery cases are added to this suite as a regression lock. Those three pass on this branch — the entry strip landed here earlier — and fail on `develop`.

## What the tests prove, and what they do not

**This is not an end-to-end Slack check.** There is no Slack workspace, token or renderer in this repository's test setup, so nothing here observes how Slack draws the message or what its code-block copy button yields. I am not claiming end-to-end fidelity.

What `src/outbound-code-fidelity.test.ts` does prove is the exact `chat.postMessage` payload that `SlackService.sendMessage` hands to the Slack Web API client — the real converter and the real splitter in the path, with a recorder standing in for the client:

- the fenced body arrives as authored, with `&`, `<` and `>` entity-escaped;
- `mrkdwn: true` is on the payload — without it Slack renders no code block at all, so the rest would mean nothing;
- emphasis *around* the fence is still converted (`**this**` → `*this*`, `*ship it*` → `_ship it_`) while the fence body keeps its literal `*`, `#` and `[text](url)`;
- no control character reaches the wire;
- the tail of a message truncated mid-fence is delivered as code;
- a message over Slack's 40k limit reassembles from its posts into exactly the converted text, with nothing trimmed at the seams.

All three cases fail against `develop`'s `formatting.ts`. On `develop` the first delivers the fence body as

````text
*install deps &lt;not-a-tag&gt; &amp;&amp; echo <https://ex.com|docs>*
````

where it should read

````text
# install deps &lt;not-a-tag&gt; &amp;&amp; echo [docs](https://ex.com)
````

Whether Slack's own client then renders and copies that payload as literal code is Slack's documented mrkdwn contract, not something this repository can exercise.

## Gates

- `bun run test` in `plugins/plugin-slack` → 9 files, **188 tests passed**, `EXIT=0`.
- `bunx @biomejs/biome check` on the changed files → `EXIT=0`.
- `bunx tsc --noEmit -p tsconfig.json` → 130 errors, **byte-identical to the same command run with these changes stashed**. Every one is `Cannot find module '@elizaos/core'` from an unbuilt workspace on my machine (`--ignore-scripts` install), none from this change. Flagging it rather than reporting the gate green.

Thanks to @attentionhead for the differential harness and for pinning the unterminated-fence case.
