### PR TITLE
fix(agent): use surrogate-safe truncation in maskSecret and shortenMint in api/wallet

### DIFF
--- a/packages/agent/src/api/wallet-mask-secret.test.ts
+++ b/packages/agent/src/api/wallet-mask-secret.test.ts
@@ -33,3 +33,28 @@ describe("maskSecret", () => {
     expect(masked).toBe("sk-M...MEND"); // first4 "sk-M" + last4 "MEND"
   });
 });
+
+describe("maskSecret surrogate safety", () => {
+  const ROCKET = "\u{1F680}";
+  it("backs off an astral pair straddling the visible-start boundary", () => {
+    const masked = maskSecret(`012${ROCKET}3456789abcdefghij`);
+    expect(masked.isWellFormed()).toBe(true);
+    expect(masked.startsWith("012...")).toBe(true);
+  });
+
+  it("backs off an astral pair straddling the visible-end boundary", () => {
+    const masked = maskSecret(`0123456789abcdefg${ROCKET}hij`);
+    expect(masked.isWellFormed()).toBe(true);
+    expect(masked.endsWith("...hij")).toBe(true);
+  });
+
+  it("keeps a fitting astral pair intact at both boundaries", () => {
+    const masked = maskSecret(`${ROCKET}123456789abcdef${ROCKET}`);
+    expect(masked.isWellFormed()).toBe(true);
+  });
+
+  it("sanitizes a pre-existing lone surrogate", () => {
+    const masked = maskSecret("0123\uD83D456789abcdefghij");
+    expect(masked.isWellFormed()).toBe(true);
+  });
+});

--- a/packages/agent/src/api/wallet.ts
+++ b/packages/agent/src/api/wallet.ts
@@ -9,7 +9,7 @@
  */
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { logger, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   KeyValidationResult,
   SolanaTokenBalance,
@@ -460,8 +460,9 @@ export function validatePrivateKey(key: string): KeyValidationResult {
 
 /** Mask a secret string for safe display (e.g. logs, UI). */
 export function maskSecret(value: string): string {
-  if (!value || value.length <= 8) return "****";
-  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(value ?? "");
+  if (!wellFormed || wellFormed.length <= 8) return "****";
+  return `${truncateWellFormed(wellFormed, 4)}...${tailWellFormed(wellFormed, 4)}`;
 }
 
 // ── Key generation ────────────────────────────────────────────────────
@@ -849,8 +850,9 @@ interface SolanaDexMeta {
 }
 
 function shortenMint(mint: string): string {
-  if (mint.length <= 10) return mint;
-  return `${mint.slice(0, 4)}...${mint.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(mint ?? "");
+  if (wellFormed.length <= 10) return wellFormed;
+  return `${truncateWellFormed(wellFormed, 4)}...${tailWellFormed(wellFormed, 4)}`;
 }
 
 async function fetchSolanaDexMeta(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b1ac7338aeda03ad4514b6c2c4113f5c8900d68a -->

## Summary
In `@elizaos/agent` (`packages/agent/src/api/wallet.ts`):
1. `maskSecret` masked secrets longer than 8 characters using raw `${value.slice(0, 4)}...${value.slice(-4)}`.
2. `shortenMint` shortened Solana mint addresses using raw `${mint.slice(0, 4)}...${mint.slice(-4)}`.

When custom secret tokens, seed phrases, or test mint addresses contain multi-code-unit UTF-16 surrogate pairs at head or tail boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed(..., 4)`, and `tailWellFormed(..., 4)` from `@elizaos/core` across both masking and mint-shortening functions.

## Verification
- Verified well-formed Unicode output during wallet secret masking and token mint abbreviation.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
