### PR TITLE
fix(core): ensure maskSecretValue preserves UTF-16 surrogate integrity at visible boundaries

### DIFF
--- a/packages/core/src/features/secrets/actions/mask.test.ts
+++ b/packages/core/src/features/secrets/actions/mask.test.ts
@@ -37,4 +37,15 @@ describe("maskSecretValue", () => {
 		expect(masked.startsWith("xxxx")).toBe(true);
 		expect(masked.endsWith("xxxx")).toBe(true);
 	});
+
+	it("preserves surrogate pair integrity when emojis sit at 4-character boundaries", () => {
+		const secretWithEmojiStart = "abc🚀secret_tail_1234";
+		const maskedStart = maskSecretValue(secretWithEmojiStart);
+		expect(maskedStart.isWellFormed()).toBe(true);
+		expect(maskedStart.startsWith("abc")).toBe(true);
+
+		const secretWithEmojiEnd = "prefix_secret_123🚀";
+		const maskedEnd = maskSecretValue(secretWithEmojiEnd);
+		expect(maskedEnd.isWellFormed()).toBe(true);
+	});
 });

--- a/packages/core/src/features/secrets/actions/mask.ts
+++ b/packages/core/src/features/secrets/actions/mask.ts
@@ -1,14 +1,17 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "../../../utils/well-formed";
+
 /**
  * Mask a secret value for display.
  */
 export function maskSecretValue(value: string): string {
-	if (value.length <= 8) {
+	const wellFormed = toWellFormedUnicode(value);
+	if (wellFormed.length <= 8) {
 		return "****";
 	}
 
-	const visibleStart = value.slice(0, 4);
-	const visibleEnd = value.slice(-4);
-	const maskedLength = Math.min(value.length - 8, 20);
+	const visibleStart = truncateWellFormed(wellFormed, 4);
+	const visibleEnd = tailWellFormed(wellFormed, 4);
+	const maskedLength = Math.min(wellFormed.length - 8, 20);
 	const mask = "*".repeat(maskedLength);
 
 	return `${visibleStart}${mask}${visibleEnd}`;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:e09ca3a64a7f92e89e4a1964a13a9f482882af28 -->

## Summary
In `@elizaos/core` (`packages/core/src/features/secrets/actions/mask.ts`):
`maskSecretValue` sliced visible prefixes and suffixes with `value.slice(0, 4)` and `value.slice(-4)`. When secret values contain multi-code-unit UTF-16 surrogate pairs at the 4-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed(wellFormed, 4)`, and `tailWellFormed(wellFormed, 4)` from `packages/core/src/utils/well-formed.ts` to preserve surrogate pair integrity.
2. Added regression test in `packages/core/src/features/secrets/actions/mask.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/core/src/features/secrets/actions/mask.test.ts` (5/5 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
