### PR TITLE
fix(plugin-wallet): use surrogate-safe truncation in wallet status and inventory views

### DIFF
--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
@@ -1,3 +1,4 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * InventoryAppView — the full-screen wallet dashboard.
  *
@@ -267,8 +268,9 @@ function formatPercentDelta(value: number): string {
 }
 
 function formatCompactAddress(address: string): string {
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 5)}...${address.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(address ?? "");
+  if (wellFormed.length <= 12) return wellFormed;
+  return `${truncateWellFormed(wellFormed, 5)}...${tailWellFormed(wellFormed, 4)}`;
 }
 
 function formatBnb(value: string | null | undefined): string {
@@ -828,7 +830,7 @@ function MarketAvatar({
 
   return (
     <div className="flex size-11 shrink-0 items-center justify-center text-sm font-semibold text-txt">
-      {label.slice(0, 1).toUpperCase()}
+      {truncateWellFormed(toWellFormedUnicode(label), 1).toUpperCase()}
     </div>
   );
 }

--- a/plugins/plugin-wallet/src/ui/widgets/wallet-status.tsx
+++ b/plugins/plugin-wallet/src/ui/widgets/wallet-status.tsx
@@ -1,3 +1,4 @@
+import { tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 /**
  * `WalletStatusSidebarWidget` — the chat-sidebar widget showing abbreviated
  * EVM/Solana addresses, per-chain badges, asset count, and total USD value.
@@ -49,8 +50,9 @@ const CHAIN_DISPLAY_LABELS: Record<ChainKey, string> = {
 
 function shortenAddress(value: string | null | undefined): string | null {
   if (!value) return null;
-  if (value.length <= 10) return value;
-  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+  const wellFormed = toWellFormedUnicode(value);
+  if (wellFormed.length <= 10) return wellFormed;
+  return `${truncateWellFormed(wellFormed, 6)}…${tailWellFormed(wellFormed, 4)}`;
 }
 
 function parseUsd(value: string | null | undefined): number {
@@ -119,7 +121,7 @@ function ChainBadge({ chain }: { chain: ChainKey }) {
       role="img"
       aria-label={label}
     >
-      {label.slice(0, 3).toUpperCase()}
+      {truncateWellFormed(toWellFormedUnicode(label), 3).toUpperCase()}
     </span>
   );
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1dcc37841455e6a28c0c3d4453ae6278666a8ca9 -->

## Summary
In `@elizaos/plugin-wallet` UI:
1. `shortenAddress` and fallback chain badges in `plugins/plugin-wallet/src/ui/widgets/wallet-status.tsx` used raw `.slice(0, 6)`, `.slice(-4)`, and `.slice(0, 3)`.
2. `formatCompactAddress` and avatar monograms in `plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx` used raw `.slice(0, 5)`, `.slice(-4)`, and `.slice(0, 1)`.

When test addresses or non-standard token symbols contain multi-code-unit UTF-16 surrogate pairs at slicing boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed`, and `tailWellFormed` from `@elizaos/core` across both wallet UI components.

## Verification
- Verified well-formed Unicode output during wallet sidebar status widget and inventory app view rendering.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
