### PR TITLE
fix(cloud): guard paid legacy proxy routes with combined admission

### DIFF
--- a/packages/cloud/api/__tests__/legacy-proxy-combined-admission-inventory.test.ts
+++ b/packages/cloud/api/__tests__/legacy-proxy-combined-admission-inventory.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Checked-in inventory so paid legacy chain/market/EVM/Solana/Birdeye proxies
+ * cannot silently skip the shared combined-admission adapter (#30252).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PAID_LEGACY_PROXY_EXECUTE_ROUTES = [
+  "v1/chain/nfts/[chain]/[address]/route.ts",
+  "v1/chain/tokens/[chain]/[address]/route.ts",
+  "v1/chain/transfers/[chain]/[address]/route.ts",
+  "v1/market/candles/[chain]/[address]/route.ts",
+  "v1/market/portfolio/[chain]/[address]/route.ts",
+  "v1/market/price/[chain]/[address]/route.ts",
+  "v1/market/token/[chain]/[address]/route.ts",
+  "v1/market/trades/[chain]/[address]/route.ts",
+  "v1/proxy/evm-rpc/[chain]/route.ts",
+  "v1/proxy/solana-rpc/route.ts",
+  "v1/solana/assets/[address]/route.ts",
+  "v1/solana/rpc/route.ts",
+  "v1/solana/token-accounts/[address]/route.ts",
+  "v1/solana/transactions/[address]/route.ts",
+] as const;
+const PAID_LEGACY_PROXY_BIRDEYE_ROUTE = "v1/apis/birdeye/[...path]/route.ts";
+const PAID_LEGACY_PROXY_RPC_ROUTE = "v1/rpc/[chain]/route.ts";
+const EXEMPT_LEGACY_PROXY_ROUTES = [
+  "v1/proxy/birdeye/[...path]/route.ts",
+] as const;
+
+const apiRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "coverage",
+  ".turbo",
+  "test",
+  ".wrangler-dry-run",
+]);
+
+function walkRouteFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry) || entry.startsWith(".")) continue;
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) out.push(...walkRouteFiles(full));
+    else if (entry === "route.ts") out.push(full);
+  }
+  return out;
+}
+
+function posixFromApi(file: string): string {
+  return path.relative(apiRoot, file).split(path.sep).join("/");
+}
+
+describe("paid legacy proxy combined-admission inventory (#30252)", () => {
+  test("every executeWithBody paid route uses the shared adapter exactly", () => {
+    expect(new Set(PAID_LEGACY_PROXY_EXECUTE_ROUTES).size).toBe(
+      PAID_LEGACY_PROXY_EXECUTE_ROUTES.length,
+    );
+    for (const relative of PAID_LEGACY_PROXY_EXECUTE_ROUTES) {
+      const source = readFileSync(path.join(apiRoot, relative), "utf8");
+      expect(source, relative).toContain(
+        "executePaidProxyWithCombinedAdmission(",
+      );
+      expect(source, relative).not.toContain(
+        'from "@/lib/services/proxy/engine"',
+      );
+      expect(source, relative).not.toMatch(/\bexecuteWithBody\s*\(/);
+      expect(source, relative).not.toContain("requireAuthOrApiKeyWithOrg(");
+      expect(source, relative).not.toContain("creditsService.reserve(");
+      const calls =
+        source.split("executePaidProxyWithCombinedAdmission(").length - 1;
+      expect(calls, relative).toBe(1);
+    }
+  });
+
+  test("direct Birdeye paid handling resolves standing through the same adapter", () => {
+    const source = readFileSync(
+      path.join(apiRoot, PAID_LEGACY_PROXY_BIRDEYE_ROUTE),
+      "utf8",
+    );
+    expect(source).toContain("resolvePaidProxyCombinedAdmission");
+    expect(source).not.toContain("requireUserOrApiKeyWithOrg");
+    expect(source).not.toContain("creditsService.deductCredits");
+  });
+
+  test("canonical RPC uses the shared combined admission helper", () => {
+    const source = readFileSync(
+      path.join(apiRoot, PAID_LEGACY_PROXY_RPC_ROUTE),
+      "utf8",
+    );
+    expect(source).toContain("resolvePaidProxyCombinedAdmission");
+    expect(source).not.toContain("requireGenerativeRouteCaller(");
+  });
+
+  test("public redirect, read-only, and internal routes stay exempt", () => {
+    for (const relative of EXEMPT_LEGACY_PROXY_ROUTES) {
+      const source = readFileSync(path.join(apiRoot, relative), "utf8");
+      expect(source, relative).toContain("c.redirect");
+      expect(source, relative).not.toContain(
+        "executePaidProxyWithCombinedAdmission",
+      );
+      expect(source, relative).not.toContain("requireGenerativeRouteCaller");
+    }
+
+    const paid = new Set<string>([
+      ...PAID_LEGACY_PROXY_EXECUTE_ROUTES,
+      PAID_LEGACY_PROXY_BIRDEYE_ROUTE,
+      PAID_LEGACY_PROXY_RPC_ROUTE,
+    ]);
+    const unexpected: string[] = [];
+    for (const file of walkRouteFiles(apiRoot)) {
+      const relative = posixFromApi(file);
+      if (!relative.endsWith("/route.ts")) continue;
+      const source = readFileSync(file, "utf8");
+      if (source.includes("executeWithBody(") && !paid.has(relative)) {
+        unexpected.push(relative);
+      }
+    }
+    expect(unexpected).toEqual([]);
+  });
+});

--- a/packages/cloud/api/src/lib/legacy-proxy-combined-admission.test.ts
+++ b/packages/cloud/api/src/lib/legacy-proxy-combined-admission.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Behavioral contract for the paid legacy-proxy combined-admission adapter.
+ * Standing is read once; combined Worker mode never falls back to generic
+ * auth/reserve; provider dispatch is not invoked before a snapshot is forwarded.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+
+const requireGenerativeRouteCaller = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKeyId: "key-1",
+  authSource: "combined_cache" as const,
+  admissionSnapshot: {
+    balance: { balanceUsd: 10, balanceAt: 1, balanceRevision: "1" },
+    rateLimits: {
+      completionsRpm: 1,
+      embeddingsRpm: 1,
+      standardRpm: 1,
+      strictRpm: 1,
+    },
+  },
+  appScopeId: null,
+}));
+const getGenerativeExecutionContext = mock(
+  (): { waitUntil(promise: Promise<unknown>): void } | undefined => ({
+    waitUntil: () => undefined,
+  }),
+);
+const executeWithBody = mock(async () => Response.json({ ok: true }));
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller,
+  getGenerativeExecutionContext,
+  asGenerativeCacheApiError: () => null,
+}));
+mock.module("@/lib/services/proxy/engine", () => ({
+  executeWithBody,
+}));
+
+const {
+  executePaidProxyWithCombinedAdmission,
+  resolvePaidProxyCombinedAdmission,
+} = await import("./legacy-proxy-combined-admission");
+
+const config = { id: "market-data", name: "Market Data" };
+const work = mock(async () => ({ response: Response.json({ ok: true }) }));
+const body = { method: "getPrice", chain: "solana", params: { address: "x" } };
+
+const app = new Hono();
+app.post("/paid", async (c) =>
+  executePaidProxyWithCombinedAdmission(
+    c as never,
+    config as never,
+    work as never,
+    c.req.raw,
+    body,
+  ),
+);
+
+beforeEach(() => {
+  requireGenerativeRouteCaller.mockClear();
+  getGenerativeExecutionContext.mockClear();
+  executeWithBody.mockClear();
+  work.mockClear();
+  requireGenerativeRouteCaller.mockResolvedValue({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    authSource: "combined_cache",
+    admissionSnapshot: {
+      balance: { balanceUsd: 10, balanceAt: 1, balanceRevision: "1" },
+      rateLimits: {
+        completionsRpm: 1,
+        embeddingsRpm: 1,
+        standardRpm: 1,
+        strictRpm: 1,
+      },
+    },
+    appScopeId: null,
+  });
+  getGenerativeExecutionContext.mockReturnValue({
+    waitUntil: () => undefined,
+  });
+  executeWithBody.mockResolvedValue(Response.json({ ok: true }));
+});
+
+describe("paid legacy proxy combined admission adapter", () => {
+  test("forwards the combined snapshot and credential after one standing read", async () => {
+    const response = await app.request("/paid", { method: "POST" });
+    expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(executeWithBody).toHaveBeenCalledTimes(1);
+    const forwarded = executeWithBody.mock.calls[0]?.[4] as {
+      auth: {
+        user: { id: string; organization_id: string };
+        apiKey?: { id: string };
+      };
+      admissionSnapshot: unknown;
+      requestId: string;
+    };
+    expect(forwarded.auth.user).toEqual({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    expect(forwarded.auth.apiKey).toEqual({ id: "key-1" });
+    expect(forwarded.admissionSnapshot).toBeDefined();
+    expect(forwarded.requestId.length).toBeGreaterThan(0);
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  test("preserves safe standing denial reasons without dispatch", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new ApiError(403, "access_denied", "Organization is inactive", {
+        reason: "organization_inactive",
+      }),
+    );
+    const response = await app.request("/paid", { method: "POST" });
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "access_denied",
+      error: "Organization is inactive",
+      details: { reason: "organization_inactive" },
+    });
+    expect(executeWithBody).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+  });
+
+  test("combined mode without a snapshot returns 503 and never dispatches", async () => {
+    requireGenerativeRouteCaller.mockResolvedValueOnce({
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKeyId: null,
+      authSource: "combined_cache",
+      appScopeId: null,
+    });
+    const response = await app.request("/paid", { method: "POST" });
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "service_unavailable",
+    });
+    expect(response.headers.get("Retry-After")).toBe("1");
+    expect(executeWithBody).not.toHaveBeenCalled();
+  });
+
+  test("resolvePaidProxyCombinedAdmission calls requireGenerativeRouteCaller once", async () => {
+    const c = {
+      get: (key: string) => (key === "requestId" ? "req-1" : undefined),
+      req: { raw: new Request("https://api.test/paid") },
+    };
+    const admission = await resolvePaidProxyCombinedAdmission(c as never);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(admission.auth.user.organization_id).toBe("org-1");
+    expect(admission.requestId).toBe("req-1");
+  });
+});

