### PR TITLE
fix(auth): retain SSO mint custody and recovery intent

### DIFF
--- a/packages/cloud/api/__tests__/sso-bridge.test.ts
+++ b/packages/cloud/api/__tests__/sso-bridge.test.ts
@@ -1,5 +1,5 @@
 /**
- * Route-level contract for POST /api/auth/sso-bridge/{mint,exchange} through
+ * Route-level contract for POST /api/auth/sso-bridge/{mint,exchange,burn} through
  * the REAL route module: real HS256 Steward JWTs (jose) verified by the real
  * `verifyStewardTokenCached`, and the real POSTGRES-backed single-use code
  * store + logout-marker service on PGlite — the same atomic
@@ -156,6 +156,13 @@ function exchange(code: string, verifier?: string): Promise<Response> {
   });
 }
 
+function burn(
+  code: string,
+  origin: string = "https://eliza.app",
+): Promise<Response> {
+  return call("/burn", { origin, body: { code } });
+}
+
 /** Assert a 200 exchange body carries a REAL re-minted token for `userId`,
  * accepted by the production verifier. */
 async function expectUsableToken(
@@ -234,6 +241,7 @@ describe("origin gating", () => {
   test("exchange requires an app-host origin — the dashboard cannot exchange", async () => {
     for (const origin of [
       undefined,
+      "https://eliza.app",
       "https://elizacloud.ai",
       "https://evil.elizacloud.ai",
       "https://sandbox-1.elizacloud.ai",
@@ -244,6 +252,22 @@ describe("origin gating", () => {
       });
       expect(res.status).toBe(403);
     }
+  });
+
+  test("burn accepts only exact bridge origins", async () => {
+    const code = `esso_${"0".repeat(64)}`;
+    for (const origin of [
+      undefined,
+      "https://evil.eliza.app",
+      "https://sandbox-1.cloud.eliza.app",
+      "https://eliza.app.evil.com",
+    ]) {
+      expect((await call("/burn", { origin, body: { code } })).status).toBe(
+        403,
+      );
+    }
+    expect((await burn(code, "https://eliza.app")).status).toBe(204);
+    expect((await burn(code, "https://cloud.eliza.app")).status).toBe(204);
   });
 });
 
@@ -391,6 +415,22 @@ describe("code lifecycle", () => {
 
     const after = await exchange(code, verifier);
     expect(after.status).toBe(401);
+  });
+
+  test("the mint origin can burn through the destruction-only endpoint", async () => {
+    const token = await mintToken("user-mint-origin-burn");
+    const { verifier, challenge } = await makeVerifierPair();
+    const code = await mintCode(token, challenge);
+
+    const burned = await burn(code);
+    expect(burned.status).toBe(204);
+    expect(await burned.text()).toBe("");
+
+    const after = await exchange(code, verifier);
+    expect(after.status).toBe(401);
+    expect(((await after.json()) as { code: string }).code).toBe(
+      "invalid_code",
+    );
   });
 
   test("an expired code fails", async () => {

--- a/packages/cloud/api/__tests__/sso-bridge.test.ts
+++ b/packages/cloud/api/__tests__/sso-bridge.test.ts
@@ -269,6 +269,25 @@ describe("origin gating", () => {
     expect((await burn(code, "https://eliza.app")).status).toBe(204);
     expect((await burn(code, "https://cloud.eliza.app")).status).toBe(204);
   });
+  test("burn treats malformed JSON as explicit invalid input", async () => {
+    ipCounter += 1;
+    const res = await app.request(
+      "/burn",
+      {
+        method: "POST",
+        headers: {
+          origin: "https://eliza.app",
+          "content-type": "application/json",
+          "x-forwarded-for": `10.0.${Math.floor(ipCounter / 250)}.${ipCounter % 250}`,
+        },
+        body: "{",
+      },
+      ENV,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { code: string }).code).toBe("missing_code");
+  });
 });
 
 describe("mint authentication", () => {

--- a/packages/cloud/api/auth/sso-bridge/route.ts
+++ b/packages/cloud/api/auth/sso-bridge/route.ts
@@ -232,10 +232,20 @@ app.post("/burn", async (c) => {
       return c.json(errorBody("Forbidden", "forbidden_origin"), 403);
     }
 
-    const body = (await c.req.json().catch(() => ({}))) as {
-      code?: unknown;
-    };
-    const code = typeof body.code === "string" ? body.code : null;
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 malformed JSON is an explicit invalid request, not an
+      // empty object that could be mistaken for a successfully parsed body.
+      return c.json(errorBody("Code required", "missing_code"), 400);
+    }
+    const code =
+      body && typeof body === "object" && "code" in body
+        ? typeof body.code === "string"
+          ? body.code
+          : null
+        : null;
     if (!looksLikeSsoBridgeCode(code)) {
       return c.json(errorBody("Code required", "missing_code"), 400);
     }

--- a/packages/cloud/api/auth/sso-bridge/route.ts
+++ b/packages/cloud/api/auth/sso-bridge/route.ts
@@ -4,6 +4,7 @@
  *
  *   POST /api/auth/sso-bridge/mint      (Bearer-authenticated) → { code }
  *   POST /api/auth/sso-bridge/exchange  (public, code+verifier) → { token }
+ *   POST /api/auth/sso-bridge/burn      (public, code only) → 204
  *
  * WHY A HANDSHAKE AND NOT A SHARED JS-READABLE COOKIE: the SPA session is a
  * per-origin localStorage JWT, and this platform serves user-controlled
@@ -79,6 +80,12 @@ const MINT_ORIGIN_HOSTS = new Set<string>([
 const EXCHANGE_ORIGIN_HOSTS = new Set<string>([
   new URL(ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin).hostname,
   new URL(ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin).hostname,
+]);
+
+/** Either trusted leg may destroy a code, but this endpoint never exchanges. */
+const BURN_ORIGIN_HOSTS = new Set<string>([
+  ...MINT_ORIGIN_HOSTS,
+  ...EXCHANGE_ORIGIN_HOSTS,
 ]);
 
 /** Only honored when the worker is NOT production (local dev / tests). */
@@ -212,6 +219,36 @@ app.post("/mint", async (c) => {
     // This is also the logout-marker fail-CLOSED path: an unreadable marker
     // store throws and lands here, so an outage can never mint.
     logger.error("[sso-bridge] mint failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.json(errorBody("SSO bridge unavailable", "sso_unavailable"), 503);
+  }
+});
+
+app.post("/burn", async (c) => {
+  try {
+    const isProduction = c.env.NODE_ENV === "production";
+    if (!checkBridgeOrigin(c, BURN_ORIGIN_HOSTS, isProduction)) {
+      return c.json(errorBody("Forbidden", "forbidden_origin"), 403);
+    }
+
+    const body = (await c.req.json().catch(() => ({}))) as {
+      code?: unknown;
+    };
+    const code = typeof body.code === "string" ? body.code : null;
+    if (!looksLikeSsoBridgeCode(code)) {
+      return c.json(errorBody("Code required", "missing_code"), 400);
+    }
+
+    // `consumeSsoBridgeCode` atomically deletes before checking the missing
+    // verifier. Always return the same empty response so this destruction-only
+    // endpoint cannot reveal whether the code existed or was already spent.
+    await consumeSsoBridgeCode(code, null);
+    return c.body(null, 204);
+  } catch (error) {
+    // error-policy:J1 route boundary — a failed best-effort burn remains a
+    // structured outage; the code's short TTL is still the final boundary.
+    logger.error("[sso-bridge] burn failed", {
       error: error instanceof Error ? error.message : String(error),
     });
     return c.json(errorBody("SSO bridge unavailable", "sso_unavailable"), 503);

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.test.tsx
@@ -1,0 +1,117 @@
+/** Recovery semantics for the public authentication-error route. */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { appModeNavigation } from "../../../app-mode/app-mode";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const replaceMock = vi.hoisted(() => vi.fn());
+const searchParamsRef = vi.hoisted(() => ({
+  current: new URLSearchParams(
+    "reason=sync_failed&returnTo=%2Fchat%3Fthread%3Done",
+  ),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParamsRef.current, vi.fn()],
+  Link: ({ to, children, ...rest }: { to: string; children: ReactNode }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+
+import AuthErrorPage, { AuthErrorPageForHost } from "./auth-error-page";
+
+const realReplace = appModeNavigation.replace;
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  replaceMock.mockReset();
+  appModeNavigation.replace = replaceMock;
+  searchParamsRef.current = new URLSearchParams(
+    "reason=sync_failed&returnTo=%2Fchat%3Fthread%3Done",
+  );
+});
+
+afterEach(cleanup);
+afterAll(() => {
+  appModeNavigation.replace = realReplace;
+});
+
+describe("AuthErrorPage", () => {
+  it("announces the recovery surface by focusing its page heading", async () => {
+    render(<AuthErrorPage />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Authentication Sync Failed",
+    });
+    await waitFor(() => expect(document.activeElement).toBe(heading));
+    expect(heading.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("preserves the sanitized deep-link when the user retries", () => {
+    render(<AuthErrorPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/login?returnTo=%2Fchat%3Fthread%3Done",
+    );
+  });
+
+  it("restarts mint-host recovery on the paired app login", () => {
+    render(<AuthErrorPageForHost hostname="staging.eliza.app" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(replaceMock).toHaveBeenCalledWith(
+      "https://cloud-staging.eliza.app/login?returnTo=%2Fchat%3Fthread%3Done",
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a cross-origin retry target and falls back to join", () => {
+    searchParamsRef.current = new URLSearchParams(
+      "reason=auth_failed&returnTo=https%3A%2F%2Fevil.example%2Fsteal",
+    );
+    render(<AuthErrorPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(navigateMock).toHaveBeenCalledWith("/login?returnTo=%2Fjoin");
+  });
+
+  it("keeps visible keyboard-focus styling on both recovery actions", () => {
+    render(<AuthErrorPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Try Again" }).className,
+    ).toContain("hosted-signin-focus-emphasis");
+    expect(screen.getByRole("link", { name: "Go Home" }).className).toContain(
+      "hosted-signin-focus-emphasis",
+    );
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.tsx
@@ -4,17 +4,37 @@
  */
 
 import { AlertCircle, Home, RefreshCw } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
+import { appModeNavigation } from "../../../app-mode/app-mode";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
+import { pairedAppLoginUrlForMintHost } from "../../../sso-bridge/sso-bridge";
+import { resolveLoginReturnTo } from "../../lib/login-return-to";
 import { usePageTitle } from "../../lib/use-page-title";
 import { AuthResultShell } from "./auth-result-shell";
 
-export default function AuthErrorPage() {
+export function AuthErrorPageForHost({
+  hostname,
+}: {
+  /** Injectable for the mint-host recovery composition test. */
+  hostname: string;
+}) {
   const t = useCloudT();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const reason = searchParams.get("reason") || "unknown";
+  const returnTo = resolveLoginReturnTo(searchParams);
+  const localLoginUrl = `/login?returnTo=${encodeURIComponent(returnTo)}`;
+  const pairedAppLoginUrl = pairedAppLoginUrlForMintHost(hostname, returnTo);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    // A client-side route change does not move screen-reader focus on its own.
+    // Focus the recovery heading so the unexpected failure and next action are
+    // announced immediately without adding an assertive live-region duplicate.
+    if (reason) headingRef.current?.focus({ preventScroll: true });
+  }, [reason]);
 
   usePageTitle(
     t("cloud.authError.metaTitle", {
@@ -58,28 +78,40 @@ export default function AuthErrorPage() {
   return (
     <AuthResultShell>
       <div className="flex size-14 items-center justify-center bg-destructive-subtle">
-        <AlertCircle className="size-7 text-destructive" />
+        <AlertCircle className="size-7 text-destructive" aria-hidden="true" />
       </div>
       <div className="space-y-2">
-        <h2 className="text-xl font-semibold text-txt">{error.title}</h2>
+        <h1
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-xl font-semibold text-txt outline-none"
+        >
+          {error.title}
+        </h1>
         <p className="text-sm text-muted">{error.description}</p>
       </div>
 
       <div className="w-full space-y-3">
         <Button
-          onClick={() => navigate("/login")}
-          className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+          onClick={() => {
+            if (pairedAppLoginUrl) {
+              appModeNavigation.replace(pairedAppLoginUrl);
+              return;
+            }
+            navigate(localLoginUrl);
+          }}
+          className="hosted-signin-focus-emphasis h-11 w-full bg-accent text-accent-foreground hover:bg-accent-hover"
         >
-          <RefreshCw className="size-4 mr-2" />
+          <RefreshCw className="mr-2 size-4" aria-hidden="true" />
           {t("cloud.authError.tryAgain", { defaultValue: "Try Again" })}
         </Button>
         <Button
           variant="outline"
           asChild
-          className="w-full h-11 border-border hover:bg-bg-hover"
+          className="hosted-signin-focus-emphasis h-11 w-full border-border hover:bg-bg-hover"
         >
           <Link to="/">
-            <Home className="size-4 mr-2" />
+            <Home className="mr-2 size-4" aria-hidden="true" />
             {t("cloud.authError.goHome", { defaultValue: "Go Home" })}
           </Link>
         </Button>
@@ -92,4 +124,10 @@ export default function AuthErrorPage() {
       </p>
     </AuthResultShell>
   );
+}
+
+export default function AuthErrorPage() {
+  const hostname =
+    typeof window === "undefined" ? "" : window.location.hostname;
+  return <AuthErrorPageForHost hostname={hostname} />;
 }

--- a/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.test.tsx
+++ b/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.test.tsx
@@ -2,9 +2,17 @@
 // @vitest-environment jsdom
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import {
+  MemoryRouter,
+  type NavigateFunction,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { appModeNavigation } from "../app-mode/app-mode";
 import { SsoBridgeRoute } from "./SsoBridgeRoute";
 
@@ -67,6 +75,15 @@ function json(status: number, body: unknown): Response {
 function LocationProbe({ id }: { id: string }): React.JSX.Element {
   const location = useLocation();
   return <div data-testid={id}>{`${location.pathname}${location.search}`}</div>;
+}
+
+function NavigationCapture({
+  capture,
+}: {
+  capture: (navigate: NavigateFunction) => void;
+}): null {
+  capture(useNavigate());
+  return null;
 }
 
 function renderBridge(hostname: string, search: string): void {
@@ -186,6 +203,215 @@ describe("SsoBridgeRoute — mint leg (eliza.app auth host)", () => {
     });
   });
 
+  it("keeps a successful mint single-shot through StrictMode effect replay", async () => {
+    setReferrer("https://cloud.eliza.app/");
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    stubNetwork((url) =>
+      url.endsWith("/api/auth/sso-bridge/mint")
+        ? json(200, { ok: true, code: CODE })
+        : json(401, { error: "invalid_verifier" }),
+    );
+
+    render(
+      <StrictMode>
+        <MemoryRouter initialEntries={[`/auth/bridge${MINT_QS}`]}>
+          <Routes>
+            <Route
+              path="/auth/bridge"
+              element={<SsoBridgeRoute hostname="eliza.app" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(replacedUrls).toEqual([
+        `https://cloud.eliza.app/auth/bridge?code=${CODE}&state=${STATE}&returnTo=%2Fchat`,
+      ]),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchLog).toHaveLength(1);
+  });
+
+  it("burns a minted code when the bridge route unmounts before navigation", async () => {
+    setReferrer("https://cloud.eliza.app/");
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    let resolveMint!: (response: Response) => void;
+    fetchLog = [];
+    globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchLog.push({ url, init });
+      if (url.endsWith("/api/auth/sso-bridge/mint")) {
+        return new Promise<Response>((resolve) => {
+          resolveMint = resolve;
+        });
+      }
+      return Promise.resolve(json(401, { error: "invalid_verifier" }));
+    }) as typeof fetch;
+    replacedUrls = [];
+    appModeNavigation.replace = (url: string) => {
+      replacedUrls.push(url);
+    };
+
+    const view = render(
+      <MemoryRouter initialEntries={[`/auth/bridge${MINT_QS}`]}>
+        <Routes>
+          <Route
+            path="/auth/bridge"
+            element={<SsoBridgeRoute hostname="eliza.app" />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(fetchLog).toHaveLength(1));
+    view.unmount();
+
+    await act(async () => {
+      resolveMint(json(200, { ok: true, code: CODE }));
+      await Promise.resolve();
+    });
+
+    expect(replacedUrls).toEqual([]);
+    await waitFor(() => expect(fetchLog).toHaveLength(2));
+    expect(fetchLog[1].url).toBe("https://eliza.app/api/auth/sso-bridge/burn");
+    expect(JSON.parse(String(fetchLog[1].init?.body))).toEqual({ code: CODE });
+  });
+
+  it("burns a stale mint when the challenge changes and only hands off the current code", async () => {
+    const nextChallenge = "f".repeat(64);
+    const nextCode = `esso_${"c".repeat(64)}`;
+    setReferrer("https://cloud.eliza.app/");
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    const resolveMints: Array<(response: Response) => void> = [];
+    fetchLog = [];
+    globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchLog.push({ url, init });
+      if (url.endsWith("/api/auth/sso-bridge/mint")) {
+        return new Promise<Response>((resolve) => {
+          resolveMints.push(resolve);
+        });
+      }
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as typeof fetch;
+    replacedUrls = [];
+    appModeNavigation.replace = (url: string) => {
+      replacedUrls.push(url);
+    };
+    let navigate!: NavigateFunction;
+
+    render(
+      <MemoryRouter initialEntries={[`/auth/bridge${MINT_QS}`]}>
+        <NavigationCapture
+          capture={(capturedNavigate) => {
+            navigate = capturedNavigate;
+          }}
+        />
+        <Routes>
+          <Route
+            path="/auth/bridge"
+            element={<SsoBridgeRoute hostname="eliza.app" />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(resolveMints).toHaveLength(1));
+
+    act(() => {
+      navigate(
+        `/auth/bridge?state=${OTHER_STATE}&challenge=${nextChallenge}&returnTo=%2Fchat`,
+      );
+    });
+    await waitFor(() => expect(resolveMints).toHaveLength(2));
+
+    await act(async () => {
+      resolveMints[1](json(200, { ok: true, code: nextCode }));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(replacedUrls).toEqual([
+        `https://cloud.eliza.app/auth/bridge?code=${nextCode}&state=${OTHER_STATE}&returnTo=%2Fchat`,
+      ]),
+    );
+
+    await act(async () => {
+      resolveMints[0](json(200, { ok: true, code: CODE }));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        fetchLog.filter(({ url }) => url.endsWith("/sso-bridge/burn")),
+      ).toHaveLength(1),
+    );
+    expect(JSON.parse(String(fetchLog[2].init?.body))).toEqual({ code: CODE });
+  });
+
+  it("does not burn after a successful handoff is transferred and then unmounted", async () => {
+    setReferrer("https://cloud.eliza.app/");
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    stubNetwork((url) =>
+      url.endsWith("/api/auth/sso-bridge/mint")
+        ? json(200, { ok: true, code: CODE })
+        : new Response(null, { status: 204 }),
+    );
+
+    const view = render(
+      <MemoryRouter initialEntries={[`/auth/bridge${MINT_QS}`]}>
+        <Routes>
+          <Route
+            path="/auth/bridge"
+            element={<SsoBridgeRoute hostname="eliza.app" />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(replacedUrls).toHaveLength(1));
+
+    view.unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchLog).toHaveLength(1);
+    expect(fetchLog[0].url).toBe("https://eliza.app/api/auth/sso-bridge/mint");
+  });
+
+  it("burns once and falls back to app login when code handoff navigation throws", async () => {
+    setReferrer("https://cloud.eliza.app/");
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    stubNetwork((url) =>
+      url.endsWith("/api/auth/sso-bridge/mint")
+        ? json(200, { ok: true, code: CODE })
+        : json(401, { error: "invalid_verifier" }),
+    );
+    const exchangeUrl = `https://cloud.eliza.app/auth/bridge?code=${CODE}&state=${STATE}&returnTo=%2Fchat`;
+    appModeNavigation.replace = (url: string) => {
+      replacedUrls.push(url);
+      if (url === exchangeUrl) {
+        throw new DOMException("Blocked", "SecurityError");
+      }
+    };
+
+    renderBridge("eliza.app", MINT_QS);
+
+    await waitFor(() =>
+      expect(replacedUrls).toEqual([
+        exchangeUrl,
+        "https://cloud.eliza.app/login?returnTo=%2Fchat",
+      ]),
+    );
+    expect(
+      fetchLog.filter(({ url }) => url.endsWith("/sso-bridge/mint")),
+    ).toHaveLength(1);
+    expect(
+      fetchLog.filter(({ url }) => url.endsWith("/sso-bridge/burn")),
+    ).toHaveLength(1);
+    expect(JSON.parse(String(fetchLog[1].init?.body))).toEqual({ code: CODE });
+  });
+
   it("mint failure → the app host's own login, never a loop back here", async () => {
     setReferrer("https://cloud.eliza.app/");
     localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
@@ -223,8 +449,9 @@ describe("SsoBridgeRoute — exchange leg (app host)", () => {
   function expectBurnOnly(): void {
     expect(fetchLog).toHaveLength(1);
     expect(fetchLog[0].url).toBe(
-      "https://cloud.eliza.app/api/auth/sso-bridge/exchange",
+      "https://cloud.eliza.app/api/auth/sso-bridge/burn",
     );
+    expect(fetchLog[0].init?.keepalive).toBe(true);
     expect(JSON.parse(String(fetchLog[0].init?.body))).toEqual({ code: CODE });
   }
 

--- a/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.test.tsx
+++ b/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.test.tsx
@@ -31,10 +31,10 @@ function base64url(value: unknown): string {
     .replace(/=+$/, "");
 }
 
-function liveToken(): string {
+function liveToken(userId = "u1"): string {
   return [
     base64url({ alg: "none", typ: "JWT" }),
-    base64url({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 3600 }),
+    base64url({ userId, exp: Math.floor(Date.now() / 1000) + 3600 }),
     "sig",
   ].join(".");
 }
@@ -91,6 +91,10 @@ function renderBridge(hostname: string, search: string): void {
     <MemoryRouter initialEntries={[`/auth/bridge${search}`]}>
       <Routes>
         <Route path="/login" element={<LocationProbe id="login-page" />} />
+        <Route
+          path="/auth/error"
+          element={<LocationProbe id="auth-error-page" />}
+        />
         <Route path="/" element={<LocationProbe id="home-page" />} />
         <Route
           path="/auth/bridge"
@@ -411,6 +415,72 @@ describe("SsoBridgeRoute — mint leg (eliza.app auth host)", () => {
     ).toHaveLength(1);
     expect(JSON.parse(String(fetchLog[1].init?.body))).toEqual({ code: CODE });
   });
+
+  it("burns once and exposes an unexpected handoff failure distinctly", async () => {
+    setReferrer("https://cloud.eliza.app/");
+    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    stubNetwork((url) =>
+      url.endsWith("/api/auth/sso-bridge/mint")
+        ? json(200, { ok: true, code: CODE })
+        : new Response(null, { status: 204 }),
+    );
+    appModeNavigation.replace = (url: string) => {
+      replacedUrls.push(url);
+      throw new Error("Unexpected navigation adapter failure");
+    };
+
+    renderBridge("eliza.app", MINT_QS);
+
+    expect((await screen.findByTestId("auth-error-page")).textContent).toBe(
+      "/auth/error?reason=auth_failed&returnTo=%2Fchat",
+    );
+    expect(
+      fetchLog.filter(({ url }) => url.endsWith("/sso-bridge/burn")),
+    ).toHaveLength(1);
+    expect(JSON.parse(String(fetchLog[1].init?.body))).toEqual({ code: CODE });
+  });
+
+  it.each(["removed", "replaced"])(
+    "burns the issued code if the minting session is %s while mint is pending",
+    async (mutation) => {
+      setReferrer("https://cloud.eliza.app/");
+      const originalToken = liveToken();
+      localStorage.setItem(STEWARD_TOKEN_KEY, originalToken);
+      let resolveMint!: (response: Response) => void;
+      const pendingMint = new Promise<Response>((resolve) => {
+        resolveMint = resolve;
+      });
+      fetchLog = [];
+      replacedUrls = [];
+      globalThis.fetch = vi.fn(
+        (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          fetchLog.push({ url, init });
+          return url.endsWith("/mint")
+            ? pendingMint
+            : Promise.resolve(new Response(null, { status: 204 }));
+        },
+      ) as typeof fetch;
+      appModeNavigation.replace = (url) => replacedUrls.push(url);
+      renderBridge("eliza.app", MINT_QS);
+      await waitFor(() => expect(fetchLog).toHaveLength(1));
+
+      const nextToken = mutation === "replaced" ? liveToken("new-user") : null;
+      if (nextToken) localStorage.setItem(STEWARD_TOKEN_KEY, nextToken);
+      else localStorage.removeItem(STEWARD_TOKEN_KEY);
+      await act(async () => resolveMint(json(200, { code: CODE })));
+
+      await waitFor(() =>
+        expect(replacedUrls).toEqual([
+          "https://cloud.eliza.app/login?returnTo=%2Fchat",
+        ]),
+      );
+      const burns = fetchLog.filter(({ url }) => url.endsWith("/burn"));
+      expect(burns).toHaveLength(1);
+      expect(JSON.parse(String(burns[0].init?.body))).toEqual({ code: CODE });
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(nextToken);
+    },
+  );
 
   it("mint failure → the app host's own login, never a loop back here", async () => {
     setReferrer("https://cloud.eliza.app/");

--- a/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx
+++ b/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx
@@ -119,6 +119,103 @@ function referrerIsPairedAppOrigin(
   }
 }
 
+type MintedCodeHandoff = {
+  /** Destroy the code while this document still owns it. Idempotent. */
+  burn(): void;
+  /** Relinquish custody after the browser accepts the app-origin navigation. */
+  transfer(): void;
+};
+
+type MintLegOutcome =
+  | { kind: "not-initiated" }
+  | { handoff?: MintedCodeHandoff; kind: "redirect"; url: string };
+
+/** Run one challenge-bound mint transaction for the component lifetime. */
+async function runMintLegOperation(
+  hostname: string,
+  state: string,
+  challenge: string,
+  returnTo: string,
+): Promise<MintLegOutcome> {
+  const appOrigin = pairedAppOrigin(hostname);
+  if (!appOrigin) return { kind: "not-initiated" };
+
+  const referrer = document.referrer;
+  const appInitiated = referrerIsPairedAppOrigin(appOrigin, referrer);
+  const remembered = hasRememberedMintIntent(state);
+  if (!appInitiated && !remembered) {
+    if (!referrer) {
+      // Referrer-stripping privacy settings make a legitimate app handoff
+      // indistinguishable from a direct visit. Keep minting fail-closed, but
+      // send the user to the app's ordinary login instead of stranding them
+      // on the public homepage.
+      return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+    }
+    // Not a handshake the app origin initiated (direct visit, or a
+    // third-party page forcing a signed-in user here): mint nothing.
+    return { kind: "not-initiated" };
+  }
+
+  if (appInitiated && !remembered && !rememberMintIntent(state)) {
+    return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+  }
+
+  if (!hasHydratableStewardToken()) {
+    // Login is owned by this public/auth origin. Preserve the exact bridge
+    // leg as a same-origin returnTo; once Steward succeeds, the remembered
+    // referrer-approved intent permits minting and sends the user back to
+    // the managed app. No credential is ever entered on the app host.
+    const bridgeReturnTo = `${SSO_BRIDGE_PATH}?state=${encodeURIComponent(state)}&challenge=${encodeURIComponent(challenge)}&returnTo=${encodeURIComponent(returnTo)}`;
+    return {
+      kind: "redirect",
+      url: `/login?returnTo=${encodeURIComponent(bridgeReturnTo)}`,
+    };
+  }
+
+  forgetMintIntent(state);
+  let mintedCode: string | null = null;
+  const burnMintedCodeOnce = (): void => {
+    if (!mintedCode) return;
+    const code = mintedCode;
+    mintedCode = null;
+    try {
+      burnSsoBridgeCode(code, hostname);
+    } catch {
+      // error-policy:J6 the abandoned code still expires after its short
+      // server TTL; clearing local custody keeps this teardown exactly-once.
+    }
+  };
+
+  try {
+    const result = await mintSsoCode(hostname, challenge);
+    if (!result.ok) {
+      return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+    }
+
+    mintedCode = result.code;
+    const url = buildBridgeExchangeUrl(hostname, result.code, state, returnTo);
+    if (!url) {
+      burnMintedCodeOnce();
+      return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+    }
+
+    return {
+      handoff: {
+        burn: burnMintedCodeOnce,
+        transfer: () => {
+          mintedCode = null;
+        },
+      },
+      kind: "redirect",
+      url,
+    };
+  } catch {
+    // A late failure after mint must not leave a live code without a consumer.
+    burnMintedCodeOnce();
+    return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+  }
+}
+
 function MintLeg({
   hostname,
   state,
@@ -130,57 +227,80 @@ function MintLeg({
   challenge: string;
   returnTo: string;
 }): React.JSX.Element {
-  const startedRef = useRef(false);
+  const operationRef = useRef<{
+    activeEffects: Set<number>;
+    key: string;
+    promise: Promise<MintLegOutcome>;
+  } | null>(null);
+  const effectGenerationRef = useRef(0);
   const [notInitiated, setNotInitiated] = useState(false);
 
   useEffect(() => {
-    if (startedRef.current) return;
-    startedRef.current = true;
-    const appOrigin = pairedAppOrigin(hostname);
-    if (!appOrigin) return;
+    const effectGeneration = effectGenerationRef.current + 1;
+    effectGenerationRef.current = effectGeneration;
+    const effectIsCurrent = () =>
+      effectGenerationRef.current === effectGeneration;
+    const operationKey = JSON.stringify([hostname, state, challenge, returnTo]);
+    const previousOperation = operationRef.current;
+    const operation =
+      previousOperation?.key === operationKey
+        ? previousOperation
+        : {
+            activeEffects: new Set<number>(),
+            key: operationKey,
+            promise: runMintLegOperation(hostname, state, challenge, returnTo),
+          };
+    operationRef.current = operation;
+    operation.activeEffects.add(effectGeneration);
 
-    const referrer = document.referrer;
-    const appInitiated = referrerIsPairedAppOrigin(appOrigin, referrer);
-    const remembered = hasRememberedMintIntent(state);
-    if (!appInitiated && !remembered) {
-      if (!referrer) {
-        // Referrer-stripping privacy settings make a legitimate app handoff
-        // indistinguishable from a direct visit. Keep minting fail-closed, but
-        // send the user to the app's ordinary login instead of stranding them
-        // on the public homepage.
-        appModeNavigation.replace(appLoginUrl(appOrigin, returnTo));
-        return;
+    const redirectToAppLogin = (): void => {
+      const appOrigin = pairedAppOrigin(hostname);
+      try {
+        appModeNavigation.replace(
+          appOrigin ? appLoginUrl(appOrigin, returnTo) : "/",
+        );
+      } catch {
+        // error-policy:J6 navigation is unavailable; any owned code has already
+        // been burned and its short server TTL remains the final boundary.
       }
-      // Not a handshake the app origin initiated (direct visit, or a
-      // third-party page forcing a signed-in user here): mint nothing.
-      setNotInitiated(true);
-      return;
-    }
+    };
 
-    if (appInitiated && !remembered && !rememberMintIntent(state)) {
-      appModeNavigation.replace(appLoginUrl(appOrigin, returnTo));
-      return;
-    }
+    void operation.promise
+      .then((outcome) => {
+        if (!effectIsCurrent()) {
+          if (outcome.kind === "redirect" && outcome.handoff) {
+            // StrictMode immediately re-subscribes to the same operation. A
+            // microtask distinguishes that replay from a real abandonment.
+            queueMicrotask(() => {
+              if (operation.activeEffects.size === 0) outcome.handoff?.burn();
+            });
+          }
+          return;
+        }
+        if (outcome.kind === "not-initiated") {
+          setNotInitiated(true);
+          return;
+        }
+        try {
+          appModeNavigation.replace(outcome.url);
+          outcome.handoff?.transfer();
+        } catch {
+          outcome.handoff?.burn();
+          redirectToAppLogin();
+        }
+      })
+      .catch(() => {
+        // error-policy:J4 an unforeseen operation failure must still leave the
+        // current user on a recoverable terminal surface.
+        if (effectIsCurrent()) redirectToAppLogin();
+      });
 
-    if (!hasHydratableStewardToken()) {
-      // Login is owned by this public/auth origin. Preserve the exact bridge
-      // leg as a same-origin returnTo; once Steward succeeds, the remembered
-      // referrer-approved intent permits minting and sends the user back to
-      // the managed app. No credential is ever entered on the app host.
-      const bridgeReturnTo = `${SSO_BRIDGE_PATH}?state=${encodeURIComponent(state)}&challenge=${encodeURIComponent(challenge)}&returnTo=${encodeURIComponent(returnTo)}`;
-      appModeNavigation.replace(
-        `/login?returnTo=${encodeURIComponent(bridgeReturnTo)}`,
-      );
-      return;
-    }
-
-    forgetMintIntent(state);
-    void mintSsoCode(hostname, challenge).then((result) => {
-      const url = result.ok
-        ? buildBridgeExchangeUrl(hostname, result.code, state, returnTo)
-        : null;
-      appModeNavigation.replace(url ?? appLoginUrl(appOrigin, returnTo));
-    });
+    return () => {
+      operation.activeEffects.delete(effectGeneration);
+      if (effectIsCurrent()) {
+        effectGenerationRef.current = effectGeneration + 1;
+      }
+    };
   }, [hostname, state, challenge, returnTo]);
 
   if (notInitiated) {

--- a/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx
+++ b/packages/ui/src/cloud/sso-bridge/SsoBridgeRoute.tsx
@@ -18,19 +18,23 @@
  *  - every other hostname (localhost, previews, per-agent subdomains): inert —
  *    an immediate local redirect home, no bridge code paths reachable.
  *
- * Every failure path lands on the app origin's OWN /login (the loop-guard
- * marker set at initiation keeps that login from bouncing back here), and the
- * transient legs use replace-style navigation so Back never re-enters the
- * handshake.
+ * Expected failures return to the app origin's own login; unexpected mint
+ * failures use the distinct authentication-error page with a retry destination.
+ * The loop guard suppresses repeated handshakes, and replace-style navigation
+ * keeps Back from re-entering a completed bridge leg.
  */
 
+import { ElizaError } from "@elizaos/core";
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { useEffect, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { Card } from "../../components/ui/card";
+import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
 import { appModeNavigation } from "../app-mode/app-mode";
 import { hasHydratableStewardToken } from "../lib/steward-session";
 import {
   buildBridgeExchangeUrl,
+  buildSsoBridgeErrorUrl,
   burnSsoBridgeCode,
   consumeSsoBridgeState,
   consumeSsoBridgeVerifier,
@@ -120,6 +124,8 @@ function referrerIsPairedAppOrigin(
 }
 
 type MintedCodeHandoff = {
+  /** Recheck the minting account at the navigation boundary. */
+  isCurrent(): boolean;
   /** Destroy the code while this document still owns it. Idempotent. */
   burn(): void;
   /** Relinquish custody after the browser accepts the app-origin navigation. */
@@ -173,17 +179,13 @@ async function runMintLegOperation(
   }
 
   forgetMintIntent(state);
+  const mintingToken = readStoredStewardToken();
   let mintedCode: string | null = null;
   const burnMintedCodeOnce = (): void => {
     if (!mintedCode) return;
     const code = mintedCode;
     mintedCode = null;
-    try {
-      burnSsoBridgeCode(code, hostname);
-    } catch {
-      // error-policy:J6 the abandoned code still expires after its short
-      // server TTL; clearing local custody keeps this teardown exactly-once.
-    }
+    burnSsoBridgeCode(code, hostname);
   };
 
   try {
@@ -193,6 +195,13 @@ async function runMintLegOperation(
     }
 
     mintedCode = result.code;
+    if (
+      readStoredStewardToken() !== mintingToken ||
+      !hasHydratableStewardToken()
+    ) {
+      burnMintedCodeOnce();
+      return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+    }
     const url = buildBridgeExchangeUrl(hostname, result.code, state, returnTo);
     if (!url) {
       burnMintedCodeOnce();
@@ -201,6 +210,9 @@ async function runMintLegOperation(
 
     return {
       handoff: {
+        isCurrent: () =>
+          readStoredStewardToken() === mintingToken &&
+          hasHydratableStewardToken(),
         burn: burnMintedCodeOnce,
         transfer: () => {
           mintedCode = null;
@@ -209,10 +221,16 @@ async function runMintLegOperation(
       kind: "redirect",
       url,
     };
-  } catch {
-    // A late failure after mint must not leave a live code without a consumer.
+  } catch (error) {
+    // error-policy:J2 a late failure after mint first relinquishes local code
+    // custody, then reaches the UI boundary as a typed failure with its cause.
     burnMintedCodeOnce();
-    return { kind: "redirect", url: appLoginUrl(appOrigin, returnTo) };
+    throw new ElizaError("SSO mint handoff failed after code issuance", {
+      code: "SSO_BRIDGE_MINT_HANDOFF_FAILED",
+      cause: error,
+      severity: "fatal",
+      context: { hostname },
+    });
   }
 }
 
@@ -234,6 +252,7 @@ function MintLeg({
   } | null>(null);
   const effectGenerationRef = useRef(0);
   const [notInitiated, setNotInitiated] = useState(false);
+  const [unexpectedFailure, setUnexpectedFailure] = useState(false);
 
   useEffect(() => {
     const effectGeneration = effectGenerationRef.current + 1;
@@ -253,15 +272,22 @@ function MintLeg({
     operationRef.current = operation;
     operation.activeEffects.add(effectGeneration);
 
-    const redirectToAppLogin = (): void => {
+    const redirectToAppLogin = (): boolean => {
       const appOrigin = pairedAppOrigin(hostname);
       try {
         appModeNavigation.replace(
           appOrigin ? appLoginUrl(appOrigin, returnTo) : "/",
         );
-      } catch {
-        // error-policy:J6 navigation is unavailable; any owned code has already
-        // been burned and its short server TTL remains the final boundary.
+        return true;
+      } catch (error) {
+        // error-policy:J1 the UI navigation boundary reports the browser error;
+        // its caller renders the distinct authentication-error route.
+        reportRendererDiagnostic({
+          scope: "steward.sso-bridge.login-navigation",
+          error,
+          severity: "error",
+        });
+        return false;
       }
     };
 
@@ -281,18 +307,43 @@ function MintLeg({
           setNotInitiated(true);
           return;
         }
+        if (outcome.handoff && !outcome.handoff.isCurrent()) {
+          outcome.handoff.burn();
+          if (!redirectToAppLogin()) setUnexpectedFailure(true);
+          return;
+        }
         try {
           appModeNavigation.replace(outcome.url);
           outcome.handoff?.transfer();
-        } catch {
+        } catch (error) {
+          // error-policy:J1 report the failed handoff navigation at the UI
+          // boundary before burning custody. Only the expected browser-policy
+          // rejection degrades to the safe login path.
+          reportRendererDiagnostic({
+            scope: "steward.sso-bridge.handoff-navigation",
+            error,
+            severity: "error",
+          });
           outcome.handoff?.burn();
-          redirectToAppLogin();
+          if (
+            !(
+              error instanceof DOMException && error.name === "SecurityError"
+            ) ||
+            !redirectToAppLogin()
+          ) {
+            setUnexpectedFailure(true);
+          }
         }
       })
-      .catch(() => {
-        // error-policy:J4 an unforeseen operation failure must still leave the
-        // current user on a recoverable terminal surface.
-        if (effectIsCurrent()) redirectToAppLogin();
+      .catch((error) => {
+        // error-policy:J1 an unforeseen lifecycle rejection is reported and
+        // becomes a visibly distinct error route rather than ordinary login.
+        reportRendererDiagnostic({
+          scope: "steward.sso-bridge.mint-lifecycle",
+          error,
+          severity: "error",
+        });
+        if (effectIsCurrent()) setUnexpectedFailure(true);
       });
 
     return () => {
@@ -303,6 +354,11 @@ function MintLeg({
     };
   }, [hostname, state, challenge, returnTo]);
 
+  if (unexpectedFailure) {
+    return (
+      <Navigate to={buildSsoBridgeErrorUrl("auth_failed", returnTo)} replace />
+    );
+  }
   if (notInitiated) {
     return <Navigate to="/" replace />;
   }

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -513,14 +513,13 @@ describe("performSsoExchange", () => {
 });
 
 describe("burnSsoBridgeCode", () => {
-  it("fires a verifier-less exchange POST that destroys the code server-side", () => {
-    const { fn, calls } = fetchStub(() => json(401, { error: "invalid_code" }));
-    burnSsoBridgeCode(CODE, "cloud.eliza.app", fn);
+  it("fires a keepalive destruction-only POST from either bridge origin", () => {
+    const { fn, calls } = fetchStub(() => new Response(null, { status: 204 }));
+    burnSsoBridgeCode(CODE, "eliza.app", fn);
     expect(calls).toHaveLength(1);
-    expect(calls[0].url).toBe(
-      "https://cloud.eliza.app/api/auth/sso-bridge/exchange",
-    );
+    expect(calls[0].url).toBe("https://eliza.app/api/auth/sso-bridge/burn");
     expect(JSON.parse(String(calls[0].init?.body))).toEqual({ code: CODE });
+    expect(calls[0].init?.keepalive).toBe(true);
   });
 
   it("is inert for malformed codes and unmapped hosts", () => {

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -567,12 +567,10 @@ export async function performSsoExchange(
 }
 
 /**
- * Destroy a code this origin refuses to exchange (state mismatch, missing
- * verifier). The server consumes atomically BEFORE checking the verifier, so
- * presenting the bare code burns it: without this, an abandoned handshake
- * leaves a live code sitting in the address bar and both origins' request
- * logs for the rest of its TTL. Fire-and-forget — the reply is always 401 and
- * failure to burn only restores the pre-existing exposure.
+ * Destroy a code this document refuses to hand off or exchange. The dedicated
+ * endpoint accepts either exact bridge origin but can only consume: it never
+ * returns a session. Keepalive lets the tiny fire-and-forget POST survive the
+ * fallback navigation; failure leaves only the code's short server TTL.
  */
 export function burnSsoBridgeCode(
   code: string,
@@ -581,9 +579,10 @@ export function burnSsoBridgeCode(
 ): void {
   const base = apiBaseForHostname(hostname);
   if (!base || !isWellFormedSsoCode(code)) return;
-  void fetchFn(`${base}/api/auth/sso-bridge/exchange`, {
+  void fetchFn(`${base}/api/auth/sso-bridge/burn`, {
     method: "POST",
     credentials: "include",
+    keepalive: true,
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ code }),
   }).catch(() => {

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -51,6 +51,7 @@ import {
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { shellLocalStorage } from "../../surface-realm-channel";
+import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
 import { appModeNavigation } from "../app-mode/app-mode";
 import { decodeJwtPayload } from "../lib/jwt";
 import { invalidateStewardServerCookieSyncMarker } from "../lib/steward-session-cookie-sync-marker";
@@ -146,6 +147,39 @@ export function sanitizeBridgeReturnTo(
   const path = value.split(/[?#]/, 1)[0];
   if (path === SSO_BRIDGE_PATH) return "/";
   return value;
+}
+
+/**
+ * Local recovery URL for an unexpected bridge failure. Keep the original
+ * same-origin destination so retrying authentication does not discard a deep
+ * link such as `/chat`, while applying the same open-redirect and loop guards
+ * as the cross-origin handshake itself.
+ */
+export function buildSsoBridgeErrorUrl(
+  reason: "auth_failed" | "sync_failed",
+  returnTo: string,
+): string {
+  const params = new URLSearchParams({
+    reason,
+    returnTo: sanitizeBridgeReturnTo(returnTo),
+  });
+  return `/auth/error?${params.toString()}`;
+}
+
+/**
+ * Recovery from a mint-host error must restart on the paired app host. A
+ * same-origin `/login` on the marketing host cannot restore app-only paths
+ * such as `/chat`: its authenticated catch-all intentionally hands users to
+ * `/cloud` instead. The hostname is resolved only through the fixed bridge
+ * pair allowlist, and the destination remains a sanitized app-local path.
+ */
+export function pairedAppLoginUrlForMintHost(
+  hostname: string,
+  returnTo: string,
+): string | null {
+  const appOrigin = pairedAppOrigin(hostname);
+  if (!appOrigin) return null;
+  return `${appOrigin}/login?returnTo=${encodeURIComponent(sanitizeBridgeReturnTo(returnTo))}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -579,16 +613,31 @@ export function burnSsoBridgeCode(
 ): void {
   const base = apiBaseForHostname(hostname);
   if (!base || !isWellFormedSsoCode(code)) return;
-  void fetchFn(`${base}/api/auth/sso-bridge/burn`, {
-    method: "POST",
-    credentials: "include",
-    keepalive: true,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ code }),
-  }).catch(() => {
-    // error-policy:J6 best-effort destruction of an already-abandoned code;
-    // the code still dies on its own 60s TTL.
-  });
+  try {
+    void fetchFn(`${base}/api/auth/sso-bridge/burn`, {
+      method: "POST",
+      credentials: "include",
+      keepalive: true,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    }).catch((error) => {
+      // error-policy:J6 best-effort destruction of an already-abandoned code;
+      // report the failure while the code's 60s TTL remains the final boundary.
+      reportRendererDiagnostic({
+        scope: "steward.sso-bridge.code-burn",
+        error,
+        severity: "warning",
+      });
+    });
+  } catch (error) {
+    // error-policy:J6 a fetch adapter may reject synchronously during teardown;
+    // report it and rely on the same short server-side expiry boundary.
+    reportRendererDiagnostic({
+      scope: "steward.sso-bridge.code-burn",
+      error,
+      severity: "warning",
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Abandoning an SSO mint could leave its issued one-time code live until expiry. This change keeps custody of the code until navigation succeeds, destroys it once if the route is superseded or unmounted, and rejects handoff if the minting account was removed or replaced while the request was pending.

The API adds a destruction-only `POST /api/auth/sso-bridge/burn`, restricted to the exact trusted bridge origins. It returns no session and gives the same response for spent and unknown codes. Unexpected mint/navigation failures reach a distinct recovery page; retry preserves a sanitized destination and restarts from the paired app host. The recovery heading receives focus on SPA navigation.

Relates to #29918 and #25020. The draft has been narrowed to this complete, independently useful fix. Exchange finalization, cookie synchronization, logout authority, and session-family protocols retain their develop implementations; the broader authentication epic and #30257 remain separate.

Risk: medium, because regressions could strand an authentication handoff. The new endpoint must be deployed before clients can use it; failed destruction retains the existing short code expiry. No public exports or deployment settings are removed.

Validation on `a7330fec319ed5b2b895eab48299f6dd175aca64`:

- Bun 1.3.14 / Node 24.15.0; dependency install passed with native inference setup skipped.
- Focused UI: 69 tests across three suites passed.
- Actual Hono route and PGlite: 20 tests / 101 assertions passed.
- Browser: unmount, account removal during mint, accepted handoff, and navigation-failure recovery all passed against the actual API and isolated database. Abandoned live rows were deleted; accepted handoff was not burned.
- App audit: 219/219 checks passed; 216 views had zero broken/needs-work verdicts. OCR: zero broken, 12 views marked for visual inspection. One unrelated mobile Skills hover probe timed out; affected recovery views were independently inspected at desktop/mobile sizes in rest and hover states.
- Root verification: All required checks passed across the initial full run and targeted reruns. The full run passed 375/376 Turbo tasks; temporary browser fixtures and a Vite cache contaminated the UI source inventory. After removing them, both affected graph tests passed, tight graph enforcement reported zero findings, the molecular inventory and stories gates passed, and all post-Turbo repository audits passed. Passing unchanged tests were retained rather than repeated. The worktree is clean.

Rebased onto `develop@86689515631daa982fb9f0cc823a92ff0b3da20e`. While validation ran, develop advanced through the cloud SDK fix #30617 and Account terminal-state fix #30534 to `92eb3cd6fd5`. Neither changes any file in this PR; the merged tree remains conflict-free. The scoped authentication source and evidence are unchanged.

The browser harness uses the actual React components, Hono route, real signed disposable JWTs and PGlite code store. Only API URL routing, response timing and the navigation boundary are controlled. This proves the scoped custody flow; it does not claim provider-backed staging sign-in, cross-tab cookie ordering or completion of the authentication epic.

# Evidence

<!-- evidence-head:a7330fec319ed5b2b895eab48299f6dd175aca64 -->


<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: ![Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-before-desktop.jpg) ![Mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-before-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: ![Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30243-custody-20260905-after-desktop.jpg) ![Mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-after-mobile.jpg)

[desktop hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-after-desktop-hover.jpg), [mobile hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30243-custody-20260905-after-mobile-hover.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough: [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-custody-review.mp4)

<!-- evidence-row:backend-logs -->
- [x] Real API and database execution: [backend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-custody-backend.log)

<!-- evidence-row:frontend-logs -->
- [x] [Console](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-custody-frontend-console.txt), [network status trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-custody-network.json). The deliberate navigation failure produces the expected renderer diagnostic.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider or agent-behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] [Database lifecycle proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-custody-lifecycle-proof.json)

<!-- evidence-row:ocr-review -->
- [x] [OCR and visual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30243-custody-20260905-ocr-review.json).
