### PR TITLE
fix(ui): use truncateWellFormed for table monograms in DatabaseView

### DIFF
--- a/packages/ui/src/components/pages/DatabaseView.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * The Database view (`/database`): browse the agent's SQL store — tables, rows,
  * and an ad-hoc query editor — behind a segmented Tables/SQL control.
@@ -459,7 +460,7 @@ export function DatabaseView({
             active={selectedTable === table.name}
             onClick={() => handleSelectTable(table.name)}
           >
-            {table.name.slice(0, 1).toUpperCase()}
+            {truncateWellFormed(toWellFormedUnicode(table.name), 1).toUpperCase()}
           </SidebarContent.RailItem>
         ))}
       >
@@ -497,7 +498,7 @@ export function DatabaseView({
                       <SidebarContent.ItemIcon
                         active={selectedTable === table.name}
                       >
-                        {table.name.slice(0, 1).toUpperCase()}
+                        {truncateWellFormed(toWellFormedUnicode(table.name), 1).toUpperCase()}
                       </SidebarContent.ItemIcon>
                       <SidebarContent.ItemBody>
                         <SidebarContent.ItemTitle>
@@ -731,7 +732,7 @@ export function DatabaseView({
                         <SidebarContent.ItemIcon
                           active={selectedTable === t.name}
                         >
-                          {t.name.slice(0, 1).toUpperCase()}
+                          {truncateWellFormed(toWellFormedUnicode(t.name), 1).toUpperCase()}
                         </SidebarContent.ItemIcon>
                         <SidebarContent.ItemBody>
                           <SidebarContent.ItemTitle>


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2a105cde37ba142535a3f564842245e7cbf291d1 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/pages/DatabaseView.tsx`):
Rail item icons and sidebar item icons for database tables extracted table monograms using raw `table.name.slice(0, 1).toUpperCase()` and `t.name.slice(0, 1).toUpperCase()`. When table names begin with multi-code-unit UTF-16 surrogate pairs, raw slicing severed the surrogate pair.

## Proposed Changes
1. Replaced raw `.slice(0, 1)` with `truncateWellFormed(toWellFormedUnicode(...), 1)` from `@elizaos/core`.

## Verification
- Verified well-formed Unicode output in table rail item and sidebar item monogram rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
