### PR TITLE
fix(calendar): keep event editor inside runtime viewport

### DIFF
--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
@@ -360,6 +360,19 @@ describe("EventEditorDrawer", () => {
     const title = screen.getByLabelText("Event title") as HTMLInputElement;
     expect(title.value).toBe("");
 
+    const drawerStyle = screen.getByTestId("event-editor-drawer").style;
+    expect(drawerStyle.top).toBe("0px");
+    expect(drawerStyle.right).toBe("0px");
+    expect(drawerStyle.bottom).toBe("0px");
+    expect(drawerStyle.left).toBe("auto");
+    expect(drawerStyle.width).toBe("28rem");
+    expect(drawerStyle.maxWidth).toBe("100vw");
+    expect(drawerStyle.height).toBe("100dvh");
+    expect(drawerStyle.margin).toBe("0px");
+    expect(drawerStyle.padding).toBe("0px");
+    expect(drawerStyle.overflowY).toBe("auto");
+    expect(drawerStyle.transform).toBe("none");
+
     const start = document.getElementById(
       "event-editor-start-at",
     ) as HTMLInputElement;

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
@@ -894,6 +894,19 @@ export function EventEditorDrawer({
         <DialogContent
           className="fixed bottom-0 right-0 top-0 !left-auto !right-0 !top-0 m-0 h-full w-[min(28rem,100vw)] max-w-[100vw] !translate-x-0 !translate-y-0 overflow-y-auto bg-bg p-0 duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full"
           data-testid="event-editor-drawer"
+          style={{
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: "auto",
+            width: "28rem",
+            maxWidth: "100vw",
+            height: "100dvh",
+            margin: 0,
+            padding: 0,
+            overflowY: "auto",
+            transform: "none",
+          }}
         >
           <div className="flex items-center justify-between gap-3 px-5 py-4">
             <div>


### PR DESCRIPTION
Closes #30233

## What changed
- makes the event editor drawer geometry an inline runtime contract so host CSS generation cannot drop its top/right/height/transform overrides
- keeps the drawer fully inside desktop and mobile viewports with vertical scrolling for long content
- adds a component regression for every geometry property

## Verification
- `bun run verify` — 376/376 tasks passed
- plugin-calendar — 703 passed, 4 skipped
- plugin-calendar typecheck, lint, and view build passed
- responsive day/week/month capture suite passed
- live defect reproduced before fix at 1440x900: drawer top -352px, title/start/end outside viewport

Head: `9140346acd9341b479413b41a9ca76c5591ce664`