### PR TITLE
fix(ui): use truncateWellFormed for fallback subagent session ID in task pipeline

### DIFF
--- a/packages/ui/src/components/chat/widgets/task-pipeline.tsx
+++ b/packages/ui/src/components/chat/widgets/task-pipeline.tsx
@@ -7,9 +7,11 @@
  * from `task-activity-store`; these components only render it — no fetching.
  */
 
-import type {
-  SwarmActivityPlanEntry,
-  SwarmActivityStatus,
+import {
+  type SwarmActivityPlanEntry,
+  type SwarmActivityStatus,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   CircleAlert,
@@ -229,7 +231,7 @@ export function SubagentBlock({ agent }: { agent: SubagentActivity }) {
       <div className="flex items-center gap-2">
         <StatusDot status={agent.status} />
         <span className="truncate text-sm font-medium text-txt">
-          {agent.label ?? agent.sessionId.slice(0, 8)}
+          {agent.label ?? truncateWellFormed(toWellFormedUnicode(agent.sessionId), 8)}
         </span>
         <span className={`text-xs ${STATUS_TONE[agent.status]}`}>
           {STATUS_LABEL[agent.status]}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:35facddd70efb08111f2588343b687ad85b9721e -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/chat/widgets/task-pipeline.tsx`):
`SubagentBlock` rendered fallback subagent identifiers using raw `agent.sessionId.slice(0, 8)`. When custom or simulated session identifiers contain multi-code-unit UTF-16 surrogate pairs at the 8-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 8)` from `@elizaos/core` to generate safe subagent session previews.

## Verification
- Verified well-formed Unicode output during subagent activity block rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
