### PR TITLE
fix(ui): use truncateWellFormed for string node preview in RuntimeView

### DIFF
--- a/packages/ui/src/components/pages/RuntimeView.tsx
+++ b/packages/ui/src/components/pages/RuntimeView.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Runtime inspector page: fetches a deep snapshot of the live AgentRuntime
  * (services, actions, providers, evaluators, plugins, and their registration
@@ -87,7 +88,11 @@ const SECTION_TAB_KEYS: Array<{
 function nodeSummary(value: unknown): string {
   if (value === null) return "null";
   if (typeof value === "string") {
-    const compact = value.length > 100 ? `${value.slice(0, 100)}...` : value;
+    const wellFormed = toWellFormedUnicode(value);
+    const compact =
+      wellFormed.length > 100
+        ? `${truncateWellFormed(wellFormed, 100)}...`
+        : wellFormed;
     return JSON.stringify(compact);
   }
   if (typeof value === "number" || typeof value === "boolean") {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c1d3a232c4abae016297326d77f0429a7ee70623 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/pages/RuntimeView.tsx`):
`nodeSummary` formatted long string values using raw `${value.slice(0, 100)}...`. When strings exceed 100 characters and contain multi-code-unit UTF-16 surrogate pairs at the 100-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(wellFormed, 100)` from `@elizaos/core` to ensure safe truncation.

## Verification
- Verified well-formed Unicode output during runtime debug tree node preview rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
