### PR TITLE
fix(plugin-discord): use truncateWellFormed and toWellFormedUnicode for auditReason in guild-management

### DIFF
--- a/plugins/plugin-discord/__tests__/guild-management.test.ts
+++ b/plugins/plugin-discord/__tests__/guild-management.test.ts
@@ -1130,3 +1130,17 @@ describe("apply_template reconcile", () => {
 		).toEqual(["CODE OPS", "builds", "prs"]);
 	});
 });
+
+describe("auditReason surrogate safety", () => {
+  it("formats audit reason cleanly and preserves surrogate pairs without severing", async () => {
+    const { auditReason } = await import("../guild-management");
+    const ROCKET = "\u{1F680}";
+    const longReason = "a".repeat(500) + ROCKET + "extra";
+    const result = auditReason(
+      { reasonPrefix: "eliza" } as any,
+      { reason: longReason } as any
+    );
+    expect(result.isWellFormed()).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(512);
+  });
+});

--- a/plugins/plugin-discord/guild-management.ts
+++ b/plugins/plugin-discord/guild-management.ts
@@ -25,7 +25,7 @@
  * live discord.js `Guild` to it.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { ChannelType, PermissionsBitField } from "discord.js";
 import {
 	BUILT_IN_GUILD_TEMPLATES,
@@ -662,13 +662,15 @@ function resolveChannelType(raw: string | undefined): number {
 	return mapped;
 }
 
-function auditReason(
+export function auditReason(
 	context: GuildManagementContext,
 	request: GuildManagementRequest,
 ): string {
 	const prefix = context.reasonPrefix ?? "eliza guild management";
 	const extra = request.reason?.trim();
-	return extra ? `${prefix}: ${extra}`.slice(0, 512) : prefix;
+	return extra
+		? truncateWellFormed(toWellFormedUnicode(`${prefix}: ${extra}`), 512)
+		: prefix;
 }
 
 async function authorizeMutation(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:894422c4e406343ff5528354791502e68c56391d -->

## Summary
In `plugins/plugin-discord/guild-management.ts`:
`auditReason` formatted Discord audit log reasons by applying raw `.slice(0, 512)` to `${prefix}: ${extra}`. When custom reason strings contain multi-byte Unicode or lone surrogate code units at index 512, raw slicing could truncate code unit pairs midway, producing invalid UTF-16 strings in Discord API audit log payloads.

## Proposed Changes
1. Used `truncateWellFormed` and `toWellFormedUnicode` on the concatenated audit log reason.
2. Added unit tests in `plugins/plugin-discord/__tests__/guild-management.test.ts`.

## Verification
- Passed unit tests in `plugins/plugin-discord/__tests__/guild-management.test.ts`.

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-3-7-sonnet","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
