### PR TITLE
fix(ui): use surrogate-safe truncation in cloud crypto address formatters

### DIFF
--- a/packages/ui/src/cloud/admin/RedemptionsPage.tsx
+++ b/packages/ui/src/cloud/admin/RedemptionsPage.tsx
@@ -1,3 +1,4 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * /cloud/admin/redemptions — review and approve token redemption requests.
  *
@@ -324,7 +325,9 @@ export default function RedemptionsPage(): React.JSX.Element {
 
   const truncateAddress = (address: string) => {
     if (!address) return "-";
-    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+    const wellFormed = toWellFormedUnicode(address);
+    if (wellFormed.length <= 10) return wellFormed;
+    return `${truncateWellFormed(wellFormed, 6)}...${tailWellFormed(wellFormed, 4)}`;
   };
 
   return (

--- a/packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx
+++ b/packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx
@@ -1,3 +1,4 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 "use client";
 
 /**
@@ -115,7 +116,9 @@ const NETWORK_LABELS: Record<DirectNetwork, string> = {
 
 function formatAddress(value: string | null | undefined) {
   if (!value) return "";
-  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(value);
+  if (wellFormed.length <= 10) return wellFormed;
+  return `${truncateWellFormed(wellFormed, 6)}...${tailWellFormed(wellFormed, 4)}`;
 }
 
 function bytesToBase64(bytes: Uint8Array): string {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:ac7d9d019056c86fae5308354b617157ce323c47 -->

## Summary
In `@elizaos/ui`:
1. `truncateAddress` in `packages/ui/src/cloud/admin/RedemptionsPage.tsx` formatted crypto addresses using raw `${address.slice(0, 6)}...${address.slice(-4)}`.
2. `formatAddress` in `packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx` formatted direct crypto card addresses using raw `${value.slice(0, 6)}...${value.slice(-4)}`.

When non-standard or simulated wallet addresses contain multi-code-unit UTF-16 surrogate pairs at head or tail boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed(wellFormed, 6)`, and `tailWellFormed(wellFormed, 4)` from `@elizaos/core` across both address formatters.

## Verification
- Verified well-formed Unicode output during cloud billing and admin redemption address formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
