### PR TITLE
fix(plugin-workflow): use truncateWellFormed for shortId in getUserTagName

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/context.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/context.test.ts
@@ -63,4 +63,17 @@ describe('getUserTagName', () => {
       'Customer 12345678-1111-2222-3333-444455556666_12345678_agent_87654321222233334444555566667777'
     );
   });
+
+  it('preserves surrogate integrity when custom user ID contains astral characters', async () => {
+    const astralUserId = '1234567🚀-1111-2222-3333-444455556666' as UUID;
+    const runtime = {
+      agentId,
+      getEntityById: vi.fn().mockResolvedValue(null),
+    } as unknown as IAgentRuntime;
+
+    const tag = await getUserTagName(runtime, astralUserId);
+    expect(tag.isWellFormed()).toBe(true);
+    expect(tag.startsWith('user_1234567_agent_')).toBe(true);
+  });
+
 });

--- a/plugins/plugin-workflow/src/utils/context.ts
+++ b/plugins/plugin-workflow/src/utils/context.ts
@@ -9,6 +9,8 @@ import {
   type Memory,
   resolveCanonicalOwnerId,
   type State,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from '@elizaos/core';
 
@@ -43,7 +45,7 @@ export function buildConversationContext(message: Memory, state: State | undefin
 
 export async function getUserTagName(runtime: IAgentRuntime, userId: string): Promise<string> {
   const entity = await runtime.getEntityById(userId as UUID);
-  const shortId = userId.replace(/-/g, '').slice(0, 8);
+  const shortId = truncateWellFormed(toWellFormedUnicode(userId).replace(/-/g, ''), 8);
   const agentScopeId = runtime.agentId.replace(/-/g, '');
   const name = entity?.names?.[0];
   const isDefaultName = name === `User ${userId}` || name === `User${userId}`;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:64aa8d443c28000f74ed1b9d7b4dd5f80606890d -->

## Summary
In `@elizaos/plugin-workflow` (`plugins/plugin-workflow/src/utils/context.ts`):
`getUserTagName` derived user tag short IDs using raw `userId.replace(/-/g, '').slice(0, 8)`. When custom or simulated user identifiers contain multi-code-unit UTF-16 surrogate pairs at the 8-character boundary, raw slicing severed the surrogate pair.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(userId).replace(/-/g, ''), 8)` from `@elizaos/core` to generate safe user tag short IDs.
2. Added unit tests in `plugins/plugin-workflow/__tests__/unit/context.test.ts`.

## Verification
- Ran vitest: `bunx vitest run plugins/plugin-workflow/__tests__/unit/context.test.ts` (5/5 passed).

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
