### PR TITLE
fix(plugin-slack): use truncateWellFormed and toWellFormedUnicode for vault segment normalization

### DIFF
--- a/plugins/plugin-slack/src/connector-credential-refs.test.ts
+++ b/plugins/plugin-slack/src/connector-credential-refs.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeVaultSegment } from "./connector-credential-refs";
+
+describe("normalizeVaultSegment", () => {
+  it("normalizes and trims characters cleanly", () => {
+    expect(normalizeVaultSegment(" my-agent-123 ")).toBe("my-agent-123");
+    expect(normalizeVaultSegment("___test___")).toBe("test");
+    expect(normalizeVaultSegment("")).toBe("unknown");
+    expect(normalizeVaultSegment("____")).toBe("unknown");
+  });
+
+  it("handles surrogate pairs and astral characters safely", () => {
+    expect(normalizeVaultSegment("agent🚀test")).toBe("agent_test");
+    expect(normalizeVaultSegment("agent_🚀_test")).toBe("agent___test");
+    const longName = "a".repeat(70);
+    expect(normalizeVaultSegment(longName).length).toBe(64);
+  });
+});

--- a/plugins/plugin-slack/src/connector-credential-refs.ts
+++ b/plugins/plugin-slack/src/connector-credential-refs.ts
@@ -13,6 +13,8 @@ import {
   CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
   type ConnectorAccountManager,
   type IAgentRuntime,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 type JsonValue =
@@ -310,14 +312,15 @@ function buildConnectorCredentialVaultRef(params: {
   ].join(".");
 }
 
-function normalizeVaultSegment(value: string): string {
-  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+export function normalizeVaultSegment(value: string): string {
+  const wellFormed = toWellFormedUnicode(value);
+  const slug = wellFormed.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
   let start = 0;
   let end = slug.length;
   while (start < end && slug.charCodeAt(start) === 95) start += 1;
   while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
   const normalized = slug.slice(start, end);
-  return (normalized || "unknown").slice(0, 64);
+  return truncateWellFormed(normalized || "unknown", 64);
 }
 
 function getFirstService(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9ecb74a76b1a151a586b95b83deb3cfb263aaab0 -->

## Summary
In `plugins/plugin-slack/src/connector-credential-refs.ts`:
`normalizeVaultSegment` normalized vault path segments using standard `.slice(0, 64)`. When inputs contained multi-byte Unicode or lone surrogate code units, raw slicing could truncate code unit pairs midway, producing invalid UTF-16 strings in durable vault keys.

## Proposed Changes
1. Used `toWellFormedUnicode` on input strings prior to slug sanitization.
2. Used `truncateWellFormed` for surrogate-safe length limiting to 64 characters.
3. Added unit tests in `plugins/plugin-slack/src/connector-credential-refs.test.ts`.

## Verification
- Passed unit tests in `plugins/plugin-slack/src/connector-credential-refs.test.ts`.

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-3-7-sonnet","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
