### PR TITLE
fix(agent): use truncateWellFormed for cloudApiKeyFingerprint in runtime/eliza

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * elizaOS runtime entry point for Eliza.
  *
@@ -2346,9 +2347,9 @@ export function bindCloudGithubTokenToRuntime(
  * mean "yes, a 31-char placeholder" without the log showing it.
  */
 export function cloudApiKeyFingerprint(value: string | undefined): string {
-  const v = value?.trim();
+  const v = value ? toWellFormedUnicode(value).trim() : "";
   if (!v) return "(none)";
-  return `${v.slice(0, 6)}…(len ${v.length})`;
+  return `${truncateWellFormed(v, 6)}…(len ${v.length})`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c9a181a9dc5b7f7d4568359151e311728ed902d1 -->

## Summary
In `@elizaos/agent` (`packages/agent/src/runtime/eliza.ts`):
`cloudApiKeyFingerprint` logged cloud API key prefix fingerprints using raw `v.slice(0, 6)`. When test tokens or custom cloud credentials contain multi-code-unit UTF-16 surrogate pairs at the 6-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(v, 6)` from `@elizaos/core` to generate safe fingerprint logs.

## Verification
- Verified well-formed Unicode output during runtime cloud configuration logging and fingerprint derivation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
