### PR TITLE
fix(ui): use truncateWellFormed for error detail preview in ModelDownloadWidget

### DIFF
--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Home widget with a real progress track for the recommended local model's
  * download (see the `ModelDownloadWidget` JSDoc below). `useLocalModelDownloads`
@@ -489,8 +490,8 @@ function ModelProgressCard({
 
 /** Keep the error detail meta tight so it never wraps the naked tile. */
 function truncateDetail(detail: string): string {
-  const trimmed = detail.trim();
-  return trimmed.length > 40 ? `${trimmed.slice(0, 39)}…` : trimmed;
+  const wellFormed = toWellFormedUnicode(detail).trim();
+  return wellFormed.length > 40 ? `${truncateWellFormed(wellFormed, 39)}…` : wellFormed;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:8e692bbe92ca2181a91669f9840a2f09a8239df1 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/chat/widgets/model-download.tsx`):
`truncateDetail` clamped error detail previews using raw `${trimmed.slice(0, 39)}…`. When error messages or localized strings contain multi-code-unit UTF-16 surrogate pairs around the 39-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(wellFormed, 39)` from `@elizaos/core` to generate safe error detail previews.

## Verification
- Verified well-formed Unicode output during model download tile error state rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
