### PR TITLE
fix(scenario-runner): keep seeded Google grants valid across strict batches

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -54,6 +54,7 @@ import {
 } from "@elizaos/scenario-runner/schema";
 import { actionMatchesScenarioExpectation } from "./action-families.ts";
 import { runFinalCheck } from "./final-checks/index.ts";
+import { unexpectedGoogleMockAuthorizationFailure } from "./google-mock-auth.ts";
 import { attachInterceptor } from "./interceptor.ts";
 import { judgeTextWithLlm } from "./judge.ts";
 import {
@@ -3327,6 +3328,15 @@ export async function runScenario(
     }
     actionScope.restore();
     report.durationMs = Date.now() - startedAt;
+  }
+
+  const googleAuthFailure = await unexpectedGoogleMockAuthorizationFailure();
+  if (googleAuthFailure) {
+    report.status = "failed";
+    report.failedAssertions.push({
+      label: "googleMockAuthorization",
+      detail: googleAuthFailure,
+    });
   }
 
   if (judgeScores.length > 0) {

--- a/packages/scenario-runner/src/google-mock-auth.test.ts
+++ b/packages/scenario-runner/src/google-mock-auth.test.ts
@@ -1,0 +1,55 @@
+/** Unit tests for unexpected Google mock 401/403 detection without live Google. */
+import { describe, expect, it } from "vitest";
+import { unexpectedGoogleMockAuthFailureDetail } from "./google-mock-auth.ts";
+
+describe("unexpectedGoogleMockAuthFailureDetail", () => {
+  it("returns null when every Google request was admitted or reset", () => {
+    expect(
+      unexpectedGoogleMockAuthFailureDetail([
+        {
+          method: "GET",
+          path: "/gmail/v1/users/me/messages",
+          statusCode: 200,
+          googleAuth: {
+            action: "auth",
+            authStatus: "admitted",
+            admittedAccountEmail: "owner@example.test",
+            requiredScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+            resetGeneration: 0,
+            statusCode: 200,
+          },
+        },
+        {
+          method: "POST",
+          path: "/__mock/google/reset",
+          statusCode: 200,
+          googleAuth: {
+            action: "reset",
+            authStatus: "reset",
+            resetGeneration: 1,
+          },
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("fails closed on rejected 401/403 instead of treating empty data as a pass", () => {
+    const detail = unexpectedGoogleMockAuthFailureDetail([
+      {
+        method: "GET",
+        path: "/gmail/v1/users/me/messages",
+        statusCode: 401,
+        googleAuth: {
+          action: "auth",
+          authStatus: "rejected",
+          admittedAccountEmail: "owner@example.test",
+          statusCode: 401,
+        },
+      },
+    ]);
+    expect(detail).toMatch(/Unexpected Google mock authorization failure/);
+    expect(detail).toMatch(/GET \/gmail\/v1\/users\/me\/messages/);
+    expect(detail).toContain("account=owner@example.test");
+    expect(detail).not.toMatch(/Bearer|access.token|refresh/i);
+  });
+});

--- a/packages/scenario-runner/src/google-mock-auth.ts
+++ b/packages/scenario-runner/src/google-mock-auth.ts
@@ -1,0 +1,65 @@
+/** Detect unexpected Google mock 401/403 so scenarios cannot pass on empty data. */
+import { isLoopbackUrl } from "./utils.ts";
+
+const GOOGLE_MOCK_AUTH_TIMEOUT_MS = 15_000;
+
+export interface GoogleMockAuthLedgerSnapshot {
+  method?: string;
+  path?: string;
+  statusCode?: number;
+  googleAuth?: {
+    action?: string;
+    authStatus?: string;
+    admittedAccountId?: string;
+    admittedAccountEmail?: string;
+    admittedGrantId?: string;
+    requiredScopes?: readonly string[];
+    grantedScopeCount?: number;
+    resetGeneration?: number;
+    statusCode?: number;
+  };
+}
+
+export function unexpectedGoogleMockAuthFailureDetail(
+  entries: readonly GoogleMockAuthLedgerSnapshot[],
+): string | null {
+  const rejected = entries.filter(
+    (entry) => entry.googleAuth?.authStatus === "rejected",
+  );
+  if (rejected.length === 0) return null;
+  const first = rejected[0];
+  const status =
+    first?.googleAuth?.statusCode ?? first?.statusCode ?? "401/403";
+  const method = first?.method ?? "GET";
+  const path = first?.path ?? "unknown";
+  const account =
+    first?.googleAuth?.admittedAccountEmail ??
+    first?.googleAuth?.admittedAccountId ??
+    first?.googleAuth?.admittedGrantId;
+  const accountSuffix = account ? ` account=${account}` : "";
+  return (
+    `Unexpected Google mock authorization failure: ${method} ${path} ` +
+    `returned ${status} (authStatus=rejected${accountSuffix}). ` +
+    "Seeded grants must remain valid; empty calendar/inbox sections are not a pass."
+  );
+}
+
+export async function unexpectedGoogleMockAuthorizationFailure(): Promise<
+  string | null
+> {
+  const base = process.env.ELIZA_MOCK_GOOGLE_BASE?.trim();
+  if (!base || !isLoopbackUrl(base)) return null;
+  try {
+    const response = await fetch(`${base.replace(/\/$/, "")}/__mock/requests`, {
+      signal: AbortSignal.timeout(GOOGLE_MOCK_AUTH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as {
+      requests?: GoogleMockAuthLedgerSnapshot[];
+    };
+    const entries = Array.isArray(body.requests) ? body.requests : [];
+    return unexpectedGoogleMockAuthFailureDetail(entries);
+  } catch {
+    return null;
+  }
+}

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -72,6 +72,7 @@ async function loadTestMocks() {
       benchmarkFixtures.seedBenchmarkLifeOpsFixtures,
     seedGoogleConnectorGrant: grants.seedGoogleConnectorGrant,
     seedXConnectorGrant: grants.seedXConnectorGrant,
+    SIMULATED_OWNER_GOOGLE_GRANT_ID: grants.SIMULATED_OWNER_GOOGLE_GRANT_ID,
   };
 }
 
@@ -1168,7 +1169,10 @@ export async function createScenarioRuntime(
       ? await mockedEnvironment.applyRuntimeFixtures?.(runtime)
       : undefined;
   if (executionProfile === "simulated" && testMocks) {
-    await testMocks.seedGoogleConnectorGrant(runtime);
+    await testMocks.seedGoogleConnectorGrant(runtime, {
+      grantId: testMocks.SIMULATED_OWNER_GOOGLE_GRANT_ID,
+      email: "owner@example.test",
+    });
     await testMocks.seedXConnectorGrant(runtime);
     await testMocks.seedBenchmarkLifeOpsFixtures(runtime);
     await testMocks.seedLifeOpsSimulatorRuntime(runtime);

--- a/packages/scenario-runner/test/mocks/__tests__/google-gmail-auth.test.ts
+++ b/packages/scenario-runner/test/mocks/__tests__/google-gmail-auth.test.ts
@@ -1,0 +1,242 @@
+/** Covers seeded Google grant admission, ledger metadata, and reset without live Google. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { type StartedMocks, startMocks } from "../scripts/start-mocks.ts";
+
+const OWNER_EMAIL = "owner@example.test";
+const OWNER_GRANT_ID = "mock-google-work-grant";
+const OWNER_ACCESS_TOKEN = "mock-google-access-token-mock-google-work-grant";
+const GMAIL_READONLY = "https://www.googleapis.com/auth/gmail.readonly";
+const CALENDAR_READONLY = "https://www.googleapis.com/auth/calendar.readonly";
+
+let activeMocks: StartedMocks | null = null;
+const envSnapshot = {
+  ELIZA_OAUTH_DIR: process.env.ELIZA_OAUTH_DIR,
+  ELIZA_STATE_DIR: process.env.ELIZA_STATE_DIR,
+  XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+  ELIZA_NAMESPACE: process.env.ELIZA_NAMESPACE,
+  HOME: process.env.HOME,
+};
+let tempRoot: string | null = null;
+
+afterEach(async () => {
+  if (activeMocks) {
+    await activeMocks.stop();
+    activeMocks = null;
+  }
+  restoreEnv();
+  if (tempRoot) {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    tempRoot = null;
+  }
+});
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(envSnapshot)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function isolateGrantHome(): string {
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "google-grant-auth-"));
+  delete process.env.ELIZA_OAUTH_DIR;
+  delete process.env.ELIZA_STATE_DIR;
+  process.env.XDG_STATE_HOME = path.join(tempRoot, "xdg-state");
+  process.env.ELIZA_NAMESPACE = "eliza-google-grant-test";
+  process.env.HOME = path.join(tempRoot, "home");
+  fs.mkdirSync(process.env.HOME, { recursive: true });
+  return process.env.XDG_STATE_HOME;
+}
+
+function writeOwnerGrant(xdgStateHome: string): string {
+  const dir = path.join(
+    xdgStateHome,
+    "eliza-google-grant-test",
+    "credentials",
+    "lifeops",
+    "google",
+    "agent",
+    "owner",
+  );
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const filePath = path.join(
+    dir,
+    "local.mock-google-work-grant.mocked-tests.json",
+  );
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify(
+      {
+        provider: "google",
+        accessToken: OWNER_ACCESS_TOKEN,
+        refreshToken: "mock-google-refresh-token-mock-google-work-grant",
+        grantedScopes: [GMAIL_READONLY, CALENDAR_READONLY],
+        grantId: OWNER_GRANT_ID,
+        accountEmail: OWNER_EMAIL,
+        gmailAccountId: "work",
+      },
+      null,
+      2,
+    ),
+    { encoding: "utf-8", mode: 0o600 },
+  );
+  return filePath;
+}
+
+async function jsonRequest(
+  url: string,
+  init?: RequestInit,
+): Promise<{ response: Response; body: Record<string, unknown> }> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  return { response, body: (await response.json()) as Record<string, unknown> };
+}
+
+function ownerAuthHeaders(): HeadersInit {
+  return { Authorization: `Bearer ${OWNER_ACCESS_TOKEN}` };
+}
+
+function assertLedgerHasNoCredentialValues(
+  requests: readonly Record<string, unknown>[],
+): void {
+  const serialized = JSON.stringify(requests);
+  expect(serialized).not.toContain(OWNER_ACCESS_TOKEN);
+  expect(serialized).not.toContain("mock-google-refresh-token");
+}
+
+describe("Google mock seeded-grant authorization", () => {
+  it("keeps an XDG-seeded owner grant valid across Gmail, Calendar, unrelated traffic, and reset", async () => {
+    const xdg = isolateGrantHome();
+    writeOwnerGrant(xdg);
+    activeMocks = await startMocks({ envs: ["google"] });
+    const baseUrl = activeMocks.baseUrls.google;
+
+    const gmailBefore = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages`,
+      { headers: ownerAuthHeaders() },
+    );
+    expect(gmailBefore.response.status).toBe(200);
+    expect(Array.isArray(gmailBefore.body.messages)).toBe(true);
+    expect((gmailBefore.body.messages as unknown[]).length).toBeGreaterThan(0);
+
+    const calendarBefore = await jsonRequest(
+      `${baseUrl}/calendar/v3/users/me/calendarList`,
+      { headers: ownerAuthHeaders() },
+    );
+    expect(calendarBefore.response.status).toBe(200);
+    const calendarItems = calendarBefore.body.items;
+    expect(Array.isArray(calendarItems)).toBe(true);
+    expect((calendarItems as unknown[]).length).toBeGreaterThan(0);
+
+    const unknown = await jsonRequest(`${baseUrl}/gmail/v1/users/me/messages`, {
+      headers: { Authorization: "Bearer unknown-or-expired-token" },
+    });
+    expect(unknown.response.status).toBe(401);
+
+    const reset = await jsonRequest(`${baseUrl}/__mock/google/reset`, {
+      method: "POST",
+    });
+    expect(reset.response.status).toBe(200);
+    expect(reset.body.ok).toBe(true);
+    expect(typeof reset.body.resetGeneration).toBe("number");
+
+    const gmailAfter = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages`,
+      { headers: ownerAuthHeaders() },
+    );
+    expect(gmailAfter.response.status).toBe(200);
+    expect(Array.isArray(gmailAfter.body.messages)).toBe(true);
+    expect((gmailAfter.body.messages as unknown[]).length).toBeGreaterThan(0);
+
+    const ledger = await jsonRequest(`${baseUrl}/__mock/requests`);
+    expect(ledger.response.status).toBe(200);
+    const requests = ledger.body.requests as Array<Record<string, unknown>>;
+    expect(Array.isArray(requests)).toBe(true);
+    assertLedgerHasNoCredentialValues(requests);
+
+    const googleAuthEntries = requests
+      .map((entry) => ({
+        method: entry.method,
+        path: entry.path,
+        statusCode: entry.statusCode,
+        googleAuth: entry.googleAuth as Record<string, unknown> | undefined,
+      }))
+      .filter((entry) => entry.googleAuth);
+
+    const admitted = googleAuthEntries.filter(
+      (entry) => entry.googleAuth?.authStatus === "admitted",
+    );
+    expect(admitted.length).toBeGreaterThanOrEqual(3);
+    expect(admitted[0]?.googleAuth).toEqual(
+      expect.objectContaining({
+        action: "auth",
+        admittedAccountId: "work",
+        admittedAccountEmail: OWNER_EMAIL,
+        admittedGrantId: OWNER_GRANT_ID,
+      }),
+    );
+    const admittedScopes = admitted[0]?.googleAuth?.requiredScopes;
+    expect(Array.isArray(admittedScopes)).toBe(true);
+    expect(admittedScopes?.length ?? 0).toBeGreaterThan(0);
+
+    const rejected = googleAuthEntries.filter(
+      (entry) => entry.googleAuth?.authStatus === "rejected",
+    );
+    expect(rejected).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "/gmail/v1/users/me/messages",
+          googleAuth: expect.objectContaining({
+            authStatus: "rejected",
+            statusCode: 401,
+          }),
+        }),
+      ]),
+    );
+
+    const resetEntries = googleAuthEntries.filter(
+      (entry) => entry.googleAuth?.authStatus === "reset",
+    );
+    expect(resetEntries).toHaveLength(1);
+    expect(resetEntries[0]?.path).toBe("/__mock/google/reset");
+
+    const paths = googleAuthEntries.map(
+      (entry) => `${entry.method} ${entry.path}`,
+    );
+    expect(paths.indexOf("GET /gmail/v1/users/me/messages")).toBeLessThan(
+      paths.indexOf("GET /calendar/v3/users/me/calendarList"),
+    );
+    expect(paths.indexOf("POST /__mock/google/reset")).toBeGreaterThan(
+      paths.indexOf("GET /calendar/v3/users/me/calendarList"),
+    );
+  });
+
+  it("admits a grant written after the mock starts (runtime seed order)", async () => {
+    const xdg = isolateGrantHome();
+    activeMocks = await startMocks({ envs: ["google"] });
+    const baseUrl = activeMocks.baseUrls.google;
+
+    const beforeSeed = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages`,
+      { headers: ownerAuthHeaders() },
+    );
+    expect(beforeSeed.response.status).toBe(401);
+
+    writeOwnerGrant(xdg);
+
+    const afterSeed = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages`,
+      { headers: ownerAuthHeaders() },
+    );
+    expect(afterSeed.response.status).toBe(200);
+    expect(Array.isArray(afterSeed.body.messages)).toBe(true);
+  });
+});

--- a/packages/scenario-runner/test/mocks/scripts/google-gmail-state.ts
+++ b/packages/scenario-runner/test/mocks/scripts/google-gmail-state.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import type http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import {
   getLifeOpsSimulatorPerson,
@@ -27,10 +28,31 @@ interface DynamicFixtureResponse {
   headers?: Record<string, string>;
 }
 
+export type GoogleAuthLedgerStatus =
+  | "admitted"
+  | "rejected"
+  | "unauthenticated"
+  | "fault"
+  | "reset";
+
+export interface GoogleAuthLedgerMetadata {
+  action?: "auth" | "reset";
+  authStatus: GoogleAuthLedgerStatus;
+  admittedAccountId?: string;
+  admittedAccountEmail?: string;
+  admittedGrantId?: string;
+  requiredScopes?: readonly string[];
+  grantedScopeCount?: number;
+  resetGeneration?: number;
+  statusCode?: number;
+}
+
 interface GoogleMockLedgerEntry {
   gmail?: GmailRequestLedgerMetadata;
   calendar?: GoogleCalendarRequestLedgerMetadata;
+  googleAuth?: GoogleAuthLedgerMetadata;
   runId?: string;
+  statusCode?: number;
 }
 
 function jsonFixture(
@@ -524,6 +546,8 @@ export interface GoogleMockState {
   gmailFaultInjection: GoogleGmailFaultInjection | null;
   googleTokens: Map<string, GoogleMockToken>;
   calendar: GoogleCalendarMockState;
+  resetGeneration: number;
+  options?: GoogleMockStateOptions;
 }
 
 export interface GoogleMockStateOptions {
@@ -639,6 +663,7 @@ function buildGmailFixtureManifest(
 export function createGoogleMockState(
   opts?: GoogleMockStateOptions,
 ): GoogleMockState {
+  discoveredGoogleGrantDirs.clear();
   const accounts = gmailAccountsMap();
   const messages = new Map<string, GmailMockMessage>();
   for (const fixture of gmailFixtureMessages(opts)) {
@@ -674,7 +699,7 @@ export function createGoogleMockState(
     account: accounts.get(DEFAULT_GMAIL_ACCOUNT_ID),
   });
 
-  return {
+  const state: GoogleMockState = {
     gmailAccounts: accounts,
     gmailMessages: messages,
     gmailFixtureManifest: buildGmailFixtureManifest(
@@ -709,7 +734,11 @@ export function createGoogleMockState(
     gmailFaultInjection: null,
     googleTokens: new Map(),
     calendar: createGoogleCalendarMockState(opts),
+    resetGeneration: 0,
+    ...(opts ? { options: opts } : {}),
   };
+  admitSeededGoogleGrants(state);
+  return state;
 }
 
 export function setGoogleGmailFaultInjection(
@@ -1590,15 +1619,34 @@ function bearerToken(headers: http.IncomingHttpHeaders): string | null {
   return match?.[1]?.trim() ?? null;
 }
 
+const discoveredGoogleGrantDirs = new Set<string>();
+
+function rememberGoogleGrantDir(dir: string): void {
+  discoveredGoogleGrantDirs.add(path.resolve(dir));
+}
+
+function defaultCredentialsGoogleDir(): string {
+  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const xdg = process.env.XDG_STATE_HOME?.trim();
+  const stateDir = xdg
+    ? path.join(xdg, namespace)
+    : path.join(os.homedir(), ".local", "state", namespace);
+  return path.join(stateDir, "credentials", "lifeops", "google");
+}
+
 function googleOAuthSearchDirs(): string[] {
-  const explicitOAuthDir = process.env.ELIZA_OAUTH_DIR?.trim();
-  if (explicitOAuthDir) {
-    return [path.join(explicitOAuthDir, "lifeops", "google")];
-  }
+  const dirs: string[] = [];
+  const add = (dir: string) => {
+    const resolved = path.resolve(dir);
+    if (!dirs.includes(resolved)) dirs.push(resolved);
+  };
+  const oauthDir = process.env.ELIZA_OAUTH_DIR?.trim();
+  if (oauthDir) add(path.join(oauthDir, "lifeops", "google"));
   const stateDir = process.env.ELIZA_STATE_DIR?.trim();
-  return stateDir
-    ? [path.join(stateDir, "credentials", "lifeops", "google")]
-    : [];
+  if (stateDir) add(path.join(stateDir, "credentials", "lifeops", "google"));
+  if (!oauthDir) add(defaultCredentialsGoogleDir());
+  for (const remembered of discoveredGoogleGrantDirs) add(remembered);
+  return dirs;
 }
 
 function readJsonFilesRecursively(
@@ -1622,23 +1670,17 @@ function readJsonFilesRecursively(
   return remaining;
 }
 
-function refreshGoogleTokensFromSeededGrants(state: GoogleMockState): void {
-  const files: string[] = [];
-  for (const dir of googleOAuthSearchDirs()) {
-    readJsonFilesRecursively(dir, files, 100);
+function tokenFromGrantRecord(
+  record: Record<string, JsonValue>,
+): { accessToken: string; token: GoogleMockToken } | null {
+  const accessToken = record.accessToken;
+  const grantedScopes = record.grantedScopes;
+  if (typeof accessToken !== "string" || !isStringArray(grantedScopes)) {
+    return null;
   }
-  for (const file of files) {
-    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as JsonValue;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      continue;
-    }
-    const record = parsed as Record<string, JsonValue>;
-    const accessToken = record.accessToken;
-    const grantedScopes = record.grantedScopes;
-    if (typeof accessToken !== "string" || !isStringArray(grantedScopes)) {
-      continue;
-    }
-    state.googleTokens.set(accessToken, {
+  return {
+    accessToken,
+    token: {
       scopes: new Set(grantedScopes),
       ...(typeof record.gmailAccountId === "string"
         ? { gmailAccountId: record.gmailAccountId }
@@ -1651,7 +1693,109 @@ function refreshGoogleTokensFromSeededGrants(state: GoogleMockState): void {
         : typeof record.email === "string"
           ? { gmailAccountEmail: record.email }
           : {}),
-    });
+    },
+  };
+}
+
+export function admitSeededGoogleGrants(state: GoogleMockState): number {
+  const files: string[] = [];
+  for (const dir of googleOAuthSearchDirs()) {
+    const before = files.length;
+    readJsonFilesRecursively(dir, files, Math.max(0, 100 - files.length));
+    if (files.length > before) rememberGoogleGrantDir(dir);
+  }
+  let admitted = 0;
+  for (const file of files) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as JsonValue;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        continue;
+      }
+      const loaded = tokenFromGrantRecord(parsed as Record<string, JsonValue>);
+      if (!loaded) continue;
+      state.googleTokens.set(loaded.accessToken, loaded.token);
+      rememberGoogleGrantDir(path.dirname(file));
+      admitted += 1;
+    } catch {}
+  }
+  return admitted;
+}
+
+function refreshGoogleTokensFromSeededGrants(state: GoogleMockState): void {
+  admitSeededGoogleGrants(state);
+}
+
+function persistIssuedGoogleAccessToken(args: {
+  accessToken: string;
+  scopes: string[];
+  grantId?: string;
+  accountEmail?: string;
+  gmailAccountId?: string;
+  refreshToken?: string;
+}): void {
+  const files: string[] = [];
+  for (const dir of googleOAuthSearchDirs()) {
+    readJsonFilesRecursively(dir, files, Math.max(0, 100 - files.length));
+  }
+  const matches = (record: Record<string, JsonValue>): boolean => {
+    if (args.grantId && record.grantId === args.grantId) return true;
+    if (
+      args.accountEmail &&
+      (record.accountEmail === args.accountEmail ||
+        record.email === args.accountEmail)
+    ) {
+      return true;
+    }
+    if (args.refreshToken && record.refreshToken === args.refreshToken) {
+      return true;
+    }
+    return false;
+  };
+  for (const file of files) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as JsonValue;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        continue;
+      }
+      const record = parsed as Record<string, JsonValue>;
+      if (!matches(record)) continue;
+      record.accessToken = args.accessToken;
+      record.grantedScopes = args.scopes;
+      record.updatedAt = new Date().toISOString();
+      fs.writeFileSync(file, JSON.stringify(record, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+      rememberGoogleGrantDir(path.dirname(file));
+    } catch {}
+  }
+}
+
+export function resetGoogleMockState(state: GoogleMockState): number {
+  const generation = (state.resetGeneration ?? 0) + 1;
+  const next = createGoogleMockState(state.options);
+  state.gmailAccounts = next.gmailAccounts;
+  state.gmailMessages = next.gmailMessages;
+  state.gmailFixtureManifest = next.gmailFixtureManifest;
+  state.gmailDrafts = next.gmailDrafts;
+  state.gmailHistoryId = next.gmailHistoryId;
+  state.gmailHistory = next.gmailHistory;
+  state.gmailFaultInjection = null;
+  state.googleTokens = next.googleTokens;
+  state.calendar = next.calendar;
+  state.options = next.options;
+  state.resetGeneration = generation;
+  admitSeededGoogleGrants(state);
+  return generation;
+}
+
+function recordGoogleAuth(
+  ledgerEntry: GoogleMockLedgerEntry,
+  metadata: GoogleAuthLedgerMetadata,
+): void {
+  ledgerEntry.googleAuth = metadata;
+  if (typeof metadata.statusCode === "number") {
+    ledgerEntry.statusCode = metadata.statusCode;
   }
 }
 
@@ -1697,6 +1841,7 @@ function enforceGoogleAuthIfPresent(
   method: string,
   pathname: string,
   headers: http.IncomingHttpHeaders,
+  ledgerEntry: GoogleMockLedgerEntry,
 ): DynamicFixtureResponse | null {
   const requiredScopes = requiredGoogleScopes(method, pathname);
   if (requiredScopes.length === 0) return null;
@@ -1705,13 +1850,38 @@ function enforceGoogleAuthIfPresent(
   if (!state.googleTokens.has(token)) {
     refreshGoogleTokensFromSeededGrants(state);
   }
-  const scopes = state.googleTokens.get(token);
-  if (!scopes) {
+  const admitted = state.googleTokens.get(token);
+  if (!admitted) {
+    recordGoogleAuth(ledgerEntry, {
+      action: "auth",
+      authStatus: "rejected",
+      requiredScopes: [...requiredScopes],
+      resetGeneration: state.resetGeneration,
+      statusCode: 401,
+    });
     return jsonError(401, "Unknown or expired mock Google access token");
   }
-  return requiredScopes.some((scope) => scopes.scopes.has(scope))
-    ? null
-    : jsonError(403, "Google mock token is missing required scope");
+  if (!requiredScopes.some((scope) => admitted.scopes.has(scope))) {
+    recordGoogleAuth(ledgerEntry, {
+      action: "auth",
+      authStatus: "rejected",
+      requiredScopes: [...requiredScopes],
+      grantedScopeCount: admitted.scopes.size,
+      ...(admitted.gmailAccountId
+        ? { admittedAccountId: admitted.gmailAccountId }
+        : {}),
+      ...(admitted.gmailAccountEmail
+        ? { admittedAccountEmail: admitted.gmailAccountEmail }
+        : {}),
+      ...(admitted.gmailGrantId
+        ? { admittedGrantId: admitted.gmailGrantId }
+        : {}),
+      resetGeneration: state.resetGeneration,
+      statusCode: 403,
+    });
+    return jsonError(403, "Google mock token is missing required scope");
+  }
+  return null;
 }
 
 function googleTokenForRequest(
@@ -1760,16 +1930,42 @@ export function googleDynamicFixture(
       typeof requestBody.accountEmail === "string"
         ? requestBody.accountEmail
         : undefined;
+    const refreshToken =
+      typeof requestBody.refresh_token === "string"
+        ? requestBody.refresh_token
+        : typeof requestBody.refreshToken === "string"
+          ? requestBody.refreshToken
+          : undefined;
+    persistIssuedGoogleAccessToken({
+      accessToken,
+      scopes,
+      ...(gmailGrantId ? { grantId: gmailGrantId } : {}),
+      ...(gmailAccountEmail ? { accountEmail: gmailAccountEmail } : {}),
+      ...(gmailAccountId ? { gmailAccountId } : {}),
+      ...(refreshToken ? { refreshToken } : {}),
+    });
+    admitSeededGoogleGrants(state);
     state.googleTokens.set(accessToken, {
       scopes: new Set(scopes),
       ...(gmailAccountId ? { gmailAccountId } : {}),
       ...(gmailGrantId ? { gmailGrantId } : {}),
       ...(gmailAccountEmail ? { gmailAccountEmail } : {}),
     });
+    recordGoogleAuth(ledgerEntry, {
+      action: "auth",
+      authStatus: "admitted",
+      ...(gmailAccountId ? { admittedAccountId: gmailAccountId } : {}),
+      ...(gmailAccountEmail ? { admittedAccountEmail: gmailAccountEmail } : {}),
+      ...(gmailGrantId ? { admittedGrantId: gmailGrantId } : {}),
+      requiredScopes: scopes,
+      grantedScopeCount: scopes.length,
+      resetGeneration: state.resetGeneration,
+      statusCode: 200,
+    });
     return jsonFixture({
       access_token: accessToken,
       expires_in: 3600,
-      refresh_token: "mock-google-refresh-token",
+      refresh_token: refreshToken ?? "mock-google-refresh-token",
       token_type: "Bearer",
       scope: scopes.join(" "),
     });
@@ -1783,7 +1979,15 @@ export function googleDynamicFixture(
     headers,
   );
   if (gmailFault && gmailFault !== "partial_failure") {
-    return gmailFaultError(gmailFault);
+    const faultResponse = gmailFaultError(gmailFault);
+    recordGoogleAuth(ledgerEntry, {
+      action: "auth",
+      authStatus: "fault",
+      requiredScopes: [...requiredGoogleScopes(method, pathname)],
+      resetGeneration: state.resetGeneration,
+      statusCode: faultResponse.statusCode,
+    });
+    return faultResponse;
   }
 
   const authFailure = enforceGoogleAuthIfPresent(
@@ -1791,9 +1995,38 @@ export function googleDynamicFixture(
     method,
     pathname,
     headers,
+    ledgerEntry,
   );
   if (authFailure) return authFailure;
   const googleToken = googleTokenForRequest(state, headers);
+  if (googleToken) {
+    const account = gmailTokenAccount(state, googleToken);
+    recordGoogleAuth(ledgerEntry, {
+      action: "auth",
+      authStatus: "admitted",
+      ...(account
+        ? {
+            admittedAccountId: account.id,
+            admittedAccountEmail: account.email,
+            admittedGrantId: account.grantId,
+          }
+        : {
+            ...(googleToken.gmailAccountId
+              ? { admittedAccountId: googleToken.gmailAccountId }
+              : {}),
+            ...(googleToken.gmailAccountEmail
+              ? { admittedAccountEmail: googleToken.gmailAccountEmail }
+              : {}),
+            ...(googleToken.gmailGrantId
+              ? { admittedGrantId: googleToken.gmailGrantId }
+              : {}),
+          }),
+      requiredScopes: [...requiredGoogleScopes(method, pathname)],
+      grantedScopeCount: googleToken.scopes.size,
+      resetGeneration: state.resetGeneration,
+      statusCode: 200,
+    });
+  }
   const gmailSelection = gmailAccountSelection(
     state,
     searchParams,

--- a/packages/scenario-runner/test/mocks/scripts/start-mocks.ts
+++ b/packages/scenario-runner/test/mocks/scripts/start-mocks.ts
@@ -29,10 +29,12 @@ import { loadCorpusGmailMockOptions } from "./google-gmail-corpus.ts";
 import {
   createGoogleMockState,
   type GmailRequestLedgerMetadata,
+  type GoogleAuthLedgerMetadata,
   type GoogleGmailFaultInjection,
   type GoogleGmailFaultMode,
   type GoogleMockState,
   googleDynamicFixture,
+  resetGoogleMockState,
   setGoogleGmailFaultInjection,
 } from "./google-gmail-state.ts";
 import { MockHttpError } from "./mock-http-error.ts";
@@ -134,6 +136,8 @@ export interface MockRequestLedgerEntry {
   body: RequestBody;
   createdAt: string;
   runId?: string;
+  statusCode?: number;
+  googleAuth?: GoogleAuthLedgerMetadata;
   gmail?: GmailRequestLedgerMetadata;
   calendar?: GoogleCalendarRequestLedgerMetadata;
   x?: XRequestLedgerMetadata;
@@ -3504,6 +3508,29 @@ function readGoogleGmailFaultInjection(
   };
 }
 
+function handleGoogleResetControl(
+  provider: DynamicProviderState,
+  method: string,
+  pathname: string,
+  ledgerEntry: MockRequestLedgerEntry,
+): DynamicFixtureResponse | null {
+  if (provider?.kind !== "google" || pathname !== "/__mock/google/reset") {
+    return null;
+  }
+  if (method !== "POST" && method !== "DELETE") {
+    throw new MockHttpError(405, "Unsupported Google mock reset method");
+  }
+  const resetGeneration = resetGoogleMockState(provider.state);
+  ledgerEntry.googleAuth = {
+    action: "reset",
+    authStatus: "reset",
+    resetGeneration,
+    statusCode: 200,
+  };
+  ledgerEntry.statusCode = 200;
+  return { statusCode: 200, body: { ok: true, resetGeneration } };
+}
+
 function handleGoogleGmailFaultControl(
   provider: DynamicProviderState,
   method: string,
@@ -3802,6 +3829,20 @@ async function startFixtureServer(
           : {}),
       };
       requests.push(ledgerEntry);
+      const googleReset = handleGoogleResetControl(
+        dynamicProvider,
+        method,
+        requestUrl.pathname,
+        ledgerEntry,
+      );
+      if (googleReset) {
+        res.writeHead(googleReset.statusCode, {
+          "Content-Type": "application/json",
+          ...(googleReset.headers ?? {}),
+        });
+        res.end(JSON.stringify(googleReset.body));
+        return;
+      }
       if (
         isLifeOpsPresenceActiveEnvironment &&
         method === "GET" &&
@@ -4015,6 +4056,16 @@ async function startFixtureServer(
         ledgerEntry,
       });
       if (dynamicResponse) {
+        ledgerEntry.statusCode = dynamicResponse.statusCode;
+        if (
+          ledgerEntry.googleAuth &&
+          ledgerEntry.googleAuth.statusCode == null
+        ) {
+          ledgerEntry.googleAuth = {
+            ...ledgerEntry.googleAuth,
+            statusCode: dynamicResponse.statusCode,
+          };
+        }
         res.writeHead(dynamicResponse.statusCode, {
           "Content-Type": "application/json",
           ...(dynamicResponse.headers ?? {}),

--- a/plugins/plugin-personal-assistant/test/support/helpers/seed-grants.ts
+++ b/plugins/plugin-personal-assistant/test/support/helpers/seed-grants.ts
@@ -29,8 +29,24 @@ interface MockConnectorCredentialStore {
   reveal(vaultRef: string, caller?: string): Promise<string>;
 }
 
+/** Stable owner grant id that matches GMAIL_MOCK_ACCOUNTS[0]. */
+export const SIMULATED_OWNER_GOOGLE_GRANT_ID = "mock-google-work-grant";
+export const SIMULATED_OWNER_GOOGLE_ACCOUNT_ID = "work";
+
 function sanitizePathSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function mockGmailAccountIdForEmail(email: string): string | undefined {
+  if (email === "owner@example.test") return "work";
+  if (email === "owner.home@example.test") return "home";
+  return undefined;
+}
+
+function buildMockGoogleRefreshToken(grantId?: string): string {
+  return grantId
+    ? `mock-google-refresh-token-${sanitizePathSegment(grantId)}`
+    : "mock-google-refresh-token";
 }
 
 function buildMockGoogleTokenRef(
@@ -129,6 +145,7 @@ function writeMockGoogleToken(args: {
     tokenRef,
   );
   const now = Date.now();
+  const gmailAccountId = mockGmailAccountIdForEmail(args.email);
   const token = {
     provider: "google" as const,
     agentId: args.agentId,
@@ -137,11 +154,12 @@ function writeMockGoogleToken(args: {
     clientId: "mock-google-client",
     redirectUri: "http://127.0.0.1/mock-google/callback",
     accessToken: buildMockGoogleAccessToken(args.grantId),
-    refreshToken: "mock-google-refresh-token",
+    refreshToken: buildMockGoogleRefreshToken(args.grantId),
     tokenType: "Bearer",
     grantedScopes: args.grantedScopes,
     grantId: args.grantId ?? null,
     accountEmail: args.email,
+    ...(gmailAccountId ? { gmailAccountId } : {}),
     expiresAt: now + 24 * 60 * 60 * 1000,
     refreshTokenExpiresAt: now + 30 * 24 * 60 * 60 * 1000,
     createdAt: new Date(now).toISOString(),
@@ -208,6 +226,7 @@ export async function seedGoogleConnectorGrant(
     vaultRef,
     JSON.stringify({
       access_token: accessToken,
+      refresh_token: buildMockGoogleRefreshToken(id),
       token_type: "Bearer",
       scope: grantedScopes.join(" "),
       expiry_date: expiresAt,
@@ -255,7 +274,7 @@ export async function seedGoogleConnectorGrant(
       identity: { email },
       grantedCapabilities: ["google.basic_identity", ...capabilities],
       grantedScopes,
-      hasRefreshToken: false,
+      hasRefreshToken: true,
       expiresAt,
       oauthCredentialVersion: String(expiresAt),
       credentialRefs: [


### PR DESCRIPTION
## Summary

- Seeded simulated-runtime Google grants now use the stable owner grant id that matches the Gmail mock account, persist refresh tokens, and tag the work/home mock account so the mock can admit the same bearer the runtime still reports as connected.
- The Google mock discovers grant files from `ELIZA_OAUTH_DIR`, `ELIZA_STATE_DIR`, and the default XDG credentials dir, re-admits them after reset/refresh, and records account, scopes, request order, and reset generation on the request ledger without credential values.
- Unexpected mock 401/403 responses fail the owning scenario instead of allowing empty calendar/inbox sections to report green.

Fixes #29065

## Test plan

- [x] `packages/scenario-runner` mock tests fail on unpatched `develop` (`GET /gmail/v1/users/me/messages` with an XDG-seeded owner bearer returns 401).
- [x] After this change, `bun x vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/google-gmail-auth.test.ts test/mocks/__tests__/google-gmail-fault.test.ts` passes.
- [x] `bun x vitest run --config vitest.config.ts src/google-mock-auth.test.ts` passes.
- [x] Biome check on touched files is clean.