### PR TITLE
fix(plugin-whatsapp): use truncateWellFormed for chatId in resolveWhatsAppSystemLocation

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -167,3 +167,25 @@ describe("text chunking", () => {
     expect(chunks.join("")).toBe(text);
   });
 });
+
+describe("resolveWhatsAppSystemLocation", () => {
+  it("resolves location with chatName when present", () => {
+    expect(
+      resolveWhatsAppSystemLocation({
+        chatType: "group",
+        chatId: "1234567890",
+        chatName: "Family Group",
+      })
+    ).toBe("WhatsApp group:Family Group");
+  });
+
+  it("truncates chatId safely with surrogate pairs when chatName is absent", () => {
+    const ROCKET = "\u{1F680}";
+    const result = resolveWhatsAppSystemLocation({
+      chatType: "user",
+      chatId: `1234567${ROCKET}rest`,
+    });
+    expect(result.isWellFormed()).toBe(true);
+    expect(result).toBe("WhatsApp user:1234567");
+  });
+});

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -339,7 +339,7 @@ export function resolveWhatsAppSystemLocation(params: {
   chatName?: string;
 }): string {
   const { chatType, chatId, chatName } = params;
-  const name = chatName || chatId.slice(0, 8);
+  const name = chatName || truncateWellFormed(toWellFormedUnicode(chatId), 8);
   return `WhatsApp ${chatType}:${name}`;
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5a1bde8c7f5ffc0810aaaa525c708b50118359ff -->

## Summary
In `plugins/plugin-whatsapp/src/normalize.ts`:
`resolveWhatsAppSystemLocation` constructed system location strings fallback naming using raw `.slice(0, 8)` on `chatId`. When `chatId` contains multi-byte Unicode or lone surrogate code units at boundary index 8, raw slicing could truncate code unit pairs midway, producing invalid UTF-16 strings in logs and system location records.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(chatId), 8)` for surrogate-safe truncation.
2. Added unit test cases in `plugins/plugin-whatsapp/src/normalize.test.ts`.

## Verification
- Passed unit tests in `plugins/plugin-whatsapp/src/normalize.test.ts`.

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-3-7-sonnet","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
