### PR TITLE
fix(ui): use truncateWellFormed for ASR error reason and TTS fetch target debug formatting

### DIFF
--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Mic-capture recorder for local ASR: records mono PCM16, exposes a live analyser
  * for amplitude visualization, and stops/cancels the audio context cleanly.
@@ -445,10 +446,10 @@ export async function startLocalAsrRecorder(
   } catch (err) {
     voiceCaptureDebug("gum:err", {
       name: err instanceof Error ? err.name : "Error",
-      reason:
-        err instanceof Error
-          ? err.message.slice(0, 80)
-          : String(err).slice(0, 80),
+      reason: truncateWellFormed(
+        toWellFormedUnicode(err instanceof Error ? err.message : String(err)),
+        80,
+      ),
     });
     throw err;
   }

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Types, constants, and config interfaces for the voice chat system.
  */
@@ -466,7 +467,7 @@ export function describeTtsFetchTargetForDebug(target: string): string {
       return `${new URL(target).origin} (absolute)`;
     } catch {
       // error-policy:J3 unparseable target — show the raw string (debug-only)
-      return target.slice(0, 120);
+      return truncateWellFormed(toWellFormedUnicode(target), 120);
     }
   }
   const origin =


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:13caadf07618b1fdf49cc167d9c1e188f5f51189 -->

## Summary
In `@elizaos/ui`:
1. `describeTtsFetchTargetForDebug` (`packages/ui/src/voice/voice-chat-types.ts`) clamped unparseable TTS fetch target URLs using raw `target.slice(0, 120)`.
2. `startLocalAsrRecorder` (`packages/ui/src/voice/local-asr-capture.ts`) clamped `gum:err` debug breadcrumb reasons using raw `.slice(0, 80)`.

When error messages or target URLs contain multi-code-unit UTF-16 surrogate pairs at character clamp boundaries, raw slicing severed surrogate pairs.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core` across both voice modules.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/voice/voice-chat-types.asr-default.test.ts packages/ui/src/voice/local-asr-capture.test.ts` (35/35 passed).
- Verified well-formed Unicode output during TTS target display and ASR error debugging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
