### PR TITLE
fix(agent): use truncateWellFormed for lastInteractionAt in rolodex provider

### DIFF
--- a/packages/agent/src/providers/rolodex.test.ts
+++ b/packages/agent/src/providers/rolodex.test.ts
@@ -324,4 +324,15 @@ describe("rolodexProvider.get", () => {
       expect.any(String),
     );
   });
+
+  it("preserves surrogate integrity when lastInteractionAt contains multi-byte characters at 10-char boundary", async () => {
+    const person = makePerson("Astral User", {
+      lastInteractionAt: "2026-08-2🚀-time",
+    });
+    const result = await getRolodex({
+      getGraphSnapshot: vi.fn(async () => makeSnapshot([person])),
+    });
+    expect(result.text?.isWellFormed()).toBe(true);
+  });
+
 });

--- a/packages/agent/src/providers/rolodex.ts
+++ b/packages/agent/src/providers/rolodex.ts
@@ -16,7 +16,7 @@ import type {
   Service,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { getValidationKeywordTerms } from "@elizaos/shared";
 
 function formatPerson(person: RelationshipsPersonSummary): string {
@@ -33,7 +33,7 @@ function formatPerson(person: RelationshipsPersonSummary): string {
     parts.push(`aka: ${person.aliases.join(", ")}`);
   }
   if (person.lastInteractionAt) {
-    parts.push(`last: ${person.lastInteractionAt.slice(0, 10)}`);
+    parts.push(`last: ${truncateWellFormed(toWellFormedUnicode(person.lastInteractionAt), 10)}`);
   }
   if (person.factCount > 0) {
     parts.push(`${person.factCount} facts`);


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:e9196f43f093d26921f98063af4cb012b67d6a96 -->

## Summary
In `@elizaos/agent` (`packages/agent/src/providers/rolodex.ts`):
`formatPerson` formatted contact last interaction timestamps using raw `person.lastInteractionAt.slice(0, 10)`. When interaction timestamp strings contain multi-code-unit UTF-16 surrogate pairs at the 10-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed(..., 10)` from `@elizaos/core` to generate safe timestamp prefixes.
2. Added unit tests in `packages/agent/src/providers/rolodex.test.ts`.

## Verification
- Ran vitest: `bunx vitest run packages/agent/src/providers/rolodex.test.ts` (13/13 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
