### PR TITLE
fix(ui): use truncateWellFormed for iOS conversation titles in handleIosLocalAgentRequest

### DIFF
--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * In-renderer fetch kernel for the iOS local agent: services a subset of routes
  * (market data, steward session) directly in the webview when the full-bun agent
@@ -4037,7 +4038,7 @@ export async function handleIosLocalAgentRequest(
       };
       conversation.messages.push(userMessage);
       if (conversation.title === "New chat") {
-        conversation.title = text.slice(0, 60) || conversation.title;
+        conversation.title = truncateWellFormed(toWellFormedUnicode(text), 60) || conversation.title;
       }
       const reply = await generateLocalReply(conversation, text);
       const assistantMessage: LocalMessage = {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b259dc95fb12e20ecc1e9304068bde7decd3ecf4 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/api/ios-local-agent-kernel.ts`):
`handleIosLocalAgentRequest` derived default conversation titles from first messages using raw `text.slice(0, 60)`. When first user messages contain multi-code-unit UTF-16 surrogate pairs at the 60-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(text), 60)` from `@elizaos/core` to generate safe conversation titles.

## Verification
- Verified well-formed Unicode output during iOS local agent webview kernel conversation title derivation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
