### PR TITLE
fix(ui): use truncateWellFormed for connector account initials in ConnectorAccountCard

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorAccountCard.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountCard.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Card for one connector account in the account-management list: shows
  * status/role/privacy, an editable label, and the per-account actions (set
@@ -151,12 +152,12 @@ function deriveStatus(
 }
 
 function initials(label: string): string {
-  const trimmed = label.trim();
+  const trimmed = toWellFormedUnicode(label).trim();
   if (!trimmed) return "?";
   return trimmed
     .split(/\s+/)
     .slice(0, 2)
-    .map((part) => part.charAt(0).toUpperCase())
+    .map((part) => truncateWellFormed(part, 1).toUpperCase())
     .join("");
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9544572d20fa79089f2d91a0c31b907b6ff1cc0e -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/connectors/ConnectorAccountCard.tsx`):
`initials` extracted initials for connector accounts using `part.charAt(0).toUpperCase()`. When account labels start with multi-code-unit UTF-16 surrogate pairs (e.g. emoji avatars or international symbols), `charAt(0)` sliced only the leading high surrogate, creating a broken lone surrogate.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(part, 1)` from `@elizaos/core` to extract initial graphemes/code units safely.

## Verification
- Verified well-formed Unicode output during connector account card initials generation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
