### PR TITLE
fix(cloud): guard paid proxy routes with combined admission

### DIFF
--- a/packages/cloud/api/__tests__/paid-proxy-admission-inventory.test.ts
+++ b/packages/cloud/api/__tests__/paid-proxy-admission-inventory.test.ts
@@ -32,7 +32,7 @@ const paidLegacyRoutes = [
 ] as const;
 
 const GUARDED_ROUTE_CALL =
-  /\b(?:executeGuardedPaidProxyWithBody|executeGuardedPaidProxyRequest|withGuardedPaidProxyAdmission)\s*\(/;
+  /\b(?:executeGuardedPaidProxyWithPreflight|executeGuardedPaidProxyRequest|withGuardedPaidProxyAdmission)\s*\(/;
 
 function materializeGeneratedPath(path: string): string {
   return path
@@ -57,10 +57,10 @@ async function generatedRouteEntries(): Promise<
   return entries;
 }
 
-test("all 14 paid legacy proxy routes enter the shared guarded adapter", async () => {
+test("all 14 paid legacy proxy routes defer local parsing to the shared guarded adapter", async () => {
   for (const route of paidLegacyRoutes) {
     const source = await readFile(resolve(apiRoot, route), "utf8");
-    expect(source, route).toContain("executeGuardedPaidProxyWithBody");
+    expect(source, route).toContain("executeGuardedPaidProxyWithPreflight");
     expect(source, route).not.toMatch(/\bexecuteWithBody\s*\(/);
   }
 });
@@ -123,5 +123,27 @@ test("global auth bypasses exactly the guarded generated v1 route inventory", as
   expect(bypassedRoutes.size).toBe(16);
   for (const route of bypassedRoutes) {
     expect(guardedAdapterRoutes.has(route), route).toBe(true);
+  }
+});
+
+test("every guarded mount enters standing admission before route-local validation", async () => {
+  const generatedV1Routes = (await generatedRouteEntries()).filter((entry) =>
+    entry.path.startsWith("/api/v1/"),
+  );
+  for (const entry of generatedV1Routes) {
+    const source = await readFile(
+      resolve(apiRoot, "src", `${entry.import}.ts`),
+      "utf8",
+    );
+    if (!GUARDED_ROUTE_CALL.test(source)) continue;
+    if (
+      paidLegacyRoutes.some(
+        (route) => entry.import === `../${route.slice(0, -3)}`,
+      )
+    ) {
+      expect(source, entry.path).toContain(
+        "executeGuardedPaidProxyWithPreflight",
+      );
+    }
   }
 });

--- a/packages/cloud/api/__tests__/paid-proxy-admission-inventory.test.ts
+++ b/packages/cloud/api/__tests__/paid-proxy-admission-inventory.test.ts
@@ -110,12 +110,14 @@ test("global auth bypasses exactly the guarded generated v1 route inventory", as
   for (const entry of generatedV1Routes) {
     const pathname = materializeGeneratedPath(entry.path);
     const getBypass = isRouteAuthenticatedPaidProxyPath("GET", pathname);
+    const headBypass = isRouteAuthenticatedPaidProxyPath("HEAD", pathname);
     const postBypass = isRouteAuthenticatedPaidProxyPath("POST", pathname);
     const optionsBypass = isRouteAuthenticatedPaidProxyPath(
       "OPTIONS",
       pathname,
     );
     expect(optionsBypass, entry.path).toBe(getBypass || postBypass);
+    expect(headBypass, entry.path).toBe(getBypass);
     if (getBypass || postBypass) bypassedRoutes.add(entry.path);
   }
 

--- a/packages/cloud/api/__tests__/paid-proxy-admission-inventory.test.ts
+++ b/packages/cloud/api/__tests__/paid-proxy-admission-inventory.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Locks the paid legacy proxy inventory to the shared standing guard so adding
+ * or reverting a route cannot bypass combined account admission unnoticed.
+ */
+
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+
+process.env.MOCK_REDIS = "1";
+
+const { isRouteAuthenticatedPaidProxyPath } = await import(
+  "../src/middleware/auth"
+);
+
+const apiRoot = resolve(import.meta.dir, "..");
+const paidLegacyRoutes = [
+  "v1/chain/nfts/[chain]/[address]/route.ts",
+  "v1/chain/tokens/[chain]/[address]/route.ts",
+  "v1/chain/transfers/[chain]/[address]/route.ts",
+  "v1/market/candles/[chain]/[address]/route.ts",
+  "v1/market/portfolio/[chain]/[address]/route.ts",
+  "v1/market/price/[chain]/[address]/route.ts",
+  "v1/market/token/[chain]/[address]/route.ts",
+  "v1/market/trades/[chain]/[address]/route.ts",
+  "v1/proxy/evm-rpc/[chain]/route.ts",
+  "v1/proxy/solana-rpc/route.ts",
+  "v1/solana/assets/[address]/route.ts",
+  "v1/solana/rpc/route.ts",
+  "v1/solana/token-accounts/[address]/route.ts",
+  "v1/solana/transactions/[address]/route.ts",
+] as const;
+
+const GUARDED_ROUTE_CALL =
+  /\b(?:executeGuardedPaidProxyWithBody|executeGuardedPaidProxyRequest|withGuardedPaidProxyAdmission)\s*\(/;
+
+function materializeGeneratedPath(path: string): string {
+  return path
+    .replace(/:\*\{\.\+\}/g, "guarded-catch-all/tail")
+    .replace(/:[^/]+/g, "guarded-param");
+}
+
+async function generatedRouteEntries(): Promise<
+  Array<{ path: string; import: string }>
+> {
+  const source = await readFile(
+    resolve(apiRoot, "src/_router.generated.ts"),
+    "utf8",
+  );
+  const paths = [...source.matchAll(/^ {4}path: "([^"]+)",$/gm)];
+  const entries = [
+    ...source.matchAll(
+      /^ {4}path: "([^"]+)",\n {4}shard: (?:"[^"]+"|null),\n {4}load: \(\) =>\s*import\(\s*"([^"]+)"\s*\),$/gm,
+    ),
+  ].map((match) => ({ path: match[1], import: match[2] }));
+  expect(entries.length).toBe(paths.length);
+  return entries;
+}
+
+test("all 14 paid legacy proxy routes enter the shared guarded adapter", async () => {
+  for (const route of paidLegacyRoutes) {
+    const source = await readFile(resolve(apiRoot, route), "utf8");
+    expect(source, route).toContain("executeGuardedPaidProxyWithBody");
+    expect(source, route).not.toMatch(/\bexecuteWithBody\s*\(/);
+  }
+});
+
+test("the shared adapter is the only cloud-api executeWithBody caller", async () => {
+  const directCallers: string[] = [];
+  const glob = new Bun.Glob("**/*.ts");
+  for await (const file of glob.scan({ cwd: apiRoot, absolute: true })) {
+    if (file.includes(".test.") || file.includes("__tests__")) continue;
+    const source = await readFile(file, "utf8");
+    if (/\bexecuteWithBody\s*\(/.test(source)) {
+      directCallers.push(relative(apiRoot, file));
+    }
+  }
+
+  expect(directCallers.sort()).toEqual(["src/lib/guarded-paid-proxy.ts"]);
+});
+
+test("canonical RPC and direct Birdeye also consume the shared guard", async () => {
+  const canonicalRpc = await readFile(
+    resolve(apiRoot, "v1/rpc/[chain]/route.ts"),
+    "utf8",
+  );
+  const birdeye = await readFile(
+    resolve(apiRoot, "v1/apis/birdeye/[...path]/route.ts"),
+    "utf8",
+  );
+
+  expect(canonicalRpc).toContain("executeGuardedPaidProxyRequest");
+  expect(birdeye).toContain("withGuardedPaidProxyAdmission");
+});
+
+test("global auth bypasses exactly the guarded generated v1 route inventory", async () => {
+  const generatedV1Routes = (await generatedRouteEntries()).filter((entry) =>
+    entry.path.startsWith("/api/v1/"),
+  );
+  const guardedAdapterRoutes = new Set<string>();
+  for (const entry of generatedV1Routes) {
+    const source = await readFile(
+      resolve(apiRoot, "src", `${entry.import}.ts`),
+      "utf8",
+    );
+    if (GUARDED_ROUTE_CALL.test(source)) guardedAdapterRoutes.add(entry.path);
+  }
+
+  const bypassedRoutes = new Set<string>();
+  for (const entry of generatedV1Routes) {
+    const pathname = materializeGeneratedPath(entry.path);
+    const getBypass = isRouteAuthenticatedPaidProxyPath("GET", pathname);
+    const postBypass = isRouteAuthenticatedPaidProxyPath("POST", pathname);
+    const optionsBypass = isRouteAuthenticatedPaidProxyPath(
+      "OPTIONS",
+      pathname,
+    );
+    expect(optionsBypass, entry.path).toBe(getBypass || postBypass);
+    if (getBypass || postBypass) bypassedRoutes.add(entry.path);
+  }
+
+  expect([...bypassedRoutes].sort()).toEqual([...guardedAdapterRoutes].sort());
+  expect(bypassedRoutes.size).toBe(16);
+  for (const route of bypassedRoutes) {
+    expect(guardedAdapterRoutes.has(route), route).toBe(true);
+  }
+});

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -416,6 +416,8 @@ export async function admitFlatGenerativeOperation(params: {
 export async function requireGenerativeRouteCaller(
   c: AppContext,
   options: {
+    /** Effective request after any route-local credential rewrite. */
+    request?: Request;
     compatibility?: "hono" | "raw";
     rateLimitEndpoint?: EndpointType;
     /**
@@ -430,10 +432,11 @@ export async function requireGenerativeRouteCaller(
     deferStrongCredentialCheck?: boolean;
   } = {},
 ): Promise<GenerativeRouteCaller> {
+  const request = options.request ?? c.req.raw;
   const executionCtx = getGenerativeExecutionContext(c);
   if (!executionCtx) {
     if (options.compatibility === "raw") {
-      const { user, apiKey } = await requireAuthOrApiKeyWithOrg(c.req.raw);
+      const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
       return {
         user: { id: user.id, organization_id: user.organization_id },
         apiKeyId: apiKey?.id ?? null,
@@ -456,7 +459,7 @@ export async function requireGenerativeRouteCaller(
     "@/lib/services/inference-auth-context"
   );
   const resolveCallerAuth = () =>
-    resolveInferenceAuthContext(c.req.raw, {
+    resolveInferenceAuthContext(request, {
       traceId: c.get("traceId") ?? c.get("requestId"),
       cacheOnly: Boolean(executionCtx),
       executionCtx,
@@ -509,6 +512,9 @@ export async function requireGenerativeRouteCaller(
             limited.status === 429
               ? "Rate limit exceeded"
               : "Rate limiter is unavailable",
+            limited.status === 503
+              ? { retryable: true, retryAfterSeconds: 1 }
+              : undefined,
           );
         }
       }
@@ -569,7 +575,7 @@ export async function requireGenerativeRouteCaller(
   // authoritative compatibility path. API keys and Steward sessions never
   // reach this branch.
   if (options.compatibility === "raw") {
-    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(c.req.raw);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     return {
       user: { id: user.id, organization_id: user.organization_id },
       apiKeyId: apiKey?.id ?? null,

--- a/packages/cloud/api/src/lib/guarded-paid-proxy.test.ts
+++ b/packages/cloud/api/src/lib/guarded-paid-proxy.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Proves the paid proxy route adapter consumes one standing decision, forwards
+ * its credential and snapshot, and suppresses dispatch after a safe denial.
+ */
+
+import { expect, mock, test } from "bun:test";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+import type { AppContext } from "@/types/cloud-worker-env";
+
+const combinedStandingRead = mock();
+const executionContextRead = mock();
+const executeWithBody = mock();
+
+mock.module("./generative-route-auth", () => ({
+  asGenerativeCacheApiError: () => null,
+  requireGenerativeRouteCaller: combinedStandingRead,
+  getGenerativeExecutionContext: executionContextRead,
+}));
+mock.module("@/lib/services/proxy/engine", () => ({
+  executeWithBody,
+  createHandler: mock(),
+}));
+
+const { executeGuardedPaidProxyWithBody } = await import(
+  "./guarded-paid-proxy"
+);
+
+const snapshot = {
+  balance: { balanceUsd: 10, balanceAt: Date.now(), balanceRevision: "9" },
+  rateLimits: {
+    completionsRpm: 10,
+    embeddingsRpm: 10,
+    standardRpm: 10,
+    strictRpm: 10,
+  },
+};
+
+function makeContext(): AppContext {
+  const request = new Request(
+    "https://api.test/api/v1/market/price/solana/token",
+  );
+  return {
+    req: { raw: request, url: request.url },
+    env: {},
+    get: (key: string) =>
+      key === "requestId" ? "paid-proxy-request-1" : undefined,
+  } as unknown as AppContext;
+}
+
+test("one standing read forwards the credential and admission snapshot", async () => {
+  combinedStandingRead.mockReset();
+  executionContextRead.mockReset();
+  executeWithBody.mockReset();
+  combinedStandingRead.mockResolvedValue({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    authSource: "combined_cache",
+    admissionSnapshot: snapshot,
+    credential: {
+      kind: "api_key",
+      credentialId: "key-1",
+      userId: "user-1",
+    },
+    appScopeId: null,
+  });
+  const retained: Promise<unknown>[] = [];
+  const executionCtx = {
+    waitUntil: (promise: Promise<unknown>) => retained.push(promise),
+  };
+  executionContextRead.mockReturnValue(executionCtx);
+  executeWithBody.mockResolvedValue(Response.json({ ok: true }));
+  const provider = mock();
+  const config = {
+    id: "market-data",
+    name: "Market data",
+    auth: "apiKeyWithOrg" as const,
+    getCost: async () => 0.01,
+  };
+
+  const response = await executeGuardedPaidProxyWithBody(
+    makeContext(),
+    config,
+    provider,
+    { method: "getPrice" },
+  );
+
+  expect(response.status).toBe(200);
+  expect(combinedStandingRead).toHaveBeenCalledTimes(1);
+  expect(executeWithBody).toHaveBeenCalledTimes(1);
+  expect(executeWithBody.mock.calls[0]?.[4]).toMatchObject({
+    mode: "combined",
+    auth: {
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKey: { id: "key-1" },
+    },
+    requestId: "paid-proxy-request-1",
+    admissionSnapshot: snapshot,
+    credential: {
+      kind: "api_key",
+      credentialId: "key-1",
+      userId: "user-1",
+    },
+    executionCtx,
+  });
+  const admission = executeWithBody.mock.calls[0]?.[4];
+  expect(admission.credentialForAdmission()).toEqual({
+    kind: "api_key",
+    credentialId: "key-1",
+    userId: "user-1",
+  });
+});
+
+test("standing denial preserves its safe reason and suppresses provider dispatch", async () => {
+  combinedStandingRead.mockReset();
+  executionContextRead.mockReset();
+  executeWithBody.mockReset();
+  const denial = new ApiError(
+    403,
+    "access_denied",
+    "Organization is inactive",
+    { reason: "organization_inactive" },
+  );
+  combinedStandingRead.mockRejectedValueOnce(denial);
+
+  const response = await executeGuardedPaidProxyWithBody(
+    makeContext(),
+    {
+      id: "market-data",
+      name: "Market data",
+      auth: "apiKeyWithOrg",
+      getCost: async () => 0.01,
+    },
+    mock(),
+    { method: "getPrice" },
+  );
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({
+    code: "access_denied",
+    details: { reason: "organization_inactive" },
+  });
+  expect(combinedStandingRead).toHaveBeenCalledTimes(1);
+  expect(executeWithBody).not.toHaveBeenCalled();
+  expect(denial.details?.reason).toBe("organization_inactive");
+});
+
+test("production without a Worker lifetime fails closed before reserve or dispatch", async () => {
+  combinedStandingRead.mockReset();
+  executionContextRead.mockReset();
+  executeWithBody.mockReset();
+  combinedStandingRead.mockResolvedValue({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    authSource: "compatibility",
+    appScopeId: null,
+  });
+  executionContextRead.mockReturnValue(undefined);
+  const context = makeContext();
+  Object.assign(context, { env: { NODE_ENV: "production" } });
+
+  const response = await executeGuardedPaidProxyWithBody(
+    context,
+    {
+      id: "market-data",
+      name: "Market data",
+      auth: "apiKeyWithOrg",
+      getCost: async () => 0.01,
+    },
+    mock(),
+    { method: "getPrice" },
+  );
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("Retry-After")).toBe("1");
+  expect(combinedStandingRead).not.toHaveBeenCalled();
+  expect(executeWithBody).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/src/lib/guarded-paid-proxy.test.ts
+++ b/packages/cloud/api/src/lib/guarded-paid-proxy.test.ts
@@ -21,9 +21,10 @@ mock.module("@/lib/services/proxy/engine", () => ({
   createHandler: mock(),
 }));
 
-const { executeGuardedPaidProxyWithBody } = await import(
-  "./guarded-paid-proxy"
-);
+const {
+  executeGuardedPaidProxyWithBody,
+  executeGuardedPaidProxyWithPreflight,
+} = await import("./guarded-paid-proxy");
 
 const snapshot = {
   balance: { balanceUsd: 10, balanceAt: Date.now(), balanceRevision: "9" },
@@ -142,6 +143,36 @@ test("standing denial preserves its safe reason and suppresses provider dispatch
   expect(combinedStandingRead).toHaveBeenCalledTimes(1);
   expect(executeWithBody).not.toHaveBeenCalled();
   expect(denial.details?.reason).toBe("organization_inactive");
+});
+
+test("preflight sees the caller after one standing read and can reject without provider admission", async () => {
+  combinedStandingRead.mockReset();
+  executionContextRead.mockReset();
+  executeWithBody.mockReset();
+  let resolved = false;
+  combinedStandingRead.mockImplementation(async () => {
+    resolved = true;
+    return {
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKeyId: "key-1",
+      authSource: "combined_cache",
+      admissionSnapshot: snapshot,
+      appScopeId: null,
+    };
+  });
+  executionContextRead.mockReturnValue({ waitUntil: () => undefined });
+
+  const response = await executeGuardedPaidProxyWithPreflight(
+    makeContext(),
+    () => {
+      expect(resolved).toBe(true);
+      return Response.json({ error: "Invalid input" }, { status: 400 });
+    },
+  );
+
+  expect(response.status).toBe(400);
+  expect(combinedStandingRead).toHaveBeenCalledTimes(1);
+  expect(executeWithBody).not.toHaveBeenCalled();
 });
 
 test("production without a Worker lifetime fails closed before reserve or dispatch", async () => {

--- a/packages/cloud/api/src/lib/guarded-paid-proxy.ts
+++ b/packages/cloud/api/src/lib/guarded-paid-proxy.ts
@@ -1,0 +1,158 @@
+/**
+ * Admits paid legacy proxy routes through the same one-read standing boundary
+ * as generative inference before any provider-specific work can run.
+ */
+
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
+import type { EndpointType } from "@/lib/services/org-rate-limits";
+import type { ProxyCombinedAdmission } from "@/lib/services/proxy/engine";
+import { createHandler, executeWithBody } from "@/lib/services/proxy/engine";
+import type {
+  ProxyRequestBody,
+  ServiceConfig,
+  ServiceHandler,
+} from "@/lib/services/proxy/types";
+import { logger } from "@/lib/utils/logger";
+import type { AppContext } from "@/types/cloud-worker-env";
+import {
+  asGenerativeCacheApiError,
+  getGenerativeExecutionContext,
+  requireGenerativeRouteCaller,
+} from "./generative-route-auth";
+
+interface GuardedPaidProxyOptions {
+  request?: Request;
+  rateLimitEndpoint?: EndpointType;
+  deferStrongCredentialCheck?: boolean;
+}
+
+function paidProxyApiErrorResponse(error: ApiError): Response {
+  const retryAfterSeconds = error.details?.retryAfterSeconds;
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (typeof retryAfterSeconds === "number" && retryAfterSeconds > 0) {
+    headers.set("Retry-After", String(Math.ceil(retryAfterSeconds)));
+  }
+  return Response.json(error.toJSON(), { status: error.status, headers });
+}
+
+/** Resolve caller standing exactly once and pass the decision to paid work. */
+export async function withGuardedPaidProxyAdmission(
+  c: AppContext,
+  dispatch: (admission: ProxyCombinedAdmission) => Promise<Response>,
+  options: GuardedPaidProxyOptions = {},
+): Promise<Response> {
+  const request = options.request ?? c.req.raw;
+  const executionCtx = getGenerativeExecutionContext(c);
+  const requestId =
+    c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID();
+  if (!executionCtx && c.env.NODE_ENV === "production") {
+    logger.error("[PaidProxyAdmission] Worker execution context missing", {
+      requestId,
+      route: new URL(request.url).pathname,
+    });
+    return paidProxyApiErrorResponse(
+      new ApiError(
+        503,
+        "service_unavailable",
+        "Provider admission is unavailable; retry shortly",
+        { retryable: true, retryAfterSeconds: 1 },
+      ),
+    );
+  }
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      request,
+      compatibility: "raw",
+      deferStrongCredentialCheck: options.deferStrongCredentialCheck ?? true,
+      rateLimitEndpoint: options.rateLimitEndpoint ?? "standard",
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
+    const auth = {
+      user: caller.user,
+      ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
+    };
+
+    if (!executionCtx) {
+      return dispatch({ mode: "compatibility", auth, requestId });
+    }
+    if (!caller.admissionSnapshot) {
+      logger.error("[PaidProxyAdmission] Combined admission snapshot missing", {
+        requestId,
+        route: new URL(c.req.url).pathname,
+        organizationId: caller.user.organization_id,
+        authSource: caller.authSource,
+      });
+      return paidProxyApiErrorResponse(
+        new ApiError(
+          503,
+          "service_unavailable",
+          "Provider admission is unavailable; retry shortly",
+          { retryable: true, retryAfterSeconds: 1 },
+        ),
+      );
+    }
+
+    return dispatch({
+      mode: "combined",
+      auth,
+      requestId,
+      admissionSnapshot: caller.admissionSnapshot,
+      ...(caller.credential ? { credential: caller.credential } : {}),
+      credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      executionCtx,
+    });
+  } catch (error) {
+    // error-policy:J1 the shared paid boundary preserves canonical standing
+    // denials and converts known cache warm-up failures into retryable 503s.
+    const mapped =
+      error instanceof ApiError
+        ? error
+        : asGenerativeCacheApiError(error, {
+            route: new URL(request.url).pathname,
+            traceId: c.get("traceId") ?? c.get("requestId"),
+          });
+    if (mapped) return paidProxyApiErrorResponse(mapped);
+    throw error;
+  }
+}
+
+/** Execute a paid proxy body only after the shared standing decision. */
+export async function executeGuardedPaidProxyWithBody(
+  c: AppContext,
+  config: ServiceConfig,
+  work: ServiceHandler,
+  body: ProxyRequestBody,
+  options: GuardedPaidProxyOptions = {},
+): Promise<Response> {
+  return withGuardedPaidProxyAdmission(
+    c,
+    (admission) =>
+      executeWithBody(
+        config,
+        work,
+        options.request ?? c.req.raw,
+        body,
+        admission,
+      ),
+    { ...options, request: options.request ?? c.req.raw },
+  );
+}
+
+/** Execute a body-carrying paid proxy request after the shared admission. */
+export async function executeGuardedPaidProxyRequest(
+  c: AppContext,
+  config: ServiceConfig,
+  work: ServiceHandler,
+  options: GuardedPaidProxyOptions = {},
+): Promise<Response> {
+  return withGuardedPaidProxyAdmission(
+    c,
+    (admission) =>
+      createHandler(config, work, admission)(options.request ?? c.req.raw),
+    { ...options, request: options.request ?? c.req.raw },
+  );
+}

--- a/packages/cloud/api/src/lib/guarded-paid-proxy.ts
+++ b/packages/cloud/api/src/lib/guarded-paid-proxy.ts
@@ -27,6 +27,18 @@ interface GuardedPaidProxyOptions {
   deferStrongCredentialCheck?: boolean;
 }
 
+/** Delays route-local parsing until the shared caller standing decision exists. */
+export interface PreparedPaidProxyBody {
+  config: ServiceConfig;
+  work: ServiceHandler;
+  body: ProxyRequestBody;
+}
+
+export type PaidProxyPreflight = () =>
+  | PreparedPaidProxyBody
+  | Response
+  | Promise<PreparedPaidProxyBody | Response>;
+
 function paidProxyApiErrorResponse(error: ApiError): Response {
   const retryAfterSeconds = error.details?.retryAfterSeconds;
   const headers = new Headers({ "Content-Type": "application/json" });
@@ -138,6 +150,32 @@ export async function executeGuardedPaidProxyWithBody(
         body,
         admission,
       ),
+    { ...options, request: options.request ?? c.req.raw },
+  );
+}
+
+/**
+ * Resolves identity and standing before a route reads or validates paid input.
+ * Invalid input can return a local response without opening provider admission.
+ */
+export async function executeGuardedPaidProxyWithPreflight(
+  c: AppContext,
+  preflight: PaidProxyPreflight,
+  options: GuardedPaidProxyOptions = {},
+): Promise<Response> {
+  return withGuardedPaidProxyAdmission(
+    c,
+    async (admission) => {
+      const prepared = await preflight();
+      if (prepared instanceof Response) return prepared;
+      return executeWithBody(
+        prepared.config,
+        prepared.work,
+        options.request ?? c.req.raw,
+        prepared.body,
+        admission,
+      );
+    },
     { ...options, request: options.request ?? c.req.raw },
   );
 }

--- a/packages/cloud/api/src/middleware/auth.test.ts
+++ b/packages/cloud/api/src/middleware/auth.test.ts
@@ -413,6 +413,9 @@ describe("isRouteAuthenticatedPaidProxyPath", () => {
 
     for (const [method, path] of routes) {
       expect(isRouteAuthenticatedPaidProxyPath(method, path)).toBe(true);
+      expect(isRouteAuthenticatedPaidProxyPath("HEAD", path)).toBe(
+        method === "GET",
+      );
       expect(isRouteAuthenticatedPaidProxyPath("OPTIONS", path)).toBe(true);
     }
   });
@@ -424,6 +427,8 @@ describe("isRouteAuthenticatedPaidProxyPath", () => {
       ["POST", "/api/internal/worker"],
       ["POST", "/api/v1/market/price/ethereum/address"],
       ["GET", "/api/v1/rpc/ethereum"],
+      ["HEAD", "/api/v1/rpc/ethereum"],
+      ["HEAD", "/api/v1/proxy/evm-rpc/ethereum"],
       ["POST", "/api/v1/rpc/ethereum/extra"],
       ["DELETE", "/api/v1/solana/assets/address"],
     ] as const) {

--- a/packages/cloud/api/src/middleware/auth.test.ts
+++ b/packages/cloud/api/src/middleware/auth.test.ts
@@ -52,6 +52,7 @@ const {
   authMiddleware,
   isPublicPath,
   isRouteAuthenticatedInferencePath,
+  isRouteAuthenticatedPaidProxyPath,
   isRouteAuthenticatedRemoteHostRequest,
 } = await import("./auth");
 
@@ -386,6 +387,48 @@ describe("isRouteAuthenticatedInferencePath", () => {
     expect(
       isRouteAuthenticatedInferencePath("POST", "/api/v1/eliza/agents//stream"),
     ).toBe(false);
+  });
+});
+
+describe("isRouteAuthenticatedPaidProxyPath", () => {
+  test("delegates only the paid proxy method and path inventory", () => {
+    const routes = [
+      ["GET", "/api/v1/chain/nfts/ethereum/address"],
+      ["GET", "/api/v1/chain/tokens/ethereum/address"],
+      ["GET", "/api/v1/chain/transfers/ethereum/address"],
+      ["GET", "/api/v1/market/candles/ethereum/address"],
+      ["GET", "/api/v1/market/portfolio/ethereum/address"],
+      ["GET", "/api/v1/market/price/ethereum/address"],
+      ["GET", "/api/v1/market/token/ethereum/address"],
+      ["GET", "/api/v1/market/trades/ethereum/address"],
+      ["POST", "/api/v1/proxy/evm-rpc/ethereum"],
+      ["POST", "/api/v1/proxy/solana-rpc"],
+      ["POST", "/api/v1/rpc/ethereum"],
+      ["GET", "/api/v1/solana/assets/address"],
+      ["POST", "/api/v1/solana/rpc"],
+      ["GET", "/api/v1/solana/token-accounts/address"],
+      ["GET", "/api/v1/solana/transactions/address"],
+      ["GET", "/api/v1/apis/birdeye/defi/price"],
+    ] as const;
+
+    for (const [method, path] of routes) {
+      expect(isRouteAuthenticatedPaidProxyPath(method, path)).toBe(true);
+      expect(isRouteAuthenticatedPaidProxyPath("OPTIONS", path)).toBe(true);
+    }
+  });
+
+  test("does not delegate public previews, reads, internal routes, or neighboring mutations", () => {
+    for (const [method, path] of [
+      ["GET", "/api/v1/market/preview"],
+      ["GET", "/api/v1/models"],
+      ["POST", "/api/internal/worker"],
+      ["POST", "/api/v1/market/price/ethereum/address"],
+      ["GET", "/api/v1/rpc/ethereum"],
+      ["POST", "/api/v1/rpc/ethereum/extra"],
+      ["DELETE", "/api/v1/solana/assets/address"],
+    ] as const) {
+      expect(isRouteAuthenticatedPaidProxyPath(method, path)).toBe(false);
+    }
   });
 });
 

--- a/packages/cloud/api/src/middleware/auth.ts
+++ b/packages/cloud/api/src/middleware/auth.ts
@@ -304,6 +304,45 @@ export function isRouteAuthenticatedPaidStandingPath(
 }
 
 /**
+ * Paid proxy routes own their combined identity, standing, and organization
+ * admission decision. The global session gate must not resolve the same
+ * Steward credential first, or a session request would perform an additional
+ * authoritative user lookup before the route's one-read cache decision.
+ */
+export function isRouteAuthenticatedPaidProxyPath(
+  method: string,
+  pathname: string,
+): boolean {
+  if (method === "OPTIONS") {
+    return (
+      isRouteAuthenticatedPaidProxyPath("GET", pathname) ||
+      isRouteAuthenticatedPaidProxyPath("POST", pathname)
+    );
+  }
+  if (method === "GET") {
+    return (
+      /^\/api\/v1\/chain\/(?:nfts|tokens|transfers)\/[^/]+\/[^/]+\/?$/.test(
+        pathname,
+      ) ||
+      /^\/api\/v1\/market\/(?:candles|portfolio|price|token|trades)\/[^/]+\/[^/]+\/?$/.test(
+        pathname,
+      ) ||
+      /^\/api\/v1\/solana\/(?:assets|token-accounts|transactions)\/[^/]+\/?$/.test(
+        pathname,
+      ) ||
+      /^\/api\/v1\/apis\/birdeye\/.+/.test(pathname)
+    );
+  }
+  if (method !== "POST") return false;
+  return (
+    /^\/api\/v1\/proxy\/evm-rpc\/[^/]+\/?$/.test(pathname) ||
+    /^\/api\/v1\/proxy\/solana-rpc\/?$/.test(pathname) ||
+    /^\/api\/v1\/rpc\/[^/]+\/?$/.test(pathname) ||
+    /^\/api\/v1\/solana\/rpc\/?$/.test(pathname)
+  );
+}
+
+/**
  * Remote hosts reach these activation handlers before they have a Cloud
  * session. Keep this pre-auth delegation exact: a syntactically valid,
  * host-bound credential may reach only the two handlers introduced by the
@@ -327,6 +366,14 @@ export function isRouteAuthenticatedRemoteHostRequest(
       pathname,
     );
   return managedNetworkMatch?.[1] === credential.hostId;
+}
+
+/** Keeps any remote-host credential attempt out of unrelated paid route bypasses. */
+function hasRemoteHostCredentialAttempt(request: Request): boolean {
+  return (
+    request.headers.has("x-remote-host-id") ||
+    /^Bearer rhost_v1_/.test(request.headers.get("authorization") ?? "")
+  );
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -403,12 +450,16 @@ export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
     return;
   }
 
-  if (isRouteAuthenticatedPaidStandingPath(c.req.method, pathname)) {
+  if (isRouteAuthenticatedRemoteHostRequest(c.req.raw)) {
     await next();
     return;
   }
 
-  if (isRouteAuthenticatedRemoteHostRequest(c.req.raw)) {
+  if (
+    !hasRemoteHostCredentialAttempt(c.req.raw) &&
+    (isRouteAuthenticatedPaidStandingPath(c.req.method, pathname) ||
+      isRouteAuthenticatedPaidProxyPath(c.req.method, pathname))
+  ) {
     await next();
     return;
   }

--- a/packages/cloud/api/src/middleware/auth.ts
+++ b/packages/cloud/api/src/middleware/auth.ts
@@ -319,7 +319,7 @@ export function isRouteAuthenticatedPaidProxyPath(
       isRouteAuthenticatedPaidProxyPath("POST", pathname)
     );
   }
-  if (method === "GET") {
+  if (method === "GET" || method === "HEAD") {
     return (
       /^\/api\/v1\/chain\/(?:nfts|tokens|transfers)\/[^/]+\/[^/]+\/?$/.test(
         pathname,

--- a/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
+++ b/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Exercises paid proxy admission through mounted Hono middleware and real
+ * route adapters while replacing only remote cache, Durable Object, and
+ * upstream-provider boundaries with deterministic fakes.
+ */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const globalSessionReads = mock();
+const standingReads: Request[] = [];
+const admissionCalls: Array<Record<string, unknown>> = [];
+const providerDispatch = mock(async () => ({
+  response: Response.json({ ok: true }),
+}));
+const genericReserve = mock(async () => {
+  throw new Error("generic reserve must not run");
+});
+const orgRateLimit = mock(async () => null);
+let authOutcome: "authorized" | "denied" | "warming" = "authorized";
+let includeStrongCredential = true;
+
+const snapshot = {
+  balance: { balanceUsd: 10, balanceAt: Date.now(), balanceRevision: "19" },
+  rateLimits: {
+    completionsRpm: 100,
+    embeddingsRpm: 100,
+    standardRpm: 100,
+    strictRpm: 100,
+  },
+};
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  getCurrentUser: globalSessionReads,
+  requireUserOrApiKeyWithOrg: mock(async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  })),
+}));
+const rawAuth = mock(async (request: Request) => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  ...(request.headers.has("x-api-key") ||
+  request.headers.get("authorization")?.startsWith("Bearer eliza_")
+    ? { apiKey: { id: "key-1" } }
+    : {}),
+}));
+mock.module("@/lib/auth", () => ({
+  requireAuth: rawAuth,
+  requireAuthWithOrg: rawAuth,
+  requireAuthOrApiKey: rawAuth,
+  requireAuthOrApiKeyWithOrg: rawAuth,
+}));
+mock.module("@/lib/services/inference-auth-context", () => ({
+  observeInferenceApiKeyUsage: () => undefined,
+  resolveInferenceAuthContext: mock(
+    async (
+      request: Request,
+      options: { deferStrongCredentialCheck?: boolean },
+    ) => {
+      standingReads.push(request);
+      expect(options.deferStrongCredentialCheck).toBe(true);
+      if (authOutcome === "warming") return { kind: "warming" };
+      if (authOutcome === "denied") {
+        return {
+          kind: "rejected",
+          status: 403,
+          reason: "organization_inactive",
+        };
+      }
+      const authorization = request.headers.get("authorization") ?? "";
+      const apiKey =
+        request.headers.get("x-api-key") ??
+        (authorization.startsWith("Bearer eliza_")
+          ? authorization.slice(7)
+          : null);
+      const apiKeyId = apiKey ? "key-1" : null;
+      return {
+        kind: "authorized",
+        source: "cache",
+        ctx: {
+          v: 1,
+          cachedAt: Date.now(),
+          userId: "user-1",
+          orgId: "org-1",
+          apiKeyId,
+          admission: snapshot,
+        },
+        ...(includeStrongCredential
+          ? {
+              credential: apiKeyId
+                ? {
+                    kind: "api_key",
+                    credentialId: apiKeyId,
+                    userId: "user-1",
+                  }
+                : {
+                    kind: "steward_session",
+                    userId: "user-1",
+                    stewardUserId: "steward-1",
+                    issuedAt: 1,
+                  },
+            }
+          : {}),
+      };
+    },
+  ),
+}));
+mock.module("@/lib/middleware/rate-limit", () => ({
+  enforceOrgRateLimit: orgRateLimit,
+  withRateLimit: (handler: unknown) => handler,
+}));
+mock.module("@/lib/services/inference-admission-snapshot", () => ({
+  inferenceRateLimitConfig: () => ({ windowMs: 60_000, maxRequests: 100 }),
+}));
+mock.module("@/lib/services/organization-inference-admission", () => ({
+  admitOrganizationInference: mock(async (params: Record<string, unknown>) => {
+    admissionCalls.push(params);
+    return {
+      mode: "durable_object_debit",
+      markProviderDispatched: async () => undefined,
+      settle: async () => null,
+      settleUnknown: async () => null,
+    };
+  }),
+}));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { reserve: genericReserve },
+  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+}));
+mock.module("@/lib/services/usage", () => ({
+  usageService: { create: async () => undefined },
+}));
+mock.module("@/lib/cache/client", () => ({
+  cache: { get: async () => null, set: async () => undefined },
+}));
+mock.module("@/lib/services/proxy/pricing", () => ({
+  calculateBatchCost: async () => 0.01,
+  getServiceMethodCost: async () => 0.01,
+  PricingNotFoundError: class PricingNotFoundError extends Error {},
+}));
+mock.module("@/lib/services/proxy/services/market-data", () => ({
+  marketDataConfig: {
+    id: "market-data",
+    name: "Market data",
+    auth: "apiKeyWithOrg",
+    getCost: async () => 0.01,
+  },
+  marketDataHandler: providerDispatch,
+}));
+mock.module("@/lib/services/proxy/services/rpc", () => ({
+  SUPPORTED_RPC_CHAINS: new Set(["ethereum"]),
+  isValidRpcChain: (chain: string) => chain === "ethereum",
+  rpcConfigForChain: () => ({
+    id: "evm-rpc",
+    name: "EVM RPC",
+    auth: "apiKeyWithOrg",
+    getCost: async () => 0.01,
+  }),
+  rpcHandlerForChain: () => providerDispatch,
+}));
+mock.module("@/lib/services/proxy/services/solana-rpc", () => ({
+  solanaRpcConfig: {
+    id: "solana-rpc",
+    name: "Solana RPC",
+    auth: "apiKeyWithOrg",
+    getCost: async () => 0.01,
+  },
+  solanaRpcHandler: providerDispatch,
+}));
+
+const [
+  { authMiddleware },
+  { default: marketPriceRoute },
+  { default: canonicalRpcRoute },
+  { default: legacyEvmRpcRoute },
+  { default: legacySolanaRpcRoute },
+  { default: solanaRpcRoute },
+  { default: birdeyeRoute },
+  { default: solanaAssetsRoute },
+  { default: solanaTokenAccountsRoute },
+  { default: solanaTransactionsRoute },
+] = await Promise.all([
+  import("./middleware/auth"),
+  import("../v1/market/price/[chain]/[address]/route"),
+  import("../v1/rpc/[chain]/route"),
+  import("../v1/proxy/evm-rpc/[chain]/route"),
+  import("../v1/proxy/solana-rpc/route"),
+  import("../v1/solana/rpc/route"),
+  import("../v1/apis/birdeye/[...path]/route"),
+  import("../v1/solana/assets/[address]/route"),
+  import("../v1/solana/token-accounts/[address]/route"),
+  import("../v1/solana/transactions/[address]/route"),
+]);
+
+function mountedApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("requestId", crypto.randomUUID());
+    c.set("traceId", crypto.randomUUID());
+    c.set("user", undefined);
+    await next();
+  });
+  app.use("*", authMiddleware);
+  app.route("/api/v1/market/price/:chain/:address", marketPriceRoute);
+  app.route("/api/v1/rpc/:chain", canonicalRpcRoute);
+  app.route("/api/v1/proxy/evm-rpc/:chain", legacyEvmRpcRoute);
+  app.route("/api/v1/proxy/solana-rpc", legacySolanaRpcRoute);
+  app.route("/api/v1/solana/rpc", solanaRpcRoute);
+  app.route("/api/v1/apis/birdeye", birdeyeRoute);
+  app.route("/api/v1/solana/assets/:address", solanaAssetsRoute);
+  app.route("/api/v1/solana/token-accounts/:address", solanaTokenAccountsRoute);
+  app.route("/api/v1/solana/transactions/:address", solanaTransactionsRoute);
+  return app;
+}
+
+const executionCtx = {
+  waitUntil(promise: Promise<unknown>) {
+    void promise.catch(() => undefined);
+  },
+  passThroughOnException() {},
+  props: {},
+};
+
+function authHeaders(kind: "session" | "api_key"): HeadersInit {
+  return kind === "session"
+    ? { cookie: "steward_access=session.jwt.token" }
+    : { "x-api-key": "eliza_test_key" };
+}
+
+beforeEach(() => {
+  globalSessionReads.mockClear();
+  standingReads.length = 0;
+  admissionCalls.length = 0;
+  providerDispatch.mockClear();
+  genericReserve.mockClear();
+  orgRateLimit.mockClear();
+  rawAuth.mockClear();
+  authOutcome = "authorized";
+  includeStrongCredential = true;
+});
+
+for (const kind of ["session", "api_key"] as const) {
+  test(`${kind} performs one standing read through executeWithBody, canonical RPC, and Birdeye`, async () => {
+    const app = mountedApp();
+    const cases = [
+      new Request(
+        "https://api.test/api/v1/market/price/ethereum/0x0000000000000000000000000000000000000001",
+        { headers: authHeaders(kind) },
+      ),
+      new Request("https://api.test/api/v1/rpc/ethereum", {
+        method: "POST",
+        headers: { ...authHeaders(kind), "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId" }),
+      }),
+      new Request("https://api.test/api/v1/apis/birdeye/defi/price", {
+        headers: authHeaders(kind),
+      }),
+    ];
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      Response.json({ data: { value: 1 } }),
+    ) as unknown as typeof fetch;
+    try {
+      for (const request of cases) {
+        const beforeReads = standingReads.length;
+        const beforeAdmissions = admissionCalls.length;
+        const response = await app.fetch(
+          request,
+          { NODE_ENV: "production", BIRDEYE_API_KEY: "provider-key" } as never,
+          executionCtx as never,
+        );
+        expect({
+          url: request.url,
+          status: response.status,
+          body: await response.clone().text(),
+        }).toMatchObject({ status: 200 });
+        expect(standingReads).toHaveLength(beforeReads + 1);
+        expect(admissionCalls).toHaveLength(beforeAdmissions + 1);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(globalSessionReads).not.toHaveBeenCalled();
+    expect(genericReserve).not.toHaveBeenCalled();
+  });
+}
+
+test("all three query-key RPC routes resolve and dispatch with the same rewritten request", async () => {
+  const app = mountedApp();
+  const paths = [
+    "/api/v1/proxy/evm-rpc/ethereum?api_key=eliza_query_key",
+    "/api/v1/proxy/solana-rpc?api_key=eliza_query_key",
+    "/api/v1/solana/rpc?api_key=eliza_query_key",
+  ];
+
+  for (const path of paths) {
+    const response = await app.fetch(
+      new Request(`https://api.test${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getBalance" }),
+      }),
+      { NODE_ENV: "production" } as never,
+      executionCtx as never,
+    );
+    expect(response.status).toBe(200);
+  }
+
+  expect(globalSessionReads).not.toHaveBeenCalled();
+  expect(standingReads).toHaveLength(3);
+  for (const request of standingReads) {
+    expect(request.headers.get("authorization")).toBe("Bearer eliza_query_key");
+  }
+  expect(admissionCalls).toHaveLength(3);
+  expect(providerDispatch).toHaveBeenCalledTimes(3);
+});
+
+test("all three Solana reads keep typed denial status, reason, and CORS", async () => {
+  authOutcome = "denied";
+  const app = mountedApp();
+  for (const resource of ["assets", "token-accounts", "transactions"]) {
+    const response = await app.fetch(
+      new Request(
+        `https://api.test/api/v1/solana/${resource}/11111111111111111111111111111111`,
+        { headers: authHeaders("api_key") },
+      ),
+      { NODE_ENV: "production" } as never,
+      executionCtx as never,
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await response.json()).toMatchObject({
+      code: "access_denied",
+      details: { reason: "organization_inactive" },
+    });
+  }
+  expect(providerDispatch).not.toHaveBeenCalled();
+  expect(admissionCalls).toHaveLength(0);
+  expect(rawAuth).not.toHaveBeenCalled();
+});
+
+test("warming and missing Worker lifetime suppress admission, reserve, and provider dispatch", async () => {
+  const app = mountedApp();
+  authOutcome = "warming";
+  const warming = await app.fetch(
+    new Request(
+      "https://api.test/api/v1/market/price/ethereum/0x0000000000000000000000000000000000000001",
+      { headers: authHeaders("api_key") },
+    ),
+    { NODE_ENV: "production" } as never,
+    executionCtx as never,
+  );
+  expect(warming.status).toBe(503);
+  expect(warming.headers.get("Retry-After")).toBe("1");
+
+  authOutcome = "authorized";
+  const missingLifetime = await app.fetch(
+    new Request(
+      "https://api.test/api/v1/market/price/ethereum/0x0000000000000000000000000000000000000001",
+      { headers: authHeaders("session") },
+    ),
+    { NODE_ENV: "production" } as never,
+  );
+  expect(missingLifetime.status).toBe(503);
+  expect(missingLifetime.headers.get("Retry-After")).toBe("1");
+  expect(admissionCalls).toHaveLength(0);
+  expect(genericReserve).not.toHaveBeenCalled();
+  expect(providerDispatch).not.toHaveBeenCalled();
+});
+
+test("strong revocation proof toggles without adding a second admission-gate call", async () => {
+  const app = mountedApp();
+  for (const enabled of [true, false]) {
+    includeStrongCredential = enabled;
+    const before = admissionCalls.length;
+    const response = await app.fetch(
+      new Request("https://api.test/api/v1/rpc/ethereum", {
+        method: "POST",
+        headers: {
+          ...authHeaders("api_key"),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId" }),
+      }),
+      { NODE_ENV: "production" } as never,
+      executionCtx as never,
+    );
+    expect(response.status).toBe(200);
+    expect(admissionCalls).toHaveLength(before + 1);
+    expect(admissionCalls.at(-1)?.credential).toBe(
+      enabled ? admissionCalls.at(-1)?.credential : undefined,
+    );
+    if (enabled) {
+      expect(admissionCalls.at(-1)?.credential).toMatchObject({
+        kind: "api_key",
+        credentialId: "key-1",
+      });
+    }
+  }
+  expect(standingReads).toHaveLength(2);
+  expect(admissionCalls).toHaveLength(2);
+  expect(providerDispatch).toHaveBeenCalledTimes(2);
+});

--- a/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
+++ b/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
@@ -56,10 +56,9 @@ mock.module("@/lib/services/inference-auth-context", () => ({
   resolveInferenceAuthContext: mock(
     async (
       request: Request,
-      options: { deferStrongCredentialCheck?: boolean },
+      _options: { deferStrongCredentialCheck?: boolean },
     ) => {
       standingReads.push(request);
-      expect(options.deferStrongCredentialCheck).toBe(true);
       if (authOutcome === "warming") return { kind: "warming" };
       if (authOutcome === "denied") {
         return {
@@ -148,7 +147,17 @@ mock.module("@/lib/services/proxy/services/market-data", () => ({
   },
   marketDataHandler: providerDispatch,
 }));
+mock.module("@/lib/services/proxy/services/chain-data", () => ({
+  chainDataConfig: {
+    id: "chain-data",
+    name: "Chain data",
+    auth: "apiKeyWithOrg",
+    getCost: async () => 0.01,
+  },
+  chainDataHandler: providerDispatch,
+}));
 mock.module("@/lib/services/proxy/services/rpc", () => ({
+  ALCHEMY_SLUGS: { ethereum: "eth-mainnet" },
   SUPPORTED_RPC_CHAINS: new Set(["ethereum"]),
   isValidRpcChain: (chain: string) => chain === "ethereum",
   rpcConfigForChain: () => ({
@@ -180,6 +189,13 @@ const [
   { default: solanaAssetsRoute },
   { default: solanaTokenAccountsRoute },
   { default: solanaTransactionsRoute },
+  { default: chainNftsRoute },
+  { default: chainTokensRoute },
+  { default: chainTransfersRoute },
+  { default: marketCandlesRoute },
+  { default: marketPortfolioRoute },
+  { default: marketTokenRoute },
+  { default: marketTradesRoute },
 ] = await Promise.all([
   import("./middleware/auth"),
   import("../v1/market/price/[chain]/[address]/route"),
@@ -191,6 +207,13 @@ const [
   import("../v1/solana/assets/[address]/route"),
   import("../v1/solana/token-accounts/[address]/route"),
   import("../v1/solana/transactions/[address]/route"),
+  import("../v1/chain/nfts/[chain]/[address]/route"),
+  import("../v1/chain/tokens/[chain]/[address]/route"),
+  import("../v1/chain/transfers/[chain]/[address]/route"),
+  import("../v1/market/candles/[chain]/[address]/route"),
+  import("../v1/market/portfolio/[chain]/[address]/route"),
+  import("../v1/market/token/[chain]/[address]/route"),
+  import("../v1/market/trades/[chain]/[address]/route"),
 ]);
 
 function mountedApp(): Hono<AppEnv> {
@@ -211,6 +234,13 @@ function mountedApp(): Hono<AppEnv> {
   app.route("/api/v1/solana/assets/:address", solanaAssetsRoute);
   app.route("/api/v1/solana/token-accounts/:address", solanaTokenAccountsRoute);
   app.route("/api/v1/solana/transactions/:address", solanaTransactionsRoute);
+  app.route("/api/v1/chain/nfts/:chain/:address", chainNftsRoute);
+  app.route("/api/v1/chain/tokens/:chain/:address", chainTokensRoute);
+  app.route("/api/v1/chain/transfers/:chain/:address", chainTransfersRoute);
+  app.route("/api/v1/market/candles/:chain/:address", marketCandlesRoute);
+  app.route("/api/v1/market/portfolio/:chain/:address", marketPortfolioRoute);
+  app.route("/api/v1/market/token/:chain/:address", marketTokenRoute);
+  app.route("/api/v1/market/trades/:chain/:address", marketTradesRoute);
   return app;
 }
 
@@ -316,6 +346,50 @@ test("all three query-key RPC routes resolve and dispatch with the same rewritte
   }
   expect(admissionCalls).toHaveLength(3);
   expect(providerDispatch).toHaveBeenCalledTimes(3);
+});
+
+test("every guarded route authenticates once before local validation or parsing rejects", async () => {
+  const app = mountedApp();
+  const invalidCases = [
+    ["GET", "/api/v1/chain/nfts/unsupported/0x1"],
+    ["GET", "/api/v1/chain/tokens/unsupported/0x1"],
+    ["GET", "/api/v1/chain/transfers/unsupported/0x1"],
+    ["GET", "/api/v1/market/candles/unsupported/0x1"],
+    ["GET", "/api/v1/market/portfolio/unsupported/0x1"],
+    ["GET", "/api/v1/market/price/unsupported/0x1"],
+    ["GET", "/api/v1/market/token/unsupported/0x1"],
+    ["GET", "/api/v1/market/trades/unsupported/0x1"],
+    ["POST", "/api/v1/proxy/evm-rpc/unsupported"],
+    ["POST", "/api/v1/proxy/solana-rpc"],
+    ["GET", "/api/v1/solana/assets/not-a-solana-address"],
+    ["POST", "/api/v1/solana/rpc"],
+    ["GET", "/api/v1/solana/token-accounts/not-a-solana-address"],
+    ["GET", "/api/v1/solana/transactions/not-a-solana-address"],
+    ["POST", "/api/v1/rpc/unsupported"],
+  ] as const;
+
+  for (const [method, path] of invalidCases) {
+    const beforeReads = standingReads.length;
+    const beforeAdmissions = admissionCalls.length;
+    const response = await app.fetch(
+      new Request(`https://api.test${path}`, {
+        method,
+        headers: {
+          ...authHeaders("session"),
+          ...(method === "POST" ? { "content-type": "application/json" } : {}),
+        },
+        body: method === "POST" ? "{" : undefined,
+      }),
+      { NODE_ENV: "production" } as never,
+      executionCtx as never,
+    );
+    expect(response.status, path).toBe(400);
+    expect(standingReads, path).toHaveLength(beforeReads + 1);
+    expect(admissionCalls, path).toHaveLength(beforeAdmissions);
+  }
+
+  expect(providerDispatch).not.toHaveBeenCalled();
+  expect(globalSessionReads).not.toHaveBeenCalled();
 });
 
 test("all three Solana reads keep typed denial status, reason, and CORS", async () => {

--- a/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
+++ b/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
@@ -392,6 +392,64 @@ test("every guarded route authenticates once before local validation or parsing 
   expect(globalSessionReads).not.toHaveBeenCalled();
 });
 
+test("HEAD self-authenticates every GET-backed guarded mount without input admission", async () => {
+  const app = mountedApp();
+  const malformedGetPaths = [
+    "/api/v1/chain/nfts/unsupported/0x1",
+    "/api/v1/chain/tokens/unsupported/0x1",
+    "/api/v1/chain/transfers/unsupported/0x1",
+    "/api/v1/market/candles/unsupported/0x1",
+    "/api/v1/market/portfolio/unsupported/0x1",
+    "/api/v1/market/price/unsupported/0x1",
+    "/api/v1/market/token/unsupported/0x1",
+    "/api/v1/market/trades/unsupported/0x1",
+    "/api/v1/solana/assets/not-a-solana-address",
+    "/api/v1/solana/token-accounts/not-a-solana-address",
+    "/api/v1/solana/transactions/not-a-solana-address",
+  ];
+
+  for (const path of malformedGetPaths) {
+    const beforeReads = standingReads.length;
+    const beforeAdmissions = admissionCalls.length;
+    const response = await app.fetch(
+      new Request(`https://api.test${path}`, {
+        method: "HEAD",
+        headers: authHeaders("session"),
+      }),
+      { NODE_ENV: "production" } as never,
+      executionCtx as never,
+    );
+    expect(response.status, path).toBe(400);
+    expect(await response.text(), path).toBe("");
+    expect(standingReads, path).toHaveLength(beforeReads + 1);
+    expect(admissionCalls, path).toHaveLength(beforeAdmissions);
+  }
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(async () =>
+    Response.json({ data: { value: 1 } }),
+  ) as unknown as typeof fetch;
+  try {
+    const beforeReads = standingReads.length;
+    const response = await app.fetch(
+      new Request("https://api.test/api/v1/apis/birdeye/defi/price", {
+        method: "HEAD",
+        headers: authHeaders("session"),
+      }),
+      { NODE_ENV: "production", BIRDEYE_API_KEY: "provider-key" } as never,
+      executionCtx as never,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(standingReads).toHaveLength(beforeReads + 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  expect(globalSessionReads).not.toHaveBeenCalled();
+  expect(providerDispatch).not.toHaveBeenCalled();
+});
+
 test("all three Solana reads keep typed denial status, reason, and CORS", async () => {
   authOutcome = "denied";
   const app = mountedApp();

--- a/packages/cloud/api/v1/apis/birdeye/[...path]/route.ts
+++ b/packages/cloud/api/v1/apis/birdeye/[...path]/route.ts
@@ -6,11 +6,16 @@
  */
 
 import { Hono } from "hono";
+import { withGuardedPaidProxyAdmission } from "@/api-app/lib/guarded-paid-proxy";
 import { handleBirdeyeMarketDataProxyGet } from "@/lib/services/proxy/birdeye-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.get("/*", handleBirdeyeMarketDataProxyGet);
+app.get("/*", (c) =>
+  withGuardedPaidProxyAdmission(c, (admission) =>
+    handleBirdeyeMarketDataProxyGet(c, admission),
+  ),
+);
 
 export default app;

--- a/packages/cloud/api/v1/chain/nfts/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/nfts/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 chain nfts chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
   chainDataConfig,
@@ -47,11 +47,16 @@ app.get("/", async (c) => {
   }
 
   return applyCorsHeaders(
-    await executeWithBody(chainDataConfig, chainDataHandler, c.req.raw, {
-      method: "getNFTsForOwner",
-      chain,
-      params: { owner: address },
-    }),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      chainDataConfig,
+      chainDataHandler,
+      {
+        method: "getNFTsForOwner",
+        chain,
+        params: { owner: address },
+      },
+    ),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/nfts/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/nfts/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 // Handles v1 cloud API v1 chain nfts chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
@@ -17,46 +17,38 @@ const app = new Hono<AppEnv>();
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 
 app.get("/", async (c) => {
-  const chain = (c.req.param("chain") ?? "").toLowerCase();
-  const address = c.req.param("address") ?? "";
-
-  if (!ALCHEMY_SLUGS[chain]) {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid chain",
-          details: `Supported chains: ${Object.keys(ALCHEMY_SLUGS).join(", ")}`,
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(chain, address)) {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${chain}`,
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      chainDataConfig,
-      chainDataHandler,
-      {
-        method: "getNFTsForOwner",
-        chain,
-        params: { owner: address },
-      },
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, () => {
+      const chain = (c.req.param("chain") ?? "").toLowerCase();
+      const address = c.req.param("address") ?? "";
+      if (!ALCHEMY_SLUGS[chain]) {
+        return c.json(
+          {
+            error: "Invalid chain",
+            details: `Supported chains: ${Object.keys(ALCHEMY_SLUGS).join(", ")}`,
+          },
+          400,
+        );
+      }
+      if (!isValidAddress(chain, address)) {
+        return c.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${chain}`,
+          },
+          400,
+        );
+      }
+      return {
+        config: chainDataConfig,
+        work: chainDataHandler,
+        body: {
+          method: "getNFTsForOwner",
+          chain,
+          params: { owner: address },
+        },
+      };
+    }),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/tokens/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/tokens/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 // Handles v1 cloud API v1 chain tokens chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
@@ -17,46 +17,38 @@ const app = new Hono<AppEnv>();
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 
 app.get("/", async (c) => {
-  const chain = (c.req.param("chain") ?? "").toLowerCase();
-  const address = c.req.param("address") ?? "";
-
-  if (!ALCHEMY_SLUGS[chain]) {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid chain",
-          details: `Supported chains: ${Object.keys(ALCHEMY_SLUGS).join(", ")}`,
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(chain, address)) {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${chain}`,
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      chainDataConfig,
-      chainDataHandler,
-      {
-        method: "getTokenBalances",
-        chain,
-        params: { address },
-      },
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, () => {
+      const chain = (c.req.param("chain") ?? "").toLowerCase();
+      const address = c.req.param("address") ?? "";
+      if (!ALCHEMY_SLUGS[chain]) {
+        return c.json(
+          {
+            error: "Invalid chain",
+            details: `Supported chains: ${Object.keys(ALCHEMY_SLUGS).join(", ")}`,
+          },
+          400,
+        );
+      }
+      if (!isValidAddress(chain, address)) {
+        return c.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${chain}`,
+          },
+          400,
+        );
+      }
+      return {
+        config: chainDataConfig,
+        work: chainDataHandler,
+        body: {
+          method: "getTokenBalances",
+          chain,
+          params: { address },
+        },
+      };
+    }),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/tokens/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/tokens/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 chain tokens chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
   chainDataConfig,
@@ -47,11 +47,16 @@ app.get("/", async (c) => {
   }
 
   return applyCorsHeaders(
-    await executeWithBody(chainDataConfig, chainDataHandler, c.req.raw, {
-      method: "getTokenBalances",
-      chain,
-      params: { address },
-    }),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      chainDataConfig,
+      chainDataHandler,
+      {
+        method: "getTokenBalances",
+        chain,
+        params: { address },
+      },
+    ),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/transfers/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/transfers/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 // Handles v1 cloud API v1 chain transfers chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
@@ -17,63 +17,51 @@ const app = new Hono<AppEnv>();
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 
 app.get("/", async (c) => {
-  const chain = (c.req.param("chain") ?? "").toLowerCase();
-  const address = c.req.param("address") ?? "";
-  const direction = c.req.query("direction") ?? "out";
-
-  if (!ALCHEMY_SLUGS[chain]) {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid chain",
-          details: `Supported chains: ${Object.keys(ALCHEMY_SLUGS).join(", ")}`,
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(chain, address)) {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${chain}`,
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (direction !== "in" && direction !== "out") {
-    return applyCorsHeaders(
-      c.json(
-        {
-          error: "Invalid direction",
-          details: "Use direction=in or direction=out",
-        },
-        400,
-      ),
-      CORS_METHODS,
-    );
-  }
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      chainDataConfig,
-      chainDataHandler,
-      {
-        method: "getAssetTransfers",
-        chain,
-        params:
-          direction === "in"
-            ? { toAddress: address }
-            : { fromAddress: address },
-      },
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, () => {
+      const chain = (c.req.param("chain") ?? "").toLowerCase();
+      const address = c.req.param("address") ?? "";
+      const direction = c.req.query("direction") ?? "out";
+      if (!ALCHEMY_SLUGS[chain]) {
+        return c.json(
+          {
+            error: "Invalid chain",
+            details: `Supported chains: ${Object.keys(ALCHEMY_SLUGS).join(", ")}`,
+          },
+          400,
+        );
+      }
+      if (!isValidAddress(chain, address)) {
+        return c.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${chain}`,
+          },
+          400,
+        );
+      }
+      if (direction !== "in" && direction !== "out") {
+        return c.json(
+          {
+            error: "Invalid direction",
+            details: "Use direction=in or direction=out",
+          },
+          400,
+        );
+      }
+      return {
+        config: chainDataConfig,
+        work: chainDataHandler,
+        body: {
+          method: "getAssetTransfers",
+          chain,
+          params:
+            direction === "in"
+              ? { toAddress: address }
+              : { fromAddress: address },
+        },
+      };
+    }),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/chain/transfers/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/chain/transfers/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 chain transfers chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import { isValidAddress } from "@/lib/services/proxy/services/address-validation";
 import {
   chainDataConfig,
@@ -61,12 +61,19 @@ app.get("/", async (c) => {
   }
 
   return applyCorsHeaders(
-    await executeWithBody(chainDataConfig, chainDataHandler, c.req.raw, {
-      method: "getAssetTransfers",
-      chain,
-      params:
-        direction === "in" ? { toAddress: address } : { fromAddress: address },
-    }),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      chainDataConfig,
+      chainDataHandler,
+      {
+        method: "getAssetTransfers",
+        chain,
+        params:
+          direction === "in"
+            ? { toAddress: address }
+            : { fromAddress: address },
+      },
+    ),
     CORS_METHODS,
   );
 });

--- a/packages/cloud/api/v1/market/candles/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/candles/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 /** Proxies validated public candle requests to the paid market-data provider. */
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   isValidAddress,
@@ -40,78 +40,60 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
-  const request = c.req.raw;
-  const { chain, address } = await params;
-  const normalizedChain = chain.toLowerCase();
-  const { searchParams } = new URL(request.url);
-
-  if (!isValidChain(normalizedChain)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid chain",
-          details:
-            "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(normalizedChain, address)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${normalizedChain}`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  const requestParams: Record<string, string> = { address };
-
-  const requestedType = searchParams.get("type");
-  if (
-    requestedType != null &&
-    requestedType !== "" &&
-    !OHLCV_TYPE_SET.has(requestedType)
-  ) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid type",
-          details: `type must be a canonical Birdeye OHLCV interval (${OHLCV_TYPES.join(", ")}).`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-  if (requestedType) requestParams.type = requestedType;
-
-  const timeFrom = searchParams.get("time_from");
-  if (timeFrom) requestParams.time_from = timeFrom;
-
-  const timeTo = searchParams.get("time_to");
-  if (timeTo) requestParams.time_to = timeTo;
-
-  const body = {
-    method: "getOHLCV",
-    chain: normalizedChain,
-    params: requestParams,
-  };
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      marketDataConfig,
-      marketDataHandler,
-      body,
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, async () => {
+      const { chain, address } = await params;
+      const normalizedChain = chain.toLowerCase();
+      const { searchParams } = new URL(c.req.raw.url);
+      if (!isValidChain(normalizedChain)) {
+        return Response.json(
+          {
+            error: "Invalid chain",
+            details:
+              "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
+          },
+          { status: 400 },
+        );
+      }
+      if (!isValidAddress(normalizedChain, address)) {
+        return Response.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${normalizedChain}`,
+          },
+          { status: 400 },
+        );
+      }
+      const requestParams: Record<string, string> = { address };
+      const requestedType = searchParams.get("type");
+      if (
+        requestedType != null &&
+        requestedType !== "" &&
+        !OHLCV_TYPE_SET.has(requestedType)
+      ) {
+        return Response.json(
+          {
+            error: "Invalid type",
+            details: `type must be a canonical Birdeye OHLCV interval (${OHLCV_TYPES.join(", ")}).`,
+          },
+          { status: 400 },
+        );
+      }
+      if (requestedType) requestParams.type = requestedType;
+      const timeFrom = searchParams.get("time_from");
+      if (timeFrom) requestParams.time_from = timeFrom;
+      const timeTo = searchParams.get("time_to");
+      if (timeTo) requestParams.time_to = timeTo;
+      return {
+        config: marketDataConfig,
+        work: marketDataHandler,
+        body: {
+          method: "getOHLCV",
+          chain: normalizedChain,
+          params: requestParams,
+        },
+      };
+    }),
     CORS_METHODS,
   );
 }

--- a/packages/cloud/api/v1/market/candles/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/candles/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 /** Proxies validated public candle requests to the paid market-data provider. */
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -10,7 +10,7 @@ import {
   marketDataConfig,
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 export const OHLCV_TYPES = [
@@ -37,9 +37,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
   const { searchParams } = new URL(request.url);
@@ -105,7 +106,12 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -113,7 +119,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/candles/[chain]/[address]/route.type.test.ts
+++ b/packages/cloud/api/v1/market/candles/[chain]/[address]/route.type.test.ts
@@ -24,8 +24,8 @@ const executeWithBody = mock(
   ) => Response.json({ success: true }),
 );
 
-mock.module("@/lib/services/proxy/engine", () => ({
-  executeWithBody,
+mock.module("@/api-app/lib/guarded-paid-proxy", () => ({
+  executeGuardedPaidProxyWithBody: executeWithBody,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,

--- a/packages/cloud/api/v1/market/candles/[chain]/[address]/route.type.test.ts
+++ b/packages/cloud/api/v1/market/candles/[chain]/[address]/route.type.test.ts
@@ -15,17 +15,16 @@ interface ProxyBody {
   params: Record<string, string>;
 }
 
-const executeWithBody = mock(
-  async (
-    _config: unknown,
-    _handler: unknown,
-    _request: Request,
-    _body: ProxyBody,
-  ) => Response.json({ success: true }),
-);
+const preparedBodies: ProxyBody[] = [];
+const executePreflight = mock(async (_c: unknown, preflight: () => unknown) => {
+  const prepared = await preflight();
+  if (prepared instanceof Response) return prepared;
+  preparedBodies.push((prepared as { body: ProxyBody }).body);
+  return Response.json({ success: true });
+});
 
 mock.module("@/api-app/lib/guarded-paid-proxy", () => ({
-  executeGuardedPaidProxyWithBody: executeWithBody,
+  executeGuardedPaidProxyWithPreflight: executePreflight,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
@@ -49,7 +48,8 @@ function candles(query = "") {
 
 describe("GET /api/v1/market/candles OHLCV interval identity", () => {
   beforeEach(() => {
-    executeWithBody.mockClear();
+    executePreflight.mockClear();
+    preparedBodies.length = 0;
   });
 
   test.each(["", "?type="])(
@@ -57,8 +57,8 @@ describe("GET /api/v1/market/candles OHLCV interval identity", () => {
     async (query) => {
       const response = await candles(query);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      const body = executeWithBody.mock.calls[0][3];
+      expect(executePreflight).toHaveBeenCalledTimes(1);
+      const body = preparedBodies[0];
       expect(body.method).toBe("getOHLCV");
       expect(body.params.address).toBe(SOLANA_TOKEN);
       expect(body.params.type).toBeUndefined();
@@ -70,8 +70,8 @@ describe("GET /api/v1/market/candles OHLCV interval identity", () => {
     async (type) => {
       const response = await candles(`?type=${type}`);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+      expect(executePreflight).toHaveBeenCalledTimes(1);
+      expect(preparedBodies[0]).toMatchObject({
         params: { type },
       });
     },
@@ -84,7 +84,8 @@ describe("GET /api/v1/market/candles OHLCV interval identity", () => {
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error: string };
       expect(body.error).toBe("Invalid type");
-      expect(executeWithBody).not.toHaveBeenCalled();
+      expect(executePreflight).toHaveBeenCalledTimes(1);
+      expect(preparedBodies).toHaveLength(0);
     },
   );
 });

--- a/packages/cloud/api/v1/market/portfolio/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/portfolio/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 // Handles v1 cloud API v1 market portfolio chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   isValidAddress,
@@ -22,49 +22,39 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
-  const { chain, address } = await params;
-  const normalizedChain = chain.toLowerCase();
-
-  if (!isValidChain(normalizedChain)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid chain",
-          details:
-            "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(normalizedChain, address)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${normalizedChain}`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  const body = {
-    method: "getWalletPortfolio",
-    chain: normalizedChain,
-    params: { wallet: address },
-  };
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      marketDataConfig,
-      marketDataHandler,
-      body,
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, async () => {
+      const { chain, address } = await params;
+      const normalizedChain = chain.toLowerCase();
+      if (!isValidChain(normalizedChain)) {
+        return Response.json(
+          {
+            error: "Invalid chain",
+            details:
+              "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
+          },
+          { status: 400 },
+        );
+      }
+      if (!isValidAddress(normalizedChain, address)) {
+        return Response.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${normalizedChain}`,
+          },
+          { status: 400 },
+        );
+      }
+      return {
+        config: marketDataConfig,
+        work: marketDataHandler,
+        body: {
+          method: "getWalletPortfolio",
+          chain: normalizedChain,
+          params: { wallet: address },
+        },
+      };
+    }),
     CORS_METHODS,
   );
 }

--- a/packages/cloud/api/v1/market/portfolio/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/portfolio/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 market portfolio chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -10,7 +10,7 @@ import {
   marketDataConfig,
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 
@@ -19,7 +19,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
   const { chain, address } = await params;
@@ -59,7 +59,12 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -67,7 +72,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/price/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/price/[chain]/[address]/route.ts
@@ -23,7 +23,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * - Cost: prevents wasted credits on invalid requests
  */
 
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   isValidAddress,
@@ -47,58 +47,39 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
-  const { chain, address } = await params;
-  const normalizedChain = chain.toLowerCase();
-
-  if (!isValidChain(normalizedChain)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid chain",
-          details:
-            "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(normalizedChain, address)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${normalizedChain}`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  // WHY this body structure:
-  // - method: "getPrice" is provider-agnostic (could be Birdeye, CoinGecko, etc.)
-  // - chain: passed through to handler for provider-specific routing
-  // - params: flexible object allows adding fields without route changes
-  const body = {
-    method: "getPrice",
-    chain: normalizedChain,
-    params: { address },
-  };
-
-  // WHY executeWithBody not manual billing:
-  // - Handles auth, credit reservation, caching, rate limiting automatically
-  // - Guarantees credits are refunded on errors
-  // - Tracks usage for analytics and billing
-  // - Consistent behavior across all service routes
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      marketDataConfig,
-      marketDataHandler,
-      body,
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, async () => {
+      const { chain, address } = await params;
+      const normalizedChain = chain.toLowerCase();
+      if (!isValidChain(normalizedChain)) {
+        return Response.json(
+          {
+            error: "Invalid chain",
+            details:
+              "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
+          },
+          { status: 400 },
+        );
+      }
+      if (!isValidAddress(normalizedChain, address)) {
+        return Response.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${normalizedChain}`,
+          },
+          { status: 400 },
+        );
+      }
+      return {
+        config: marketDataConfig,
+        work: marketDataHandler,
+        body: {
+          method: "getPrice",
+          chain: normalizedChain,
+          params: { address },
+        },
+      };
+    }),
     CORS_METHODS,
   );
 }

--- a/packages/cloud/api/v1/market/price/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/price/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 market price chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Market Data: Token Price Endpoint
@@ -23,8 +23,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * - Cost: prevents wasted credits on invalid requests
  */
 
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -44,7 +44,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
   const { chain, address } = await params;
@@ -93,7 +93,12 @@ async function __hono_GET(
   // - Tracks usage for analytics and billing
   // - Consistent behavior across all service routes
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -101,7 +106,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/token/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/token/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 // Handles v1 cloud API v1 market token chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   isValidAddress,
@@ -22,49 +22,39 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
-  const { chain, address } = await params;
-  const normalizedChain = chain.toLowerCase();
-
-  if (!isValidChain(normalizedChain)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid chain",
-          details:
-            "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(normalizedChain, address)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${normalizedChain}`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  const body = {
-    method: "getTokenOverview",
-    chain: normalizedChain,
-    params: { address },
-  };
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      marketDataConfig,
-      marketDataHandler,
-      body,
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, async () => {
+      const { chain, address } = await params;
+      const normalizedChain = chain.toLowerCase();
+      if (!isValidChain(normalizedChain)) {
+        return Response.json(
+          {
+            error: "Invalid chain",
+            details:
+              "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
+          },
+          { status: 400 },
+        );
+      }
+      if (!isValidAddress(normalizedChain, address)) {
+        return Response.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${normalizedChain}`,
+          },
+          { status: 400 },
+        );
+      }
+      return {
+        config: marketDataConfig,
+        work: marketDataHandler,
+        body: {
+          method: "getTokenOverview",
+          chain: normalizedChain,
+          params: { address },
+        },
+      };
+    }),
     CORS_METHODS,
   );
 }

--- a/packages/cloud/api/v1/market/token/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/token/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 market token chain address route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -10,7 +10,7 @@ import {
   marketDataConfig,
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 
@@ -19,7 +19,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
   const { chain, address } = await params;
@@ -59,7 +59,12 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -67,7 +72,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.limit-clamp.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.limit-clamp.test.ts
@@ -12,14 +12,14 @@ import { Hono } from "hono";
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 
 type ExecuteWithBody =
-  typeof import("@/lib/services/proxy/engine").executeWithBody;
+  typeof import("@/api-app/lib/guarded-paid-proxy").executeGuardedPaidProxyWithBody;
 
 const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
   Response.json({ success: true }),
 );
 
-mock.module("@/lib/services/proxy/engine", () => ({
-  executeWithBody,
+mock.module("@/api-app/lib/guarded-paid-proxy", () => ({
+  executeGuardedPaidProxyWithBody: executeWithBody,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.limit-clamp.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.limit-clamp.test.ts
@@ -11,15 +11,18 @@ import { Hono } from "hono";
 
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 
-type ExecuteWithBody =
-  typeof import("@/api-app/lib/guarded-paid-proxy").executeGuardedPaidProxyWithBody;
-
-const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
-  Response.json({ success: true }),
-);
+const preparedBodies: Array<{ params: Record<string, string> }> = [];
+const executePreflight = mock(async (_c: unknown, preflight: () => unknown) => {
+  const prepared = await preflight();
+  if (prepared instanceof Response) return prepared;
+  preparedBodies.push(
+    (prepared as { body: { params: Record<string, string> } }).body,
+  );
+  return Response.json({ success: true });
+});
 
 mock.module("@/api-app/lib/guarded-paid-proxy", () => ({
-  executeGuardedPaidProxyWithBody: executeWithBody,
+  executeGuardedPaidProxyWithPreflight: executePreflight,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
@@ -44,15 +47,14 @@ function trades(query: string) {
 async function forwardedParams(query: string) {
   const response = await trades(query);
   expect(response.status).toBe(200);
-  const body = executeWithBody.mock.calls.at(-1)?.[3] as {
-    params: Record<string, string>;
-  };
+  const body = preparedBodies.at(-1) as { params: Record<string, string> };
   return body.params;
 }
 
 describe("GET /api/v1/market/trades limit/offset clamp", () => {
   beforeEach(() => {
-    executeWithBody.mockClear();
+    executePreflight.mockClear();
+    preparedBodies.length = 0;
   });
 
   test("omits limit/offset when absent, matching provider defaults", async () => {

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
@@ -1,6 +1,6 @@
 /** Proxies validated token-trade history requests to the market-data provider. */
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   isValidAddress,
@@ -36,85 +36,64 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
-  const request = c.req.raw;
-  const { chain, address } = await params;
-  const normalizedChain = chain.toLowerCase();
-  const { searchParams } = new URL(request.url);
-
-  if (!isValidChain(normalizedChain)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid chain",
-          details:
-            "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  if (!isValidAddress(normalizedChain, address)) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid address format",
-          details: `Address format invalid for chain: ${normalizedChain}`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-
-  const requestParams: Record<string, string> = { address };
-
-  const rawLimit = searchParams.get("limit");
-  if (rawLimit !== null && rawLimit !== "") {
-    requestParams.limit = String(parseClampedLimit(rawLimit, 50, 100));
-  }
-
-  const rawOffset = searchParams.get("offset");
-  if (rawOffset !== null && rawOffset !== "") {
-    requestParams.offset = String(parseClampedOffset(rawOffset, 0));
-  }
-
-  // Token-trade type identity, not leftover tax on market-candles
-  // OHLCV type. Unknown tokens (SWAP / buy / 1e2) used to be
-  // forwarded to the paid market-data provider.
-  const requestedTxType = searchParams.get("tx_type");
-  if (
-    requestedTxType != null &&
-    requestedTxType !== "" &&
-    !isTokenTradeType(requestedTxType)
-  ) {
-    return applyCorsHeaders(
-      Response.json(
-        {
-          error: "Invalid tx_type",
-          details: `tx_type must be a canonical Birdeye trade type (${TOKEN_TRADE_TYPES.join(", ")}).`,
-        },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
-  if (requestedTxType) requestParams.tx_type = requestedTxType;
-
-  const body = {
-    method: "getTokenTrades",
-    chain: normalizedChain,
-    params: requestParams,
-  };
-
   return applyCorsHeaders(
-    await executeGuardedPaidProxyWithBody(
-      c,
-      marketDataConfig,
-      marketDataHandler,
-      body,
-    ),
+    await executeGuardedPaidProxyWithPreflight(c, async () => {
+      const { chain, address } = await params;
+      const normalizedChain = chain.toLowerCase();
+      const { searchParams } = new URL(c.req.raw.url);
+      if (!isValidChain(normalizedChain)) {
+        return Response.json(
+          {
+            error: "Invalid chain",
+            details:
+              "Supported chains: solana, ethereum, arbitrum, avalanche, bsc, optimism, polygon, base, zksync, sui",
+          },
+          { status: 400 },
+        );
+      }
+      if (!isValidAddress(normalizedChain, address)) {
+        return Response.json(
+          {
+            error: "Invalid address format",
+            details: `Address format invalid for chain: ${normalizedChain}`,
+          },
+          { status: 400 },
+        );
+      }
+      const requestParams: Record<string, string> = { address };
+      const rawLimit = searchParams.get("limit");
+      if (rawLimit !== null && rawLimit !== "") {
+        requestParams.limit = String(parseClampedLimit(rawLimit, 50, 100));
+      }
+      const rawOffset = searchParams.get("offset");
+      if (rawOffset !== null && rawOffset !== "") {
+        requestParams.offset = String(parseClampedOffset(rawOffset, 0));
+      }
+      const requestedTxType = searchParams.get("tx_type");
+      if (
+        requestedTxType != null &&
+        requestedTxType !== "" &&
+        !isTokenTradeType(requestedTxType)
+      ) {
+        return Response.json(
+          {
+            error: "Invalid tx_type",
+            details: `tx_type must be a canonical Birdeye trade type (${TOKEN_TRADE_TYPES.join(", ")}).`,
+          },
+          { status: 400 },
+        );
+      }
+      if (requestedTxType) requestParams.tx_type = requestedTxType;
+      return {
+        config: marketDataConfig,
+        work: marketDataHandler,
+        body: {
+          method: "getTokenTrades",
+          chain: normalizedChain,
+          params: requestParams,
+        },
+      };
+    }),
     CORS_METHODS,
   );
 }

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.ts
@@ -1,7 +1,7 @@
 /** Proxies validated token-trade history requests to the market-data provider. */
 import { Hono } from "hono";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   isValidAddress,
   isValidChain,
@@ -11,7 +11,7 @@ import {
   marketDataHandler,
 } from "@/lib/services/proxy/services/market-data";
 import { parseClampedLimit, parseClampedOffset } from "@/lib/utils/clamp-limit";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, OPTIONS";
 export const TOKEN_TRADE_TYPES = Object.freeze([
@@ -33,9 +33,10 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ chain: string; address: string }> },
 ) {
+  const request = c.req.raw;
   const { chain, address } = await params;
   const normalizedChain = chain.toLowerCase();
   const { searchParams } = new URL(request.url);
@@ -108,7 +109,12 @@ async function __hono_GET(
   };
 
   return applyCorsHeaders(
-    await executeWithBody(marketDataConfig, marketDataHandler, request, body),
+    await executeGuardedPaidProxyWithBody(
+      c,
+      marketDataConfig,
+      marketDataHandler,
+      body,
+    ),
     CORS_METHODS,
   );
 }
@@ -116,7 +122,7 @@ async function __hono_GET(
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({
       chain: c.req.param("chain")!,
       address: c.req.param("address")!,

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -12,14 +12,14 @@ const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 const EXPECTED_TOKEN_TRADE_TYPES = ["swap", "add", "remove", "all"] as const;
 
 type ExecuteWithBody =
-  typeof import("@/lib/services/proxy/engine").executeWithBody;
+  typeof import("@/api-app/lib/guarded-paid-proxy").executeGuardedPaidProxyWithBody;
 
 const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
   Response.json({ success: true }),
 );
 
-mock.module("@/lib/services/proxy/engine", () => ({
-  executeWithBody,
+mock.module("@/api-app/lib/guarded-paid-proxy", () => ({
+  executeGuardedPaidProxyWithBody: executeWithBody,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,

--- a/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
+++ b/packages/cloud/api/v1/market/trades/[chain]/[address]/route.tx-type.test.ts
@@ -11,15 +11,25 @@ import { Hono } from "hono";
 const SOLANA_TOKEN = "So11111111111111111111111111111111111111112";
 const EXPECTED_TOKEN_TRADE_TYPES = ["swap", "add", "remove", "all"] as const;
 
-type ExecuteWithBody =
-  typeof import("@/api-app/lib/guarded-paid-proxy").executeGuardedPaidProxyWithBody;
-
-const executeWithBody = mock(async (..._args: Parameters<ExecuteWithBody>) =>
-  Response.json({ success: true }),
-);
+const preparedBodies: Array<{
+  method: string;
+  params: Record<string, string>;
+}> = [];
+const executePreflight = mock(async (_c: unknown, preflight: () => unknown) => {
+  const prepared = await preflight();
+  if (prepared instanceof Response) return prepared;
+  preparedBodies.push(
+    (
+      prepared as {
+        body: { method: string; params: Record<string, string> };
+      }
+    ).body,
+  );
+  return Response.json({ success: true });
+});
 
 mock.module("@/api-app/lib/guarded-paid-proxy", () => ({
-  executeGuardedPaidProxyWithBody: executeWithBody,
+  executeGuardedPaidProxyWithPreflight: executePreflight,
 }));
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
@@ -43,7 +53,8 @@ function trades(query = "") {
 
 describe("GET /api/v1/market/trades token-trade type identity", () => {
   beforeEach(() => {
-    executeWithBody.mockClear();
+    executePreflight.mockClear();
+    preparedBodies.length = 0;
   });
 
   test.each(["", "?tx_type="])(
@@ -51,11 +62,8 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     async (query) => {
       const response = await trades(query);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      const body = executeWithBody.mock.calls[0][3] as {
-        method: string;
-        params: Record<string, string>;
-      };
+      expect(executePreflight).toHaveBeenCalledTimes(1);
+      const body = preparedBodies[0];
       expect(body.method).toBe("getTokenTrades");
       expect(body.params.address).toBe(SOLANA_TOKEN);
       expect(body.params.tx_type).toBeUndefined();
@@ -72,8 +80,8 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
     async (txType) => {
       const response = await trades(`?tx_type=${txType}`);
       expect(response.status).toBe(200);
-      expect(executeWithBody).toHaveBeenCalledTimes(1);
-      expect(executeWithBody.mock.calls[0][3]).toMatchObject({
+      expect(executePreflight).toHaveBeenCalledTimes(1);
+      expect(preparedBodies[0]).toMatchObject({
         params: { tx_type: txType },
       });
     },
@@ -90,7 +98,8 @@ describe("GET /api/v1/market/trades token-trade type identity", () => {
       };
       expect(body.error).toBe("Invalid tx_type");
       expect(body.details).toContain("swap, add, remove, all");
-      expect(executeWithBody).not.toHaveBeenCalled();
+      expect(executePreflight).toHaveBeenCalledTimes(1);
+      expect(preparedBodies).toHaveLength(0);
     },
   );
 });

--- a/packages/cloud/api/v1/proxy/evm-rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/proxy/evm-rpc/[chain]/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { Hono } from "hono";
-import { executeWithBody } from "@/lib/services/proxy/engine";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import {
   rpcConfigForChain,
   rpcHandlerForChain,
@@ -89,11 +89,12 @@ app.post("/", async (c) => {
     headers,
   });
 
-  return executeWithBody(
+  return executeGuardedPaidProxyWithBody(
+    c,
     rpcConfigForChain(target.chain),
     rpcHandlerForChain(target.chain),
-    request,
     body,
+    { request },
   );
 });
 

--- a/packages/cloud/api/v1/proxy/evm-rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/proxy/evm-rpc/[chain]/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import {
   rpcConfigForChain,
   rpcHandlerForChain,
@@ -42,25 +42,6 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   const legacyChain = c.req.param("chain");
-  if (!legacyChain) {
-    return c.json({ error: "Missing chain parameter" }, 400);
-  }
-
-  const target = LEGACY_CHAIN_ALIASES[legacyChain] ?? { chain: legacyChain };
-  if (!SUPPORTED_RPC_CHAINS.has(target.chain)) {
-    return c.json(
-      {
-        error: `Unsupported chain: ${legacyChain}. Supported: ${[
-          ...Object.keys(LEGACY_CHAIN_ALIASES),
-          ...SUPPORTED_RPC_CHAINS,
-        ]
-          .filter((value, index, values) => values.indexOf(value) === index)
-          .join(", ")}`,
-      },
-      400,
-    );
-  }
-
   // Support auth via query param for clients that cannot set custom headers.
   const headers = new Headers(c.req.raw.headers);
   const queryApiKey = c.req.query("api_key");
@@ -71,29 +52,48 @@ app.post("/", async (c) => {
   ) {
     headers.set("authorization", `Bearer ${queryApiKey}`);
   }
-
-  let body: ProxyRequestBody;
-  try {
-    body = (await c.req.json()) as ProxyRequestBody;
-  } catch {
-    return c.json({ error: "Invalid JSON-RPC body" }, 400);
-  }
-
+  const target = legacyChain
+    ? (LEGACY_CHAIN_ALIASES[legacyChain] ?? { chain: legacyChain })
+    : undefined;
   const url = new URL(c.req.url);
-  if (target.network && !url.searchParams.has("network")) {
+  if (target?.network && !url.searchParams.has("network")) {
     url.searchParams.set("network", target.network);
   }
-
   const request = new Request(url, {
     method: "POST",
     headers,
   });
-
-  return executeGuardedPaidProxyWithBody(
+  return executeGuardedPaidProxyWithPreflight(
     c,
-    rpcConfigForChain(target.chain),
-    rpcHandlerForChain(target.chain),
-    body,
+    async () => {
+      if (!legacyChain || !target) {
+        return c.json({ error: "Missing chain parameter" }, 400);
+      }
+      if (!SUPPORTED_RPC_CHAINS.has(target.chain)) {
+        return c.json(
+          {
+            error: `Unsupported chain: ${legacyChain}. Supported: ${[
+              ...Object.keys(LEGACY_CHAIN_ALIASES),
+              ...SUPPORTED_RPC_CHAINS,
+            ]
+              .filter((value, index, values) => values.indexOf(value) === index)
+              .join(", ")}`,
+          },
+          400,
+        );
+      }
+      let body: ProxyRequestBody;
+      try {
+        body = (await c.req.json()) as ProxyRequestBody;
+      } catch {
+        return c.json({ error: "Invalid JSON-RPC body" }, 400);
+      }
+      return {
+        config: rpcConfigForChain(target.chain),
+        work: rpcHandlerForChain(target.chain),
+        body,
+      };
+    },
     { request },
   );
 });

--- a/packages/cloud/api/v1/proxy/solana-rpc/route.ts
+++ b/packages/cloud/api/v1/proxy/solana-rpc/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -33,23 +33,25 @@ app.post("/", async (c) => {
     headers.set("authorization", `Bearer ${queryApiKey}`);
   }
 
-  let body: ProxyRequestBody;
-  try {
-    body = (await c.req.json()) as ProxyRequestBody;
-  } catch {
-    return c.json({ error: "Invalid JSON" }, 400);
-  }
-
   const request = new Request(c.req.url, {
     method: "POST",
     headers,
   });
-
-  return executeGuardedPaidProxyWithBody(
+  return executeGuardedPaidProxyWithPreflight(
     c,
-    solanaRpcConfig,
-    solanaRpcHandler,
-    body,
+    async () => {
+      let body: ProxyRequestBody;
+      try {
+        body = (await c.req.json()) as ProxyRequestBody;
+      } catch {
+        return c.json({ error: "Invalid JSON" }, 400);
+      }
+      return {
+        config: solanaRpcConfig,
+        work: solanaRpcHandler,
+        body,
+      };
+    },
     { request },
   );
 });

--- a/packages/cloud/api/v1/proxy/solana-rpc/route.ts
+++ b/packages/cloud/api/v1/proxy/solana-rpc/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { Hono } from "hono";
-import { executeWithBody } from "@/lib/services/proxy/engine";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -45,7 +45,13 @@ app.post("/", async (c) => {
     headers,
   });
 
-  return executeWithBody(solanaRpcConfig, solanaRpcHandler, request, body);
+  return executeGuardedPaidProxyWithBody(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    body,
+    { request },
+  );
 });
 
 export default app;

--- a/packages/cloud/api/v1/rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/rpc/[chain]/route.ts
@@ -1,12 +1,10 @@
 // Handles v1 cloud API v1 rpc chain route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import {
-  getGenerativeExecutionContext,
-  requireGenerativeRouteCaller,
-} from "@/api-app/lib/generative-route-auth";
-import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
+  executeGuardedPaidProxyRequest,
+  withGuardedPaidProxyAdmission,
+} from "@/api-app/lib/guarded-paid-proxy";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { createHandler } from "@/lib/services/proxy/engine";
 import {
   isValidRpcChain,
   rpcConfigForChain,
@@ -30,48 +28,28 @@ async function __hono_POST(
 
   const chainIsValid = isValidRpcChain(normalized);
   const pendingResponse = !chainIsValid
-    ? applyCorsHeaders(
-        Response.json(
-          { error: "Unsupported chain", supported: [...SUPPORTED_RPC_CHAINS] },
-          { status: 400 },
-        ),
-        CORS_METHODS,
+    ? Response.json(
+        { error: "Unsupported chain", supported: [...SUPPORTED_RPC_CHAINS] },
+        { status: 400 },
       )
     : undefined;
 
-  const caller = await requireGenerativeRouteCaller(c, {
-    rateLimitEndpoint: "standard",
-    deferStrongCredentialCheck: chainIsValid,
-  });
-  await using credentialGuard = deferredCredentialAdmissionGuard({
-    organizationId: () => caller.user.organization_id,
-    credential: () => caller.credential,
-  });
-  if (pendingResponse) return pendingResponse;
-  if (!chainIsValid) throw new Error("Validated RPC chain was not retained");
-  const config = rpcConfigForChain(normalized);
-  const executionCtx = getGenerativeExecutionContext(c);
-  if (executionCtx && !caller.admissionSnapshot) {
+  if (pendingResponse) {
     return applyCorsHeaders(
-      Response.json(
-        { error: "Provider admission is unavailable; retry shortly" },
-        { status: 503, headers: { "Retry-After": "1" } },
-      ),
+      await withGuardedPaidProxyAdmission(c, async () => pendingResponse, {
+        deferStrongCredentialCheck: false,
+      }),
       CORS_METHODS,
     );
   }
-  const handler = createHandler(config, rpcHandlerForChain(normalized), {
-    auth: {
-      user: caller.user,
-      ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
-    },
-    admissionSnapshot: caller.admissionSnapshot,
-    credential: caller.credential,
-    credentialForAdmission: () => credentialGuard.credentialForAdmission(),
-    executionCtx,
-    requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
-  });
-  return applyCorsHeaders(await handler(c.req.raw), CORS_METHODS);
+  return applyCorsHeaders(
+    await executeGuardedPaidProxyRequest(
+      c,
+      rpcConfigForChain(normalized),
+      rpcHandlerForChain(normalized),
+    ),
+    CORS_METHODS,
+  );
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud/api/v1/solana/assets/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/assets/[address]/route.ts
@@ -13,7 +13,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   solanaRpcConfig,
@@ -29,39 +29,29 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
-  const { address } = await params;
-
-  // Validate Solana address format to prevent DoS and invalid requests
-  if (!isValidSolanaAddress(address)) {
-    const corsHeaders = getCorsHeaders("GET, OPTIONS");
-    return Response.json(
-      {
-        error: "Invalid Solana address",
-        details: "Address must be a valid base58-encoded public key",
-      },
-      { status: 400, headers: corsHeaders },
-    );
-  }
-
-  const body = {
-    jsonrpc: "2.0",
-    id: "eliza-cloud",
-    method: "getAssetsByOwner",
-    params: {
-      ownerAddress: address,
-      page: 1,
-      limit: 1000,
-    },
-  };
-
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
-
-  const response = await executeGuardedPaidProxyWithBody(
-    c,
-    solanaRpcConfig,
-    solanaRpcHandler,
-    body,
-  );
+  const response = await executeGuardedPaidProxyWithPreflight(c, async () => {
+    const { address } = await params;
+    if (!isValidSolanaAddress(address)) {
+      return Response.json(
+        {
+          error: "Invalid Solana address",
+          details: "Address must be a valid base58-encoded public key",
+        },
+        { status: 400 },
+      );
+    }
+    return {
+      config: solanaRpcConfig,
+      work: solanaRpcHandler,
+      body: {
+        jsonrpc: "2.0",
+        id: "eliza-cloud",
+        method: "getAssetsByOwner",
+        params: { ownerAddress: address, page: 1, limit: 1000 },
+      },
+    };
+  });
 
   for (const [key, value] of Object.entries(corsHeaders)) {
     response.headers.set(key, value);

--- a/packages/cloud/api/v1/solana/assets/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/assets/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 solana assets address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Solana Assets API - Get assets by owner address
@@ -13,8 +13,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -26,7 +26,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
   const { address } = await params;
@@ -56,31 +56,24 @@ async function __hono_GET(
 
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
 
-  try {
-    const response = await executeWithBody(
-      solanaRpcConfig,
-      solanaRpcHandler,
-      request,
-      body,
-    );
+  const response = await executeGuardedPaidProxyWithBody(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    body,
+  );
 
-    for (const [key, value] of Object.entries(corsHeaders)) {
-      response.headers.set(key, value);
-    }
-
-    return response;
-  } catch {
-    return new Response("Internal Server Error", {
-      status: 500,
-      headers: corsHeaders,
-    });
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value);
   }
+
+  return response;
 }
 
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({ address: c.req.param("address")! }),
   }),
 );

--- a/packages/cloud/api/v1/solana/rpc/route.ts
+++ b/packages/cloud/api/v1/solana/rpc/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { Hono } from "hono";
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -31,23 +31,25 @@ app.post("/", async (c) => {
     headers.set("authorization", `Bearer ${queryApiKey}`);
   }
 
-  let body: ProxyRequestBody;
-  try {
-    body = (await c.req.json()) as ProxyRequestBody;
-  } catch {
-    return c.json({ error: "Invalid JSON" }, 400);
-  }
-
   const request = new Request(c.req.url, {
     method: "POST",
     headers,
   });
-
-  return executeGuardedPaidProxyWithBody(
+  return executeGuardedPaidProxyWithPreflight(
     c,
-    solanaRpcConfig,
-    solanaRpcHandler,
-    body,
+    async () => {
+      let body: ProxyRequestBody;
+      try {
+        body = (await c.req.json()) as ProxyRequestBody;
+      } catch {
+        return c.json({ error: "Invalid JSON" }, 400);
+      }
+      return {
+        config: solanaRpcConfig,
+        work: solanaRpcHandler,
+        body,
+      };
+    },
     { request },
   );
 });

--- a/packages/cloud/api/v1/solana/rpc/route.ts
+++ b/packages/cloud/api/v1/solana/rpc/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { Hono } from "hono";
-import { executeWithBody } from "@/lib/services/proxy/engine";
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -43,7 +43,13 @@ app.post("/", async (c) => {
     headers,
   });
 
-  return executeWithBody(solanaRpcConfig, solanaRpcHandler, request, body);
+  return executeGuardedPaidProxyWithBody(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    body,
+    { request },
+  );
 });
 
 export default app;

--- a/packages/cloud/api/v1/solana/token-accounts/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/token-accounts/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 solana token accounts address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Solana Token Accounts API - Get token accounts by owner
@@ -13,8 +13,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -26,7 +26,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
   const { address } = await params;
@@ -54,31 +54,24 @@ async function __hono_GET(
 
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
 
-  try {
-    const response = await executeWithBody(
-      solanaRpcConfig,
-      solanaRpcHandler,
-      request,
-      body,
-    );
+  const response = await executeGuardedPaidProxyWithBody(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    body,
+  );
 
-    for (const [key, value] of Object.entries(corsHeaders)) {
-      response.headers.set(key, value);
-    }
-
-    return response;
-  } catch {
-    return new Response("Internal Server Error", {
-      status: 500,
-      headers: corsHeaders,
-    });
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value);
   }
+
+  return response;
 }
 
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({ address: c.req.param("address")! }),
   }),
 );

--- a/packages/cloud/api/v1/solana/token-accounts/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/token-accounts/[address]/route.ts
@@ -13,7 +13,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   solanaRpcConfig,
@@ -29,37 +29,29 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
-  const { address } = await params;
-
-  // Validate Solana address format to prevent DoS and invalid requests
-  if (!isValidSolanaAddress(address)) {
-    const corsHeaders = getCorsHeaders("GET, OPTIONS");
-    return Response.json(
-      {
-        error: "Invalid Solana address",
-        details: "Address must be a valid base58-encoded public key",
-      },
-      { status: 400, headers: corsHeaders },
-    );
-  }
-
-  const body = {
-    jsonrpc: "2.0",
-    id: "eliza-cloud",
-    method: "getTokenAccounts",
-    params: {
-      owner: address,
-    },
-  };
-
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
-
-  const response = await executeGuardedPaidProxyWithBody(
-    c,
-    solanaRpcConfig,
-    solanaRpcHandler,
-    body,
-  );
+  const response = await executeGuardedPaidProxyWithPreflight(c, async () => {
+    const { address } = await params;
+    if (!isValidSolanaAddress(address)) {
+      return Response.json(
+        {
+          error: "Invalid Solana address",
+          details: "Address must be a valid base58-encoded public key",
+        },
+        { status: 400 },
+      );
+    }
+    return {
+      config: solanaRpcConfig,
+      work: solanaRpcHandler,
+      body: {
+        jsonrpc: "2.0",
+        id: "eliza-cloud",
+        method: "getTokenAccounts",
+        params: { owner: address },
+      },
+    };
+  });
 
   for (const [key, value] of Object.entries(corsHeaders)) {
     response.headers.set(key, value);

--- a/packages/cloud/api/v1/solana/transactions/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/transactions/[address]/route.ts
@@ -13,7 +13,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
-import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
+import { executeGuardedPaidProxyWithPreflight } from "@/api-app/lib/guarded-paid-proxy";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   solanaRpcConfig,
@@ -29,36 +29,28 @@ async function __hono_GET(
   c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
-  const { address } = await params;
-
-  if (!isValidSolanaAddress(address)) {
-    return Response.json(
-      {
-        error: "Invalid Solana address",
-        details: "Address must be a valid base58-encoded public key",
+  const response = await executeGuardedPaidProxyWithPreflight(c, async () => {
+    const { address } = await params;
+    if (!isValidSolanaAddress(address)) {
+      return Response.json(
+        {
+          error: "Invalid Solana address",
+          details: "Address must be a valid base58-encoded public key",
+        },
+        { status: 400 },
+      );
+    }
+    return {
+      config: solanaRpcConfig,
+      work: solanaRpcHandler,
+      body: {
+        jsonrpc: "2.0",
+        id: "eliza-cloud",
+        method: "getTransactionsForAddress",
+        params: { address },
       },
-      {
-        status: 400,
-        headers: getCorsHeaders("GET, OPTIONS"),
-      },
-    );
-  }
-
-  const body = {
-    jsonrpc: "2.0",
-    id: "eliza-cloud",
-    method: "getTransactionsForAddress",
-    params: {
-      address,
-    },
-  };
-
-  const response = await executeGuardedPaidProxyWithBody(
-    c,
-    solanaRpcConfig,
-    solanaRpcHandler,
-    body,
-  );
+    };
+  });
 
   const corsHeaders = getCorsHeaders("GET, OPTIONS");
   for (const [key, value] of Object.entries(corsHeaders)) {

--- a/packages/cloud/api/v1/solana/transactions/[address]/route.ts
+++ b/packages/cloud/api/v1/solana/transactions/[address]/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 solana transactions address route traffic with route-local auth expectations.
 import { Hono } from "hono";
 
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * Solana Transactions API - Get transactions by address
@@ -13,8 +13,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Rate Limiting: Per API key
  */
 
+import { executeGuardedPaidProxyWithBody } from "@/api-app/lib/guarded-paid-proxy";
 import { getCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { executeWithBody } from "@/lib/services/proxy/engine";
 import {
   solanaRpcConfig,
   solanaRpcHandler,
@@ -26,7 +26,7 @@ async function __hono_OPTIONS() {
 }
 
 async function __hono_GET(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ address: string }> },
 ) {
   const { address } = await params;
@@ -53,32 +53,25 @@ async function __hono_GET(
     },
   };
 
-  try {
-    const response = await executeWithBody(
-      solanaRpcConfig,
-      solanaRpcHandler,
-      request,
-      body,
-    );
+  const response = await executeGuardedPaidProxyWithBody(
+    c,
+    solanaRpcConfig,
+    solanaRpcHandler,
+    body,
+  );
 
-    const corsHeaders = getCorsHeaders("GET, OPTIONS");
-    for (const [key, value] of Object.entries(corsHeaders)) {
-      response.headers.set(key, value);
-    }
-
-    return response;
-  } catch {
-    return new Response("Internal Server Error", {
-      status: 500,
-      headers: getCorsHeaders("GET, OPTIONS"),
-    });
+  const corsHeaders = getCorsHeaders("GET, OPTIONS");
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value);
   }
+
+  return response;
 }
 
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", async () => __hono_OPTIONS());
 __hono_app.get("/", async (c) =>
-  __hono_GET(c.req.raw, {
+  __hono_GET(c, {
     params: Promise.resolve({ address: c.req.param("address")! }),
   }),
 );

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.test.ts
@@ -421,6 +421,28 @@ test("warm Worker admission writes only the Durable Object lease before provider
   expect(settleInferenceAdmissionLease.mock.calls[0]?.[1]).toBe(0.01);
 });
 
+test("strong proof on and off each acquire exactly one Durable Object lease", async () => {
+  const model = nextModel();
+  await hydratePricing(model);
+  const credential = {
+    kind: "api_key" as const,
+    credentialId: "key-1",
+    userId: "user-1",
+  };
+
+  for (const strongProof of [credential, undefined]) {
+    acquireInferenceAdmissionLease.mockClear();
+    await admitOrganizationInference({
+      ...admissionParams(model, []),
+      ...(strongProof ? { credential: strongProof } : {}),
+    });
+
+    expect(acquireInferenceAdmissionLease).toHaveBeenCalledTimes(1);
+    expect(acquireInferenceAdmissionLease.mock.calls[0]?.[0].credential).toEqual(strongProof);
+  }
+  expect(reserveCredits).not.toHaveBeenCalled();
+});
+
 test("flat Worker admission leases the fixed catalog cost without token pricing reads", async () => {
   const background: Promise<unknown>[] = [];
   const flatCost = {

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.combined-admission.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Proves the canonical Birdeye route hands its single standing decision to the
+ * proxy engine without invoking the legacy auth or direct-debit path.
+ */
+
+import { expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+
+const executeWithBody = mock(async () => Response.json({ ok: true }));
+const legacyAuth = mock(async () => {
+  throw new Error("legacy auth must not run");
+});
+const directDebit = mock(async () => {
+  throw new Error("direct debit must not run");
+});
+
+mock.module("./engine", () => ({ executeWithBody }));
+mock.module("../../auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: legacyAuth,
+}));
+mock.module("../credits", () => ({
+  creditsService: { deductCredits: directDebit },
+}));
+
+const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
+
+test("combined Birdeye handling forwards admission without legacy standing or debit", async () => {
+  const request = new Request("https://api.test/api/v1/apis/birdeye/defi/price?address=token");
+  const c = {
+    req: {
+      raw: request,
+      url: request.url,
+      param: (name: string) => (name === "*" ? "defi/price" : undefined),
+      header: () => undefined,
+    },
+    env: { BIRDEYE_API_KEY: "configured" },
+    json: (body: unknown, status = 200) => Response.json(body, { status }),
+  } as unknown as Context<AppEnv>;
+  const admission = {
+    mode: "combined" as const,
+    auth: {
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKey: { id: "key-1" },
+    },
+    requestId: "birdeye-1",
+    admissionSnapshot: {
+      balance: {
+        balanceUsd: 10,
+        balanceAt: Date.now(),
+        balanceRevision: "5",
+      },
+      rateLimits: {
+        completionsRpm: 10,
+        embeddingsRpm: 10,
+        standardRpm: 10,
+        strictRpm: 10,
+      },
+    },
+    executionCtx: { waitUntil: () => undefined },
+  };
+
+  const response = await handleBirdeyeMarketDataProxyGet(c, admission);
+
+  expect(response.status).toBe(200);
+  expect(executeWithBody).toHaveBeenCalledTimes(1);
+  expect(executeWithBody.mock.calls[0]?.[3]).toEqual({
+    method: "getPrice",
+    path: "defi/price",
+  });
+  expect(executeWithBody.mock.calls[0]?.[4]).toBe(admission);
+  expect(legacyAuth).not.toHaveBeenCalled();
+  expect(directDebit).not.toHaveBeenCalled();
+});

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
@@ -1,166 +1,72 @@
 /**
- * Error-policy proof for the Birdeye market-data proxy handler (#13415).
- *
- * Pins that a designed-invalid / not-configured result stays visually distinct
- * from an internal failure, and that an internal failure PROPAGATES through the
- * J1 route boundary (`failureResponse`) as a structured `{ success: false }`
- * rather than being swallowed into a fabricated 2xx/empty body. The auth,
- * pricing, and credits boundaries plus `fetch` are mocked; `failureResponse`
- * runs for real so the boundary translation is the unit under test. mock.module
- * is process-global but the suite runs under `bun test --isolate`, so each file
- * gets a fresh registry.
+ * Proves designed Birdeye route failures remain explicit and that the shared
+ * paid engine's failure response is returned without fabricating success.
  */
 
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, expect, mock, test } from "bun:test";
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
-import * as authActual from "../../auth/workers-hono-auth";
-import * as creditsActual from "../credits";
-import * as pricingActual from "./pricing";
 
-const realCredits = { ...creditsActual };
-const realPricing = { ...pricingActual };
-const realAuth = { ...authActual };
-
-const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
-const COST = 0.0003;
-
-const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
-const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
-const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
-const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
-
-mock.module("../credits", () => ({
-  ...realCredits,
-  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
-}));
-
-mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
-
-mock.module("../../auth/workers-hono-auth", () => ({
-  ...realAuth,
-  requireUserOrApiKeyWithOrg,
-}));
+const executeWithBody = mock();
+mock.module("./engine", () => ({ executeWithBody }));
 
 const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
 
-const originalFetch = globalThis.fetch;
+const admission = {
+  mode: "compatibility" as const,
+  auth: {
+    user: {
+      id: "user-1",
+      organization_id: "00000000-0000-4000-8000-0000000000aa",
+    },
+  },
+  requestId: "birdeye-errors",
+};
 
-function makeContext(path: string, env: Record<string, unknown> = {}): Context<AppEnv> {
+function makeContext(path: string, env: Record<string, unknown>): Context<AppEnv> {
   const url = `https://api.elizacloud.ai/proxy/${path}`;
+  const raw = new Request(url);
   return {
     env,
     req: {
+      raw,
       param: (key: string) => (key === "*" ? path : undefined),
       url,
-      header: (_name: string) => undefined,
+      header: () => undefined,
     },
     json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
   } as unknown as Context<AppEnv>;
 }
 
-function mockUpstream(status: number, body = "{}") {
-  globalThis.fetch = mock(
-    async () => new Response(body, { status, headers: { "Content-Type": "application/json" } }),
-  ) as unknown as typeof fetch;
-}
+beforeEach(() => executeWithBody.mockReset());
 
-beforeEach(() => {
-  deductCredits.mockReset();
-  refundCredits.mockReset();
-  getServiceMethodCost.mockReset();
-  requireUserOrApiKeyWithOrg.mockReset();
-  deductCredits.mockResolvedValue({ success: true });
-  refundCredits.mockResolvedValue({ success: true });
-  getServiceMethodCost.mockResolvedValue(COST);
-  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
-  mockUpstream(200, '{"data":{"value":1}}');
+test("unpriced path is a designed 400 before provider admission", async () => {
+  const response = await handleBirdeyeMarketDataProxyGet(
+    makeContext("defi/not_a_real_path", { BIRDEYE_API_KEY: "key" }),
+    admission,
+  );
+
+  expect(response.status).toBe(400);
+  expect(executeWithBody).not.toHaveBeenCalled();
 });
 
-afterEach(() => {
-  globalThis.fetch = originalFetch;
+test("missing provider configuration is a designed 503 before dispatch", async () => {
+  const response = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price", {}), admission);
+
+  expect(response.status).toBe(503);
+  expect(executeWithBody).not.toHaveBeenCalled();
 });
 
-afterAll(() => {
-  mock.module("../credits", () => realCredits);
-  mock.module("./pricing", () => realPricing);
-  mock.module("../../auth/workers-hono-auth", () => realAuth);
-});
+test("shared engine failure stays a visible non-success response", async () => {
+  executeWithBody.mockResolvedValueOnce(
+    Response.json({ error: "Upstream service error" }, { status: 502 }),
+  );
+  const response = await handleBirdeyeMarketDataProxyGet(
+    makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    admission,
+  );
 
-describe("birdeye proxy — designed-invalid results stay distinct from failures", () => {
-  test("unpriced path is a designed 400 reject, not a boundary failure", async () => {
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/not_a_real_path", { BIRDEYE_API_KEY: "key" }),
-    );
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string; supportedPaths: string[] };
-    expect(body.error).toContain("Unpriced Birdeye proxy path");
-    expect(Array.isArray(body.supportedPaths)).toBe(true);
-    // Short-circuits BEFORE any auth / billing work.
-    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
-    expect(deductCredits).not.toHaveBeenCalled();
-  });
-
-  test("missing BIRDEYE_API_KEY is a designed 503 not-configured, no debit", async () => {
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price", {}));
-    expect(res.status).toBe(503);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("server misconfigured");
-    expect(deductCredits).not.toHaveBeenCalled();
-  });
-});
-
-describe("birdeye proxy — internal failures propagate through the J1 boundary", () => {
-  test("a pricing-store failure surfaces as a structured 5xx, never a fake 2xx", async () => {
-    getServiceMethodCost.mockRejectedValue(new Error("pricing store unavailable"));
-
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-
-    expect(res.status).toBe(500);
-    const body = (await res.json()) as { success: boolean };
-    expect(body.success).toBe(false);
-    // The failure aborts before any debit — nothing charged for a broken call.
-    expect(deductCredits).not.toHaveBeenCalled();
-  });
-
-  test("an auth failure is translated, not swallowed into a healthy response", async () => {
-    requireUserOrApiKeyWithOrg.mockRejectedValue(new Error("token verification failed"));
-
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-
-    expect(res.ok).toBe(false);
-    const body = (await res.json()) as { success: boolean };
-    expect(body.success).toBe(false);
-    expect(deductCredits).not.toHaveBeenCalled();
-  });
-});
-
-describe("birdeye proxy — money-path debit failures stay distinct", () => {
-  // Designed insufficient balance is a user-facing 402. A thrown debit failure
-  // is an internal ledger failure and must go through the route boundary as a
-  // structured 5xx, never the same 402 as a legitimate empty balance.
-  test("designed insufficient balance returns 402", async () => {
-    deductCredits.mockResolvedValue({ success: false });
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-    expect(res.status).toBe(402);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("Insufficient credits");
-  });
-
-  test("an internal debit failure surfaces as a structured 5xx", async () => {
-    deductCredits.mockRejectedValue(new Error("credits ledger write failed"));
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-    expect(res.status).toBe(500);
-    const body = (await res.json()) as { success: boolean; error: string };
-    expect(body.success).toBe(false);
-    expect(body.error).toBe("An unexpected error occurred");
-  });
+  expect(response.status).toBe(502);
+  expect(response.ok).toBe(false);
+  expect(executeWithBody).toHaveBeenCalledTimes(1);
 });

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
@@ -1,36 +1,32 @@
 /**
- * Covers Birdeye proxy deadlines and credit refunds with deterministic upstream mocks.
+ * Covers Birdeye proxy deadlines and credit reconciliation with deterministic upstream mocks.
  * The harness exercises failures during both fetch and response-body consumption.
  */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
-import * as authActual from "../../auth/workers-hono-auth";
 import * as creditsActual from "../credits";
 import * as pricingActual from "./pricing";
 
 const realCredits = { ...creditsActual };
 const realPricing = { ...pricingActual };
-const realAuth = { ...authActual };
 
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
 const COST = 0.0003;
 
-const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
-const refundCredits = mock<(args: unknown) => Promise<unknown>>();
+const reconcile = mock<(actualCost: number) => Promise<unknown>>();
+const reserve = mock(async () => ({ reconcile }));
 const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
-const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
 
 mock.module("../credits", () => ({
   ...realCredits,
-  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
+  creditsService: { ...realCredits.creditsService, reserve },
 }));
 
 mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
 
-mock.module("../../auth/workers-hono-auth", () => ({
-  ...realAuth,
-  requireUserOrApiKeyWithOrg,
+mock.module("../usage", () => ({
+  usageService: { create: mock(async () => undefined) },
 }));
 
 const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
@@ -39,11 +35,13 @@ const originalFetch = globalThis.fetch;
 
 function makeContext(path: string): Context<AppEnv> {
   const url = `https://api.elizacloud.ai/proxy/${path}`;
+  const raw = new Request(url);
   return {
     env: { BIRDEYE_API_KEY: "key" } as unknown as AppEnv["Bindings"],
     req: {
       param: (key: string) => (key === "*" ? path : undefined),
       url,
+      raw,
       header: (_name: string) => undefined,
     },
     json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
@@ -51,14 +49,11 @@ function makeContext(path: string): Context<AppEnv> {
 }
 
 beforeEach(() => {
-  deductCredits.mockReset();
-  refundCredits.mockReset();
+  reserve.mockClear();
+  reconcile.mockReset();
   getServiceMethodCost.mockReset();
-  requireUserOrApiKeyWithOrg.mockReset();
-  deductCredits.mockResolvedValue({ success: true });
-  refundCredits.mockResolvedValue({ success: true });
+  reconcile.mockResolvedValue(null);
   getServiceMethodCost.mockResolvedValue(COST);
-  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
 });
 
 afterEach(() => {
@@ -68,30 +63,30 @@ afterEach(() => {
 afterAll(() => {
   mock.module("../credits", () => realCredits);
   mock.module("./pricing", () => realPricing);
-  mock.module("../../auth/workers-hono-auth", () => realAuth);
 });
 
-describe("birdeye proxy — timeout covers fetch+body and transport refunds", () => {
-  test("AbortError during fetch refunds once and returns 504", async () => {
+const admission = {
+  mode: "compatibility" as const,
+  auth: { user: { id: "user-1", organization_id: ORG_ID } },
+  requestId: "birdeye-timeout",
+};
+
+describe("birdeye proxy — timeout covers fetch+body and async-safe reconciliation", () => {
+  test("AbortError during fetch reconciles to zero once and returns 504", async () => {
     globalThis.fetch = mock(async () => {
       const err = new Error("This operation was aborted");
       err.name = "AbortError";
       throw err;
     }) as unknown as typeof fetch;
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"), admission);
     expect(res.status).toBe(504);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("timeout");
-    expect(refundCredits).toHaveBeenCalledTimes(1);
-    const args = refundCredits.mock.calls[0]?.[0] as {
-      organizationId: string;
-      amount: number;
-    };
-    expect(args.organizationId).toBe(ORG_ID);
-    expect(args.amount).toBe(COST);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(0);
   });
 
-  test("AbortError during body read (stalled body) refunds once and returns 504", async () => {
+  test("AbortError during body read reconciles to zero once and returns 504", async () => {
     globalThis.fetch = mock(
       async () =>
         new Response("{}", {
@@ -107,42 +102,42 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
       throw err;
     }) as unknown as typeof Response.prototype.text;
     try {
-      const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+      const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"), admission);
       expect(res.status).toBe(504);
-      expect(refundCredits).toHaveBeenCalledTimes(1);
+      expect(reconcile).toHaveBeenCalledWith(0);
     } finally {
       Response.prototype.text = originalText;
     }
   });
 
-  test("non-Abort transport failure refunds once and returns 502", async () => {
+  test("non-Abort transport failure reconciles to zero once and returns 502", async () => {
     globalThis.fetch = mock(async () => {
       throw new TypeError("fetch failed: DNS error");
     }) as unknown as typeof fetch;
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"), admission);
     expect(res.status).toBe(502);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(0);
   });
 
-  test("upstream 5xx refunds once and forwards status", async () => {
+  test("upstream 5xx reconciles to zero once and forwards status", async () => {
     globalThis.fetch = mock(
       async () =>
         new Response("upstream down", { status: 502, headers: { "Content-Type": "text/plain" } }),
     ) as unknown as typeof fetch;
-    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"), admission);
     expect(res.status).toBe(502);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(0);
   });
 
-  test("success 200 and 4xx do not refund", async () => {
+  test("success 200 and paid-upstream 4xx reconcile the priced cost", async () => {
     globalThis.fetch = mock(
       async () =>
         new Response('{"ok":1}', { status: 200, headers: { "Content-Type": "application/json" } }),
     ) as unknown as typeof fetch;
-    let res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    let res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"), admission);
     expect(res.status).toBe(200);
-    expect(refundCredits).not.toHaveBeenCalled();
-    refundCredits.mockReset();
+    expect(reconcile).toHaveBeenCalledWith(COST);
+    reconcile.mockClear();
     globalThis.fetch = mock(
       async () =>
         new Response('{"error":"bad"}', {
@@ -150,8 +145,8 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
           headers: { "Content-Type": "application/json" },
         }),
     ) as unknown as typeof fetch;
-    res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"), admission);
     expect(res.status).toBe(400);
-    expect(refundCredits).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledWith(COST);
   });
 });

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -6,10 +6,10 @@
 import type { Context } from "hono";
 import type { AppEnv } from "../../../types/cloud-worker-env";
 import { failureResponse } from "../../api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "../../auth/workers-hono-auth";
 import { logger } from "../../utils/logger";
-import { creditsService } from "../credits";
+import { executeWithBody, type ProxyCombinedAdmission } from "./engine";
 import { getServiceMethodCost } from "./pricing";
+import type { ServiceConfig, ServiceHandler } from "./types";
 
 const BIRDEYE_BASE = "https://public-api.birdeye.so";
 
@@ -32,9 +32,87 @@ export const BIRDEYE_PRICED_PATHS: Record<string, string> = {
   "v1/wallet/tx_list": "getWalletTxList",
 };
 
-export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promise<Response> {
+const combinedBirdeyeConfig: ServiceConfig = {
+  id: "market-data",
+  name: "Birdeye market data proxy",
+  auth: "apiKeyWithOrg",
+  getCost: async (body) => {
+    if (!body || Array.isArray(body) || typeof body !== "object") {
+      throw new Error("Invalid Birdeye proxy request");
+    }
+    const method = "method" in body ? String(body.method) : "";
+    return getServiceMethodCost("market-data", method);
+  },
+};
+
+function createCombinedBirdeyeHandler(
+  c: Context<AppEnv>,
+  pathStr: string,
+  birdeyeApiKey: string,
+): ServiceHandler {
+  return async () => {
+    const upstreamUrl = new URL(`${BIRDEYE_BASE}/${pathStr}`);
+    const requestUrl = new URL(c.req.url);
+    requestUrl.searchParams.forEach((value, key) => {
+      upstreamUrl.searchParams.set(key, value);
+    });
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const upstreamResponse = await fetch(upstreamUrl.toString(), {
+        headers: {
+          Accept: "application/json",
+          "x-chain": c.req.header("x-chain") ?? "solana",
+          "X-API-KEY": birdeyeApiKey,
+        },
+        signal: controller.signal,
+      });
+      const body = await upstreamResponse.text();
+      return {
+        response: new Response(body, {
+          status: upstreamResponse.status,
+          headers: {
+            "Content-Type": upstreamResponse.headers.get("Content-Type") ?? "application/json",
+          },
+        }),
+        ...(upstreamResponse.status >= 500 ? { actualCost: 0 } : {}),
+      };
+    } catch (error) {
+      // error-policy:J1 the paid proxy boundary returns an explicit upstream
+      // failure while the engine asynchronously reconciles the admission to 0.
+      const isAbort = error instanceof Error && error.name === "AbortError";
+      logger.warn("[BirdeyeProxy] upstream dispatch failed", {
+        path: pathStr,
+        kind: isAbort ? "timeout" : "transport",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        response: Response.json(
+          {
+            error: isAbort ? "Upstream service timeout" : "Upstream service unavailable",
+          },
+          { status: isAbort ? 504 : 502 },
+        ),
+        actualCost: 0,
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
+}
+
+export async function handleBirdeyeMarketDataProxyGet(
+  c: Context<AppEnv>,
+  combinedAdmission: ProxyCombinedAdmission,
+): Promise<Response> {
   try {
-    const pathStr = (c.req.param("*") ?? "").replace(/^\/+|\/+$/g, "");
+    const routePath = c.req.param("*");
+    const pathStr = (
+      routePath && routePath.length > 0
+        ? routePath
+        : new URL(c.req.url).pathname.replace(/^\/api\/v1\/apis\/birdeye\/?/, "")
+    ).replace(/^\/+|\/+$/g, "");
     const pricedMethod = BIRDEYE_PRICED_PATHS[pathStr];
     if (!pricedMethod) {
       return c.json(
@@ -46,127 +124,19 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
       );
     }
 
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const { organization_id } = user;
-
     const birdeyeApiKey = c.env.BIRDEYE_API_KEY as string | undefined;
     if (!birdeyeApiKey) {
       logger.error("BIRDEYE_API_KEY not configured on cloud server");
       return c.json({ error: "Birdeye proxy not available — server misconfigured" }, 503);
     }
 
-    const cost = await getServiceMethodCost("market-data", pricedMethod);
-    const deductResult = await creditsService.deductCredits({
-      organizationId: organization_id,
-      amount: cost,
-      description: `API proxy: market-data — ${pricedMethod}`,
-      metadata: {
-        type: "proxy_market-data",
-        service: "market-data",
-        provider: "birdeye",
-        method: pricedMethod,
-        path: pathStr,
-      },
-    });
-
-    if (!deductResult.success) {
-      return c.json(
-        {
-          error: "Insufficient credits",
-          topUpUrl: "https://cloud.eliza.app/cloud/settings?tab=billing",
-        },
-        402,
-      );
-    }
-
-    const upstreamUrl = new URL(`${BIRDEYE_BASE}/${pathStr}`);
-    const url = new URL(c.req.url);
-    url.searchParams.forEach((value, key) => {
-      upstreamUrl.searchParams.set(key, value);
-    });
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
-    let upstreamResponse: Response;
-    let body: string;
-    try {
-      upstreamResponse = await fetch(upstreamUrl.toString(), {
-        headers: {
-          Accept: "application/json",
-          "x-chain": c.req.header("x-chain") ?? "solana",
-          "X-API-KEY": birdeyeApiKey,
-        },
-        signal: controller.signal,
-      });
-      body = await upstreamResponse.text();
-    } catch (error) {
-      // error-policy:J1 upstream boundary — transport and deadline failures
-      // become explicit 502/504 responses after the prepaid cost is refunded.
-      const isAbort = error instanceof Error && error.name === "AbortError";
-      await creditsService
-        .refundCredits({
-          organizationId: organization_id,
-          amount: cost,
-          description: `API proxy refund: market-data — ${pricedMethod} (${isAbort ? "upstream timeout" : "upstream transport failure"})`,
-          metadata: {
-            type: "proxy_market-data_refund",
-            service: "market-data",
-            provider: "birdeye",
-            method: pricedMethod,
-          },
-        })
-        .catch((refundError) => {
-          // error-policy:J4 the upstream request is already a visible failure;
-          // preserve that response while recording the secondary refund fault.
-          logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
-            method: pricedMethod,
-            error: refundError instanceof Error ? refundError.message : String(refundError),
-          });
-        });
-      if (isAbort) {
-        return c.json({ error: "Upstream service timeout" }, 504);
-      }
-      return c.json({ error: "Upstream service unavailable" }, 502);
-    } finally {
-      clearTimeout(timeoutId);
-    }
-
-    // Mirror the engine's billing policy (resolveBillableCost refunds on >=500):
-    // we already debited `cost` upfront, so refund it when the upstream FAILS
-    // server-side (Birdeye 5xx outage) — the customer got no usable response. We
-    // keep the charge on 4xx (the customer's own bad request still consumed our
-    // Birdeye quota). Engine-backed market-data routes already refund; this
-    // direct handler must match.
-    if (upstreamResponse.status >= 500) {
-      await creditsService
-        .refundCredits({
-          organizationId: organization_id,
-          amount: cost,
-          description: `API proxy refund: market-data — ${pricedMethod} (upstream ${upstreamResponse.status})`,
-          metadata: {
-            type: "proxy_market-data_refund",
-            service: "market-data",
-            provider: "birdeye",
-            method: pricedMethod,
-          },
-        })
-        .catch((refundError) => {
-          // error-policy:J4 the upstream 5xx remains visible to the caller;
-          // preserve it while recording the secondary refund fault.
-          logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
-            method: pricedMethod,
-            status: upstreamResponse.status,
-            error: refundError instanceof Error ? refundError.message : String(refundError),
-          });
-        });
-    }
-
-    return new Response(body, {
-      status: upstreamResponse.status,
-      headers: {
-        "Content-Type": upstreamResponse.headers.get("Content-Type") ?? "application/json",
-      },
-    });
+    return executeWithBody(
+      combinedBirdeyeConfig,
+      createCombinedBirdeyeHandler(c, pathStr, birdeyeApiKey),
+      c.req.raw,
+      { method: pricedMethod, path: pathStr },
+      combinedAdmission,
+    );
   } catch (error) {
     // error-policy:J1 route boundary — translate any handler throw (auth
     // rejection, pricing lookup, upstream fetch) into a structured failure

--- a/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
@@ -1,36 +1,62 @@
 /**
- * Proves the generic RPC proxy consumes one pre-resolved standing/admission
- * snapshot, marks immediately before provider dispatch, and retains settlement
- * asynchronously without a second auth or balance-cache read.
+ * Proves the generic paid proxy engine consumes a pre-resolved combined
+ * admission, marks before dispatch, and retains exactly one async settlement.
  */
 
-import { afterAll, beforeEach, expect, mock, test } from "bun:test";
-import * as authActual from "../../auth";
-import * as creditsActual from "../credits";
+import { beforeEach, expect, mock, test } from "bun:test";
 import { InferenceCredentialRevokedError } from "../inference-credential-revocation";
-import * as admissionActual from "../organization-inference-admission";
 import type { ServiceConfig } from "./types";
 
-const realAuth = { ...authActual };
-const realAdmission = { ...admissionActual };
 const legacyAuth = mock(async () => {
   throw new Error("legacy auth must not run");
 });
-const admit = mock<typeof admissionActual.admitOrganizationInference>();
+const genericReserve = mock(async () => {
+  throw new Error("generic reserve must not run");
+});
+const admit = mock();
+const proxyCacheGet = mock();
+const proxyCacheSet = mock();
+const rateLimitWrap = mock((handler: unknown) => handler);
+
+class TestInsufficientCreditsError extends Error {
+  constructor(
+    readonly required: number,
+    readonly available: number,
+  ) {
+    super("Insufficient credits");
+  }
+}
 
 mock.module("../../auth", () => ({
-  ...realAuth,
   requireAuth: legacyAuth,
   requireAuthOrApiKey: legacyAuth,
   requireAuthOrApiKeyWithOrg: legacyAuth,
   requireAuthWithOrg: legacyAuth,
 }));
+mock.module("../credits", () => ({
+  creditsService: { reserve: genericReserve },
+  InsufficientCreditsError: TestInsufficientCreditsError,
+}));
 mock.module("../organization-inference-admission", () => ({
-  ...realAdmission,
   admitOrganizationInference: admit,
 }));
+mock.module("../../cache/client", () => ({
+  cache: { get: proxyCacheGet, set: proxyCacheSet },
+}));
+mock.module("../usage", () => ({
+  usageService: { create: mock(async () => undefined) },
+}));
+mock.module("../../middleware/rate-limit", () => ({
+  withRateLimit: rateLimitWrap,
+}));
+mock.module("./pricing", () => ({
+  PricingNotFoundError: class PricingNotFoundError extends Error {},
+}));
 
-const { createHandler } = await import("./engine");
+const [{ InferenceBalanceCacheWarmingError }, { createHandler }] = await Promise.all([
+  import("../inference-billing-fast-path"),
+  import("./engine"),
+]);
 
 const config: ServiceConfig = {
   id: "evm-rpc",
@@ -50,15 +76,14 @@ const snapshot = {
 
 beforeEach(() => {
   legacyAuth.mockClear();
+  genericReserve.mockClear();
   admit.mockReset();
+  proxyCacheGet.mockClear();
+  proxyCacheSet.mockClear();
+  rateLimitWrap.mockClear();
 });
 
-afterAll(() => {
-  mock.module("../../auth", () => realAuth);
-  mock.module("../organization-inference-admission", () => realAdmission);
-});
-
-test("combined RPC admission orders mark before dispatch and defers settlement", async () => {
+test("combined admission orders mark before dispatch and returns before settlement", async () => {
   const credential = {
     kind: "api_key" as const,
     credentialId: "key-1",
@@ -83,19 +108,21 @@ test("combined RPC admission orders mark before dispatch and defers settlement",
     settleUnknown: settle,
   });
   const retained: Promise<unknown>[] = [];
-  const work = mock(async () => {
+  const work = mock(async ({ auth }) => {
+    expect(auth.apiKey?.id).toBe("key-1");
     order.push("dispatch");
     return { response: Response.json({ ok: true }) };
   });
   const handler = createHandler(config, work, {
+    mode: "combined",
     auth: {
       user: { id: "user-1", organization_id: "org-1" },
       apiKey: { id: "key-1" },
     },
     admissionSnapshot: snapshot,
-    credential,
     executionCtx: { waitUntil: (promise) => retained.push(promise) },
     requestId: "rpc-1",
+    credentialForAdmission: () => credential,
   });
 
   const response = await handler(
@@ -108,18 +135,64 @@ test("combined RPC admission orders mark before dispatch and defers settlement",
   expect(response.status).toBe(200);
   expect(order).toEqual(["mark", "dispatch", "settle"]);
   expect(legacyAuth).not.toHaveBeenCalled();
+  expect(genericReserve).not.toHaveBeenCalled();
   expect(admit).toHaveBeenCalledTimes(1);
+  expect(admit.mock.calls[0]?.[0].apiKeyId).toBe("key-1");
   expect(admit.mock.calls[0]?.[0].admissionSnapshot).toBe(snapshot);
   expect(admit.mock.calls[0]?.[0].credential).toBe(credential);
+  expect(settle).toHaveBeenCalledTimes(1);
+  expect(proxyCacheGet).not.toHaveBeenCalled();
+  expect(proxyCacheSet).not.toHaveBeenCalled();
   expect(retained).toHaveLength(1);
   finishSettlement?.();
   await Promise.all(retained);
 });
 
-test("combined RPC admission denial performs zero provider dispatch", async () => {
-  admit.mockRejectedValueOnce(new creditsActual.InsufficientCreditsError(0.25, 0));
+test("combined warming failure is a sanitized retryable 503 before provider dispatch", async () => {
+  admit.mockRejectedValueOnce(new InferenceBalanceCacheWarmingError());
   const work = mock(async () => ({ response: new Response("not reached") }));
   const handler = createHandler(config, work, {
+    mode: "combined",
+    auth: { user: { id: "user-1", organization_id: "org-1" } },
+    admissionSnapshot: snapshot,
+    executionCtx: { waitUntil: () => undefined },
+    requestId: "rpc-warming",
+  });
+
+  const response = await handler(
+    new Request("https://api.test/api/v1/rpc/ethereum", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", id: 1 }),
+    }),
+  );
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("Retry-After")).toBe("1");
+  expect(await response.json()).toEqual({
+    success: false,
+    error: "Provider admission is unavailable; retry shortly",
+    code: "service_unavailable",
+    details: { retryable: true, retryAfterSeconds: 1 },
+  });
+  expect(work).not.toHaveBeenCalled();
+  expect(genericReserve).not.toHaveBeenCalled();
+});
+
+test("explicit local compatibility retains the configured proxy limiter", () => {
+  createHandler({ ...config, rateLimit: { windowMs: 60_000, maxRequests: 10 } }, mock(), {
+    mode: "compatibility",
+    auth: { user: { id: "user-1", organization_id: "org-1" } },
+    requestId: "local-compatibility",
+  });
+
+  expect(rateLimitWrap).toHaveBeenCalledTimes(1);
+});
+
+test("combined admission denial performs zero provider dispatch", async () => {
+  admit.mockRejectedValueOnce(new TestInsufficientCreditsError(0.25, 0));
+  const work = mock(async () => ({ response: new Response("not reached") }));
+  const handler = createHandler(config, work, {
+    mode: "combined",
     auth: { user: { id: "user-1", organization_id: "org-1" } },
     admissionSnapshot: snapshot,
     executionCtx: { waitUntil: () => undefined },
@@ -136,12 +209,14 @@ test("combined RPC admission denial performs zero provider dispatch", async () =
   expect(response.status).toBe(402);
   expect(work).not.toHaveBeenCalled();
   expect(legacyAuth).not.toHaveBeenCalled();
+  expect(genericReserve).not.toHaveBeenCalled();
 });
 
 test("combined credential denial is a safe standing response with zero dispatch", async () => {
   admit.mockRejectedValueOnce(new InferenceCredentialRevokedError("session_binding_revoked"));
   const work = mock(async () => ({ response: new Response("not reached") }));
   const handler = createHandler(config, work, {
+    mode: "combined",
     auth: { user: { id: "user-1", organization_id: "org-1" } },
     admissionSnapshot: snapshot,
     credential: {

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -12,8 +12,10 @@ import { withRateLimit } from "../../middleware/rate-limit";
 import { logger } from "../../utils/logger";
 import { creditsService, InsufficientCreditsError } from "../credits";
 import type { InferenceAdmissionSnapshot } from "../inference-auth-cache";
+import { InferenceBalanceCacheWarmingError } from "../inference-billing-fast-path";
 import {
   type InferenceCredentialCheck,
+  InferenceCredentialRevocationUnavailableError,
   InferenceCredentialRevokedError,
   inferenceCredentialRevocationReason,
 } from "../inference-credential-revocation";
@@ -36,17 +38,31 @@ type CachedProxyResponse = {
   ttl?: number;
 };
 
-export interface ProxyCombinedAdmission {
+interface ProxyResolvedAuth {
   auth: {
     user: { id: string; organization_id: string };
     apiKey?: { id: string };
   };
-  admissionSnapshot?: InferenceAdmissionSnapshot;
-  credential?: InferenceCredentialCheck;
-  credentialForAdmission?: () => InferenceCredentialCheck | undefined;
-  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   requestId: string;
 }
+
+/**
+ * Carries the route boundary's single caller-standing decision into the proxy
+ * engine. Worker requests use the combined snapshot and durable admission;
+ * local compatibility callers remain explicitly pre-resolved and therefore
+ * never trigger a second authentication read inside the engine.
+ */
+export type ProxyCombinedAdmission =
+  | (ProxyResolvedAuth & {
+      mode: "combined";
+      admissionSnapshot: InferenceAdmissionSnapshot;
+      executionCtx: { waitUntil(promise: Promise<unknown>): void };
+      credential?: InferenceCredentialCheck;
+      credentialForAdmission?: () => InferenceCredentialCheck | undefined;
+    })
+  | (ProxyResolvedAuth & {
+      mode: "compatibility";
+    });
 
 interface ProxySettlement {
   settle(actualCostUsd: number): Promise<unknown>;
@@ -236,10 +252,7 @@ export function createHandler(
       const cost = await config.getCost(body, searchParams);
 
       let settlement: ProxySettlement;
-      if (combinedAdmission?.executionCtx) {
-        if (!combinedAdmission.admissionSnapshot) {
-          throw new Error("Combined proxy admission snapshot is required");
-        }
+      if (combinedAdmission?.mode === "combined") {
         settlement = await admitOrganizationInference({
           context: {
             organizationId,
@@ -283,7 +296,7 @@ export function createHandler(
 
       const settle = async (actualCostUsd: number, operation: string) => {
         const pending = settlement.settle(actualCostUsd);
-        if (combinedAdmission?.executionCtx) {
+        if (combinedAdmission?.mode === "combined") {
           void retainProxySettlement(pending, combinedAdmission.executionCtx, {
             serviceId: config.id,
             operation,
@@ -379,10 +392,11 @@ export function createHandler(
       } catch (error) {
         // error-policy:J2 provider dispatch may have been accepted before the
         // transport threw, so conservatively settle the marked admission.
-        const pending = combinedAdmission?.executionCtx
-          ? settlement.settleUnknown()
-          : settlement.settle(0);
-        if (combinedAdmission?.executionCtx) {
+        const pending =
+          combinedAdmission?.mode === "combined"
+            ? settlement.settleUnknown()
+            : settlement.settle(0);
+        if (combinedAdmission?.mode === "combined") {
           void retainProxySettlement(pending, combinedAdmission.executionCtx, {
             serviceId: config.id,
             operation: "provider_error",
@@ -490,23 +504,32 @@ export function createHandler(
         );
       }
 
+      if (error instanceof ApiError) {
+        const headers = new Headers();
+        const retryAfterSeconds = error.details?.retryAfterSeconds;
+        if (typeof retryAfterSeconds === "number" && retryAfterSeconds > 0) {
+          headers.set("Retry-After", String(Math.ceil(retryAfterSeconds)));
+        }
+        return Response.json(error.toJSON(), { status: error.status, headers });
+      }
+
       if (error instanceof InferenceCredentialRevokedError) {
         const reason = inferenceCredentialRevocationReason(error.reason);
         const status =
-          reason === "credential_inactive" || reason === "credential_invalid" ? 401 : 403;
-        logger.warn(
-          "[Proxy Engine] blocked provider dispatch at combined credential and balance gate",
-          {
-            serviceId: config.id,
-            requestId: combinedAdmission?.requestId ?? "unavailable",
-            organizationId: combinedAdmission?.auth.user.organization_id ?? "unavailable",
-            userId: combinedAdmission?.auth.user.id ?? "unavailable",
-            credentialKind: combinedAdmission?.credential?.kind ?? "unavailable",
-            reason,
-          },
-        );
+          error.reason === "credential_revoked" ||
+          error.reason === "session_revoked" ||
+          error.reason === "session_binding_revoked"
+            ? 401
+            : 403;
+        logger.warn("[Proxy Engine] Strong credential admission denied", {
+          serviceId: config.id,
+          requestId: combinedAdmission?.requestId,
+          reason,
+          status,
+        });
         return Response.json(
           {
+            success: false,
             error: status === 401 ? "Authentication required" : "Access denied",
             code: status === 401 ? "authentication_required" : "access_denied",
             details: { reason },
@@ -515,8 +538,24 @@ export function createHandler(
         );
       }
 
-      if (error instanceof ApiError) {
-        return Response.json({ error: error.message }, { status: error.status });
+      if (
+        error instanceof InferenceBalanceCacheWarmingError ||
+        error instanceof InferenceCredentialRevocationUnavailableError
+      ) {
+        logger.warn("[Proxy Engine] Combined admission unavailable", {
+          serviceId: config.id,
+          requestId: combinedAdmission?.requestId,
+          error: error.name,
+        });
+        return Response.json(
+          {
+            success: false,
+            error: "Provider admission is unavailable; retry shortly",
+            code: "service_unavailable",
+            details: { retryable: true, retryAfterSeconds: 1 },
+          },
+          { status: 503, headers: { "Retry-After": "1" } },
+        );
       }
 
       if (error instanceof PricingNotFoundError) {
@@ -542,7 +581,7 @@ export function createHandler(
     }
   };
 
-  if (config.rateLimit && !combinedAdmission) {
+  if (config.rateLimit && combinedAdmission?.mode !== "combined") {
     return withRateLimit(handler, config.rateLimit);
   }
 
@@ -554,8 +593,9 @@ export async function executeWithBody(
   work: ServiceHandler,
   request: Request,
   body: ProxyRequestBody,
+  combinedAdmission?: ProxyCombinedAdmission,
 ): Promise<Response> {
-  const handler = createHandler(config, work);
+  const handler = createHandler(config, work, combinedAdmission);
   const mockRequest = new Request(request.url, {
     method: "POST",
     headers: request.headers,

--- a/packages/cloud/shared/src/lib/services/proxy/refund-on-failure.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/refund-on-failure.test.ts
@@ -1,14 +1,9 @@
 /**
- * Direct API-proxy refund-on-failure (#10269).
+ * Direct free-upstream API-proxy refund-on-failure (#10269).
  *
- * The birdeye + dexscreener direct handlers debit the per-call cost up front,
- * then return the upstream response. They must mirror the engine routes' refund
- * policy so the same failure isn't charged here while being refunded there:
- *   - birdeye (PAID upstream): refund on >=500 (server outage, no usable
- *     response), but KEEP the charge on 4xx (the customer's own bad request
- *     still consumed our Birdeye quota);
- *   - dexscreener (FREE upstream): refund on ANY non-ok (the failed call cost us
- *     nothing).
+ * Dexscreener's direct handler debits the per-call cost up front and refunds
+ * any non-ok response because the upstream is free. Paid Birdeye traffic now
+ * uses the shared combined-admission proxy engine and is covered separately.
  *
  * The refund must happen EXACTLY ONCE for the cost that was debited. Only the
  * credits, pricing, auth, and `fetch` boundaries are mocked; the handlers'
@@ -54,7 +49,6 @@ mock.module("../../auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg: async () => ({ organization_id: ORG_ID }),
 }));
 
-const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
 const { handleDexscreenerProxyGet } = await import("./dexscreener-handler");
 
 const originalFetch = globalThis.fetch;
@@ -98,51 +92,6 @@ afterAll(() => {
   mock.module("../credits", () => realCredits);
   mock.module("./pricing", () => realPricing);
   mock.module("../../auth/workers-hono-auth", () => realAuth);
-});
-
-describe("birdeye proxy refund-on-failure", () => {
-  test("upstream 500 refunds the upfront cost exactly once", async () => {
-    mockUpstream(500, '{"error":"upstream down"}');
-
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-
-    // Status is passed through (the customer sees the upstream failure).
-    expect(res.status).toBe(500);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits).toHaveBeenCalledTimes(1);
-    const refundArg = refundCredits.mock.calls[0]?.[0] as {
-      organizationId: string;
-      amount: number;
-    };
-    expect(refundArg.organizationId).toBe(ORG_ID);
-    expect(refundArg.amount).toBeCloseTo(COST, 12);
-  });
-
-  test("upstream 4xx does NOT refund (paid API, customer's bad request)", async () => {
-    mockUpstream(400, '{"error":"bad request"}');
-
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-
-    expect(res.status).toBe(400);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits).not.toHaveBeenCalled();
-  });
-
-  test("upstream 200 does NOT refund (successful call)", async () => {
-    mockUpstream(200, '{"data":{"value":1}}');
-
-    const res = await handleBirdeyeMarketDataProxyGet(
-      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
-    );
-
-    expect(res.status).toBe(200);
-    expect(deductCredits).toHaveBeenCalledTimes(1);
-    expect(refundCredits).not.toHaveBeenCalled();
-  });
 });
 
 describe("dexscreener proxy refund-on-failure", () => {


### PR DESCRIPTION
Closes #30252

## Summary

- add one shared paid-proxy route adapter that resolves generative-route standing once and forwards the resulting credential plus admission snapshot into the proxy engine
- classify the paid proxy inventory as route-authenticated so session and API-key callers avoid a global database auth read before the one combined standing decision
- make the rewritten effective Request authoritative for bypass, standing resolution, and execution, including all three query-string API-key RPC variants
- fail closed in production when the Worker lifetime context is absent; explicit local compatibility retains the limiter and never silently dispatches unmetered
- fuse optional strong credential proof into the single durable admission lease and translate typed revocation, warming, and standing denials without provider dispatch
- migrate all 14 paid legacy chain, market, EVM, and Solana routes, the canonical RPC route, and Birdeye through the shared admission path
- preserve typed Solana denial status, code, bounded reason, Retry-After where applicable, and CORS

## Safety contract

- provider dispatch happens only after combined admission succeeds
- session and API-key mounted paths perform exactly one standing cache read and no global user lookup
- denial preserves structured safe reason/logging; warming and unavailable failures are sanitized retryable 503 responses
- combined mode cannot invoke legacy auth or generic reserve
- strong credential proof on and off each acquire exactly one Durable Object admission lease
- settlement remains asynchronous through waitUntil; the response does not wait for projection update and no cache value is read back
- public, read-only, and internal-only routes remain outside this paid adapter

## Verification

- exact final head: 217 passed, 0 failed across generated reverse inventory, global auth, generative auth, mounted paid-proxy integration, and organization admission tests
- reverse inventory derives all 708 generated routes and proves exactly 16 bypassed routes, each owned by the guarded adapter; no unrelated route bypasses
- cloud shared typecheck passed
- cloud API typecheck passed, including the 708-route contract and production Wrangler dry bundle
- Biome on all 34 changed files passed
- git diff check against origin/develop passed
- root verify passed 376/376 tasks plus repository audits on the immediately preceding rebased head; final base-only integration was revalidated by the exact-head focused tests and package gates above

Exact tested head: 0cdf8cebad642bd4718e729bd474937786d99960
Exact base: c1305ba3d8d809743359cb7ef02f20e8f6a36803