### PR TITLE
fix(agent): use truncateWellFormed for stepId in reportLateTrajectoryCapture

### DIFF
--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -10,6 +10,8 @@ import path from "node:path";
 import {
   canonicalPromptForModelCall,
   composeToolDiagnosticRedactor,
+  toWellFormedUnicode,
+  truncateWellFormed,
   logger as coreLogger,
   ElizaError,
   type IAgentRuntime,
@@ -183,7 +185,7 @@ function reportLateTrajectoryCapture(
   entry.rejects += 1;
   const ageMs = Date.now() - entry.closedAt;
   const age = `${Math.round(ageMs / 1000)}s`;
-  const detail = `step=${stepId.slice(0, 12)} type=${captureType} purpose=${purpose ?? "unknown"} age=${age}`;
+  const detail = `step=${truncateWellFormed(toWellFormedUnicode(stepId), 12)} type=${captureType} purpose=${purpose ?? "unknown"} age=${age}`;
   // The voice-gate rephrase races its own turn's terminalization by design
   // (delivery does not wait for the diagnostic copy); a same-instant reject
   // is expected once per racy turn and had the overnight watch paging on


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1fcefb2d28917bda4ca859f27215c9e5ac1dfeca -->

## Summary
In `@elizaos/agent` (`packages/agent/src/runtime/trajectory-storage.ts`):
`reportLateTrajectoryCapture` formatted trajectory step diagnostic details using raw `stepId.slice(0, 12)`. When step identifiers contain multi-code-unit UTF-16 surrogate pairs at the 12-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 12)` from `@elizaos/core` to generate safe step diagnostic logs.

## Verification
- Verified well-formed Unicode output during trajectory diagnostic capture reporting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
