### PR TITLE
fix(ui): use truncateWellFormed for segment base keys in MessageContent

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -14,7 +14,7 @@
  * exports here drive their own mutations through the typed `ElizaClient`.
  */
 
-import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
+import { stripUnclaimedInteractionMarkup, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
 import { Check, ShieldCheck } from "lucide-react";
 import {
@@ -1594,9 +1594,9 @@ export function MessageContent({
         return segments.map((seg) => {
           const baseKey =
             seg.kind === "text"
-              ? `text:${seg.text.slice(0, 80)}`
+              ? `text:${truncateWellFormed(toWellFormedUnicode(seg.text), 80)}`
               : seg.kind === "code"
-                ? `code:${seg.code.slice(0, 80)}`
+                ? `code:${truncateWellFormed(toWellFormedUnicode(seg.code), 80)}`
                 : seg.kind === "config"
                   ? `config:${seg.pluginId}`
                   : seg.kind === "widget"
@@ -1606,7 +1606,7 @@ export function MessageContent({
                       ? `permission:${seg.payload.feature}`
                       : seg.kind === "analysis-xml"
                         ? `analysis:${seg.tag}`
-                        : `ui:${seg.raw.slice(0, 80)}`;
+                        : `ui:${truncateWellFormed(toWellFormedUnicode(seg.raw), 80)}`;
           const segmentKey = nextKey(baseKey);
 
           switch (seg.kind) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f1c2b08d7dfd533285f3ce9316678a5b17c884af -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/chat/MessageContent.tsx`):
Segment base keys for message body rendering clamped segment content using raw `.slice(0, 80)` for `text`, `code`, and `ui` segments. When segment content contains multi-code-unit UTF-16 surrogate pairs at the 80-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` to generate safe segment base keys.

## Verification
- Verified well-formed Unicode output during message segment key derivation and rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
