### PR TITLE
fix(agent): use surrogate-safe truncation for tokenFingerprint in server-helpers-auth

### DIFF
--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -4,7 +4,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
-import { logger } from "@elizaos/core";
+import { logger, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   isCloudProvisionedContainer,
   isLoopbackBindHost,
@@ -515,7 +515,7 @@ export function ensureApiTokenForBindHost(host: string): void {
       `[eliza-api] ELIZA_API_BIND=${host} is non-loopback and ELIZA_API_TOKEN is unset.`,
     );
   }
-  const tokenFingerprint = `${generated.slice(0, 4)}...${generated.slice(-4)}`;
+  const tokenFingerprint = `${truncateWellFormed(toWellFormedUnicode(generated), 4)}...${tailWellFormed(toWellFormedUnicode(generated), 4)}`;
   logger.warn(
     `[eliza-api] Generated temporary API token (${tokenFingerprint}) for this process. Set ELIZA_API_TOKEN explicitly to override.`,
   );


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2ef66531b756b7d701d7750944a820868204d372 -->

## Summary
In `@elizaos/agent` (`packages/agent/src/api/server-helpers-auth.ts`):
`ensureApiTokenForBindHost` generated token log fingerprints using raw `${generated.slice(0, 4)}...${generated.slice(-4)}`. When random tokens contain multi-code-unit UTF-16 surrogate pairs at head or tail boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed(..., 4)`, and `tailWellFormed(..., 4)` from `@elizaos/core` to generate safe token fingerprints.

## Verification
- Verified well-formed Unicode output during server auth bootstrap token fingerprint logging.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
