### PR TITLE
fix(ui): use truncateWellFormed for execution IDs in WorkflowEditor

### DIFF
--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Native Smithers workflow studio for source authoring, visual structure,
  * widgets, revisions, and live run inspection through elizaOS Cloud APIs.
@@ -701,7 +702,7 @@ export function WorkflowEditor({
                     <span className="sr-only">{execution.status}</span>
                   </span>
                   <span className="min-w-0 flex-1 truncate font-mono text-2xs text-muted-foreground">
-                    {execution.id.slice(0, 12)}
+                    {truncateWellFormed(toWellFormedUnicode(execution.id), 12)}
                   </span>
                   <span className="text-2xs text-muted-foreground/70">
                     {new Date(execution.startedAt).toLocaleTimeString([], {
@@ -733,7 +734,7 @@ export function WorkflowEditor({
                     <span className="sr-only">{selectedRun.status}</span>
                   </span>
                   <span className="font-mono text-xs text-muted-foreground">
-                    {selectedRun.id.slice(0, 12)}
+                    {truncateWellFormed(toWellFormedUnicode(selectedRun.id), 12)}
                   </span>
                   <div className="flex-1" />
                   {!terminal(selectedRun.status) ? (


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:89ac6fe300b44047de9b6ed58b7f977e29e9a8c4 -->

## Summary
In `@elizaos/ui` (`packages/ui/src/components/pages/WorkflowEditor.tsx`):
`WorkflowEditor` formatted execution run identifiers in the sidebar runs list and header detail view using raw `execution.id.slice(0, 12)` and `selectedRun.id.slice(0, 12)`. When execution identifiers contain multi-code-unit UTF-16 surrogate pairs at the 12-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 12)` from `@elizaos/core` to generate safe execution ID previews.

## Verification
- Verified well-formed Unicode output during workflow execution runs list and inspector header rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
