### PR TITLE
fix(ui): use truncateWellFormed for session lastActivity in startup hydrate

### DIFF
--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -4,7 +4,7 @@
  * after the shell can paint, then releases them when the phase is torn down.
  */
 
-import { MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core";
+import { MESSAGE_SOURCE_CLIENT_CHAT, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import {
   isRuntimeManagementOperation,
@@ -956,7 +956,7 @@ export function bindReadyPhase(
                     ...s,
                     status: "tool_running" as const,
                     toolDescription: td,
-                    lastActivity: `Running ${td}`.slice(0, 60),
+                    lastActivity: truncateWellFormed(toWellFormedUnicode(`Running ${td}`), 60),
                   }
                 : s,
             );
@@ -970,7 +970,7 @@ export function bindReadyPhase(
                     status: "active" as const,
                     toolDescription: undefined,
                     lastActivity: p
-                      ? `Approved: ${p}`.slice(0, 60)
+                      ? truncateWellFormed(toWellFormedUnicode(`Approved: ${p}`), 60)
                       : "Approved",
                   }
                 : s,
@@ -985,12 +985,16 @@ export function bindReadyPhase(
                     ...s,
                     status: "active" as const,
                     toolDescription: undefined,
-                    lastActivity: (esc
-                      ? `Escalated: ${r}`
-                      : r
-                        ? `Responded: ${r}`
-                        : "Responded"
-                    ).slice(0, 60),
+                    lastActivity: truncateWellFormed(
+                      toWellFormedUnicode(
+                        esc
+                          ? `Escalated: ${r}`
+                          : r
+                            ? `Responded: ${r}`
+                            : "Responded",
+                      ),
+                      60,
+                    ),
                   }
                 : s,
             );
@@ -1013,7 +1017,7 @@ export function bindReadyPhase(
                 ? {
                     ...s,
                     status: "error" as const,
-                    lastActivity: `Error: ${em}`.slice(0, 60),
+                    lastActivity: truncateWellFormed(toWellFormedUnicode(`Error: ${em}`), 60),
                   }
                 : s,
             );


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d2d7c03269041b56eb40d61d2e0e30d72bbc00f6 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/state/startup-phase-hydrate.ts`):
`bindReadyPhase` clamped session lastActivity strings using raw `.slice(0, 60)` during `tool_running`, `blocked_auto_resolved`, `coordination_decision`, and `error` events. When tool descriptions, prompts, reasoning, or error messages contain multi-code-unit UTF-16 surrogate pairs at index 60, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output during session lastActivity event formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
