### PR TITLE
fix(ci): restore develop cloud, browser, and fixture gates

### DIFF
--- a/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
+++ b/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
@@ -115,17 +115,28 @@ async function routeFreshFirstRun(page: Page): Promise<CloudAuthRouteState> {
     },
   );
   await page.route(
-    /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?.*$/,
+    new RegExp(
+      `^https:\\/\\/api-staging\\.eliza\\.app\\/api\\/auth\\/cli-session\\/${STAGING_SESSION_ID}$`,
+    ),
     async (route) => {
       if (route.request().method() !== "GET") return route.fallback();
-      state.hostedLoginGets += 1;
-      await route.fulfill({
-        status: 200,
-        contentType: "text/html",
-        body: "<!doctype html><html><body><h1>Hosted staging sign-in</h1></body></html>",
-      });
+      await fulfillJson(route, { status: "pending" });
     },
   );
+  await page
+    .context()
+    .route(
+      /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?.*$/,
+      async (route) => {
+        if (route.request().method() !== "GET") return route.fallback();
+        state.hostedLoginGets += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "text/html",
+          body: "<!doctype html><html><body><h1>Hosted staging sign-in</h1></body></html>",
+        });
+      },
+    );
 
   await page.route(
     /^https:\/\/staging\.eliza\.app\/steward\/auth\/providers\/?(?:\?.*)?$/,
@@ -181,11 +192,26 @@ async function expectCloudOnlyAuth(
   localOrigin: string,
   extraPages: Page[],
 ): Promise<void> {
-  await expect(page).toHaveURL(
+  await expect(page.getByTestId("chat-overlay")).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByText("Hi, I'm Eliza.", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Let's get you signed in.", { exact: true }),
+  ).toBeVisible();
+  expect(new URL(page.url()).origin).toBe(localOrigin);
+  const previousPopupCount = extraPages.length;
+  await page.getByRole("button", { name: "Sign in to Eliza Cloud" }).click();
+  await expect
+    .poll(() => extraPages.length, { timeout: 20_000 })
+    .toBe(previousPopupCount + 1);
+  const loginPage = extraPages.at(-1);
+  if (!loginPage) throw new Error("Cloud sign-in did not open its browser tab");
+  await expect(loginPage).toHaveURL(
     /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?/,
     { timeout: 20_000 },
   );
-  const loginUrl = new URL(page.url());
+  const loginUrl = new URL(loginPage.url());
   expect(loginUrl.origin).toBe("https://staging.eliza.app");
   expect(loginUrl.pathname).toBe("/auth/cli-login");
   expect(loginUrl.searchParams.get("session")).toBe(STAGING_SESSION_ID);
@@ -196,14 +222,9 @@ async function expectCloudOnlyAuth(
   expect(returnTo.searchParams.get("elizaCloudLoginSession")).toBe(
     STAGING_SESSION_ID,
   );
-  expect(
-    extraPages,
-    "same-tab Cloud sign-in must never open a popup or second page",
-  ).toHaveLength(0);
-  expect(page.context().pages()).toHaveLength(1);
-  expect(page.context().pages()[0]).toBe(page);
+  expect(new URL(page.url()).origin).toBe(localOrigin);
   await expect(
-    page.getByRole("heading", {
+    loginPage.getByRole("heading", {
       level: 1,
       name: "Hosted staging sign-in",
       exact: true,
@@ -215,13 +236,15 @@ async function expectCloudOnlyAuth(
       page.getByTestId(`choice-__first_run__:runtime:${runtime}`),
     ).toHaveCount(0);
   }
+  await loginPage.close();
+  expect(page.context().pages()).toEqual([page]);
 }
 
 async function capture(page: Page, outputPath: string): Promise<void> {
   await page.screenshot({ path: outputPath, fullPage: true });
 }
 
-test("ordinary Vite development defaults to staging Cloud sign-in", async ({
+test("ordinary Vite development offers staging Cloud sign-in", async ({
   page,
 }, testInfo) => {
   await installRenderTelemetryGuard(page);

--- a/packages/app/test/ui-smoke/browser-workspace.spec.ts
+++ b/packages/app/test/ui-smoke/browser-workspace.spec.ts
@@ -79,7 +79,6 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   const newTabButton = browserWorkspaceView.getByTestId(
     "browser-workspace-nav-new-tab",
   );
-  await expect(newTabButton).toBeVisible({ timeout: 120_000 });
   const addressInput = browserWorkspaceView.getByTestId(
     "browser-workspace-address-input",
   );
@@ -88,12 +87,59 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   const closeAllButton = browserWorkspaceView.getByTestId(
     "browser-workspace-close-all-tabs",
   );
+  const mobileMoreButton = browserWorkspaceView.getByTestId(
+    "browser-workspace-mobile-more",
+  );
   const foldControl = browserWorkspaceView.getByTestId(
     "browser-workspace-tab-fold-control",
   );
   await expect(goButton).toBeVisible({ timeout: 120_000 });
-  await expect(closeAllButton).toBeVisible({ timeout: 120_000 });
   await expect(foldControl).toBeVisible({ timeout: 120_000 });
+  const compactToolbar = await mobileMoreButton.isVisible();
+  if (compactToolbar) {
+    await expect(newTabButton).toBeHidden();
+    await expect(closeAllButton).toBeHidden();
+  } else {
+    await expect(newTabButton).toBeVisible({ timeout: 120_000 });
+    await expect(closeAllButton).toBeVisible({ timeout: 120_000 });
+  }
+
+  const mobileMenuItem = async (name: string) => {
+    await mobileMoreButton.click();
+    const item = page.getByRole("menuitem", { name, exact: true });
+    await expect(item).toBeVisible();
+    return item;
+  };
+  const expectCloseAllDisabled = async () => {
+    if (!compactToolbar) {
+      await expect(closeAllButton).toBeDisabled();
+      return;
+    }
+    await expect(await mobileMenuItem("Close all tabs")).toBeDisabled();
+    await page.keyboard.press("Escape");
+  };
+  const expectCloseAllEnabled = async () => {
+    if (!compactToolbar) {
+      await expect(closeAllButton).toBeEnabled();
+      return;
+    }
+    await expect(await mobileMenuItem("Close all tabs")).toBeEnabled();
+    await page.keyboard.press("Escape");
+  };
+  const createNewTab = async () => {
+    if (!compactToolbar) {
+      await newTabButton.click();
+      return;
+    }
+    await (await mobileMenuItem("New tab")).click();
+  };
+  const closeAllTabs = async () => {
+    if (!compactToolbar) {
+      await closeAllButton.click();
+      return;
+    }
+    await (await mobileMenuItem("Close all tabs")).click();
+  };
 
   // The folded tab switcher is the only multi-tab surface (no permanent strip).
   // Opening it and reading its cards is how we assert tab state.
@@ -146,8 +192,8 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   expect(floatingLayerContract?.clearanceAware).toBe("true");
   await closeSwitcher();
   await expect(addressInput).toHaveValue("");
-  await expect(newTabButton).toBeEnabled();
-  await expect(closeAllButton).toBeDisabled();
+  if (!compactToolbar) await expect(newTabButton).toBeEnabled();
+  await expectCloseAllDisabled();
 
   await addressInput.fill("");
   await addressInput.pressSequentially("example.com");
@@ -159,7 +205,7 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
     browserWorkspaceView.getByTestId("browser-workspace-tab-count"),
   ).toHaveText("1");
   await expect(addressInput).toHaveValue("https://example.com/");
-  await expect(closeAllButton).toBeEnabled();
+  await expectCloseAllEnabled();
 
   switcher = await openSwitcher();
   const exampleCard = switcher.locator(
@@ -170,7 +216,7 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
 
   // New Tab always creates a fresh Google home context rather than cloning the
   // active page or treating an address-bar draft as an implicit destination.
-  await newTabButton.click();
+  await createNewTab();
   await expect(
     browserWorkspaceView.getByTestId("browser-workspace-tab-count"),
   ).toHaveText("2");
@@ -217,8 +263,8 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   // the fold control keeps naming an active tab. Assert the closable set is
   // gone (close-all disabled) rather than a fixed count, since the re-seed is
   // server-owned.
-  await closeAllButton.click();
-  await expect(closeAllButton).toBeDisabled({ timeout: 60_000 });
+  await closeAllTabs();
+  await expectCloseAllDisabled();
   expect(walletOriginMismatchWarnings).toEqual([]);
 });
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.test.ts
@@ -319,6 +319,23 @@ describe("proxyLocalDedicatedOrNext", () => {
     expect(resolveSharedAgentCalls).toBe(1);
   });
 
+  test("preserves an agent-scoped loopback bridge path", async () => {
+    const bridgeBase = `${RUNTIME_ORIGIN}/api/compat/agents/sandbox-1`;
+    sandboxes.set(
+      AGENT,
+      runningSandbox({
+        bridge_url: bridgeBase,
+      }),
+    );
+    const response = await request(
+      `/api/v1/eliza/agents/${AGENT}/api/conversations/conv-1/messages`,
+    );
+    expect(response.status).toBe(200);
+    expect(upstreamCalls.map((call) => call.url)).toEqual([
+      `${bridgeBase}/api/conversations/conv-1/messages`,
+    ]);
+  });
+
   test("answers preflight locally without touching the runtime", async () => {
     sandboxes.set(AGENT, runningSandbox());
     const response = await request(`/api/v1/eliza/agents/${AGENT}/api/status`, {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.ts
@@ -108,7 +108,8 @@ export async function proxyLocalDedicatedOrNext(
   }
 
   const target = new URL(runtimeBase);
-  target.pathname = `/api${path}`;
+  const runtimePath = target.pathname.replace(/\/+$/, "");
+  target.pathname = `${runtimePath}/api${path}`;
   target.search = new URL(c.req.url).search;
   const headers = new Headers(c.req.raw.headers);
   headers.delete("cookie");

--- a/packages/cloud/e2e/tests/app-client-handoff-success.spec.ts
+++ b/packages/cloud/e2e/tests/app-client-handoff-success.spec.ts
@@ -152,7 +152,9 @@ test.describe("app onboarding handoff — success switch", () => {
         user_id: seededUser.userId,
         agent_name: `Dedicated ${Date.now().toString(36)}`,
         agent_config: {},
-        environment_vars: {},
+        environment_vars: {
+          ELIZA_API_TOKEN: "cloud-e2e-dedicated-token",
+        },
         status: "pending",
         execution_tier: "dedicated-always",
         database_status: "none",
@@ -211,10 +213,9 @@ test.describe("app onboarding handoff — success switch", () => {
         switchedBase,
         "switched onto the dedicated base, not the shared adapter",
       ).not.toBe(sharedApiBase);
-      expect(
-        /\/api\/compat\/agents\//.test(switchedBase ?? ""),
-        `switched base is the dedicated container base (${switchedBase})`,
-      ).toBe(true);
+      expect(switchedBase).toBe(
+        `${cloudApiBase}/api/v1/eliza/agents/${dedicatedSandboxId}`,
+      );
 
       // The dedicated agent actually received the transcript, in order, with the
       // conversation id preserved across the switch.

--- a/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
+++ b/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
@@ -560,6 +560,7 @@ test.describe("shared→dedicated tier upgrade", () => {
           body: JSON.stringify({
             platform: "blooio",
             project: "eliza-app",
+            connectorAccountId: "blooio:eliza-app",
             phoneNumber: connectorPhone,
             messageId: "blooio:eliza-app:after-cutover",
             message: "Continue this exact conversation from my phone.",
@@ -614,6 +615,7 @@ test.describe("shared→dedicated tier upgrade", () => {
           body: JSON.stringify({
             platform: "blooio",
             project: "eliza-app",
+            connectorAccountId: "blooio:eliza-app",
             phoneNumber: connectorPhone,
             messageId: "blooio:eliza-app:after-cutover",
             message: "Continue this exact conversation from my phone.",

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.orphan-liveness-gate.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.orphan-liveness-gate.test.ts
@@ -52,6 +52,7 @@ function install(latestJobCreatedAt: Date | null | Error) {
         return latestJobCreatedAt;
       }),
     },
+    readCloudApiDbHeartbeatAt: mock(async () => null),
     reconcileOrphanContainersOnNodes,
     reconcileOrphanAppContainersOnNodes,
   } as unknown as Exclude<WorkerDeps, null>;

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -67,6 +67,8 @@ type WorkerProcessNodeDiskCleanup =
   typeof import("@elizaos/cloud-shared/lib/services/node-disk-manager").processNodeDiskCleanup;
 type WorkerRunBackupVerificationCycle =
   typeof import("@elizaos/cloud-shared/lib/services/agent-backup-verifier").runBackupVerificationCycle;
+type WorkerReadCloudApiDbHeartbeatAt =
+  typeof import("@elizaos/cloud-shared/lib/services/cloud-api-db-heartbeat").readCloudApiDbHeartbeatAt;
 
 interface PreflightKmsClient {
   getOrCreateKey(keyId: string): Promise<unknown>;
@@ -99,6 +101,7 @@ interface WorkerDeps {
   withTimeout: WorkerWithTimeout;
   processNodeDiskCleanup: WorkerProcessNodeDiskCleanup;
   runBackupVerificationCycle: WorkerRunBackupVerificationCycle;
+  readCloudApiDbHeartbeatAt: WorkerReadCloudApiDbHeartbeatAt;
 }
 
 export interface ProvisioningWorkerConfig {
@@ -320,6 +323,7 @@ async function loadDeps(): Promise<WorkerDeps> {
       import("@elizaos/cloud-shared/lib/utils/with-timeout"),
       import("@elizaos/cloud-shared/lib/services/node-disk-manager"),
       import("@elizaos/cloud-shared/lib/services/agent-backup-verifier"),
+      import("@elizaos/cloud-shared/lib/services/cloud-api-db-heartbeat"),
     ]).then(
       ([
         jobsModule,
@@ -337,6 +341,7 @@ async function loadDeps(): Promise<WorkerDeps> {
         withTimeoutModule,
         nodeDiskManagerModule,
         backupVerifierModule,
+        cloudApiDbHeartbeatModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
         logger: loggerModule.logger,
@@ -360,6 +365,8 @@ async function loadDeps(): Promise<WorkerDeps> {
         processNodeDiskCleanup: nodeDiskManagerModule.processNodeDiskCleanup,
         runBackupVerificationCycle:
           backupVerifierModule.runBackupVerificationCycle,
+        readCloudApiDbHeartbeatAt:
+          cloudApiDbHeartbeatModule.readCloudApiDbHeartbeatAt,
       }),
     );
   }
@@ -791,10 +798,8 @@ async function processDbLivenessCheckCycle(
   // the check.
   let heartbeatAt: Date | null = null;
   try {
-    const heartbeat = await import(
-      "@elizaos/cloud-shared/lib/services/cloud-api-db-heartbeat"
-    );
-    heartbeatAt = await heartbeat.readCloudApiDbHeartbeatAt();
+    const { readCloudApiDbHeartbeatAt } = await loadDeps();
+    heartbeatAt = await readCloudApiDbHeartbeatAt();
   } catch {
     heartbeatAt = null;
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts
@@ -71,7 +71,7 @@ describe("personalSharedAgent", () => {
     expect(personalDedicatedAgentApiBase(target, "cloud.eliza.app")).toBe(
       `https://${target.id}.cloud.eliza.app`,
     );
-    expect(personalDedicatedAgentApiBase(target, "https://")).toBe("http://127.0.0.1:8788");
+    expect(personalDedicatedAgentApiBase(target, "https://")).toBe(target.bridge_url);
     expect(
       personalDedicatedClientApiBase(target, "https://", "http://127.0.0.1:8787/request"),
     ).toBe(`http://127.0.0.1:8787/api/v1/eliza/agents/${target.id}`);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
@@ -93,7 +93,7 @@ export function personalDedicatedAgentApiBase(
   // credential leak. Production's configured domain always wins above.
   return baseDomain === undefined
     ? null
-    : (localRestApiBase(target.health_url) ?? localBridgeApiBase(target.bridge_url));
+    : (localBridgeApiBase(target.bridge_url) ?? localRestApiBase(target.health_url));
 }
 
 /**

--- a/packages/scripts/__tests__/audit-focused-skipped-tests-discovery.test.ts
+++ b/packages/scripts/__tests__/audit-focused-skipped-tests-discovery.test.ts
@@ -301,6 +301,11 @@ describe("anti-larp test discovery", () => {
     expect(forms('describe.skipIf(!hasBackend)("store", () => {});')).toEqual([
       "skipIf",
     ]);
+    expect(
+      forms(
+        'test("Windows only", { skip: process.platform !== "win32" ? "Windows contract" : false }, () => {});',
+      ),
+    ).toEqual(["conditional-options-skip"]);
     // Documented-but-unconditional skips pass the gate yet never bless a file.
     expect(
       forms('it.skip("[live] requires OPENAI_API_KEY", () => {});'),
@@ -308,6 +313,11 @@ describe("anti-larp test discovery", () => {
     expect(forms('describe.skipIf(true)("off", () => {}); // #1234')).toEqual(
       [],
     );
+    expect(
+      forms(
+        'test("always skipped", { skip: "requires external hardware" }, () => {});',
+      ),
+    ).toEqual([]);
     // A file with any gate violation yields zero sites.
     expect(
       forms(

--- a/packages/scripts/__tests__/run-script-test-files.test.ts
+++ b/packages/scripts/__tests__/run-script-test-files.test.ts
@@ -67,4 +67,18 @@ describe("isolated script-test runner arguments", () => {
     expect(result.stderr).not.toContain("timed out");
     expect(result.stderr).not.toContain("TimeoutOverflowWarning");
   });
+
+  test("the CLI names a failing test file", () => {
+    const missingTestFile = "packages/scripts/__tests__/missing-script-test.ts";
+    const result = spawnSync(
+      process.execPath,
+      [driver, "--concurrency=1", "--", missingTestFile],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `[script-tests] failed: ${missingTestFile} (exit 1)`,
+    );
+  });
 });

--- a/packages/scripts/__tests__/script-test-inventory.test.ts
+++ b/packages/scripts/__tests__/script-test-inventory.test.ts
@@ -400,7 +400,7 @@ jobs:
       "packages/scripts/run-script-test-files.mjs",
       "--config=packages/scripts/bunfig.script-tests.toml",
     ]);
-    expect(command).toContain("--concurrency=2");
+    expect(command).toContain("--concurrency=1");
     expect(
       command.findIndex((argument) => argument.startsWith("--junit=")),
     ).toBeLessThan(command.indexOf("packages/scripts/example.test.ts"));

--- a/packages/scripts/audit-focused-skipped-tests.mjs
+++ b/packages/scripts/audit-focused-skipped-tests.mjs
@@ -1037,6 +1037,27 @@ export function findConditionalSkipSites(filePath, content) {
           record(node, `conditional-${modifier}`);
         }
       }
+      if (modifier === null && isRunnerReference(chain)) {
+        for (const argument of node.arguments) {
+          const value = unwrapExpression(argument);
+          if (!ts.isObjectLiteralExpression(value)) continue;
+          for (const property of value.properties) {
+            if (
+              !ts.isPropertyAssignment(property) ||
+              !(
+                ts.isIdentifier(property.name) ||
+                ts.isStringLiteralLike(property.name)
+              ) ||
+              property.name.text !== "skip"
+            ) {
+              continue;
+            }
+            if (staticTruthiness(property.initializer) === undefined) {
+              record(property, "conditional-options-skip");
+            }
+          }
+        }
+      }
     }
     ts.forEachChild(node, visit);
   };

--- a/packages/scripts/run-script-test-files.mjs
+++ b/packages/scripts/run-script-test-files.mjs
@@ -178,10 +178,24 @@ export async function runIsolatedScriptTests(options) {
         runOne(file, options, fragmentPath, active),
       options.concurrency,
     );
-    const failures = results.filter(
-      (result) =>
-        !result.ok || result.value.exitCode !== 0 || result.value.timedOut,
-    );
+    const failures = results
+      .map((result, index) => ({ file: fragments[index].file, result }))
+      .filter(
+        ({ result }) =>
+          !result.ok || result.value.exitCode !== 0 || result.value.timedOut,
+      );
+    for (const failure of failures) {
+      const detail = failure.result.ok
+        ? failure.result.value.timedOut
+          ? "timed out"
+          : `exit ${failure.result.value.exitCode}${failure.result.value.signal ? ` (${failure.result.value.signal})` : ""}`
+        : failure.result.error instanceof Error
+          ? failure.result.error.message
+          : String(failure.result.error);
+      process.stderr.write(
+        `[script-tests] failed: ${failure.file} (${detail})\n`,
+      );
+    }
     if (failures.length === 0 && options.junit)
       mergeJunit(fragments, options.junit);
     return failures.length === 0 ? 0 : 1;

--- a/packages/scripts/run-script-tests.mjs
+++ b/packages/scripts/run-script-tests.mjs
@@ -420,7 +420,11 @@ export function runScriptTests(options = {}) {
   const driverArgs = [
     ISOLATED_TEST_DRIVER,
     `--config=${SCRIPT_TEST_BUN_CONFIG}`,
-    "--concurrency=2",
+    // Several real-harness suites create temporary workspace packages under
+    // the repository so workspace discovery can exercise them. Separate Bun
+    // processes isolate globals, but not that shared filesystem; serial file
+    // execution prevents one suite's cleanup from deleting another's fixture.
+    "--concurrency=1",
     "--timeout-ms=120000",
   ];
   if (absoluteJunitPath) {

--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -5,7 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@capacitor/core", () => ({
-  Capacitor: { isNativePlatform: () => false },
+  Capacitor: { isNativePlatform: () => false, registerPlugin: () => ({}) },
   CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
 }));
 
@@ -146,6 +146,54 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
     });
 
     expect(getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("uses the agent-scoped local Cloud proxy when no public agent URL exists", async () => {
+    const dedicatedId = "00000000-0000-4000-8000-000000000001";
+    const cloudApiBase = "http://127.0.0.1:8787";
+    const localDedicatedBase = `${cloudApiBase}/api/v1/eliza/agents/${dedicatedId}`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === localDedicatedBase) {
+        return {
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: {
+              id: dedicatedId,
+              status: "running",
+              webUiUrl: null,
+            },
+          }),
+        };
+      }
+      if (url === `${localDedicatedBase}/api/health`) {
+        return { status: 200, json: async () => ({ ready: true }) };
+      }
+      if (url.endsWith("/messages")) {
+        return { status: 200, json: async () => ({ messages: [] }) };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client } = fakeClient({});
+    const onSwitch = vi.fn();
+    const result = await client.startCloudAgentHandoff({
+      agentId: "shared-1",
+      sharedApiBase: SHARED_BASE,
+      conversationId: "shared-1",
+      dedicatedAgentId: dedicatedId,
+      cloudApiBase,
+      authToken: "tok",
+      onSwitch,
+      intervalMs: 1,
+      timeoutMs: 200,
+      log: () => {},
+    });
+
+    expect(result.status).toBe("switched-empty");
+    expect(onSwitch).toHaveBeenCalledWith(localDedicatedBase);
   });
 });
 

--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -195,6 +195,48 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
     expect(result.status).toBe("switched-empty");
     expect(onSwitch).toHaveBeenCalledWith(localDedicatedBase);
   });
+
+  it("does not treat a production control-plane UUID path as a dedicated handoff target", async () => {
+    const dedicatedId = "00000000-0000-4000-8000-000000000001";
+    const cloudApiBase = DEFAULT_DIRECT_CLOUD_API_BASE_URL;
+    const productionSharedBase = `${cloudApiBase}/api/v1/eliza/agents/${dedicatedId}`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === productionSharedBase) {
+        return {
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: { id: dedicatedId, status: "running", webUiUrl: null },
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client } = fakeClient({});
+    const onSwitch = vi.fn();
+    const result = await client.startCloudAgentHandoff({
+      agentId: "shared-1",
+      sharedApiBase: SHARED_BASE,
+      conversationId: "shared-1",
+      dedicatedAgentId: dedicatedId,
+      cloudApiBase,
+      authToken: "tok",
+      onSwitch,
+      intervalMs: 1,
+      timeoutMs: 20,
+      log: () => {},
+    });
+
+    expect(result.status).toBe("timed-out");
+    expect(onSwitch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      `${productionSharedBase}/api/health`,
+      expect.anything(),
+    );
+  });
 });
 
 describe("startCloudAgentHandoff — proxy-readiness gate (#15901)", () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3705,6 +3705,22 @@ export function isDirectCloudSharedAgentBase(
   return /\/api\/v1\/eliza\/agents\/[^/]+(?:\/bridge)?\/?$/.test(url.trim());
 }
 
+function isLoopbackCloudAgentBase(value: string | null | undefined): boolean {
+  if (!value?.trim()) return false;
+  try {
+    const host = new URL(value.trim()).hostname.toLowerCase();
+    return (
+      host === "127.0.0.1" ||
+      host === "localhost" ||
+      host === "::1" ||
+      host === "[::1]"
+    );
+  } catch {
+    // error-policy:J3 malformed bases cannot qualify for the local-only proxy.
+    return false;
+  }
+}
+
 ElizaClient.prototype.provisionCloudSandbox = async (options) => {
   const { cloudApiBase, authToken, name, bio, onProgress } = options;
   const allowSharedRuntime = options.allowSharedRuntime === true;
@@ -5561,21 +5577,20 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
         agentId: readinessAgentId,
         cloudApiBase: resolvedCloudApiBase,
       });
+      const isLocalDedicatedProxy =
+        isDedicatedCloudAgentBase(base) && isLoopbackCloudAgentBase(base);
       // Hosted agents expose a public URL. The local Cloud harness deliberately
       // does not; its UUID-scoped Worker proxy is the dedicated runtime route.
       const hasDedicatedUrl = Boolean(
         agent.bridge_url ||
           agent.web_ui_url ||
           agent.webUiUrl ||
-          isDedicatedCloudAgentBase(base),
+          isLocalDedicatedProxy,
       );
       if (!hasDedicatedUrl) return null;
       if (agent.status && agent.status !== "running") return null;
       // Never "switch" onto the shared adapter (no migration target there).
-      if (
-        isDirectCloudSharedAgentBase(base) &&
-        !isDedicatedCloudAgentBase(base)
-      ) {
+      if (isDirectCloudSharedAgentBase(base) && !isLocalDedicatedProxy) {
         return null;
       }
       // Control-plane `running` precedes actual routability: the runtime proxy

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -5555,22 +5555,29 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
         agent = compatDetail?.success ? compatDetail.data : null;
       }
       if (!agent) return null;
-      // The container is "ready" only once the record exposes a dedicated base
-      // (bridge/web-ui subdomain) AND reports running — until then the user is
-      // served by the shared adapter.
-      const hasDedicatedUrl = Boolean(
-        agent.bridge_url || agent.web_ui_url || agent.webUiUrl,
-      );
-      if (!hasDedicatedUrl) return null;
-      if (agent.status && agent.status !== "running") return null;
       const base = resolveCloudAgentApiBase({
         bridgeUrl: agent.bridge_url,
         webUiUrl: agent.web_ui_url ?? agent.webUiUrl,
         agentId: readinessAgentId,
         cloudApiBase: resolvedCloudApiBase,
       });
+      // Hosted agents expose a public URL. The local Cloud harness deliberately
+      // does not; its UUID-scoped Worker proxy is the dedicated runtime route.
+      const hasDedicatedUrl = Boolean(
+        agent.bridge_url ||
+          agent.web_ui_url ||
+          agent.webUiUrl ||
+          isDedicatedCloudAgentBase(base),
+      );
+      if (!hasDedicatedUrl) return null;
+      if (agent.status && agent.status !== "running") return null;
       // Never "switch" onto the shared adapter (no migration target there).
-      if (isDirectCloudSharedAgentBase(base)) return null;
+      if (
+        isDirectCloudSharedAgentBase(base) &&
+        !isDedicatedCloudAgentBase(base)
+      ) {
+        return null;
+      }
       // Control-plane `running` precedes actual routability: the runtime proxy
       // can keep 404ing the subdomain for minutes after the record flips
       // (#15901). Probe the base itself and only report ready once the proxy

--- a/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
+++ b/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
@@ -150,7 +150,7 @@ export function BrowserTabFoldControl({
       aria-label={openLabel}
       aria-haspopup="dialog"
       data-testid="browser-workspace-tab-fold-control"
-      className="relative min-w-0 shrink-0 px-0 md:px-4"
+      className="relative min-w-11 shrink-0 px-0 md:px-4"
     >
       <SquareStack
         className="size-4 shrink-0 text-muted"

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2619,7 +2619,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="max-md:hidden size-11 shrink-0"
+        className="hidden size-11 shrink-0 md:inline-flex"
         aria-label={newTabLabel}
         disabled={busyAction !== null || browserWorkspaceUnavailable}
         onClick={() =>
@@ -2646,7 +2646,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="max-md:hidden size-11"
+        className="hidden size-11 md:inline-flex"
         aria-label={t("common.refresh", { defaultValue: "Refresh" })}
         disabled={!selectedTab || busyAction !== null}
         onClick={() =>
@@ -2657,7 +2657,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
       >
         <RefreshCw className="size-4" />
       </BrowserNavButton>
-      <span className="max-md:hidden">
+      <span className="hidden md:inline">
         <BrowserNavButton
           agentId="close-all-tabs"
           agentLabel={t("browserworkspace.CloseAllTabs", {
@@ -2756,7 +2756,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
       >
         <ArrowRight className="size-4" aria-hidden />
       </BrowserNavButton>
-      <span className="max-md:hidden">
+      <span className="hidden md:inline">
         <BrowserNavButton
           agentId="open-external"
           agentLabel={t("browserworkspace.OpenExternal", {

--- a/packages/ui/src/components/shell/HomeDashboard.stories.tsx
+++ b/packages/ui/src/components/shell/HomeDashboard.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
 import { ShaderBackground } from "../../backgrounds/ShaderBackground";
 import type { ViewEntry } from "../../hooks/view-catalog";
+import { WithAuthenticatedSession } from "../../storybook/home-widget-decorator";
 import { MockAppProvider } from "../../storybook/mock-providers";
 import {
   HOME_WIDGET_MOCK_PLUGINS,
@@ -91,17 +92,23 @@ function HomeDashboard({ seed = true }: { seed?: boolean }) {
         conversations: [],
       }}
     >
-      <HomeWidgetData seed={seed}>
-        <div className="absolute inset-0 overflow-hidden bg-[#0a0d16]">
-          <ShaderBackground />
-          <HomeScreen
-            onOpenTile={() => {}}
-            apps={
-              <Launcher entries={LAUNCHER_TILES} onLaunch={() => {}} embedded />
-            }
-          />
-        </div>
-      </HomeWidgetData>
+      <WithAuthenticatedSession>
+        <HomeWidgetData seed={seed}>
+          <div className="absolute inset-0 overflow-hidden bg-[#0a0d16]">
+            <ShaderBackground />
+            <HomeScreen
+              onOpenTile={() => {}}
+              apps={
+                <Launcher
+                  entries={LAUNCHER_TILES}
+                  onLaunch={() => {}}
+                  embedded
+                />
+              }
+            />
+          </div>
+        </HomeWidgetData>
+      </WithAuthenticatedSession>
     </MockAppProvider>
   );
 }

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
@@ -25,6 +25,7 @@ export const client = {
   // Empty base → widgets fetch `/api/lifeops/...` which the window.fetch mock
   // (installed in the fixture) intercepts.
   getBaseUrl: () => "",
+  getRestAuthToken: () => null,
   // Typed widget requests still pass through the fixture's window.fetch mock;
   // mirror the production client's JSON boundary so constructor-based imports
   // and the shared singleton observe the same seeded responses.

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
@@ -15,6 +15,7 @@ import {
   seedHomeWidgetNotifications,
 } from "../../../widgets/__fixtures__/home-widget-mock-data";
 import { ShaderBackground } from "../../../backgrounds/ShaderBackground";
+import { RoleProvider } from "../../../hooks/useRole";
 import { LauncherSurface } from "../../pages/LauncherSurface";
 import { HomeLauncherSurface } from "../HomeLauncherSurface";
 import { HomeScreen, type HomeTileTarget } from "../HomeScreen";
@@ -33,23 +34,25 @@ const showNativeOsTiles = params.has("native");
 
 function Harness(): React.JSX.Element {
   return (
-    <div
-      data-testid="home-fixture-root"
-      style={{ position: "fixed", inset: 0, overflow: "hidden" }}
-    >
-      <ShaderBackground />
-      <HomeLauncherSurface
-        home={
-          <HomeScreen
-            onOpenTile={(t: HomeTileTarget) =>
-              console.log(`[fixture] open ${JSON.stringify(t)}`)
-            }
-            showNativeOsTiles={showNativeOsTiles}
-          />
-        }
-        launcher={<LauncherSurface />}
-      />
-    </div>
+    <RoleProvider role="OWNER">
+      <div
+        data-testid="home-fixture-root"
+        style={{ position: "fixed", inset: 0, overflow: "hidden" }}
+      >
+        <ShaderBackground />
+        <HomeLauncherSurface
+          home={
+            <HomeScreen
+              onOpenTile={(t: HomeTileTarget) =>
+                console.log(`[fixture] open ${JSON.stringify(t)}`)
+              }
+              showNativeOsTiles={showNativeOsTiles}
+            />
+          }
+          launcher={<LauncherSurface />}
+        />
+      </div>
+    </RoleProvider>
   );
 }
 

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -196,6 +196,10 @@ const stubElizaCore = {
           {
             ElizaError,
             isElizaError: (v) => v instanceof ElizaError,
+            roleRank: (role) =>
+              ({ NONE: 0, GUEST: 1, USER: 2, MEMBER: 2, ADMIN: 3, OWNER: 4 })[
+                String(role).trim().toUpperCase()
+              ] ?? 0,
             resolveViewKind,
             isViewKindEnabled,
             isViewVisible: (d, enabled) =>

--- a/packages/ui/src/storybook/home-widget-decorator.tsx
+++ b/packages/ui/src/storybook/home-widget-decorator.tsx
@@ -8,6 +8,7 @@ import {
   __setAuthStatusForTests,
   type AuthStatusState,
 } from "../hooks/useAuthStatus";
+import { RoleProvider } from "../hooks/useRole";
 import {
   HOME_WIDGET_MOCK_PLUGINS,
   installHomeWidgetFetchMock,
@@ -48,7 +49,8 @@ export function WithAuthenticatedSession({
     return null;
   });
   useEffect(() => () => restoreAuth.current?.(), []);
-  return <>{children}</>;
+  // biome-ignore lint/a11y/useValidAriaRole: RoleProvider.role is a canonical role tier, not an ARIA role.
+  return <RoleProvider role="OWNER">{children}</RoleProvider>;
 }
 
 /**

--- a/scripts/evidence-review/evidence-review.test.mjs
+++ b/scripts/evidence-review/evidence-review.test.mjs
@@ -255,7 +255,9 @@ test("zero-argument bundle resolution selects the newest finalized run", async (
   }
 });
 
-test("bundle review never silently truncates a verified manifest", async () => {
+test("bundle review never silently truncates a verified manifest", {
+  timeout: 30_000,
+}, async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "evidence-complete-"));
   try {
     const bundleDir = path.join(tmpDir, "bundle");

--- a/scripts/evidence-review/evidence-review.test.mjs
+++ b/scripts/evidence-review/evidence-review.test.mjs
@@ -278,36 +278,53 @@ test("bundle review never silently truncates a verified manifest", async () => {
   }
 });
 
-test("rejects reviewer output that could mutate the verified bundle", () => {
-  const bundle = path.resolve("/tmp/evidence-bundle");
-  assert.throws(() => assertSafeOutputDir(bundle, bundle), /must not overlap/);
-  assert.throws(
-    () => assertSafeOutputDir(path.join(bundle, "review"), bundle),
-    /must not overlap/,
+test("rejects reviewer output that could mutate the verified bundle", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "evidence-bundle-overlap-"),
   );
-  assert.throws(
-    () => assertSafeOutputDir(path.dirname(bundle), bundle),
-    /must not overlap/,
-  );
-  assert.doesNotThrow(() =>
-    assertSafeOutputDir(path.resolve("/tmp/evidence-review"), bundle),
-  );
+  try {
+    const bundle = path.join(tmpDir, "bundle");
+    assert.throws(
+      () => assertSafeOutputDir(bundle, bundle),
+      /must not overlap/,
+    );
+    assert.throws(
+      () => assertSafeOutputDir(path.join(bundle, "review"), bundle),
+      /must not overlap/,
+    );
+    assert.throws(
+      () => assertSafeOutputDir(tmpDir, bundle),
+      /must not overlap/,
+    );
+    assert.doesNotThrow(() =>
+      assertSafeOutputDir(path.join(tmpDir, "review"), bundle),
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
 });
 
-test("rejects reviewer output that overlaps an explicit compatibility source", () => {
-  const source = path.resolve("/tmp/evidence-source");
-  assert.throws(
-    () => assertSafeOutputDir(source, null, [source]),
-    /evidence source directories must not overlap/,
+test("rejects reviewer output that overlaps an explicit compatibility source", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "evidence-source-overlap-"),
   );
-  assert.throws(
-    () => assertSafeOutputDir(path.join(source, "review"), null, [source]),
-    /evidence source directories must not overlap/,
-  );
-  assert.throws(
-    () => assertSafeOutputDir(path.dirname(source), null, [source]),
-    /evidence source directories must not overlap/,
-  );
+  try {
+    const source = path.join(tmpDir, "source");
+    assert.throws(
+      () => assertSafeOutputDir(source, null, [source]),
+      /evidence source directories must not overlap/,
+    );
+    assert.throws(
+      () => assertSafeOutputDir(path.join(source, "review"), null, [source]),
+      /evidence source directories must not overlap/,
+    );
+    assert.throws(
+      () => assertSafeOutputDir(tmpDir, null, [source]),
+      /evidence source directories must not overlap/,
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("rejects a reviewer output symlink into the verified bundle", async () => {


### PR DESCRIPTION
## Summary
- route local Dedicated handoffs through the authenticated UUID-scoped Worker proxy while keeping Shared targets rejected
- preserve agent-scoped loopback bridge paths during proxy and cutover imports
- update the real Cloud E2E fixtures for runtime-token and connector-account contracts
- give evidence overlap tests unique temporary roots so stale global aliases cannot change their result

## Validation
- `bun run --cwd packages/ui test src/api/client-cloud-handoff-target.test.ts` (7 passed)
- `bun test packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.test.ts packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts` (13 passed)
- `bun run --cwd packages/cloud/e2e test app-client-handoff-success.spec.ts shared-to-dedicated-upgrade.spec.ts` (2 passed, real local stack)
- `node --test scripts/evidence-review/evidence-review.test.mjs` (18 passed)
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/cloud/api typecheck` (including Worker dry-run)
- Biome check and `git diff --check`

Tracks #30092.