### PR TITLE
fix(ui): use truncateWellFormed for fallback column type badges in database-utils

### DIFF
--- a/packages/ui/src/components/pages/database-utils.tsx
+++ b/packages/ui/src/components/pages/database-utils.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Presentational building blocks for `DatabaseView`: the results grid, a cell
  * value popover, the pagination bar, and the shared `DbView`/`SortDir` types.
@@ -58,7 +59,7 @@ function typeLabel(type: string): string {
     return "text";
   if (t.includes("vector")) return "vector";
   if (t.includes("bytea")) return "bytes";
-  return type.slice(0, 6);
+  return truncateWellFormed(toWellFormedUnicode(type), 6);
 }
 
 /** Semantic tone for column type badges. */


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:59b66e854c2ed8ef72e511c9e90c53a71746f3b8 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/pages/database-utils.tsx`):
`typeLabel` extracted fallback database column type labels using raw `type.slice(0, 6)`. When custom or dialect-specific column types contain multi-code-unit UTF-16 surrogate pairs at the 6-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(type), 6)` from `@elizaos/core` to ensure safe truncation.

## Verification
- Verified well-formed Unicode output during fallback database column type badge rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
