### PR TITLE
fix(plugin-wallet): use surrogate-safe truncation in shortenAddress in birdeye utils

### DIFF
--- a/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
@@ -3,7 +3,7 @@
  * extraction from free-form user text, response formatting for chat display,
  * and the shared `fetch` wrapper (`makeApiRequest`) used by the Birdeye service.
  */
-import { logger } from "@elizaos/core";
+import { logger, tailWellFormed, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { sanitizeWalletDisplayLabel } from "../../security/wallet-context-safety.js";
 import type { BirdeyeApiParams } from "./types/api/common";
 import type {
@@ -341,8 +341,10 @@ export const formatPercentChange = (change?: number): string => {
 };
 
 export const shortenAddress = (address?: string): string => {
-  if (!address || address.length <= 12) return address || "Unknown";
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  if (!address) return "Unknown";
+  const wellFormed = toWellFormedUnicode(address);
+  if (wellFormed.length <= 12) return wellFormed;
+  return `${truncateWellFormed(wellFormed, 6)}...${tailWellFormed(wellFormed, 4)}`;
 };
 
 export const formatTimestamp = (timestamp?: number): string => {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7758af0edb1ce5c3b666fa317540562538e60691 -->

## Summary
In `@elizaos/plugin-wallet` (`plugins/plugin-wallet/src/analytics/birdeye/utils.ts`):
`shortenAddress` abbreviated addresses using raw `${address.slice(0, 6)}...${address.slice(-4)}`. When non-standard or simulated wallet addresses contain multi-code-unit UTF-16 surrogate pairs at head or tail boundaries, raw slicing severed the surrogate pairs.

## Proposed Changes
1. Used `toWellFormedUnicode`, `truncateWellFormed(..., 6)`, and `tailWellFormed(..., 4)` from `@elizaos/core` to generate safe shortened addresses.

## Verification
- Verified well-formed Unicode output during Birdeye token market and search address formatting.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
