### PR TITLE
fix(agent): use truncateWellFormed for safeDisplay in validateSkillId in server-helpers-config

### DIFF
--- a/packages/agent/src/api/server-helpers-config.ts
+++ b/packages/agent/src/api/server-helpers-config.ts
@@ -4,7 +4,7 @@
 
 import type http from "node:http";
 import path from "node:path";
-import { ElizaError, logger, sendJsonError } from "@elizaos/core";
+import { ElizaError, logger, sendJsonError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   getDefaultStylePreset,
   getStylePresets,
@@ -280,7 +280,7 @@ export function validateSkillId(
     skillId === "." ||
     skillId.includes("..")
   ) {
-    const safeDisplay = skillId.slice(0, 80).replace(/[^\x20-\x7e]/g, "?");
+    const safeDisplay = truncateWellFormed(toWellFormedUnicode(skillId), 80).replace(/[^\x20-\x7e]/g, "?");
     sendJsonError(res, `Invalid skill ID: "${safeDisplay}"`, 400);
     return null;
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:572c7a4b9570778d70df01d74eab815c2aab42b5 -->

## Summary
In `@elizaos/agent` (`packages/agent/src/api/server-helpers-config.ts`):
`validateSkillId` formatted error response preview strings using raw `skillId.slice(0, 80)`. When invalid skill IDs contain multi-code-unit UTF-16 surrogate pairs at the 80-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 80)` from `@elizaos/core` to generate safe error message displays.

## Verification
- Verified well-formed Unicode output during invalid skill identifier error sanitization.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
