### PR TITLE
fix(ui): use surrogate-safe truncation in cloud moderation admin views

### DIFF
--- a/packages/ui/src/cloud/admin/ModerationPage.tsx
+++ b/packages/ui/src/cloud/admin/ModerationPage.tsx
@@ -1,3 +1,4 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * /cloud/admin — moderation panel.
  *
@@ -347,7 +348,7 @@ export default function ModerationPage(): React.JSX.Element {
                           {new Date(v.createdAt).toLocaleString()}
                         </TableCell>
                         <TableCell className="text-xs">
-                          {v.userId.slice(0, 8)}...
+                          {truncateWellFormed(toWellFormedUnicode(v.userId), 8)}...
                         </TableCell>
                         <TableCell>
                           {v.categories.map((c) => (
@@ -423,7 +424,7 @@ export default function ModerationPage(): React.JSX.Element {
                         className="flex items-center justify-between rounded-sm border p-3"
                       >
                         <div>
-                          <p className="text-sm">{u.userId.slice(0, 12)}...</p>
+                          <p className="text-sm">{truncateWellFormed(toWellFormedUnicode(u.userId), 12)}...</p>
                           <div className="flex gap-2 text-xs text-muted-foreground">
                             <span>
                               {u.totalViolations}{" "}
@@ -498,7 +499,7 @@ export default function ModerationPage(): React.JSX.Element {
                         className="flex items-center justify-between rounded-sm border border-destructive/20 bg-destructive/5 p-3"
                       >
                         <div>
-                          <p className="text-sm">{u.userId.slice(0, 12)}...</p>
+                          <p className="text-sm">{truncateWellFormed(toWellFormedUnicode(u.userId), 12)}...</p>
                           <p className="text-xs text-muted-foreground">
                             {u.banReason ??
                               t("cloud.admin.noReasonProvided", {
@@ -577,8 +578,8 @@ export default function ModerationPage(): React.JSX.Element {
                     {admins.map((admin) => (
                       <TableRow key={admin.id}>
                         <TableCell className="text-sm">
-                          {admin.walletAddress.slice(0, 10)}...
-                          {admin.walletAddress.slice(-8)}
+                          {truncateWellFormed(toWellFormedUnicode(admin.walletAddress), 10)}...
+                          {tailWellFormed(toWellFormedUnicode(admin.walletAddress), 8)}
                         </TableCell>
                         <TableCell>
                           <Badge
@@ -753,7 +754,7 @@ export default function ModerationPage(): React.JSX.Element {
                       :
                     </span>{" "}
                     <span>
-                      {userDetail.user?.wallet_address?.slice(0, 10)}...
+                      {truncateWellFormed(toWellFormedUnicode(userDetail.user?.wallet_address ?? ""), 10)}...
                     </span>
                   </div>
                   <div>


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f550360098506e007f22f4fba4290e61b02294c0 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/cloud/admin/ModerationPage.tsx`):
User identifiers, admin wallet addresses, and flagged user IDs were clamped for display using raw `.slice(0, 8)`, `.slice(0, 10)`, `.slice(0, 12)`, and `.slice(-8)`. When identifiers or wallet strings contain multi-code-unit UTF-16 surrogate pairs, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed`, and `tailWellFormed` from `@elizaos/core` across all table and detail rows in `ModerationPage`.

## Verification
- Verified well-formed Unicode output during moderation admin table and user detail rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
