### PR TITLE
fix(shared): use truncateWellFormed in normalizeMalformedCandidate in base-url

### DIFF
--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -66,6 +66,13 @@ describe("Eliza Cloud base URL normalization", () => {
     ).toBe("https://127.999.999.999:8080");
   });
 
+
+  it("preserves surrogate pair integrity when malformed candidate exceeds 8192 chars", () => {
+    const raw = "http://bad.domain.example.com/" + "A".repeat(8160) + "🚀" + "/api/v1";
+    const out = normalizeCloudSiteUrl(raw);
+    expect(out.isWellFormed()).toBe(true);
+  });
+
   it("prefers isolated env override over raw URL", () => {
     process.env.ELIZAOS_CLOUD_BASE_URL =
       "http://env.example.com:8080/api/v1?debug=1";

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Pure URL normalizer for Eliza Cloud site/API base URLs. No host-layer deps.
  */
@@ -83,8 +84,9 @@ function trimApiPath(pathname: string): string {
 }
 
 function normalizeMalformedCandidate(candidate: string): string {
+  const wellFormed = toWellFormedUnicode(candidate);
   const truncated =
-    candidate.length > 8192 ? candidate.slice(0, 8192) : candidate;
+    wellFormed.length > 8192 ? truncateWellFormed(wellFormed, 8192) : wellFormed;
   const withoutFragment = truncated.split("#", 1)[0] ?? "";
   const withoutQuery = withoutFragment.split("?", 1)[0] ?? "";
   const withoutApiPath = withoutQuery.replace(/\/api\/v1\/?$/i, "");


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:4a3dabe5d65b227294ea0e77a28cceac3b782ead -->

## Summary
In `@elizaos/shared` (`packages/shared/src/elizacloud/base-url.ts`):
`normalizeMalformedCandidate` clamped candidate base URL strings using raw `candidate.slice(0, 8192)`. When malformed or custom candidate strings contain multi-code-unit UTF-16 surrogate pairs at the 8192-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(wellFormed, 8192)` from `@elizaos/core` to generate safe URL candidates.
2. Added unit tests in `packages/shared/src/elizacloud/base-url.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/elizacloud/base-url.test.ts` (14/14 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
