### PR TITLE
fix(ui): use truncateWellFormed for plugin monograms in plugin-list-utils

### DIFF
--- a/packages/ui/src/components/pages/plugin-list-utils.test.ts
+++ b/packages/ui/src/components/pages/plugin-list-utils.test.ts
@@ -10,6 +10,7 @@ import { Puzzle } from "lucide-react";
 import { describe, expect, it } from "vitest";
 import type { PluginInfo } from "../../api";
 import {
+  pluginMonogram,
   buildPluginListState,
   iconImageSource,
   resolveIcon,
@@ -194,5 +195,14 @@ describe("buildPluginListState", () => {
       "needs-config",
       "disabled",
     ]);
+  });
+});
+describe("pluginMonogram", () => {
+  it("preserves surrogate pair integrity for astral characters in plugin names", () => {
+    const monoSingle = pluginMonogram(plugin({ id: "p1", name: "🚀Rocket" }));
+    expect(monoSingle.isWellFormed()).toBe(true);
+
+    const monoMulti = pluginMonogram(plugin({ id: "p2", name: "🚀 Rocket" }));
+    expect(monoMulti.isWellFormed()).toBe(true);
   });
 });

--- a/packages/ui/src/components/pages/plugin-list-utils.ts
+++ b/packages/ui/src/components/pages/plugin-list-utils.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Plugin list utilities — pure functions, constants, and type aliases
  * shared across the plugin management UI.
@@ -611,13 +612,15 @@ function hashString(input: string): number {
 
 /** One- or two-character monogram for a plugin (skips leading punctuation). */
 export function pluginMonogram(plugin: PluginInfo): string {
-  const source = (plugin.name ?? plugin.id ?? "?").replace(/^[^a-z0-9]+/i, "");
+  const source = toWellFormedUnicode(plugin.name ?? plugin.id ?? "?").replace(/^[^a-z0-9]+/i, "");
   const words = source.split(/[\s_\-./]+/).filter(Boolean);
   if (words.length >= 2) {
-    return (words[0][0] + words[1][0]).toUpperCase();
+    const first = truncateWellFormed(words[0], 1);
+    const second = truncateWellFormed(words[1], 1);
+    return (first + second).toUpperCase();
   }
   const single = words[0] ?? source;
-  return single.slice(0, 2).toUpperCase() || "·";
+  return truncateWellFormed(single, 2).toUpperCase() || "·";
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f140ca983ebdeeb9abce8375d784b98e6625bc16 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/pages/plugin-list-utils.ts`):
`pluginMonogram` extracted single-word and multi-word monograms using raw string indexing `words[0][0] + words[1][0]` and `single.slice(0, 2)`. When plugin names contain multi-code-unit UTF-16 surrogate pairs, raw indexing and slicing severed surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` to extract individual characters and two-character prefixes safely without splitting astral surrogate pairs.
2. Added unit tests in `packages/ui/src/components/pages/plugin-list-utils.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/components/pages/plugin-list-utils.test.ts` (6/6 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
