### PR TITLE
fix(calendar): preserve canonical all-day event dates

### DIFF
--- a/packages/shared/src/contracts/calendar.ts
+++ b/packages/shared/src/contracts/calendar.ts
@@ -501,6 +501,12 @@ export interface CreateLifeOpsCalendarEventAttendee {
   optional?: boolean;
 }
 
+/** A provider-neutral all-day interval using an exclusive civil-date end. */
+export interface LifeOpsCalendarAllDayRange {
+  startDate: string;
+  endDateExclusive: string;
+}
+
 export interface CreateLifeOpsCalendarEventRequest {
   side?: LifeOpsConnectorSide;
   mode?: LifeOpsConnectorMode;
@@ -511,6 +517,8 @@ export interface CreateLifeOpsCalendarEventRequest {
   location?: string;
   startAt?: string;
   endAt?: string;
+  /** Mutually exclusive with timed bounds and window presets. */
+  allDay?: LifeOpsCalendarAllDayRange;
   timeZone?: string;
   durationMinutes?: number;
   windowPreset?: LifeOpsCalendarWindowPreset;
@@ -592,6 +600,8 @@ export interface LifeOpsCalendarEventUpdate {
   title?: string;
   startAt?: string;
   endAt?: string;
+  /** Replaces timed bounds with one all-day civil-date interval. */
+  allDay?: LifeOpsCalendarAllDayRange;
   timeZone?: string;
   notes?: string;
   location?: string;

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -4489,10 +4489,13 @@ const calendarAction: CalendarHandlerAction = {
             operation: "create",
             payload: requestToApprove,
           });
-          const createdEvent = await service.createCalendarEvent(INTERNAL_URL, {
-            ...requestToApprove,
-            idempotencyKey,
-          });
+          const { startAt, endAt, ...dateOnlyRequest } = requestToApprove;
+          const createdEvent = await service.createCalendarEvent(
+            INTERNAL_URL,
+            requestToApprove.allDay
+              ? { ...dateOnlyRequest, idempotencyKey }
+              : { ...requestToApprove, startAt, endAt, idempotencyKey },
+          );
           if (travelBuffer && travel) {
             await travel.reserveTravelBuffer({
               runtime,

--- a/plugins/plugin-calendar/src/actions/deps.ts
+++ b/plugins/plugin-calendar/src/actions/deps.ts
@@ -8,6 +8,7 @@ import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import type {
   CreateLifeOpsCalendarEventAttendee,
   CreateLifeOpsCalendarEventRequest,
+  LifeOpsCalendarAllDayRange,
   LifeOpsCalendarEvent,
   LifeOpsCalendarRecurrenceScope,
 } from "@elizaos/shared";
@@ -150,6 +151,7 @@ export interface CalendarMutationUpdateRequest {
   readonly location?: string;
   readonly startAt?: string;
   readonly endAt?: string;
+  readonly allDay?: LifeOpsCalendarAllDayRange;
   readonly timeZone?: string;
   readonly attendees?: CreateLifeOpsCalendarEventAttendee[];
   readonly recurrence?: string[];

--- a/plugins/plugin-calendar/src/apple-calendar.ts
+++ b/plugins/plugin-calendar/src/apple-calendar.ts
@@ -935,6 +935,7 @@ export async function createNativeAppleCalendarEvent(args: {
     startAt: args.request.startAt,
     endAt: args.request.endAt,
     timeZone: args.request.timeZone,
+    isAllDay: args.request.allDay !== undefined,
     attendees: args.request.attendees,
   });
   if (!payload.ok) {

--- a/plugins/plugin-calendar/src/internal/calendar-normalize.all-day.test.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.all-day.test.ts
@@ -1,0 +1,67 @@
+/** Deterministic coverage for provider-neutral all-day and legacy timed range normalization. */
+import { describe, expect, it } from "vitest";
+import { resolveCalendarEventRange } from "./calendar-normalize.js";
+
+describe("resolveCalendarEventRange all-day contract", () => {
+  it.each([
+    ["2026-01-15", "2026-01-16"],
+    ["2026-07-15", "2026-07-16"],
+    ["2026-03-08", "2026-03-09"],
+    ["2026-11-01", "2026-11-02"],
+  ])(
+    "preserves civil dates across DST for %s",
+    (startDate, endDateExclusive) => {
+      expect(
+        resolveCalendarEventRange(
+          {
+            title: "School closed",
+            allDay: { startDate, endDateExclusive },
+            timeZone: "America/New_York",
+          },
+          new Date("2026-01-01T12:00:00.000Z"),
+        ),
+      ).toEqual({
+        startAt: `${startDate}T00:00:00.000Z`,
+        endAt: `${endDateExclusive}T00:00:00.000Z`,
+        timeZone: "America/New_York",
+        isAllDay: true,
+        startDate,
+        endDateExclusive,
+      });
+    },
+  );
+
+  it("keeps timed RFC 3339 requests classified as timed", () => {
+    expect(
+      resolveCalendarEventRange(
+        {
+          title: "Meeting",
+          startAt: "2026-03-08T09:00:00-04:00",
+          endAt: "2026-03-08T10:00:00-04:00",
+          timeZone: "America/New_York",
+        },
+        new Date("2026-01-01T12:00:00.000Z"),
+      ),
+    ).toMatchObject({
+      startAt: "2026-03-08T13:00:00.000Z",
+      endAt: "2026-03-08T14:00:00.000Z",
+      isAllDay: false,
+    });
+  });
+
+  it("rejects mixed timed and all-day bounds", () => {
+    expect(() =>
+      resolveCalendarEventRange(
+        {
+          title: "Invalid",
+          startAt: "2026-03-08T09:00:00-04:00",
+          allDay: {
+            startDate: "2026-03-08",
+            endDateExclusive: "2026-03-09",
+          },
+        },
+        new Date(),
+      ),
+    ).toThrow("allDay cannot be combined");
+  });
+});

--- a/plugins/plugin-calendar/src/internal/calendar-normalize.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.ts
@@ -338,8 +338,47 @@ export function resolveCalendarPresetStart(
 export function resolveCalendarEventRange(
   request: CreateLifeOpsCalendarEventRequest,
   now: Date,
-): { startAt: string; endAt: string; timeZone: string } {
+): {
+  startAt: string;
+  endAt: string;
+  timeZone: string;
+  isAllDay: boolean;
+  startDate?: string;
+  endDateExclusive?: string;
+} {
   const timeZone = normalizeCalendarTimeZone(request.timeZone);
+  if (request.allDay !== undefined) {
+    if (
+      request.startAt !== undefined ||
+      request.endAt !== undefined ||
+      request.windowPreset !== undefined ||
+      request.durationMinutes !== undefined
+    ) {
+      fail(
+        400,
+        "allDay cannot be combined with timed bounds, a window preset, or durationMinutes",
+      );
+    }
+    const startDate = normalizeCalendarDateOnly(
+      request.allDay.startDate,
+      "allDay.startDate",
+    );
+    const endDateExclusive = normalizeCalendarDateOnly(
+      request.allDay.endDateExclusive,
+      "allDay.endDateExclusive",
+    );
+    if (endDateExclusive <= startDate) {
+      fail(400, "allDay.endDateExclusive must follow allDay.startDate");
+    }
+    return {
+      startAt: `${startDate}T00:00:00.000Z`,
+      endAt: `${endDateExclusive}T00:00:00.000Z`,
+      timeZone,
+      isAllDay: true,
+      startDate,
+      endDateExclusive,
+    };
+  }
   const durationMinutes =
     normalizeOptionalMinutes(request.durationMinutes, "durationMinutes") ?? 60;
   if (durationMinutes <= 0) {
@@ -363,6 +402,7 @@ export function resolveCalendarEventRange(
       startAt: start.toISOString(),
       endAt: addMinutes(start, durationMinutes).toISOString(),
       timeZone,
+      isAllDay: false,
     };
   }
 
@@ -384,7 +424,20 @@ export function resolveCalendarEventRange(
     startAt,
     endAt,
     timeZone,
+    isAllDay: false,
   };
+}
+
+export function normalizeCalendarDateOnly(
+  value: unknown,
+  field: string,
+): string {
+  const text = requireNonEmptyString(value, field);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+    fail(400, `${field} must be a YYYY-MM-DD calendar date`);
+  }
+  validateIsoCalendarDatePrefix(text, field);
+  return text;
 }
 
 export function buildNextCalendarEventContext(

--- a/plugins/plugin-calendar/src/internal/eliza-calendar.all-day.test.ts
+++ b/plugins/plugin-calendar/src/internal/eliza-calendar.all-day.test.ts
@@ -1,0 +1,32 @@
+/** Deterministic coverage for built-in calendar all-day classification and timed compatibility. */
+import { describe, expect, it } from "vitest";
+import { createElizaCalendarEvent } from "./eliza-calendar.js";
+
+const base = {
+  agentId: "agent-a",
+  request: { title: "School closed", idempotencyKey: "school:closed" },
+  startAt: "2026-03-08T00:00:00.000Z",
+  endAt: "2026-03-09T00:00:00.000Z",
+  timeZone: "America/New_York",
+  attendees: [],
+  now: new Date("2026-01-01T12:00:00.000Z"),
+};
+
+describe("built-in calendar event classification", () => {
+  it("persists an all-day event for renderer classification", () => {
+    expect(createElizaCalendarEvent({ ...base, isAllDay: true })).toMatchObject(
+      {
+        startAt: "2026-03-08T00:00:00.000Z",
+        endAt: "2026-03-09T00:00:00.000Z",
+        isAllDay: true,
+        timezone: "America/New_York",
+      },
+    );
+  });
+
+  it("preserves timed event classification", () => {
+    expect(
+      createElizaCalendarEvent({ ...base, isAllDay: false }).isAllDay,
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-calendar/src/internal/eliza-calendar.ts
+++ b/plugins/plugin-calendar/src/internal/eliza-calendar.ts
@@ -114,6 +114,7 @@ export function createElizaCalendarEvent(args: {
   startAt: string;
   endAt: string;
   timeZone: string;
+  isAllDay: boolean;
   attendees: readonly CreateLifeOpsCalendarEventAttendee[];
   now: Date;
 }): LifeOpsCalendarEvent {
@@ -164,7 +165,7 @@ export function createElizaCalendarEvent(args: {
     status: "confirmed",
     startAt: args.startAt,
     endAt: args.endAt,
-    isAllDay: false,
+    isAllDay: args.isAllDay,
     timezone: args.timeZone,
     htmlLink: null,
     conferenceLink: null,
@@ -190,6 +191,7 @@ export function updateElizaCalendarEvent(args: {
   startAt?: string;
   endAt?: string;
   timeZone?: string;
+  isAllDay?: boolean;
   attendees?: readonly CreateLifeOpsCalendarEventAttendee[];
   now: Date;
 }): LifeOpsCalendarEvent {
@@ -236,6 +238,7 @@ export function updateElizaCalendarEvent(args: {
     startAt,
     endAt,
     timezone: args.timeZone ?? args.event.timezone,
+    isAllDay: args.isAllDay ?? args.event.isAllDay,
     attendees:
       args.attendees === undefined
         ? args.event.attendees

--- a/plugins/plugin-calendar/src/internal/google-delegates.all-day.test.ts
+++ b/plugins/plugin-calendar/src/internal/google-delegates.all-day.test.ts
@@ -1,0 +1,40 @@
+/** Deterministic coverage that provider-neutral all-day dates remain date-only at Google. */
+import { describe, expect, it } from "vitest";
+import {
+  googleCalendarEventInput,
+  googleCalendarEventPatchInput,
+} from "./google-delegates.js";
+
+describe("Google all-day mutation adapters", () => {
+  it("preserves date-only create bounds", () => {
+    expect(
+      googleCalendarEventInput({
+        accountId: "account-a",
+        title: "School closed",
+        startAt: "2026-03-08",
+        endAt: "2026-03-09",
+        timeZone: "America/New_York",
+      }),
+    ).toMatchObject({
+      start: "2026-03-08",
+      end: "2026-03-09",
+      timeZone: "America/New_York",
+    });
+  });
+
+  it("preserves date-only update bounds", () => {
+    expect(
+      googleCalendarEventPatchInput({
+        accountId: "account-a",
+        eventId: "event-a",
+        startAt: "2026-11-01",
+        endAt: "2026-11-02",
+        timeZone: "America/New_York",
+      }),
+    ).toMatchObject({
+      start: "2026-11-01",
+      end: "2026-11-02",
+      timeZone: "America/New_York",
+    });
+  });
+});

--- a/plugins/plugin-calendar/src/microsoft/graph.ts
+++ b/plugins/plugin-calendar/src/microsoft/graph.ts
@@ -134,6 +134,7 @@ export interface MicrosoftGraphCalendarPort {
     location?: string | null;
     startAt: string;
     endAt: string;
+    isAllDay: boolean;
     attendees: readonly CreateLifeOpsCalendarEventAttendee[];
     notifyAttendees: boolean;
     idempotencyKey: string;
@@ -902,6 +903,7 @@ export class DefaultMicrosoftGraphCalendarPort
     location?: string | null;
     startAt: string;
     endAt: string;
+    isAllDay: boolean;
     attendees: readonly CreateLifeOpsCalendarEventAttendee[];
     notifyAttendees: boolean;
     idempotencyKey: string;
@@ -965,6 +967,7 @@ export class DefaultMicrosoftGraphCalendarPort
           },
           start: { dateTime: startAt, timeZone: "UTC" },
           end: { dateTime: endAt, timeZone: "UTC" },
+          isAllDay: args.isAllDay,
           location: { displayName: args.location?.trim() ?? "" },
           attendees: args.attendees.map((attendee) => ({
             emailAddress: {

--- a/plugins/plugin-calendar/src/routes/calendar-routes.ts
+++ b/plugins/plugin-calendar/src/routes/calendar-routes.ts
@@ -461,6 +461,7 @@ export async function handleCalendarRoutes(
           description: body.notes,
           startAt: body.startAt,
           endAt: body.endAt,
+          allDay: body.allDay,
           timeZone: body.timeZone,
           location: body.location,
           attendees: body.attendees,

--- a/plugins/plugin-calendar/src/routes/mutation-gateway.ts
+++ b/plugins/plugin-calendar/src/routes/mutation-gateway.ts
@@ -10,6 +10,7 @@ import type {
   CreateLifeOpsCalendarEventResponse,
   CreateLifeOpsLinkedCalendarLinkRequest,
   DisconnectLifeOpsLinkedCalendarRequest,
+  LifeOpsCalendarAllDayRange,
   LifeOpsCalendarCancellationMode,
   LifeOpsCalendarEvent,
   LifeOpsCalendarEventCancellationResult,
@@ -42,6 +43,7 @@ export interface CalendarOwnerMutationGateway {
       location?: string;
       startAt?: string;
       endAt?: string;
+      allDay?: LifeOpsCalendarAllDayRange;
       timeZone?: string;
       attendees?: CreateLifeOpsCalendarEventAttendee[] | null;
       recurrence?: string[] | null;

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -47,6 +47,7 @@ import type {
   DisconnectLifeOpsLinkedCalendarRequest,
   FeatureResult,
   GetLifeOpsCalendarFeedRequest,
+  LifeOpsCalendarAllDayRange,
   LifeOpsCalendarEvent,
   LifeOpsCalendarFeed,
   LifeOpsCalendarImportedDataPurgeReceipt,
@@ -5531,10 +5532,8 @@ export class CalendarService extends Service {
     // Validate recurrence up front so an invalid rule fails the request
     // instead of silently creating a one-off event.
     const recurrence = normalizeRecurrence(request.recurrence);
-    const { startAt, endAt, timeZone } = resolveCalendarEventRange(
-      request,
-      now,
-    );
+    const range = resolveCalendarEventRange(request, now);
+    const { startAt, endAt, timeZone, isAllDay } = range;
     if (!request.grantId || isElizaCalendarGrant(request.grantId)) {
       if (calendarId !== ELIZA_CALENDAR_ID) {
         fail(
@@ -5554,6 +5553,7 @@ export class CalendarService extends Service {
         startAt,
         endAt,
         timeZone,
+        isAllDay,
         attendees: normalizeCalendarAttendees(request.attendees),
         now,
       });
@@ -5607,6 +5607,7 @@ export class CalendarService extends Service {
         location: normalizeOptionalString(request.location),
         startAt,
         endAt,
+        isAllDay,
         attendees: normalizeCalendarAttendees(request.attendees),
         notifyAttendees: request.notifyAttendees === true,
         idempotencyKey: requireNonEmptyString(
@@ -5692,8 +5693,8 @@ export class CalendarService extends Service {
           accountId: accountIdForGrant(grant),
           calendarId,
           title: requireNonEmptyString(request.title, "title"),
-          startAt,
-          endAt,
+          startAt: range.startDate ?? startAt,
+          endAt: range.endDateExclusive ?? endAt,
           timeZone,
           description: normalizeOptionalString(request.description),
           location: normalizeOptionalString(request.location),
@@ -5843,6 +5844,7 @@ export class CalendarService extends Service {
       location?: string;
       startAt?: string;
       endAt?: string;
+      allDay?: LifeOpsCalendarAllDayRange;
       timeZone?: string;
       attendees?: CreateLifeOpsCalendarEventAttendee[] | null;
       recurrence?: string[] | null;
@@ -5888,6 +5890,11 @@ export class CalendarService extends Service {
       ...(args.request.endAt !== undefined
         ? { endAt: args.request.endAt }
         : {}),
+      ...(args.request.allDay !== undefined
+        ? { isAllDay: true }
+        : args.request.startAt !== undefined || args.request.endAt !== undefined
+          ? { isAllDay: false }
+          : {}),
       ...(args.request.timeZone !== undefined
         ? { timeZone: args.request.timeZone }
         : {}),
@@ -5994,6 +6001,7 @@ export class CalendarService extends Service {
       location?: string;
       startAt?: string;
       endAt?: string;
+      allDay?: LifeOpsCalendarAllDayRange;
       timeZone?: string;
       attendees?: CreateLifeOpsCalendarEventAttendee[] | null;
       recurrence?: string[] | null;
@@ -6025,26 +6033,52 @@ export class CalendarService extends Service {
       ? normalizeCalendarTimeZone(request.timeZone)
       : undefined;
     const parseTimeZone = timeZone ?? normalizeCalendarTimeZone(undefined);
+    const allDayRange = request.allDay
+      ? resolveCalendarEventRange(
+          {
+            title: request.title ?? "Calendar event",
+            allDay: request.allDay,
+            timeZone,
+          },
+          new Date(),
+        )
+      : null;
+    if (
+      allDayRange &&
+      (request.startAt !== undefined || request.endAt !== undefined)
+    ) {
+      fail(400, "allDay cannot be combined with timed bounds");
+    }
     const nativePatch = {
       calendarId: request.calendarId ?? undefined,
       title: request.title,
       description: request.description,
       location: request.location,
-      startAt: request.startAt
-        ? normalizeCalendarDateTimeInTimeZone(
-            request.startAt,
-            "startAt",
-            parseTimeZone,
-          )
-        : undefined,
-      endAt: request.endAt
-        ? normalizeCalendarDateTimeInTimeZone(
-            request.endAt,
-            "endAt",
-            parseTimeZone,
-          )
-        : undefined,
+      startAt:
+        allDayRange?.startAt ??
+        (request.startAt
+          ? normalizeCalendarDateTimeInTimeZone(
+              request.startAt,
+              "startAt",
+              parseTimeZone,
+            )
+          : undefined),
+      endAt:
+        allDayRange?.endAt ??
+        (request.endAt
+          ? normalizeCalendarDateTimeInTimeZone(
+              request.endAt,
+              "endAt",
+              parseTimeZone,
+            )
+          : undefined),
       timeZone,
+      isAllDay:
+        allDayRange !== null
+          ? true
+          : request.startAt !== undefined || request.endAt !== undefined
+            ? false
+            : undefined,
       attendees:
         request.attendees === undefined
           ? undefined
@@ -6058,6 +6092,7 @@ export class CalendarService extends Service {
         request: {
           ...request,
           ...nativePatch,
+          allDay: request.allDay,
           recurrence,
           recurrenceScope,
         },
@@ -6127,20 +6162,24 @@ export class CalendarService extends Service {
           title: request.title,
           description: request.description,
           location: request.location,
-          startAt: request.startAt
-            ? normalizeCalendarDateTimeInTimeZone(
-                request.startAt,
-                "startAt",
-                parseTimeZone,
-              )
-            : undefined,
-          endAt: request.endAt
-            ? normalizeCalendarDateTimeInTimeZone(
-                request.endAt,
-                "endAt",
-                parseTimeZone,
-              )
-            : undefined,
+          startAt:
+            allDayRange?.startDate ??
+            (request.startAt
+              ? normalizeCalendarDateTimeInTimeZone(
+                  request.startAt,
+                  "startAt",
+                  parseTimeZone,
+                )
+              : undefined),
+          endAt:
+            allDayRange?.endDateExclusive ??
+            (request.endAt
+              ? normalizeCalendarDateTimeInTimeZone(
+                  request.endAt,
+                  "endAt",
+                  parseTimeZone,
+                )
+              : undefined),
           timeZone,
           attendees:
             request.attendees === undefined

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -368,6 +368,7 @@ export function createCalendarMutationApprovalGateway(options?: {
         title: args.request.title,
         startsAtMs: requireCalendarTimestamp(args.request.startAt, "startAt"),
         endsAtMs: requireCalendarTimestamp(args.request.endAt, "endAt"),
+        allDay: args.request.allDay ?? null,
         timeZone: args.request.timeZone ?? null,
         durationMinutes: args.request.durationMinutes ?? null,
         windowPreset: args.request.windowPreset ?? null,
@@ -400,7 +401,9 @@ export function createCalendarMutationApprovalGateway(options?: {
         action: "schedule_event",
         provider: boundCalendarProviderForGrant(args.request.grantId),
         payload,
-        reason: `Create "${approvalSafeLabel(payload.title)}" at ${new Date(payload.startsAtMs).toISOString()} on the bound calendar${travel}, ${notification}.`,
+        reason: payload.allDay
+          ? `Create "${approvalSafeLabel(payload.title)}" as an all-day event from ${payload.allDay.startDate} through ${payload.allDay.endDateExclusive} (exclusive) on the bound calendar${travel}, ${notification}.`
+          : `Create "${approvalSafeLabel(payload.title)}" at ${new Date(payload.startsAtMs).toISOString()} on the bound calendar${travel}, ${notification}.`,
       });
     },
     async modify(args) {
@@ -435,6 +438,7 @@ export function createCalendarMutationApprovalGateway(options?: {
           endsAtMs: args.request.endAt
             ? requireCalendarTimestamp(args.request.endAt, "endAt")
             : null,
+          allDay: args.request.allDay ?? null,
           timeZone: args.request.timeZone ?? null,
           attendees:
             args.request.attendees?.map((attendee) => ({

--- a/plugins/plugin-personal-assistant/src/lifeops/approval-queue.types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/approval-queue.types.ts
@@ -129,6 +129,11 @@ export interface CalendarApprovalAttendee {
   readonly optional?: boolean;
 }
 
+export interface CalendarApprovalAllDayRange {
+  readonly startDate: string;
+  readonly endDateExclusive: string;
+}
+
 /** String entries remain readable for approvals persisted before attendee metadata was retained. */
 export type CalendarApprovalAttendeeInput = string | CalendarApprovalAttendee;
 
@@ -176,6 +181,7 @@ export type ApprovalPayload =
       title: string;
       startsAtMs: number;
       endsAtMs: number;
+      allDay?: CalendarApprovalAllDayRange | null;
       timeZone?: string | null;
       durationMinutes?: number | null;
       windowPreset?:
@@ -218,6 +224,7 @@ export type ApprovalPayload =
         title: string | null;
         startsAtMs: number | null;
         endsAtMs: number | null;
+        allDay?: CalendarApprovalAllDayRange | null;
         timeZone?: string | null;
         attendees: ReadonlyArray<CalendarApprovalAttendeeInput> | null;
         location: string | null;

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/lifeops-port.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/lifeops-port.ts
@@ -11,6 +11,7 @@ import {
 } from "@elizaos/plugin-calendar";
 import {
   normalizeCalendarAttendees,
+  normalizeCalendarDateOnly,
   normalizeCalendarTimeZone,
 } from "@elizaos/plugin-calendar/internal/calendar-normalize";
 import {
@@ -151,6 +152,26 @@ function validateDeterministicPayload(payload: CalendarMutationPayload): void {
           "endsAtMs must be after startsAtMs.",
         );
       }
+      if (payload.allDay) {
+        const startDate = normalizeCalendarDateOnly(
+          payload.allDay.startDate,
+          "allDay.startDate",
+        );
+        const endDateExclusive = normalizeCalendarDateOnly(
+          payload.allDay.endDateExclusive,
+          "allDay.endDateExclusive",
+        );
+        if (
+          endDateExclusive <= startDate ||
+          payload.startsAtMs !== Date.parse(`${startDate}T00:00:00.000Z`) ||
+          payload.endsAtMs !== Date.parse(`${endDateExclusive}T00:00:00.000Z`)
+        ) {
+          throw new CalendarMutationPreflightError(
+            "CALENDAR_MUTATION_INVALID_PAYLOAD",
+            "The approved all-day range does not match its immutable date boundaries.",
+          );
+        }
+      }
       normalizeCalendarAttendees(
         payload.attendees.map(calendarAttendeeRequest),
       );
@@ -214,6 +235,22 @@ function validateDeterministicPayload(payload: CalendarMutationPayload): void {
           "CALENDAR_MUTATION_INVALID_PAYLOAD",
           "The approved event end must be after its start.",
         );
+      }
+      if (payload.patch.allDay) {
+        const startDate = normalizeCalendarDateOnly(
+          payload.patch.allDay.startDate,
+          "patch.allDay.startDate",
+        );
+        const endDateExclusive = normalizeCalendarDateOnly(
+          payload.patch.allDay.endDateExclusive,
+          "patch.allDay.endDateExclusive",
+        );
+        if (endDateExclusive <= startDate) {
+          throw new CalendarMutationPreflightError(
+            "CALENDAR_MUTATION_INVALID_PAYLOAD",
+            "The approved all-day patch end must follow its start.",
+          );
+        }
       }
       if (payload.patch.attendees !== null) {
         normalizeCalendarAttendees(
@@ -1074,8 +1111,20 @@ export function createLifeOpsCalendarMutationPort(
             grantId: preflight.sourceId,
             calendarId: preflight.calendarId,
             title: payload.title,
-            startAt: new Date(payload.startsAtMs).toISOString(),
-            endAt: new Date(payload.endsAtMs).toISOString(),
+            ...(!payload.allDay
+              ? {
+                  startAt: new Date(payload.startsAtMs).toISOString(),
+                  endAt: new Date(payload.endsAtMs).toISOString(),
+                }
+              : {}),
+            ...(payload.allDay
+              ? {
+                  allDay: {
+                    startDate: payload.allDay.startDate,
+                    endDateExclusive: payload.allDay.endDateExclusive,
+                  },
+                }
+              : {}),
             ...(payload.timeZone !== null && payload.timeZone !== undefined
               ? { timeZone: payload.timeZone }
               : {}),
@@ -1174,12 +1223,20 @@ export function createLifeOpsCalendarMutationPort(
             ...(payload.patch.location !== null
               ? { location: payload.patch.location }
               : {}),
-            ...(payload.patch.startsAtMs !== null
+            ...(payload.patch.allDay
+              ? {
+                  allDay: {
+                    startDate: payload.patch.allDay.startDate,
+                    endDateExclusive: payload.patch.allDay.endDateExclusive,
+                  },
+                }
+              : {}),
+            ...(payload.patch.startsAtMs !== null && !payload.patch.allDay
               ? {
                   startAt: new Date(payload.patch.startsAtMs).toISOString(),
                 }
               : {}),
-            ...(payload.patch.endsAtMs !== null
+            ...(payload.patch.endsAtMs !== null && !payload.patch.allDay
               ? { endAt: new Date(payload.patch.endsAtMs).toISOString() }
               : {}),
             ...(payload.patch.timeZone !== null &&

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/owner-editor-gateway.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/owner-editor-gateway.integration.test.ts
@@ -579,6 +579,37 @@ describe("OwnerCalendarMutationGatewayService — real PGlite", () => {
     });
   });
 
+  it("preserves civil all-day dates in the immutable approval", async () => {
+    const gateway = new OwnerCalendarMutationGatewayService(
+      runtime,
+      deps(readablePort()),
+    );
+    const {
+      startAt: _startAt,
+      endAt: _endAt,
+      ...allDayRequest
+    } = createRequest;
+    await gateway.create(new URL("http://internal.local"), {
+      ...allDayRequest,
+      allDay: {
+        startDate: "2027-03-14",
+        endDateExclusive: "2027-03-15",
+      },
+      timeZone: "America/Los_Angeles",
+      idempotencyKey: "owner-editor-all-day-1",
+    });
+    expect(executedApprovals[0]?.payload).toMatchObject({
+      action: "schedule_event",
+      startsAtMs: Date.parse("2027-03-14T00:00:00.000Z"),
+      endsAtMs: Date.parse("2027-03-15T00:00:00.000Z"),
+      allDay: {
+        startDate: "2027-03-14",
+        endDateExclusive: "2027-03-15",
+      },
+      timeZone: "America/Los_Angeles",
+    });
+  });
+
   it("resolves preset and duration into an exact immutable range", async () => {
     const gateway = new OwnerCalendarMutationGatewayService(
       runtime,

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/owner-editor-gateway.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/owner-editor-gateway.ts
@@ -467,6 +467,13 @@ export class OwnerCalendarMutationGatewayService
       title: request.title,
       startsAtMs,
       endsAtMs,
+      allDay:
+        range.isAllDay && range.startDate && range.endDateExclusive
+          ? {
+              startDate: range.startDate,
+              endDateExclusive: range.endDateExclusive,
+            }
+          : null,
       timeZone: range.timeZone,
       durationMinutes: request.durationMinutes ?? null,
       windowPreset: request.windowPreset ?? null,
@@ -572,6 +579,7 @@ export class OwnerCalendarMutationGatewayService
             request.endAt !== undefined
               ? requireAbsoluteTimestamp(request.endAt, "endAt")
               : null,
+          allDay: request.allDay ?? null,
           timeZone: request.timeZone ?? null,
           attendees:
             request.attendees?.map((attendee) => ({

--- a/plugins/plugin-personal-assistant/src/lifeops/school/calendar-workflow.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/school/calendar-workflow.pglite.test.ts
@@ -250,6 +250,11 @@ describe("SchoolCalendarWorkflow with real PGlite", () => {
     title: string;
     startAt: string | undefined;
     endAt: string | undefined;
+    allDay: { startDate: string; endDateExclusive: string } | undefined;
+  }>;
+  let updatedRanges: Array<{
+    eventId: string;
+    allDay: { startDate: string; endDateExclusive: string } | undefined;
   }>;
   let clock: Date;
 
@@ -270,6 +275,7 @@ describe("SchoolCalendarWorkflow with real PGlite", () => {
     text = twoColumnText;
     creates = 0;
     createdRanges = [];
+    updatedRanges = [];
     clock = new Date("2026-08-30T12:00:00.000Z");
     const lookupFn = async () => [{ address: "93.184.216.34", family: 4 }];
     const pinnedFetchImpl = vi.fn(async ({ url }: { url: URL }) => {
@@ -302,6 +308,7 @@ describe("SchoolCalendarWorkflow with real PGlite", () => {
           title: request.title,
           startAt: request.startAt,
           endAt: request.endAt,
+          allDay: request.allDay,
         });
         return {
           outcome: "event",
@@ -310,6 +317,10 @@ describe("SchoolCalendarWorkflow with real PGlite", () => {
         };
       },
       async update(_url, request) {
+        updatedRanges.push({
+          eventId: request.eventId,
+          allDay: request.allDay,
+        });
         return event(request.eventId, request.title ?? "updated");
       },
       async cancel() {
@@ -376,7 +387,7 @@ describe("SchoolCalendarWorkflow with real PGlite", () => {
     expect(creates).toBe(2);
   });
 
-  it("sends all-day boundaries with DST-aware RFC 3339 offsets", async () => {
+  it("sends civil all-day ranges across standard and daylight time", async () => {
     text = ["2026-01-15 | Winter event", "Summer event | 2026-07-15"].join(
       "\n",
     );
@@ -392,15 +403,66 @@ describe("SchoolCalendarWorkflow with real PGlite", () => {
     expect(createdRanges).toEqual([
       {
         title: "Winter event",
-        startAt: "2026-01-15T00:00:00-05:00",
-        endAt: "2026-01-16T00:00:00-05:00",
+        startAt: undefined,
+        endAt: undefined,
+        allDay: {
+          startDate: "2026-01-15",
+          endDateExclusive: "2026-01-16",
+        },
       },
       {
         title: "Summer event",
-        startAt: "2026-07-15T00:00:00-04:00",
-        endAt: "2026-07-16T00:00:00-04:00",
+        startAt: undefined,
+        endAt: undefined,
+        allDay: {
+          startDate: "2026-07-15",
+          endDateExclusive: "2026-07-16",
+        },
       },
     ]);
+  });
+
+  it("creates a reviewable one-time migration for legacy timed school rows, then returns to hash no-op", async () => {
+    const first = await workflow.run();
+    if (first.state !== "awaiting_approval") throw new Error("expected plan");
+    await workflow.applyApprovedPlan({
+      runId: first.runId,
+      requestUrl: new URL("http://localhost"),
+      gateway,
+    });
+    await db.exec(
+      "UPDATE app_lifeops.life_school_calendar_sources SET calendar_contract_version = 1",
+    );
+
+    const migration = await workflow.run(undefined, "scheduled");
+    expect(migration.state).toBe("awaiting_approval");
+    if (migration.state !== "awaiting_approval") {
+      throw new Error("expected migration plan");
+    }
+    expect(migration.plan.calendarContractVersion).toBe(2);
+    expect(migration.plan.changes.map((change) => change.kind)).toEqual([
+      "update",
+      "update",
+    ]);
+    await workflow.applyApprovedPlan({
+      runId: migration.runId,
+      requestUrl: new URL("http://localhost"),
+      gateway,
+    });
+    expect(updatedRanges).toEqual([
+      {
+        eventId: "provider-1",
+        allDay: { startDate: "2026-09-01", endDateExclusive: "2026-09-02" },
+      },
+      {
+        eventId: "provider-2",
+        allDay: { startDate: "2026-10-09", endDateExclusive: "2026-10-10" },
+      },
+    ]);
+    await expect(workflow.run(undefined, "scheduled")).resolves.toMatchObject({
+      state: "unchanged",
+      contentSha256: hash(pdfBytes),
+    });
   });
 
   it("rejects a concurrent apply owner while the first lease is active", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/school/calendar-workflow.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/school/calendar-workflow.ts
@@ -28,10 +28,6 @@ import {
   sqlQuote,
   toText,
 } from "../sql.js";
-import {
-  buildUtcDateFromLocalParts,
-  formatInstantAsRfc3339InTimeZone,
-} from "../time.js";
 
 export const CONCORD_SCHOOL_CALENDAR_SOURCE: SchoolCalendarSourceConfig = {
   sourceId: "concord-cps-school-year-calendar",
@@ -54,6 +50,7 @@ const MAX_LANDING_BYTES = 512 * 1024;
 const MAX_PDF_BYTES = 20 * 1024 * 1024;
 const FETCH_TIMEOUT_MS = 10_000;
 const LEASE_MS = 5 * 60_000;
+const SCHOOL_CALENDAR_CONTRACT_VERSION = 2;
 
 const SCHEMA = [
   `CREATE SCHEMA IF NOT EXISTS app_lifeops`,
@@ -63,6 +60,7 @@ const SCHEMA = [
     lease_expires_at TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
     PRIMARY KEY (agent_id, source_id)
   )`,
+  `ALTER TABLE app_lifeops.life_school_calendar_sources ADD COLUMN IF NOT EXISTS calendar_contract_version INTEGER NOT NULL DEFAULT 1`,
   `CREATE TABLE IF NOT EXISTS app_lifeops.life_school_calendar_runs (
     agent_id TEXT NOT NULL, run_id TEXT NOT NULL, source_id TEXT NOT NULL,
     state TEXT NOT NULL, trigger_kind TEXT NOT NULL, discovered_pdf_url TEXT,
@@ -148,6 +146,7 @@ export type SchoolCalendarChange =
 
 export interface SchoolCalendarApprovalPlan {
   version: 1;
+  calendarContractVersion: 2;
   sourceId: string;
   runId: string;
   contentSha256: string;
@@ -223,34 +222,6 @@ export class SchoolCalendarWorkflowError extends Error {
     super(message, options);
     this.name = "SchoolCalendarWorkflowError";
   }
-}
-
-const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/u;
-
-function allDayBoundary(dateOnly: string, timeZone: string): string {
-  const match = DATE_ONLY.exec(dateOnly);
-  if (!match) {
-    throw new SchoolCalendarWorkflowError(
-      "School calendar event has an invalid local date.",
-      "SCHOOL_CALENDAR_DATE_INVALID",
-    );
-  }
-  const instant = buildUtcDateFromLocalParts(timeZone, {
-    year: Number(match[1]),
-    month: Number(match[2]),
-    day: Number(match[3]),
-    hour: 0,
-    minute: 0,
-    second: 0,
-  });
-  const boundary = formatInstantAsRfc3339InTimeZone(instant, timeZone);
-  if (!boundary.startsWith(`${dateOnly}T00:00:00`)) {
-    throw new SchoolCalendarWorkflowError(
-      "School calendar local date cannot be represented at midnight in its timezone.",
-      "SCHOOL_CALENDAR_DATE_INVALID",
-    );
-  }
-  return boundary;
 }
 
 function sha256(value: Buffer | string): string {
@@ -642,6 +613,7 @@ function parsePositionedSchoolCalendar(
 export function diffSchoolCalendarEvents(
   previous: readonly PersistedEvent[],
   current: readonly SchoolCalendarSemanticEvent[],
+  options: { migrateToAllDay?: boolean } = {},
 ): SchoolCalendarChange[] {
   const oldByKey = new Map(
     previous
@@ -682,6 +654,21 @@ export function diffSchoolCalendarEvents(
         endDateExclusive: event.endDateExclusive,
       })
     ) {
+      if (options.migrateToAllDay) {
+        if (!before.providerEventId || !before.providerVersion) {
+          throw new SchoolCalendarWorkflowError(
+            `Cannot migrate ${key} to all-day without its provider identity and version.`,
+            "SCHOOL_CALENDAR_PROVIDER_IDENTITY_MISSING",
+          );
+        }
+        return {
+          kind: "update",
+          before,
+          event,
+          providerEventId: before.providerEventId,
+          providerVersion: before.providerVersion,
+        };
+      }
       return { kind: "unchanged", event };
     }
     if (!before.providerEventId || !before.providerVersion) {
@@ -807,7 +794,10 @@ export class SchoolCalendarWorkflow {
         );
       }
       const source = await this.source(config.sourceId);
-      if (source.lastContentSha256 === contentSha256) {
+      if (
+        source.lastContentSha256 === contentSha256 &&
+        source.calendarContractVersion >= SCHOOL_CALENDAR_CONTRACT_VERSION
+      ) {
         await this.completeNoop(
           runId,
           config.sourceId,
@@ -826,7 +816,10 @@ export class SchoolCalendarWorkflow {
       const text = await this.extract(bytes);
       const current = parseSchoolCalendarText(text);
       const previous = await this.events(config.sourceId);
-      const changes = diffSchoolCalendarEvents(previous, current);
+      const changes = diffSchoolCalendarEvents(previous, current, {
+        migrateToAllDay:
+          source.calendarContractVersion < SCHOOL_CALENDAR_CONTRACT_VERSION,
+      });
       if (changes.every((change) => change.kind === "unchanged")) {
         await this.completeNoop(
           runId,
@@ -845,6 +838,7 @@ export class SchoolCalendarWorkflow {
       }
       const plan: SchoolCalendarApprovalPlan = {
         version: 1,
+        calendarContractVersion: SCHOOL_CALENDAR_CONTRACT_VERSION,
         sourceId: config.sourceId,
         runId,
         contentSha256,
@@ -961,11 +955,10 @@ export class SchoolCalendarWorkflow {
             grantId: config.targetGrantId,
             calendarId: config.targetCalendarId,
             title: change.event.title,
-            startAt: allDayBoundary(change.event.startDate, config.timeZone),
-            endAt: allDayBoundary(
-              change.event.endDateExclusive,
-              config.timeZone,
-            ),
+            allDay: {
+              startDate: change.event.startDate,
+              endDateExclusive: change.event.endDateExclusive,
+            },
             timeZone: config.timeZone,
             notifyAttendees: false,
             idempotencyKey: `${config.sourceId}:${change.event.eventKey}:${plan.contentSha256}`,
@@ -989,11 +982,10 @@ export class SchoolCalendarWorkflow {
             calendarId: config.targetCalendarId,
             eventId: change.providerEventId,
             title: change.event.title,
-            startAt: allDayBoundary(change.event.startDate, config.timeZone),
-            endAt: allDayBoundary(
-              change.event.endDateExclusive,
-              config.timeZone,
-            ),
+            allDay: {
+              startDate: change.event.startDate,
+              endDateExclusive: change.event.endDateExclusive,
+            },
             timeZone: config.timeZone,
             expectedProviderVersion: change.providerVersion,
             idempotencyKey: `${config.sourceId}:${change.event.eventKey}:${plan.contentSha256}`,
@@ -1048,7 +1040,7 @@ export class SchoolCalendarWorkflow {
         );
       await executeRawSql(
         this.runtime,
-        `UPDATE app_lifeops.life_school_calendar_sources SET last_content_sha256=${sqlQuote(plan.contentSha256)},last_media_url=${sqlQuote(plan.mediaUrl)},updated_at=${sqlQuote(completedAt)} WHERE agent_id=${sqlQuote(this.runtime.agentId)} AND source_id=${sqlQuote(config.sourceId)}`,
+        `UPDATE app_lifeops.life_school_calendar_sources SET last_content_sha256=${sqlQuote(plan.contentSha256)},last_media_url=${sqlQuote(plan.mediaUrl)},calendar_contract_version=${SCHOOL_CALENDAR_CONTRACT_VERSION},updated_at=${sqlQuote(completedAt)} WHERE agent_id=${sqlQuote(this.runtime.agentId)} AND source_id=${sqlQuote(config.sourceId)}`,
       );
     } catch (error) {
       // error-policy:J2 Restore the exact owned apply leases, then rethrow a
@@ -1238,17 +1230,19 @@ export class SchoolCalendarWorkflow {
     );
   }
 
-  private async source(
-    sourceId: string,
-  ): Promise<{ lastContentSha256: string | null }> {
+  private async source(sourceId: string): Promise<{
+    lastContentSha256: string | null;
+    calendarContractVersion: number;
+  }> {
     const rows = await executeRawSql(
       this.runtime,
-      `SELECT last_content_sha256 FROM app_lifeops.life_school_calendar_sources WHERE agent_id = ${sqlQuote(this.runtime.agentId)} AND source_id = ${sqlQuote(sourceId)} LIMIT 1`,
+      `SELECT last_content_sha256, calendar_contract_version FROM app_lifeops.life_school_calendar_sources WHERE agent_id = ${sqlQuote(this.runtime.agentId)} AND source_id = ${sqlQuote(sourceId)} LIMIT 1`,
     );
     return {
       lastContentSha256: rows[0]?.last_content_sha256
         ? toText(rows[0].last_content_sha256)
         : null,
+      calendarContractVersion: Number(rows[0]?.calendar_contract_version ?? 1),
     };
   }
 
@@ -1286,7 +1280,7 @@ export class SchoolCalendarWorkflow {
     );
     await executeRawSql(
       this.runtime,
-      `UPDATE app_lifeops.life_school_calendar_sources SET last_content_sha256 = ${sqlQuote(hash)}, last_media_url = ${sqlQuote(mediaUrl)}, updated_at = ${sqlQuote(at)} WHERE agent_id = ${sqlQuote(this.runtime.agentId)} AND source_id = ${sqlQuote(sourceId)}`,
+      `UPDATE app_lifeops.life_school_calendar_sources SET last_content_sha256 = ${sqlQuote(hash)}, last_media_url = ${sqlQuote(mediaUrl)}, calendar_contract_version = ${SCHOOL_CALENDAR_CONTRACT_VERSION}, updated_at = ${sqlQuote(at)} WHERE agent_id = ${sqlQuote(this.runtime.agentId)} AND source_id = ${sqlQuote(sourceId)}`,
     );
     await this.release(sourceId, lease, at);
   }
@@ -1363,6 +1357,8 @@ function parseApprovalPlan(
 ): SchoolCalendarApprovalPlan {
   if (
     value.version !== 1 ||
+    (value.calendarContractVersion !== undefined &&
+      value.calendarContractVersion !== SCHOOL_CALENDAR_CONTRACT_VERSION) ||
     typeof value.sourceId !== "string" ||
     typeof value.runId !== "string" ||
     typeof value.contentSha256 !== "string" ||
@@ -1375,6 +1371,7 @@ function parseApprovalPlan(
   }
   return {
     version: 1,
+    calendarContractVersion: SCHOOL_CALENDAR_CONTRACT_VERSION,
     sourceId: value.sourceId,
     runId: value.runId,
     contentSha256: value.contentSha256,


### PR DESCRIPTION
Closes #30239

## What changed
- Add a mutually exclusive `allDay` civil-date contract for calendar create/update mutations.
- Preserve all-day dates through owner approval payloads and execution.
- Teach built-in, Google, Apple, and Microsoft adapters to retain all-day semantics.
- Make school workflow v2 migrate legacy v1 midnight-timed events through provider-bound in-place updates, then return to unchanged-hash no-op behavior.
- Keep timed-event behavior compatible.

## Verification
- `bun install --frozen-lockfile`
- `bun run verify` (376/376 tasks)
- Shared/calendar/personal-assistant typechecks and lint
- Focused all-day/DST/workflow tests: 27 passed
- Owner approval integration: 15 passed
- Calendar package: 712 passed; one unrelated existing Google watch fixture failure requires a stable external identity

## Live acceptance after merge
Run the unchanged Concord source, review exactly 43 update operations and zero creates/deletes, approve/apply, verify 43 unique all-day events, then rerun and require unchanged/no-op with a stable count.