### PR TITLE
fix(agent): use truncateWellFormed in sanitizeToken in integration-observability

### DIFF
--- a/packages/agent/src/diagnostics/integration-observability.test.ts
+++ b/packages/agent/src/diagnostics/integration-observability.test.ts
@@ -106,4 +106,18 @@ describe("integration-observability", () => {
     expect(loggerMock.info).toHaveBeenCalledTimes(1);
     expect(loggerMock.warn).not.toHaveBeenCalled();
   });
+
+  it("preserves surrogate integrity when error message exceeds 1024 characters", () => {
+    const loggerMock = { info: vi.fn(), warn: vi.fn() };
+    const span = createIntegrationTelemetrySpan(
+      { boundary: "cloud", operation: "sync" },
+      { sink: loggerMock },
+    );
+    const huge = "err_" + "a".repeat(1020) + "🚀" + "_failed";
+    span.failure({ error: huge });
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+    const line = loggerMock.warn.mock.calls[0][0] as string;
+    expect(line.isWellFormed()).toBe(true);
+  });
+
 });

--- a/packages/agent/src/diagnostics/integration-observability.ts
+++ b/packages/agent/src/diagnostics/integration-observability.ts
@@ -5,7 +5,7 @@
  * failure, and emits a single `[integration]` JSON line to the logger — at info
  * level for successes and known-transient failures, at warn level otherwise.
  */
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 export type IntegrationBoundary =
   | "cloud"
@@ -79,12 +79,14 @@ function inferErrorKind(error: unknown): string | undefined {
 
 function sanitizeToken(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const safe = value.length > 1024 ? value.slice(0, 1024) : value;
+  const wellFormed = toWellFormedUnicode(value);
+  const safe =
+    wellFormed.length > 1024 ? truncateWellFormed(wellFormed, 1024) : wellFormed;
   const token = safe.toLowerCase().replace(/[^a-z0-9_-]/g, "_");
   const normalized = token
     .replace(/_{1,1024}/g, "_")
     .replace(/^_{1,1024}|_{1,1024}$/g, "");
-  return normalized ? normalized.slice(0, 64) : undefined;
+  return normalized ? truncateWellFormed(normalized, 64) : undefined;
 }
 
 function emitEvent(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3eadd3b8c51004c1c8192af2a2c157619315922c -->

## Summary
In `@elizaos/agent` (`packages/agent/src/diagnostics/integration-observability.ts`):
`sanitizeToken` clamped input error tokens using raw `value.slice(0, 1024)` and `normalized.slice(0, 64)`. When error messages contain multi-code-unit UTF-16 surrogate pairs at the 1024-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` to generate safe error tokens.
2. Added unit tests in `packages/agent/src/diagnostics/integration-observability.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/diagnostics/integration-observability.test.ts` (4/4 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
