### PR TITLE
fix(ui): use truncateWellFormed for agent and job IDs in cloud instances views

### DIFF
--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Agent detail page (`/cloud/agents/:id`).
  */
@@ -30,7 +31,7 @@ export default function AgentDetailPage() {
   const enabled = session.ready && session.authenticated;
   const query = useAgent(enabled ? id : undefined);
 
-  const titleId = id ? id.slice(0, 8) : "";
+  const titleId = id ? truncateWellFormed(toWellFormedUnicode(id), 8) : "";
   useDocumentTitle(
     t("cloud.agents.detail.metaTitle", {
       defaultValue: "Agent {{id}} — Agents",

--- a/packages/ui/src/cloud/instances/components/agent-actions.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-actions.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * ElizaAgentActions — start/stop/deactivate/reactivate/upgrade/delete
  * controls on the agent detail page.
@@ -784,7 +785,7 @@ export function ElizaAgentActions({
                 {t("cloud.containers.agentActions.jobLabel", {
                   defaultValue: "Job",
                 })}{" "}
-                {upgradeJob.jobId.slice(0, 8)} • {upgradeJob.status}
+                {truncateWellFormed(toWellFormedUnicode(upgradeJob.jobId), 8)} • {upgradeJob.status}
               </p>
             )}
           </div>
@@ -828,7 +829,7 @@ export function ElizaAgentActions({
                 {t("cloud.containers.agentActions.jobLabel", {
                   defaultValue: "Job",
                 })}{" "}
-                {trackedJob.jobId.slice(0, 8)} • {trackedJob.status}
+                {truncateWellFormed(toWellFormedUnicode(trackedJob.jobId), 8)} • {trackedJob.status}
               </p>
             )}
           </div>

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Eliza Agents Table — lists hosted agent sandboxes on the Instances page.
  * Auto-refreshes while any sandbox is in an active (pending/provisioning) state.
@@ -327,7 +328,7 @@ function StatusCell({
         <span className="text-2xs text-muted flex items-center gap-1 pl-0.5">
           <Loader2 className="size-2.5 animate-spin" />
           {t("cloud.elizaAgentsTable.jobLabel", {
-            jobId: trackedJob.jobId.slice(0, 8),
+            jobId: truncateWellFormed(toWellFormedUnicode(trackedJob.jobId), 8),
             defaultValue: "Job {{jobId}}",
           })}
         </span>


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2b1d3b194c1455bd744a7375dba645ef34c05a08 -->

## Summary
In `@elizaos/ui`:
1. `AgentDetailPage` (`packages/ui/src/cloud/instances/AgentDetailPage.tsx`) formatted document title agent IDs using raw `id.slice(0, 8)`.
2. `ElizaAgentActions` (`packages/ui/src/cloud/instances/components/agent-actions.tsx`) formatted upgrade and tracked job labels using raw `.slice(0, 8)`.
3. `ElizaAgentsTable` (`packages/ui/src/cloud/instances/components/eliza-agents-table.tsx`) formatted provisioning job labels using raw `.slice(0, 8)`.

When agent or job identifiers contain multi-code-unit UTF-16 surrogate pairs at the 8-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 8)` from `@elizaos/core` across all three cloud instance components.

## Verification
- Verified well-formed Unicode output during agent detail meta title and hosted instance job badge rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