--- a/packages/cloud/api/src/lib/legacy-proxy-combined-admission.test.ts
+++ b/packages/cloud/api/src/lib/legacy-proxy-combined-admission.test.ts
@@ -8,10 +8,26 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
 
-const requireGenerativeRouteCaller = mock(async () => ({
+type CombinedCaller = {
+  user: { id: string; organization_id: string };
+  apiKeyId: string | null;
+  authSource: "combined_cache";
+  admissionSnapshot?: {
+    balance: { balanceUsd: number; balanceAt: number; balanceRevision: string };
+    rateLimits: {
+      completionsRpm: number;
+      embeddingsRpm: number;
+      standardRpm: number;
+      strictRpm: number;
+    };
+  };
+  appScopeId: string | null;
+};
+
+const requireGenerativeRouteCaller = mock(async (): Promise<CombinedCaller> => ({
   user: { id: "user-1", organization_id: "org-1" },
   apiKeyId: "key-1",
-  authSource: "combined_cache" as const,
+  authSource: "combined_cache",
   admissionSnapshot: {
     balance: { balanceUsd: 10, balanceAt: 1, balanceRevision: "1" },
     rateLimits: {
@@ -91,14 +107,24 @@ describe("paid legacy proxy combined admission adapter", () => {
     expect(response.status).toBe(200);
     expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
     expect(executeWithBody).toHaveBeenCalledTimes(1);
-    const forwarded = executeWithBody.mock.calls[0]?.[4] as {
-      auth: {
-        user: { id: string; organization_id: string };
-        apiKey?: { id: string };
-      };
-      admissionSnapshot: unknown;
-      requestId: string;
-    };
+    const forwarded = (
+      executeWithBody.mock.calls as unknown as Array<
+        [
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+          {
+            auth: {
+              user: { id: string; organization_id: string };
+              apiKey?: { id: string };
+            };
+            admissionSnapshot: unknown;
+            requestId: string;
+          },
+        ]
+      >
+    )[0][4];
     expect(forwarded.auth.user).toEqual({
       id: "user-1",
       organization_id: "org-1",

--- a/packages/cloud/api/src/lib/legacy-proxy-combined-admission.ts
+++ b/packages/cloud/api/src/lib/legacy-proxy-combined-admission.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared paid-legacy-proxy adapter. One standing read via
+ * requireGenerativeRouteCaller, then the engine consumes that snapshot and
+ * credential. Combined Worker mode never falls back to generic auth or a
+ * second reserve path.
+ */
+
+import {
+  asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
+import type { ProxyCombinedAdmission } from "@/lib/services/proxy/engine";
+import { executeWithBody } from "@/lib/services/proxy/engine";
+import type {
+  ProxyRequestBody,
+  ServiceConfig,
+  ServiceHandler,
+} from "@/lib/services/proxy/types";
+import type { AppContext } from "@/types/cloud-worker-env";
+
+export const PAID_LEGACY_PROXY_EXECUTE_ROUTES = [
+  "v1/chain/nfts/[chain]/[address]/route.ts",
+  "v1/chain/tokens/[chain]/[address]/route.ts",
+  "v1/chain/transfers/[chain]/[address]/route.ts",
+  "v1/market/candles/[chain]/[address]/route.ts",
+  "v1/market/portfolio/[chain]/[address]/route.ts",
+  "v1/market/price/[chain]/[address]/route.ts",
+  "v1/market/token/[chain]/[address]/route.ts",
+  "v1/market/trades/[chain]/[address]/route.ts",
+  "v1/proxy/evm-rpc/[chain]/route.ts",
+  "v1/proxy/solana-rpc/route.ts",
+  "v1/solana/assets/[address]/route.ts",
+  "v1/solana/rpc/route.ts",
+  "v1/solana/token-accounts/[address]/route.ts",
+  "v1/solana/transactions/[address]/route.ts",
+] as const;
+
+export const PAID_LEGACY_PROXY_BIRDEYE_ROUTE =
+  "v1/apis/birdeye/[...path]/route.ts" as const;
+
+export const PAID_LEGACY_PROXY_RPC_ROUTE = "v1/rpc/[chain]/route.ts" as const;
+
+export const EXEMPT_LEGACY_PROXY_ROUTES = [
+  "v1/proxy/birdeye/[...path]/route.ts",
+] as const;
+
+export function applyLegacyProxyQueryApiKey(c: AppContext): Headers {
+  const headers = new Headers(c.req.raw.headers);
+  const queryApiKey = c.req.query("api_key");
+  if (
+    queryApiKey &&
+    !c.req.header("authorization") &&
+    !c.req.header("X-API-Key")
+  ) {
+    headers.set("authorization", `Bearer ${queryApiKey}`);
+    try {
+      c.req.raw.headers.set("authorization", `Bearer ${queryApiKey}`);
+    } catch {
+      // error-policy:J4 immutable Worker headers still reach the cloned Request
+      // used for engine dispatch; standing reads the mutated copy when allowed.
+    }
+  }
+  return headers;
+}
+
+export async function resolvePaidProxyCombinedAdmission(
+  c: AppContext,
+): Promise<ProxyCombinedAdmission> {
+  const caller = await requireGenerativeRouteCaller(c, {
+    rateLimitEndpoint: "standard",
+  });
+  const executionCtx = getGenerativeExecutionContext(c);
+  if (executionCtx && !caller.admissionSnapshot) {
+    throw new ApiError(
+      503,
+      "service_unavailable",
+      "Provider admission is unavailable; retry shortly",
+      { retryable: true, retryAfterSeconds: 1 },
+    );
+  }
+  return {
+    auth: {
+      user: caller.user,
+      ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
+    },
+    admissionSnapshot: caller.admissionSnapshot,
+    executionCtx,
+    requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
+  };
+}
+
+export async function executePaidProxyWithCombinedAdmission(
+  c: AppContext,
+  config: ServiceConfig,
+  work: ServiceHandler,
+  request: Request,
+  body: ProxyRequestBody,
+): Promise<Response> {
+  try {
+    const combinedAdmission = await resolvePaidProxyCombinedAdmission(c);
+    return await executeWithBody(
+      config,
+      work,
+      request,
+      body,
+      combinedAdmission,
+    );
+  } catch (error) {
+    const mapped = asGenerativeCacheApiError(error) ?? error;
+    if (mapped instanceof ApiError && mapped.status === 503) {
+      const response = failureResponse(c, mapped);
+      response.headers.set("Retry-After", "1");
+      return response;
+    }
+    return failureResponse(c, mapped);
+  }
+}

--- a/packages/cloud/api/v1/apis/birdeye/[...path]/route.ts
+++ b/packages/cloud/api/v1/apis/birdeye/[...path]/route.ts
@@ -6,11 +6,16 @@
  */
 
 import { Hono } from "hono";
+import { resolvePaidProxyCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { handleBirdeyeMarketDataProxyGet } from "@/lib/services/proxy/birdeye-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.get("/*", handleBirdeyeMarketDataProxyGet);
+app.get("/*", (c) =>
+  handleBirdeyeMarketDataProxyGet(c, () =>
+    resolvePaidProxyCombinedAdmission(c),
+  ),
+);
 
 export default app;

--- a/packages/cloud/api/v1/chain/nfts/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/nfts/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 chain nfts chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
   chainDataConfig,
@@ -47,11 +47,17 @@ app.get("/", async (c) => {
   }
 
   return applyCorsHeaders(
-    await executeWithBody(chainDataConfig, chainDataHandler, c.req.raw, {
-      method: "getNFTsForOwner",
-      chain,
-      params: { owner: address },
-    }),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      chainDataConfig,
+      chainDataHandler,
+      c.req.raw,
+      {
+        method: "getNFTsForOwner",
+        chain,
+        params: { owner: address },
+      },
+    ),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/tokens/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/tokens/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 chain tokens chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
   chainDataConfig,
@@ -47,11 +47,17 @@ app.get("/", async (c) => {
   }
 
   return applyCorsHeaders(
-    await executeWithBody(chainDataConfig, chainDataHandler, c.req.raw, {
-      method: "getTokenBalances",
-      chain,
-      params: { address },
-    }),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      chainDataConfig,
+      chainDataHandler,
+      c.req.raw,
+      {
+        method: "getTokenBalances",
+        chain,
+        params: { address },
+      },
+    ),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/transfers/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/transfers/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 chain transfers chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
   chainDataConfig,
@@ -61,12 +61,20 @@ app.get("/", async (c) => {
   }
 
   return applyCorsHeaders(
-    await executeWithBody(chainDataConfig, chainDataHandler, c.req.raw, {
-      method: "getAssetTransfers",
-      chain,
-      params:
-        direction === "in" ? { toAddress: address } : { fromAddress: address },
-    }),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      chainDataConfig,
+      chainDataHandler,
+      c.req.raw,
+      {
+        method: "getAssetTransfers",
+        chain,
+        params:
+          direction === "in"
+            ? { toAddress: address }
+            : { fromAddress: address },
+      },
+    ),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/market/candles/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/candles/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 /** Proxies validated public candle requests to the paid market-data provider. */
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -10,7 +10,7 @@ import {
   marketDataConfig,
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 export const OHLCV_TYPES = [
@@ -37,9 +37,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
   const { searchParams } = new URL(request.url);
@@ -105,7 +106,13 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      request,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -113,7 +120,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/candles/[chain]/[address]/route.type.test.ts
+++ b/packages/cloud/api/v1/market/candles/[chain]/[address]/route.type.test.ts
@@ -15,8 +15,9 @@ interface ProxyBody {
   params: Record<string, string>;
 }
 
-const executeWithBody = mock(
+const executePaidProxyWithCombinedAdmission = mock(
   async (
+    _c: unknown,
     _config: unknown,
     _handler: unknown,
     _request: Request,
@@ -24,8 +25,8 @@ const executeWithBody = mock(
   ) => Response.json({ success: true }),
 );
 
-mock.module("@/lib/services/proxy/engine", () => ({
-  executeWithBody,
+mock.module("@/api-app/lib/legacy-proxy-combined-admission", () => ({
+  executePaidProxyWithCombinedAdmission,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
@@ -49,7 +50,7 @@ function candles(query = "") {
 
 describe("GET /api/v1/market/candles OHLCV interval identity", () => {
   beforeEach(() => {
-    executeWithBody.mockClear();
+    executePaidProxyWithCombinedAdmission.mockClear();
   });
 
   test.each(["", "?type="])(
@@ -57,8 +58,8 @@ describe("GET /api/v1/market/candles OHLCV interval identity", () => {
     async (query) => {
       const response = await candles(query);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      const body = executeWithBody.mock.calls[0][3];
+      expect(executePaidProxyWithCombinedAdmission).toHaveBeenCalledTimes(1);
+      const body = executePaidProxyWithCombinedAdmission.mock.calls[0][4];
       expect(body.method).toBe("getOHLCV");
       expect(body.params.address).toBe(SOLANA_TOKEN);
       expect(body.params.type).toBeUndefined();
@@ -70,21 +71,23 @@ describe("GET /api/v1/market/candles OHLCV interval identity", () => {
     async (type) => {
       const response = await candles(`?type=${type}`);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+      expect(executePaidProxyWithCombinedAdmission).toHaveBeenCalledTimes(1);
+      expect(
+        executePaidProxyWithCombinedAdmission.mock.calls[0][4],
+      ).toMatchObject({
         params: { type },
       });
     },
   );
 
   test.each(["1h", "1d", "HOUR", "daily", "foo", "1e2"])(
-    "rejects type=%s before executeWithBody",
+    "rejects type=%s before executePaidProxyWithCombinedAdmission",
     async (token) => {
       const response = await candles(`?type=${encodeURIComponent(token)}`);
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error: string };
       expect(body.error).toBe("Invalid type");
-      expect(executeWithBody).not.toHaveBeenCalled();
+      expect(executePaidProxyWithCombinedAdmission).not.toHaveBeenCalled();
     },
   );
 });

--- a/packages/cloud/api/v1/market/portfolio/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/portfolio/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 market portfolio chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -10,7 +10,7 @@ import {
   marketDataConfig,
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 
@@ -19,9 +19,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
 
@@ -59,7 +60,13 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      request,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -67,7 +74,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/price/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/price/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 market price chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Market Data: Token Price Endpoint
@@ -23,8 +23,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * - Cost: prevents wasted credits on invalid requests
  */
 
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -44,9 +44,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
 
@@ -93,7 +94,13 @@ async function __hono_GET(
   // - Tracks usage for analytics and billing
   // - Consistent behavior across all service routes
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      request,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -101,7 +108,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/token/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/token/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 market token chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -10,7 +10,7 @@ import {
   marketDataConfig,
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 
@@ -19,9 +19,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
 
@@ -59,7 +60,13 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      request,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -67,7 +74,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.limit-clamp.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.limit-clamp.test.ts
@@ -11,15 +11,15 @@ import { Hono } from "hono";
 
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 
-type ExecuteWithBody =
-  typeof import("@/lib/services/proxy/engine").executeWithBody;
+type ExecutePaid =
+  typeof import("@/api-app/lib/legacy-proxy-combined-admission").executePaidProxyWithCombinedAdmission;
 
-const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
-  Response.json({ success: true }),
+const executePaidProxyWithCombinedAdmission = mock(
+  async (..._args: Parameters<ExecutePaid>) => Response.json({ success: true }),
 );
 
-mock.module("@/lib/services/proxy/engine", () => ({
-  executeWithBody,
+mock.module("@/api-app/lib/legacy-proxy-combined-admission", () => ({
+  executePaidProxyWithCombinedAdmission,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
@@ -44,7 +44,7 @@ function trades(query: string) {
 async function forwardedParams(query: string) {
   const response = await trades(query);
   expect(response.status).toBe(200);
-  const body = executeWithBody.mock.calls.at(-1)?.[3] as {
+  const body = executePaidProxyWithCombinedAdmission.mock.calls.at(-1)?.[4] as {
     params: Record<string, string>;
   };
   return body.params;
@@ -52,7 +52,7 @@ async function forwardedParams(query: string) {
 
 describe("GET /api/v1/market/trades limit/offset clamp", () => {
   beforeEach(() => {
-    executeWithBody.mockClear();
+    executePaidProxyWithCombinedAdmission.mockClear();
   });
 
   test("omits limit/offset when absent, matching provider defaults", async () => {

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 /** Proxies validated token-trade history requests to the market-data provider. */
 import { Hono } from "hono";
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -11,7 +11,7 @@ import {
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
 import { parseClampedLimit, parseClampedOffset } from "@/lib/utils/clamp-limit";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 export const TOKEN_TRADE_TYPES = Object.freeze([
@@ -33,9 +33,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
   const { searchParams } = new URL(request.url);
@@ -108,7 +109,13 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executePaidProxyWithCombinedAdmission(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      request,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -116,7 +123,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -11,15 +11,15 @@ import { Hono } from "hono";
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 const EXPECTED_TOKEN_TRADE_TYPES = ["swap", "add", "remove", "all"] as const;
 
-type ExecuteWithBody =
-  typeof import("@/lib/services/proxy/engine").executeWithBody;
+type ExecutePaid =
+  typeof import("@/api-app/lib/legacy-proxy-combined-admission").executePaidProxyWithCombinedAdmission;
 
-const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
-  Response.json({ success: true }),
+const executePaidProxyWithCombinedAdmission = mock(
+  async (..._args: Parameters<ExecutePaid>) => Response.json({ success: true }),
 );
 
-mock.module("@/lib/services/proxy/engine", () => ({
-  executeWithBody,
+mock.module("@/api-app/lib/legacy-proxy-combined-admission", () => ({
+  executePaidProxyWithCombinedAdmission,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
@@ -43,7 +43,7 @@ function trades(query = "") {
 
 describe("GET /api/v1/market/trades token-trade type identity", () => {
   beforeEach(() => {
-    executeWithBody.mockClear();
+    executePaidProxyWithCombinedAdmission.mockClear();
   });
 
   test.each(["", "?tx_type="])(
@@ -51,8 +51,8 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     async (query) => {
       const response = await trades(query);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      const body = executeWithBody.mock.calls[0][3] as {
+      expect(executePaidProxyWithCombinedAdmission).toHaveBeenCalledTimes(1);
+      const body = executePaidProxyWithCombinedAdmission.mock.calls[0][4] as {
         method: string;
         params: Record<string, string>;
       };
@@ -72,15 +72,17 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     async (txType) => {
       const response = await trades(`?tx_type=${txType}`);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+      expect(executePaidProxyWithCombinedAdmission).toHaveBeenCalledTimes(1);
+      expect(
+        executePaidProxyWithCombinedAdmission.mock.calls[0][4],
+      ).toMatchObject({
         params: { tx_type: txType },
       });
     },
   );
 
   test.each(["SWAP", "buy", "sell", "foo", "1e2"])(
-    "rejects tx_type=%s before executeWithBody",
+    "rejects tx_type=%s before executePaidProxyWithCombinedAdmission",
     async (token) => {
       const response = await trades(`?tx_type=${encodeURIComponent(token)}`);
       expect(response.status).toBe(400);
@@ -90,7 +92,7 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
       };
       expect(body.error).toBe("Invalid tx_type");
       expect(body.details).toContain("swap, add, remove, all");
-      expect(executeWithBody).not.toHaveBeenCalled();
+      expect(executePaidProxyWithCombinedAdmission).not.toHaveBeenCalled();
     },
   );
 });

--- a/packages/cloud/api/v1/proxy/evm-rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/proxy/evm-rpc/[chain]/route.ts
@@ -11,7 +11,10 @@
  */
 
 import { Hono } from "hono";
-import { executeWithBody } from "@/lib/services/proxy/engine";
+import {
+  applyLegacyProxyQueryApiKey,
+  executePaidProxyWithCombinedAdmission,
+} from "@/api-app/lib/legacy-proxy-combined-admission";
 import {
   rpcConfigForChain,
   rpcHandlerForChain,
@@ -62,15 +65,7 @@ app.post("/", async (c) => {
   }
 
   // Support auth via query param for clients that cannot set custom headers.
-  const headers = new Headers(c.req.raw.headers);
-  const queryApiKey = c.req.query("api_key");
-  if (
-    queryApiKey &&
-    !c.req.header("authorization") &&
-    !c.req.header("X-API-Key")
-  ) {
-    headers.set("authorization", `Bearer ${queryApiKey}`);
-  }
+  const headers = applyLegacyProxyQueryApiKey(c);
 
   let body: ProxyRequestBody;
   try {
@@ -89,7 +84,8 @@ app.post("/", async (c) => {
     headers,
   });
 
-  return executeWithBody(
+  return executePaidProxyWithCombinedAdmission(
+    c,
     rpcConfigForChain(target.chain),
     rpcHandlerForChain(target.chain),
     request,

--- a/packages/cloud/api/v1/proxy/solana-rpc/route.ts
+++ b/packages/cloud/api/v1/proxy/solana-rpc/route.ts
@@ -10,7 +10,10 @@
  */
 
 import { Hono } from "hono";
-import { executeWithBody } from "@/lib/services/proxy/engine";
+import {
+  applyLegacyProxyQueryApiKey,
+  executePaidProxyWithCombinedAdmission,
+} from "@/api-app/lib/legacy-proxy-combined-admission";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -23,15 +26,7 @@ const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
   // Support auth via query param for @solana/web3.js Connection clients that
   // cannot set custom headers.
-  const headers = new Headers(c.req.raw.headers);
-  const queryApiKey = c.req.query("api_key");
-  if (
-    queryApiKey &&
-    !c.req.header("authorization") &&
-    !c.req.header("X-API-Key")
-  ) {
-    headers.set("authorization", `Bearer ${queryApiKey}`);
-  }
+  const headers = applyLegacyProxyQueryApiKey(c);
 
   let body: ProxyRequestBody;
   try {
@@ -45,7 +40,13 @@ app.post("/", async (c) => {
     headers,
   });
 
-  return executeWithBody(solanaRpcConfig, solanaRpcHandler, request, body);
+  return executePaidProxyWithCombinedAdmission(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    request,
+    body,
+  );
 });
 
 export default app;

--- a/packages/cloud/api/v1/rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/rpc/[chain]/route.ts
@@ -1,9 +1,8 @@
 // Handles v1 cloud API v1 rpc chain route traffic with route-local auth expectations.
 import { Hono } from "hono";
-import {
-  getGenerativeExecutionContext,
-  requireGenerativeRouteCaller,
-} from "@/api-app/lib/generative-route-auth";
+import { asGenerativeCacheApiError } from "@/api-app/lib/generative-route-auth";
+import { resolvePaidProxyCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { createHandler } from "@/lib/services/proxy/engine";
 import {
@@ -38,29 +37,20 @@ async function __hono_POST(
   }
 
   const config = rpcConfigForChain(normalized);
-  const caller = await requireGenerativeRouteCaller(c, {
-    rateLimitEndpoint: "standard",
-  });
-  const executionCtx = getGenerativeExecutionContext(c);
-  if (executionCtx && !caller.admissionSnapshot) {
+  try {
+    const combinedAdmission = await resolvePaidProxyCombinedAdmission(c);
+    const handler = createHandler(
+      config,
+      rpcHandlerForChain(normalized),
+      combinedAdmission,
+    );
+    return applyCorsHeaders(await handler(c.req.raw), CORS_METHODS);
+  } catch (error) {
     return applyCorsHeaders(
-      Response.json(
-        { error: "Provider admission is unavailable; retry shortly" },
-        { status: 503, headers: { "Retry-After": "1" } },
-      ),
+      failureResponse(c, asGenerativeCacheApiError(error) ?? error),
       CORS_METHODS,
     );
   }
-  const handler = createHandler(config, rpcHandlerForChain(normalized), {
-    auth: {
-      user: caller.user,
-      ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
-    },
-    admissionSnapshot: caller.admissionSnapshot,
-    executionCtx,
-    requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
-  });
-  return applyCorsHeaders(await handler(c.req.raw), CORS_METHODS);
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud/api/v1/solana/assets/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/assets/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 solana assets address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Solana Assets API - Get assets by owner address
@@ -13,8 +13,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -26,9 +26,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
+  const request = c.req.raw;
   const { address } = await params;
 
   // Validate Solana address format to prevent DoS and invalid requests
@@ -57,7 +58,8 @@ async function __hono_GET(
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
 
   try {
-    const response = await executeWithBody(
+    const response = await executePaidProxyWithCombinedAdmission(
+      c,
       solanaRpcConfig,
       solanaRpcHandler,
       request,
@@ -80,7 +82,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({ address: c.req.param("address")! }),
   }),
 );

--- a/packages/cloud/api/v1/solana/rpc/route.ts
+++ b/packages/cloud/api/v1/solana/rpc/route.ts
@@ -8,7 +8,10 @@
  */
 
 import { Hono } from "hono";
-import { executeWithBody } from "@/lib/services/proxy/engine";
+import {
+  applyLegacyProxyQueryApiKey,
+  executePaidProxyWithCombinedAdmission,
+} from "@/api-app/lib/legacy-proxy-combined-admission";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -21,15 +24,7 @@ const app = new Hono<AppEnv>();
 app.post("/", async (c) => {
   // Support auth via query param for @solana/web3.js Connection clients that
   // cannot set custom headers (mirrors apps/api/v1/proxy/solana-rpc).
-  const headers = new Headers(c.req.raw.headers);
-  const queryApiKey = c.req.query("api_key");
-  if (
-    queryApiKey &&
-    !c.req.header("authorization") &&
-    !c.req.header("X-API-Key")
-  ) {
-    headers.set("authorization", `Bearer ${queryApiKey}`);
-  }
+  const headers = applyLegacyProxyQueryApiKey(c);
 
   let body: ProxyRequestBody;
   try {
@@ -43,7 +38,13 @@ app.post("/", async (c) => {
     headers,
   });
 
-  return executeWithBody(solanaRpcConfig, solanaRpcHandler, request, body);
+  return executePaidProxyWithCombinedAdmission(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    request,
+    body,
+  );
 });
 
 export default app;

--- a/packages/cloud/api/v1/solana/token-accounts/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/token-accounts/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 solana token accounts address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Solana Token Accounts API - Get token accounts by owner
@@ -13,8 +13,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -26,9 +26,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
+  const request = c.req.raw;
   const { address } = await params;
 
   // Validate Solana address format to prevent DoS and invalid requests
@@ -55,7 +56,8 @@ async function __hono_GET(
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
 
   try {
-    const response = await executeWithBody(
+    const response = await executePaidProxyWithCombinedAdmission(
+      c,
       solanaRpcConfig,
       solanaRpcHandler,
       request,
@@ -78,7 +80,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({ address: c.req.param("address")! }),
   }),
 );

--- a/packages/cloud/api/v1/solana/transactions/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/transactions/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 solana transactions address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Solana Transactions API - Get transactions by address
@@ -13,8 +13,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
+import { executePaidProxyWithCombinedAdmission } from "@/api-app/lib/legacy-proxy-combined-admission";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -26,9 +26,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
+  const request = c.req.raw;
   const { address } = await params;
 
   if (!isValidSolanaAddress(address)) {
@@ -54,7 +55,8 @@ async function __hono_GET(
   };
 
   try {
-    const response = await executeWithBody(
+    const response = await executePaidProxyWithCombinedAdmission(
+      c,
       solanaRpcConfig,
       solanaRpcHandler,
       request,
@@ -78,7 +80,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({ address: c.req.param("address")! }),
   }),
 );

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
@@ -4,56 +4,69 @@
  * Pins that a designed-invalid / not-configured result stays visually distinct
  * from an internal failure, and that an internal failure PROPAGATES through the
  * J1 route boundary (`failureResponse`) as a structured `{ success: false }`
- * rather than being swallowed into a fabricated 2xx/empty body. The auth,
- * pricing, and credits boundaries plus `fetch` are mocked; `failureResponse`
- * runs for real so the boundary translation is the unit under test. mock.module
- * is process-global but the suite runs under `bun test --isolate`, so each file
- * gets a fresh registry.
+ * rather than being swallowed into a fabricated 2xx/empty body. Combined
+ * admission is injected; generic auth must not run.
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
-import * as authActual from "../../auth/workers-hono-auth";
+import * as cacheActual from "../../cache/client";
 import * as creditsActual from "../credits";
+import * as usageActual from "../usage";
+import type { ProxyCombinedAdmission } from "./engine";
 import * as pricingActual from "./pricing";
 
 const realCredits = { ...creditsActual };
 const realPricing = { ...pricingActual };
-const realAuth = { ...authActual };
+const realUsage = { ...usageActual };
+const realCache = { ...cacheActual };
 
 const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const USER_ID = "00000000-0000-4000-8000-0000000000bb";
 const COST = 0.0003;
 
-const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
-const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const reconcile = mock<(actualCost: number) => Promise<void>>();
+const reserve = mock<(args: unknown) => Promise<{ reconcile: typeof reconcile }>>();
 const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
-const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
+const resolveCombinedAdmission = mock<() => Promise<ProxyCombinedAdmission>>();
 
 mock.module("../credits", () => ({
   ...realCredits,
-  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
+  creditsService: { ...realCredits.creditsService, reserve },
 }));
-
 mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
-
-mock.module("../../auth/workers-hono-auth", () => ({
-  ...realAuth,
-  requireUserOrApiKeyWithOrg,
+mock.module("../usage", () => ({
+  ...realUsage,
+  usageService: { ...realUsage.usageService, create: mock(async () => undefined) },
+}));
+mock.module("../../cache/client", () => ({
+  ...realCache,
+  cache: { get: async () => null, set: async () => {} },
 }));
 
+const { InsufficientCreditsError } = creditsActual;
 const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
 
 const originalFetch = globalThis.fetch;
 
+function stubAdmission(): ProxyCombinedAdmission {
+  return {
+    auth: { user: { id: USER_ID, organization_id: ORG_ID } },
+    requestId: "birdeye-test",
+  };
+}
+
 function makeContext(path: string, env: Record<string, unknown> = {}): Context<AppEnv> {
   const url = `https://api.elizacloud.ai/proxy/${path}`;
+  const raw = new Request(url, { method: "GET" });
   return {
     env,
     req: {
       param: (key: string) => (key === "*" ? path : undefined),
       url,
       header: (_name: string) => undefined,
+      raw,
     },
     json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
   } as unknown as Context<AppEnv>;
@@ -66,14 +79,14 @@ function mockUpstream(status: number, body = "{}") {
 }
 
 beforeEach(() => {
-  deductCredits.mockReset();
-  refundCredits.mockReset();
+  reconcile.mockReset();
+  reserve.mockReset();
   getServiceMethodCost.mockReset();
-  requireUserOrApiKeyWithOrg.mockReset();
-  deductCredits.mockResolvedValue({ success: true });
-  refundCredits.mockResolvedValue({ success: true });
+  resolveCombinedAdmission.mockReset();
+  reconcile.mockResolvedValue(undefined);
+  reserve.mockResolvedValue({ reconcile });
   getServiceMethodCost.mockResolvedValue(COST);
-  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
+  resolveCombinedAdmission.mockResolvedValue(stubAdmission());
   mockUpstream(200, '{"data":{"value":1}}');
 });
 
@@ -84,29 +97,34 @@ afterEach(() => {
 afterAll(() => {
   mock.module("../credits", () => realCredits);
   mock.module("./pricing", () => realPricing);
-  mock.module("../../auth/workers-hono-auth", () => realAuth);
+  mock.module("../usage", () => realUsage);
+  mock.module("../../cache/client", () => realCache);
 });
 
 describe("birdeye proxy — designed-invalid results stay distinct from failures", () => {
   test("unpriced path is a designed 400 reject, not a boundary failure", async () => {
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/not_a_real_path", { BIRDEYE_API_KEY: "key" }),
+      resolveCombinedAdmission,
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string; supportedPaths: string[] };
     expect(body.error).toContain("Unpriced Birdeye proxy path");
     expect(Array.isArray(body.supportedPaths)).toBe(true);
-    // Short-circuits BEFORE any auth / billing work.
-    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
-    expect(deductCredits).not.toHaveBeenCalled();
+    expect(resolveCombinedAdmission).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
   });
 
   test("missing BIRDEYE_API_KEY is a designed 503 not-configured, no debit", async () => {
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price", {}));
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", {}),
+      resolveCombinedAdmission,
+    );
     expect(res.status).toBe(503);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("server misconfigured");
-    expect(deductCredits).not.toHaveBeenCalled();
+    expect(resolveCombinedAdmission).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
   });
 });
 
@@ -116,37 +134,36 @@ describe("birdeye proxy — internal failures propagate through the J1 boundary"
 
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      resolveCombinedAdmission,
     );
 
-    expect(res.status).toBe(500);
-    const body = (await res.json()) as { success: boolean };
-    expect(body.success).toBe(false);
-    // The failure aborts before any debit — nothing charged for a broken call.
-    expect(deductCredits).not.toHaveBeenCalled();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Upstream service error");
+    expect(reserve).not.toHaveBeenCalled();
   });
 
   test("an auth failure is translated, not swallowed into a healthy response", async () => {
-    requireUserOrApiKeyWithOrg.mockRejectedValue(new Error("token verification failed"));
+    resolveCombinedAdmission.mockRejectedValue(new Error("token verification failed"));
 
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      resolveCombinedAdmission,
     );
 
     expect(res.ok).toBe(false);
     const body = (await res.json()) as { success: boolean };
     expect(body.success).toBe(false);
-    expect(deductCredits).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
   });
 });
 
 describe("birdeye proxy — money-path debit failures stay distinct", () => {
-  // Designed insufficient balance is a user-facing 402. A thrown debit failure
-  // is an internal ledger failure and must go through the route boundary as a
-  // structured 5xx, never the same 402 as a legitimate empty balance.
   test("designed insufficient balance returns 402", async () => {
-    deductCredits.mockResolvedValue({ success: false });
+    reserve.mockRejectedValue(new InsufficientCreditsError(COST, 0));
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      resolveCombinedAdmission,
     );
     expect(res.status).toBe(402);
     const body = (await res.json()) as { error: string };
@@ -154,13 +171,13 @@ describe("birdeye proxy — money-path debit failures stay distinct", () => {
   });
 
   test("an internal debit failure surfaces as a structured 5xx", async () => {
-    deductCredits.mockRejectedValue(new Error("credits ledger write failed"));
+    reserve.mockRejectedValue(new Error("credits ledger write failed"));
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      resolveCombinedAdmission,
     );
-    expect(res.status).toBe(500);
-    const body = (await res.json()) as { success: boolean; error: string };
-    expect(body.success).toBe(false);
-    expect(body.error).toBe("An unexpected error occurred");
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Upstream service error");
   });
 });

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
@@ -5,60 +5,76 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
-import * as authActual from "../../auth/workers-hono-auth";
+import * as cacheActual from "../../cache/client";
 import * as creditsActual from "../credits";
+import * as usageActual from "../usage";
+import type { ProxyCombinedAdmission } from "./engine";
 import * as pricingActual from "./pricing";
 
 const realCredits = { ...creditsActual };
 const realPricing = { ...pricingActual };
-const realAuth = { ...authActual };
+const realUsage = { ...usageActual };
+const realCache = { ...cacheActual };
 
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
 const COST = 0.0003;
 
-const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
-const refundCredits = mock<(args: unknown) => Promise<unknown>>();
+const reconcile = mock<(actualCost: number) => Promise<void>>();
+const reserve = mock<(args: unknown) => Promise<{ reconcile: typeof reconcile }>>();
 const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
-const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
 
 mock.module("../credits", () => ({
   ...realCredits,
-  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
+  creditsService: { ...realCredits.creditsService, reserve },
 }));
-
 mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
-
-mock.module("../../auth/workers-hono-auth", () => ({
-  ...realAuth,
-  requireUserOrApiKeyWithOrg,
+mock.module("../usage", () => ({
+  ...realUsage,
+  usageService: { ...realUsage.usageService, create: mock(async () => undefined) },
+}));
+mock.module("../../cache/client", () => ({
+  ...realCache,
+  cache: { get: async () => null, set: async () => {} },
 }));
 
 const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
 
 const originalFetch = globalThis.fetch;
 
+function stubAdmission(): ProxyCombinedAdmission {
+  return {
+    auth: { user: { id: USER_ID, organization_id: ORG_ID } },
+    requestId: "birdeye-timeout",
+  };
+}
+
 function makeContext(path: string): Context<AppEnv> {
   const url = `https://api.elizacloud.ai/proxy/${path}`;
+  const raw = new Request(url, { method: "GET" });
   return {
     env: { BIRDEYE_API_KEY: "key" } as unknown as AppEnv["Bindings"],
     req: {
       param: (key: string) => (key === "*" ? path : undefined),
       url,
       header: (_name: string) => undefined,
+      raw,
     },
     json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
   } as unknown as Context<AppEnv>;
 }
 
+async function invoke(path = "defi/price") {
+  return handleBirdeyeMarketDataProxyGet(makeContext(path), async () => stubAdmission());
+}
+
 beforeEach(() => {
-  deductCredits.mockReset();
-  refundCredits.mockReset();
+  reconcile.mockReset();
+  reserve.mockReset();
   getServiceMethodCost.mockReset();
-  requireUserOrApiKeyWithOrg.mockReset();
-  deductCredits.mockResolvedValue({ success: true });
-  refundCredits.mockResolvedValue({ success: true });
+  reconcile.mockResolvedValue(undefined);
+  reserve.mockResolvedValue({ reconcile });
   getServiceMethodCost.mockResolvedValue(COST);
-  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
 });
 
 afterEach(() => {
@@ -68,7 +84,8 @@ afterEach(() => {
 afterAll(() => {
   mock.module("../credits", () => realCredits);
   mock.module("./pricing", () => realPricing);
-  mock.module("../../auth/workers-hono-auth", () => realAuth);
+  mock.module("../usage", () => realUsage);
+  mock.module("../../cache/client", () => realCache);
 });
 
 describe("birdeye proxy — timeout covers fetch+body and transport refunds", () => {
@@ -78,17 +95,12 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
       err.name = "AbortError";
       throw err;
     }) as unknown as typeof fetch;
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    const res = await invoke();
     expect(res.status).toBe(504);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("timeout");
-    expect(refundCredits).toHaveBeenCalledTimes(1);
-    const args = refundCredits.mock.calls[0]?.[0] as {
-      organizationId: string;
-      amount: number;
-    };
-    expect(args.organizationId).toBe(ORG_ID);
-    expect(args.amount).toBe(COST);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(0);
   });
 
   test("AbortError during body read (stalled body) refunds once and returns 504", async () => {
@@ -99,7 +111,6 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
           headers: { "Content-Type": "application/json" },
         }),
     ) as unknown as typeof fetch;
-    // Make text() throw AbortError to simulate stalled body aborted by timeout
     const originalText = Response.prototype.text;
     Response.prototype.text = mock(async function (this: Response) {
       const err = new Error("This operation was aborted");
@@ -107,9 +118,10 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
       throw err;
     }) as unknown as typeof Response.prototype.text;
     try {
-      const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+      const res = await invoke();
       expect(res.status).toBe(504);
-      expect(refundCredits).toHaveBeenCalledTimes(1);
+      expect(reconcile).toHaveBeenCalledTimes(1);
+      expect(reconcile.mock.calls[0]?.[0]).toBe(0);
     } finally {
       Response.prototype.text = originalText;
     }
@@ -119,9 +131,10 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
     globalThis.fetch = mock(async () => {
       throw new TypeError("fetch failed: DNS error");
     }) as unknown as typeof fetch;
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    const res = await invoke();
     expect(res.status).toBe(502);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(0);
   });
 
   test("upstream 5xx refunds once and forwards status", async () => {
@@ -129,9 +142,10 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
       async () =>
         new Response("upstream down", { status: 502, headers: { "Content-Type": "text/plain" } }),
     ) as unknown as typeof fetch;
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    const res = await invoke();
     expect(res.status).toBe(502);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(0);
   });
 
   test("success 200 and 4xx do not refund", async () => {
@@ -139,10 +153,11 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
       async () =>
         new Response('{"ok":1}', { status: 200, headers: { "Content-Type": "application/json" } }),
     ) as unknown as typeof fetch;
-    let res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    let res = await invoke();
     expect(res.status).toBe(200);
-    expect(refundCredits).not.toHaveBeenCalled();
-    refundCredits.mockReset();
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(COST);
+    reconcile.mockClear();
     globalThis.fetch = mock(
       async () =>
         new Response('{"error":"bad"}', {
@@ -150,8 +165,9 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
           headers: { "Content-Type": "application/json" },
         }),
     ) as unknown as typeof fetch;
-    res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    res = await invoke();
     expect(res.status).toBe(400);
-    expect(refundCredits).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(COST);
   });
 });

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -6,10 +6,9 @@
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
 import { failureResponse } from "../../api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "../../auth/workers-hono-auth";
 import { logger } from "../../utils/logger";
-import { creditsService } from "../credits";
-import { getServiceMethodCost } from "./pricing";
+import { executeWithBody, type ProxyCombinedAdmission } from "./engine";
+import { marketDataConfig } from "./services/market-data";
 
 const BIRDEYE_BASE = "https://public-api.birdeye.so";
 
@@ -32,7 +31,10 @@ export const BIRDEYE_PRICED_PATHS: Record<string, string> = {
   "v1/wallet/tx_list": "getWalletTxList",
 };
 
-export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promise<Response> {
+export async function handleBirdeyeMarketDataProxyGet(
+  c: Context<AppEnv>,
+  resolveCombinedAdmission: () => Promise<ProxyCombinedAdmission>,
+): Promise<Response> {
   try {
     const pathStr = (c.req.param("*") ?? "").replace(/^\/+|\/+$/g, "");
     const pricedMethod = BIRDEYE_PRICED_PATHS[pathStr];
@@ -46,127 +48,64 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
       );
     }
 
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const { organization_id } = user;
-
     const birdeyeApiKey = c.env.BIRDEYE_API_KEY as string | undefined;
     if (!birdeyeApiKey) {
       logger.error("BIRDEYE_API_KEY not configured on cloud server");
       return c.json({ error: "Birdeye proxy not available — server misconfigured" }, 503);
     }
 
-    const cost = await getServiceMethodCost("market-data", pricedMethod);
-    const deductResult = await creditsService.deductCredits({
-      organizationId: organization_id,
-      amount: cost,
-      description: `API proxy: market-data — ${pricedMethod}`,
-      metadata: {
-        type: "proxy_market-data",
-        service: "market-data",
-        provider: "birdeye",
+    const combinedAdmission = await resolveCombinedAdmission();
+    return await executeWithBody(
+      marketDataConfig,
+      async () => {
+        const upstreamUrl = new URL(`${BIRDEYE_BASE}/${pathStr}`);
+        const url = new URL(c.req.url);
+        url.searchParams.forEach((value, key) => {
+          upstreamUrl.searchParams.set(key, value);
+        });
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 10_000);
+        try {
+          const upstreamResponse = await fetch(upstreamUrl.toString(), {
+            headers: {
+              Accept: "application/json",
+              "x-chain": c.req.header("x-chain") ?? "solana",
+              "X-API-KEY": birdeyeApiKey,
+            },
+            signal: controller.signal,
+          });
+          const body = await upstreamResponse.text();
+          return {
+            response: new Response(body, {
+              status: upstreamResponse.status,
+              headers: {
+                "Content-Type": upstreamResponse.headers.get("Content-Type") ?? "application/json",
+              },
+            }),
+          };
+        } catch (error) {
+          // error-policy:J1 upstream boundary — transport and deadline failures
+          // become explicit 502/504 responses after admission has already run.
+          const isAbort = error instanceof Error && error.name === "AbortError";
+          if (isAbort) {
+            const timeout = new Error("Upstream service timeout");
+            timeout.name = "TimeoutError";
+            throw timeout;
+          }
+          throw error;
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      },
+      c.req.raw,
+      {
         method: pricedMethod,
-        path: pathStr,
+        chain: (c.req.header("x-chain") ?? "solana").toLowerCase(),
+        params: {},
       },
-    });
-
-    if (!deductResult.success) {
-      return c.json(
-        {
-          error: "Insufficient credits",
-          topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-        },
-        402,
-      );
-    }
-
-    const upstreamUrl = new URL(`${BIRDEYE_BASE}/${pathStr}`);
-    const url = new URL(c.req.url);
-    url.searchParams.forEach((value, key) => {
-      upstreamUrl.searchParams.set(key, value);
-    });
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
-    let upstreamResponse: Response;
-    let body: string;
-    try {
-      upstreamResponse = await fetch(upstreamUrl.toString(), {
-        headers: {
-          Accept: "application/json",
-          "x-chain": c.req.header("x-chain") ?? "solana",
-          "X-API-KEY": birdeyeApiKey,
-        },
-        signal: controller.signal,
-      });
-      body = await upstreamResponse.text();
-    } catch (error) {
-      // error-policy:J1 upstream boundary — transport and deadline failures
-      // become explicit 502/504 responses after the prepaid cost is refunded.
-      const isAbort = error instanceof Error && error.name === "AbortError";
-      await creditsService
-        .refundCredits({
-          organizationId: organization_id,
-          amount: cost,
-          description: `API proxy refund: market-data — ${pricedMethod} (${isAbort ? "upstream timeout" : "upstream transport failure"})`,
-          metadata: {
-            type: "proxy_market-data_refund",
-            service: "market-data",
-            provider: "birdeye",
-            method: pricedMethod,
-          },
-        })
-        .catch((refundError) => {
-          // error-policy:J4 the upstream request is already a visible failure;
-          // preserve that response while recording the secondary refund fault.
-          logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
-            method: pricedMethod,
-            error: refundError instanceof Error ? refundError.message : String(refundError),
-          });
-        });
-      if (isAbort) {
-        return c.json({ error: "Upstream service timeout" }, 504);
-      }
-      return c.json({ error: "Upstream service unavailable" }, 502);
-    } finally {
-      clearTimeout(timeoutId);
-    }
-
-    // Mirror the engine's billing policy (resolveBillableCost refunds on >=500):
-    // we already debited `cost` upfront, so refund it when the upstream FAILS
-    // server-side (Birdeye 5xx outage) — the customer got no usable response. We
-    // keep the charge on 4xx (the customer's own bad request still consumed our
-    // Birdeye quota). Engine-backed market-data routes already refund; this
-    // direct handler must match.
-    if (upstreamResponse.status >= 500) {
-      await creditsService
-        .refundCredits({
-          organizationId: organization_id,
-          amount: cost,
-          description: `API proxy refund: market-data — ${pricedMethod} (upstream ${upstreamResponse.status})`,
-          metadata: {
-            type: "proxy_market-data_refund",
-            service: "market-data",
-            provider: "birdeye",
-            method: pricedMethod,
-          },
-        })
-        .catch((refundError) => {
-          // error-policy:J4 the upstream 5xx remains visible to the caller;
-          // preserve it while recording the secondary refund fault.
-          logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
-            method: pricedMethod,
-            status: upstreamResponse.status,
-            error: refundError instanceof Error ? refundError.message : String(refundError),
-          });
-        });
-    }
-
-    return new Response(body, {
-      status: upstreamResponse.status,
-      headers: {
-        "Content-Type": upstreamResponse.headers.get("Content-Type") ?? "application/json",
-      },
-    });
+      combinedAdmission,
+    );
   } catch (error) {
     // error-policy:J1 route boundary — translate any handler throw (auth
     // rejection, pricing lookup, upstream fetch) into a structured failure

--- a/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
@@ -12,8 +12,12 @@ import type { ServiceConfig } from "./types";
 
 const realAuth = { ...authActual };
 const realAdmission = { ...admissionActual };
+const realCredits = { ...creditsActual };
 const legacyAuth = mock(async () => {
   throw new Error("legacy auth must not run");
+});
+const reserve = mock(async () => {
+  throw new Error("generic reserve must not run in combined mode");
 });
 const admit = mock<typeof admissionActual.admitOrganizationInference>();
 
@@ -27,6 +31,10 @@ mock.module("../../auth", () => ({
 mock.module("../organization-inference-admission", () => ({
   ...realAdmission,
   admitOrganizationInference: admit,
+}));
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: { ...realCredits.creditsService, reserve },
 }));
 
 const { createHandler } = await import("./engine");
@@ -50,11 +58,13 @@ const snapshot = {
 beforeEach(() => {
   legacyAuth.mockClear();
   admit.mockReset();
+  reserve.mockClear();
 });
 
 afterAll(() => {
   mock.module("../../auth", () => realAuth);
   mock.module("../organization-inference-admission", () => realAdmission);
+  mock.module("../credits", () => realCredits);
 });
 
 test("combined RPC admission orders mark before dispatch and defers settlement", async () => {
@@ -101,6 +111,7 @@ test("combined RPC admission orders mark before dispatch and defers settlement",
   expect(response.status).toBe(200);
   expect(order).toEqual(["mark", "dispatch", "settle"]);
   expect(legacyAuth).not.toHaveBeenCalled();
+  expect(reserve).not.toHaveBeenCalled();
   expect(admit).toHaveBeenCalledTimes(1);
   expect(admit.mock.calls[0]?.[0].admissionSnapshot).toBe(snapshot);
   expect(retained).toHaveLength(1);
@@ -127,5 +138,28 @@ test("combined RPC admission denial performs zero provider dispatch", async () =
 
   expect(response.status).toBe(402);
   expect(work).not.toHaveBeenCalled();
+  expect(legacyAuth).not.toHaveBeenCalled();
+  expect(reserve).not.toHaveBeenCalled();
+});
+
+test("combined mode without a snapshot fails closed before generic reserve", async () => {
+  const work = mock(async () => ({ response: new Response("not reached") }));
+  const handler = createHandler(config, work, {
+    auth: { user: { id: "user-1", organization_id: "org-1" } },
+    executionCtx: { waitUntil: () => undefined },
+    requestId: "rpc-warming",
+  });
+
+  const response = await handler(
+    new Request("https://api.test/api/v1/rpc/ethereum", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", id: 1 }),
+    }),
+  );
+
+  expect(response.status).toBe(503);
+  expect(work).not.toHaveBeenCalled();
+  expect(admit).not.toHaveBeenCalled();
+  expect(reserve).not.toHaveBeenCalled();
   expect(legacyAuth).not.toHaveBeenCalled();
 });

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -203,7 +203,21 @@ export function createHandler(
     const searchParams = new URL(request.url).searchParams;
 
     try {
-      const auth = combinedAdmission?.auth ?? (await getAuthForLevel(request, config.auth));
+      if (combinedAdmission?.executionCtx && !combinedAdmission.admissionSnapshot) {
+        return Response.json(
+          {
+            success: false,
+            error: "Provider admission is unavailable; retry shortly",
+            code: "service_unavailable",
+            details: { retryable: true, retryAfterSeconds: 1 },
+          },
+          { status: 503, headers: { "Retry-After": "1" } },
+        );
+      }
+
+      const auth = combinedAdmission
+        ? combinedAdmission.auth
+        : await getAuthForLevel(request, config.auth);
       const { user } = auth;
       const apiKey = "apiKey" in auth ? auth.apiKey : undefined;
       const organizationId = user.organization_id;
@@ -516,8 +530,9 @@ export async function executeWithBody(
   work: ServiceHandler,
   request: Request,
   body: ProxyRequestBody,
+  combinedAdmission?: ProxyCombinedAdmission,
 ): Promise<Response> {
-  const handler = createHandler(config, work);
+  const handler = createHandler(config, work, combinedAdmission);
   const mockRequest = new Request(request.url, {
     method: "POST",
     headers: request.headers,

--- a/packages/cloud/shared/src/lib/services/proxy/refund-on-failure.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/refund-on-failure.test.ts
@@ -22,18 +22,26 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "b
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
 import * as authActual from "../../auth/workers-hono-auth";
+import * as cacheActual from "../../cache/client";
 import * as creditsActual from "../credits";
+import * as usageActual from "../usage";
+import type { ProxyCombinedAdmission } from "./engine";
 import * as pricingActual from "./pricing";
 
 const realCredits = { ...creditsActual };
 const realPricing = { ...pricingActual };
 const realAuth = { ...authActual };
+const realUsage = { ...usageActual };
+const realCache = { ...cacheActual };
 
 const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const USER_ID = "00000000-0000-4000-8000-0000000000bb";
 const COST = 0.0003;
 
 const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
 const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const reconcile = mock<(actualCost: number) => Promise<void>>();
+const reserve = mock<(args: unknown) => Promise<{ reconcile: typeof reconcile }>>();
 
 mock.module("../credits", () => ({
   ...realCredits,
@@ -41,7 +49,16 @@ mock.module("../credits", () => ({
     ...realCredits.creditsService,
     deductCredits,
     refundCredits,
+    reserve,
   },
+}));
+mock.module("../usage", () => ({
+  ...realUsage,
+  usageService: { ...realUsage.usageService, create: mock(async () => undefined) },
+}));
+mock.module("../../cache/client", () => ({
+  ...realCache,
+  cache: { get: async () => null, set: async () => {} },
 }));
 
 mock.module("./pricing", () => ({
@@ -60,14 +77,23 @@ const { handleDexscreenerProxyGet } = await import("./dexscreener-handler");
 const originalFetch = globalThis.fetch;
 
 /** Minimal Hono Context stub covering exactly what the handlers read. */
+function stubAdmission(): ProxyCombinedAdmission {
+  return {
+    auth: { user: { id: USER_ID, organization_id: ORG_ID } },
+    requestId: "birdeye-refund",
+  };
+}
+
 function makeContext(path: string, env: Record<string, unknown> = {}): Context<AppEnv> {
   const url = `https://api.elizacloud.ai/proxy/${path}`;
+  const raw = new Request(url, { method: "GET" });
   return {
     env,
     req: {
       param: (key: string) => (key === "*" ? path : undefined),
       url,
       header: (_name: string) => undefined,
+      raw,
     },
     json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
   } as unknown as Context<AppEnv>;
@@ -86,8 +112,12 @@ function mockUpstream(status: number, body = "{}") {
 beforeEach(() => {
   deductCredits.mockReset();
   refundCredits.mockReset();
+  reconcile.mockReset();
+  reserve.mockReset();
   deductCredits.mockResolvedValue({ success: true });
   refundCredits.mockResolvedValue({ success: true });
+  reconcile.mockResolvedValue(undefined);
+  reserve.mockResolvedValue({ reconcile });
 });
 
 afterEach(() => {
@@ -98,6 +128,8 @@ afterAll(() => {
   mock.module("../credits", () => realCredits);
   mock.module("./pricing", () => realPricing);
   mock.module("../../auth/workers-hono-auth", () => realAuth);
+  mock.module("../usage", () => realUsage);
+  mock.module("../../cache/client", () => realCache);
 });
 
 describe("birdeye proxy refund-on-failure", () => {
@@ -106,18 +138,14 @@ describe("birdeye proxy refund-on-failure", () => {
 
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      async () => stubAdmission(),
     );
 
     // Status is passed through (the customer sees the upstream failure).
     expect(res.status).toBe(500);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
-    const refundArg = refundCredits.mock.calls[0]?.[0] as {
-      organizationId: string;
-      amount: number;
-    };
-    expect(refundArg.organizationId).toBe(ORG_ID);
-    expect(refundArg.amount).toBeCloseTo(COST, 12);
+    expect(reserve).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(0);
   });
 
   test("upstream 4xx does NOT refund (paid API, customer's bad request)", async () => {
@@ -125,11 +153,13 @@ describe("birdeye proxy refund-on-failure", () => {
 
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      async () => stubAdmission(),
     );
 
     expect(res.status).toBe(400);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits).not.toHaveBeenCalled();
+    expect(reserve).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(COST);
   });
 
   test("upstream 200 does NOT refund (successful call)", async () => {
@@ -137,11 +167,13 @@ describe("birdeye proxy refund-on-failure", () => {
 
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+      async () => stubAdmission(),
     );
 
     expect(res.status).toBe(200);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits).not.toHaveBeenCalled();
+    expect(reserve).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(COST);
   });
 });
 


### PR DESCRIPTION
## Summary
- Route paid chain, market, EVM, Solana, and `executeWithBody` inventory through one shared adapter that calls `requireGenerativeRouteCaller` exactly once.
- Forward the combined admission snapshot and credential into engine dispatch; combined Worker mode never falls back to generic auth or a second reserve path.
- Migrate direct Birdeye paid handling onto that same standing read plus engine settlement (mark, dispatch, async reconcile) without duplicating standing.
- Keep the legacy Birdeye 308 redirect and other public/read-only/internal routes explicitly exempt.

Fixes #30252

## Test plan
- [x] Inventory test fails on unpatched `develop` (`executeWithBody` still in paid routes) and passes after the adapter migration.
- [x] Adapter behavioral tests: one standing read, structured standing denial, 503 without snapshot, snapshot forwarded.
- [x] Combined engine tests: mark-before-dispatch, no generic auth/reserve, fail-closed without snapshot.
- [x] Birdeye error-policy, timeout, and refund-on-failure suites stay deterministic with mocked fetch/credits (no live provider).