### PR TITLE
fix(lifeops): report active iMessage transport

### DIFF
--- a/packages/shared/src/contracts/personal-assistant.ts
+++ b/packages/shared/src/contracts/personal-assistant.ts
@@ -4221,10 +4221,10 @@ export type LifeOpsIMessageHostPlatform =
 export interface LifeOpsIMessageConnectorStatus {
   available: boolean;
   connected: boolean;
-  bridgeType: "native" | "imsg" | "bluebubbles" | "none";
+  bridgeType: "native" | "blooio" | "imsg" | "bluebubbles" | "none";
   hostPlatform: LifeOpsIMessageHostPlatform;
   accountHandle: string | null;
-  sendMode: "cli" | "private-api" | "apple-script" | "none";
+  sendMode: "cli" | "private-api" | "provider-api" | "apple-script" | "none";
   helperConnected: boolean | null;
   privateApiEnabled: boolean | null;
   diagnostics: string[];

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/imessage-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/imessage-service.ts
@@ -1,8 +1,8 @@
 /**
  * iMessage domain for LifeOps: reads and sends the owner's iMessages through the
- * native runtime-service delegates (Full Disk Access-gated chat DB on macOS) and
- * projects native status into assistant connector DTOs. The bridge implementation
- * lives in the native macOS packages; this layer owns the assistant projection.
+ * registered runtime service and projects its active native or Blooio transport
+ * into assistant connector DTOs. The connector plugin owns transport behavior;
+ * this layer owns only the LifeOps projection and native plugin-load fallback.
  */
 import { basename } from "node:path";
 import type { Plugin } from "@elizaos/core";
@@ -16,7 +16,8 @@ import {
 import type { Constructor, LifeOpsServiceBase } from "../service-mixin-core.js";
 import { fail } from "../service-normalize.js";
 
-type NativeIMessageStatus = {
+type RuntimeIMessageStatus = {
+  transport: "native" | "blooio";
   available: boolean;
   connected: boolean;
   chatDbAvailable: boolean;
@@ -29,6 +30,8 @@ type NativeIMessageStatus = {
     url: string;
     instructions: string[];
   } | null;
+  webhookPath: string | null;
+  channelId: string | null;
 };
 
 type NativeIMessageMessage = {
@@ -49,9 +52,9 @@ type NativeIMessageChat = {
   participants: Array<{ handle: string; isPhoneNumber: boolean }>;
 };
 
-type NativeIMessageServiceLike = {
+type RuntimeIMessageServiceLike = {
   isConnected(): boolean;
-  getStatus?(): NativeIMessageStatus;
+  getStatus?(): RuntimeIMessageStatus;
   sendMessage(
     to: string,
     text: string,
@@ -213,12 +216,12 @@ async function ensureNativeIMessagePluginLoaded(
   return false;
 }
 
-async function getNativeIMessageService(
+async function getRuntimeIMessageService(
   runtime: Constructor<LifeOpsServiceBase>["prototype"]["runtime"],
-): Promise<NativeIMessageServiceLike | null> {
+): Promise<RuntimeIMessageServiceLike | null> {
   let service = runtime.getService(
     "imessage",
-  ) as NativeIMessageServiceLike | null;
+  ) as RuntimeIMessageServiceLike | null;
   if (service) {
     return service;
   }
@@ -233,7 +236,7 @@ async function getNativeIMessageService(
     );
   }
 
-  service = runtime.getService("imessage") as NativeIMessageServiceLike | null;
+  service = runtime.getService("imessage") as RuntimeIMessageServiceLike | null;
   return service ?? null;
 }
 
@@ -257,15 +260,16 @@ function unavailableIMessageStatus(
   };
 }
 
-function nativeStatusToLifeOps(
-  service: NativeIMessageServiceLike,
+function runtimeStatusToLifeOps(
+  service: RuntimeIMessageServiceLike,
   checkedAt: string,
 ): LifeOpsIMessageConnectorStatus {
   const status = service.getStatus?.();
   const diagnostics: string[] = [];
   const connected = status?.connected ?? service.isConnected();
+  const transport = status?.transport ?? "native";
 
-  if (status && !status.chatDbAvailable) {
+  if (transport === "native" && status && !status.chatDbAvailable) {
     diagnostics.push(
       status.permissionAction?.type === "full_disk_access"
         ? "full_disk_access_required"
@@ -273,31 +277,45 @@ function nativeStatusToLifeOps(
     );
   }
   if (!connected) {
-    diagnostics.push("native_bridge_not_connected");
+    diagnostics.push(
+      transport === "blooio"
+        ? "blooio_transport_not_connected"
+        : "native_bridge_not_connected",
+    );
   }
 
   return {
     available: status?.available ?? true,
     connected,
-    bridgeType: "native",
+    bridgeType: transport === "blooio" ? "blooio" : "native",
     hostPlatform: normalizeHostPlatform(),
     accountHandle: null,
-    sendMode: connected ? "apple-script" : "none",
+    sendMode:
+      connected && transport === "blooio"
+        ? "provider-api"
+        : connected
+          ? "apple-script"
+          : "none",
     helperConnected: null,
     privateApiEnabled: null,
     diagnostics,
     lastSyncAt: null,
     lastCheckedAt: checkedAt,
     error: status?.reason ?? null,
-    chatDbAvailable: status?.chatDbAvailable ?? false,
-    sendOnly: status?.sendOnly ?? !status?.chatDbAvailable,
-    chatDbPath: status?.chatDbPath,
+    chatDbAvailable:
+      transport === "native" ? (status?.chatDbAvailable ?? false) : undefined,
+    sendOnly:
+      transport === "native"
+        ? (status?.sendOnly ?? !status?.chatDbAvailable)
+        : undefined,
+    chatDbPath: transport === "native" ? status?.chatDbPath : undefined,
     reason: status?.reason ?? null,
-    permissionAction: status?.permissionAction ?? null,
+    permissionAction:
+      transport === "native" ? (status?.permissionAction ?? null) : null,
   };
 }
 
-function nativeServiceCanRead(service: NativeIMessageServiceLike): boolean {
+function nativeServiceCanRead(service: RuntimeIMessageServiceLike): boolean {
   const status = service.getStatus?.();
   if (status && !status.chatDbAvailable) {
     return false;
@@ -367,17 +385,17 @@ function unknownDeliveryStatus(messageIds: string[]): IMessageDeliveryResult[] {
 }
 
 /**
- * Native iMessage connector reads/sends, delegated to the runtime
- * `@elizaos/plugin-imessage` service with a native AppleScript fallback.
+ * iMessage connector reads and sends through the active transport exposed by
+ * the runtime `@elizaos/plugin-imessage` service.
  */
 export class IMessageDomain {
   constructor(private readonly ctx: LifeOpsContext) {}
 
   async getIMessageConnectorStatus(): Promise<LifeOpsIMessageConnectorStatus> {
     const checkedAt = new Date().toISOString();
-    const nativeService = await getNativeIMessageService(this.ctx.runtime);
-    return nativeService
-      ? nativeStatusToLifeOps(nativeService, checkedAt)
+    const runtimeService = await getRuntimeIMessageService(this.ctx.runtime);
+    return runtimeService
+      ? runtimeStatusToLifeOps(runtimeService, checkedAt)
       : unavailableIMessageStatus(checkedAt);
   }
 
@@ -410,7 +428,7 @@ export class IMessageDomain {
       }
     }
 
-    const nativeService = await getNativeIMessageService(this.ctx.runtime);
+    const nativeService = await getRuntimeIMessageService(this.ctx.runtime);
     if (!nativeService) {
       fail(503, IMESSAGE_PLUGIN_SETUP_MESSAGE);
     }
@@ -460,7 +478,7 @@ export class IMessageDomain {
       );
     }
 
-    const nativeService = await getNativeIMessageService(this.ctx.runtime);
+    const nativeService = await getRuntimeIMessageService(this.ctx.runtime);
     if (!nativeService || !nativeServiceCanRead(nativeService)) {
       fail(503, IMESSAGE_PLUGIN_SETUP_MESSAGE);
     }
@@ -474,7 +492,7 @@ export class IMessageDomain {
   }
 
   async listIMessageChats(): Promise<IMessageChat[]> {
-    const nativeService = await getNativeIMessageService(this.ctx.runtime);
+    const nativeService = await getRuntimeIMessageService(this.ctx.runtime);
     if (nativeService?.getChats && nativeServiceCanRead(nativeService)) {
       return (await nativeService.getChats()).map(nativeChatToLifeOps);
     }
@@ -486,7 +504,7 @@ export class IMessageDomain {
     chatId?: string;
     limit?: number;
   }): Promise<IMessageRecord[]> {
-    const nativeService = await getNativeIMessageService(this.ctx.runtime);
+    const nativeService = await getRuntimeIMessageService(this.ctx.runtime);
     if (!nativeService || !nativeServiceCanRead(nativeService)) {
       fail(503, IMESSAGE_PLUGIN_SETUP_MESSAGE);
     }

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-imessage-status-route.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-imessage-status-route.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Proves the owner-facing LifeOps iMessage status route projects the active
+ * runtime transport. The harness uses the real AgentRuntime service registry,
+ * LifeOps domain adapter, route dispatcher, and serialized HTTP response while
+ * replacing only the external iMessage provider.
+ */
+
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import {
+  AgentRuntime,
+  createCharacter,
+  type IAgentRuntime,
+  Service,
+  stringToUuid,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LifeOpsRouteContext } from "./lifeops-routes.js";
+
+vi.mock("./authenticated-entity-principal.js", () => ({
+  entityHasVerifiedMachineAuthBinding: vi.fn(async () => false),
+}));
+
+const { handleLifeOpsRoutes } = await import("./lifeops-routes.js");
+
+interface CapturedResponse {
+  statusCode: number;
+  body: string;
+}
+
+class BlooioIMessageService extends Service {
+  static override serviceType = "imessage";
+  capabilityDescription = "Blooio iMessage test transport";
+  connected = true;
+
+  static override async start(
+    runtime: IAgentRuntime,
+  ): Promise<BlooioIMessageService> {
+    return new BlooioIMessageService(runtime);
+  }
+
+  override async stop(): Promise<void> {}
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getStatus() {
+    return {
+      transport: "blooio" as const,
+      available: true,
+      connected: this.connected,
+      chatDbAvailable: false,
+      sendOnly: false,
+      chatDbPath: "",
+      reason: null,
+      permissionAction: null,
+      webhookPath: "/api/imessage/webhook/blooio",
+      channelId: "channel-test",
+    };
+  }
+
+  async sendMessage(): Promise<{ success: true; messageId: string }> {
+    return { success: true, messageId: "message-test" };
+  }
+}
+
+function routeContext(runtime: AgentRuntime): {
+  context: LifeOpsRouteContext;
+  response: CapturedResponse;
+} {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const request = new IncomingMessage(socket);
+  request.method = "GET";
+  const response = new ServerResponse(request);
+  const captured: CapturedResponse = { statusCode: 0, body: "" };
+  response.statusCode = 0;
+  response.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+  ): ServerResponse {
+    captured.statusCode = this.statusCode;
+    captured.body = typeof chunk === "string" ? chunk : "";
+    return this;
+  };
+
+  const pathname = "/api/lifeops/connectors/imessage/status";
+  return {
+    context: {
+      req: request,
+      res: response,
+      method: "GET",
+      pathname,
+      url: new URL(`http://localhost${pathname}`),
+      state: { runtime, adminEntityId: null },
+      json(res, data, status = 200) {
+        res.statusCode = status;
+        res.end(JSON.stringify(data));
+      },
+      error(res, message, status = 400) {
+        res.statusCode = status;
+        res.end(JSON.stringify({ error: message }));
+      },
+      async readJsonBody() {
+        return null;
+      },
+      decodePathComponent(raw) {
+        return decodeURIComponent(raw);
+      },
+    },
+    response: captured,
+  };
+}
+
+describe("LifeOps iMessage runtime status projection", () => {
+  let runtime: AgentRuntime;
+  let imessage: BlooioIMessageService;
+
+  beforeEach(async () => {
+    runtime = new AgentRuntime({
+      agentId: stringToUuid(`imessage-status-${crypto.randomUUID()}`),
+      character: createCharacter({ name: "iMessage status projection" }),
+      disableBasicCapabilities: true,
+      enableAutonomy: false,
+      logLevel: "fatal",
+    });
+    await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+    Object.defineProperty(runtime, "adapter", {
+      value: null,
+      configurable: true,
+    });
+    await runtime.registerService(BlooioIMessageService);
+    const loaded = await runtime.getServiceLoadPromise(
+      BlooioIMessageService.serviceType,
+    );
+    if (!(loaded instanceof BlooioIMessageService)) {
+      throw new Error("Blooio iMessage test service did not start.");
+    }
+    imessage = loaded;
+  });
+
+  afterEach(async () => {
+    await runtime.stop();
+  });
+
+  it("reports Blooio provider API instead of native AppleScript", async () => {
+    const { context, response } = routeContext(runtime);
+
+    await expect(handleLifeOpsRoutes(context)).resolves.toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      available: true,
+      connected: true,
+      bridgeType: "blooio",
+      sendMode: "provider-api",
+      diagnostics: [],
+      error: null,
+      permissionAction: null,
+    });
+    expect(response.body).not.toContain("apple-script");
+    expect(response.body).not.toContain("native_bridge_not_connected");
+    expect(response.body).not.toContain("chatDbPath");
+  });
+
+  it("reports a disconnected Blooio transport without native diagnostics", async () => {
+    imessage.connected = false;
+    const { context, response } = routeContext(runtime);
+
+    await expect(handleLifeOpsRoutes(context)).resolves.toBe(true);
+    expect(JSON.parse(response.body)).toMatchObject({
+      available: true,
+      connected: false,
+      bridgeType: "blooio",
+      sendMode: "none",
+      diagnostics: ["blooio_transport_not_connected"],
+    });
+    expect(response.body).not.toContain("native_bridge_not_connected");
+    expect(response.body).not.toContain("full_disk_access_required");
+  });
+});


### PR DESCRIPTION
Closes #30247

Projects the runtime iMessage service's active Blooio transport into the LifeOps connector status instead of falsely reporting native AppleScript/chat.db diagnostics on Linux.

Validation:
- route integration tests: 2 passed
- plugin-personal-assistant lint: passed
- packages/shared typecheck: passed
- root verify reached the Cloud API wrangler dry-run gate; that external dry-run remained idle and the run was stopped after all preceding checks passed