### PR TITLE
fix(plugin-computeruse): use truncateWellFormed for session kind label formatting

### DIFF
--- a/plugins/plugin-computeruse/src/views/ComputerUseSessionsView.tsx
+++ b/plugins/plugin-computeruse/src/views/ComputerUseSessionsView.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Renders live computer-use sessions as a responsive monitor grid. It polls
  * authenticated snapshots and read-only frames, keeps failures visibly
@@ -232,7 +233,9 @@ function errorMessage(error: unknown): string {
 
 function kindLabel(kind: SessionKind): string {
   if (kind === "remote_guest") return "Remote guest";
-  return `${kind.slice(0, 1).toUpperCase()}${kind.slice(1)}`;
+  const wellFormed = toWellFormedUnicode(kind);
+  const head = truncateWellFormed(wellFormed, 1);
+  return `${head.toUpperCase()}${wellFormed.slice(head.length)}`;
 }
 
 function statusTone(status: SessionSnapshot["status"]): string {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c2ff0c7445c3dd65b86dcf59e34645e6c325f6fd -->

## Summary
In `@elizaos/plugin-computeruse` (`plugins/plugin-computeruse/src/views/ComputerUseSessionsView.tsx`):
`kindLabel` extracted session kind labels using raw `${kind.slice(0, 1).toUpperCase()}${kind.slice(1)}`. When session kind strings begin with multi-code-unit UTF-16 surrogate pairs, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(wellFormed, 1)` from `@elizaos/core` to extract the initial grapheme/code-unit safely without splitting astral surrogate pairs.

## Verification
- Verified well-formed Unicode output during session kind label formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
