### PR TITLE
fix(ci): align gateway workflow fixtures with Telegram identity

### DIFF
--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -269,27 +269,10 @@ exit 1
   chmodSync(join(binRoot, "railway"), 0o755);
   chmodSync(join(binRoot, "shred"), 0o755);
   chmodSync(join(binRoot, "node"), 0o755);
-  const inheritedEnvironment = { ...Bun.env };
-  for (const name of [
-    "TELEGRAM_BOT_TOKEN",
-    "TELEGRAM_WEBHOOK_SECRET",
-    "TELEGRAM_EXPECTED_BOT_ID",
-    "TELEGRAM_EXPECTED_BOT_USERNAME",
-    "TELEGRAM_ATTESTATION_CONTEXT",
-    "EXPECTED_TELEGRAM_BOT_ID_FIXTURE",
-    "EXPECTED_TELEGRAM_BOT_USERNAME_FIXTURE",
-    "EXPECTED_TELEGRAM_BOT_TOKEN_FIXTURE",
-    "EXPECTED_TELEGRAM_WEBHOOK_SECRET_FIXTURE",
-    ...protectedNames,
-    ...protectedNames.map((name) => `WORKER_${name}`),
-  ]) {
-    delete inheritedEnvironment[name];
-  }
 
   try {
     return Bun.spawnSync([GNU_BASH ?? "bash", "-c", verification.run ?? ""], {
       env: {
-        ...inheritedEnvironment,
         EXPECTED_AGENT_BASE_DOMAIN: canonical.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
         EXPECTED_CLOUD_URL: canonical.ELIZA_CLOUD_URL,
         EXPECTED_ROUTER_ORIGIN: canonical.AGENT_ROUTER_ORIGIN_HOST,
@@ -718,6 +701,30 @@ describe("protected gateway-webhook deployment workflow", () => {
     const name = "ELIZA_APP_TELEGRAM_BOT_TOKEN" as const;
     const inheritedValue = Bun.env[name];
     Bun.env[name] = "host-telegram-token-must-not-reach-fixture";
+
+    try {
+      const isolated = verifyRailwayVariableInventory(
+        "staging",
+        {},
+        {},
+        {
+          run: `test -z "\${${name}:-}"`,
+        },
+      );
+      expect(isolated.exitCode).toBe(0);
+    } finally {
+      if (inheritedValue === undefined) {
+        delete Bun.env[name];
+      } else {
+        Bun.env[name] = inheritedValue;
+      }
+    }
+  });
+
+  executedTest("does not expose unrelated inherited credentials", () => {
+    const name = ["GITHUB", "TOKEN"].join("_");
+    const inheritedValue = Bun.env[name];
+    Bun.env[name] = "host-github-token-must-not-reach-fixture";
 
     try {
       const isolated = verifyRailwayVariableInventory(

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -280,6 +280,7 @@ exit 1
     "EXPECTED_TELEGRAM_BOT_USERNAME_FIXTURE",
     "EXPECTED_TELEGRAM_BOT_TOKEN_FIXTURE",
     "EXPECTED_TELEGRAM_WEBHOOK_SECRET_FIXTURE",
+    ...protectedNames,
     ...protectedNames.map((name) => `WORKER_${name}`),
   ]) {
     delete inheritedEnvironment[name];
@@ -709,6 +710,30 @@ describe("protected gateway-webhook deployment workflow", () => {
         delete Bun.env[workerName];
       } else {
         Bun.env[workerName] = inheritedValue;
+      }
+    }
+  });
+
+  executedTest("does not expose inherited raw protected credentials", () => {
+    const name = "ELIZA_APP_TELEGRAM_BOT_TOKEN" as const;
+    const inheritedValue = Bun.env[name];
+    Bun.env[name] = "host-telegram-token-must-not-reach-fixture";
+
+    try {
+      const isolated = verifyRailwayVariableInventory(
+        "staging",
+        {},
+        {},
+        {
+          run: `test -z "\${${name}:-}"`,
+        },
+      );
+      expect(isolated.exitCode).toBe(0);
+    } finally {
+      if (inheritedValue === undefined) {
+        delete Bun.env[name];
+      } else {
+        Bun.env[name] = inheritedValue;
       }
     }
   });

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -49,10 +49,6 @@ const telegramValues: Record<(typeof telegramNames)[number], string> = {
   ELIZA_APP_TELEGRAM_BOT_TOKEN: "railway-telegram-token-private-canary",
   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "railway-telegram-webhook-private-canary",
 };
-const expectedTelegramConsumerValues = {
-  TELEGRAM_BOT_TOKEN: "railway-telegram-token-private-canary",
-  TELEGRAM_WEBHOOK_SECRET: "railway-telegram-webhook-private-canary",
-} as const;
 const protectedNames = [...blooioNames, ...telegramNames] as const;
 const protectedValues = { ...blooioValues, ...telegramValues };
 
@@ -280,9 +276,13 @@ exit 1
         EXPECTED_TELEGRAM_BOT_USERNAME_FIXTURE:
           canonical.ELIZA_APP_TELEGRAM_BOT_USERNAME,
         EXPECTED_TELEGRAM_BOT_TOKEN_FIXTURE:
-          expectedTelegramConsumerValues.TELEGRAM_BOT_TOKEN,
+          variables.ELIZA_APP_TELEGRAM_BOT_TOKEN?.trim()
+            ? variables.ELIZA_APP_TELEGRAM_BOT_TOKEN
+            : telegramValues.ELIZA_APP_TELEGRAM_BOT_TOKEN,
         EXPECTED_TELEGRAM_WEBHOOK_SECRET_FIXTURE:
-          expectedTelegramConsumerValues.TELEGRAM_WEBHOOK_SECRET,
+          variables.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET?.trim()
+            ? variables.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
+            : telegramValues.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET,
         PATH: `${binRoot}:${process.env.PATH ?? ""}`,
         RAILWAY_ENVIRONMENT_ID: "22222222-2222-4222-8222-222222222222",
         RAILWAY_PROJECT_ID: "11111111-1111-4111-8111-111111111111",
@@ -815,9 +815,15 @@ describe("protected gateway-webhook deployment workflow", () => {
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
           "worker-telegram-webhook-private-canary",
       } as const;
+      const customTelegramValues = {
+        ELIZA_APP_TELEGRAM_BOT_TOKEN: "custom-telegram-token-private-canary",
+        ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
+          "custom-telegram-webhook-private-canary",
+      } as const;
       const allSecretValues = [
         ...Object.values(protectedValues),
         ...Object.values(workerValues),
+        ...Object.values(customTelegramValues),
       ];
 
       for (const target of ["staging", "production"] as const) {
@@ -827,6 +833,16 @@ describe("protected gateway-webhook deployment workflow", () => {
           `protected ${target} Blooio Worker/Railway value matches by salted digest`,
         );
         expect(matched.stdout.toString()).toContain(
+          `protected ${target} Telegram credential pair, selected identity, and getMe attestation`,
+        );
+
+        const matchedCustomTelegram = verifyRailwayVariableInventory(
+          target,
+          customTelegramValues,
+          customTelegramValues,
+        );
+        expect(matchedCustomTelegram.exitCode).toBe(0);
+        expect(matchedCustomTelegram.stdout.toString()).toContain(
           `protected ${target} Telegram credential pair, selected identity, and getMe attestation`,
         );
 

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -41,12 +41,27 @@ const blooioValues: Record<(typeof blooioNames)[number], string> = {
   ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550200",
   ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "railway-webhook-private-canary",
 };
-const telegramValues = {
-  ELIZA_APP_TELEGRAM_BOT_ID: "123456789",
-  ELIZA_APP_TELEGRAM_BOT_USERNAME: "eliza_fixture_bot",
-  ELIZA_APP_TELEGRAM_BOT_TOKEN: "telegram-token-private-canary",
-  ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "telegram-webhook-private-canary",
+const telegramNames = [
+  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+] as const;
+const telegramValues: Record<(typeof telegramNames)[number], string> = {
+  ELIZA_APP_TELEGRAM_BOT_TOKEN: "railway-telegram-token-private-canary",
+  ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "railway-telegram-webhook-private-canary",
+};
+const expectedTelegramConsumerValues = {
+  TELEGRAM_BOT_TOKEN: "railway-telegram-token-private-canary",
+  TELEGRAM_WEBHOOK_SECRET: "railway-telegram-webhook-private-canary",
 } as const;
+const protectedNames = [...blooioNames, ...telegramNames] as const;
+const protectedValues = { ...blooioValues, ...telegramValues };
+
+function protectedFamily(
+  name: (typeof protectedNames)[number],
+): "Blooio" | "Telegram" {
+  return name.startsWith("ELIZA_APP_TELEGRAM_") ? "Telegram" : "Blooio";
+}
+
 interface WorkflowStep {
   env?: Record<string, string>;
   id?: string;
@@ -168,6 +183,7 @@ function verifyRailwayVariableInventory(
   target: "staging" | "production",
   overrides: Record<string, string | undefined> = {},
   workerOverrides: Record<string, string | undefined> = {},
+  verification = step("Verify canonical Railway variables and sensitive names"),
 ): ReturnType<typeof Bun.spawnSync> {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "gateway-webhook-vars-"));
   const binRoot = join(fixtureRoot, "bin");
@@ -178,11 +194,15 @@ function verifyRailwayVariableInventory(
           ELIZA_CLOUD_URL: "https://api-staging.eliza.app",
           AGENT_ROUTER_ORIGIN_HOST: "eliza-staging-1.eliza.app",
           ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
+          ELIZA_APP_TELEGRAM_BOT_ID: "1111111111",
+          ELIZA_APP_TELEGRAM_BOT_USERNAME: "eliza_staging_bot",
         }
       : {
           ELIZA_CLOUD_URL: "https://api.eliza.app",
           AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
           ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+          ELIZA_APP_TELEGRAM_BOT_ID: "2222222222",
+          ELIZA_APP_TELEGRAM_BOT_USERNAME: "eliza_production_bot",
         };
   const variables: Record<string, string | undefined> = {
     ...canonical,
@@ -191,23 +211,22 @@ function verifyRailwayVariableInventory(
     AGENT_SERVER_SHARED_SECRET: "server-private-canary",
     ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "forwarder-private-canary",
     REDIS_URL: "redis-private-canary",
-    ...blooioValues,
-    ...telegramValues,
+    ...protectedValues,
     ...overrides,
   };
   // The Worker side receives these as GitHub Environment secrets; by default
   // they agree with Railway, so only an explicit override models divergence.
   const workerEnvironment: Record<string, string> = {};
-  for (const name of blooioNames) {
+  for (const name of protectedNames) {
+    const workerName = `WORKER_${name}`;
+    if (
+      verification.env?.[workerName] !== githubExpression(`secrets.${name}`)
+    ) {
+      continue;
+    }
     const value =
-      name in workerOverrides ? workerOverrides[name] : blooioValues[name];
-    if (value !== undefined) workerEnvironment[`WORKER_${name}`] = value;
-  }
-  for (const name of [
-    "ELIZA_APP_TELEGRAM_BOT_TOKEN",
-    "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
-  ] as const) {
-    workerEnvironment[`WORKER_${name}`] = telegramValues[name];
+      name in workerOverrides ? workerOverrides[name] : protectedValues[name];
+    if (value !== undefined) workerEnvironment[workerName] = value;
   }
   writeFileSync(
     join(binRoot, "railway"),
@@ -231,21 +250,55 @@ fi
 exit 98
 `,
   );
-  writeFileSync(join(binRoot, "node"), "#!/bin/sh\nexit 0\n");
+  writeFileSync(
+    join(binRoot, "node"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "packages/cloud/scripts/verify-telegram-bot-identity.mjs" ] &&
+   [ "\${TELEGRAM_BOT_TOKEN:-}" = "$EXPECTED_TELEGRAM_BOT_TOKEN_FIXTURE" ] &&
+   [ "\${TELEGRAM_WEBHOOK_SECRET:-}" = "$EXPECTED_TELEGRAM_WEBHOOK_SECRET_FIXTURE" ] &&
+   [ "\${TELEGRAM_EXPECTED_BOT_ID:-}" = "$EXPECTED_TELEGRAM_BOT_ID_FIXTURE" ] &&
+   [ "\${TELEGRAM_EXPECTED_BOT_USERNAME:-}" = "$EXPECTED_TELEGRAM_BOT_USERNAME_FIXTURE" ] &&
+   [ "$TELEGRAM_ATTESTATION_CONTEXT" = "$TARGET_ENVIRONMENT" ]; then
+  exit 0
+fi
+printf '%s\n' "::error::Telegram identity attestation failed for $TARGET_ENVIRONMENT (not_configured)" >&2
+exit 1
+`,
+  );
   chmodSync(join(binRoot, "railway"), 0o755);
   chmodSync(join(binRoot, "shred"), 0o755);
   chmodSync(join(binRoot, "node"), 0o755);
+  const inheritedEnvironment = { ...Bun.env };
+  for (const name of [
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_WEBHOOK_SECRET",
+    "TELEGRAM_EXPECTED_BOT_ID",
+    "TELEGRAM_EXPECTED_BOT_USERNAME",
+    "TELEGRAM_ATTESTATION_CONTEXT",
+    "EXPECTED_TELEGRAM_BOT_ID_FIXTURE",
+    "EXPECTED_TELEGRAM_BOT_USERNAME_FIXTURE",
+    "EXPECTED_TELEGRAM_BOT_TOKEN_FIXTURE",
+    "EXPECTED_TELEGRAM_WEBHOOK_SECRET_FIXTURE",
+    ...protectedNames.map((name) => `WORKER_${name}`),
+  ]) {
+    delete inheritedEnvironment[name];
+  }
 
   try {
-    const verification = step(
-      "Verify canonical Railway variables and sensitive names",
-    );
     return Bun.spawnSync([GNU_BASH ?? "bash", "-c", verification.run ?? ""], {
       env: {
-        ...process.env,
+        ...inheritedEnvironment,
         EXPECTED_AGENT_BASE_DOMAIN: canonical.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
         EXPECTED_CLOUD_URL: canonical.ELIZA_CLOUD_URL,
         EXPECTED_ROUTER_ORIGIN: canonical.AGENT_ROUTER_ORIGIN_HOST,
+        EXPECTED_TELEGRAM_BOT_ID_FIXTURE: canonical.ELIZA_APP_TELEGRAM_BOT_ID,
+        EXPECTED_TELEGRAM_BOT_USERNAME_FIXTURE:
+          canonical.ELIZA_APP_TELEGRAM_BOT_USERNAME,
+        EXPECTED_TELEGRAM_BOT_TOKEN_FIXTURE:
+          expectedTelegramConsumerValues.TELEGRAM_BOT_TOKEN,
+        EXPECTED_TELEGRAM_WEBHOOK_SECRET_FIXTURE:
+          expectedTelegramConsumerValues.TELEGRAM_WEBHOOK_SECRET,
         PATH: `${binRoot}:${process.env.PATH ?? ""}`,
         RAILWAY_ENVIRONMENT_ID: "22222222-2222-4222-8222-222222222222",
         RAILWAY_PROJECT_ID: "11111111-1111-4111-8111-111111111111",
@@ -253,9 +306,9 @@ exit 98
         RAILWAY_VARIABLES_FIXTURE: JSON.stringify(variables),
         RUNNER_TEMP: fixtureRoot,
         TARGET_ENVIRONMENT: target,
-        TELEGRAM_EXPECTED_BOT_ID: telegramValues.ELIZA_APP_TELEGRAM_BOT_ID,
+        TELEGRAM_EXPECTED_BOT_ID: canonical.ELIZA_APP_TELEGRAM_BOT_ID,
         TELEGRAM_EXPECTED_BOT_USERNAME:
-          telegramValues.ELIZA_APP_TELEGRAM_BOT_USERNAME,
+          canonical.ELIZA_APP_TELEGRAM_BOT_USERNAME,
         ...workerEnvironment,
       },
       stderr: "pipe",
@@ -304,14 +357,22 @@ function assertExactForwarderAuthReadinessProbe(run: string): void {
     readiness: '.status == "enforced"',
     project: '.project == "eliza-app"',
   } as const;
-  const routeStart = run.indexOf(required.route);
-  const routeEnd = run.indexOf("telegram_probe_path=", routeStart);
-  if (routeStart < 0 || routeEnd < 0) {
+  const forwarderBlockStart = run.indexOf(
+    'forwarder_probe_path="$RUNNER_TEMP/gateway-webhook-forwarder-auth-readiness.json"',
+  );
+  if (forwarderBlockStart < 0) {
     throw new Error("forwarder readiness route contract drifted");
   }
-  const forwarderProbe = run.slice(routeStart, routeEnd);
+  const forwarderBlockEnd = run.indexOf(
+    'telegram_probe_path="$RUNNER_TEMP/gateway-webhook-telegram-identity-readiness.json"',
+    forwarderBlockStart,
+  );
+  if (forwarderBlockEnd < 0) {
+    throw new Error("forwarder readiness block boundary drifted");
+  }
+  const forwarderBlock = run.slice(forwarderBlockStart, forwarderBlockEnd);
   for (const [contract, fragment] of Object.entries(required)) {
-    if (!forwarderProbe.includes(fragment)) {
+    if (!forwarderBlock.includes(fragment)) {
       throw new Error(`forwarder readiness ${contract} contract drifted`);
     }
   }
@@ -326,7 +387,8 @@ function assertExactForwarderAuthReadinessProbe(run: string): void {
     }
   }
   if (
-    run.indexOf("assert_active_deployment after") < run.indexOf(required.route)
+    run.indexOf("assert_active_deployment after") <
+    run.indexOf(required.route, forwarderBlockStart)
   ) {
     throw new Error("forwarder readiness active-deployment recheck drifted");
   }
@@ -505,7 +567,154 @@ describe("protected gateway-webhook deployment workflow", () => {
   });
 
   executedTest(
-    "requires the complete protected-environment Blooio set",
+    "rejects broken Telegram credential translation into the identity verifier",
+    () => {
+      const variables = step(
+        "Verify canonical Railway variables and sensitive names",
+      );
+      for (const consumerName of [
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_WEBHOOK_SECRET",
+      ]) {
+        const mutatedRun = (variables.run ?? "").replace(
+          `"${consumerName}=`,
+          `"BROKEN_${consumerName}=`,
+        );
+        expect(mutatedRun).not.toBe(variables.run);
+
+        const brokenTranslation = verifyRailwayVariableInventory(
+          "staging",
+          {},
+          {},
+          { ...variables, run: mutatedRun },
+        );
+        expect(brokenTranslation.exitCode).toBe(1);
+        expect(brokenTranslation.stderr.toString()).toContain(
+          "Telegram identity attestation failed for staging (not_configured)",
+        );
+      }
+
+      const wrongBotIdRun = (variables.run ?? "").replace(
+        '"TELEGRAM_EXPECTED_BOT_ID=$TELEGRAM_EXPECTED_BOT_ID"',
+        '"TELEGRAM_EXPECTED_BOT_ID=$TELEGRAM_EXPECTED_BOT_USERNAME"',
+      );
+      expect(wrongBotIdRun).not.toBe(variables.run);
+      const wrongBotIdTranslation = verifyRailwayVariableInventory(
+        "staging",
+        {},
+        {},
+        { ...variables, run: wrongBotIdRun },
+      );
+      expect(wrongBotIdTranslation.exitCode).toBe(1);
+      expect(wrongBotIdTranslation.stderr.toString()).toContain(
+        "Telegram identity attestation failed for staging (not_configured)",
+      );
+
+      const wrongBotUsernameRun = (variables.run ?? "").replace(
+        '"TELEGRAM_EXPECTED_BOT_USERNAME=$TELEGRAM_EXPECTED_BOT_USERNAME"',
+        '"TELEGRAM_EXPECTED_BOT_USERNAME=$TELEGRAM_EXPECTED_BOT_ID"',
+      );
+      expect(wrongBotUsernameRun).not.toBe(variables.run);
+      const wrongBotUsernameTranslation = verifyRailwayVariableInventory(
+        "staging",
+        {},
+        {},
+        { ...variables, run: wrongBotUsernameRun },
+      );
+      expect(wrongBotUsernameTranslation.exitCode).toBe(1);
+      expect(wrongBotUsernameTranslation.stderr.toString()).toContain(
+        "Telegram identity attestation failed for staging (not_configured)",
+      );
+
+      for (const [consumerName, correctSource, wrongSource] of [
+        [
+          "TELEGRAM_BOT_TOKEN",
+          "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+          "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+        ],
+        [
+          "TELEGRAM_WEBHOOK_SECRET",
+          "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+          "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+        ],
+      ] as const) {
+        const wrongSourceRun = (variables.run ?? "").replace(
+          `${consumerName}=\${railway_${correctSource}:-}`,
+          `${consumerName}=\${railway_${wrongSource}:-}`,
+        );
+        expect(wrongSourceRun).not.toBe(variables.run);
+        const wrongSourceTranslation = verifyRailwayVariableInventory(
+          "staging",
+          {},
+          {},
+          {
+            ...variables,
+            run: wrongSourceRun,
+          },
+        );
+        expect(wrongSourceTranslation.exitCode).toBe(1);
+        expect(wrongSourceTranslation.stderr.toString()).toContain(
+          "Telegram identity attestation failed for staging (not_configured)",
+        );
+      }
+    },
+  );
+
+  executedTest("rejects broken Telegram Worker secret mappings", () => {
+    const variables = step(
+      "Verify canonical Railway variables and sensitive names",
+    );
+    const brokenMapping = verifyRailwayVariableInventory(
+      "staging",
+      {},
+      {},
+      {
+        ...variables,
+        env: {
+          ...variables.env,
+          WORKER_ELIZA_APP_TELEGRAM_BOT_TOKEN: githubExpression(
+            "secrets.WRONG_TELEGRAM_BOT_TOKEN",
+          ),
+        },
+      },
+    );
+    expect(brokenMapping.exitCode).toBe(1);
+    expect(
+      `${brokenMapping.stdout.toString()}${brokenMapping.stderr.toString()}`,
+    ).toContain(
+      "Required protected staging Telegram GitHub environment secret is absent or blank: ELIZA_APP_TELEGRAM_BOT_TOKEN",
+    );
+  });
+
+  executedTest("ignores inherited protected Worker credentials", () => {
+    const name = "ELIZA_APP_TELEGRAM_BOT_TOKEN" as const;
+    const workerName = `WORKER_${name}`;
+    const inheritedValue = Bun.env[workerName];
+    Bun.env[workerName] = protectedValues[name];
+
+    try {
+      const missing = verifyRailwayVariableInventory(
+        "staging",
+        {},
+        { [name]: undefined },
+      );
+      expect(missing.exitCode).toBe(1);
+      expect(
+        `${missing.stdout.toString()}${missing.stderr.toString()}`,
+      ).toContain(
+        `Required protected staging Telegram GitHub environment secret is absent or blank: ${name}`,
+      );
+    } finally {
+      if (inheritedValue === undefined) {
+        delete Bun.env[workerName];
+      } else {
+        Bun.env[workerName] = inheritedValue;
+      }
+    }
+  });
+
+  executedTest(
+    "requires the complete protected-environment credential set",
     () => {
       for (const target of ["staging", "production"] as const) {
         const complete = verifyRailwayVariableInventory(target);
@@ -514,21 +723,27 @@ describe("protected gateway-webhook deployment workflow", () => {
           "required sensitive variable names are present",
         );
         const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
-        for (const value of Object.values(blooioValues)) {
+        for (const value of Object.values(protectedValues)) {
           expect(completeOutput).not.toContain(value);
         }
 
-        for (const name of blooioNames) {
+        for (const name of protectedNames) {
           for (const missingValue of [undefined, "", " \t "]) {
             const missing = verifyRailwayVariableInventory(target, {
               [name]: missingValue,
             });
-            expect(missing.exitCode).toBe(1);
             const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
-            expect(output).toContain(
-              `Required protected ${target} Blooio Railway variable name is absent or blank: ${name}`,
-            );
-            for (const value of Object.values(blooioValues)) {
+            expect(missing.exitCode).toBe(1);
+            if (protectedFamily(name) === "Blooio") {
+              expect(output).toContain(
+                `Required protected ${target} Blooio Railway variable name is absent or blank: ${name}`,
+              );
+            } else {
+              expect(output).toContain(
+                `Telegram identity attestation failed for ${target} (not_configured)`,
+              );
+            }
+            for (const value of Object.values(protectedValues)) {
               expect(output).not.toContain(value);
             }
           }
@@ -539,12 +754,12 @@ describe("protected gateway-webhook deployment workflow", () => {
   );
 
   executedTest(
-    "requires protected Worker and Railway Blooio values to actually match",
+    "requires protected Worker and Railway credential values to actually match",
     () => {
       const variables = step(
         "Verify canonical Railway variables and sensitive names",
       );
-      for (const name of blooioNames) {
+      for (const name of protectedNames) {
         expect(variables.env?.[`WORKER_${name}`]).toBe(
           githubExpression(`secrets.${name}`),
         );
@@ -562,11 +777,14 @@ describe("protected gateway-webhook deployment workflow", () => {
 
       const workerValues = {
         ELIZA_APP_BLOOIO_API_KEY: "worker-api-key-private-canary",
-        ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550999",
+        ELIZA_APP_BLOOIO_PHONE_NUMBER: "+155****0999",
         ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "worker-webhook-private-canary",
+        ELIZA_APP_TELEGRAM_BOT_TOKEN: "worker-telegram-token-private-canary",
+        ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
+          "worker-telegram-webhook-private-canary",
       } as const;
       const allSecretValues = [
-        ...Object.values(blooioValues),
+        ...Object.values(protectedValues),
         ...Object.values(workerValues),
       ];
 
@@ -576,8 +794,11 @@ describe("protected gateway-webhook deployment workflow", () => {
         expect(matched.stdout.toString()).toContain(
           `protected ${target} Blooio Worker/Railway value matches by salted digest`,
         );
+        expect(matched.stdout.toString()).toContain(
+          `protected ${target} Telegram credential pair, selected identity, and getMe attestation`,
+        );
 
-        for (const name of blooioNames) {
+        for (const name of protectedNames) {
           // A divergent-but-nonblank Worker secret is precisely the case a
           // names-only inventory accepts and a live webhook then rejects with 401.
           const divergent = verifyRailwayVariableInventory(
@@ -588,7 +809,7 @@ describe("protected gateway-webhook deployment workflow", () => {
           expect(divergent.exitCode).toBe(1);
           const divergentOutput = `${divergent.stdout.toString()}${divergent.stderr.toString()}`;
           expect(divergentOutput).toContain(
-            `Protected ${target} Blooio value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: ${name}`,
+            `Protected ${target} ${protectedFamily(name)} value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: ${name}`,
           );
           for (const value of allSecretValues) {
             expect(divergentOutput).not.toContain(value);
@@ -603,7 +824,7 @@ describe("protected gateway-webhook deployment workflow", () => {
             expect(absent.exitCode).toBe(1);
             const absentOutput = `${absent.stdout.toString()}${absent.stderr.toString()}`;
             expect(absentOutput).toContain(
-              `Required protected ${target} Blooio GitHub environment secret is absent or blank: ${name}`,
+              `Required protected ${target} ${protectedFamily(name)} GitHub environment secret is absent or blank: ${name}`,
             );
             for (const value of allSecretValues) {
               expect(absentOutput).not.toContain(value);
@@ -776,8 +997,16 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(() =>
       assertExactForwarderAuthReadinessProbe(
         verifyRun.replace(
-          "--max-time 15",
-          "--max-time 15 --header X-Eliza-Webhook-Forwarder-Secret:guess",
+          '--output "$forwarder_probe_path"',
+          '--header X-Eliza-Webhook-Forwarder-Secret:guess --output "$forwarder_probe_path"',
+        ),
+      ),
+    ).toThrow("forwarder readiness probe entered a forbidden path");
+    expect(() =>
+      assertExactForwarderAuthReadinessProbe(
+        verifyRun.replace(
+          '--output "$telegram_probe_path"',
+          '--request POST --output "$telegram_probe_path"',
         ),
       ),
     ).toThrow("forwarder readiness probe entered a forbidden path");


### PR DESCRIPTION
# Relates to

Closes #30261.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after the final sync.
- [x] A reviewer can confirm the workflow-contract repair from the reproducible red/green test evidence below.

# Sync with develop

- [x] Based on `origin/develop` `357084b3092efb39f95807bcd459baadcc39f095`; zero conflicts and zero commits behind at publication.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed post-sync (**373/373 tasks**).

# Risks

**Low.** This changes one workflow contract-test fixture. Production workflows and runtime code are untouched. The main risk is making a fixture too permissive; the change instead executes the real workflow step, narrows positive forwarder assertions to their owning readiness block, preserves global forbidden-path checks, and directly exercises Telegram credential and environment-translation failures.

# Background

## What does this PR do?

Restores the gateway deployment workflow contract tests after Telegram identity attestation became mandatory:

- adds protected Telegram credentials and canonical bot identity to the Railway fixture;
- stubs only the external identity-verification boundary;
- includes `telegramIdentity: "attested"` in the active-deployment receipt fixture;
- serves the Telegram identity readiness response;
- checks the generalized `protected_match_salt`; and
- isolates forwarder-auth assertions to the exact forwarder readiness block so the Telegram probe cannot mask drift.
- preserves the full-run forbidden-path scan so the adjacent Telegram probe cannot authenticate, POST, or touch the webhook route.
- makes Railway missing/blank values, Worker missing/blank/divergent values, exact GitHub secret mappings, exact consumer translations (including wrong or swapped sources), and inherited-environment contamination load-bearing.

## What kind of change is this?

Bug fix: non-breaking CI workflow contract repair.

## Why is this test-only change material?

The tests execute and mutate the deployment workflow's externally relevant receipt, protected-variable, and readiness proof contracts. Before this repair, a realistic forwarder project-identity regression could be masked by the Telegram probe's duplicate `.project == "eliza-app"` predicate, while the stale fixtures also prevented the current mandatory Telegram identity path from executing. Higher-level hosted CI consumes these tests; it does not independently mutate the workflow to prove each fail-closed contract.

# Documentation changes needed?

No. The production contract is already documented in the workflow and dedicated Telegram identity tests; this PR realigns stale executable fixtures.

# Testing

## Where should a reviewer start?

- `packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts`
- `packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts`

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts \
  packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
```

Exact results:

- Untouched `develop`, Linux arm64, Bun 1.3.14 + jq: **12 pass, 4 fail**.
- PR head, Linux arm64, Bun 1.3.14 + jq: **16 pass, 0 fail, 552 assertions**.
- Current PR head `c4fa44a2cd4a8aad161eead15f0152831b415417`, macOS, Bun 1.3.14: **21 pass, 0 fail, 1077 assertions**.
- Independent immutable-diff review at SHA-256 `8a7aa05768951ba120da676a2a682c3bbcb1bba1d02d606f42be61147b47fc59` found no security or logic findings.
- Biome check for both focused files: passed with 15 existing GitHub-expression placeholder warnings.
- `git diff --check`: passed.
- Canonical `bun run verify`: passed (**373/373 tasks**).

# Evidence Gate

<!-- evidence-head:c4fa44a2cd4a8aad161eead15f0152831b415417 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - non-visual workflow contract tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend is changed; deterministic workflow-test output is recorded under Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduled task, wallet, generated file, audio, or other domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the affected boundary is a deterministic deployment workflow contract test. Reproduction and exact results are under **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

No local verification gaps remain at the published head. Hosted PR Static Smoke checks were running when this evidence was refreshed; their final status is tracked by GitHub rather than claimed here.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Hermes TUI 0.20.0
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [hankbob-hermes]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes TUI 0.20.0","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza"} -->


