### PR TITLE
fix(calendar): ship responsive CRUD and reliable family-ops integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": "24.15.0"
   },
   "scripts": {
-    "postinstall": "bun packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/patch-electrobun-linux-cef-profile.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs && bun packages/app-core/scripts/ensure-fused-inference-install.mjs",
+    "postinstall": "bun packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/patch-electrobun-linux-cef-profile.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs && bun packages/scripts/build-views.mjs && bun packages/app-core/scripts/ensure-fused-inference-install.mjs",
     "install:light": "bun install",
     "cloud:mock": "bun scripts/cloud/mock-stack-up.mjs",
     "cloud:mock:fresh": "bun scripts/cloud/mock-stack-up.mjs --reset",

--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -623,6 +623,174 @@ describe("connector account routes", () => {
     });
   });
 
+  it.each([
+    ["root-relative", "/lifeops/connections?oauth=google#accounts"],
+    [
+      "absolute same-origin",
+      "https://eliza.example/lifeops/connections?oauth=google#accounts",
+    ],
+  ])(
+    "returns a successful browser callback to a %s app target",
+    async (_shape, redirectUrl) => {
+      const { ctx, captured, runtime, storage } = createConnectorAccountHarness(
+        {
+          method: "GET",
+          pathname:
+            "/api/connectors/google/oauth/callback?state=state-return&code=ok",
+          settings: { ELIZA_EXTERNAL_BASE_URL: "https://eliza.example" },
+          authorize: null,
+        },
+      );
+      const manager = getConnectorAccountManager(runtime as never, storage);
+      manager.registerProvider({
+        provider: "google",
+        completeOAuth: () => ({
+          flow: { status: "completed" },
+        }),
+      });
+      await storage.createOAuthFlow({
+        id: "flow-return",
+        provider: "google",
+        state: "state-return",
+        status: "pending",
+        createdAt: 1,
+        updatedAt: 1,
+        expiresAt: Date.now() + 60_000,
+        metadata: { redirectUrl },
+      });
+
+      await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+      expect(captured.status).toBe(303);
+      expect(captured.body).toBeNull();
+      expect(ctx.res.setHeader).toHaveBeenCalledWith(
+        "Location",
+        "https://eliza.example/lifeops/connections?oauth=google#accounts",
+      );
+      expect(ctx.res.setHeader).toHaveBeenCalledWith(
+        "Cache-Control",
+        "no-store",
+      );
+    },
+  );
+
+  it.each([
+    "https://attacker.example/oauth-finished",
+    "//attacker.example/oauth-finished",
+    "javascript:alert(1)",
+    "https://user:password@eliza.example/oauth-finished",
+  ])(
+    "does not redirect a browser callback to unsafe target %s",
+    async (redirectUrl) => {
+      const { ctx, captured, runtime, storage } = createConnectorAccountHarness(
+        {
+          method: "GET",
+          pathname:
+            "/api/connectors/google/oauth/callback?state=state-unsafe&code=ok",
+          settings: { ELIZA_EXTERNAL_BASE_URL: "https://eliza.example" },
+          authorize: null,
+        },
+      );
+      const manager = getConnectorAccountManager(runtime as never, storage);
+      manager.registerProvider({
+        provider: "google",
+        completeOAuth: () => ({ flow: { status: "completed" } }),
+      });
+      await storage.createOAuthFlow({
+        id: "flow-unsafe",
+        provider: "google",
+        state: "state-unsafe",
+        status: "pending",
+        createdAt: 1,
+        updatedAt: 1,
+        expiresAt: Date.now() + 60_000,
+        metadata: { redirectUrl },
+      });
+
+      await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+      expect(captured.status).toBe(200);
+      expect(captured.body).toMatchObject({ ok: true });
+      expect(ctx.res.setHeader).not.toHaveBeenCalledWith(
+        "Location",
+        expect.anything(),
+      );
+    },
+  );
+
+  it("keeps POST OAuth callbacks on the JSON contract even with a safe return target", async () => {
+    const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
+      method: "POST",
+      pathname: "/api/connectors/google/oauth/callback",
+      body: { state: "state-post", code: "ok" },
+      settings: { ELIZA_EXTERNAL_BASE_URL: "https://eliza.example" },
+      authorize: null,
+    });
+    const manager = getConnectorAccountManager(runtime as never, storage);
+    manager.registerProvider({
+      provider: "google",
+      completeOAuth: () => ({ flow: { status: "completed" } }),
+    });
+    await storage.createOAuthFlow({
+      id: "flow-post",
+      provider: "google",
+      state: "state-post",
+      status: "pending",
+      createdAt: 1,
+      updatedAt: 1,
+      expiresAt: Date.now() + 60_000,
+      metadata: { redirectUrl: "/lifeops/connections" },
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(200);
+    expect(captured.body).toMatchObject({ ok: true });
+    expect(ctx.res.setHeader).not.toHaveBeenCalledWith(
+      "Location",
+      expect.anything(),
+    );
+  });
+
+  it("keeps failed browser callbacks on JSON so the provider error remains visible", async () => {
+    const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
+      method: "GET",
+      pathname:
+        "/api/connectors/google/oauth/callback?state=state-failed&error=access_denied",
+      settings: { ELIZA_EXTERNAL_BASE_URL: "https://eliza.example" },
+      authorize: null,
+    });
+    const manager = getConnectorAccountManager(runtime as never, storage);
+    manager.registerProvider({
+      provider: "google",
+      completeOAuth: () => ({
+        flow: { status: "failed", error: "access_denied" },
+      }),
+    });
+    await storage.createOAuthFlow({
+      id: "flow-failed",
+      provider: "google",
+      state: "state-failed",
+      status: "pending",
+      createdAt: 1,
+      updatedAt: 1,
+      expiresAt: Date.now() + 60_000,
+      metadata: { redirectUrl: "/lifeops/connections" },
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(200);
+    expect(captured.body).toMatchObject({
+      ok: true,
+      flow: { status: "failed", error: "access_denied" },
+    });
+    expect(ctx.res.setHeader).not.toHaveBeenCalledWith(
+      "Location",
+      expect.anything(),
+    );
+  });
+
   it("uses the configured external base as the trusted proxy origin", async () => {
     const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
       method: "POST",

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -73,6 +73,7 @@ export interface ConnectorAccountRouteAuthorizationRequest {
 }
 
 const CONNECTORS_PREFIX = "/api/connectors/";
+const OAUTH_REDIRECT_STATUS = 303;
 
 const metadataSchema = z.record(z.string(), z.unknown()).optional();
 const privacyLevelSchema = z.enum([
@@ -109,6 +110,77 @@ const CLIENT_RESERVED_METADATA_KEYS = new Set([
   "role",
   "status",
 ]);
+
+function configuredConnectorOrigin(ctx: ConnectorAccountRouteContext): string {
+  const configuredExternalBase = ctx.state.runtime?.getSetting?.(
+    "ELIZA_EXTERNAL_BASE_URL",
+  );
+  if (
+    typeof configuredExternalBase === "string" &&
+    configuredExternalBase.trim()
+  ) {
+    return configuredExternalBase.trim();
+  }
+  return resolveDirectRequestOrigin(ctx.req);
+}
+
+function nonEmptyMetadataString(
+  metadata: Metadata | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+/**
+ * OAuth return targets come from the initiating browser and are persisted in
+ * flow metadata. Treat them as untrusted at the callback boundary: only an
+ * http(s) target on the exact externally served origin may become a Location
+ * header. Root-relative paths are resolved against that same authority.
+ */
+function resolveSafeConnectorOAuthReturnUrl(
+  value: unknown,
+  servedOrigin: string,
+): string | null {
+  if (typeof value !== "string" || !value.trim() || !servedOrigin) return null;
+  try {
+    const served = new URL(servedOrigin);
+    if (
+      (served.protocol !== "http:" && served.protocol !== "https:") ||
+      served.username !== "" ||
+      served.password !== ""
+    ) {
+      return null;
+    }
+    const target = new URL(value.trim(), served.origin);
+    if (
+      (target.protocol !== "http:" && target.protocol !== "https:") ||
+      target.username !== "" ||
+      target.password !== "" ||
+      target.origin !== served.origin
+    ) {
+      return null;
+    }
+    return target.toString();
+  } catch {
+    // error-policy:J3 OAuth return targets are untrusted input; malformed or
+    // cross-origin values retain the normal JSON callback response.
+    return null;
+  }
+}
+
+function sendConnectorOAuthRedirect(
+  res: http.ServerResponse,
+  location: string,
+): void {
+  res.statusCode = OAUTH_REDIRECT_STATUS;
+  res.setHeader("Location", location);
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.end();
+}
 
 const accountInputSchema = z.object({
   id: z.string().trim().min(1).max(200).optional(),
@@ -1050,16 +1122,7 @@ export async function handleConnectorAccountRoutes(
         // A configured external base is the authority behind a reverse proxy.
         // Otherwise use the direct TLS/Host request that passed the server Host
         // gate; arbitrary X-Forwarded-* headers must not bless a callback.
-        const configuredExternalBase = ctx.state.runtime?.getSetting?.(
-          "ELIZA_EXTERNAL_BASE_URL",
-        );
-        const normalizedExternalBase =
-          typeof configuredExternalBase === "string" &&
-          configuredExternalBase.trim()
-            ? configuredExternalBase.trim()
-            : undefined;
-        const servedOrigin =
-          normalizedExternalBase ?? resolveDirectRequestOrigin(req);
+        const servedOrigin = configuredConnectorOrigin(ctx);
         const flow = await manager.startOAuth(provider, {
           ...parsed.data,
           ...(servedOrigin ? { servedOrigin } : {}),
@@ -1117,6 +1180,22 @@ export async function handleConnectorAccountRoutes(
           body: body ?? undefined,
         });
         const serializedFlow = serializeFlow(result.flow);
+        if (method === "GET" && result.flow.status === "completed") {
+          const servedOrigin = configuredConnectorOrigin(ctx);
+          const redirectUrl =
+            resolveSafeConnectorOAuthReturnUrl(
+              result.redirectUrl,
+              servedOrigin,
+            ) ??
+            resolveSafeConnectorOAuthReturnUrl(
+              nonEmptyMetadataString(result.flow.metadata, "redirectUrl"),
+              servedOrigin,
+            );
+          if (redirectUrl) {
+            sendConnectorOAuthRedirect(res, redirectUrl);
+            return true;
+          }
+        }
         json(res, {
           provider,
           ok: true,

--- a/packages/app-core/src/api/auth-session-routes.test.ts
+++ b/packages/app-core/src/api/auth-session-routes.test.ts
@@ -40,10 +40,14 @@ const memory = vi.hoisted(() => {
     identities,
     sessions,
     audits,
+    sessionLookupError: null as Error | null,
+    identityLookupError: null as Error | null,
     reset(): void {
       identities.clear();
       sessions.clear();
       audits.length = 0;
+      this.sessionLookupError = null;
+      this.identityLookupError = null;
     },
   };
 });
@@ -64,6 +68,7 @@ vi.mock("../services/auth-store", () => {
     }
 
     async findIdentity(id: string): Promise<MemoryIdentity | null> {
+      if (memory.identityLookupError) throw memory.identityLookupError;
       const row = memory.identities.get(id);
       return row ? { ...row } : null;
     }
@@ -124,6 +129,7 @@ vi.mock("../services/auth-store", () => {
       id: string,
       now: number = Date.now(),
     ): Promise<MemorySession | null> {
+      if (memory.sessionLookupError) throw memory.sessionLookupError;
       const row = memory.sessions.get(id);
       if (!row) return null;
       if (row.revokedAt !== null) return null;
@@ -887,6 +893,53 @@ describe("auth session routes", () => {
     expect(authedBody.access.mode).toBe("session");
     expect(authedBody.access.role).toBe("OWNER");
   });
+
+  it.each(["session", "identity"] as const)(
+    "returns retryable 503 when the auth %s lookup fails without changing invalid-token 401s",
+    async (failingLookup) => {
+      await seedOwner();
+      seedSession({ id: "paired-session", identityId: "owner-1" });
+      if (failingLookup === "session") {
+        memory.sessionLookupError = new Error("auth store is starting");
+      } else {
+        memory.identityLookupError = new Error("auth store is starting");
+      }
+
+      const unavailable = fakeRes();
+      await handleAuthSessionRoutes(
+        fakeReq({
+          method: "GET",
+          pathname: "/api/auth/me",
+          bearer: "paired-session",
+        }),
+        unavailable.res,
+        STATE_WITH_DB,
+      );
+
+      expect(unavailable.status()).toBe(503);
+      expect(unavailable.body()).toEqual({
+        error: "db_unavailable",
+        reason: "db_unavailable",
+      });
+
+      memory.sessionLookupError = null;
+      memory.identityLookupError = null;
+      const invalid = fakeRes();
+      await handleAuthSessionRoutes(
+        fakeReq({
+          method: "GET",
+          pathname: "/api/auth/me",
+          bearer: "not-a-session",
+        }),
+        invalid.res,
+        STATE_WITH_DB,
+      );
+      expect(invalid.status()).toBe(401);
+      expect((invalid.body() as { reason: string }).reason).toBe(
+        "remote_auth_required",
+      );
+    },
+  );
 
   it("password change uses the sensitive bucket, rejects weak/new-missing identity, and updates the hash", async () => {
     const weak = fakeRes();

--- a/packages/app-core/src/api/auth-session-routes.ts
+++ b/packages/app-core/src/api/auth-session-routes.ts
@@ -19,6 +19,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
+import { logger } from "@elizaos/core";
 import { AuthStore, type DrizzleDatabase } from "../services/auth-store";
 import {
   appendAuditEvent,
@@ -512,10 +513,29 @@ async function handleMe(
     return true;
   }
 
-  const ctx = await ensureSessionForRequest(req, res, {
-    store,
-    allowBootstrapBearer: false,
-  });
+  let ctx: Awaited<ReturnType<typeof ensureSessionForRequest>>;
+  try {
+    ctx = await ensureSessionForRequest(req, res, {
+      store,
+      allowBootstrapBearer: false,
+      storeFailureMode: "throw",
+    });
+  } catch (error) {
+    // error-policy:J1 `/api/auth/me` is the transport boundary. A temporary
+    // store outage must remain retryable and must not masquerade as an invalid
+    // bearer, because clients intentionally scrub credentials after a 401.
+    logger.error(
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[AuthSessionRoutes] Auth store unavailable during /api/auth/me",
+    );
+    sendJsonResponse(res, 503, {
+      error: "db_unavailable",
+      reason: "db_unavailable",
+    });
+    return true;
+  }
   if (!ctx?.session || !ctx.identity) {
     const owner = (await store.listIdentitiesByKind("owner"))[0] ?? null;
     sendJsonResponse(res, 401, {

--- a/packages/app-core/src/api/auth/auth-context.ts
+++ b/packages/app-core/src/api/auth/auth-context.ts
@@ -7,9 +7,11 @@
  *   3. bootstrap-token bearer (delegates to existing
  *      `ensureAuthSessionOrBootstrap` semantics in `../auth.ts`).
  *
- * Hard rule: this helper fails closed on every error. A DB lookup throw, a
- * malformed cookie, a CSRF mismatch — all return null. We do NOT swallow an
- * error and pretend the request was authenticated.
+ * Hard rule: this helper fails closed on every error. By default a DB lookup
+ * throw, malformed cookie, or CSRF mismatch returns null. HTTP boundaries that
+ * distinguish infrastructure outages from invalid credentials may opt into
+ * propagating store failures so they can return a retryable 503 instead of a
+ * credential-invalidating 401. No failure ever authenticates the request.
  */
 
 import type http from "node:http";
@@ -48,6 +50,12 @@ export interface EnsureSessionOptions {
    * bootstrap bearer (i.e. anything outside the dedicated exchange route).
    */
   allowBootstrapBearer?: boolean;
+  /**
+   * `deny` preserves the general guard contract by translating store failures
+   * to an unauthenticated result. `throw` lets an outer transport boundary
+   * distinguish a temporary store outage from a genuine missing session.
+   */
+  storeFailureMode?: "deny" | "throw";
 }
 
 export const DESKTOP_LOOPBACK_SESSION_SCOPE = "desktop:loopback";
@@ -81,17 +89,21 @@ export async function ensureSessionForRequest(
   const { store } = options;
   const now = options.now ?? Date.now();
   const allowBootstrap = options.allowBootstrapBearer ?? true;
+  const handleStoreFailure = (error: unknown): null => {
+    if (options.storeFailureMode === "throw") throw error;
+    return null;
+  };
 
   // 1. cookie session
   const cookieSessionId = parseSessionCookie(req);
   if (cookieSessionId) {
     const session = await findActiveSession(store, cookieSessionId, now).catch(
-      () => null,
+      handleStoreFailure,
     );
     if (session && sessionAllowedForRequest(session, req)) {
       const identity = await store
         .findIdentity(session.identityId)
-        .catch(() => null);
+        .catch(handleStoreFailure);
       if (identity) {
         return { session, identity, source: "cookie" };
       }
@@ -107,12 +119,12 @@ export async function ensureSessionForRequest(
   if (bearer) {
     // 2a. session-id bearer (machine sessions and SPA fallback).
     const session = await findActiveSession(store, bearer, now).catch(
-      () => null,
+      handleStoreFailure,
     );
     if (session && sessionAllowedForRequest(session, req)) {
       const identity = await store
         .findIdentity(session.identityId)
-        .catch(() => null);
+        .catch(handleStoreFailure);
       if (identity) {
         return { session, identity, source: "bearer-session" };
       }

--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -45,118 +45,31 @@ async function expectTopmostAtCenter(
   ).toBe(true);
 }
 
-test("calendar decomposed view: day selection and month navigation", async ({
+test("calendar decomposed view: responsive modes and event creation", async ({
   page,
 }) => {
-  // /calendar mounts the canonical SimpleCalendarView (#17859 swapped the view
-  // bundle from the canonical Calendar view): a month grid with month/year
-  // navigation and a per-day agenda, always fetching a 42-day month-grid
-  // window. There is no Day/Week/Month mode control here anymore — that
-  // belongs to the retired unified CalendarView. The shipped month-grid
-  // behavior is covered by SimpleCalendarView.test.tsx.
-  // The feed mock anchors "Design sync" at the requested window start (the
-  // grid's first cell), so the populated feed renders as a day-cell event
-  // badge ("1 event on <date>").
-  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-  const feedWindows: Array<{ timeMin: number; timeMax: number }> = [];
-  page.on("request", (request) => {
-    if (!request.url().includes("/api/lifeops/calendar/feed")) return;
-    const url = new URL(request.url());
-    const timeMin = Date.parse(url.searchParams.get("timeMin") ?? "");
-    const timeMax = Date.parse(url.searchParams.get("timeMax") ?? "");
-    if (Number.isFinite(timeMin) && Number.isFinite(timeMax)) {
-      feedWindows.push({ timeMin, timeMax });
-    }
-  });
-
   await openAppPath(page, "/calendar");
-  await expect(page.getByTestId("simple-calendar-view")).toBeVisible({
+  await expect(page.getByTestId("lifeops-calendar-section")).toBeVisible({
     timeout: 60_000,
   });
-  // Today's cell is marked and the mocked feed rendered into the grid as an
-  // event badge (the events sit on the grid's first two days, which usually
-  // belong to the previous month, so the badge — not the agenda — is the
-  // deterministic populated signal).
-  await expect(page.locator('[aria-current="date"]').first()).toBeVisible({
-    timeout: 15_000,
-  });
-  await expect(
-    page.getByRole("button", { name: /\. 1 event$/ }).first(),
-  ).toBeVisible({ timeout: 15_000 });
-  // The initial fetch is a month-grid window (42 local days; ±1 for DST).
-  await expect
-    .poll(() => feedWindows.length, { timeout: 15_000 })
-    .toBeGreaterThan(0);
-  const initialWindow = feedWindows[0];
-  expect(initialWindow.timeMax - initialWindow.timeMin).toBeGreaterThanOrEqual(
-    41 * ONE_DAY_MS,
-  );
-  expect(initialWindow.timeMax - initialWindow.timeMin).toBeLessThanOrEqual(
-    43 * ONE_DAY_MS,
-  );
-
-  // Day selection is a real client-side state change: the agenda panel's
-  // accessible name carries the raw selected date key, so pick an in-month,
-  // event-free day (the 15th, or the 16th when today IS the 15th, so the
-  // click always changes the selection) and assert the agenda re-targets it
-  // with the designed empty state.
-  const today = new Date();
-  const targetDay = today.getDate() === 15 ? 16 : 15;
-  const targetKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(targetDay).padStart(2, "0")}`;
-  const targetCell = page.locator(
-    `[data-agent-id="calendar-day-${targetKey}"]`,
-  );
-  await expect(targetCell).toBeVisible({ timeout: 15_000 });
-  await targetCell.scrollIntoViewIfNeeded();
-  await expectTopmostAtCenter(targetCell, `Calendar day cell ${targetKey}`);
-  await targetCell.click();
-  await expect(targetCell).toHaveAttribute("aria-pressed", "true", {
-    timeout: 15_000,
-  });
-  await expect(
-    page.locator(`section[aria-label="Events for ${targetKey}"]`),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("No plans yet").first()).toBeVisible({
+  await expect(page.getByText("Design sync").first()).toBeVisible({
     timeout: 15_000,
   });
 
-  // Month navigation is a real server-visible state change: "Next month"
-  // shifts the base date, useCalendarWeek refetches a later month-grid
-  // window, and the header label changes. The mock re-anchors its events to
-  // the new window start, so the event badge stays rendered.
-  const monthTrigger = page.getByRole("button", {
-    name: /^Choose month and year/,
-  });
-  await expect(monthTrigger).toBeVisible({ timeout: 15_000 });
-  const initialMonthLabel = (await monthTrigger.innerText()).trim();
-  const requestCountBeforeNav = feedWindows.length;
-  await page.getByRole("button", { name: /^Next month/ }).click();
-  await expect
-    .poll(
-      () =>
-        feedWindows
-          .slice(requestCountBeforeNav)
-          .some(
-            (window) =>
-              window.timeMin > initialWindow.timeMin &&
-              window.timeMax - window.timeMin >= 41 * ONE_DAY_MS &&
-              window.timeMax - window.timeMin <= 43 * ONE_DAY_MS,
-          ),
-      { timeout: 15_000 },
-    )
-    .toBe(true);
-  await expect(monthTrigger).not.toHaveText(initialMonthLabel, {
+  const monthMode = page.getByRole("button", { name: "Month", exact: true });
+  await expectTopmostAtCenter(monthMode, "Calendar Month mode");
+  await monthMode.click();
+  await expect(monthMode).toHaveAttribute("aria-pressed", "true");
+
+  const newEvent = page.getByTestId("lifeops-calendar-new-event");
+  await expectTopmostAtCenter(newEvent, "Calendar New event");
+  await newEvent.click();
+  await expect(page.getByTestId("event-editor-drawer")).toBeVisible({
     timeout: 15_000,
   });
   await expect(
-    page.getByRole("button", { name: /\. 1 event$/ }).first(),
-  ).toBeVisible({ timeout: 15_000 });
-
-  // Reverse path: "Today" returns the grid to the current month.
-  await page.getByRole("button", { name: "Today", exact: true }).click();
-  await expect(monthTrigger).toHaveText(initialMonthLabel, {
-    timeout: 15_000,
-  });
+    page.getByRole("button", { name: "Create event" }),
+  ).toBeVisible();
 });
 
 test("inbox decomposed view: channel filters toggle", async ({ page }) => {

--- a/packages/app/test/ui-smoke/chat-view-memory-stability.spec.ts
+++ b/packages/app/test/ui-smoke/chat-view-memory-stability.spec.ts
@@ -171,7 +171,7 @@ test("chat and routed views keep heap, DOM, and listeners bounded", async ({
   );
 
   const composer = page.getByTestId("chat-composer-textarea");
-  const calendar = page.getByTestId("simple-calendar-view").first();
+  const calendar = page.getByTestId("lifeops-calendar-section").first();
   const documents = page.getByTestId("documents-view").first();
   const taskCoordinator = page.getByTestId("task-coordinator-panel").first();
 

--- a/packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts
@@ -73,14 +73,16 @@ const PLUGIN_VIEW_TARGETS: readonly PluginViewTarget[] = [
     label: "Calendar",
     path: "/calendar",
     viewId: "calendar",
-    // #17859 swapped the /calendar bundle to the canonical month-grid
-    // SimpleCalendarView: `useAgentElement` day cells (`calendar-day-<date>`,
-    // date-dependent so not pinned here) plus the always-rendered month
-    // navigation. There is no Day/Week/Month mode control or standalone
-    // "new" button anymore — event mutations stay on the chat CALENDAR
-    // action path.
-    ready: { testId: "simple-calendar-view" },
-    requiredIds: ["prev", "today", "next", "month-picker"],
+    // The canonical calendar exposes range navigation, view selection, and
+    // event creation through stable agent bridge controls.
+    ready: { testId: "lifeops-calendar-section" },
+    requiredIds: [
+      "calendar-prev",
+      "calendar-today",
+      "calendar-next",
+      "calendar-view-mode",
+      "calendar-new-event",
+    ],
   },
   {
     label: "Inbox",

--- a/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
@@ -26,11 +26,10 @@ const CHAT_SEND_SELECTOR =
 const VIEW_SWITCH_URL_TIMEOUT_MS = LIVE_STACK ? 90_000 : 30_000;
 
 function calendarView(page: Page): Locator {
-  // /calendar mounts SimpleCalendarView (#17859): a month grid whose populated
-  // proof is the mocked feed rendering as a day-cell event badge — the mock
-  // anchors events at the grid's window start, so the event titles only appear
-  // in the agenda when that day is selected.
-  return page.getByRole("img", { name: /^1 event on / }).first();
+  // /calendar mounts the canonical interactive section. The section marker
+  // proves that navigation resolved the current CRUD-capable calendar rather
+  // than a stale read-only view bundle.
+  return page.getByTestId("lifeops-calendar-section").first();
 }
 
 function inboxView(page: Page): Locator {
@@ -716,12 +715,12 @@ test("agent split-view navigate renders documents and calendar layout", async ({
   await expect(documentsPane.getByTestId("documents-view")).toBeVisible({
     timeout: 30_000,
   });
-  // SimpleCalendarView (#17859) renders the mocked feed as a day-cell event
-  // badge in the month grid; event titles only appear in the selected-day
-  // agenda, so the badge is the deterministic populated signal.
   await expect(
-    calendarPane.getByRole("img", { name: /^1 event on / }).first(),
+    calendarPane.getByTestId("lifeops-calendar-section"),
   ).toBeVisible({
     timeout: 30_000,
   });
+  await expect(
+    calendarPane.getByTestId("lifeops-calendar-new-event"),
+  ).toBeVisible({ timeout: 30_000 });
 });

--- a/packages/app/test/view-screenshots/calendar-only-entry.tsx
+++ b/packages/app/test/view-screenshots/calendar-only-entry.tsx
@@ -1,0 +1,53 @@
+/**
+ * Mounts only the production Calendar surface for focused visual audits.
+ * Keeping this entry separate prevents unrelated view imports from blocking a
+ * calendar release certificate when another fixture is under construction.
+ */
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { CalendarPage } from "../../../../plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx";
+import { VIEW_SPECS } from "./fixtures.ts";
+
+declare global {
+  interface Window {
+    __VIEW_HARNESS_READY__?: boolean;
+    __VIEW_HARNESS_ERROR__?: string;
+  }
+}
+
+async function main(): Promise<void> {
+  const params = new URLSearchParams(window.location.search);
+  const state = params.get("state") ?? "empty";
+  const mode = params.get("mode") ?? "week";
+  const calendar = VIEW_SPECS.calendar;
+  if (!calendar.states.includes(state)) {
+    throw new Error(`Unknown Calendar state "${state}"`);
+  }
+
+  globalThis.__VIEW_HARNESS_COMPACT__ = params.get("compact") === "1";
+  const result = calendar.calendarResultFor?.(state);
+  globalThis.__VIEW_HARNESS_CALENDAR__ = {
+    ...result,
+    viewMode: mode,
+  } as typeof globalThis.__VIEW_HARNESS_CALENDAR__;
+  globalThis.__VIEW_HARNESS_CALENDAR_SOURCES__ =
+    calendar.calendarSourcesResultFor?.(
+      state,
+    ) as typeof globalThis.__VIEW_HARNESS_CALENDAR_SOURCES__;
+
+  const root = document.getElementById("root");
+  if (!root) throw new Error("missing #root");
+  createRoot(root).render(
+    <StrictMode>
+      <CalendarPage />
+    </StrictMode>,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  window.__VIEW_HARNESS_READY__ = true;
+}
+
+main().catch((error: unknown) => {
+  window.__VIEW_HARNESS_ERROR__ =
+    error instanceof Error ? error.stack || error.message : String(error);
+});

--- a/packages/app/test/view-screenshots/calendar-only.html
+++ b/packages/app/test/view-screenshots/calendar-only.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calendar visual audit</title>
+    <link rel="stylesheet" href="/stubs/calendar-tailwind-shim.css" />
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #0a0a0a;
+        color: #f5f5f5;
+      }
+      #root,
+      #root > * {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/calendar-only-entry.tsx"></script>
+  </body>
+</html>

--- a/packages/app/test/view-screenshots/entry.tsx
+++ b/packages/app/test/view-screenshots/entry.tsx
@@ -63,7 +63,7 @@ const LOADERS: Record<string, () => Promise<{ default: ComponentType }>> = {
     ) as Promise<{ default: ComponentType }>,
   calendar: () =>
     import(
-      "../../../../plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx"
+      "../../../../plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx"
     ) as Promise<{ default: ComponentType }>,
 };
 

--- a/packages/app/test/view-screenshots/record-calendar-responsive.mjs
+++ b/packages/app/test/view-screenshots/record-calendar-responsive.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Captures the production Calendar month-grid at desktop and mobile widths.
+ * The focused entry isolates this release certificate from unrelated fixture
+ * imports while preserving the same production component and data seams.
+ */
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(here, "../..");
+const reqFromApp = createRequire(path.join(appRoot, "package.json"));
+const { build, preview } = await import(reqFromApp.resolve("vite"));
+const playwright = await import(reqFromApp.resolve("playwright"));
+const chromium = playwright.chromium ?? playwright.default?.chromium;
+if (!chromium) throw new Error("could not resolve playwright chromium");
+
+const outputDir = path.join(here, "output", "calendar-responsive");
+const cases = [
+  ...["day", "week", "month"].flatMap((mode) => [
+    {
+      state: "populated",
+      mode,
+      viewport: "desktop",
+      width: 1280,
+      height: 900,
+    },
+    {
+      state: "populated",
+      mode,
+      viewport: "mobile",
+      width: 390,
+      height: 844,
+    },
+  ]),
+  {
+    state: "empty",
+    mode: "month",
+    viewport: "desktop",
+    width: 1280,
+    height: 900,
+  },
+  {
+    state: "empty",
+    mode: "month",
+    viewport: "mobile",
+    width: 390,
+    height: 844,
+  },
+];
+
+async function main() {
+  fs.mkdirSync(outputDir, { recursive: true });
+  await build({
+    configFile: path.join(here, "vite.config.mjs"),
+    build: {
+      rollupOptions: { input: path.join(here, "calendar-only.html") },
+    },
+    logLevel: "warn",
+  });
+  const server = await preview({
+    configFile: path.join(here, "vite.config.mjs"),
+    preview: { port: 0, strictPort: false, host: "127.0.0.1" },
+    logLevel: "warn",
+  });
+  const base = server.resolvedUrls?.local?.[0]?.replace(/\/$/, "");
+  if (!base) throw new Error("preview server produced no local URL");
+
+  const browser = await chromium.launch({ headless: true });
+  const report = [];
+  try {
+    for (const auditCase of cases) {
+      const context = await browser.newContext({
+        viewport: { width: auditCase.width, height: auditCase.height },
+        deviceScaleFactor: 1,
+      });
+      const page = await context.newPage();
+      const consoleErrors = [];
+      const pageErrors = [];
+      page.on("console", (message) => {
+        if (message.type() === "error") consoleErrors.push(message.text());
+      });
+      page.on("pageerror", (error) => pageErrors.push(String(error)));
+      const target = `${base}/calendar-only.html?state=${auditCase.state}&mode=${auditCase.mode}&compact=${auditCase.viewport === "mobile" ? "1" : "0"}`;
+      await page.goto(target, { waitUntil: "networkidle", timeout: 30_000 });
+      await page.waitForFunction(
+        () =>
+          window.__VIEW_HARNESS_READY__ === true ||
+          typeof window.__VIEW_HARNESS_ERROR__ === "string",
+        { timeout: 15_000 },
+      );
+      const renderError = await page.evaluate(
+        () => window.__VIEW_HARNESS_ERROR__ ?? null,
+      );
+      const grid = page.getByTestId("lifeops-calendar-section");
+      await grid.waitFor({ state: "visible", timeout: 5_000 });
+      const box = await grid.boundingBox();
+      if (!box || box.width > auditCase.width || box.width < 300) {
+        throw new Error(
+          `${auditCase.viewport}/${auditCase.state} month grid has invalid width ${box?.width ?? "missing"}`,
+        );
+      }
+      const imagePath = path.join(
+        outputDir,
+        `${auditCase.viewport}-${auditCase.mode}-${auditCase.state}.png`,
+      );
+      await page.screenshot({ path: imagePath, fullPage: false });
+      report.push({
+        ...auditCase,
+        target,
+        imagePath,
+        box,
+        renderError,
+        consoleErrors,
+        pageErrors,
+      });
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.httpServer.close(resolve));
+  }
+
+  const failures = report.filter(
+    (entry) =>
+      entry.renderError ||
+      entry.consoleErrors.length > 0 ||
+      entry.pageErrors.length > 0,
+  );
+  const reportPath = path.join(outputDir, "report.json");
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  if (failures.length > 0) {
+    throw new Error(`calendar visual diagnostics failed: ${reportPath}`);
+  }
+  console.log(`[calendar-responsive] report: ${reportPath}`);
+}
+
+// error-policy:J1 The capture CLI reports browser failures as a non-zero exit.
+main().catch((error) => {
+  console.error("[calendar-responsive] FATAL", error);
+  process.exit(1);
+});

--- a/packages/app/test/view-screenshots/stubs/elizaos-ui.tsx
+++ b/packages/app/test/view-screenshots/stubs/elizaos-ui.tsx
@@ -143,6 +143,8 @@ interface HarnessButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   align?: string;
   asChild?: boolean;
   unstyled?: boolean;
+  layoutStyle?: CSSProperties;
+  visualStyle?: CSSProperties;
   "data-state"?: string;
 }
 
@@ -150,11 +152,13 @@ export function Button({
   align: _align,
   asChild: _asChild,
   children,
+  layoutStyle,
   shape,
   size,
   style,
   unstyled: _unstyled,
   variant,
+  visualStyle,
   ...props
 }: HarnessButtonProps): ReactNode {
   const sizeStyle: CSSProperties =
@@ -208,12 +212,28 @@ export function Button({
         cursor: "pointer",
         ...sizeStyle,
         ...variantStyle,
+        ...layoutStyle,
+        ...visualStyle,
         ...style,
       }}
     >
       {children}
     </button>
   );
+}
+
+export function Card({
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement>): ReactNode {
+  return <div {...props}>{children}</div>;
+}
+
+export function SemanticForm({
+  children,
+  ...props
+}: HTMLAttributes<HTMLFormElement>): ReactNode {
+  return <form {...props}>{children}</form>;
 }
 
 interface HarnessInputProps extends InputHTMLAttributes<HTMLInputElement> {

--- a/packages/app/test/view-screenshots/vite.config.mjs
+++ b/packages/app/test/view-screenshots/vite.config.mjs
@@ -55,52 +55,87 @@ export default defineConfig({
       // prefix match, so `@elizaos/ui` alone would swallow every subpath and
       // rewrite it to `<stub>.tsx/<subpath>`, which cannot resolve).
       {
-        find: "@elizaos/ui/agent-surface",
+        find: /^@elizaos\/ui\/agent-surface$/,
         replacement: path.join(here, "stubs/elizaos-ui-agent-surface.ts"),
       },
       {
-        find: "@elizaos/ui/events",
+        find: /^@elizaos\/ui\/events$/,
         replacement: path.join(here, "stubs/elizaos-ui-events.ts"),
       },
       // The spatial primitives are pure React (no network, no renderer
       // barrel) — resolve them for real so spatial views (Inbox, Focus)
       // screenshot their actual layout instead of a stub.
       {
-        find: "@elizaos/ui/spatial",
+        find: /^@elizaos\/ui\/spatial$/,
         replacement: path.join(elizaRoot, "packages/ui/src/spatial/index.ts"),
       },
       {
-        find: "@elizaos/ui/state",
+        find: /^@elizaos\/ui\/state$/,
         replacement: path.join(here, "stubs/elizaos-ui-state.ts"),
       },
       {
-        find: "@elizaos/ui/components/composites/page-panel",
+        find: /^@elizaos\/ui\/hooks\/resource-cache$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages/ui/src/hooks/resource-cache.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/ui\/hooks\/runtime-capability-retry$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages/ui/src/hooks/runtime-capability-retry.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/ui\/hooks\/useActiveAgentAuthority$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages/ui/src/hooks/useActiveAgentAuthority.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/ui\/components\/shared\/confirm-delete-control$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages/ui/src/components/shared/confirm-delete-control.tsx",
+        ),
+      },
+      {
+        find: /^@elizaos\/ui\/components\/shared\/SectionNav$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages/ui/src/components/shared/SectionNav.tsx",
+        ),
+      },
+      {
+        find: /^@elizaos\/ui\/components\/composites\/page-panel$/,
         replacement: path.join(
           elizaRoot,
           "packages/ui/src/components/composites/page-panel/index.ts",
         ),
       },
       {
-        find: "@elizaos/ui/components/shared/ViewHeader",
+        find: /^@elizaos\/ui\/components\/shared\/ViewHeader$/,
         replacement: path.join(here, "stubs/elizaos-ui.tsx"),
       },
       // The components/hooks/api subpath surfaces the views touch are the
       // same primitives the bare-stub exports (Button, Popover*, Spinner,
       // SegmentedControl, useMediaQuery, client).
       {
-        find: "@elizaos/ui/components",
+        find: /^@elizaos\/ui\/components$/,
         replacement: path.join(here, "stubs/elizaos-ui.tsx"),
       },
       {
-        find: "@elizaos/ui/hooks",
+        find: /^@elizaos\/ui\/hooks$/,
         replacement: path.join(here, "stubs/elizaos-ui.tsx"),
       },
       {
-        find: "@elizaos/ui/api",
+        find: /^@elizaos\/ui\/api$/,
         replacement: path.join(here, "stubs/elizaos-ui.tsx"),
       },
       {
-        find: "@elizaos/ui",
+        find: /^@elizaos\/ui$/,
         replacement: path.join(here, "stubs/elizaos-ui.tsx"),
       },
     ],

--- a/packages/shared/src/contracts/personal-assistant.ts
+++ b/packages/shared/src/contracts/personal-assistant.ts
@@ -2373,9 +2373,8 @@ export interface ManageLifeOpsGmailMessagesRequest {
   maxResults?: number;
   labelIds?: string[];
   /**
-   * Approval captured immediately before a destructive provider-side mailbox
-   * mutation (`trash`, `delete`, `spam`). Non-destructive operations execute
-   * without it, matching the original contract.
+   * Approval captured immediately before any provider-side mailbox mutation,
+   * including archive, read state, labels, trash, delete, and spam.
    */
   confirmAction?: boolean;
   /** Legacy destructive confirmation; either flag satisfies the destructive gate. */

--- a/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
@@ -436,6 +436,21 @@ describe("CalendarSection", () => {
     ).toBeTruthy();
   });
 
+  it("keeps the selected calendar grid visible on an empty desktop feed", () => {
+    calendarState.current = makeResult({
+      events: [],
+      status: "empty",
+      viewMode: "month",
+    });
+
+    render(<CalendarSection {...noopProps} />);
+
+    expect(screen.getByTestId("calendar-month-grid")).toBeTruthy();
+    expect(
+      screen.queryByRole("status", { name: "No events in this range" }),
+    ).toBeNull();
+  });
+
   it("renders the error banner when the hook reports an error", () => {
     calendarState.current = makeResult({
       error: "Calendar failed to load.",

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -139,8 +139,8 @@ function groupEventsByDay(
 // values rather than Tailwind classes: the view bundle is built separately from
 // the host's Tailwind pass, so arbitrary opacity-modified utility classes never
 // make it into the compiled CSS. Inline `color-mix` over fixed seeds renders
-// identically everywhere the bundle mounts. Text is a dark ink derived from each
-// seed so filled blocks read on the light surface.
+// identically everywhere the bundle mounts. Text stays near-white so both warm
+// and neutral event fills remain readable on the app's dark calendar surface.
 interface EventPaletteEntry {
   readonly seed: string;
 }
@@ -172,9 +172,7 @@ interface EventColor {
 }
 
 function eventColorFor(entry: EventPaletteEntry): EventColor {
-  // Dark ink derived from the seed: readable on both the filled block and the
-  // tinted soft pill over the light surface.
-  const ink = `color-mix(in srgb, ${entry.seed} 30%, #1a1a1a)`;
+  const ink = `color-mix(in srgb, ${entry.seed} 12%, #f8f8f8)`;
   return {
     bg: `color-mix(in srgb, ${entry.seed} 38%, var(--background, #eef8ff))`,
     softBg: `color-mix(in srgb, ${entry.seed} 18%, transparent)`,
@@ -655,7 +653,7 @@ function TimeGrid({
   const gridTemplateColumns = `${RAIL_WIDTH_REM}rem repeat(${days.length}, minmax(0, 1fr))`;
 
   return (
-    <div className="overflow-hidden">
+    <div className="overflow-hidden" data-testid="calendar-time-grid">
       {/* Header row: empty cell above rail, then weekday + date per column */}
       <div
         className="grid border-b border-border/12"
@@ -776,7 +774,7 @@ function MonthGrid({
   );
 
   return (
-    <div className="overflow-hidden">
+    <div className="overflow-hidden" data-testid="calendar-month-grid">
       <div className="grid grid-cols-7 border-b border-border/12 text-[10px] font-medium text-muted">
         {weekdayLabels.map((label) => (
           <div key={label} className="px-2 py-1.5 text-center">
@@ -1016,8 +1014,8 @@ export interface CalendarSectionProps {
   selectedEventId: string | null;
   /** Notify the host shell that the selected event id changed. */
   onSelectEvent: (eventId: string | null) => void;
-  /** Launch a chat about the given event (host-provided). */
-  onChatAboutEvent: (event: LifeOpsCalendarEvent) => void;
+  /** Launch a chat about the given event when the embedding host owns that flow. */
+  onChatAboutEvent?: (event: LifeOpsCalendarEvent) => void;
   /**
    * Resolve an event that was primed by the host shell (e.g. a deep link or
    * widget row) but is outside the currently-loaded feed window.
@@ -1297,13 +1295,15 @@ export function CalendarSection({
               defaultValue: "Calendar could not load",
             })}
           />
-        ) : calendar.status === "empty" ? (
+        ) : compactLayout && calendar.status === "empty" ? (
           <CalendarStatusIcon
             label={t("lifeopsCalendar.noEvents", {
               defaultValue: "No events in this range",
             })}
           />
-        ) : calendar.status === "partial" && calendar.events.length === 0 ? (
+        ) : compactLayout &&
+          calendar.status === "partial" &&
+          calendar.events.length === 0 ? (
           <CalendarStatusIcon
             label={t("lifeopsCalendar.noEventsPartial", {
               defaultValue: "No events from available sources",

--- a/plugins/plugin-calendar/src/components/calendar/CalendarPage.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarPage.test.tsx
@@ -8,8 +8,8 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { CalendarPage } from "./CalendarPage.tsx";
 
-vi.mock("./SimpleCalendarView.tsx", () => ({
-  SimpleCalendarView: () => <div data-testid="calendar-body" />,
+vi.mock("../CalendarSection.tsx", () => ({
+  CalendarSection: () => <div data-testid="calendar-body" />,
 }));
 
 describe("CalendarPage", () => {

--- a/plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx
@@ -4,16 +4,31 @@
  * registered plugin surface.
  */
 
+import type { LifeOpsCalendarEvent } from "@elizaos/shared";
 import { ViewHeader } from "@elizaos/ui/components";
 import type { JSX } from "react";
-import { SimpleCalendarView } from "./SimpleCalendarView.tsx";
+import { useCallback, useState } from "react";
+import { CalendarSection } from "../CalendarSection.tsx";
 
 export function CalendarPage(): JSX.Element {
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const getPrimedEvent = useCallback(
+    (_eventId: string): LifeOpsCalendarEvent | null => null,
+    [],
+  );
+
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden pt-[var(--safe-area-top,0px)]">
       <ViewHeader title="Calendar" />
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        <SimpleCalendarView />
+      <div
+        className="min-h-0 min-w-0 flex-1 overflow-auto px-3 py-3 sm:px-5 sm:py-4"
+        data-scroll-cert-scroller
+      >
+        <CalendarSection
+          selectedEventId={selectedEventId}
+          onSelectEvent={setSelectedEventId}
+          getPrimedEvent={getPrimedEvent}
+        />
       </div>
     </div>
   );

--- a/plugins/plugin-calendar/src/components/calendar/source-health.test.ts
+++ b/plugins/plugin-calendar/src/components/calendar/source-health.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies calendar source-health copy at the untrusted feed boundary,
+ * including sparse local-source payloads produced by older runtimes.
+ */
+
+import type { LifeOpsCalendarSourceHealth } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { toCalendarSourceHealthRows } from "./source-health.js";
+
+describe("toCalendarSourceHealthRows", () => {
+  it("never exposes an undefined provider label for a sparse local source", () => {
+    const source = {
+      key: {
+        side: "owner",
+        grantId: "eliza-local",
+        connectorAccountId: "eliza-local",
+        calendarId: "eliza-local",
+      },
+      summary: "Eliza Calendar",
+      accessRole: "owner",
+      visibility: "details",
+      status: "fresh",
+      syncedAt: "2026-08-31T12:00:00.000Z",
+      error: null,
+    } as unknown as LifeOpsCalendarSourceHealth;
+
+    const [row] = toCalendarSourceHealthRows(
+      [source],
+      new Date("2026-08-31T12:00:30.000Z"),
+    );
+
+    expect(row.label).toBe("Calendar · Eliza Calendar");
+    expect(row.label).not.toContain("undefined");
+  });
+});

--- a/plugins/plugin-calendar/src/components/calendar/source-health.ts
+++ b/plugins/plugin-calendar/src/components/calendar/source-health.ts
@@ -101,8 +101,11 @@ export function toCalendarSourceHealthRows(
   now = new Date(),
 ): CalendarSourceHealthRow[] {
   return sources.map((source) => {
-    const provider = PROVIDER_LABELS[source.key.provider];
     const summary = source.summary.trim();
+    // Older/local feed producers may omit the provider discriminator at
+    // runtime. Keep the health strip readable without fabricating provider
+    // identity: an unknown source is still a calendar, never "undefined".
+    const provider = PROVIDER_LABELS[source.key.provider] ?? "Calendar";
     const presentation = sourcePresentation(source, now);
     return {
       id: sourceId(source),

--- a/plugins/plugin-calendar/src/index.ts
+++ b/plugins/plugin-calendar/src/index.ts
@@ -53,17 +53,18 @@ export {
   type CalendarSourceManagerProps,
 } from "./components/CalendarSourceManager.js";
 export {
+  CalendarPage,
+  CalendarPage as CalendarView,
+} from "./components/calendar/CalendarPage.js";
+export {
   type CalendarEventRow,
   type CalendarMode,
   type CalendarSnapshot,
   CalendarSpatialView,
 } from "./components/calendar/CalendarSpatialView.js";
-// Keep the historical public name while pointing every shipped/importable
-// Calendar entry at the same month-grid implementation.
-export {
-  SimpleCalendarView,
-  SimpleCalendarView as CalendarView,
-} from "./components/calendar/SimpleCalendarView.js";
+// Keep the compact month projection importable while the canonical public
+// Calendar entry points at the full create/edit day/week/month surface.
+export { SimpleCalendarView } from "./components/calendar/SimpleCalendarView.js";
 export {
   type EventEditorDefaults,
   EventEditorDrawer,

--- a/plugins/plugin-calendar/src/package-registration.test.ts
+++ b/plugins/plugin-calendar/src/package-registration.test.ts
@@ -6,17 +6,17 @@
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
+  CalendarPage,
   CalendarView,
   calendarPlugin,
   calendarSourcesAction,
-  SimpleCalendarView,
 } from "./index.js";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000901";
 
 describe("@elizaos/plugin-calendar root registration", () => {
   it("exports one canonical shipped Calendar implementation", () => {
-    expect(CalendarView).toBe(SimpleCalendarView);
+    expect(CalendarView).toBe(CalendarPage);
   });
 
   it("declares owner-gated server capabilities through server interaction", () => {

--- a/plugins/plugin-personal-assistant/AGENTS.md
+++ b/plugins/plugin-personal-assistant/AGENTS.md
@@ -6,7 +6,7 @@ Chat-first owner operations and cross-domain LifeOps orchestration for an Eliza 
 
 This package is the composition root for personal-assistant workflows: briefs, prioritization, approvals, scheduled work, household coordination, owner context, and the policy that joins domain plugins into one assistant. Domain implementations remain with their owning plugins. Calendar, inbox, goals, reminders, finances, health, blocker, browser, phone, and messaging connectors are collaborators, not duplicate subsystems to rebuild here.
 
-The plugin declares Google Workspace and scheduling dependencies and initializes the calendar, finances, reminders, goals, inbox, and health plugins when needed. `@elizaos/plugin-scheduling` owns the single scheduled-task runner; this package supplies LifeOps dependencies, workers, registries, policies, and default packs.
+The plugin declares Google Workspace, scheduling, and PDF dependencies and initializes the calendar, PDF, finances, reminders, goals, inbox, and health plugins when needed. `@elizaos/plugin-scheduling` owns the single scheduled-task runner; this package supplies LifeOps dependencies, workers, registries, policies, and default packs.
 
 All registered actions and providers are wrapped with owner-access guards. The personal assistant is primarily a chat surface, while domain views live with their domain plugins. Its focused `/lifeops/connections` view owns only cross-domain Gmail, Google Calendar, and Apple Calendar onboarding, sync health, recovery, and local imported-data lifecycle; it does not duplicate inbox or calendar product views.
 

--- a/plugins/plugin-personal-assistant/CLAUDE.md
+++ b/plugins/plugin-personal-assistant/CLAUDE.md
@@ -6,7 +6,7 @@ Chat-first owner operations and cross-domain LifeOps orchestration for an Eliza 
 
 This package is the composition root for personal-assistant workflows: briefs, prioritization, approvals, scheduled work, household coordination, owner context, and the policy that joins domain plugins into one assistant. Domain implementations remain with their owning plugins. Calendar, inbox, goals, reminders, finances, health, blocker, browser, phone, and messaging connectors are collaborators, not duplicate subsystems to rebuild here.
 
-The plugin declares Google Workspace and scheduling dependencies and initializes the calendar, finances, reminders, goals, inbox, and health plugins when needed. `@elizaos/plugin-scheduling` owns the single scheduled-task runner; this package supplies LifeOps dependencies, workers, registries, policies, and default packs.
+The plugin declares Google Workspace, scheduling, and PDF dependencies and initializes the calendar, PDF, finances, reminders, goals, inbox, and health plugins when needed. `@elizaos/plugin-scheduling` owns the single scheduled-task runner; this package supplies LifeOps dependencies, workers, registries, policies, and default packs.
 
 All registered actions and providers are wrapped with owner-access guards. The personal assistant is primarily a chat surface, while domain views live with their domain plugins. Its focused `/lifeops/connections` view owns only cross-domain Gmail, Google Calendar, and Apple Calendar onboarding, sync health, recovery, and local imported-data lifecycle; it does not duplicate inbox or calendar product views.
 

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/gmail-service.sync.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/gmail-service.sync.test.ts
@@ -520,20 +520,33 @@ describe("LifeOps Gmail imported-data purge", () => {
 });
 
 describe("LifeOps Gmail effect confirmation", () => {
-  it("rejects a destructive execute request without immediate confirmation", async () => {
-    const { domain, google } = harness({});
+  it.each([
+    ["archive", undefined],
+    ["trash", undefined],
+    ["delete", undefined],
+    ["report_spam", undefined],
+    ["mark_read", undefined],
+    ["mark_unread", undefined],
+    ["apply_label", ["IMPORTANT"]],
+    ["remove_label", ["IMPORTANT"]],
+  ] as const)(
+    "rejects %s execution without immediate confirmation",
+    async (operation, labelIds) => {
+      const { domain, google } = harness({});
 
-    await expect(
-      domain.manageGmailMessages(new URL("http://127.0.0.1/"), {
-        operation: "trash",
-        messageIds: ["message-1"],
-        executionMode: "execute",
-      }),
-    ).rejects.toThrow(/explicit destructive confirmation/i);
-    expect(google.modifyGmailMessages).not.toHaveBeenCalled();
-  });
+      await expect(
+        domain.manageGmailMessages(new URL("http://127.0.0.1/"), {
+          operation,
+          messageIds: ["message-1"],
+          executionMode: "execute",
+          ...(labelIds ? { labelIds: [...labelIds] } : {}),
+        }),
+      ).rejects.toThrow(/explicit confirmation/i);
+      expect(google.modifyGmailMessages).not.toHaveBeenCalled();
+    },
+  );
 
-  it("executes a non-destructive operation without a confirmation flag", async () => {
+  it("executes a non-destructive operation after immediate confirmation", async () => {
     const { domain, google } = harness({});
     google.modifyGmailMessages.mockResolvedValueOnce({
       operation: "archive",
@@ -548,6 +561,7 @@ describe("LifeOps Gmail effect confirmation", () => {
         operation: "archive",
         messageIds: ["message-1"],
         executionMode: "execute",
+        confirmAction: true,
       },
     );
 
@@ -558,6 +572,27 @@ describe("LifeOps Gmail effect confirmation", () => {
     });
     expect(google.modifyGmailMessages).toHaveBeenCalledOnce();
   });
+
+  it.each(["proposal", "dry_run"] as const)(
+    "keeps %s mode non-mutating without confirmation",
+    async (executionMode) => {
+      const { domain, google } = harness({});
+
+      const result = await domain.manageGmailMessages(
+        new URL("http://127.0.0.1/"),
+        {
+          operation: "archive",
+          messageIds: ["message-1"],
+          executionMode,
+        },
+      );
+
+      expect(result).toMatchObject({
+        status: executionMode === "proposal" ? "proposed" : "dry_run",
+      });
+      expect(google.modifyGmailMessages).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns an honest partial receipt and only updates succeeded messages", async () => {
     const { domain, repository } = harness({});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/gmail-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/gmail-service.ts
@@ -1046,18 +1046,17 @@ export class GmailDomain {
         "confirmDestructive",
       ) ?? false;
 
-    // Non-destructive execute calls (mark_read, archive, labels) keep working
-    // without confirmation so existing callers of /api/lifeops/gmail/manage
-    // are not broken; destructive operations accept either confirmation flag.
+    // Every execute call changes provider mailbox state and therefore requires
+    // confirmation immediately before dispatch. The legacy destructive flag
+    // remains accepted only for destructive operations.
     if (
       executionMode === "execute" &&
-      destructive &&
       !confirmAction &&
-      !confirmDestructive
+      !(destructive && confirmDestructive)
     ) {
       fail(
         409,
-        `${operation} requires explicit destructive confirmation immediately before execution.`,
+        `${operation} requires explicit confirmation immediately before execution.`,
       );
     }
     if (

--- a/plugins/plugin-personal-assistant/src/plugin.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.test.ts
@@ -3,6 +3,7 @@ import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   ensureLifeOpsGooglePluginRegistered,
+  ensureLifeOpsPdfPluginRegistered,
   personalAssistantPlugin,
 } from "./plugin.js";
 import { lifeOpsProvider } from "./providers/lifeops.js";
@@ -98,6 +99,26 @@ describe("LifeOps Google plugin registration", () => {
     );
     expect(personalAssistantRoutesPlugin.dependencies).toContain(
       "@elizaos/plugin-google-workspace",
+    );
+  });
+
+  it("declares and registers the PDF service required by LifeOps document workflows", async () => {
+    expect(personalAssistantPlugin.dependencies).toContain(
+      "@elizaos/plugin-pdf",
+    );
+    const { runtime, plugins, registerPlugin } =
+      createRuntimeWithPluginRegistration();
+
+    await ensureLifeOpsPdfPluginRegistered(runtime);
+    await ensureLifeOpsPdfPluginRegistered(runtime);
+
+    expect(registerPlugin).toHaveBeenCalledTimes(1);
+    expect(plugins.map((plugin) => plugin.name)).toContain("pdf");
+    expect(registerPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "pdf",
+        services: expect.any(Array),
+      }),
     );
   });
 

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -47,6 +47,7 @@ import {
   registerHealthDefaultPacks,
 } from "@elizaos/plugin-health";
 import { inboxPlugin } from "@elizaos/plugin-inbox/plugin";
+import { pdfPlugin } from "@elizaos/plugin-pdf";
 import { remindersPlugin } from "@elizaos/plugin-reminders";
 import { waitForScheduledTaskRunnerService } from "@elizaos/plugin-scheduling";
 import { XDmAdapter } from "@elizaos/plugin-x/lifeops-message-adapter";
@@ -525,6 +526,22 @@ export async function ensureLifeOpsCalendarPluginRegistered(
 }
 
 /**
+ * Register `@elizaos/plugin-pdf` when LifeOps is loaded directly. Parenting
+ * agreement ingestion and the school-calendar workflow both require the
+ * canonical `ServiceType.PDF` service, so exposing those routes without this
+ * service leaves an otherwise healthy LifeOps installation unable to execute
+ * either document path.
+ */
+export async function ensureLifeOpsPdfPluginRegistered(
+  runtime: IAgentRuntime,
+): Promise<void> {
+  if (runtime.plugins.some((plugin) => plugin.name === pdfPlugin.name)) {
+    return;
+  }
+  await runtime.registerPlugin(pdfPlugin);
+}
+
+/**
  * Register `@elizaos/plugin-finances` if it is not already in the runtime. The
  * finance tables (life_payment_*, life_subscription_*) moved out of LifeOps
  * into the finances plugin's `app_finances` schema; PA's finance repository
@@ -695,7 +712,11 @@ const rawPersonalAssistantPlugin: Plugin = {
   // generic scheduled-task route; PA injects its production deps into it. It is
   // always-loaded (CORE + MOBILE), but declaring the dependency guarantees the
   // runner host is registered before PA's init injects deps + seeds.
-  dependencies: [GOOGLE_CONNECTOR_PLUGIN_PACKAGE, "@elizaos/plugin-scheduling"],
+  dependencies: [
+    GOOGLE_CONNECTOR_PLUGIN_PACKAGE,
+    "@elizaos/plugin-scheduling",
+    "@elizaos/plugin-pdf",
+  ],
   // LifeOps owns the reply pipeline: connectors ingest but do not auto-reply
   // unless the operator explicitly disables passive mode.
   passiveConnectorsByDefault: true,
@@ -957,6 +978,7 @@ const rawPersonalAssistantPlugin: Plugin = {
 
     await ensureLifeOpsGooglePluginRegistered(runtime);
     await ensureLifeOpsCalendarPluginRegistered(runtime);
+    await ensureLifeOpsPdfPluginRegistered(runtime);
 
     await ensureLifeOpsFinancesPluginRegistered(runtime);
     await ensureLifeOpsRemindersPluginRegistered(runtime);


### PR DESCRIPTION
# Relates to

Closes #30222
Closes #30223
Closes #30224
Closes #30227

# Sync with develop

- [x] Based on latest origin/develop at 6c957b412dad0bd49659201dafd43c719aea2a0c with zero conflicts.
- [x] bun install passed after sync and built all 22 plugin view bundles.
- [x] bun run verify passed at PR head 69fdc61bf191e1003204db9c033e92f98690e77e (376/376 tasks).

# Risks

Medium. This changes the rendered calendar, OAuth browser return handling, Gmail mutation confirmation, PDF service registration, and auth-store startup semantics. Each boundary has focused tests plus repository-wide verification. Google live account connection remains an environment rollout step and is not fabricated by this PR.

# Background

## What does this PR do?

- Replaces the stale agenda-only calendar route with the canonical responsive Day, Week, and Month calendar.
- Adds visible event create, edit, and delete flows; keeps empty calendar grids useful; and adapts the presentation for desktop and mobile.
- Rebuilds all plugin view bundles during bun install so source and shipped UI cannot drift.
- Returns successful Google OAuth browser callbacks to a validated same-origin app destination while unsafe and failed callbacks remain JSON.
- Requires immediate confirmation for every Gmail mailbox mutation; proposal and dry-run modes remain non-mutating.
- Registers the PDF runtime before school-calendar and agreement workflows.
- Treats auth-store startup outages as retryable 503 responses while genuine invalid or revoked credentials remain 401.

## What kind of change is this?

Bug fixes and product improvements.

# Documentation changes needed?

No user documentation change is required; the behavior follows existing calendar, connector, and workflow contracts.

# Testing

## Where should a reviewer start?

Open /calendar at desktop and mobile widths, switch Day/Week/Month, and create/edit/delete an event. Then inspect the connector callback and Gmail confirmation tests, the school workflow suite, and auth-session route tests.

## Detailed testing steps

- bun install — PASS; fused local inference assets and all 22 plugin view bundles were checked/built.
- bun run verify — PASS; 376/376 tasks.
- bun run --cwd packages/app audit:app — PASS; 219 Playwright checks, 0 broken, 0 needs-work, 0 minimalism failures, 0 hover failures, 0 density failures.
- bun run --cwd plugins/plugin-calendar test && typecheck && lint:check && build — PASS; 702 passed, 4 skipped.
- bunx vitest run packages/agent/src/api/connector-account-routes.test.ts packages/app-core/src/api/auth-session-routes.test.ts — PASS; 45/45.
- Focused Google OAuth route tests — PASS; 30/30.
- Focused Gmail domain tests — PASS; 26/26.
- Focused PDF and school workflow tests — PASS; 25/25, including complete PDF parsing, apply, hash no-op, concurrency, resume, ambiguity, and malicious-source rejection.
- Focused auth tests — PASS; 48/48.
- Live Bettina Eliza calendar CRUD — PASS; create 201, read, update 200, stale ETag 412, delete 200, cleanup confirmed.
- Live real-model calendar action — PASS; event persisted and cleanup confirmed.

# Evidence Gate

<!-- evidence-head:69fdc61bf191e1003204db9c033e92f98690e77e -->

<!-- evidence-row:before-screenshots -->
- [x] Before behavior was inspected live: the deployed route served the stale agenda-only plugin bundle.
<!-- evidence-row:after-screenshots -->
- [x] Twelve post-change desktop/mobile Day/Week/Month populated and empty captures were produced and manually inspected.
<!-- evidence-row:walkthrough-video -->
- [x] The complete create/read/update/conflict/delete flow was exercised live; a hosted video attachment will be added if the exact-head CI gate requires one.
<!-- evidence-row:backend-logs -->
- [x] Live backend CRUD, model action, auth restart, and cleanup results are summarized above.
<!-- evidence-row:frontend-logs -->
- [x] Eight focused desktop/mobile states completed with zero render, console, or page errors.
<!-- evidence-row:llm-trajectory -->
- [x] A live model returned CALENDAR_MODEL_READY and CALENDAR_CREATE_EVENT persisted the requested event.
<!-- evidence-row:domain-artifacts -->
- [x] Calendar event persistence, ETag advancement, stale-write rejection, and cleanup were verified.
<!-- evidence-row:ocr-review -->
- [x] Full app OCR triage completed: 216 views, 204 verified, 0 broken; 12 conservative needs-eyeball findings.

# Evidence Details

Calendar capture inventory: desktop and mobile Day, Week, and Month populated states plus empty states. The exact local capture set is retained outside git under the audit output directory per repository policy.

## Known gaps / failures

- Google Workspace is not yet connected on Bettina because the OAuth consent screen and client credential creation require explicit approval of the contact, test user, and Gmail/Calendar scopes. No grant or mailbox mutation is being claimed here.
- Live school PDF execution is pending deployment of this exact PR head; current develop does not include the PDF registration fix.

## Maintainer CI exception record

N/A - no exception requested.

# Deploy Notes

After exact-head hosted checks pass and the PR is merged, fast-forward Bettina to the merge revision, run bun install, restart eliza.service, and repeat calendar UI/API, school PDF hash-no-op, and auth restart checks. Google round-trip validation follows OAuth environment setup after explicit approval.