### PR TITLE
fix(plugin-whatsapp): use truncateWellFormed for fallback chatId in resolveWhatsAppSystemLocation

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeCloudApiSendTarget,
   normalizeE164,
   normalizeWhatsAppTarget,
+  resolveWhatsAppSystemLocation,
 } from "./normalize.ts";
 
 /**
@@ -166,4 +167,14 @@ describe("text chunking", () => {
     expect(chunks.every((chunk) => chunk.length <= 10)).toBe(true);
     expect(chunks.join("")).toBe(text);
   });
+
+  it("preserves surrogate integrity when chatId without chatName contains astral characters", () => {
+    const loc = resolveWhatsAppSystemLocation({
+      chatType: "group",
+      chatId: "1234567🚀99",
+    });
+    expect(loc.isWellFormed()).toBe(true);
+    expect(loc).toBe("WhatsApp group:1234567");
+  });
+
 });

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -339,7 +339,8 @@ export function resolveWhatsAppSystemLocation(params: {
   chatName?: string;
 }): string {
   const { chatType, chatId, chatName } = params;
-  const name = chatName || chatId.slice(0, 8);
+  const name =
+    chatName || truncateWellFormed(toWellFormedUnicode(chatId), 8);
   return `WhatsApp ${chatType}:${name}`;
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f44c1d7ad7fd10ee849e5d7ad94bb170ff258159 -->

## Summary
In `@elizaos/plugin-whatsapp` (`plugins/plugin-whatsapp/src/normalize.ts`):
`resolveWhatsAppSystemLocation` formatted fallback chat locations when `chatName` was omitted using raw `chatId.slice(0, 8)`. When custom or simulated chat identifiers contain multi-code-unit UTF-16 surrogate pairs at the 8-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(chatId), 8)` from `@elizaos/core` to generate safe fallback location labels.
2. Added unit tests in `plugins/plugin-whatsapp/src/normalize.test.ts`.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-whatsapp/src/normalize.test.ts` (19/19 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
