### PR TITLE
fix(agent): use truncateWellFormed and toWellFormedUnicode for connector vault segment normalization

### DIFF
--- a/packages/agent/src/services/connector-credential-store.test.ts
+++ b/packages/agent/src/services/connector-credential-store.test.ts
@@ -133,3 +133,14 @@ describe("hasDurableHostVault", () => {
     expect(hasDurableHostVault()).toBe(true);
   });
 });
+
+describe("normalizeVaultSegment", () => {
+  it("normalizes and handles surrogate pairs safely", async () => {
+    const { normalizeVaultSegment } = await import("./connector-credential-store");
+    expect(normalizeVaultSegment("agent🚀test")).toBe("agent_test");
+    expect(normalizeVaultSegment(" my-agent-123 ")).toBe("my-agent-123");
+    expect(normalizeVaultSegment("")).toBe("unknown");
+    const longName = "a".repeat(70);
+    expect(normalizeVaultSegment(longName).length).toBe(64);
+  });
+});

--- a/packages/agent/src/services/connector-credential-store.ts
+++ b/packages/agent/src/services/connector-credential-store.ts
@@ -28,7 +28,7 @@
  * which credential resolvers probe first when reading refs.
  */
 
-import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { type IAgentRuntime, logger, Service, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { createVault, type Vault } from "@elizaos/vault";
 import {
   getAgentHostBridge,
@@ -140,10 +140,10 @@ export function buildConnectorCredentialVaultRef(params: {
   ].join(".");
 }
 
-function normalizeVaultSegment(value: string): string {
-  const normalized = value
+export function normalizeVaultSegment(value: string): string {
+  const normalized = toWellFormedUnicode(value)
     .trim()
     .replace(/[^a-zA-Z0-9_-]+/g, "_")
     .replace(/^_+|_+$/g, "");
-  return (normalized || "unknown").slice(0, 64);
+  return truncateWellFormed(normalized || "unknown", 64);
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:bb0ce3b07bd1df38f93d8b79854fe2e024d0a604 -->

## Summary
In `packages/agent/src/services/connector-credential-store.ts`:
`normalizeVaultSegment` normalized connector vault path segments using standard `.slice(0, 64)`. When inputs contained multi-byte Unicode or lone surrogate code units, raw slicing could truncate code unit pairs midway, producing invalid UTF-16 strings in durable vault keys.

## Proposed Changes
1. Used `toWellFormedUnicode` on input strings prior to slug sanitization.
2. Used `truncateWellFormed` for surrogate-safe length limiting to 64 characters.
3. Added unit tests in `packages/agent/src/services/connector-credential-store.test.ts`.

## Verification
- Passed unit tests in `packages/agent/src/services/connector-credential-store.test.ts`.

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-3-7-sonnet","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
