### PR TITLE
fix(calendar): keep mobile editor within viewport

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -8,7 +8,7 @@
 // real state-changing interaction (channel/kind/status filters, calendar day
 // selection and month navigation). This is the interaction owner that closes
 
-import type { Locator } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
@@ -45,9 +45,7 @@ async function expectTopmostAtCenter(
   ).toBe(true);
 }
 
-test("calendar decomposed view: responsive modes and event creation", async ({
-  page,
-}) => {
+async function openPopulatedCalendar(page: Page): Promise<void> {
   await openAppPath(page, "/calendar");
   await expect(page.getByTestId("lifeops-calendar-section")).toBeVisible({
     timeout: 60_000,
@@ -55,6 +53,12 @@ test("calendar decomposed view: responsive modes and event creation", async ({
   await expect(page.getByText("Design sync").first()).toBeVisible({
     timeout: 15_000,
   });
+}
+
+test("calendar decomposed view: responsive modes and event creation", async ({
+  page,
+}) => {
+  await openPopulatedCalendar(page);
 
   const monthMode = page.getByRole("button", { name: "Month", exact: true });
   await expectTopmostAtCenter(monthMode, "Calendar Month mode");
@@ -67,6 +71,45 @@ test("calendar decomposed view: responsive modes and event creation", async ({
   await expect(page.getByTestId("event-editor-drawer")).toBeVisible({
     timeout: 15_000,
   });
+  await expect(
+    page.getByRole("button", { name: "Create event" }),
+  ).toBeVisible();
+});
+
+test("calendar mobile layout keeps navigation and editor inside 390px viewport", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openPopulatedCalendar(page);
+
+  const dayMode = page.getByRole("button", { name: "Day", exact: true });
+  await expectTopmostAtCenter(dayMode, "Calendar Day mode");
+  await dayMode.click();
+  await expect(dayMode).toHaveAttribute("aria-pressed", "true");
+
+  const newEvent = page.getByTestId("lifeops-calendar-new-event");
+  await expectTopmostAtCenter(newEvent, "Calendar New event");
+  await expect(newEvent).toBeInViewport();
+  await expect(page.getByRole("button", { name: "Previous" })).toBeInViewport();
+  await expect(page.getByRole("button", { name: "Today" })).toBeInViewport();
+  await expect(page.getByRole("button", { name: "Next" })).toBeInViewport();
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth),
+    "Calendar mobile shell must not introduce page-level horizontal overflow",
+  ).toBe(390);
+
+  await newEvent.click();
+  const editor = page.getByTestId("event-editor-drawer");
+  await expect(editor).toBeVisible({ timeout: 15_000 });
+  const editorBounds = await editor.boundingBox();
+  expect(editorBounds).not.toBeNull();
+  expect(editorBounds?.x).toBeGreaterThanOrEqual(0);
+  expect(
+    (editorBounds?.x ?? 0) + (editorBounds?.width ?? 0),
+  ).toBeLessThanOrEqual(390);
+  await expect(page.getByLabel("Event title")).toBeInViewport();
+  await expect(page.getByLabel("Start time")).toBeInViewport();
+  await expect(page.getByLabel("End time")).toBeInViewport();
   await expect(
     page.getByRole("button", { name: "Create event" }),
   ).toBeVisible();

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
@@ -365,13 +365,18 @@ describe("EventEditorDrawer", () => {
     expect(drawerStyle.right).toBe("0px");
     expect(drawerStyle.bottom).toBe("0px");
     expect(drawerStyle.left).toBe("auto");
-    expect(drawerStyle.width).toBe("28rem");
-    expect(drawerStyle.maxWidth).toBe("100vw");
+    expect(drawerStyle.width).toBe("100vw");
+    expect(drawerStyle.maxWidth).toBe("28rem");
+    expect(drawerStyle.boxSizing).toBe("border-box");
     expect(drawerStyle.height).toBe("100dvh");
+    expect(drawerStyle.maxHeight).toBe("100dvh");
     expect(drawerStyle.margin).toBe("0px");
     expect(drawerStyle.padding).toBe("0px");
+    expect(drawerStyle.overflowX).toBe("hidden");
     expect(drawerStyle.overflowY).toBe("auto");
     expect(drawerStyle.transform).toBe("none");
+    expect(drawerStyle.translate).toBe("none");
+    expect(drawerStyle.animation).toBe("none");
 
     const start = document.getElementById(
       "event-editor-start-at",

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
@@ -892,20 +892,25 @@ export function EventEditorDrawer({
     <>
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
         <DialogContent
-          className="fixed bottom-0 right-0 top-0 !left-auto !right-0 !top-0 m-0 h-full w-[min(28rem,100vw)] max-w-[100vw] !translate-x-0 !translate-y-0 overflow-y-auto bg-bg p-0 duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full"
+          className="fixed bottom-0 right-0 top-0 !left-auto !right-0 !top-0 m-0 h-full min-w-0 max-w-none !translate-x-0 !translate-y-0 overflow-x-hidden overflow-y-auto bg-bg p-0"
           data-testid="event-editor-drawer"
           style={{
             top: 0,
             right: 0,
             bottom: 0,
             left: "auto",
-            width: "28rem",
-            maxWidth: "100vw",
+            width: "100vw",
+            maxWidth: "28rem",
+            boxSizing: "border-box",
             height: "100dvh",
+            maxHeight: "100dvh",
             margin: 0,
             padding: 0,
+            overflowX: "hidden",
             overflowY: "auto",
             transform: "none",
+            translate: "none",
+            animation: "none",
           }}
         >
           <div className="flex items-center justify-between gap-3 px-5 py-4">
@@ -923,7 +928,7 @@ export function EventEditorDrawer({
             </Button>
           </div>
 
-          <div className="space-y-4 p-5">
+          <div className="min-w-0 space-y-4 p-5">
             {error ? (
               <div className="p-1 text-xs text-danger">{error}</div>
             ) : null}
@@ -962,8 +967,8 @@ export function EventEditorDrawer({
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
+            <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="min-w-0 space-y-1.5">
                 <label
                   htmlFor="event-editor-start-at"
                   className="block text-xs font-medium text-muted"
@@ -984,7 +989,7 @@ export function EventEditorDrawer({
                   })}
                 />
               </div>
-              <div className="space-y-1.5">
+              <div className="min-w-0 space-y-1.5">
                 <label
                   htmlFor="event-editor-end-at"
                   className="block text-xs font-medium text-muted"


### PR DESCRIPTION
Closes #30250

Fixes the shipped 390x844 calendar regression where the New Event drawer inherited the centered dialog's CSS translate and rendered half offscreen. The drawer now explicitly resets individual translation, stays within the viewport, prevents horizontal overflow, and stacks datetime fields on mobile.

Validation:
- exact 390x844 UI E2E and native desktop/mobile project lanes: 4/4
- calendar unit tests: 38/38
- plugin typecheck/build/lint: passed
- root verify: 376/376
- app visual audit: 219/219, broken=0, needs-work=0, OCR broken=0
- recorded after-run visually inspected