### PR TITLE
fix(plugin-discord): use truncateWellFormed for thread name in createConnectorThread

### DIFF
--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -3279,7 +3279,7 @@ export class DiscordService extends Service implements IDiscordService {
 				`Discord channel ${channel.id} does not support thread creation.`,
 			);
 		}
-		const name = (params.name ?? "thread").slice(0, 100);
+		const name = truncateWellFormed(toWellFormedUnicode(params.name ?? "thread"), 100);
 		let startMessage: Message | undefined;
 		if (params.parentMessageId) {
 			try {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d80d2a1d20ab94dbf36f1ead688ae1d6005b9475 -->

## Summary
In `plugins/plugin-discord/service.ts`:
`createConnectorThread` formatted the thread name using raw `.slice(0, 100)`. When custom thread names contain multi-byte Unicode or lone surrogate code units at boundary index 100, raw slicing could truncate code unit pairs midway, producing invalid UTF-16 strings in Discord API thread creation payloads.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(params.name ?? "thread"), 100)` for thread naming.

## Verification
- Verified build and TypeScript types clean across `plugins/plugin-discord`.

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-3-7-sonnet","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
