### PR TITLE
fix(ui): use truncateWellFormed in normalizeBaseUrl in client-base

### DIFF
--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * ElizaClient class — core infrastructure only.
  *
@@ -267,10 +268,12 @@ type StreamChatState = {
 };
 
 function normalizeBaseUrl(value: string | null | undefined): string {
-  const trimmed = value?.slice(0, 4096).trim() ?? "";
+  if (!value) return "";
+  const wellFormed = toWellFormedUnicode(value);
+  const trimmed = truncateWellFormed(wellFormed, 4096).trim();
   let end = trimmed.length;
   while (end > 0 && trimmed.charCodeAt(end - 1) === 47) end--;
-  return trimmed.slice(0, end);
+  return truncateWellFormed(trimmed, end);
 }
 
 function isElizaCloudControlPlaneBase(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:62e00ba1766436731722507cea988b393a47e28e -->

## Summary
In `@elizaos/ui` (`packages/ui/src/api/client-base.ts`):
`normalizeBaseUrl` clamped input base URLs using raw `value?.slice(0, 4096)`. When malformed or custom URLs contain multi-code-unit UTF-16 surrogate pairs at the 4096-character limit, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(wellFormed, 4096)` from `@elizaos/core` to ensure safe normalization.

## Verification
- Verified well-formed Unicode output during base URL sanitization in `normalizeBaseUrl`.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
