### PR TITLE
fix(shared): use truncateWellFormed in interpolateString for long config templates

### DIFF
--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -6,6 +6,7 @@
 import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
+  interpolateString,
   builtInValidators,
   evaluateFieldVisibility,
   evaluateLogicExpression,
@@ -572,5 +573,14 @@ describe("evaluateLogicExpression budget", () => {
         {},
       ),
     ).toThrowError(ElizaError);
+  });
+});
+
+describe("interpolateString", () => {
+  it("interpolates path values and preserves surrogate pair integrity beyond 100_000 chars", () => {
+    const big = "A".repeat(99_999) + "🚀" + "{{/name}}";
+    const out = interpolateString(big, { name: "World" });
+    expect(out.isWellFormed()).toBe(true);
+    expect(out.startsWith("A".repeat(99_999))).toBe(true);
   });
 });

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Plugin config catalog & registry — reverse-engineered from vercel-labs/json-render.
  *
@@ -326,8 +327,11 @@ export function interpolateString(
   template: string,
   context: Record<string, unknown>,
 ): string {
+  const wellFormed = toWellFormedUnicode(template);
   const safeTemplate =
-    template.length > 100_000 ? template.slice(0, 100_000) : template;
+    wellFormed.length > 100_000
+      ? truncateWellFormed(wellFormed, 100_000)
+      : wellFormed;
   return safeTemplate.replace(/\{\{([^}]{1,1024})\}\}/g, (_, path) => {
     const value = getByPath(
       context,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1b16474aa282adcf781b8559ad25dc7e7e4d55b8 -->

## Summary
In `@elizaos/shared` (`packages/shared/src/config/config-catalog.ts`):
`interpolateString` clamped oversized template strings using raw `template.slice(0, 100_000)`. When template strings contain multi-code-unit UTF-16 surrogate pairs at the 100_000-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(wellFormed, 100_000)` from `@elizaos/core` to ensure safe template bounds.
2. Added unit tests in `packages/shared/src/config/config-catalog.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/config/config-catalog.test.ts` (64/64 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
