### PR TITLE
fix(agent): use surrogate-safe truncation for short wallet addresses in agent-status-routes

### DIFF
--- a/packages/agent/src/api/agent-status-routes.ts
+++ b/packages/agent/src/api/agent-status-routes.ts
@@ -3,7 +3,7 @@
  */
 
 import type http from "node:http";
-import type { AgentRuntime, ReadJsonBodyOptions } from "@elizaos/core";
+import { type AgentRuntime, type ReadJsonBodyOptions, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { TradePermissionMode } from "@elizaos/shared";
 import {
   PostRegistryRegisterRequestSchema,
@@ -227,12 +227,12 @@ export async function handleAgentStatusRoutes(
         evmAddress,
         evmAddressShort:
           evmAddress && evmAddress.length >= 12
-            ? `${evmAddress.slice(0, 6)}...${evmAddress.slice(-4)}`
+            ? `${truncateWellFormed(toWellFormedUnicode(evmAddress), 6)}...${tailWellFormed(toWellFormedUnicode(evmAddress), 4)}`
             : evmAddress,
         solanaAddress: addrs.solanaAddress ?? null,
         solanaAddressShort:
           addrs.solanaAddress && addrs.solanaAddress.length >= 12
-            ? `${addrs.solanaAddress.slice(0, 4)}...${addrs.solanaAddress.slice(-4)}`
+            ? `${truncateWellFormed(toWellFormedUnicode(addrs.solanaAddress), 4)}...${tailWellFormed(toWellFormedUnicode(addrs.solanaAddress), 4)}`
             : (addrs.solanaAddress ?? null),
         localSignerAvailable: capability.localSignerAvailable,
         managedBscRpcReady: bscRpcReady,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:6d87c76db99ef2c04328c4b38dd8b4a3fbd9efe9 -->

## Summary
In `@elizaos/agent` (`packages/agent/src/api/agent-status-routes.ts`):
`handleAgentStatusRoutes` formatted short EVM and Solana wallet address responses (`evmAddressShort` and `solanaAddressShort`) using raw `.slice(0, 6)`, `.slice(0, 4)`, and `.slice(-4)`. When test keys or custom wallet addresses contain multi-code-unit UTF-16 surrogate pairs at head or tail boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed`, and `tailWellFormed` from `@elizaos/core` to generate safe short address strings.

## Verification
- Verified well-formed Unicode output during agent status route wallet payload construction.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
