### PR TITLE
fix(shared): use truncateWellFormed for decoded Teams nativeMeetingId in parseMeetingUrl

### DIFF
--- a/packages/shared/src/meetings.test.ts
+++ b/packages/shared/src/meetings.test.ts
@@ -72,4 +72,9 @@ describe("parseMeetingUrl", () => {
     expect(parseMeetingUrl("https://example.com/not-a-meeting")).toBeNull();
     expect(parseMeetingUrl("")).toBeNull();
   });
+  it("preserves surrogate pair integrity when decoded Teams id exceeds 128 chars", () => {
+    const raw = "https://teams.microsoft.com/l/meetup-join/" + "a".repeat(127) + "%F0%9F%9A%80" + "/0";
+    const parsed = parseMeetingUrl(raw);
+    expect(parsed?.nativeMeetingId?.isWellFormed()).toBe(true);
+  });
 });

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Meetings — the canonical contract for agent-attended meetings.
  *
@@ -274,7 +275,7 @@ export function parseMeetingUrl(raw: string): ParsedMeetingUrl | null {
     return {
       platform: "teams",
       meetingUrl: url,
-      nativeMeetingId: decoded.slice(0, 128),
+      nativeMeetingId: truncateWellFormed(toWellFormedUnicode(decoded), 128),
     };
   }
   return null;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9a92daa7f45d004cf8adfbaa2d75b78b8163a0b6 -->

## Summary
In `@elizaos/shared` (`packages/shared/src/meetings.ts`):
`parseMeetingUrl` extracted Teams native meeting IDs from decoded URI path segments using raw `decoded.slice(0, 128)`. When percent-decoded identifiers contain multi-code-unit UTF-16 surrogate pairs at the 128-character limit, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 128)` from `@elizaos/core` to generate safe Teams native meeting IDs.
2. Added unit tests in `packages/shared/src/meetings.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/meetings.test.ts` (8/8 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
