### PR TITLE
fix(calendar): preserve seven-column month grid at runtime

### DIFF
--- a/packages/app/test/view-screenshots/record-calendar-responsive.mjs
+++ b/packages/app/test/view-screenshots/record-calendar-responsive.mjs
@@ -103,6 +103,20 @@ async function main() {
           `${auditCase.viewport}/${auditCase.state} month grid has invalid width ${box?.width ?? "missing"}`,
         );
       }
+      const monthLayout =
+        auditCase.mode === "month" && auditCase.viewport === "desktop"
+          ? await page
+              .getByTestId("calendar-month-grid")
+              .locator(":scope > div")
+              .evaluateAll((rows) =>
+                rows.map((row) => ({
+                  columns: getComputedStyle(row).gridTemplateColumns
+                    .split(" ")
+                    .filter(Boolean).length,
+                  cells: row.children.length,
+                })),
+              )
+          : null;
       const imagePath = path.join(
         outputDir,
         `${auditCase.viewport}-${auditCase.mode}-${auditCase.state}.png`,
@@ -113,6 +127,7 @@ async function main() {
         target,
         imagePath,
         box,
+        monthLayout,
         renderError,
         consoleErrors,
         pageErrors,
@@ -128,7 +143,13 @@ async function main() {
     (entry) =>
       entry.renderError ||
       entry.consoleErrors.length > 0 ||
-      entry.pageErrors.length > 0,
+      entry.pageErrors.length > 0 ||
+      (entry.monthLayout !== null &&
+        (entry.monthLayout.length !== 2 ||
+          entry.monthLayout[0]?.columns !== 7 ||
+          entry.monthLayout[0]?.cells !== 7 ||
+          entry.monthLayout[1]?.columns !== 7 ||
+          entry.monthLayout[1]?.cells !== 42)),
   );
   const reportPath = path.join(outputDir, "report.json");
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);

--- a/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
@@ -451,6 +451,26 @@ describe("CalendarSection", () => {
     ).toBeNull();
   });
 
+  it("defines the month columns inline for runtime plugin bundles", () => {
+    calendarState.current = makeResult({
+      events: [],
+      status: "empty",
+      viewMode: "month",
+    });
+
+    render(<CalendarSection {...noopProps} />);
+
+    const monthGrid = screen.getByTestId("calendar-month-grid");
+    const [weekdayHeader, dayCells] = Array.from(monthGrid.children);
+    expect((weekdayHeader as HTMLElement).style.gridTemplateColumns).toBe(
+      "repeat(7, minmax(0, 1fr))",
+    );
+    expect((dayCells as HTMLElement).style.gridTemplateColumns).toBe(
+      "repeat(7, minmax(0, 1fr))",
+    );
+    expect(dayCells?.children).toHaveLength(42);
+  });
+
   it("renders the error banner when the hook reports an error", () => {
     calendarState.current = makeResult({
       error: "Calendar failed to load.",

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -775,14 +775,20 @@ function MonthGrid({
 
   return (
     <div className="overflow-hidden" data-testid="calendar-month-grid">
-      <div className="grid grid-cols-7 border-b border-border/12 text-[10px] font-medium text-muted">
+      <div
+        className="grid border-b border-border/12 text-[10px] font-medium text-muted"
+        style={{ gridTemplateColumns: "repeat(7, minmax(0, 1fr))" }}
+      >
         {weekdayLabels.map((label) => (
           <div key={label} className="px-2 py-1.5 text-center">
             {label}
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-px bg-border/8">
+      <div
+        className="grid gap-px bg-border/8"
+        style={{ gridTemplateColumns: "repeat(7, minmax(0, 1fr))" }}
+      >
         {days.map((day) => {
           const key = toLocalDayKey(day);
           const dayEvents = eventsByDay.get(key) ?? [];


### PR DESCRIPTION
Closes #30231

## What changed
- makes the month header and six-week date grid use an explicit seven-column CSS grid contract instead of relying on a dynamically generated Tailwind utility
- adds a component regression for both month grid rows and all 42 date cells
- adds a real Playwright computed-style assertion so the host bundle must render seven columns

## Verification
- `bun run verify` — 376/376 tasks passed
- plugin-calendar — 703 passed, 4 skipped
- plugin-calendar typecheck, lint, and view build passed
- responsive calendar Playwright capture passed with computed 7-column assertions

Head: `58d99ea2ed4a81d2693c6a4af3400327338f640b`