### PR TITLE
fix(cloud): add shred -f to cloud-cf-deploy and railway-audit cleanup (#30204)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -817,7 +817,7 @@ jobs:
             "$RUNNER_TEMP/production-binding-recovery-authority" \
             "$RUNNER_TEMP/production-binding-recovery-worker"; do
             if [ -d "$evidence_dir" ]; then
-              find "$evidence_dir" -type f -exec shred -u -- {} +
+              find "$evidence_dir" -type f -exec shred -f -u -- {} +
               find "$evidence_dir" -depth -type d -empty -delete
             fi
           done

--- a/.github/workflows/production-railway-database-authority-audit.yml
+++ b/.github/workflows/production-railway-database-authority-audit.yml
@@ -170,7 +170,7 @@ jobs:
           set +e
           evidence_dir="$RUNNER_TEMP/production-db-authority-audit"
           if [ -d "$evidence_dir" ]; then
-            find "$evidence_dir" -type f -exec shred -u -- {} +
+            find "$evidence_dir" -type f -exec shred -f -u -- {} +
             find "$evidence_dir" -depth -type d -empty -delete
           fi
           exit 0

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -29,6 +29,13 @@ const releaseWorkflow = readFileSync(
   resolve(repoRoot, ".github/workflows/cloud-cf-release.yml"),
   "utf8",
 ).replaceAll("\r\n", "\n");
+const auditWorkflow = readFileSync(
+  resolve(
+    repoRoot,
+    ".github/workflows/production-railway-database-authority-audit.yml",
+  ),
+  "utf8",
+).replaceAll("\r\n", "\n");
 const sourceSha = "a".repeat(40);
 const treeSha = "b".repeat(40);
 const workflowSha256 = "c".repeat(64);
@@ -453,6 +460,9 @@ describe("Cloud CF workflow staging certification gate", () => {
       2,
     );
     expect(authorize).toContain("Destroy private bounded-recovery evidence");
+    expect(authorize).toContain("shred -f -u --");
+    expect(auditWorkflow).toContain("Destroy private audit evidence");
+    expect(auditWorkflow).toContain("shred -f -u --");
     expect(release).toContain("environment == 'production'");
     expect(release).toContain("group: cloud-cf-release-v6-");
     expect(release).toContain("cancel-in-progress: false");

--- a/packages/scripts/__tests__/production-railway-database-authority-audit-workflow.test.ts
+++ b/packages/scripts/__tests__/production-railway-database-authority-audit-workflow.test.ts
@@ -127,7 +127,7 @@ describe("production Railway database authority audit workflow", () => {
       /\b(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b/,
     );
     const cleanup = step("Destroy private audit evidence");
-    expect(cleanup.run).toContain("shred -u");
+    expect(cleanup.run).toContain("shred -f -u");
     expect(cleanup.run).toContain("find");
   });
 });


### PR DESCRIPTION
Fixes #30204

## Summary
e08934f52a added -f to shred in .github/workflows/cloud-cf-release.yml to securely shred read-only recovery evidence, but two sibling workflows (cloud-cf-deploy.yml and production-railway-database-authority-audit.yml) retained shred -u -- without -f. Because read-only admission scripts (e.g. chmod 0500) cannot be opened for writing without -f, evidence survived cleanup on the runner.

## Changes
- Added -f flag (shred -f -u --) to the evidence destruction steps in .github/workflows/cloud-cf-deploy.yml and .github/workflows/production-railway-database-authority-audit.yml.
- Updated packages/cloud/scripts/staging-release-certification.test.mjs to pin the -f flag across all three sibling workflows to prevent silent regression.