### PR TITLE
fix(plugin-discord): use surrogate-safe truncation in banner mask helper

### DIFF
--- a/plugins/plugin-discord/__tests__/banner-defaults.test.ts
+++ b/plugins/plugin-discord/__tests__/banner-defaults.test.ts
@@ -80,3 +80,19 @@ describe("printDiscordBanner conversational defaults", () => {
 		expect(prefix.length).toBe(6); // backed off by 1 unit to avoid splitting U+1D11E
 	});
 });
+
+describe("mask surrogate safety in banner", () => {
+  it("masks short values fully", async () => {
+    const { mask } = await import("../banner");
+    expect(mask("")).toBe("••••••••");
+    expect(mask("12345678")).toBe("••••••••");
+  });
+
+  it("preserves surrogate integrity without severing astral code pairs", async () => {
+    const { mask } = await import("../banner");
+    const ROCKET = "\u{1F680}";
+    const masked = mask(`012${ROCKET}3456789abcdefghij`);
+    expect(masked.isWellFormed()).toBe(true);
+    expect(masked.startsWith("012")).toBe(true);
+  });
+});

--- a/plugins/plugin-discord/banner.ts
+++ b/plugins/plugin-discord/banner.ts
@@ -7,6 +7,7 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import {
 	lifeOpsPassiveConnectorsEnabled,
+	toWellFormedUnicode,
 	truncateWellFormed,
 } from "@elizaos/core";
 import { listEnabledDiscordAccounts } from "./accounts";
@@ -263,11 +264,16 @@ export interface BannerOptions {
 	discordPermissions?: DiscordPermissionValues;
 }
 
-function mask(v: string): string {
-	if (!v || v.length <= 8) {
+export function mask(v: string): string {
+	const sanitized = toWellFormedUnicode(v);
+	if (!sanitized || sanitized.length <= 8) {
 		return "••••••••";
 	}
-	return `${v.slice(0, 4)}${"•".repeat(Math.min(12, v.length - 8))}${v.slice(-4)}`;
+	const start = truncateWellFormed(sanitized, 4);
+	const endLength = Math.min(4, sanitized.length - start.length);
+	const endCut = truncateWellFormed(sanitized, sanitized.length - endLength);
+	const end = sanitized.slice(endCut.length);
+	return `${start}${"•".repeat(Math.min(12, Math.max(0, sanitized.length - 8)))}${end}`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c6fe22488c150b849c7fd20fe251cddf2dc089f8 -->

## Summary
In `plugins/plugin-discord/banner.ts`:
`mask` formatted masked secrets using raw `.slice(0, 4)` and `.slice(-4)`. When inputs contained multi-byte Unicode or lone surrogate code units, raw slicing could truncate code unit pairs midway, producing invalid UTF-16 strings in startup banner logs.

## Proposed Changes
1. Used `toWellFormedUnicode` on input strings.
2. Applied `truncateWellFormed` for surrogate-safe head and tail slicing.
3. Added unit tests in `plugins/plugin-discord/__tests__/banner-defaults.test.ts`.

## Verification
- Passed unit tests in `plugins/plugin-discord/__tests__/banner-defaults.test.ts`.

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-3-7-sonnet","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
