### PR TITLE
fix(ui): use truncateWellFormed for sentence window splitting in voice playback

### DIFF
--- a/packages/ui/src/voice/voice-chat-playback.test.ts
+++ b/packages/ui/src/voice/voice-chat-playback.test.ts
@@ -3,7 +3,11 @@
  * text/actions vs plain). Pure function, no live TTS.
  */
 import { describe, expect, it } from "vitest";
-import { extractVoiceText, toSpeakableText } from "./voice-chat-playback";
+import {
+  extractVoiceText,
+  splitFirstSentence,
+  toSpeakableText,
+} from "./voice-chat-playback";
 
 describe("extractVoiceText", () => {
   it("extracts text from JSON assistant payloads", () => {
@@ -16,6 +20,15 @@ describe("extractVoiceText", () => {
     expect(
       extractVoiceText('{"actions":["BENCHMARK_ACTION"],"params":{"foo":1}}'),
     ).toBe("");
+  });
+});
+
+describe("splitFirstSentence", () => {
+  it("splits long sentence window safely when surrogate pairs appear near 180 chars", () => {
+    const text = "A".repeat(170) + " " + "B".repeat(8) + "🚀" + " " + "C".repeat(50);
+    const result = splitFirstSentence(text);
+    expect(result.firstSentence.isWellFormed()).toBe(true);
+    expect(result.remainder.isWellFormed()).toBe(true);
   });
 });
 

--- a/packages/ui/src/voice/voice-chat-playback.ts
+++ b/packages/ui/src/voice/voice-chat-playback.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Playback / TTS logic for voice chat — text processing, sentence splitting,
  * speech text extraction, and mouth animation helpers.
@@ -168,12 +169,12 @@ export function splitFirstSentence(text: string): {
   }
 
   if (value.length >= 180) {
-    const window = value.slice(0, 180);
+    const window = truncateWellFormed(toWellFormedUnicode(value), 180);
     const splitAt = window.lastIndexOf(" ");
     if (splitAt > 100) {
       return {
         complete: true,
-        firstSentence: window.slice(0, splitAt).trim(),
+        firstSentence: truncateWellFormed(window, splitAt).trim(),
         remainder: value.slice(splitAt).trim(),
       };
     }
@@ -232,10 +233,10 @@ export function queueableSpeechPrefix(text: string, isFinal: boolean): string {
   }
 
   if (value.length >= 180) {
-    const window = value.slice(0, 180);
+    const window = truncateWellFormed(toWellFormedUnicode(value), 180);
     const splitAt = window.lastIndexOf(" ");
     if (splitAt > 100) {
-      return window.slice(0, splitAt).trim();
+      return truncateWellFormed(window, splitAt).trim();
     }
   }
   return "";


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:65dba557cbd4a95b59d7a8c06c0317753462b2c2 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/voice/voice-chat-playback.ts`):
1. `splitFirstSentence` sliced long streaming text windows using raw `value.slice(0, 180)` and `window.slice(0, splitAt)`.
2. `queueableSpeechPrefix` sliced long speech prefixes using raw `value.slice(0, 180)` and `window.slice(0, splitAt)`.

When multi-code-unit UTF-16 surrogate pairs occur around the 180-character boundary or word boundaries, raw slicing severed the surrogate pairs, causing lone surrogate exceptions during speech synthesis.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.
2. Added unit test in `packages/ui/src/voice/voice-chat-playback.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/voice/voice-chat-playback.test.ts` (4/4 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
