### PR TITLE
fix(shared): use surrogate-safe truncation in sanitizeApiKey

### DIFF
--- a/packages/shared/src/voice.test.ts
+++ b/packages/shared/src/voice.test.ts
@@ -17,6 +17,9 @@ describe("voice", () => {
     expect(sanitizeApiKey("short")).toBe("short");
     expect(sanitizeApiKey("  key123456789  ")).toContain("...");
     expect(sanitizeApiKey("[REDACTED]")).toBe("[REDACTED]");
+    expect(sanitizeApiKey("🔑🔑🔑🔑secret🔑🔑🔑🔑")).toBe("🔑🔑...🔑🔑");
+    expect(sanitizeApiKey("key_🚀_value_🛰️")?.isWellFormed()).toBe(true);
+
   });
   it("checks configured", () => {
     expect(hasConfiguredApiKey("abc")).toBe(true);

--- a/packages/shared/src/voice.ts
+++ b/packages/shared/src/voice.ts
@@ -1,3 +1,4 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * Shared voice contracts and voice-selection data consumed across runtime,
  * cloud, plugins, and UI surfaces.
@@ -39,11 +40,12 @@ export interface VoicePreset {
 export function sanitizeApiKey(apiKey: string | undefined): string | undefined {
   if (!apiKey) return apiKey;
   if (apiKey === "[REDACTED]") return apiKey;
+  const wellFormed = toWellFormedUnicode(apiKey);
   // If the key is long enough to be real, mask the middle
-  if (apiKey.length > 8) {
-    return `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`;
+  if (wellFormed.length > 8) {
+    return `${truncateWellFormed(wellFormed, 4)}...${tailWellFormed(wellFormed, 4)}`;
   }
-  return apiKey;
+  return wellFormed;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:4a795935488311c3eaf1f4b393324277a520d63a -->

## Summary
In `@elizaos/shared` (`packages/shared/src/voice.ts`):
`sanitizeApiKey` masked API keys longer than 8 characters using raw `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`. When custom, tokenized, or test keys contain multi-code-unit UTF-16 surrogate pairs at head or tail boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed(wellFormed, 4)`, and `tailWellFormed(wellFormed, 4)` from `@elizaos/core` to generate safe masked keys.
2. Added unit tests in `packages/shared/src/voice.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/shared/src/voice.test.ts` (3/3 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
