### PR TITLE
fix(shared): use surrogate-safe unicode iteration for monograms in getAppHeroMonogram

### DIFF
--- a/packages/shared/src/app-hero-art.test.ts
+++ b/packages/shared/src/app-hero-art.test.ts
@@ -32,6 +32,9 @@ describe("app-hero-art", () => {
       "CS",
     );
     expect(getAppHeroMonogram({ name: "" })).toBe("?");
+    expect(getAppHeroMonogram({ name: "🚀 Rocket App" })).toBe("🚀R");
+    expect(getAppHeroMonogram({ name: "🛸" })).toBe("🛸");
+
   });
 
   it("categorizes apps into appropriate theme keys", () => {

--- a/packages/shared/src/app-hero-art.ts
+++ b/packages/shared/src/app-hero-art.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Deterministically derives hero artwork (theme + gradient) for an app from its
  * name/category so every app gets stable, distinct placeholder art without a
@@ -85,13 +86,14 @@ export function getAppHeroDisplayLabel(app: AppHeroArtworkSource): string {
 }
 
 export function getAppHeroMonogram(app: AppHeroArtworkSource): string {
-  const label = trimPackagePrefix(app.displayName ?? app.name);
+  const label = toWellFormedUnicode(trimPackagePrefix(app.displayName ?? app.name));
   const words = label.split(/[\s._/-]+/).filter(Boolean);
   const initials = words
     .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? "")
+    .map((word) => Array.from(word)[0]?.toUpperCase() ?? "")
     .join("");
-  return (initials || label.slice(0, 2).toUpperCase() || "?").slice(0, 2);
+  const fallback = Array.from(label).slice(0, 2).join("").toUpperCase() || "?";
+  return initials || fallback;
 }
 
 export function getAppHeroThemeKey(app: AppHeroArtworkSource): AppHeroThemeKey {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:e4018811bcb419996fadf05d407b7018a4c8d7f6 -->

## Summary
In `@elizaos/shared` (`packages/shared/src/app-hero-art.ts`):
`getAppHeroMonogram` extracted monograms using raw string indexing `word[0]` and `label.slice(0, 2)`. When app names or display labels begin with astral Unicode characters (such as emojis or multi-code-unit symbols), raw string indexing severed the UTF-16 surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode` and Unicode-aware iteration (`Array.from(...)`) to extract initials and fallback monogram strings without splitting surrogate pairs.
2. Added unit tests in `packages/shared/src/app-hero-art.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/app-hero-art.test.ts` (5/5 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
