### PR TITLE
fix(ui): use truncateWellFormed for fallback avatar and logo initials

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/chat/public-chat-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/chat/public-chat-page.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Public shared-chat landing for a character. Fetches the redacted public
  * character from /api/characters/:ref/public (no-login funnel) and presents it
@@ -163,7 +164,7 @@ export default function PublicChatPage() {
           />
         ) : (
           <div className="mx-auto flex size-20 items-center justify-center rounded-full border border-border bg-bg-elevated text-2xl font-semibold text-muted">
-            {character.name.slice(0, 2).toUpperCase()}
+            {truncateWellFormed(toWellFormedUnicode(character.name), 2).toUpperCase()}
           </div>
         )}
         <div className="space-y-2">

--- a/packages/ui/src/cloud/public-pages/pages/payment/app-charge-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/app-charge-page.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Hosted public page for an app credit-charge request. Reads the charge +
  * owning app from /api/v1/apps/:appId/charges/:chargeId, then begins a
@@ -325,7 +326,7 @@ export default function AppChargePaymentPage() {
                 />
               ) : (
                 <div className="flex size-12 shrink-0 items-center justify-center border border-border bg-bg-elevated text-sm font-semibold text-muted">
-                  {details.app.name.slice(0, 2).toUpperCase()}
+                  {truncateWellFormed(toWellFormedUnicode(details.app.name), 2).toUpperCase()}
                 </div>
               )}
               <div className="min-w-0">

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /** Provider logo mapping — maps AI provider IDs to their logo image paths. */
 
 export {
@@ -147,7 +148,7 @@ export function getProviderLogo(
  * Creates a colored square with the provider's initials
  */
 function generateFallbackLogo(providerId: string): string {
-  const initials = providerId.slice(0, 2).toUpperCase();
+  const initials = truncateWellFormed(toWellFormedUnicode(providerId), 2).toUpperCase();
   const colors = ["3b82f6", "ef4444", "10b981", "f59e0b", "8b5cf6", "ec4899"];
   const colorIndex = providerId.charCodeAt(0) % colors.length;
   const bgColor = colors[colorIndex];


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7d38e26f511286175aaf8c37fbcf691fa13e4616 -->

## Summary
In `@elizaos/ui`:
1. `generateFallbackLogo` (`packages/ui/src/providers/index.ts`) extracted provider initials using raw `providerId.slice(0, 2)`.
2. Public character page (`packages/ui/src/cloud/public-pages/pages/chat/public-chat-page.tsx`) extracted character initials using raw `character.name.slice(0, 2)`.
3. Hosted charge payment page (`packages/ui/src/cloud/public-pages/pages/payment/app-charge-page.tsx`) extracted app initials using raw `details.app.name.slice(0, 2)`.

When names begin with multi-code-unit UTF-16 surrogate pairs, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Replaced raw `.slice(0, 2)` with `truncateWellFormed(toWellFormedUnicode(...), 2)` from `@elizaos/core` across all three modules.

## Verification
- Verified well-formed Unicode output in provider logo fallback and avatar initials rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
